### PR TITLE
Pin OS image for release builds

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -39,6 +39,10 @@ export CGO_ENABLED=0
 case "${MODE}" in
 release)
 	TAGS="${TAGS} release"
+	if test -n "${RELEASE_IMAGE}"
+	then
+		LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/asset/ignition/bootstrap.defaultReleaseImage=${RELEASE_IMAGE}"
+	fi
 	if test "${SKIP_GENERATION}" != y
 	then
 		go generate ./data

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -43,6 +43,10 @@ release)
 	then
 		LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/asset/ignition/bootstrap.defaultReleaseImage=${RELEASE_IMAGE}"
 	fi
+	if test -n "${RHCOS_BUILD_NAME}"
+	then
+		LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/rhcos.buildName=${RHCOS_BUILD_NAME}"
+	fi
 	if test "${SKIP_GENERATION}" != y
 	then
 		go generate ./data

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -29,11 +29,14 @@ import (
 
 const (
 	rootDir              = "/opt/openshift"
-	defaultReleaseImage  = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
 	bootstrapIgnFilename = "bootstrap.ign"
 	etcdCertSignerImage  = "quay.io/coreos/kube-etcd-signer-server:678cc8e6841e2121ebfdb6e2db568fce290b67d6"
 	etcdctlImage         = "quay.io/coreos/etcd:v3.2.14"
 	ignitionUser         = "core"
+)
+
+var t(
+	defaultReleaseImage = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
 )
 
 // bootstrapTemplateData is the data to use to replace values in bootstrap

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -35,7 +35,7 @@ const (
 	ignitionUser         = "core"
 )
 
-var t(
+var (
 	defaultReleaseImage = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
 )
 


### PR DESCRIPTION
Three environment variables have been introduce for build time that will pin the exact OS image to be pulled.
        **OPENSHIFT_INSTALL_RHCOS_BASE_URL**: points to the base url from where to pick the image from. Defaults to "https://releases-rhcos.svc.ci.openshift.org/storage/releases" (as it was before this PR).
        **OPENSHIFT_INSTALL_RHCOS_DEFAULT_CHANNEL**: points to the channel where the image is available. Defaults to "maipo" (as it was before this PR).
        **OPENSHIFT_INSTALL_RHCOS_BUILD_NAME**: a string representing the build name. If empty (the default is empty), then the latest one will be picked up. If the provided build name is wrong/unavailable, then the installer will error out.

This PR is a follow up on #732 
