### PR TITLE
hack/build: Add the local vendor directory for generate

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -10,7 +10,7 @@ TAGS=
 case "${MODE}" in
 release)
 	TAGS=release
-	go generate ./data
+	GOPATH="${PWD}/vendor:${GOPATH}" go generate ./data
 	;;
 dev)
 	;;

--- a/vendor/github.com/shurcooL/httpfs/vfsutil/file.go
+++ b/vendor/github.com/shurcooL/httpfs/vfsutil/file.go
@@ -1,0 +1,21 @@
+package vfsutil
+
+import (
+	"net/http"
+	"os"
+)
+
+// File implements http.FileSystem using the native file system restricted to a
+// specific file served at root.
+//
+// While the FileSystem.Open method takes '/'-separated paths, a File's string
+// value is a filename on the native file system, not a URL, so it is separated
+// by filepath.Separator, which isn't necessarily '/'.
+type File string
+
+func (f File) Open(name string) (http.File, error) {
+	if name != "/" {
+		return nil, &os.PathError{Op: "open", Path: name, Err: os.ErrNotExist}
+	}
+	return os.Open(string(f))
+}

--- a/vendor/github.com/shurcooL/httpfs/vfsutil/vfsutil.go
+++ b/vendor/github.com/shurcooL/httpfs/vfsutil/vfsutil.go
@@ -1,0 +1,39 @@
+// Package vfsutil implements some I/O utility functions for http.FileSystem.
+package vfsutil
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+// ReadDir reads the contents of the directory associated with file and
+// returns a slice of FileInfo values in directory order.
+func ReadDir(fs http.FileSystem, name string) ([]os.FileInfo, error) {
+	f, err := fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return f.Readdir(0)
+}
+
+// Stat returns the FileInfo structure describing file.
+func Stat(fs http.FileSystem, name string) (os.FileInfo, error) {
+	f, err := fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return f.Stat()
+}
+
+// ReadFile reads the file named by path from fs and returns the contents.
+func ReadFile(fs http.FileSystem, path string) ([]byte, error) {
+	rc, err := fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return ioutil.ReadAll(rc)
+}

