### PR TITLE
asset/manifests: disable olm api server

### DIFF
--- a/pkg/asset/manifests/content/bootkube/cvo-overrides.go
+++ b/pkg/asset/manifests/content/bootkube/cvo-overrides.go
@@ -55,5 +55,8 @@ overrides:
   namespace: openshift-cluster-dns-operator
   name: cluster-dns-operator
   unmanaged: true
+- kind: APIService                    # packages.apps.redhat.com fails to start properly
+  name: v1alpha1.packages.apps.redhat.com
+  unmanaged: true
 `))
 )


### PR DESCRIPTION
This is filling the logs with the following errors and causing failures:

    Error discoverying server preferred namespaced resources:
      unable to retrieve the complete list of server APIs:
        packages.apps.redhat.com/v1alpha1:
          the server is currently unable to handle the request, retrying
          in 2s.

    discovery error for unexpected group:
      schema.GroupVersion{Group:"packages.apps.redhat.com",
      Version:"v1alpha1"}