### PR TITLE
modules/aws/vpc/sg-elb: Split out aws_security_group_rule

### DIFF
--- a/modules/aws/vpc/sg-elb.tf
+++ b/modules/aws/vpc/sg-elb.tf
@@ -6,28 +6,36 @@ resource "aws_security_group" "tnc" {
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
       "tectonicClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
+}
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    self        = true
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_security_group_rule" "tnc_egress" {
+  type              = "egress"
+  security_group_id = "${aws_security_group.tnc.id}"
 
-  ingress {
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 80
-    to_port     = 80
-  }
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+}
 
-  ingress {
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 443
-    to_port     = 443
-  }
+resource "aws_security_group_rule" "tnc_ingress_http" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.tnc.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 80
+  to_port     = 80
+}
+
+resource "aws_security_group_rule" "tnc_ingress_https" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.tnc.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 443
+  to_port     = 443
 }
 
 resource "aws_security_group" "api" {
@@ -38,21 +46,26 @@ resource "aws_security_group" "api" {
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
       "tectonicClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
+}
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    self        = true
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_security_group_rule" "api_egress" {
+  type              = "egress"
+  security_group_id = "${aws_security_group.api.id}"
 
-  ingress {
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 6443
-    to_port     = 6443
-  }
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "api_ingress_console" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.api.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 6443
+  to_port     = 6443
 }
 
 resource "aws_security_group" "console" {
@@ -63,26 +76,34 @@ resource "aws_security_group" "console" {
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
       "tectonicClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
+}
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    self        = true
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_security_group_rule" "console_egress" {
+  type              = "egress"
+  security_group_id = "${aws_security_group.console.id}"
 
-  ingress {
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 80
-    to_port     = 80
-  }
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+}
 
-  ingress {
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 443
-    to_port     = 443
-  }
+resource "aws_security_group_rule" "console_ingress_http" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.console.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 80
+  to_port     = 80
+}
+
+resource "aws_security_group_rule" "console_ingress_https" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.console.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 443
+  to_port     = 443
 }


### PR DESCRIPTION
This happend for masters and workers in b620c16f (coreos/tectonic-installer#264).  This commit catches up for consistency with the other node classes. From [the Terraform docs][1]:

> Terraform currently provides both a standalone Security Group Rule resource (a single ingress or egress rule), and a Security Group resource with ingress and egress rules defined in-line.  At this time you cannot use a Security Group with in-line rules in conjunction with any Security Group Rule resources.  Doing so will cause a conflict of rule settings and will overwrite rules.

We can also use the rule name to hint at the purpose of a rule (e.g. `tnc_ingress_http`), while with inline rules we just have port numbers.

This also drops some `self` properties from egress rules, which didn't make sense.  `self` and `cidr_blocks` are incompatible, resulting [in][2]:

```
3 error(s) occurred:

* module.vpc.aws_security_group_rule.api_egress: 1 error(s) occurred:

* aws_security_group_rule.api_egress: 'self': conflicts with 'cidr_blocks' ([]interface {}{"0.0.0.0/0"})
* module.vpc.aws_security_group_rule.tnc_egress: 1 error(s) occurred:

* aws_security_group_rule.tnc_egress: 'self': conflicts with 'cidr_blocks' ([]interface {}{"0.0.0.0/0"})
* module.vpc.aws_security_group_rule.console_egress: 1 error(s) occurred:

* aws_security_group_rule.console_egress: 'self': conflicts with 'cidr_blocks' ([]interface {}{"0.0.0.0/0"})
```

And these are supposed to be generic egress blocks anyway.  The erroneous use of `self` and `cidr_blocks` together dates back to e2709ba8 (Build VPC and ETCD cluster, 2017-02-21).

[1]: https://www.terraform.io/docs/providers/aws/r/security_group_rule.html
[2]: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_installer/151/pull-ci-origin-installer-e2e-aws/552/build-log.txt