### PR TITLE
config: Only determine AMI for aws platform.

### DIFF
--- a/pkg/types/config/parser.go
+++ b/pkg/types/config/parser.go
@@ -33,7 +33,7 @@ func ParseConfig(data []byte) (*Cluster, error) {
 		cluster.PullSecret = string(data)
 	}
 
-	if cluster.EC2AMIOverride == "" {
+	if cluster.Platform == PlatformAWS && cluster.EC2AMIOverride == "" {
 		ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
 		defer cancel()
 


### PR DESCRIPTION
A recent commit, d01ac5d70bfcfa6f0c1da7e57e24dc0554e3122c, introduced
a regression for libvirt.

    $ tectonic init --config=../libvirt.yaml
    FATA[0020] failed to get configuration from file "../libvirt.yaml": ../libvirt.yaml is not a valid config file: failed to determine default AMI: ...

Fix this by only bothering to determine the default AMI when the platform
is aws.