### PR TITLE
cmd/openshift-install: Add Terraform version to 'version' output

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,23 +7,10 @@ If we can't reproduce a bug we might close your issue.
 If we're wrong, PLEASE feel free to reopen it and explain why.
 -->
 
-# Versions
-
-## Installer version:
+# Version
 
 ```console
 $ openshift-install version
-<your output here>
-```
-
-## Terraform version
-
-<!---
-If you are not running the latest version of Terraform, please try upgrading because your issue may have already been fixed.
--->
-
-```console
-$ terraform version
 <your output here>
 ```
 

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -11,6 +12,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/stock"
 	"github.com/openshift/installer/pkg/destroy"
 	_ "github.com/openshift/installer/pkg/destroy/libvirt"
+	"github.com/openshift/installer/pkg/terraform"
 )
 
 var (
@@ -44,6 +46,15 @@ func main() {
 
 	if command == versionCommand.FullCommand() {
 		fmt.Printf("%s %s\n", os.Args[0], version)
+		terraformVersion, err := terraform.Version()
+		if err != nil {
+			exitError, ok := err.(*exec.ExitError)
+			if ok && len(exitError.Stderr) > 0 {
+				logrus.Error(string(exitError.Stderr))
+			}
+			logrus.Fatalf("Failed to calculate Terraform version: %v", err)
+		}
+		fmt.Println(terraformVersion)
 		return
 	}
 

--- a/pkg/terraform/executor.go
+++ b/pkg/terraform/executor.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -71,6 +72,24 @@ func (ex *executor) execute(clusterDir string, args ...string) error {
 
 	// Start Terraform.
 	return cmd.Run()
+}
+
+// Version gets the output of 'terrraform version'.
+func Version() (version string, err error) {
+	// Find the Terraform binary.
+	binPath, err := tfBinaryPath()
+	if err != nil {
+		return "", err
+	}
+
+	output, err := exec.Command(binPath, "version").Output()
+	if err != nil {
+		exitError := err.(*exec.ExitError)
+		if len(exitError.Stderr) == 0 {
+			exitError.Stderr = output
+		}
+	}
+	return strings.TrimRight(string(output), "\n"), err
 }
 
 // tfBinaryPath searches for a Terraform binary on disk:


### PR DESCRIPTION
And print the error information if we can't extract it.

The `.Stderr` stuffing is because Terraform just prints usage information to stdout (not stderr!) if you call it with an unrecognized command:

```console
$ terraform does-not-exit >stdout 2>stderr
$ head -n1 stdout
Usage: terraform [-version] [-help] <command> [args]
$ ls -l stderr
-rw-r--r--. 1 trking trking 0 Oct  2 17:14 stderr
```

and in this case we want to see that usage information.  Ideally Terraform would have printed "unrecognized command `does-no-exist`" or some such to stderr, but that's a bit bigger than we can work around here.

We'll want something in this vein for capturing Terraform apply output when we aren't running with `--log-level=debug`, but I've left that off for now. 

/assign @crawford