### PR TITLE
Update core operators with changes for route image and default config

### DIFF
--- a/config.tf
+++ b/config.tf
@@ -59,18 +59,18 @@ variable "tectonic_container_images" {
   default = {
     addon_resizer                        = "gcr.io/google_containers/addon-resizer:2.1"
     bootkube                             = "quay.io/coreos/bootkube:v0.10.0"
-    tnc_operator                         = "quay.io/coreos/tectonic-node-controller-operator-dev:3cc48802d92c3f694fbbe78ded1018e976d12871"
+    tnc_operator                         = "quay.io/coreos/tectonic-node-controller-operator-dev:c56e9aa2ea01bb7bf638e56c5c43f1ae6740b23a"
     etcd_cert_signer                     = "quay.io/coreos/kube-etcd-signer-server:678cc8e6841e2121ebfdb6e2db568fce290b67d6"
     etcd                                 = "quay.io/coreos/etcd:v3.2.14"
     hyperkube                            = "openshift/origin-node:latest"
-    kube_core_renderer                   = "quay.io/coreos/kube-core-renderer-dev:3cc48802d92c3f694fbbe78ded1018e976d12871"
-    kube_core_operator                   = "quay.io/coreos/kube-core-operator-dev:3cc48802d92c3f694fbbe78ded1018e976d12871"
-    tectonic_channel_operator            = "quay.io/coreos/tectonic-channel-operator-dev:3cc48802d92c3f694fbbe78ded1018e976d12871"
-    kube_addon_operator                  = "quay.io/coreos/kube-addon-operator-dev:3cc48802d92c3f694fbbe78ded1018e976d12871"
+    kube_core_renderer                   = "quay.io/coreos/kube-core-renderer-dev:c56e9aa2ea01bb7bf638e56c5c43f1ae6740b23a"
+    kube_core_operator                   = "quay.io/coreos/kube-core-operator-dev:c56e9aa2ea01bb7bf638e56c5c43f1ae6740b23a"
+    tectonic_channel_operator            = "quay.io/coreos/tectonic-channel-operator-dev:c56e9aa2ea01bb7bf638e56c5c43f1ae6740b23a"
+    kube_addon_operator                  = "quay.io/coreos/kube-addon-operator-dev:c56e9aa2ea01bb7bf638e56c5c43f1ae6740b23a"
     tectonic_alm_operator                = "quay.io/coreos/tectonic-alm-operator:v0.3.1"
-    tectonic_ingress_controller_operator = "quay.io/coreos/tectonic-ingress-controller-operator-dev:3cc48802d92c3f694fbbe78ded1018e976d12871"
-    tectonic_utility_operator            = "quay.io/coreos/tectonic-utility-operator-dev:3cc48802d92c3f694fbbe78ded1018e976d12871"
-    tectonic_network_operator            = "quay.io/coreos/tectonic-network-operator-dev:3cc48802d92c3f694fbbe78ded1018e976d12871"
+    tectonic_ingress_controller_operator = "quay.io/coreos/tectonic-ingress-controller-operator-dev:c56e9aa2ea01bb7bf638e56c5c43f1ae6740b23a"
+    tectonic_utility_operator            = "quay.io/coreos/tectonic-utility-operator-dev:c56e9aa2ea01bb7bf638e56c5c43f1ae6740b23a"
+    tectonic_network_operator            = "quay.io/coreos/tectonic-network-operator-dev:c56e9aa2ea01bb7bf638e56c5c43f1ae6740b23a"
   }
 }
 


### PR DESCRIPTION
Helps fix a few more tests around images (we don't restrict allowed
registries anymore) and uses a newer router image with fixes from 3.11