### PR TITLE
cmd/openshift-install: Add 'destroy bootstrap' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ export KUBECONFIG="${DIR}/auth/kubeconfig"
 Destroy the cluster and release associated resources with:
 
 ```sh
-openshift-install destroy-cluster
+openshift-install destroy cluster
 ```

--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -6,14 +6,36 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/installer/pkg/destroy"
+	"github.com/openshift/installer/pkg/destroy/bootstrap"
 	_ "github.com/openshift/installer/pkg/destroy/libvirt"
 )
 
 func newDestroyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "destroy",
+		Short: "Destroy part of an OpenShift cluster",
+		Long:  "",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newDestroyBootstrapCmd())
+	cmd.AddCommand(newDestroyClusterCmd())
+	return cmd
+}
+
+func newLegacyDestroyClusterCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "destroy-cluster",
+		Short: "DEPRECATED: Use 'destroy cluster' instead.",
+		RunE:  runDestroyCmd,
+	}
+}
+
+func newDestroyClusterCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cluster",
 		Short: "Destroy an OpenShift cluster",
-		Long:  "",
 		RunE:  runDestroyCmd,
 	}
 }
@@ -28,4 +50,14 @@ func runDestroyCmd(cmd *cobra.Command, args []string) error {
 
 	}
 	return nil
+}
+
+func newDestroyBootstrapCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Destroy the bootstrap resources",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return bootstrap.Destroy(rootOpts.dir)
+		},
+	}
 }

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -22,6 +22,7 @@ func main() {
 	}
 	subCmds = append(subCmds,
 		newDestroyCmd(),
+		newLegacyDestroyClusterCmd(),
 		newVersionCmd(),
 		newGraphCmd(),
 	)

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -10,7 +10,7 @@ The following dependencies must be installed on your system before you can build
 sudo dnf install golang-bin gcc-c++
 ```
 
-If you need support for [libvirt destroy](libvirt-howto#cleanup), you should also install `libvirt-devel`.
+If you need support for [libvirt destroy](libvirt-howto.md#cleanup), you should also install `libvirt-devel`.
 
 ### CentOS, RHEL
 
@@ -18,7 +18,7 @@ If you need support for [libvirt destroy](libvirt-howto#cleanup), you should als
 sudo yum install golang-bin gcc-c++
 ```
 
