### PR TITLE
pkg/types/config: Prefix "pull secret" in validatePullSecret

### DIFF
--- a/pkg/types/config/validate.go
+++ b/pkg/types/config/validate.go
@@ -252,7 +252,7 @@ func (c *Cluster) validateS3Bucket() error {
 func (c *Cluster) validatePullSecret() []error {
 	var errs []error
 	if err := ValidateJSON([]byte(c.PullSecret)); err != nil {
-		errs = append(errs, err)
+		errs = append(errs, prefixError("pull secret", err))
 	}
 	return errs
 }


### PR DESCRIPTION
To match a lot of other error handling in this package and give more useful error messages (if we somehow get past the input validation in `pkg/asset/installconfig`).

/assign @crawford

Dunno if you're tearing this out with your overhaul, but here it is in case it doesn't collide ;).