### PR TITLE
pkg/asset/store: Use '%q' for formatting quoted strings

### DIFF
--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -113,7 +113,7 @@ func (s *StoreImpl) fetch(asset Asset, indent string) error {
 	logrus.Debugf("%sLooking up asset from state file: %s", indent, reflect.TypeOf(asset).String())
 	ok, err := s.GetStateAsset(asset)
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal asset '%s' from state file '%s'", asset.Name(), stateFileName)
+		return errors.Wrapf(err, "failed to unmarshal asset %q from state file %q", asset.Name(), stateFileName)
 	}
 	if ok {
 		logrus.Debugf("%sAsset found in state file", indent)


### PR DESCRIPTION
This saves us a few characters and gives us better handling when the string values themselves contain quotes (although only the former matters much in this case).  The old manual quoting is from 971eea9f (#388).

CC @rajatchopra