### PR TITLE
steps: Assign master and etcd security groups to both node classes

### DIFF
--- a/steps/etcd/aws/etcd.tf
+++ b/steps/etcd/aws/etcd.tf
@@ -63,7 +63,7 @@ module "etcd" {
   root_volume_size        = "${var.tectonic_aws_etcd_root_volume_size}"
   root_volume_type        = "${var.tectonic_aws_etcd_root_volume_type}"
   s3_bucket               = "${local.s3_bucket}"
-  sg_ids                  = "${concat(var.tectonic_aws_etcd_extra_sg_ids, list(local.sg_id))}"
+  sg_ids                  = "${concat(var.tectonic_aws_etcd_extra_sg_ids, local.sg_ids)}"
   subnets                 = ["${local.subnet_ids_workers}"]
   etcd_iam_role           = "${var.tectonic_aws_etcd_iam_role_name}"
   ec2_ami                 = "${var.tectonic_aws_ec2_ami_override}"

--- a/steps/etcd/aws/inputs.tf
+++ b/steps/etcd/aws/inputs.tf
@@ -17,7 +17,7 @@ data "terraform_remote_state" "assets" {
 
 locals {
   ignition           = "${data.terraform_remote_state.assets.ignition_etcd}"
-  sg_id              = "${data.terraform_remote_state.topology.etcd_sg_id}"
+  sg_ids             = ["${data.terraform_remote_state.topology.etcd_sg_id}", "${data.terraform_remote_state.topology.master_sg_id}"]
   subnet_ids_workers = "${data.terraform_remote_state.topology.subnet_ids_workers}"
   s3_bucket          = "${data.terraform_remote_state.topology.s3_bucket}"
   private_zone_id    = "${var.tectonic_aws_external_private_zone != "" ? var.tectonic_aws_external_private_zone : data.terraform_remote_state.topology.private_zone_id}"

--- a/steps/masters/aws/inputs.tf
+++ b/steps/masters/aws/inputs.tf
@@ -9,5 +9,5 @@ data "terraform_remote_state" "topology" {
 locals {
   subnet_ids = "${data.terraform_remote_state.topology.subnet_ids_masters}"
   aws_lbs    = "${data.terraform_remote_state.topology.aws_lbs}"
-  sg_id      = "${data.terraform_remote_state.topology.master_sg_id}"
+  sg_ids     = ["${data.terraform_remote_state.topology.master_sg_id}", "${data.terraform_remote_state.topology.etcd_sg_id}"]
 }

--- a/steps/masters/aws/main.tf
+++ b/steps/masters/aws/main.tf
@@ -36,7 +36,7 @@ module "masters" {
   extra_tags                   = "${var.tectonic_aws_extra_tags}"
   instance_count               = "${var.tectonic_bootstrap == "true" ? 1 : var.tectonic_master_count}"
   master_iam_role              = "${var.tectonic_aws_master_iam_role_name}"
-  master_sg_ids                = "${concat(var.tectonic_aws_master_extra_sg_ids, list(local.sg_id))}"
+  master_sg_ids                = "${concat(var.tectonic_aws_master_extra_sg_ids, local.sg_ids)}"
   private_endpoints            = "${local.private_endpoints}"
   public_endpoints             = "${local.public_endpoints}"
   region                       = "${var.tectonic_aws_region}"


### PR DESCRIPTION
This reduces isolation between the master and etcd nodes, and grants the etcd nodes more access to workers than they had before.  But we're going to move etcd onto the master nodes soon, which will have the same effect.  Hopefully this relaxed isolation helps us avoid:

```
$ curl -s https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_installer/150/pull-ci-origin-installer-e2e-aws/546/build-log.txt | grep Ginkgo
  |  Ginkgo timed out waiting for all parallel nodes to report back!  |
Ginkgo ran 1 suite in 10m6.626061944s
```