### PR TITLE
cmd/openshift-install: Push creation under 'openshift create'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ hack/build.sh
 This will create `bin/openshift-install`. This binary can then be invoked to create an OpenShift cluster, like so:
 
 ```sh
-bin/openshift-install cluster
+bin/openshift-install create cluster
 ```
 
 The installer requires the terraform binary either alongside openshift-install or in `$PATH`.
@@ -41,8 +41,8 @@ Log in using the admin credentials you configured when creating the cluster.
 
 #### Kubeconfig
 
-You can also use the admin kubeconfig which `openshift-install cluster` placed under `--dir` (which defaults to `.`) in `auth/kubeconfig`.
-If you launched the cluster with `openshift-install --dir "${DIR}" cluster`, you can use:
+You can also use the admin kubeconfig which `openshift-install create cluster` placed under `--dir` (which defaults to `.`) in `auth/kubeconfig`.
+If you launched the cluster with `openshift-install --dir "${DIR}" create cluster`, you can use:
 
 ```sh
 export KUBECONFIG="${DIR}/auth/kubeconfig"

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -16,17 +16,17 @@ var (
 func main() {
 	rootCmd := newRootCmd()
 
-	var subCmds []*cobra.Command
 	for _, cmd := range newTargetsCmd() {
-		subCmds = append(subCmds, cmd)
+		rootCmd.AddCommand(cmd)
 	}
-	subCmds = append(subCmds,
+
+	for _, subCmd := range []*cobra.Command{
+		newCreateCmd(),
 		newDestroyCmd(),
 		newLegacyDestroyClusterCmd(),
 		newVersionCmd(),
 		newGraphCmd(),
-	)
-	for _, subCmd := range subCmds {
+	} {
 		rootCmd.AddCommand(subCmd)
 	}
 

--- a/docs/design/assetgeneration.md
+++ b/docs/design/assetgeneration.md
@@ -72,10 +72,10 @@ After being loaded and consumed by a children asset, the existing on-disk asset 
 E.g.
 
 ```shell
-$ openshift-install install-config
+$ openshift-install create install-config
 # Generate install-config.yml
 
-$ openshift-install manifests
+$ openshift-install create manifests
 # Generate manifests/ and tectonic/ dir, also remove install-config.yml
 ```
 


### PR DESCRIPTION
To mirror `openshift-install destroy` and make it easier for folks using multiple invocations to see what their options are.

I haven't bothered with deprecated backwards-compat invocations, because I didn't know which targets we'd want it for (all of them?  None of them?  Just `cluster`?).  Thoughts?