### PR TITLE
pkg/asset/machines/libvirt: allow empty machinepool

### DIFF
--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -17,7 +17,8 @@ func Machines(config *types.InstallConfig, pool *types.MachinePool, role, userDa
 	if configPlatform := config.Platform.Name(); configPlatform != types.PlatformNameLibvirt {
 		return nil, fmt.Errorf("non-Libvirt configuration: %q", configPlatform)
 	}
-	if poolPlatform := pool.Platform.Name(); poolPlatform != types.PlatformNameLibvirt {
+	// FIXME: empty is a valid case for Libvirt as we don't use it.
+	if poolPlatform := pool.Platform.Name(); poolPlatform != "" && poolPlatform != types.PlatformNameLibvirt {
 		return nil, fmt.Errorf("non-Libvirt machine-pool: %q", poolPlatform)
 	}
 	clustername := config.ObjectMeta.Name

--- a/pkg/asset/machines/libvirt/machinesets.go
+++ b/pkg/asset/machines/libvirt/machinesets.go
@@ -17,7 +17,8 @@ func MachineSets(config *types.InstallConfig, pool *types.MachinePool, role, use
 	if configPlatform := config.Platform.Name(); configPlatform != types.PlatformNameLibvirt {
 		return nil, fmt.Errorf("non-Libvirt configuration: %q", configPlatform)
 	}
-	if poolPlatform := pool.Platform.Name(); poolPlatform != types.PlatformNameLibvirt {
+	// FIXME: empty is a valid case for Libvirt as we don't use it.
+	if poolPlatform := pool.Platform.Name(); poolPlatform != "" && poolPlatform != types.PlatformNameLibvirt {
 		return nil, fmt.Errorf("non-Libvirt machine-pool: %q", poolPlatform)
 	}
 	clustername := config.ObjectMeta.Name


### PR DESCRIPTION
Empty machinepool is a valid for libvirt because we don't use it.

Fixes the error
```console
FATAL Error executing openshift-install: non-Libvirt machine-pool: ""
```
introduced in https://github.com/openshift/installer/pull/573
/cc @wking 