### PR TITLE
OpenStack provider support

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -1,0 +1,46 @@
+resource "openstack_objectstorage_object_v1" "ignition" {
+  container_name = "${var.swift_container}"
+  name           = "bootstrap.ign"
+  content        = "${var.ignition}"
+}
+
+resource "openstack_objectstorage_tempurl_v1" "ignition_tmpurl" {
+  container = "${var.swift_container}"
+  method    = "get"
+  object    = "${openstack_objectstorage_object_v1.ignition.name}"
+  ttl       = 3600
+}
+
+data "ignition_config" "redirect" {
+  replace {
+    source = "${openstack_objectstorage_tempurl_v1.ignition_tmpurl.url}"
+  }
+}
+
+data "openstack_images_image_v2" "bootstrap_image" {
+  name        = "${var.image_name}"
+  most_recent = true
+}
+
+data "openstack_compute_flavor_v2" "bootstrap_flavor" {
+  name = "${var.flavor_name}"
+}
+
+resource "openstack_compute_instance_v2" "bootstrap" {
+  name      = "${var.cluster_name}-bootstrap"
+  flavor_id = "${data.openstack_compute_flavor_v2.bootstrap_flavor.id}"
+  image_id  = "${data.openstack_images_image_v2.bootstrap_image.id}"
+
+  user_data = "${data.ignition_config.redirect.rendered}"
+
+  network {
+    port = "${var.bootstrap_port_id}"
+  }
+
+  metadata {
+    Name = "${var.cluster_name}-bootstrap"
+
+    # "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+    tectonicClusterID = "${var.cluster_id}"
+  }
+}

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -1,0 +1,34 @@
+variable "image_name" {
+  type        = "string"
+  description = "The name of the Glance image for the bootstrap node."
+}
+
+variable "swift_container" {
+  type        = "string"
+  description = "The Swift container name for bootstrap ignition file."
+}
+
+variable "cluster_name" {
+  type        = "string"
+  description = "The name of the cluster."
+}
+
+variable "cluster_id" {
+  type = "string"
+}
+
+variable "ignition" {
+  type        = "string"
+  description = "The content of the bootstrap ignition file."
+}
+
+variable "flavor_name" {
+  type        = "string"
+  default     = "m1.medium"
+  description = "The Nova flavor for the bootstrap node."
+}
+
+variable "bootstrap_port_id" {
+  type        = "string"
+  description = "The subnet ID for the bootstrap node."
+}

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -1,0 +1,73 @@
+provider "openstack" {
+  auth_url            = "${var.tectonic_openstack_credentials_auth_url}"
+  cert                = "${var.tectonic_openstack_credentials_cert}"
+  cloud               = "${var.tectonic_openstack_credentials_cloud}"
+  domain_id           = "${var.tectonic_openstack_credentials_domain_id}"
+  domain_name         = "${var.tectonic_openstack_credentials_domain_name}"
+  endpoint_type       = "${var.tectonic_openstack_credentials_endpoint_type}"
+  insecure            = "${var.tectonic_openstack_credentials_insecure}"
+  key                 = "${var.tectonic_openstack_credentials_key}"
+  password            = "${var.tectonic_openstack_credentials_password}"
+  project_domain_id   = "${var.tectonic_openstack_credentials_project_domain_id}"
+  project_domain_name = "${var.tectonic_openstack_credentials_project_domain_name}"
+  region              = "${var.tectonic_openstack_region}"
+  region              = "${var.tectonic_openstack_credentials_region}"
+  swauth              = "${var.tectonic_openstack_credentials_swauth}"
+  tenant_id           = "${var.tectonic_openstack_credentials_tenant_id}"
+  tenant_name         = "${var.tectonic_openstack_credentials_tenant_name}"
+  token               = "${var.tectonic_openstack_credentials_token}"
+  use_octavia         = "${var.tectonic_openstack_credentials_use_octavia}"
+  user_domain_id      = "${var.tectonic_openstack_credentials_user_domain_id}"
+  user_domain_name    = "${var.tectonic_openstack_credentials_user_domain_name}"
+  user_id             = "${var.tectonic_openstack_credentials_user_id}"
+  user_name           = "${var.tectonic_openstack_credentials_user_name}"
+  version             = ">=1.6.0"
+}
+
+module "bootstrap" {
+  source = "./bootstrap"
+
+  swift_container   = "${openstack_objectstorage_container_v1.tectonic.name}"
+  cluster_name      = "${var.tectonic_cluster_name}"
+  cluster_id        = "${var.tectonic_cluster_id}"
+  image_name        = "${var.tectonic_openstack_base_image}"
+  flavor_name       = "${var.tectonic_openstack_master_flavor_name}"
+  ignition          = "${var.ignition_bootstrap}"
+  bootstrap_port_id = "${module.topology.bootstrap_port_id}"
+}
+
+module "masters" {
+  source = "./masters"
+
+  base_image     = "${var.tectonic_openstack_base_image}"
+  cluster_id     = "${var.tectonic_cluster_id}"
+  cluster_name   = "${var.tectonic_cluster_name}"
+  flavor_name    = "${var.tectonic_openstack_master_flavor_name}"
+  instance_count = "${var.tectonic_master_count}"
+  master_sg_ids  = "${concat(var.tectonic_openstack_master_extra_sg_ids, list(module.topology.master_sg_id))}"
+  subnet_ids     = "${module.topology.master_subnet_ids}"
+  user_data_igns = ["${var.ignition_masters}"]
+}
+
+# TODO(shadower) add a dns module here
+
+module "topology" {
+  source = "./topology"
+
+  cidr_block                 = "${var.tectonic_openstack_network_cidr_block}"
+  cluster_id                 = "${var.tectonic_cluster_id}"
+  cluster_name               = "${var.tectonic_cluster_name}"
+  external_master_subnet_ids = "${compact(var.tectonic_openstack_external_master_subnet_ids)}"
+  external_network           = "${var.tectonic_openstack_external_network}"
+  masters_count              = "${var.tectonic_master_count}"
+}
+
+resource "openstack_objectstorage_container_v1" "tectonic" {
+  name = "${lower(var.tectonic_cluster_name)}.${var.tectonic_base_domain}"
+
+  metadata = "${merge(map(
+      "Name", "${var.tectonic_cluster_name}-ignition-master",
+      "KubernetesCluster", "${var.tectonic_cluster_name}",
+      "tectonicClusterID", "${var.tectonic_cluster_id}"
+    ), var.tectonic_openstack_extra_tags)}"
+}

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -1,0 +1,28 @@
+data "openstack_images_image_v2" "masters_img" {
+  name        = "${var.base_image}"
+  most_recent = true
+}
+
+data "openstack_compute_flavor_v2" "masters_flavor" {
+  name = "${var.flavor_name}"
+}
+
+resource "openstack_compute_instance_v2" "master_conf" {
+  name  = "${var.cluster_name}-master-${count.index}"
+  count = "${var.instance_count}"
+
+  flavor_id       = "${data.openstack_compute_flavor_v2.masters_flavor.id}"
+  image_id        = "${data.openstack_images_image_v2.masters_img.id}"
+  security_groups = ["${var.master_sg_ids}"]
+  user_data       = "${var.user_data_igns[count.index]}"
+
+  network = {
+    port = "${var.subnet_ids[count.index]}"
+  }
+
+  metadata {
+    Name              = "${var.cluster_name}-master"
+    owned             = "kubernetes.io/cluster/${var.cluster_name}"
+    tectonicClusterID = "${var.cluster_id}"
+  }
+}

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -1,0 +1,33 @@
+variable "base_image" {
+  type = "string"
+}
+
+variable "cluster_id" {
+  type = "string"
+}
+
+variable "cluster_name" {
+  type = "string"
+}
+
+variable "flavor_name" {
+  type = "string"
+}
+
+variable "instance_count" {
+  type = "string"
+}
+
+variable "master_sg_ids" {
+  type        = "list"
+  default     = ["default"]
+  description = "The security group IDs to be applied to the master nodes."
+}
+
+variable "subnet_ids" {
+  type = "list"
+}
+
+variable "user_data_igns" {
+  type = "list"
+}

