### PR TITLE
data/libvirt: Resize to 16 GiB

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -2,17 +2,17 @@ provider "libvirt" {
   uri = "${var.tectonic_libvirt_uri}"
 }
 
-module "libvirt_base_volume" {
-  source = "./volume"
-
-  image = "${var.tectonic_os_image}"
+resource "libvirt_volume" "base" {
+  name   = "coreos_base"
+  source = "${var.tectonic_os_image}"
+  size   = 17179869184
 }
 
 module "bootstrap" {
   source = "./bootstrap"
 
   addresses      = ["${var.tectonic_libvirt_bootstrap_ip}"]
-  base_volume_id = "${module.libvirt_base_volume.coreos_base_volume_id}"
+  base_volume_id = "${libvirt_volume.base.id}"
   cluster_name   = "${var.tectonic_cluster_name}"
   ignition       = "${var.ignition_bootstrap}"
   network_id     = "${libvirt_network.tectonic_net.id}"
@@ -21,7 +21,7 @@ module "bootstrap" {
 resource "libvirt_volume" "master" {
   count          = "${var.tectonic_master_count}"
   name           = "master${count.index}"
-  base_volume_id = "${module.libvirt_base_volume.coreos_base_volume_id}"
+  base_volume_id = "${libvirt_volume.base.id}"
 }
 
 resource "libvirt_ignition" "master" {

--- a/data/data/libvirt/volume/main.tf
+++ b/data/data/libvirt/volume/main.tf
@@ -1,4 +1,0 @@
-resource "libvirt_volume" "coreos_base" {
-  name   = "coreos_base"
-  source = "${var.image}"
-}

--- a/data/data/libvirt/volume/outputs.tf
+++ b/data/data/libvirt/volume/outputs.tf
@@ -1,3 +1,0 @@
-output "coreos_base_volume_id" {
-  value = "${libvirt_volume.coreos_base.id}"
-}

--- a/data/data/libvirt/volume/variables.tf
+++ b/data/data/libvirt/volume/variables.tf
@@ -1,4 +1,0 @@
-variable "image" {
-  description = "The URL of the OS disk image"
-  type        = "string"
-}


### PR DESCRIPTION
This is the size of the current RHCOS images, but resizing here will allow the OS folks to stop guessing which size we need (#126, openshift/os#228).

Explicitly closing the file before resizing ensures we've flushed the cache after the earlier copy.  We probably should have been doing that before the `Rename` anyway.  With this explict close, the deferred close call may fail, but that's fine.

Dropping to `qemu-img` makes me a bit jumpy, but at least most folks with a `libvirtd` running will have `qemu-img` available.

Fixes #126.