### PR TITLE
gitignore: Anchor /bin to the toplevel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-bin/
+/bin/
 .openshift-install.log


### PR DESCRIPTION
At one point I went to add a new file in e.g.
`data/data/bootstrap/files/usr/local/bin/foo.sh`
and was confused why it wasn't showing up in `git status`.

It was because the `bin` here also matched the `usr/local/bin`.