### PR TITLE
hack/build: Drop GOPATH stuffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 First, install all [build dependencies](docs/dev/dependencies.md).
 
-After cloning this repository, the installer binary will need to be built by running the following:
+After cloning this repository into your `GOPATH`, build the installer binary with:
 
 ```sh
 hack/build.sh

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -12,7 +12,7 @@ export CGO_ENABLED=0
 case "${MODE}" in
 release)
 	TAGS="${TAGS} release"
-	GOPATH="${PWD}/vendor:$(go env GOPATH)" go generate ./data
+	go generate ./data
 	;;
 dev)
 	;;


### PR DESCRIPTION
I'd added this in f230c3e9 (#340), citing golang/go#20406.  But:

* `vendor/` is not a useful `GOPATH` addition, because it lacks the `src/` that Go requires.  Go might look in `vendor/src/github.com/...` with our `GOPATH` stuffing, but that won't help it find our vendored
  libraries.

* All that really seems to matter is whether the repository as a whole is checked out into your `GOPATH`.  I'm not sure how to square that with golang/go#20406.

I'm really looking forward to Go 1.11's modules killing the `GOPATH` idea.

Reported by @justaugustus.

[1]: https://github.com/golang/go/issues/20406