### PR TITLE
*: revert to older libvirt provider implementation

### DIFF
--- a/Documentation/design/installconfig.md
+++ b/Documentation/design/installconfig.md
@@ -128,6 +128,8 @@ type LibvirtNetwork struct {
     Name string `json:"name"`
     // IfName is the name of the network interface.
     IfName string `json:"if"`
+    // DNSServer is the name of the DNS server.
+    DNSServer string `json:"resolver"`
     // IPRange is the range of IPs to use.
     IPRange string `json:"ipRange"`
 }

--- a/Documentation/dev/libvirt-howto.md
+++ b/Documentation/dev/libvirt-howto.md
@@ -79,7 +79,7 @@ echo server=/tt.testing/192.168.124.1 | sudo tee /etc/NetworkManager/dnsmasq.d/t
 1. Make sure you have the `virsh` binary installed: `sudo dnf install libvirt-client libvirt-devel`
 2. Install the libvirt terraform provider:
 ```sh
-GOBIN=~/.terraform.d/plugins go get -u github.com/dmacvicar/terraform-provider-libvirt
+GOBIN=~/.terraform.d/plugins go get github.com/crawford/terraform-provider-libvirt
 ```
 
 #### 1.9 Cache terrafrom plugins (optional, but makes subsequent runs a bit faster)

--- a/examples/tectonic.libvirt.yaml
+++ b/examples/tectonic.libvirt.yaml
@@ -15,6 +15,7 @@ libvirt:
   network:
     name: tectonic
     ifName: tt0
+    dnsServer: 8.8.8.8
     ipRange: 192.168.124.0/24
   imagePath: /path/to/image
 

--- a/installer/pkg/config/cluster.go
+++ b/installer/pkg/config/cluster.go
@@ -60,7 +60,8 @@ var defaultCluster = Cluster{
 	},
 	Libvirt: libvirt.Libvirt{
 		Network: libvirt.Network{
-			IfName: libvirt.DefaultIfName,
+			DNSServer: libvirt.DefaultDNSServer,
+			IfName:    libvirt.DefaultIfName,
 		},
 	},
 	Networking: Networking{

--- a/installer/pkg/config/libvirt/libvirt.go
+++ b/installer/pkg/config/libvirt/libvirt.go
@@ -8,6 +8,8 @@ import (
 )
 
 const (
+	// DefaultDNSServer is the default DNS server for libvirt.
+	DefaultDNSServer = "8.8.8.8"
 	// DefaultIfName is the default interface name for libvirt.
 	DefaultIfName = "osbr0"
 )
@@ -24,9 +26,10 @@ type Libvirt struct {
 
 // Network describes a libvirt network configuration.
 type Network struct {
-	Name    string `json:"tectonic_libvirt_network_name,omitempty" yaml:"name"`
-	IfName  string `json:"tectonic_libvirt_network_if,omitempty" yaml:"ifName"`
-	IPRange string `json:"tectonic_libvirt_ip_range,omitempty" yaml:"ipRange"`
+	Name      string `json:"tectonic_libvirt_network_name,omitempty" yaml:"name"`
+	IfName    string `json:"tectonic_libvirt_network_if,omitempty" yaml:"ifName"`
+	DNSServer string `json:"tectonic_libvirt_resolver,omitempty" yaml:"dnsServer"`
+	IPRange   string `json:"tectonic_libvirt_ip_range,omitempty" yaml:"ipRange"`
 }
 
 // TFVars fills in computed Terraform variables.

--- a/installer/pkg/config/validate.go
+++ b/installer/pkg/config/validate.go
@@ -189,6 +189,9 @@ func (c *Cluster) validateLibvirt() []error {
 	if err := validate.PrefixError("libvirt network ifName", validate.NonEmpty(c.Libvirt.Network.IfName)); err != nil {
 		errs = append(errs, err)
 	}
+	if err := validate.PrefixError("libvirt network dnsServer", validate.IPv4(c.Libvirt.Network.DNSServer)); err != nil {
+		errs = append(errs, err)
+	}
 	errs = append(errs, c.validateOverlapWithPodOrServiceCIDR(c.Libvirt.Network.IPRange, "libvirt ipRange")...)
 	return errs
 }

--- a/installer/pkg/config/validate_test.go
+++ b/installer/pkg/config/validate_test.go
@@ -574,9 +574,10 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:    "tectonic",
-						IfName:  libvirt.DefaultIfName,
-						IPRange: "10.0.1.0/24",
+						Name:      "tectonic",
+						IfName:    libvirt.DefaultIfName,
+						DNSServer: libvirt.DefaultDNSServer,
+						IPRange:   "10.0.1.0/24",
 					},
 					QCOWImagePath: fInvalid.Name(),
 					URI:           "baz",
@@ -589,9 +590,10 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:    "tectonic",
-						IfName:  libvirt.DefaultIfName,
-						IPRange: "10.0.1.0/24",
+						Name:      "tectonic",
+						IfName:    libvirt.DefaultIfName,
+						DNSServer: libvirt.DefaultDNSServer,
+						IPRange:   "10.0.1.0/24",
 					},
 					QCOWImagePath: fValid.Name(),
 					URI:           "baz",
