### PR TITLE
tests/run: Destroy with --continue-on-error

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -21,7 +21,7 @@ exec &> >(tee -ai "$CLUSTER_NAME.log")
 
 function destroy() {
   echo -e "\\e[34m Exiting... Destroying Tectonic...\\e[0m"
-  "${TECTONIC}" destroy --dir="${CLUSTER_NAME}"
+  "${TECTONIC}" destroy --dir="${CLUSTER_NAME}" --continue-on-error
   echo -e "\\e[36m Finished! Smoke test output:\\e[0m ${SMOKE_TEST_OUTPUT}"
   echo -e "\\e[34m So Long, and Thanks for All the Fish\\e[0m"
 }


### PR DESCRIPTION
Taking advantage of #252 so we can reap at least most of our resources even if the cluster doesn't come up enough for the machine API operator to be able to destroy workers.  With various stages of cluster health:

1. Cluster never comes up at all.
2. Cluster healthy enough to create workers.
3. Cluster healthy enough to destroy workers.

we're only worried about leakage in the space between 2 and 3.  Hopefully there isn't any space there, but without this commit we're currently leaking resources from 1 as well.