### PR TITLE
steps/etcd/libvirt: Fix obsolete local.etcd_count reference

### DIFF
--- a/steps/etcd/libvirt/main.tf
+++ b/steps/etcd/libvirt/main.tf
@@ -9,7 +9,7 @@ module "defaults" {
 }
 
 resource "libvirt_volume" "etcd" {
-  count          = "${local.etcd_count}"
+  count          = "${module.defaults.etcd_count}"
   name           = "etcd${count.index}"
   base_volume_id = "${local.libvirt_base_volume_id}"
 }


### PR DESCRIPTION
I'd missed this line in #74.  Fixing it avoids `tectonic install` dying with:

    Error: libvirt_volume.etcd: local.etcd_count: no local value of this name has been declared

CC @crawford.