### PR TITLE
pkg/asset/ignition/bootstrap: Add /root/.docker/config.json

### DIFF
--- a/data/data/bootstrap/files/root/.docker/config.json.template
+++ b/data/data/bootstrap/files/root/.docker/config.json.template
@@ -1,0 +1,1 @@
+{{.PullSecret}}

--- a/data/data/manifests/bootkube/pull.yaml.template
+++ b/data/data/manifests/bootkube/pull.yaml.template
@@ -7,6 +7,6 @@
     "name": "coreos-pull-secret"
   },
   "data": {
-    ".dockerconfigjson": "{{.PullSecret}}"
+    ".dockerconfigjson": "{{.PullSecretBase64}}"
   }
 }

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -40,6 +40,7 @@ type bootstrapTemplateData struct {
 	EtcdCertSignerImage   string
 	EtcdCluster           string
 	EtcdctlImage          string
+	PullSecret            string
 	ReleaseImage          string
 	AdminKubeConfigBase64 string
 }
@@ -148,6 +149,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, adminKub
 	return &bootstrapTemplateData{
 		EtcdCertSignerImage:   "quay.io/coreos/kube-etcd-signer-server:678cc8e6841e2121ebfdb6e2db568fce290b67d6",
 		EtcdctlImage:          "quay.io/coreos/etcd:v3.2.14",
+		PullSecret:            installConfig.PullSecret,
 		ReleaseImage:          releaseImage,
 		EtcdCluster:           strings.Join(etcdEndpoints, ","),
 		AdminKubeConfigBase64: base64.StdEncoding.EncodeToString(adminKubeConfig),

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -150,7 +150,7 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		KubeCaKey:                       base64.StdEncoding.EncodeToString(kubeCA.Key()),
 		McsTLSCert:                      base64.StdEncoding.EncodeToString(mcsCertKey.Cert()),
 		McsTLSKey:                       base64.StdEncoding.EncodeToString(mcsCertKey.Key()),
-		PullSecret:                      base64.StdEncoding.EncodeToString([]byte(installConfig.Config.PullSecret)),
+		PullSecretBase64:                base64.StdEncoding.EncodeToString([]byte(installConfig.Config.PullSecret)),
 		RootCaCert:                      string(rootCA.Cert()),
 		ServiceServingCaCert:            base64.StdEncoding.EncodeToString(serviceServingCA.Cert()),
 		ServiceServingCaKey:             base64.StdEncoding.EncodeToString(serviceServingCA.Key()),

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -25,7 +25,7 @@ type bootkubeTemplateData struct {
 	KubeCaKey                       string
 	McsTLSCert                      string
 	McsTLSKey                       string
-	PullSecret                      string
+	PullSecretBase64                string
 	RootCaCert                      string
 	ServiceServingCaCert            string
 	ServiceServingCaKey             string


### PR DESCRIPTION
And export `REGISTRY_AUTH_FILE` pointing at that file.  We already provide `/opt/tectonic/manifests/pull.json` with a Kubernetes secret that contains the auth JSON, but the new file has the auth JSON without any wrapping.  This resolves [issues with auth-protected update payloads][1]:

```console
[core@ip-10-0-10-189 ~]$ journalctl -n5 -u bootkube.service
-- Logs begin at Mon 2018-12-03 06:54:37 UTC, end at Mon 2018-12-03 07:24:52 UTC. --
Dec 03 07:24:48 ip-10-0-10-189 bootkube.sh[696]: Trying to pull quay.io/openshift-release-dev/ocp-v4.0@sha256:69bae91f6a933045175170cebd1caf00b8216a096fd4d402c41957a99aa3435b...Failed
Dec 03 07:24:48 ip-10-0-10-189 bootkube.sh[696]: unable to pull quay.io/openshift-release-dev/ocp-v4.0@sha256:69bae91f6a933045175170cebd1caf00b8216a096fd4d402c41957a99aa3435b: unable to pull image: Error determining manifest MIME type for docker://quay.io/openshift-release-dev/ocp-v4.0@sha256:69bae91f6a933045175170cebd1caf00b8216a096fd4d402c41957a99aa3435b: Error reading manifest sha256:69bae91f6a933045175170cebd1caf00b8216a096fd4d402c41957a99aa3435b in quay.io/openshift-release-dev/ocp-v4.0: unauthorized: access to the requested resource is not authorized
Dec 03 07:24:48 ip-10-0-10-189 systemd[1]: bootkube.service: main process exited, code=exited, status=125/n/a
Dec 03 07:24:48 ip-10-0-10-189 systemd[1]: Unit bootkube.service entered failed state.
Dec 03 07:24:48 ip-10-0-10-189 systemd[1]: bootkube.service failed.
```

The environment variable is documented [here][2].

I've also renamed the manifest template variable to `PullSecretBase64` to distinguish it from the unencoded `PullSecret` I'm adding to the bootstrap template parameters.  These are different template parameter sets, but I think recycling the same name would be unnecessarily confusing.

[1]: https://github.com/openshift/installer/pull/773#issuecomment-443621991
[2]: https://github.com/containers/libpod/blob/v0.11.1.1/docs/podman-pull.1.md#options