### PR TITLE
.github/ISSUE_TEMPLATE: Ask for libvirt version information

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,6 +12,8 @@ If we're wrong, PLEASE feel free to reopen it and explain why.
 ```console
 $ openshift-install version
 <your output here>
+$ ~/.terraform.d/plugins/terraform-provider-libvirt -version  # only needed if you're using libvirt
+<your output here>
 ```
 
 # Platform (aws|libvirt|openstack):


### PR DESCRIPTION
We see a lot of libvirt issues do to ancient libvirt versions.  Just today, I fielded one from someone running QEMU 1.5.3 (from 2013!).  Asking for this information up front saves a follow up request/response, and hopefully it's obvious enough that folks using other providers can skip it.

Terraform can [load plugins from a few places][1], but I've used the standard path on POSIX systems.  I expect folks who install to non-standard locations will be able to adapt, and we'll worry about making it easy for Windows when we get users on Windows ;).

[1]: https://www.terraform.io/docs/extend/how-terraform-works.html#plugin-locations