### PR TITLE
Change the ApiVersion to the correct awsproviderconfig.k8s.io/v1alpha1

### DIFF
--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -77,7 +77,7 @@ func provider(clusterID, clusterName string, platform *aws.Platform, mpool *aws.
 	}
 	return &awsprovider.AWSMachineProviderConfig{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "aws.cluster.k8s.io/v1alpha1",
+			APIVersion: "awsproviderconfig.k8s.io/v1alpha1",
 			Kind:       "AWSMachineProviderConfig",
 		},
 		InstanceType:       mpool.InstanceType,


### PR DESCRIPTION
Since migration to CRD the ApiVersion string changed into awsproviderconfig.k8s.io/v1alpha1.
It needs to be reflected on the installer side.