### PR TITLE
installer/pkg: Replace writeFile with ioutil.WriteFile

### DIFF
--- a/installer/pkg/config-generator/ignition.go
+++ b/installer/pkg/config-generator/ignition.go
@@ -158,5 +158,5 @@ func ignCfgToFile(ignCfg ignconfigtypes.Config, filePath string) error {
 		return err
 	}
 
-	return writeFile(filePath, string(data))
+	return ioutil.WriteFile(filePath, data, 0666)
 }

--- a/installer/pkg/config-generator/tls.go
+++ b/installer/pkg/config-generator/tls.go
@@ -136,7 +136,7 @@ func generatePrivateKey(clusterDir string, path string) (*rsa.PrivateKey, error)
 	if err != nil {
 		return nil, fmt.Errorf("error writing private key: %v", err)
 	}
-	if err := writeFile(fileTargetPath, tls.PrivateKeyToPem(key)); err != nil {
+	if err := ioutil.WriteFile(fileTargetPath, []byte(tls.PrivateKeyToPem(key)), 0600); err != nil {
 		return nil, err
 	}
 	return key, nil
@@ -240,7 +240,7 @@ func generateRootCA(path string, key *rsa.PrivateKey) (*x509.Certificate, error)
 	if err != nil {
 		return nil, fmt.Errorf("error generating self signed certificate: %v", err)
 	}
-	if err := writeFile(fileTargetPath, tls.CertToPem(cert)); err != nil {
+	if err := ioutil.WriteFile(fileTargetPath, []byte(tls.CertToPem(cert)), 0666); err != nil {
 		return nil, err
 	}
 	return cert, nil
@@ -258,7 +258,7 @@ func generateSignedCert(cfg *tls.CertCfg,
 		return nil, fmt.Errorf("error signing certificate: %v", err)
 	}
 	fileTargetPath := filepath.Join(clusterDir, path)
-	if err := writeFile(fileTargetPath, tls.CertToPem(cert)); err != nil {
+	if err := ioutil.WriteFile(fileTargetPath, []byte(tls.CertToPem(cert)), 0666); err != nil {
 		return nil, err
 	}
 	return cert, nil

--- a/installer/pkg/config-generator/utils.go
+++ b/installer/pkg/config-generator/utils.go
@@ -1,25 +1,9 @@
 package configgenerator
 
 import (
-	"bufio"
 	"io"
 	"os"
 )
-
-func writeFile(path, content string) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	w := bufio.NewWriter(f)
-	if _, err := f.WriteString(content); err != nil {
-		return err
-	}
-	w.Flush()
-
-	return nil
-}
 
 func copyFile(fromFilePath, toFilePath string) error {
 	from, err := os.Open(fromFilePath)

--- a/installer/pkg/workflow/init.go
+++ b/installer/pkg/workflow/init.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -57,7 +58,7 @@ func buildInternalConfig(clusterDir string) error {
 	if err != nil {
 		return err
 	}
-	return writeFile(filepath.Join(clusterDir, internalFileName), string(internalFileContent))
+	return ioutil.WriteFile(filepath.Join(clusterDir, internalFileName), internalFileContent, 0666)
 }
 
 func generateTerraformVariablesStep(m *metadata) error {
@@ -67,7 +68,7 @@ func generateTerraformVariablesStep(m *metadata) error {
 	}
 
 	terraformVariablesFilePath := filepath.Join(m.clusterDir, terraformVariablesFileName)
-	return writeFile(terraformVariablesFilePath, vars)
+	return ioutil.WriteFile(terraformVariablesFilePath, []byte(vars), 0666)
 }
 
 func prepareWorspaceStep(m *metadata) error {

--- a/installer/pkg/workflow/init_test.go
+++ b/installer/pkg/workflow/init_test.go
@@ -125,7 +125,7 @@ func TestGenerateTerraformVariablesStep(t *testing.T) {
 	}
 	expected := string(expectedData)
 
-	if got != expected {
+	if got + "\n" != expected {
 		t.Errorf("expected: %s, got: %s", expected, got)
 	}
 }

--- a/installer/pkg/workflow/utils.go
+++ b/installer/pkg/workflow/utils.go
@@ -1,10 +1,10 @@
 package workflow
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -98,7 +98,7 @@ func generateClusterConfigMaps(m *metadata) error {
 	}
 
 	kcoConfigFilePath := filepath.Join(clusterGeneratedPath, kcoConfigFileName)
-	if err := writeFile(kcoConfigFilePath, kcoConfig); err != nil {
+	if err := ioutil.WriteFile(kcoConfigFilePath, []byte(kcoConfig), 0666); err != nil {
 		return err
 	}
 
@@ -108,7 +108,7 @@ func generateClusterConfigMaps(m *metadata) error {
 	}
 
 	tncoConfigFilePath := filepath.Join(clusterGeneratedPath, tncoConfigFileName)
-	if err := writeFile(tncoConfigFilePath, tncoConfig); err != nil {
+	if err := ioutil.WriteFile(tncoConfigFilePath, []byte(tncoConfig), 0666); err != nil {
 		return err
 	}
 
@@ -123,7 +123,7 @@ func generateClusterConfigMaps(m *metadata) error {
 	}
 
 	kubeSystemConfigFilePath := filepath.Join(kubePath, kubeSystemFileName)
-	if err := writeFile(kubeSystemConfigFilePath, kubeSystem); err != nil {
+	if err := ioutil.WriteFile(kubeSystemConfigFilePath, []byte(kubeSystem), 0666); err != nil {
 		return err
 	}
 
@@ -138,7 +138,7 @@ func generateClusterConfigMaps(m *metadata) error {
 	}
 
 	tectonicSystemConfigFilePath := filepath.Join(tectonicPath, tectonicSystemFileName)
-	return writeFile(tectonicSystemConfigFilePath, tectonicSystem)
+	return ioutil.WriteFile(tectonicSystemConfigFilePath, []byte(tectonicSystem), 0666)
 }
 
 func readClusterConfig(configFilePath string, internalFilePath string) (*config.Cluster, error) {
@@ -175,22 +175,6 @@ func readClusterConfigStep(m *metadata) error {
 	}
 
 	m.cluster = *cluster
-
-	return nil
-}
-
-func writeFile(path, content string) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	w := bufio.NewWriter(f)
-	if _, err := fmt.Fprintln(w, content); err != nil {
-		return err
-	}
-	w.Flush()
 
 	return nil
 }


### PR DESCRIPTION
The `writeFile` helpers are from 2b82fbe6 (coreos/tectonic-installer#2960) and 461ff5f1 (coreos/tectonic-installer#3120).  But ioutil's function has almost the same signature.  Remove our local versions and use the stdlib's instead.

I've used [`os.Create`'s 0666][1] in most cases; callers can set a umask if they want to restrict that.  The exception is in `generatePrivateKey`, where I've set 0600 to avoid leaking a private key even in the presence of a weak umask.

[1]: https://golang.org/pkg/os/#Create