### PR TITLE
modules/bootkube: update operatorstatus to namespaced

### DIFF
--- a/modules/bootkube/resources/manifests/operatorstatus-crd.yaml
+++ b/modules/bootkube/resources/manifests/operatorstatus-crd.yaml
@@ -14,7 +14,7 @@ spec:
       # One and only one version must be marked as the storage version.
       storage: true
   # either Namespaced or Cluster
-  scope: Cluster
+  scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
     plural: operatorstatuses


### PR DESCRIPTION
#232 made operatorstatus `ClusterScoped`, while it should have been `Namespaced.`