### PR TITLE
pkg/tfvars/aws: Drop custom subnets

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -93,10 +93,6 @@ module "vpc" {
   external_worker_subnet_ids = "${compact(var.tectonic_aws_external_worker_subnet_ids)}"
   extra_tags                 = "${var.tectonic_aws_extra_tags}"
 
-  // empty map subnet_configs will have the vpc module creating subnets in all availabile AZs
-  new_master_subnet_configs = "${var.tectonic_aws_master_custom_subnets}"
-  new_worker_subnet_configs = "${var.tectonic_aws_worker_custom_subnets}"
-
   private_master_endpoints = "${local.private_endpoints}"
   public_master_endpoints  = "${local.public_endpoints}"
 }

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -171,29 +171,6 @@ Ignored if the volume type is not io1.
 EOF
 }
 
-variable "tectonic_aws_master_custom_subnets" {
-  type    = "map"
-  default = {}
-
-  description = <<EOF
-(optional) This configures master availability zones and their corresponding subnet CIDRs directly.
-
-Example:
-`{ eu-west-1a = "10.0.0.0/20", eu-west-1b = "10.0.16.0/20" }`
-EOF
-}
-
-variable "tectonic_aws_worker_custom_subnets" {
-  type    = "map"
-  default = {}
-
-  description = <<EOF
-(optional) This configures worker availability zones and their corresponding subnet CIDRs directly.
-
-Example: `{ eu-west-1a = "10.0.64.0/20", eu-west-1b = "10.0.80.0/20" }`
-EOF
-}
-
 variable "tectonic_aws_region" {
   type        = "string"
   description = "The target AWS region for the cluster."

--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -11,8 +11,8 @@ locals {
   external_vpc_mode = "${var.external_vpc_id != ""}"
 
   // List of possible AZs for each type of subnet
-  new_worker_subnet_azs = ["${coalescelist(keys(var.new_worker_subnet_configs), data.aws_availability_zones.azs.names)}"]
-  new_master_subnet_azs = ["${coalescelist(keys(var.new_master_subnet_configs), data.aws_availability_zones.azs.names)}"]
+  new_worker_subnet_azs = ["${data.aws_availability_zones.azs.names}"]
+  new_master_subnet_azs = ["${data.aws_availability_zones.azs.names}"]
 
   // How many AZs to create worker and master subnets in (always zero if external_vpc_mode)
   new_worker_az_count = "${local.external_vpc_mode ? 0 : length(local.new_worker_subnet_azs)}"

--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -32,16 +32,6 @@ variable "extra_tags" {
   default     = {}
 }
 
-variable "new_master_subnet_configs" {
-  description = "{az_name = new_subnet_cidr}: Empty map means create new subnets in all availability zones in region with generated cidrs"
-  type        = "map"
-}
-
-variable "new_worker_subnet_configs" {
-  description = "{az_name = new_subnet_cidr}: Empty map means create new subnets in all availability zones in region with generated cidrs"
-  type        = "map"
-}
-
 variable "private_master_endpoints" {
   description = "If set to true, private-facing ingress resources are created."
   default     = true

--- a/data/data/aws/vpc/vpc-private.tf
+++ b/data/data/aws/vpc/vpc-private.tf
@@ -22,10 +22,7 @@ resource "aws_subnet" "worker_subnet" {
 
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
-  cidr_block = "${lookup(var.new_worker_subnet_configs,
-    local.new_worker_subnet_azs[count.index],
-    cidrsubnet(local.new_worker_cidr_range, 3, count.index),
-  )}"
+  cidr_block = "${cidrsubnet(local.new_worker_cidr_range, 3, count.index)}"
 
   availability_zone = "${local.new_worker_subnet_azs[count.index]}"
 

--- a/data/data/aws/vpc/vpc-public.tf
+++ b/data/data/aws/vpc/vpc-public.tf
@@ -37,10 +37,7 @@ resource "aws_subnet" "master_subnet" {
   count  = "${local.new_master_az_count}"
   vpc_id = "${data.aws_vpc.cluster_vpc.id}"
 
-  cidr_block = "${lookup(var.new_master_subnet_configs,
-    local.new_master_subnet_azs[count.index],
-    cidrsubnet(local.new_master_cidr_range, 3, count.index),
-  )}"
+  cidr_block = "${cidrsubnet(local.new_master_cidr_range, 3, count.index)}"
 
   availability_zone = "${local.new_master_subnet_azs[count.index]}"
 

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -39,10 +39,9 @@ type External struct {
 
 // Master converts master related config.
 type Master struct {
-	CustomSubnets    map[string]string `json:"tectonic_aws_master_custom_subnets,omitempty"`
-	EC2Type          string            `json:"tectonic_aws_master_ec2_type,omitempty"`
-	ExtraSGIDs       []string          `json:"tectonic_aws_master_extra_sg_ids,omitempty"`
-	IAMRoleName      string            `json:"tectonic_aws_master_iam_role_name,omitempty"`
+	EC2Type          string   `json:"tectonic_aws_master_ec2_type,omitempty"`
+	ExtraSGIDs       []string `json:"tectonic_aws_master_extra_sg_ids,omitempty"`
+	IAMRoleName      string   `json:"tectonic_aws_master_iam_role_name,omitempty"`
 	MasterRootVolume `json:",inline"`
 }
 
@@ -55,11 +54,10 @@ type MasterRootVolume struct {
 
 // Worker converts worker related config.
 type Worker struct {
-	CustomSubnets    map[string]string `json:"tectonic_aws_worker_custom_subnets,omitempty"`
-	EC2Type          string            `json:"tectonic_aws_worker_ec2_type,omitempty"`
-	ExtraSGIDs       []string          `json:"tectonic_aws_worker_extra_sg_ids,omitempty"`
-	IAMRoleName      string            `json:"tectonic_aws_worker_iam_role_name,omitempty"`
-	LoadBalancers    []string          `json:"tectonic_aws_worker_load_balancers,omitempty"`
+	EC2Type          string   `json:"tectonic_aws_worker_ec2_type,omitempty"`
+	ExtraSGIDs       []string `json:"tectonic_aws_worker_extra_sg_ids,omitempty"`
+	IAMRoleName      string   `json:"tectonic_aws_worker_iam_role_name,omitempty"`
+	LoadBalancers    []string `json:"tectonic_aws_worker_load_balancers,omitempty"`
 	WorkerRootVolume `json:",inline"`
 }
 


### PR DESCRIPTION
This functionality was originally from 8324c212 (coreos/tectonic-installer#267), but we haven't exposed it in `openshift-install` (which has never used the parsers removed by f7a4e68b, #403).

Currently we are unable to scale masters post-install, because auto-scaling etcd is difficult.  Depending on how long that takes us to get working, we may need to re-enable this for masters later.

Workers are already managable via the cluster API and `MachineSet`s, so folks who need custom worker subnets can create a cluster without workers and then launch their worker machine-sets directly as a day-2 operation.  The cluster-API type chain is:

* [`MachineSet.Spec`][1]
* [`MachineSetSpec.Template`][2]
* [`MachineTemplateSpec.Spec`][3]
* [`MachineSpec.ProviderConfig`][4]
* [`ProviderConfig.Value`][5]
* `RawExtension`

which is nice and generic, but a dead-end for structured configuration ;).  Jumping over to the OpenShift AWS provider, there is an [`AWSMachineProviderConfig.Subnet`][6].  I don't see code for auto-creating those subnets, but an admin could manually create the subnet wherever they wanted and then use the cluster API to launch new workers into that subnet.  And maybe there will be generic tooling to automate that subnet creation (setting up routing, etc.) to make that less tedious/error-prone.

Also in this space, see kubernetes/kops#1333 and [here][8].

[1]: https://github.com/kubernetes-sigs/cluster-api/blob/0734939e05aeb64ab198e3feeee8b4e90ee5cbb2/pkg/apis/cluster/v1alpha1/machineset_types.go#L42
[2]: https://github.com/kubernetes-sigs/cluster-api/blob/0734939e05aeb64ab198e3feeee8b4e90ee5cbb2/pkg/apis/cluster/v1alpha1/machineset_types.go#L68-L71
[3]: https://github.com/kubernetes-sigs/cluster-api/blob/0734939e05aeb64ab198e3feeee8b4e90ee5cbb2/pkg/apis/cluster/v1alpha1/machineset_types.go#L84-L87
[4]: https://github.com/kubernetes-sigs/cluster-api/blob/0734939e05aeb64ab198e3feeee8b4e90ee5cbb2/pkg/apis/cluster/v1alpha1/machine_types.go#L62-L64
[5]: https://github.com/kubernetes-sigs/cluster-api/blob/0734939e05aeb64ab198e3feeee8b4e90ee5cbb2/pkg/apis/cluster/v1alpha1/common_types.go#L29-L34
[6]: https://github.com/openshift/cluster-api-provider-aws/blob/e6986093d1fbac2084c50b04fe2f78125ffca582/pkg/apis/awsproviderconfig/v1alpha1/awsmachineproviderconfig_types.go#L130-L131
[8]: https://github.com/kubernetes-sigs/cluster-api/blob/0734939e05aeb64ab198e3feeee8b4e90ee5cbb2/pkg/apis/cluster/v1alpha1/cluster_types.go#L62-L82