### PR TITLE
libvirt-howto: fix `sshKey` section name

### DIFF
--- a/Documentation/dev/libvirt-howto.md
+++ b/Documentation/dev/libvirt-howto.md
@@ -48,7 +48,7 @@ Go to https://account.coreos.com/ and obtain a Tectonic license. Save the *pull 
 1. Edit the configuration file:
     1. Set an email and password in the `admin` section
     1. Set a `baseDomain` (to `tt.testing`)
-    1. Set the `sshKey` in the `libvirt` section to the **contents** of an ssh key (e.g. `ssh-rsa AAAA...`)
+    1. Set the `sshKey` in the `admin` section to the **contents** of an ssh key (e.g. `ssh-rsa AAAA...`)
     1. Set the `imagePath` to the **absolute** path of the operating system image you downloaded
     1. Set the `licensePath` to the **absolute** path of your downloaded license file.
     1. Set the `name` (e.g. test1)


### PR DESCRIPTION
The `sshKey` is in the `admin` section, not `libvirt`.