### PR TITLE
pkg/asset/installconfig/ssh: Add OPENSHIFT_INSTALL_SSH_PUB_KEY_PATH

### DIFF
--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -25,6 +25,8 @@ The installer accepts a number of environment variable that allow the interactiv
 * `OPENSHIFT_INSTALL_SSH_PUB_KEY`:
      The SSH public key used to access all nodes within the cluster (e.g. `ssh-rsa AAAA...`).
      This is optional.
+* `OPENSHIFT_INSTALL_SSH_PUB_KEY_PATH`:
+     As an alternative to `OPENSHIFT_INSTALL_SSH_PUB_KEY`, you can configure this variable with a path containing your SSH public key (e.g. `~/.ssh/id_rsa.pub`).
 
 ## Platform-Specific
 

--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -4,19 +4,32 @@ The installer accepts a number of environment variable that allow the interactiv
 
 ## General
 
-| Environment Variable              | Description                                                                                 |
-|:----------------------------------|:--------------------------------------------------------------------------------------------|
-| `OPENSHIFT_INSTALL_BASE_DOMAIN`   | The base domain of the cluster. All DNS records will be sub-domains of this base.           |
-| `OPENSHIFT_INSTALL_CLUSTER_NAME`  | The name of the cluster. This will be used when generating sub-domains.                     |
-| `OPENSHIFT_INSTALL_EMAIL_ADDRESS` | The email address of the cluster administrator. This will be used to log in to the console. |
-| `OPENSHIFT_INSTALL_PASSWORD`      | The password of the cluster administrator. This will be used to log in to the console.      |
-| `OPENSHIFT_INSTALL_PLATFORM`      | The platform onto which the cluster will be installed.                                      |
-| `OPENSHIFT_INSTALL_PULL_SECRET`   | The container registry pull secret for this cluster.                                        |
-| `OPENSHIFT_INSTALL_SSH_PUB_KEY`   | The SSH key used to access all nodes within the cluster. This is optional.                  |
+* `OPENSHIFT_INSTALL_BASE_DOMAIN`:
+    The base domain of the cluster. All DNS records will be sub-domains of this base.
+
+* `OPENSHIFT_INSTALL_CLUSTER_NAME`:
+     The name of the cluster.
+     This will be used when generating sub-domains.
+* `OPENSHIFT_INSTALL_EMAIL_ADDRESS`:
+     The email address of the cluster administrator.
+     This will be used to log in to the console.
+* `OPENSHIFT_INSTALL_PASSWORD`:
+     The password of the cluster administrator.
+     This will be used to log in to the console.
+* `OPENSHIFT_INSTALL_PLATFORM`:
+     The platform onto which the cluster will be installed.
+     Valid values are `aws` and `libvirt`.
+* `OPENSHIFT_INSTALL_PULL_SECRET`:
+     The container registry pull secret for this cluster (e.g. `{"auths": {...}}`).
+     You can generate these secrets with the `podman login` command.
+* `OPENSHIFT_INSTALL_SSH_PUB_KEY`:
+     The SSH public key used to access all nodes within the cluster (e.g. `ssh-rsa AAAA...`).
+     This is optional.
 
 ## Platform-Specific
 
-| Environment Variable              | Description                                                                              |
-|:----------------------------------|:-----------------------------------------------------------------------------------------|
-| `OPENSHIFT_INSTALL_AWS_REGION`    | The AWS region to be used for installation.                                              |
-| `OPENSHIFT_INSTALL_LIBVIRT_URI`   | The libvirt connection URI to be used. This must be accessible from the running cluster. |
+* `OPENSHIFT_INSTALL_AWS_REGION`:
+    The AWS region to be used for installation.
+* `OPENSHIFT_INSTALL_LIBVIRT_URI`:
+    The libvirt connection URI to be used.
+    This must be accessible from the running cluster.

--- a/pkg/asset/installconfig/stock.go
+++ b/pkg/asset/installconfig/stock.go
@@ -3,6 +3,7 @@ package installconfig
 import (
 	"github.com/AlecAivazis/survey"
 
+	"github.com/openshift/installer/installer/pkg/validate"
 	"github.com/openshift/installer/pkg/asset"
 )
 
