### PR TITLE
examples/*: re-order examples and make them consistent

### DIFF
--- a/examples/tectonic.aws.yaml
+++ b/examples/tectonic.aws.yaml
@@ -2,9 +2,109 @@ admin:
   email: "a@b.c"
   password: "verysecure"
   sshKey: "ssh-ed25519 AAAA..."
+
+# The base DNS domain of the cluster. It must NOT contain a trailing period. Some
+# DNS providers will automatically add this if necessary.
+#
+# Example: `openshift.example.com`.
+#
+# Note: This field MUST be set manually prior to creating the cluster.
+baseDomain:
+
+# The name of the cluster.
+# If used in a cloud-environment, this will be prepended to `baseDomain` resulting in the URL to the Tectonic console.
+#
+# Note: This field MUST be set manually prior to creating the cluster.
+# Warning: Special characters in the name like '.' may cause errors on OpenStack platforms due to resource name constraints.
+name:
+
+# The pull secret in JSON format.
+# This is known to be a "Docker pull secret" as produced by the docker login [1] command.
+# A sample JSON content is shown in [2].
+# You can download the pull secret from your Account overview page at [3].
+#
+# [1] https://docs.docker.com/engine/reference/commandline/login/
+#
+# [2] https://coreos.com/os/docs/latest/registry-authentication.html#manual-registry-auth-setup
+#
+# [3] https://account.coreos.com/overview
+#
+# You may use either pullSecretPath and supply the path to the file with the secret or pullSecret and embed the contents.
+# pullSecretPath: /path/to/secret
+pullSecret: '{"auths": {}}'
+
+# The platform used for deploying.
+platform: aws
 aws:
   # (optional) AMI override for all nodes. Example: `ami-foobar123`.
   # ec2AMIOverride:
+
+  # (optional) This declares the AWS credentials profile to use.
+  # profile: default
+
+  # The target AWS region for the cluster.
+  region: us-east-1
+
+  # Block of IP addresses used by the VPC.
+  # This should not overlap with any other networks, such as a private datacenter connected via Direct Connect.
+  vpcCIDRBlock: 10.0.0.0/16
+
+  # (optional) If set to true, create private-facing ingress resources (ELB, A-records).
+  # If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
+  # privateEndpoints: true
+
+  # (optional) If set to true, create public-facing ingress resources (ELB, A-records).
+  # If set to false, no public-facing ingress resources will be created.
+  # publicEndpoints: true
+
+  master:
+    # (optional) This configures master availability zones and their corresponding subnet CIDRs directly.
+    #
+    # Example:
+    # `{ eu-west-1a = "10.0.0.0/20", eu-west-1b = "10.0.16.0/20" }`
+    # customSubnets:
+
+    # Instance size for the master node(s). Example: `t2.medium`.
+    ec2Type: t2.medium
+
+    # (optional) List of additional security group IDs for master nodes.
+    #
+    # Example: `["sg-51530134", "sg-b253d7cc"]`
+    # extraSGIDs:
+
+    # (optional) Name of IAM role to use for the instance profiles of master nodes.
+    # The name is also the last part of a role's ARN.
+    #
+    # Example:
+    #  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer
+    #  * Role Name = tectonic-installer
+    # iamRoleName:
+
+    rootVolume:
+      # The amount of provisioned IOPS for the root block device of master nodes.
+      # Ignored if the volume type is not io1.
+      iops: 100
+
+      # The size of the volume in gigabytes for the root block device of master nodes.
+      size: 30
+
+      # The type of volume for the root block device of master nodes.
+      type: gp2
+
+  # You may use any of the options available to masters here. Such a customSubnets or extraSGIDs.
+  worker:
+    ec2Type: t2.medium
+    rootVolume:
+      iops: 100
+      size: 30
+      type: gp2
+
+    # (optional) List of ELBs to attach all worker instances to.
+    # This is useful for exposing NodePort services via load-balancers managed separately from the cluster.
+    #
+    # Example:
+    #  * `["ingress-nginx"]`
+    # loadBalancers:
 
   external:
     # (optional) List of subnet IDs within an existing VPC to deploy master nodes into.
@@ -44,106 +144,29 @@ aws:
   #  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer
   # installerRole:
 
-  master:
-    # (optional) This configures master availability zones and their corresponding subnet CIDRs directly.
-    #
-    # Example:
-    # `{ eu-west-1a = "10.0.0.0/20", eu-west-1b = "10.0.16.0/20" }`
-    # customSubnets:
+nodePools:
+    # The number of master nodes to be created.
+  - count: 1
+    name: master
 
-    # Instance size for the master node(s). Example: `t2.medium`.
-    ec2Type: t2.medium
+    # The number of worker nodes to be created.
+  - count: 2
+    name: worker
 
-    # (optional) List of additional security group IDs for master nodes.
-    #
-    # Example: `["sg-51530134", "sg-b253d7cc"]`
-    # extraSGIDs:
+networking:
+  # This declares the IP range to assign Kubernetes pod IPs in CIDR notation.
+  podCIDR: 10.2.0.0/16
 
-    # (optional) Name of IAM role to use for the instance profiles of master nodes.
-    # The name is also the last part of a role's ARN.
-    #
-    # Example:
-    #  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer
-    #  * Role Name = tectonic-installer
-    # iamRoleName:
+  # This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
+  # The maximum size of this IP range is /12
+  serviceCIDR: 10.3.0.0/16
 
-    rootVolume:
-      # The amount of provisioned IOPS for the root block device of master nodes.
-      # Ignored if the volume type is not io1.
-      iops: 100
-
-      # The size of the volume in gigabytes for the root block device of master nodes.
-      size: 30
-
-      # The type of volume for the root block device of master nodes.
-      type: gp2
-
-  # (optional) If set to true, create private-facing ingress resources (ELB, A-records).
-  # If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
-  # privateEndpoints: true
-
-  # (optional) This declares the AWS credentials profile to use.
-  # profile: default
-
-  # (optional) If set to true, create public-facing ingress resources (ELB, A-records).
-  # If set to false, no public-facing ingress resources will be created.
-  # publicEndpoints: true
-
-  # The target AWS region for the cluster.
-  region: us-east-1
-
-  # Block of IP addresses used by the VPC.
-  # This should not overlap with any other networks, such as a private datacenter connected via Direct Connect.
-  vpcCIDRBlock: 10.0.0.0/16
-
-  worker:
-    # (optional) This configures worker availability zones and their corresponding subnet CIDRs directly.
-    #
-    # Example: `{ eu-west-1a = "10.0.64.0/20", eu-west-1b = "10.0.80.0/20" }`
-    # customSubnets:
-
-    # Instance size for the worker node(s). Example: `t2.medium`.
-    ec2Type: t2.medium
-
-    # (optional) List of additional security group IDs for worker nodes.
-    #
-    # Example: `["sg-51530134", "sg-b253d7cc"]`
-    # extraSGIDs:
-
-    # (optional) Name of IAM role to use for the instance profiles of worker nodes.
-    # The name is also the last part of a role's ARN.
-    #
-    # Example:
-    #  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer
-    #  * Role Name = tectonic-installer
-    # iamRoleName:
-
-    # (optional) List of ELBs to attach all worker instances to.
-    # This is useful for exposing NodePort services via load-balancers managed separately from the cluster.
-    #
-    # Example:
-    #  * `["ingress-nginx"]`
-    # loadBalancers:
-
-    rootVolume:
-      # The amount of provisioned IOPS for the root block device of worker nodes.
-      # Ignored if the volume type is not io1.
-      iops: 100
-
-      # The size of the volume in gigabytes for the root block device of worker nodes.
-      size: 30
-
-      # The type of volume for the root block device of worker nodes.
-      type: gp2
-
-# The base DNS domain of the cluster. It must NOT contain a trailing period. Some
-# DNS providers will automatically add this if necessary.
-#
-# Example: `openshift.example.com`.
-#
-# Note: This field MUST be set manually prior to creating the cluster.
-# This applies only to cloud platforms.
-baseDomain:
+  # (optional) Configures the network to be used in Tectonic. One of the following values can be used:
+  #
+  # - "flannel": enables overlay networking only. This is implemented by flannel using VXLAN.
+  #
+  # - "none": disables the installation of any Pod level networking layer provided by Tectonic. By setting this value, users are expected to deploy their own solution to enable network connectivity for Pods and Services.
+  # type: flannel
 
 ca:
   # (optional) The content of the PEM-encoded CA certificate, used to generate Tectonic Console's server certificate.
@@ -159,71 +182,12 @@ ca:
   # This field is mandatory if `ca_cert` is set.
   # keyAlg: RSA
 
-iscsi:
-  # (optional) Start iscsid.service to enable iscsi volume attachment.
-  # enabled: false
-
 master:
   # The name of the node pool(s) to use for master nodes
   nodePools:
     - master
 
-# The name of the cluster.
-# If used in a cloud-environment, this will be prepended to `baseDomain` resulting in the URL to the Tectonic console.
-#
-# Note: This field MUST be set manually prior to creating the cluster.
-# Warning: Special characters in the name like '.' may cause errors on OpenStack platforms due to resource name constraints.
-name:
-
-networking:
-  # (optional) This declares the MTU used by Calico.
-  # mtu:
-
-  # This declares the IP range to assign Kubernetes pod IPs in CIDR notation.
-  podCIDR: 10.2.0.0/16
-
-  # This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
-  # The maximum size of this IP range is /12
-  serviceCIDR: 10.3.0.0/16
-
-  # (optional) Configures the network to be used in Tectonic. One of the following values can be used:
-  #
-  # - "flannel": enables overlay networking only. This is implemented by flannel using VXLAN.
-  #
-  # - "canal": enables overlay networking including network policy. Overlay is implemented by flannel using VXLAN. Network policy is implemented by Calico.
-  #
-  # - "calico-ipip": [ALPHA] enables BGP based networking. Routing and network policy is implemented by Calico. Note this has been tested on baremetal installations only.
-  #
-  # - "none": disables the installation of any Pod level networking layer provided by Tectonic. By setting this value, users are expected to deploy their own solution to enable network connectivity for Pods and Services.
-  # type: flannel
-
-nodePools:
-    # The number of master nodes to be created.
-    # This applies only to cloud platforms.
-  - count: 1
-    name: master
-
-    # The number of worker nodes to be created.
-    # This applies only to cloud platforms.
-  - count: 3
-    name: worker
-
-# The platform used for deploying.
-platform: aws
-
-# The pull secret in JSON format.
-# This is known to be a "Docker pull secret" as produced by the docker login [1] command.
-# A sample JSON content is shown in [2].
-# You can download the pull secret from your Account overview page at [3].
-#
-# [1] https://docs.docker.com/engine/reference/commandline/login/
-#
-# [2] https://coreos.com/os/docs/latest/registry-authentication.html#manual-registry-auth-setup
-#
-# [3] https://account.coreos.com/overview
-pullSecret: '{"auths": {}}'
-
 worker:
-  # The name of the node pool(s) to use for workers
+  # The name of the node pool(s) to use for worker nodes
   nodePools:
     - worker

--- a/examples/tectonic.libvirt.yaml
+++ b/examples/tectonic.libvirt.yaml
@@ -1,7 +1,8 @@
 admin:
-  email: a@b.c
-  password: verysecure
+  email: "a@b.c"
+  password: "verysecure"
   sshKey: "ssh-ed25519 AAAA..."
+
 # The base DNS domain of the cluster. It must NOT contain a trailing period. Some
 # DNS providers will automatically add this if necessary.
 #
@@ -10,6 +11,30 @@ admin:
 # Note: This field MUST be set manually prior to creating the cluster.
 baseDomain:
 
+# The name of the cluster.
+# If used in a cloud-environment, this will be prepended to `baseDomain` resulting in the URL to the Tectonic console.
+#
+# Note: This field MUST be set manually prior to creating the cluster.
+# Warning: Special characters in the name like '.' may cause errors on OpenStack platforms due to resource name constraints.
+name:
+
+# The pull secret in JSON format.
+# This is known to be a "Docker pull secret" as produced by the docker login [1] command.
+# A sample JSON content is shown in [2].
+# You can download the pull secret from your Account overview page at [3].
+#
+# [1] https://docs.docker.com/engine/reference/commandline/login/
+#
+# [2] https://coreos.com/os/docs/latest/registry-authentication.html#manual-registry-auth-setup
+#
+# [3] https://account.coreos.com/overview
+#
+# You may use either pullSecretPath and supply the path to the file with the secret or pullSecret and embed the contents.
+# pullSecretPath: /path/to/secret
+pullSecret: '{"auths": {}}'
+
+# The platform used for deploying.
+platform: libvirt
 libvirt:
   # You must specify an IP address here that libvirtd is listening on,
   # and that the cluster-api controller pod will be able to connect
@@ -20,6 +45,30 @@ libvirt:
     ifName: tt0
     ipRange: 192.168.124.0/24
   imagePath: /path/to/image
+
+nodePools:
+    # The number of master nodes to be created.
+  - count: 1
+    name: master
+
+    # The number of worker nodes to be created.
+  - count: 2
+    name: worker
+
+networking:
+  # This declares the IP range to assign Kubernetes pod IPs in CIDR notation.
+  podCIDR: 10.2.0.0/16
+
+  # This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
+  # The maximum size of this IP range is /12
+  serviceCIDR: 10.3.0.0/16
+
+  # (optional) Configures the network to be used in Tectonic. One of the following values can be used:
+  #
+  # - "flannel": enables overlay networking only. This is implemented by flannel using VXLAN.
+  #
+  # - "none": disables the installation of any Pod level networking layer provided by Tectonic. By setting this value, users are expected to deploy their own solution to enable network connectivity for Pods and Services.
+  # type: flannel
 
 ca:
   # (optional) The content of the PEM-encoded CA certificate, used to generate Tectonic Console's server certificate.
@@ -35,69 +84,12 @@ ca:
   # This field is mandatory if `ca_cert` is set.
   # keyAlg: RSA
 
-iscsi:
-  # (optional) Start iscsid.service to enable iscsi volume attachment.
-  # enabled: false
-
 master:
+  # The name of the node pool(s) to use for master nodes
   nodePools:
     - master
 
-# The name of the cluster.
-# If used in a cloud-environment, this will be prepended to `baseDomain` resulting in the URL to the Tectonic console.
-#
-# Note: This field MUST be set manually prior to creating the cluster.
-# Warning: Special characters in the name like '.' may cause errors on OpenStack platforms due to resource name constraints.
-name:
-
-networking:
-  # (optional) This declares the MTU used by Calico.
-  # mtu:
-
-  # (optional) This declares the IP range to assign Kubernetes pod IPs in CIDR notation.
-  podCIDR: 10.2.0.0/16
-
-  # (optional) This declares the IP range to assign Kubernetes service cluster IPs in CIDR notation.
-  # The maximum size of this IP range is /12
-  serviceCIDR: 10.3.0.0/16
-
-  # (optional) Configures the network to be used in Tectonic. One of the following values can be used:
-  #
-  # - "flannel": enables overlay networking only. This is implemented by flannel using VXLAN.
-  #
-  # - "canal": enables overlay networking including network policy. Overlay is implemented by flannel using VXLAN. Network policy is implemented by Calico.
-  #
-  # - "calico-ipip": [ALPHA] enables BGP based networking. Routing and network policy is implemented by Calico. Note this has been tested on baremetal installations only.
-  #
-  # - "none": disables the installation of any Pod level networking layer provided by Tectonic. By setting this value, users are expected to deploy their own solution to enable network connectivity for Pods and Services.
-  # type: flannel
-
-nodePools:
-    # The number of master nodes to be created.
-    # This applies only to cloud platforms.
-  - count: 1
-    name: master
-
-    # The number of worker nodes to be created.
-    # This applies only to cloud platforms.
-  - count: 2
-    name: worker
-
-# The platform used for deploying.
-platform: libvirt
-
-# The pull secret in JSON format.
-# This is known to be a "Docker pull secret" as produced by the docker login [1] command.
-# A sample JSON content is shown in [2].
-# You can download the pull secret from your Account overview page at [3].
-#
-# [1] https://docs.docker.com/engine/reference/commandline/login/
-#
-# [2] https://coreos.com/os/docs/latest/registry-authentication.html#manual-registry-auth-setup
-#
-# [3] https://account.coreos.com/overview
-pullSecret: '{"auths": {}}'
-
 worker:
+  # The name of the node pool(s) to use for worker nodes
   nodePools:
     - worker


### PR DESCRIPTION
Put the things people MUST set at the top (admin, baseDomain, name,
pullSecret.) And things people probably don't care about at the bottom
(CA, nodepools). Remove some things we don't want people to touch
(some networking options and the iSCSI block)

Hopefully it's just a little easier to find and set what matters.