### PR TITLE
data/aws/vpc/vpc-private: Set worker subnet availability_zone

### DIFF
--- a/data/data/aws/vpc/vpc-private.tf
+++ b/data/data/aws/vpc/vpc-private.tf
@@ -27,6 +27,8 @@ resource "aws_subnet" "worker_subnet" {
     cidrsubnet(local.new_worker_cidr_range, 3, count.index),
   )}"
 
+  availability_zone = "${local.new_worker_subnet_azs[count.index]}"
+
   tags = "${merge(map(
     "Name", "${var.cluster_name}-worker-${local.new_worker_subnet_azs[count.index]}",
     "kubernetes.io/cluster/${var.cluster_name}","shared",


### PR DESCRIPTION
It looks like this was (accidentally?) removed in f8286662 (coreos/tectonic-installer#3092).  We need to set it to spread worker subnets over the available zones.

CC @frobware