### PR TITLE
installer/pkg/workflow/utils: Format quoted paths with %q

### DIFF
--- a/installer/pkg/workflow/utils.go
+++ b/installer/pkg/workflow/utils.go
@@ -64,10 +64,10 @@ func findStepTemplates(stepName string, platform config.Platform) (string, error
 			if os.IsNotExist(err) {
 				continue
 			}
-			return "", fmt.Errorf("invalid path for '%s' templates: %s", base, err)
+			return "", fmt.Errorf("invalid path for %q templates: %s", base, err)
 		}
 		if !stat.IsDir() {
-			return "", fmt.Errorf("invalid path for '%s' templates", base)
+			return "", fmt.Errorf("invalid path for %q templates", base)
 		}
 		return path, nil
 	}


### PR DESCRIPTION
It's unlikely that `base` contains single quotes, so this is just a nit.  But since [`%q`][1] gives us more robust quoting with fewer source-code characters, it seems like a worthwhile change.

[1]: https://golang.org/pkg/fmt/#hdr-Printing