### PR TITLE
README: Add console and cleanup information

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,28 @@ hack/get-terraform.sh
 ```
 
 The installer will show a series of prompts for user-specific information (e.g. admin password) and use reasonable defaults for everything else. In non-interactive contexts, prompts can be bypassed by providing appropriately-named environment variables. Refer to the [user documentation](docs/user) for more information.
+
+### Connect to the cluster
+
+#### Console
+
+Shortly after the `cluster` command completes, the OpenShift console will come up at `https://${OPENSHIFT_INSTALL_CLUSTER_NAME}-api.${OPENSHIFT_INSTALL_BASE_DOMAIN}:6443/console/`.
+You may need to ignore a certificate warning if you did not configure a certificate authority known to your browser.
+Log in using the admin credentials you configured when creating the cluster.
+
+#### Kubeconfig
+
+You can also use the admin kubeconfig which `openshift-install cluster` placed under `--dir` (which defaults to `.`) in `auth/kubeconfig`.
+If you launched the cluster with `openshift-install --dir "${DIR}" cluster`, you can use:
+
+```sh
+export KUBECONFIG="${DIR}/auth/kubeconfig"
+```
+
+### Cleanup
+
+Destroy the cluster and release associated resources with:
+
+```sh
+openshift-install destroy-cluster
+```

--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -244,15 +244,12 @@ ssh core@$MASTER_IP
 
 ### Inspect the cluster with kubectl
 
-You'll need a `kubectl` binary on your path.
-If you launched the cluster with `openshift-install --dir "${DIR}" cluster`, you can use:
+You'll need a `kubectl` binary on your path and [the kubeconfig from your `cluster` call](../../README.md#kubeconfig).
 
 ```sh
 export KUBECONFIG="${DIR}/auth/kubeconfig"
 kubectl get -n tectonic-system pods
 ```
-
-If you didn't set `--dir`, you can use `KUBECONFIG=auth/kubeconfig`.
 
 Alternatively, you can run `kubectl` from the bootstrap or master nodes.
 [SSH in](#ssh-access), and run:
@@ -261,10 +258,6 @@ Alternatively, you can run `kubectl` from the bootstrap or master nodes.
 export KUBECONFIG=/var/opt/tectonic/auth/kubeconfig
 kubectl get --all-namespaces pods
 ```
-
-### Connect to the cluster console
-
-Visit `https://${OPENSHIFT_INSTALL_CLUSTER_NAME}-api.${OPENSHIFT_INSTALL_BASE_DOMAIN}:6443/console/` and log in using the admin credentials you configured when creating the cluster.
 
 ## FAQ
 


### PR DESCRIPTION
This restores the console docs which we'd removed from the README in feb41e9d (#328).  And it moves the kubeconfig location information over from the libvirt-specific docs.  Launching the cluster is nice, but these other operations are important too ;).  Putting them in the README makes increases their visibility.  It also lets us drom them from the libvirt-specific docs, now that the libvirt docs link to the README quick-start for these generic operations.