### PR TITLE
fix typo with kubeadmin password

### DIFF
--- a/pkg/asset/password/password.go
+++ b/pkg/asset/password/password.go
@@ -65,7 +65,7 @@ func (a *KubeadminPassword) generateRandomPasswordHash(length int) error {
 	if a.Password == "" {
 		a.Password = string(pw)
 	}
-	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	bytes, err := bcrypt.GenerateFromPassword([]byte(a.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@wking 
My bad, there was a typo in the generateRandomPasswordHash, tests coming in follow-up
@enj ,this fixes the broken match, thanks for finding my typo : ( 