### PR TITLE
bootkube: remove ctrl mgr --disable-phase-2 after default change

### DIFF
--- a/pkg/asset/ignition/bootstrap/content/bootkube.go
+++ b/pkg/asset/ignition/bootstrap/content/bootkube.go
@@ -96,8 +96,7 @@ then
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-controller-manager-bootstrap \
 		--config-output-file=/assets/kube-controller-manager-bootstrap/config \
-		--config-override-files=/assets/bootkube-config-overrides/kube-controller-manager-config-overrides.yaml \
-		--disable-phase-2
+		--config-override-files=/assets/bootkube-config-overrides/kube-controller-manager-config-overrides.yaml
 
 	cp kube-controller-manager-bootstrap/config /etc/kubernetes/bootstrap-configs/kube-controller-manager-config.yaml
 	cp kube-controller-manager-bootstrap/bootstrap-manifests/* bootstrap-manifests/


### PR DESCRIPTION
Clone of https://github.com/openshift/installer/pull/583 for controller manager.

Follow-up of https://github.com/openshift/cluster-kube-controller-manager-operator/pull/74 as the default changed and the flag is not necessary anymore.