### PR TITLE
hack/tf-fmt: Fix default-argument injection

### DIFF
--- a/hack/tf-fmt.sh
+++ b/hack/tf-fmt.sh
@@ -2,7 +2,7 @@
 
 # in prow, already in container, so no 'podman run'
 if [ "$IS_CONTAINER" != "" ]; then
-  if [ "${#N}" -gt 1 ]; then
+  if [ "${#N}" -eq 0 ]; then
     set -- -list -check -write=false
   fi
   set -x


### PR DESCRIPTION
We want to stuff these in when the user gave us no arguments, not clobber arguments when the user passed some in :p.  Fixes a bug from 4b9cbdd9 (#248).