### PR TITLE
*: Replace '$(pwd)' with '${PWD}'

### DIFF
--- a/Documentation/dev/libvirt-howto.md
+++ b/Documentation/dev/libvirt-howto.md
@@ -103,7 +103,7 @@ bazel build tarball
 ```sh
 tar -zxf bazel-bin/tectonic-dev.tar.gz
 cd tectonic-dev
-export PATH=$(pwd)/installer:$PATH
+export PATH="${PWD}/installer:${PATH}"
 ```
 
 Initialize (the environment variables are a convenience):
@@ -139,7 +139,7 @@ You'll have to wait for etcd to reach quorum before this makes any progress.
 ## Inspect the cluster with kubectl
 You'll need a kubectl binary on your path.
 ```sh
-export KUBECONFIG=$(pwd)/$CLUSTER_NAME/generated/auth/kubeconfig
+export KUBECONFIG="${PWD}/${CLUSTER_NAME}/generated/auth/kubeconfig"
 kubectl get -n tectonic-system pods
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ These instructions can be used for AWS:
 
 4. Add binaries to $PATH
     ```sh
-    export PATH=$(pwd)/installer:$PATH
+    export PATH="${PWD}/installer:${PATH}"
     ```
 
 5. Edit Tectonic configuration file including the $CLUSTER_NAME

--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -5,7 +5,7 @@ echo "Rendering Kubernetes core manifests..."
 
 # shellcheck disable=SC2154
 /usr/bin/docker run \
-    --volume "$(pwd)":/assets:z \
+    --volume "$PWD:/assets:z" \
     --volume /etc/kubernetes:/etc/kubernetes:z \
     "${kube_core_renderer_image}" \
     --config=/assets/kco-config.yaml \
@@ -16,15 +16,15 @@ echo "Rendering TNC manifests..."
 # shellcheck disable=SC2154
 /usr/bin/docker run \
     --user 0 \
-    --volume "$(pwd)":/assets:z \
+    --volume "$PWD:/assets:z" \
     "${tnc_operator_image}" \
     --config=/assets/tnco-config.yaml \
     --render-bootstrap=true \
     --render-output=/assets/tnc-bootstrap
 
 mkdir -p /etc/kubernetes/manifests/
-cp "$(pwd)/tnc-bootstrap/tectonic-node-controller-pod.yaml" /etc/kubernetes/manifests/
-cp "$(pwd)/tnc-bootstrap/tectonic-node-controller-config.yaml" /etc/kubernetes/tnc-config
+cp "$PWD/tnc-bootstrap/tectonic-node-controller-pod.yaml" /etc/kubernetes/manifests/
+cp "$PWD/tnc-bootstrap/tectonic-node-controller-config.yaml" /etc/kubernetes/tnc-config
 
 # We originally wanted to run the etcd cert signer as
 # a static pod, but kubelet could't remove static pod
@@ -90,13 +90,13 @@ echo "etcd cluster up. Killing etcd certificate signer..."
 /usr/bin/docker kill $${signer_id}
 rm /etc/kubernetes/manifests/tectonic-node-controller-pod.yaml
 
-cp -r "$(pwd)/bootstrap-configs" /etc/kubernetes/bootstrap-configs
+cp -r "$PWD/bootstrap-configs" /etc/kubernetes/bootstrap-configs
 
 echo "Starting bootkube..."
 
 # shellcheck disable=SC2154
 /usr/bin/docker run \
-    --volume "$(pwd)":/assets:z \
+    --volume "$PWD:/assets:z" \
     --volume /etc/kubernetes:/etc/kubernetes:z \
     --network=host \
     --entrypoint=/bootkube \

--- a/modules/tectonic/resources/tectonic-wrapper.sh
+++ b/modules/tectonic/resources/tectonic-wrapper.sh
@@ -3,7 +3,7 @@ set -e
 
 # shellcheck disable=SC2086,SC2154
 /usr/bin/docker run \
-    --volume "$(pwd)":/assets \
+    --volume "$PWD:/assets" \
     --network=host \
     --entrypoint=/bin/sh \
     ${hyperkube_image} \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -36,7 +36,7 @@ bazel build tarball smoke_tests
 echo -e "\\e[36m Unpacking artifacts...\\e[0m"
 tar -zxf bazel-bin/tectonic-dev.tar.gz
 cp bazel-bin/tests/smoke/linux_amd64_stripped/go_default_test tectonic-dev/smoke
-export PATH="$(pwd)/tectonic-dev/installer:${PATH}"
+export PATH="${PWD}/tectonic-dev/installer:${PATH}"
 cd tectonic-dev
 
 echo -e "\\e[36m Creating Tectonic configuration...\\e[0m"
@@ -87,8 +87,8 @@ export TF_VAR_tectonic_admin_ssh_key="$(cat ~/.ssh/id_rsa.pub)"
 echo -e "\\e[36m Deploying Tectonic...\\e[0m"
 tectonic install --dir="${CLUSTER_NAME}"
 echo -e "\\e[36m Running smoke test...\\e[0m"
-export SMOKE_KUBECONFIG="$(pwd)/$CLUSTER_NAME/generated/auth/kubeconfig"
+export SMOKE_KUBECONFIG="${PWD}/${CLUSTER_NAME}/generated/auth/kubeconfig"
 export SMOKE_NODE_COUNT="5"  # Sum of all nodes (master + worker)
-export SMOKE_MANIFEST_PATHS="$(pwd)/$CLUSTER_NAME/generated"
+export SMOKE_MANIFEST_PATHS="${PWD}/${CLUSTER_NAME}/generated"
 exec 5>&1
 SMOKE_TEST_OUTPUT=$(./smoke -test.v --cluster | tee >(cat - >&5))


### PR DESCRIPTION
`PWD` is [in POSIX][1], so there's no need to execute a `pwd` process to get this value.  This fixes everthing found by:

```console
$ git grep '\(pwd\)'
```

except for `hack/*.sh`, which is being addressed by #174.

[1]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08_03