### PR TITLE
CONTRIBUTING: Drop stale structure-check references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,18 @@ For contributors who want to work up pull requests, the workflow is roughly:
 3. Make sure your commit messages are in the proper format (see [below](#commit-message-format)).
 4. Push your changes to a topic branch in your fork of the repository.
 5. Make sure the tests pass, and add any new tests as appropriate.
-6. Please run this command before submitting your pull request:
+6. We run a number of linters and tests on each pull request.
+    You may wish to run these locally before submitting your pull request:
     ```sh
-    make structure-check
+    hack/go-fmt.sh .
+    hack/go-lint.sh $(go list -f '{{ .ImportPath }}' ./...)
+    hack/go-vet.sh ./...
+    hack/shellcheck.sh
+    hack/test-bazel-build-tarball.sh
+    hack/tf-fmt.sh -list -check
+    hack/tf-lint.sh
+    hack/yaml-lint.sh
     ```
-    Note that a portion of the docs and examples are generated and that the generated files are to be committed by you. `make structure-check` checks that what is generated is what you must commit.
 7. Submit a pull request to the original repository.
 8. The [repo](OWNERS) [owners](OWNERS_ALIASES) will respond to your issue promptly, following [the ususal Prow workflow][prow-review].
 
@@ -52,9 +59,7 @@ Thanks for your contributions!
 
 The coding style suggested by the Golang community is used in installer. See the [style doc][golang-style] for details. Please follow them when working on your contributions.
 
-Tectonic Installer includes syntax checks on the Terraform templates which will fail the PR checker for non-standard formatted code.
-
-Use `make structure-check` to identify files that don't meet the canonical format and style. Then, use `terraform fmt` to align the template syntax, if necessary.
+Terraform has similar standards, and you can run `terraform fmt` to rewrite Terraform files to the canonical format.
 
 ## Commit Message Format
 

--- a/hack/shellcheck.sh
+++ b/hack/shellcheck.sh
@@ -4,12 +4,15 @@ if [ "$IS_CONTAINER" != "" ]; then
   find "${TOP_DIR}" \
     -path "${TOP_DIR}/vendor" -prune \
     -o -path "${TOP_DIR}/.build" -prune \
+    -o -path "${TOP_DIR}/tests/smoke/vendor" -prune \
+    -o -path "${TOP_DIR}/tests/smoke/.build" -prune \
     -o -type f -name '*.sh' -exec shellcheck --format=gcc {} \+
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/workdir:ro,z" \
     --entrypoint sh \
+    --workdir /workdir \
     quay.io/coreos/shellcheck-alpine:v0.5.0 \
-    /workdir/hack/shellcheck.sh /workdir
+    /workdir/hack/shellcheck.sh "${@}"
 fi;

--- a/hack/tf-fmt.sh
+++ b/hack/tf-fmt.sh
@@ -2,12 +2,15 @@
 
 # in prow, already in container, so no 'podman run'
 if [ "$IS_CONTAINER" != "" ]; then
+  if [ "${#N}" -gt 1 ]; then
+    set -- -list -check -write=false
+  fi
   set -x
-  /terraform fmt -list -check -write=false
+  /terraform fmt "${@}"
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \
-    --volume "${PWD}:${PWD}:ro,z" \
+    --volume "${PWD}:${PWD}:z" \
     --workdir "${PWD}" \
     quay.io/coreos/terraform-alpine:v0.11.7 \
     ./hack/tf-fmt.sh


### PR DESCRIPTION
They haven't worked since d61abd48 (coreos/tectonic-installer#3137).  Recommend out new `hack/*` scripts instead.

I've also included two commits to make those hack scripts easier for devs to use.  Details on those changes in their commit messages.