### PR TITLE
pkg/types/installconfig: Add an (*InstallConfig).Tags() helper

### DIFF
--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -48,6 +48,21 @@ func (c *InstallConfig) MasterCount() int {
 	return 1
 }
 
+// Tags returns tags which should be added to resources created for
+// the cluster.  This includes both installer- and user-specified tags.
+func (c *InstallConfig) Tags() (tags map[string]string) {
+	tags = make(map[string]string)
+	tags["tectonicClusterID"] = c.ClusterID
+
+	if c.Platform.AWS != nil {
+		for key, value := range c.Platform.AWS.UserTags {
+			tags[key] = value
+		}
+	}
+
+	return tags
+}
+
 // Admin is the configuration for the admin user.
 type Admin struct {
 	// Email is the email address of the admin user.

--- a/pkg/types/installconfig_test.go
+++ b/pkg/types/installconfig_test.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTags(t *testing.T) {
+	config := &InstallConfig{
+		ClusterID: "123",
+		Platform: Platform{
+			AWS: &AWSPlatform{
+				UserTags: map[string]string{
+					"abc": "def",
+				},
+			},
+		},
+	}
+
+	expected := map[string]string{
+		"abc":               "def",
+		"tectonicClusterID": "123",
+	}
+
+	assert.Equal(t, expected, config.Tags())
+}


### PR DESCRIPTION
Some AWS resources created by the cluster (e.g. some elastic load-balancers) are [currently missing the `tectonicClusterID` tag][1], which makes cleanup difficult.  This helper makes it easy for those external tools to set the appropriate tags without needing local logic to generate them.

CC @joelddiaz

[1]: https://github.com/openshift/installer/issues/458#issuecomment-429876113