### PR TITLE
[DO-NOT-MERGE] Add dns operator manifests to installer.

### DIFF
--- a/pkg/asset/manifests/dns-operator.go
+++ b/pkg/asset/manifests/dns-operator.go
@@ -1,0 +1,101 @@
+package manifests
+
+import (
+	"path/filepath"
+	"sort"
+
+	"github.com/ghodss/yaml"
+
+	dnsopapi "github.com/openshift/cluster-dns-operator/pkg/apis/dns/v1alpha1"
+	dnsopmanifests "github.com/openshift/cluster-dns-operator/pkg/manifests"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/types"
+)
+
+// dnsOperator generates the dns-operator-*.yml files
+type dnsOperator struct {
+	installConfigAsset asset.Asset
+	installConfig      *types.InstallConfig
+}
+
+var _ asset.Asset = (*dnsOperator)(nil)
+
+// Name returns a human friendly name for the operator
+func (doh *dnsOperator) Name() string {
+	return "DNS Operator"
+}
+
+// Dependencies returns all of the dependencies directly needed by an
+// dnsOperator asset.
+func (doh *dnsOperator) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		doh.installConfigAsset,
+	}
+}
+
+// Generate generates the dns-operator-config.yml and dns-operator-manifests.yml files
+func (doh *dnsOperator) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+	ic, err := installconfig.GetInstallConfig(doh.installConfigAsset, dependencies)
+	if err != nil {
+		return nil, err
+	}
+	doh.installConfig = ic
+
+	// installconfig is ready, we can create the core config from it now
+	dnsConfig, err := doh.dnsConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	assetData, err := doh.assetData()
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0)
+	for k := range assetData {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	assetContents := make([]asset.Content, 0)
+	for _, k := range keys {
+		assetContents = append(assetContents, asset.Content{
+			Name: filepath.Join("dns-operator", k),
+			Data: assetData[k],
+		})
+	}
+
+	assetContents = append(assetContents, asset.Content{
+		Name: "dns-operator-config.yml",
+		Data: dnsConfig,
+	})
+
+	return &asset.State{Contents: assetContents}, nil
+}
+
+func (doh *dnsOperator) dnsOperatorConfig() (*dnsopapi.ClusterDNS, error) {
+	clusterIP, err := installconfig.ClusterDNSIP(doh.installConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dnsopapi.ClusterDNS{
+		Spec: dnsopapi.ClusterDNSSpec{
+			// Check if BaseDomain is correct?
+			ClusterIP:     &clusterIP,
+			ClusterDomain: &doh.installConfig.BaseDomain,
+		},
+	}, nil
+}
+
+func (doh *dnsOperator) dnsConfig() ([]byte, error) {
+	return yaml.Marshal(doh.dnsOperatorConfig())
+}
+
+func (doh *dnsOperator) assetData() (map[string][]byte, error) {
+	f := dnsopmanifests.NewFactory()
+	return f.AssetContent(doh.dnsOperatorConfig())
+}

--- a/pkg/asset/manifests/stock.go
+++ b/pkg/asset/manifests/stock.go
@@ -21,6 +21,9 @@ type Stock interface {
 	// NetworkOperator returns the network operator asset object
 	NetworkOperator() asset.Asset
 
+	// DNSOperator returns the dns operator asset object
+	DNSOperator() asset.Asset
+
 	// KubeAddonOperator returns the addon asset object
 	KubeAddonOperator() asset.Asset
 
@@ -37,6 +40,7 @@ type StockImpl struct {
 	clusterVersionOperator asset.Asset
 	kubeCoreOperator       asset.Asset
 	networkOperator        asset.Asset
+	dnsOperator            asset.Asset
 	addonOperator          asset.Asset
 	mao                    asset.Asset
 	tectonic               asset.Asset
@@ -74,6 +78,9 @@ func (s *StockImpl) EstablishStock(stock installconfig.Stock, tlsStock tls.Stock
 	s.networkOperator = &networkOperator{
 		installConfigAsset: stock.InstallConfig(),
 	}
+	s.dnsOperator = &dnsOperator{
+		installConfigAsset: stock.InstallConfig(),
+	}
 	s.mao = &machineAPIOperator{
 		installConfigAsset: stock.InstallConfig(),
 		aggregatorCA:       tlsStock.AggregatorCA(),
@@ -98,6 +105,9 @@ func (s *StockImpl) KubeCoreOperator() asset.Asset { return s.kubeCoreOperator }
 
 // NetworkOperator returns the network operator asset object
 func (s *StockImpl) NetworkOperator() asset.Asset { return s.networkOperator }
+
+// DNSOperator returns the dns operator asset object
+func (s *StockImpl) DNSOperator() asset.Asset { return s.dnsOperator }
 
 // KubeAddonOperator returns the addon operator asset object
 func (s *StockImpl) KubeAddonOperator() asset.Asset { return s.addonOperator }


### PR DESCRIPTION
Adding dns operator manifest to installer as per a conversation this morning with @rajatchopra 
This is dependent on a cluster-dns-operator PR: https://github.com/openshift/cluster-dns-operator/pull/17

@pravisankar @ironcladlou  FYI

@rajatchopra  PTAL   Thx
Operator noob here so I am not entirely sure about the asset contents to be added, so if you can please verify that would be great. And wasn't sure on the testing front/how to test this. Thx