@@ -51,41 +52,63 @@ func (s *StockImpl) EstablishStock() {
 	s.clusterID = &clusterID{}
 	s.emailAddress = &asset.UserProvided{
 		AssetName: "Email Address",
-		Prompt: &survey.Input{
-			Message: "Email Address",
-			Help:    "The email address of the cluster administrator. This will be used to log in to the console.",
+		Question: &survey.Question{
+			Prompt: &survey.Input{
+				Message: "Email Address",
+				Help:    "The email address of the cluster administrator. This will be used to log in to the console.",
+			},
+			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				return validate.Email(ans.(string))
+			}),
 		},
 		EnvVarName: "OPENSHIFT_INSTALL_EMAIL_ADDRESS",
 	}
 	s.password = &asset.UserProvided{
 		AssetName: "Password",
-		Prompt: &survey.Password{
-			Message: "Password",
-			Help:    "The password of the cluster administrator. This will be used to log in to the console.",
+		Question: &survey.Question{
+			Prompt: &survey.Password{
+				Message: "Password",
+				Help:    "The password of the cluster administrator. This will be used to log in to the console.",
+			},
 		},
 		EnvVarName: "OPENSHIFT_INSTALL_PASSWORD",
 	}
 	s.baseDomain = &asset.UserProvided{
 		AssetName: "Base Domain",
-		Prompt: &survey.Input{
-			Message: "Base Domain",
-			Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base.",
+		Question: &survey.Question{
+			Prompt: &survey.Input{
+				Message: "Base Domain",
+				Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base.",
+			},
+			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				return validate.DomainName(ans.(string))
+			}),
 		},
 		EnvVarName: "OPENSHIFT_INSTALL_BASE_DOMAIN",
 	}
 	s.clusterName = &asset.UserProvided{
 		AssetName: "Cluster Name",
-		Prompt: &survey.Input{
-			Message: "Cluster Name",
-			Help:    "The name of the cluster. This will be used when generating sub-domains.",
+		Question: &survey.Question{
+			Prompt: &survey.Input{
+				Message: "Cluster Name",
+				Help:    "The name of the cluster. This will be used when generating sub-domains.",
+			},
+			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				return validate.DomainName(ans.(string))
+			}),
 		},
 		EnvVarName: "OPENSHIFT_INSTALL_CLUSTER_NAME",
 	}
 	s.pullSecret = &asset.UserProvided{
 		AssetName: "Pull Secret",
-		Prompt: &survey.Input{
-			Message: "Pull Secret",
-			Help:    "The container registry pull secret for this cluster.",
+		Question: &survey.Question{
+			Prompt: &survey.Input{
+				Message: "Pull Secret",
+				Help:    "The container registry pull secret for this cluster.",
+			},
+			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				return validate.JSON([]byte(ans.(string)))
+			}),
 		},
 		EnvVarName: "OPENSHIFT_INSTALL_PULL_SECRET",
 	}

--- a/pkg/asset/userprovided.go
+++ b/pkg/asset/userprovided.go
@@ -9,7 +9,7 @@ import (
 // UserProvided generates an asset that is supplied by a user.
 type UserProvided struct {
 	AssetName  string
-	Prompt     survey.Prompt
+	Question   *survey.Question
 	EnvVarName string
 }
 
@@ -25,8 +25,13 @@ func (a *UserProvided) Generate(map[Asset]*State) (*State, error) {
 	var response string
 	if value, ok := os.LookupEnv(a.EnvVarName); ok {
 		response = value
+		if a.Question.Validate != nil {
+			if err := a.Question.Validate(response); err != nil {
+				return nil, err
+			}
+		}
 	} else {
-		survey.AskOne(a.Prompt, &response, survey.Required)
+		survey.AskOne(a.Question.Prompt, &response, a.Question.Validate)
 	}
 
 	return &State{


### PR DESCRIPTION
Builds on #350; review that first.

To make it easier to pass this in when you don't have a shell for:

```console
$ OPENSHIFT_INSTALL_SSH_PUB_KEY="$(cat path/to/key)" openshift-install install-config
```

For example, this is useful in CI where we can launch the cluster without hitting a shell at all.  And it's also a bit more compact for folks who are reading from files anyway.

I've also added a check for "do we only have one choice?".  If so, I just pick that value instead of bothering the user when they don't have a decision to make.

And I've reformatted the docs to use a list.  Tables are annoying to maintain in ASCII, and lists give us more space to talk about the expected input format, etc.

/assign @crawford