### PR TITLE
openstack: Cloud config install config

### DIFF
--- a/data/data/manifests/bootkube/kube-cloud-config.yaml
+++ b/data/data/manifests/bootkube/kube-cloud-config.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: kube-system
 type: Opaque
 data:
-  config: ""
+  config:
+    {{.CloudProviderConfig | indent 4}}

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -138,22 +138,27 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		etcdEndpointHostnames[i] = fmt.Sprintf("%s-etcd-%d", installConfig.Config.ObjectMeta.Name, i)
 	}
 
+	platformConfig, err := yaml.Marshal(installConfig.Config.Platform)
+	if err != nil {
+		panic(err)
+	}
+
 	templateData := &bootkubeTemplateData{
-		Base64encodeCloudProviderConfig: "", // FIXME
-		EtcdCaCert:                      string(etcdCA.Cert()),
-		EtcdClientCert:                  base64.StdEncoding.EncodeToString(etcdClientCertKey.Cert()),
-		EtcdClientKey:                   base64.StdEncoding.EncodeToString(etcdClientCertKey.Key()),
-		KubeCaCert:                      base64.StdEncoding.EncodeToString(kubeCA.Cert()),
-		KubeCaKey:                       base64.StdEncoding.EncodeToString(kubeCA.Key()),
-		McsTLSCert:                      base64.StdEncoding.EncodeToString(mcsCertKey.Cert()),
-		McsTLSKey:                       base64.StdEncoding.EncodeToString(mcsCertKey.Key()),
-		PullSecret:                      base64.StdEncoding.EncodeToString([]byte(installConfig.Config.PullSecret)),
-		RootCaCert:                      string(rootCA.Cert()),
-		ServiceServingCaCert:            base64.StdEncoding.EncodeToString(serviceServingCA.Cert()),
-		ServiceServingCaKey:             base64.StdEncoding.EncodeToString(serviceServingCA.Key()),
-		CVOClusterID:                    installConfig.Config.ClusterID,
-		EtcdEndpointHostnames:           etcdEndpointHostnames,
-		EtcdEndpointDNSSuffix:           installConfig.Config.BaseDomain,
+		CloudProviderConfig:   string(platformConfig),
+		EtcdCaCert:            string(etcdCA.Cert()),
+		EtcdClientCert:        base64.StdEncoding.EncodeToString(etcdClientCertKey.Cert()),
+		EtcdClientKey:         base64.StdEncoding.EncodeToString(etcdClientCertKey.Key()),
+		KubeCaCert:            base64.StdEncoding.EncodeToString(kubeCA.Cert()),
+		KubeCaKey:             base64.StdEncoding.EncodeToString(kubeCA.Key()),
+		McsTLSCert:            base64.StdEncoding.EncodeToString(mcsCertKey.Cert()),
+		McsTLSKey:             base64.StdEncoding.EncodeToString(mcsCertKey.Key()),
+		PullSecret:            base64.StdEncoding.EncodeToString([]byte(installConfig.Config.PullSecret)),
+		RootCaCert:            string(rootCA.Cert()),
+		ServiceServingCaCert:  base64.StdEncoding.EncodeToString(serviceServingCA.Cert()),
+		ServiceServingCaKey:   base64.StdEncoding.EncodeToString(serviceServingCA.Key()),
+		CVOClusterID:          installConfig.Config.ClusterID,
+		EtcdEndpointHostnames: etcdEndpointHostnames,
+		EtcdEndpointDNSSuffix: installConfig.Config.BaseDomain,
 	}
 
 	kubeCloudConfig := &bootkube.KubeCloudConfig{}

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -17,22 +17,22 @@ type cloudCredsSecretData struct {
 }
 
 type bootkubeTemplateData struct {
-	Base64encodeCloudProviderConfig string
-	EtcdCaCert                      string
-	EtcdClientCert                  string
-	EtcdClientKey                   string
-	KubeCaCert                      string
-	KubeCaKey                       string
-	McsTLSCert                      string
-	McsTLSKey                       string
-	PullSecret                      string
-	RootCaCert                      string
-	ServiceServingCaCert            string
-	ServiceServingCaKey             string
-	WorkerIgnConfig                 string
-	CVOClusterID                    string
-	EtcdEndpointHostnames           []string
-	EtcdEndpointDNSSuffix           string
+	CloudProviderConfig   string
+	EtcdCaCert            string
+	EtcdClientCert        string
+	EtcdClientKey         string
+	KubeCaCert            string
+	KubeCaKey             string
+	McsTLSCert            string
+	McsTLSKey             string
+	PullSecret            string
+	RootCaCert            string
+	ServiceServingCaCert  string
+	ServiceServingCaKey   string
+	WorkerIgnConfig       string
+	CVOClusterID          string
+	EtcdEndpointHostnames []string
+	EtcdEndpointDNSSuffix string
 }
 
 type tectonicTemplateData struct {

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -1,5 +1,9 @@
 package openstack
 
+import (
+	"github.com/gophercloud/utils/openstack/clientconfig"
+)
+
 // Platform stores all the global configuration that all
 // machinesets use.
 type Platform struct {
@@ -22,6 +26,9 @@ type Platform struct {
 	// Cloud
 	// Name of OpenStack cloud to use from clouds.yaml
 	Cloud string `json:"cloud"`
+
+	// Cloud config instance
+	CloudConfig *clientconfig.Cloud
 
 	// ExternalNetwork
 	// The OpenStack external network to be used for installation.


### PR DESCRIPTION
We need to pass the cloud's config data to the MCO in order to be able
to configure the cloud provider openstack. This commit passes such data
as part of the platform configuration since MCO consumes install-config
to get the cluster conifguration.

As part of this commit, we're now also validating the user's input to
verify whether the cloud name passed is correct.

This PR depends on #588 