### PR TITLE
Add SRV records for bootstrapping etcd using DNS.

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -117,6 +117,14 @@ resource "aws_route53_record" "etcd_a_nodes" {
   records = ["${module.masters.ip_addresses[count.index]}"]
 }
 
+resource "aws_route53_record" "etcd_cluster" {
+  type    = "SRV"
+  ttl     = "60"
+  zone_id = "${local.private_zone_id}"
+  name    = "_etcd-server-ssl._tcp"
+  records = ["${formatlist("0 10 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)}"]
+}
+
 resource "aws_route53_zone" "tectonic_int" {
   count         = "${local.private_endpoints ? "${var.tectonic_aws_external_private_zone == "" ? 1 : 0 }" : 0}"
   vpc_id        = "${module.vpc.vpc_id}"

--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -195,7 +195,7 @@ This step is optional, but useful for being able to resolve cluster-internal hos
 1. Make sure you have the `virsh` binary installed: `sudo dnf install libvirt-client libvirt-devel`
 2. Install the libvirt terraform provider:
 ```sh
-GOBIN=~/.terraform.d/plugins go get -u github.com/dmacvicar/terraform-provider-libvirt
+GOBIN=~/.terraform.d/plugins go get -u github.com/abhinavdahiya/terraform-provider-libvirt
 ```
 
 ### Cache Terrafrom plugins (optional, but makes subsequent runs a bit faster)


### PR DESCRIPTION
Add SRV records for bootstrapping etcd using DNS.

xref: https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/clustering.md#dns-discovery

Requires: https://github.com/dmacvicar/terraform-provider-libvirt/pull/460 
This allows MCO to use this to bootstrap etcd https://github.com/openshift/machine-config-operator/pull/143