### PR TITLE
pkg/tfvars/libvirt/cache: Remove .gz suffix handling

### DIFF
--- a/pkg/tfvars/libvirt/cache.go
+++ b/pkg/tfvars/libvirt/cache.go
@@ -1,7 +1,6 @@
 package libvirt
 
 import (
-	"compress/gzip"
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
@@ -76,16 +75,7 @@ func (libvirt *Libvirt) UseCachedImage() (err error) {
 			return err
 		}
 
-		var reader io.Reader
-		if strings.HasSuffix(libvirt.Image, ".gz") {
-			reader, err = gzip.NewReader(resp.Body)
-			if err != nil {
-				return err
-			}
-		} else {
-			reader = resp.Body
-		}
-		err = cacheImage(reader, imagePath)
+		err = cacheImage(resp.Body, imagePath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The new pipeline handles Content-Encoding gzip:

```console
$ curl -LI --compressed https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/47.73/redhat-coreos-maipo-47.73-qemu.qcow2
HTTP/1.1 302 Moved Temporarily
Server: nginx/1.12.1
Date: Tue, 06 Nov 2018 20:55:06 GMT
Content-Type: text/html
Content-Length: 161
Location: https://d26v6vn1y7q7fv.cloudfront.net/releases/maipo/47.73/redhat-coreos-maipo-47.73-qemu.qcow2
Set-Cookie: ...; path=/; HttpOnly; Secure

HTTP/1.1 200 OK
Content-Type: binary/octet-stream
Content-Length: 726878219
Connection: keep-alive
Date: Tue, 06 Nov 2018 20:23:37 GMT
Last-Modified: Tue, 06 Nov 2018 17:56:36 GMT
ETag: "021080ef3b515d2443be3749ebbb0b08-87"
Content-Encoding: gzip
Accept-Ranges: bytes
Server: AmazonS3
Age: 1890
X-Cache: Hit from cloudfront
Via: 1.1 d85d7507ed6501757cfe600c02a26c7d.cloudfront.net (CloudFront)
X-Amz-Cf-Id: ...
```

so we can rely on Go's default compression handling.  See [`DisableCompression`][1], which defaults to `false`.  To confirm the default handling, try to retrieve from a local server:

```console
$ export OPENSHIFT_INSTALL_LIBVIRT_IMAGE=http://localhost:8080/example.qcow
$ openshift-install --dir=wking create cluster
INFO Fetching OS image...
FATAL Error executing openshift-install: failed to fetch Terraform Variables: failed to generate asset "Terraform Variables": failed to get Tfvars: failed to use cached libvirt image: Get http://localhost:8080/example.qcow: EOF
```

In another terminal, I was using [Ncat][2] as a dummy server to capture request headers:

```console
$ nc -l -p 8080 </dev/null
GET /example.qcow HTTP/1.1
Host: localhost:8080
User-Agent: Go-http-client/1.1
Accept-Encoding: gzip
```

This commit drops the now-unnecessary suffix handling from 7abe94d4 (#280).

[1]: https://golang.org/pkg/net/http/#Transport
[2]: https://nmap.org/ncat/