### PR TITLE
WORKSPACE: Get back to bazelbuild/rules_go releases

### DIFF
--- a/Documentation/dev/build.md
+++ b/Documentation/dev/build.md
@@ -4,9 +4,8 @@ The Tectonic Installer leverages the [Bazel build system](https://bazel.build/) 
 
 ## Getting Started
 
-Install Bazel > 0.10.x using the instructions [provided online](https://docs.bazel.build/versions/master/install.html).
+Install Bazel > 0.11.x using the instructions [provided online](https://docs.bazel.build/versions/master/install.html).
 *Note*: compiling Bazel from source requires Bazel.
-*Note*: cross-compilation of Golang binaries, which the Tectonic Installer leverages, is [broken in Bazel 0.9.0](https://github.com/bazelbuild/rules_go/issues/1161).
 *Note*: some Linux platforms may require installing _Static libraries for the GNU standard C++ library_ (on Fedora `dnf install libstdc++-static`)
 
 Clone the Tectonic Installer git repository locally:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,25 +7,16 @@ supported_platforms = [
     "darwin",
 ]
 
-# We need a feature from recent master to get rid of the platform specific part of the go_binary path.
-# https://github.com/bazelbuild/rules_go/pull/1393
-
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    commit = "361556b0d27318d1b8fa42c91a4baa4ab5ea1c58"
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz",
+    sha256 = "8b68d0630d63d95dacc0016c3bb4b76154fe34fca93efd65d1c366de3fcb4294",
 )
-
-# http_archive(
-#     name = "io_bazel_rules_go",
-#     url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.1/rules_go-0.10.1.tar.gz",
-#     sha256 = "4b14d8dd31c6dbaf3ff871adcd03f28c3274e42abc855cb8fb4d01233c0154dc",
-# )
 
 http_archive(
     name = "bazel_gazelle",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.10.1/bazel-gazelle-0.10.1.tar.gz",
-    sha256 = "d03625db67e9fb0905bbd206fa97e32ae9da894fe234a493e7517fd25faec914",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.12.0/bazel-gazelle-0.12.0.tar.gz",
+    sha256 = "ddedc7aaeb61f2654d7d7d4fd7940052ea992ccdb031b8f9797ed143ac7e8d43"
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains", "go_repository")


### PR DESCRIPTION
The most recent issue was bazelbuild/rules_go#1393, which [landed on March 21st][1].  That code went out with `rules_go` v0.11.0:

```console
rules_go$ git log --oneline -1 361556b
361556b Add go_binary out attribute for custom file names (#1393)
rules_go$ git describe --contains 361556b
0.11.0~26
```

I'm bumping to 0.12.1 as [the most-recent tagged release][2] (although 0.13.0 was cut two days ago, and seems to just be [missing a tag][3]).

[1]: https://github.com/bazelbuild/rules_go/pull/1393#event-1533378289
[2]: https://github.com/bazelbuild/rules_go/releases
[3]: https://github.com/bazelbuild/rules_go/pull/1584#issuecomment-403149863