### PR TITLE
data/aws/vpc: Add an S3 endpoint to new VPCs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -392,11 +392,11 @@
   revision = "fb8b55a1072436a51b153de9acf5bf5525efcf83"
 
 [[projects]]
-  digest = "1:c2edaeee2250d3886f1e2223a8c6698498ecdc467a72949888f89dc1dde89045"
+  digest = "1:fff47662f79ac206b6c6c466afb79f0458fbdf1390f527cad9255e07f8de1369"
   name = "github.com/openshift/hive"
   packages = ["contrib/pkg/awstagdeprovision"]
   pruneopts = "NUT"
-  revision = "2349f175d3e4fc6542dec79add881a59f2d7b1b8"
+  revision = "802db5420da6a88f034fc2501081e2ab12e8463e"
 
 [[projects]]
   digest = "1:93b1d84c5fa6d1ea52f4114c37714cddd84d5b78f151b62bb101128dd51399bf"
@@ -825,6 +825,8 @@
     "github.com/apparentlymart/go-cidr/cidr",
     "github.com/awalterschulze/gographviz",
     "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/credentials",
+    "github.com/aws/aws-sdk-go/aws/defaults",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/ec2",
     "github.com/coreos/ignition/config/util",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -70,7 +70,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/openshift/hive"
-  revision = "2349f175d3e4fc6542dec79add881a59f2d7b1b8"
+  revision = "802db5420da6a88f034fc2501081e2ab12e8463e"
 
 [[constraint]]
   name = "k8s.io/utils"

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -89,6 +89,7 @@ module "vpc" {
   cluster_id      = "${var.cluster_id}"
   cluster_name    = "${var.cluster_name}"
   external_vpc_id = "${var.aws_external_vpc_id}"
+  region          = "${var.aws_region}"
 
   external_master_subnet_ids = "${compact(var.aws_external_master_subnet_ids)}"
   external_worker_subnet_ids = "${compact(var.aws_external_worker_subnet_ids)}"

--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -51,3 +51,8 @@ variable "public_master_endpoints" {
   description = "If set to true, public-facing ingress resources are created."
   default     = true
 }
+
+variable "region" {
+  type        = "string"
+  description = "The target AWS region for the cluster."
+}

--- a/data/data/aws/vpc/vpc.tf
+++ b/data/data/aws/vpc/vpc.tf
@@ -16,3 +16,9 @@ resource "aws_vpc" "new_vpc" {
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id          = "${aws_vpc.new_vpc.id}"
+  service_name    = "com.amazonaws.${var.region}.s3"
+  route_table_ids = ["${concat(aws_route_table.private_routes.*.id, aws_route_table.default.*.id)}"]
+}


### PR DESCRIPTION
As suggested by @cuppett, this allows registry <-> S3 transfers to bypass the (NAT) gateways.  Traffic over the NAT gateways costs money, so the new endpoint should make S3 access from the cluster cheaper (and possibly more reliable).  This also allows for additional security policy flexibility, although I'm not taking advantage of that in this commit.  Docs for VPC endpoints are [here][1], [here][2], [here][3], and [here][4].

Endpoints [do not currently support cross-region requests][1].  And based on discussion with @cuppett, adding an endpoint may *break* access to S3 on other regions.  But I can't find docs to back that up, and [the docs][3] say:

> We use the most specific route that matches the traffic to determine how to route the traffic (longest prefix match).  If you have an existing route in your route table for all internet traffic (0.0.0.0/0) that points to an internet gateway, the endpoint route takes precedence for all traffic destined for the service, because the IP address range for the service is more specific than 0.0.0.0/0.  All other internet traffic goes to your internet gateway, including traffic that's destined for the service in other regions.

which suggests that access to S3 on other regions may be unaffected.  In any case, our registry buckets, and likely any other buckets associated with the cluster, will be living in the same region.

`concat` is documented [here][5].

[1]: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints-s3.html
[2]: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints.html
[3]: https://docs.aws.amazon.com/vpc/latest/userguide/vpce-gateway.html
[4]: https://www.terraform.io/docs/providers/aws/r/vpc_endpoint.html
[5]: https://www.terraform.io/docs/configuration/interpolation.html#concat-list1-list2-