### PR TITLE
pkg/destroy/libvirt: Add behind a libvirt_destroy build tag

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/stock"
 	"github.com/openshift/installer/pkg/destroy"
+	_ "github.com/openshift/installer/pkg/destroy/libvirt"
 )
 
 var (
@@ -77,7 +78,7 @@ func main() {
 			}
 		}
 	case destroyCommand.FullCommand():
-		destroyer, err := destroy.NewDestroyer(l, *dirFlag)
+		destroyer, err := destroy.New(l, *dirFlag)
 		if err != nil {
 			log.Fatalf("failed to create destroyer: %v", err)
 			os.Exit(1)

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -10,11 +10,15 @@ The following dependencies must be installed on your system before you can build
 sudo dnf install golang-bin gcc-c++
 ```
 
+If you need support for [libvirt destroy](libvirt-howto#cleanup), you should also install `libvirt-devel`.
+
 ### CentOS, RHEL
 
 ```sh
 sudo yum install golang-bin gcc-c++
 ```
+
+If you need support for [libvirt destroy](libvirt-howto#cleanup), you should also install `libvirt-devel`.
 
 ## Go
 

--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -184,6 +184,12 @@ EOF
 ## Build and run the installer
 
 With [libvirt configured](#install-and-enable-libvirt), you can proceed with [the usual quick-start](../../README.md#quick-start).
+Set `TAGS` when building if you need `destroy-cluster` support for libvirt; this is not enabled by default because it requires [cgo][]:
+
+```sh
+TAGS=libvirt_destroy hack/build.sh
+```
+
 To avoid being prompted repeatedly, you can set [environment variables](../user/environment-variables.md) to reflect your libvirt choices.  For example, selecting libvirt, setting [our earlier name choices](#pick-names), [our pull secret](#get-a-pull-secret), and telling both the installer and the machine-API operator to contact `libvirtd` at [the usual libvirt IP](#firewall), you can use:
 
 ```sh
@@ -196,9 +202,13 @@ export OPENSHIFT_INSTALL_LIBVIRT_URI=qemu+tcp://192.168.122.1/system
 
 ## Cleanup
 
-Be sure to destroy your cluster when you're done with it, or else you will need to manually use `virsh` to clean up the leaked resources.
-The [`virsh-cleanup`](../../scripts/maintenance/virsh-cleanup.sh) script may help with this, but note it will currently destroy *all* libvirt resources.
-We plan on adding `openshift-install destroy-cluster` support for libvirt in the near future.
+If you compiled with `libvirt_destroy`, you can use:
+
+```sh
+openshift-install destroy-cluster
+```
+
+If you did not compile with `libvirt_destroy`, you can use [`virsh-cleanup.sh`](../../scripts/maintenance/virsh-cleanup.sh), but note it will currently destroy *all* libvirt resources.
 
 ### Firewall
 
@@ -328,6 +338,7 @@ If your issue is not reported, please do.
 [arch_firewall_superuser]: https://superuser.com/questions/1063240/libvirt-failed-to-initialize-a-valid-firewall-backend
 [brokenmacosissue201]: https://github.com/openshift/installer/issues/201
 [bugzilla_libvirt_race]: https://bugzilla.redhat.com/show_bug.cgi?id=1576464
+[cgo]: https://golang.org/cmd/cgo/
 [issues_libvirt]: https://github.com/openshift/installer/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+libvirt
 [libvirt_selinux_issues]: https://github.com/dmacvicar/terraform-provider-libvirt/issues/142#issuecomment-409040151
 [tfprovider_libvirt_race]: https://github.com/dmacvicar/terraform-provider-libvirt/issues/402#issuecomment-419500064

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -5,11 +5,12 @@ set -ex
 cd "$(dirname "$0")/.."
 
 MODE="${MODE:-release}"
-TAGS=
+TAGS="${TAGS:-}"
+export CGO_ENABLED=0
 
 case "${MODE}" in
 release)
-	TAGS=release
+	TAGS="${TAGS} release"
 	GOPATH="${PWD}/vendor:${GOPATH}" go generate ./data
 	;;
 dev)
@@ -19,4 +20,9 @@ dev)
 	exit 1
 esac
 
-CGO_ENABLED=0 go build -tags "${TAGS}" -o ./bin/openshift-install ./cmd/openshift-install
+if (echo "${TAGS}" | grep -q 'libvirt_destroy')
+then
+	export CGO_ENABLED=1
+fi
+
+go build -tags "${TAGS}" -o ./bin/openshift-install ./cmd/openshift-install