--- a/data/data/openstack/topology/common.tf
+++ b/data/data/openstack/topology/common.tf
@@ -1,0 +1,3 @@
+locals {
+  master_subnet_ids = ["${coalescelist(openstack_networking_port_v2.masters.*.id,var.external_master_subnet_ids)}"]
+}

--- a/data/data/openstack/topology/outputs.tf
+++ b/data/data/openstack/topology/outputs.tf
@@ -1,0 +1,11 @@
+output "bootstrap_port_id" {
+  value = "${openstack_networking_port_v2.bootstrap_port.id}"
+}
+
+output "master_sg_id" {
+  value = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+output "master_subnet_ids" {
+  value = "${local.master_subnet_ids}"
+}

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -1,0 +1,69 @@
+locals {
+  new_master_cidr_range = "${cidrsubnet(var.cidr_block, 1, 0)}"
+  new_worker_cidr_range = "${cidrsubnet(var.cidr_block, 1, 1)}"
+}
+
+resource "openstack_networking_network_v2" "openshift-private" {
+  name           = "openshift"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "masters" {
+  name       = "masters"
+  cidr       = "${local.new_master_cidr_range}"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.openshift-private.id}"
+}
+
+resource "openstack_networking_subnet_v2" "workers" {
+  name       = "worker"
+  cidr       = "${local.new_worker_cidr_range}"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.openshift-private.id}"
+}
+
+resource "openstack_networking_port_v2" "masters" {
+  name  = "master-port-${count.index}"
+  count = "${var.masters_count}"
+
+  admin_state_up     = "true"
+  network_id         = "${openstack_networking_network_v2.openshift-private.id}"
+  security_group_ids = ["${openstack_networking_secgroup_v2.master.id}"]
+
+  fixed_ip {
+    "subnet_id" = "${openstack_networking_subnet_v2.masters.id}"
+  }
+}
+
+resource "openstack_networking_port_v2" "bootstrap_port" {
+  name = "bootstrap-port"
+
+  admin_state_up     = "true"
+  network_id         = "${openstack_networking_network_v2.openshift-private.id}"
+  security_group_ids = ["${openstack_networking_secgroup_v2.master.id}"]
+
+  fixed_ip {
+    "subnet_id" = "${openstack_networking_subnet_v2.masters.id}"
+  }
+}
+
+data "openstack_networking_network_v2" "external_network" {
+  name     = "${var.external_network}"
+  external = true
+}
+
+resource "openstack_networking_router_v2" "openshift-external-router" {
+  name                = "openshift-external-router"
+  admin_state_up      = true
+  external_network_id = "${data.openstack_networking_network_v2.external_network.id}"
+}
+
+resource "openstack_networking_router_interface_v2" "masters_router_interface" {
+  router_id = "${openstack_networking_router_v2.openshift-external-router.id}"
+  subnet_id = "${openstack_networking_subnet_v2.masters.id}"
+}
+
+resource "openstack_networking_router_interface_v2" "workers_router_interface" {
+  router_id = "${openstack_networking_router_v2.openshift-external-router.id}"
+  subnet_id = "${openstack_networking_subnet_v2.workers.id}"
+}

