### PR TITLE
cmd/openshift-install/create: don't log nil errors

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -164,8 +164,9 @@ func destroyBootstrap(ctx context.Context, directory string) (err error) {
 		if err == nil {
 			logrus.Infof("API %s up", version)
 			cancel()
+		} else {
+			logrus.Debugf("API not up yet: %s", err)
 		}
-		logrus.Debugf("API not up yet: %s", err)
 	}, 2*time.Second, apiContext.Done())
 
 	events := client.CoreV1().Events("kube-system")


### PR DESCRIPTION
The call to cancel isn't a synchronous operation and the closure
executes to completion. As a result, the debug call which logs the error
should be in an else branch so it isn't printed if there is no error.
Without this change, the following would show up in the log:

    INFO API v1.11.0+d4cacc0 up
    DEBUG API not up yet: %!s(<nil>)