### PR TITLE
installer/pkg/config-generator/tls: Don't Sprintf string literals

### DIFF
--- a/installer/pkg/config-generator/tls.go
+++ b/installer/pkg/config-generator/tls.go
@@ -133,7 +133,7 @@ func (c *ConfigGenerator) GenerateTLSConfig(clusterDir string) error {
 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		DNSNames: []string{
 			baseAddress,
-			fmt.Sprintf("%s.%s", "*", baseAddress),
+			fmt.Sprintf("*.%s", baseAddress),
 		},
 		Subject:  pkix.Name{CommonName: baseAddress, Organization: []string{"ingress"}},
 		Validity: validityThreeYears,
@@ -187,7 +187,7 @@ func (c *ConfigGenerator) GenerateTLSConfig(clusterDir string) error {
 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		Subject:      pkix.Name{CommonName: "openshift-apiserver", Organization: []string{"kube-master"}},
 		DNSNames: []string{
-			fmt.Sprintf("%s-%s.%s", c.Name, "api", c.BaseDomain),
+			fmt.Sprintf("%s-api.%s", c.Name, c.BaseDomain),
 			"openshift-apiserver",
 			"openshift-apiserver.kube-system",
 			"openshift-apiserver.kube-system.svc",


### PR DESCRIPTION
Both of these lines were touched by ae41b0a3 (#22), but there's no need to use `Sprintf` to inject string literals into the format template.  26930f2b (#22) fixed one such instance, but left these.  The `*` instance dates back to bf61dc9e5 (#16).