### PR TITLE
v0.5.0: pkg: Pin to RHCOS 47.167 and quay.io/openshift-release-dev/ocp-release:4.0.0-3

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	rootDir              = "/opt/tectonic"
-	defaultReleaseImage  = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
+	defaultReleaseImage  = "quay.io/openshift-release-dev/ocp-release:4.0.0-3"
 	bootstrapIgnFilename = "bootstrap.ign"
 )
 
@@ -141,7 +141,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, adminKub
 	}
 
 	releaseImage := defaultReleaseImage
-	if ri, ok := os.LookupEnv("OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"); ok && ri != "" {
+	if ri, ok := os.LookupEnv("_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"); ok && ri != "" {
 		logrus.Warn("Found override for ReleaseImage. Please be warned, this is not advised")
 		releaseImage = ri
 	}

--- a/pkg/rhcos/builds.go
+++ b/pkg/rhcos/builds.go
@@ -33,9 +33,15 @@ type metadata struct {
 }
 
 func fetchLatestMetadata(ctx context.Context, channel string) (metadata, error) {
-	build, err := fetchLatestBuild(ctx, channel)
-	if err != nil {
-		return metadata{}, errors.Wrap(err, "failed to fetch latest build")
+	var build string
+	var err error
+	if channel == DefaultChannel {
+		build = "47.165"
+	} else {
+		build, err = fetchLatestBuild(ctx, channel)
+		if err != nil {
+			return metadata{}, errors.Wrap(err, "failed to fetch latest build")
+		}
 	}
 
 	url := fmt.Sprintf("%s/%s/%s/meta.json", baseURL, channel, build)


### PR DESCRIPTION
DO NOT MERGE!

That's the latest RHCOS release:

```console
$ curl -s https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/builds.json | jq '{latest: .builds[0], timestamp}'
{
  "latest": "47.165",
  "timestamp": "2018-12-02T06:41:22Z"
}
```

And @smarterclayton just [pushed 4.0.0-0.alpha-2018-12-02-020136 to quay.io/openshift-release-dev/ocp-release:4.0.0-3][1].

This PR builds on #772.  The CHANGELOG commit (also in #772) will be merged into master.  The pin commit (unique to this PR) will get the v0.5.0 tag, but not be merged into master.  I'm just targetting master with the PR because I want CI to pass on the pinned dependencies before we tag the release.

/hold

[1]: https://github.com/openshift/installer/pull/772#issuecomment-443486056