### PR TITLE
pkg/asset/cluster: Drop duplicate path from "Failed to read tfstate"

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -84,7 +84,7 @@ func (c *Cluster) Generate(parents map[asset.Asset]*asset.State) (*asset.State, 
 		if err == nil {
 			err = err2
 		} else {
-			logrus.Errorf("Failed to read tfstate (%q): %v", stateFile, err2)
+			logrus.Errorf("Failed to read tfstate: %v", err2)
 		}
 	}
 


### PR DESCRIPTION
Before this commit, the errors looked like:

```
ERROR Failed to read tfstate ("/tmp/openshift-install-122374392/terraform.tfstate"): open /tmp/openshift-install-122374392/terraform.tfstate: no such file or directory
```

now they will look like:

```
ERROR Failed to read tfstate: open /tmp/openshift-install-122374392/terraform.tfstate: no such file or directory
```