### PR TITLE
data/aws: Switch to m4.large

### DIFF
--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -26,7 +26,7 @@ variable "ignition" {
 
 variable "instance_type" {
   type        = "string"
-  default     = "t3.medium"
+  default     = "m4.large"
   description = "The EC2 instance type for the bootstrap node."
 }
 

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -9,10 +9,10 @@ EOF
 
 variable "tectonic_aws_master_ec2_type" {
   type        = "string"
-  description = "Instance size for the master node(s). Example: `t3.medium`."
+  description = "Instance size for the master node(s). Example: `m4.large`."
 
   # FIXME: get this wired up to the machine default
-  default = "t3.medium"
+  default = "m4.large"
 }
 
 variable "tectonic_aws_ec2_ami_override" {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -27,7 +27,7 @@ import (
 
 func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
 	return awstypes.MachinePool{
-		InstanceType: "t3.medium",
+		InstanceType: "m4.large",
 	}
 }
 


### PR DESCRIPTION
We were hitting:

```console
$ oc --namespace=openshift-cluster-api logs clusterapi-manager-controllers-559fc8d878-d5p65  --container=machine-controller
...
E1130 05:38:29.574505       1 actuator.go:96] error creating machine: error launching instance: error creating EC2 instance: InstanceLimitExceeded: You have requested more instances (21) than your current instance limit of 20 allows for the specified instance type. Please visit http://aws.amazon.com/contact-us/ec2-request to request an adjustment to this limit.
        status code: 400, request id: 01da30c5-c310-48c0-9550-79cc78cccd7e
...
```

with t3.medium, where our current CI account limit is 20 in us-east-1.  Switching gives us similar performance with a higher cap while we get the limits bumped.

/assign @smarterclayton