### PR TITLE
openstack: Support setting network UUID via terraform variable.

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -68,12 +68,13 @@ module "masters" {
 module "topology" {
   source = "./topology"
 
-  cidr_block       = "${var.machine_cidr}"
-  cluster_id       = "${var.cluster_id}"
-  external_network = "${var.openstack_external_network}"
-  masters_count    = "${var.master_count}"
-  lb_floating_ip   = "${var.openstack_lb_floating_ip}"
-  trunk_support    = "${var.openstack_trunk_support}"
+  cidr_block          = "${var.machine_cidr}"
+  cluster_id          = "${var.cluster_id}"
+  external_network    = "${var.openstack_external_network}"
+  external_network_id = "${var.openstack_external_network_id}"
+  masters_count       = "${var.master_count}"
+  lb_floating_ip      = "${var.openstack_lb_floating_ip}"
+  trunk_support       = "${var.openstack_trunk_support}"
 }
 
 resource "openstack_objectstorage_container_v1" "container" {

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -76,8 +76,9 @@ resource "openstack_networking_port_v2" "service_port" {
 }
 
 data "openstack_networking_network_v2" "external_network" {
-  name     = "${var.external_network}"
-  external = true
+  name       = "${var.external_network}"
+  network_id = "${var.external_network_id}"
+  external   = true
 }
 
 resource "openstack_networking_floatingip_associate_v2" "service_fip" {

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -7,6 +7,12 @@ variable "cluster_id" {
 }
 
 variable "external_network" {
+  description = "Name of the external network providing Floating IP addresses."
+  type        = "string"
+  default     = ""
+}
+
+variable "external_network_id" {
   description = "UUID of the external network providing Floating IP addresses."
   type        = "string"
   default     = ""

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -195,8 +195,20 @@ variable "openstack_external_network" {
   default = ""
 
   description = <<EOF
+(optional) Name of the external network. The network is used to provide
+Floating IP access to the deployed nodes. Optional, but either the Name
+or UUID option must be specified.
+EOF
+}
+
+variable "openstack_external_network_id" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
 (optional) UUID of the external network. The network is used to provide
-Floating IP access to the deployed nodes.
+Floating IP access to the deployed nodes. Optional, but either the Name
+or UUID option must be specified.
 EOF
 }
 

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -274,6 +274,18 @@ api VM:
 
 * `openstack server delete <cluster name>-api`
 
+## Disambiguating the External Network
+
+The installer assumes that the name of the external network is unique.  In case
+there is more than one network with the same name as the desired external
+network, it’s possible to provide a UUID to specify which network should be
+used.
+
+```
+$ env TF_VAR_openstack_external_network_id="6a32627e-d98d-40d8-9324-5da7cf1452fc" \
+> bin/openshift-install create cluster
+```
+
 ## Troubleshooting
 
 See the [troubleshooting installer issues in OpenStack](./troubleshooting.md) guide.

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -17,7 +17,7 @@ type Platform struct {
 	Cloud string `json:"cloud"`
 
 	// ExternalNetwork
-	// The OpenStack external network to be used for installation.
+	// The OpenStack external network name to be used for installation.
 	ExternalNetwork string `json:"externalNetwork"`
 
 	// FlavorName


### PR DESCRIPTION
    openstack: Support setting network UUID via terraform variable.
    
    Technically, network names in OpenStack are not unique.  We would
    expect almost every deployment to be using a unique name for its
    external network, though.
    
    In the rare case where you must disambiguate networks, it's possible
    to specify the UUID via a terraform variable.
    
    $ env TF_VAR_openstack_external_network_id="6a32627e-d98d-40d8-9324-5da7cf1452fc" \
    > bin/openshift-install create cluster