### PR TITLE
bootkube: use etcd-client-ca as serving CA of etcd

### DIFF
--- a/pkg/asset/ignition/content/bootkube.go
+++ b/pkg/asset/ignition/content/bootkube.go
@@ -80,6 +80,7 @@ then
 		--volume "$PWD:/assets:z" \
 		"${KUBE_APISERVER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-apiserver-operator render \
+		--manifest-etcd-serving-ca=etcd-client-ca.crt \
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-apiserver-bootstrap \
 		--config-override-file=/usr/share/bootkube/manifests/config/config-overrides.yaml \


### PR DESCRIPTION
Make use of https://github.com/openshift/cluster-kube-apiserver-operator/pull/56 to use the etcd serving ca that the installer uses to sign the actual etcd serving certs.