### PR TITLE
clarify logComplete msgs and return err if wait for bootstrap complete exceeds timeout

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -243,14 +243,15 @@ func destroyBootstrap(ctx context.Context, directory string) (err error) {
 	return destroybootstrap.Destroy(rootOpts.dir)
 }
 
-// logComplete prints info upon completion
+// logComplete prints info and suggestions to manage installed cluster
 func logComplete(directory string) error {
 	absDir, err := filepath.Abs(directory)
 	if err != nil {
 		return err
 	}
 	kubeconfig := filepath.Join(absDir, "auth", "kubeconfig")
-	logrus.Infof("Install complete! Run 'export KUBECONFIG=%s' to manage your cluster.", kubeconfig)
-	logrus.Info("After exporting your kubeconfig, run 'oc -h' for a list of OpenShift client commands.")
+	logrus.Infof("Install complete! Run 'export KUBECONFIG=%s' to manage the cluster.", kubeconfig)
+	logrus.Info("Wait for workers to become ready. Run 'oc get nodes -w' to watch for workers coming up.")
+	logrus.Info("Run 'oc -h' for a list of OpenShift client commands.")
 	return nil
 }


### PR DESCRIPTION
@crawford 
This PR
* adds info about checking for nodes, waiting for workers upon install completion
* ~adds an error return if bootstrap process exceeds the timeout (rather than returning nil)~  

@droslean noticed the successful logComplete msg was shown after an install exited due to timeout exceeded, since that error was not being returned.  Any reason it should not return the error there?
EDIT: @wking suggested `revert #615 now that we're comfortable with the robustness of #606` below.