### PR TITLE
modules/aws/vpc/vpc-public: Tag new EIPs with tectonicClusterID

### DIFF
--- a/modules/aws/vpc/vpc-public.tf
+++ b/modules/aws/vpc/vpc-public.tf
@@ -61,6 +61,10 @@ resource "aws_eip" "nat_eip" {
   count = "${min(local.new_master_az_count,local.new_worker_az_count)}"
   vpc   = true
 
+  tags = "${merge(map(
+      "tectonicClusterID", "${var.cluster_id}"
+    ), var.extra_tags)}"
+
   # Terraform does not declare an explicit dependency towards the internet gateway.
   # this can cause the internet gateway to be deleted/detached before the EIPs.
   # https://github.com/coreos/tectonic-installer/issues/1017#issuecomment-307780549


### PR DESCRIPTION
The tags I'm adding lack `Name` and `kubernetes.io/cluster/${var.cluster_name}`, which are part of the tagging for most other resources created in this module.  But @chancez, pointed out that Kubernetes doesn't manage EIPs, so we don't need to set the kubernetes.io tags at all.  And naming EIPs doesn't add much information; after setup completes you can get all the naming information you need from the associated NAT gateway.

Setting the cluster ID makes it easier for us to reap leaked resources after tearing down a cluster (for example, if a test which creates and deletes a cluster is evicted before completing deletion).  And passing `extra_tags` through allows us to set expiration dates and such for our new resources, which will also help with cleanup.

CC @smarterclayton.