### PR TITLE
modules/aws/vpc/outputs: Drop join/split comment

### DIFF
--- a/modules/aws/vpc/outputs.tf
+++ b/modules/aws/vpc/outputs.tf
@@ -2,8 +2,6 @@ output "vpc_id" {
   value = "${data.aws_vpc.cluster_vpc.id}"
 }
 
-# We have to do this join() & split() 'trick' because null_data_source and
-# the ternary operator can't output lists or maps
 output "master_subnet_ids" {
   value = "${local.master_subnet_ids}"
 }


### PR DESCRIPTION
This should have happened in ec2cfa50 (coreos/tectonic-installer#2177), which removed the join/split code referenced by the comment.