### PR TITLE
modules/container_linux: Add a README

### DIFF
--- a/modules/container_linux/README.md
+++ b/modules/container_linux/README.md
@@ -1,0 +1,26 @@
+# Container Linux Module
+
+This [Terraform][] [module][] supports `latest` versions for [Container Linux][container-linux] release channels.
+
+## Example
+
+From the module directory:
+
+```console
+$ terraform init
+$ terraform apply
+$ terraform output version
+1745.7.0
+$ terraform apply --var release_channel=alpha
+$ terraform output version
+1828.0.0
+$ terraform apply --var release_version=1814.0.0
+$ terraform output version
+1814.0.0
+```
+
+When you're done, clean up by removing the `.terraform` directory created by `init` and the `terraform.tfstate*` files created by `apply`.
+
+[container-linux]: https://coreos.com/os/docs/latest/
+[module]: https://www.terraform.io/docs/modules/
+[Terraform]: https://www.terraform.io/

--- a/modules/container_linux/variables.tf
+++ b/modules/container_linux/variables.tf
@@ -1,5 +1,6 @@
 variable "release_channel" {
-  type = "string"
+  type    = "string"
+  default = "stable"
 
   description = <<EOF
 The Container Linux update channel.
@@ -9,7 +10,8 @@ EOF
 }
 
 variable "release_version" {
-  type = "string"
+  type    = "string"
+  default = "latest"
 
   description = <<EOF
 The Container Linux version to use. Set to `latest` to select the latest available version for the selected update channel.


### PR DESCRIPTION
READMEs are part of [the standard module structure][1], and docs like this should make onboarding new contributors easier.  I've also added some defaults, so users who are not interested lower-level settings can ignore them.

The hcl pretty printing is [supported by Linguist][2], which GitHub [uses for syntax highlighting][3].

[1]: https://www.terraform.io/docs/modules/create.html#standard-module-structure
[2]: https://github.com/github/linguist/blob/v6.3.1/lib/linguist/languages.yml#L1723-L1733
[3]: https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting