### PR TITLE
Revert "cmd/openshift-install/create: Allow hung watch"

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -235,8 +235,7 @@ func destroyBootstrap(ctx context.Context, directory string) (err error) {
 		},
 	)
 	if err != nil {
-		logrus.Error(errors.Wrap(err, "waiting for bootstrap-complete"))
-		return nil
+		return errors.Wrap(err, "waiting for bootstrap-complete")
 	}
 
 	logrus.Info("Destroying the bootstrap resources...")


### PR DESCRIPTION
This reverts commit 6dc1bf60cdb42ee26937e0e5702c536a52f9fdbb, #615.

109531f3 (#606) made the watch re-connects reliable, so make watch timeouts fatal again.  This avoids confusing users by showing "Install complete!" messages when they may actually have a hung bootstrap process.