### PR TITLE
OpenStack Destroy - retry router interface when subnet in use

### DIFF
--- a/pkg/destroy/openstack/openstack_deprovision.go
+++ b/pkg/destroy/openstack/openstack_deprovision.go
@@ -327,8 +327,8 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 				logger.Debugf("Removing Subnet %v from Router %v\n", IP.SubnetID, router.ID)
 				_, err = routers.RemoveInterface(conn, router.ID, removeOpts).Extract()
 				if err != nil {
-					logger.Fatalf("%v", err)
-					os.Exit(1)
+					// This can fail when subnet is still in use
+					return false, nil
 				}
 			}
 		}


### PR DESCRIPTION
This can fail because ports/floating_ips still exist on the subnet
so return such that we retry rather than exit.

The error (reported by @tomassedovic - thanks!) looks like this:

```
HTTP response code [200] when accessing [PUT http://10.1.8.86:9696/v2.0/routers/baf128bd-850c-4a35-862d-7c9ab87b5673/remove_router_interface], but got 409 instead
{"NeutronError": {"message": "Router interface for subnet e43843c7-64e5-4f8a-a592-b06c998bc73b on router baf128bd-850c-4a35-862d-7c9ab87b5673 cannot be deleted, as it is required by one or more floating IPs.", "type": "RouterInterfaceInUseByFloatingIP", "detail": ""}} 
```