### PR TITLE
pkg/asset/installconfig: Pull AWS region default from usual places

### DIFF
--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -37,7 +37,7 @@ The installer accepts a number of environment variable that allow the interactiv
 ## Platform-Specific
 
 * `AWS_PROFILE`:
-     The AWS profile that corresponds to value in `${HOME}/.aws/credentials`.  If not provided, the default is "default".
+    The AWS profile that corresponds to value in `${HOME}/.aws/credentials`.  If not provided, the default is "default".
 * `OPENSHIFT_INSTALL_AWS_REGION`:
     The AWS region to be used for installation.
 * `OPENSHIFT_INSTALL_LIBVIRT_URI`:


### PR DESCRIPTION
The `AWS_DEFAULT_REGION` environment variable is widely supported, e.g. by [the AWS command line][1], [the AWS Go library][2], and [Terraform][3].  By dropping our custom environment variable in favor of the common one, we make life easier on users who may already have `AWS_DEFAULT_REGION` configured for one of the non-installer consumers.

The usual AWS configuration also supplies other ways to declare a default region (e.g. `~/.aws/config` [here][4] and [here][5]).  With this commit, we check those locations instead of assuming `us-east-1`.  In most cases, we still prompt the user to confirm, but we treat the `AWS_DEFAULT_REGION` case as already-chosen and skip the prompt.

If we want this, we'll need to land openshift/release#2152 first.

This is related to, but not quite the same as, when we dropped the profile config in #466.

[1]: https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html
[2]: https://godoc.org/github.com/aws/aws-sdk-go/aws/session#hdr-Environment_Variables
[3]: https://www.terraform.io/docs/providers/aws/#environment-variables
[4]: https://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
[5]: https://godoc.org/github.com/aws/aws-sdk-go/aws/session#hdr-Creating_Sessions