### PR TITLE
Ignore the vendor and .build directories when running shellcheck.

### DIFF
--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 if [ "$IS_CONTAINER" != "" ]; then
-  find "${1:-.}" -type f -name '*.sh' -exec shellcheck --format=gcc {} \+
+  TOP_DIR="${1:-.}"
+  find "${TOP_DIR}" \
+    -path "${TOP_DIR}/vendor" -prune \
+    -o -path "${TOP_DIR}/.build" -prune \
+    -o -type f -name '*.sh' -exec shellcheck --format=gcc {} \+
 else
   docker run -e IS_CONTAINER='TRUE' --rm -v "$(pwd)":/workdir:ro --entrypoint sh quay.io/coreos/shellcheck-alpine:v0.5.0 /workdir/hack/shellcheck.sh /workdir;
 fi;


### PR DESCRIPTION
When adding github.com/testify/stretchr, shellcheck failed due to scripts added in the vendored code. This PR modifies shellcheck to ignore the vendored code. It also ignores the .build directory to make the output of shellcheck cleaner when run in a local development environment.
