### PR TITLE
pkg/asset: Check survey.Ask*() for errors

### DIFF
--- a/pkg/asset/installconfig/ssh.go
+++ b/pkg/asset/installconfig/ssh.go
@@ -95,7 +95,7 @@ func (a *sshPublicKey) Generate(map[asset.Asset]*asset.State) (state *asset.Stat
 	sort.Strings(paths)
 
 	var path string
-	survey.AskOne(&survey.Select{
+	err = survey.AskOne(&survey.Select{
 		Message: "SSH Public Key",
 		Help:    "The SSH public key used to access all nodes within the cluster. This is optional.",
 		Options: paths,
@@ -108,6 +108,9 @@ func (a *sshPublicKey) Generate(map[asset.Asset]*asset.State) (state *asset.Stat
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	return &asset.State{
 		Contents: []asset.Content{{

--- a/pkg/asset/userprovided.go
+++ b/pkg/asset/userprovided.go
@@ -37,7 +37,9 @@ func (a *UserProvided) Generate(map[Asset]*State) (*State, error) {
 	}
 
 	if response == "" {
-		survey.Ask([]*survey.Question{a.Question}, &response)
+		if err := survey.Ask([]*survey.Question{a.Question}, &response); err != nil {
+			return nil, err
+		}
 	} else if a.Question.Validate != nil {
 		if err := a.Question.Validate(response); err != nil {
 			return nil, err


### PR DESCRIPTION
Instead of ignoring them.  This probably fixes a number of issues, including the fact that crtl-C wasn't killing `openshift-install install-config`.

/assign @crawford

Fixes #366.