### PR TITLE
test: update aws example to use rhcos

### DIFF
--- a/examples/tectonic.aws.yaml
+++ b/examples/tectonic.aws.yaml
@@ -14,7 +14,8 @@ aws:
   # autoScalingGroupExtraTags:
 
   # (optional) AMI override for all nodes. Example: `ami-foobar123`.
-  # ec2AMIOverride:
+  # XXX: The following overrides the Container Linux settings below and uses an RHCOS image (3.10-7.5) instead of Container Linux.
+  ec2AMIOverride: ami-02323e873420d8eab
 
   etcd:
     # Instance size for the etcd node(s). Example: `t2.medium`. Read the [etcd recommended hardware](https://coreos.com/etcd/docs/latest/op-guide/hardware.html) guide for best performance


### PR DESCRIPTION
This example config is used by the tests to create a cluster. Instead of
booting a Container Linux image, use RHCOS (3.10-7.5).
