### PR TITLE
bootstrap assets: remove secret copy for kube-controller-manager and kube-scheduler

### DIFF
--- a/pkg/asset/ignition/bootstrap/content/bootkube.go
+++ b/pkg/asset/ignition/bootstrap/content/bootkube.go
@@ -111,7 +111,6 @@ then
 
 	# TODO: copy the bootstrap manifests to replace kube-core-operator
 	cp --recursive kube-controller-manager-bootstrap/manifests/00_openshift-kube-controller-manager-ns.yaml manifests/00_openshift-kube-controller-manager-ns.yaml
-	cp --recursive kube-controller-manager-bootstrap/manifests/secret-* manifests/
 	cp --recursive kube-controller-manager-bootstrap/manifests/configmap-* manifests/
 fi
 
@@ -131,7 +130,6 @@ then
 
 	# TODO: copy the bootstrap manifests to replace kube-core-operator
 	cp --recursive kube-scheduler-bootstrap/manifests/00_openshift-kube-scheduler-ns.yaml manifests/00_openshift-kube-scheduler-ns.yaml
-	cp --recursive kube-scheduler-bootstrap/manifests/secret-* manifests/
 	cp --recursive kube-scheduler-bootstrap/manifests/configmap-* manifests/
 fi
 


### PR DESCRIPTION
these components don't have any `secret-*` files and result in an error and restart of the bootkube service on the bootstrap node during install.

https://github.com/openshift/cluster-kube-scheduler-operator/tree/master/bindata/bootkube/manifests
https://github.com/openshift/cluster-kube-controller-manager-operator/tree/master/bindata/bootkube/manifests

@abhinavdahiya @rphillips 