### PR TITLE
modules/aws/vpc/vpc-public: Tag NAT gateways

### DIFF
--- a/modules/aws/vpc/vpc-public.tf
+++ b/modules/aws/vpc/vpc-public.tf
@@ -75,4 +75,8 @@ resource "aws_nat_gateway" "nat_gw" {
   count         = "${min(local.new_master_az_count,local.new_worker_az_count)}"
   allocation_id = "${aws_eip.nat_eip.*.id[count.index]}"
   subnet_id     = "${aws_subnet.master_subnet.*.id[count.index]}"
+
+  tags = "${merge(map(
+      "tectonicClusterID", "${var.cluster_id}"
+    ), var.extra_tags)}"
 }


### PR DESCRIPTION
This resource landed without tags in 3616172c (2017-02-28).  We grew more tagging in this file in coreos/tectonic-installer#776 and #78, but hadn't got the NAT gateways tagged yet.

Docs for `aws_nat_gateway`'s `tags` property are [here][1].

Reported by @joelddiaz.  He also reported a lack of tags on network interfaces, but we don't seem to create those directly:

```console
$ git grep -h 'resource "aws_' | sed 's/^\([^"]*"[^"]*"\).*/\1/'  | sort | uniq
resource "aws_eip"
resource "aws_elb"
resource "aws_elb_attachment"
resource "aws_iam_instance_profile"
resource "aws_iam_role"
resource "aws_iam_role_policy"
resource "aws_instance"
resource "aws_internet_gateway"
resource "aws_main_route_table_association"
resource "aws_nat_gateway"
resource "aws_route"
resource "aws_route53_record"
resource "aws_route53_zone"
resource "aws_route_table"
resource "aws_route_table_association"
resource "aws_s3_bucket"
resource "aws_s3_bucket_object"
resource "aws_security_group"
resource "aws_security_group_rule"
resource "aws_subnet"
resource "aws_vpc"
```

[1]: https://www.terraform.io/docs/providers/aws/r/nat_gateway.html#tags