### PR TITLE
tests/run: Add a backend argument and support libvirt

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -70,7 +70,7 @@ AWS_REGION
 ```
 
 ### 2. Launch the tests
-Once the environment variables are set, run `./tests/run.sh`.
+Once the environment variables are set, run `./tests/run.sh aws`.
 
 ## Or, if you already have a cluster running
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -34,6 +34,7 @@ bazel build tarball smoke_tests
 echo -e "\\e[36m Unpacking artifacts...\\e[0m"
 tar -zxf bazel-bin/tectonic-dev.tar.gz
 cp bazel-bin/tests/smoke/linux_amd64_pure_stripped/go_default_test tectonic-dev/smoke
+chmod 755 tectonic-dev/smoke
 cd tectonic-dev
 
 ### HANDLE SSH KEY ###

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -17,7 +17,7 @@ SMOKE_TEST_OUTPUT="Never executed. Problem with one of previous stages"
 [ -z ${JOB_NAME+x} ] && PREFIX="${USER:-test}" || PREFIX="ci-${JOB_NAME#*/}"
 CLUSTER_NAME=$(echo "${PREFIX}-$(uuidgen -r | cut -c1-5)" | tr '[:upper:]' '[:lower:]')
 TECTONIC="${PWD}/tectonic-dev/installer/tectonic"
-exec &> >(tee -a "$CLUSTER_NAME.log")
+exec &> >(tee -ai "$CLUSTER_NAME.log")
 
 function destroy() {
   echo -e "\\e[34m Exiting... Destroying Tectonic...\\e[0m"
@@ -128,4 +128,4 @@ if test "${LEAVE_RUNNING}" = y; then
   echo "leaving running; tear down manually with: cd ${PWD} && installer/tectonic destroy --dir=${CLUSTER_NAME}"
   trap - EXIT
 fi
-SMOKE_TEST_OUTPUT=$(./smoke -test.v --cluster | tee >(cat - >&5))
+SMOKE_TEST_OUTPUT=$(./smoke -test.v --cluster | tee -i >(cat - >&5))

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,6 +10,7 @@ set -e
 set -eo pipefail
 
 BACKEND="${1}"
+LEAVE_RUNNING="${LEAVE_RUNNING:-n}"  # do not teardown after successful initialization
 SMOKE_TEST_OUTPUT="Never executed. Problem with one of previous stages"
 [ -z ${PULL_SECRET_PATH+x} ] && (echo "Please set PULL_SECRET_PATH"; exit 1)
 [ -z ${DOMAIN+x} ] && DOMAIN="tectonic-ci.de"
@@ -122,4 +123,8 @@ libvirt)
   ;;
 esac
 exec 5>&1
+if test "${LEAVE_RUNNING}" = y; then
+  echo "leaving running; tear down manually with: cd ${PWD} && installer/tectonic destroy --dir=${CLUSTER_NAME}"
+  trap - EXIT
+fi
 SMOKE_TEST_OUTPUT=$(./smoke -test.v --cluster | tee >(cat - >&5))


### PR DESCRIPTION
Make it easier for folks to run the smoke tests on libvirt.  This also shifts our teardown trap installation to right before we start creating resources that might need destroying.

Also add `LEAVE_RUNNING` to allow using the script for cluster setup.  Running the script is easier than following the README and libvirt-howto notes by hand.  We still automatically destroy clusters where `tectonic install` fails.

This PR is a follow-up to #121.