### PR TITLE
libvirt: switch back to upstream terraform libvirt provider

### DIFF
--- a/Documentation/dev/libvirt-howto.md
+++ b/Documentation/dev/libvirt-howto.md
@@ -79,7 +79,7 @@ echo server=/tt.testing/192.168.124.1 | sudo tee /etc/NetworkManager/dnsmasq.d/t
 1. Make sure you have the `virsh` binary installed: `sudo dnf install libvirt-client libvirt-devel`
 2. Install the libvirt terraform provider:
 ```sh
-GOBIN=~/.terraform.d/plugins go get github.com/crawford/terraform-provider-libvirt
+GOBIN=~/.terraform.d/plugins go get -u github.com/dmacvicar/terraform-provider-libvirt
 ```
 
 #### 1.9 Cache terrafrom plugins (optional, but makes subsequent runs a bit faster)

--- a/examples/tectonic.libvirt.yaml
+++ b/examples/tectonic.libvirt.yaml
@@ -15,7 +15,6 @@ libvirt:
   network:
     name: tectonic
     ifName: tt0
-    dnsServer: 8.8.8.8
     ipRange: 192.168.124.0/24
   imagePath: /path/to/image
 

--- a/installer/pkg/config/cluster.go
+++ b/installer/pkg/config/cluster.go
@@ -60,8 +60,7 @@ var defaultCluster = Cluster{
 	},
 	Libvirt: libvirt.Libvirt{
 		Network: libvirt.Network{
-			DNSServer: libvirt.DefaultDNSServer,
-			IfName:    libvirt.DefaultIfName,
+			IfName: libvirt.DefaultIfName,
 		},
 	},
 	Networking: Networking{

--- a/installer/pkg/config/libvirt/libvirt.go
+++ b/installer/pkg/config/libvirt/libvirt.go
@@ -8,8 +8,6 @@ import (
 )
 
 const (
-	// DefaultDNSServer is the default DNS server for libvirt.
-	DefaultDNSServer = "8.8.8.8"
 	// DefaultIfName is the default interface name for libvirt.
 	DefaultIfName = "osbr0"
 )
@@ -26,10 +24,9 @@ type Libvirt struct {
 
 // Network describes a libvirt network configuration.
 type Network struct {
-	Name      string `json:"tectonic_libvirt_network_name,omitempty" yaml:"name"`
-	IfName    string `json:"tectonic_libvirt_network_if,omitempty" yaml:"ifName"`
-	DNSServer string `json:"tectonic_libvirt_resolver,omitempty" yaml:"dnsServer"`
-	IPRange   string `json:"tectonic_libvirt_ip_range,omitempty" yaml:"ipRange"`
+	Name    string `json:"tectonic_libvirt_network_name,omitempty" yaml:"name"`
+	IfName  string `json:"tectonic_libvirt_network_if,omitempty" yaml:"ifName"`
+	IPRange string `json:"tectonic_libvirt_ip_range,omitempty" yaml:"ipRange"`
 }
 
 // TFVars fills in computed Terraform variables.

--- a/installer/pkg/config/validate.go
+++ b/installer/pkg/config/validate.go
@@ -189,9 +189,6 @@ func (c *Cluster) validateLibvirt() []error {
 	if err := validate.PrefixError("libvirt network ifName", validate.NonEmpty(c.Libvirt.Network.IfName)); err != nil {
 		errs = append(errs, err)
 	}
-	if err := validate.PrefixError("libvirt network dnsServer", validate.IPv4(c.Libvirt.Network.DNSServer)); err != nil {
-		errs = append(errs, err)
-	}
 	errs = append(errs, c.validateOverlapWithPodOrServiceCIDR(c.Libvirt.Network.IPRange, "libvirt ipRange")...)
 	return errs
 }

--- a/installer/pkg/config/validate_test.go
+++ b/installer/pkg/config/validate_test.go
@@ -574,10 +574,9 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:      "tectonic",
-						IfName:    libvirt.DefaultIfName,
-						DNSServer: libvirt.DefaultDNSServer,
-						IPRange:   "10.0.1.0/24",
+						Name:    "tectonic",
+						IfName:  libvirt.DefaultIfName,
+						IPRange: "10.0.1.0/24",
 					},
 					QCOWImagePath: fInvalid.Name(),
 					URI:           "baz",
@@ -590,10 +589,9 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:      "tectonic",
-						IfName:    libvirt.DefaultIfName,
-						DNSServer: libvirt.DefaultDNSServer,
-						IPRange:   "10.0.1.0/24",
+						Name:    "tectonic",
+						IfName:  libvirt.DefaultIfName,
+						IPRange: "10.0.1.0/24",
 					},
 					QCOWImagePath: fValid.Name(),
 					URI:           "baz",
