### PR TITLE
data/aws: Drop the bucket name

### DIFF
--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -10,7 +10,7 @@ variable "associate_public_ip_address" {
 
 variable "bucket" {
   type        = "string"
-  description = "The S3 bucket name for bootstrap ignition file."
+  description = "The S3 bucket name or ID for bootstrap ignition file."
 }
 
 variable "cluster_name" {

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -19,7 +19,7 @@ module "bootstrap" {
 
   ami                         = "${var.tectonic_aws_ec2_ami_override}"
   associate_public_ip_address = "${var.tectonic_aws_endpoints != "private"}"
-  bucket                      = "${aws_s3_bucket.tectonic.bucket}"
+  bucket                      = "${aws_s3_bucket.bootstrap.id}"
   cluster_name                = "${var.tectonic_cluster_name}"
   elbs                        = "${module.vpc.aws_lbs}"
   elbs_length                 = "${module.vpc.aws_lbs_length}"
@@ -130,10 +130,7 @@ resource "aws_route53_zone" "tectonic_int" {
     ), var.tectonic_aws_extra_tags)}"
 }
 
-resource "aws_s3_bucket" "tectonic" {
-  # bucket name is cluster_name + base domain, minus the trailing dot, if one exists
-  bucket = "${lower(var.tectonic_cluster_name)}.${join(".",(compact(split(".",var.tectonic_base_domain))))}"
-
+resource "aws_s3_bucket" "bootstrap" {
   acl = "private"
 
   tags = "${merge(map(

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -12,28 +12,6 @@ import (
 	"unicode/utf8"
 )
 
-const (
-	maxS3BucketNameLength = 63
-)
-
-// S3Bucket does some basic validation to ensure that the S3 bucket
-// matches the S3 bucket naming rules. Not all rules are checked
-// because Tectonic controls the generation of S3 bucket names, creating
-// buckets of the form: <cluster-name>.<domain-name>
-// If domain-name contains a trailing dot, it's removed from the bucket name.
-func S3Bucket(name string) error {
-	if len(name) < 3 {
-		return fmt.Errorf("the S3 bucket name %q is too short; S3 bucket names must contain at least three characters", name)
-	}
-	if len(name) > maxS3BucketNameLength {
-		return fmt.Errorf("the S3 bucket name %q is too long; S3 bucket names must be less than 63 characters", name)
-	}
-	if !regexp.MustCompile("^[a-z0-9][a-z0-9-.]{1,61}[a-z0-9]$").MatchString(name) {
-		return fmt.Errorf("invalid characters in S3 bucket name: %q", name)
-	}
-	return nil
-}
-
 // DomainName checks if the given string is a valid domain name and returns an error if not.
 func DomainName(v string) error {
 	if err := nonEmpty(v); err != nil {

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -10,46 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestS3BucketNames(t *testing.T) {
-	cases := []struct {
-		name string
-		err  *regexp.Regexp
-	}{
-		{
-			name: "a.example.com",
-		},
-		{
-			name: "",
-			err:  regexp.MustCompile("^the S3 bucket name \"\" is too short; S3 bucket names must contain at least three characters$"),
-		},
-		{
-			name: ".a.example.com",
-			err:  regexp.MustCompile("^invalid characters in S3 bucket name: \".a.example.com\"$"),
-		},
-		{
-			name: "a.example.com.",
-			err:  regexp.MustCompile("^invalid characters in S3 bucket name: \"a.example.com.\"$"),
-		},
-		{
-			name: "a.012345678901234567890123456789012345678901234567890123456789.com",
-			err:  regexp.MustCompile("^the S3 bucket name \"a.012345678901234567890123456789012345678901234567890123456789.com\" is too long; S3 bucket names must be less than 63 characters$"),
-		},
-	}
-
-	for _, testCase := range cases {
-		t.Run(testCase.name, func(t *testing.T) {
-			err := S3Bucket(testCase.name)
-			if testCase.err == nil {
-				if err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				assert.Regexp(t, testCase.err, err)
-			}
-		})
-	}
-}
-
 func TestLastIP(t *testing.T) {
 	cases := []struct {
 		in  net.IPNet


### PR DESCRIPTION
@crawford [gave the history][1] behind our previous bucket name:

> We should probably just fix the creation of the S3 bucket since we no longer rely on CNAMEs (which required the S3 bucket to match the domain name).

But now we can just let AWS pick a random bucket name for us.

I've also dropped the no-longer-used `S3Bucket` validator.

[1]: https://github.com/openshift/installer/pull/359#issuecomment-426051251
[2]: https://github.com/openshift/installer/issues/458#issuecomment-431111724