### PR TITLE
Use string as the asset map key instead of the object itself

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -11,7 +11,7 @@ type Asset interface {
 	Dependencies() []Asset
 
 	// Generate generates this asset given the states of its dependent assets.
-	Generate(map[Asset]*State) (*State, error)
+	Generate(map[string]*State) (*State, error)
 
 	// Name returns the human-friendly name of the asset.
 	Name() string
@@ -19,8 +19,8 @@ type Asset interface {
 
 // GetDataByFilename searches the file in the asset.State.Contents, and returns its data.
 // filename is the base name of the file.
-func GetDataByFilename(a Asset, parents map[Asset]*State, filename string) ([]byte, error) {
-	st, ok := parents[a]
+func GetDataByFilename(a Asset, parents map[string]*State, filename string) ([]byte, error) {
+	st, ok := parents[a.Name()]
 	if !ok {
 		return nil, fmt.Errorf("failed to find %T in parents", a)
 	}

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -42,8 +42,8 @@ func (c *Cluster) Dependencies() []asset.Asset {
 }
 
 // Generate launches the cluster and generates the terraform state file on disk.
-func (c *Cluster) Generate(parents map[asset.Asset]*asset.State) (*asset.State, error) {
-	state, ok := parents[c.tfvars]
+func (c *Cluster) Generate(parents map[string]*asset.State) (*asset.State, error) {
+	state, ok := parents[c.tfvars.Name()]
 	if !ok {
 		return nil, fmt.Errorf("failed to get terraform.tfvar state in the parent asset states")
 	}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -36,7 +36,7 @@ func (t *TerraformVariables) Dependencies() []asset.Asset {
 }
 
 // Generate generates the terraform.tfvars file.
-func (t *TerraformVariables) Generate(parents map[asset.Asset]*asset.State) (*asset.State, error) {
+func (t *TerraformVariables) Generate(parents map[string]*asset.State) (*asset.State, error) {
 	installCfg, err := installconfig.GetInstallConfig(t.installConfig, parents)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get install config state in the parent asset states")
@@ -49,7 +49,7 @@ func (t *TerraformVariables) Generate(parents map[asset.Asset]*asset.State) (*as
 		t.masterIgnition,
 		t.workerIgnition,
 	} {
-		state, ok := parents[ign]
+		state, ok := parents[ign.Name()]
 		if !ok {
 			return nil, fmt.Errorf("failed to get the ignition state for %v in the parent asset states", ign)
 		}

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -130,7 +130,7 @@ func (a *bootstrap) Dependencies() []asset.Asset {
 }
 
 // Generate generates the ignition config for the bootstrap asset.
-func (a *bootstrap) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+func (a *bootstrap) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
 	installConfig, err := installconfig.GetInstallConfig(a.installConfig, dependencies)
 	if err != nil {
 		return nil, err
@@ -214,45 +214,45 @@ func (a *bootstrap) getTemplateData(installConfig *types.InstallConfig) (*bootst
 	}, nil
 }
 
-func (a *bootstrap) addBootstrapFiles(config *igntypes.Config, dependencies map[asset.Asset]*asset.State) {
+func (a *bootstrap) addBootstrapFiles(config *igntypes.Config, dependencies map[string]*asset.State) {
 	config.Storage.Files = append(
 		config.Storage.Files,
-		ignition.FileFromBytes("/etc/kubernetes/kubeconfig", 0600, dependencies[a.kubeconfigKubelet].Contents[0].Data),
-		ignition.FileFromBytes("/var/lib/kubelet/kubeconfig", 0600, dependencies[a.kubeconfigKubelet].Contents[0].Data),
+		ignition.FileFromBytes("/etc/kubernetes/kubeconfig", 0600, dependencies[a.kubeconfigKubelet.Name()].Contents[0].Data),
+		ignition.FileFromBytes("/var/lib/kubelet/kubeconfig", 0600, dependencies[a.kubeconfigKubelet.Name()].Contents[0].Data),
 	)
 	config.Storage.Files = append(
 		config.Storage.Files,
-		ignition.FilesFromContents(rootDir, 0644, dependencies[a.kubeCoreOperator].Contents)...,
+		ignition.FilesFromContents(rootDir, 0644, dependencies[a.kubeCoreOperator.Name()].Contents)...,
 	)
 }
 
-func (a *bootstrap) addBootkubeFiles(config *igntypes.Config, dependencies map[asset.Asset]*asset.State, templateData *bootstrapTemplateData) {
+func (a *bootstrap) addBootkubeFiles(config *igntypes.Config, dependencies map[string]*asset.State, templateData *bootstrapTemplateData) {
 	config.Storage.Files = append(
 		config.Storage.Files,
 		ignition.FileFromString("/opt/tectonic/bootkube.sh", 0555, applyTemplateData(content.BootkubeShFileTemplate, templateData)),
 	)
 	config.Storage.Files = append(
 		config.Storage.Files,
-		ignition.FilesFromContents(rootDir, 0600, dependencies[a.kubeconfig].Contents)...,
+		ignition.FilesFromContents(rootDir, 0600, dependencies[a.kubeconfig.Name()].Contents)...,
 	)
 	config.Storage.Files = append(
 		config.Storage.Files,
-		ignition.FilesFromContents(rootDir, 0644, dependencies[a.manifests].Contents)...,
+		ignition.FilesFromContents(rootDir, 0644, dependencies[a.manifests.Name()].Contents)...,
 	)
 }
 
-func (a *bootstrap) addTectonicFiles(config *igntypes.Config, dependencies map[asset.Asset]*asset.State, templateData *bootstrapTemplateData) {
+func (a *bootstrap) addTectonicFiles(config *igntypes.Config, dependencies map[string]*asset.State, templateData *bootstrapTemplateData) {
 	config.Storage.Files = append(
 		config.Storage.Files,
 		ignition.FileFromString("/opt/tectonic/tectonic.sh", 0555, content.TectonicShFileContents),
 	)
 	config.Storage.Files = append(
 		config.Storage.Files,
-		ignition.FilesFromContents(rootDir, 0644, dependencies[a.tectonic].Contents)...,
+		ignition.FilesFromContents(rootDir, 0644, dependencies[a.tectonic.Name()].Contents)...,
 	)
 }
 
-func (a *bootstrap) addTLSCertFiles(config *igntypes.Config, dependencies map[asset.Asset]*asset.State) {
+func (a *bootstrap) addTLSCertFiles(config *igntypes.Config, dependencies map[string]*asset.State) {
 	for _, asset := range []asset.Asset{
 		a.rootCA,
 		a.kubeCA,
@@ -269,12 +269,12 @@ func (a *bootstrap) addTLSCertFiles(config *igntypes.Config, dependencies map[as
 		a.mcsCertKey,
 		a.serviceAccountKeyPair,
 	} {
-		config.Storage.Files = append(config.Storage.Files, ignition.FilesFromContents(rootDir, 0600, dependencies[asset].Contents)...)
+		config.Storage.Files = append(config.Storage.Files, ignition.FilesFromContents(rootDir, 0600, dependencies[asset.Name()].Contents)...)
 	}
 
 	config.Storage.Files = append(
 		config.Storage.Files,
-		ignition.FileFromBytes("/etc/ssl/etcd/ca.crt", 0600, dependencies[a.etcdClientCertKey].Contents[tls.CertIndex].Data),
+		ignition.FileFromBytes("/etc/ssl/etcd/ca.crt", 0600, dependencies[a.etcdClientCertKey.Name()].Contents[tls.CertIndex].Data),
 	)
 }
 

--- a/pkg/asset/ignition/machine/master.go
+++ b/pkg/asset/ignition/machine/master.go
@@ -36,7 +36,7 @@ func (a *master) Dependencies() []asset.Asset {
 }
 
 // Generate generates the ignition config for the master asset.
-func (a *master) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+func (a *master) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
 	installConfig, err := installconfig.GetInstallConfig(a.installConfig, dependencies)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func (a *master) Generate(dependencies map[asset.Asset]*asset.State) (*asset.Sta
 	}
 	for i := range state.Contents {
 		state.Contents[i].Name = fmt.Sprintf("master-%d.ign", i)
-		state.Contents[i].Data = pointerIgnitionConfig(installConfig, dependencies[a.rootCA].Contents[tls.CertIndex].Data, "master", fmt.Sprintf("etcd_index=%d", i))
+		state.Contents[i].Data = pointerIgnitionConfig(installConfig, dependencies[a.rootCA.Name()].Contents[tls.CertIndex].Data, "master", fmt.Sprintf("etcd_index=%d", i))
 	}
 
 	return state, nil

--- a/pkg/asset/ignition/machine/master_test.go
+++ b/pkg/asset/ignition/machine/master_test.go
@@ -29,9 +29,9 @@ machines:
 		installConfig: installConfigAsset,
 		rootCA:        rootCAAsset,
 	}
-	dependencies := map[asset.Asset]*asset.State{
-		installConfigAsset: stateWithContentsData(installConfig),
-		rootCAAsset:        stateWithContentsData("test-rootCA-priv", "test-rootCA-pub"),
+	dependencies := map[string]*asset.State{
+		installConfigAsset.Name(): stateWithContentsData(installConfig),
+		rootCAAsset.Name():        stateWithContentsData("test-rootCA-priv", "test-rootCA-pub"),
 	}
 	masterState, err := master.Generate(dependencies)
 	assert.NoError(t, err, "unexpected error generating master asset")

--- a/pkg/asset/ignition/machine/testasset_test.go
+++ b/pkg/asset/ignition/machine/testasset_test.go
@@ -1,6 +1,7 @@
 package machine
 
 import (
+	"fmt"
 	"github.com/openshift/installer/pkg/asset"
 )
 
@@ -12,12 +13,12 @@ func (a *testAsset) Dependencies() []asset.Asset {
 	return []asset.Asset{}
 }
 
-func (a *testAsset) Generate(map[asset.Asset]*asset.State) (*asset.State, error) {
+func (a *testAsset) Generate(map[string]*asset.State) (*asset.State, error) {
 	return nil, nil
 }
 
 func (a *testAsset) Name() string {
-	return "Test Asset"
+	return fmt.Sprintf("Test Asset (%s)", a.name)
 }
 
 func stateWithContentsData(contentsData ...string) *asset.State {

--- a/pkg/asset/ignition/machine/worker.go
+++ b/pkg/asset/ignition/machine/worker.go
@@ -34,7 +34,7 @@ func (a *worker) Dependencies() []asset.Asset {
 }
 
 // Generate generates the ignition config for the worker asset.
-func (a *worker) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+func (a *worker) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
 	installConfig, err := installconfig.GetInstallConfig(a.installConfig, dependencies)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (a *worker) Generate(dependencies map[asset.Asset]*asset.State) (*asset.Sta
 	return &asset.State{
 		Contents: []asset.Content{{
 			Name: "worker.ign",
-			Data: pointerIgnitionConfig(installConfig, dependencies[a.rootCA].Contents[tls.CertIndex].Data, "worker", ""),
+			Data: pointerIgnitionConfig(installConfig, dependencies[a.rootCA.Name()].Contents[tls.CertIndex].Data, "worker", ""),
 		}},
 	}, nil
 }

--- a/pkg/asset/ignition/machine/worker_test.go
+++ b/pkg/asset/ignition/machine/worker_test.go
@@ -23,9 +23,9 @@ region: us-east
 		installConfig: installConfigAsset,
 		rootCA:        rootCAAsset,
 	}
-	dependencies := map[asset.Asset]*asset.State{
-		installConfigAsset: stateWithContentsData(installConfig),
-		rootCAAsset:        stateWithContentsData("test-rootCA-priv", "test-rootCA-pub"),
+	dependencies := map[string]*asset.State{
+		installConfigAsset.Name(): stateWithContentsData(installConfig),
+		rootCAAsset.Name():        stateWithContentsData("test-rootCA-priv", "test-rootCA-pub"),
 	}
 	workerState, err := worker.Generate(dependencies)
 	assert.NoError(t, err, "unexpected error generating worker asset")

--- a/pkg/asset/installconfig/clusterid.go
+++ b/pkg/asset/installconfig/clusterid.go
@@ -16,7 +16,7 @@ func (a *clusterID) Dependencies() []asset.Asset {
 }
 
 // Generate generates a new UUID
-func (a *clusterID) Generate(map[asset.Asset]*asset.State) (*asset.State, error) {
+func (a *clusterID) Generate(map[string]*asset.State) (*asset.State, error) {
 	return &asset.State{
 		Contents: []asset.Content{
 			{Data: []byte(uuid.New())},

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -43,14 +43,14 @@ func (a *installConfig) Dependencies() []asset.Asset {
 }
 
 // Generate generates the install-config.yml file.
-func (a *installConfig) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
-	clusterID := string(dependencies[a.assetStock.ClusterID()].Contents[0].Data)
-	emailAddress := string(dependencies[a.assetStock.EmailAddress()].Contents[0].Data)
-	password := string(dependencies[a.assetStock.Password()].Contents[0].Data)
-	sshKey := string(dependencies[a.assetStock.SSHKey()].Contents[0].Data)
-	baseDomain := string(dependencies[a.assetStock.BaseDomain()].Contents[0].Data)
-	clusterName := string(dependencies[a.assetStock.ClusterName()].Contents[0].Data)
-	pullSecret := string(dependencies[a.assetStock.PullSecret()].Contents[0].Data)
+func (a *installConfig) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
+	clusterID := string(dependencies[a.assetStock.ClusterID().Name()].Contents[0].Data)
+	emailAddress := string(dependencies[a.assetStock.EmailAddress().Name()].Contents[0].Data)
+	password := string(dependencies[a.assetStock.Password().Name()].Contents[0].Data)
+	sshKey := string(dependencies[a.assetStock.SSHKey().Name()].Contents[0].Data)
+	baseDomain := string(dependencies[a.assetStock.BaseDomain().Name()].Contents[0].Data)
+	clusterName := string(dependencies[a.assetStock.ClusterName().Name()].Contents[0].Data)
+	pullSecret := string(dependencies[a.assetStock.PullSecret().Name()].Contents[0].Data)
 
 	installConfig := types.InstallConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -78,7 +78,7 @@ func (a *installConfig) Generate(dependencies map[asset.Asset]*asset.State) (*as
 		PullSecret: pullSecret,
 	}
 
-	platformState := dependencies[a.assetStock.Platform()]
+	platformState := dependencies[a.assetStock.Platform().Name()]
 	platform := string(platformState.Contents[0].Data)
 	switch platform {
 	case AWSPlatformType:
@@ -150,10 +150,10 @@ func (a installConfig) Name() string {
 }
 
 // GetInstallConfig returns the *types.InstallConfig from the parent asset map.
-func GetInstallConfig(installConfig asset.Asset, parents map[asset.Asset]*asset.State) (*types.InstallConfig, error) {
+func GetInstallConfig(installConfig asset.Asset, parents map[string]*asset.State) (*types.InstallConfig, error) {
 	var cfg types.InstallConfig
 
-	st, ok := parents[installConfig]
+	st, ok := parents[installConfig.Name()]
 	if !ok {
 		return nil, fmt.Errorf("failed to find %T in parents", installConfig)
 	}

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -19,7 +19,7 @@ func (a *testAsset) Dependencies() []asset.Asset {
 	return []asset.Asset{}
 }
 
-func (a *testAsset) Generate(map[asset.Asset]*asset.State) (*asset.State, error) {
+func (a *testAsset) Generate(map[string]*asset.State) (*asset.State, error) {
 	return nil, nil
 }
 

--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -74,7 +74,7 @@ func (a *Platform) Dependencies() []asset.Asset {
 }
 
 // Generate queries for input from the user.
-func (a *Platform) Generate(map[asset.Asset]*asset.State) (*asset.State, error) {
+func (a *Platform) Generate(map[string]*asset.State) (*asset.State, error) {
 	platform, err := a.queryUserForPlatform()
 	if err != nil {
 		return nil, err

--- a/pkg/asset/installconfig/ssh.go
+++ b/pkg/asset/installconfig/ssh.go
@@ -41,7 +41,7 @@ func readSSHKey(path string) (key []byte, err error) {
 }
 
 // Generate generates the SSH public key asset.
-func (a *sshPublicKey) Generate(map[asset.Asset]*asset.State) (state *asset.State, err error) {
+func (a *sshPublicKey) Generate(map[string]*asset.State) (state *asset.State, err error) {
 	if value, ok := os.LookupEnv("OPENSHIFT_INSTALL_SSH_PUB_KEY"); ok {
 		if value != "" {
 			if err := validateOpenSSHPublicKey(value); err != nil {

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -39,7 +39,7 @@ func (k *Kubeconfig) Dependencies() []asset.Asset {
 }
 
 // Generate generates the kubeconfig.
-func (k *Kubeconfig) Generate(parents map[asset.Asset]*asset.State) (*asset.State, error) {
+func (k *Kubeconfig) Generate(parents map[string]*asset.State) (*asset.State, error) {
 	var err error
 
 	caCertData, err := asset.GetDataByFilename(k.rootCA, parents, tls.RootCACertName)

--- a/pkg/asset/kubeconfig/kubeconfig_test.go
+++ b/pkg/asset/kubeconfig/kubeconfig_test.go
@@ -16,7 +16,7 @@ func (f fakeAsset) Dependencies() []asset.Asset {
 	return nil
 }
 
-func (f fakeAsset) Generate(map[asset.Asset]*asset.State) (*asset.State, error) {
+func (f fakeAsset) Generate(map[string]*asset.State) (*asset.State, error) {
 	return nil, nil
 }
 
@@ -85,7 +85,7 @@ metadata:
 		name         string
 		userName     string
 		certKey      asset.Asset
-		parents      map[asset.Asset]*asset.State
+		parents      map[string]*asset.State
 		errString    string
 		expectedData []byte
 	}{
@@ -93,10 +93,10 @@ metadata:
 			name:     "admin kubeconfig",
 			userName: "admin",
 			certKey:  adminCertKey,
-			parents: map[asset.Asset]*asset.State{
-				rootCA:        rootCAState,
-				adminCertKey:  adminCertState,
-				installConfig: installConfigState,
+			parents: map[string]*asset.State{
+				rootCA.Name():        rootCAState,
+				adminCertKey.Name():  adminCertState,
+				installConfig.Name(): installConfigState,
 			},
 			expectedData: []byte(`clusters:
 - cluster:
@@ -121,10 +121,10 @@ users:
 			name:     "kubelet kubeconfig",
 			userName: "kubelet",
 			certKey:  kubeletCertKey,
-			parents: map[asset.Asset]*asset.State{
-				rootCA:         rootCAState,
-				kubeletCertKey: kubeletCertState,
-				installConfig:  installConfigState,
+			parents: map[string]*asset.State{
+				rootCA.Name():         rootCAState,
+				kubeletCertKey.Name(): kubeletCertState,
+				installConfig.Name():  installConfigState,
 			},
 			expectedData: []byte(`clusters:
 - cluster:
@@ -149,9 +149,9 @@ users:
 			name:     "no root ca",
 			userName: "admin", // No root ca in parents.
 			certKey:  adminCertKey,
-			parents: map[asset.Asset]*asset.State{
-				adminCertKey:  adminCertState,
-				installConfig: installConfigState,
+			parents: map[string]*asset.State{
+				adminCertKey.Name():  adminCertState,
+				installConfig.Name(): installConfigState,
 			},
 			errString:    "failed to find kubeconfig.fakeAsset in parents",
 			expectedData: nil,
@@ -160,10 +160,10 @@ users:
 			name:     "no admin certs",
 			userName: "admin", // No admin cert in parents.
 			certKey:  adminCertKey,
-			parents: map[asset.Asset]*asset.State{
-				rootCA:         rootCAState,
-				kubeletCertKey: kubeletCertState,
-				installConfig:  installConfigState,
+			parents: map[string]*asset.State{
+				rootCA.Name():         rootCAState,
+				kubeletCertKey.Name(): kubeletCertState,
+				installConfig.Name():  installConfigState,
 			},
 			errString:    "failed to find kubeconfig.fakeAsset in parents",
 			expectedData: nil,
@@ -172,10 +172,10 @@ users:
 			name:     "no kubelet certs",
 			userName: "kubelet", // No kubelet cert in parents.
 			certKey:  kubeletCertKey,
-			parents: map[asset.Asset]*asset.State{
-				rootCA:        rootCAState,
-				adminCertKey:  adminCertState,
-				installConfig: installConfigState,
+			parents: map[string]*asset.State{
+				rootCA.Name():        rootCAState,
+				adminCertKey.Name():  adminCertState,
+				installConfig.Name(): installConfigState,
 			},
 			errString:    "failed to find kubeconfig.fakeAsset in parents",
 			expectedData: nil,
@@ -184,9 +184,9 @@ users:
 			name:     "no install config",
 			userName: "admin", // No install config in parents.
 			certKey:  adminCertKey,
-			parents: map[asset.Asset]*asset.State{
-				rootCA:       rootCAState,
-				adminCertKey: adminCertState,
+			parents: map[string]*asset.State{
+				rootCA.Name():       rootCAState,
+				adminCertKey.Name(): adminCertState,
 			},
 			errString:    "failed to find kubeconfig.fakeAsset in parents",
 			expectedData: nil,

--- a/pkg/asset/manifests/kube-addon-operator.go
+++ b/pkg/asset/manifests/kube-addon-operator.go
@@ -35,7 +35,7 @@ func (kao *kubeAddonOperator) Dependencies() []asset.Asset {
 }
 
 // Generate generates the network-operator-config.yml and network-operator-manifest.yml files
-func (kao *kubeAddonOperator) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+func (kao *kubeAddonOperator) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
 	ic, err := installconfig.GetInstallConfig(kao.installConfigAsset, dependencies)
 	if err != nil {
 		return nil, err

--- a/pkg/asset/manifests/kube-core-operator.go
+++ b/pkg/asset/manifests/kube-core-operator.go
@@ -43,7 +43,7 @@ func (kco *kubeCoreOperator) Dependencies() []asset.Asset {
 }
 
 // Generate generates the kube-core-operator-config.yml files
-func (kco *kubeCoreOperator) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+func (kco *kubeCoreOperator) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
 	ic, err := installconfig.GetInstallConfig(kco.installConfigAsset, dependencies)
 	if err != nil {
 		return nil, err

--- a/pkg/asset/manifests/machine-api-operator.go
+++ b/pkg/asset/manifests/machine-api-operator.go
@@ -77,7 +77,7 @@ func (mao *machineAPIOperator) Dependencies() []asset.Asset {
 }
 
 // Generate generates the network-operator-config.yml and network-operator-manifest.yml files
-func (mao *machineAPIOperator) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+func (mao *machineAPIOperator) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
 	ic, err := installconfig.GetInstallConfig(mao.installConfigAsset, dependencies)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func (mao *machineAPIOperator) Generate(dependencies map[asset.Asset]*asset.Stat
 	return state, nil
 }
 
-func (mao *machineAPIOperator) maoConfig(dependencies map[asset.Asset]*asset.State) (string, error) {
+func (mao *machineAPIOperator) maoConfig(dependencies map[string]*asset.State) (string, error) {
 	cfg := maoOperatorConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -111,7 +111,7 @@ func (mao *machineAPIOperator) maoConfig(dependencies map[asset.Asset]*asset.Sta
 		TargetNamespace: maoTargetNamespace,
 	}
 
-	ca := dependencies[mao.aggregatorCA].Contents[certIndex].Data
+	ca := dependencies[mao.aggregatorCA.Name()].Contents[certIndex].Data
 	cfg.APIServiceCA = string(ca)
 	cfg.Provider = tectonicCloudProvider(mao.installConfig.Platform)
 

--- a/pkg/asset/manifests/network-operator.go
+++ b/pkg/asset/manifests/network-operator.go
@@ -37,7 +37,7 @@ func (no *networkOperator) Dependencies() []asset.Asset {
 }
 
 // Generate generates the network-operator-config.yml and network-operator-manifest.yml files
-func (no *networkOperator) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+func (no *networkOperator) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
 	ic, err := installconfig.GetInstallConfig(no.installConfigAsset, dependencies)
 	if err != nil {
 		return nil, err

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -79,13 +79,13 @@ func (m *manifests) Dependencies() []asset.Asset {
 }
 
 // Generate generates the respective operator config.yml files
-func (m *manifests) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+func (m *manifests) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
 	//cvo := dependencies[m.assetStock.ClusterVersionOperator()].Contents[0]
-	kco := dependencies[m.assetStock.KubeCoreOperator()].Contents[0]
-	no := dependencies[m.assetStock.NetworkOperator()].Contents[0]
-	addon := dependencies[m.assetStock.KubeAddonOperator()].Contents[0]
-	mao := dependencies[m.assetStock.Mao()].Contents[0]
-	installConfig := dependencies[m.installConfig].Contents[0]
+	kco := dependencies[m.assetStock.KubeCoreOperator().Name()].Contents[0]
+	no := dependencies[m.assetStock.NetworkOperator().Name()].Contents[0]
+	addon := dependencies[m.assetStock.KubeAddonOperator().Name()].Contents[0]
+	mao := dependencies[m.assetStock.Mao().Name()].Contents[0]
+	installConfig := dependencies[m.installConfig.Name()].Contents[0]
 
 	// kco+no+mao go to kube-system config map
 	kubeSys, err := configMap("kube-system", "cluster-config-v1", genericData{
@@ -122,40 +122,40 @@ func (m *manifests) Generate(dependencies map[asset.Asset]*asset.State) (*asset.
 	return state, nil
 }
 
-func (m *manifests) generateBootKubeManifests(dependencies map[asset.Asset]*asset.State) []asset.Content {
+func (m *manifests) generateBootKubeManifests(dependencies map[string]*asset.State) []asset.Content {
 	ic, err := installconfig.GetInstallConfig(m.installConfig, dependencies)
 	if err != nil {
 		return nil
 	}
 	templateData := &bootkubeTemplateData{
-		AggregatorCaCert:                base64.StdEncoding.EncodeToString(dependencies[m.aggregatorCA].Contents[certIndex].Data),
-		AggregatorCaKey:                 base64.StdEncoding.EncodeToString(dependencies[m.aggregatorCA].Contents[keyIndex].Data),
-		ApiserverCert:                   base64.StdEncoding.EncodeToString(dependencies[m.apiServerCertKey].Contents[certIndex].Data),
-		ApiserverKey:                    base64.StdEncoding.EncodeToString(dependencies[m.apiServerCertKey].Contents[keyIndex].Data),
-		ApiserverProxyCert:              base64.StdEncoding.EncodeToString(dependencies[m.apiServerProxyCertKey].Contents[certIndex].Data),
-		ApiserverProxyKey:               base64.StdEncoding.EncodeToString(dependencies[m.apiServerProxyCertKey].Contents[keyIndex].Data),
+		AggregatorCaCert:                base64.StdEncoding.EncodeToString(dependencies[m.aggregatorCA.Name()].Contents[certIndex].Data),
+		AggregatorCaKey:                 base64.StdEncoding.EncodeToString(dependencies[m.aggregatorCA.Name()].Contents[keyIndex].Data),
+		ApiserverCert:                   base64.StdEncoding.EncodeToString(dependencies[m.apiServerCertKey.Name()].Contents[certIndex].Data),
+		ApiserverKey:                    base64.StdEncoding.EncodeToString(dependencies[m.apiServerCertKey.Name()].Contents[keyIndex].Data),
+		ApiserverProxyCert:              base64.StdEncoding.EncodeToString(dependencies[m.apiServerProxyCertKey.Name()].Contents[certIndex].Data),
+		ApiserverProxyKey:               base64.StdEncoding.EncodeToString(dependencies[m.apiServerProxyCertKey.Name()].Contents[keyIndex].Data),
 		Base64encodeCloudProviderConfig: "", // FIXME
-		ClusterapiCaCert:                base64.StdEncoding.EncodeToString(dependencies[m.clusterAPIServerCertKey].Contents[certIndex].Data),
-		ClusterapiCaKey:                 base64.StdEncoding.EncodeToString(dependencies[m.clusterAPIServerCertKey].Contents[keyIndex].Data),
-		EtcdCaCert:                      base64.StdEncoding.EncodeToString(dependencies[m.etcdCA].Contents[certIndex].Data),
-		EtcdClientCert:                  base64.StdEncoding.EncodeToString(dependencies[m.etcdClientCertKey].Contents[certIndex].Data),
-		EtcdClientKey:                   base64.StdEncoding.EncodeToString(dependencies[m.etcdClientCertKey].Contents[keyIndex].Data),
-		KubeCaCert:                      base64.StdEncoding.EncodeToString(dependencies[m.kubeCA].Contents[certIndex].Data),
-		KubeCaKey:                       base64.StdEncoding.EncodeToString(dependencies[m.kubeCA].Contents[keyIndex].Data),
-		McsTLSCert:                      base64.StdEncoding.EncodeToString(dependencies[m.mcsCertKey].Contents[certIndex].Data),
-		McsTLSKey:                       base64.StdEncoding.EncodeToString(dependencies[m.mcsCertKey].Contents[keyIndex].Data),
-		OidcCaCert:                      base64.StdEncoding.EncodeToString(dependencies[m.kubeCA].Contents[certIndex].Data),
-		OpenshiftApiserverCert:          base64.StdEncoding.EncodeToString(dependencies[m.openshiftAPIServerCertKey].Contents[certIndex].Data),
-		OpenshiftApiserverKey:           base64.StdEncoding.EncodeToString(dependencies[m.openshiftAPIServerCertKey].Contents[keyIndex].Data),
-		OpenshiftLoopbackKubeconfig:     base64.StdEncoding.EncodeToString(dependencies[m.kubeconfig].Contents[0].Data),
+		ClusterapiCaCert:                base64.StdEncoding.EncodeToString(dependencies[m.clusterAPIServerCertKey.Name()].Contents[certIndex].Data),
+		ClusterapiCaKey:                 base64.StdEncoding.EncodeToString(dependencies[m.clusterAPIServerCertKey.Name()].Contents[keyIndex].Data),
+		EtcdCaCert:                      base64.StdEncoding.EncodeToString(dependencies[m.etcdCA.Name()].Contents[certIndex].Data),
+		EtcdClientCert:                  base64.StdEncoding.EncodeToString(dependencies[m.etcdClientCertKey.Name()].Contents[certIndex].Data),
+		EtcdClientKey:                   base64.StdEncoding.EncodeToString(dependencies[m.etcdClientCertKey.Name()].Contents[keyIndex].Data),
+		KubeCaCert:                      base64.StdEncoding.EncodeToString(dependencies[m.kubeCA.Name()].Contents[certIndex].Data),
+		KubeCaKey:                       base64.StdEncoding.EncodeToString(dependencies[m.kubeCA.Name()].Contents[keyIndex].Data),
+		McsTLSCert:                      base64.StdEncoding.EncodeToString(dependencies[m.mcsCertKey.Name()].Contents[certIndex].Data),
+		McsTLSKey:                       base64.StdEncoding.EncodeToString(dependencies[m.mcsCertKey.Name()].Contents[keyIndex].Data),
+		OidcCaCert:                      base64.StdEncoding.EncodeToString(dependencies[m.kubeCA.Name()].Contents[certIndex].Data),
+		OpenshiftApiserverCert:          base64.StdEncoding.EncodeToString(dependencies[m.openshiftAPIServerCertKey.Name()].Contents[certIndex].Data),
+		OpenshiftApiserverKey:           base64.StdEncoding.EncodeToString(dependencies[m.openshiftAPIServerCertKey.Name()].Contents[keyIndex].Data),
+		OpenshiftLoopbackKubeconfig:     base64.StdEncoding.EncodeToString(dependencies[m.kubeconfig.Name()].Contents[0].Data),
 		PullSecret:                      base64.StdEncoding.EncodeToString([]byte(ic.PullSecret)),
-		RootCaCert:                      base64.StdEncoding.EncodeToString(dependencies[m.rootCA].Contents[certIndex].Data),
-		ServiceaccountKey:               base64.StdEncoding.EncodeToString(dependencies[m.serviceAccountKeyPair].Contents[keyIndex].Data),
-		ServiceaccountPub:               base64.StdEncoding.EncodeToString(dependencies[m.serviceAccountKeyPair].Contents[certIndex].Data),
-		ServiceServingCaCert:            base64.StdEncoding.EncodeToString(dependencies[m.serviceServingCA].Contents[certIndex].Data),
-		ServiceServingCaKey:             base64.StdEncoding.EncodeToString(dependencies[m.serviceServingCA].Contents[keyIndex].Data),
+		RootCaCert:                      base64.StdEncoding.EncodeToString(dependencies[m.rootCA.Name()].Contents[certIndex].Data),
+		ServiceaccountKey:               base64.StdEncoding.EncodeToString(dependencies[m.serviceAccountKeyPair.Name()].Contents[keyIndex].Data),
+		ServiceaccountPub:               base64.StdEncoding.EncodeToString(dependencies[m.serviceAccountKeyPair.Name()].Contents[certIndex].Data),
+		ServiceServingCaCert:            base64.StdEncoding.EncodeToString(dependencies[m.serviceServingCA.Name()].Contents[certIndex].Data),
+		ServiceServingCaKey:             base64.StdEncoding.EncodeToString(dependencies[m.serviceServingCA.Name()].Contents[keyIndex].Data),
 		TectonicNetworkOperatorImage:    "quay.io/coreos/tectonic-network-operator-dev:3b6952f5a1ba89bb32dd0630faddeaf2779c9a85",
-		WorkerIgnConfig:                 base64.StdEncoding.EncodeToString(dependencies[m.workerIgnition].Contents[0].Data),
+		WorkerIgnConfig:                 base64.StdEncoding.EncodeToString(dependencies[m.workerIgnition.Name()].Contents[0].Data),
 		CVOClusterID:                    ic.ClusterID,
 	}
 

--- a/pkg/asset/manifests/tectonic.go
+++ b/pkg/asset/manifests/tectonic.go
@@ -35,14 +35,14 @@ func (t *tectonic) Dependencies() []asset.Asset {
 }
 
 // Generate generates the respective operator config.yml files
-func (t *tectonic) Generate(dependencies map[asset.Asset]*asset.State) (*asset.State, error) {
+func (t *tectonic) Generate(dependencies map[string]*asset.State) (*asset.State, error) {
 	ic, err := installconfig.GetInstallConfig(t.installConfig, dependencies)
 	if err != nil {
 		return nil, err
 	}
-	ingressContents := dependencies[t.ingressCertKey].Contents
+	ingressContents := dependencies[t.ingressCertKey.Name()].Contents
 	templateData := &tectonicTemplateData{
-		IngressCaCert:                          base64.StdEncoding.EncodeToString(dependencies[t.kubeCA].Contents[certIndex].Data),
+		IngressCaCert:                          base64.StdEncoding.EncodeToString(dependencies[t.kubeCA.Name()].Contents[certIndex].Data),
 		IngressKind:                            "haproxy-router",
 		IngressStatusPassword:                  ic.Admin.Password, // FIXME: generate a new random one instead?
 		IngressTLSBundle:                       base64.StdEncoding.EncodeToString(bytes.Join([][]byte{ingressContents[certIndex].Data, ingressContents[keyIndex].Data}, []byte{})),

--- a/pkg/asset/metadata/metadata.go
+++ b/pkg/asset/metadata/metadata.go
@@ -34,7 +34,7 @@ func (m *Metadata) Dependencies() []asset.Asset {
 }
 
 // Generate generates the metadata.yaml file.
-func (m *Metadata) Generate(parents map[asset.Asset]*asset.State) (*asset.State, error) {
+func (m *Metadata) Generate(parents map[string]*asset.State) (*asset.State, error) {
 	installCfg, err := installconfig.GetInstallConfig(m.installConfig, parents)
 	if err != nil {
 		return nil, err

--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -15,7 +15,7 @@ type Store interface {
 
 // StoreImpl is the implementation of Store.
 type StoreImpl struct {
-	assets map[Asset]*State
+	assets map[string]*State
 }
 
 // Fetch retrieves the state of the given asset, generating it and its
@@ -26,14 +26,14 @@ func (s *StoreImpl) Fetch(asset Asset) (*State, error) {
 
 func (s *StoreImpl) fetch(asset Asset, indent string) (*State, error) {
 	logrus.Debugf("%sFetching %s...", indent, asset.Name())
-	state, ok := s.assets[asset]
+	state, ok := s.assets[asset.Name()]
 	if ok {
 		logrus.Debugf("%sFound %s...", indent, asset.Name())
 		return state, nil
 	}
 
 	dependencies := asset.Dependencies()
-	dependenciesStates := make(map[Asset]*State, len(dependencies))
+	dependenciesStates := make(map[string]*State, len(dependencies))
 	if len(dependencies) > 0 {
 		logrus.Debugf("%sGenerating dependencies of %s...", indent, asset.Name())
 	}
@@ -42,7 +42,7 @@ func (s *StoreImpl) fetch(asset Asset, indent string) (*State, error) {
 		if err != nil {
 			return nil, err
 		}
-		dependenciesStates[d] = ds
+		dependenciesStates[d.Name()] = ds
 	}
 
 	logrus.Debugf("%sGenerating %s...", indent, asset.Name())
@@ -51,8 +51,8 @@ func (s *StoreImpl) fetch(asset Asset, indent string) (*State, error) {
 		return nil, fmt.Errorf("failed to generate asset %q: %v", asset.Name(), err)
 	}
 	if s.assets == nil {
-		s.assets = make(map[Asset]*State)
+		s.assets = make(map[string]*State)
 	}
-	s.assets[asset] = state
+	s.assets[asset.Name()] = state
 	return state, nil
 }

--- a/pkg/asset/store_test.go
+++ b/pkg/asset/store_test.go
@@ -24,7 +24,7 @@ func (a *testAsset) Dependencies() []Asset {
 	return a.dependencies
 }
 
-func (a *testAsset) Generate(map[Asset]*State) (*State, error) {
+func (a *testAsset) Generate(map[string]*State) (*State, error) {
 	a.generationLog.logGeneration(a)
 	return nil, nil
 }

--- a/pkg/asset/tls/certkey.go
+++ b/pkg/asset/tls/certkey.go
@@ -64,7 +64,7 @@ func (c *CertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (c *CertKey) Generate(parents map[asset.Asset]*asset.State) (*asset.State, error) {
+func (c *CertKey) Generate(parents map[string]*asset.State) (*asset.State, error) {
 	cfg := &CertCfg{
 		Subject:      c.Subject,
 		KeyUsages:    c.KeyUsages,
@@ -74,7 +74,7 @@ func (c *CertKey) Generate(parents map[asset.Asset]*asset.State) (*asset.State, 
 	}
 
 	if c.GenSubject != nil || c.GenDNSNames != nil || c.GenIPAddresses != nil {
-		state, ok := parents[c.installConfig]
+		state, ok := parents[c.installConfig.Name()]
 		if !ok {
 			return nil, fmt.Errorf("failed to get install config state in the parent asset states")
 		}
@@ -109,7 +109,7 @@ func (c *CertKey) Generate(parents map[asset.Asset]*asset.State) (*asset.State, 
 	var crt *x509.Certificate
 	var err error
 
-	state, ok := parents[c.ParentCA]
+	state, ok := parents[c.ParentCA.Name()]
 	if !ok {
 		return nil, fmt.Errorf("failed to get parent CA %v in the parent asset states", c.ParentCA)
 	}

--- a/pkg/asset/tls/certkey.go
+++ b/pkg/asset/tls/certkey.go
@@ -90,6 +90,8 @@ func (c *CertKey) Generate(parents map[string]*asset.State) (*asset.State, error
 			if err != nil {
 				return nil, fmt.Errorf("failed to generate Subject: %v", err)
 			}
+			// assign it to the asset object also so that Name() can be generated correctly
+			c.Subject = cfg.Subject
 		}
 		if c.GenDNSNames != nil {
 			cfg.DNSNames, err = c.GenDNSNames(&installConfig)

--- a/pkg/asset/tls/certkey_test.go
+++ b/pkg/asset/tls/certkey_test.go
@@ -19,7 +19,7 @@ func (f fakeInstallConfig) Dependencies() []asset.Asset {
 	return nil
 }
 
-func (f fakeInstallConfig) Generate(map[asset.Asset]*asset.State) (*asset.State, error) {
+func (f fakeInstallConfig) Generate(map[string]*asset.State) (*asset.State, error) {
 	return &asset.State{
 		Contents: []asset.Content{
 			{
@@ -63,7 +63,7 @@ func TestCertKeyGenerate(t *testing.T) {
 		name      string
 		certKey   *CertKey
 		errString string
-		parents   map[asset.Asset]*asset.State
+		parents   map[string]*asset.State
 	}{
 		{
 			name: "simple ca",
@@ -77,8 +77,8 @@ func TestCertKeyGenerate(t *testing.T) {
 				IsCA:          true,
 				ParentCA:      root,
 			},
-			parents: map[asset.Asset]*asset.State{
-				root: rootState,
+			parents: map[string]*asset.State{
+				root.Name(): rootState,
 			},
 		},
 		{
@@ -97,9 +97,9 @@ func TestCertKeyGenerate(t *testing.T) {
 				GenDNSNames:    testGenDNSNames,
 				GenIPAddresses: testGenIPAddresses,
 			},
-			parents: map[asset.Asset]*asset.State{
-				root:          rootState,
-				installConfig: installConfigState,
+			parents: map[string]*asset.State{
+				root.Name():          rootState,
+				installConfig.Name(): installConfigState,
 			},
 		},
 		{

--- a/pkg/asset/tls/keypair.go
+++ b/pkg/asset/tls/keypair.go
@@ -21,7 +21,7 @@ func (k *KeyPair) Dependencies() []asset.Asset {
 }
 
 // Generate generates the rsa private / public key pair.
-func (k *KeyPair) Generate(map[asset.Asset]*asset.State) (*asset.State, error) {
+func (k *KeyPair) Generate(map[string]*asset.State) (*asset.State, error) {
 	key, err := PrivateKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate private key: %v", err)

--- a/pkg/asset/tls/root.go
+++ b/pkg/asset/tls/root.go
@@ -20,7 +20,7 @@ func (c *RootCA) Dependencies() []asset.Asset {
 }
 
 // Generate generates the root-ca key and cert pair.
-func (c *RootCA) Generate(parents map[asset.Asset]*asset.State) (*asset.State, error) {
+func (c *RootCA) Generate(parents map[string]*asset.State) (*asset.State, error) {
 	cfg := &CertCfg{
 		Subject:   pkix.Name{CommonName: "root-ca", OrganizationalUnit: []string{"openshift"}},
 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,

--- a/pkg/asset/userprovided.go
+++ b/pkg/asset/userprovided.go
@@ -23,7 +23,7 @@ func (a *UserProvided) Dependencies() []Asset {
 }
 
 // Generate queries for input from the user.
-func (a *UserProvided) Generate(map[Asset]*State) (*State, error) {
+func (a *UserProvided) Generate(map[string]*State) (*State, error) {
 	var response string
 
 	if value, ok := os.LookupEnv(a.EnvVarName); ok {


### PR DESCRIPTION
The store has a map of assets and states, where the key is the asset object currently. This is an issue with json serialization and deserialization.
If we move the key to be the Name() or Type(), then deserialization can happen assuming there are only singleton asset objects (which they are in this project).
This PR only changes the asset map key to be the Name() of the asset. We can use reflect.TypeOf(assetObj).String() but for that we need at least #344 and some normalization of package reference paths and pointers.