--- a/vendor/github.com/shurcooL/httpfs/vfsutil/walk.go
+++ b/vendor/github.com/shurcooL/httpfs/vfsutil/walk.go
@@ -1,0 +1,146 @@
+package vfsutil
+
+import (
+	"io"
+	"net/http"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"sort"
+)
+
+// Walk walks the filesystem rooted at root, calling walkFn for each file or
+// directory in the filesystem, including root. All errors that arise visiting files
+// and directories are filtered by walkFn. The files are walked in lexical
+// order.
+func Walk(fs http.FileSystem, root string, walkFn filepath.WalkFunc) error {
+	info, err := Stat(fs, root)
+	if err != nil {
+		return walkFn(root, nil, err)
+	}
+	return walk(fs, root, info, walkFn)
+}
+
+// readDirNames reads the directory named by dirname and returns
+// a sorted list of directory entries.
+func readDirNames(fs http.FileSystem, dirname string) ([]string, error) {
+	fis, err := ReadDir(fs, dirname)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(fis))
+	for i := range fis {
+		names[i] = fis[i].Name()
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// walk recursively descends path, calling walkFn.
+func walk(fs http.FileSystem, path string, info os.FileInfo, walkFn filepath.WalkFunc) error {
+	err := walkFn(path, info, nil)
+	if err != nil {
+		if info.IsDir() && err == filepath.SkipDir {
+			return nil
+		}
+		return err
+	}
+
+	if !info.IsDir() {
+		return nil
+	}
+
+	names, err := readDirNames(fs, path)
+	if err != nil {
+		return walkFn(path, info, err)
+	}
+
+	for _, name := range names {
+		filename := pathpkg.Join(path, name)
+		fileInfo, err := Stat(fs, filename)
+		if err != nil {
+			if err := walkFn(filename, fileInfo, err); err != nil && err != filepath.SkipDir {
+				return err
+			}
+		} else {
+			err = walk(fs, filename, fileInfo, walkFn)
+			if err != nil {
+				if !fileInfo.IsDir() || err != filepath.SkipDir {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// WalkFilesFunc is the type of the function called for each file or directory visited by WalkFiles.
+// It's like filepath.WalkFunc, except it provides an additional ReadSeeker parameter for file being visited.
+type WalkFilesFunc func(path string, info os.FileInfo, rs io.ReadSeeker, err error) error
+
+// WalkFiles walks the filesystem rooted at root, calling walkFn for each file or
+// directory in the filesystem, including root. In addition to FileInfo, it passes an
+// ReadSeeker to walkFn for each file it visits.
+func WalkFiles(fs http.FileSystem, root string, walkFn WalkFilesFunc) error {
+	file, info, err := openStat(fs, root)
+	if err != nil {
+		return walkFn(root, nil, nil, err)
+	}
+	return walkFiles(fs, root, info, file, walkFn)
+}
+
+// walkFiles recursively descends path, calling walkFn.
+// It closes the input file after it's done with it, so the caller shouldn't.
+func walkFiles(fs http.FileSystem, path string, info os.FileInfo, file http.File, walkFn WalkFilesFunc) error {
+	err := walkFn(path, info, file, nil)
+	file.Close()
+	if err != nil {
+		if info.IsDir() && err == filepath.SkipDir {
+			return nil
+		}
+		return err
+	}
+
+	if !info.IsDir() {
+		return nil
+	}
+
+	names, err := readDirNames(fs, path)
+	if err != nil {
+		return walkFn(path, info, nil, err)
+	}
+
+	for _, name := range names {
+		filename := pathpkg.Join(path, name)
+		file, fileInfo, err := openStat(fs, filename)
+		if err != nil {
+			if err := walkFn(filename, nil, nil, err); err != nil && err != filepath.SkipDir {
+				return err
+			}
+		} else {
+			err = walkFiles(fs, filename, fileInfo, file, walkFn)
+			// file is closed by walkFiles, so we don't need to close it here.
+			if err != nil {
+				if !fileInfo.IsDir() || err != filepath.SkipDir {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// openStat performs Open and Stat and returns results, or first error encountered.
+// The caller is responsible for closing the returned file when done.
+func openStat(fs http.FileSystem, name string) (http.File, os.FileInfo, error) {
+	f, err := fs.Open(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, nil, err
+	}
+	return f, fi, nil
+}


### PR DESCRIPTION
Because `go run` ignores `vendor/` otherwise (golang/go#20406).  Also vendor shurcooL/httpfs/vfsutil, although I did this manually because I haven't been able to talk Glide into doing it right ;).  This should address our:

```console
$ ./hack/build.sh 
++ dirname ./hack/build.sh
+ cd ./hack/..
+ MODE=release
+ TAGS=
+ case "${MODE}" in
+ TAGS=release
+ GOPATH=/home/trking/src/openshift/installer/vendor:/home/trking/.local/lib/go
+ go generate ./data
../vendor/github.com/shurcooL/vfsgen/generator.go:18:2: cannot find package "github.com/shurcooL/httpfs/vfsutil" in any of:
  /home/trking/.local/lib/go/src/github.com/openshift/installer/vendor/github.com/shurcooL/httpfs/vfsutil (vendor tree)
  /home/trking/.local/go/src/github.com/shurcooL/httpfs/vfsutil (from $GOROOT)
  /home/trking/src/openshift/installer/vendor/src/github.com/shurcooL/httpfs/vfsutil (from $GOPATH)
  /home/trking/.local/lib/go/src/github.com/shurcooL/httpfs/vfsutil
../../../.local/lib/go/src/github.com/openshift/installer/data/assets.go:2: running "go": exit status 1
```

CC @abhinavdahiya, @sallyom, @crawford