### PR TITLE
asset/ignition: fix bootkube and tectonic retries

### DIFF
--- a/pkg/asset/ignition/bootstrap/content/bootkube.go
+++ b/pkg/asset/ignition/bootstrap/content/bootkube.go
@@ -12,10 +12,10 @@ const (
 Description=Bootstrap a Kubernetes cluster
 Wants=kubelet.service
 After=kubelet.service
+ConditionPathExists=!/opt/tectonic/.bootkube.done
 
 [Service]
 WorkingDirectory=/opt/tectonic
-RemainAfterExit=true
 ExecStart=/usr/local/bin/bootkube.sh
 
 Restart=on-failure

--- a/pkg/asset/ignition/bootstrap/content/tectonic.go
+++ b/pkg/asset/ignition/bootstrap/content/tectonic.go
@@ -7,10 +7,10 @@ const (
 Description=Bootstrap a Tectonic cluster
 Wants=bootkube.service
 After=bootkube.service
+ConditionPathExists=!/opt/tectonic/.tectonic.done
 
 [Service]
 WorkingDirectory=/opt/tectonic/tectonic
-RemainAfterExit=true
 ExecStart=/usr/local/bin/tectonic.sh /opt/tectonic/auth/kubeconfig
 
 Restart=on-failure


### PR DESCRIPTION
Back in 54242f8, RemainAfterExit was added to prevent bootkube.service
and tectonic.service from running multiple times when progress.service
restarted. Due to a systemd bug [1], this causes the restart to be
ignored on those services.

This new approach uses conditions instead. This allows systemd to
activate the services but not actually start them if they have already
completed.

[1]: https://github.com/systemd/systemd/issues/3396