### PR TITLE
bootkube: Print release image we're installing

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -3,6 +3,19 @@ set -e
 
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
 
+if ! podman inspect {{.ReleaseImage}} &>/dev/null; then
+    echo "Pulling release image"
+    podman pull {{.ReleaseImage}}
+fi
+
+if ! grep -q 'Installing release image' /etc/motd; then
+    (echo
+     echo 'Installing release image: '
+     # Yeah this is a hack...we don't ship jq.  Tempting to ship a binary to just do this;
+     # or make it part of `oc adm release`?
+     podman inspect {{.ReleaseImage}} | grep -o 'io\.openshift\.release.*$' | tail -2) >> /etc/motd
+fi
+
 MACHINE_CONFIG_OPERATOR_IMAGE=$(podman run --rm {{.ReleaseImage}} image machine-config-operator)
 MACHINE_CONFIG_CONTROLLER_IMAGE=$(podman run --rm {{.ReleaseImage}} image machine-config-controller)
 MACHINE_CONFIG_SERVER_IMAGE=$(podman run --rm {{.ReleaseImage}} image machine-config-server)


### PR DESCRIPTION
This should help people debug; I believe the relevant tuple is

 (installer version, RHCOS version, release payload)