### PR TITLE
cvo-overrides: remove pod checkpointer operator

### DIFF
--- a/pkg/asset/manifests/content/bootkube/cvo-overrides.go
+++ b/pkg/asset/manifests/content/bootkube/cvo-overrides.go
@@ -34,13 +34,5 @@ overrides:
 - kind: APIService                    # packages.apps.redhat.com fails to start properly
   name: v1alpha1.packages.apps.redhat.com
   unmanaged: true
-- kind: Deployment                    # still testing this new component
-  namespace: kube-system
-  name: pod-checkpointer-operator
-  unmanaged: true
-- kind: Deployment                    # still testing this new component
-  namespace: openshift-pod-checkpointer
-  name: pod-checkpointer-operator
-  unmanaged: true
 `))
 )


### PR DESCRIPTION
pod-checkpointer-operator has been removed from the release image.

Going to leverage a static pod solution from @deads2k.