### PR TITLE
docs/dev/libvirt-howto: Fix "firewalld-cmd" -> "firewall-cmd" typo

### DIFF
--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -129,7 +129,7 @@ sudo firewall-cmd --zone=FedoraWorkstation --list-ports
 sudo firewall-cmd --zone=FedoraWorkstation --list-sources
 ```
 
-NOTE: When the firewall rules are no longer needed, `sudo firewalld-cmd --reload`
+NOTE: When the firewall rules are no longer needed, `sudo firewall-cmd --reload`
 will remove the changes made as they were not permanently added. For persistence,
 add `--permanent` to the `firewall-cmd` commands and run them a second time.
 


### PR DESCRIPTION
The typo is from af6d904c (#293), which was itself fixing typos from 21ef0d4f (#284).