### PR TITLE
asset/ignition: use sdnotify in kubelet service

### DIFF
--- a/pkg/asset/ignition/bootstrap/content/kubelet.go
+++ b/pkg/asset/ignition/bootstrap/content/kubelet.go
@@ -9,6 +9,7 @@ Description=Kubernetes Kubelet
 Wants=rpc-statd.service
 
 [Service]
+Type=notify
 ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
 ExecStartPre=/usr/bin/bash -c "gawk '/certificate-authority-data/ {print $2}' /etc/kubernetes/kubeconfig | base64 --decode > /etc/kubernetes/ca.crt"
 Environment=KUBELET_RUNTIME_REQUEST_TIMEOUT=10m


### PR DESCRIPTION
Kubelet has support for systemd's notify mechanism. We'd might as well
make use of it.