### PR TITLE
bootkube.sh: add trap to report errors in the log

### DIFF
--- a/pkg/asset/ignition/content/bootkube.go
+++ b/pkg/asset/ignition/content/bootkube.go
@@ -27,6 +27,11 @@ var (
 	BootkubeShFileTemplate = template.Must(template.New("bootkube.sh").Parse(`#!/usr/bin/env bash
 set -e
 
+error_trap() {
+  echo "ERROR: bootkube.sh on line $(caller)"
+}
+trap error_trap ERR
+
 mkdir --parents /etc/kubernetes/manifests/
 
 MACHINE_CONFIG_OPERATOR_IMAGE=$(podman run --rm {{.ReleaseImage}} image machine-config-operator)


### PR DESCRIPTION
grepping journalctl log for error will now yield a log line when
bootkube.sh errors