### PR TITLE
aws: Increase default master disk size to 120GB for IO

### DIFF
--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -135,13 +135,13 @@ variable "tectonic_aws_master_root_volume_type" {
 
 variable "tectonic_aws_master_root_volume_size" {
   type        = "string"
-  default     = "30"
+  default     = "120"
   description = "The size of the volume in gigabytes for the root block device of master nodes."
 }
 
 variable "tectonic_aws_master_root_volume_iops" {
   type    = "string"
-  default = "100"
+  default = "400"
 
   description = <<EOF
 The amount of provisioned IOPS for the root block device of master nodes.


### PR DESCRIPTION
With colocated masters we are seeing about ~120 IOP/s sustained, and
a 30GB gp2 drive is limited to 100 IOP/s. etcd is ~75% of the write
workload, but we are seeing some syncs take ~1s and occasional
heartbeat latency. Increase master disk by 4x to get slightly more
head room - this would in practice result in about $30-40/month more
disk on top of the ~200/mo the instances cost.

https://github.com/openshift/origin/issues/21552 may be related