### PR TITLE
Re-disable the cluster-ingress-operator

### DIFF
--- a/pkg/asset/manifests/content/bootkube/cvo-overrides.go
+++ b/pkg/asset/manifests/content/bootkube/cvo-overrides.go
@@ -24,8 +24,8 @@ overrides:
   name: cluster-network-operator
   unmanaged: true
 - kind: Deployment                    # this conflicts with tectonic-ingress-controller-operator
-  namespace: openshift-cluster-ingress-operator
-  name: cluster-ingress-operator
+  namespace: openshift-ingress-operator
+  name: ingress-operator
   unmanaged: true
 - kind: ServiceAccount                # missing run level 0 on the namespace and has 0000_08
   namespace: openshift-cluster-dns-operator


### PR DESCRIPTION
Fix the cluster-ingress-operator override to match the
cluster-ingress-operator's new namespace and deployment name[1].

[1] https://github.com/openshift/cluster-ingress-operator/pull/52