### PR TITLE
scripts/maintenance/virsh-cleanup: Help with libvirt cleanup

### DIFF
--- a/Documentation/dev/libvirt-howto.md
+++ b/Documentation/dev/libvirt-howto.md
@@ -108,7 +108,7 @@ When you're done, destroy:
 ```sh
 tectonic destroy --dir=$CLUSTER_NAME
 ```
-Be sure to destroy, or else you will need to manually use virsh to clean up the leaked resources.
+Be sure to destroy, or else you will need to manually use virsh to clean up the leaked resources (the [`virsh-cleanup`](../../scripts/maintenance/virsh-cleanup) script may help with this).
 
 # Exploring your cluster
 Some things you can do:

--- a/scripts/maintenance/virsh-cleanup
+++ b/scripts/maintenance/virsh-cleanup
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+CONNECT="${CONNECT:=qemu:///system}"
+POOL="${POOL:=default}"
+
+run()
+{
+	echo "$*"
+	"$@"
+}
+
+for DOMAIN in $(virsh -c "${CONNECT}" list --all --name)
+do
+	run virsh -c "${CONNECT}" destroy "${DOMAIN}"
+	run virsh -c "${CONNECT}" undefine "${DOMAIN}"
+done
+
+virsh -c "${CONNECT}" vol-list "${POOL}" | tail -n +3 | while read VOLUME DETAILS
+do
+	if test -z "${VOLUME}"
+	then
+		continue
+	fi
+	run virsh -c "${CONNECT}" vol-delete --pool "${POOL}" "${VOLUME}"
+done
+
+for NET in $(virsh -c "${CONNECT}" net-list --all --name)
+do
+	if test "${NET}" = default
+	then
+		continue
+	fi
+	run virsh -c "${CONNECT}" net-destroy "${NET}"
+	run virsh -c "${CONNECT}" net-undefine "${NET}"
+done


### PR DESCRIPTION
Make it a bit easier for virsh newcomers to cleanup from a failed install in situations where `tectonic destroy` is unavailable or broken.

The default QEMU URI matches the default in `examples/tectonic.libvirt.yaml`.

It's unforuntate that `vol-list` doesn't support `--name` or similar, but at least my virsh v3.9.0 had no such option.  To work around that I'm using `tail` to strip the table header and `read` to store the first word from each line in `VOLUME`.