### PR TITLE
userprovided: change AskOne to Ask as it doesn't run Transform

### DIFF
--- a/pkg/asset/userprovided.go
+++ b/pkg/asset/userprovided.go
@@ -37,7 +37,7 @@ func (a *UserProvided) Generate(map[Asset]*State) (*State, error) {
 	}
 
 	if response == "" {
-		survey.AskOne(a.Question.Prompt, &response, a.Question.Validate)
+		survey.Ask([]*survey.Question{a.Question}, &response)
 	} else if a.Question.Validate != nil {
 		if err := a.Question.Validate(response); err != nil {
 			return nil, err


### PR DESCRIPTION
https://github.com/AlecAivazis/survey/blob/f30c5d1830c892f533140f29a1de89141dc217f5/survey.go#L88-L95
```go
func AskOne(p Prompt, response interface{}, v Validator, opts ...AskOpt) error {
	err := Ask([]*Question{{Prompt: p, Validate: v}}, response, opts...)
	if err != nil {
		return err
	}

	return nil
}
```
AskOne was not passing Transform. This would cause error reading region for aws
```console
FATA[0023] failed to generate asset: failed to generate asset "Machine API Operator": failed to lookup
           RHCOS AMI: InvalidEndpointURL: invalid endpoint uri
caused by: parse https://ec2.us-east-1 (N. Virginia).amazonaws.com/: invalid character " " in host name
```
/cc @wking 