### PR TITLE
installer/pkg/config/fixtures: Bump to version 2.2.0

### DIFF
--- a/installer/pkg/config/fixtures/ign.ign
+++ b/installer/pkg/config/fixtures/ign.ign
@@ -1,5 +1,5 @@
 {
-  "ignition": { "version": "2.0.0" },
+  "ignition": { "version": "2.2.0" },
   "systemd": {
     "units": [{
       "name": "example.service",

--- a/installer/pkg/config/fixtures/invalid-ign.ign
+++ b/installer/pkg/config/fixtures/invalid-ign.ign
@@ -1,5 +1,5 @@
 {
-  "ignition": { "version": "2.0.0" },
+  "ignition": { "version": "2.2.0" },
   "systemd": {
     "units": [{
       "name": "example.service",


### PR DESCRIPTION
Catching up with c71394d1 (coreos/tectonic-installer#3294).

It would be nice if we could prune the vendored Go for older ignition config versions, but they're currently chained for translation:

```config
$ git grep coreos/ignition/config/v2_1 | grep '/v2_2/.*.go:'
vendor/github.com/coreos/ignition/config/v2_2/config.go:				"github.com/coreos/ignition/config/v2_1"
vendor/github.com/coreos/ignition/config/v2_2/translate.go:			v2_1 "github.com/coreos/ignition/config/v2_1/types"
```

I've filed coreos/ignition#602 asking for optional old-version imports.