### PR TITLE
Add OpenStack to clustermetadata.go

### DIFF
--- a/pkg/types/clustermetadata.go
+++ b/pkg/types/clustermetadata.go
@@ -27,6 +27,9 @@ func (cpm *ClusterPlatformMetadata) Platform() string {
 	if cpm.Libvirt != nil {
 		return "libvirt"
 	}
+	if cpm.OpenStack != nil {
+		return "openstack"
+	}
 	return ""
 }
 


### PR DESCRIPTION
This code was recently reworked in:

https://github.com/openshift/installer/pull/493

Adding OpenStack here means the destroy bootstrap option will
work for OpenStack, which is a first step towards full destroy
support for the OpenStack platform.