### PR TITLE
Revert "installer/pkg/config-generator/ignition: Ignore etcd node pools"

### DIFF
--- a/installer/pkg/config-generator/ignition.go
+++ b/installer/pkg/config-generator/ignition.go
@@ -27,7 +27,6 @@ func (c *ConfigGenerator) GenerateIgnConfig(clusterDir string) error {
 			masters = pool
 		case "worker":
 			workers = pool
-		case "etcd": // FIXME: ignore these until openshift/release stops defining them
 		default:
 			return fmt.Errorf("unrecognized role: %s", pool.Name)
 		}


### PR DESCRIPTION
This reverts commit ee97cc2d1521ee89399b6732e5bbbd35f7b32963.
