### PR TITLE
asset/ignition: clean up templates

### DIFF
--- a/pkg/asset/ignition/BUILD.bazel
+++ b/pkg/asset/ignition/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/asset:go_default_library",
-        "//pkg/asset/ignition/templates:go_default_library",
+        "//pkg/asset/ignition/content:go_default_library",
         "//pkg/asset/installconfig:go_default_library",
         "//pkg/asset/kubeconfig:go_default_library",
         "//pkg/asset/tls:go_default_library",
@@ -37,7 +37,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/asset:go_default_library",
-        "//pkg/asset/ignition/templates:go_default_library",
+        "//pkg/asset/ignition/content:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/vincent-petithory/dataurl:go_default_library",
     ],

--- a/pkg/asset/ignition/bootstrap_test.go
+++ b/pkg/asset/ignition/bootstrap_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/asset/ignition/templates"
+	"github.com/openshift/installer/pkg/asset/ignition/content"
 )
 
 // TestBootstrapGenerate tests generating the bootstrap asset.
@@ -245,11 +245,11 @@ machines:
 		bootstrapState.Contents[0].Data,
 		systemdUnitAssertion{
 			name:     "bootkube.service",
-			contents: templates.BootkubeSystemdContents,
+			contents: content.BootkubeSystemdContents,
 		},
 		systemdUnitAssertion{
 			name:     "tectonic.service",
-			contents: templates.TectonicSystemdContents,
+			contents: content.TectonicSystemdContents,
 		},
 		systemdUnitAssertion{
 			name:     "kubelet.service",

--- a/pkg/asset/ignition/content/BUILD.bazel
+++ b/pkg/asset/ignition/content/BUILD.bazel
@@ -8,6 +8,6 @@ go_library(
         "kubelet.go",
         "tectonic.go",
     ],
-    importpath = "github.com/openshift/installer/pkg/asset/ignition/templates",
+    importpath = "github.com/openshift/installer/pkg/asset/ignition/content",
     visibility = ["//visibility:public"],
 )

--- a/pkg/asset/ignition/content/bootkube.go
+++ b/pkg/asset/ignition/content/bootkube.go
@@ -1,4 +1,8 @@
-package templates
+package content
+
+import (
+	"text/template"
+)
 
 const (
 	// BootkubeSystemdContents is a service for running bootkube on the bootstrap
@@ -15,10 +19,12 @@ ExecStart=/opt/tectonic/bootkube.sh
 
 Restart=on-failure
 RestartSec=5s`
+)
 
-	// BootkubeShFileContents is a script file for running bootkube on the
+var (
+	// BootkubeShFileTemplate is a script file for running bootkube on the
 	// bootstrap nodes.
-	BootkubeShFileContents = `#!/usr/bin/env bash
+	BootkubeShFileTemplate = template.Must(template.New("bootkube.sh").Parse(`#!/usr/bin/env bash
 set -e
 
 mkdir --parents /etc/kubernetes/manifests/
@@ -137,5 +143,5 @@ podman run \
 	--network=host \
 	--entrypoint=/bootkube \
 	"{{.BootkubeImage}}" \
-	start --asset-dir=/assets`
+	start --asset-dir=/assets`))
 )

--- a/pkg/asset/ignition/content/doc.go
+++ b/pkg/asset/ignition/content/doc.go
@@ -1,0 +1,3 @@
+// Package content contains the contents of files and systemd units to be added
+// to Ignition configs.
+package content

--- a/pkg/asset/ignition/content/kubelet.go
+++ b/pkg/asset/ignition/content/kubelet.go
@@ -1,9 +1,13 @@
-package templates
+package content
 
-const (
-	// KubeletSystemdContents is a service for running the kubelet on the
+import (
+	"text/template"
+)
+
+var (
+	// KubeletSystemdTemplate is a service for running the kubelet on the
 	// bootstrap nodes.
-	KubeletSystemdContents = `[Unit]
+	KubeletSystemdTemplate = template.Must(template.New("kubelet.service").Parse(`[Unit]
 Description=Kubernetes Kubelet
 Wants=rpc-statd.service
 
@@ -39,5 +43,5 @@ Restart=always
 RestartSec=10
 
 [Install]
-WantedBy=multi-user.target`
+WantedBy=multi-user.target`))
 )

--- a/pkg/asset/ignition/content/tectonic.go
+++ b/pkg/asset/ignition/content/tectonic.go
@@ -1,4 +1,4 @@
-package templates
+package content
 
 const (
 	// TectonicSystemdContents is a service that runs tectonic on the masters.

--- a/pkg/asset/ignition/node.go
+++ b/pkg/asset/ignition/node.go
@@ -25,6 +25,11 @@ func fileFromAsset(path string, mode int, assetState *asset.State, contentIndex 
 	return fileFromBytes(path, mode, assetState.Contents[contentIndex].Data)
 }
 
+// fileFromString creates an ignition-config file with the given contents.
+func fileFromString(path string, mode int, contents string) ignition.File {
+	return fileFromBytes(path, mode, []byte(contents))
+}
+
 // fileFromAsset creates an ignition-config file with the given contents.
 func fileFromBytes(path string, mode int, contents []byte) ignition.File {
 	return ignition.File{

--- a/pkg/asset/ignition/templates/doc.go
+++ b/pkg/asset/ignition/templates/doc.go
@@ -1,3 +1,0 @@
-// Package templates contains consts for the contents of files and systemd units
-// to add to ignition configs.
-package templates


### PR DESCRIPTION
This now distinguishes between constant strings and templates, which
will make it less likely that a template isn't executed when it should
be. This also has the advantage that the binary will panic immediately
if any of the templates are invalid.