### PR TITLE
 libvirt: Add Terraform variables for memory/CPU, bump master to 4GiB 

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -64,8 +64,8 @@ resource "libvirt_domain" "master" {
 
   name = "${var.tectonic_cluster_name}-master-${count.index}"
 
-  memory = "3072"
-  vcpu   = "2"
+  memory = "${var.libvirt_master_memory}"
+  vcpu   = "${var.libvirt_master_vcpu}"
 
   coreos_ignition = "${libvirt_ignition.master.id}"
 

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -32,3 +32,19 @@ variable "tectonic_libvirt_master_ips" {
   type        = "list"
   description = "the list of desired master ips. Must match tectonic_master_count"
 }
+
+# It's definitely recommended to bump this if you can.
+variable "libvirt_master_memory" {
+  type        = "string"
+  description = "RAM in MiB allocated to masters"
+  default     = "4096"
+}
+
+# At some point this one is likely to default to the number
+# of physical cores you have.  See also
+# https://pagure.io/standard-test-roles/pull-request/223
+variable "libvirt_master_vcpu" {
+  type        = "string"
+  description = "CPUs allocated to masters"
+  default     = "2"
+}


### PR DESCRIPTION
My main dev environment is a Lenovo P50 with 64GB of RAM - I got
it specifically to run some large VMs (and/or many VMs) specifically
with OpenShift in mind.

Increasing RAM on my master to 8GB is a *very* noticeable speed improvement
and I think reliabilty; before I saw the apiserver be `OOMKilled`
sometimes, and `kswapd0` was constantly doing writeback.

These variables aren't bubbled all the way up to the documented
installer config, but one can now do e.g.:

```
$ env TF_VAR_tectonic_libvirt_memory=8192 TF_VAR_tectonic_libvirt_vcpu=4 ./bin/openshift-install create cluster --dir=osiris
```

Previously:
    
  - https://github.com/openshift/installer/pull/408
  - https://github.com/openshift/installer/pull/163
