### PR TITLE
pkg/types/config: Get the region from the install config

### DIFF
--- a/pkg/types/config/cluster.go
+++ b/pkg/types/config/cluster.go
@@ -180,7 +180,7 @@ func ConvertInstallConfigToTFVars(cfg *types.InstallConfig, bootstrapIgn string,
 	if cfg.Platform.AWS != nil {
 		ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
 		defer cancel()
-		ami, err := rhcos.AMI(ctx, rhcos.DefaultChannel, cluster.AWS.Region)
+		ami, err := rhcos.AMI(ctx, rhcos.DefaultChannel, cfg.Platform.AWS.Region)
 		if err != nil {
 			return nil, fmt.Errorf("failed to determine default AMI: %v", err)
 		}


### PR DESCRIPTION
We haven't set it in the cluster struct yet, that's a few lines below.  This was from c6f02bae (#324); likely a copy/paste bug.

/assign @abhinavdahiya

Fixes #324.

[1]: https://github.com/openshift/installer/issues/335#issue-363995958