### PR TITLE
installer/workflow: don't regenerate tfvars

### DIFF
--- a/installer/pkg/workflow/destroy.go
+++ b/installer/pkg/workflow/destroy.go
@@ -31,7 +31,6 @@ func DestroyWorkflow(clusterDir string, contOnErr bool) Workflow {
 		},
 		steps: []step{
 			readClusterConfigStep,
-			generateTerraformVariablesStep,
 			destroyWorkersStep,
 			destroyInfraStep,
 			destroyAssetsStep,


### PR DESCRIPTION
927e18c86 introduced a bug by generating the Ignition configs in
generateIgnConfigStep() instead of generateTerraformVariablesStep(). In
doing so, callers of generateTerraformVariablesStep() were left with a
partial terraform.tfvars file which was missing certain required
variables. This wasn't a problem when running install (because both
steps were run, but it did cause destroy to fail with:

    * libvirt_ignition.master: At column 23, line 1: list
    "var.ignition_masters" does not have any elements so cannot
    determine type

When destroying the cluster, there is no need to regenerate
terraform.tfvars (it was already generated during installation).