### PR TITLE
steps/infra/aws: sync libvirt default for ignition_bootstrap to aws

### DIFF
--- a/steps/infra/aws/inputs.tf
+++ b/steps/infra/aws/inputs.tf
@@ -4,6 +4,10 @@ data "terraform_remote_state" "assets" {
   config {
     path = "${path.cwd}/assets.tfstate"
   }
+
+  defaults {
+    ignition_bootstrap = ""
+  }
 }
 
 locals {


### PR DESCRIPTION
#289 missed this.

/cc @yifan-gu 