### PR TITLE
asset: Only persistent data to disk for targetable assets and tests refactor

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -37,8 +37,14 @@ func main() {
 	log.SetLevel(l)
 
 	assetStore := &asset.StoreImpl{}
-	if _, err := assetStore.Fetch(targetAsset); err != nil {
+	st, err := assetStore.Fetch(targetAsset)
+	if err != nil {
 		log.Fatalf("failed to generate asset: %v", err)
+		os.Exit(1)
+	}
+
+	if err := st.PersistToFile(); err != nil {
+		log.Fatalf("failed to write target to disk: %v", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -84,18 +84,14 @@ func (a *installConfig) Generate(dependencies map[asset.Asset]*asset.State) (*as
 		return nil, err
 	}
 
-	state := &asset.State{
+	return &asset.State{
 		Contents: []asset.Content{
 			{
 				Name: filepath.Join(a.directory, "install-config.yml"),
 				Data: data,
 			},
 		},
-	}
-
-	state.PersistToFile()
-
-	return state, nil
+	}, nil
 }
 
 // GetInstallConfig returns the *types.InstallConfig from the parent asset map.

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -158,8 +158,6 @@ func TestInstallConfigGenerate(t *testing.T) {
 			filename := filepath.Join(dir, "install-config.yml")
 			assert.Equal(t, 1, len(state.Contents), "unexpected number of contents in asset state")
 			assert.Equal(t, filename, state.Contents[0].Name, "unexpected filename in asset state")
-			data, err := ioutil.ReadFile(filename)
-			assert.NoError(t, err, "unexpected error reading install-config.yml file")
 
 			exp := fmt.Sprintf(`admin:
   email: test-email
@@ -185,7 +183,7 @@ platform:
 pullSecret: test-pull-secret
 `, tc.expectedPlatformYaml)
 
-			assert.Equal(t, exp, string(data), "unexpected data in install-config.yml")
+			assert.Equal(t, exp, string(state.Contents[0].Data), "unexpected data in install-config.yml")
 		})
 	}
 }

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -104,7 +104,7 @@ func (k *Kubeconfig) Generate(parents map[asset.Asset]*asset.State) (*asset.Stat
 		return nil, err
 	}
 
-	st := &asset.State{
+	return &asset.State{
 		Contents: []asset.Content{
 			{
 				// E.g. generated/auth/kubeconfig-admin.
@@ -112,11 +112,5 @@ func (k *Kubeconfig) Generate(parents map[asset.Asset]*asset.State) (*asset.Stat
 				Data: data,
 			},
 		},
-	}
-
-	if err := st.PersistToFile(); err != nil {
-		return nil, err
-	}
-
-	return st, nil
+	}, nil
 }

--- a/pkg/asset/kubeconfig/kubeconfig_test.go
+++ b/pkg/asset/kubeconfig/kubeconfig_test.go
@@ -1,7 +1,6 @@
 package kubeconfig
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -213,17 +212,7 @@ users:
 		}
 
 		filename := filepath.Join(testDir, "auth", fmt.Sprintf("kubeconfig-%s", tt.userName))
-		data, err := ioutil.ReadFile(filename)
-		if err != nil {
-			t.Errorf("test #%d failed to read kubeconfig %q: %v", i, filename, err)
-		}
-
-		if !bytes.Equal(st.Contents[0].Data, data) {
-			t.Errorf("test #%d expect kubeconfig data: %q, saw %q", i, string(st.Contents[0].Data), string(data))
-		}
-
-		if !bytes.Equal(tt.expectedData, data) {
-			t.Errorf("test #%d expect kubeconfig data: %q, saw %q", i, string(tt.expectedData), string(data))
-		}
+		assert.Equal(t, filename, st.Contents[0].Name, "unexpected filename")
+		assert.Equal(t, tt.expectedData, st.Contents[0].Data, "unexpected data in kubeconfig")
 	}
 }

--- a/pkg/asset/tls/certkey.go
+++ b/pkg/asset/tls/certkey.go
@@ -122,23 +122,18 @@ func (c *CertKey) Generate(parents map[asset.Asset]*asset.State) (*asset.State, 
 		certData = append(certData, []byte(CertToPem(caCert))...)
 	}
 
