### PR TITLE
bootkube: remove unused config overrides

### DIFF
--- a/data/data/bootstrap/files/opt/openshift/bootkube-config-overrides/kube-apiserver-config-overrides.yaml
+++ b/data/data/bootstrap/files/opt/openshift/bootkube-config-overrides/kube-apiserver-config-overrides.yaml
@@ -1,4 +1,0 @@
-apiVersion: kubecontrolplane.config.openshift.io/v1
-kind: KubeAPIServerConfig
-kubeletClientInfo:
-  ca: ""  # kubelet uses self-signed serving certs. TODO: fix kubelet pki

--- a/data/data/bootstrap/files/opt/openshift/bootkube-config-overrides/kube-controller-manager-config-overrides.yaml
+++ b/data/data/bootstrap/files/opt/openshift/bootkube-config-overrides/kube-controller-manager-config-overrides.yaml
@@ -1,2 +1,0 @@
-apiVersion: kubecontrolplane.config.openshift.io/v1
-kind: KubeControllerManagerConfig

--- a/data/data/bootstrap/files/opt/openshift/bootkube-config-overrides/kube-scheduler-config-overrides.yaml
+++ b/data/data/bootstrap/files/opt/openshift/bootkube-config-overrides/kube-scheduler-config-overrides.yaml
@@ -1,2 +1,0 @@
-apiVersion: componentconfig/v1alpha1
-kind: KubeSchedulerConfiguration

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -65,7 +65,6 @@ then
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-apiserver-bootstrap \
 		--config-output-file=/assets/kube-apiserver-bootstrap/config \
-		--config-override-files=/assets/bootkube-config-overrides/kube-apiserver-config-overrides.yaml \
 		--cluster-config-file=/assets/openshift/99_openshift-cluster-api_cluster.yaml
 
 	cp kube-apiserver-bootstrap/config /etc/kubernetes/bootstrap-configs/kube-apiserver-config.yaml
@@ -86,7 +85,6 @@ then
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-controller-manager-bootstrap \
 		--config-output-file=/assets/kube-controller-manager-bootstrap/config \
-		--config-override-files=/assets/bootkube-config-overrides/kube-controller-manager-config-overrides.yaml \
 		--cluster-config-file=/assets/openshift/99_openshift-cluster-api_cluster.yaml
 
 	cp kube-controller-manager-bootstrap/config /etc/kubernetes/bootstrap-configs/kube-controller-manager-config.yaml
@@ -107,7 +105,6 @@ then
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-scheduler-bootstrap \
 		--config-output-file=/assets/kube-scheduler-bootstrap/config \
-		--config-override-files=/assets/bootkube-config-overrides/kube-scheduler-config-overrides.yaml \
 		--disable-phase-2
 
 	cp kube-scheduler-bootstrap/config /etc/kubernetes/bootstrap-configs/kube-scheduler-config.yaml


### PR DESCRIPTION
We originally introduces these to have a way to customize config from the installer. But this is not against the design we decided on: the installer just passes in existing config files and the operators extract the information they need.