### PR TITLE
installer/pkg/config/libvirt: Caching for libvirt pulls

### DIFF
--- a/installer/pkg/workflow/BUILD.bazel
+++ b/installer/pkg/workflow/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//installer/pkg/config-generator:go_default_library",
-        "//installer/pkg/copy:go_default_library",
         "//pkg/types/config:go_default_library",
         "//vendor/github.com/Sirupsen/logrus:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",

--- a/pkg/types/config/libvirt/BUILD.bazel
+++ b/pkg/types/config/libvirt/BUILD.bazel
@@ -2,8 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["libvirt.go"],
+    srcs = [
+        "cache.go",
+        "libvirt.go",
+    ],
     importpath = "github.com/openshift/installer/pkg/types/config/libvirt",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/apparentlymart/go-cidr/cidr:go_default_library"],
+    deps = [
+        "//vendor/github.com/apparentlymart/go-cidr/cidr:go_default_library",
+        "//vendor/github.com/gregjones/httpcache:go_default_library",
+        "//vendor/github.com/gregjones/httpcache/diskcache:go_default_library",
+    ],
 )

--- a/pkg/types/config/libvirt/cache.go
+++ b/pkg/types/config/libvirt/cache.go
@@ -1,0 +1,68 @@
+package libvirt
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gregjones/httpcache"
+	"github.com/gregjones/httpcache/diskcache"
+)
+
+// UseCachedImage leaves non-file:// image URIs unalterered.
+// Other URIs are retrieved with a local cache at
+// $XDG_CACHE_HOME/openshift-install/libvirt [1].  This allows you to
+// use the same remote image URI multiple times without needing to
+// worry about redundant downloads, although you will want to
+// periodically blow away your cache.
+//
+// [1]: https://standards.freedesktop.org/basedir-spec/basedir-spec-0.7.html
+func (libvirt *Libvirt) UseCachedImage() (err error) {
+	// FIXME: set the default URI here?  Leave it elsewhere?
+
+	if strings.HasPrefix(libvirt.Image, "file://") {
+		return nil
+	}
+
+	baseCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return err
+	}
+
+	cacheDir := filepath.Join(baseCacheDir, "openshift-install", "libvirt")
+	err = os.MkdirAll(cacheDir, 0777)
+	if err != nil {
+		return err
+	}
+
+	cache := diskcache.New(cacheDir)
+	transport := httpcache.NewTransport(cache)
+	resp, err := transport.Client().Get(libvirt.Image)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("%s while getting %s", resp.Status, libvirt.Image)
+	}
+	defer resp.Body.Close()
+
+	// FIXME: diskcache's diskv backend doesn't expose direct file access.
+	// We can write our own cache implementation to get around this,
+	// but for now just dump this into /tmp without cleanup.
+	file, err := ioutil.TempFile("", "openshift-install-")
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	libvirt.Image = fmt.Sprintf("file://%s", filepath.ToSlash(file.Name()))
+	return nil
+}

--- a/pkg/types/config/libvirt/cache.go
+++ b/pkg/types/config/libvirt/cache.go
@@ -27,10 +27,12 @@ func (libvirt *Libvirt) UseCachedImage() (err error) {
 		return nil
 	}
 
-	baseCacheDir, err := os.UserCacheDir()
-	if err != nil {
-		return err
-	}
+	// FIXME: Use os.UserCacheDir() once we bump to Go 1.11
+	// baseCacheDir, err := os.UserCacheDir()
+	// if err != nil {
+	// 	return err
+	// }
+	baseCacheDir := filepath.Join(os.Getenv("HOME"), ".cache")
 
 	cacheDir := filepath.Join(baseCacheDir, "openshift-install", "libvirt")
 	err = os.MkdirAll(cacheDir, 0777)

--- a/pkg/types/config/parser.go
+++ b/pkg/types/config/parser.go
@@ -31,6 +31,7 @@ func ParseConfig(data []byte) (*Cluster, error) {
 			return nil, err
 		}
 		cluster.PullSecret = string(data)
