### PR TITLE
installer/pkg/workflow/utils: Simplify findStepTemplates path logic

### DIFF
--- a/installer/pkg/workflow/utils.go
+++ b/installer/pkg/workflow/utils.go
@@ -55,9 +55,10 @@ func findStepTemplates(stepName string, platform config.Platform) (string, error
 	if err != nil {
 		return "", fmt.Errorf("error looking up step %s templates: %v", stepName, err)
 	}
+	stepDir := filepath.Join(base, stepsBaseDir, stepName)
 	for _, path := range []string{
-		filepath.Join(base, stepsBaseDir, stepName, platformPath(platform)),
-		filepath.Join(base, stepsBaseDir, stepName)} {
+		filepath.Join(stepDir, string(platform)),
+		stepDir} {
 
 		stat, err := os.Stat(path)
 		if err != nil {
@@ -72,16 +73,6 @@ func findStepTemplates(stepName string, platform config.Platform) (string, error
 		return path, nil
 	}
 	return "", os.ErrNotExist
-}
-
-func platformPath(platform config.Platform) string {
-	switch platform {
-	case config.PlatformLibvirt:
-		return "libvirt"
-	case config.PlatformAWS:
-		return "aws"
-	}
-	panic("invalid platform")
 }
 
 func generateClusterConfigMaps(m *metadata) error {


### PR DESCRIPTION
Add a `stepDir` variable to avoid joining base through `stepName` twice.

Also drop the `platformPath` helper, which is from 496750ce (coreos/tectonic-installer#3301).  That commit added unmarshal checks for unsupported platforms, we don't need the additional guards here.  If someone wants to create an unsupported `Platform` in Go and pass it through to `findStepTemplates`, I'm fine letting them keep the pieces.  For everyone else, the `Platform` typing should be a sufficient Go guard.