### PR TITLE
pkg/tfvars: Pull from []Machine instead of InstallConfig

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -1,27 +1,47 @@
 package cluster
 
 import (
+	"fmt"
 	"os"
 
+	libvirtprovider "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1alpha1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/tfvars"
+	awstfvars "github.com/openshift/installer/pkg/tfvars/aws"
+	libvirttfvars "github.com/openshift/installer/pkg/tfvars/libvirt"
+	openstacktfvars "github.com/openshift/installer/pkg/tfvars/openstack"
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/none"
+	"github.com/openshift/installer/pkg/types/openstack"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
+	openstackprovider "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 )
 
 const (
 	// TfVarsFileName is the filename for Terraform variables.
-	TfVarsFileName  = "terraform.tfvars"
+	TfVarsFileName = "terraform.tfvars"
+
+	// TfPlatformVarsFileName is a template for platform-specific
+	// Terraform variable files.
+	//
+	// https://www.terraform.io/docs/configuration/variables.html#variable-files
+	TfPlatformVarsFileName = "terraform.%s.auto.tfvars"
+
 	tfvarsAssetName = "Terraform Variables"
 )
 
 // TerraformVariables depends on InstallConfig and
 // Ignition to generate the terrafor.tfvars.
 type TerraformVariables struct {
-	File *asset.File
+	FileList []*asset.File
 }
 
 var _ asset.WritableAsset = (*TerraformVariables)(nil)
@@ -39,6 +59,7 @@ func (t *TerraformVariables) Dependencies() []asset.Asset {
 		new(rhcos.Image),
 		&bootstrap.Bootstrap{},
 		&machine.Master{},
+		&machines.Master{},
 	}
 }
 
