### PR TITLE
pkg/asset/manifests: Drop oidc-ca.crt

### DIFF
--- a/pkg/asset/manifests/content/bootkube/kube-apiserver-secret.go
+++ b/pkg/asset/manifests/content/bootkube/kube-apiserver-secret.go
@@ -27,7 +27,6 @@ data:
   etcd-client-ca.crt: {{.EtcdCaCert}}
   etcd-client.crt: {{.EtcdClientCert}}
   etcd-client.key: {{.EtcdClientKey}}
-  oidc-ca.crt: {{.OidcCaCert}}
   service-serving-ca.crt: {{.ServiceServingCaCert}}
   service-serving-ca.key: {{.ServiceServingCaKey}}
   kubeconfig: {{.OpenshiftLoopbackKubeconfig}}

--- a/pkg/asset/manifests/content/bootkube/openshift-apiserver-secret.go
+++ b/pkg/asset/manifests/content/bootkube/openshift-apiserver-secret.go
@@ -29,7 +29,6 @@ data:
   etcd-client-ca.crt: {{.EtcdCaCert}}
   etcd-client.crt: {{.EtcdClientCert}}
   etcd-client.key: {{.EtcdClientKey}}
-  oidc-ca.crt: {{.OidcCaCert}}
   service-serving-ca.crt: {{.ServiceServingCaCert}}
   service-serving-ca.key: {{.ServiceServingCaKey}}
   kubeconfig: {{.OpenshiftLoopbackKubeconfig}}

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -146,7 +146,6 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		KubeCaKey:                       base64.StdEncoding.EncodeToString(kubeCA.Key()),
 		McsTLSCert:                      base64.StdEncoding.EncodeToString(mcsCertKey.Cert()),
 		McsTLSKey:                       base64.StdEncoding.EncodeToString(mcsCertKey.Key()),
-		OidcCaCert:                      base64.StdEncoding.EncodeToString(kubeCA.Cert()),
 		OpenshiftApiserverCert:          base64.StdEncoding.EncodeToString(openshiftAPIServerCertKey.Cert()),
 		OpenshiftApiserverKey:           base64.StdEncoding.EncodeToString(openshiftAPIServerCertKey.Key()),
 		OpenshiftLoopbackKubeconfig:     base64.StdEncoding.EncodeToString(adminKubeconfig.Files()[0].Data),

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -31,7 +31,6 @@ type bootkubeTemplateData struct {
 	KubeCaKey                       string
 	McsTLSCert                      string
 	McsTLSKey                       string
-	OidcCaCert                      string
 	OpenshiftApiserverCert          string
 	OpenshiftApiserverKey           string
 	OpenshiftLoopbackKubeconfig     string


### PR DESCRIPTION
We set this in both `kube-apiserver-secret.go` and `openshift-apiserver-secret.go`, and we started setting this in db65ea27 (coreos/tectonic-installer#1811).  But we have been using the kube-ca value for it since at least 4d636d34 (#286) and I see [no other OpenShift consumers][1].

Fixes #564.

[1]: https://github.com/search?q=org%3Aopenshift+oidc-ca.crt&type=Code