### PR TITLE
asset/manifests: include worker ignition config

### DIFF
--- a/pkg/asset/cluster/stock.go
+++ b/pkg/asset/cluster/stock.go
@@ -2,7 +2,8 @@ package cluster
 
 import (
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/asset/ignition"
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
+	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 )
@@ -24,12 +25,12 @@ type StockImpl struct {
 var _ Stock = (*StockImpl)(nil)
 
 // EstablishStock establishes the stock of assets in the specified directory.
-func (s *StockImpl) EstablishStock(installConfigStock installconfig.Stock, ignitionStock ignition.Stock, kubeconfigStock kubeconfig.Stock) {
+func (s *StockImpl) EstablishStock(installConfigStock installconfig.Stock, bootstrapStock bootstrap.Stock, machineStock machine.Stock, kubeconfigStock kubeconfig.Stock) {
 	s.tfvars = &TerraformVariables{
 		installConfig:     installConfigStock.InstallConfig(),
-		bootstrapIgnition: ignitionStock.BootstrapIgnition(),
-		masterIgnition:    ignitionStock.MasterIgnition(),
-		workerIgnition:    ignitionStock.WorkerIgnition(),
+		bootstrapIgnition: bootstrapStock.BootstrapIgnition(),
+		masterIgnition:    machineStock.MasterIgnition(),
+		workerIgnition:    machineStock.WorkerIgnition(),
 	}
 
 	s.cluster = &Cluster{

--- a/pkg/asset/ignition/bootstrap/stock.go
+++ b/pkg/asset/ignition/bootstrap/stock.go
@@ -1,4 +1,4 @@
-package ignition
+package bootstrap
 
 import (
 	"github.com/openshift/installer/pkg/asset"
@@ -8,24 +8,17 @@ import (
 	"github.com/openshift/installer/pkg/asset/tls"
 )
 
-// Stock is the stock of ignition assets that can be generated.
+// Stock is the stock of the bootstrap ignition asset.
 type Stock interface {
 	// BootstrapIgnition is the asset that generates the bootstrap.ign ignition
 	// config file for the bootstrap node.
 	BootstrapIgnition() asset.Asset
-	// MasterIgnition is the asset that generates the master.ign ignition config
-	// files for the master nodes.
-	MasterIgnition() asset.Asset
-	// WorkerIgnition is the asset that generates the worker.ign ignition config
-	// file for the worker nodes.
-	WorkerIgnition() asset.Asset
 }
 
-// StockImpl is the implementation of the ignition asset stock.
+// StockImpl is the implementation of the master and worker ignition
+// asset stock.
 type StockImpl struct {
 	boostrap asset.Asset
-	master   asset.Asset
-	worker   asset.Asset
 }
 
 // EstablishStock establishes the stock of assets.
@@ -36,15 +29,7 @@ func (s *StockImpl) EstablishStock(
 	manifestStock manifests.Stock,
 ) {
 	s.boostrap = newBootstrap(installConfigStock, tlsStock, kubeconfigStock, manifestStock)
-	s.master = newMaster(installConfigStock, tlsStock)
-	s.worker = newWorker(installConfigStock, tlsStock)
 }
 
 // BootstrapIgnition returns the bootstrap asset.
 func (s *StockImpl) BootstrapIgnition() asset.Asset { return s.boostrap }
-
-// MasterIgnition returns the master asset.
-func (s *StockImpl) MasterIgnition() asset.Asset { return s.master }
-
-// WorkerIgnition returns the worker asset.
-func (s *StockImpl) WorkerIgnition() asset.Asset { return s.worker }

--- a/pkg/asset/ignition/content/tectonic.go
+++ b/pkg/asset/ignition/content/tectonic.go
@@ -106,11 +106,13 @@ kubectl create --filename updater/migration-status-kind.yaml
 
 kubectl create --filename updater/operators/kube-core-operator.yaml
 kubectl create --filename updater/operators/kube-addon-operator.yaml
+kubectl create --filename updater/operators/tectonic-ingress-controller-operator.yaml
 
 kubectl --namespace=tectonic-system get customresourcedefinition appversions.tco.coreos.com
 kubectl create --filename updater/app_versions/app-version-tectonic-cluster.yaml
 kubectl create --filename updater/app_versions/app-version-kube-core.yaml
 kubectl create --filename updater/app_versions/app-version-kube-addon.yaml
+kubectl create --filename updater/app_versions/app-version-tectonic-ingress.yaml
 
 # Wait for Tectonic pods
 wait_for_pods tectonic-system

--- a/pkg/asset/ignition/doc.go
+++ b/pkg/asset/ignition/doc.go
@@ -1,2 +1,0 @@
-// Package ignition generates the ignition config assets.
-package ignition

--- a/pkg/asset/ignition/machine/master.go
+++ b/pkg/asset/ignition/machine/master.go
@@ -1,4 +1,4 @@
-package ignition
+package machine
 
 import (
 	"fmt"

--- a/pkg/asset/ignition/machine/master_test.go
+++ b/pkg/asset/ignition/machine/master_test.go
@@ -1,4 +1,4 @@
-package ignition
+package machine
 
 import (
 	"testing"

--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -1,0 +1,52 @@
+package machine
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	ignition "github.com/coreos/ignition/config/v2_2/types"
+	"github.com/vincent-petithory/dataurl"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+// pointerIgnitionConfig generates a config which references the remote config
+// served by the machine config server.
+func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, role string, query string) []byte {
+	data, err := json.Marshal(ignition.Config{
+		Ignition: ignition.Ignition{
+			Version: ignition.MaxVersion.String(),
+			Config: ignition.IgnitionConfig{
+				Append: []ignition.ConfigReference{{
+					Source: func() *url.URL {
+						return &url.URL{
+							Scheme:   "https",
+							Host:     fmt.Sprintf("%s-api.%s:49500", installConfig.Name, installConfig.BaseDomain),
+							Path:     fmt.Sprintf("/config/%s", role),
+							RawQuery: query,
+						}
+					}().String(),
+				}},
+			},
+			Security: ignition.Security{
+				TLS: ignition.TLS{
+					CertificateAuthorities: []ignition.CaReference{{
+						Source: dataurl.EncodeBytes(rootCA),
+					}},
+				},
+			},
+		},
+		// XXX: Remove this once MCO supports injecting SSH keys.
+		Passwd: ignition.Passwd{
+			Users: []ignition.PasswdUser{{
+				Name:              "core",
+				SSHAuthorizedKeys: []ignition.SSHAuthorizedKey{ignition.SSHAuthorizedKey(installConfig.Admin.SSHKey)},
+			}},
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("Failed to marshal pointer Ignition config: %v", err))
+	}
+	return data
+}

--- a/pkg/asset/ignition/machine/stock.go
+++ b/pkg/asset/ignition/machine/stock.go
@@ -1,0 +1,38 @@
+package machine
+
+import (
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/tls"
+)
+
+// Stock is the stock of master and worker ignition assets.
+type Stock interface {
+	// MasterIgnition is the asset that generates the master.ign ignition config
+	// files for the master nodes.
+	MasterIgnition() asset.Asset
+	// WorkerIgnition is the asset that generates the worker.ign ignition config
+	// file for the worker nodes.
+	WorkerIgnition() asset.Asset
+}
+
+// StockImpl is the implementation of the bootstrap ignition asset stock.
+type StockImpl struct {
+	master asset.Asset
+	worker asset.Asset
+}
+
+// EstablishStock establishes the stock of assets.
+func (s *StockImpl) EstablishStock(
+	installConfigStock installconfig.Stock,
+	tlsStock tls.Stock,
+) {
+	s.master = newMaster(installConfigStock, tlsStock)
+	s.worker = newWorker(installConfigStock, tlsStock)
+}
+
+// MasterIgnition returns the master asset.
+func (s *StockImpl) MasterIgnition() asset.Asset { return s.master }
+
+// WorkerIgnition returns the worker asset.
+func (s *StockImpl) WorkerIgnition() asset.Asset { return s.worker }

--- a/pkg/asset/ignition/machine/testasset_test.go
+++ b/pkg/asset/ignition/machine/testasset_test.go
@@ -1,4 +1,4 @@
-package ignition
+package machine
 
 import (
 	"github.com/openshift/installer/pkg/asset"

--- a/pkg/asset/ignition/machine/testutils_test.go
+++ b/pkg/asset/ignition/machine/testutils_test.go
@@ -1,4 +1,4 @@
-package ignition
+package machine
 
 import (
 	"encoding/json"

--- a/pkg/asset/ignition/machine/worker.go
+++ b/pkg/asset/ignition/machine/worker.go
@@ -1,4 +1,4 @@
-package ignition
+package machine
 
 import (
 	"github.com/openshift/installer/pkg/asset"

--- a/pkg/asset/ignition/machine/worker_test.go
+++ b/pkg/asset/ignition/machine/worker_test.go
@@ -1,4 +1,4 @@
-package ignition
+package machine
 
 import (
 	"testing"

--- a/pkg/asset/ignition/node.go
+++ b/pkg/asset/ignition/node.go
@@ -1,16 +1,12 @@
 package ignition
 
 import (
-	"encoding/json"
-	"fmt"
-	"net/url"
 	"path/filepath"
 
 	ignition "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/vincent-petithory/dataurl"
 
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/types"
 )
 
 const (
@@ -20,23 +16,23 @@ const (
 	keyCertAssetCrtIndex = 1
 )
 
-// fileFromContents creates an ignition-config file with the contents from the
+// FilesFromContents creates an ignition-config file with the contents from the
 // specified index in the specified asset state.
-func filesFromContents(pathPrefix string, mode int, contents []asset.Content) []ignition.File {
+func FilesFromContents(pathPrefix string, mode int, contents []asset.Content) []ignition.File {
 	var files []ignition.File
 	for _, c := range contents {
-		files = append(files, fileFromBytes(filepath.Join(pathPrefix, c.Name), mode, c.Data))
+		files = append(files, FileFromBytes(filepath.Join(pathPrefix, c.Name), mode, c.Data))
 	}
 	return files
 }
 
-// fileFromString creates an ignition-config file with the given contents.
-func fileFromString(path string, mode int, contents string) ignition.File {
-	return fileFromBytes(path, mode, []byte(contents))
+// FileFromString creates an ignition-config file with the given contents.
+func FileFromString(path string, mode int, contents string) ignition.File {
+	return FileFromBytes(path, mode, []byte(contents))
 }
 
-// fileFromBytes creates an ignition-config file with the given contents.
-func fileFromBytes(path string, mode int, contents []byte) ignition.File {
+// FileFromBytes creates an ignition-config file with the given contents.
+func FileFromBytes(path string, mode int, contents []byte) ignition.File {
 	return ignition.File{
 		Node: ignition.Node{
 			Filesystem: "root",
@@ -49,44 +45,4 @@ func fileFromBytes(path string, mode int, contents []byte) ignition.File {
 			},
 		},
 	}
-}
-
-// pointerIgnitionConfig generates a config which references the remote config
-// served by the machine config server.
-func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, role string, query string) []byte {
-	data, err := json.Marshal(ignition.Config{
-		Ignition: ignition.Ignition{
-			Version: ignition.MaxVersion.String(),
-			Config: ignition.IgnitionConfig{
-				Append: []ignition.ConfigReference{{
-					Source: func() *url.URL {
-						return &url.URL{
-							Scheme:   "https",
-							Host:     fmt.Sprintf("%s-api.%s:49500", installConfig.Name, installConfig.BaseDomain),
-							Path:     fmt.Sprintf("/config/%s", role),
-							RawQuery: query,
-						}
-					}().String(),
-				}},
-			},
-			Security: ignition.Security{
-				TLS: ignition.TLS{
-					CertificateAuthorities: []ignition.CaReference{{
-						Source: dataurl.EncodeBytes(rootCA),
-					}},
-				},
-			},
-		},
-		// XXX: Remove this once MCO supports injecting SSH keys.
-		Passwd: ignition.Passwd{
-			Users: []ignition.PasswdUser{{
-				Name:              "core",
-				SSHAuthorizedKeys: []ignition.SSHAuthorizedKey{ignition.SSHAuthorizedKey(installConfig.Admin.SSHKey)},
-			}},
-		},
-	})
-	if err != nil {
-		panic(fmt.Sprintf("Failed to marshal pointer Ignition config: %v", err))
-	}
-	return data
 }

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -37,6 +37,7 @@ type manifests struct {
 	mcsCertKey                asset.Asset
 	serviceAccountKeyPair     asset.Asset
 	kubeconfig                asset.Asset
+	workerIgnition            asset.Asset
 }
 
 var _ asset.Asset = (*manifests)(nil)
@@ -73,6 +74,7 @@ func (m *manifests) Dependencies() []asset.Asset {
 		m.kubeletCertKey,
 		m.serviceAccountKeyPair,
 		m.kubeconfig,
+		m.workerIgnition,
 	}
 }
 
@@ -154,7 +156,7 @@ func (m *manifests) generateBootKubeManifests(dependencies map[asset.Asset]*asse
 		ServiceServingCaCert:            base64.StdEncoding.EncodeToString(dependencies[m.serviceServingCA].Contents[certIndex].Data),
 		ServiceServingCaKey:             base64.StdEncoding.EncodeToString(dependencies[m.serviceServingCA].Contents[keyIndex].Data),
 		TectonicNetworkOperatorImage:    "quay.io/coreos/tectonic-network-operator-dev:3b6952f5a1ba89bb32dd0630faddeaf2779c9a85",
-		WorkerIgnConfig:                 "", // FIXME: this means depending on ignition assets (risk of cyclical dependencies)
+		WorkerIgnConfig:                 base64.StdEncoding.EncodeToString(dependencies[m.workerIgnition].Contents[0].Data),
 	}
 
 	assetData := map[string][]byte{

--- a/pkg/asset/manifests/stock.go
+++ b/pkg/asset/manifests/stock.go
@@ -2,6 +2,7 @@ package manifests
 
 import (
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/tls"
@@ -45,7 +46,7 @@ type StockImpl struct {
 var _ Stock = (*StockImpl)(nil)
 
 // EstablishStock establishes the stock of assets.
-func (s *StockImpl) EstablishStock(stock installconfig.Stock, tlsStock tls.Stock, kubeConfigStock kubeconfig.Stock) {
+func (s *StockImpl) EstablishStock(stock installconfig.Stock, tlsStock tls.Stock, kubeConfigStock kubeconfig.Stock, machineStock machine.Stock) {
 	s.manifests = &manifests{
 		assetStock:                s,
 		installConfig:             stock.InstallConfig(),
@@ -64,6 +65,7 @@ func (s *StockImpl) EstablishStock(stock installconfig.Stock, tlsStock tls.Stock
 		mcsCertKey:                tlsStock.MCSCertKey(),
 		serviceAccountKeyPair:     tlsStock.ServiceAccountKeyPair(),
 		kubeconfig:                kubeConfigStock.KubeconfigAdmin(),
+		workerIgnition:            machineStock.WorkerIgnition(),
 	}
 	s.kubeCoreOperator = &kubeCoreOperator{
 		installConfigAsset: stock.InstallConfig(),

--- a/pkg/asset/manifests/tectonic.go
+++ b/pkg/asset/manifests/tectonic.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	"bytes"
 	"encoding/base64"
 	"path/filepath"
 
@@ -50,7 +51,7 @@ func (t *tectonic) Generate(dependencies map[asset.Asset]*asset.State) (*asset.S
 		IngressCaCert:                          base64.StdEncoding.EncodeToString(dependencies[t.kubeCA].Contents[certIndex].Data),
 		IngressKind:                            "haproxy-router",
 		IngressStatusPassword:                  ic.Admin.Password, // FIXME: generate a new random one instead?
-		IngressTLSBundle:                       base64.StdEncoding.EncodeToString(ingressContents[certIndex].Data),
+		IngressTLSBundle:                       base64.StdEncoding.EncodeToString(bytes.Join([][]byte{ingressContents[certIndex].Data, ingressContents[keyIndex].Data}, []byte{})),
 		IngressTLSCert:                         base64.StdEncoding.EncodeToString(ingressContents[certIndex].Data),
 		IngressTLSKey:                          base64.StdEncoding.EncodeToString(ingressContents[keyIndex].Data),
 		KubeAddonOperatorImage:                 "quay.io/coreos/kube-addon-operator-dev:3b6952f5a1ba89bb32dd0630faddeaf2779c9a85",

--- a/pkg/asset/stock/stock.go
+++ b/pkg/asset/stock/stock.go
@@ -64,7 +64,7 @@ func EstablishStock() *Stock {
 	s.tlsStock.EstablishStock(&s.installConfigStock)
 	s.kubeconfigStock.EstablishStock(&s.installConfigStock, &s.tlsStock)
 	s.machineStock.EstablishStock(s, s)
-	s.manifestsStock.EstablishStock(&s.installConfigStock, s, s)
+	s.manifestsStock.EstablishStock(&s.installConfigStock, s, s, s)
 	s.bootstrapStock.EstablishStock(s, s, s, s)
 	s.clusterStock.EstablishStock(s, s, s, s)
 	s.metadataStock.EstablishStock(s, s)

--- a/pkg/asset/stock/stock.go
+++ b/pkg/asset/stock/stock.go
@@ -2,7 +2,8 @@ package stock
 
 import (
 	"github.com/openshift/installer/pkg/asset/cluster"
-	"github.com/openshift/installer/pkg/asset/ignition"
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
+	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/manifests"
@@ -15,7 +16,8 @@ type Stock struct {
 	installConfigStock
 	kubeconfigStock
 	tlsStock
-	ignitionStock
+	bootstrapStock
+	machineStock
 	clusterStock
 	manifestsStock
 	metadataStock
@@ -33,8 +35,12 @@ type kubeconfigStock struct {
 	kubeconfig.StockImpl
 }
 
-type ignitionStock struct {
-	ignition.StockImpl
+type bootstrapStock struct {
+	bootstrap.StockImpl
+}
+
+type machineStock struct {
+	machine.StockImpl
 }
 
 type clusterStock struct {
@@ -57,10 +63,10 @@ func EstablishStock() *Stock {
 	s.installConfigStock.EstablishStock()
 	s.tlsStock.EstablishStock(&s.installConfigStock)
 	s.kubeconfigStock.EstablishStock(&s.installConfigStock, &s.tlsStock)
+	s.machineStock.EstablishStock(s, s)
 	s.manifestsStock.EstablishStock(&s.installConfigStock, s, s)
-	s.ignitionStock.EstablishStock(s, s, s, s)
-	s.clusterStock.EstablishStock(s, s, s)
-	s.manifestsStock.EstablishStock(&s.installConfigStock, s, s)
+	s.bootstrapStock.EstablishStock(s, s, s, s)
+	s.clusterStock.EstablishStock(s, s, s, s)
 	s.metadataStock.EstablishStock(s, s)
 	return s
 }


### PR DESCRIPTION
This is needed in order for the MachineAPI operator to create workers
properly.