### PR TITLE
pkg/ipnet: Add DeepCopy(Into) support to IPNet

### DIFF
--- a/pkg/ipnet/ipnet.go
+++ b/pkg/ipnet/ipnet.go
@@ -16,6 +16,15 @@ type IPNet struct {
 	net.IPNet
 }
 
+// String returns a CIDR serialization of the subnet, or an empty
+// string if the subnet is nil.
+func (ipnet *IPNet) String() string {
+	if ipnet == nil {
+		return ""
+	}
+	return ipnet.IPNet.String()
+}
+
 // MarshalJSON interface for an IPNet
 func (ipnet IPNet) MarshalJSON() (data []byte, err error) {
 	if reflect.DeepEqual(ipnet.IPNet, emptyIPNet) {

--- a/pkg/ipnet/ipnet.go
+++ b/pkg/ipnet/ipnet.go
@@ -25,6 +25,26 @@ func (ipnet *IPNet) String() string {
 	return ipnet.IPNet.String()
 }
 
+// DeepCopyInto copies the receiver into out.  out must be non-nil.
+func (ipnet *IPNet) DeepCopyInto(out *IPNet) {
+	if ipnet == nil {
+		*out = *new(IPNet)
+	} else {
+		*out = *ipnet
+	}
+	return
+}
+
+// DeepCopy copies the receiver, creating a new IPNet.
+func (ipnet *IPNet) DeepCopy() *IPNet {
+	if ipnet == nil {
+		return nil
+	}
+	out := new(IPNet)
+	ipnet.DeepCopyInto(out)
+	return out
+}
+
 // MarshalJSON interface for an IPNet
 func (ipnet IPNet) MarshalJSON() (data []byte, err error) {
 	if reflect.DeepEqual(ipnet.IPNet, emptyIPNet) {

--- a/pkg/ipnet/ipnet_test.go
+++ b/pkg/ipnet/ipnet_test.go
@@ -38,23 +38,19 @@ func TestUnmarshal(t *testing.T) {
 			Mask: net.IPv4Mask(255, 255, 255, 0),
 		}},
 	} {
-		data, err := json.Marshal(ipNetIn)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		t.Run(string(data), func(t *testing.T) {
-			var ipNetOut *IPNet
-			err := json.Unmarshal(data, &ipNetOut)
+		t.Run(ipNetIn.String(), func(t *testing.T) {
+			data, err := json.Marshal(ipNetIn)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if ipNetIn == nil {
-				if ipNetOut != nil {
-					t.Fatalf("%v != %v", ipNetOut, ipNetIn)
-				}
-			} else if ipNetOut.String() != ipNetIn.String() {
+			var ipNetOut *IPNet
+			err = json.Unmarshal(data, &ipNetOut)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ipNetOut.String() != ipNetIn.String() {
 				t.Fatalf("%v != %v", ipNetOut, ipNetIn)
 			}
 		})

--- a/pkg/ipnet/ipnet_test.go
+++ b/pkg/ipnet/ipnet_test.go
@@ -56,3 +56,42 @@ func TestUnmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestDeepCopy(t *testing.T) {
+	for _, ipNetIn := range []*IPNet{
+		{},
+		{IPNet: net.IPNet{
+			IP:   net.IP{192, 168, 0, 10},
+			Mask: net.IPv4Mask(255, 255, 255, 0),
+		}},
+	} {
+		t.Run(ipNetIn.String(), func(t *testing.T) {
+			t.Run("DeepCopyInto", func(t *testing.T) {
+				ipNetOut := &IPNet{IPNet: net.IPNet{
+					IP:   net.IP{10, 0, 0, 0},
+					Mask: net.IPv4Mask(255, 0, 0, 0),
+				}}
+
+				ipNetIn.DeepCopyInto(ipNetOut)
+				if ipNetOut.String() != ipNetIn.String() {
+					t.Fatalf("%v != %v", ipNetOut, ipNetIn)
+				}
+			})
+
+			t.Run("DeepCopy", func(t *testing.T) {
+				ipNetOut := ipNetIn.DeepCopy()
+				if ipNetOut.String() != ipNetIn.String() {
+					t.Fatalf("%v != %v", ipNetOut, ipNetIn)
+				}
+
+				ipNetIn.IPNet = net.IPNet{
+					IP:   net.IP{192, 168, 10, 10},
+					Mask: net.IPv4Mask(255, 255, 255, 255),
+				}
+				if ipNetOut.String() == ipNetIn.String() {
+					t.Fatalf("%v (%q) == %v (%q)", ipNetOut, ipNetOut.String(), ipNetIn, ipNetIn.String())
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
@dgoodwin [needs `DeepCopyInto` on `IPNet`][1] as part of embedding our types into Hive's `ClusterDeployment` CRD.  The `zz_generated.deepcopy` prefix matches the current Kubernetes pattern, namespaces us from other future generators besides deepcopy, and sorts the file after human-generated entries in collated directory listings.

`deepcopy-gen` only looks for the package tag in file-level comments in a `doc.go` file (kubernetes/gengo#124).  I think that's an unfortunate restriction, but with this pull request I'm playing along by moving our package doc over to a new `doc.go`.  I'm also adding [the tag that deepcopy-gen is expecting][3].  And I'm also adding [a `go:generate` tag][4] that will run `deepcopy-gen` for us.

I expect this generated output to be pretty stable, which gives us some time to work up CI tooling for this approach.  Once we have CI coverage to protect from folks forgetting to regenerate, I'll extend this approach to cover more of the `InstallConfig` types.  But focusing on `IPNet` seemed like a reasonable starting point for testing the waters.

[1]: https://github.com/openshift/installer/issues/256#issue-360875062
[2]: https://github.com/kubernetes/gengo/pull/124
[3]: https://github.com/kubernetes/gengo/blob/4242d8e6c5dba56827bb7bcf14ad11cda38f3991/examples/deepcopy-gen/main.go#L33-L36
[4]: https://golang.org/pkg/cmd/go/internal/generate/