### PR TITLE
cmd/openshift-install: Remove deprecated commands

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -101,18 +100,6 @@ var (
 
 	targets = []target{installConfigTarget, manifestTemplatesTarget, manifestsTarget, ignitionConfigsTarget, clusterTarget}
 )
-
-// Deprecated: Use 'create' subcommands instead.
-func newTargetsCmd() []*cobra.Command {
-	var cmds []*cobra.Command
-	for _, t := range targets {
-		cmd := *t.command
-		cmd.Short = fmt.Sprintf("DEPRECATED: USE 'create %s' instead.", cmd.Use)
-		cmd.RunE = runTargetCmd(t.assets...)
-		cmds = append(cmds, &cmd)
-	}
-	return cmds
-}
 
 func newCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -26,14 +26,6 @@ func newDestroyCmd() *cobra.Command {
 	return cmd
 }
 
-func newLegacyDestroyClusterCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "destroy-cluster",
-		Short: "DEPRECATED: Use 'destroy cluster' instead.",
-		RunE:  runDestroyCmd,
-	}
-}
-
 func newDestroyClusterCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "cluster",

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -20,14 +20,9 @@ var (
 func main() {
 	rootCmd := newRootCmd()
 
-	for _, cmd := range newTargetsCmd() {
-		rootCmd.AddCommand(cmd)
-	}
-
 	for _, subCmd := range []*cobra.Command{
 		newCreateCmd(),
 		newDestroyCmd(),
-		newLegacyDestroyClusterCmd(),
 		newVersionCmd(),
 		newGraphCmd(),
 	} {


### PR DESCRIPTION
These have been deprecated since 3f4fe574 (#493) and 85c76c98 (#513).  The `destroy` commands were deprecated before the 0.3.0 release, so removing them now should be fine.  The `create` commands landed after 0.3.0, but it's been a long time since they were deprecated.  Our released versions currently go stale pretty fast, so there are unlikely to be any consumers of the old `create` commands that this removal would break.

/assign @crawford