### PR TITLE
pkg/types/installconfig: Add AWSPlatform.UserTags

### DIFF
--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -79,6 +79,9 @@ type AWSPlatform struct {
 	// Region specifies the AWS region where the cluster will be created.
 	Region string `json:"region"`
 
+	// UserTags specifies additional tags for AWS resources created by the cluster.
+	UserTags map[string]string `json:"tags,omitempty"`
+
 	// VPCID specifies the vpc to associate with the cluster.
 	// If empty, new vpc will be created.
 	// +optional


### PR DESCRIPTION
To support use-cases like #169.  Spun off from [here][1].

I've gone with `Tags` (vs. our old `ExtraTags`), and just explained in the godoc that any tags set via this property will be used in a addition to tags the installer sets on its own.

I haven't added it to the interactive prompt, because I don't have time to write up a map-import command line UI.  For now, folks that care about this property should write their own install-config YAML instead of using the interactive command line generator.

[1]: https://github.com/openshift/installer/pull/236#issuecomment-420717148