### PR TITLE
gitignore: bazel-openshift-installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ bazel-out
 bazel-genfiles
 bazel-testlogs
 bazel-tectonic-installer
+bazel-openshift-installer
 .cache


### PR DESCRIPTION
The bazel-openshift-installer is an artifact of bazel and should be
ignored by git.
