### PR TITLE
docs/dev/dependencies: Nest "Go" under "Build Dependencies"

### DIFF
--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -12,7 +12,7 @@ sudo yum install golang-bin gcc-c++
 
 If you need support for [libvirt destroy](libvirt-howto.md#cleanup), you should also install `libvirt-devel`.
 
-## Go
+### Go
 
 We follow a hard flattening approach; i.e. direct and inherited dependencies are installed in the base `vendor/`.
 


### PR DESCRIPTION
This should have happened when "Build Dependencies" landed in 4278ba3f (#315).