### PR TITLE
docs/dev/libvirt-howto: get GOPATH from go

### DIFF
--- a/Documentation/dev/libvirt-howto.md
+++ b/Documentation/dev/libvirt-howto.md
@@ -79,9 +79,7 @@ echo server=/tt.testing/192.168.124.1 | sudo tee /etc/NetworkManager/dnsmasq.d/t
 1. Make sure you have the `virsh` binary installed: `sudo dnf install libvirt-client libvirt-devel`
 2. Install the libvirt terraform provider:
 ```sh
-go get github.com/crawford/terraform-provider-libvirt
-mkdir -p ~/.terraform.d/plugins
-cp $GOPATH/bin/terraform-provider-libvirt ~/.terraform.d/plugins/
+GOBIN=~/.terraform.d/plugins go get github.com/crawford/terraform-provider-libvirt
 ```
 
 #### 1.9 Cache terrafrom plugins (optional, but makes subsequent runs a bit faster)


### PR DESCRIPTION
On some systems GOPATH might not be set. The go compiler can be used to emit the default location.
