### PR TITLE
github: remove pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,0 @@
-Before creating your PR, please make sure to add the appropriate GitHub label; i.e. `run-smoke-tests`. For more details see
-[tests/README.md](../tests/README.md).
-
-(In case you don't have permissions to add labels, please ask [a](../OWNERS) [maintainer](../OWNERS_ALIASES).)


### PR DESCRIPTION
Ever since removing Jenkins from our CI, we no longer make use of labels
to affect tests.
