### PR TITLE
README: Add more hints about cleanup and reinstallation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ Destroy the cluster and release associated resources with:
 ```sh
 openshift-install destroy cluster
 ```
+
+Note that you almost certainly also want to clean up the installer state files too, including `auth/`, `terraform.tfstate`, etc.
+The best thing to do is always pass the `--dir` argument to `install` and `destroy`.
+And if you want to reinstall from scratch, `rm -rf` the asset directory beforehand.


### PR DESCRIPTION
The stale `auth` directory was what was breaking my cluster reinstalls.
Let's encourage people to use `--dir`.