### PR TITLE
.*: generate and embed Openshift's InstallConfig from Tectonic's Config

### DIFF
--- a/installer/pkg/config-generator/BUILD.bazel
+++ b/installer/pkg/config-generator/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//installer/pkg/config:go_default_library",
         "//installer/pkg/copy:go_default_library",
         "//pkg/asset/tls:go_default_library",
+        "//pkg/types:go_default_library",
         "//vendor/github.com/apparentlymart/go-cidr/cidr:go_default_library",
         "//vendor/github.com/coreos/ignition/config/v2_2:go_default_library",
         "//vendor/github.com/coreos/ignition/config/v2_2/types:go_default_library",

--- a/installer/pkg/config-generator/fixtures/kube-system.yaml
+++ b/installer/pkg/config-generator/fixtures/kube-system.yaml
@@ -1,5 +1,49 @@
 apiVersion: v1
 data:
+  install-config: |
+    admin:
+      email: test@coreos.com
+      password: asd123
+    baseDomain: cluster.com
+    clusterID: ""
+    machines:
+    - name: master
+      platformConfig:
+        aws:
+          iamRoleName: ""
+          rootVolume:
+            iops: 100
+            size: 30
+            type: gp2
+          type: t2.medium
+      replicas: 3
+    - name: worker
+      platformConfig:
+        aws:
+          iamRoleName: ""
+          rootVolume:
+            iops: 100
+            size: 30
+            type: gp2
+          type: t2.medium
+      replicas: 3
+    metadata:
+      creationTimestamp: null
+      name: test
+    networking:
+      podCIDR:
+        IP: 10.2.0.0
+        Mask: //8AAA==
+      serviceCIDR:
+        IP: 10.3.0.0
+        Mask: //8AAA==
+      type: canal
+    platform:
+      aws:
+        region: eu-west-1
+        vpcCIDRBlock: 10.0.0.0/16
+        vpcID: ""
+    pullSecret: '{"auths": {}}'
   kco-config: |
     apiVersion: v1
     authConfig:

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -3,13 +3,13 @@ package types
 // MachinePool is a pool of machines to be installed.
 type MachinePool struct {
 	// Name is the name of the machine pool.
-	Name string
+	Name string `json:"name"`
 
 	// Replicas is the count of machines for this machine pool.
 	// Default is 1.
 	Replicas *int64 `json:"replicas"`
 
-	// PlatformConfig is configuration for machine pool specfic to the platfrom.
+	// PlatformConfig is configuration for machine pool specific to the platfrom.
 	PlatformConfig MachinePoolPlatformConfig `json:"platformConfig"`
 }
 


### PR DESCRIPTION
embedding the Openshift's InstallConfig in clusters created by tectonic
installer binary allows operators to start building on their config discovery
logic.