### PR TITLE
scripts for nested-libvirt ci

### DIFF
--- a/images/nested-libvirt/Dockerfile
+++ b/images/nested-libvirt/Dockerfile
@@ -1,0 +1,21 @@
+# This Dockerfile is a used by CI to test a libvirt cluster launched in a gce instance
+# It builds an image containing google-cloud-sdk, ns_wrapper and scripts to launch a VM for a libvirt install.
+FROM openshift/origin-release:golang-1.10 AS build
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN hack/build.sh && hack/get-terraform.sh
+
+FROM centos:7
+COPY --from=build /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=build /go/src/github.com/openshift/installer/bin/terraform /bin/terraform
+COPY --from=build /go/src/github.com/openshift/installer/images/nested-libvirt/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
+COPY --from=build /go/src/github.com/openshift/installer/images/nested-libvirt/mock-nss.sh /bin/mock-nss.sh
+
+RUN yum install -y \
+    epel-release \
+    gettext \
+    google-cloud-sdk \
+    openssh-clients && \
+    yum --enablerepo=epel-testing install -y nss_wrapper && \
+    yum -y update && \
+    yum clean all

--- a/images/nested-libvirt/README.md
+++ b/images/nested-libvirt/README.md
@@ -1,0 +1,52 @@
+# Nested libvirt on GCE
+
+This image enables launching a libvirt cluster nested in a GCE instance, for libvirt CI testing.
+
+This image contains [`nss_wrapper`](https://cwrap.org/nss_wrapper.html) to execute `ssh` commands as
+a mock user to interact with a GCE instance from an OpenShift container.
+
+OpenShift containers run with an arbitrary uid, but SSH requires a valid user.  `nss_wrapper`
+allows for the container's user ID to be mapped to a username inside of a container.
+
+### Example Usage
+
+You can override the container's current user ID and group ID by providing `NSS_WRAPPER_GROUP`
+and `NSS_WRAPPER_PASSWD` for the mock files, as well as `NSS_USERNAME`, `NSS_UID`, `NSS_GROUPNAME`,
+and/or `NSS_GID`. In OpenShift CI, `NSS_USERNAME` and `NSS_GROUPNAME` are set.
+The random UID assigned to the container is the UID that the mock username is mapped to.
+
+```console
+$ podman run --rm \
+>   -e NSS_WRAPPER_GROUP=/tmp/group \
+>   -e NSS_WRAPPER_PASSWD=/tmp/passwd \
+>   -e NSS_UID=1000 \
+>   -e NSS_GID=1000 \
+>   -e NSS_USERNAME=testuser \
+>   -e NSS_GROUPNAME=testuser \
+>   nss_wrapper_img mock-nss.sh id testuser
+uid=1000(testuser) gid=1000(testuser) groups=1000(testuser)
+```
+
+Or, in an OpenShift container:
+
+```yaml
+containers:
+- name: setup
+  image: nss-wrapper-image
+  env:
+  - name: NSS_WRAPPER_PASSWD
+    value: /tmp/passwd
+  - name: NSS_WRAPPER_GROUP
+    value: /tmp/group
+  - name: NSS_USERNAME
+    value: mockuser
+  - name: NSS_GROUPNAME
+    value: mockuser
+  command:
+  - /bin/sh
+  - -c
+  - |
+    #!/bin/sh
+    mock-nss.sh
+    LD_PRELOAD=/usr/lib64/libnss_wrapper.so gcloud compute scp [gcloud scp args]
+```

--- a/images/nested-libvirt/google-cloud-sdk.repo
+++ b/images/nested-libvirt/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/images/nested-libvirt/mock-nss.sh
+++ b/images/nested-libvirt/mock-nss.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# mock passwd and group files
+(
+  exec 2>/dev/null
+  username="${NSS_USERNAME:-$(id -un)}"
+  uid="${NSS_UID:-$(id -u)}"
+
+  groupname="${NSS_GROUPNAME:-$(id -gn)}"
+  gid="${NSS_GID:-$(id -g)}"
+
+  echo "${username}:x:${uid}:${uid}:gecos:${HOME}:/bin/bash" > "${NSS_WRAPPER_PASSWD}"
+  echo "${groupname}:x:${gid}:" > "${NSS_WRAPPER_GROUP}"
+)
+
+# wrap command
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+exec "$@"


### PR DESCRIPTION
This PR enables testing of libvirt cluster in a GCE instance, for a CI job to ensure developer libvirt workflow is not broken.
* for use with this: https://github.com/openshift/release/pull/2078
* can test with this: https://github.com/sallyom/installer-e2e/blob/master/templates/nested-libvirt-installer-e2e-modified.yaml until 2078 merges
    