### PR TITLE
hack/get-terraform.sh: Add a helper for pulling Terraform

### DIFF
--- a/hack/get-terraform.sh
+++ b/hack/get-terraform.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+TERRAFORM_VERSION="0.11.8" &&
+TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" &&
+cd "$(dirname "$0")/.." &&
+mkdir -p bin &&
+curl -L "${TERRAFORM_URL}" | funzip > bin/terraform &&
+chmod +x bin/terraform


### PR DESCRIPTION
This is mostly for CI, so we can give the release repo a stable script to run.  And we can bump our Terraform version in the script here without bothering with release pull-requests.