### PR TITLE
config: Remove gcloudsdk

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -59,7 +59,6 @@ variable "tectonic_container_images" {
   default = {
     addon_resizer                        = "gcr.io/google_containers/addon-resizer:2.1"
     awscli                               = "quay.io/coreos/awscli:025a357f05242fdad6a81e8a6b520098aa65a600"
-    gcloudsdk                            = "google/cloud-sdk:178.0.0-alpine"
     bootkube                             = "quay.io/coreos/bootkube:v0.10.0"
     tnc_operator                         = "quay.io/coreos/tectonic-node-controller-operator-dev:df42b97af403702013f4739fc82cd005cfd0c766"
     etcd_cert_signer                     = "quay.io/coreos/kube-etcd-signer-server:678cc8e6841e2121ebfdb6e2db568fce290b67d6"


### PR DESCRIPTION
The last consumer was removed in b2e0bcf2 (coreos/tectonic-installer#3183).