### PR TITLE
modules/aws/etcd/ignition: Drop hard-coded ignition_etcd_keys

### DIFF
--- a/modules/aws/etcd/ignition.tf
+++ b/modules/aws/etcd/ignition.tf
@@ -1,7 +1,3 @@
-locals {
-  ignition_etcd_keys = ["ignition_etcd_0.json", "ignition_etcd_1.json", "ignition_etcd_2.json"]
-}
-
 data "ignition_config" "tnc" {
   count = "${var.instance_count}"
 
@@ -13,7 +9,7 @@ data "ignition_config" "tnc" {
 
   # Used for loading certificates
   append {
-    source = "${format("s3://%s/%s", var.s3_bucket, local.ignition_etcd_keys[count.index])}"
+    source = "${format("s3://%s/ignition_etcd_%d.json", var.s3_bucket, count.index)}"
 
     # TODO: add verification
   }


### PR DESCRIPTION
The local variable is from cd71f30b (coreos/tectonic-installer#2940), but it doesn't scale beyond three etcd nodes.  This commit pivots to an approach that scales to an arbitrary number of nodes, matching the scalable generation logic we've had since 0c7ac90f (coreos/tectonic-installer#2362).