### PR TITLE
wip: steps/topology/aws: Restore etcd-specific subnet

### DIFF
--- a/installer/pkg/config/aws/aws.go
+++ b/installer/pkg/config/aws/aws.go
@@ -41,10 +41,12 @@ type External struct {
 	PrivateZone     string   `json:"tectonic_aws_external_private_zone,omitempty" yaml:"privateZone,omitempty"`
 	VPCID           string   `json:"tectonic_aws_external_vpc_id,omitempty" yaml:"vpcID,omitempty"`
 	WorkerSubnetIDs []string `json:"tectonic_aws_external_worker_subnet_ids,omitempty" yaml:"workerSubnetIDs,omitempty"`
+	// FIXME: Do I need to add EtcdSubnetIDs as well?
 }
 
 // Etcd converts etcd related config.
 type Etcd struct {
+	// FIXME: Do I need to add CustomSubnets as well?
 	EC2Type        string   `json:"tectonic_aws_etcd_ec2_type,omitempty" yaml:"ec2Type,omitempty"`
 	ExtraSGIDs     []string `json:"tectonic_aws_etcd_extra_sg_ids,omitempty" yaml:"extraSGIDs,omitempty"`
 	IAMRoleName    string   `json:"tectonic_aws_etcd_iam_role_name,omitempty" yaml:"iamRoleName,omitempty"`

--- a/modules/aws/vpc/common.tf
+++ b/modules/aws/vpc/common.tf
@@ -15,10 +15,12 @@ locals {
   // List of possible AZs for each type of subnet
   new_worker_subnet_azs = ["${coalescelist(keys(var.new_worker_subnet_configs), data.aws_availability_zones.azs.names)}"]
   new_master_subnet_azs = ["${coalescelist(keys(var.new_master_subnet_configs), data.aws_availability_zones.azs.names)}"]
+  new_etcd_subnet_azs   = ["${coalescelist(keys(var.new_etcd_subnet_configs), data.aws_availability_zones.azs.names)}"]
 
   // How many AZs to create worker and master subnets in (always zero if external_vpc_mode)
   new_worker_az_count = "${local.external_vpc_mode ? 0 : length(local.new_worker_subnet_azs)}"
   new_master_az_count = "${local.external_vpc_mode ? 0 : length(local.new_master_subnet_azs)}"
+  new_etcd_az_count   = "${local.external_vpc_mode ? 0 : length(local.new_etcd_subnet_azs)}"
 
   // The base set of ids needs to build rest of vpc data sources
   // This is crux of dealing with existing vpc / new vpc incongruity
@@ -27,8 +29,10 @@ locals {
   // When referencing the _ids arrays or data source arrays via count = , always use the *_count variable rather than taking the length of the list
   worker_subnet_ids   = ["${coalescelist(aws_subnet.worker_subnet.*.id,var.external_worker_subnet_ids)}"]
   master_subnet_ids   = ["${coalescelist(aws_subnet.master_subnet.*.id,var.external_master_subnet_ids)}"]
+  etcd_subnet_ids     = ["${coalescelist(aws_subnet.etcd_subnet.*.id,var.external_etcd_subnet_ids)}"]
   worker_subnet_count = "${local.external_vpc_mode ? length(var.external_worker_subnet_ids) : local.new_worker_az_count}"
   master_subnet_count = "${local.external_vpc_mode ? length(var.external_master_subnet_ids) : local.new_master_az_count}"
+  etcd_subnet_count   = "${local.external_vpc_mode ? length(var.external_etcd_subnet_ids) : local.new_etcd_az_count}"
 }
 
 # all data sources should be input variable-agnostic and used as canonical source for querying "state of resources" and building outputs
@@ -47,6 +51,12 @@ data "aws_subnet" "worker" {
 data "aws_subnet" "master" {
   count  = "${local.master_subnet_count}"
   id     = "${local.master_subnet_ids[count.index]}"
+  vpc_id = "${local.vpc_id}"
+}
+
+data "aws_subnet" "etcd" {
+  count  = "${local.etcd_subnet_count}"
+  id     = "${local.etcd_subnet_ids[count.index]}"
   vpc_id = "${local.vpc_id}"
 }
 

--- a/modules/aws/vpc/outputs.tf
+++ b/modules/aws/vpc/outputs.tf
@@ -8,6 +8,10 @@ output "master_subnet_ids" {
   value = "${local.master_subnet_ids}"
 }
 
+output "etcd_subnet_ids" {
+  value = "${local.etcd_subnet_ids}"
+}
+
 output "worker_subnet_ids" {
   value = "${local.worker_subnet_ids}"
 }

--- a/modules/aws/vpc/sg-etcd.tf
+++ b/modules/aws/vpc/sg-etcd.tf
@@ -23,27 +23,30 @@ resource "aws_security_group" "etcd" {
   }
 
   ingress {
-    protocol  = "tcp"
-    from_port = 22
-    to_port   = 22
-    self      = true
+    protocol    = "tcp"
+    from_port   = 22
+    to_port     = 22
+    self        = true
+    cidr_blocks = ["${local.new_master_cidr_range}"]
 
     security_groups = ["${aws_security_group.master.id}"]
   }
 
   ingress {
-    protocol  = "tcp"
-    from_port = 2379
-    to_port   = 2379
-    self      = true
+    protocol    = "tcp"
+    from_port   = 2379
+    to_port     = 2379
+    self        = true
+    cidr_blocks = ["${local.new_master_cidr_range}"]
 
     security_groups = ["${aws_security_group.master.id}"]
   }
 
   ingress {
-    protocol  = "tcp"
-    from_port = 2380
-    to_port   = 2380
-    self      = true
+    protocol    = "tcp"
+    from_port   = 2380
+    to_port     = 2380
+    self        = true
+    cidr_blocks = ["${local.new_master_cidr_range}"]
   }
 }

--- a/modules/aws/vpc/variables.tf
+++ b/modules/aws/vpc/variables.tf
@@ -22,6 +22,10 @@ variable "external_master_subnet_ids" {
   type = "list"
 }
 
+variable "external_etcd_subnet_ids" {
+  type = "list"
+}
+
 variable "external_worker_subnet_ids" {
   type = "list"
 }
@@ -33,6 +37,11 @@ variable "extra_tags" {
 }
 
 variable "new_master_subnet_configs" {
+  description = "{az_name = new_subnet_cidr}: Empty map means create new subnets in all availability zones in region with generated cidrs"
+  type        = "map"
+}
+
+variable "new_etcd_subnet_configs" {
   description = "{az_name = new_subnet_cidr}: Empty map means create new subnets in all availability zones in region with generated cidrs"
   type        = "map"
 }

--- a/modules/aws/vpc/vpc.tf
+++ b/modules/aws/vpc/vpc.tf
@@ -1,6 +1,7 @@
 locals {
+  new_master_cidr_range = "${cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block,2,0)}"
+  new_etcd_cidr_range   = "${cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block,2,1)}"
   new_worker_cidr_range = "${cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block,1,1)}"
-  new_master_cidr_range = "${cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block,1,0)}"
 }
 
 resource "aws_vpc" "new_vpc" {

--- a/steps/etcd/aws/etcd.tf
+++ b/steps/etcd/aws/etcd.tf
@@ -57,7 +57,7 @@ module "etcd" {
   s3_bucket               = "${local.s3_bucket}"
   sg_ids                  = "${concat(var.tectonic_aws_etcd_extra_sg_ids, list(local.sg_id))}"
   ssh_key                 = "${var.tectonic_aws_ssh_key}"
-  subnets                 = ["${local.subnet_ids_workers}"]
+  subnets                 = ["${local.subnet_ids}"]
   etcd_iam_role           = "${var.tectonic_aws_etcd_iam_role_name}"
   ec2_ami                 = "${var.tectonic_aws_ec2_ami_override}"
 }

--- a/steps/etcd/aws/inputs.tf
+++ b/steps/etcd/aws/inputs.tf
@@ -16,9 +16,9 @@ data "terraform_remote_state" "assets" {
 }
 
 locals {
-  ignition           = "${data.terraform_remote_state.assets.ignition_etcd}"
-  sg_id              = "${data.terraform_remote_state.topology.etcd_sg_id}"
-  subnet_ids_workers = "${data.terraform_remote_state.topology.subnet_ids_workers}"
-  s3_bucket          = "${data.terraform_remote_state.topology.s3_bucket}"
-  private_zone_id    = "${var.tectonic_aws_external_private_zone != "" ? var.tectonic_aws_external_private_zone : data.terraform_remote_state.topology.private_zone_id}"
+  ignition        = "${data.terraform_remote_state.assets.ignition_etcd}"
+  sg_id           = "${data.terraform_remote_state.topology.etcd_sg_id}"
+  subnet_ids      = "${data.terraform_remote_state.topology.subnet_ids_etcd}"
+  s3_bucket       = "${data.terraform_remote_state.topology.s3_bucket}"
+  private_zone_id = "${var.tectonic_aws_external_private_zone != "" ? var.tectonic_aws_external_private_zone : data.terraform_remote_state.topology.private_zone_id}"
 }

--- a/steps/topology/aws/main.tf
+++ b/steps/topology/aws/main.tf
@@ -47,11 +47,13 @@ module "vpc" {
   external_vpc_id = "${var.tectonic_aws_external_vpc_id}"
 
   external_master_subnet_ids = "${compact(var.tectonic_aws_external_master_subnet_ids)}"
+  external_etcd_subnet_ids   = "${compact(var.tectonic_aws_external_etcd_subnet_ids)}"
   external_worker_subnet_ids = "${compact(var.tectonic_aws_external_worker_subnet_ids)}"
   extra_tags                 = "${var.tectonic_aws_extra_tags}"
 
   // empty map subnet_configs will have the vpc module creating subnets in all availabile AZs
   new_master_subnet_configs = "${var.tectonic_aws_master_custom_subnets}"
+  new_etcd_subnet_configs   = "${var.tectonic_aws_etcd_custom_subnets}"
   new_worker_subnet_configs = "${var.tectonic_aws_worker_custom_subnets}"
 
   private_master_endpoints = "${local.private_endpoints}"

--- a/steps/topology/aws/outputs.tf
+++ b/steps/topology/aws/outputs.tf
@@ -1,4 +1,8 @@
 # Etcd
+output "subnet_ids_etcds" {
+  value = "${module.vpc.etcd_subnet_ids}"
+}
+
 output "etcd_sg_id" {
   value = "${module.vpc.etcd_sg_id}"
 }


### PR DESCRIPTION
We used to have a separate subnet for etcd, but it was removed in be1a7e51 (coreos/tectonic-installer#26).  That commit talks about an optional stand-alone etcd cluster, but that became the required stand-alone etcd cluster in 6805200d (coreos/tectonic-installer#2648).  Now that all AWS installs have a separate etcd cluster, we should return to putting them in a separate subnet.  From [the Kubernetes docs][1]:

> Access to etcd is equivalent to root permission in the cluster so ideally only the API server should have access to it.

Putting the etcd nodes in their own subnet is one step towards securing the etcd <-> API-server communication.

This PR is a work in progress, because I'm not sure I've pushed these changes out through all the consumers.  I've left some FIXMEs in the installer Go where I may still need to add etcd-subnet support.

[1]: https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/#securing-etcd-clusters