### PR TITLE
Remove clusterID from installconfig and move it to cluster

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -9,12 +9,12 @@ import (
 )
 
 // Metadata converts an install configuration to AWS metadata.
-func Metadata(config *types.InstallConfig) *aws.Metadata {
+func Metadata(clusterID string, config *types.InstallConfig) *aws.Metadata {
 	return &aws.Metadata{
 		Region: config.Platform.AWS.Region,
 		Identifier: []map[string]string{
 			{
-				"openshiftClusterID": config.ClusterID,
+				"openshiftClusterID": clusterID,
 			},
 			{
 				fmt.Sprintf("kubernetes.io/cluster/%s", config.ObjectMeta.Name): "owned",

--- a/pkg/asset/cluster/openstack/openstack.go
+++ b/pkg/asset/cluster/openstack/openstack.go
@@ -8,12 +8,12 @@ import (
 )
 
 // Metadata converts an install configuration to OpenStack metadata.
-func Metadata(config *types.InstallConfig) *openstack.Metadata {
+func Metadata(clusterID string, config *types.InstallConfig) *openstack.Metadata {
 	return &openstack.Metadata{
 		Region: config.Platform.OpenStack.Region,
 		Cloud:  config.Platform.OpenStack.Cloud,
 		Identifier: map[string]string{
-			"openshiftClusterID": config.ClusterID,
+			"openshiftClusterID": clusterID,
 		},
 	}
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -33,6 +33,7 @@ func (t *TerraformVariables) Name() string {
 // Dependencies returns the dependency of the TerraformVariable
 func (t *TerraformVariables) Dependencies() []asset.Asset {
 	return []asset.Asset{
+		&installconfig.ClusterID{},
 		&installconfig.InstallConfig{},
 		&bootstrap.Bootstrap{},
 		&machine.Master{},
@@ -41,16 +42,17 @@ func (t *TerraformVariables) Dependencies() []asset.Asset {
 
 // Generate generates the terraform.tfvars file.
 func (t *TerraformVariables) Generate(parents asset.Parents) error {
+	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
 	bootstrap := &bootstrap.Bootstrap{}
 	master := &machine.Master{}
-	parents.Get(installConfig, bootstrap, master)
+	parents.Get(clusterID, installConfig, bootstrap, master)
 
 	bootstrapIgn := string(bootstrap.Files()[0].Data)
 
 	masterIgn := string(master.Files()[0].Data)
 
-	data, err := tfvars.TFVars(installConfig.Config, bootstrapIgn, masterIgn)
+	data, err := tfvars.TFVars(clusterID.ClusterID, installConfig.Config, bootstrapIgn, masterIgn)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Tfvars")
 	}

--- a/pkg/asset/installconfig/clusterid.go
+++ b/pkg/asset/installconfig/clusterid.go
@@ -6,24 +6,25 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 )
 
-type clusterID struct {
+// ClusterID is the unique ID of the cluster, immutable during the cluster's life
+type ClusterID struct {
 	ClusterID string
 }
 
-var _ asset.Asset = (*clusterID)(nil)
+var _ asset.Asset = (*ClusterID)(nil)
 
 // Dependencies returns no dependencies.
-func (a *clusterID) Dependencies() []asset.Asset {
+func (a *ClusterID) Dependencies() []asset.Asset {
 	return []asset.Asset{}
 }
 
 // Generate generates a new UUID
-func (a *clusterID) Generate(asset.Parents) error {
+func (a *ClusterID) Generate(asset.Parents) error {
 	a.ClusterID = uuid.New()
 	return nil
 }
 
 // Name returns the human-friendly name of the asset.
-func (a *clusterID) Name() string {
+func (a *ClusterID) Name() string {
 	return "Cluster ID"
 }

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -41,7 +41,6 @@ var _ asset.WritableAsset = (*InstallConfig)(nil)
 // InstallConfig asset.
 func (a *InstallConfig) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		&clusterID{},
 		&sshPublicKey{},
 		&baseDomain{},
 		&clusterName{},
@@ -52,14 +51,12 @@ func (a *InstallConfig) Dependencies() []asset.Asset {
 
 // Generate generates the install-config.yaml file.
 func (a *InstallConfig) Generate(parents asset.Parents) error {
-	clusterID := &clusterID{}
 	sshPublicKey := &sshPublicKey{}
 	baseDomain := &baseDomain{}
 	clusterName := &clusterName{}
 	pullSecret := &pullSecret{}
 	platform := &platform{}
 	parents.Get(
-		clusterID,
 		sshPublicKey,
 		baseDomain,
 		clusterName,
@@ -71,7 +68,6 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName.ClusterName,
 		},
-		ClusterID:  clusterID.ClusterID,
 		SSHKey:     sshPublicKey.Key,
 		BaseDomain: baseDomain.BaseDomain,
 		Networking: types.Networking{

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Machines returns a list of machines for a machinepool.
-func Machines(config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]clusterapi.Machine, error) {
+func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]clusterapi.Machine, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != aws.Name {
 		return nil, fmt.Errorf("non-AWS configuration: %q", configPlatform)
 	}
@@ -37,7 +37,7 @@ func Machines(config *types.InstallConfig, pool *types.MachinePool, role, userDa
 	var machines []clusterapi.Machine
 	for idx := int64(0); idx < total; idx++ {
 		azIndex := int(idx) % len(azs)
-		provider, err := provider(config.ClusterID, clustername, platform, mpool, azIndex, role, userDataSecret)
+		provider, err := provider(clusterID, clustername, platform, mpool, azIndex, role, userDataSecret)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]clusterapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]clusterapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != aws.Name {
 		return nil, fmt.Errorf("non-AWS configuration: %q", configPlatform)
 	}
@@ -38,7 +38,7 @@ func MachineSets(config *types.InstallConfig, pool *types.MachinePool, role, use
 			replicas++
 		}
 
-		provider, err := provider(config.ClusterID, clustername, platform, mpool, idx, role, userDataSecret)
+		provider, err := provider(clusterID, clustername, platform, mpool, idx, role, userDataSecret)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Machines returns a list of machines for a machinepool.
-func Machines(config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]clusterapi.Machine, error) {
+func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]clusterapi.Machine, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != libvirt.Name {
 		return nil, fmt.Errorf("non-Libvirt configuration: %q", configPlatform)
 	}

--- a/pkg/asset/machines/libvirt/machinesets.go
+++ b/pkg/asset/machines/libvirt/machinesets.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]clusterapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]clusterapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != libvirt.Name {
 		return nil, fmt.Errorf("non-Libvirt configuration: %q", configPlatform)
 	}

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -52,6 +52,7 @@ func (m *Manifests) Name() string {
 // Manifests asset.
 func (m *Manifests) Dependencies() []asset.Asset {
 	return []asset.Asset{
+		&installconfig.ClusterID{},
 		&installconfig.InstallConfig{},
 		&Ingress{},
 		&DNS{},
@@ -121,6 +122,7 @@ func (m *Manifests) Files() []*asset.File {
 }
 
 func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*asset.File {
+	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
 	etcdCA := &tls.EtcdCA{}
 	kubeCA := &tls.KubeCA{}
@@ -129,6 +131,7 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 	rootCA := &tls.RootCA{}
 	serviceServingCA := &tls.ServiceServingCA{}
 	dependencies.Get(
+		clusterID,
 		installConfig,
 		etcdCA,
 		etcdClientCertKey,
@@ -156,7 +159,7 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		RootCaCert:                      string(rootCA.Cert()),
 		ServiceServingCaCert:            base64.StdEncoding.EncodeToString(serviceServingCA.Cert()),
 		ServiceServingCaKey:             base64.StdEncoding.EncodeToString(serviceServingCA.Key()),
-		CVOClusterID:                    installConfig.Config.ClusterID,
+		CVOClusterID:                    clusterID.ClusterID,
 		EtcdEndpointHostnames:           etcdEndpointHostnames,
 		EtcdEndpointDNSSuffix:           installConfig.Config.BaseDomain,
 	}

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -31,9 +31,9 @@ type config struct {
 
 // TFVars converts the InstallConfig and Ignition content to
 // terraform.tfvar JSON.
-func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, error) {
+func TFVars(clusterID string, cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, error) {
 	config := &config{
-		ClusterID:   cfg.ClusterID,
+		ClusterID:   clusterID,
 		Name:        cfg.ObjectMeta.Name,
 		BaseDomain:  cfg.BaseDomain,
 		MachineCIDR: cfg.Networking.MachineCIDR.String(),

--- a/pkg/types/clustermetadata.go
+++ b/pkg/types/clustermetadata.go
@@ -10,6 +10,7 @@ import (
 // regarding the cluster that was created by installer.
 type ClusterMetadata struct {
 	ClusterName             string `json:"clusterName"`
+	ClusterID               string `json:"clusterID"`
 	ClusterPlatformMetadata `json:",inline"`
 }
 

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -33,9 +33,6 @@ type InstallConfig struct {
 
 	metav1.ObjectMeta `json:"metadata"`
 
-	// ClusterID is the ID of the cluster.
-	ClusterID string `json:"clusterID"`
-
 	// SSHKey is the public ssh key to provide access to instances.
 	SSHKey string `json:"sshKey"`
 

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -25,9 +25,6 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 	if c.ObjectMeta.Name == "" {
 		allErrs = append(allErrs, field.Required(field.NewPath("metadata", "name"), "cluster name required"))
 	}
-	if c.ClusterID == "" {
-		allErrs = append(allErrs, field.Required(field.NewPath("clusterID"), "cluster ID required"))
-	}
 	if c.SSHKey != "" {
 		if err := validate.SSHPublicKey(c.SSHKey); err != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("sshKey"), c.SSHKey, err.Error()))


### PR DESCRIPTION
ClusterID is now removed from installconfig. The reason is that it should not be possible for a user to override this value. The clusterID is still needed for destroy - and hence it is now a separate asset which gets stored in ClusterMetadata. Other assets needing the clusterID (e.g. legacy manifests) issue a separate dependency on this asset.
For convenience of package depenencies, the asset still lives in the installconfig package.
A follow up PR can move it to cluster package if needed (currently blocked by legacy CVO overrides).

Fixes issue #761 