--- a/data/data/openstack/topology/sg-lb.tf
+++ b/data/data/openstack/topology/sg-lb.tf
@@ -1,0 +1,51 @@
+resource "openstack_networking_secgroup_v2" "mcs" {
+  name = "mcs"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "mcs_https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 49500
+  port_range_max    = 49500
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.mcs.id}"
+}
+
+resource "openstack_networking_secgroup_v2" "api" {
+  name = "api"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "api_https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6443
+  port_range_max    = 6443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.api.id}"
+}
+
+resource "openstack_networking_secgroup_v2" "console" {
+  name = "console"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "console_http" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.console.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "console_https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.console.id}"
+}

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -1,0 +1,185 @@
+resource "openstack_networking_secgroup_v2" "master" {
+  name = "master"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_mcs" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 49500
+  port_range_max    = 49500
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  port_range_min    = 0
+  port_range_max    = 0
+  remote_ip_prefix  = "${var.cidr_block}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_ssh" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_http" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "${var.cidr_block}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6443
+  port_range_max    = 6445
+  remote_ip_prefix  = "${var.cidr_block}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_heapster" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 4194
+  port_range_max    = 4194
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_heapster_from_worker" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 4194
+  port_range_max    = 4194
+  remote_group_id   = "${openstack_networking_secgroup_v2.worker.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_flannel" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 4789
+  port_range_max    = 4789
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_flannel_from_worker" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 4789
+  port_range_max    = 4789
+  remote_group_id   = "${openstack_networking_secgroup_v2.worker.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_node_exporter" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9100
+  port_range_max    = 9100
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_node_exporter_from_worker" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9100
+  port_range_max    = 9100
+  remote_group_id   = "${openstack_networking_secgroup_v2.worker.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_insecure" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10250
+  port_range_max    = 10250
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_insecure_from_worker" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10250
+  port_range_max    = 10250
+  remote_group_id   = "${openstack_networking_secgroup_v2.worker.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10255
+  port_range_max    = 10255
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure_from_worker" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10255
+  port_range_max    = 10255
+  remote_group_id   = "${openstack_networking_secgroup_v2.worker.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_etcd" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 2379
+  port_range_max    = 2380
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_bootstrap_etcd" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 12379
+  port_range_max    = 12380
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_services" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_from_console" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_group_id   = "${openstack_networking_secgroup_v2.console.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -1,0 +1,157 @@
+resource "openstack_networking_secgroup_v2" "worker" {
+  name = "worker"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  port_range_min    = 0
+  port_range_max    = 0
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_http" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_heapster" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  port_range_min    = 4194
+  port_range_max    = 4194
+  protocol          = "tcp"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_heapster_from_master" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 4194
+  port_range_max    = 4194
+  remote_group_id   = "${openstack_networking_secgroup_v2.master.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_flannel" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 4789
+  port_range_max    = 4789
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_flannel_from_master" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 4789
+  port_range_max    = 4789
+  remote_group_id   = "${openstack_networking_secgroup_v2.master.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_node_exporter" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9100
+  port_range_max    = 9100
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_node_exporter_from_master" {
+  direction         = "ingress"
+  protocol          = "tcp"
+  ethertype         = "IPv4"
+  port_range_min    = 9100
+  port_range_max    = 9100
+  remote_group_id   = "${openstack_networking_secgroup_v2.master.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecure" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10250
+  port_range_max    = 10250
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecure_from_master" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10250
+  port_range_max    = 10250
+  remote_group_id   = "${openstack_networking_secgroup_v2.master.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_secure" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10255
+  port_range_max    = 10255
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_secure_from_master" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10255
+  port_range_max    = 10255
+  remote_group_id   = "${openstack_networking_secgroup_v2.master.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_from_console" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_group_id   = "${openstack_networking_secgroup_v2.console.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -1,0 +1,25 @@
+variable "cidr_block" {
+  type = "string"
+}
+
+variable "cluster_id" {
+  type = "string"
+}
+
+variable "cluster_name" {
+  type = "string"
+}
+
+variable "external_master_subnet_ids" {
+  type = "list"
+}
+
+variable "external_network" {
+  description = "UUID of the external network providing Floating IP addresses."
+  type        = "string"
+  default     = ""
+}
+
+variable "masters_count" {
+  type = "string"
+}

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -1,0 +1,255 @@
+variable "tectonic_openstack_base_image" {
+  type        = "string"
+  default     = "rhcos"
+  description = "Name of the base image to use for the nodes."
+}
+
+variable "tectonic_openstack_credentials_auth_url" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+required if cloud is not specified) The Identity authentication URL. If omitted, the OS_AUTH_URL environment variable is used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_cert" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+Specify client certificate file for SSL client authentication. You can specify either a path to the file or the contents of the certificate. If omitted the OS_CERT environment variable is used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_cloud" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+required if auth_url is not specified) An entry in a clouds.yaml file. See the OpenStack os-client-config documentation for more information about clouds.yaml files. If omitted, the OS_CLOUD environment variable is used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_domain_id" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The ID of the Domain to scope to (Identity v3). If omitted, the OS_DOMAIN_ID environment variable is checked.
+EOF
+}
+
+variable "tectonic_openstack_credentials_domain_name" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The Name of the Domain to scope to (Identity v3). If omitted, the following environment variables are checked (in this order): OS_DOMAIN_NAME, OS_DEFAULT_DOMAIN.
+EOF
+}
+
+variable "tectonic_openstack_credentials_endpoint_type" {
+  type    = "string"
+  default = "public"
+
+  description = <<EOF
+Specify which type of endpoint to use from the service catalog. It can be set using the OS_ENDPOINT_TYPE environment variable. If not set, public endpoints is used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_insecure" {
+  default = false
+
+  description = <<EOF
+Trust self-signed SSL certificates. If omitted, the OS_INSECURE environment variable is used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_key" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+Specify client private key file for SSL client authentication. You can specify either a path to the file or the contents of the key. If omitted the OS_KEY environment variable is used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_password" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The Password to login with. If omitted, the OS_PASSWORD environment variable is used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_project_domain_id" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The domain ID where the project is located If omitted, the OS_PROJECT_DOMAIN_ID environment variable is checked.
+EOF
+}
+
+variable "tectonic_openstack_credentials_project_domain_name" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The domain name where the project is located. If omitted, the OS_PROJECT_DOMAIN_NAME environment variable is checked.
+EOF
+}
+
+variable "tectonic_openstack_credentials_region" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The region of the OpenStack cloud to use. If omitted, the OS_REGION_NAME environment variable is used. If OS_REGION_NAME is not set, then no region will be used. It should be possible to omit the region in single-region OpenStack environments, but this behavior may vary depending on the OpenStack environment being used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_swauth" {
+  default = false
+
+  description = <<EOF
+Set to true to authenticate against Swauth, a Swift-native authentication system. If omitted, the OS_SWAUTH environment variable is used. You must also set username to the Swauth/Swift username such as username:project. Set the password to the Swauth/Swift key. Finally, set auth_url as the location of the Swift service. Note that this will only work when used with the OpenStack Object Storage resources.
+EOF
+}
+
+variable "tectonic_openstack_credentials_tenant_id" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The ID of the Tenant (Identity v2) or Project (Identity v3) to login with. If omitted, the OS_TENANT_ID or OS_PROJECT_ID environment variables are used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_tenant_name" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The Name of the Tenant (Identity v2) or Project (Identity v3) to login with. If omitted, the OS_TENANT_NAME or OS_PROJECT_NAME environment variable are used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_token" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+Required if not using user_name and password) A token is an expiring, temporary means of access issued via the Keystone service. By specifying a token, you do not have to specify a username/password combination, since the token was already created by a username/password out of band of Terraform. If omitted, the OS_TOKEN or OS_AUTH_TOKEN environment variables are used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_use_octavia" {
+  default = false
+
+  description = <<EOF
+If set to true, API requests will go the Load Balancer service (Octavia) instead of the Networking service (Neutron).
+EOF
+}
+
+variable "tectonic_openstack_credentials_user_domain_id" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The domain ID where the user is located. If omitted, the OS_USER_DOMAIN_ID environment variable is checked.
+EOF
+}
+
+variable "tectonic_openstack_credentials_user_domain_name" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The domain name where the user is located. If omitted, the OS_USER_DOMAIN_NAME environment variable is checked.
+EOF
+}
+
+variable "tectonic_openstack_credentials_user_id" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The User ID to login with. If omitted, the OS_USER_ID environment variable is used.
+EOF
+}
+
+variable "tectonic_openstack_credentials_user_name" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+The Username to login with. If omitted, the OS_USERNAME environment variable is used.
+EOF
+}
+
+variable "tectonic_openstack_external_master_subnet_ids" {
+  type    = "list"
+  default = []
+
+  description = <<EOF
+(optional) List of subnet IDs within an existing VPC to deploy master nodes into.
+Required to use an existing VPC, not applicable otherwise.
+
+Example: `["subnet-111111", "subnet-222222", "subnet-333333"]`
+EOF
+}
+
+variable "tectonic_openstack_external_network" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+(optional) UUID of the external network. The network is used to provide
+Floating IP access to the deployed nodes.
+EOF
+}
+
+variable "tectonic_openstack_extra_tags" {
+  type    = "map"
+  default = {}
+
+  description = <<EOF
+(optional) Extra AWS tags to be applied to created resources.
+
+Example: `{ "key" = "value", "foo" = "bar" }`
+EOF
+}
+
+variable "tectonic_openstack_master_extra_sg_ids" {
+  type    = "list"
+  default = []
+
+  description = <<EOF
+(optional) List of additional security group IDs for master nodes.
+
+Example: `["sg-51530134", "sg-b253d7cc"]`
+EOF
+}
+
+variable "tectonic_openstack_master_flavor_name" {
+  type        = "string"
+  default     = "m1.medium"
+  description = "Instance size for the master node(s). Example: `m1.medium`."
+}
+
+variable "tectonic_openstack_region" {
+  type        = "string"
+  description = "The target OpenStack region for the cluster."
+}
+
+variable "tectonic_openstack_network_cidr_block" {
+  type = "string"
+
+  description = <<EOF
+Block of IP addresses used by the VPC.
+This should not overlap with any other networks, such as a private datacenter connected via Direct Connect.
+EOF
+}

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -96,6 +96,20 @@ func (a *installConfig) Generate(dependencies map[asset.Asset]*asset.State) (*as
 				Replicas: func(x int64) *int64 { return &x }(3),
 			},
 		}
