### PR TITLE
fix typo in lifecycle/ignore_changes for workers

### DIFF
--- a/modules/aws/worker/main.tf
+++ b/modules/aws/worker/main.tf
@@ -93,7 +93,7 @@ resource "aws_instance" "worker" {
     # Ignore changes in the AMI which force recreation of the resource. This
     # avoids accidental deletion of nodes whenever a new CoreOS Release comes
     # out.
-    ignore_changes = ["image_id"]
+    ignore_changes = ["ami"]
   }
 
   tags = "${merge(map(


### PR DESCRIPTION
When checking out how lifecycle/ignore_changes is implemented in openshift/installer I realized that there's a typo in the configuration for worker instances.