### PR TITLE
steps/infra: serialize master and worker domain sets for libvirt

### DIFF
--- a/steps/infra/libvirt/main.tf
+++ b/steps/infra/libvirt/main.tf
@@ -105,6 +105,8 @@ resource "libvirt_domain" "worker" {
     hostname   = "${var.tectonic_cluster_name}-worker-${count.index}"
     addresses  = ["${var.tectonic_libvirt_worker_ips[count.index]}"]
   }
+
+  depends_on = ["libvirt_domain.master"]
 }
 
 locals {


### PR DESCRIPTION
We are seeing race like symptoms when creating multiple domainsets in parallel.
For more info: https://github.com/dmacvicar/terraform-provider-libvirt/issues/402
The issue suggests that its most proabaly a libvirt bug that we can avoid by
serializing master and worker domain sets.