### PR TITLE
cmd/openshift-install/create: Retry watch connections

### DIFF
--- a/cmd/openshift-install/watch.go
+++ b/cmd/openshift-install/watch.go
@@ -24,7 +24,6 @@ type RetryWatcher struct {
 	watcherFunc         WatcherFunc
 	resultChan          chan watch.Event
 	stopChan            chan struct{}
-	doneChan            chan struct{}
 }
 
 // Until is from https://github.com/kubernetes/kubernetes/pull/50102.
@@ -38,7 +37,6 @@ func NewRetryWatcher(initialResourceVersion string, watcherFunc WatcherFunc) *Re
 		lastResourceVersion: initialResourceVersion,
 		watcherFunc:         watcherFunc,
 		stopChan:            make(chan struct{}),
-		doneChan:            make(chan struct{}),
 		resultChan:          make(chan watch.Event, 0),
 	}
 	go rw.receive()
@@ -133,7 +131,7 @@ func (rw *RetryWatcher) doReceive() bool {
 }
 
 func (rw *RetryWatcher) receive() {
-	defer close(rw.doneChan)
+	defer close(rw.resultChan)
 
 	for {
 		select {
@@ -157,9 +155,4 @@ func (rw *RetryWatcher) ResultChan() <-chan watch.Event {
 // Stop is from https://github.com/kubernetes/kubernetes/pull/50102.
 func (rw *RetryWatcher) Stop() {
 	close(rw.stopChan)
-}
-
-// Done is from https://github.com/kubernetes/kubernetes/pull/50102.
-func (rw *RetryWatcher) Done() <-chan struct{} {
-	return rw.doneChan
 }


### PR DESCRIPTION
It seems like we lose our watch when bootkube goes down.  From [this job][1]:

```console
$ oc project ci-op-9g1vhqtz
$ oc logs -f --timestamps e2e-aws -c setup | tee /tmp/setup.log
...
2018-11-03T04:19:55.121757935Z level=debug msg="added openshift-master-controllers.1563825412a4d77b: controller-manager-b5v49 became leader"
...
2018-11-03T04:20:14.679215171Z level=warning msg="RetryWatcher - getting event failed! Re-creating the watcher. Last RV: 3069"
2018-11-03T04:20:16.539967372Z level=debug msg="added bootstrap-complete: cluster bootstrapping has completed"
2018-11-03T04:20:16.540030121Z level=info msg="Destroying the bootstrap resources..."
...
```

And simultaneously:

```console
$ ssh -i libra.pem core@34.204.8.60 journalctl -f | tee /tmp/bootstrap.log
...
Nov 03 04:20:14 ip-10-0-10-86 bootkube.sh[1033]: All self-hosted control plane components successfully started
Nov 03 04:20:14 ip-10-0-10-86 bootkube.sh[1033]: Tearing down temporary bootstrap control plane...
Nov 03 04:20:15 ip-10-0-10-86 hyperkube[840]: E1103 04:20:15.968877     840 kuberuntime_container.go:65] Can't make a ref to pod "bootstrap-cluster-version-operator-ip-10-0-10-86_openshift-cluster-version(99ccfef8309f84bf88a0ca4a277097ac)", container cluster-version-operator: selfLink was empty, can't make reference
Nov 03 04:20:15 ip-10-0-10-86 hyperkube[840]: E1103 04:20:15.975624     840 kuberuntime_container.go:65] Can't make a ref to pod "bootstrap-kube-apiserver-ip-10-0-10-86_kube-system(427a4a342e137b5a9bb39a0feff24625)", container kube-apiserver: selfLink was empty, can't make reference
Nov 03 04:20:16 ip-10-0-10-86 hyperkube[840]: W1103 04:20:16.002990     840 pod_container_deletor.go:75] Container "0c647bcd6317ac2e06b625c44151aa6a3487aa1c47c5f1468213756f9a48ef91" not found in pod's containers
Nov 03 04:20:16 ip-10-0-10-86 hyperkube[840]: W1103 04:20:16.005146     840 pod_container_deletor.go:75] Container "bc47233151f1c0afaaee9e7abcfec9a515fe0a720ed2251fd7a51602c59060c5" not found in pod's containers
Nov 03 04:20:16 ip-10-0-10-86 systemd[1]: progress.service holdoff time over, scheduling restart.
Nov 03 04:20:16 ip-10-0-10-86 systemd[1]: Starting Report the completion of the cluster bootstrap process...
Nov 03 04:20:16 ip-10-0-10-86 systemd[1]: Started Report the completion of the cluster bootstrap process.
Nov 03 04:20:16 ip-10-0-10-86 report-progress.sh[6828]: Reporting install progress...
Nov 03 04:20:16 ip-10-0-10-86 report-progress.sh[6828]: event/bootstrap-complete created
Nov 03 04:20:16 ip-10-0-10-86 hyperkube[840]: I1103 04:20:16.719526     840 reconciler.go:181] operationExecutor.UnmountVolume started for volume "secrets" (UniqueName: "kubernetes.io/host-path/427a4a342e137b5a9bb39a0feff24625-secrets") pod "427a4a342e137b5a9bb39a0feff24625" (UID: "427a4a342e137b5a9bb39a0feff24625")
...
```

Ideally, the `resourceVersion` watch would allow the re-created watcher to [pick up where its predecessor left off][2].  But in at least [some cases][3], that doesn't seem to be happening:

```
2018/11/02 23:30:00 Running pod e2e-aws
2018/11/02 23:48:00 Container test in pod e2e-aws completed successfully
2018/11/02 23:51:52 Container teardown in pod e2e-aws completed successfully
2018/11/03 00:08:33 Copying artifacts from e2e-aws into /logs/artifacts/e2e-aws
level=debug msg="Fetching \"Terraform Variables\"..."
...
level=debug msg="added openshift-master-controllers.1563734e367132e0: controller-manager-xlw62 became leader"
level=warning msg="RetryWatcher - getting event failed! Re-creating the watcher. Last RV: 3288"
level=fatal msg="Error executing openshift-install: waiting for bootstrap-complete: timed out waiting for the condition"
2018/11/03 00:08:33 Container setup in pod e2e-aws failed, exit code 1, reason Error
```

That's unfortunately missing timestamps for the setup logs, but in the successful logs from ci-op-9g1vhqtz, you can see the `controller-manager` becoming a leader around 20 seconds before `bootstrap-complete`.  That means the `bootstrap-complete` event probably fired around when the watcher dropped, which was probably well before the setup container timed out (~38 minutes after it was launched).  The setup container timing out was probably the watch re-connect event hitting the 30 minute eventContext timeout.

I think what's happening is something like:

1. The pods bootkube is waiting for come up.
2. Bootkube tears itself down.
3. Our initial watch breaks.
4. The API becomes unstable.
5. Watch reconnects here hang forever.
6. The API stabilizes around the production control plane.
7. Watch reconnects here successfully reconnect and pick up where the broken watch left off.

With this commit, I've added a short sleep to the watch re-connect.  Hopefully this is enough to more consistently put us into step 7; as it stands in master now we seem to be about evenly split between 5 and 7.

A more robust approach would be to put a short connection timeout on the watch re-connect, so that even when we did end up in case 5, we'd give up before too long and re-try, with the second re-connect attemp ending up in case 7.  But I'm currently not clear on how to code that up.

CC @abhinavdahiya, @crawford

[1]: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_installer/595/pull-ci-openshift-installer-master-e2e-aws/1173
[2]: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency
[3]: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-version-operator/45/pull-ci-openshift-cluster-version-operator-master-e2e-aws/58/build-log.txt