### PR TITLE
cvo-override: disable checkpointer operator on new namespace

### DIFF
--- a/pkg/asset/manifests/content/bootkube/cvo-overrides.go
+++ b/pkg/asset/manifests/content/bootkube/cvo-overrides.go
@@ -42,5 +42,9 @@ overrides:
   namespace: kube-system
   name: pod-checkpointer-operator
   unmanaged: true
+- kind: Deployment                    # still testing this new component
+  namespace: openshift-pod-checkpointer
+  name: pod-checkpointer-operator
+  unmanaged: true
 `))
 )


### PR DESCRIPTION
migrating to a new namespace. both overrides will be deleted once the
operator is stable.