### PR TITLE
.github/ISSUE_TEMPLATE: Update platform choices (drop azure, etc.)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,7 +23,7 @@ If you are not running the latest version of Terraform, please try upgrading bec
 ```
 enter text here
 ```
-### Platform (aws|azure|openstack|metal|vmware):
+### Platform (aws|libvirt):
 
 ```
 enter text here


### PR DESCRIPTION
Backend support for these was removed in bdef6ddc (coreos/tectonic-installer#3278).