### PR TITLE
Documentation/dev: Remove libvirt RHCOS resize

### DIFF
--- a/Documentation/dev/libvirt-howto.md
+++ b/Documentation/dev/libvirt-howto.md
@@ -27,11 +27,6 @@ wget http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest
 gunzip rhcos-qemu.qcow2.gz
 ```
 
-Because of the greater disk requirements of OpenShift, you'll need to expand the root drive with the following:
-```sh
-qemu-img resize rhcos-qemu.qcow2 +8G
-```
-
 #### 1.3b Container Linux
 
 Download the latest stable Container Linux image:


### PR DESCRIPTION
https://github.com/openshift/os/pull/228 has been added as a
workaround until the installer has the ability to resize images.