### PR TITLE
modules/aws/vpc/sg-elb: Fix name for TNC security group

### DIFF
--- a/modules/aws/vpc/sg-elb.tf
+++ b/modules/aws/vpc/sg-elb.tf
@@ -2,7 +2,7 @@ resource "aws_security_group" "tnc" {
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
   tags = "${merge(map(
-      "Name", "${var.cluster_name}_console_sg",
+      "Name", "${var.cluster_name}_tnc_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
       "tectonicClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"


### PR DESCRIPTION
In 251147eb (coreos/tectonic-installer#3053), the resource was renamed from `ncg` to `tnc`, but the name property wasn't updated to match.