### PR TITLE
cmd/openshift-install: Log Terraform errors when not in debug mode

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -56,7 +58,7 @@ func main() {
 		if err != nil {
 			exitError, ok := err.(*exec.ExitError)
 			if ok && len(exitError.Stderr) > 0 {
-				logrus.Error(string(exitError.Stderr))
+				logrus.Error(strings.Trim(string(exitError.Stderr), "\n"))
 			}
 			logrus.Fatalf("Failed to calculate Terraform version: %v", err)
 		}
@@ -97,6 +99,9 @@ func main() {
 		for _, a := range targetAssets {
 			err := assetStore.Fetch(a)
 			if err != nil {
+				if exitError, ok := errors.Cause(err).(*exec.ExitError); ok && len(exitError.Stderr) > 0 {
+					logrus.Error(strings.Trim(string(exitError.Stderr), "\n"))
+				}
 				logrus.Fatalf("Failed to generate %s: %v", a.Name(), err)
 			}
 

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -29,6 +29,7 @@ func Apply(dir string, extraArgs ...string) (string, error) {
 	defaultArgs := []string{
 		"apply",
 		"-auto-approve",
+		"-no-color",
 		fmt.Sprintf("-state=%s", stateFileName),
 	}
 	args := append(defaultArgs, extraArgs...)
@@ -38,5 +39,5 @@ func Apply(dir string, extraArgs ...string) (string, error) {
 
 // Init runs "terraform init" in the given directory.
 func Init(dir string) error {
-	return terraformExec(dir, "init")
+	return terraformExec(dir, "init", "-no-color")
 }


### PR DESCRIPTION
We want to spit these out right away, instead of asking the caller to re-run with `--log-level=debug`.

The `-no-color` additions work around hashicorp/terraform#15264; without them stripping newlines doesn't work, because there are color escapes in the way.

Inserting a bug to test:

```console
$ git diff -U1
diff --git a/pkg/tfvars/tfvars.go b/pkg/tfvars/tfvars.go
index d5f5543..8f44646 100644
--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -19,3 +19,3 @@ type config struct {
 	 Name       string `json:"tectonic_cluster_name,omitempty"`
-	 BaseDomain string `json:"tectonic_base_domain,omitempty"`
+	 BaseDomain string `json:"xtectonic_base_domain,omitempty"`
 	 Masters    int    `json:"tectonic_master_count,omitempty"`
$ hack/build.sh
$ openshift-install cluster
INFO Fetching OS image...
INFO Using Terraform to create cluster...
ERROR Failed to read tfstate ("/tmp/openshift-install-122374392/terraform.tfstate"): open /tmp/openshift-install-122374392/terraform.tfstate: no such file or directory
ERROR Error: Error asking for user input: missing required value for "tectonic_base_domain"
FATAL Failed to generate Cluster: failed to generate asset Cluster: failed to run terraform: failed to execute Terraform: exit status 1
```