### PR TITLE
modules/bootkube/resources/bootkube: Restore --tmpfs

### DIFF
--- a/installer/pkg/config-generator/fixtures/kube-system.yaml
+++ b/installer/pkg/config-generator/fixtures/kube-system.yaml
@@ -89,7 +89,7 @@ data:
       availabilityZone: ""
       clusterID: ""
       clusterName: test
-      image: ami-07307c397daf4d02e
+      image: ami-0af8953af3ec06b7c
       region: us-east-1
       replicas: 3
     kind: machineAPIOperatorConfig

--- a/installer/pkg/workflow/fixtures/terraform.tfvars
+++ b/installer/pkg/workflow/fixtures/terraform.tfvars
@@ -1,7 +1,7 @@
 {
   "tectonic_admin_email": "fake-email@example.com",
   "tectonic_admin_password": "fake-password",
-  "tectonic_aws_ec2_ami_override": "ami-07307c397daf4d02e",
+  "tectonic_aws_ec2_ami_override": "ami-0af8953af3ec06b7c",
   "tectonic_aws_endpoints": "all",
   "tectonic_aws_master_ec2_type": "m4.large",
   "tectonic_aws_master_root_volume_iops": 100,

--- a/modules/aws/bootstrap/README.md
+++ b/modules/aws/bootstrap/README.md
@@ -29,7 +29,7 @@ resource "aws_subnet" "example" {
 module "bootstrap" {
   source = "github.com/openshift/installer//modules/aws/bootstrap"
 
-  ami            = "ami-07307c397daf4d02e"
+  ami            = "ami-0af8953af3ec06b7c"
   bucket         = "${aws_s3_bucket.example.id}"
   cluster_name   = "my-cluster"
   ignition       = "{\"ignition\": {\"version\": \"2.2.0\"}}",

--- a/modules/bootkube/resources/bootkube.sh
+++ b/modules/bootkube/resources/bootkube.sh
@@ -64,6 +64,7 @@ trap "podman rm --force etcd-signer" ERR
 podman run \
 	--name etcd-signer \
 	--detach \
+	--tmpfs /tmp \
 	--volume /opt/tectonic/tls:/opt/tectonic/tls:ro,z \
 	--network host \
 	"${etcd_cert_signer_image}" \

--- a/pkg/rhcos/ami.go
+++ b/pkg/rhcos/ami.go
@@ -14,5 +14,5 @@ func AMI(channel, region string) (ami string, err error) {
 		return "", fmt.Errorf("region %q is not yet supported", region)
 	}
 
-	return "ami-07307c397daf4d02e", nil
+	return "ami-0af8953af3ec06b7c", nil
 }


### PR DESCRIPTION
We'd removed this in c234fc3f (#207) to work around [this][1] and [this][2].  Now that RHCOS is up to:

```console
$ curl -s http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/pkglist.txt | grep runc
 runc-1.0.0-52.dev.git70ca035.el7_5.x86_64
```

we can restore the option.

/hold

We'll probably need to bump our AMI too...

[1]: https://github.com/openshift/os/issues/284
[2]: https://github.com/containers/libpod/issues/1396