### PR TITLE
hack/get-terraform: Use 'go env ...' to support other platforms

### DIFF
--- a/hack/get-terraform.sh
+++ b/hack/get-terraform.sh
@@ -1,8 +1,23 @@
 #!/bin/sh
 
+have() {
+	command -v "${@}" >/dev/null 2>/dev/null
+}
+
 OS=linux
 ARCH=amd64
-if command -v go >/dev/null 2>/dev/null
+FUNZIP="${FUNZIP:-funzip}"
+if ! have "${FUNZIP}"
+then
+	if have gunzip
+	then
+		FUNZIP=gunzip
+	else
+		command -V "${FUNZIP}"
+		exit 1
+	fi
+fi &&
+if have go
 then
 	OS="$(go env GOOS)" &&
 	ARCH="$(go env GOARCH)"
@@ -12,5 +27,5 @@ TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/ter
 echo "pulling ${TERRAFORM_URL}" >&2 &&
 cd "$(dirname "$0")/.." &&
 mkdir -p bin &&
-curl -L "${TERRAFORM_URL}" | funzip > bin/terraform &&
+curl -L "${TERRAFORM_URL}" | "${FUNZIP}" >bin/terraform &&
 chmod +x bin/terraform

--- a/hack/get-terraform.sh
+++ b/hack/get-terraform.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 
+OS=linux
+ARCH=amd64
+if command -v go >/dev/null 2>/dev/null
+then
+	OS="$(go env GOOS)" &&
+	ARCH="$(go env GOARCH)"
+fi &&
 TERRAFORM_VERSION="0.11.8" &&
-TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" &&
+TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${OS}_${ARCH}.zip" &&
+echo "pulling ${TERRAFORM_URL}" >&2 &&
 cd "$(dirname "$0")/.." &&
 mkdir -p bin &&
 curl -L "${TERRAFORM_URL}" | funzip > bin/terraform &&


### PR DESCRIPTION
With this change, we use Go to give the correct OS and architecture constants for the Terraform URL.  Go, because Terraform is a Go project, so Hashicorp is building the binaries using Go's cross-compilation with the Go naming.

If you don't have Go, I'm just assuming you're on amd64 Linux, because
that's what our CI infrastructure is running.