### PR TITLE
docs/dev/libvirt-howto: Masters lack the admin kubeconfig

### DIFF
--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -279,10 +279,10 @@ kubectl get -n tectonic-system pods
 ```
 
 Alternatively, you can run `kubectl` from the bootstrap or master nodes.
-[SSH in](#ssh-access), and run:
+Use `scp` or similar to transfer your local `${DIR}/auth/kubeconfig`, then [SSH in](#ssh-access) and run:
 
 ```sh
-export KUBECONFIG=/var/opt/tectonic/auth/kubeconfig
+export KUBECONFIG=/where/you/put/your/kubeconfig
 kubectl get --all-namespaces pods
 ```
 


### PR DESCRIPTION
Or at least, it's in what looks like an unreliable location ;).  Here's my local `kubeconfig`:

```console
$ sha1sum wking/auth/kubeconfig
dd7f1796fe5aed9b0f453498e60bfea9c6a56586  wking/auth/kubeconfig
```

And here's looking on master:

```console
[core@wking-master-0 ~]$ sudo find / -xdev -name 'kubeconfig*' -exec sha1sum {} \+ 2>/dev/null
aa7e5544c36f2b070c33cbbea12102d64bc52928  /sysroot/ostree/deploy/rhcos/var/lib/kubelet/kubeconfig
aa7e5544c36f2b070c33cbbea12102d64bc52928  /var/lib/kubelet/kubeconfig
227e8aa1c09c7b5f8602a5528077f3bd34b8544e  /etc/kubernetes/kubeconfig
dd7f1796fe5aed9b0f453498e60bfea9c6a56586  /etc/kubernetes/checkpoint-secrets/kube-system/pod-checkpointer-5crhb/controller-manager-kubeconfig/kubeconfig
[core@wking-master-0 ~]$ grep 'user: ' /etc/kubernetes/kubeconfig
    user: kubelet
```

Reaching into `checkpoint-secrets` is probably not what we want to recommend, so I'm suggesting folks just copy their `kubeconfig` over from their local host.

CC @alejovicu