### PR TITLE
Update libvirt cluster-api provider config version

### DIFF
--- a/pkg/asset/machines/libvirt/master.go
+++ b/pkg/asset/machines/libvirt/master.go
@@ -36,7 +36,7 @@ items:
   spec:
     providerConfig:
       value:
-        apiVersion: libvirtproviderconfig/v1alpha1
+        apiVersion: libvirtproviderconfig.k8s.io/v1alpha1
         kind: LibvirtMachineProviderConfig
         domainMemory: 2048
         domainVcpu: 2

--- a/pkg/asset/machines/libvirt/worker.go
+++ b/pkg/asset/machines/libvirt/worker.go
@@ -43,7 +43,7 @@ spec:
     spec:
       providerConfig:
         value:
-          apiVersion: libvirtproviderconfig/v1alpha1
+          apiVersion: libvirtproviderconfig.k8s.io/v1alpha1
           kind: LibvirtMachineProviderConfig
           domainMemory: 2048
           domainVcpu: 2


### PR DESCRIPTION
With the move to the kubebuilder CRD based cluster-api components, the
API version for the libvirt provider config subresources has changed
to: `libvirtproviderconfig.k8s.io/v1alpha1`
