### PR TITLE
pkg/asset/installconfig/pullsecret: Help for single JSON line

### DIFF
--- a/pkg/asset/installconfig/pullsecret.go
+++ b/pkg/asset/installconfig/pullsecret.go
@@ -25,7 +25,7 @@ func (a *pullSecret) Generate(asset.Parents) error {
 		&survey.Question{
 			Prompt: &survey.Input{
 				Message: "Pull Secret",
-				Help:    "The container registry pull secret for this cluster.",
+				Help:    "The container registry pull secret for this cluster, as a single line of JSON (e.g. {\"auths\": {...}}).",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 				return validate.JSON([]byte(ans.(string)))


### PR DESCRIPTION
@brianredbeard [says][1]:

> It appears that the pull-secret prompt expects the input to be compacted. This should be more clearly specified.

The `auths` hint is from [our existing `OPENSHIFT_INSTALL_PULL_SECRET` docs][2].

Fixes #627.

[1]: https://github.com/openshift/installer/issues/627#issuecomment-436441021
[2]: https://github.com/openshift/installer/blame/25ceecc296bd020219967ae1258180df01acff0f/docs/user/environment-variables.md#L28-L29