@@ -46,21 +67,86 @@ func (t *TerraformVariables) Dependencies() []asset.Asset {
 func (t *TerraformVariables) Generate(parents asset.Parents) error {
 	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
-	bootstrap := &bootstrap.Bootstrap{}
-	master := &machine.Master{}
+	bootstrapIgnAsset := &bootstrap.Bootstrap{}
+	masterIgnAsset := &machine.Master{}
+	mastersAsset := &machines.Master{}
 	rhcosImage := new(rhcos.Image)
-	parents.Get(clusterID, installConfig, bootstrap, master, rhcosImage)
+	parents.Get(clusterID, installConfig, bootstrapIgnAsset, masterIgnAsset, mastersAsset, rhcosImage)
 
-	bootstrapIgn := string(bootstrap.Files()[0].Data)
-	masterIgn := string(master.Files()[0].Data)
+	bootstrapIgn := string(bootstrapIgnAsset.Files()[0].Data)
+	masterIgn := string(masterIgnAsset.Files()[0].Data)
 
-	data, err := tfvars.TFVars(clusterID.ClusterID, installConfig.Config, string(*rhcosImage), bootstrapIgn, masterIgn)
-	if err != nil {
-		return errors.Wrap(err, "failed to get Tfvars")
+	masterCount := len(mastersAsset.Machines)
+	if mastersAsset.Machines == nil {
+		masterCount = len(mastersAsset.MachinesDeprecated)
 	}
-	t.File = &asset.File{
-		Filename: TfVarsFileName,
-		Data:     data,
+	data, err := tfvars.TFVars(
+		clusterID.ClusterID,
+		installConfig.Config.ObjectMeta.Name,
+		installConfig.Config.BaseDomain,
+		&installConfig.Config.Networking.MachineCIDR.IPNet,
+		bootstrapIgn,
+		masterIgn,
+		masterCount,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to get Terraform variables")
+	}
+	t.FileList = []*asset.File{
+		{
+			Filename: TfVarsFileName,
+			Data:     data,
+		},
+	}
+
+	if masterCount == 0 {
+		return errors.Errorf("master slice cannot be empty")
+	}
+
+	switch platform := installConfig.Config.Platform.Name(); platform {
+	case aws.Name:
+		data, err = awstfvars.TFVars(
+			mastersAsset.Machines[0].Spec.ProviderSpec.Value.Object.(*awsprovider.AWSMachineProviderConfig),
+		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
+		}
+		t.FileList = append(t.FileList, &asset.File{
+			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Data:     data,
+		})
+	case libvirt.Name:
+		data, err = libvirttfvars.TFVars(
+			mastersAsset.MachinesDeprecated[0].Spec.ProviderSpec.Value.Object.(*libvirtprovider.LibvirtMachineProviderConfig),
+			string(*rhcosImage),
+			&installConfig.Config.Networking.MachineCIDR.IPNet,
+			installConfig.Config.Platform.Libvirt.Network.IfName,
+			masterCount,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
+		}
+		t.FileList = append(t.FileList, &asset.File{
+			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Data:     data,
+		})
+	case none.Name:
+	case openstack.Name:
+		data, err = openstacktfvars.TFVars(
+			mastersAsset.MachinesDeprecated[0].Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec),
+			installConfig.Config.Platform.OpenStack.Region,
+			installConfig.Config.Platform.OpenStack.ExternalNetwork,
+			installConfig.Config.Platform.OpenStack.TrunkSupport,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
+		}
+		t.FileList = append(t.FileList, &asset.File{
+			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Data:     data,
+		})
+	default:
+		logrus.Warnf("unrecognized platform %s", platform)
 	}
 
 	return nil
@@ -68,10 +154,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 
 // Files returns the files generated by the asset.
 func (t *TerraformVariables) Files() []*asset.File {
-	if t.File != nil {
-		return []*asset.File{t.File}
-	}
-	return []*asset.File{}
+	return t.FileList
 }
 
 // Load reads the terraform.tfvars from disk.
@@ -83,7 +166,13 @@ func (t *TerraformVariables) Load(f asset.FileFetcher) (found bool, err error) {
 		}
 		return false, err
 	}
+	t.FileList = []*asset.File{file}
 
-	t.File = file
+	fileList, err := f.FetchByPattern(fmt.Sprintf(TfPlatformVarsFileName, "*"))
+	if err != nil {
+		return false, err
+	}
+	t.FileList = append(t.FileList, fileList...)
+
 	return true, nil
 }

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -38,7 +38,6 @@ func Apply(dir string, platform string, extraArgs ...string) (path string, err e
 		"-input=false",
 		fmt.Sprintf("-state=%s", filepath.Join(dir, StateFileName)),
 		fmt.Sprintf("-state-out=%s", filepath.Join(dir, StateFileName)),
-		fmt.Sprintf("-var-file=%s", filepath.Join(dir, VarFileName)),
 	}
 	args := append(defaultArgs, extraArgs...)
 	args = append(args, dir)
@@ -71,7 +70,6 @@ func Destroy(dir string, platform string, extraArgs ...string) (err error) {
 		"-input=false",
 		fmt.Sprintf("-state=%s", filepath.Join(dir, StateFileName)),
 		fmt.Sprintf("-state-out=%s", filepath.Join(dir, StateFileName)),
-		fmt.Sprintf("-var-file=%s", filepath.Join(dir, VarFileName)),
 	}
 	args := append(defaultArgs, extraArgs...)
 	args = append(args, dir)

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -1,22 +1,63 @@
+// Package aws contains AWS-specific Terraform-variable logic.
 package aws
 
-// AWS converts AWS related config.
-type AWS struct {
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
+)
+
+type config struct {
 	EC2AMIOverride string            `json:"aws_ec2_ami_override,omitempty"`
 	ExtraTags      map[string]string `json:"aws_extra_tags,omitempty"`
-	Master         `json:",inline"`
-	Region         string `json:"aws_region,omitempty"`
+	EC2Type        string            `json:"aws_master_ec2_type,omitempty"`
+	IOPS           int64             `json:"aws_master_root_volume_iops,omitempty"`
+	Size           int64             `json:"aws_master_root_volume_size,omitempty"`
+	Type           string            `json:"aws_master_root_volume_type,omitempty"`
+	Region         string            `json:"aws_region,omitempty"`
 }
 
-// Master converts master related config.
-type Master struct {
-	EC2Type          string `json:"aws_master_ec2_type,omitempty"`
-	MasterRootVolume `json:",inline"`
-}
+// TFVars generates AWS-specific Terraform variables launching the cluster.
+func TFVars(masterConfig *v1alpha1.AWSMachineProviderConfig) ([]byte, error) {
+	tags := make(map[string]string, len(masterConfig.Tags))
+	for _, tag := range masterConfig.Tags {
+		tags[tag.Name] = tag.Value
+	}
 
-// MasterRootVolume converts master rool volume related config.
-type MasterRootVolume struct {
-	IOPS int    `json:"aws_master_root_volume_iops,omitempty"`
-	Size int    `json:"aws_master_root_volume_size,omitempty"`
-	Type string `json:"aws_master_root_volume_type,omitempty"`
+	if len(masterConfig.BlockDevices) == 0 {
+		return nil, errors.New("block device slice cannot be empty")
+	}
+
+	rootVolume := masterConfig.BlockDevices[0]
+	if rootVolume.EBS == nil {
+		return nil, errors.New("EBS information must be configured for the root volume")
+	}
+
+	if rootVolume.EBS.VolumeType == nil {
+		return nil, errors.New("EBS volume type must be configured for the root volume")
+	}
+
+	if rootVolume.EBS.VolumeSize == nil {
+		return nil, errors.New("EBS volume size must be configured for the root volume")
+	}
+
+	if *rootVolume.EBS.VolumeType == "io1" && rootVolume.EBS.Iops == nil {
+		return nil, errors.New("EBS IOPS must be configured for the io1 root volume")
+	}
+
+	cfg := &config{
+		Region:         masterConfig.Placement.Region,
+		ExtraTags:      tags,
+		EC2AMIOverride: *masterConfig.AMI.ID,
+		EC2Type:        masterConfig.InstanceType,
+		Size:           *rootVolume.EBS.VolumeSize,
+		Type:           *rootVolume.EBS.VolumeType,
+	}
+
+	if rootVolume.EBS.Iops != nil {
+		cfg.IOPS = *rootVolume.EBS.Iops
+	}
+
+	return json.MarshalIndent(cfg, "", "  ")
 }

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -1,49 +1,31 @@
+// Package openstack contains OpenStack-specific Terraform-variable logic.
 package openstack
 
-// OpenStack converts OpenStack related config.
-type OpenStack struct {
-	BaseImage       string `json:"openstack_base_image,omitempty"`
-	Credentials     `json:",inline"`
-	External        `json:",inline"`
-	ExternalNetwork string            `json:"openstack_external_network,omitempty"`
-	ExtraTags       map[string]string `json:"openstack_extra_tags,omitempty"`
-	Master          `json:",inline"`
+import (
+	"encoding/json"
+
+	"sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
+)
+
+type config struct {
 	Region          string `json:"openstack_region,omitempty"`
+	BaseImage       string `json:"openstack_base_image,omitempty"`
+	ExternalNetwork string `json:"openstack_external_network,omitempty"`
+	Cloud           string `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName      string `json:"openstack_master_flavor_name,omitempty"`
 	TrunkSupport    string `json:"openstack_trunk_support,omitempty"`
 }
 
-// External converts external related config.
-type External struct {
-	MasterSubnetIDs []string `json:"openstack_external_master_subnet_ids,omitempty"`
-}
+// TFVars generates OpenStack-specific Terraform variables.
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, region string, externalNetwork string, trunkSupport string) ([]byte, error) {
+	cfg := &config{
+		Region:          region,
+		BaseImage:       masterConfig.Image,
+		ExternalNetwork: externalNetwork,
+		Cloud:           masterConfig.CloudName,
+		FlavorName:      masterConfig.Flavor,
+		TrunkSupport:    trunkSupport,
+	}
 
-// Master converts master related config.
-type Master struct {
-	FlavorName string   `json:"openstack_master_flavor_name,omitempty"`
-	ExtraSGIDs []string `json:"openstack_master_extra_sg_ids,omitempty"`
-}
-
-// Credentials converts credentials related config.
-type Credentials struct {
-	AuthURL           string `json:"openstack_credentials_auth_url,omitempty"`
-	Cert              string `json:"openstack_credentials_cert,omitempty"`
-	Cloud             string `json:"openstack_credentials_cloud,omitempty"`
-	DomainID          string `json:"openstack_credentials_domain_id,omitempty"`
-	DomainName        string `json:"openstack_credentials_domain_name,omitempty"`
-	EndpointType      string `json:"openstack_credentials_endpoint_type,omitempty"`
-	Insecure          bool   `json:"openstack_credentials_insecure,omitempty"`
-	Key               string `json:"openstack_credentials_key,omitempty"`
-	Password          string `json:"openstack_credentials_password,omitempty"`
-	ProjectDomainID   string `json:"openstack_credentials_project_domain_id,omitempty"`
-	ProjectDomainName string `json:"openstack_credentials_project_domain_name,omitempty"`
-	Region            string `json:"openstack_credentials_region,omitempty"`
-	Swauth            bool   `json:"openstack_credentials_swauth,omitempty"`
-	TenantID          string `json:"openstack_credentials_tenant_id,omitempty"`
-	TenantName        string `json:"openstack_credentials_tenant_name,omitempty"`
-	Token             string `json:"openstack_credentials_token,omitempty"`
-	UseOctavia        bool   `json:"openstack_credentials_use_octavia,omitempty"`
-	UserDomainID      string `json:"openstack_credentials_user_domain_id,omitempty"`
-	UserDomainName    string `json:"openstack_credentials_user_domain_name,omitempty"`
-	UserID            string `json:"openstack_credentials_user_id,omitempty"`
-	UserName          string `json:"openstack_credentials_user_name,omitempty"`
+	return json.MarshalIndent(cfg, "", "  ")
 }

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -1,14 +1,9 @@
-// Package tfvars converts an InstallConfig to Terraform variables.
+// Package tfvars generates Terraform variables for launching the cluster.
 package tfvars
 
 import (
 	"encoding/json"
-
-	"github.com/openshift/installer/pkg/tfvars/aws"
-	"github.com/openshift/installer/pkg/tfvars/libvirt"
-	"github.com/openshift/installer/pkg/tfvars/openstack"
-	"github.com/openshift/installer/pkg/types"
-	"github.com/pkg/errors"
+	"net"
 )
 
 type config struct {
@@ -20,81 +15,18 @@ type config struct {
 
 	IgnitionBootstrap string `json:"ignition_bootstrap,omitempty"`
 	IgnitionMaster    string `json:"ignition_master,omitempty"`
-
-	aws.AWS             `json:",inline"`
-	libvirt.Libvirt     `json:",inline"`
-	openstack.OpenStack `json:",inline"`
 }
 
-// TFVars converts the InstallConfig and Ignition content to
-// terraform.tfvar JSON.
-func TFVars(clusterID string, cfg *types.InstallConfig, osImage, bootstrapIgn, masterIgn string) ([]byte, error) {
+// TFVars generates terraform.tfvar JSON for launching the cluster.
+func TFVars(clusterID string, clusterName string, baseDomain string, machineCIDR *net.IPNet, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
 	config := &config{
-		ClusterID:   clusterID,
-		Name:        cfg.ObjectMeta.Name,
-		BaseDomain:  cfg.BaseDomain,
-		MachineCIDR: cfg.Networking.MachineCIDR.String(),
-
-		IgnitionMaster:    masterIgn,
+		ClusterID:         clusterID,
+		Name:              clusterName,
+		BaseDomain:        baseDomain,
+		MachineCIDR:       machineCIDR.String(),
+		Masters:           masterCount,
 		IgnitionBootstrap: bootstrapIgn,
-	}
-
-	for _, m := range cfg.Machines {
-		switch m.Name {
-		case "master":
-			var replicas int
-			if m.Replicas == nil {
-				replicas = 1
-			} else {
-				replicas = int(*m.Replicas)
-			}
-
-			config.Masters += replicas
-			if m.Platform.AWS != nil {
-				config.AWS.Master = aws.Master{
-					EC2Type: m.Platform.AWS.InstanceType,
-					MasterRootVolume: aws.MasterRootVolume{
-						IOPS: m.Platform.AWS.EC2RootVolume.IOPS,
-						Size: m.Platform.AWS.EC2RootVolume.Size,
-						Type: m.Platform.AWS.EC2RootVolume.Type,
-					},
-				}
-			}
-		}
-	}
-
-	if cfg.Platform.AWS != nil {
-		config.AWS.Region = cfg.Platform.AWS.Region
-		config.AWS.ExtraTags = cfg.Platform.AWS.UserTags
-		config.AWS.EC2AMIOverride = osImage
-	} else if cfg.Platform.Libvirt != nil {
-		masterIPs := make([]string, len(cfg.Platform.Libvirt.MasterIPs))
-		for i, ip := range cfg.Platform.Libvirt.MasterIPs {
-			masterIPs[i] = ip.String()
-		}
-		config.Libvirt = libvirt.Libvirt{
-			URI: cfg.Platform.Libvirt.URI,
-			Network: libvirt.Network{
-				IfName: cfg.Platform.Libvirt.Network.IfName,
-			},
-			Image:     osImage,
-			MasterIPs: masterIPs,
-		}
-		if err := config.Libvirt.TFVars(&cfg.Networking.MachineCIDR.IPNet, config.Masters); err != nil {
-			return nil, errors.Wrap(err, "failed to insert libvirt variables")
-		}
-		if err := config.Libvirt.UseCachedImage(); err != nil {
-			return nil, errors.Wrap(err, "failed to use cached libvirt image")
-		}
-	} else if cfg.Platform.OpenStack != nil {
-		config.OpenStack = openstack.OpenStack{
-			Region:    cfg.Platform.OpenStack.Region,
-			BaseImage: osImage,
-		}
-		config.OpenStack.Credentials.Cloud = cfg.Platform.OpenStack.Cloud
-		config.OpenStack.ExternalNetwork = cfg.Platform.OpenStack.ExternalNetwork
-		config.OpenStack.Master.FlavorName = cfg.Platform.OpenStack.FlavorName
-		config.OpenStack.TrunkSupport = cfg.Platform.OpenStack.TrunkSupport
+		IgnitionMaster:    masterIgn,
 	}
 
 	return json.MarshalIndent(config, "", "  ")

--- a/pkg/types/libvirt/platform.go
+++ b/pkg/types/libvirt/platform.go
@@ -1,9 +1,5 @@
 package libvirt
 
-import (
-	"net"
-)
-
 // Platform stores all the global configuration that all
 // machinesets use.
 type Platform struct {
@@ -24,8 +20,4 @@ type Platform struct {
 	// Network
 	// +optional
 	Network *Network `json:"network,omitempty"`
-
-	// MasterIPs
-	// +optional
-	MasterIPs []net.IP `json:"masterIPs,omitempty"`
 }


### PR DESCRIPTION
The previous implementation pulled from the install-config, but that missed downstream changes like AWS instance type defaults being applied in `pkg/asset/machines`.  With this commit, we pull that information from the cluster-API types, since they're the last touch point for that data.  The remaining information still comes from the `InstallConfig`, but I've split it into explicit arguments to avoid confusion about where data is coming from when `InstallConfig`'s machine pools, etc. overlap with `clusterapi.Machine` fields.

This is a WIP because there are some FIXMEs around cluster-API support for some of the settings we're currently configuring in `InstallConfig` machine pools.

Fixes #671.