### PR TITLE
CHANGELOG: Remove redundant 'emacs'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
     ```console
     $ openshift-install --dir=example manifests
-    $ $EDITOR emacs example/manifests/cluster-config.yaml
+    $ $EDITOR example/manifests/cluster-config.yaml
     $ openshift-install --dir=example install-config
     ```
 


### PR DESCRIPTION
I'd partially replaced this with the generic `$EDITOR` in ec34840 (#461), but forgotten to remove my personal choice ;).