### PR TITLE
pkg/rhcos/ami: Update name filter to "redhat-coreos-*"

### DIFF
--- a/pkg/rhcos/ami.go
+++ b/pkg/rhcos/ami.go
@@ -34,7 +34,7 @@ func AMI(ctx context.Context, channel, region string) (ami string, err error) {
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("name"),
-				Values: aws.StringSlice([]string{"rhcos*"}),
+				Values: aws.StringSlice([]string{"redhat-coreos-*"}),
 			},
 			{
 				Name:   aws.String("architecture"),


### PR DESCRIPTION
The OS folks have a new pipeline for publishing these AMIs, and they're setting these new names.  Current output:

```console
$ curl -sL https://rhcos-release-browser-coreos.int.open.paas.redhat.com/storage/releases/maipo/47.33/meta.json | jq .amis
[
  {
    "name": "us-east-1",
    "hvm": "ami-0fd0205c3c81d0412"
  }
]
$ AWS_DEFAULT_REGION=us-east-1 aws ec2 describe-images --image-ids ami-0fd0205c3c81d0412 --output json
{
   "Images": [
       {
           "VirtualizationType": "hvm",
           "Description": "Red Hat CoreOS \"maipo\" (OpenShift) 47.33",
           "Tags": [
               {
                   "Value": "redhat-coreos-maipo-47.33-hvm",
                   "Key": "Name"
               }
           ],
           "Hypervisor": "xen",
           "EnaSupport": true,
           "SriovNetSupport": "simple",
           "ImageId": "ami-0fd0205c3c81d0412",
           "State": "available",
           "BlockDeviceMappings": [
               {
                   "DeviceName": "/dev/xvda",
                   "Ebs": {
                       "Encrypted": false,
                       "DeleteOnTermination": true,
                       "VolumeType": "gp2",
                       "VolumeSize": 8,
                       "SnapshotId": "snap-08318a8024617da0b"
                   }
               },
               {
                   "DeviceName": "/dev/xvdb",
                   "VirtualName": "ephemeral0"
               }
           ],
           "Architecture": "x86_64",
           "ImageLocation": "531415883065/redhat-coreos-maipo-47.33-hvm",
           "RootDeviceType": "ebs",
           "OwnerId": "531415883065",
           "RootDeviceName": "/dev/xvda",
           "CreationDate": "2018-10-30T15:27:07.000Z",
           "Public": false,
           "ImageType": "machine",
           "Name": "redhat-coreos-maipo-47.33-hvm"
       }
   ]
}
```

For the previous pipeline, see the output in d01ac5d7 (#290).

CC @abhinavdahiya, @crawford, @cgwalters.