### PR TITLE
data/data/aws/variables-aws: Drop tectonic_aws_worker_ec2_type, etc.

### DIFF
--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -13,12 +13,6 @@ variable "tectonic_aws_master_ec2_type" {
   default     = "t2.medium"
 }
 
-variable "tectonic_aws_worker_ec2_type" {
-  type        = "string"
-  description = "Instance size for the worker node(s). Example: `t2.medium`."
-  default     = "t2.medium"
-}
-
 variable "tectonic_aws_ec2_ami_override" {
   type        = "string"
   description = "(optional) AMI override for all nodes. Example: `ami-foobar123`."
@@ -28,17 +22,6 @@ variable "tectonic_aws_ec2_ami_override" {
 variable "tectonic_aws_master_extra_sg_ids" {
   description = <<EOF
 (optional) List of additional security group IDs for master nodes.
-
-Example: `["sg-51530134", "sg-b253d7cc"]`
-EOF
-
-  type    = "list"
-  default = []
-}
-
-variable "tectonic_aws_worker_extra_sg_ids" {
-  description = <<EOF
-(optional) List of additional security group IDs for worker nodes.
 
 Example: `["sg-51530134", "sg-b253d7cc"]`
 EOF
@@ -149,28 +132,6 @@ Ignored if the volume type is not io1.
 EOF
 }
 
-variable "tectonic_aws_worker_root_volume_type" {
-  type        = "string"
-  default     = "gp2"
-  description = "The type of volume for the root block device of worker nodes."
-}
-
-variable "tectonic_aws_worker_root_volume_size" {
-  type        = "string"
-  default     = "30"
-  description = "The size of the volume in gigabytes for the root block device of worker nodes."
-}
-
-variable "tectonic_aws_worker_root_volume_iops" {
-  type    = "string"
-  default = "100"
-
-  description = <<EOF
-The amount of provisioned IOPS for the root block device of worker nodes.
-Ignored if the volume type is not io1.
-EOF
-}
-
 variable "tectonic_aws_master_custom_subnets" {
   type    = "map"
   default = {}
@@ -237,18 +198,5 @@ The name is also the last part of a role's ARN.
 Example:
  * Role ARN  = arn:aws:iam::123456789012:role/tectonic-installer
  * Role Name = tectonic-installer
-EOF
-}
-
-variable "tectonic_aws_worker_load_balancers" {
-  type    = "list"
-  default = []
-
-  description = <<EOF
-(optional) List of ELBs to attach all worker instances to.
-This is useful for exposing NodePort services via load-balancers managed separately from the cluster.
-
-Example:
- * `["ingress-nginx"]`
 EOF
 }

--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -12,16 +12,6 @@ This applies only to cloud platforms.
 EOF
 }
 
-variable "tectonic_worker_count" {
-  type    = "string"
-  default = "3"
-
-  description = <<EOF
-The number of worker nodes to be created.
-This applies only to cloud platforms.
-EOF
-}
-
 variable "tectonic_base_domain" {
   type = "string"
 

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -53,7 +53,6 @@ resource "libvirt_network" "tectonic_net" {
       data.libvirt_network_dns_host_template.bootstrap.*.rendered,
       data.libvirt_network_dns_host_template.masters.*.rendered,
       data.libvirt_network_dns_host_template.etcds.*.rendered,
-      data.libvirt_network_dns_host_template.workers.*.rendered,
     ))}"]
   }]
 
