### PR TITLE
add openshift-tests binary to libvirt CI setup

### DIFF
--- a/images/nested-libvirt/Dockerfile
+++ b/images/nested-libvirt/Dockerfile
@@ -4,8 +4,10 @@ FROM openshift/origin-release:golang-1.10 AS build
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh && hack/get-terraform.sh
+RUN cd ../ && git clone https://github.com/openshift/origin && cd origin && make WHAT=cmd/openshift-tests
 
 FROM centos:7
+COPY --from=build /go/src/github.com/openshift/origin/_output/local/bin/linux/amd64/openshift-tests /bin/openshift-tests
 COPY --from=build /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=build /go/src/github.com/openshift/installer/bin/terraform /bin/terraform
 COPY --from=build /go/src/github.com/openshift/installer/images/nested-libvirt/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo


### PR DESCRIPTION
@wking
For the CI libvirt template, I'm adding the `openshift-tests` binary, enabling the libvirt CI job to run the same tests as our other e2e jobs. This makes the libvirt-installer CI image build take a considerably longer time, so if there is a better way to get `openshift-tests`  into the CI test container I'll close this PR.

depends on this: https://github.com/openshift/release/pull/2143