### PR TITLE
OpenStack Destroy - retry port delete when in use

### DIFF
--- a/pkg/destroy/openstack/openstack_deprovision.go
+++ b/pkg/destroy/openstack/openstack_deprovision.go
@@ -235,8 +235,8 @@ func deletePorts(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fie
 		logger.Debugf("Deleting Port: %+v", port.ID)
 		err = ports.Delete(conn, port.ID).ExtractErr()
 		if err != nil {
-			logger.Fatalf("%v", err)
-			os.Exit(1)
+			// This can fail when port is still in use so return/retry
+			return false, nil
 		}
 	}
 	return len(allPorts) == 0, nil


### PR DESCRIPTION
We can get a 409 on port delete e.g until the router/subnets are
deleted so return & retry in this case