### PR TITLE
Docs: update instructions to install libvirt and libvirt-devel packages

### DIFF
--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -11,7 +11,7 @@ Before you begin, install the [build dependencies](dependencies.md).
 On Fedora, CentOS/RHEL:
 
 ```sh
-sudo yum install libvirt-daemon
+sudo yum install libvirt libvirt-devel
 ```
 
 Then start libvirtd:


### PR DESCRIPTION
`libvirt-daemon-config-network` is not installed by default when only installing `libvirt-daemon` and is necessary for setting up the libvirt bridge and default networking.

For reference, the error I was seeing running through a by the book install on a fresh F28:

```
ERROR Failed to read tfstate: open /tmp/openshift-install-301304036/terraform.tfstate: no such file or directory 
ERROR Error: Error refreshing state: 1 error(s) occurred:

* provider.libvirt: virError(Code=38, Domain=7, Message='unable to connect to server at '192.168.122.1:16509': Connection timed out') 
FATAL Error executing openshift-install: exit status 1 
```