### PR TITLE
pkg/asset/cluster: Drop redundant os.TempDir()

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -56,7 +56,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	parents.Get(installConfig, terraformVariables, adminKubeconfig)
 
 	// Copy the terraform.tfvars to a temp directory where the terraform will be invoked within.
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "openshift-install-")
+	tmpDir, err := ioutil.TempDir("", "openshift-install-")
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir for terraform execution")
 	}


### PR DESCRIPTION
From [the Go docs][1]:

> If dir is the empty string, `TempDir` uses the default directory for temporary files (see `os.TempDir`).

so there's no point in us calling `TempDir()` directly.

The explicit call is from 408c0663 (#319).

[1]: https://golang.org/pkg/io/ioutil/#TempDir