### PR TITLE
data/aws: Move S3 bucket to bootstrap module

### DIFF
--- a/data/data/aws/bootstrap/README.md
+++ b/data/data/aws/bootstrap/README.md
@@ -12,9 +12,6 @@ provider "aws" {
   region = "us-east-1"
 }
 
-resource "aws_s3_bucket" "example" {
-}
-
 resource "aws_vpc" "example" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
@@ -30,7 +27,6 @@ module "bootstrap" {
   source = "github.com/openshift/installer//data/data/aws/bootstrap"
 
   ami            = "ami-0af8953af3ec06b7c"
-  bucket         = "${aws_s3_bucket.example.id}"
   cluster_name   = "my-cluster"
   ignition       = "{\"ignition\": {\"version\": \"2.2.0\"}}",
   subnet_id      = "${aws_subnet.example.id}"

--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -1,5 +1,15 @@
+resource "aws_s3_bucket" "ignition" {
+  acl = "private"
+
+  tags = "${var.tags}"
+
+  lifecycle {
+    ignore_changes = ["*"]
+  }
+}
+
 resource "aws_s3_bucket_object" "ignition" {
-  bucket  = "${var.bucket}"
+  bucket  = "${aws_s3_bucket.ignition.id}"
   key     = "bootstrap.ign"
   content = "${var.ignition}"
   acl     = "private"
@@ -15,7 +25,7 @@ resource "aws_s3_bucket_object" "ignition" {
 
 data "ignition_config" "redirect" {
   replace {
-    source = "s3://${var.bucket}/bootstrap.ign"
+    source = "s3://${aws_s3_bucket.ignition.id}/bootstrap.ign"
   }
 }
 

--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -8,11 +8,6 @@ variable "associate_public_ip_address" {
   description = "If set to true, public-facing ingress resources are created."
 }
 
-variable "bucket" {
-  type        = "string"
-  description = "The S3 bucket name or ID for bootstrap ignition file."
-}
-
 variable "cluster_name" {
   type        = "string"
   description = "The name of the cluster."

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -19,7 +19,6 @@ module "bootstrap" {
 
   ami                              = "${var.tectonic_aws_ec2_ami_override}"
   associate_public_ip_address      = "${var.tectonic_aws_endpoints != "private"}"
-  bucket                           = "${aws_s3_bucket.bootstrap.id}"
   cluster_name                     = "${var.tectonic_cluster_name}"
   public_target_group_arns         = "${module.vpc.aws_lb_public_target_group_arns}"
   public_target_group_arns_length  = "${module.vpc.aws_lb_public_target_group_arns_length}"
@@ -135,18 +134,4 @@ resource "aws_route53_zone" "tectonic_int" {
       "KubernetesCluster", "${var.tectonic_cluster_name}",
       "tectonicClusterID", "${var.tectonic_cluster_id}"
     ), var.tectonic_aws_extra_tags)}"
-}
-
-resource "aws_s3_bucket" "bootstrap" {
-  acl = "private"
-
-  tags = "${merge(map(
-      "Name", "${var.tectonic_cluster_name}-tectonic",
-      "KubernetesCluster", "${var.tectonic_cluster_name}",
-      "tectonicClusterID", "${var.tectonic_cluster_id}"
-    ), var.tectonic_aws_extra_tags)}"
-
-  lifecycle {
-    ignore_changes = ["*"]
-  }
 }


### PR DESCRIPTION
Since 3f4fe574 (#493), the bootstrap module is targeted for deletion by `destroy bootstrap`.  Moving the S3 bucket into the module means that the bucket, which we only use for hosting the bootstrap Ignition configuration, will be removed along with the rest of the bootstrap resources.