### PR TITLE
hack: Add :z to --volume mounts

### DIFF
--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -4,9 +4,11 @@
 if [ "$IS_CONTAINER" != "" ]; then
   golint -set_exit_status "${@}"
 else
-  docker run --rm --env IS_CONTAINER='TRUE' \
-    -v "$PWD":/go/src/github.com/openshift/installer \
-    -w /go/src/github.com/openshift/installer \
-    --entrypoint sh quay.io/coreos/golang-testing \
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
+    --workdir /go/src/github.com/openshift/installer \
+    --entrypoint sh \
+    quay.io/coreos/golang-testing \
     ./hack/go-lint.sh "${@}"
 fi

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -2,5 +2,10 @@
 if [ "$IS_CONTAINER" != "" ]; then
   go vet "${@}"
 else
-  docker run --rm --env IS_CONTAINER='TRUE' -v "$PWD":/go/src/github.com/openshift/installer -w /go/src/github.com/openshift/installer quay.io/coreos/golang-testing ./hack/go-vet.sh "${@}"
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
+    --workdir /go/src/github.com/openshift/installer \
+    quay.io/coreos/golang-testing \
+    ./hack/go-vet.sh "${@}"
 fi;

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -6,5 +6,10 @@ if [ "$IS_CONTAINER" != "" ]; then
     -o -path "${TOP_DIR}/.build" -prune \
     -o -type f -name '*.sh' -exec shellcheck --format=gcc {} \+
 else
-  docker run -e IS_CONTAINER='TRUE' --rm -v "$(pwd)":/workdir:ro --entrypoint sh quay.io/coreos/shellcheck-alpine:v0.5.0 /workdir/hack/shellcheck.sh /workdir;
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:ro,z" \
+    --entrypoint sh \
+    quay.io/coreos/shellcheck-alpine:v0.5.0 \
+    /workdir/hack/shellcheck.sh /workdir
 fi;

--- a/hack/test-bazel-build-tarball.sh
+++ b/hack/test-bazel-build-tarball.sh
@@ -6,7 +6,6 @@ else
   docker run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:${PWD}:z" \
-    --volume /tmp:/tmp:z \
     --workdir "${PWD}" \
     quay.io/coreos/tectonic-builder:bazel-v0.3 \
     ./hack/test-bazel-build-tarball.sh

--- a/hack/test-bazel-build-tarball.sh
+++ b/hack/test-bazel-build-tarball.sh
@@ -3,5 +3,11 @@ if [ "$IS_CONTAINER" != "" ]; then
   set -x
   bazel --output_base=/tmp build "$@" tarball
 else
-  docker run -e IS_CONTAINER='TRUE' --rm -v "$PWD":"$PWD" -v /tmp:/tmp:rw -w "$PWD" quay.io/coreos/tectonic-builder:bazel-v0.3 ./hack/test-bazel-build-tarball.sh
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:${PWD}:z" \
+    --volume /tmp:/tmp:z \
+    --workdir "${PWD}" \
+    quay.io/coreos/tectonic-builder:bazel-v0.3 \
+    ./hack/test-bazel-build-tarball.sh
 fi

--- a/hack/tf-fmt.sh
+++ b/hack/tf-fmt.sh
@@ -8,7 +8,6 @@ else
   docker run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:${PWD}:ro,z" \
-    --volume /tmp:/tmp:z \
     --workdir "${PWD}" \
     quay.io/coreos/terraform-alpine:v0.11.7 \
     ./hack/tf-fmt.sh

--- a/hack/tf-fmt.sh
+++ b/hack/tf-fmt.sh
@@ -5,5 +5,11 @@ if [ "$IS_CONTAINER" != "" ]; then
   set -x
   /terraform fmt -list -check -write=false
 else
-  docker run -e IS_CONTAINER='TRUE' --rm -v "$PWD":"$PWD":ro -v /tmp:/tmp:rw -w "$PWD" quay.io/coreos/terraform-alpine:v0.11.7 ./hack/tf-fmt.sh
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:${PWD}:ro,z" \
+    --volume /tmp:/tmp:z \
+    --workdir "${PWD}" \
+    quay.io/coreos/terraform-alpine:v0.11.7 \
+    ./hack/tf-fmt.sh
 fi

--- a/hack/tf-lint.sh
+++ b/hack/tf-lint.sh
@@ -2,5 +2,10 @@
 if [ "$IS_CONTAINER" != "" ]; then
   tflint
 else
-  docker run -t --rm -v "$(pwd)":/data --env IS_CONTAINER='TRUE' --entrypoint sh quay.io/coreos/tflint ./hack/tf-lint.sh
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/data:z" \
+    --entrypoint sh \
+    quay.io/coreos/tflint \
+    ./hack/tf-lint.sh
 fi;

--- a/hack/yaml-lint.sh
+++ b/hack/yaml-lint.sh
@@ -2,5 +2,10 @@
 if [ "$IS_CONTAINER" != "" ]; then
   yamllint --config-data "{extends: default, rules: {line-length: {level: warning, max: 120}}}" ./examples/ ./installer/
 else
-  docker run -t --rm -v "$(pwd)":/workdir --env IS_CONTAINER='TRUE' --entrypoint sh quay.io/coreos/yamllint ./hack/yaml-lint.sh
+  docker run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/workdir:z" \
+    --entrypoint sh \
+    quay.io/coreos/yamllint \
+    ./hack/yaml-lint.sh
 fi;


### PR DESCRIPTION
Like we did in bootkube.sh in 0fa4eb13 (#134).  This gives us permission to access the mounted volume when SELinux is enabled (docs [here][1]).

I've also normalized these invocations for consistency between the various `hack/` scripts:

* Adding slash separators to put each option on its own line, excepting the final command being run in the container.  This makes the long commands slightly easier to skim.  It will also make it easier to track down motivation for an option with `git blame`, because commits touching options on other lines won't clutter the blame.

* Use long-form options (`-v` -> `--volume`, etc.).  This makes the options a bit more accessible to newcomers, and now that each option is on it's own line we have plenty of space.

* Dropped single quotes from `'TRUE'`.  There are no shell-sensitive characters in `TRUE`, so there's no need to quote it.

* Use `${PWD}` consistently.  [It's in POSIX][2], so there's no need to execute a `pwd` process to get this value.

* Drop `-t`.  None of these commands should need a pseudoterminal.

* Drop explicit `rw` `--volume` options.  They're [the default][3].

[1]: https://github.com/containers/libpod/blame/v0.8.3/docs/podman-run.1.md#L628
[2]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_03
[3]: https://github.com/containers/libpod/blame/v0.8.3/docs/podman-run.1.md#L646