### PR TITLE
hack: Run Go tools over ./...

### DIFF
--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
-# Example: ./hack/go-lint.sh installer/... tests/smoke
-
 if [ "$IS_CONTAINER" != "" ]; then
   for TARGET in "${@}"; do
     find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec gofmt -s -w {} \+

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Example:  ./hack/go-lint.sh installer/... tests/smoke
+# Example:  ./hack/go-lint.sh installer/... pkg/... tests/smoke
 
 if [ "$IS_CONTAINER" != "" ]; then
   golint -set_exit_status "${@}"

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -1,18 +1,6 @@
 #!/bin/sh
 if [ "$IS_CONTAINER" != "" ]; then
-  cd ..
-  SOURCE_DIR="$(pwd)"
-  cd .. || exit
-  ROOT_DIR="$(pwd)"
-  TARGET_DIR="${ROOT_DIR}/openshift"
-  if [ "$SOURCE_DIR" != "$TARGET_DIR" ]; then
-    mv "$SOURCE_DIR" "$TARGET_DIR"
-  fi;
-  cd "${TARGET_DIR}/installer/" || exit
-  go vet "$1"
+  go vet "${@}"
 else
-  for dir in "$@"
-  do
-    docker run --rm --env IS_CONTAINER='TRUE' -v "$PWD":/go/src/github.com/openshift/installer -w /go/src/github.com/openshift/installer quay.io/coreos/golang-testing ./hack/go-vet.sh "$dir"
-  done;
+  docker run --rm --env IS_CONTAINER='TRUE' -v "$PWD":/go/src/github.com/openshift/installer -w /go/src/github.com/openshift/installer quay.io/coreos/golang-testing ./hack/go-vet.sh "${@}"
 fi;


### PR DESCRIPTION
Catching up with the new directories from #120.

* Drop the go-lint comment from `go-fmt.sh`.  I'd accidentally copy/pasted this over in 87b3e170 (hack/go-fmt: Make it easy to auto-format Go, 2018-08-24, #173).
* Suggest users run go-lint over `pkg/...` as well.
* Simplify the `go vet` invocation.  The code I'm removing is from eb71c8de (#110).  The Travis config it replaced was removed in #123, but was just running:

  ```sh
  go vet ./installer/...
  ```

  inside the container.  So I don't think we need the directory changing or moving here.  And we should certainly be able to cover the test from a single container, instead of launch a new container for each requested directory (at least as long as the requested directories are under `$PWD`, and the old script required that anyway).