@@ -604,9 +606,10 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:    "tectonic",
-						IfName:  libvirt.DefaultIfName,
-						IPRange: "10.2.1.0/24",
+						Name:      "tectonic",
+						IfName:    libvirt.DefaultIfName,
+						DNSServer: libvirt.DefaultDNSServer,
+						IPRange:   "10.2.1.0/24",
 					},
 					QCOWImagePath: fValid.Name(),
 					URI:           "baz",
@@ -619,9 +622,10 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:    "tectonic",
-						IfName:  libvirt.DefaultIfName,
-						IPRange: "x",
+						Name:      "tectonic",
+						IfName:    libvirt.DefaultIfName,
+						DNSServer: libvirt.DefaultDNSServer,
+						IPRange:   "x",
 					},
 					QCOWImagePath: "foo",
 					URI:           "baz",
@@ -634,9 +638,10 @@ func TestValidateLibvirt(t *testing.T) {
 			cluster: Cluster{
 				Libvirt: libvirt.Libvirt{
 					Network: libvirt.Network{
-						Name:    "tectonic",
-						IfName:  libvirt.DefaultIfName,
-						IPRange: "192.168.0.1/24",
+						Name:      "tectonic",
+						IfName:    libvirt.DefaultIfName,
+						DNSServer: "foo",
+						IPRange:   "192.168.0.1/24",
 					},
 					QCOWImagePath: "foo",
 					URI:           "baz",

--- a/installer/pkg/workflow/fixtures/terraform.tfvars
+++ b/installer/pkg/workflow/fixtures/terraform.tfvars
@@ -22,6 +22,7 @@
   ],
   "tectonic_ignition_worker": "worker.ign",
   "tectonic_libvirt_network_if": "osbr0",
+  "tectonic_libvirt_resolver": "8.8.8.8",
   "tectonic_master_count": 2,
   "tectonic_cluster_name": "aws-basic",
   "tectonic_networking": "canal",

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -87,7 +87,8 @@ func TestInstallConfigGenerate(t *testing.T) {
     network:
       if: ""
       ipRange: ""
-      name: ""`,
+      name: ""
+      resolver: ""`,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -107,6 +107,8 @@ type LibvirtNetwork struct {
 	Name string `json:"name"`
 	// IfName is the name of the network interface.
 	IfName string `json:"if"`
+	// DNSServer is the name of the DNS server.
+	DNSServer string `json:"resolver"`
 	// IPRange is the range of IPs to use.
 	IPRange string `json:"ipRange"`
 }

--- a/steps/infra/libvirt/main.tf
+++ b/steps/infra/libvirt/main.tf
@@ -44,15 +44,15 @@ resource "libvirt_network" "tectonic_net" {
   ]
 
   dns = [{
-    local_only = true
-
-    hosts = ["${flatten(list(
-      data.libvirt_network_dns_host_template.bootstrap.*.rendered,
-      data.libvirt_network_dns_host_template.masters.*.rendered,
-      data.libvirt_network_dns_host_template.etcds.*.rendered,
-      data.libvirt_network_dns_host_template.workers.*.rendered,
-    ))}"]
+    local_only = true,
   }]
+
+  dns_host = ["${flatten(list(
+    data.libvirt_network_dns_host_template.bootstrap.*.rendered,
+    data.libvirt_network_dns_host_template.masters.*.rendered,
+    data.libvirt_network_dns_host_template.etcds.*.rendered,
+    data.libvirt_network_dns_host_template.workers.*.rendered,
+  ))}"]
 
   autostart = true
 }

--- a/steps/infra/libvirt/main.tf
+++ b/steps/infra/libvirt/main.tf
@@ -43,9 +43,9 @@ resource "libvirt_network" "tectonic_net" {
     "${var.tectonic_libvirt_ip_range}",
   ]
 
-  dns = [{
-    local_only = true,
-  }]
+  dns_forwarder {
+    address = "${var.tectonic_libvirt_resolver}"
+  }
 
   dns_host = ["${flatten(list(
     data.libvirt_network_dns_host_template.bootstrap.*.rendered,

--- a/steps/variables-libvirt.tf
+++ b/steps/variables-libvirt.tf
@@ -18,6 +18,11 @@ variable "tectonic_libvirt_ip_range" {
   description = "IP range for the libvirt machines"
 }
 
+variable "tectonic_libvirt_resolver" {
+  type        = "string"
+  description = "the upstream dns resolver"
+}
+
 variable "tectonic_coreos_qcow_path" {
   type        = "string"
   description = "path to a container linux qcow image"


### PR DESCRIPTION
These changes ended up being problematic. We'll have to follow-up with upstream.