### PR TITLE
.github/ISSUE_TEMPLATE: Bring this back up to speed

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,69 +1,63 @@
 <!--
 Thanks for opening a bug report!
 Before hitting the button, please fill in as much of the template below as you can.
-If you leave out information, we can't help you as well.
+If you leave out information, it's harder to help you.
 Be ready for follow-up questions, and please respond in a timely manner.
 If we can't reproduce a bug we might close your issue.
 If we're wrong, PLEASE feel free to reopen it and explain why.
 -->
 
-## Versions
+# Versions
 
-### Tectonic version ([release](https://github.com/openshift/installer/releases) or commit hash):
-```
-enter text here
+## Installer version:
+
+```console
+$ openshift-install version
+<your output here>
 ```
 
-### Terraform version (`terraform version`):
+## Terraform version
+
 <!---
-Run `terraform -v` to show the version, and paste the result between the ``` marks below.
 If you are not running the latest version of Terraform, please try upgrading because your issue may have already been fixed.
 -->
 
-```
-enter text here
-```
-### Platform (aws|libvirt):
-
-```
-enter text here
+```console
+$ terraform version
+<your output here>
 ```
 
-### What happened?
+# Platform (aws|libvirt|openshift):
+
+Enter text here.
+
+# What happened?
+
+Enter text here.
+
+# What you expected to happen?
+
+Enter text here.
+
+# How to reproduce it (as minimally and precisely as possible)?
+
 <!--
-What actually happened?
+Please list the full steps required to reproduce the issue.
 -->
-```
-enter text here
+
+```console
+$ your-commands-here
 ```
 
-### What you expected to happen?
-<!--
-What should have happened?
--->
-```
-enter text here
-```
+# Anything else we need to know?
 
-### How to reproduce it (as minimally and precisely as possible)?
-<!--
-Please list the full steps required to reproduce the issue, for example:
--->
-```
-enter text here
-```
+Enter text here.
 
-### Anything else we need to know?
-```
-enter text here
-```
+# References
 
-### References
 <!--
 Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
 - #6017
 -->
-```
-enter text here
-```
 
+- enter text here.


### PR DESCRIPTION
Drop "Tectonic", mention the new `openshift-install version`, and tidy other nits.