### PR TITLE
manifests: add missing asset dependency

### DIFF
--- a/pkg/asset/templates/templates.go
+++ b/pkg/asset/templates/templates.go
@@ -30,6 +30,7 @@ func (m *Templates) Dependencies() []asset.Asset {
 		&bootkube.CVOOverrides{},
 		&bootkube.LegacyCVOOverrides{},
 		&bootkube.EtcdServiceEndpointsKubeSystem{},
+		&bootkube.HostEtcdServiceEndpointsKubeSystem{},
 		&bootkube.KubeSystemConfigmapEtcdServingCA{},
 		&bootkube.KubeSystemConfigmapRootCA{},
 		&bootkube.KubeSystemSecretEtcdClient{},


### PR DESCRIPTION
missing asset dependecy for recently added host-etcd endpoints

@deads2k 
@abhinavdahiya 