### PR TITLE
asset/ignition: properly signal bootstrap complete

### DIFF
--- a/pkg/asset/ignition/bootstrap/content/bootkube.go
+++ b/pkg/asset/ignition/bootstrap/content/bootkube.go
@@ -15,10 +15,7 @@ After=kubelet.service
 
 [Service]
 WorkingDirectory=/opt/tectonic
-
 ExecStart=/opt/tectonic/bootkube.sh
-# Workaround for https://github.com/opencontainers/runc/pull/1807
-ExecStartPost=/usr/bin/touch /opt/tectonic/.bootkube.done
 
 Restart=on-failure
 RestartSec=5s
@@ -229,6 +226,9 @@ podman run \
 	--entrypoint=/bootkube \
 	"{{.BootkubeImage}}" \
 	start --asset-dir=/assets
+
+# Workaround for https://github.com/opencontainers/runc/pull/1807
+touch /opt/tectonic/.bootkube.done
 `))
 )
 

--- a/pkg/asset/ignition/bootstrap/content/bootkube.go
+++ b/pkg/asset/ignition/bootstrap/content/bootkube.go
@@ -15,6 +15,7 @@ After=kubelet.service
 
 [Service]
 WorkingDirectory=/opt/tectonic
+RemainAfterExit=true
 ExecStart=/opt/tectonic/bootkube.sh
 
 Restart=on-failure
@@ -188,7 +189,6 @@ podman run \
 echo "Waiting for etcd cluster..."
 
 # Wait for the etcd cluster to come up.
-set +e
 # shellcheck disable=SC2154,SC2086
 until podman run \
 		--rm \
@@ -208,7 +208,6 @@ do
 	echo "etcdctl failed. Retrying in 5 seconds..."
 	sleep 5
 done
-set -e
 
 echo "etcd cluster up. Killing etcd certificate signer..."
 

--- a/pkg/asset/ignition/bootstrap/content/tectonic.go
+++ b/pkg/asset/ignition/bootstrap/content/tectonic.go
@@ -10,10 +10,7 @@ After=bootkube.service
 
 [Service]
 WorkingDirectory=/opt/tectonic/tectonic
-
 ExecStart=/opt/tectonic/tectonic.sh /opt/tectonic/auth/kubeconfig
-# Workaround for https://github.com/opencontainers/runc/pull/1807
-ExecStartPost=/usr/bin/touch /opt/tectonic/.tectonic.done
 
 Restart=on-failure
 RestartSec=5s
@@ -90,6 +87,9 @@ done
 
 # Wait for Tectonic pods
 wait_for_pods tectonic-system
+
+# Workaround for https://github.com/opencontainers/runc/pull/1807
+touch /opt/tectonic/.tectonic.done
 
 echo "Tectonic installation is done"
 `

--- a/pkg/asset/ignition/bootstrap/content/tectonic.go
+++ b/pkg/asset/ignition/bootstrap/content/tectonic.go
@@ -10,6 +10,7 @@ After=bootkube.service
 
 [Service]
 WorkingDirectory=/opt/tectonic/tectonic
+RemainAfterExit=true
 ExecStart=/opt/tectonic/tectonic.sh /opt/tectonic/auth/kubeconfig
 
 Restart=on-failure


### PR DESCRIPTION
3dbbbf6 incorrectly signalled the completion of bootstrap.sh and
tectonic.sh using systemd's ExecStartPost stanza. This doesn't work in
Type=simple services, because systemd runs the ExecStartPost stanza
immediately after spawning the main process. This could be fixed by
changing the service type to "oneshot", where systemd waits for the
ExecStart stanzas to complete, but oneshot services don't respect the
Restart stanza. It's easiest to just signal the completion of these
scripts at the end of the script itself, even if it couples the scripts
to the service unit for progress.service (which is responsible for
checking for the completion of the scripts).