### PR TITLE
images: Remove references to CoreOS Terraform

### DIFF
--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -1,15 +1,8 @@
 ###
 # Update the builder image manually by running:
-# (See README.md/##Upstream-and-CoreOS-Terraform)
 #
 # docker build -t quay.io/coreos/tectonic-builder:<next-semver> -f images/builder/Dockerfile .
 # docker push quay.io/coreos/tectonic-builder:<next-semver>
-#
-# docker build \
-# --build-arg TERRAFORM_URL=<upstream terraform download url> \
-# -t quay.io/coreos/tectonic-builder:<next-semver>-upstream-terraform \
-# -f images/builder/Dockerfile .
-# docker push quay.io/coreos/tectonic-builder:<next-semver>-upstream-terraform
 ###
 
 FROM golang:1.9.2-stretch
@@ -47,8 +40,6 @@ RUN mkdir -p ${HOME} && \
     openvpn xauth
 
 # Install Terraform
-# TERRAFORM_URL enables us to build the upstream-terraform Tectonic builder
-# image (See README.md/##Upstream-and-CoreOS-Terraform)
 ARG TERRAFORM_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 RUN curl -L ${TERRAFORM_URL} | funzip > /usr/local/bin/terraform && chmod +x /usr/local/bin/terraform
 

--- a/images/tectonic-builder/README.md
+++ b/images/tectonic-builder/README.md
@@ -7,18 +7,8 @@ This container image contains the environment required to build and test the
 of CI/CD pipelines. More particularly, this image is used in several Jenkins
 jobs today for testing purposes.
 
-## Upstream and CoreOS Terraform
-
-The Tectonic CI is currently using a custom Terraform version for the default
-pipeline (See https://github.com/coreos/tectonic-installer/pull/1247). As end
-users of Tectonic installer use upstream Terraform we need to test with upstream
-Terraform as well. We are building and publishing the Tectonic builder image
-both with CoreOS Terraform as well as upstream Terraform. This is done via
-docker `--build-arg` `TERRAFORM_URL`. CoreOS Terraform is used for normal PR and
-branch tests, upstream Terraform is used once per day on master.
-
 Example:
-- CoreOS Terraform (default):
-`docker build -t quay.io/coreos/tectonic-builder:v1.33 -f images/tectonic-builder/Dockerfile .`
-- Upstream Terraform:
-`docker build -t quay.io/coreos/tectonic-builder:v1.33-upstream-terraform --build-arg TERRAFORM_URL=https://releases.hashicorp.com/terraform/0.9.11/terraform_0.9.11_linux_amd64.zip -f images/tectonic-builder/Dockerfile .`
+
+```sh
+docker build -t quay.io/coreos/tectonic-builder:v1.33 -f images/tectonic-builder/Dockerfile .
+```

--- a/images/tectonic-installer/Dockerfile.ci
+++ b/images/tectonic-installer/Dockerfile.ci
@@ -5,9 +5,6 @@ WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 ### Install Terraform
 ENV TERRAFORM_VERSION="0.11.1"
-# Install Terraform
-# TERRAFORM_URL enables us to build the upstream-terraform Tectonic builder
-# image (See README.md/##Upstream-and-CoreOS-Terraform)
 ARG TERRAFORM_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 RUN go build -o ./installer/tectonic ./installer/cmd/tectonic && \


### PR DESCRIPTION
These were added in 15394f82 (coreos/tectonic-installer#1444), but we returned to upstream Terraform in all cases in 379fd19b (coreos/tectonic-installer#2041).  Remove the stale docs.