### PR TITLE
data/libvirt: Single coreos_ignition for libvirt_domain.master

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -68,7 +68,7 @@ resource "libvirt_domain" "master" {
   memory = "3072"
   vcpu   = "2"
 
-  coreos_ignition = "${libvirt_ignition.master.*.id[count.index]}"
+  coreos_ignition = "${libvirt_ignition.master.id}"
 
   disk {
     volume_id = "${element(libvirt_volume.master.*.id, count.index)}"


### PR DESCRIPTION
Catching up with 4fbf790d (#553).  Before this commit, building with a master count larger than one would yield:

```
* libvirt_domain.master[1]: index 1 out of range for list libvirt_ignition.master.*.id (max 1) in:

${libvirt_ignition.master.*.id[count.index]}
```

/assign @abhinavdahiya 