### PR TITLE
pkg/types/installconfig: Fix 'tags' -> 'userTags' JSON serialization

### DIFF
--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -79,8 +79,8 @@ type AWSPlatform struct {
 	// Region specifies the AWS region where the cluster will be created.
 	Region string `json:"region"`
 
-	// UserTags specifies additional tags for AWS resources created by the cluster.
-	UserTags map[string]string `json:"tags,omitempty"`
+	// UserTags specifies additional tags for AWS resources created for the cluster.
+	UserTags map[string]string `json:"userTags,omitempty"`
 
 	// VPCID specifies the vpc to associate with the cluster.
 	// If empty, new vpc will be created.


### PR DESCRIPTION
I'd missed this while rerolling 89f05dac (#239).

I've also updated the UserTags comment to use "for the cluster" instead of "by the cluster".  Resources can be created by the installer (not part of the cluster) or by operators living inside the cluster, but regardless of the creator, these cluster resources should get `UserTags`.

Spun off from #236.