### PR TITLE
assets: disable pod-checkpointer-operator during bringup phase

### DIFF
--- a/pkg/asset/manifests/content/bootkube/cvo-overrides.go
+++ b/pkg/asset/manifests/content/bootkube/cvo-overrides.go
@@ -38,5 +38,9 @@ overrides:
 - kind: APIService                    # packages.apps.redhat.com fails to start properly
   name: v1alpha1.packages.apps.redhat.com
   unmanaged: true
+- kind: Deployment                    # still testing this new component
+  namespace: openshift-pod-checkpointer
+  name: pod-checkpointer-operator
+  unmanaged: true
 `))
 )


### PR DESCRIPTION
fyi @derekwaynecarr @rphillips

This component is brand new and don't want to cause problems while we bring it up.