### PR TITLE
Install qemu-kvm as part of Libvirt flow

### DIFF
--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -22,7 +22,7 @@ If it is missing, try some of the ideas [here][kvm-install].
 On Fedora, CentOS/RHEL:
 
 ```sh
-sudo yum install libvirt libvirt-devel
+sudo yum install libvirt libvirt-devel libvirt-daemon-kvm qemu-kvm
 ```
 
 Then start libvirtd:


### PR DESCRIPTION
On RHEL (and IIRC Fedora as well) installing Libvirt doesn't actually
automatically mean you pulled in a hypervisor to actually run VMs on. As
a result you can encounter this error because qemu-kvm or equivalent is
not present:

    Could not find any guests for architecure type hvm/x86_64

To avoid this, explicitly install qemu-kvm (if qemu-kvm-rhev or
qemu-kvm-ev are available in the machine's yum/dnf configuration they
will automatically get pulled in instead).