### PR TITLE
OWNERS: Configure Prow with approver and reviewer information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,19 +39,21 @@ Due to their public nature, GitHub and mailing lists are not appropriate places 
 
 ### Contribution Flow
 
-This is a rough outline of what a contributor's workflow looks like:
+Anyone may [file issues][new-issue].
+For contributors who want to work up pull requests, the workflow is roughly:
 
-- Create a topic branch from where you want to base your work (usually master).
-- Make commits of logical units.
-- Make sure your commit messages are in the proper format (see below).
-- Push your changes to a topic branch in your fork of the repository.
-- Make sure the tests pass, and add any new tests as appropriate.
-- Please run this command before submitting your pull request:
+1. Create a topic branch from where you want to base your work (usually master).
+2. Make commits of logical units.
+3. Make sure your commit messages are in the proper format (see [below](#commit-message-format)).
+4. Push your changes to a topic branch in your fork of the repository.
+5. Make sure the tests pass, and add any new tests as appropriate.
+6. Please run this command before submitting your pull request:
     ```sh
     make structure-check
     ```
-- Note that a portion of the docs and examples are generated and that the generated files are to be committed by you. `make structure-check` checks that what is generated is what you must commit.
-- Submit a pull request to the original repository.
+    Note that a portion of the docs and examples are generated and that the generated files are to be committed by you. `make structure-check` checks that what is generated is what you must commit.
+7. Submit a pull request to the original repository.
+8. The [repo owners](OWNERS) will respond to your issue promptly, following [the ususal Prow workflow][prow-review].
 
 Thanks for your contributions!
 
@@ -63,7 +65,7 @@ Tectonic Installer includes syntax checks on the Terraform templates which will 
 
 Use `make structure-check` to identify files that don't meet the canonical format and style. Then, use `terraform fmt` to align the template syntax, if necessary.
 
-## Format of the Commit Message
+## Commit Message Format
 
 We follow a rough convention for commit messages that is designed to answer two
 questions: what changed and why. The subject line should feature the what and
@@ -98,3 +100,5 @@ git tools.
 [tf-doc]: https://www.terraform.io/docs/index.html
 [golang-style]: https://github.com/golang/go/wiki/CodeReviewComments
 [disclosure]: https://coreos.com/security/disclosure/
+[new-issue]: https://github.com/openshift/installer/issues/new
+[prow-review]: https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#the-code-review-process

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - aaronlevey
+  - crawford
+  - smarterclayton
+  - yifan-gu
+reviewers:
+  - abhinavdahiya
+  - vikramsk
+  - wking


### PR DESCRIPTION
The folks I've listed here are all under @aaronlevel in Red Hat, with @yifan-gu being the installer lead.  I'm guessing about roles, but we can always adjust later as we see fit.

[Approvers can also `/lgtm`][1], so there's no need to list them under `reviewers` as well.

The docs link in `OWNERS` is from kubernetes/kubernetes-template-project#15.

While updating `CONTRIBUTING.md` to mention `OWNERS` (using wording based on [this][3]), I've also:

* Added a line to make it clear that filing issues is helpful to (for folks who don't have the time or inclination to work up a PR).
* Turned the unordered list into an ordered list.  These entries happen sequentially, and an ordered list makes that more obvious.
* Made "below" a link, to make finding the referenced content more convenient.
* Shuffled words in the commit message format title to make it shorter.

The references to 'make structure-check' are stale since d61abd48 (coreos/tectonic-installer#3137), but I've left fixing that to follow-up work.

Fixes #32.  CC @paulfantom.

[1]: https://github.com/kubernetes/community/blob/4c0c2e9e659d2f989f3d23c3634c16bb099f3064/contributors/guide/owners.md#quirks-of-the-process
[3]: https://github.com/kubernetes/kubernetes-template-project/blame/16f1588e6d4746876beb08cc64769657530d4872/CONTRIBUTING.md#L10