+		cluster.PullSecretPath = ""
 	}
 
 	if cluster.Platform == PlatformAWS && cluster.EC2AMIOverride == "" {


### PR DESCRIPTION
Checking our RHCOS source against [`ETag`][1] / [`If-None-Match`][2] and [`Last-Modified`][3] / [`If-Modified-Since`][4], it seems to support `In-None-Match` well, but only supports `If-Modified-Since` for exact matches:

```console
$ URL=http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz
$ curl -I "${URL}"
HTTP/1.1 200 OK
Server: nginx/1.8.0
Date: Wed, 19 Sep 2018 04:32:19 GMT
Content-Type: application/octet-stream
Content-Length: 684934062
Last-Modified: Tue, 18 Sep 2018 20:05:24 GMT
Connection: keep-alive
ETag: "5ba15a84-28d343ae"
Accept-Ranges: bytes
$ curl -sIH 'If-None-Match: "5ba15a84-28d343ae"' "${URL}" | head -n1
HTTP/1.1 304 Not Modified
$ curl -sIH 'If-Modified-Since: Tue, 18 Sep 2018 20:05:24 GMT' "${URL}" | head -n1
HTTP/1.1 304 Not Modified
$ curl -sIH 'If-Modified-Since: Tue, 18 Sep 2015 20:05:24 GMT' "${URL}" | head -n1
HTTP/1.1 200 OK
$ curl -sIH 'If-Modified-Since: Tue, 18 Sep 2018 20:05:25 GMT' "${URL}" | grep 'HTTP\|Last-Modified'
HTTP/1.1 200 OK
Last-Modified: Tue, 18 Sep 2018 20:05:24 GMT
```

That last entry should have 304ed, although [the spec has][4]:

> When used for cache updates, a cache will typically use the value of the cached message's `Last-Modified` field to generate the field value of `If-Modified-Since`.  This behavior is most interoperable for cases where clocks are poorly synchronized or when the server has chosen to only honor exact timestamp matches (due to a problem with `Last-Modified` dates that appear to go "back in time" when the origin server's clock is corrected or a representation is restored from an archived backup)...

So the server is violating the SHOULD by not 304ing dates greater than `Last-Modified`, but it's not violating a MUST-level requirement.  The server requirements around `If-None-Match` [are MUST-level][2], so using it should be more portable.  The RFC also seems [to][4] [prefer][5] clients use `If(-None)-Match`.

I'm using gregjones/httpcache for the caching, since that implemenation seems reasonably popular and the repo's been around for a few years.  That library uses the belt-and-suspenders approach of [setting both `If-None-Match` (to the cached `ETag`) and `If-Modified-Since` (to the cached `Last-Modified`)][6], so we should be fine.

`UserCacheDir` [requires][7] [Go][8] [1.11][9].

No unit tests, but you can excercise the logic with:

```
$ go1.11 build ./installer/cmd/tectonic
$ cat libvirt.yaml 
admin:
  email: a@b.c
  password: verysecure
  sshKey: "ssh-rsa AAAA..."
baseDomain: installer.testing
name: wking
platform: libvirt
libvirt:
  uri: qemu+tcp://192.168.122.1/system
  network:
    name: tectonic
    ifName: tt0
    dnsServer: 8.8.8.8
    ipRange: 192.168.124.0/24
  image: http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz
pullSecretPath: /home/trking/src/openshift/installer/pull-secret.json
master:
  nodePools:
    - master
worker:
  nodePools:
    - worker
nodePools:
  - count: 1
    name: master
  - count: 2
    name: worker
$ rm -rf wking && ./tectonic init --config=libvirt.yaml && cat wking/config.yaml  # slow....
...
  image: file:///tmp/openshift-install-092942808
...
$ rm -rf wking && ./tectonic init --config=libvirt.yaml && cat wking/config.yaml  # fast :)
...
  image: file:///tmp/openshift-install-567329896
...
$ sha1sum /tmp/openshift-install-*
d4554ab97c91f1d807fafab0c81b5492a98219a8  /tmp/openshift-install-092942808
d4554ab97c91f1d807fafab0c81b5492a98219a8  /tmp/openshift-install-567329896
$ tree -a ~/.cache/openshift-install/
/home/trking/.cache/openshift-install/
└── libvirt
    └── 914a1ca2be4f5adecaea8ceda514b02e

1 directory, 1 file
```

[1]: https://tools.ietf.org/html/rfc7232#section-2.3
[2]: https://tools.ietf.org/html/rfc7232#section-3.2
[3]: https://tools.ietf.org/html/rfc7232#section-2.2
[4]: https://tools.ietf.org/html/rfc7232#section-3.3
[5]: https://tools.ietf.org/html/rfc7232#section-2.4
[6]: https://github.com/gregjones/httpcache/blob/9cad4c3443a7200dd6400aef47183728de563a38/httpcache.go#L169-L181
[7]: https://github.com/golang/go/issues/22536
[8]: https://github.com/golang/go/commit/816154b06553a4cf8ee7ad089f5e444b37bed43d
[9]: https://github.com/golang/go/commit/50bd1c4d4eb4fac8ddeb5f063c099daccfb71b26