### PR TITLE
images/installer: Rewrite tectonic-installer for openshift-install

### DIFF
--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -1,0 +1,13 @@
+# This Dockerfile is a used by CI to publish openshift/origin-v4.0:installer
+
+FROM openshift/origin-release:golang-1.10 AS build
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN hack/build.sh && hack/get-terraform.sh
+
+FROM scratch
+COPY --from=build /go/src/github.com/openshift/installer/bin /bin
+ENV PATH /bin
+ENV HOME /
+WORKDIR /
+ENTRYPOINT ["/bin/openshift-install"]


### PR DESCRIPTION
The golang-1.10 image has everything we need to build now.  I run the build in a golang-1.10 container using [`FROM ... AS ...`][1] like we used to.  But now I no longer install packages with `yum`.  And I use a recursive [`COPY`][2] to bring the built/fetched binaries over into the output container, which is based on `scratch`.

/assign @abhinavdahiya

[1]: https://docs.docker.com/engine/reference/builder/#from
[2]: https://docs.docker.com/engine/reference/builder/#copy