@@ -102,12 +101,6 @@ data "libvirt_network_dns_host_template" "etcds" {
   count    = "${var.tectonic_master_count}"
   ip       = "${var.tectonic_libvirt_master_ips[count.index]}"
   hostname = "${var.tectonic_cluster_name}-etcd-${count.index}"
-}
-
-data "libvirt_network_dns_host_template" "workers" {
-  count    = "${var.tectonic_worker_count}"
-  ip       = "${var.tectonic_libvirt_worker_ips[count.index]}"
-  hostname = "${var.tectonic_cluster_name}"
 }
 
 data "libvirt_network_dns_srv_template" "etcd_cluster" {

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -32,8 +32,3 @@ variable "tectonic_libvirt_master_ips" {
   type        = "list"
   description = "the list of desired master ips. Must match tectonic_master_count"
 }
-
-variable "tectonic_libvirt_worker_ips" {
-  type        = "list"
-  description = "the list of desired worker ips. Must match tectonic_worker_count"
-}

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -55,17 +55,6 @@ type MasterRootVolume struct {
 
 // Worker converts worker related config.
 type Worker struct {
-	CustomSubnets    map[string]string `json:"tectonic_aws_worker_custom_subnets,omitempty"`
-	EC2Type          string            `json:"tectonic_aws_worker_ec2_type,omitempty"`
-	ExtraSGIDs       []string          `json:"tectonic_aws_worker_extra_sg_ids,omitempty"`
-	IAMRoleName      string            `json:"tectonic_aws_worker_iam_role_name,omitempty"`
-	LoadBalancers    []string          `json:"tectonic_aws_worker_load_balancers,omitempty"`
-	WorkerRootVolume `json:",inline"`
-}
-
-// WorkerRootVolume converts worker rool volume related config.
-type WorkerRootVolume struct {
-	IOPS int    `json:"tectonic_aws_worker_root_volume_iops,omitempty"`
-	Size int    `json:"tectonic_aws_worker_root_volume_size,omitempty"`
-	Type string `json:"tectonic_aws_worker_root_volume_type,omitempty"`
+	CustomSubnets map[string]string `json:"tectonic_aws_worker_custom_subnets,omitempty"`
+	IAMRoleName   string            `json:"tectonic_aws_worker_iam_role_name,omitempty"`
 }

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -18,7 +18,6 @@ type Libvirt struct {
 	Image       string `json:"tectonic_os_image,omitempty"`
 	Network     `json:",inline"`
 	MasterIPs   []string `json:"tectonic_libvirt_master_ips,omitempty"`
-	WorkerIPs   []string `json:"tectonic_libvirt_worker_ips,omitempty"`
 	BootstrapIP string   `json:"tectonic_libvirt_bootstrap_ip,omitempty"`
 }
 
@@ -29,7 +28,7 @@ type Network struct {
 }
 
 // TFVars fills in computed Terraform variables.
-func (l *Libvirt) TFVars(masterCount int, workerCount int) error {
+func (l *Libvirt) TFVars(masterCount int) error {
 	_, network, err := net.ParseCIDR(l.Network.IPRange)
 	if err != nil {
 		return fmt.Errorf("failed to parse libvirt network ipRange: %v", err)
@@ -50,18 +49,6 @@ func (l *Libvirt) TFVars(masterCount int, workerCount int) error {
 	} else {
 		if ips, err := generateIPs("master", network, masterCount, 11); err == nil {
 			l.MasterIPs = ips
-		} else {
-			return err
-		}
-	}
-
-	if len(l.WorkerIPs) > 0 {
-		if len(l.WorkerIPs) != workerCount {
-			return fmt.Errorf("length of WorkerIPs doesn't match worker count")
-		}
-	} else {
-		if ips, err := generateIPs("worker", network, workerCount, 50); err == nil {
-			l.WorkerIPs = ips
 		} else {
 			return err
 		}

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -19,7 +19,6 @@ type config struct {
 	Name       string `json:"tectonic_cluster_name,omitempty"`
 	BaseDomain string `json:"tectonic_base_domain,omitempty"`
 	Masters    int    `json:"tectonic_master_count,omitempty"`
-	Workers    int    `json:"tectonic_worker_count,omitempty"`
 
 	IgnitionBootstrap string `json:"ignition_bootstrap,omitempty"`
 	IgnitionMaster    string `json:"ignition_master,omitempty"`
@@ -42,15 +41,15 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 	}
 
 	for _, m := range cfg.Machines {
-		var replicas int
-		if m.Replicas == nil {
-			replicas = 1
-		} else {
-			replicas = int(*m.Replicas)
-		}
-
 		switch m.Name {
 		case "master":
+			var replicas int
+			if m.Replicas == nil {
+				replicas = 1
+			} else {
+				replicas = int(*m.Replicas)
+			}
+
 			config.Masters += replicas
 			if m.Platform.AWS != nil {
 				config.AWS.Master = aws.Master{
@@ -64,7 +63,6 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 				}
 			}
 		case "worker":
-			config.Workers += replicas
 			if m.Platform.AWS != nil {
 				config.AWS.Worker = aws.Worker{
 					IAMRoleName: m.Platform.AWS.IAMRoleName,
@@ -107,7 +105,7 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 			Image:     cfg.Platform.Libvirt.DefaultMachinePlatform.Image,
 			MasterIPs: masterIPs,
 		}
-		if err := config.Libvirt.TFVars(config.Masters, config.Workers); err != nil {
+		if err := config.Libvirt.TFVars(config.Masters); err != nil {
 			return nil, errors.Wrap(err, "failed to insert libvirt variables")
 		}
 		if err := config.Libvirt.UseCachedImage(); err != nil {

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -67,13 +67,7 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 			config.Workers += replicas
 			if m.Platform.AWS != nil {
 				config.AWS.Worker = aws.Worker{
-					EC2Type:     m.Platform.AWS.InstanceType,
 					IAMRoleName: m.Platform.AWS.IAMRoleName,
-					WorkerRootVolume: aws.WorkerRootVolume{
-						IOPS: m.Platform.AWS.EC2RootVolume.IOPS,
-						Size: m.Platform.AWS.EC2RootVolume.Size,
-						Type: m.Platform.AWS.EC2RootVolume.Type,
-					},
 				}
 			}
 		default:


### PR DESCRIPTION
The last consumers for these were removed by 124ac351 (#119).