### PR TITLE
tests/run: Set aws.extraTags.expirationDate

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -41,7 +41,9 @@ cd tectonic-dev
 
 echo -e "\\e[36m Creating Tectonic configuration...\\e[0m"
 python <<-EOF >"${CLUSTER_NAME}.yaml"
+	import datetime
 	import sys
+
 	import yaml
 
 	with open('examples/tectonic.aws.yaml') as f:
@@ -53,6 +55,11 @@ python <<-EOF >"${CLUSTER_NAME}.yaml"
 	config['aws']['region'] = '${AWS_REGION}'
 	config['aws']['master']['iamRoleName'] = 'tf-tectonic-master-node'
 	config['aws']['worker']['iamRoleName'] = 'tf-tectonic-worker-node'
+	config['aws']['extraTags'] = {
+	    'expirationDate': (
+	        datetime.datetime.utcnow() + datetime.timedelta(hours=4)
+	    ).strftime('%Y-%m-%dT%H:%M+0000'),
+	}
 	yaml.safe_dump(config, sys.stdout)
 	EOF
 


### PR DESCRIPTION
For four hours in the future.  Successful runs are [currently taking around 30 minutes][1], so this gives us a reasonable buffer without leaving leaked resources around forever.

Adding an explicit `+0000` offset makes it obvious that the times are in UTC (even for folks viewing the tag without knowledge of the generating script).  And it matches what we're doing for the e2e-aws tests since openshift/release@f64b8eaf (openshift/release#1103).

The empty line between the sys and yaml imports conforms to [PEP 8][2]'s:

> Imports should be grouped in the following order:
>
> 1. Standard library imports.
> 2. Related third party imports.
> 3. Local application/library specific imports.
>
> You should put a blank line between each group of imports.

[1]: https://jenkins-tectonic-installer.prod.coreos.systems/job/openshift-installer/view/change-requests/job/PR-166/
[2]: https://www.python.org/dev/peps/pep-0008/#imports