### PR TITLE
cvo: remove (ignored) network-operator override

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -8,10 +8,6 @@ spec:
   channel: fast
   clusterID: {{.CVOClusterID}}
   overrides:
-  - kind: Deployment                    # this conflicts with kube-core-operator
-    namespace: openshift-cluster-network-operator
-    name: cluster-network-operator
-    unmanaged: true
   - kind: APIService                    # packages.apps.redhat.com fails to start properly
     name: v1alpha1.packages.apps.redhat.com
     unmanaged: true

--- a/data/data/manifests/bootkube/legacy-cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/legacy-cvo-overrides.yaml.template
@@ -7,10 +7,6 @@ upstream: http://localhost:8080/graph
 channel: fast
 clusterID: {{.CVOClusterID}}
 overrides:
-- kind: Deployment                    # this conflicts with kube-core-operator
-  namespace: openshift-cluster-network-operator
-  name: cluster-network-operator
-  unmanaged: true
 - kind: APIService                    # packages.apps.redhat.com fails to start properly
   name: v1alpha1.packages.apps.redhat.com
   unmanaged: true


### PR DESCRIPTION
This should have been removed some time ago, but was missed in a rebase. It had no effect anyways, as the network operator is a DaemonSet.