### PR TITLE
tests/smoke: build with bazel's "pure" mode

### DIFF
--- a/images/installer-origin-release/Dockerfile.ci
+++ b/images/installer-origin-release/Dockerfile.ci
@@ -8,5 +8,5 @@ ENV USER="bazel"
 ENV HOME="/tmp"
 
 RUN bazel --output_base=/tmp build smoke_tests && \
-    cp bazel-bin/tests/smoke/linux_amd64_stripped/go_default_test /usr/bin/smoke && \
+    cp bazel-bin/tests/smoke/linux_amd64_pure_stripped/go_default_test /usr/bin/smoke && \
     bazel clean

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -33,7 +33,7 @@ bazel build tarball smoke_tests
 
 echo -e "\\e[36m Unpacking artifacts...\\e[0m"
 tar -zxf bazel-bin/tectonic-dev.tar.gz
-cp bazel-bin/tests/smoke/linux_amd64_stripped/go_default_test tectonic-dev/smoke
+cp bazel-bin/tests/smoke/linux_amd64_pure_stripped/go_default_test tectonic-dev/smoke
 cd tectonic-dev
 
 ### HANDLE SSH KEY ###

--- a/tests/smoke/BUILD.bazel
+++ b/tests/smoke/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
+    pure = "on",
     srcs = [
         "cluster_test.go",
         "common_test.go",

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -24,7 +24,7 @@ Compile the smoke test binary from the root directory of the project:
 bazel build smoke_tests
 ```
 
-The tests can then be run by invoking the `go_default_test` binary in the `bazel-bin/tests/smoke/linux_amd64_stripped` directory.
+The tests can then be run by invoking the `go_default_test` binary in the `bazel-bin/tests/smoke/linux_amd64_pure_stripped` directory.
 
 *Note*: the `go_default_test` binary accepts several flags available to the `go test` command; to list them, invoke the `go_default_test` binary with the `-help` flag.
 
@@ -49,5 +49,5 @@ To run the cluster test suite, invoke the smoke test binary with the `-cluster` 
 To run the cluster suite verbosely, add the `-test.v` flag:
 
 ```sh
-bazel-bin/tests/smoke/linux_amd64_stripped/go_default_test -cluster -test.v
+bazel-bin/tests/smoke/linux_amd64_pure_stripped/go_default_test -cluster -test.v
 ```


### PR DESCRIPTION
This makes the smoke test binary a statically linked which is necessary
on my system due to:

> ldd bazel-bin/tests/smoke/linux_amd64_stripped/go_default_test
>     (...)
>     libstdc++.so.6 => not found
>     (...)

We already use "pure" for building the installer itself, so this also
adds more consistency.