### PR TITLE
CHANGELOG: Document changes since v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,71 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.2.0 - 2018-10-12
+
+### Added
+
+- Asset state is preserved between invocations, allowing for a staged
+    install like:
+
+    ```console
+    $ openshift-install --dir=example manifests
+    $ $EDITOR emacs example/manifests/cluster-config.yaml
+    $ openshift-install --dir=example install-config
+    ```
+
+    which creates a cluster with a customized `cluster-config.yaml`.
+- [The kube-apiserver][kube-apiserver-operator] and
+  [kube-controller-manager][kube-controller-manager-operator]
+  operators are called to render additional cluster manifests.
+- etcd is now available as a service in the `kube-system` namespace,
+  and the new service is labeled so [Prometheus][] will scrape it.
+- The `service-serving-cert-signer-signing-key` secret is now
+  available in the `openshift-service-cert-signer` namespace, which
+  gives [the service-serving cert signer][] the keys it needs to mint
+  and manage certificates for Kubernetes services.
+- The etcd-serving certificate is now passed through to [the
+  kube-controller-manager operator][kube-controller-manager-operator].
+- We disable some components which [the cluster-version
+  operator][cluster-version-operator] would otherwise install but
+  which conflict with the legacy tectonic-operators.
+- The new `openshift-install graph` outputs the asset graph in [the
+  DOT language][dot].
+- `openshift-install version` now outputs the Terraform version as
+  well as the installer version.
+
+### Changed
+
+- The [cluster-version operator][cluster-version-operator] is no
+  longer run as a static pod.  Instead, we just wait until the control
+  plane comes up and run it them.
+- Terraform errors are logged to standard error even when
+  `--log-level` is less than `debug`.
+- Terraform is now invoked with `-no-color` and `-input=false`.
+- The `cluster` target now includes both launching the cluster and
+  populating `metadata.json`, regardless of whether the `terraform`
+  invocation succeeds.  This allows `destroy-cluster` to cleanup
+  cluster resources even when the `terraform` invocation fails.
+- Reported errors now include more context, making them less
+  enigmatic.
+- Libvirt image caching is more efficient, caching unzipped images
+  with a cache that grows by one unzipped image per RHCOS release in
+  `$XDG_CACHE_HOME/openshift-install/libvirt/image`.  The previous
+  implementation unzipped, when necessary, for every launched cluster,
+  which was slow.  And the previous implementation added one unzipped
+  image to `/tmp` per cluster launch, which consumed more disk space.
+- Work continues on the OpenStack platform.
+- Lots of internal cleanup, especially around asset generation.
+
+### Removed
+
+- The operatorstatus CRD.  Now [the cluster-version
+  operator][cluster-version-operator] creates this on its own.
+- The `machine-config-operator-images` config-map.  Now [the
+  cluster-version operator][cluster-version-operator] pulls these from
+  [the machine-config images][machine-config-operator].
+- The `machine-api` app-version from the `tectonic-system` namespace.
+
 ## 0.1.0 - 2018-10-02
 
 ### Added
@@ -33,3 +98,10 @@ installer and follow along as it guides you through the process.
 The `tectonic` command and tarball distribution are gone.  Please use
 the new `openshift-install` command instead.
 
+[cluster-version-operator]: https://github.com/openshift/cluster-version-operator
+[dot]: https://www.graphviz.org/doc/info/lang.html
+[kube-apiserver-operator]: https://github.com/openshift/cluster-kube-apiserver-operator
+[kube-controller-manager-operator]: https://github.com/openshift/cluster-kube-controller-manager-operator
+[machine-config-operator]: https://github.com/openshift/machine-config-operator
+[Prometheus]: https://github.com/prometheus/prometheus
+[service-serving-cert-signer]: https://github.com/openshift/service-serving-cert-signer


### PR DESCRIPTION
Through f25e53a4 (Merge pull request #388, 2018-10-12).  Once this lands, we can tag a v0.2.0.

CC @abhinavdahiya, @crawford.