### PR TITLE
update to allow openshift operator to run

### DIFF
--- a/pkg/asset/manifests/content/bootkube/cvo-overrides.go
+++ b/pkg/asset/manifests/content/bootkube/cvo-overrides.go
@@ -32,14 +32,6 @@ overrides:
   name: openshift-cluster-kube-controller-manager-operator
   unmanaged: true
 - kind: Deployment                    # this conflicts with kube-core-operator
-  namespace: openshift-core-operators
-  name: openshift-cluster-openshift-apiserver-operator
-  unmanaged: true
-- kind: Deployment                    # this conflicts with kube-core-operator
-  namespace: openshift-core-operators
-  name: openshift-cluster-openshift-controller-manager-operator
-  unmanaged: true
-- kind: Deployment                    # this conflicts with kube-core-operator
   namespace: openshift-cluster-network-operator
   name: cluster-network-operator
   unmanaged: true


### PR DESCRIPTION
This re-enables the two openshift control plane operators.

/hold

Wait until https://github.com/openshift/cluster-openshift-apiserver-operator/pull/30 merges to prevent registering apiservices that will never work.  Doing that would prevent namespace cleanup controller from running.