### PR TITLE
Documentation/design/installconfig: Reword embedding subsection

### DIFF
--- a/Documentation/design/installconfig.md
+++ b/Documentation/design/installconfig.md
@@ -379,6 +379,6 @@ type LibvirtMachinePoolPlatformConfig struct {
 }
 ```
 
-### Why not MachineSets in InstallConfig?
+### Why not embed `MachineSets` in `InstallConfig`?
 
-To controll and delegate MachineSet implementation to Machine Operator and restrict the configuration options in InstallConfig, there will not be MachineSet object embedded.
+This installer is opinionated, and the `ClusterMachineSet` properties do not need to be configured by users.


### PR DESCRIPTION
I intially wanted to touch this line to fix the "controll" -> "control" typo.  But I ended up rewording the subsection to lean more obviously on our "we have opinions" position ;).  Of course, having opinions doesn't mean we won't allow users to override those opinions.  I haven't gone into that level of detail, because we didn't have it before, but I expect it has to do with "our operators are responsible for cluster maintenance, and that's a lot more difficult as the number of user knobs increases".

CC @abhinavdahiya, since the old wording is his from #45.