### PR TITLE
Skip generation of dependencies for on-disk assets

### DIFF
--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -26,21 +26,39 @@ type Store interface {
 	Destroy(Asset) error
 }
 
-// assetState includes an asset and a boolean that indicates
-// whether it's dirty or not.
+// assetSource indicates from where the asset was fetched
+type assetSource int
+
+const (
+	// unsourced indicates that the asset has not been fetched
+	unfetched assetSource = iota
+	// generatedSource indicates that the asset was generated
+	generatedSource
+	// onDiskSource indicates that the asset was fetched from disk
+	onDiskSource
+	// stateFileSource indicates that the asset was fetched from the state file
+	stateFileSource
+)
+
 type assetState struct {
+	// asset is the asset.
+	// If the asset has not been fetched, then this will be nil.
 	asset Asset
-	dirty bool
+	// source is the source from which the asset was fetched
+	source assetSource
+	// anyParentsDirty is true if any of the parents of the asset are dirty
+	anyParentsDirty bool
+	// presentOnDisk is true if the asset in on-disk. This is set whether the
+	// asset is sourced from on-disk or not. It is used in purging consumed assets.
+	presentOnDisk bool
 }
 
 // StoreImpl is the implementation of Store.
 type StoreImpl struct {
 	directory       string
-	assets          map[reflect.Type]assetState
+	assets          map[reflect.Type]*assetState
 	stateFileAssets map[string]json.RawMessage
-	fileFetcher     *fileFetcher
-
-	markedForPurge []WritableAsset // This records the on-disk assets that are loaded already, which will be cleaned up in the end.
+	fileFetcher     FileFetcher
 }
 
 // NewStore returns an asset store that implements the Store interface.