--- a/pkg/destroy/aws.go
+++ b/pkg/destroy/aws.go
@@ -1,0 +1,30 @@
+package destroy
+
+import (
+	"os"
+
+	atd "github.com/openshift/hive/contrib/pkg/awstagdeprovision"
+	"github.com/openshift/installer/pkg/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// NewAWS returns an AWS destroyer from ClusterMetadata.
+func NewAWS(level log.Level, metadata *types.ClusterMetadata) (Destroyer, error) {
+	return &atd.ClusterUninstaller{
+		Filters:     metadata.ClusterPlatformMetadata.AWS.Identifier,
+		Region:      metadata.ClusterPlatformMetadata.AWS.Region,
+		ClusterName: metadata.ClusterName,
+		Logger: log.NewEntry(&log.Logger{
+			Out: os.Stdout,
+			Formatter: &log.TextFormatter{
+				FullTimestamp: true,
+			},
+			Hooks: make(log.LevelHooks),
+			Level: level,
+		}),
+	}, nil
+}
+
+func init() {
+	Registry["aws"] = NewAWS
+}

--- a/pkg/destroy/libvirt/doc.go
+++ b/pkg/destroy/libvirt/doc.go
@@ -1,0 +1,2 @@
+// Package libvirt provides a cluster-destroyer for libvirt clusters.
+package libvirt

--- a/pkg/destroy/libvirt/libvirt_prefix_deprovision.go
+++ b/pkg/destroy/libvirt/libvirt_prefix_deprovision.go
@@ -1,3 +1,5 @@
+// +build libvirt_destroy
+
 package libvirt
 
 import (
@@ -6,6 +8,8 @@ import (
 	"time"
 
 	libvirt "github.com/libvirt/libvirt-go"
+	"github.com/openshift/installer/pkg/destroy"
+	"github.com/openshift/installer/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -238,4 +242,20 @@ func deleteNetwork(conn *libvirt.Connect, filter filterFunc, logger log.FieldLog
 		logger.WithField("network", nName).Info("Deleted network")
 	}
 	return true, nil
+}
+
+// New returns libvirt Uninstaller from ClusterMetadata.
+func New(level log.Level, metadata *types.ClusterMetadata) (destroy.Destroyer, error) {
+	return &ClusterUninstaller{
+		LibvirtURI: metadata.ClusterPlatformMetadata.Libvirt.URI,
+		Filter:     AlwaysTrueFilter(), //TODO: change to ClusterNamePrefixFilter when all resources are prefixed.
+		Logger: log.NewEntry(&log.Logger{
+			Out: os.Stdout,
+			Formatter: &log.TextFormatter{
+				FullTimestamp: true,
+			},
+			Hooks: make(log.LevelHooks),
+			Level: level,
+		}),
+	}, nil
 }

--- a/pkg/destroy/libvirt/register.go
+++ b/pkg/destroy/libvirt/register.go
@@ -1,0 +1,11 @@
+// +build libvirt_destroy
+
+package libvirt
+
+import (
+	"github.com/openshift/installer/pkg/destroy"
+)
+
+func init() {
+	destroy.Registry["libvirt"] = New
+}

--- a/pkg/types/clustermetadata.go
+++ b/pkg/types/clustermetadata.go
@@ -13,6 +13,22 @@ type ClusterPlatformMetadata struct {
 	Libvirt *ClusterLibvirtPlatformMetadata `json:"libvirt,omitempty"`
 }
 
+// Platform returns a string representation of the platform
+// (e.g. "aws" if AWS is non-nil).  It returns an empty string if no
+// platform is configured.
+func (cpm *ClusterPlatformMetadata) Platform() string {
+	if cpm == nil {
+		return ""
+	}
+	if cpm.AWS != nil {
+		return "aws"
+	}
+	if cpm.Libvirt != nil {
+		return "libvirt"
+	}
+	return ""
+}
+
 // ClusterAWSPlatformMetadata contains AWS metadata.
 type ClusterAWSPlatformMetadata struct {
 	Region string `json:"region"`


### PR DESCRIPTION
Docs for Go's build constraints are [here][1].  This pull request allows folks with local libvirt C libraries to compile our libvirt deletion logic (and get a dynamically-linked executable), while release binaries and folks without libvirt C libraries can continue to get statically-linked executables that lack libvirt deletion.

/assign @abhinavdahiya

Testing this locally, I'm getting:

```console
$ env | grep OPENSHIFT_INSTALL_ | sort
OPENSHIFT_INSTALL_BASE_DOMAIN=installer.testing
OPENSHIFT_INSTALL_CLUSTER_NAME=wking
OPENSHIFT_INSTALL_DATA=/home/trking/src/openshift/installer/data/data
OPENSHIFT_INSTALL_EMAIL_ADDRESS=wking@tremily.us
OPENSHIFT_INSTALL_LIBVIRT_IMAGE=http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz
OPENSHIFT_INSTALL_LIBVIRT_URI=qemu+tcp://192.168.122.1/system
OPENSHIFT_INSTALL_PASSWORD=asdf
OPENSHIFT_INSTALL_PLATFORM=libvirt
OPENSHIFT_INSTALL_PULL_SECRET_PATH=/home/trking/src/openshift/installer/pull-secret.json
OPENSHIFT_INSTALL_SSH_PUB_KEY_PATH=/home/trking/.ssh/id_rsa.pub
$ openshift-install --log-level=debug cluster
...
DEBU[0021] Generating Cluster...                        
FATA[0021] failed to generate asset: failed to generate asset "Cluster": failed to run Terraform: signal: segmentation fault 
```

Dunno what's going on there yet.

[1]: https://golang.org/pkg/go/build/#hdr-Build_Constraints