### PR TITLE
OWNERS_ALIASES: Define aliases for reviewers and approvers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 Before creating your PR, please make sure to add the appropriate GitHub label; i.e. `run-smoke-tests`. For more details see
 [tests/README.md](../tests/README.md).
 
-(In case you don't have permissions to add labels, please ask a [maintainer](../OWNERS).)
+(In case you don't have permissions to add labels, please ask [a](../OWNERS) [maintainer](../OWNERS_ALIASES).)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ For contributors who want to work up pull requests, the workflow is roughly:
     ```
     Note that a portion of the docs and examples are generated and that the generated files are to be committed by you. `make structure-check` checks that what is generated is what you must commit.
 7. Submit a pull request to the original repository.
-8. The [repo owners](OWNERS) will respond to your issue promptly, following [the ususal Prow workflow][prow-review].
+8. The [repo](OWNERS) [owners](OWNERS_ALIASES) will respond to your issue promptly, following [the ususal Prow workflow][prow-review].
 
 Thanks for your contributions!
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,7 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
 
 approvers:
-  - aaronlevy
-  - abhinavdahiya
-  - crawford
-  - smarterclayton
-  - wking
-  - yifan-gu
+  - installer-approvers
 reviewers:
-  - vikramsk
+  - installer-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,12 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+
+aliases:
+  installer-approvers:
+    - aaronlevy
+    - abhinavdahiya
+    - crawford
+    - smarterclayton
+    - wking
+    - yifan-gu
+  installer-reviewers:
+    - vikramsk

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,7 +25,7 @@ In addition to our basic set of tests we have smoke tests which are running on A
 ### FAQ
 - *I am not able to add labels, what should I do?*
 
-  Please ask one of [the repository maintainers](../OWNERS) to add the
+  Please ask one of the [repository](../OWNERS) [maintainers](../OWNERS_ALIASES) to add the
   labels.
 
 - *How do I retrigger the tests?*


### PR DESCRIPTION
This will make it easier to add special-case `OWNERS` files to openshift/release while still getting the members slurped up with the `populate-owners.py` script from openshift/release#1285.

/hold

We can't merge this until openshift/release#1285 lands, because then the `OWNERS` file would be copied into the release repo, but the `OWNERS_ALIASES` needed to correctly unpack the aliases would not.