### PR TITLE
images/tectonic-builder/Dockerfile: Drop stale installer 'rm -rf'

### DIFF
--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -19,7 +19,6 @@ RUN go get -u github.com/golang/lint/golint
 RUN go get github.com/jstemmer/go-junit-report
 
 ### Tools used by 'make structure-check'
-RUN rm -rf /go/src/github.com/openshift/installer/
 RUN go get github.com/bronze1man/yaml2json
 
 ### License parser


### PR DESCRIPTION
1a49fbbb (coreos/tectonic-installer#1889), added a:

```Dockerfile
RUN go get github.com/s-urbaniak/terraform-examples
```

to this `Dockerfile`.  That package moved into the installer repository, but all we need for generation/testing is the `terraform-examples` binary, so a68555df (coreos/tectonic-installer#2600) removed the associated source with:

```Dockerfile
RUN go get github.com/coreos/tectonic-installer/contrib/terraform-examples && \
  rm -rf /go/src/github.com/coreos/tectonic-installer/
```

(i.e. "download github.com/coreos/tectonic-installer/contrib/terraform-examples, build `terraform-examples`, install it into `$GOBIN`, and remove the source").

d61abd48 (coreos/tectonic-installer#3137) removed the `Makefile` which had been calling `terraform-examples`, and 7c73c34c (coreos/tectonic-installer#3239) removed the `terraform-examples` install from this `Dockerfile`.  With the `terraform-examples` install removed, Go will no longer be downloading that source, so there's no longer any reason to remove it.  This commit removes the unnecessary removal, which should make `Dockerfile` builds a bit faster and save an empty layer in the resulting images.  More importantly, it avoids distracting future devs reading the `Dockerfile` source ;).