### PR TITLE
data/aws/vpc: Drop unused depends_on variable

### DIFF
--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -51,8 +51,3 @@ variable "public_master_endpoints" {
   description = "If set to true, public-facing ingress resources are created."
   default     = true
 }
-
-variable "depends_on" {
-  default = []
-  type    = "list"
-}


### PR DESCRIPTION
This variable was added in a2232f30 (coreos/tectonic-installer#2946), to force VPC creation after the S3 bucket.  But that dependency was removed in b2e0bcf2 (coreos/tectonic-installer#3183), so we no longer need the variable.