### PR TITLE
pkg/tfvars/libvirt/cache: Close before renaming

### DIFF
--- a/pkg/tfvars/libvirt/cache.go
+++ b/pkg/tfvars/libvirt/cache.go
@@ -151,12 +151,23 @@ func cacheImage(reader io.Reader, imagePath string) (err error) {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
+	closed := false
+	defer func() {
+		if !closed {
+			file.Close()
+		}
+	}()
 
 	_, err = io.Copy(file, reader)
 	if err != nil {
 		return err
 	}
+
+	err = file.Close()
+	if err != nil {
+		return err
+	}
+	closed = true
 
 	return os.Rename(tempPath, imagePath)
 }


### PR DESCRIPTION
To ensure we've flushed everything to disk before we move the file into a location that other parallel calls might consume.

Spun off from #413, now that that PR is going to handle the resize via Terraform.  I've also added a deferred closure to avoid doubled `Close` attempts.