@@ -606,10 +604,9 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:      "tectonic",
-						IfName:    libvirt.DefaultIfName,
-						DNSServer: libvirt.DefaultDNSServer,
-						IPRange:   "10.2.1.0/24",
+						Name:    "tectonic",
+						IfName:  libvirt.DefaultIfName,
+						IPRange: "10.2.1.0/24",
 					},
 					QCOWImagePath: fValid.Name(),
 					URI:           "baz",
@@ -622,10 +619,9 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:      "tectonic",
-						IfName:    libvirt.DefaultIfName,
-						DNSServer: libvirt.DefaultDNSServer,
-						IPRange:   "x",
+						Name:    "tectonic",
+						IfName:  libvirt.DefaultIfName,
+						IPRange: "x",
 					},
 					QCOWImagePath: "foo",
 					URI:           "baz",
@@ -638,10 +634,9 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:      "tectonic",
-						IfName:    libvirt.DefaultIfName,
-						DNSServer: "foo",
-						IPRange:   "192.168.0.1/24",
+						Name:    "tectonic",
+						IfName:  libvirt.DefaultIfName,
+						IPRange: "192.168.0.1/24",
 					},
 					QCOWImagePath: "foo",
 					URI:           "baz",

--- a/installer/pkg/workflow/fixtures/terraform.tfvars
+++ b/installer/pkg/workflow/fixtures/terraform.tfvars
@@ -22,7 +22,6 @@
   ],
   "tectonic_ignition_worker": "worker.ign",
   "tectonic_libvirt_network_if": "osbr0",
-  "tectonic_libvirt_resolver": "8.8.8.8",
   "tectonic_master_count": 2,
   "tectonic_cluster_name": "aws-basic",
   "tectonic_networking": "canal",

--- a/steps/infra/libvirt/main.tf
+++ b/steps/infra/libvirt/main.tf
@@ -44,15 +44,15 @@ resource "libvirt_network" "tectonic_net" {
   ]
 
   dns = [{
-    local_only = true,
-  }]
+    local_only = true
 
-  dns_host = ["${flatten(list(
-    data.libvirt_network_dns_host_template.bootstrap.*.rendered,
-    data.libvirt_network_dns_host_template.masters.*.rendered,
-    data.libvirt_network_dns_host_template.etcds.*.rendered,
-    data.libvirt_network_dns_host_template.workers.*.rendered,
-  ))}"]
+    hosts = ["${flatten(list(
+      data.libvirt_network_dns_host_template.bootstrap.*.rendered,
+      data.libvirt_network_dns_host_template.masters.*.rendered,
+      data.libvirt_network_dns_host_template.etcds.*.rendered,
+      data.libvirt_network_dns_host_template.workers.*.rendered,
+    ))}"]
+  }]
 
   autostart = true
 }

--- a/steps/infra/libvirt/main.tf
+++ b/steps/infra/libvirt/main.tf
@@ -43,9 +43,9 @@ resource "libvirt_network" "tectonic_net" {
     "${var.tectonic_libvirt_ip_range}",
   ]
 
-  dns_forwarder {
-    address = "${var.tectonic_libvirt_resolver}"
-  }
+  dns = [{
+    local_only = true,
+  }]
 
   dns_host = ["${flatten(list(
     data.libvirt_network_dns_host_template.bootstrap.*.rendered,

--- a/steps/variables-libvirt.tf
+++ b/steps/variables-libvirt.tf
@@ -18,11 +18,6 @@ variable "tectonic_libvirt_ip_range" {
   description = "IP range for the libvirt machines"
 }
 
-variable "tectonic_libvirt_resolver" {
-  type        = "string"
-  description = "the upstream dns resolver"
-}
-
 variable "tectonic_coreos_qcow_path" {
   type        = "string"
   description = "path to a container linux qcow image"


### PR DESCRIPTION
Upstream merged something very similar to our forked changes. Use that.
Also remove the option to set DNS forwarders, we don't need it anymore with local_only=yes