### PR TITLE
Pass cluster CIDR info to controller-manager render call during bootstrap

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -68,7 +68,8 @@ then
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-controller-manager-bootstrap \
 		--config-output-file=/assets/kube-controller-manager-bootstrap/config \
-		--config-override-files=/assets/bootkube-config-overrides/kube-controller-manager-config-overrides.yaml
+		--config-override-files=/assets/bootkube-config-overrides/kube-controller-manager-config-overrides.yaml \
+		--cluster-config-file=/assets/tectonic/99_openshift-cluster-api_cluster.yaml
 
 	cp kube-controller-manager-bootstrap/config /etc/kubernetes/bootstrap-configs/kube-controller-manager-config.yaml
 	cp kube-controller-manager-bootstrap/bootstrap-manifests/* bootstrap-manifests/


### PR DESCRIPTION
Depends on https://github.com/openshift/cluster-kube-controller-manager-operator/pull/76

Pass the cluster api config file to `cluster-kube-controller-manager-operator` so that it can render restricted CIDRs parsed from that file for bootstrapping