### PR TITLE
hack/build.sh: Check that source is in GOPATH.

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,7 +2,22 @@
 
 set -ex
 
+LAUNCH_PATH="${PWD}"
 cd "$(dirname "$0")/.."
+
+PACKAGE_PATH="$(go list -e -f '{{.Dir}}' github.com/openshift/installer)"
+if test -z "${PACKAGE_PATH}"
+then
+	echo "build from your \${GOPATH} (${LAUNCH_PATH} is not in $(go env GOPATH))" 2>&1
+	exit 1
+fi
+
+LOCAL_PATH="${PWD}"
+if test "${PACKAGE_PATH}" != "${LOCAL_PATH}"
+then
+	echo "build from your \${GOPATH} (${PACKAGE_PATH}, not ${LAUNCH_PATH})" 2>&1
+	exit 1
+fi
 
 MODE="${MODE:-release}"
 LDFLAGS="${LDFLAGS} -X main.version=$(git describe --always --abbrev=40 --dirty)"


### PR DESCRIPTION
This seems to be a very common mistake when people try building the
installer.  Do a sanity check to catch this and make the error more
clear.