### PR TITLE
Use TLS authentication for cluster-api libvirt connection

### DIFF
--- a/examples/libvirt.yaml
+++ b/examples/libvirt.yaml
@@ -11,10 +11,11 @@ admin:
 baseDomain:
 
 libvirt:
-  # You must specify an IP address here that libvirtd is listening on,
-  # and that the cluster-api controller pod will be able to connect
-  # to.  Often 192.168.122.1 is the default for the virbr0 interface.
-  uri: qemu+tcp://192.168.122.1/system
+  uri: qemu:///system
+  tls:
+    caPath: /path/to/cacert.pem
+    certPath: /path/to/clientcert.pem
+    keyPath: /path/to/clientkey.pem
   network:
     name: tectonic
     ifName: tt0

--- a/hack/libvirt-ca/main.go
+++ b/hack/libvirt-ca/main.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/apparentlymart/go-cidr/cidr"
+	"github.com/openshift/installer/pkg/asset/tls"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+const (
+	orgUnit          = "openshift"
+	caCommonName     = "libvirt"
+	serverCommonName = "libvirt"
+	clientCommonName = "openshift-cluster-api"
+	defaultNetwork   = "192.168.124.0/24"
+	defaultOutDir    = "."
+
+	// Libvirt is picky about the naming here:
+	// https://libvirt.org/remote.html
+	caCertFile     = "cacert.pem"
+	caKeyFile      = "cakey.pem"
+	serverCertFile = "servercert.pem"
+	serverKeyFile  = "serverkey.pem"
+	clientCertFile = "clientcert.pem"
+	clientKeyFile  = "clientkey.pem"
+)
+
+var (
+	network = kingpin.Flag("network", "Cluster network CIDR.").
+		Short('n').Default(defaultNetwork).String()
+
+	outDir = kingpin.Flag("out", "Output directory.").
+		Short('o').Default(defaultOutDir).ExistingDir()
+)
+
+type certificate struct {
+	key  *rsa.PrivateKey
+	cert *x509.Certificate
+}
+
+func (c *certificate) WritePEMs(certPath, keyPath string) error {
+	if err := ioutil.WriteFile(keyPath, []byte(tls.PrivateKeyToPem(c.key)), 0600); err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(certPath, []byte(tls.CertToPem(c.cert)), 0644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getGateway(network string) (net.IP, error) {
+	_, ipNet, err := net.ParseCIDR(network)
+	if err != nil {
+		return nil, err
+	}
+
+	gateway, err := cidr.Host(ipNet, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return gateway, nil
+}
+
+func generateCA() (*certificate, error) {
+	var ca certificate
+	var err error
+
+	cfg := &tls.CertCfg{
+		Subject: pkix.Name{
+			CommonName:         caCommonName,
+			OrganizationalUnit: []string{orgUnit},
+		},
+		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		Validity:  tls.ValidityTenYears,
+		IsCA:      true,
+	}
+
+	ca.key, ca.cert, err = tls.GenerateRootCertKey(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ca, err
+}
+
+func generateServerCert(dnsNames []string, ips []net.IP, ca *certificate) (*certificate, error) {
+	var server certificate
+	var err error
+
+	cfg := &tls.CertCfg{
+		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Subject: pkix.Name{
+			CommonName:         serverCommonName,
+			OrganizationalUnit: []string{orgUnit},
+		},
+		DNSNames:    dnsNames,
+		Validity:    tls.ValidityTenYears,
+		IPAddresses: ips,
+		IsCA:        false,
+	}
+
+	server.key, server.cert, err = tls.GenerateCert(ca.key, ca.cert, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &server, err
+}
+
+func generateClientCert(ca *certificate) (*certificate, error) {
+	var client certificate
+	var err error
+
+	cfg := &tls.CertCfg{
+		Subject: pkix.Name{
+			CommonName:         clientCommonName,
+			OrganizationalUnit: []string{orgUnit},
+		},
+		KeyUsages:    x509.KeyUsageKeyEncipherment,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Validity:     tls.ValidityTenYears,
+	}
+
+	client.key, client.cert, err = tls.GenerateCert(ca.key, ca.cert, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client, nil
+}
+
+func writeCertificates(dir string, ca, server, client *certificate) error {
+	// Certificate Authority
+	caCertPath := filepath.Join(dir, caCertFile)
+	caKeyPath := filepath.Join(dir, caKeyFile)
+	if err := ca.WritePEMs(caCertPath, caKeyPath); err != nil {
+		return err
+	}
+
+	// Server Certificate
+	serverCertPath := filepath.Join(dir, serverCertFile)
+	serverKeyPath := filepath.Join(dir, serverKeyFile)
+	if err := server.WritePEMs(serverCertPath, serverKeyPath); err != nil {
+		return err
+	}
+
+	// Client Certificate
+	clientCertPath := filepath.Join(dir, clientCertFile)
+	clientKeyPath := filepath.Join(dir, clientKeyFile)
+	if err := server.WritePEMs(clientCertPath, clientKeyPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	kingpin.Parse()
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		fmt.Printf("Failed to determine hostname: %v\n", err)
+		os.Exit(1)
+	}
+
+	gateway, err := getGateway(*network)
+	if err != nil {
+		fmt.Printf("Failed to read network: %v\n", err)
+		os.Exit(1)
+	}
+
+	ca, err := generateCA()
+	if err != nil {
+		fmt.Printf("Failed to generate CA: %v\n", err)
+		os.Exit(1)
+	}
+
+	server, err := generateServerCert([]string{hostname}, []net.IP{gateway}, ca)
+	if err != nil {
+		fmt.Printf("Failed to generate server certificate: %v\n", err)
+		os.Exit(1)
+	}
+
+	client, err := generateClientCert(ca)
+	if err != nil {
+		fmt.Printf("Failed to generate client certificate: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := writeCertificates(*outDir, ca, server, client); err != nil {
+		fmt.Printf("Failed to write certificate files: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/modules/bootkube/outputs.tf
+++ b/modules/bootkube/outputs.tf
@@ -26,5 +26,6 @@ output "ignition_file_id_list" {
       data.ignition_file.kubeconfig-kubelet.id,
     ),
     data.ignition_file.manifest_file_list.*.id,
+    data.ignition_file.libvirt_certs_secret.*.id,
   ))}"]
 }

--- a/modules/bootkube/resources/manifests/libvirt-certs-secret.yaml
+++ b/modules/bootkube/resources/manifests/libvirt-certs-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: libvirt-certs
+  namespace: openshift-cluster-api
+type: Opaque
+data:
+  cacert.pem: ${ca_cert}
+  clientcert.pem: ${client_cert}
+  clientkey.pem: ${client_key}

--- a/modules/bootkube/resources/manifests/machine-api-operator.yaml
+++ b/modules/bootkube/resources/manifests/machine-api-operator.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: machine-api-operator
-        image: quay.io/coreos/machine-api-operator:b6a04c2
+        image: quay.io/coreos/machine-api-operator:6ce7a77
         command:
         - "/machine-api-operator"
         resources:

--- a/modules/bootkube/variables.tf
+++ b/modules/bootkube/variables.tf
@@ -166,3 +166,21 @@ variable "worker_ign_config" {
   type        = "string"
   default     = ""
 }
+
+variable "libvirt_tls_ca_pem" {
+  type        = "string"
+  description = "The libvirt CA certificate in PEM format"
+  default     = ""
+}
+
+variable "libvirt_tls_cert_pem" {
+  type        = "string"
+  description = "The libvirt client certificate in PEM format"
+  default     = ""
+}
+
+variable "libvirt_tls_key_pem" {
+  type        = "string"
+  description = "The libvirt client private key in PEM format"
+  default     = ""
+}

--- a/pkg/types/config/libvirt/libvirt.go
+++ b/pkg/types/config/libvirt/libvirt.go
@@ -16,10 +16,18 @@ const (
 type Libvirt struct {
 	URI         string `json:"tectonic_libvirt_uri,omitempty" yaml:"uri"`
 	Image       string `json:"tectonic_os_image,omitempty" yaml:"image"`
+	TLS         `json:",inline" yaml:"tls"`
 	Network     `json:",inline" yaml:"network"`
 	MasterIPs   []string `json:"tectonic_libvirt_master_ips,omitempty" yaml:"masterIPs"`
 	WorkerIPs   []string `json:"tectonic_libvirt_worker_ips,omitempty" yaml:"workerIPs"`
 	BootstrapIP string   `json:"tectonic_libvirt_bootstrap_ip,omitempty" yaml:"bootstrapIP"`
+}
+
+// TLS represents paths to TLS assets for libvirt clients.
+type TLS struct {
+	CAPath   string `json:"tectonic_libvirt_tls_ca_path,omitempty" yaml:"caPath"`
+	CertPath string `json:"tectonic_libvirt_tls_cert_path,omitempty" yaml:"certPath"`
+	KeyPath  string `json:"tectonic_libvirt_tls_key_path,omitempty" yaml:"keyPath"`
 }
 
 // Network describes a libvirt network configuration.

--- a/steps/assets/base/tectonic.tf
+++ b/steps/assets/base/tectonic.tf
@@ -52,6 +52,10 @@ module "bootkube" {
   etcd_endpoints = "${data.template_file.etcd_hostname_list.*.rendered}"
 
   worker_ign_config = "${var.aws_worker_ign_config}"
+
+  libvirt_tls_ca_pem   = "${var.libvirt_tls_ca_pem}"
+  libvirt_tls_cert_pem = "${var.libvirt_tls_cert_pem}"
+  libvirt_tls_key_pem  = "${var.libvirt_tls_key_pem}"
 }
 
 module "tectonic" {

--- a/steps/assets/base/variables.tf
+++ b/steps/assets/base/variables.tf
@@ -12,3 +12,18 @@ variable "aws_worker_ign_config" {
   type    = "string"
   default = ""
 }
+
+variable "libvirt_tls_ca_pem" {
+  type    = "string"
+  default = ""
+}
+
+variable "libvirt_tls_cert_pem" {
+  type    = "string"
+  default = ""
+}
+
+variable "libvirt_tls_key_pem" {
+  type    = "string"
+  default = ""
+}

--- a/steps/assets/libvirt/main.tf
+++ b/steps/assets/libvirt/main.tf
@@ -1,3 +1,9 @@
+locals {
+  libvirt_tls_ca_pem   = "${file("${var.tectonic_libvirt_tls_ca_path}")}"
+  libvirt_tls_cert_pem = "${file("${var.tectonic_libvirt_tls_cert_path}")}"
+  libvirt_tls_key_pem  = "${file("${var.tectonic_libvirt_tls_key_path}")}"
+}
+
 module assets_base {
   source = "../base"
 
@@ -20,4 +26,8 @@ module assets_base {
   tectonic_service_cidr         = "${var.tectonic_service_cidr}"
   tectonic_update_channel       = "${var.tectonic_update_channel}"
   tectonic_versions             = "${var.tectonic_versions}"
+
+  libvirt_tls_ca_pem   = "${local.libvirt_tls_ca_pem}"
+  libvirt_tls_cert_pem = "${local.libvirt_tls_cert_pem}"
+  libvirt_tls_key_pem  = "${local.libvirt_tls_key_pem}"
 }

--- a/steps/variables-libvirt.tf
+++ b/steps/variables-libvirt.tf
@@ -3,6 +3,21 @@ variable "tectonic_libvirt_uri" {
   description = "libvirt connection URI"
 }
 
+variable "tectonic_libvirt_tls_ca_path" {
+  type        = "string"
+  description = "path to the libvirt CA certificate"
+}
+
+variable "tectonic_libvirt_tls_cert_path" {
+  type        = "string"
+  description = "path to the libvirt client certificate"
+}
+
+variable "tectonic_libvirt_tls_key_path" {
+  type        = "string"
+  description = "path to the libvirt client private key"
+}
+
 variable "tectonic_libvirt_network_name" {
   type        = "string"
   description = "Name of the libvirt network to create"


### PR DESCRIPTION
This enables TLS authentication for the connection from the in-cluster cluster-api components to the host libvirtd. It includes a script under `hack/` to generate the necessary TLS assets, and includes Terraform changes to conditionally render a secret containing the client credentials.

@crawford mentioned that it might be best to hold off on this until the asset generation is rewritten, but I wanted to get something up for reference. If this needs to be put on hold, that's fine. I can rebase when ready.