### PR TITLE
pkg/rhcos/ami: Start supporting RHCOS channels

### DIFF
--- a/pkg/asset/manifests/machine-api-operator.go
+++ b/pkg/asset/manifests/machine-api-operator.go
@@ -13,8 +13,6 @@ import (
 
 const (
 	maoTargetNamespace = "openshift-cluster-api"
-	// DefaultChannel is the default RHCOS channel for the cluster.
-	DefaultChannel = "tested"
 )
 
 // machineAPIOperator generates the network-operator-*.yml files
@@ -118,7 +116,7 @@ func (mao *machineAPIOperator) maoConfig(dependencies map[asset.Asset]*asset.Sta
 	if mao.installConfig.Platform.AWS != nil {
 		var ami string
 
-		ami, err := rhcos.AMI(context.TODO(), DefaultChannel, mao.installConfig.Platform.AWS.Region)
+		ami, err := rhcos.AMI(context.TODO(), rhcos.DefaultChannel, mao.installConfig.Platform.AWS.Region)
 		if err != nil {
 			return "", fmt.Errorf("failed to lookup RHCOS AMI: %v", err)
 		}


### PR DESCRIPTION
openshift/os@76b3ae5d (openshift/os#314) started adding `rhcos_tag=alpha` tags to tested AMIs.  The likely plan for RHCOS tagging is [here][1], although they don't have stable docs for that yet.  With this commit, we allow the user to specify whichever channel they want, and we search for that tag.  If they give us nonsense, we'll now hit AWS, see no images in the nonsense channel, and report that back to the caller.

Users that don't care about release channels and just want to use the latest image regardless of channel, can set `channel` to an empty string.

/hold

We don't want to merge this until we sort out why [CI seems to lack alpha tags][2].

[1]: https://github.com/openshift/os/issues/201#issuecomment-423214423
[2]: https://github.com/openshift/os/pull/314#issuecomment-426715727