### PR TITLE
pkg/tfvars: Drop YAML tags

### DIFF
--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -18,54 +18,54 @@ const (
 
 // AWS converts AWS related config.
 type AWS struct {
-	EC2AMIOverride string    `json:"tectonic_aws_ec2_ami_override,omitempty" yaml:"ec2AMIOverride,omitempty"`
-	Endpoints      Endpoints `json:"tectonic_aws_endpoints,omitempty" yaml:"endpoints,omitempty"`
-	External       `json:",inline" yaml:"external,omitempty"`
-	ExtraTags      map[string]string `json:"tectonic_aws_extra_tags,omitempty" yaml:"extraTags,omitempty"`
-	InstallerRole  string            `json:"tectonic_aws_installer_role,omitempty" yaml:"installerRole,omitempty"`
-	Master         `json:",inline" yaml:"master,omitempty"`
-	Region         string `json:"tectonic_aws_region,omitempty" yaml:"region,omitempty"`
-	VPCCIDRBlock   string `json:"tectonic_aws_vpc_cidr_block,omitempty" yaml:"vpcCIDRBlock,omitempty"`
-	Worker         `json:",inline" yaml:"worker,omitempty"`
+	EC2AMIOverride string    `json:"tectonic_aws_ec2_ami_override,omitempty"`
+	Endpoints      Endpoints `json:"tectonic_aws_endpoints,omitempty"`
+	External       `json:",inline"`
+	ExtraTags      map[string]string `json:"tectonic_aws_extra_tags,omitempty"`
+	InstallerRole  string            `json:"tectonic_aws_installer_role,omitempty"`
+	Master         `json:",inline"`
+	Region         string `json:"tectonic_aws_region,omitempty"`
+	VPCCIDRBlock   string `json:"tectonic_aws_vpc_cidr_block,omitempty"`
+	Worker         `json:",inline"`
 }
 
 // External converts external related config.
 type External struct {
-	MasterSubnetIDs []string `json:"tectonic_aws_external_master_subnet_ids,omitempty" yaml:"masterSubnetIDs,omitempty"`
-	PrivateZone     string   `json:"tectonic_aws_external_private_zone,omitempty" yaml:"privateZone,omitempty"`
-	VPCID           string   `json:"tectonic_aws_external_vpc_id,omitempty" yaml:"vpcID,omitempty"`
-	WorkerSubnetIDs []string `json:"tectonic_aws_external_worker_subnet_ids,omitempty" yaml:"workerSubnetIDs,omitempty"`
+	MasterSubnetIDs []string `json:"tectonic_aws_external_master_subnet_ids,omitempty"`
+	PrivateZone     string   `json:"tectonic_aws_external_private_zone,omitempty"`
+	VPCID           string   `json:"tectonic_aws_external_vpc_id,omitempty"`
+	WorkerSubnetIDs []string `json:"tectonic_aws_external_worker_subnet_ids,omitempty"`
 }
 
 // Master converts master related config.
 type Master struct {
-	CustomSubnets    map[string]string `json:"tectonic_aws_master_custom_subnets,omitempty" yaml:"customSubnets,omitempty"`
-	EC2Type          string            `json:"tectonic_aws_master_ec2_type,omitempty" yaml:"ec2Type,omitempty"`
-	ExtraSGIDs       []string          `json:"tectonic_aws_master_extra_sg_ids,omitempty" yaml:"extraSGIDs,omitempty"`
-	IAMRoleName      string            `json:"tectonic_aws_master_iam_role_name,omitempty" yaml:"iamRoleName,omitempty"`
-	MasterRootVolume `json:",inline" yaml:"rootVolume,omitempty"`
+	CustomSubnets    map[string]string `json:"tectonic_aws_master_custom_subnets,omitempty"`
+	EC2Type          string            `json:"tectonic_aws_master_ec2_type,omitempty"`
+	ExtraSGIDs       []string          `json:"tectonic_aws_master_extra_sg_ids,omitempty"`
+	IAMRoleName      string            `json:"tectonic_aws_master_iam_role_name,omitempty"`
+	MasterRootVolume `json:",inline"`
 }
 
 // MasterRootVolume converts master rool volume related config.
 type MasterRootVolume struct {
-	IOPS int    `json:"tectonic_aws_master_root_volume_iops,omitempty" yaml:"iops,omitempty"`
-	Size int    `json:"tectonic_aws_master_root_volume_size,omitempty" yaml:"size,omitempty"`
-	Type string `json:"tectonic_aws_master_root_volume_type,omitempty" yaml:"type,omitempty"`
+	IOPS int    `json:"tectonic_aws_master_root_volume_iops,omitempty"`
+	Size int    `json:"tectonic_aws_master_root_volume_size,omitempty"`
+	Type string `json:"tectonic_aws_master_root_volume_type,omitempty"`
 }
 
 // Worker converts worker related config.
 type Worker struct {
-	CustomSubnets    map[string]string `json:"tectonic_aws_worker_custom_subnets,omitempty" yaml:"customSubnets,omitempty"`
-	EC2Type          string            `json:"tectonic_aws_worker_ec2_type,omitempty" yaml:"ec2Type,omitempty"`
-	ExtraSGIDs       []string          `json:"tectonic_aws_worker_extra_sg_ids,omitempty" yaml:"extraSGIDs,omitempty"`
-	IAMRoleName      string            `json:"tectonic_aws_worker_iam_role_name,omitempty" yaml:"iamRoleName,omitempty"`
-	LoadBalancers    []string          `json:"tectonic_aws_worker_load_balancers,omitempty" yaml:"loadBalancers,omitempty"`
-	WorkerRootVolume `json:",inline" yaml:"rootVolume,omitempty"`
+	CustomSubnets    map[string]string `json:"tectonic_aws_worker_custom_subnets,omitempty"`
+	EC2Type          string            `json:"tectonic_aws_worker_ec2_type,omitempty"`
+	ExtraSGIDs       []string          `json:"tectonic_aws_worker_extra_sg_ids,omitempty"`
+	IAMRoleName      string            `json:"tectonic_aws_worker_iam_role_name,omitempty"`
+	LoadBalancers    []string          `json:"tectonic_aws_worker_load_balancers,omitempty"`
+	WorkerRootVolume `json:",inline"`
 }
 
 // WorkerRootVolume converts worker rool volume related config.
 type WorkerRootVolume struct {
-	IOPS int    `json:"tectonic_aws_worker_root_volume_iops,omitempty" yaml:"iops,omitempty"`
-	Size int    `json:"tectonic_aws_worker_root_volume_size,omitempty" yaml:"size,omitempty"`
-	Type string `json:"tectonic_aws_worker_root_volume_type,omitempty" yaml:"type,omitempty"`
+	IOPS int    `json:"tectonic_aws_worker_root_volume_iops,omitempty"`
+	Size int    `json:"tectonic_aws_worker_root_volume_size,omitempty"`
+	Type string `json:"tectonic_aws_worker_root_volume_type,omitempty"`
 }

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -14,18 +14,18 @@ const (
 
 // Libvirt encompasses configuration specific to libvirt.
 type Libvirt struct {
-	URI         string `json:"tectonic_libvirt_uri,omitempty" yaml:"uri"`
-	Image       string `json:"tectonic_os_image,omitempty" yaml:"image"`
-	Network     `json:",inline" yaml:"network"`
-	MasterIPs   []string `json:"tectonic_libvirt_master_ips,omitempty" yaml:"masterIPs"`
-	WorkerIPs   []string `json:"tectonic_libvirt_worker_ips,omitempty" yaml:"workerIPs"`
-	BootstrapIP string   `json:"tectonic_libvirt_bootstrap_ip,omitempty" yaml:"bootstrapIP"`
+	URI         string `json:"tectonic_libvirt_uri,omitempty"`
+	Image       string `json:"tectonic_os_image,omitempty"`
+	Network     `json:",inline"`
+	MasterIPs   []string `json:"tectonic_libvirt_master_ips,omitempty"`
+	WorkerIPs   []string `json:"tectonic_libvirt_worker_ips,omitempty"`
+	BootstrapIP string   `json:"tectonic_libvirt_bootstrap_ip,omitempty"`
 }
 
 // Network describes a libvirt network configuration.
 type Network struct {
-	IfName  string `json:"tectonic_libvirt_network_if,omitempty" yaml:"ifName"`
-	IPRange string `json:"tectonic_libvirt_ip_range,omitempty" yaml:"ipRange"`
+	IfName  string `json:"tectonic_libvirt_network_if,omitempty"`
+	IPRange string `json:"tectonic_libvirt_ip_range,omitempty"`
 }
 
 // TFVars fills in computed Terraform variables.

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -9,48 +9,48 @@ const (
 
 // OpenStack converts OpenStack related config.
 type OpenStack struct {
-	BaseImage        string `json:"tectonic_openstack_base_image,omitempty" yaml:"baseImage,omitempty"`
-	Credentials      `json:",inline" yaml:"credentials,omitempty"`
-	External         `json:",inline" yaml:"external,omitempty"`
-	ExternalNetwork  string            `json:"tectonic_openstack_external_network,omitempty" yaml:"externalNetwork,omitempty"`
-	ExtraTags        map[string]string `json:"tectonic_openstack_extra_tags,omitempty" yaml:"extraTags,omitempty"`
-	Master           `json:",inline" yaml:"master,omitempty"`
-	Region           string `json:"tectonic_openstack_region,omitempty" yaml:"region,omitempty"`
-	NetworkCIDRBlock string `json:"tectonic_openstack_network_cidr_block,omitempty" yaml:"networkCIDRBlock,omitempty"`
+	BaseImage        string `json:"tectonic_openstack_base_image,omitempty"`
+	Credentials      `json:",inline"`
+	External         `json:",inline"`
+	ExternalNetwork  string            `json:"tectonic_openstack_external_network,omitempty"`
+	ExtraTags        map[string]string `json:"tectonic_openstack_extra_tags,omitempty"`
+	Master           `json:",inline"`
+	Region           string `json:"tectonic_openstack_region,omitempty"`
+	NetworkCIDRBlock string `json:"tectonic_openstack_network_cidr_block,omitempty"`
 }
 
 // External converts external related config.
 type External struct {
-	MasterSubnetIDs []string `json:"tectonic_openstack_external_master_subnet_ids,omitempty" yaml:"masterSubnetIDs,omitempty"`
+	MasterSubnetIDs []string `json:"tectonic_openstack_external_master_subnet_ids,omitempty"`
 }
 
 // Master converts master related config.
 type Master struct {
-	FlavorName string   `json:"tectonic_openstack_master_flavor_name,omitempty" yaml:"flavorName,omitempty"`
-	ExtraSGIDs []string `json:"tectonic_openstack_master_extra_sg_ids,omitempty" yaml:"extraSGIDs,omitempty"`
+	FlavorName string   `json:"tectonic_openstack_master_flavor_name,omitempty"`
+	ExtraSGIDs []string `json:"tectonic_openstack_master_extra_sg_ids,omitempty"`
 }
 
 // Credentials converts credentials related config.
 type Credentials struct {
-	AuthURL           string `json:"tectonic_openstack_credentials_auth_url,omitempty" yaml:"authUrl,omitempty"`
-	Cert              string `json:"tectonic_openstack_credentials_cert,omitempty" yaml:"cert,omitempty"`
-	Cloud             string `json:"tectonic_openstack_credentials_cloud,omitempty" yaml:"cloud,omitempty"`
-	DomainID          string `json:"tectonic_openstack_credentials_domain_id,omitempty" yaml:"domainId,omitempty"`
-	DomainName        string `json:"tectonic_openstack_credentials_domain_name,omitempty" yaml:"domainName,omitempty"`
-	EndpointType      string `json:"tectonic_openstack_credentials_endpoint_type,omitempty" yaml:"endpointType,omitempty"`
-	Insecure          bool   `json:"tectonic_openstack_credentials_insecure,omitempty" yaml:"insecure,omitempty"`
-	Key               string `json:"tectonic_openstack_credentials_key,omitempty" yaml:"key,omitempty"`
-	Password          string `json:"tectonic_openstack_credentials_password,omitempty" yaml:"password,omitempty"`
-	ProjectDomainID   string `json:"tectonic_openstack_credentials_project_domain_id,omitempty" yaml:"projectDomainId,omitempty"`
-	ProjectDomainName string `json:"tectonic_openstack_credentials_project_domain_name,omitempty" yaml:"projectDomainName,omitempty"`
-	Region            string `json:"tectonic_openstack_credentials_region,omitempty" yaml:"region,omitempty"`
-	Swauth            bool   `json:"tectonic_openstack_credentials_swauth,omitempty" yaml:"swauth,omitempty"`
-	TenantID          string `json:"tectonic_openstack_credentials_tenant_id,omitempty" yaml:"tenantId,omitempty"`
-	TenantName        string `json:"tectonic_openstack_credentials_tenant_name,omitempty" yaml:"tenantName,omitempty"`
-	Token             string `json:"tectonic_openstack_credentials_token,omitempty" yaml:"token,omitempty"`
-	UseOctavia        bool   `json:"tectonic_openstack_credentials_use_octavia,omitempty" yaml:"useOctavia,omitempty"`
-	UserDomainID      string `json:"tectonic_openstack_credentials_user_domain_id,omitempty" yaml:"userDomainId,omitempty"`
-	UserDomainName    string `json:"tectonic_openstack_credentials_user_domain_name,omitempty" yaml:"userDomainName,omitempty"`
-	UserID            string `json:"tectonic_openstack_credentials_user_id,omitempty" yaml:"userId,omitempty"`
-	UserName          string `json:"tectonic_openstack_credentials_user_name,omitempty" yaml:"userName,omitempty"`
+	AuthURL           string `json:"tectonic_openstack_credentials_auth_url,omitempty"`
+	Cert              string `json:"tectonic_openstack_credentials_cert,omitempty"`
+	Cloud             string `json:"tectonic_openstack_credentials_cloud,omitempty"`
+	DomainID          string `json:"tectonic_openstack_credentials_domain_id,omitempty"`
+	DomainName        string `json:"tectonic_openstack_credentials_domain_name,omitempty"`
+	EndpointType      string `json:"tectonic_openstack_credentials_endpoint_type,omitempty"`
+	Insecure          bool   `json:"tectonic_openstack_credentials_insecure,omitempty"`
+	Key               string `json:"tectonic_openstack_credentials_key,omitempty"`
+	Password          string `json:"tectonic_openstack_credentials_password,omitempty"`
+	ProjectDomainID   string `json:"tectonic_openstack_credentials_project_domain_id,omitempty"`
+	ProjectDomainName string `json:"tectonic_openstack_credentials_project_domain_name,omitempty"`
+	Region            string `json:"tectonic_openstack_credentials_region,omitempty"`
+	Swauth            bool   `json:"tectonic_openstack_credentials_swauth,omitempty"`
+	TenantID          string `json:"tectonic_openstack_credentials_tenant_id,omitempty"`
+	TenantName        string `json:"tectonic_openstack_credentials_tenant_name,omitempty"`
+	Token             string `json:"tectonic_openstack_credentials_token,omitempty"`
+	UseOctavia        bool   `json:"tectonic_openstack_credentials_use_octavia,omitempty"`
+	UserDomainID      string `json:"tectonic_openstack_credentials_user_domain_id,omitempty"`
+	UserDomainName    string `json:"tectonic_openstack_credentials_user_domain_name,omitempty"`
+	UserID            string `json:"tectonic_openstack_credentials_user_id,omitempty"`
+	UserName          string `json:"tectonic_openstack_credentials_user_name,omitempty"`
 }


### PR DESCRIPTION
We haven't needed these since we dropped the parsers in f7a4e68b (#403).

Generated with:

```console
$ sed -i 's/ yaml:.*/`/' $(git grep -l yaml pkg/tfvars)
```