### PR TITLE
hack/test-bazel-build-tarball: Pass args through to bazel build

### DIFF
--- a/hack/test-bazel-build-tarball.sh
+++ b/hack/test-bazel-build-tarball.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 if [ "$IS_CONTAINER" != "" ]; then
   set -x
-  bazel --output_base=/tmp build tarball
+  bazel --output_base=/tmp build "$@" tarball
 else
   docker run -e IS_CONTAINER='TRUE' --rm -v "$PWD":"$PWD" -v /tmp:/tmp:rw -w "$PWD" quay.io/coreos/tectonic-builder:bazel-v0.3 ./hack/test-bazel-build-tarball.sh
 fi


### PR DESCRIPTION
This allows callers to set [build options][1] if needed.  The Prow tests need this to set `HOME` to [avoid][2]:

```
ERROR: /home/prow/go/src/github.com/openshift/installer/BUILD.bazel:106:1: error executing shell command: 'bazel-out/host/bin/external/bazel_tools/tools/build_defs/pkg/build_tar --flagfile=bazel-out/k8-fastbuild/bin/tf_bin.args' failed (Exit 1)
Traceback (most recent call last):
  File "/usr/lib/python2.7/site.py", line 554, in <module>
    main()
  File "/usr/lib/python2.7/site.py", line 536, in main
    known_paths = addusersitepackages(known_paths)
  File "/usr/lib/python2.7/site.py", line 272, in addusersitepackages
    user_site = getusersitepackages()
  File "/usr/lib/python2.7/site.py", line 247, in getusersitepackages
    user_base = getuserbase() # this will also set USER_BASE
  File "/usr/lib/python2.7/site.py", line 237, in getuserbase
    USER_BASE = get_config_var('userbase')
  File "/usr/lib/python2.7/sysconfig.py", line 582, in get_config_var
    return get_config_vars().get(name)
  File "/usr/lib/python2.7/sysconfig.py", line 533, in get_config_vars
    _CONFIG_VARS['userbase'] = _getuserbase()
  File "/usr/lib/python2.7/sysconfig.py", line 210, in _getuserbase
    return env_base if env_base else joinuser("~", ".local")
  File "/usr/lib/python2.7/sysconfig.py", line 196, in joinuser
    return os.path.expanduser(os.path.join(*args))
  File "/usr/lib/python2.7/posixpath.py", line 262, in expanduser
    userhome = pwd.getpwuid(os.getuid()).pw_dir
KeyError: 'getpwuid(): uid not found: 1000130000'
```

The chain for that crash is:

1. Bazel invokes `build_tar` via [`run_shell` with `use_default_shell_env=True`][3], so only environment variables declared with [`--action_env`][1] are exposed to `build_tar`.
2. Python sees `$HOME` is empty and [falls back to `pwd.getpwuid(os.getuid()).pw_dir`][4].
3. [OpenShift Prow containers execute with arbitrary container-side UIDs][5], so the `getpwuid` call fails.

With this commit, [Prow can setup `--action_env`][6] to work around its arbitrary container-side UIDs.  We'll probably need openshift/release#1185 to be merged and go live before we can land this PR, and we'll need this PR to land before we can land any other installer PRs.

[1]: https://docs.bazel.build/versions/master/command-line-reference.html#build-options
[2]: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_installer/123/ci-pull-openshift-installer-bazel-build-tarball/4/build-log.txt
[3]: https://github.com/bazelbuild/bazel/blob/0.16.1/tools/build_defs/pkg/pkg.bzl#L82-L89
[4]: https://github.com/python/cpython/blob/1f34aece28d143edb94ca202e661364ca394dc8c/Lib/posixpath.py#L260-L262
[5]: https://github.com/openshift/release/pull/1178#issuecomment-412965330
[6]: https://github.com/openshift/release/pull/1185