### PR TITLE
data/aws: Consolidate pivate and public load balancer target groups

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -130,16 +130,9 @@ resource "aws_instance" "bootstrap" {
   volume_tags = "${var.tags}"
 }
 
-resource "aws_lb_target_group_attachment" "public" {
-  count = "${var.public_target_group_arns_length}"
+resource "aws_lb_target_group_attachment" "bootstrap" {
+  count = "${var.target_group_arns_length}"
 
-  target_group_arn = "${var.public_target_group_arns[count.index]}"
-  target_id        = "${aws_instance.bootstrap.private_ip}"
-}
-
-resource "aws_lb_target_group_attachment" "private" {
-  count = "${var.private_target_group_arns_length}"
-
-  target_group_arn = "${var.private_target_group_arns[count.index]}"
+  target_group_arn = "${var.target_group_arns[count.index]}"
   target_id        = "${aws_instance.bootstrap.private_ip}"
 }

--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -30,26 +30,6 @@ variable "instance_type" {
   description = "The EC2 instance type for the bootstrap node."
 }
 
-variable "private_target_group_arns" {
-  type        = "list"
-  default     = []
-  description = "The list of target group ARNs for the private load balancer."
-}
-
-variable "private_target_group_arns_length" {
-  description = "The length of the 'private_target_group_arns' variable, to work around https://github.com/hashicorp/terraform/issues/12570."
-}
-
-variable "public_target_group_arns" {
-  type        = "list"
-  default     = []
-  description = "The list of target group ARNs for the public load balancer."
-}
-
-variable "public_target_group_arns_length" {
-  description = "The length of the 'public_target_group_arns' variable, to work around https://github.com/hashicorp/terraform/issues/12570."
-}
-
 variable "subnet_id" {
   type        = "string"
   description = "The subnet ID for the bootstrap node."
@@ -59,6 +39,16 @@ variable "tags" {
   type        = "map"
   default     = {}
   description = "AWS tags to be applied to created resources."
+}
+
+variable "target_group_arns" {
+  type        = "list"
+  default     = []
+  description = "The list of target group ARNs for the load balancer."
+}
+
+variable "target_group_arns_length" {
+  description = "The length of the 'target_group_arns' variable, to work around https://github.com/hashicorp/terraform/issues/12570."
 }
 
 variable "volume_iops" {

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -17,17 +17,15 @@ provider "aws" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  ami                              = "${var.tectonic_aws_ec2_ami_override}"
-  associate_public_ip_address      = "${var.tectonic_aws_endpoints != "private"}"
-  cluster_name                     = "${var.tectonic_cluster_name}"
-  public_target_group_arns         = "${module.vpc.aws_lb_public_target_group_arns}"
-  public_target_group_arns_length  = "${module.vpc.aws_lb_public_target_group_arns_length}"
-  private_target_group_arns        = "${module.vpc.aws_lb_private_target_group_arns}"
-  private_target_group_arns_length = "${module.vpc.aws_lb_private_target_group_arns_length}"
-  iam_role                         = "${var.tectonic_aws_master_iam_role_name}"
-  ignition                         = "${var.ignition_bootstrap}"
-  subnet_id                        = "${module.vpc.master_subnet_ids[0]}"
-  vpc_security_group_ids           = ["${concat(var.tectonic_aws_master_extra_sg_ids, list(module.vpc.master_sg_id))}"]
+  ami                         = "${var.tectonic_aws_ec2_ami_override}"
+  associate_public_ip_address = "${var.tectonic_aws_endpoints != "private"}"
+  cluster_name                = "${var.tectonic_cluster_name}"
+  iam_role                    = "${var.tectonic_aws_master_iam_role_name}"
+  ignition                    = "${var.ignition_bootstrap}"
+  subnet_id                   = "${module.vpc.master_subnet_ids[0]}"
+  target_group_arns           = "${module.vpc.aws_lb_target_group_arns}"
+  target_group_arns_length    = "${module.vpc.aws_lb_target_group_arns_length}"
+  vpc_security_group_ids      = ["${concat(var.tectonic_aws_master_extra_sg_ids, list(module.vpc.master_sg_id))}"]
 
   tags = "${merge(map(
       "Name", "${var.tectonic_cluster_name}-bootstrap",
@@ -38,26 +36,23 @@ module "bootstrap" {
 module "masters" {
   source = "./master"
 
-  public_target_group_arns         = "${module.vpc.aws_lb_public_target_group_arns}"
-  public_target_group_arns_length  = "${module.vpc.aws_lb_public_target_group_arns_length}"
-  private_target_group_arns        = "${module.vpc.aws_lb_private_target_group_arns}"
-  private_target_group_arns_length = "${module.vpc.aws_lb_private_target_group_arns_length}"
-  base_domain                      = "${var.tectonic_base_domain}"
-  cluster_id                       = "${var.tectonic_cluster_id}"
-  cluster_name                     = "${var.tectonic_cluster_name}"
-  ec2_type                         = "${var.tectonic_aws_master_ec2_type}"
-  extra_tags                       = "${var.tectonic_aws_extra_tags}"
-  instance_count                   = "${var.tectonic_master_count}"
-  master_iam_role                  = "${var.tectonic_aws_master_iam_role_name}"
-  master_sg_ids                    = "${concat(var.tectonic_aws_master_extra_sg_ids, list(module.vpc.master_sg_id))}"
-  private_endpoints                = "${local.private_endpoints}"
-  public_endpoints                 = "${local.public_endpoints}"
-  root_volume_iops                 = "${var.tectonic_aws_master_root_volume_iops}"
-  root_volume_size                 = "${var.tectonic_aws_master_root_volume_size}"
-  root_volume_type                 = "${var.tectonic_aws_master_root_volume_type}"
-  subnet_ids                       = "${module.vpc.master_subnet_ids}"
-  ec2_ami                          = "${var.tectonic_aws_ec2_ami_override}"
-  user_data_ign                    = "${var.ignition_master}"
+  base_domain              = "${var.tectonic_base_domain}"
+  cluster_id               = "${var.tectonic_cluster_id}"
+  cluster_name             = "${var.tectonic_cluster_name}"
+  ec2_type                 = "${var.tectonic_aws_master_ec2_type}"
+  extra_tags               = "${var.tectonic_aws_extra_tags}"
+  instance_count           = "${var.tectonic_master_count}"
+  master_iam_role          = "${var.tectonic_aws_master_iam_role_name}"
+  master_sg_ids            = "${concat(var.tectonic_aws_master_extra_sg_ids, list(module.vpc.master_sg_id))}"
+  public_endpoints         = "${local.public_endpoints}"
+  root_volume_iops         = "${var.tectonic_aws_master_root_volume_iops}"
+  root_volume_size         = "${var.tectonic_aws_master_root_volume_size}"
+  root_volume_type         = "${var.tectonic_aws_master_root_volume_type}"
+  subnet_ids               = "${module.vpc.master_subnet_ids}"
+  target_group_arns        = "${module.vpc.aws_lb_target_group_arns}"
+  target_group_arns_length = "${module.vpc.aws_lb_target_group_arns_length}"
+  ec2_ami                  = "${var.tectonic_aws_ec2_ami_override}"
+  user_data_ign            = "${var.ignition_master}"
 }
 
 module "iam" {

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -113,16 +113,9 @@ resource "aws_instance" "master" {
   ), var.extra_tags)}"
 }
 
-resource "aws_lb_target_group_attachment" "public" {
-  count = "${var.public_endpoints ? var.instance_count * var.public_target_group_arns_length : 0}"
+resource "aws_lb_target_group_attachment" "master" {
+  count = "${var.instance_count * var.target_group_arns_length}"
 
-  target_group_arn = "${var.public_target_group_arns[count.index % var.public_target_group_arns_length]}"
-  target_id        = "${aws_instance.master.*.private_ip[count.index / var.public_target_group_arns_length]}"
-}
-
-resource "aws_lb_target_group_attachment" "private" {
-  count = "${var.private_endpoints ? var.instance_count * var.private_target_group_arns_length : 0}"
-
-  target_group_arn = "${var.private_target_group_arns[count.index % var.private_target_group_arns_length]}"
-  target_id        = "${aws_instance.master.*.private_ip[count.index / var.private_target_group_arns_length]}"
+  target_group_arn = "${var.target_group_arns[count.index % var.target_group_arns_length]}"
+  target_id        = "${aws_instance.master.*.private_ip[count.index / var.target_group_arns_length]}"
 }

--- a/data/data/aws/master/variables.tf
+++ b/data/data/aws/master/variables.tf
@@ -11,6 +11,11 @@ variable "cluster_name" {
   type = "string"
 }
 
+variable "dns_server_ip" {
+  type    = "string"
+  default = ""
+}
+
 variable "ec2_type" {
   type = "string"
 }
@@ -30,6 +35,11 @@ variable "instance_count" {
   type = "string"
 }
 
+variable "kubeconfig_content" {
+  type    = "string"
+  default = ""
+}
+
 variable "master_iam_role" {
   type        = "string"
   default     = ""
@@ -41,34 +51,9 @@ variable "master_sg_ids" {
   description = "The security group IDs to be applied to the master nodes."
 }
 
-variable "private_endpoints" {
-  description = "If set to true, private-facing ingress resources are created."
-  default     = true
-}
-
-variable "private_target_group_arns" {
-  type        = "list"
-  default     = []
-  description = "The list of target group ARNs for the private load balancer."
-}
-
-variable "private_target_group_arns_length" {
-  description = "The length of the 'private_target_group_arns' variable, to work around https://github.com/hashicorp/terraform/issues/12570."
-}
-
 variable "public_endpoints" {
   description = "If set to true, public-facing ingress resources are created."
   default     = true
-}
-
-variable "public_target_group_arns" {
-  type        = "list"
-  default     = []
-  description = "The list of target group ARNs for the public load balancer."
-}
-
-variable "public_target_group_arns_length" {
-  description = "The length of the 'public_target_group_arns' variable, to work around https://github.com/hashicorp/terraform/issues/12570."
 }
 
 variable "root_volume_iops" {
@@ -91,14 +76,14 @@ variable "subnet_ids" {
   type = "list"
 }
 
-variable "dns_server_ip" {
-  type    = "string"
-  default = ""
+variable "target_group_arns" {
+  type        = "list"
+  default     = []
+  description = "The list of target group ARNs for the load balancer."
 }
 
-variable "kubeconfig_content" {
-  type    = "string"
-  default = ""
+variable "target_group_arns_length" {
+  description = "The length of the 'target_group_arns' variable, to work around https://github.com/hashicorp/terraform/issues/12570."
 }
 
 variable "user_data_ign" {

--- a/data/data/aws/vpc/outputs.tf
+++ b/data/data/aws/vpc/outputs.tf
@@ -26,20 +26,12 @@ output "console_sg_id" {
   value = "${aws_security_group.console.id}"
 }
 
-output "aws_lb_private_target_group_arns" {
-  value = "${compact(concat(aws_lb_target_group.api_internal.*.arn, aws_lb_target_group.services.*.arn))}"
+output "aws_lb_target_group_arns" {
+  value = "${compact(concat(aws_lb_target_group.api_internal.*.arn, aws_lb_target_group.services.*.arn, aws_lb_target_group.api_external.*.arn))}"
 }
 
-output "aws_lb_private_target_group_arns_length" {
-  value = "${var.private_master_endpoints ? 2 : 0}"
-}
-
-output "aws_lb_public_target_group_arns" {
-  value = "${compact(concat(aws_lb_target_group.api_external.*.arn))}"
-}
-
-output "aws_lb_public_target_group_arns_length" {
-  value = "${var.public_master_endpoints ? 1 : 0}"
+output "aws_lb_target_group_arns_length" {
+  value = "${(var.private_master_endpoints ? 2 : 0) + (var.public_master_endpoints ? 1 : 0)}"
 }
 
 output "aws_lb_api_external_dns_name" {


### PR DESCRIPTION
The listeners may be private or public, but as far as the bootstrap and master modules are concerned, these are just lists of ARNs that need attaching.  This partially unwinds changes from 16dfbb35 (#594), before which the bootstrap module used a unified list of load balancers while the master module made private/public distinctions.

CC @crawford