### PR TITLE
Docs/installer:update directory explaination for repo clone to avoid confuse when build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 First, install all [build dependencies](docs/dev/dependencies.md).
 
-After cloning this repository, the installer binary will need to be built by running the following:
+Clone this repository to `src/github.com/openshift/installer` in your [GOPATH](https://golang.org/cmd/go/#hdr-GOPATH_environment_variable). Then build the `openshift-install` binary with:
 
 ```sh
 hack/build.sh


### PR DESCRIPTION
Docs/installer:update directory explaination for repo clone to avoid confuse when build.

If just clone installer to any directory, when run hack/build.sh will get error due to an hard-code path was specified in build.sh such as PACKAGE_PATH="$(go list -e -f '{{.Dir}}' github.com/openshift/installer)".
So it's better to guide user for the path about work directory for build.