### PR TITLE
stop creating cvo static pod

### DIFF
--- a/pkg/asset/ignition/content/bootkube.go
+++ b/pkg/asset/ignition/content/bootkube.go
@@ -49,7 +49,6 @@ then
 			--release-image="{{.ReleaseImage}}"
 
 	cp --recursive cvo-bootstrap/manifests .
-	cp --recursive cvo-bootstrap/bootstrap/bootstrap-pod.yaml /etc/kubernetes/manifests/
 fi
 
 if [ ! -d kco-bootstrap ]


### PR DESCRIPTION
Since the CVO can be installed after the control plane is up, there is no reason to start a CVO static pod.  We can simply create the CVO deployment (in manifests) instead.

/assign @abhinavdahiya 