### PR TITLE
.travis.yml: Prune moved-to-Prow tf-lint, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,7 @@ branches:
 jobs:
   include:
     - stage: Lint & Test
-      script: ./hack/tf-lint.sh
-      name: Terraform lint
-    - script: ./hack/yaml-lint.sh
-      name: YAML lint
-    - script: ./hack/shellcheck.sh
-      name: shellcheck
-    - script: ./hack/tf-fmt.sh
-      name: Terraform format
-    - script: ./hack/gotest.sh
+      script: ./hack/gotest.sh
       name: Installer unit tests
-    - script: "docker run -v $PWD:/go/src/github.com/openshift/installer -w /go/src/github.com/openshift/installer quay.io/coreos/golang-testing go vet ./installer/..."
-      name: Go vet
     - script: "docker run -v $PWD:$PWD -w $PWD quay.io/coreos/golang-testing golint -set_exit_status installer/..."
       name: Go lint
-    - stage: Build
-      script: ./hack/test-bazel-build-tarball.sh
-      name: Build tarball


### PR DESCRIPTION
These have moved into Prow presubmit jobs:

* Terraform lint: openshift/release@82e00346 (openshift/release#1124).
* YAML lint: openshift/release@457be2cd (openshift/release#1138).
* ShellCheck: openshift/release@e12a7a06 (openshift/release#1131).
* Terraform format: openshift/release@f67e06e4 (openshift/release#1152).
* Building the tarball: openshift/release@42a5a0d0 (openshift/release#1178).