-If you need support for [libvirt destroy](libvirt-howto#cleanup), you should also install `libvirt-devel`.
+If you need support for [libvirt destroy](libvirt-howto.md#cleanup), you should also install `libvirt-devel`.
 
 ## Go
 

--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -184,7 +184,7 @@ EOF
 ## Build and run the installer
 
 With [libvirt configured](#install-and-enable-libvirt), you can proceed with [the usual quick-start](../../README.md#quick-start).
-Set `TAGS` when building if you need `destroy-cluster` support for libvirt; this is not enabled by default because it requires [cgo][]:
+Set `TAGS` when building if you need `destroy cluster` support for libvirt; this is not enabled by default because it requires [cgo][]:
 
 ```sh
 TAGS=libvirt_destroy hack/build.sh
@@ -205,7 +205,7 @@ export OPENSHIFT_INSTALL_LIBVIRT_URI=qemu+tcp://192.168.122.1/system
 If you compiled with `libvirt_destroy`, you can use:
 
 ```sh
-openshift-install destroy-cluster
+openshift-install destroy cluster
 ```
 
 If you did not compile with `libvirt_destroy`, you can use [`virsh-cleanup.sh`](../../scripts/maintenance/virsh-cleanup.sh), but note it will currently destroy *all* libvirt resources.

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -21,8 +21,6 @@ import (
 const (
 	// MetadataFilename is name of the file where clustermetadata is stored.
 	MetadataFilename = "metadata.json"
-
-	stateFileName = "terraform.tfstate"
 )
 
 // Cluster uses the terraform executable to launch a cluster
@@ -136,7 +134,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	data, err2 := ioutil.ReadFile(stateFile)
 	if err2 == nil {
 		c.FileList = append(c.FileList, &asset.File{
-			Filename: stateFileName,
+			Filename: terraform.StateFileName,
 			Data:     data,
 		})
 	} else {
@@ -159,7 +157,7 @@ func (c *Cluster) Files() []*asset.File {
 // Load returns error if the tfstate file is already on-disk, because we want to
 // prevent user from accidentally re-launching the cluster.
 func (c *Cluster) Load(f asset.FileFetcher) (found bool, err error) {
-	_, err = f.FetchByName(stateFileName)
+	_, err = f.FetchByName(terraform.StateFileName)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
@@ -167,5 +165,5 @@ func (c *Cluster) Load(f asset.FileFetcher) (found bool, err error) {
 		return false, err
 	}
 
-	return true, fmt.Errorf("%q already exisits.  There may already be a running cluster", stateFileName)
+	return true, fmt.Errorf("%q already exisits.  There may already be a running cluster", terraform.StateFileName)
 }

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/openshift/installer/data"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
@@ -19,8 +18,8 @@ import (
 )
 
 const (
-	// MetadataFilename is name of the file where clustermetadata is stored.
-	MetadataFilename = "metadata.json"
+	// metadataFileName is name of the file where clustermetadata is stored.
+	metadataFileName = "metadata.json"
 )
 
 // Cluster uses the terraform executable to launch a cluster
@@ -65,11 +64,6 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		return errors.Wrap(err, "failed to write terraform.tfvars file")
 	}
 
-	platform := installConfig.Config.Platform.Name()
-	if err := data.Unpack(tmpDir, platform); err != nil {
-		return err
-	}
-
 	metadata := &types.ClusterMetadata{
 		ClusterName: installConfig.Config.ObjectMeta.Name,
 	}
@@ -77,7 +71,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	defer func() {
 		if data, err2 := json.Marshal(metadata); err2 == nil {
 			c.FileList = append(c.FileList, &asset.File{
-				Filename: MetadataFilename,
+				Filename: metadataFileName,
 				Data:     data,
 			})
 		} else {
@@ -114,19 +108,8 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		return fmt.Errorf("no known platform")
 	}
 
-	if err := data.Unpack(filepath.Join(tmpDir, "config.tf"), "config.tf"); err != nil {
-		return err
-	}
-
 	logrus.Infof("Using Terraform to create cluster...")
-
-	// This runs the terraform in a temp directory, the tfstate file will be returned
-	// to the asset store to persist it on the disk.
-	if err := terraform.Init(tmpDir); err != nil {
-		return errors.Wrap(err, "failed to initialize terraform")
-	}
-
-	stateFile, err := terraform.Apply(tmpDir)
+	stateFile, err := terraform.Apply(tmpDir, installConfig.Config.Platform.Name())
 	if err != nil {
 		err = errors.Wrap(err, "failed to run terraform")
 	}
@@ -166,4 +149,18 @@ func (c *Cluster) Load(f asset.FileFetcher) (found bool, err error) {
 	}
 
 	return true, fmt.Errorf("%q already exisits.  There may already be a running cluster", terraform.StateFileName)
+}
+
+// LoadMetadata loads the cluster metadata from an asset directory.
+func LoadMetadata(dir string) (cmetadata *types.ClusterMetadata, err error) {
+	raw, err := ioutil.ReadFile(filepath.Join(dir, metadataFileName))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read %s file", metadataFileName)
+	}
+
+	if err = json.Unmarshal(raw, &cmetadata); err != nil {
+		return nil, errors.Wrapf(err, "failed to Unmarshal data from %s file to types.ClusterMetadata", metadataFileName)
+	}
+
+	return cmetadata, err
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	tfvarsFilename  = "terraform.tfvars"
+	// TfVarsFileName is the filename for Terraform variables.
+	TfVarsFileName  = "terraform.tfvars"
 	tfvarsAssetName = "Terraform Variables"
 )
 
@@ -62,7 +63,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		return errors.Wrap(err, "failed to get Tfvars")
 	}
 	t.File = &asset.File{
-		Filename: tfvarsFilename,
+		Filename: TfVarsFileName,
 		Data:     data,
 	}
 
@@ -79,7 +80,7 @@ func (t *TerraformVariables) Files() []*asset.File {
 
 // Load reads the terraform.tfvars from disk.
 func (t *TerraformVariables) Load(f asset.FileFetcher) (found bool, err error) {
-	file, err := f.FetchByName(tfvarsFilename)
+	file, err := f.FetchByName(TfVarsFileName)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -1,0 +1,56 @@
+// Package bootstrap uses Terraform to remove bootstrap resources.
+package bootstrap
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/asset/cluster"
+	"github.com/openshift/installer/pkg/terraform"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// Destroy uses Terraform to remove bootstrap resources.
+func Destroy(dir string) (err error) {
+	metadata, err := cluster.LoadMetadata(dir)
+	if err != nil {
+		return err
+	}
+
+	platform := metadata.Platform()
+	if platform == "" {
+		return errors.New("no platform configured in metadata")
+	}
+
+	tempDir, err := ioutil.TempDir("", "openshift-install-")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temporary directory for Terraform execution")
+	}
+	defer os.RemoveAll(tempDir)
+
+	for _, filename := range []string{terraform.StateFileName, cluster.TfVarsFileName} {
+		err = copy(filepath.Join(dir, filename), filepath.Join(tempDir, filename))
+		if err != nil {
+			return errors.Wrapf(err, "failed to copy %s to the temporary directory", filename)
+		}
+	}
+
+	logrus.Infof("Using Terraform to destroy bootstrap resources...")
+	err = terraform.Destroy(tempDir, platform, "-target=module.bootstrap")
+	if err != nil {
+		err = errors.Wrap(err, "failed to run terraform")
+	}
+
+	return os.Rename(filepath.Join(dir, terraform.StateFileName), filepath.Join(tempDir, terraform.StateFileName))
+}
+
+func copy(from string, to string) error {
+	data, err := ioutil.ReadFile(from)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(to, data, 0666)
+}

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -7,6 +7,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// StateFileName is the default name for Terraform state files.
+	StateFileName string = "terraform.tfstate"
+)
+
 func terraformExec(clusterDir string, args ...string) error {
 	// Create an executor
 	ex, err := newExecutor()
@@ -25,17 +30,16 @@ func terraformExec(clusterDir string, args ...string) error {
 // path of the tfstate file, rooted in the specified directory, along with any
 // errors from Terraform.
 func Apply(dir string, extraArgs ...string) (string, error) {
-	stateFileName := "terraform.tfstate"
 	defaultArgs := []string{
 		"apply",
 		"-auto-approve",
 		"-input=false",
 		"-no-color",
-		fmt.Sprintf("-state=%s", stateFileName),
+		fmt.Sprintf("-state=%s", StateFileName),
 	}
 	args := append(defaultArgs, extraArgs...)
 
-	return path.Join(dir, stateFileName), terraformExec(dir, args...)
+	return path.Join(dir, StateFileName), terraformExec(dir, args...)
 }
 
 // Init runs "terraform init" in the given directory.


### PR DESCRIPTION
Using Terraform to remove all resources created by the bootstrap modules.  For this to work, all platforms must define a bootstrap module (and they all currently do).

I've also created a `LoadMetadata` helper to share the "retrieve the metadata from the asset directory" logic between the `destroy-cluster` and `destroy-bootstrap` logic.  The new helper lives in the cluster asset plackage close to the code that determines that file's location.

/assign @crawford