### PR TITLE
Docfix: Update instructions to use destroy-cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ export KUBECONFIG="${DIR}/auth/kubeconfig"
 Destroy the cluster and release associated resources with:
 
 ```sh
-openshift-install destroy cluster
+openshift-install destroy-cluster
 ```

--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -209,7 +209,7 @@ EOF
 ## Build and run the installer
 
 With [libvirt configured](#install-and-enable-libvirt), you can proceed with [the usual quick-start](../../README.md#quick-start).
-Set `TAGS` when building if you need `destroy cluster` support for libvirt; this is not enabled by default because it requires [cgo][]:
+Set `TAGS` when building if you need `destroy-cluster` support for libvirt; this is not enabled by default because it requires [cgo][]:
 
 ```sh
 TAGS=libvirt_destroy hack/build.sh
@@ -230,7 +230,7 @@ export OPENSHIFT_INSTALL_LIBVIRT_URI=qemu+tcp://192.168.122.1/system
 If you compiled with `libvirt_destroy`, you can use:
 
 ```sh
-openshift-install destroy cluster
+openshift-install destroy-cluster
 ```
 
 If you did not compile with `libvirt_destroy`, you can use [`virsh-cleanup.sh`](../../scripts/maintenance/virsh-cleanup.sh), but note it will currently destroy *all* libvirt resources.


### PR DESCRIPTION
Current instructions use `destroy cluster` but that command gives an error:
```
$ bin/openshift-install destroy cluster
FATA[0000] Error executing openshift-install: unknown command "destroy" for "openshift-install"

Did you mean this?
	destroy-cluster
``` 
Update  docs to use correct command: `destroy-cluster`