### PR TITLE
build: read go path from go env

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -11,7 +11,7 @@ export CGO_ENABLED=0
 case "${MODE}" in
 release)
 	TAGS="${TAGS} release"
-	GOPATH="${PWD}/vendor:${GOPATH}" go generate ./data
+	GOPATH="${PWD}/vendor:$(go env GOPATH)" go generate ./data
 	;;
 dev)
 	;;


### PR DESCRIPTION
Reading the GOPATH from `go env` allows for environments in which GOPATH
hasn't been set. In this case, `go env` will default to ~/go.