### PR TITLE
modules/*/target-defaults: Consolidate default counts for etcd

### DIFF
--- a/modules/aws/target-defaults/README.md
+++ b/modules/aws/target-defaults/README.md
@@ -1,0 +1,30 @@
+# AWS Default Module
+
+This [Terraform][] [module][] gives us a central location for [AWS][]-specific defaults.
+For example, on AWS our default [etcd][] count depends on the availability zone count.
+On libvirt, on the other hand, our default etcd count is one.
+Because Terraform's [HashiCorp Configuration Language (HCL)[hcl] does not allow us to declare such conditional defaults directly, we use this module to convert user-supplied default values to values appropriate to the target system.
+
+## Example
+
+From the module directory:
+
+```console
+$ terraform init
+$ terraform apply --var region=us-east-1  # currently 6 zones
+$ terraform output etcd_count
+5
+$ terraform apply --var region=us-east-2
+$ terraform output etcd_count
+3
+$ terraform apply --var region=us-east-2 --var etcd_count=1  # currently 3 zones
+$ terraform output etcd_count
+1
+```
+
+When you're done, clean up by removing the `.terraform` directory created by `init` and the `terraform.tfstate*` files created by `apply`.
+
+[AWS]: https://aws.amazon.com/
+[etcd]: https://github.com/coreos/etcd
+[module]: https://www.terraform.io/docs/modules/
+[Terraform]: https://www.terraform.io/

--- a/modules/aws/target-defaults/main.tf
+++ b/modules/aws/target-defaults/main.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region  = "${var.region}"
+  profile = "${var.profile}"
+  version = "1.8.0"
+
+  assume_role {
+    role_arn = "${var.role_arn}"
+  }
+}
+
+data "aws_availability_zones" "zones" {}
+
+locals {
+  zone_count     = "${length(data.aws_availability_zones.zones.names)}"
+  zone_count_odd = "${local.zone_count % 2 == 0 ? local.zone_count - 1 : local.zone_count}"
+}

--- a/modules/aws/target-defaults/outputs.tf
+++ b/modules/aws/target-defaults/outputs.tf
@@ -1,0 +1,8 @@
+output "etcd_count" {
+  value = "${var.etcd_count > 0 ? var.etcd_count : max(local.zone_count_odd, 3)}"
+
+  description = <<EOF
+The number of etcd nodes to be created.
+This will always be greater than zero.
+EOF
+}

--- a/modules/aws/target-defaults/variables.tf
+++ b/modules/aws/target-defaults/variables.tf
@@ -1,0 +1,38 @@
+variable "profile" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+(Optional) This is the AWS profile name as set in the shared credentials file.
+This is passed through to the Terraform aws provider: https://www.terraform.io/docs/providers/aws/#profile
+EOF
+}
+
+variable "region" {
+  type = "string"
+
+  description = <<EOF
+This is the AWS region.
+It is passed through to the Terraform aws provider: https://www.terraform.io/docs/providers/aws/#region
+EOF
+}
+
+variable "role_arn" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+(Optional) Name (full ARN) of IAM role to use to access AWS.
+It is passed through to the Terraform aws provider: https://www.terraform.io/docs/providers/aws/#role_arn
+EOF
+}
+
+variable "etcd_count" {
+  type    = "string"
+  default = "0"
+
+  description = <<EOF
+The number of etcd nodes to be created.
+If set to zero, the count of etcd nodes will be determined automatically.
+EOF
+}

--- a/modules/libvirt/target-defaults/README.md
+++ b/modules/libvirt/target-defaults/README.md
@@ -1,0 +1,27 @@
+# Libvirt Default Module
+
+This [Terraform][] [module][] gives us a central location for [libvirt][]-specific defaults.
+For example, on AWS our default [etcd][] count depends on the availability zone count.
+On libvirt, on the other hand, our default etcd count is one.
+Because Terraform's [HashiCorp Configuration Language (HCL)[hcl] does not allow us to declare such conditional defaults directly, we use this module to convert user-supplied default values to values appropriate to the target system.
+
+## Example
+
+From the module directory:
+
+```console
+$ terraform init
+$ terraform apply
+$ terraform output etcd_count
+1
+$ terraform apply --var etcd_count=3
+$ terraform output etcd_count
+3
+```
+
+When you're done, clean up by removing the `terraform.tfstate*` files created by `apply`.
+
+[etcd]: https://github.com/coreos/etcd
+[libvirt]: https://libvirt.org/
+[module]: https://www.terraform.io/docs/modules/
+[Terraform]: https://www.terraform.io/

--- a/modules/libvirt/target-defaults/main.tf
+++ b/modules/libvirt/target-defaults/main.tf
@@ -1,0 +1,4 @@
+# nothing to do here, just conforming to [1]:
+#
+# [1]: https://www.terraform.io/docs/modules/create.html#standard-module-structure
+

--- a/modules/libvirt/target-defaults/outputs.tf
+++ b/modules/libvirt/target-defaults/outputs.tf
@@ -1,0 +1,8 @@
+output "etcd_count" {
+  value = "${var.etcd_count > 0 ? var.etcd_count : 1}"
+
+  description = <<EOF
+The number of etcd nodes to be created.
+This will always be greater than zero.
+EOF
+}

--- a/modules/libvirt/target-defaults/variables.tf
+++ b/modules/libvirt/target-defaults/variables.tf
@@ -1,0 +1,9 @@
+variable "etcd_count" {
+  type    = "string"
+  default = "0"
+
+  description = <<EOF
+The number of etcd nodes to be created.
+If set to zero, the count of etcd nodes will be determined automatically.
+EOF
+}

--- a/steps/assets/aws/main.tf
+++ b/steps/assets/aws/main.tf
@@ -1,23 +1,19 @@
-provider "aws" {
-  region  = "${var.tectonic_aws_region}"
-  profile = "${var.tectonic_aws_profile}"
-  version = "1.8.0"
-
-  assume_role {
-    role_arn     = "${var.tectonic_aws_installer_role == "" ? "" : "${var.tectonic_aws_installer_role}"}"
-    session_name = "TECTONIC_INSTALLER_${var.tectonic_cluster_name}"
-  }
-}
-
-data "aws_availability_zones" "azs" {}
-
 # Terraform doesn't support "inheritance"
 # So we have to pass all variables down
+module "defaults" {
+  source = "../../../modules/aws/target-defaults"
+
+  region     = "${var.tectonic_aws_region}"
+  profile    = "${var.tectonic_aws_profile}"
+  role_arn   = "${var.tectonic_aws_installer_role}"
+  etcd_count = "${var.tectonic_etcd_count}"
+}
+
 module assets_base {
   source = "../base"
 
   cloud_provider = "aws"
-  etcd_count     = "${var.tectonic_etcd_count > 0 ? var.tectonic_etcd_count : length(data.aws_availability_zones.azs.names) == 5 ? 5 : 3}"
+  etcd_count     = "${module.defaults.etcd_count}"
   ingress_kind   = "haproxy-router"
 
   tectonic_admin_email             = "${var.tectonic_admin_email}"

--- a/steps/assets/libvirt/main.tf
+++ b/steps/assets/libvirt/main.tf
@@ -1,10 +1,16 @@
+module "defaults" {
+  source = "../../../modules/libvirt/target-defaults"
+
+  etcd_count = "${var.tectonic_etcd_count}"
+}
+
 # Terraform doesn't support "inheritance"
 # So we have to pass all variables down
 module assets_base {
   source = "../base"
 
   cloud_provider = ""
-  etcd_count     = "${var.tectonic_etcd_count > 0 ? var.tectonic_etcd_count : 1}"
+  etcd_count     = "${module.defaults.etcd_count}"
 
   ingress_kind = "haproxy-router"
 
@@ -66,7 +72,7 @@ data "ignition_config" "bootstrap" {
 }
 
 data "ignition_config" "etcd" {
-  count = "${var.tectonic_etcd_count}"
+  count = "${module.defaults.etcd_count}"
 
   users = [
     "${data.ignition_user.core.id}",

--- a/steps/etcd/aws/etcd.tf
+++ b/steps/etcd/aws/etcd.tf
@@ -9,6 +9,15 @@ provider "aws" {
   }
 }
 
+module "defaults" {
+  source = "../../../modules/aws/target-defaults"
+
+  region     = "${var.tectonic_aws_region}"
+  profile    = "${var.tectonic_aws_profile}"
+  role_arn   = "${var.tectonic_aws_installer_role}"
+  etcd_count = "${var.tectonic_etcd_count}"
+}
+
 module "container_linux" {
   source = "../../../modules/container_linux"
 
@@ -16,10 +25,8 @@ module "container_linux" {
   release_version = "${var.tectonic_container_linux_version}"
 }
 
-data "aws_availability_zones" "azs" {}
-
 data "template_file" "etcd_hostname_list" {
-  count    = "${var.tectonic_etcd_count > 0 ? var.tectonic_etcd_count : length(data.aws_availability_zones.azs.names) == 5 ? 5 : 3}"
+  count    = "${module.defaults.etcd_count}"
   template = "${var.tectonic_cluster_name}-etcd-${count.index}.${var.tectonic_base_domain}"
 }
 

--- a/steps/etcd/libvirt/main.tf
+++ b/steps/etcd/libvirt/main.tf
@@ -2,20 +2,26 @@ provider "libvirt" {
   uri = "qemu:///system" #XXX fixme
 }
 
+module "defaults" {
+  source = "../../../modules/libvirt/target-defaults"
+
+  etcd_count = "${var.tectonic_etcd_count}"
+}
+
 resource "libvirt_volume" "etcd" {
-  count          = "${var.tectonic_etcd_count}"
+  count          = "${local.etcd_count}"
   name           = "etcd${count.index}"
   base_volume_id = "${local.libvirt_base_volume_id}"
 }
 
 resource "libvirt_ignition" "etcd" {
-  count   = "${var.tectonic_etcd_count}"
+  count   = "${module.defaults.etcd_count}"
   name    = "etcd${count.index}.ign"
   content = "${local.ignition[count.index]}"
 }
 
 resource "libvirt_domain" "etcd" {
-  count = "${var.tectonic_etcd_count}"
+  count = "${module.defaults.etcd_count}"
 
   name            = "etcd${count.index}"
   memory          = "${var.tectonic_libvirt_etcd_memory}"


### PR DESCRIPTION
The 5/3 ternaries seem to be descended from f2d2613b (2017-03-01), but I don't see why we picked those values.  The number of zones depends on the region; for example:

```console
$ for region in $(aws ec2 describe-regions | jq -r '.Regions[] | .RegionName' | sort); do
>   zones=$(aws --region "${region}" ec2 describe-availability-zones 2>&1);
>   if test "$?" -eq 0; then
>     count=$(echo "${zones}" | jq '.AvailabilityZones | length');
>   else
>     count=$(echo "${zones}" | grep .);
>   fi;
>   echo "${region} ${count}";
> done
ap-northeast-1 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
ap-northeast-2 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
ap-south-1 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
ap-southeast-1 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
ap-southeast-2 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
ca-central-1 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
eu-central-1 3
eu-west-1 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
eu-west-2 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
eu-west-3 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
sa-east-1 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
us-east-1 6
us-east-2 3
us-west-1 An error occurred (UnauthorizedOperation) when calling the DescribeAvailabilityZones operation: You are not authorized to perform this operation.
us-west-2 3
```

In this commit, I've shifted the default to the odd number <= the zone count with a floor of three.

For AWS, the ability to set this at all dates back to 02139037 (coreos/tectonic-installer#255), before which the user-supplied `tectonic_etcd_config` was ignored.

The new target-defaults modules allow us to DRY up, with the default logic in a single location from which consumers can access it.

The trailing blank line in `modules/libvirt/target-defaults/main.tf` is required by `terraform fmt` (with Terraform v0.11.7).