### PR TITLE
BUILD.bazel: Explicitly set file modes

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -74,6 +74,7 @@ alias(
 
 pkg_tar(
     name = "tectonic-%s" % TECTONIC_VERSION,
+    mode = "0666",
     srcs = [
         "//:template_resources",
         "//examples:tectonic_cli_examples",
@@ -89,6 +90,7 @@ pkg_tar(
 
 pkg_tar(
     name = "cli_bin",
+    mode = "0777",
     srcs = ["//installer/cmd/tectonic"],
     package_dir = "installer",
 )
@@ -103,6 +105,7 @@ filegroup(
 
 pkg_tar(
     name = "tf_bin",
+    mode = "0777",
     srcs = [":terraform_runtime"],
     package_dir = "installer",
 )


### PR DESCRIPTION
Overriding the [default 0555][1] (bazelbuild/bazel#2925), which doesn't make sense for Terraform configs, etc.  Bazel still (as of 0.15.0) doesn't support setting permissions for the tarball itself (bazelbuild/bazel#5588), but we can address that in followup work if/when it becomes possible.

With this change, the unpacked tarball permissions are:

```console
$ tar -tvf bazel-bin/tectonic-dev.tar.gz | head -n5
drwxr-xr-x 0/0               0 1969-12-31 16:00 ./
drwxr-xr-x 0/0               0 1969-12-31 16:00 ./tectonic-dev/
-rw-rw-rw- 0/0           10522 1969-12-31 16:00 ./tectonic-dev/config.tf
drwxr-xr-x 0/0               0 1969-12-31 16:00 ./tectonic-dev/modules/
drwxr-xr-x 0/0               0 1969-12-31 16:00 ./tectonic-dev/modules/aws/
$ tar -tvf bazel-bin/tectonic-dev.tar.gz | grep /installer/
drwxr-xr-x 0/0               0 1969-12-31 16:00 ./tectonic-dev/installer/
-rwxrwxrwx 0/0        11214398 1969-12-31 16:00 ./tectonic-dev/installer/tectonic
-rwxrwxrwx 0/0        69122624 1969-12-31 16:00 ./tectonic-dev/installer/terraform
```

[1]: https://docs.bazel.build/versions/master/be/pkg.html#pkg_tar