### PR TITLE
Add missing BaseImage to OpenStack tfvars

### DIFF
--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -125,6 +125,7 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn, workerIgn string)
 		config.OpenStack = openstack.OpenStack{
 			Region:           cfg.Platform.OpenStack.Region,
 			NetworkCIDRBlock: cfg.Platform.OpenStack.NetworkCIDRBlock,
+			BaseImage:        cfg.Platform.OpenStack.BaseImage,
 		}
 		config.OpenStack.Credentials.Cloud = cfg.Platform.OpenStack.Cloud
 		config.OpenStack.ExternalNetwork = cfg.Platform.OpenStack.ExternalNetwork


### PR DESCRIPTION
Currently the OPENSHIFT_INSTALL_OPENSTACK_IMAGE environment variable
is correctly parsed but then ignored by terraform because we don't
pass it via the tfvars.