### PR TITLE
add Dockerfiles for ci

### DIFF
--- a/images/installer-origin-release/Dockerfile
+++ b/images/installer-origin-release/Dockerfile
@@ -1,0 +1,12 @@
+# This Dockerfile is used to create the image quay.io/coreos/origin-release:bazel used in CI
+# to build smoke tests.
+# EX: docker build --rm -t this-image:latest .
+
+FROM docker.io/openshift/origin-release:golang-1.10
+
+RUN wget -P /etc/yum.repos.d https://copr.fedorainfracloud.org/coprs/vbatts/bazel/repo/epel-7/vbatts-bazel-epel-7.repo
+
+RUN yum install -y bazel gcc-c++ libtool && \
+    yum clean all
+
+WORKDIR /go/src/github.com/openshift/origin

--- a/images/installer-origin-release/Dockerfile.ci
+++ b/images/installer-origin-release/Dockerfile.ci
@@ -1,0 +1,13 @@
+# This Dockerfile is used as a CI job to build smoke tests for OpenShift installer
+# FIXME: Move this image to an openshift repo?
+
+FROM  quay.io/coreos/origin-release-oc:bazel
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+
+ENV USER="bazel"
+ENV HOME="/tmp"
+
+RUN bazel --output_base=/tmp build smoke_tests && \
+    cp bazel-bin/tests/smoke/linux_amd64_stripped/go_default_test /usr/bin/smoke && \
+    bazel clean


### PR DESCRIPTION
These images are used in the prow e2e-aws-smoke test
1) installer-origin-release/Dockerfile used to create image `quay.io/coreos/origin-release-oc:bazel`, that is, the origin-release:golang-1.10 image + bazel + oc
2) installer-origin-release/Dockerfile.ci is for the image that builds the smoke tests in CI

This PR needs a merge with https://github.com/openshift/release/pull/1317