### PR TITLE
security: Open ports 9000-9999 inside the cluster for host network services

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -118,24 +118,24 @@ resource "aws_security_group_rule" "master_ingress_flannel_from_worker" {
   to_port   = 4789
 }
 
-resource "aws_security_group_rule" "master_ingress_node_exporter" {
+resource "aws_security_group_rule" "master_ingress_internal" {
   type              = "ingress"
   security_group_id = "${aws_security_group.master.id}"
 
   protocol  = "tcp"
-  from_port = 9100
-  to_port   = 9100
+  from_port = 9000
+  to_port   = 9990
   self      = true
 }
 
-resource "aws_security_group_rule" "master_ingress_node_exporter_from_worker" {
+resource "aws_security_group_rule" "master_ingress_internal_from_worker" {
   type                     = "ingress"
   security_group_id        = "${aws_security_group.master.id}"
   source_security_group_id = "${aws_security_group.worker.id}"
 
   protocol  = "tcp"
-  from_port = 9100
-  to_port   = 9100
+  from_port = 9000
+  to_port   = 9990
 }
 
 resource "aws_security_group_rule" "master_ingress_kubelet_insecure" {

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -90,21 +90,21 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_flannel_from_wo
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_node_exporter" {
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 9100
-  port_range_max    = 9100
+  port_range_min    = 9000
+  port_range_max    = 9999
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_node_exporter_from_worker" {
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_from_worker" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 9100
-  port_range_max    = 9100
+  port_range_min    = 9000
+  port_range_max    = 9999
   remote_group_id   = "${openstack_networking_secgroup_v2.worker.id}"
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }


### PR DESCRIPTION
In OpenShift 3.x we opened 9000-9999 for TCP for all internal connections
between masters, infra, and workers so that we could have a range that
host level services inside the cluster could coordinate on. This range
is analogous to node ports, except unlike node ports it is only available
on the inside. The most common consumers are node network metrics ports
(node exporter, cluster version operator, network operator, sdn, node
proxy) that need to be reachable from prometheus without magic tricks.
A second set is internal secured services that want to connect but must
be host network, like gluster, storage services, or other cluster level
proxies.

Open the range 9000-9999 by default so that new services don't require
either a reinstall or manual management. Future changes in the platform
may autoallocate from this range, but for now teams must reserve.

Consistent with 3.x, blocks CVO metrics from being read by prometheus-k8s.