### PR TITLE
asset/*: allow prompts to be read from environment

### DIFF
--- a/pkg/asset/installconfig/ssh.go
+++ b/pkg/asset/installconfig/ssh.go
@@ -25,6 +25,14 @@ func (a *sshPublicKey) Dependencies() []asset.Asset {
 
 // Generate generates the SSH public key asset.
 func (a *sshPublicKey) Generate(map[asset.Asset]*asset.State) (state *asset.State, err error) {
+	if value, ok := os.LookupEnv("OPENSHIFT_INSTALL_SSH_PUB_KEY"); ok {
+		return &asset.State{
+			Contents: []asset.Content{{
+				Data: []byte(value),
+			}},
+		}, nil
+	}
+
 	pubKeys := map[string][]byte{
 		none: {},
 	}

--- a/pkg/asset/installconfig/stock.go
+++ b/pkg/asset/installconfig/stock.go
@@ -55,6 +55,7 @@ func (s *StockImpl) EstablishStock() {
 			Message: "Email Address",
 			Help:    "The email address of the cluster administrator. This will be used to log in to the console.",
 		},
+		EnvVarName: "OPENSHIFT_INSTALL_EMAIL_ADDRESS",
 	}
 	s.password = &asset.UserProvided{
 		AssetName: "Password",
@@ -62,6 +63,7 @@ func (s *StockImpl) EstablishStock() {
 			Message: "Password",
 			Help:    "The password of the cluster administrator. This will be used to log in to the console.",
 		},
+		EnvVarName: "OPENSHIFT_INSTALL_PASSWORD",
 	}
 	s.baseDomain = &asset.UserProvided{
 		AssetName: "Base Domain",
@@ -69,6 +71,7 @@ func (s *StockImpl) EstablishStock() {
 			Message: "Base Domain",
 			Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base.",
 		},
+		EnvVarName: "OPENSHIFT_INSTALL_BASE_DOMAIN",
 	}
 	s.clusterName = &asset.UserProvided{
 		AssetName: "Cluster Name",
@@ -76,6 +79,7 @@ func (s *StockImpl) EstablishStock() {
 			Message: "Cluster Name",
 			Help:    "The name of the cluster. This will be used when generating sub-domains.",
 		},
+		EnvVarName: "OPENSHIFT_INSTALL_CLUSTER_NAME",
 	}
 	s.pullSecret = &asset.UserProvided{
 		AssetName: "Pull Secret",
@@ -83,6 +87,7 @@ func (s *StockImpl) EstablishStock() {
 			Message: "Pull Secret",
 			Help:    "The container registry pull secret for this cluster.",
 		},
+		EnvVarName: "OPENSHIFT_INSTALL_PULL_SECRET",
 	}
 	s.platform = &Platform{}
 	s.sshKey = &sshPublicKey{}

--- a/pkg/asset/userprovided.go
+++ b/pkg/asset/userprovided.go
@@ -1,13 +1,16 @@
 package asset
 
 import (
+	"os"
+
 	"github.com/AlecAivazis/survey"
 )
 
 // UserProvided generates an asset that is supplied by a user.
 type UserProvided struct {
-	AssetName string
-	Prompt    survey.Prompt
+	AssetName  string
+	Prompt     survey.Prompt
+	EnvVarName string
 }
 
 var _ Asset = (*UserProvided)(nil)
@@ -20,7 +23,11 @@ func (a *UserProvided) Dependencies() []Asset {
 // Generate queries for input from the user.
 func (a *UserProvided) Generate(map[Asset]*State) (*State, error) {
 	var response string
-	survey.AskOne(a.Prompt, &response, survey.Required)
+	if value, ok := os.LookupEnv(a.EnvVarName); ok {
+		response = value
+	} else {
+		survey.AskOne(a.Prompt, &response, survey.Required)
+	}
 
 	return &State{
 		Contents: []Content{{


### PR DESCRIPTION
This adds support for reading user prompts from the environment. This
will allow CI to test the installer without needing `expect` or a
similar utility. It can be used like the following:

    OPENSHIFT_INSTALL_CLUSTER_NAME=crawford
    OPENSHIFT_INSTALL_PLATFORM=libvirt
    openshift-install cluster