### PR TITLE
inject registries.conf with docker.io to use crio for bootstrap kubelet

### DIFF
--- a/modules/ignition/assets.tf
+++ b/modules/ignition/assets.tf
@@ -16,3 +16,13 @@ data "ignition_systemd_unit" "kubelet" {
   enabled = true
   content = "${data.template_file.kubelet.rendered}"
 }
+
+data "ignition_file" "registries_config" {
+  filesystem = "root"
+  mode       = "0644"
+  path       = "/etc/containers/registries.conf"
+
+  content {
+    content = "${file("${path.module}/resources/files/registries.conf")}"
+  }
+}

--- a/modules/ignition/outputs.tf
+++ b/modules/ignition/outputs.tf
@@ -18,6 +18,7 @@ output "ignition_file_id_list" {
     "${data.ignition_file.root_ca_cert_pem.id}",
     "${data.ignition_file.ingress_ca_cert_pem.id}",
     "${data.ignition_file.etcd_ca_cert_pem.id}",
+    "${data.ignition_file.registries_config.id}",
   ]
 }
 

--- a/modules/ignition/resources/files/registries.conf
+++ b/modules/ignition/resources/files/registries.conf
@@ -1,0 +1,25 @@
+# This is a system-wide configuration file used to
+# keep track of registries for various container backends.
+# It adheres to TOML format and does not support recursive
+# lists of registries.
+
+# The default location for this configuration file is /etc/containers/registries.conf.
+
+# The only valid categories are: 'registries.search', 'registries.insecure',
+# and 'registries.block'.
+
+[registries.search]
+registries = ['registry.access.redhat.com', 'docker.io']
+
+# If you need to access insecure registries, add the registry's fully-qualified name.
+# An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
+[registries.insecure]
+registries = []
+
+
+# If you need to block pull access from a registry, uncomment the section below
+# and add the registries fully-qualified name.
+#
+# Docker only
+[registries.block]
+registries = []


### PR DESCRIPTION
@mrunalp @eparis @derekwaynecarr 

static pods do not use fully qualified image names and `docker.io` is not in the registry search list in `/etc/containers/registries.conf` by default.  We need to inject it.

TNC change will also be needed if we want this change in the masters/workers.