### PR TITLE
Add Terraform module for IAM resources

### DIFF
--- a/modules/aws/iam/main.tf
+++ b/modules/aws/iam/main.tf
@@ -1,0 +1,80 @@
+locals {
+  arn = "aws"
+}
+
+resource "aws_iam_instance_profile" "worker" {
+  name = "${var.cluster_name}-worker-profile"
+
+  role = "${var.worker_iam_role == "" ?
+    join("|", aws_iam_role.worker_role.*.name) :
+    join("|", data.aws_iam_role.worker_role.*.name)
+  }"
+}
+
+data "aws_iam_role" "worker_role" {
+  count = "${var.worker_iam_role == "" ? 0 : 1}"
+  name  = "${var.worker_iam_role}"
+}
+
+resource "aws_iam_role" "worker_role" {
+  count = "${var.worker_iam_role == "" ? 1 : 0}"
+  name  = "${var.cluster_name}-worker-role"
+  path  = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "worker_policy" {
+  count = "${var.worker_iam_role == "" ? 1 : 0}"
+  name  = "${var.cluster_name}_worker_policy"
+  role  = "${aws_iam_role.worker_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "ec2:Describe*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:AttachVolume",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:DetachVolume",
+      "Resource": "*"
+    },
+    {
+      "Action": "elasticloadbalancing:*",
+      "Resource": "*",
+      "Effect": "Allow"
+    },
+    {
+      "Action" : [
+        "s3:GetObject"
+      ],
+      "Resource": "arn:${local.arn}:s3:::*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}

--- a/modules/aws/iam/variables.tf
+++ b/modules/aws/iam/variables.tf
@@ -1,0 +1,9 @@
+variable "cluster_name" {
+  type = "string"
+}
+
+variable "worker_iam_role" {
+  type        = "string"
+  default     = ""
+  description = "IAM role to use for the instance profiles of worker nodes."
+}

--- a/modules/bootkube/resources/manifests/machine-api-operator.yaml
+++ b/modules/bootkube/resources/manifests/machine-api-operator.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: machine-api-operator
-        image: quay.io/coreos/machine-api-operator:225ff56
+        image: quay.io/coreos/machine-api-operator:b6a04c2
         command:
         - "/machine-api-operator"
         resources:

--- a/steps/infra/aws/main.tf
+++ b/steps/infra/aws/main.tf
@@ -41,6 +41,13 @@ module "masters" {
   user_data_igns      = "${var.tectonic_ignition_masters}"
 }
 
+module "iam" {
+  source = "../../../modules/aws/iam"
+
+  cluster_name     = "${var.tectonic_cluster_name}"
+  worker_iam_role  = "${var.tectonic_aws_worker_iam_role_name}"
+}
+
 module "dns" {
   source = "../../../modules/dns/route53"
 


### PR DESCRIPTION
Adds a Terraform module for IAM resources. The worker module was removed in #119 which removed the code that was creating the IAM profile for workers. This adds that bit back in a dedicated IAM module, and bumps the machine-api-operator image to latest, which includes a fix to use the correct instance profile for workers.