### PR TITLE
Allow `openstack-approvers` LGTM

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,4 @@ approvers:
   - openstack-approvers
 reviewers:
   - installer-reviewers
+  - openstack-approvers


### PR DESCRIPTION
Commit c1aa022 allowed openstack-approvers to approve the commits, but
not merge them (via `/lgtm`). This is an oversight fixed by adding the
group to `reviewers` in addition to `approvers`.