### PR TITLE
pkg/asset: add OpenStack machines.Worker assets

### DIFF
--- a/pkg/asset/machines/openstack/openstack.go
+++ b/pkg/asset/machines/openstack/openstack.go
@@ -1,0 +1,74 @@
+// Package openstack generates Machine objects for openstack.
+package openstack
+
+import (
+	"text/template"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+// Config is used to generate the machine.
+type Config struct {
+	ClusterName string
+	Replicas    int64
+	Image       string
+	Tags        map[string]string
+	Region      string
+	Machine     types.OpenStackMachinePoolPlatform
+}
+
+// WorkerMachineSetTmpl is template for worker machineset.
+var WorkerMachineSetTmpl = template.Must(template.New("openstack-worker-machineset").Parse(`
+apiVersion: cluster.k8s.io/v1alpha1
+kind: MachineSet
+metadata:
+  name: {{.ClusterName}}-worker-0
+  namespace: openshift-cluster-api
+  labels:
+    sigs.k8s.io/cluster-api-cluster: {{.ClusterName}}
+    sigs.k8s.io/cluster-api-machine-role: worker
+    sigs.k8s.io/cluster-api-machine-type: worker
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    matchLabels:
+      sigs.k8s.io/cluster-api-machineset: worker
+      sigs.k8s.io/cluster-api-cluster: {{.ClusterName}}
+  template:
+    metadata:
+      labels:
+        sigs.k8s.io/cluster-api-machineset: worker
+        sigs.k8s.io/cluster-api-cluster: {{.ClusterName}}
+        sigs.k8s.io/cluster-api-machine-role: worker
+        sigs.k8s.io/cluster-api-machine-type: worker
+    spec:
+      providerConfig:
+        value:
+          apiVersion: openstack.cluster.k8s.io/v1alpha1
+          kind: OpenStackMachineProviderConfig
+          image:
+            id: {{.Image}}
+          flavor: {{.Machine.FlavorName}}
+          placement:
+            region: {{.Region}}
+          subnet:
+            filters:
+            - name: "tag:Name"
+              values:
+              - "{{.ClusterName}}-worker-*"
+          tags:
+{{- range $key,$value := .Tags}}
+            - name: "{{$key}}"
+              value: "{{$value}}"
+{{- end}}
+          securityGroups:
+            - filters:
+              - name: "tag:Name"
+                values:
+                - "{{.ClusterName}}_worker_sg"
+          userDataSecret:
+            name: worker-user-data
+      versions:
+        kubelet: ""
+        controlPlane: ""
+`))

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -137,6 +137,11 @@ type OpenStackPlatform struct {
 	// Region specifies the OpenStack region where the cluster will be created.
 	Region string `json:"region"`
 
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on OpenStack for machine pools which do not define their own
+	// platform configuration.
+	DefaultMachinePlatform *OpenStackMachinePoolPlatform `json:"defaultMachinePlatform,omitempty"`
+
 	// VPCID specifies the vpc to associate with the cluster.
 	// If empty, new vpc will be created.
 	// +optional


### PR DESCRIPTION
The libvirt and AWS worker assets were added in commit
e2dc955003ec3d2d59664561203d6d89133b3e9c. This fills the gap for
OpenStack.