### PR TITLE
tests/run: Shift "Generating SSH key-pair..." message into if block

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -67,10 +67,9 @@ export AWS_ACCESS_KEY_ID=$(echo  "${RES}" | jq --raw-output '.Credentials.Access
 export AWS_SESSION_TOKEN=$(echo "${RES}" | jq --raw-output '.Credentials.SessionToken')
 
 ### HANDLE SSH KEY ###
-echo -e "\\e[36m Generating SSH key-pair...\\e[0m"
 if [ ! -f ~/.ssh/id_rsa.pub ]; then
-  #shellcheck disable=SC2034
-  SSH=$(ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -N "" < /dev/zero)
+  echo -e "\\e[36m Generating SSH key-pair...\\e[0m"
+  ssh-keygen -qb 2048 -t rsa -f ~/.ssh/id_rsa -N "" </dev/zero
 fi
 export TF_VAR_tectonic_admin_ssh_key="$(cat ~/.ssh/id_rsa.pub)"
 


### PR DESCRIPTION
37f623c5 (#127) replaced our old key-pair upload with the `TF_VAR_tectonic_admin_ssh_key` export, and updated the message from "Uploading SSH key-pair to AWS..." to our current "Generation SSH key-pair..." message.  But while we used to *always* upload a key to AWS, we've only ever generated a new key if `~/.ssh/id_rsa.pub` was missing.  This commit moves the Generating... mesage into the if block to avoid freaking out callers who may think we're clobbering their SSH key ;).

While I'm in the area, I've also dropped the `SSH` variable and its associated SC2034 (unused variable) disable.  The output of ssh-keygen isn't particularly interesting, so I've just set `-q` to quiet it instead.  We'd had the old `SSH` and SC2034 disable since the script landed in a2405e4d (coreos/tectonic-installer#3284).