### PR TITLE
*: Copy route53 baseDomain advice to openshift-install locations

### DIFF
--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -7,6 +7,12 @@ The installer accepts a number of environment variable that allow the interactiv
 * `OPENSHIFT_INSTALL_BASE_DOMAIN`:
     The base domain of the cluster. All DNS records will be sub-domains of this base.
 
+    For AWS, this must be a previously-existing public Route 53 zone.  You can check for any already in your account with:
+
+    ```sh
+    aws route53 list-hosted-zones --query 'HostedZones[? !(Config.PrivateZone)].Name' --output text
+    ```
+
 * `OPENSHIFT_INSTALL_CLUSTER_NAME`:
      The name of the cluster.
      This will be used when generating sub-domains.

--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -4,19 +4,32 @@ The installer accepts a number of environment variable that allow the interactiv
 
 ## General
 
-| Environment Variable              | Description                                                                                 |
-|:----------------------------------|:--------------------------------------------------------------------------------------------|
-| `OPENSHIFT_INSTALL_BASE_DOMAIN`   | The base domain of the cluster. All DNS records will be sub-domains of this base.           |
-| `OPENSHIFT_INSTALL_CLUSTER_NAME`  | The name of the cluster. This will be used when generating sub-domains.                     |
-| `OPENSHIFT_INSTALL_EMAIL_ADDRESS` | The email address of the cluster administrator. This will be used to log in to the console. |
-| `OPENSHIFT_INSTALL_PASSWORD`      | The password of the cluster administrator. This will be used to log in to the console.      |
-| `OPENSHIFT_INSTALL_PLATFORM`      | The platform onto which the cluster will be installed.                                      |
-| `OPENSHIFT_INSTALL_PULL_SECRET`   | The container registry pull secret for this cluster.                                        |
-| `OPENSHIFT_INSTALL_SSH_PUB_KEY`   | The SSH key used to access all nodes within the cluster. This is optional.                  |
+* `OPENSHIFT_INSTALL_BASE_DOMAIN`:
+    The base domain of the cluster. All DNS records will be sub-domains of this base.
+
+* `OPENSHIFT_INSTALL_CLUSTER_NAME`:
+     The name of the cluster.
+     This will be used when generating sub-domains.
+* `OPENSHIFT_INSTALL_EMAIL_ADDRESS`:
+     The email address of the cluster administrator.
+     This will be used to log in to the console.
+* `OPENSHIFT_INSTALL_PASSWORD`:
+     The password of the cluster administrator.
+     This will be used to log in to the console.
+* `OPENSHIFT_INSTALL_PLATFORM`:
+     The platform onto which the cluster will be installed.
+     Valid values are `aws` and `libvirt`.
+* `OPENSHIFT_INSTALL_PULL_SECRET`:
+     The container registry pull secret for this cluster (e.g. `{"auths": {...}}`).
+     You can generate these secrets with the `podman login` command.
+* `OPENSHIFT_INSTALL_SSH_PUB_KEY`:
+     The SSH public key used to access all nodes within the cluster (e.g. `ssh-rsa AAAA...`).
+     This is optional.
 
 ## Platform-Specific
 
-| Environment Variable              | Description                                                                              |
-|:----------------------------------|:-----------------------------------------------------------------------------------------|
-| `OPENSHIFT_INSTALL_AWS_REGION`    | The AWS region to be used for installation.                                              |
-| `OPENSHIFT_INSTALL_LIBVIRT_URI`   | The libvirt connection URI to be used. This must be accessible from the running cluster. |
+* `OPENSHIFT_INSTALL_AWS_REGION`:
+    The AWS region to be used for installation.
+* `OPENSHIFT_INSTALL_LIBVIRT_URI`:
+    The libvirt connection URI to be used.
+    This must be accessible from the running cluster.

--- a/pkg/asset/installconfig/stock.go
+++ b/pkg/asset/installconfig/stock.go
@@ -78,7 +78,7 @@ func (s *StockImpl) EstablishStock() {
 		Question: &survey.Question{
 			Prompt: &survey.Input{
 				Message: "Base Domain",
-				Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base.",
+				Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base.\n\nFor AWS, this must be a previously-existing public Route 53 zone.  You can check for any already in your account with:\n\n  $ aws route53 list-hosted-zones --query 'HostedZones[? !(Config.PrivateZone)].Name' --output text",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 				return validate.DomainName(ans.(string))


### PR DESCRIPTION
Builds on #351; review that first.

The old `examples/aws.yaml` location is no longer discoverable for folks using the new installer.