### PR TITLE
Add OpenStack team as reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,5 +3,6 @@
 
 approvers:
   - installer-approvers
+  - openstack-approvers
 reviewers:
   - installer-reviewers


### PR DESCRIPTION
As the work progresses and the familiarity with the code base grows, it
would be ideal for the OpenStack team to join the reviewers team and
help with specific and more focused reviews.

Specifically, the team is interested in reviewing OpenStack related
patches (like #588 ) in order to ease the workload from the rest of the
team.

The OpenStack team won't be reviewing patches outside their area of
competence.

@hardys @tomassedovic @russellb FYI