### PR TITLE
Bump Terraform from 0.11.7 to 0.11.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 workspace(name = "installer")
 
-terrafom_version = "0.11.7"
+terrafom_version = "0.11.8"
 
 supported_platforms = [
     "linux",

--- a/hack/tf-fmt.sh
+++ b/hack/tf-fmt.sh
@@ -6,12 +6,12 @@ if [ "$IS_CONTAINER" != "" ]; then
     set -- -list -check -write=false
   fi
   set -x
-  /terraform fmt "${@}"
+  terraform fmt "${@}"
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:${PWD}:z" \
     --workdir "${PWD}" \
-    quay.io/coreos/terraform-alpine:v0.11.7 \
+    quay.io/coreos/terraform-alpine:v0.11.8 \
     ./hack/tf-fmt.sh
 fi

--- a/hack/tf-fmt.sh
+++ b/hack/tf-fmt.sh
@@ -6,7 +6,7 @@ if [ "$IS_CONTAINER" != "" ]; then
     set -- -list -check -write=false
   fi
   set -x
-  terraform fmt "${@}"
+  /terraform fmt "${@}"  # FIXME: drop this slash after we update openshift/release
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \

--- a/images/tectonic-installer/Dockerfile.ci
+++ b/images/tectonic-installer/Dockerfile.ci
@@ -4,7 +4,7 @@ FROM openshift/origin-release:golang-1.10 as build
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 ### Install Terraform
-ENV TERRAFORM_VERSION="0.11.1"
+ENV TERRAFORM_VERSION="0.11.8"
 ARG TERRAFORM_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 RUN go build -o ./installer/tectonic ./installer/cmd/tectonic && \


### PR DESCRIPTION
[0.11.8][2] was [cut on 2018-08-15][1].  We'll need to wait until @sallyom pushes a 0.11.8 version of [her image][3] before the `tf-fmt.sh` change works.

/hold

[1]: https://github.com/hashicorp/terraform/releases/tag/v0.11.8
[2]: https://releases.hashicorp.com/terraform/0.11.8/
[3]: https://github.com/sallyom/scripts-images/blob/0c71369b7cbddd9ac7f7f0c14c19156cc746359d/buildah-from-alpine/terraform-alpine.sh#L15