### PR TITLE
Create a pty by default

### DIFF
--- a/steps/etcd/libvirt/main.tf
+++ b/steps/etcd/libvirt/main.tf
@@ -31,6 +31,11 @@ resource "libvirt_domain" "etcd" {
     volume_id = "${element(libvirt_volume.etcd.*.id, count.index)}"
   }
 
+  console {
+    type        = "pty"
+    target_port = 0
+  }
+
   network_interface {
     network_id = "${local.libvirt_network_id}"
     hostname   = "${var.tectonic_cluster_name}-etcd-${count.index}"

--- a/steps/joining_workers/libvirt/workers.tf
+++ b/steps/joining_workers/libvirt/workers.tf
@@ -24,6 +24,11 @@ resource "libvirt_domain" "worker" {
     volume_id = "${element(libvirt_volume.worker.*.id, count.index)}"
   }
 
+  console {
+    type        = "pty"
+    target_port = 0
+  }
+
   network_interface {
     network_id = "${local.libvirt_network_id}"
     hostname   = "${var.tectonic_cluster_name}-worker-${count.index}"

--- a/steps/masters/libvirt/main.tf
+++ b/steps/masters/libvirt/main.tf
@@ -40,6 +40,11 @@ resource "libvirt_domain" "master" {
     volume_id = "${element(libvirt_volume.master.*.id, count.index)}"
   }
 
+  console {
+    type        = "pty"
+    target_port = 0
+  }
+
   network_interface {
     network_id = "${local.libvirt_network_id}"
     hostname   = "${var.tectonic_cluster_name}-master-${count.index}"


### PR DESCRIPTION
RHCOS defaults to use ttyS0 (the first serial port) as the console for init
(and things after init). Since our domains do not have a pty defined these
go into the void. With this change one can use `virsh console` and see the
messages.  (If RHCOS can figure out how to send output to both tty0 and ttyS0
we wouldn't need this)