### PR TITLE
hack/go-fmt: Make it easy to auto-format Go

### DIFF
--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Example: ./hack/go-lint.sh installer/... tests/smoke
+
+if [ "$IS_CONTAINER" != "" ]; then
+  for TARGET in "${@}"; do
+    find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec gofmt -s -w {} \+
+  done
+  git diff --exit-code
+else
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
+    --workdir /go/src/github.com/openshift/installer \
+    --entrypoint sh \
+    quay.io/coreos/golang-testing \
+    ./hack/go-fmt.sh "${@}"
+fi


### PR DESCRIPTION
So users and CI tooling can keep our Go clean :).

The `find` call avoids formatting `.build/*` (Bazel output) and `vendor/*` (controlled upstream), because [`gofmt` has no special `vendor/` handling built in][1].

Formatting our Go and then using `git diff` to show the changes (and error if there were any) makes it easy for:

* CI to see if there were issues (because of the exit code).
* Users to see the required changes in the CI logs (because of the output diff).

[1]: https://github.com/golang/go/issues/22173#issuecomment-338782431