### PR TITLE
OWNERS: Fix 'aaronlevey' typo and promote abhinavdahiya and wking to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,10 +2,10 @@
 
 approvers:
   - aaronlevy
+  - abhinavdahiya
   - crawford
   - smarterclayton
+  - wking
   - yifan-gu
 reviewers:
-  - abhinavdahiya
   - vikramsk
-  - wking

--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,7 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - aaronlevey
+  - aaronlevy
   - crawford
   - smarterclayton
   - yifan-gu


### PR DESCRIPTION
I can't spell.  Typo is from 49779c3e (#71).

/assign @aaronlevy