### PR TITLE
docs/user/troubleshooting: Drop 'sh' highlighting from error message

### DIFF
--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -80,7 +80,7 @@ If an older version of Red Hat CoreOS is in use, it will need to be updated. Try
 
 During the bootstrap process, the Kubelet may emit errors like the following:
 
-```sh
+```
 Error signing CSR provided in request from agent: error parsing profile: invalid organization
 ```
 


### PR DESCRIPTION
This isn't shell content, so we shouldn't be highlighting it.  Before this commit, GitHub was styling `in` (which is a shell keyword):

```console
$ curl -s https://github.com/openshift/installer/blob/fffc4775376d0758ac31e17126f6d401658c9012/docs/user/troubleshooting.md#etcd-is-not-running | grep 'Error signing'
<div class="highlight highlight-source-shell"><pre>Error signing CSR provided <span class="pl-k">in</span> request from agent: error parsing profile: invalid organization</pre></div>
```

Slipped through in #638.