### PR TITLE
cmd/openshift-install/create: Fatal Kube API wait timeouts

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -217,6 +217,10 @@ func destroyBootstrap(ctx context.Context, config *rest.Config, directory string
 			}
 		}
 	}, 2*time.Second, apiContext.Done())
+	err = apiContext.Err()
+	if err != nil && err != context.Canceled {
+		return errors.Wrap(err, "waiting for Kubernetes API")
+	}
 
 	events := client.CoreV1().Events("kube-system")
 

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -91,23 +91,31 @@ var (
 			Short: "Create an OpenShift cluster",
 			// FIXME: add longer descriptions for our commands with examples for better UX.
 			// Long:  "",
-			PostRunE: func(_ *cobra.Command, _ []string) error {
+			PostRun: func(_ *cobra.Command, _ []string) {
 				ctx := context.Background()
+
+				cleanup := setupFileHook(rootOpts.dir)
+				defer cleanup()
+
 				config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(rootOpts.dir, "auth", "kubeconfig"))
 				if err != nil {
-					return errors.Wrap(err, "loading kubeconfig")
+					logrus.Fatal(errors.Wrap(err, "loading kubeconfig"))
 				}
 
 				err = destroyBootstrap(ctx, config, rootOpts.dir)
 				if err != nil {
-					return err
-				}
-				consoleURL, err := waitForConsole(ctx, config, rootOpts.dir)
-				if err != nil {
-					return err
+					logrus.Fatal(err)
 				}
 
-				return logComplete(rootOpts.dir, consoleURL)
+				consoleURL, err := waitForConsole(ctx, config, rootOpts.dir)
+				if err != nil {
+					logrus.Fatal(err)
+				}
+
+				err = logComplete(rootOpts.dir, consoleURL)
+				if err != nil {
+					logrus.Fatal(err)
+				}
 			},
 		},
 		assets: []asset.WritableAsset{&cluster.TerraformVariables{}, &kubeconfig.Admin{}, &cluster.Cluster{}},
@@ -126,22 +134,16 @@ func newCreateCmd() *cobra.Command {
 	}
 
 	for _, t := range targets {
-		t.command.RunE = runTargetCmd(t.assets...)
+		t.command.Run = runTargetCmd(t.assets...)
 		cmd.AddCommand(t.command)
 	}
 
 	return cmd
 }
 
-func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		cleanup, err := setupFileHook(rootOpts.dir)
-		if err != nil {
-			return errors.Wrap(err, "failed to setup logging hook")
-		}
-		defer cleanup()
-
-		assetStore, err := asset.NewStore(rootOpts.dir)
+func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args []string) {
+	runner := func(directory string) error {
+		assetStore, err := asset.NewStore(directory)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create asset store")
 		}
@@ -155,7 +157,7 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 				err = errors.Wrapf(err, "failed to fetch %s", a.Name())
 			}
 
-			if err2 := asset.PersistToFile(a, rootOpts.dir); err2 != nil {
+			if err2 := asset.PersistToFile(a, directory); err2 != nil {
 				err2 = errors.Wrapf(err2, "failed to write asset (%s) to disk", a.Name())
 				if err != nil {
 					logrus.Error(err2)
@@ -170,17 +172,21 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 		}
 		return nil
 	}
+
+	return func(cmd *cobra.Command, args []string) {
+		cleanup := setupFileHook(rootOpts.dir)
+		defer cleanup()
+
+		err := runner(rootOpts.dir)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+	}
 }
 
 // FIXME: pulling the kubeconfig and metadata out of the root
 // directory is a bit cludgy when we already have them in memory.
 func destroyBootstrap(ctx context.Context, config *rest.Config, directory string) (err error) {
-	cleanup, err := setupFileHook(rootOpts.dir)
-	if err != nil {
-		return errors.Wrap(err, "failed to setup logging hook")
-	}
-	defer cleanup()
-
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return errors.Wrap(err, "creating a Kubernetes client")

--- a/cmd/openshift-install/log.go
+++ b/cmd/openshift-install/log.go
@@ -44,14 +44,14 @@ func (h *fileHook) Fire(entry *logrus.Entry) error {
 	return err
 }
 
-func setupFileHook(baseDir string) (func(), error) {
+func setupFileHook(baseDir string) func() {
 	if err := os.MkdirAll(baseDir, 0755); err != nil {
-		return nil, errors.Wrap(err, "failed to create base directory for logs")
+		logrus.Fatal(errors.Wrap(err, "failed to create base directory for logs"))
 	}
 
 	logfile, err := os.OpenFile(filepath.Join(baseDir, ".openshift_install.log"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open log file")
+		logrus.Fatal(errors.Wrap(err, "failed to open log file"))
 	}
 
 	originalHooks := logrus.LevelHooks{}
@@ -68,5 +68,5 @@ func setupFileHook(baseDir string) (func(), error) {
 	return func() {
 		logfile.Close()
 		logrus.StandardLogger().ReplaceHooks(originalHooks)
-	}, nil
+	}
 }


### PR DESCRIPTION
Since it landed in 127219f9 (#579), the Kube-API `wait.Until` loop has lacked "did we timeout?" error checking.  That means that a hung bootstrap node could lead to logs like:

```
...
DEBUG Still waiting for the Kubernetes API: Get https://wking-api.installer.testing:6443/version?timeout=32s: dial tcp 192.168.126.10:6443: connect: connection refused
INFO Waiting 30m0s for the bootstrap-complete event...
WARNING Failed to connect events watcher: Get https://wking-api.installer.testing:6443/api/v1/namespaces/kube-system/events?watch=true: dial tcp 192.168.126.10:6443: connect: connection refused
...
```

where the Kube API never comes up and we waste 30 minutes of failed event-watcher connection attempts anyway.  With this commit, we'll fail if apiContext expires without an API coming up.  From [the `Context.Err` docs][1]:

> If `Done` is not yet closed, `Err` returns `nil`.  If `Done` is closed, `Err` returns a non-nil error explaining why: `Canceled` if the context was canceled or `DeadlineExceeded` if the context's deadline passed.  After `Err` returns a non-nil error, successive calls to `Err` return the same error.

[1]: https://golang.org/pkg/context/#Context