### PR TITLE
hack: pin the release image in build flags

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -28,6 +28,10 @@ export CGO_ENABLED=0
 case "${MODE}" in
 release)
 	TAGS="${TAGS} release"
+	if test -n "${OPENSHIFT_INSTALL_RELEASE_IMAGE}"
+	then
+		LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/asset/ignition/bootstrap.defaultReleaseImage=${OPENSHIFT_INSTALL_RELEASE_IMAGE}"
+	fi
 	if test "${SKIP_GENERATION}" != y
 	then
 		go generate ./data

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -30,8 +30,11 @@ import (
 
 const (
 	rootDir              = "/opt/tectonic"
-	defaultReleaseImage  = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
 	bootstrapIgnFilename = "bootstrap.ign"
+)
+
+var (
+	defaultReleaseImage = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
 )
 
 // bootstrapTemplateData is the data to use to replace values in bootstrap


### PR DESCRIPTION
But still leave an override env var so that it can be overridden. Use the following env var to pin the image while building the binary:
```
$ # export the release-image variable
$ export OPENSHIFT_INSTALL_RELEASE_IMAGE=registry.redhat.io/openshift/origin-release:v4.0"
$ # build the openshift-install binary
$ ./hack/build.sh
$ # distribute the binary to customers and run with pinned image being picked up
$ ./bin/openshift-install create cluster...
```
The only way to override it would be to use an env var OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE while running the openshift-install binary.