### PR TITLE
Documentation/dev/build: "tectonic-installer" -> "installer"

### DIFF
--- a/Documentation/dev/build.md
+++ b/Documentation/dev/build.md
@@ -62,17 +62,9 @@ This will create a tarball named `tectonic.tar.gz` in the `bazel-bin` directory 
 tectonic
 ├── config.tf
 ├── examples
+├── installer
 ├── modules
-├── steps
-└── tectonic-installer
-    ├── darwin
-    │   ├── tectonic
-    │   ├── terraform
-    │   └── terraform-provider-matchbox
-    └── linux
-        ├── tectonic
-        ├── terraform
-        └── terraform-provider-matchbox
+└── steps
 ```
 
 In order to build a release tarball with the version string in the directory name within the tarball, export a `TECTONIC_VERSION` environment variable and then build the tarball while passing the variable to the build:
@@ -88,9 +80,9 @@ This will create a tarball named `tectonic.tar.gz` in the `bazel-bin` directory 
 tectonic_1.2.3-beta
 ├── config.tf
 ├── examples
+├── installer
 ├── modules
-├── steps
-└── tectonic-installer
+└── steps
 ```
 
 *Note*: the generated tarball will not include the version string in its own name since output names must be known ahead of time in Bazel. To include the version in the tarball name, copy or move the archive with the desired name in the destination.


### PR DESCRIPTION
Catching up with e22e31f1 (coreos/tectonic-installer#3142).  Running `bazel build tarball` on master actually gets you a `tectonic-dev.tar.gz` with a root `tectonic-dev` directory, but I've left that alone for now (maybe it depends on environment variables like cutting releases?).  The tarball I built also lacks the `darwin`/`linux` subdirectories:

```console
$ tree tectonic-dev/installer/
tectonic-dev/installer/
├── tectonic
└── terraform
```

But by stopping at the `installer` directory I don't have to worry about figuring out how cross-platform builds work now ;).

Fixes #33.