### PR TITLE
Mention that terraform is needed before you actually need it

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ Clone this repository to `src/github.com/openshift/installer` in your [GOPATH](h
 hack/build.sh
 ```
 
-This will create `bin/openshift-install`. This binary can then be invoked to create an OpenShift cluster, like so:
-
-```sh
-bin/openshift-install create cluster
-```
+This will create `bin/openshift-install`.
 
 The installer requires the terraform binary either alongside openshift-install or in `$PATH`.
 If you don't have [terraform](https://www.terraform.io/), run the following to create `bin/terraform`:
 
 ```sh
 hack/get-terraform.sh
+```
+
+Now run the `openshift-install` binary to create an OpenShift cluster, like so:
+
+```sh
+bin/openshift-install create cluster
 ```
 
 The installer will show a series of prompts for user-specific information and use reasonable defaults for everything else. In non-interactive contexts, prompts can be bypassed by providing appropriately-named environment variables. Refer to the [user documentation](docs/user) for more information.


### PR DESCRIPTION
Someone naively following the directions in README.md will end up getting:

    INFO Using Terraform to create cluster...         
    ERROR Failed to read tfstate: open : no such file or directory 
    FATAL Error executing openshift-install: failed to fetch Cluster: failed to generate asset "Cluster": failed to run terraform: failed to initialize Terraform: failed to create Terraform executor: failed to get Terraform binary's path: terraform not in executable's folder, cwd nor PATH 

because it tells you to run `bin/openshift-install` before mentioning that you have to have already installed terraform...