### PR TITLE
manifests: add cvo-overrides

### DIFF
--- a/pkg/asset/manifests/content/bootkube/cvo-overrides.go
+++ b/pkg/asset/manifests/content/bootkube/cvo-overrides.go
@@ -1,0 +1,59 @@
+package bootkube
+
+import (
+	"text/template"
+)
+
+var (
+	// CVOOverrides is the constant to represent contents of cvo-override.yaml file
+	// This is a gate to prevent CVO from installing these operators which is conflicting
+	// with already owned resources by tectonic-operators.
+	// This files can be dropped when the overrides list becomes empty.
+	CVOOverrides = template.Must(template.New("cvo-override.yaml").Parse(`
+apiVersion: clusterversion.openshift.io/v1
+kind: CVOConfig
+metadata:
+  namespace: openshift-cluster-version
+  name: cluster-version-operator
+upstream: http://localhost:8080/graph
+channel: fast
+clusterID: {{.CVOClusterID}}
+overrides:
+- kind: Deployment                    # this conflicts with kube-core-operator
+  namespace: openshift-core-operators
+  name: openshift-cluster-kube-apiserver-operator
+  unmanaged: true
+- kind: Deployment                    # this conflicts with kube-core-operator
+  namespace: openshift-core-operators
+  name: openshift-cluster-kube-scheduler-operator
+  unmanaged: true
+- kind: Deployment                    # this conflicts with kube-core-operator
+  namespace: openshift-core-operators
+  name: openshift-cluster-kube-controller-manager-operator
+  unmanaged: true
+- kind: Deployment                    # this conflicts with kube-core-operator
+  namespace: openshift-core-operators
+  name: openshift-cluster-openshift-apiserver-operator
+  unmanaged: true
+- kind: Deployment                    # this conflicts with kube-core-operator
+  namespace: openshift-core-operators
+  name: openshift-cluster-openshift-controller-manager-operator
+  unmanaged: true
+- kind: Deployment                    # this conflicts with kube-core-operator
+  namespace: openshift-cluster-network-operator
+  name: cluster-network-operator
+  unmanaged: true
+- kind: Deployment                    # this conflicts with tectonic-ingress-controller-operator
+  namespace: openshift-cluster-ingress-operator
+  name: cluster-ingress-operator
+  unmanaged: true
+- kind: ServiceAccount                # missing run level 0 on the namespace and has 0000_08
+  namespace: openshift-cluster-dns-operator
+  name: cluster-dns-operator
+  unmanaged: true
+- kind: Deployment                    # this conflicts with kube-core-operator
+  namespace: openshift-cluster-dns-operator
+  name: cluster-dns-operator
+  unmanaged: true
+`))
+)

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -156,6 +156,7 @@ func (m *manifests) generateBootKubeManifests(dependencies map[asset.Asset]*asse
 		ServiceServingCaKey:             base64.StdEncoding.EncodeToString(dependencies[m.serviceServingCA].Contents[keyIndex].Data),
 		TectonicNetworkOperatorImage:    "quay.io/coreos/tectonic-network-operator-dev:3b6952f5a1ba89bb32dd0630faddeaf2779c9a85",
 		WorkerIgnConfig:                 base64.StdEncoding.EncodeToString(dependencies[m.workerIgnition].Contents[0].Data),
+		CVOClusterID:                    ic.ClusterID,
 	}
 
 	assetData := map[string][]byte{
@@ -168,6 +169,7 @@ func (m *manifests) generateBootKubeManifests(dependencies map[asset.Asset]*asse
 		"openshift-apiserver-secret.yaml":       applyTemplateData(bootkube.OpenshiftApiserverSecret, templateData),
 		"pull.json":                             applyTemplateData(bootkube.Pull, templateData),
 		"tectonic-network-operator.yaml":        applyTemplateData(bootkube.TectonicNetworkOperator, templateData),
+		"cvo-overrides.yaml":                    applyTemplateData(bootkube.CVOOverrides, templateData),
 
 		"01-tectonic-namespace.yaml":                       []byte(bootkube.TectonicNamespace),
 		"02-ingress-namespace.yaml":                        []byte(bootkube.IngressNamespace),

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -29,6 +29,7 @@ type bootkubeTemplateData struct {
 	ServiceServingCaKey             string
 	TectonicNetworkOperatorImage    string
 	WorkerIgnConfig                 string
+	CVOClusterID                    string
 }
 
 type tectonicTemplateData struct {


### PR DESCRIPTION
This allows installer to block installation of components in release
manifests that are casing conflicts with old tectonic-operators

Requires https://github.com/openshift/cluster-version-operator/pull/30

@wking this should allow us to stop installing conflicting new operators
/cc @wking 