### PR TITLE
Revert "Adds egresses to the worker and master"

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -2,15 +2,6 @@ resource "openstack_networking_secgroup_v2" "master" {
   name = "master"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_egress" {
-  direction         = "egress"
-  ethertype         = "IPv4"
-  port_range_min    = 0
-  port_range_max    = 0
-  remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
-}
-
 resource "openstack_networking_secgroup_rule_v2" "master_mcs" {
   direction         = "ingress"
   ethertype         = "IPv4"

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -2,15 +2,6 @@ resource "openstack_networking_secgroup_v2" "worker" {
   name = "worker"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "worker_egress" {
-  direction         = "egress"
-  ethertype         = "IPv4"
-  port_range_min    = 0
-  port_range_max    = 0
-  remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
-}
-
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
   direction         = "ingress"
   ethertype         = "IPv4"


### PR DESCRIPTION
This reverts commit 725af9ec07a57b5fd7a7a1c2fed010376ca8b03c.

Whenever a new security group is created in OpenStack, an egress rule is
added as well by default.

The rules here are not necessary and they break the deployment. When
Terraform attemts to create the egress rules, it recieves a 409 response
from Neutron and errors out.