### PR TITLE
modules: services shouldn't remain after exit 

### DIFF
--- a/modules/bootkube/resources/bootkube.service
+++ b/modules/bootkube/resources/bootkube.service
@@ -4,7 +4,6 @@ Wants=kubelet.service
 After=kubelet.service
 
 [Service]
-RemainAfterExit=true
 WorkingDirectory=/opt/tectonic
 
 ExecStart=/opt/tectonic/bootkube.sh

--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -3,7 +3,7 @@ set -e
 
 mkdir --parents /etc/kubernetes/manifests/
 
-if [ ! -d "$PWD/kco-bootstrap" ]
+if [ ! -d kco-bootstrap ]
 then
 	echo "Rendering Kubernetes core manifests..."
 
@@ -15,13 +15,12 @@ then
 		--config=/assets/kco-config.yaml \
 		--output=/assets/kco-bootstrap
 
-	cp --recursive "$PWD/kco-bootstrap/bootstrap-configs" /etc/kubernetes/bootstrap-configs
-	cp --recursive "$PWD/kco-bootstrap/bootstrap-configs" .
-	cp --recursive "$PWD/kco-bootstrap/bootstrap-manifests" .
-	cp --recursive "$PWD/kco-bootstrap/manifests" .
+	cp --recursive kco-bootstrap/bootstrap-configs /etc/kubernetes/bootstrap-configs
+	cp --recursive kco-bootstrap/bootstrap-manifests .
+	cp --recursive kco-bootstrap/manifests .
 fi
 
-if [ ! -d "$PWD/mco-bootstrap" ]
+if [ ! -d "mco-bootstrap" ]
 then
 	echo "Rendering MCO manifests..."
 
@@ -42,13 +41,13 @@ then
 	# 2. read the default MachineConfigPools rendered by MachineConfigOperator
 	# 3. read any additional MachineConfigs that are needed for the default MachineConfigPools.
 	mkdir --parents /etc/mcc/bootstrap/
-	cp --recursive "$PWD/mco-bootstrap/manifests" /etc/mcc/bootstrap/manifests
-	cp "$PWD/mco-bootstrap/machineconfigoperator-bootstrap-pod.yaml" /etc/kubernetes/manifests/
+	cp --recursive mco-bootstrap/manifests /etc/mcc/bootstrap/manifests
+	cp mco-bootstrap/machineconfigoperator-bootstrap-pod.yaml /etc/kubernetes/manifests/
 
 	# /etc/ssl/mcs/tls.{crt, key} are locations for MachineConfigServer's tls assets.
 	mkdir --parents /etc/ssl/mcs/
-	cp "$PWD/tls/machine-config-server.crt" /etc/ssl/mcs/tls.crt
-	cp "$PWD/tls/machine-config-server.key" /etc/ssl/mcs/tls.key
+	cp tls/machine-config-server.crt /etc/ssl/mcs/tls.crt
+	cp tls/machine-config-server.key /etc/ssl/mcs/tls.key
 fi
 
 # We originally wanted to run the etcd cert signer as

--- a/modules/tectonic/resources/tectonic.service
+++ b/modules/tectonic/resources/tectonic.service
@@ -4,7 +4,6 @@ Wants=bootkube.service
 After=bootkube.service
 
 [Service]
-RemainAfterExit=true
 WorkingDirectory=/opt/tectonic/tectonic
 
 ExecStart=/opt/tectonic/tectonic.sh /opt/tectonic/auth/kubeconfig

--- a/modules/tectonic/resources/tectonic.sh
+++ b/modules/tectonic/resources/tectonic.sh
@@ -4,7 +4,7 @@ set -e
 KUBECONFIG="$1"
 
 kubectl() {
-	(>&2 echo "Executing kubectl $*")
+	echo "Executing kubectl $*" >&2
 	while true
 	do
 		set +e
@@ -14,7 +14,7 @@ kubectl() {
 
 		if grep --quiet "AlreadyExists" <<< "$out"
 		then
-			(>&2 echo "$out, skipping")
+			echo "$out, skipping" >&2
 			return
 		fi
 
@@ -24,7 +24,7 @@ kubectl() {
 			return
 		fi
 
-		(>&2 echo "kubectl $* failed. Retrying in 5 seconds...")
+		echo "kubectl $* failed. Retrying in 5 seconds..." >&2
 		sleep 5
 	done
 }


### PR DESCRIPTION
954c009 added a restart policy to bootkube.service and tectonic.service,
but left RemainAfterExit=true. systemd won't restart on failure when
this option is present since the service never terminates.