+	case OpenStackPlatformType:
+		if err := json.Unmarshal(platformState.Contents[1].Data, &installConfig.OpenStack); err != nil {
+			return nil, err
+		}
+		installConfig.Machines = []types.MachinePool{
+			{
+				Name:     "master",
+				Replicas: func(x int64) *int64 { return &x }(3),
+			},
+			{
+				Name:     "worker",
+				Replicas: func(x int64) *int64 { return &x }(3),
+			},
+		}
 	case LibvirtPlatformType:
 		if err := json.Unmarshal(platformState.Contents[1].Data, &installConfig.Libvirt); err != nil {
 			return nil, err

--- a/pkg/asset/manifests/machine-api-operator.go
+++ b/pkg/asset/manifests/machine-api-operator.go
@@ -30,11 +30,12 @@ var _ asset.Asset = (*machineAPIOperator)(nil)
 // TODO(enxebre): move up to github.com/coreos/tectonic-config (to install-config? /rchopra)
 type maoOperatorConfig struct {
 	metav1.TypeMeta `json:",inline"`
-	TargetNamespace string         `json:"targetNamespace"`
-	APIServiceCA    string         `json:"apiServiceCA"`
-	Provider        string         `json:"provider"`
-	AWS             *awsConfig     `json:"aws"`
-	Libvirt         *libvirtConfig `json:"libvirt"`
+	TargetNamespace string           `json:"targetNamespace"`
+	APIServiceCA    string           `json:"apiServiceCA"`
+	Provider        string           `json:"provider"`
+	AWS             *awsConfig       `json:"aws"`
+	Libvirt         *libvirtConfig   `json:"libvirt"`
+	OpenStack       *openstackConfig `json:"openstack"`
 }
 
 type libvirtConfig struct {
@@ -52,6 +53,13 @@ type awsConfig struct {
 	AvailabilityZone string `json:"availabilityZone"`
 	Image            string `json:"image"`
 	Replicas         int    `json:"replicas"`
+}
+
+type openstackConfig struct {
+	ClusterName string `json:"clusterName"`
+	ClusterID   string `json:"clusterID"`
+	Region      string `json:"region"`
+	Replicas    int    `json:"replicas"`
 }
 
 // Name returns a human friendly name for the operator
@@ -129,6 +137,13 @@ func (mao *machineAPIOperator) maoConfig(dependencies map[asset.Asset]*asset.Sta
 			URI:         mao.installConfig.Platform.Libvirt.URI,
 			NetworkName: mao.installConfig.Platform.Libvirt.Network.Name,
 			IPRange:     mao.installConfig.Platform.Libvirt.Network.IPRange,
+			Replicas:    int(*mao.installConfig.Machines[1].Replicas),
+		}
+	} else if mao.installConfig.Platform.OpenStack != nil {
+		cfg.OpenStack = &openstackConfig{
+			ClusterName: mao.installConfig.Name,
+			ClusterID:   mao.installConfig.ClusterID,
+			Region:      mao.installConfig.Platform.OpenStack.Region,
 			Replicas:    int(*mao.installConfig.Machines[1].Replicas),
 		}
 	} else {

--- a/pkg/asset/metadata/metadata.go
+++ b/pkg/asset/metadata/metadata.go
@@ -51,6 +51,13 @@ func (m *Metadata) Generate(parents map[asset.Asset]*asset.State) (*asset.State,
 				"tectonicClusterID": installCfg.ClusterID,
 			},
 		}
+	case installCfg.Platform.OpenStack != nil:
+		cm.ClusterPlatformMetadata.OpenStack = &types.ClusterOpenStackPlatformMetadata{
+			Region: installCfg.Platform.OpenStack.Region,
+			Identifier: map[string]string{
+				"tectonicClusterID": installCfg.ClusterID,
+			},
+		}
 	case installCfg.Platform.Libvirt != nil:
 		cm.ClusterPlatformMetadata.Libvirt = &types.ClusterLibvirtPlatformMetadata{
 			URI: installCfg.Platform.Libvirt.URI,

--- a/pkg/types/clustermetadata.go
+++ b/pkg/types/clustermetadata.go
@@ -9,14 +9,22 @@ type ClusterMetadata struct {
 
 // ClusterPlatformMetadata contains metadata for platfrom.
 type ClusterPlatformMetadata struct {
-	AWS     *ClusterAWSPlatformMetadata     `json:"aws,omitempty"`
-	Libvirt *ClusterLibvirtPlatformMetadata `json:"libvirt,omitempty"`
+	AWS       *ClusterAWSPlatformMetadata       `json:"aws,omitempty"`
+	OpenStack *ClusterOpenStackPlatformMetadata `json:"openstack,omitempty"`
+	Libvirt   *ClusterLibvirtPlatformMetadata   `json:"libvirt,omitempty"`
 }
 
 // ClusterAWSPlatformMetadata contains AWS metadata.
 type ClusterAWSPlatformMetadata struct {
 	Region string `json:"region"`
 	// Most AWS resources are tagged with these tags as identifier.
+	Identifier map[string]string `json:"identifier"`
+}
+
+// ClusterOpenStackPlatformMetadata contains OpenStack metadata.
+type ClusterOpenStackPlatformMetadata struct {
+	Region string `json:"region"`
+	// Most OpenStack resources are tagged with these tags as identifier.
 	Identifier map[string]string `json:"identifier"`
 }
 

--- a/pkg/types/config/openstack/openstack.go
+++ b/pkg/types/config/openstack/openstack.go
@@ -1,0 +1,56 @@
+package openstack
+
+const (
+	// DefaultNetworkCIDRBlock is the default CIDR range for an OpenStack network.
+	DefaultNetworkCIDRBlock = "10.0.0.0/16"
+	// DefaultRegion is the default OpenStack region for the cluster.
+	DefaultRegion = "regionOne"
+)
+
+// OpenStack converts OpenStack related config.
+type OpenStack struct {
+	BaseImage        string `json:"tectonic_openstack_base_image,omitempty" yaml:"baseImage,omitempty"`
+	Credentials      `json:",inline" yaml:"credentials,omitempty"`
+	External         `json:",inline" yaml:"external,omitempty"`
+	ExternalNetwork  string            `json:"tectonic_openstack_external_network,omitempty" yaml:"externalNetwork,omitempty"`
+	ExtraTags        map[string]string `json:"tectonic_openstack_extra_tags,omitempty" yaml:"extraTags,omitempty"`
+	Master           `json:",inline" yaml:"master,omitempty"`
+	Region           string `json:"tectonic_openstack_region,omitempty" yaml:"region,omitempty"`
+	NetworkCIDRBlock string `json:"tectonic_openstack_network_cidr_block,omitempty" yaml:"networkCIDRBlock,omitempty"`
+}
+
+// External converts external related config.
+type External struct {
+	MasterSubnetIDs []string `json:"tectonic_openstack_external_master_subnet_ids,omitempty" yaml:"masterSubnetIDs,omitempty"`
+}
+
+// Master converts master related config.
+type Master struct {
+	FlavorName string   `json:"tectonic_openstack_master_flavor_name,omitempty" yaml:"flavorName,omitempty"`
+	ExtraSGIDs []string `json:"tectonic_openstack_master_extra_sg_ids,omitempty" yaml:"extraSGIDs,omitempty"`
+}
+
+// Credentials converts credentials related config.
+type Credentials struct {
+	AuthURL           string `json:"tectonic_openstack_credentials_auth_url,omitempty" yaml:"authUrl,omitempty"`
+	Cert              string `json:"tectonic_openstack_credentials_cert,omitempty" yaml:"cert,omitempty"`
+	Cloud             string `json:"tectonic_openstack_credentials_cloud,omitempty" yaml:"cloud,omitempty"`
+	DomainID          string `json:"tectonic_openstack_credentials_domain_id,omitempty" yaml:"domainId,omitempty"`
+	DomainName        string `json:"tectonic_openstack_credentials_domain_name,omitempty" yaml:"domainName,omitempty"`
+	EndpointType      string `json:"tectonic_openstack_credentials_endpoint_type,omitempty" yaml:"endpointType,omitempty"`
+	Insecure          bool   `json:"tectonic_openstack_credentials_insecure,omitempty" yaml:"insecure,omitempty"`
+	Key               string `json:"tectonic_openstack_credentials_key,omitempty" yaml:"key,omitempty"`
+	Password          string `json:"tectonic_openstack_credentials_password,omitempty" yaml:"password,omitempty"`
+	ProjectDomainID   string `json:"tectonic_openstack_credentials_project_domain_id,omitempty" yaml:"projectDomainId,omitempty"`
+	ProjectDomainName string `json:"tectonic_openstack_credentials_project_domain_name,omitempty" yaml:"projectDomainName,omitempty"`
+	Region            string `json:"tectonic_openstack_credentials_region,omitempty" yaml:"region,omitempty"`
+	Swauth            bool   `json:"tectonic_openstack_credentials_swauth,omitempty" yaml:"swauth,omitempty"`
+	TenantID          string `json:"tectonic_openstack_credentials_tenant_id,omitempty" yaml:"tenantId,omitempty"`
+	TenantName        string `json:"tectonic_openstack_credentials_tenant_name,omitempty" yaml:"tenantName,omitempty"`
+	Token             string `json:"tectonic_openstack_credentials_token,omitempty" yaml:"token,omitempty"`
+	UseOctavia        bool   `json:"tectonic_openstack_credentials_use_octavia,omitempty" yaml:"useOctavia,omitempty"`
+	UserDomainID      string `json:"tectonic_openstack_credentials_user_domain_id,omitempty" yaml:"userDomainId,omitempty"`
+	UserDomainName    string `json:"tectonic_openstack_credentials_user_domain_name,omitempty" yaml:"userDomainName,omitempty"`
+	UserID            string `json:"tectonic_openstack_credentials_user_id,omitempty" yaml:"userId,omitempty"`
+	UserName          string `json:"tectonic_openstack_credentials_user_name,omitempty" yaml:"userName,omitempty"`
+}

--- a/pkg/types/config/validate.go
+++ b/pkg/types/config/validate.go
@@ -78,6 +78,7 @@ func (c *Cluster) Validate() []error {
 	errs = append(errs, c.validateNodePools()...)
 	errs = append(errs, c.validateNetworking()...)
 	errs = append(errs, c.validateAWS()...)
+	errs = append(errs, c.validateOpenStack()...)
 	errs = append(errs, c.validatePullSecret()...)
 	errs = append(errs, c.validateLibvirt()...)
 	if err := prefixError("cluster name", validateClusterName(c.Name)); err != nil {
@@ -116,6 +117,15 @@ func (c *Cluster) validateAWS() []error {
 	}
 	if err := prefixError("aws region", validateNonEmpty(c.AWS.Region)); err != nil {
 		errs = append(errs, err)
+	}
+	return errs
+}
+
+// validateOpenStack validates all fields specific to OpenStack.
+func (c *Cluster) validateOpenStack() []error {
+	var errs []error
+	if c.Platform != PlatformOpenStack {
+		return errs
 	}
 	return errs
 }

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -63,8 +63,12 @@ type Admin struct {
 type Platform struct {
 	// AWS is the configuration used when installing on AWS.
 	AWS *AWSPlatform `json:"aws,omitempty"`
+
 	// Libvirt is the configuration used when installing on libvirt.
 	Libvirt *LibvirtPlatform `json:"libvirt,omitempty"`
+
+	// OpenStack is the configuration used when installing on OpenStack.
+	OpenStack *OpenStackPlatform `json:"openstack,omitempty"`
 }
 
 // Networking defines the pod network provider in the cluster.
@@ -106,6 +110,34 @@ type AWSPlatform struct {
 	// VPCCIDRBlock
 	// +optional
 	VPCCIDRBlock string `json:"vpcCIDRBlock"`
+}
+
+// OpenStackPlatform stores all the global configuration that
+// all machinesets use.
+type OpenStackPlatform struct {
+	// Region specifies the OpenStack region where the cluster will be created.
+	Region string `json:"region"`
+
+	// VPCID specifies the vpc to associate with the cluster.
+	// If empty, new vpc will be created.
+	// +optional
+	VPCID string `json:"vpcID"`
+
+	// NetworkCIDRBlock
+	// +optional
+	NetworkCIDRBlock string `json:"NetworkCIDRBlock"`
+
+	// BaseImage
+	// Name of image to use from OpenStack cloud
+	BaseImage string `json:"baseImage"`
+
+	// Cloud
+	// Name of OpenStack cloud to use from clouds.yaml
+	Cloud string `json:"cloud"`
+
+	// ExternalNetwork
+	// The OpenStack external network to be used for installation.
+	ExternalNetwork string `json:"externalNetwork"`
 }
 
 // LibvirtPlatform stores all the global configuration that

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -18,8 +18,12 @@ type MachinePool struct {
 type MachinePoolPlatform struct {
 	// AWS is the configuration used when installing on AWS.
 	AWS *AWSMachinePoolPlatform `json:"aws,omitempty"`
+
 	// Libvirt is the configuration used when installing on libvirt.
 	Libvirt *LibvirtMachinePoolPlatform `json:"libvirt,omitempty"`
+
+	// OpenStack is the configuration used when installing on OpenStack.
+	OpenStack *OpenStackMachinePoolPlatform `json:"openstack,omitempty"`
 }
 
 // AWSMachinePoolPlatform stores the configuration for a machine pool
@@ -39,6 +43,27 @@ type AWSMachinePoolPlatform struct {
 
 // EC2RootVolume defines the storage for an ec2 instance.
 type EC2RootVolume struct {
+	// IOPS defines the iops for the instance.
+	IOPS int `json:"iops"`
+	// Size defines the size of the instance.
+	Size int `json:"size"`
+	// Type defines the type of the instance.
+	Type string `json:"type"`
+}
+
+// OpenStackMachinePoolPlatform stores the configuration for a machine pool
+// installed on OpenStack.
+type OpenStackMachinePoolPlatform struct {
+	// FlavorName defines the OpenStack Nova flavor.
+	// eg. m1.large
+	FlavorName string `json:"type"`
+
+	// OpenStackRootVolume defines the storage for Nova instance.
+	OpenStackRootVolume `json:"rootVolume"`
+}
+
+// OpenStackRootVolume defines the storage for a Nova instance.
+type OpenStackRootVolume struct {
 	// IOPS defines the iops for the instance.
 	IOPS int `json:"iops"`
 	// Size defines the size of the instance.


### PR DESCRIPTION
This PR adds an OpenStack module and the respective steps to run tectonic against an OpenStack cloud.


Fully implemented steps

- [x] Assets creation
- [x] Infra
- [x] Masters
- [x] workers

Features implementation:

- [x] Networks creation
- [x] Subnets creation
- [x] IPs allocation and assignment
- [x] Security groups management
- [x] Ignition config upload/download from the object store (swift)
- [x] Instance creation
- [x] ~Installation/Configuration of the OpenStack provider (currently disabled)~
- [x] LB creation
- [ ] DNS Records creation

@yifan-gu r? 
