### PR TITLE
cmd/openshift-install: Add a 'version' subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## 0.1.0 - 2018-10-02
+
+### Added
+
+The `openshift-install` command.  This moves us to the new
+install-config approach with [asset
+generation](docs/design/assetgeneration.md) in Go instead of in
+Terraform.  Terraform is still used to push the assets out to
+resources on the backing platform (AWS, libvirt, or OpenStack), but
+that push happens in a single Terraform invocation instead of in
+multiple steps.  This makes installation faster, because more
+resources can be created in parallel.  `openshift-install` also
+dispenses with the distribution tarball; all required assets except
+for a `terraform` binary are distributed in the `openshift-install`
+binary.
+
+The configuration and command-line interface are quite different, so
+previous `tectonic` users are encouraged to start from scratch when
+getting acquainted with `openshift-install`.  AWS users should look
+[here](README.md#quick-start).  Libvirt users should look
+[here](docs/dev/libvirt-howto.md).  The new `openshift-install` also
+includes an interactive configuration generator, so you can launch the
+installer and follow along as it guides you through the process.
+
+### Removed
+
+The `tectonic` command and tarball distribution are gone.  Please use
+the new `openshift-install` command instead.
+

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -17,11 +18,14 @@ var (
 	ignitionConfigsCommand = kingpin.Command("ignition-configs", "Generate the Ignition Config assets")
 	manifestsCommand       = kingpin.Command("manifests", "Generate the Kubernetes manifests")
 	clusterCommand         = kingpin.Command("cluster", "Create an OpenShift cluster")
+	versionCommand         = kingpin.Command("version", "Print version information and exit")
 
 	destroyCommand = kingpin.Command("destroy-cluster", "Destroy an OpenShift cluster")
 
 	dirFlag  = kingpin.Flag("dir", "assets directory").Default(".").String()
 	logLevel = kingpin.Flag("log-level", "log level (e.g. \"debug\")").Default("warn").Enum("debug", "info", "warn", "error", "fatal", "panic")
+
+	version = "was not built correctly" // set in hack/build.sh
 )
 
 func main() {
@@ -32,6 +36,11 @@ func main() {
 		log.Fatalf("invalid log-level: %v", err)
 	}
 	log.SetLevel(l)
+
+	if command == versionCommand.FullCommand() {
+		fmt.Printf("%s %s\n", os.Args[0], version)
+		return
+	}
 
 	assetStock := stock.EstablishStock()
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -5,6 +5,7 @@ set -ex
 cd "$(dirname "$0")/.."
 
 MODE="${MODE:-release}"
+LDFLAGS="${LDFLAGS} -X main.version=$(git describe --always --abbrev=0 --dirty)"
 TAGS="${TAGS:-}"
 export CGO_ENABLED=0
 
@@ -25,4 +26,4 @@ then
 	export CGO_ENABLED=1
 fi
 
-go build -tags "${TAGS}" -o ./bin/openshift-install ./cmd/openshift-install
+go build -ldflags "${LDFLAGS}" -tags "${TAGS}" -o ./bin/openshift-install ./cmd/openshift-install


### PR DESCRIPTION
And calculate its value based on the most recent Git tag (relative to `HEAD`).  This makes it easy for callers to report the version they're using when reporting issues (or successes :).

Also start up a changelog, so occasional users can get a quick summary of important changes between the current version and whichever one they used most recently.

If the above two changes sound appealing, I think we want to start cutting regular releases (weekly?  Every other week?  After each sprint?) and start funneling users towards released versions.