### PR TITLE
scripts/maintenance/clean-aws.sh: Skip $tag_file for unset --tag-file

### DIFF
--- a/scripts/maintenance/clean-aws.sh
+++ b/scripts/maintenance/clean-aws.sh
@@ -124,8 +124,6 @@ fi
 if [ -n "$tag_file" ]; then
   cat "$tag_file" >"$tmp_dir/tag.json"
 else
-  tag_file="$(mktemp -p "$tmp_dir")"
-
   date_string="$(date "+%Y-%m-%d" -d "-1 day")\",\"$(date "+%Y-%-m-%-d" -d "-1 day")\",
   \"$(date "+%m-%-d-%-Y" -d "-1 day")\",\"$(date "+%-m-%-d-%-Y" -d "-1 day")\",\"$(date "+%d-%m-%-Y" -d "-1 day")\",
   \"$(date "+%d-%-m-%-Y" -d "-1 day")\",\"$(date +%m-%d-%Y)\",\"$(date +%d-%m-%Y)\",
@@ -140,7 +138,7 @@ EOF
 fi
 
 echo "Deleting resources with the following tags:"
-jq '.' "$tag_file"
+jq '.' "$tmp_dir/tag.json"
 
 if [ -n "$dry_run" ]; then
   echo "Dry run flag set. Not deleting any resources."


### PR DESCRIPTION
d541760f (#34) cleaned up some related handling, but missed this.  Before this commit, an unset `--tag-file` would have resulted in a useless `$tag_file` creation which was never written to, and the "Deleting resources with the following tags:" line wouldn't actually print the actual `tag.json` content.