### PR TITLE
build: add build script for new installer

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+CGO_ENABLED=0 go build -o ./bin/openshift-install ./cmd/openshift-install


### PR DESCRIPTION
The installer will soon move away from Bazel and the old codebase. This
script will serve as the new build system.