### PR TITLE
fix copy statement

### DIFF
--- a/pkg/asset/ignition/content/bootkube.go
+++ b/pkg/asset/ignition/content/bootkube.go
@@ -84,7 +84,7 @@ then
 		--config-output-file=/assets/kube-apiserver-bootstrap/config
 
 	# TODO: copy the bootstrap manifests to replace kube-core-operator
-	cp --recursive kube-apiserver-bootstrap/manifests/openshift-kube-apiserver-ns.yaml manifests/00_openshift-kube-apiserver-ns.yaml
+	cp --recursive kube-apiserver-bootstrap/manifests/00_openshift-kube-apiserver-ns.yaml manifests/00_openshift-kube-apiserver-ns.yaml
 	cp --recursive kube-apiserver-bootstrap/manifests/secret-* manifests/
 	cp --recursive kube-apiserver-bootstrap/manifests/configmap-* manifests/
 fi
@@ -104,7 +104,7 @@ then
 		--config-output-file=/assets/kube-controller-manager-bootstrap/config
 
 	# TODO: copy the bootstrap manifests to replace kube-core-operator
-	cp --recursive kube-controller-manager-bootstrap/manifests/openshift-kube-controller-manager-ns.yaml manifests/00_openshift-kube-controller-manager-ns.yaml
+	cp --recursive kube-controller-manager-bootstrap/manifests/00_openshift-kube-controller-manager-ns.yaml manifests/00_openshift-kube-controller-manager-ns.yaml
 	cp --recursive kube-controller-manager-bootstrap/manifests/secret-* manifests/
 	cp --recursive kube-controller-manager-bootstrap/manifests/configmap-* manifests/
 fi
@@ -124,7 +124,7 @@ then
                 --config-output-file=/assets/kube-scheduler-bootstrap/config
 
         # TODO: copy the bootstrap manifests to replace kube-core-operator
-        cp --recursive kube-scheduler-bootstrap/manifests/openshift-kube-scheduler-ns.yaml manifests/00_openshift-kube-scheduler-ns.yaml
+        cp --recursive kube-scheduler-bootstrap/manifests/00_openshift-kube-scheduler-ns.yaml manifests/00_openshift-kube-scheduler-ns.yaml
         cp --recursive kube-scheduler-bootstrap/manifests/secret-* manifests/
         cp --recursive kube-scheduler-bootstrap/manifests/configmap-* manifests/
 fi


### PR DESCRIPTION
There is a bad copy statement in the script trying to set up the bootkube manifests that stops us from copying resources we need for other operators.  We don't copy the entire directory until we're ready to switch away from the KCO.  This fixes the individual copy statement.

/cc @mfojtik 
/assign @abhinavdahiya 

```
Oct 09 13:11:26 test1-bootstrap bootkube.sh[2638]: cp: cannot stat ‘kube-controller-manager-bootstrap/manifests/openshift-kube-controller-manager-ns.yaml’: No such file 
Oct 09 13:11:26 test1-bootstrap systemd[1]: bootkube.service: main process exited, code=exited, status=1/FAILURE
Oct 09 13:11:26 test1-bootstrap systemd[1]: Unit bootkube.service entered failed state.
Oct 09 13:11:26 test1-bootstrap systemd[1]: bootkube.service failed.
```