### PR TITLE
MAINTAINERS: Drop stale file

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,4 @@
 <!--
-NOTE: New feature requests are no longer accepted in this repo. Only issues
-reporting critical bug-fixes and security patches will be accepted.
-
-See our blog for details:
-https://coreos.com/blog/coreos-tech-to-combine-with-red-hat-openshift
--->
-
-
-<!--
 Thanks for opening a bug report!
 Before hitting the button, please fill in as much of the template below as you can.
 If you leave out information, we can't help you as well.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,4 @@
 Before creating your PR, please make sure to add the appropriate GitHub label; i.e. `run-smoke-tests`. For more details see
 [tests/README.md](../tests/README.md).
 
-(In case you don't have permissions to add labels, please ask a
-[Maintainer](../MAINTAINERS).)
+(In case you don't have permissions to add labels, please ask a [maintainer](../OWNERS).)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,15 +18,6 @@ Origin (DCO). This document was created by the Linux Kernel community and is a
 simple statement that you, as a contributor, have the legal right to make the
 contribution. See the [DCO](DCO) file for details.
 
-## Email and Chat
-
-The project currently uses the general CoreOS email list and IRC channel:
-- Email: [coreos-dev](https://groups.google.com/forum/#!forum/coreos-dev)
-- IRC: #[coreos](irc://irc.freenode.org:6667/#coreos) IRC channel on freenode.org
-
-Please avoid emailing maintainers found in the MAINTAINERS file directly. They
-are very busy and read the mailing lists.
-
 ##  Reporting a security vulnerability
 
 Due to their public nature, GitHub and mailing lists are not appropriate places for reporting vulnerabilities. Please refer to CoreOS's [security disclosure][disclosure] process when reporting issues that may be security related.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,0 @@
-Alberto Lamela @enxebre <alberto.lamela@coreos.com>
-Alex Somesan @alexsomesan <alex.somesan@coreos.com>
-Daniel Spangenberg @spangenberg <daniel.spangenberg@coreos.com>
-Ed Rooth @sym3tri <ed.rooth@coreos.com>
-Karen Almog @kalmog <karen.almog@coreos.com>
-Lucas Servén @squat <lucas.serven@coreos.com>

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,7 +25,7 @@ In addition to our basic set of tests we have smoke tests which are running on A
 ### FAQ
 - *I am not able to add labels, what should I do?*
 
-  Please ask one of the repository [maintainers](../MAINTAINERS) to add the
+  Please ask one of [the repository maintainers](../OWNERS) to add the
   labels.
 
 - *How do I retrigger the tests?*


### PR DESCRIPTION
MAINTAINERS is obsolete since 49779c3e (#71).  I've also dropped the email/IRC section, since as far as I know there are currently no public lists or IRC channels for installer discussion. Folks outside of Red Hat should communicate via GitHub issues and pull requests, and I think that's the expectation for projects that don't give alternatives in their `CONTRIBUTING` file.

I've also dropped the feature-freeze comment from the `ISSUE_TEMPLATE`.  It was for coreos/tectonic-installer, but new features are welcome for openshift/installer.

/assign @smarterclayton