### PR TITLE
installer/pkg: Lowercase some capitalized error messages

### DIFF
--- a/installer/pkg/config/parser.go
+++ b/installer/pkg/config/parser.go
@@ -34,7 +34,7 @@ func ParseConfig(data []byte) (*Cluster, error) {
 	if cluster.EC2AMIOverride == "" {
 		ami, err := rhcos.AMI(DefaultChannel, cluster.AWS.Region)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to determine default AMI: %v", err)
+			return nil, fmt.Errorf("failed to determine default AMI: %v", err)
 		}
 		cluster.EC2AMIOverride = ami
 	}

--- a/installer/pkg/workflow/executor.go
+++ b/installer/pkg/workflow/executor.go
@@ -9,11 +9,11 @@ import (
 	"runtime"
 )
 
-// executor enables calling TerraForm from Go, across platforms, with any
+// executor enables calling Terraform from Go, across platforms, with any
 // additional providers/provisioners that the currently executing binary
 // exposes.
 //
-// The TerraForm binary is expected to be in the executing binary's folder, in
+// The Terraform binary is expected to be in the executing binary's folder, in
 // the current working directory or in the PATH.
 type executor struct {
 	binaryPath string
@@ -25,17 +25,17 @@ const (
 	tfBinWindows = "terraform.exe"
 )
 
-// errBinaryNotFound denotes the fact that the TerraForm binary could not be
+// errBinaryNotFound denotes the fact that the Terraform binary could not be
 // found on disk.
 var errBinaryNotFound = errors.New(
-	"TerraForm not in executable's folder, cwd nor PATH",
+	"terraform not in executable's folder, cwd nor PATH",
 )
 
 // newExecutor initializes a new Executor.
 func newExecutor() (*executor, error) {
 	ex := new(executor)
 
-	// Find the TerraForm binary.
+	// Find the Terraform binary.
 	binPath, err := tfBinaryPath()
 	if err != nil {
 		return nil, err
@@ -45,13 +45,13 @@ func newExecutor() (*executor, error) {
 	return ex, nil
 }
 
-// Execute runs the given command and arguments against TerraForm.
+// Execute runs the given command and arguments against Terraform.
 //
-// An error is returned if the TerraForm binary could not be found, or if the
-// TerraForm call itself failed, in which case, details can be found in the
+// An error is returned if the Terraform binary could not be found, or if the
+// Terraform call itself failed, in which case, details can be found in the
 // output.
 func (ex *executor) execute(clusterDir string, args ...string) error {
-	// Prepare TerraForm command by setting up the command, configuration,
+	// Prepare Terraform command by setting up the command, configuration,
 	// and the working directory
 	if clusterDir == "" {
 		return fmt.Errorf("clusterDir is unset. Quitting")
@@ -63,11 +63,11 @@ func (ex *executor) execute(clusterDir string, args ...string) error {
 	cmd.Stderr = os.Stderr
 	cmd.Dir = clusterDir
 
-	// Start TerraForm.
+	// Start Terraform.
 	return cmd.Run()
 }
 
-// tfBinaryPath searches for a TerraForm binary on disk:
+// tfBinaryPath searches for a Terraform binary on disk:
 // - in the executing binary's folder,
 // - in the current working directory,
 // - in the PATH.

--- a/installer/pkg/workflow/terraform.go
+++ b/installer/pkg/workflow/terraform.go
@@ -10,12 +10,12 @@ func terraformExec(clusterDir string, args ...string) error {
 	// Create an executor
 	ex, err := newExecutor()
 	if err != nil {
-		return fmt.Errorf("Could not create Terraform executor: %s", err)
+		return fmt.Errorf("could not create Terraform executor: %s", err)
 	}
 
 	err = ex.execute(clusterDir, args...)
 	if err != nil {
-		return fmt.Errorf("Failed to run Terraform: %s", err)
+		return fmt.Errorf("failed to run Terraform: %s", err)
 	}
 	return nil
 }

--- a/installer/pkg/workflow/utils.go
+++ b/installer/pkg/workflow/utils.go
@@ -53,7 +53,7 @@ func findStepTemplates(stepName string, platform config.Platform) (string, error
 func generateClusterConfigMaps(m *metadata) error {
 	clusterGeneratedPath := filepath.Join(m.clusterDir, generatedPath)
 	if err := os.MkdirAll(clusterGeneratedPath, os.ModeDir|0755); err != nil {
-		return fmt.Errorf("Failed to create cluster generated directory at %s", clusterGeneratedPath)
+		return fmt.Errorf("failed to create cluster generated directory at %s", clusterGeneratedPath)
 	}
 
 	configGenerator := configgenerator.New(m.cluster)
@@ -75,7 +75,7 @@ func generateClusterConfigMaps(m *metadata) error {
 
 	kubePath := filepath.Join(m.clusterDir, kubeSystemPath)
 	if err := os.MkdirAll(kubePath, os.ModeDir|0755); err != nil {
-		return fmt.Errorf("Failed to create manifests directory at %s", kubePath)
+		return fmt.Errorf("failed to create manifests directory at %s", kubePath)
 	}
 
 	kubeSystemConfigFilePath := filepath.Join(kubePath, kubeSystemFileName)
@@ -90,7 +90,7 @@ func generateClusterConfigMaps(m *metadata) error {
 
 	tectonicPath := filepath.Join(m.clusterDir, tectonicSystemPath)
 	if err := os.MkdirAll(tectonicPath, os.ModeDir|0755); err != nil {
-		return fmt.Errorf("Failed to create tectonic directory at %s", tectonicPath)
+		return fmt.Errorf("failed to create tectonic directory at %s", tectonicPath)
 	}
 
 	tectonicSystemConfigFilePath := filepath.Join(tectonicPath, tectonicSystemFileName)


### PR DESCRIPTION
Errors [should not be capitalized][1].  We haven't been picking these up in our golint CI, because error-cap violations [have a confidence of 0.6][2] (vs. [the default 0.8][3]).  This commit avoids:

```console
$ golint -min_confidence 0.6 ./installer/...
installer/pkg/config/parser.go:37:27: error strings should not be capitalized or end with punctuation or a newline
installer/pkg/workflow/executor.go:31:2: error strings should not be capitalized or end with punctuation or a newline
installer/pkg/workflow/terraform.go:13:21: error strings should not be capitalized or end with punctuation or a newline
installer/pkg/workflow/terraform.go:18:21: error strings should not be capitalized or end with punctuation or a newline
installer/pkg/workflow/utils.go:56:21: error strings should not be capitalized or end with punctuation or a newline
installer/pkg/workflow/utils.go:78:21: error strings should not be capitalized or end with punctuation or a newline
installer/pkg/workflow/utils.go:93:21: error strings should not be capitalized or end with punctuation or a newline
```

I've also fixed a number of TerraForm -> Terraform typos (maybe they re-branded upstream at some point?).  Upstream references to the project prefer the Terraform capitalization (e.g. [here][4]).  I've downcased the "terraform not in executable..." error message to make golint happy, and using a lowercase form matches the command name we were searching for (`terraform` the command, vs. `Terraform` the project).

Spun off from [here][5].

[1]: https://github.com/golang/go/wiki/CodeReviewComments#error-strings
[2]: https://github.com/golang/lint/blob/06c8688daad7faa9da5a0c2f163a3d14aac986ca/lint.go#L1186
[3]: https://github.com/golang/lint/blob/06c8688daad7faa9da5a0c2f163a3d14aac986ca/golint/golint.go#L23
[4]: https://www.terraform.io/
[5]: https://github.com/openshift/installer/pull/119#discussion_r217498510