### PR TITLE
pkg/asset/installconfig/ssh: Fix OPENSHIFT_INSTALL_SSH_PUB_KEY injection

### DIFF
--- a/pkg/asset/installconfig/ssh.go
+++ b/pkg/asset/installconfig/ssh.go
@@ -81,11 +81,13 @@ func (a *sshPublicKey) Generate(map[asset.Asset]*asset.State) (state *asset.Stat
 	}
 
 	if len(pubKeys) == 1 {
-		return &asset.State{
-			Contents: []asset.Content{{
-				Data: []byte{},
-			}},
-		}, nil
+		for _, value := range pubKeys {
+			return &asset.State{
+				Contents: []asset.Content{{
+					Data: value,
+				}},
+			}, nil
+		}
 	}
 
 	var paths []string


### PR DESCRIPTION
Fixes the public key in OPENSHIFT_INSTALL_SSH_PUB_KEY_PATH. The file would be read, but
an empty byte array would be returned causing the machine to not inject a public key.