### PR TITLE
scripts/maintenance: Fix dates (tomorrow vs. today, etc.)

### DIFF
--- a/scripts/maintenance/tag-route53-hosted-zones.sh
+++ b/scripts/maintenance/tag-route53-hosted-zones.sh
@@ -14,15 +14,15 @@ Options:
   --force           Override user input prompts. Useful for automation.
 
   --date-override   (optional) Date of the format YYYY-MM-DD that overrides the
-                    default tag value of today's date. This script tags resources
+                    default tag value of tomorrow's date. This script tags resources
                     with 'expirationDate: some-date-string', where some-date-string
-                    is replaced with either the following days' date or date-override.
+                    is replaced with either tomorrow's date or date-override.
 
 EOF
 }
 
 force=
-date_override=
+date_string=
 
 while [ $# -gt 0 ]; do
   case $1 in
@@ -34,7 +34,7 @@ while [ $# -gt 0 ]; do
       force=true
     ;;
     --date-override)
-      date_override="${2:-}"
+      date_string="${2:-}"
       shift
     ;;
     *)
@@ -53,11 +53,10 @@ fi
 set -e
 
 # Tag all Route53 hosted zones that do not already have a tag with the same keys,
-# in this case 'expirationDate', with today's date as default, or
-# with the DATE_VALUE_OVERRIDE value. Format YYYY-MM-DD.
-date_string="$(date "+%Y-%m-%d")"
-if [ -n "$date_override" ]; then
-	date_string="${date_override}"
+# in this case 'expirationDate', with tomorrow's date as default, or
+# with the --date-override value. Format YYYY-MM-DD.
+if [ -z "$date_string" ]; then
+  date_string="$(date -d tomorrow '+%Y-%m-%d')"
 fi
 
 tags="[{\"Key\":\"expirationDate\",\"Value\":\"$date_string\"}]"


### PR DESCRIPTION
**Builds on #76; review that first.**

`tag-aws.sh` is using grafiti, whose [`tagPatterns` takes jq expressions][1].  We've been using `strftime` since the script landed in 82bdd9fe (coreos/tectonic-installer#1239).  jq's strftime doesn't respect your configured `$TZ`, but [the coming jq 1.6][2] will [add `strflocaltime`][3] which does.  jq [uses seconds since the epoch][4] for date-time values. You can test the new construct with:

```console
$ jq --null-input --raw-output 'now + 24*60*60 | strftime("%Y-%m-%d")'
2018-07-27
```

`-d` is not part of [the POSIX `date` specification][5], but it (and [the `tomorrow` value][6]) [are supported][7] by GNU Coreutils [6,7].  But we've been using `-d` in `clean-aws.sh` for a while now, so this is now a new dependency.

I've also dropped `date_override`, since we can just set `date_string` directly.  And I've shuffled around some of the conditionals to avoid calling the `date` (or `jq`) command needlessly when `--date-override` is set.

I've also replaced the multiple `date` calls in `clean-aws.sh` with a single call to `jq`.  `jq` was already a required dependency for this script, and only needing a single child process is much faster:

```console
$ time for i in $(seq 100); do A="$(jq --null-input '[["%Y-%m-%d", "%Y-%-m-%-d", "%m-%d-%Y", "%m-%-d-%-Y", "%-m-%-d-%-Y", "%d-%m-%Y", "%d-%-m-%-Y"][] | . as $format | [now, now - 24*60*60][] | strftime($format)]')"; done

real   0m0.256s
user   0m0.186s
sys    0m0.077s
$ time for i in $(seq 100); do A="$(date "+%Y-%m-%d" -d "-1 day")\",\"$(date "+%Y-%-m-%-d" -d "-1 day")\",\"$(date "+%m-%-d-%-Y" -d "-1 day")\",\"$(date "+%-m-%-d-%-Y" -d "-1 day")\",\"$(date "+%d-%m-%-Y" -d "-1 day")\",\"$(date "+%d-%-m-%-Y" -d "-1 day")\",\"$(date +%m-%d-%Y)\",\"$(date +%d-%m-%Y)\",\"$(date +%d-%-m-%Y)\",\"$(date +%Y-%m-%d)\",\"$(date +%Y-%-m-%-d)"; done

real   0m1.358s
user   0m0.604s
sys    0m0.832s
```

and that's despite the fact that the old approach skipped some formats for today (e.g. `%m-%-d-%-Y` had been only used to format yesterday).

[1]: https://github.com/coreos/grafiti/blob/89a8bc92ad7fde49cd3dd78197c6b3616a857f36/README.md#configure-grafiti
[2]: https://github.com/stedolan/jq/wiki/FAQ
[3]: https://github.com/stedolan/jq/commit/06f20603f6022b721fa6a001969fbbb1111f113d
[4]: https://stedolan.github.io/jq/manual/v1.5/#Dates
[5]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/date.html
[6]: https://www.gnu.org/software/coreutils/manual/html_node/Relative-items-in-date-strings.html
[7]: https://www.gnu.org/software/coreutils/manual/html_node/Options-for-date.html