### PR TITLE
pkg/types: Push platform-specific types (AWS, etc.) into subdirs

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -15,6 +15,9 @@ import (
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/openstack"
 )
 
 const (
@@ -87,7 +90,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 
 	switch {
 	case installConfig.Config.Platform.AWS != nil:
-		metadata.ClusterPlatformMetadata.AWS = &types.ClusterAWSPlatformMetadata{
+		metadata.ClusterPlatformMetadata.AWS = &aws.Metadata{
 			Region: installConfig.Config.Platform.AWS.Region,
 			Identifier: []map[string]string{
 				{
@@ -99,14 +102,14 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 			},
 		}
 	case installConfig.Config.Platform.OpenStack != nil:
-		metadata.ClusterPlatformMetadata.OpenStack = &types.ClusterOpenStackPlatformMetadata{
+		metadata.ClusterPlatformMetadata.OpenStack = &openstack.Metadata{
 			Region: installConfig.Config.Platform.OpenStack.Region,
 			Identifier: map[string]string{
 				"tectonicClusterID": installConfig.Config.ClusterID,
 			},
 		}
 	case installConfig.Config.Platform.Libvirt != nil:
-		metadata.ClusterPlatformMetadata.Libvirt = &types.ClusterLibvirtPlatformMetadata{
+		metadata.ClusterPlatformMetadata.Libvirt = &libvirt.Metadata{
 			URI: installConfig.Config.Platform.Libvirt.URI,
 		}
 	default:

--- a/pkg/asset/ignition/machine/master_test.go
+++ b/pkg/asset/ignition/machine/master_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/aws"
 )
 
 // TestMasterGenerate tests generating the master asset.
@@ -31,7 +32,7 @@ func TestMasterGenerate(t *testing.T) {
 				},
 			},
 			Platform: types.Platform{
-				AWS: &types.AWSPlatform{
+				AWS: &aws.Platform{
 					Region: "us-east",
 				},
 			},

--- a/pkg/asset/ignition/machine/worker_test.go
+++ b/pkg/asset/ignition/machine/worker_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/aws"
 )
 
 // TestWorkerGenerate tests generating the worker asset.
@@ -26,7 +27,7 @@ func TestWorkerGenerate(t *testing.T) {
 				},
 			},
 			Platform: types.Platform{
-				AWS: &types.AWSPlatform{
+				AWS: &aws.Platform{
 					Region: "us-east",
 				},
 			},

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -100,8 +100,8 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 	switch {
 	case platform.AWS != nil:
 		a.Config.AWS = platform.AWS
-	case platform.Openstack != nil:
-		a.Config.OpenStack = platform.Openstack
+	case platform.OpenStack != nil:
+		a.Config.OpenStack = platform.OpenStack
 	case platform.Libvirt != nil:
 		a.Config.Libvirt = platform.Libvirt
 		a.Config.Libvirt.Network.Name = clusterName.ClusterName

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -14,6 +14,7 @@ import (
 	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/aws"
 )
 
 // Machines returns a list of machines for a machinepool.
@@ -68,7 +69,7 @@ func Machines(config *types.InstallConfig, pool *types.MachinePool, role, userDa
 	return machines, nil
 }
 
-func provider(clusterID, clusterName string, platform *types.AWSPlatform, mpool *types.AWSMachinePoolPlatform, azIdx int, role, userDataSecret string) (*awsprovider.AWSMachineProviderConfig, error) {
+func provider(clusterID, clusterName string, platform *aws.Platform, mpool *aws.MachinePool, azIdx int, role, userDataSecret string) (*awsprovider.AWSMachineProviderConfig, error) {
 	az := mpool.Zones[azIdx]
 	tags, err := tagsFromUserTags(clusterID, clusterName, platform.UserTags)
 	if err != nil {

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -10,6 +10,7 @@ import (
 	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/libvirt"
 )
 
 // Machines returns a list of machines for a machinepool.
@@ -60,7 +61,7 @@ func Machines(config *types.InstallConfig, pool *types.MachinePool, role, userDa
 	return machines, nil
 }
 
-func provider(platform *types.LibvirtPlatform, name string) *libvirtprovider.LibvirtMachineProviderConfig {
+func provider(platform *libvirt.Platform, name string) *libvirtprovider.LibvirtMachineProviderConfig {
 	return &libvirtprovider.LibvirtMachineProviderConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "libvirtproviderconfig.k8s.io/v1alpha1",

--- a/pkg/asset/machines/openstack/OWNERS
+++ b/pkg/asset/machines/openstack/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers

--- a/pkg/asset/machines/openstack/master.go
+++ b/pkg/asset/machines/openstack/master.go
@@ -4,7 +4,7 @@ package openstack
 import (
 	"text/template"
 
-	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/openstack"
 )
 
 // MasterConfig is used to generate the machine.
@@ -14,7 +14,7 @@ type MasterConfig struct {
 	Image       string
 	Tags        map[string]string
 	Region      string
-	Machine     types.OpenStackMachinePoolPlatform
+	Machine     openstack.MachinePool
 }
 
 // MasterMachinesTmpl is the template for master machines.

--- a/pkg/asset/machines/openstack/worker.go
+++ b/pkg/asset/machines/openstack/worker.go
@@ -4,7 +4,7 @@ package openstack
 import (
 	"text/template"
 
-	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/openstack"
 )
 
 // Config is used to generate the machine.
@@ -14,7 +14,7 @@ type Config struct {
 	Image       string
 	Tags        map[string]string
 	Region      string
-	Machine     types.OpenStackMachinePoolPlatform
+	Machine     openstack.MachinePool
 }
 
 // WorkerMachineSetTmpl is template for worker machineset.

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -21,16 +21,18 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines/openstack"
 	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
+	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
 )
 
-func defaultAWSMachinePoolPlatform() types.AWSMachinePoolPlatform {
-	return types.AWSMachinePoolPlatform{
+func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
+	return awstypes.MachinePool{
 		InstanceType: "t2.medium",
 	}
 }
 
-func defaultOpenStackMachinePoolPlatform() types.OpenStackMachinePoolPlatform {
-	return types.OpenStackMachinePoolPlatform{
+func defaultOpenStackMachinePoolPlatform() openstacktypes.MachinePool {
+	return openstacktypes.MachinePool{
 		FlavorName: "m1.medium",
 	}
 }

--- a/pkg/tfvars/openstack/OWNERS
+++ b/pkg/tfvars/openstack/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers

--- a/pkg/types/aws/doc.go
+++ b/pkg/types/aws/doc.go
@@ -1,0 +1,3 @@
+// Package aws contains AWS-specific structures for installer
+// configuration and management.
+package aws

--- a/pkg/types/aws/machinepool.go
+++ b/pkg/types/aws/machinepool.go
@@ -1,0 +1,62 @@
+package aws
+
+// MachinePool stores the configuration for a machine pool installed
+// on AWS.
+type MachinePool struct {
+	// Zones is list of availability zones that can be used.
+	Zones []string `json:"zones,omitempty"`
+
+	// AMIID defines the AMI that should be used.
+	AMIID string `json:"amiID,omitempty"`
+
+	// InstanceType defines the ec2 instance type.
+	// eg. m4-large
+	InstanceType string `json:"type"`
+
+	// IAMRoleName defines the IAM role associated
+	// with the ec2 instance.
+	IAMRoleName string `json:"iamRoleName"`
+
+	// EC2RootVolume defines the storage for ec2 instance.
+	EC2RootVolume `json:"rootVolume"`
+}
+
+// Set sets the values from `required` to `a`.
+func (a *MachinePool) Set(required *MachinePool) {
+	if required == nil || a == nil {
+		return
+	}
+
+	if len(required.Zones) > 0 {
+		a.Zones = required.Zones
+	}
+	if required.AMIID != "" {
+		a.AMIID = required.AMIID
+	}
+	if required.InstanceType != "" {
+		a.InstanceType = required.InstanceType
+	}
+	if required.IAMRoleName != "" {
+		a.IAMRoleName = required.IAMRoleName
+	}
+
+	if required.EC2RootVolume.IOPS != 0 {
+		a.EC2RootVolume.IOPS = required.EC2RootVolume.IOPS
+	}
+	if required.EC2RootVolume.Size != 0 {
+		a.EC2RootVolume.Size = required.EC2RootVolume.Size
+	}
+	if required.EC2RootVolume.Type != "" {
+		a.EC2RootVolume.Type = required.EC2RootVolume.Type
+	}
+}
+
+// EC2RootVolume defines the storage for an ec2 instance.
+type EC2RootVolume struct {
+	// IOPS defines the iops for the instance.
+	IOPS int `json:"iops"`
+	// Size defines the size of the instance.
+	Size int `json:"size"`
+	// Type defines the type of the instance.
+	Type string `json:"type"`
+}

--- a/pkg/types/aws/metadata.go
+++ b/pkg/types/aws/metadata.go
@@ -1,0 +1,12 @@
+package aws
+
+// Metadata contains AWS metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	Region string `json:"region"`
+
+	// Identifier holds a slice of filter maps.  The maps hold the
+	// key/value pairs for the tags we will be matching against.  A
+	// resource matches the map if all of the key/value pairs are in its
+	// tags.  A resource matches Identifier if it matches any of the maps.
+	Identifier []map[string]string `json:"identifier"`
+}

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -1,0 +1,25 @@
+package aws
+
+// Platform stores all the global configuration that all machinesets
+// use.
+type Platform struct {
+	// Region specifies the AWS region where the cluster will be created.
+	Region string `json:"region"`
+
+	// UserTags specifies additional tags for AWS resources created for the cluster.
+	UserTags map[string]string `json:"userTags,omitempty"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on AWS for machine pools which do not define their own
+	// platform configuration.
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// VPCID specifies the vpc to associate with the cluster.
+	// If empty, new vpc will be created.
+	// +optional
+	VPCID string `json:"vpcID"`
+
+	// VPCCIDRBlock
+	// +optional
+	VPCCIDRBlock string `json:"vpcCIDRBlock"`
+}

--- a/pkg/types/clustermetadata.go
+++ b/pkg/types/clustermetadata.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/openstack"
+)
+
 // ClusterMetadata contains information
 // regarding the cluster that was created by installer.
 type ClusterMetadata struct {
@@ -9,9 +15,9 @@ type ClusterMetadata struct {
 
 // ClusterPlatformMetadata contains metadata for platfrom.
 type ClusterPlatformMetadata struct {
-	AWS       *ClusterAWSPlatformMetadata       `json:"aws,omitempty"`
-	OpenStack *ClusterOpenStackPlatformMetadata `json:"openstack,omitempty"`
-	Libvirt   *ClusterLibvirtPlatformMetadata   `json:"libvirt,omitempty"`
+	AWS       *aws.Metadata       `json:"aws,omitempty"`
+	OpenStack *openstack.Metadata `json:"openstack,omitempty"`
+	Libvirt   *libvirt.Metadata   `json:"libvirt,omitempty"`
 }
 
 // Platform returns a string representation of the platform
@@ -31,27 +37,4 @@ func (cpm *ClusterPlatformMetadata) Platform() string {
 		return "openstack"
 	}
 	return ""
-}
-
-// ClusterAWSPlatformMetadata contains AWS metadata.
-type ClusterAWSPlatformMetadata struct {
-	Region string `json:"region"`
-
-	// Identifier holds a slice of filter maps.  The maps hold the
-	// key/value pairs for the tags we will be matching against.  A
-	// resource matches the map if all of the key/value pairs are in its
-	// tags.  A resource matches Identifier if it matches any of the maps.
-	Identifier []map[string]string `json:"identifier"`
-}
-
-// ClusterOpenStackPlatformMetadata contains OpenStack metadata.
-type ClusterOpenStackPlatformMetadata struct {
-	Region string `json:"region"`
-	// Most OpenStack resources are tagged with these tags as identifier.
-	Identifier map[string]string `json:"identifier"`
-}
-
-// ClusterLibvirtPlatformMetadata contains libvirt metadata.
-type ClusterLibvirtPlatformMetadata struct {
-	URI string `json:"uri"`
 }

--- a/pkg/types/doc.go
+++ b/pkg/types/doc.go
@@ -1,2 +1,3 @@
-// Package types defines structures for user-supplied installer configuration.
+// Package types defines structures for installer configuration and
+// management.
 package types

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -1,10 +1,11 @@
 package types
 
 import (
-	"net"
-
 	netopv1 "github.com/openshift/cluster-network-operator/pkg/apis/networkoperator/v1"
 	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/openstack"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -72,13 +73,13 @@ type Admin struct {
 // the installation. Only one of the platform configuration should be set.
 type Platform struct {
 	// AWS is the configuration used when installing on AWS.
-	AWS *AWSPlatform `json:"aws,omitempty"`
+	AWS *aws.Platform `json:"aws,omitempty"`
 
 	// Libvirt is the configuration used when installing on libvirt.
-	Libvirt *LibvirtPlatform `json:"libvirt,omitempty"`
+	Libvirt *libvirt.Platform `json:"libvirt,omitempty"`
 
 	// OpenStack is the configuration used when installing on OpenStack.
-	OpenStack *OpenStackPlatform `json:"openstack,omitempty"`
+	OpenStack *openstack.Platform `json:"openstack,omitempty"`
 }
 
 // Name returns a string representation of the platform (e.g. "aws" if
@@ -116,86 +117,4 @@ type Networking struct {
 	// we will fall back to the PodCIDR
 	// TODO(cdc) remove this.
 	PodCIDR *ipnet.IPNet `json:"podCIDR,omitempty"`
-}
-
-// AWSPlatform stores all the global configuration that
-// all machinesets use.
-type AWSPlatform struct {
-	// Region specifies the AWS region where the cluster will be created.
-	Region string `json:"region"`
-
-	// UserTags specifies additional tags for AWS resources created for the cluster.
-	UserTags map[string]string `json:"userTags,omitempty"`
-
-	// DefaultMachinePlatform is the default configuration used when
-	// installing on AWS for machine pools which do not define their own
-	// platform configuration.
-	DefaultMachinePlatform *AWSMachinePoolPlatform `json:"defaultMachinePlatform,omitempty"`
-
-	// VPCID specifies the vpc to associate with the cluster.
-	// If empty, new vpc will be created.
-	// +optional
-	VPCID string `json:"vpcID"`
-
-	// VPCCIDRBlock
-	// +optional
-	VPCCIDRBlock string `json:"vpcCIDRBlock"`
-}
-
-// OpenStackPlatform stores all the global configuration that
-// all machinesets use.
-type OpenStackPlatform struct {
-	// Region specifies the OpenStack region where the cluster will be created.
-	Region string `json:"region"`
-
-	// DefaultMachinePlatform is the default configuration used when
-	// installing on OpenStack for machine pools which do not define their own
-	// platform configuration.
-	DefaultMachinePlatform *OpenStackMachinePoolPlatform `json:"defaultMachinePlatform,omitempty"`
-
-	// NetworkCIDRBlock
-	// +optional
-	NetworkCIDRBlock string `json:"NetworkCIDRBlock"`
-
-	// BaseImage
-	// Name of image to use from OpenStack cloud
-	BaseImage string `json:"baseImage"`
-
-	// Cloud
-	// Name of OpenStack cloud to use from clouds.yaml
-	Cloud string `json:"cloud"`
-
-	// ExternalNetwork
-	// The OpenStack external network to be used for installation.
-	ExternalNetwork string `json:"externalNetwork"`
-}
-
-// LibvirtPlatform stores all the global configuration that
-// all machinesets use.
-type LibvirtPlatform struct {
-	// URI is the identifier for the libvirtd connection.  It must be
-	// reachable from both the host (where the installer is run) and the
-	// cluster (where the cluster-API controller pod will be running).
-	URI string `json:"URI"`
-
-	// DefaultMachinePlatform is the default configuration used when
-	// installing on AWS for machine pools which do not define their own
-	// platform configuration.
-	DefaultMachinePlatform *LibvirtMachinePoolPlatform `json:"defaultMachinePlatform,omitempty"`
-
-	// Network
-	Network LibvirtNetwork `json:"network"`
-
-	// MasterIPs
-	MasterIPs []net.IP `json:"masterIPs"`
-}
-
-// LibvirtNetwork is the configuration of the libvirt network.
-type LibvirtNetwork struct {
-	// Name is the name of the nework.
-	Name string `json:"name"`
-	// IfName is the name of the network interface.
-	IfName string `json:"if"`
-	// IPRange is the range of IPs to use.
-	IPRange string `json:"ipRange"`
 }

--- a/pkg/types/libvirt/doc.go
+++ b/pkg/types/libvirt/doc.go
@@ -1,0 +1,3 @@
+// Package libvirt contains libvirt-specific structures for
+// installer configuration and management.
+package libvirt

--- a/pkg/types/libvirt/machinepool.go
+++ b/pkg/types/libvirt/machinepool.go
@@ -1,0 +1,33 @@
+package libvirt
+
+// MachinePool stores the configuration for a machine pool installed
+// on libvirt.
+type MachinePool struct {
+	// ImagePool is the name of the libvirt storage pool to which the storage
+	// volume containing the OS image belongs.
+	ImagePool string `json:"imagePool,omitempty"`
+	// ImageVolume is the name of the libvirt storage volume containing the OS
+	// image.
+	ImageVolume string `json:"imageVolume,omitempty"`
+
+	// Image is the URL to the OS image.
+	// E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
+	Image string `json:"image"`
+}
+
+// Set sets the values from `required` to `a`.
+func (l *MachinePool) Set(required *MachinePool) {
+	if required == nil || l == nil {
+		return
+	}
+
+	if required.ImagePool != "" {
+		l.ImagePool = required.ImagePool
+	}
+	if required.ImageVolume != "" {
+		l.ImageVolume = required.ImageVolume
+	}
+	if required.Image != "" {
+		l.Image = required.Image
+	}
+}

--- a/pkg/types/libvirt/metadata.go
+++ b/pkg/types/libvirt/metadata.go
@@ -1,0 +1,6 @@
+package libvirt
+
+// Metadata contains libvirt metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	URI string `json:"uri"`
+}

--- a/pkg/types/libvirt/network.go
+++ b/pkg/types/libvirt/network.go
@@ -1,0 +1,11 @@
+package libvirt
+
+// Network is the configuration of the libvirt network.
+type Network struct {
+	// Name is the name of the nework.
+	Name string `json:"name"`
+	// IfName is the name of the network interface.
+	IfName string `json:"if"`
+	// IPRange is the range of IPs to use.
+	IPRange string `json:"ipRange"`
+}

--- a/pkg/types/libvirt/platform.go
+++ b/pkg/types/libvirt/platform.go
@@ -1,0 +1,25 @@
+package libvirt
+
+import (
+	"net"
+)
+
+// Platform stores all the global configuration that all
+// machinesets use.
+type Platform struct {
+	// URI is the identifier for the libvirtd connection.  It must be
+	// reachable from both the host (where the installer is run) and the
+	// cluster (where the cluster-API controller pod will be running).
+	URI string `json:"URI"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on libvirt for machine pools which do not define their
+	// own platform configuration.
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// Network
+	Network Network `json:"network"`
+
+	// MasterIPs
+	MasterIPs []net.IP `json:"masterIPs"`
+}

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/openstack"
+)
+
 // MachinePool is a pool of machines to be installed.
 type MachinePool struct {
 	// Name is the name of the machine pool.
@@ -17,13 +23,13 @@ type MachinePool struct {
 // pool. Only one of the platforms should be set.
 type MachinePoolPlatform struct {
 	// AWS is the configuration used when installing on AWS.
-	AWS *AWSMachinePoolPlatform `json:"aws,omitempty"`
+	AWS *aws.MachinePool `json:"aws,omitempty"`
 
 	// Libvirt is the configuration used when installing on libvirt.
-	Libvirt *LibvirtMachinePoolPlatform `json:"libvirt,omitempty"`
+	Libvirt *libvirt.MachinePool `json:"libvirt,omitempty"`
 
 	// OpenStack is the configuration used when installing on OpenStack.
-	OpenStack *OpenStackMachinePoolPlatform `json:"openstack,omitempty"`
+	OpenStack *openstack.MachinePool `json:"openstack,omitempty"`
 }
 
 // Name returns a string representation of the platform (e.g. "aws" if
@@ -43,139 +49,4 @@ func (p *MachinePoolPlatform) Name() string {
 		return PlatformNameOpenstack
 	}
 	return ""
-}
-
-// AWSMachinePoolPlatform stores the configuration for a machine pool
-// installed on AWS.
-type AWSMachinePoolPlatform struct {
-	// Zones is list of availability zones that can be used.
-	Zones []string `json:"zones,omitempty"`
-
-	// AMIID defines the AMI that should be used.
-	AMIID string `json:"amiID,omitempty"`
-
-	// InstanceType defines the ec2 instance type.
-	// eg. m4-large
-	InstanceType string `json:"type"`
-
-	// IAMRoleName defines the IAM role associated
-	// with the ec2 instance.
-	IAMRoleName string `json:"iamRoleName"`
-
-	// EC2RootVolume defines the storage for ec2 instance.
-	EC2RootVolume `json:"rootVolume"`
-}
-
-// Set sets the values from `required` to `a`.
-func (a *AWSMachinePoolPlatform) Set(required *AWSMachinePoolPlatform) {
-	if required == nil || a == nil {
-		return
-	}
-
-	if len(required.Zones) > 0 {
-		a.Zones = required.Zones
-	}
-	if required.AMIID != "" {
-		a.AMIID = required.AMIID
-	}
-	if required.InstanceType != "" {
-		a.InstanceType = required.InstanceType
-	}
-	if required.IAMRoleName != "" {
-		a.IAMRoleName = required.IAMRoleName
-	}
-
-	if required.EC2RootVolume.IOPS != 0 {
-		a.EC2RootVolume.IOPS = required.EC2RootVolume.IOPS
-	}
-	if required.EC2RootVolume.Size != 0 {
-		a.EC2RootVolume.Size = required.EC2RootVolume.Size
-	}
-	if required.EC2RootVolume.Type != "" {
-		a.EC2RootVolume.Type = required.EC2RootVolume.Type
-	}
-}
-
-// EC2RootVolume defines the storage for an ec2 instance.
-type EC2RootVolume struct {
-	// IOPS defines the iops for the instance.
-	IOPS int `json:"iops"`
-	// Size defines the size of the instance.
-	Size int `json:"size"`
-	// Type defines the type of the instance.
-	Type string `json:"type"`
-}
-
-// OpenStackMachinePoolPlatform stores the configuration for a machine pool
-// installed on OpenStack.
-type OpenStackMachinePoolPlatform struct {
-	// FlavorName defines the OpenStack Nova flavor.
-	// eg. m1.large
-	FlavorName string `json:"type"`
-
-	// OpenStackRootVolume defines the storage for Nova instance.
-	OpenStackRootVolume `json:"rootVolume"`
-}
-
-// Set sets the values from `required` to `a`.
-func (o *OpenStackMachinePoolPlatform) Set(required *OpenStackMachinePoolPlatform) {
-	if required == nil || o == nil {
-		return
-	}
-
-	if required.FlavorName != "" {
-		o.FlavorName = required.FlavorName
-	}
-
-	if required.OpenStackRootVolume.IOPS != 0 {
-		o.OpenStackRootVolume.IOPS = required.OpenStackRootVolume.IOPS
-	}
-	if required.OpenStackRootVolume.Size != 0 {
-		o.OpenStackRootVolume.Size = required.OpenStackRootVolume.Size
-	}
-	if required.OpenStackRootVolume.Type != "" {
-		o.OpenStackRootVolume.Type = required.OpenStackRootVolume.Type
-	}
-}
-
-// OpenStackRootVolume defines the storage for a Nova instance.
-type OpenStackRootVolume struct {
-	// IOPS defines the iops for the instance.
-	IOPS int `json:"iops"`
-	// Size defines the size of the instance.
-	Size int `json:"size"`
-	// Type defines the type of the instance.
-	Type string `json:"type"`
-}
-
-// LibvirtMachinePoolPlatform stores the configuration for a machine pool
-// installed on libvirt.
-type LibvirtMachinePoolPlatform struct {
-	// ImagePool is the name of the libvirt storage pool to which the storage
-	// volume containing the OS image belongs.
-	ImagePool string `json:"imagePool,omitempty"`
-	// ImageVolume is the name of the libvirt storage volume containing the OS
-	// image.
-	ImageVolume string `json:"imageVolume,omitempty"`
-
-	// Image is the URL to the OS image.
-	// E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
-	Image string `json:"image"`
-}
-
-// Set sets the values from `required` to `a`.
-func (l *LibvirtMachinePoolPlatform) Set(required *LibvirtMachinePoolPlatform) {
-	if required == nil || l == nil {
-		return
-	}
-
-	if required.ImagePool != "" {
-		l.ImagePool = required.ImagePool
-	}
-	if required.ImageVolume != "" {
-		l.ImageVolume = required.ImageVolume
-	}
-	if required.Image != "" {
-		l.Image = required.Image
-	}
 }

--- a/pkg/types/openstack/OWNERS
+++ b/pkg/types/openstack/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers

--- a/pkg/types/openstack/doc.go
+++ b/pkg/types/openstack/doc.go
@@ -1,0 +1,3 @@
+// Package openstack contains OpenStack-specific structures for
+// installer configuration and management.
+package openstack

--- a/pkg/types/openstack/machinepool.go
+++ b/pkg/types/openstack/machinepool.go
@@ -1,0 +1,43 @@
+package openstack
+
+// MachinePool stores the configuration for a machine pool installed
+// on OpenStack.
+type MachinePool struct {
+	// FlavorName defines the OpenStack Nova flavor.
+	// eg. m1.large
+	FlavorName string `json:"type"`
+
+	// RootVolume defines the storage for Nova instance.
+	RootVolume RootVolume `json:"rootVolume"`
+}
+
+// Set sets the values from `required` to `a`.
+func (o *MachinePool) Set(required *MachinePool) {
+	if required == nil || o == nil {
+		return
+	}
+
+	if required.FlavorName != "" {
+		o.FlavorName = required.FlavorName
+	}
+
+	if required.RootVolume.IOPS != 0 {
+		o.RootVolume.IOPS = required.RootVolume.IOPS
+	}
+	if required.RootVolume.Size != 0 {
+		o.RootVolume.Size = required.RootVolume.Size
+	}
+	if required.RootVolume.Type != "" {
+		o.RootVolume.Type = required.RootVolume.Type
+	}
+}
+
+// RootVolume defines the storage for a Nova instance.
+type RootVolume struct {
+	// IOPS defines the iops for the instance.
+	IOPS int `json:"iops"`
+	// Size defines the size of the instance.
+	Size int `json:"size"`
+	// Type defines the type of the instance.
+	Type string `json:"type"`
+}

--- a/pkg/types/openstack/metadata.go
+++ b/pkg/types/openstack/metadata.go
@@ -1,0 +1,8 @@
+package openstack
+
+// Metadata contains OpenStack metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	Region string `json:"region"`
+	// Most OpenStack resources are tagged with these tags as identifier.
+	Identifier map[string]string `json:"identifier"`
+}

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -1,0 +1,29 @@
+package openstack
+
+// Platform stores all the global configuration that all
+// machinesets use.
+type Platform struct {
+	// Region specifies the OpenStack region where the cluster will be created.
+	Region string `json:"region"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on OpenStack for machine pools which do not define their own
+	// platform configuration.
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// NetworkCIDRBlock
+	// +optional
+	NetworkCIDRBlock string `json:"NetworkCIDRBlock"`
+
+	// BaseImage
+	// Name of image to use from OpenStack cloud
+	BaseImage string `json:"baseImage"`
+
+	// Cloud
+	// Name of OpenStack cloud to use from clouds.yaml
+	Cloud string `json:"cloud"`
+
+	// ExternalNetwork
+	// The OpenStack external network to be used for installation.
+	ExternalNetwork string `json:"externalNetwork"`
+}


### PR DESCRIPTION
This decouples our platforms a bit and makes it easier to distinguish between platform-specific and platform-agnostic code.  It also gives us much more compact struct names, since now we don't need to distinguish between many flavors of machine pool, etc. in a single package.

I've also added `OWNERS` files for some OpenStack-specific directories that were missing them before.

There's still more work to go in this direction (e.g. pushing default logic into subdirs), but this seems like a reasonable chunk.

CC @flaper87, @tomassedovic