### PR TITLE
installconfig: change default network blocks

### DIFF
--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -19,8 +19,8 @@ const (
 )
 
 var (
-	defaultServiceCIDR      = parseCIDR("10.3.0.0/16")
-	defaultClusterCIDR      = "10.2.0.0/16"
+	defaultServiceCIDR      = parseCIDR("172.30.0.0/16")
+	defaultClusterCIDR      = "10.128.0.0/14"
 	defaultHostSubnetLength = 9 // equivalent to a /23 per node
 )
 


### PR DESCRIPTION
This matches the default values in openshift-ansible.

Without this, we will have to update a *lot* of documentation.