### PR TITLE
add secret etcd-client.kube-system

### DIFF
--- a/pkg/asset/manifests/content/bootkube/kube-system-secret-etcd-client.go
+++ b/pkg/asset/manifests/content/bootkube/kube-system-secret-etcd-client.go
@@ -1,0 +1,20 @@
+package bootkube
+
+import (
+	"text/template"
+)
+
+var (
+	// KubeSystemSecretEtcdClient is the constant to represent contents of kube-system-secret-etcd-client.yaml file
+	KubeSystemSecretEtcdClient = template.Must(template.New("kube-system-secret-etcd-client.yaml").Parse(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-client
+  namespace: kube-system
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .EtcdClientCert }}
+  tls.key: {{ .EtcdClientKey }}
+`))
+)

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -18,6 +18,8 @@ type cloudCredsSecretData struct {
 
 type bootkubeTemplateData struct {
 	Base64encodeCloudProviderConfig string
+	EtcdClientCert                  string
+	EtcdClientKey                   string
 	KubeCaCert                      string
 	KubeCaKey                       string
 	McsTLSCert                      string


### PR DESCRIPTION
Manifest to create this resources belongs in installer. The renderer in
cluster-kube-apiserver-operator will need to be also changed to stop
creating the same manifest file.