@@ -48,10 +66,10 @@ func NewStore(dir string) (Store, error) {
 	store := &StoreImpl{
 		directory:   dir,
 		fileFetcher: &fileFetcher{directory: dir},
-		assets:      make(map[reflect.Type]assetState),
+		assets:      map[reflect.Type]*assetState{},
 	}
 
-	if err := store.load(); err != nil {
+	if err := store.loadStateFile(); err != nil {
 		return nil, err
 	}
 	return store, nil
@@ -60,14 +78,14 @@ func NewStore(dir string) (Store, error) {
 // Fetch retrieves the state of the given asset, generating it and its
 // dependencies if necessary.
 func (s *StoreImpl) Fetch(asset Asset) error {
-	if _, err := s.fetch(asset, ""); err != nil {
+	if err := s.fetch(asset, ""); err != nil {
 		return err
 	}
-	if err := s.save(); err != nil {
+	if err := s.saveStateFile(); err != nil {
 		return errors.Wrapf(err, "failed to save state")
 	}
 	if wa, ok := asset.(WritableAsset); ok {
-		return errors.Wrapf(s.purge([]WritableAsset{wa}), "failed to purge asset")
+		return errors.Wrapf(s.purge(wa), "failed to purge asset")
 	}
 	return nil
 }
@@ -94,12 +112,12 @@ func (s *StoreImpl) Destroy(asset Asset) error {
 
 	delete(s.assets, reflect.TypeOf(asset))
 	delete(s.stateFileAssets, reflect.TypeOf(asset).String())
-	return s.save()
+	return s.saveStateFile()
 }
 
-// load retrieves the state from the state file present in the given directory
+// loadStateFile retrieves the state from the state file present in the given directory
 // and returns the assets map
-func (s *StoreImpl) load() error {
+func (s *StoreImpl) loadStateFile() error {
 	path := filepath.Join(s.directory, stateFileName)
 	assets := map[string]json.RawMessage{}
 	data, err := ioutil.ReadFile(path)
@@ -132,12 +150,15 @@ func (s *StoreImpl) isAssetInState(asset Asset) bool {
 	return ok
 }
 
-// save dumps the entire state map into a file
-func (s *StoreImpl) save() error {
+// saveStateFile dumps the entire state map into a file
+func (s *StoreImpl) saveStateFile() error {
 	if s.stateFileAssets == nil {
 		s.stateFileAssets = map[string]json.RawMessage{}
 	}
 	for k, v := range s.assets {
+		if v.source == unfetched {
+			continue
+		}
 		data, err := json.MarshalIndent(v.asset, "", "    ")
 		if err != nil {
 			return err
@@ -162,117 +183,166 @@ func (s *StoreImpl) save() error {
 // fetch populates the given asset, generating it and its dependencies if
 // necessary, and returns whether or not the asset had to be regenerated and
 // any errors.
-func (s *StoreImpl) fetch(asset Asset, indent string) (bool, error) {
+func (s *StoreImpl) fetch(asset Asset, indent string) error {
 	logrus.Debugf("%sFetching %q...", indent, asset.Name())
 
-	// Return immediately if the asset is found in the cache,
+	assetState, ok := s.assets[reflect.TypeOf(asset)]
+	if !ok {
+		if _, err := s.load(asset, ""); err != nil {
+			return err
+		}
+		assetState = s.assets[reflect.TypeOf(asset)]
+	}
+
+	// Return immediately if the asset has been fetched before,
 	// this is because we are doing a depth-first-search, it's guaranteed
 	// that we always fetch the parent before children, so we don't need
 	// to worry about invalidating anything in the cache.
-	storedAsset, ok := s.assets[reflect.TypeOf(asset)]
-	if ok {
+	if assetState.source != unfetched {
 		logrus.Debugf("%sReusing previously-fetched %q", indent, asset.Name())
-		reflect.ValueOf(asset).Elem().Set(reflect.ValueOf(storedAsset.asset).Elem())
-		return storedAsset.dirty, nil
+		reflect.ValueOf(asset).Elem().Set(reflect.ValueOf(assetState.asset).Elem())
+		return nil
 	}
 
+	// Re-generate the asset
 	dependencies := asset.Dependencies()
 	parents := make(Parents, len(dependencies))
-	if len(dependencies) > 0 {
-		logrus.Debugf("%sFetching dependencies of %q...", indent, asset.Name())
-	}
-
-	var anyParentsDirty bool
 	for _, d := range dependencies {
-		dirty, err := s.fetch(d, indent+"  ")
-		if err != nil {
-			return false, errors.Wrapf(err, "failed to fetch dependency of %q", asset.Name())
-		}
-		if dirty {
-			anyParentsDirty = true
+		if err := s.fetch(d, increaseIndent(indent)); err != nil {
+			return errors.Wrapf(err, "failed to fetch dependency of %q", asset.Name())
 		}
 		parents.Add(d)
 	}
+	logrus.Debugf("%sGenerating %q...", indent, asset.Name())
+	if err := asset.Generate(parents); err != nil {
+		return errors.Wrapf(err, "failed to generate asset %q", asset.Name())
+	}
+	assetState.asset = asset
+	assetState.source = generatedSource
+	return nil
+}
 
-	// Try to find the asset from the state file.
-	foundInStateFile := s.isAssetInState(asset)
-	if foundInStateFile {
-		logrus.Debugf("%sFound %q in state file", indent, asset.Name())
+// load loads the asset and all of its ancestors from on-disk and the state file.
+func (s *StoreImpl) load(asset Asset, indent string) (*assetState, error) {
+	logrus.Debugf("%sLoading %q...", indent, asset.Name())
+
+	// Stop descent if the asset has already been loaded.
+	if state, ok := s.assets[reflect.TypeOf(asset)]; ok {
+		return state, nil
 	}
 
-	// Try to load from the provided files.
-	var foundOnDisk bool
-	if as, ok := asset.(WritableAsset); ok {
-		var err error
-		foundOnDisk, err = as.Load(s.fileFetcher)
+	// Load dependencies from on-disk.
+	anyParentsDirty := false
+	for _, d := range asset.Dependencies() {
+		state, err := s.load(d, increaseIndent(indent))
 		if err != nil {
-			return false, errors.Wrapf(err, "failed to load asset %q", asset.Name())
+			return nil, err
 		}
+		if state.anyParentsDirty || state.source == onDiskSource {
+			anyParentsDirty = true
+		}
+	}
+
+	// Try to load from on-disk.
+	var (
+		onDiskAsset WritableAsset
+		foundOnDisk bool
+	)
+	if _, isWritable := asset.(WritableAsset); isWritable {
+		onDiskAsset = reflect.New(reflect.TypeOf(asset).Elem()).Interface().(WritableAsset)
+		var err error
+		foundOnDisk, err = onDiskAsset.Load(s.fileFetcher)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to load asset %q", asset.Name())
+		}
+	}
+
+	// Try to load from state file.
+	var (
+		stateFileAsset         Asset
+		foundInStateFile       bool
+		onDiskMatchesStateFile bool
+	)
+	// Do not need to bother with loading from state file if any of the parents
+	// are dirty because the asset must be re-generated in this case.
+	if !anyParentsDirty {
+		foundInStateFile = s.isAssetInState(asset)
+		if foundInStateFile {
+			stateFileAsset = reflect.New(reflect.TypeOf(asset).Elem()).Interface().(Asset)
+			if err := s.loadAssetFromState(stateFileAsset); err != nil {
+				return nil, errors.Wrapf(err, "failed to load asset %q from state file", asset.Name())
+			}
+		}
+
+		if foundOnDisk && foundInStateFile {
+			logrus.Debugf("%sLoading %q from both state file and target directory", indent, asset.Name())
+
+			// If the on-disk asset is the same as the one in the state file, there
+			// is no need to consider the one on disk and to mark the asset dirty.
+			onDiskMatchesStateFile = reflect.DeepEqual(onDiskAsset, stateFileAsset)
+			if onDiskMatchesStateFile {
+				logrus.Debugf("%sOn-disk %q matches asset in state file", indent, asset.Name())
+			}
+		}
+	}
+
+	var (
+		assetToStore Asset
+		source       assetSource
+	)
+	switch {
+	// A parent is dirty. The asset must be re-generated.
+	case anyParentsDirty:
 		if foundOnDisk {
-			logrus.Infof("Consuming %q from target directory", asset.Name())
-			s.markedForPurge = append(s.markedForPurge, as)
+			logrus.Warningf("%sDiscarding the %q that was provided in the target directory because its dependencies are dirty and it needs to be regenerated", indent, asset.Name())
 		}
+		source = unfetched
+	// The asset is on disk and that differs from what is in the source file.
+	// The asset is sourced from on disk.
+	case foundOnDisk && !onDiskMatchesStateFile:
+		logrus.Debugf("%sUsing %q loaded from target directory", indent, asset.Name())
+		assetToStore = onDiskAsset
+		source = onDiskSource
+	// The asset is in the state file. The asset is sourced from state file.
+	case foundInStateFile:
+		logrus.Debugf("%sUsing %q loaded from state file", indent, asset.Name())
+		assetToStore = stateFileAsset
+		source = stateFileSource
+	// There is no existing source for the asset. The asset will be generated.
+	default:
+		source = unfetched
 	}
 
-	if anyParentsDirty && foundOnDisk {
-		logrus.Warningf("%sDiscarding the %q that was provided in the target directory because its dependencies are dirty and it needs to be regenerated", indent, asset.Name())
+	state := &assetState{
+		asset:           assetToStore,
+		source:          source,
+		anyParentsDirty: anyParentsDirty,
+		presentOnDisk:   foundOnDisk,
 	}
-
-	if anyParentsDirty || (!foundOnDisk && !foundInStateFile) {
-		logrus.Debugf("%sGenerating %q...", indent, asset.Name())
-		if err := asset.Generate(parents); err != nil {
-			return false, errors.Wrapf(err, "failed to generate asset %q", asset.Name())
-		}
-	} else if foundInStateFile && foundOnDisk {
-		logrus.Debugf("%sLoading %q from both state file and target directory", indent, asset.Name())
-
-		stateAsset := reflect.New(reflect.TypeOf(asset).Elem()).Interface().(Asset)
-		if err := s.loadAssetFromState(stateAsset); err != nil {
-			return false, errors.Wrapf(err, "failed to load asset %q from state file", asset.Name())
-		}
-
-		// If the on-disk asset is the same as the one in the state file, there
-		// is no need to consider the one on disk and to mark the asset dirty.
-		if reflect.DeepEqual(stateAsset, asset) {
-			foundOnDisk = false
-		}
-	} else if foundInStateFile {
-		logrus.Debugf("%sLoading %q from state file", indent, asset.Name())
-		if err := s.loadAssetFromState(asset); err != nil {
-			return false, errors.Wrapf(err, "failed to load asset %q from state file", asset.Name())
-		}
-	} else if foundOnDisk {
-		logrus.Debugf("%sLoading %q from target directory", indent, asset.Name())
-	}
-
-	dirty := anyParentsDirty || foundOnDisk
-	s.assets[reflect.TypeOf(asset)] = assetState{asset: asset, dirty: dirty}
-	return dirty, nil
+	s.assets[reflect.TypeOf(asset)] = state
+	return state, nil
 }
 
 // purge deletes the on-disk assets that are consumed already.
 // E.g., install-config.yml will be deleted after fetching 'manifests'.
-// The target assets are excluded.
-func (s *StoreImpl) purge(excluded []WritableAsset) error {
-	var toPurge []WritableAsset
-	for _, asset := range s.markedForPurge {
-		var found bool
-		for _, as := range excluded {
-			if reflect.TypeOf(as) == reflect.TypeOf(asset) {
-				found = true
-				break
-			}
+// The target asset is excluded.
+func (s *StoreImpl) purge(excluded WritableAsset) error {
+	for _, assetState := range s.assets {
+		if !assetState.presentOnDisk {
+			continue
 		}
-		if !found {
-			toPurge = append(toPurge, asset)
+		if reflect.TypeOf(assetState.asset) == reflect.TypeOf(excluded) {
+			continue
 		}
-	}
-
-	for _, asset := range toPurge {
-		if err := deleteAssetFromDisk(asset, s.directory); err != nil {
+		logrus.Infof("Consuming %q from target directory", assetState.asset.Name())
+		if err := deleteAssetFromDisk(assetState.asset.(WritableAsset), s.directory); err != nil {
 			return err
 		}
+		assetState.presentOnDisk = false
 	}
-	s.markedForPurge = []WritableAsset{}
 	return nil
+}
+
+func increaseIndent(indent string) string {
+	return indent + "  "
 }


### PR DESCRIPTION
This allows the user to supply and use an on-disk asset (such as install-config.yml) without
need to also supply the state file that was created. This is helpful when re-using an on-disk
asset for multiple installations. In particular, hive would like to run openshift-install
with a supplied install-config.yml and no state file.

To effect this behavior, the asset store loads all of the on-disk assets that a fetched asset
depends upon prior to fetching the dependencies for the fetched asset. From this, the asset
store can determine whether the fetched asset is dirty or not. If the fetched asset is not
dirty and is on-disk, then the on-disk asset is used as is without generating any of the
dependent assets--as they would be ignored in resolving the fetched asset anyway.

Conflicts can occur when the asset store resolves in different ways the fetch of two assets
that share a dependency. For example, let us say that there are two assets, A and B, that both
depend upon asset C. Asset A is present on disk, and asset B is not present on disk. When the
asset store fetchs asset A, then asset C will not be generated. However, when the asset store
fetches asset B, then asset C will be generated in order to generate asset B. Asset A could
potentially have data that conflicts with the data that would have been taken from the asset
C that was generated.

Fixes https://github.com/openshift/installer/issues/545