### PR TITLE
modules/libvirt/bootstrap: Pull libvirt bootstrap setup into a module

### DIFF
--- a/modules/libvirt/bootstrap/README.md
+++ b/modules/libvirt/bootstrap/README.md
@@ -1,0 +1,49 @@
+# Bootstrap Module
+
+This [Terraform][] [module][] manages [libvirt][] resources only needed during cluster bootstrapping.
+It uses [implicit provider inheritance][implicit-provider-inheritance] to access the [libvirt provider][libvirt-provider].
+
+## Example
+
+Set up a `main.tf` with:
+
+```hcl
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+resource "libvirt_network" "example" {
+  name   = "example"
+  mode   = "none"
+  domain = "example.com"
+  addresses = ["192.168.0.0/24"]
+}
+
+resource "libvirt_volume" "example" {
+  name   = "example"
+  source = "file:///path/to/example.qcow2"
+}
+
+module "bootstrap" {
+  source = "github.com/openshift/installer//modules/libvirt/bootstrap"
+
+  addresses      = ["192.168.0.1"]
+  base_volume_id = "${libvirt_volume.example.id}"
+  cluster_name   = "my-cluster"
+  ignition       = "{\"ignition\": {\"version\": \"2.2.0\"}}",
+  network_id     = "${libvirt_network.example.id}"
+}
+```
+
+Then run:
+
+```console
+$ terraform init
+$ terraform plan
+```
+
+[libvirt]: https://libvirt.org/
+[libvirt-provider]: https://github.com/dmacvicar/terraform-provider-libvirt
+[implicit-provider-inheritance]: https://www.terraform.io/docs/modules/usage.html#implicit-provider-inheritance
+[module]: https://www.terraform.io/docs/modules/
+[Terraform]: https://www.terraform.io/

--- a/modules/libvirt/bootstrap/main.tf
+++ b/modules/libvirt/bootstrap/main.tf
@@ -1,0 +1,34 @@
+resource "libvirt_volume" "bootstrap" {
+  name           = "bootstrap"
+  base_volume_id = "${var.base_volume_id}"
+}
+
+resource "libvirt_ignition" "bootstrap" {
+  name    = "bootstrap.ign"
+  content = "${var.ignition}"
+}
+
+resource "libvirt_domain" "bootstrap" {
+  name = "bootstrap"
+
+  memory = "2048"
+
+  vcpu = "2"
+
+  coreos_ignition = "${libvirt_ignition.bootstrap.id}"
+
+  disk {
+    volume_id = "${libvirt_volume.bootstrap.id}"
+  }
+
+  console {
+    type        = "pty"
+    target_port = 0
+  }
+
+  network_interface {
+    network_id = "${var.network_id}"
+    hostname   = "${var.cluster_name}-bootstrap"
+    addresses  = "${var.addresses}"
+  }
+}

--- a/modules/libvirt/bootstrap/variables.tf
+++ b/modules/libvirt/bootstrap/variables.tf
@@ -1,0 +1,25 @@
+variable "addresses" {
+  type        = "list"
+  default     = []
+  description = "IP addresses to assign to the boostrap node."
+}
+
+variable "base_volume_id" {
+  type        = "string"
+  description = "The ID of the base volume for the bootstrap node."
+}
+
+variable "cluster_name" {
+  type        = "string"
+  description = "The name of the cluster."
+}
+
+variable "ignition" {
+  type        = "string"
+  description = "The content of the bootstrap ignition file."
+}
+
+variable "network_id" {
+  type        = "string"
+  description = "The ID of a network resource containing the bootstrap node's addresses."
+}

--- a/steps/bootstrap/libvirt/main.tf
+++ b/steps/bootstrap/libvirt/main.tf
@@ -2,37 +2,12 @@ provider "libvirt" {
   uri = "${var.tectonic_libvirt_uri}"
 }
 
-resource "libvirt_volume" "bootstrap" {
-  name           = "bootstrap"
+module "bootstrap" {
+  source = "../../../modules/libvirt/bootstrap"
+
+  addresses      = ["${var.tectonic_libvirt_bootstrap_ip}"]
   base_volume_id = "${local.libvirt_base_volume_id}"
-}
-
-resource "libvirt_ignition" "bootstrap" {
-  name    = "bootstrap.ign"
-  content = "${local.ignition_bootstrap}"
-}
-
-resource "libvirt_domain" "bootstrap" {
-  name = "bootstrap"
-
-  memory = "2048"
-
-  vcpu = "2"
-
-  coreos_ignition = "${libvirt_ignition.bootstrap.id}"
-
-  disk {
-    volume_id = "${libvirt_volume.bootstrap.id}"
-  }
-
-  console {
-    type        = "pty"
-    target_port = 0
-  }
-
-  network_interface {
-    network_id = "${local.libvirt_network_id}"
-    hostname   = "${var.tectonic_cluster_name}-bootstrap"
-    addresses  = ["${var.tectonic_libvirt_bootstrap_ip}"]
-  }
+  cluster_name   = "${var.tectonic_cluster_name}"
+  ignition       = "${local.ignition_bootstrap}"
+  network_id     = "${local.libvirt_network_id}"
 }


### PR DESCRIPTION
This will make it easier to move into the existing infra step (like #217, but for libvirt).

The module source syntax used in the README is documented [here][1], [here][2], and [here][3], and means "the modules/libvirt/bootstrap subdirectory of the github.com/openshift/installer repository cloned over HTTPS".

[1]: https://www.terraform.io/docs/configuration/modules.html#source
[2]: https://www.terraform.io/docs/modules/sources.html#github
[3]: https://www.terraform.io/docs/modules/sources.html#modules-in-package-sub-directories