### PR TITLE
Revert "hack/tf-fmt: Add a workaround for origin/release's hardcoding v0.11.7"

### DIFF
--- a/hack/tf-fmt.sh
+++ b/hack/tf-fmt.sh
@@ -6,7 +6,7 @@ if [ "$IS_CONTAINER" != "" ]; then
     set -- -list -check -write=false
   fi
   set -x
-  /terraform fmt "${@}"  # FIXME: drop this slash after we update openshift/release
+  terraform fmt "${@}"
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \


### PR DESCRIPTION
This reverts commit 856350d5160722e93e7a0817a24f0d27e55e9fea, #218.

Once openshift/release#1515 lands, we can drop the workaround.

/hold