### PR TITLE
pkg/asset/installconfig/basedomain: Document cluster-name subdomains

### DIFF
--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -5,7 +5,8 @@ The installer accepts a number of environment variable that allow the interactiv
 ## General
 
 * `OPENSHIFT_INSTALL_BASE_DOMAIN`:
-    The base domain of the cluster. All DNS records will be sub-domains of this base.
+    The base domain of the cluster.
+    All DNS records will be sub-domains of this base and will also include the cluster name.
 
     For AWS, this must be a previously-existing public Route 53 zone.  You can check for any already in your account with:
 

--- a/pkg/asset/installconfig/basedomain.go
+++ b/pkg/asset/installconfig/basedomain.go
@@ -25,7 +25,7 @@ func (a *baseDomain) Generate(asset.Parents) error {
 		&survey.Question{
 			Prompt: &survey.Input{
 				Message: "Base Domain",
-				Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base.\n\nFor AWS, this must be a previously-existing public Route 53 zone.  You can check for any already in your account with:\n\n  $ aws route53 list-hosted-zones --query 'HostedZones[? !(Config.PrivateZone)].Name' --output text",
+				Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base and will also include the cluster name.\n\nFor AWS, this must be a previously-existing public Route 53 zone.  You can check for any already in your account with:\n\n  $ aws route53 list-hosted-zones --query 'HostedZones[? !(Config.PrivateZone)].Name' --output text",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 				return validate.DomainName(ans.(string))


### PR DESCRIPTION
@brianredbeard [says][1]:

> The third time I had to abort was when prompted for base domain followed by cluster name (I included my cluster name in my base domain because I'm using a well structure name server delegation structure).

And I've seen a number of other cases where folks suggest including the cluster name again in the base domain.  Sometimes you might need to do that (e.g. if you cannot create subdomains without the additional namespacing).  But in most cases, including the cluster name in the base domain is redundant.

[1]: https://github.com/openshift/installer/issues/627#issue-378069672