### PR TITLE
pkg/destroy/bootstrap: Remove bootstrap from DNS for libvirt

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -91,6 +91,7 @@ resource "libvirt_domain" "master" {
 }
 
 data "libvirt_network_dns_host_template" "bootstrap" {
+  count    = "${var.bootstrap_dns ? 1 : 0}"
   ip       = "${var.tectonic_libvirt_bootstrap_ip}"
   hostname = "${var.tectonic_cluster_name}-api"
 }

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -1,3 +1,8 @@
+variable "bootstrap_dns" {
+  default     = true
+  description = "Whether to include DNS entries for the bootstrap node or not."
+}
+
 variable "tectonic_libvirt_uri" {
   type        = "string"
   description = "libvirt connection URI"


### PR DESCRIPTION
Without this, round-robin clients will fail when they hit the bootstrap DNS entry (after the bootstrap node stops serving its control plane).

The implementation is a bit awkward; I'd have preferred the AWS approach, with:

```hcl
resource "aws_lb_target_group_attachment" "bootstrap" {
  count = "${var.target_group_arns_length}"

  target_group_arn = "${var.target_group_arns[count.index]}"
  target_id        = "${aws_instance.bootstrap.private_ip}"
}
```

in the bootstrap module.  But the libvirt host entries are only available as a subsection of a `libvirt_network` resource (because the whole network is defined in a single XML object, [including the DNS entries][1]).  So instead I've added an additional variable which we can tweak to disable the bootstrap entry.  The default value for the new variable includes the bootstrap entry for the initial cluster `apply` call; on destry I override it via an `*.auto.tfvars` file ([which Terraform loads automatically][2]) to remove the bootstrap entry.

CC @sjenning

[1]: https://libvirt.org/formatnetwork.html#elementsAddress
[2]: https://www.terraform.io/docs/configuration/variables.html