### PR TITLE
libvirt: bump master memory to 4096 MB

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -64,7 +64,7 @@ resource "libvirt_domain" "master" {
 
   name = "${var.tectonic_cluster_name}-master-${count.index}"
 
-  memory = "3072"
+  memory = "4096"
   vcpu   = "2"
 
   coreos_ignition = "${libvirt_ignition.master.id}"


### PR DESCRIPTION
On my development machine (libvirt) the master has started to swap after a few minutes of being up. This patch bumps the memory to 4096MB and is currently stable.