### PR TITLE
build: enable pure builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
 startup --output_base .build
-build --color=yes --workspace_status_command "${PWD}/buildvars.sh"
+build --color=yes --features=pure --workspace_status_command "${PWD}/buildvars.sh"

--- a/buildvars.sh
+++ b/buildvars.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Vars exported to the build info
 echo TECTONIC_VERSION "${TECTONIC_VERSION}"


### PR DESCRIPTION
This ensures that we don't build dynamically linked executables. Static
linking is desirable because it will allow the generated binaries to run
on any Linux distribution.