### PR TITLE
hack/release: Tag before building

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -10,6 +10,7 @@ cd "$(dirname "$0")"
 
 TAG="${1}"
 
+git tag -sm "version ${TAG}" "${TAG}"
 ./build.sh # ensure freshly-generated data
 for GOOS in darwin linux
 do
@@ -18,4 +19,3 @@ do
 	GOOS="${GOOS}" GOARCH="${GOARCH}" OUTPUT="${OUTPUT}" SKIP_GENERATION=y ./build.sh
 done
 (cd ../bin && sha256sum openshift-install-*)
-git tag -sm "version ${TAG}" "${TAG}"


### PR DESCRIPTION
This gets the correct main.version value.  Before this commit, you could have:

```console
$ hack/release.sh v0.4.0
...
+ go build -ldflags ' -X main.version=v0.3.0-273-g...' ...
...
```

With this commit, that same invocation will give you:

```
+ go build -ldflags ' -X main.version=v0.4.0' ...
```

The bug is from the initial script in 7b023303 (#397).