### PR TITLE
pkg/asset: Rename ingress config

### DIFF
--- a/pkg/asset/manifests/ingress.go
+++ b/pkg/asset/manifests/ingress.go
@@ -53,7 +53,7 @@ func (ing *Ingress) Generate(dependencies asset.Parents) error {
 			Kind:       "Ingress",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "default",
+			Name: "cluster",
 			// not namespaced
 		},
 		Spec: configv1.IngressSpec{


### PR DESCRIPTION
* `pkg/asset/manifests/ingress.go` (`Generate`): Rename ingress config object from "default" to "cluster".

Per https://github.com/openshift/cluster-openshift-apiserver-operator/pull/63#discussion_r237119532.

@ironcladlou

With this change, we have the following:

```
% oc get ingresses.config.openshift.io/cluster -o yaml
apiVersion: config.openshift.io/v1
kind: Ingress
metadata:
  creationTimestamp: 2018-11-28T18:40:09Z
  generation: 1
  name: cluster
  resourceVersion: "202"
  selfLink: /apis/config.openshift.io/v1/ingresses/cluster
  uid: 0898a6c8-f33d-11e8-820c-06b750ec8402
spec:
  domain: apps.mmasters.devcluster.openshift.com
status: {}
% oc get ingresses.config.openshift.io/default -o yaml
Error from server (NotFound): ingresses.config.openshift.io "default" not found
```