### PR TITLE
data/data/config: Drop tectonic_worker_count

### DIFF
--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -12,16 +12,6 @@ This applies only to cloud platforms.
 EOF
 }
 
-variable "tectonic_worker_count" {
-  type    = "string"
-  default = "3"
-
-  description = <<EOF
-The number of worker nodes to be created.
-This applies only to cloud platforms.
-EOF
-}
-
 variable "tectonic_base_domain" {
   type = "string"
 

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -104,12 +104,6 @@ data "libvirt_network_dns_host_template" "etcds" {
   hostname = "${var.tectonic_cluster_name}-etcd-${count.index}"
 }
 
-data "libvirt_network_dns_host_template" "workers" {
-  count    = "${var.tectonic_worker_count}"
-  ip       = "${var.tectonic_libvirt_worker_ips[count.index]}"
-  hostname = "${var.tectonic_cluster_name}"
-}
-
 data "libvirt_network_dns_srv_template" "etcd_cluster" {
   count    = "${var.tectonic_master_count}"
   service  = "etcd-server-ssl"

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -32,8 +32,3 @@ variable "tectonic_libvirt_master_ips" {
   type        = "list"
   description = "the list of desired master ips. Must match tectonic_master_count"
 }
-
-variable "tectonic_libvirt_worker_ips" {
-  type        = "list"
-  description = "the list of desired worker ips. Must match tectonic_worker_count"
-}

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -18,7 +18,6 @@ type Libvirt struct {
 	Image       string `json:"tectonic_os_image,omitempty"`
 	Network     `json:",inline"`
 	MasterIPs   []string `json:"tectonic_libvirt_master_ips,omitempty"`
-	WorkerIPs   []string `json:"tectonic_libvirt_worker_ips,omitempty"`
 	BootstrapIP string   `json:"tectonic_libvirt_bootstrap_ip,omitempty"`
 }
 
@@ -29,7 +28,7 @@ type Network struct {
 }
 
 // TFVars fills in computed Terraform variables.
-func (l *Libvirt) TFVars(masterCount int, workerCount int) error {
+func (l *Libvirt) TFVars(masterCount int) error {
 	_, network, err := net.ParseCIDR(l.Network.IPRange)
 	if err != nil {
 		return fmt.Errorf("failed to parse libvirt network ipRange: %v", err)
@@ -50,18 +49,6 @@ func (l *Libvirt) TFVars(masterCount int, workerCount int) error {
 	} else {
 		if ips, err := generateIPs("master", network, masterCount, 11); err == nil {
 			l.MasterIPs = ips
-		} else {
-			return err
-		}
-	}
-
-	if len(l.WorkerIPs) > 0 {
-		if len(l.WorkerIPs) != workerCount {
-			return fmt.Errorf("length of WorkerIPs doesn't match worker count")
-		}
-	} else {
-		if ips, err := generateIPs("worker", network, workerCount, 50); err == nil {
-			l.WorkerIPs = ips
 		} else {
 			return err
 		}

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -19,7 +19,6 @@ type config struct {
 	Name       string `json:"tectonic_cluster_name,omitempty"`
 	BaseDomain string `json:"tectonic_base_domain,omitempty"`
 	Masters    int    `json:"tectonic_master_count,omitempty"`
-	Workers    int    `json:"tectonic_worker_count,omitempty"`
 
 	IgnitionBootstrap string `json:"ignition_bootstrap,omitempty"`
 	IgnitionMaster    string `json:"ignition_master,omitempty"`
@@ -42,15 +41,15 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 	}
 
 	for _, m := range cfg.Machines {
-		var replicas int
-		if m.Replicas == nil {
-			replicas = 1
-		} else {
-			replicas = int(*m.Replicas)
-		}
-
 		switch m.Name {
 		case "master":
+			var replicas int
+			if m.Replicas == nil {
+				replicas = 1
+			} else {
+				replicas = int(*m.Replicas)
+			}
+
 			config.Masters += replicas
 			if m.Platform.AWS != nil {
 				config.AWS.Master = aws.Master{
@@ -64,7 +63,6 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 				}
 			}
 		case "worker":
-			config.Workers += replicas
 			if m.Platform.AWS != nil {
 				config.AWS.Worker = aws.Worker{
 					EC2Type:     m.Platform.AWS.InstanceType,
@@ -113,7 +111,7 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 			Image:     cfg.Platform.Libvirt.DefaultMachinePlatform.Image,
 			MasterIPs: masterIPs,
 		}
-		if err := config.Libvirt.TFVars(config.Masters, config.Workers); err != nil {
+		if err := config.Libvirt.TFVars(config.Masters); err != nil {
 			return nil, errors.Wrap(err, "failed to insert libvirt variables")
 		}
 		if err := config.Libvirt.UseCachedImage(); err != nil {


### PR DESCRIPTION
And the related, libvirt-specific, `tectonic_libvirt_worker_ips`.  This simplifies the Terraform logic for AWS and OpenStack, and consistently pushes most worker setup into the cluster-API providers who are creating the workers since 124ac351 (#119).