### PR TITLE
tests/smoke/cluster_test.go: Drop unused networkingEnv

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -78,7 +78,6 @@ echo -e "\\e[36m Deploying Tectonic...\\e[0m"
 tectonic install --dir="${CLUSTER_NAME}"
 echo -e "\\e[36m Running smoke test...\\e[0m"
 export SMOKE_KUBECONFIG="$(pwd)/$CLUSTER_NAME/generated/auth/kubeconfig"
-export SMOKE_NETWORKING="canal"
 export SMOKE_NODE_COUNT="7"  # Sum of all nodes (etcd + master + worker)
 export SMOKE_MANIFEST_PATHS="$(pwd)/$CLUSTER_NAME/generated"
 exec 5>&1

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -61,7 +61,6 @@ The cluster test suite requires four additional parameters:
 Export the following environment variables to parameterize the cluster tests:
 
 ```sh
-export SMOKE_NETWORKING=canal
 export SMOKE_NODE_COUNT=3
 export SMOKE_MANIFEST_PATHS=/path/to/kubernetes/manifests
 export SMOKE_MANIFEST_EXPERIMENTAL=true

--- a/tests/smoke/cluster_test.go
+++ b/tests/smoke/cluster_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	// networkingEnv is the environment variable that specifies if calico is running.
-	networkingEnv = "SMOKE_NETWORKING"
 	// nodeCountEnv is the environment variable that specifies the node count.
 	nodeCountEnv = "SMOKE_NODE_COUNT"
 	// manifestPathsEnv is the environment variable that defines the paths to the manifests that are deployed on the cluster.


### PR DESCRIPTION
The last consumer was commented out in ebe69617 (coreos/tectonic-installer#3270) and that comment was removed in 31eb1650 (coreos/tectonic-installer#3298).

Spun off from #94 (which is itself spun off from #92) as I keep drilling down to get the smoke-test vendor directory cleaned up :p.  Hopefully this change is scoped tightly enough to not cause any surprising breakage :p.