### PR TITLE
pkg/asset: Fix name of libvirt master machine

### DIFF
--- a/pkg/asset/machines/libvirt/master.go
+++ b/pkg/asset/machines/libvirt/master.go
@@ -27,7 +27,7 @@ items:
 - apiVersion: cluster.k8s.io/v1alpha1
   kind: Machine
   metadata:
-    name: {{$c.ClusterName}}-master-{{$index}}
+    name: master{{$index}}
     namespace: openshift-cluster-api
     labels:
       sigs.k8s.io/cluster-api-cluster: {{$c.ClusterName}}


### PR DESCRIPTION
On libvirt, master name should be `master0`, instead of the one used for cloud instances