-	var st asset.State
-	st.Contents = []asset.Content{
-		{
-			Name: assetFilePath(c.rootDir, c.KeyFileName),
-			Data: keyData,
+	return &asset.State{
+		Contents: []asset.Content{
+			{
+				Name: assetFilePath(c.rootDir, c.KeyFileName),
+				Data: keyData,
+			},
+			{
+				Name: assetFilePath(c.rootDir, c.CertFileName),
+				Data: certData,
+			},
 		},
-		{
-			Name: assetFilePath(c.rootDir, c.CertFileName),
-			Data: certData,
-		},
-	}
-
-	if err := st.PersistToFile(); err != nil {
-		return nil, err
-	}
-
-	return &st, nil
+	}, nil
 }
 
 func parseCAFromAssetState(ca *asset.State) (*rsa.PrivateKey, *x509.Certificate, error) {

--- a/pkg/asset/tls/certkey_test.go
+++ b/pkg/asset/tls/certkey_test.go
@@ -64,12 +64,14 @@ func TestCertKeyGenerate(t *testing.T) {
 	}
 
 	tests := []struct {
-		certKey *CertKey
-		err     bool
-		parents map[asset.Asset]*asset.State
+		name      string
+		certKey   *CertKey
+		errString string
+		parents   map[asset.Asset]*asset.State
 	}{
 		{
-			&CertKey{
+			name: "simple ca",
+			certKey: &CertKey{
 				rootDir:       testDir,
 				installConfig: installConfig,
 				Subject:       pkix.Name{CommonName: "test0-ca", OrganizationalUnit: []string{"openshift"}},
@@ -80,13 +82,13 @@ func TestCertKeyGenerate(t *testing.T) {
 				IsCA:          true,
 				ParentCA:      root,
 			},
-			false,
-			map[asset.Asset]*asset.State{
+			parents: map[asset.Asset]*asset.State{
 				root: rootState,
 			},
 		},
 		{
-			&CertKey{
+			name: "more complicated ca",
+			certKey: &CertKey{
 				rootDir:        testDir,
 				installConfig:  installConfig,
 				Subject:        pkix.Name{CommonName: "test1-ca", OrganizationalUnit: []string{"openshift"}},
@@ -101,14 +103,14 @@ func TestCertKeyGenerate(t *testing.T) {
 				GenDNSNames:    testGenDNSNames,
 				GenIPAddresses: testGenIPAddresses,
 			},
-			false,
-			map[asset.Asset]*asset.State{
+			parents: map[asset.Asset]*asset.State{
 				root:          rootState,
 				installConfig: installConfigState,
 			},
 		},
 		{
-			&CertKey{
+			name: "can't find parents",
+			certKey: &CertKey{
 				rootDir:        testDir,
 				installConfig:  installConfig,
 				Subject:        pkix.Name{CommonName: "test1-ca", OrganizationalUnit: []string{"openshift"}},
@@ -123,49 +125,46 @@ func TestCertKeyGenerate(t *testing.T) {
 				GenDNSNames:    testGenDNSNames,
 				GenIPAddresses: testGenIPAddresses,
 			},
-			true,
-			nil,
+			errString: "failed to get install config state in the parent asset states",
+			parents:   nil,
 		},
 	}
 
-	for i, tt := range tests {
-		st, err := tt.certKey.Generate(tt.parents)
-		if tt.err != (err != nil) {
-			t.Errorf("test #%d error is not expected, expect %v, saw %v", i, tt.err, err != nil)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st, err := tt.certKey.Generate(tt.parents)
+			if err != nil {
+				assert.EqualErrorf(t, err, tt.errString, tt.name)
+				return
+			} else if tt.errString != "" {
+				t.Errorf("expect error %v, saw nil", err)
+			}
 
-		if err != nil {
-			continue
+			keyFileName := assetFilePath(testDir, tt.certKey.KeyFileName)
+			crtFileName := assetFilePath(testDir, tt.certKey.CertFileName)
 
-		}
+			assert.Equal(t, keyFileName, st.Contents[0].Name, "unexpected key file name")
+			assert.Equal(t, crtFileName, st.Contents[1].Name, "unexpected cert file name")
 
-		keyFileName := assetFilePath(testDir, tt.certKey.KeyFileName)
-		crtFileName := assetFilePath(testDir, tt.certKey.CertFileName)
+			// Briefly check the certs.
+			certPool := x509.NewCertPool()
+			if !certPool.AppendCertsFromPEM(st.Contents[1].Data) {
+				t.Error("failed to append certs from PEM")
+			}
 
-		assert.Equal(t, keyFileName, st.Contents[0].Name, "unexpected key file name")
-		assert.Equal(t, crtFileName, st.Contents[1].Name, "unexpected cert file name")
+			opts := x509.VerifyOptions{
+				Roots:   certPool,
+				DNSName: tt.certKey.Subject.CommonName,
+			}
+			if tt.certKey.GenDNSNames != nil {
+				opts.DNSName = "test.openshift.io"
+			}
 
-		// Briefly check the certs.
-		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM(st.Contents[1].Data) {
-			t.Errorf("test #%d failed to append certs from PEM", i)
-		}
+			cert, err := PemToCertificate(st.Contents[1].Data)
+			assert.NoError(t, err, tt.name)
 
-		opts := x509.VerifyOptions{
-			Roots:   certPool,
-			DNSName: tt.certKey.Subject.CommonName,
-		}
-		if tt.certKey.GenDNSNames != nil {
-			opts.DNSName = "test.openshift.io"
-		}
-
-		cert, err := PemToCertificate(st.Contents[1].Data)
-		if err != nil {
-			t.Errorf("test #%d failed to parse certificate: %v", i, err)
-		}
-
-		if _, err := cert.Verify(opts); err != nil {
-			t.Errorf("test #%d failed to verify cert: %v", i, err)
-		}
+			_, err = cert.Verify(opts)
+			assert.NoError(t, err, tt.name)
+		})
 	}
 }

--- a/pkg/asset/tls/keypair.go
+++ b/pkg/asset/tls/keypair.go
@@ -33,21 +33,16 @@ func (k *KeyPair) Generate(map[asset.Asset]*asset.State) (*asset.State, error) {
 		return nil, fmt.Errorf("failed to get public key data: %v", err)
 	}
 
-	var st asset.State
-	st.Contents = []asset.Content{
-		{
-			Name: assetFilePath(k.rootDir, k.PrivKeyFileName),
-			Data: []byte(PrivateKeyToPem(key)),
+	return &asset.State{
+		Contents: []asset.Content{
+			{
+				Name: assetFilePath(k.rootDir, k.PrivKeyFileName),
+				Data: []byte(PrivateKeyToPem(key)),
+			},
+			{
+				Name: assetFilePath(k.rootDir, k.PubKeyFileName),
+				Data: []byte(pubkeyData),
+			},
 		},
-		{
-			Name: assetFilePath(k.rootDir, k.PubKeyFileName),
-			Data: []byte(pubkeyData),
-		},
-	}
-
-	if err := st.PersistToFile(); err != nil {
-		return nil, err
-	}
-
-	return &st, nil
+	}, nil
 }

--- a/pkg/asset/tls/root.go
+++ b/pkg/asset/tls/root.go
@@ -35,21 +35,16 @@ func (c *RootCA) Generate(parents map[asset.Asset]*asset.State) (*asset.State, e
 		return nil, fmt.Errorf("failed to generate RootCA %v", err)
 	}
 
-	var st asset.State
-	st.Contents = []asset.Content{
-		{
-			Name: assetFilePath(c.rootDir, RootCAKeyName),
-			Data: []byte(PrivateKeyToPem(key)),
+	return &asset.State{
+		Contents: []asset.Content{
+			{
+				Name: assetFilePath(c.rootDir, RootCAKeyName),
+				Data: []byte(PrivateKeyToPem(key)),
+			},
+			{
+				Name: assetFilePath(c.rootDir, RootCACertName),
+				Data: []byte(CertToPem(crt)),
+			},
 		},
-		{
-			Name: assetFilePath(c.rootDir, RootCACertName),
-			Data: []byte(CertToPem(crt)),
-		},
-	}
-
-	if err := st.PersistToFile(); err != nil {
-		return nil, err
-	}
-
-	return &st, nil
+	}, nil
 }


### PR DESCRIPTION
- Only assets that will be fetched by the command line will be written to the disk.
- Use t.Run() for iterating test cases.
- Use assert package more.
