### PR TITLE
manifests: add config map for root-ca

### DIFF
--- a/pkg/asset/manifests/content/bootkube/kube-system-configmap-root-ca.go
+++ b/pkg/asset/manifests/content/bootkube/kube-system-configmap-root-ca.go
@@ -1,0 +1,17 @@
+package bootkube
+
+import "text/template"
+
+var (
+	// KubeSystemConfigmapRootCA  is the constant to represent contents of kube-system-configmap-root-ca.yaml file
+	KubeSystemConfigmapRootCA = template.Must(template.New("kube-system-configmap-root-ca.yaml").Parse(`
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: root-ca
+  namespace: kube-system
+data:
+  ca.crt: {{.RootCaCert}}
+`))
+)

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -141,6 +141,7 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		"legacy-cvo-overrides.yaml":                  applyTemplateData(bootkube.LegacyCVOOverrides, templateData),
 		"etcd-service-endpoints.yaml":                applyTemplateData(bootkube.EtcdServiceEndpointsKubeSystem, templateData),
 		"kube-system-configmap-etcd-serving-ca.yaml": applyTemplateData(bootkube.KubeSystemConfigmapEtcdServingCA, templateData),
+		"kube-system-configmap-root-ca.yaml":         applyTemplateData(bootkube.KubeSystemConfigmapRootCA, templateData),
 		"kube-system-secret-etcd-client.yaml":        applyTemplateData(bootkube.KubeSystemSecretEtcdClient, templateData),
 
 		"01-tectonic-namespace.yaml":                 []byte(bootkube.TectonicNamespace),


### PR DESCRIPTION
operators like MachineConfigOperator can use this configmap to sync up the root ca
that needs to be provided to nodes.