### PR TITLE
add etcd prometheus scraping label and remove old etcd port

### DIFF
--- a/pkg/asset/manifests/content/bootkube/etcd-service.go
+++ b/pkg/asset/manifests/content/bootkube/etcd-service.go
@@ -9,15 +9,14 @@ kind: Service
 metadata:
   name: etcd
   namespace: kube-system
+  labels:
+    # this label is used to indicate that it should be scaped by prometheus
+    k8s-app: etcd
 spec:
   clusterIP: None
   ports:
   - name: etcd
     port: 2379
-    protocol: TCP
-  - name: legacy-etcd
-    port: 4001
-    targetPort: 2379
     protocol: TCP
 `
 )


### PR DESCRIPTION
The prometheus operator needs to have a label on the service in order to know that it should scrape it.  This causes a conflict over who owns the resource and breaks our selector, which breaks our endpoints.

This adds the label to the service we create (I think).

/assign @squat @abhinavdahiya 