### PR TITLE
dev-dependencies: Just use `yum` on Fedora too

### DIFF
--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -4,15 +4,7 @@
 
 The following dependencies must be installed on your system before you can build the installer.
 
-### Fedora
-
-```sh
-sudo dnf install golang-bin gcc-c++
-```
-
-If you need support for [libvirt destroy](libvirt-howto.md#cleanup), you should also install `libvirt-devel`.
-
-### CentOS, RHEL
+### Fedora, CentOS, RHEL
 
 ```sh
 sudo yum install golang-bin gcc-c++

--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -8,13 +8,7 @@ It's expected that you will create and destroy clusters often in the course of d
 Before you begin, install the [build dependencies](dependencies.md).
 
 ### Install and Enable Libvirt
-On Fedora:
-
-```sh
-sudo dnf install libvirt-daemon
-```
-
-or on CentOS / RHEL:
+On Fedora, CentOS/RHEL:
 
 ```sh
 sudo yum install libvirt-daemon
@@ -23,8 +17,7 @@ sudo yum install libvirt-daemon
 Then start libvirtd:
 
 ```sh
-sudo systemctl start libvirtd
-sudo systemctl enable libvirtd
+sudo systemctl enable --now libvirtd
 ```
 
 ### Pick names


### PR DESCRIPTION
This is what I do.  `dnf` no longer complains if invoked as `yum`;
there's no point to having two separate sets of instructions.