### PR TITLE
pkg/asset/cluster: Push InstallConfig -> Metadata into subpackages

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -1,0 +1,24 @@
+// Package aws extracts AWS metadata from install configurations.
+package aws
+
+import (
+	"fmt"
+
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/aws"
+)
+
+// Metadata converts an install configuration to AWS metadata.
+func Metadata(config *types.InstallConfig) *aws.Metadata {
+	return &aws.Metadata{
+		Region: config.Platform.AWS.Region,
+		Identifier: []map[string]string{
+			{
+				"tectonicClusterID": config.ClusterID,
+			},
+			{
+				fmt.Sprintf("kubernetes.io/cluster/%s", config.ObjectMeta.Name): "owned",
+			},
+		},
+	}
+}

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -11,13 +11,13 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/cluster/aws"
+	"github.com/openshift/installer/pkg/asset/cluster/libvirt"
+	"github.com/openshift/installer/pkg/asset/cluster/openstack"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/aws"
-	"github.com/openshift/installer/pkg/types/libvirt"
-	"github.com/openshift/installer/pkg/types/openstack"
 )
 
 const (
@@ -90,28 +90,11 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 
 	switch {
 	case installConfig.Config.Platform.AWS != nil:
-		metadata.ClusterPlatformMetadata.AWS = &aws.Metadata{
-			Region: installConfig.Config.Platform.AWS.Region,
-			Identifier: []map[string]string{
-				{
-					"tectonicClusterID": installConfig.Config.ClusterID,
-				},
-				{
-					fmt.Sprintf("kubernetes.io/cluster/%s", installConfig.Config.ObjectMeta.Name): "owned",
-				},
-			},
-		}
+		metadata.ClusterPlatformMetadata.AWS = aws.Metadata(installConfig.Config)
 	case installConfig.Config.Platform.OpenStack != nil:
-		metadata.ClusterPlatformMetadata.OpenStack = &openstack.Metadata{
-			Region: installConfig.Config.Platform.OpenStack.Region,
-			Identifier: map[string]string{
-				"tectonicClusterID": installConfig.Config.ClusterID,
-			},
-		}
+		metadata.ClusterPlatformMetadata.OpenStack = openstack.Metadata(installConfig.Config)
 	case installConfig.Config.Platform.Libvirt != nil:
-		metadata.ClusterPlatformMetadata.Libvirt = &libvirt.Metadata{
-			URI: installConfig.Config.Platform.Libvirt.URI,
-		}
+		metadata.ClusterPlatformMetadata.Libvirt = libvirt.Metadata(installConfig.Config)
 	default:
 		return fmt.Errorf("no known platform")
 	}

--- a/pkg/asset/cluster/libvirt/libvirt.go
+++ b/pkg/asset/cluster/libvirt/libvirt.go
@@ -1,0 +1,14 @@
+// Package libvirt extracts libvirt metadata from install configurations.
+package libvirt
+
+import (
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/libvirt"
+)
+
+// Metadata converts an install configuration to libvirt metadata.
+func Metadata(config *types.InstallConfig) *libvirt.Metadata {
+	return &libvirt.Metadata{
+		URI: config.Platform.Libvirt.URI,
+	}
+}

--- a/pkg/asset/cluster/openstack/OWNERS
+++ b/pkg/asset/cluster/openstack/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers

--- a/pkg/asset/cluster/openstack/openstack.go
+++ b/pkg/asset/cluster/openstack/openstack.go
@@ -1,0 +1,18 @@
+// Package openstack extracts OpenStack metadata from install
+// configurations.
+package openstack
+
+import (
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/openstack"
+)
+
+// Metadata converts an install configuration to OpenStack metadata.
+func Metadata(config *types.InstallConfig) *openstack.Metadata {
+	return &openstack.Metadata{
+		Region: config.Platform.OpenStack.Region,
+		Identifier: map[string]string{
+			"tectonicClusterID": config.ClusterID,
+		},
+	}
+}


### PR DESCRIPTION
To keep the platform-specific code separate.  These converters are a bit tiny for their own packages, but they seemed too application-specific to belong to `pkg/types`.