### PR TITLE
terraform/aws: remove option to use an existing vpc in aws

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -109,7 +109,7 @@ resource "aws_instance" "bootstrap" {
   subnet_id                   = "${var.subnet_id}"
   user_data                   = "${data.ignition_config.redirect.rendered}"
   vpc_security_group_ids      = ["${var.vpc_security_group_ids}"]
-  associate_public_ip_address = "${var.associate_public_ip_address}"
+  associate_public_ip_address = true
 
   lifecycle {
     # Ignore changes in the AMI which force recreation of the resource. This

--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -3,11 +3,6 @@ variable "ami" {
   description = "The AMI ID for the bootstrap node."
 }
 
-variable "associate_public_ip_address" {
-  default     = false
-  description = "If set to true, public-facing ingress resources are created."
-}
-
 variable "cluster_name" {
   type        = "string"
   description = "The name of the cluster."

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -1,31 +1,23 @@
 locals {
-  private_endpoints = "${var.aws_endpoints == "public" ? false : true}"
-  public_endpoints  = "${var.aws_endpoints == "private" ? false : true}"
-  private_zone_id   = "${join("", aws_route53_zone.int.*.zone_id)}"
+  private_zone_id = "${aws_route53_zone.int.zone_id}"
 }
 
 provider "aws" {
   region  = "${var.aws_region}"
   version = "1.39.0"
-
-  assume_role {
-    role_arn     = "${var.aws_installer_role == "" ? "" : "${var.aws_installer_role}"}"
-    session_name = "OPENSHIFT_INSTALLER_${var.cluster_name}"
-  }
 }
 
 module "bootstrap" {
   source = "./bootstrap"
 
-  ami                         = "${var.aws_ec2_ami_override}"
-  associate_public_ip_address = "${var.aws_endpoints != "private"}"
-  cluster_name                = "${var.cluster_name}"
-  iam_role                    = "${var.aws_master_iam_role_name}"
-  ignition                    = "${var.ignition_bootstrap}"
-  subnet_id                   = "${module.vpc.master_subnet_ids[0]}"
-  target_group_arns           = "${module.vpc.aws_lb_target_group_arns}"
-  target_group_arns_length    = "${module.vpc.aws_lb_target_group_arns_length}"
-  vpc_security_group_ids      = ["${concat(var.aws_master_extra_sg_ids, list(module.vpc.master_sg_id))}"]
+  ami                      = "${var.aws_ec2_ami_override}"
+  cluster_name             = "${var.cluster_name}"
+  iam_role                 = "${var.aws_master_iam_role_name}"
+  ignition                 = "${var.ignition_bootstrap}"
+  subnet_id                = "${module.vpc.master_subnet_ids[0]}"
+  target_group_arns        = "${module.vpc.aws_lb_target_group_arns}"
+  target_group_arns_length = "${module.vpc.aws_lb_target_group_arns_length}"
+  vpc_security_group_ids   = "${list(module.vpc.master_sg_id)}"
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}-bootstrap",
@@ -44,8 +36,7 @@ module "masters" {
   extra_tags               = "${var.aws_extra_tags}"
   instance_count           = "${var.master_count}"
   master_iam_role          = "${var.aws_master_iam_role_name}"
-  master_sg_ids            = "${concat(var.aws_master_extra_sg_ids, list(module.vpc.master_sg_id))}"
-  public_endpoints         = "${local.public_endpoints}"
+  master_sg_ids            = "${list(module.vpc.master_sg_id)}"
   root_volume_iops         = "${var.aws_master_root_volume_iops}"
   root_volume_size         = "${var.aws_master_root_volume_size}"
   root_volume_type         = "${var.aws_master_root_volume_type}"
@@ -72,12 +63,9 @@ module "dns" {
   api_internal_lb_zone_id  = "${module.vpc.aws_lb_api_internal_zone_id}"
   base_domain              = "${var.base_domain}"
   cluster_name             = "${var.cluster_name}"
-  elb_alias_enabled        = true
   master_count             = "${var.master_count}"
   private_zone_id          = "${local.private_zone_id}"
   extra_tags               = "${var.aws_extra_tags}"
-  private_endpoints        = "${local.private_endpoints}"
-  public_endpoints         = "${local.public_endpoints}"
 }
 
 module "vpc" {
@@ -90,13 +78,6 @@ module "vpc" {
   region       = "${var.aws_region}"
 
   extra_tags = "${var.aws_extra_tags}"
-
-  // empty map subnet_configs will have the vpc module creating subnets in all availabile AZs
-  new_master_subnet_configs = "${var.aws_master_custom_subnets}"
-  new_worker_subnet_configs = "${var.aws_worker_custom_subnets}"
-
-  private_master_endpoints = "${local.private_endpoints}"
-  public_master_endpoints  = "${local.public_endpoints}"
 }
 
 resource "aws_route53_record" "etcd_a_nodes" {
@@ -117,7 +98,6 @@ resource "aws_route53_record" "etcd_cluster" {
 }
 
 resource "aws_route53_zone" "int" {
-  count         = "${local.private_endpoints ? 1 : 0}"
   vpc_id        = "${module.vpc.vpc_id}"
   name          = "${var.base_domain}"
   force_destroy = true

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -1,7 +1,7 @@
 locals {
   private_endpoints = "${var.aws_endpoints == "public" ? false : true}"
   public_endpoints  = "${var.aws_endpoints == "private" ? false : true}"
-  private_zone_id   = "${var.aws_external_private_zone != "" ? var.aws_external_private_zone : join("", aws_route53_zone.int.*.zone_id)}"
+  private_zone_id   = "${join("", aws_route53_zone.int.*.zone_id)}"
 }
 
 provider "aws" {
@@ -89,9 +89,7 @@ module "vpc" {
   cluster_name = "${var.cluster_name}"
   region       = "${var.aws_region}"
 
-  external_master_subnet_ids = "${compact(var.aws_external_master_subnet_ids)}"
-  external_worker_subnet_ids = "${compact(var.aws_external_worker_subnet_ids)}"
-  extra_tags                 = "${var.aws_extra_tags}"
+  extra_tags = "${var.aws_extra_tags}"
 
   // empty map subnet_configs will have the vpc module creating subnets in all availabile AZs
   new_master_subnet_configs = "${var.aws_master_custom_subnets}"
@@ -119,7 +117,7 @@ resource "aws_route53_record" "etcd_cluster" {
 }
 
 resource "aws_route53_zone" "int" {
-  count         = "${local.private_endpoints ? "${var.aws_external_private_zone == "" ? 1 : 0 }" : 0}"
+  count         = "${local.private_endpoints ? 1 : 0}"
   vpc_id        = "${module.vpc.vpc_id}"
   name          = "${var.base_domain}"
   force_destroy = true

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -75,7 +75,6 @@ module "dns" {
   elb_alias_enabled        = true
   master_count             = "${var.master_count}"
   private_zone_id          = "${local.private_zone_id}"
-  external_vpc_id          = "${module.vpc.vpc_id}"
   extra_tags               = "${var.aws_extra_tags}"
   private_endpoints        = "${local.private_endpoints}"
   public_endpoints         = "${local.public_endpoints}"
@@ -84,12 +83,11 @@ module "dns" {
 module "vpc" {
   source = "./vpc"
 
-  base_domain     = "${var.base_domain}"
-  cidr_block      = "${var.aws_vpc_cidr_block}"
-  cluster_id      = "${var.cluster_id}"
-  cluster_name    = "${var.cluster_name}"
-  external_vpc_id = "${var.aws_external_vpc_id}"
-  region          = "${var.aws_region}"
+  base_domain  = "${var.base_domain}"
+  cidr_block   = "${var.aws_vpc_cidr_block}"
+  cluster_id   = "${var.cluster_id}"
+  cluster_name = "${var.cluster_name}"
+  region       = "${var.aws_region}"
 
   external_master_subnet_ids = "${compact(var.aws_external_master_subnet_ids)}"
   external_worker_subnet_ids = "${compact(var.aws_external_worker_subnet_ids)}"

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -84,7 +84,7 @@ resource "aws_instance" "master" {
   user_data            = "${var.user_data_ign}"
 
   vpc_security_group_ids      = ["${var.master_sg_ids}"]
-  associate_public_ip_address = "${var.public_endpoints}"
+  associate_public_ip_address = true
 
   lifecycle {
     # Ignore changes in the AMI which force recreation of the resource. This

--- a/data/data/aws/master/variables.tf
+++ b/data/data/aws/master/variables.tf
@@ -51,11 +51,6 @@ variable "master_sg_ids" {
   description = "The security group IDs to be applied to the master nodes."
 }
 
-variable "public_endpoints" {
-  description = "If set to true, public-facing ingress resources are created."
-  default     = true
-}
-
 variable "root_volume_iops" {
   type        = "string"
   default     = "100"

--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -1,21 +1,14 @@
-locals {
-  public_endpoints_count  = "${var.public_endpoints ? 1 : 0}"
-  private_endpoints_count = "${var.private_endpoints ? 1 : 0}"
-}
-
 data "aws_route53_zone" "base" {
   name = "${var.base_domain}"
 }
 
 locals {
-  public_zone_id = "${join("", data.aws_route53_zone.base.*.zone_id)}"
+  public_zone_id = "${data.aws_route53_zone.base.zone_id}"
 
-  zone_id = "${var.private_endpoints ? var.private_zone_id : local.public_zone_id}"
+  zone_id = "${var.private_zone_id}"
 }
 
 resource "aws_route53_record" "api_external" {
-  count = "${var.elb_alias_enabled ? local.public_endpoints_count : 0}"
-
   zone_id = "${local.public_zone_id}"
   name    = "${var.cluster_name}-api.${var.base_domain}"
   type    = "A"
@@ -28,8 +21,6 @@ resource "aws_route53_record" "api_external" {
 }
 
 resource "aws_route53_record" "api_internal" {
-  count = "${var.elb_alias_enabled ? local.private_endpoints_count : 0}"
-
   zone_id = "${var.private_zone_id}"
   name    = "${var.cluster_name}-api.${var.base_domain}"
   type    = "A"

--- a/data/data/aws/route53/master.tf
+++ b/data/data/aws/route53/master.tf
@@ -1,8 +1,0 @@
-resource "aws_route53_record" "master_nodes" {
-  count   = "${var.elb_alias_enabled ? 0 : var.master_count}"
-  zone_id = "${data.aws_route53_zone.base.zone_id}"
-  name    = "${var.cluster_name}-master-${count.index}"
-  type    = "A"
-  ttl     = "60"
-  records = ["${var.master_ip_addresses[count.index]}"]
-}

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -50,30 +50,6 @@ variable "extra_tags" {
 
 // AWS specific internal zone variables
 
-variable "elb_alias_enabled" {
-  description = <<EOF
-(optional) Whether to create an aliased record set to ELB endpoints.
-Refer to http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html
-for additional information.
-EOF
-
-  default = false
-}
-
-variable "private_endpoints" {
-  description = <<EOF
-If set to true, create private-facing ingress resources (ELB, A-records).
-If set to false, no private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
-EOF
-}
-
-variable "public_endpoints" {
-  description = <<EOF
-If set to true, create public-facing ingress resources (ELB, A-records).
-If set to false, no public-facing ingress resources will be created.
-EOF
-}
-
 variable "private_zone_id" {
   description = "Route53 Private Zone ID"
   type        = "string"

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -60,17 +60,6 @@ EOF
   default = false
 }
 
-variable "external_vpc_id" {
-  type = "string"
-
-  description = <<EOF
-ID of an existing VPC to launch nodes into.
-If unset a new VPC is created.
-
-Example: `vpc-123456`
-EOF
-}
-
 variable "private_endpoints" {
   description = <<EOF
 If set to true, create private-facing ingress resources (ELB, A-records).

--- a/data/data/aws/route53/worker.tf
+++ b/data/data/aws/route53/worker.tf
@@ -1,12 +1,3 @@
-resource "aws_route53_record" "worker_nodes" {
-  count   = "${var.elb_alias_enabled ? 0 : var.worker_count}"
-  zone_id = "${data.aws_route53_zone.base.zone_id}"
-  name    = "${var.cluster_name}-worker-${count.index}"
-  type    = "A"
-  ttl     = "60"
-  records = ["${var.worker_ip_addresses[count.index]}"]
-}
-
 resource "aws_route53_record" "worker_nodes_public" {
   // hack: worker_public_ips_enabled is a workaround for https://github.com/hashicorp/terraform/issues/10857
   count   = "${var.worker_public_ips_enabled ? var.worker_count : 0}"

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -21,31 +21,12 @@ variable "aws_ec2_ami_override" {
   default     = ""
 }
 
-variable "aws_master_extra_sg_ids" {
-  description = <<EOF
-(optional) List of additional security group IDs for master nodes.
-
-Example: `["sg-51530134", "sg-b253d7cc"]`
-EOF
-
-  type    = "list"
-  default = []
-}
-
 variable "aws_vpc_cidr_block" {
   type = "string"
 
   description = <<EOF
 Block of IP addresses used by the VPC.
 This should not overlap with any other networks, such as a private datacenter connected via Direct Connect.
-EOF
-}
-
-variable "aws_endpoints" {
-  description = <<EOF
-(optional) If set to "all", the default, then both public and private ingress resources (ELB, A-records) will be created.
-If set to "private", then only create private-facing ingress resources (ELB, A-records). No public-facing ingress resources will be created.
-If set to "public", then only create public-facing ingress resources (ELB, A-records). No private-facing ingress resources will be provisioned and all DNS records will be created in the public Route53 zone.
 EOF
 }
 
@@ -83,45 +64,9 @@ Ignored if the volume type is not io1.
 EOF
 }
 
-variable "aws_master_custom_subnets" {
-  type    = "map"
-  default = {}
-
-  description = <<EOF
-(optional) This configures master availability zones and their corresponding subnet CIDRs directly.
-
-Example:
-`{ eu-west-1a = "10.0.0.0/20", eu-west-1b = "10.0.16.0/20" }`
-EOF
-}
-
-variable "aws_worker_custom_subnets" {
-  type    = "map"
-  default = {}
-
-  description = <<EOF
-(optional) This configures worker availability zones and their corresponding subnet CIDRs directly.
-
-Example: `{ eu-west-1a = "10.0.64.0/20", eu-west-1b = "10.0.80.0/20" }`
-EOF
-}
-
 variable "aws_region" {
   type        = "string"
   description = "The target AWS region for the cluster."
-}
-
-variable "aws_installer_role" {
-  type    = "string"
-  default = ""
-
-  description = <<EOF
-(optional) Name of IAM role to use to access AWS in order to deploy the OpenShift Cluster.
-The name is also the full role's ARN.
-
-Example:
- * Role ARN  = arn:aws:iam::123456789012:role/openshift-installer
-EOF
 }
 
 variable "aws_master_iam_role_name" {

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -49,44 +49,6 @@ If set to "public", then only create public-facing ingress resources (ELB, A-rec
 EOF
 }
 
-variable "aws_external_private_zone" {
-  default = ""
-
-  description = <<EOF
-(optional) If set, the given Route53 zone ID will be used as the internal (private) zone.
-This zone will be used to create etcd DNS records as well as internal API and internal Ingress records.
-If set, no additional private zone will be created.
-
-Example: `"Z1ILINNUJGTAO1"`
-EOF
-}
-
-variable "aws_external_master_subnet_ids" {
-  type = "list"
-
-  description = <<EOF
-(optional) List of subnet IDs within an existing VPC to deploy master nodes into.
-Required to use an existing VPC, not applicable otherwise.
-
-Example: `["subnet-111111", "subnet-222222", "subnet-333333"]`
-EOF
-
-  default = []
-}
-
-variable "aws_external_worker_subnet_ids" {
-  type = "list"
-
-  description = <<EOF
-(optional) List of subnet IDs within an existing VPC to deploy worker nodes into.
-Required to use an existing VPC, not applicable otherwise.
-
-Example: `["subnet-111111", "subnet-222222", "subnet-333333"]`
-EOF
-
-  default = []
-}
-
 variable "aws_extra_tags" {
   type = "map"
 

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -41,19 +41,6 @@ This should not overlap with any other networks, such as a private datacenter co
 EOF
 }
 
-variable "aws_external_vpc_id" {
-  type = "string"
-
-  description = <<EOF
-(optional) ID of an existing VPC to launch nodes into.
-If unset a new VPC is created.
-
-Example: `vpc-123456`
-EOF
-
-  default = ""
-}
-
 variable "aws_endpoints" {
   description = <<EOF
 (optional) If set to "all", the default, then both public and private ingress resources (ELB, A-records) will be created.

--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -8,12 +8,10 @@ data "aws_availability_zones" "azs" {}
 // Only reference data sources which are gauranteed to exist at any time (above) in this locals{} block
 locals {
   // List of possible AZs for each type of subnet
-  new_worker_subnet_azs = ["${coalescelist(keys(var.new_worker_subnet_configs), data.aws_availability_zones.azs.names)}"]
-  new_master_subnet_azs = ["${coalescelist(keys(var.new_master_subnet_configs), data.aws_availability_zones.azs.names)}"]
+  new_subnet_azs = "${data.aws_availability_zones.azs.names}"
 
-  // How many AZs to create worker and master subnets in
-  new_worker_az_count = "${length(local.new_worker_subnet_azs)}"
-  new_master_az_count = "${length(local.new_master_subnet_azs)}"
+  // How many AZs to create subnets in
+  new_az_count = "${length(local.new_subnet_azs)}"
 
   // The VPC ID to use to build the rest of the vpc data sources
   vpc_id = "${aws_vpc.new_vpc.id}"
@@ -21,8 +19,8 @@ locals {
   // When referencing the _ids arrays or data source arrays via count = , always use the *_count variable rather than taking the length of the list
   worker_subnet_ids   = "${aws_subnet.worker_subnet.*.id}"
   master_subnet_ids   = "${aws_subnet.master_subnet.*.id}"
-  worker_subnet_count = "${local.new_worker_az_count}"
-  master_subnet_count = "${local.new_master_az_count}"
+  worker_subnet_count = "${local.new_az_count}"
+  master_subnet_count = "${local.new_az_count}"
 }
 
 # all data sources should be input variable-agnostic and used as canonical source for querying "state of resources" and building outputs

--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -15,12 +15,12 @@ locals {
   new_worker_az_count = "${length(local.new_worker_subnet_azs)}"
   new_master_az_count = "${length(local.new_master_subnet_azs)}"
 
-  // The base set of ids needs to build rest of vpc data sources
+  // The VPC ID to use to build the rest of the vpc data sources
   vpc_id = "${aws_vpc.new_vpc.id}"
 
   // When referencing the _ids arrays or data source arrays via count = , always use the *_count variable rather than taking the length of the list
-  worker_subnet_ids   = ["${coalescelist(aws_subnet.worker_subnet.*.id,var.external_worker_subnet_ids)}"]
-  master_subnet_ids   = ["${coalescelist(aws_subnet.master_subnet.*.id,var.external_master_subnet_ids)}"]
+  worker_subnet_ids   = "${aws_subnet.worker_subnet.*.id}"
+  master_subnet_ids   = "${aws_subnet.master_subnet.*.id}"
   worker_subnet_count = "${local.new_worker_az_count}"
   master_subnet_count = "${local.new_master_az_count}"
 }

--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -7,26 +7,22 @@ data "aws_availability_zones" "azs" {}
 
 // Only reference data sources which are gauranteed to exist at any time (above) in this locals{} block
 locals {
-  // Define canonical source of truth for this
-  external_vpc_mode = "${var.external_vpc_id != ""}"
-
   // List of possible AZs for each type of subnet
   new_worker_subnet_azs = ["${coalescelist(keys(var.new_worker_subnet_configs), data.aws_availability_zones.azs.names)}"]
   new_master_subnet_azs = ["${coalescelist(keys(var.new_master_subnet_configs), data.aws_availability_zones.azs.names)}"]
 
-  // How many AZs to create worker and master subnets in (always zero if external_vpc_mode)
-  new_worker_az_count = "${local.external_vpc_mode ? 0 : length(local.new_worker_subnet_azs)}"
-  new_master_az_count = "${local.external_vpc_mode ? 0 : length(local.new_master_subnet_azs)}"
+  // How many AZs to create worker and master subnets in
+  new_worker_az_count = "${length(local.new_worker_subnet_azs)}"
+  new_master_az_count = "${length(local.new_master_subnet_azs)}"
 
   // The base set of ids needs to build rest of vpc data sources
-  // This is crux of dealing with existing vpc / new vpc incongruity
-  vpc_id = "${local.external_vpc_mode ? var.external_vpc_id : element(concat(aws_vpc.new_vpc.*.id,list("")),0)}"
+  vpc_id = "${aws_vpc.new_vpc.id}"
 
   // When referencing the _ids arrays or data source arrays via count = , always use the *_count variable rather than taking the length of the list
   worker_subnet_ids   = ["${coalescelist(aws_subnet.worker_subnet.*.id,var.external_worker_subnet_ids)}"]
   master_subnet_ids   = ["${coalescelist(aws_subnet.master_subnet.*.id,var.external_master_subnet_ids)}"]
-  worker_subnet_count = "${local.external_vpc_mode ? length(var.external_worker_subnet_ids) : local.new_worker_az_count}"
-  master_subnet_count = "${local.external_vpc_mode ? length(var.external_master_subnet_ids) : local.new_master_az_count}"
+  worker_subnet_count = "${local.new_worker_az_count}"
+  master_subnet_count = "${local.new_master_az_count}"
 }
 
 # all data sources should be input variable-agnostic and used as canonical source for querying "state of resources" and building outputs

--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -1,6 +1,4 @@
 resource "aws_lb" "api_internal" {
-  count = "${var.private_master_endpoints ? 1 : 0}"
-
   name                             = "${var.cluster_name}-int"
   load_balancer_type               = "network"
   subnets                          = ["${local.master_subnet_ids}"]
@@ -16,8 +14,6 @@ resource "aws_lb" "api_internal" {
 }
 
 resource "aws_lb" "api_external" {
-  count = "${var.public_master_endpoints ? 1 : 0}"
-
   name                             = "${var.cluster_name}-ext"
   load_balancer_type               = "network"
   subnets                          = ["${local.master_subnet_ids}"]
@@ -33,8 +29,6 @@ resource "aws_lb" "api_external" {
 }
 
 resource "aws_lb_target_group" "api_internal" {
-  count = "${var.private_master_endpoints ? 1 : 0}"
-
   name     = "${var.cluster_name}-api-int"
   protocol = "TCP"
   port     = 6443
@@ -58,8 +52,6 @@ resource "aws_lb_target_group" "api_internal" {
 }
 
 resource "aws_lb_target_group" "api_external" {
-  count = "${var.public_master_endpoints ? 1 : 0}"
-
   name     = "${var.cluster_name}-api-ext"
   protocol = "TCP"
   port     = 6443
@@ -106,8 +98,6 @@ resource "aws_lb_target_group" "services" {
 }
 
 resource "aws_lb_listener" "api_internal_api" {
-  count = "${var.private_master_endpoints ? 1 : 0}"
-
   load_balancer_arn = "${aws_lb.api_internal.arn}"
   protocol          = "TCP"
   port              = "6443"
@@ -119,8 +109,6 @@ resource "aws_lb_listener" "api_internal_api" {
 }
 
 resource "aws_lb_listener" "api_internal_services" {
-  count = "${var.private_master_endpoints ? 1 : 0}"
-
   load_balancer_arn = "${aws_lb.api_internal.arn}"
   protocol          = "TCP"
   port              = "49500"

--- a/data/data/aws/vpc/outputs.tf
+++ b/data/data/aws/vpc/outputs.tf
@@ -7,7 +7,7 @@ output "master_subnet_ids" {
 }
 
 output "etcd_sg_id" {
-  value = "${element(concat(aws_security_group.etcd.*.id, list("")), 0)}"
+  value = "${aws_security_group.etcd.id}"
 }
 
 output "master_sg_id" {
@@ -31,21 +31,22 @@ output "aws_lb_target_group_arns" {
 }
 
 output "aws_lb_target_group_arns_length" {
-  value = "${(var.private_master_endpoints ? 2 : 0) + (var.public_master_endpoints ? 1 : 0)}"
+  // 2 for private endpoints and 1 for public endpoints
+  value = "3"
 }
 
 output "aws_lb_api_external_dns_name" {
-  value = "${element(concat(aws_lb.api_external.*.dns_name, list("")), 0)}"
+  value = "${aws_lb.api_external.dns_name}"
 }
 
 output "aws_lb_api_external_zone_id" {
-  value = "${element(concat(aws_lb.api_external.*.zone_id, list("")), 0)}"
+  value = "${aws_lb.api_external.zone_id}"
 }
 
 output "aws_lb_api_internal_dns_name" {
-  value = "${element(concat(aws_lb.api_internal.*.dns_name, list("")), 0)}"
+  value = "${aws_lb.api_internal.dns_name}"
 }
 
 output "aws_lb_api_internal_zone_id" {
-  value = "${element(concat(aws_lb.api_internal.*.zone_id, list("")), 0)}"
+  value = "${aws_lb.api_internal.zone_id}"
 }

--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -20,16 +20,6 @@ variable "extra_tags" {
   default     = {}
 }
 
-variable "new_master_subnet_configs" {
-  description = "{az_name = new_subnet_cidr}: Empty map means create new subnets in all availability zones in region with generated cidrs"
-  type        = "map"
-}
-
-variable "new_worker_subnet_configs" {
-  description = "{az_name = new_subnet_cidr}: Empty map means create new subnets in all availability zones in region with generated cidrs"
-  type        = "map"
-}
-
 variable "private_master_endpoints" {
   description = "If set to true, private-facing ingress resources are created."
   default     = true

--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -14,10 +14,6 @@ variable "cluster_name" {
   type = "string"
 }
 
-variable "external_vpc_id" {
-  type = "string"
-}
-
 variable "external_master_subnet_ids" {
   type = "list"
 }

--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -14,14 +14,6 @@ variable "cluster_name" {
   type = "string"
 }
 
-variable "external_master_subnet_ids" {
-  type = "list"
-}
-
-variable "external_worker_subnet_ids" {
-  type = "list"
-}
-
 variable "extra_tags" {
   description = "Extra AWS tags to be applied to created resources."
   type        = "map"

--- a/data/data/aws/vpc/vpc-private.tf
+++ b/data/data/aws/vpc/vpc-private.tf
@@ -1,9 +1,9 @@
 resource "aws_route_table" "private_routes" {
-  count  = "${local.new_worker_az_count}"
+  count  = "${local.new_az_count}"
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
   tags = "${merge(map(
-      "Name","${var.cluster_name}-private-${local.new_worker_subnet_azs[count.index]}",
+      "Name","${var.cluster_name}-private-${local.new_subnet_azs[count.index]}",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
       "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
@@ -11,7 +11,7 @@ resource "aws_route_table" "private_routes" {
 }
 
 resource "aws_route" "to_nat_gw" {
-  count                  = "${local.new_worker_az_count}"
+  count                  = "${local.new_az_count}"
   route_table_id         = "${aws_route_table.private_routes.*.id[count.index]}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${element(aws_nat_gateway.nat_gw.*.id, count.index)}"
@@ -19,19 +19,16 @@ resource "aws_route" "to_nat_gw" {
 }
 
 resource "aws_subnet" "worker_subnet" {
-  count = "${local.new_worker_az_count}"
+  count = "${local.new_az_count}"
 
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
-  cidr_block = "${lookup(var.new_worker_subnet_configs,
-    local.new_worker_subnet_azs[count.index],
-    cidrsubnet(local.new_worker_cidr_range, 3, count.index),
-  )}"
+  cidr_block = "${cidrsubnet(local.new_worker_cidr_range, 3, count.index)}"
 
-  availability_zone = "${local.new_worker_subnet_azs[count.index]}"
+  availability_zone = "${local.new_subnet_azs[count.index]}"
 
   tags = "${merge(map(
-    "Name", "${var.cluster_name}-worker-${local.new_worker_subnet_azs[count.index]}",
+    "Name", "${var.cluster_name}-worker-${local.new_subnet_azs[count.index]}",
     "kubernetes.io/cluster/${var.cluster_name}","shared",
     "kubernetes.io/role/internal-elb", "",
     "tectonicClusterID", "${var.cluster_id}",
@@ -41,7 +38,7 @@ resource "aws_subnet" "worker_subnet" {
 }
 
 resource "aws_route_table_association" "worker_routing" {
-  count          = "${local.new_worker_az_count}"
+  count          = "${local.new_az_count}"
   route_table_id = "${aws_route_table.private_routes.*.id[count.index]}"
   subnet_id      = "${aws_subnet.worker_subnet.*.id[count.index]}"
 }

--- a/data/data/aws/vpc/vpc-public.tf
+++ b/data/data/aws/vpc/vpc-public.tf
@@ -1,5 +1,4 @@
 resource "aws_internet_gateway" "igw" {
-  count  = "${local.external_vpc_mode ? 0 : 1}"
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
   tags = "${merge(map(
@@ -11,7 +10,6 @@ resource "aws_internet_gateway" "igw" {
 }
 
 resource "aws_route_table" "default" {
-  count  = "${var.external_vpc_id == "" ? 1 : 0}"
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
   tags = "${merge(map(
@@ -23,13 +21,11 @@ resource "aws_route_table" "default" {
 }
 
 resource "aws_main_route_table_association" "main_vpc_routes" {
-  count          = "${local.external_vpc_mode ? 0 : 1}"
   vpc_id         = "${data.aws_vpc.cluster_vpc.id}"
   route_table_id = "${aws_route_table.default.id}"
 }
 
 resource "aws_route" "igw_route" {
-  count                  = "${local.external_vpc_mode ? 0 : 1}"
   destination_cidr_block = "0.0.0.0/0"
   route_table_id         = "${aws_route_table.default.id}"
   gateway_id             = "${aws_internet_gateway.igw.id}"

--- a/data/data/aws/vpc/vpc-public.tf
+++ b/data/data/aws/vpc/vpc-public.tf
@@ -32,18 +32,15 @@ resource "aws_route" "igw_route" {
 }
 
 resource "aws_subnet" "master_subnet" {
-  count  = "${local.new_master_az_count}"
+  count  = "${local.new_az_count}"
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
-  cidr_block = "${lookup(var.new_master_subnet_configs,
-    local.new_master_subnet_azs[count.index],
-    cidrsubnet(local.new_master_cidr_range, 3, count.index),
-  )}"
+  cidr_block = "${cidrsubnet(local.new_master_cidr_range, 3, count.index)}"
 
-  availability_zone = "${local.new_master_subnet_azs[count.index]}"
+  availability_zone = "${local.new_subnet_azs[count.index]}"
 
   tags = "${merge(map(
-    "Name", "${var.cluster_name}-master-${local.new_master_subnet_azs[count.index]}",
+    "Name", "${var.cluster_name}-master-${local.new_subnet_azs[count.index]}",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
       "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
@@ -51,13 +48,13 @@ resource "aws_subnet" "master_subnet" {
 }
 
 resource "aws_route_table_association" "route_net" {
-  count          = "${local.new_master_az_count}"
+  count          = "${local.new_az_count}"
   route_table_id = "${aws_route_table.default.id}"
   subnet_id      = "${aws_subnet.master_subnet.*.id[count.index]}"
 }
 
 resource "aws_eip" "nat_eip" {
-  count = "${min(local.new_master_az_count,local.new_worker_az_count)}"
+  count = "${local.new_az_count}"
   vpc   = true
 
   tags = "${merge(map(
@@ -72,7 +69,7 @@ resource "aws_eip" "nat_eip" {
 }
 
 resource "aws_nat_gateway" "nat_gw" {
-  count         = "${min(local.new_master_az_count,local.new_worker_az_count)}"
+  count         = "${local.new_az_count}"
   allocation_id = "${aws_eip.nat_eip.*.id[count.index]}"
   subnet_id     = "${aws_subnet.master_subnet.*.id[count.index]}"
 

--- a/data/data/aws/vpc/vpc.tf
+++ b/data/data/aws/vpc/vpc.tf
@@ -4,7 +4,6 @@ locals {
 }
 
 resource "aws_vpc" "new_vpc" {
-  count                = "${var.external_vpc_id == "" ? 1 : 0}"
   cidr_block           = "${var.cidr_block}"
   enable_dns_hostnames = true
   enable_dns_support   = true

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -14,22 +14,14 @@ const (
 
 // AWS converts AWS related config.
 type AWS struct {
-	EC2AMIOverride string    `json:"aws_ec2_ami_override,omitempty"`
-	Endpoints      Endpoints `json:"aws_endpoints,omitempty"`
-	External       `json:",inline"`
+	EC2AMIOverride string            `json:"aws_ec2_ami_override,omitempty"`
+	Endpoints      Endpoints         `json:"aws_endpoints,omitempty"`
 	ExtraTags      map[string]string `json:"aws_extra_tags,omitempty"`
 	InstallerRole  string            `json:"aws_installer_role,omitempty"`
 	Master         `json:",inline"`
 	Region         string `json:"aws_region,omitempty"`
 	VPCCIDRBlock   string `json:"aws_vpc_cidr_block"`
 	Worker         `json:",inline"`
-}
-
-// External converts external related config.
-type External struct {
-	MasterSubnetIDs []string `json:"aws_external_master_subnet_ids,omitempty"`
-	PrivateZone     string   `json:"aws_external_private_zone,omitempty"`
-	WorkerSubnetIDs []string `json:"aws_external_worker_subnet_ids,omitempty"`
 }
 
 // Master converts master related config.

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -21,7 +21,7 @@ type AWS struct {
 	InstallerRole  string            `json:"aws_installer_role,omitempty"`
 	Master         `json:",inline"`
 	Region         string `json:"aws_region,omitempty"`
-	VPCCIDRBlock   string `json:"aws_vpc_cidr_block,omitempty"`
+	VPCCIDRBlock   string `json:"aws_vpc_cidr_block"`
 	Worker         `json:",inline"`
 }
 
@@ -29,7 +29,6 @@ type AWS struct {
 type External struct {
 	MasterSubnetIDs []string `json:"aws_external_master_subnet_ids,omitempty"`
 	PrivateZone     string   `json:"aws_external_private_zone,omitempty"`
-	VPCID           string   `json:"aws_external_vpc_id,omitempty"`
 	WorkerSubnetIDs []string `json:"aws_external_worker_subnet_ids,omitempty"`
 }
 

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -1,23 +1,9 @@
 package aws
 
-// Endpoints is the type of the AWS endpoints.
-type Endpoints string
-
-const (
-	// EndpointsAll represents the configuration for using both private and public endpoints.
-	EndpointsAll Endpoints = "all"
-	// EndpointsPrivate represents the configuration for using only private endpoints.
-	EndpointsPrivate Endpoints = "private"
-	// EndpointsPublic represents the configuration for using only public endpoints.
-	EndpointsPublic Endpoints = "public"
-)
-
 // AWS converts AWS related config.
 type AWS struct {
 	EC2AMIOverride string            `json:"aws_ec2_ami_override,omitempty"`
-	Endpoints      Endpoints         `json:"aws_endpoints,omitempty"`
 	ExtraTags      map[string]string `json:"aws_extra_tags,omitempty"`
-	InstallerRole  string            `json:"aws_installer_role,omitempty"`
 	Master         `json:",inline"`
 	Region         string `json:"aws_region,omitempty"`
 	VPCCIDRBlock   string `json:"aws_vpc_cidr_block"`
@@ -26,10 +12,8 @@ type AWS struct {
 
 // Master converts master related config.
 type Master struct {
-	CustomSubnets    map[string]string `json:"aws_master_custom_subnets,omitempty"`
-	EC2Type          string            `json:"aws_master_ec2_type,omitempty"`
-	ExtraSGIDs       []string          `json:"aws_master_extra_sg_ids,omitempty"`
-	IAMRoleName      string            `json:"aws_master_iam_role_name,omitempty"`
+	EC2Type          string `json:"aws_master_ec2_type,omitempty"`
+	IAMRoleName      string `json:"aws_master_iam_role_name,omitempty"`
 	MasterRootVolume `json:",inline"`
 }
 
@@ -42,6 +26,5 @@ type MasterRootVolume struct {
 
 // Worker converts worker related config.
 type Worker struct {
-	CustomSubnets map[string]string `json:"aws_worker_custom_subnets,omitempty"`
-	IAMRoleName   string            `json:"aws_worker_iam_role_name,omitempty"`
+	IAMRoleName string `json:"aws_worker_iam_role_name,omitempty"`
 }

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -82,7 +82,6 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 		}
 
 		config.AWS = aws.AWS{
-			Endpoints:      aws.EndpointsAll, // Default value for endpoints.
 			Region:         cfg.Platform.AWS.Region,
 			ExtraTags:      cfg.Platform.AWS.UserTags,
 			VPCCIDRBlock:   cfg.Platform.AWS.VPCCIDRBlock,

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -82,12 +82,9 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 		}
 
 		config.AWS = aws.AWS{
-			Endpoints: aws.EndpointsAll, // Default value for endpoints.
-			Region:    cfg.Platform.AWS.Region,
-			ExtraTags: cfg.Platform.AWS.UserTags,
-			External: aws.External{
-				VPCID: cfg.Platform.AWS.VPCID,
-			},
+			Endpoints:      aws.EndpointsAll, // Default value for endpoints.
+			Region:         cfg.Platform.AWS.Region,
+			ExtraTags:      cfg.Platform.AWS.UserTags,
 			VPCCIDRBlock:   cfg.Platform.AWS.VPCCIDRBlock,
 			EC2AMIOverride: ami,
 		}

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -14,12 +14,6 @@ type Platform struct {
 	// platform configuration.
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
 
-	// VPCID specifies the vpc to associate with the cluster.
-	// If empty, new vpc will be created.
-	// +optional
-	VPCID string `json:"vpcID"`
-
 	// VPCCIDRBlock
-	// +optional
 	VPCCIDRBlock string `json:"vpcCIDRBlock"`
 }


### PR DESCRIPTION
For the limited scope of the installer, we do not want the user to
have the ability to share the VPC between clusters. A shared VPC
could potentially be deleted when destroying one of the clusters,
leaving the rest of the clusters using the shared VPC in an unusable
state.

Fixes https://jira.coreos.com/browse/CORS-873