### PR TITLE
Jenkinsfile: Drop Quay push

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,14 +26,6 @@ creds.push(
   ]
 )
 
-quayCreds = [
-  usernamePassword(
-    credentialsId: 'quay-robot',
-    passwordVariable: 'QUAY_ROBOT_SECRET',
-    usernameVariable: 'QUAY_ROBOT_USERNAME'
-  )
-]
-
 tectonicSmokeTestEnvImage = 'quay.io/coreos/tectonic-smoke-test-env:v6.0'
 tectonicBazelImage = 'quay.io/coreos/tectonic-builder:bazel-v0.3'
 originalCommitId = 'UNKNOWN'
@@ -87,25 +79,6 @@ pipeline {
               // Produce an artifact which can be downloaded via web UI
               stash name: 'tectonic-tarball', includes: 'tectonic-dev.tar.gz'
             }
-          }
-        }
-      }
-    }
-
-    stage('Build docker image')  {
-      when {
-        branch 'master'
-      }
-      steps {
-        withCredentials(quayCreds) {
-          ansiColor('xterm') {
-            sh """
-              docker build -t quay.io/coreos/tectonic-installer:master -f images/tectonic-installer/Dockerfile .
-              docker login -u="$QUAY_ROBOT_USERNAME" -p="$QUAY_ROBOT_SECRET" quay.io
-              docker push quay.io/coreos/tectonic-installer:master
-              docker logout quay.io
-            """
-            cleanWs notFailBuild: true
           }
         }
       }


### PR DESCRIPTION
We already have something like this job from openshift/release#1044.  The backing recipe for that job is [here][1], originally from [here][2].  It's pushing to [Docker's hub][3] and [Quay][4].  So we can drop this Jenkins job and rely on Prow for these images.

[1]: https://github.com/openshift/release/blame/a4e96cf070f916417ab8b16b131851283fed1e7c/ci-operator/config/openshift/installer/master.json#L28
[2]: https://github.com/openshift/release/pull/921/files#diff-ef1e94bd2068c1382b46b826d8955db6R28
[3]: https://hub.docker.com/r/openshift/origin-installer/
[4]: https://quay.io/repository/openshift/origin-installer