### PR TITLE
Remove bazel from test process, use 'terraform fmt' 'go test' 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ jobs:
       name: YAML lint
     - script: ./hack/shellcheck.sh
       name: shellcheck
+    - script: ./hack/tf-fmt.sh
+      name: Terraform format
+    - script: ./hack/gotest.sh
+      name: Installer unit tests
     - script: "docker run -v $PWD:/go/src/github.com/openshift/installer -w /go/src/github.com/openshift/installer quay.io/coreos/golang-testing go vet ./installer/..."
       name: Go vet
     - script: "docker run -v $PWD:$PWD -w $PWD quay.io/coreos/golang-testing golint -set_exit_status installer/..."
       name: Go lint
-    - script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel test terraform_fmt --test_output=all"
-      name: Terraform tests
-    - script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel test installer:cli_units --test_output=all"
-      name: Installer unit tests
     - stage: Build
       script: "chmod 0777 $PWD && docker run -v $PWD:$PWD:rw -w $PWD $BAZEL_IMG bazel build tarball"
       name: Build tarball

--- a/hack/gotest.sh
+++ b/hack/gotest.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ "$IS_CONTAINER" != "" ]; then
+  cd ..
+  SOURCE_DIR="$(pwd)"
+  cd .. || exit
+  ROOT_DIR="$(pwd)"
+  # if running in a local prow instance, with repo ../not-openshift/installer, have to modify here
+  TARGET_DIR="${ROOT_DIR}/openshift"
+  if [ "$SOURCE_DIR" != "$TARGET_DIR" ]; then
+    mv "$SOURCE_DIR" "$TARGET_DIR"
+  fi;
+  cd "${TARGET_DIR}/installer/" || exit
+  CGO_ENABLED=0 go test ./installer/...
+else
+  docker run -e IS_CONTAINER='TRUE' -v "$PWD":/go/src/github.com/openshift/installer -w /go/src/github.com/openshift/installer quay.io/coreos/golang-testing ./hack/gotest.sh
+fi
+

--- a/hack/tf-fmt.sh
+++ b/hack/tf-fmt.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# in prow, already in container, so no 'docker run'
+if [ "$IS_CONTAINER" != "" ]; then
+  set -x
+  /terraform fmt -list -check -write=false
+else
+  docker run -e IS_CONTAINER='TRUE' --rm -v "$PWD":"$PWD":ro -v /tmp:/tmp:rw -w "$PWD" quay.io/coreos/terraform-alpine:v0.11.7 ./hack/tf-fmt.sh
+fi


### PR DESCRIPTION
CORS-749, CORS-750

prow config for 'go test', 'terraform fmt' here: https://github.com/openshift/release/pull/1152

Chipping away at the .travis.yml tasks, this PR moves Terraform fmt and Installer Unit Tests to Prow