### PR TITLE
data/aws/vpc: Drop aws_route_table data blocks

### DIFF
--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -30,38 +30,8 @@ locals {
 }
 
 # all data sources should be input variable-agnostic and used as canonical source for querying "state of resources" and building outputs
-# (ie: we don't want "data.aws_subnet.external-worker" and "data.aws_subnet.worker". just "data.aws_subnet.worker" used everwhere for list of worker subnets for any valid input var state)
+# (ie: we don't want "aws.new_vpc" and "data.aws_vpc.cluster_vpc", just "data.aws_vpc.cluster_vpc" used everwhere).
 
 data "aws_vpc" "cluster_vpc" {
   id = "${local.vpc_id}"
-}
-
-data "aws_subnet" "worker" {
-  count  = "${local.worker_subnet_count}"
-  id     = "${local.worker_subnet_ids[count.index]}"
-  vpc_id = "${local.vpc_id}"
-}
-
-data "aws_subnet" "master" {
-  count  = "${local.master_subnet_count}"
-  id     = "${local.master_subnet_ids[count.index]}"
-  vpc_id = "${local.vpc_id}"
-}
-
-data "aws_route_table" "worker" {
-  count = "${local.worker_subnet_count}"
-
-  filter = {
-    name   = "association.subnet-id"
-    values = ["${list(local.worker_subnet_ids[count.index])}"]
-  }
-}
-
-data "aws_route_table" "master" {
-  count = "${local.master_subnet_count}"
-
-  filter = {
-    name   = "association.subnet-id"
-    values = ["${list(local.master_subnet_ids[count.index])}"]
-  }
 }


### PR DESCRIPTION
These were added in f8286662 (coreos/tectonic-installer#3092), and never seem to have had a consumer.  Removing them should fix occasional flakes [like][1]:

```
level=error msg="Error: Error applying plan:\n\n1 error(s) occurred:\n\n* module.vpc.data.aws_route_table.worker[1]: data.aws_route_table.worker.1: Your query returned no results. Please change your search criteria and try again.\n\nTerraform does not automatically rollback in the face of errors.\nInstead, your Terraform state file has been partially updated with\nany resources that successfully completed. Please address the error\nabove and apply again to incrementally change your infrastructure."
```

I've also removed the data.aws_subnet blocks, whose last consumers were removed in f8286662.

[1]: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_installer/737/pull-ci-openshift-installer-master-e2e-aws/1789/build-log.txt