### PR TITLE
data/data: update etcd srv records to cluster-name subdomain

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -117,11 +117,19 @@ resource "aws_route53_record" "etcd_a_nodes" {
   records = ["${module.masters.ip_addresses[count.index]}"]
 }
 
-resource "aws_route53_record" "etcd_cluster" {
+resource "aws_route53_record" "etcd_cluster_old_srvs" {
   type    = "SRV"
   ttl     = "60"
   zone_id = "${local.private_zone_id}"
   name    = "_etcd-server-ssl._tcp"
+  records = ["${formatlist("0 10 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)}"]
+}
+
+resource "aws_route53_record" "etcd_cluster" {
+  type    = "SRV"
+  ttl     = "60"
+  zone_id = "${local.private_zone_id}"
+  name    = "_etcd-server-ssl._tcp.${var.tectonic_cluster_name}"
   records = ["${formatlist("0 10 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)}"]
 }
 

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -51,6 +51,7 @@ resource "libvirt_network" "tectonic_net" {
 
     srvs = ["${flatten(list(
       data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered,
+      data.libvirt_network_dns_srv_template.etcd_cluster_old_srvs.*.rendered,
     ))}"]
 
     hosts = ["${flatten(list(
@@ -120,11 +121,21 @@ data "libvirt_network_dns_host_template" "workers" {
   hostname = "${var.tectonic_cluster_name}"
 }
 
-data "libvirt_network_dns_srv_template" "etcd_cluster" {
+data "libvirt_network_dns_srv_template" "etcd_cluster_old_srvs" {
   count    = "${var.tectonic_master_count}"
   service  = "etcd-server-ssl"
   protocol = "tcp"
   domain   = "${var.tectonic_base_domain}"
+  port     = 2380
+  weight   = 10
+  target   = "${var.tectonic_cluster_name}-etcd-${count.index}.${var.tectonic_base_domain}"
+}
+
+data "libvirt_network_dns_srv_template" "etcd_cluster" {
+  count    = "${var.tectonic_master_count}"
+  service  = "etcd-server-ssl"
+  protocol = "tcp"
+  domain   = "${var.tectonic_cluster_name}.${var.tectonic_base_domain}"
   port     = 2380
   weight   = 10
   target   = "${var.tectonic_cluster_name}-etcd-${count.index}.${var.tectonic_base_domain}"


### PR DESCRIPTION
https://github.com/openshift/installer/pull/526 added the etcd srv records on basedomain,
this can be problematic and might collide.
This was working on AWS right now due to the fact that we were using internal route53 zone.

This keeps the old srvs inplace for now, so that when MCO switches to these new records we can comeback and remove `*_old_srvs`

:innocent: 
/cc @crawford 