### PR TITLE
pkg/tfvars: Drop unused libvirt.DefaultIfName and similar

### DIFF
--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -10,10 +10,6 @@ const (
 	EndpointsPrivate Endpoints = "private"
 	// EndpointsPublic represents the configuration for using only public endpoints.
 	EndpointsPublic Endpoints = "public"
-	// DefaultVPCCIDRBlock is the default CIDR range for an AWS VPC.
-	DefaultVPCCIDRBlock = "10.0.0.0/16"
-	// DefaultRegion is the default AWS region for the cluster.
-	DefaultRegion = "us-east-1"
 )
 
 // AWS converts AWS related config.

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -7,11 +7,6 @@ import (
 	"github.com/apparentlymart/go-cidr/cidr"
 )
 
-const (
-	// DefaultIfName is the default interface name for libvirt.
-	DefaultIfName = "osbr0"
-)
-
 // Libvirt encompasses configuration specific to libvirt.
 type Libvirt struct {
 	URI         string `json:"tectonic_libvirt_uri,omitempty"`

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -1,12 +1,5 @@
 package openstack
 
-const (
-	// DefaultNetworkCIDRBlock is the default CIDR range for an OpenStack network.
-	DefaultNetworkCIDRBlock = "10.0.0.0/16"
-	// DefaultRegion is the default OpenStack region for the cluster.
-	DefaultRegion = "regionOne"
-)
-
 // OpenStack converts OpenStack related config.
 type OpenStack struct {
 	BaseImage        string `json:"tectonic_openstack_base_image,omitempty"`


### PR DESCRIPTION
This was added in f245ca69 (coreos/tectonic-installer#3265), but the last consumer was removed by 619db925 (#412).  We currently feed the default bridge name in via `pkg/asset/installconfig/libvirt`'s `defaultNetworkIfName`.