### PR TITLE
modules/aws/etcd: Add a README

### DIFF
--- a/modules/aws/etcd/README.md
+++ b/modules/aws/etcd/README.md
@@ -1,0 +1,68 @@
+# AWS Etcd Module
+
+This [Terraform][] [module][] makes it easy to create [etcd][] nodes on [AWS][].
+
+Read the [etcd recommended hardware guide][hardware] for best performance.
+
+## Example
+
+```hcl
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "etcd_ignition" {
+}
+
+resource "aws_vpc" "example" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_subnet" "example" {
+  vpc_id     = "${aws_vpc.example.id}"
+  cidr_block = "${aws_vpc.example.cidr_block}"
+}
+
+resource "aws_security_group" "etcd" {
+  vpc_id = "${aws_vpc.example.id}"
+
+  ingress {
+    from_port   = 2379
+    to_port     = 2380
+    protocol    = "tcp"
+    cidr_blocks = ["${aws_subnet.example.cidr_block}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["${aws_subnet.example.cidr_block}"]
+  }
+}
+
+module "etcd" {
+  source = "github.com/openshift/installer//modules/aws/etcd"
+
+  base_domain    = "openshift.example.com"
+  cluster_id     = "123"
+  cluster_name   = "my-cluster"
+  instance_count = "3"
+  s3_bucket      = "${aws_s3_bucket.etcd_ignition.id}"
+  sg_ids         = ["${aws_security_group.etcd.id}"]
+  subnets        = ["${aws_subnet.example.id}"]
+}
+```
+
+You can set `container_linux_channel` and `container_linux_version` if you need a specific [Container Linux][container-linux] install.
+Alternatively, you can set `ec2_ami` directly if you want to use an [AMI][] that is not Container Linux.
+
+[AMI]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html
+[AWS]: https://aws.amazon.com/
+[container-linux]: https://coreos.com/os/docs/latest/
+[etcd]: https://github.com/coreos/etcd
+[hardware]: https://github.com/coreos/etcd/blob/v3.3.8/Documentation/op-guide/hardware.md#example-hardware-configurations
+[module]: https://www.terraform.io/docs/modules/
+[Terraform]: https://www.terraform.io/

--- a/modules/aws/etcd/nodes.tf
+++ b/modules/aws/etcd/nodes.tf
@@ -3,10 +3,17 @@ locals {
   arn       = "aws"
 }
 
+module "container_linux" {
+  source = "../../container_linux"
+
+  release_channel = "${var.container_linux_channel}"
+  release_version = "${var.container_linux_version}"
+}
+
 data "aws_ami" "coreos_ami" {
   filter {
     name   = "name"
-    values = ["CoreOS-${var.container_linux_channel}-${var.container_linux_version}-*"]
+    values = ["CoreOS-${var.container_linux_channel}-${module.container_linux.version}-*"]
   }
 
   filter {

--- a/modules/aws/etcd/variables.tf
+++ b/modules/aws/etcd/variables.tf
@@ -11,11 +11,13 @@ variable "cluster_name" {
 }
 
 variable "container_linux_channel" {
-  type = "string"
+  type    = "string"
+  default = "stable"
 }
 
 variable "container_linux_version" {
-  type = "string"
+  type    = "string"
+  default = "latest"
 }
 
 variable "instance_count" {
@@ -23,7 +25,8 @@ variable "instance_count" {
 }
 
 variable "ssh_key" {
-  type = "string"
+  type    = "string"
+  default = ""
 }
 
 variable "subnets" {
@@ -31,11 +34,13 @@ variable "subnets" {
 }
 
 variable "container_image" {
-  type = "string"
+  type    = "string"
+  default = "quay.io/coreos/etcd:v3.3.8"
 }
 
 variable "ec2_type" {
-  type = "string"
+  type    = "string"
+  default = "t2.medium"
 }
 
 variable "ec2_ami" {
@@ -51,11 +56,13 @@ variable "extra_tags" {
 
 variable "root_volume_type" {
   type        = "string"
+  default     = "gp2"
   description = "The type of volume for the root block device."
 }
 
 variable "root_volume_size" {
   type        = "string"
+  default     = "30"
   description = "The size of the volume in gigabytes for the root block device."
 }
 


### PR DESCRIPTION
READMEs are part of the [standard module structure][1], and docs like this should make onboarding new contributors easier.  The example's etcd ports are from [here][2] and [here][3].  The egress rule is based on [this example][4], although I've restricted it to the VPC.

I've also added some defaults, so users who are not interested lower-level settings can ignore them.  You can find Container Linux AMIs [here][5] if you want to test `ec2_ami`.

Some of the module variables are just passed through to lower-level providers (e.g. `ssh_key` is passed through to `aws_instance`'s `key_name`).  That sort of thing is awkward at the moment, because there's no
generic way to declare a variable unset (vs. setting it to some sort of zero value).  Terraform will grow support for that distinction (via [a `null` value][7]) [in 0.12][6] as part of HCL2.  Terraform 0.12 is due out [in the next few months][7].

The HCL pretty printing is [supported by Linguist][8], which [GitHub uses for syntax highlighting][9].

To test this locally (before the PR is merged), you'll need to change your `source` to use a local path:

```hcl
source = "/home/wking/src/openshift-installer/modules/aws/etcd"
```

~~You may also need to set `container_linux_version = "1745.7.0"` or similar (even if you're also setting `ec2_ami`), because there don't seem to be `*-latest-*` forms of the CoreOS AMIs:~~

```console
$ aws --region us-east-1 ec2 describe-images --filter 'Name=owner-id,Values=595879546273' 'Name=architecture,Values=x86_64' 'Name=virtualization-type,Values=hvm' 'Name=name,Values=CoreOS-stable-latest-*'
{
   "Images": []
}
```

~~despite our [claims for `latest` support][10].  I'm not sure what's going on there.  Maybe we should stop claiming `latest` support?~~ EDIT: Ah, `latest` support depends on `modules/container_linux`.

[1]: https://www.terraform.io/docs/modules/create.html#standard-module-structure
[2]: https://github.com/coreos/etcd/blob/master/README.md#etcd-tcp-ports
[3]: http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
[4]: https://www.terraform.io/docs/providers/aws/r/security_group.html#argument-reference
[5]: https://coreos.com/os/docs/latest/booting-on-ec2.html
[6]: https://github.com/hashicorp/terraform/issues/5471#issuecomment-393904735
[7]: https://www.hashicorp.com/blog/terraform-0-1-2-preview
[8]: https://github.com/github/linguist/blob/v6.3.1/lib/linguist/languages.yml#L1723-L1733
[9]: https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
[10]: https://github.com/openshift/installer/blob/c82db76d9570977d7a299a669c9c912018b33576/config.tf#L223