### PR TITLE
data/data/aws/vpc: Drop 'current' from aws_region

### DIFF
--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -1,8 +1,6 @@
 # Canonical internal state definitions for this module.
 # read only: only locals and data source definitions allowed. No resources or module blocks in this file
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 // Fetch a list of available AZs
 data "aws_availability_zones" "azs" {}


### PR DESCRIPTION
It's the default.  The old parameter was deprecated before terraform-providers/terraform-provider-aws@1cc81c92 (v1.9.0), and we're pinning 1.39.0 since ac5aeed6 (#594).  Changing this avoids:

```console
$ openshift-install --log-level=debug create cluster
...
- Downloading plugin for provider "aws" (1.39.0)...
...
Warning: module.vpc.data.aws_region.current: "current": [DEPRECATED] Defaults to current provider region if no other filtering is enabled
...
```