### PR TITLE
examples/tectonic.aws: Fix '#' -> '//' in etcd hardware URL

### DIFF
--- a/examples/tectonic.aws.yaml
+++ b/examples/tectonic.aws.yaml
@@ -17,7 +17,7 @@ aws:
   # ec2AMIOverride:
 
   etcd:
-    # Instance size for the etcd node(s). Example: `t2.medium`. Read the [etcd recommended hardware](https:#coreos.com/etcd/docs/latest/op-guide/hardware.html) guide for best performance
+    # Instance size for the etcd node(s). Example: `t2.medium`. Read the [etcd recommended hardware](https://coreos.com/etcd/docs/latest/op-guide/hardware.html) guide for best performance
     ec2Type: t2.medium
 
     # (optional) List of additional security group IDs for etcd nodes.


### PR DESCRIPTION
This typo landed in b965bc07 (coreos/tectonic-installer#3039) and survived the dedent in fef5a0f6 (coreos/tectonic-installer#3135).