### PR TITLE
pkg/tfvars: Drop AWS.Profile

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -6,7 +6,6 @@ locals {
 
 provider "aws" {
   region  = "${var.tectonic_aws_region}"
-  profile = "${var.tectonic_aws_profile}"
   version = "1.8.0"
 
   assume_role {

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -7,14 +7,6 @@ EOF
   default = "1.0"
 }
 
-variable "tectonic_aws_profile" {
-  description = <<EOF
-(optional) This declares the AWS credentials profile to use.
-EOF
-
-  type = "string"
-}
-
 variable "tectonic_aws_master_ec2_type" {
   type        = "string"
   description = "Instance size for the master node(s). Example: `t2.medium`."

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -12,8 +12,6 @@ const (
 	EndpointsPublic Endpoints = "public"
 	// DefaultVPCCIDRBlock is the default CIDR range for an AWS VPC.
 	DefaultVPCCIDRBlock = "10.0.0.0/16"
-	// DefaultProfile is the default AWS credentials profile to use.
-	DefaultProfile = "default"
 	// DefaultRegion is the default AWS region for the cluster.
 	DefaultRegion = "us-east-1"
 )
@@ -26,7 +24,6 @@ type AWS struct {
 	ExtraTags      map[string]string `json:"tectonic_aws_extra_tags,omitempty" yaml:"extraTags,omitempty"`
 	InstallerRole  string            `json:"tectonic_aws_installer_role,omitempty" yaml:"installerRole,omitempty"`
 	Master         `json:",inline" yaml:"master,omitempty"`
-	Profile        string `json:"tectonic_aws_profile,omitempty" yaml:"profile,omitempty"`
 	Region         string `json:"tectonic_aws_region,omitempty" yaml:"region,omitempty"`
 	VPCCIDRBlock   string `json:"tectonic_aws_vpc_cidr_block,omitempty" yaml:"vpcCIDRBlock,omitempty"`
 	Worker         `json:",inline" yaml:"worker,omitempty"`

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -92,8 +92,7 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn string, masterIgns []string, 
 		}
 
 		config.AWS = aws.AWS{
-			Endpoints: aws.EndpointsAll,   // Default value for endpoints.
-			Profile:   aws.DefaultProfile, // Default value for profile.
+			Endpoints: aws.EndpointsAll, // Default value for endpoints.
 			Region:    cfg.Platform.AWS.Region,
 			ExtraTags: cfg.Platform.AWS.UserTags,
 			External: aws.External{


### PR DESCRIPTION
We've been involved in the profile decision since e915ab16 (coreos/tectonic-installer#2320).  Instead, callers should select their profile using environment variables (docs [here][1] and [here][2]) and/or a shared credentials file (docs [here][3] and [here][4]).  The `aws' command line tool uses the [same][5] [files][6] and [environment variables][7].  Given that both our aws-sdx-go and Terraform dependencies agree on how these values should be collected, it seems easiest for us to just get out of the way and let the caller set this up directly.

Fixes #336.
CC @sallyom

[1]: https://www.terraform.io/docs/providers/aws/#environment-variables
[2]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Environment_Variables
[3]: https://www.terraform.io/docs/providers/aws/#shared-credentials-file
[4]: https://docs.aws.amazon.com/sdk-for-go/api/aws/session/#hdr-Shared_Config_Fields
[5]: https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
[6]: https://docs.aws.amazon.com/cli/latest/userguide/cli-multiple-profiles.html
[7]: https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html