### PR TITLE
WIP: Add certificate-authority injection

### DIFF
--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -13,6 +13,20 @@ import (
 // pointerIgnitionConfig generates a config which references the remote config
 // served by the machine config server.
 func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, role string, query string) *ignition.Config {
+	certificateAuthorities := []ignition.CaReference{{
+		Source: dataurl.EncodeBytes(rootCA),
+	}}
+
+	authorities := []string{} // FIXME: set from installConfig.Machines[*].CertificateAuthorities
+	if len(authorities) == 0 {
+		authorities = installConfig.DefaultCertificateAuthorities
+	}
+	for _, certificateAuthority := range authorities {
+		certificateAuthorities = append(certificateAuthorities, ignition.CaReference{
+			Source: dataurl.EncodeBytes([]byte(certificateAuthority)),
+		})
+	}
+
 	return &ignition.Config{
 		Ignition: ignition.Ignition{
 			Version: ignition.MaxVersion.String(),
@@ -30,9 +44,7 @@ func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, ro
 			},
 			Security: ignition.Security{
 				TLS: ignition.TLS{
-					CertificateAuthorities: []ignition.CaReference{{
-						Source: dataurl.EncodeBytes(rootCA),
-					}},
+					CertificateAuthorities: certificateAuthorities,
 				},
 			},
 		},

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -2,6 +2,7 @@ package installconfig
 
 import (
 	"net"
+	"os"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/ghodss/yaml"
@@ -106,6 +107,11 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 		numberOfWorkers = 1
 	default:
 		panic("unknown platform type")
+	}
+
+	certificateAuthority := os.Getenv("_FIXME_OPENSHIFT_INSTALL_CERTIFICATE_AUTHORITY")
+	if certificateAuthority != "" {
+		a.Config.DefaultCertificateAuthorities = []string{certificateAuthority}
 	}
 
 	a.Config.Machines = []types.MachinePool{

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -29,6 +29,12 @@ type InstallConfig struct {
 	// Machines is the list of MachinePools that need to be installed.
 	Machines []MachinePool `json:"machines"`
 
+	// DefaultCertificateAuthorities is the default slice of additional
+	// PEM-encoded certificated to add to machines (in addition to the
+	// system authorities) when MachinePool.CertificateAuthorities is
+	// empty.
+	DefaultCertificateAuthorities []string `json:"defaultCertificateAuthorities,omitempty"`
+
 	// Platform is the configuration for the specific platform upon which to
 	// perform the installation.
 	Platform `json:"platform"`

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -11,6 +11,11 @@ type MachinePool struct {
 
 	// Platform is configuration for machine pool specific to the platfrom.
 	Platform MachinePoolPlatform `json:"platform"`
+
+	// CertificateAuthorities is a slice of additional PEM-encoded
+	// certificates to add to machines (in addition to the system
+	// authorities).
+	CertificateAuthorities []string `json:"certificateAuthorities,omitempty"`
 }
 
 // MachinePoolPlatform is the platform-specific configuration for a machine


### PR DESCRIPTION
This allows you to connect your cluster to external services whose X.509 certificates are signed by a certificate authority that doesn't belong to the OSes list of certificate authorities.  For example, it allows you to use a local registry with a self-signed certificate.

While this might seem like a use-case for a custom root CA:

* We don't currently install the root CA for general use on the  bootstrap node, so the bootstrap node would still have trouble pulling images from a local registry with a nonstandard CA.

* The root CA for the cluster and the CA for a local registry are really completely independent.  I don't want to make a caller have to provide a complete set of custom certs and keys for all of our cluster-specific roles if all they need to do is authenticate a local registry.

The commit is a work in progress, because:

* This may be something of a niche use-case, I don't really know.  If it is, it may not belong in the install-config.  I guess users could edit generated ignition files and inject these directly once #374 lands.  Or they could edit the generated install config to inject these there.  However this shakes out, the environment variable I'm using here is almost certainly not going to be the final UI.

* I'm currently ignoring `installConfig.Machines[*].CertificateAuthorities` while I [play around with mirroring][1].  If it works out, I'll go over this again and clean up the `pointerIgnitionConfig` API to allow for selecting the appropriate `installConfig.Machines` entry.

[1]: https://github.com/wking/openshift-installer/blob/mirror-docs/docs/user/local-mirror.md