### PR TITLE
asset/ignition: Drop binaries in /usr/local/bin

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -172,7 +172,7 @@ func (a *Bootstrap) addBootstrapFiles(dependencies asset.Parents) {
 	)
 	a.Config.Storage.Files = append(
 		a.Config.Storage.Files,
-		ignition.FileFromString("/opt/tectonic/report-progress.sh", 0555, content.ReportShFileContents),
+		ignition.FileFromString("/usr/local/bin/report-progress.sh", 0555, content.ReportShFileContents),
 	)
 }
 
@@ -184,7 +184,7 @@ func (a *Bootstrap) addBootkubeFiles(dependencies asset.Parents, templateData *b
 
 	a.Config.Storage.Files = append(
 		a.Config.Storage.Files,
-		ignition.FileFromString("/opt/tectonic/bootkube.sh", 0555, applyTemplateData(content.BootkubeShFileTemplate, templateData)),
+		ignition.FileFromString("/usr/local/bin/bootkube.sh", 0555, applyTemplateData(content.BootkubeShFileTemplate, templateData)),
 	)
 	for _, o := range content.BootkubeConfigOverrides {
 		a.Config.Storage.Files = append(
@@ -238,7 +238,7 @@ func (a *Bootstrap) addTectonicFiles(dependencies asset.Parents) {
 
 	a.Config.Storage.Files = append(
 		a.Config.Storage.Files,
-		ignition.FileFromString("/opt/tectonic/tectonic.sh", 0555, content.TectonicShFileContents),
+		ignition.FileFromString("/usr/local/bin/tectonic.sh", 0555, content.TectonicShFileContents),
 	)
 	a.Config.Storage.Files = append(
 		a.Config.Storage.Files,

--- a/pkg/asset/ignition/bootstrap/content/bootkube.go
+++ b/pkg/asset/ignition/bootstrap/content/bootkube.go
@@ -16,7 +16,7 @@ After=kubelet.service
 [Service]
 WorkingDirectory=/opt/tectonic
 RemainAfterExit=true
-ExecStart=/opt/tectonic/bootkube.sh
+ExecStart=/usr/local/bin/bootkube.sh
 
 Restart=on-failure
 RestartSec=5s

--- a/pkg/asset/ignition/bootstrap/content/report.go
+++ b/pkg/asset/ignition/bootstrap/content/report.go
@@ -14,7 +14,7 @@ After=bootkube.service tectonic.service
 # Workaround for https://github.com/systemd/systemd/issues/1312 and https://github.com/opencontainers/runc/pull/1807
 ExecStartPre=/usr/bin/test -f /opt/tectonic/.bootkube.done
 ExecStartPre=/usr/bin/test -f /opt/tectonic/.tectonic.done
-ExecStart=/opt/tectonic/report-progress.sh /opt/tectonic/auth/kubeconfig bootstrap-complete "cluster bootstrapping has completed"
+ExecStart=/usr/local/bin/report-progress.sh /opt/tectonic/auth/kubeconfig bootstrap-complete "cluster bootstrapping has completed"
 
 Restart=on-failure
 RestartSec=5s

--- a/pkg/asset/ignition/bootstrap/content/tectonic.go
+++ b/pkg/asset/ignition/bootstrap/content/tectonic.go
@@ -11,7 +11,7 @@ After=bootkube.service
 [Service]
 WorkingDirectory=/opt/tectonic/tectonic
 RemainAfterExit=true
-ExecStart=/opt/tectonic/tectonic.sh /opt/tectonic/auth/kubeconfig
+ExecStart=/usr/local/bin/tectonic.sh /opt/tectonic/auth/kubeconfig
 
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
Future SELinux policies are going to be stricter here, and deny
`init_t` `{ execute }` on `var_t`.  Label them `bin_t` to be more
proper.

(Bigger picture I think we should use `/usr/local/bin/tectonic`
 or so, but this fix works fine for now)