### PR TITLE
libvirt: increase master memory to 3GB

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -66,7 +66,7 @@ resource "libvirt_domain" "master" {
 
   name = "master${count.index}"
 
-  memory = "2048"
+  memory = "3072"
   vcpu   = "2"
 
   coreos_ignition = "${libvirt_ignition.master.*.id[count.index]}"


### PR DESCRIPTION
After CVO merged, 2GB is no longer sufficient for master operations.  The VM gridlocks with kswapd and becomes slow to respond or completely unresponsive.

I bumped my master to 4GB to get this working, but 3GB should be sufficient for now.
```
[root@dev-master-0 ~]# echo 3 > /proc/sys/vm/drop_caches 
[root@dev-master-0 ~]# free -h
              total        used        free      shared  buff/cache   available
Mem:           3.9G        2.1G        1.1G        8.4M        679M        1.4G
Swap:            0B          0B          0B
```
@aveshagarwal @derekwaynecarr @rphillips @abhinavdahiya 