### PR TITLE
Create a new type of Asset called 'TargetableAsset' 

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -28,6 +28,14 @@ type WritableAsset interface {
 	Files() []*File
 }
 
+// TargetableAsset is a WritableAsset that has an Apply logic to it
+type TargetableAsset interface {
+	WritableAsset
+
+	// Apply performs any real time actions that the asset wants to do
+	Apply(Parents) error
+}
+
 // File is a file for an Asset.
 type File struct {
 	// Filename is the name of the file.


### PR DESCRIPTION
Meant for those targets (e.g. cluster) that have an action associated with them. 'Cluster' as a WritableAsset does not cover its intent.

This PR is a proposed fix for the issue raised by @wking in this [comment](https://github.com/openshift/installer/pull/388#issuecomment-430106965).

With the state file supplying asset values instead of them being generated, the cluster 'Asset' is not sufficient to describe that it is a special kind of target.
In this commit, the 'Cluster' WritableAsset is now a TargetableAsset, which has a special meaning - they will have an 'Apply' function that will be executed irrespective of whether 'Generate' is called upon the asset or not.