### PR TITLE
modules/dns/route53: Tag the tectonic zone

### DIFF
--- a/modules/dns/route53/tectonic.tf
+++ b/modules/dns/route53/tectonic.tf
@@ -5,6 +5,10 @@ locals {
 
 data "aws_route53_zone" "tectonic" {
   name = "${var.base_domain}"
+
+  tags = "${merge(map(
+      "tectonicClusterID", "${var.cluster_id}"
+    ), var.extra_tags)}"
 }
 
 locals {


### PR DESCRIPTION
We've been tagging our internal zone since 75fb49a8 (coreos/tectonic-installer#465).  Tagging this resource makes it easier to cleanup resource leaks, because the resource is more obviously associated with the given cluster (and you can use `extra_tags` to set `expirationDate`, etc.).