### PR TITLE
asset/ignition: remove bootstrap node from cluster

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -34,8 +34,6 @@ const (
 // template files.
 type bootstrapTemplateData struct {
 	BootkubeImage       string
-	CloudProvider       string
-	CloudProviderConfig string
 	ClusterDNSIP        string
 	DebugConfig         string
 	EtcdCertSignerImage string
@@ -157,8 +155,6 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig) (*bootst
 
 	return &bootstrapTemplateData{
 		ClusterDNSIP:        clusterDNSIP,
-		CloudProvider:       getCloudProvider(installConfig),
-		CloudProviderConfig: getCloudProviderConfig(installConfig),
 		DebugConfig:         "",
 		EtcdCertSignerImage: "quay.io/coreos/kube-etcd-signer-server:678cc8e6841e2121ebfdb6e2db568fce290b67d6",
 		EtcdctlImage:        "quay.io/coreos/etcd:v3.2.14",
@@ -175,7 +171,6 @@ func (a *Bootstrap) addBootstrapFiles(dependencies asset.Parents) {
 	a.Config.Storage.Files = append(
 		a.Config.Storage.Files,
 		ignition.FileFromBytes("/etc/kubernetes/kubeconfig", 0600, kubeletKubeconfig.Files()[0].Data),
-		ignition.FileFromBytes("/var/lib/kubelet/kubeconfig", 0600, kubeletKubeconfig.Files()[0].Data),
 	)
 	a.Config.Storage.Files = append(
 		a.Config.Storage.Files,
@@ -280,17 +275,6 @@ func (a *Bootstrap) addTLSCertFiles(dependencies asset.Parents) {
 		a.Config.Storage.Files,
 		ignition.FileFromBytes("/etc/ssl/etcd/ca.crt", 0600, etcdClientCertKey.Cert()),
 	)
-}
-
-func getCloudProvider(installConfig *types.InstallConfig) string {
-	if installConfig.AWS != nil {
-		return "aws"
-	}
-	return ""
-}
-
-func getCloudProviderConfig(installConfig *types.InstallConfig) string {
-	return ""
 }
 
 func applyTemplateData(template *template.Template, templateData interface{}) string {

--- a/pkg/asset/ignition/bootstrap/content/kubelet.go
+++ b/pkg/asset/ignition/bootstrap/content/kubelet.go
@@ -20,9 +20,6 @@ EnvironmentFile=-/etc/kubernetes/kubelet-env
 
 ExecStart=/usr/bin/hyperkube \
   kubelet \
-    --bootstrap-kubeconfig=/etc/kubernetes/kubeconfig \
-    --kubeconfig=/var/lib/kubelet/kubeconfig \
-    --rotate-certificates \
     --container-runtime=remote \
     --container-runtime-endpoint=/var/run/crio/crio.sock \
     --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
@@ -30,17 +27,12 @@ ExecStart=/usr/bin/hyperkube \
     --exit-on-lock-contention \
     --pod-manifest-path=/etc/kubernetes/manifests \
     --allow-privileged \
-    --node-labels=node-role.kubernetes.io/bootstrap \
-    --register-with-taints=node-role.kubernetes.io/bootstrap=:NoSchedule \
     --minimum-container-ttl-duration=6m0s \
-    --cluster-dns={{.ClusterDNSIP}} \
     --cluster-domain=cluster.local \
     --client-ca-file=/etc/kubernetes/ca.crt \
-    --cloud-provider={{.CloudProvider}} \
     --anonymous-auth=false \
     --cgroup-driver=systemd \
     --serialize-image-pulls=false \
-    {{.CloudProviderConfig}} \
     {{.DebugConfig}} \
 
 Restart=always

--- a/pkg/asset/ignition/bootstrap/content/kubelet.go
+++ b/pkg/asset/ignition/bootstrap/content/kubelet.go
@@ -1,13 +1,9 @@
 package content
 
-import (
-	"text/template"
-)
-
 var (
-	// KubeletSystemdTemplate is a service for running the kubelet on the
+	// KubeletSystemdContents is a service for running the kubelet on the
 	// bootstrap nodes.
-	KubeletSystemdTemplate = template.Must(template.New("kubelet.service").Parse(`
+	KubeletSystemdContents = `
 [Unit]
 Description=Kubernetes Kubelet
 Wants=rpc-statd.service
@@ -33,12 +29,11 @@ ExecStart=/usr/bin/hyperkube \
     --anonymous-auth=false \
     --cgroup-driver=systemd \
     --serialize-image-pulls=false \
-    {{.DebugConfig}} \
 
 Restart=always
 RestartSec=10
 
 [Install]
 WantedBy=multi-user.target
-`))
+`
 )


### PR DESCRIPTION
This runs the kubelet in localhost mode so that it does not register
itself with the control plane. This approach is advantageous because it:

  - eliminates the possibility of workloads inadvertently being scheduled to
    the bootstrap node
  - avoids needing to clean up the Kubernetes node object after the
    bootstrap node has been decommissioned
  - makes the distinction between the running cluster and the bootstrap
    node a little more clear

This ends up simplifying the invocation of the kubelet quite a bit since
we no longer need to provide kubeconfigs, node labels, or node taints.