### PR TITLE
images/tectonic-builder/Dockerfile: Drop license-bill-of-materials

### DIFF
--- a/images/tectonic-builder/Dockerfile
+++ b/images/tectonic-builder/Dockerfile
@@ -22,9 +22,6 @@ RUN go get github.com/jstemmer/go-junit-report
 RUN rm -rf /go/src/github.com/openshift/installer/
 RUN go get github.com/bronze1man/yaml2json
 
-### License parser
-RUN go get github.com/coreos/license-bill-of-materials
-
 ### 'grafiti' for cluster cleanup
 ENV GRAFITI_VERSION "v0.1.1"
 RUN git clone -q https://github.com/coreos/grafiti.git ${GOPATH}/src/github.com/coreos/grafiti \


### PR DESCRIPTION
The last code consuming this executable was removed in 7296010b (coreos/tectonic-installer#3067).