### PR TITLE
Don't allow dot at the end of domain name

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -132,7 +132,8 @@ resource "aws_route53_zone" "tectonic_int" {
 }
 
 resource "aws_s3_bucket" "tectonic" {
-  bucket = "${lower(var.tectonic_cluster_name)}.${var.tectonic_base_domain}"
+  # bucket name is cluster_name + base domain, minus the trailing dot, if one exists
+  bucket = "${lower(var.tectonic_cluster_name)}.${join(".",(compact(split(".",var.tectonic_base_domain))))}"
 
   acl = "private"
 

--- a/pkg/types/config/validate.go
+++ b/pkg/types/config/validate.go
@@ -248,8 +248,9 @@ func (c *Cluster) validateAWSEndpoints() error {
 // matches the S3 bucket naming rules. Not all rules are checked
 // because Tectonic controls the generation of S3 bucket names, creating
 // buckets of the form: <cluster-name>.<domain-name>
+// If domain-name contains a trailing dot, it's removed from the bucket name.
 func (c *Cluster) validateS3Bucket() error {
-	bucket := fmt.Sprintf("%s.%s", c.Name, c.BaseDomain)
+	bucket := fmt.Sprintf("%s.%s", c.Name, strings.TrimRight(c.BaseDomain, "."))
 	if len(bucket) > maxS3BucketNameLength {
 		return fmt.Errorf("the S3 bucket name %q, generated from the cluster name and base domain, is too long; S3 bucket names must be less than 63 characters; please choose a shorter cluster name or base domain", bucket)
 	}

--- a/pkg/types/config/validate_test.go
+++ b/pkg/types/config/validate_test.go
@@ -384,7 +384,7 @@ func TestS3BucketNames(t *testing.T) {
 				Name:       "foo",
 				BaseDomain: "example.com.",
 			},
-			err: true,
+			err: false,
 		},
 		{
 			cluster: Cluster{


### PR DESCRIPTION
This will prevent errors when creating the S3 bucket,
since the S3 bucket name may not end in dot.