### PR TITLE
bootkube: set dial-timeout to 1 minute

### DIFF
--- a/pkg/asset/ignition/bootstrap/content/bootkube.go
+++ b/pkg/asset/ignition/bootstrap/content/bootkube.go
@@ -199,7 +199,7 @@ until podman run \
 		--volume /opt/tectonic/tls:/opt/tectonic/tls:ro,z \
 		"{{.EtcdctlImage}}" \
 		/usr/local/bin/etcdctl \
-		--dial-timeout=10m \
+		--dial-timeout=1m \
 		--cacert=/opt/tectonic/tls/etcd-client-ca.crt \
 		--cert=/opt/tectonic/tls/etcd-client.crt \
 		--key=/opt/tectonic/tls/etcd-client.key \


### PR DESCRIPTION
This change would ensure etcdctl is checking cluster health more often. 
This is important for BYOH installs, where masters are being configured 
much later after bootstrap node has started. Usually masters are being 
setup in ~2-3 mins after etcdctl is spawned and bootkube is waiting for 
~5 minutes to proceed