### PR TITLE
.github/ISSUE_TEMPLATE: Link to the new troubleshooting docs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -21,6 +21,7 @@ Enter text here.
 # What happened?
 
 Enter text here.
+See [the troubleshooting documentation](https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md) for ideas about what information to collect.
 
 # What you expected to happen?
 


### PR DESCRIPTION
Make it easier for issue-reporters to find these docs, which will hopefully help improve issue quality.

Ideally this would be a relative link into the local repository, in case folks wanted to enable issues in a fork or some such.  But there's no way (that I've found) to do that which works from both [here][1] and [here][2].  And while I think hard-coding the org/repo is ugly, we already do an awful lot of that for our internal Go imports.

[1]: https://github.com/openshift/installer/blob/master/.github/ISSUE_TEMPLATE.md
[2]: https://github.com/openshift/installer/issues/new