### PR TITLE
images/installer: Copy binaries separately

### DIFF
--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -1,4 +1,5 @@
 # This Dockerfile is a used by CI to publish openshift/origin-v4.0:installer
+# It builds an image containing only the openshift-install and terraform binaries.
 
 FROM openshift/origin-release:golang-1.10 AS build
 WORKDIR /go/src/github.com/openshift/installer
@@ -6,7 +7,9 @@ COPY . .
 RUN hack/build.sh && hack/get-terraform.sh
 
 FROM scratch
-COPY --from=build /go/src/github.com/openshift/installer/bin /bin
+COPY --from=build /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=build /go/src/github.com/openshift/installer/bin/terraform /bin/terraform
+USER 1000:1000
 ENV PATH /bin
 ENV HOME /
 WORKDIR /


### PR DESCRIPTION
My old podman 0.7.3 does not support [wildcard copies][1], and the old `.../bin -> /bin` copy breaks targets where `/bin` is a symlink to `/usr/bin`.  That doesn't matter for `scratch`, but if you use this same `Dockerfile` for, say, openshift/origin-v4.0:base, the clobber means that `/bin/sh` doesn't work (because on that CentOS image, `/bin/sh` resolves to `/usr/bin/bash` via `/bin -> usr/bin` and `/usr/bin/sh -> bash` symlinks).

Also set [`USER`][2] to make it clear that the installer doesn't need to run as root.  Set both a UID and GID because our `scratch` image won't have an `/etc/passwd` or similar to resolve the 1000 user's primary group.

Yet another fixup to unstick openshift/release#1677.

CC @abhinavdahiya, @crawford.

[1]: https://docs.docker.com/engine/reference/builder/#copy
[2]: https://docs.docker.com/engine/reference/builder/#user