### PR TITLE
README: Document console URL

### DIFF
--- a/Documentation/dev/libvirt-howto.md
+++ b/Documentation/dev/libvirt-howto.md
@@ -113,7 +113,7 @@ kubectl get -n tectonic-system pods
 ```
 
 ## Connect to the cluster console
-This will take ~30 minutes to be available. Simply go to `https://$CLUSTER_NAME-api.BASE_DOMAIN:6443/console/` (e.g. `test1.tt.testing`) and log in using the credentials above.
+This will take ~30 minutes to be available. Simply go to `https://${CLUSTER_NAME}-api.${BASE_DOMAIN}:6443/console/` (e.g. `test1.tt.testing`) and log in using the credentials above.
 
 
 # Libvirt vs. AWS

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ These instructions can be used for AWS:
     tectonic install --dir=$CLUSTER_NAME
     ```
 
-8. Teardown Tectonic cluster
+8. Visit `https://{$CLUSTER_NAME}-api.${BASE_DOMAIN}:6443/console/`.
+    You may need to ignore a certificate warning if you did not configure a CA known to your browser.
+    Log in with the admin credentials you configured in `tectonic.aws.yaml`.
+
+9. Teardown Tectonic cluster
     ```sh
     tectonic destroy --dir=$CLUSTER_NAME
     ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ https://coreos.com/blog/coreos-tech-to-combine-with-red-hat-openshift
 
 These instructions can be used for AWS:
 
-1. Build the project
+1. Set you access-key and secret in `~/.aws/credentials`.
+    You can create credentials in [the IAM console][aws-iam-console], as documented [here][aws-cli-config] and [here][aws-cli-config-files].
+
+2. Build the project
     ```sh
     bazel build tarball
     ```
@@ -20,33 +23,33 @@ These instructions can be used for AWS:
     docker run --rm -v $PWD:$PWD:Z -w $PWD quay.io/coreos/tectonic-builder:bazel-v0.3 bazel --output_base=.cache build tarball
     ```
 
-2. Extract the tarball
+3. Extract the tarball
     ```sh
     tar -zxf bazel-bin/tectonic-dev.tar.gz
     cd tectonic-dev
     ```
 
-3. Add binaries to $PATH
+4. Add binaries to $PATH
     ```sh
     export PATH=$(pwd)/installer:$PATH
     ```
 
-4. Edit Tectonic configuration file including the $CLUSTER_NAME
+5. Edit Tectonic configuration file including the $CLUSTER_NAME
     ```sh
     $EDITOR examples/tectonic.aws.yaml
     ```
 
-5. Init Tectonic CLI
+6. Init Tectonic CLI
     ```sh
     tectonic init --config=examples/tectonic.aws.yaml
     ```
 
-6. Install Tectonic cluster
+7. Install Tectonic cluster
     ```sh
     tectonic install --dir=$CLUSTER_NAME
     ```
 
-7. Teardown Tectonic cluster
+8. Teardown Tectonic cluster
     ```sh
     tectonic destroy --dir=$CLUSTER_NAME
     ```
@@ -82,3 +85,7 @@ For the sake of your fellow reviewers, commit vendored code separately from any 
 ## Tests
 
 See [tests/README.md](tests/README.md).
+
+[aws-cli-config]: https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-quick-configuration
+[aws-cli-config-files]: https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
+[aws-iam-console]: https://console.aws.amazon.com/iam/home#/users


### PR DESCRIPTION
Builds on #56; review that first.  I'll rebase this down to a single commit once #56 lands.

I spent way to long trying to figure out why `https://${CLUSTER_NAME}.${BASE_DOMAIN}` was giving me an "Application is not available" error, before @dcondomitti pointed me at this one.

While I'm adding this to the AWS notes in the README, also touch the libvirt notes to add braces, so it's easier to see that `-api` is a literal, and not part of the variable name.

@chancez suggested that the `-api` hostname suffix and/or 6443 port are because production deploys might want to put an elastic load balancer in front of the current API host for production deploys.  But when we do something like that, we can update our URLs here.