### PR TITLE
tests/run: Drop jq from get-caller-identity

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -63,7 +63,7 @@ tectonic init --config="${CLUSTER_NAME}".yaml
 echo -e "\\e[36m Setting up AWS credentials...\\e[0m"
 export AWS_DEFAULT_REGION="${AWS_REGION}"
 unset AWS_SESSION_TOKEN
-ACCOUNT_ID=$(aws sts get-caller-identity | jq --raw-output '.Account')
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/tf-tectonic-installer"
 RES=$(aws sts assume-role --role-arn="${ROLE_ARN}" --role-session-name="jenkins-${CLUSTER_NAME}")
 export AWS_SECRET_ACCESS_KEY=$(echo "${RES}" | jq --raw-output '.Credentials.SecretAccessKey')


### PR DESCRIPTION
And use [JMESPath][1] to get Amazon to extract the account property for us.

[1]: http://jmespath.org/