### PR TITLE
steps/infra/aws/main: Fix Terraform format for module.iam

### DIFF
--- a/steps/infra/aws/main.tf
+++ b/steps/infra/aws/main.tf
@@ -44,8 +44,8 @@ module "masters" {
 module "iam" {
   source = "../../../modules/aws/iam"
 
-  cluster_name     = "${var.tectonic_cluster_name}"
-  worker_iam_role  = "${var.tectonic_aws_worker_iam_role_name}"
+  cluster_name    = "${var.tectonic_cluster_name}"
+  worker_iam_role = "${var.tectonic_aws_worker_iam_role_name}"
 }
 
 module "dns" {


### PR DESCRIPTION
Generated with:

```console
$ terraform fmt
```

fixing formatting issues that snuck in with 39abbbb1 (#265).