### PR TITLE
pkg/destroy/bootstrap: Fix cross-filesystem tfstate recovery

### DIFF
--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -40,10 +40,15 @@ func Destroy(dir string) (err error) {
 	logrus.Infof("Using Terraform to destroy bootstrap resources...")
 	err = terraform.Destroy(tempDir, platform, "-target=module.bootstrap")
 	if err != nil {
-		err = errors.Wrap(err, "failed to run terraform")
+		return errors.Wrap(err, "failed to run terraform")
 	}
 
-	return os.Rename(filepath.Join(dir, terraform.StateFileName), filepath.Join(tempDir, terraform.StateFileName))
+	tempStateFilePath := filepath.Join(dir, terraform.StateFileName+".new")
+	err = copy(filepath.Join(tempDir, terraform.StateFileName), tempStateFilePath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to copy %s from the temporary directory", terraform.StateFileName)
+	}
+	return os.Rename(tempStateFilePath, filepath.Join(dir, terraform.StateFileName))
 }
 
 func copy(from string, to string) error {


### PR DESCRIPTION
Use a copy and then a rename, instead of just a rename.  This avoids `invalid cross-device link` errors when the source and target directories are on different filesystems (e.g. because the source is in a tmpfs under `/tmp`).

Also fix the `terraform.Destroy` error handling, and actually return the wrapped error instead of ignoring it.