### PR TITLE
Enable parallel image pulls in kubelet

### DIFF
--- a/modules/ignition/resources/services/kubelet.service
+++ b/modules/ignition/resources/services/kubelet.service
@@ -28,6 +28,7 @@ ExecStart=/usr/bin/hyperkube \
     --cloud-provider=${cloud_provider} \
     --anonymous-auth=false \
     --cgroup-driver=systemd \
+    --serialize-image-pulls=false \
     ${cloud_provider_config} \
     ${debug_config} \
     ${node_taints_param} \


### PR DESCRIPTION
Upstream disables parallel image pulls by default for backwards compatibility with storage drivers that have problems when this is enabled (devicemapper and aufs), but since we default to overlay, we should be able to run this without a problem.