### PR TITLE
pkg/asset/installconfig: Add _CI_ONLY_STAY_AWAY_OPENSHIFT_INSTALL_AWS_USER_TAGS

### DIFF
--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 
@@ -161,6 +162,12 @@ func (a *Platform) awsPlatform() (*asset.State, error) {
 		return nil, err
 	}
 	platform.Region = string(region.Contents[0].Data)
+
+	if value, ok := os.LookupEnv("_CI_ONLY_STAY_AWAY_OPENSHIFT_INSTALL_AWS_USER_TAGS"); ok {
+		if err := json.Unmarshal([]byte(value), &platform.UserTags); err != nil {
+			return nil, fmt.Errorf("_CI_ONLY_STAY_AWAY_OPENSHIFT_INSTALL_AWS_USER_TAGS contains invalid JSON: %s (%v)", value, err)
+		}
+	}
 
 	data, err := json.Marshal(platform)
 	if err != nil {


### PR DESCRIPTION
With a JSON string containing the intended values.

This is probably not how we're going to expose this long-term, so I'm not documenting the enviroment variable yet.  But I want this so we can get back to tagging expirationData in CI, without waiting for asset state <-> disk (de)serialization.

I've also adjusted installconfig to pass platforms as JSON instead of as an array of strings.  This makes it much easier to add control over additional properties, because the consuming logic remains "just unpack the JSON into the appropriate structure".  This may conflict with #344, but it's a small enough change that rebasing either way should be easy.  CC @staebler.