### PR TITLE
pkg/types/machinepools: Replace platformConfig with platform

### DIFF
--- a/Documentation/design/installconfig.md
+++ b/Documentation/design/installconfig.md
@@ -147,20 +147,20 @@ type MachinePools struct {
     // Default is 1.
     Replicas *int64 `json:"replicas"`
 
-    // PlatformConfig is configuration for machine pool specfic to the platfrom.
-    PlatformConfig MachinePoolPlatformConfig `json: platformConfig`
+    // Platform is configuration for machine pool specfic to the platfrom.
+    Platform MachinePoolPlatform `json: platform`
 }
 
-type MachinePoolPlatformConfig struct {
-    AWS *AWSMachinePoolPlatformConfig `json: "aws,omitempty"`
-    Libvirt *LibvirtMachinePoolPlatformConfig `json:"libvirt,omitempty"`
+type MachinePoolPlatform struct {
+    AWS *AWSMachinePoolPlatform `json: "aws,omitempty"`
+    Libvirt *LibvirtMachinePoolPlatform `json:"libvirt,omitempty"`
 }
 ```
 
 AWS specific config options for machine pool.
 
 ```go
-type AWSMachinePoolPlatformConfig struct {
+type AWSMachinePoolPlatform struct {
     // InstanceType defines the ec2 instance type.
     // eg. m4-large
     InstanceType    string `json:"type"`
@@ -184,7 +184,7 @@ type EC2RootVolume struct {
 Libvirt specific config options for machine pool.
 
 ```go
-type LibvirtMachinePoolPlatformConfig struct {
+type LibvirtMachinePoolPlatform struct {
     // QCOWImagePath
     QCOWImagePath string `json:"qcowImagePath"`
 }

--- a/installer/pkg/config-generator/fixtures/kube-system.yaml
+++ b/installer/pkg/config-generator/fixtures/kube-system.yaml
@@ -8,7 +8,7 @@ data:
     clusterID: ""
     machines:
     - name: master
-      platformConfig:
+      platform:
         aws:
           iamRoleName: ""
           rootVolume:
@@ -18,7 +18,7 @@ data:
           type: t2.medium
       replicas: 3
     - name: worker
-      platformConfig:
+      platform:
         aws:
           iamRoleName: ""
           rootVolume:

--- a/installer/pkg/config-generator/generator.go
+++ b/installer/pkg/config-generator/generator.go
@@ -116,9 +116,9 @@ func (c *ConfigGenerator) installConfig() (*types.InstallConfig, error) {
 	}
 
 	var (
-		platform             types.Platform
-		masterPlatformConfig types.MachinePoolPlatformConfig
-		workerPlatformConfig types.MachinePoolPlatformConfig
+		platform       types.Platform
+		masterPlatform types.MachinePoolPlatform
+		workerPlatform types.MachinePoolPlatform
 	)
 	switch c.Platform {
 	case config.PlatformAWS:
@@ -127,7 +127,7 @@ func (c *ConfigGenerator) installConfig() (*types.InstallConfig, error) {
 			VPCID:        c.VPCID,
 			VPCCIDRBlock: c.VPCCIDRBlock,
 		}
-		masterPlatformConfig.AWS = &types.AWSMachinePoolPlatformConfig{
+		masterPlatform.AWS = &types.AWSMachinePoolPlatform{
 			InstanceType: c.AWS.Master.EC2Type,
 			IAMRoleName:  c.AWS.Master.IAMRoleName,
 			EC2RootVolume: types.EC2RootVolume{
@@ -136,7 +136,7 @@ func (c *ConfigGenerator) installConfig() (*types.InstallConfig, error) {
 				Type: c.AWS.Master.MasterRootVolume.Type,
 			},
 		}
-		workerPlatformConfig.AWS = &types.AWSMachinePoolPlatformConfig{
+		workerPlatform.AWS = &types.AWSMachinePoolPlatform{
 			InstanceType: c.AWS.Worker.EC2Type,
 			IAMRoleName:  c.AWS.Worker.IAMRoleName,
 			EC2RootVolume: types.EC2RootVolume{
@@ -154,10 +154,10 @@ func (c *ConfigGenerator) installConfig() (*types.InstallConfig, error) {
 				IPRange: c.Network.IPRange,
 			},
 		}
-		masterPlatformConfig.Libvirt = &types.LibvirtMachinePoolPlatformConfig{
+		masterPlatform.Libvirt = &types.LibvirtMachinePoolPlatform{
 			QCOWImagePath: c.Libvirt.QCOWImagePath,
 		}
-		workerPlatformConfig.Libvirt = &types.LibvirtMachinePoolPlatformConfig{
+		workerPlatform.Libvirt = &types.LibvirtMachinePoolPlatform{
 			QCOWImagePath: c.Libvirt.QCOWImagePath,
 		}
 	default:
@@ -185,13 +185,13 @@ func (c *ConfigGenerator) installConfig() (*types.InstallConfig, error) {
 		},
 		Platform: platform,
 		Machines: []types.MachinePool{{
-			Name:           "master",
-			Replicas:       &masterCount,
-			PlatformConfig: masterPlatformConfig,
+			Name:     "master",
+			Replicas: &masterCount,
+			Platform: masterPlatform,
 		}, {
-			Name:           "worker",
-			Replicas:       &workerCount,
-			PlatformConfig: workerPlatformConfig,
+			Name:     "worker",
+			Replicas: &workerCount,
+			Platform: workerPlatform,
 		}},
 	}, nil
 }

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -9,22 +9,22 @@ type MachinePool struct {
 	// Default is 1.
 	Replicas *int64 `json:"replicas"`
 
-	// PlatformConfig is configuration for machine pool specific to the platfrom.
-	PlatformConfig MachinePoolPlatformConfig `json:"platformConfig"`
+	// Platform is configuration for machine pool specific to the platfrom.
+	Platform MachinePoolPlatform `json:"platform"`
 }
 
-// MachinePoolPlatformConfig is the platform-specific configuration for a machine
+// MachinePoolPlatform is the platform-specific configuration for a machine
 // pool. Only one of the platforms should be set.
-type MachinePoolPlatformConfig struct {
+type MachinePoolPlatform struct {
 	// AWS is the configuration used when installing on AWS.
-	AWS *AWSMachinePoolPlatformConfig `json:"aws,omitempty"`
+	AWS *AWSMachinePoolPlatform `json:"aws,omitempty"`
 	// Libvirt is the configuration used when installing on libvirt.
-	Libvirt *LibvirtMachinePoolPlatformConfig `json:"libvirt,omitempty"`
+	Libvirt *LibvirtMachinePoolPlatform `json:"libvirt,omitempty"`
 }
 
-// AWSMachinePoolPlatformConfig stores the configuration for a machine pool
+// AWSMachinePoolPlatform stores the configuration for a machine pool
 // installed on AWS.
-type AWSMachinePoolPlatformConfig struct {
+type AWSMachinePoolPlatform struct {
 	// InstanceType defines the ec2 instance type.
 	// eg. m4-large
 	InstanceType string `json:"type"`
@@ -47,9 +47,9 @@ type EC2RootVolume struct {
 	Type string `json:"type"`
 }
 
-// LibvirtMachinePoolPlatformConfig stores the configuration for a machine pool
+// LibvirtMachinePoolPlatform stores the configuration for a machine pool
 // installed on libvirt.
-type LibvirtMachinePoolPlatformConfig struct {
+type LibvirtMachinePoolPlatform struct {
 	// QCOWImagePath
 	QCOWImagePath string `json:"qcowImagePath"`
 }


### PR DESCRIPTION
All of these properties are for configuration, we don't need to include `Config` in the name to make that clear.

Spun off from [here][1].

/assign @abhinavdahiya

[1]: https://github.com/openshift/installer/pull/236#issuecomment-420717148