### PR TITLE
types/libvirt: remove per-machine-pool configuration

### DIFF
--- a/pkg/asset/installconfig/libvirt/libvirt.go
+++ b/pkg/asset/installconfig/libvirt/libvirt.go
@@ -49,10 +49,8 @@ func Platform() (*libvirt.Platform, error) {
 		Network: libvirt.Network{
 			IfName: defaultNetworkIfName,
 		},
-		DefaultMachinePlatform: &libvirt.MachinePool{
-			Image: qcowImage,
-		},
-		URI: uri,
+		Image: qcowImage,
+		URI:   uri,
 	}, nil
 }
 

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -18,14 +18,11 @@ func Machines(config *types.InstallConfig, pool *types.MachinePool, role, userDa
 	if configPlatform := config.Platform.Name(); configPlatform != libvirt.Name {
 		return nil, fmt.Errorf("non-Libvirt configuration: %q", configPlatform)
 	}
-	// FIXME: empty is a valid case for Libvirt as we don't use it.
-	if poolPlatform := pool.Platform.Name(); poolPlatform != "" && poolPlatform != libvirt.Name {
+	if poolPlatform := pool.Platform.Name(); poolPlatform != libvirt.Name {
 		return nil, fmt.Errorf("non-Libvirt machine-pool: %q", poolPlatform)
 	}
 	clustername := config.ObjectMeta.Name
 	platform := config.Platform.Libvirt
-	// FIXME: libvirt actuator does not support any options from machinepool.
-	// mpool := pool.Platform.Libvirt
 
 	total := int64(1)
 	if pool.Replicas != nil {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -97,6 +97,10 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		}
 		m.MachinesRaw = raw
 	case libvirttypes.Name:
+		mpool := defaultLibvirtMachinePoolPlatform()
+		mpool.Set(ic.Platform.Libvirt.DefaultMachinePlatform)
+		mpool.Set(pool.Platform.Libvirt)
+		pool.Platform.Libvirt = &mpool
 		machines, err := libvirt.Machines(ic, &pool, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -33,6 +33,10 @@ func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
 	}
 }
 
+func defaultLibvirtMachinePoolPlatform() libvirttypes.MachinePool {
+	return libvirttypes.MachinePool{}
+}
+
 func defaultOpenStackMachinePoolPlatform(flavor string) openstacktypes.MachinePool {
 	return openstacktypes.MachinePool{
 		FlavorName: flavor,
@@ -119,6 +123,10 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		}
 		w.MachineSetRaw = raw
 	case libvirttypes.Name:
+		mpool := defaultLibvirtMachinePoolPlatform()
+		mpool.Set(ic.Platform.Libvirt.DefaultMachinePlatform)
+		mpool.Set(pool.Platform.Libvirt)
+		pool.Platform.Libvirt = &mpool
 		sets, err := libvirt.MachineSets(ic, &pool, "worker", "worker-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create worker machine objects")

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -98,7 +98,7 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 			Network: libvirt.Network{
 				IfName: cfg.Platform.Libvirt.Network.IfName,
 			},
-			Image:     cfg.Platform.Libvirt.DefaultMachinePlatform.Image,
+			Image:     cfg.Platform.Libvirt.Image,
 			MasterIPs: masterIPs,
 		}
 		if err := config.Libvirt.TFVars(&cfg.Networking.MachineCIDR.IPNet, config.Masters); err != nil {

--- a/pkg/types/libvirt/machinepool.go
+++ b/pkg/types/libvirt/machinepool.go
@@ -3,31 +3,11 @@ package libvirt
 // MachinePool stores the configuration for a machine pool installed
 // on libvirt.
 type MachinePool struct {
-	// ImagePool is the name of the libvirt storage pool to which the storage
-	// volume containing the OS image belongs.
-	ImagePool string `json:"imagePool,omitempty"`
-	// ImageVolume is the name of the libvirt storage volume containing the OS
-	// image.
-	ImageVolume string `json:"imageVolume,omitempty"`
-
-	// Image is the URL to the OS image.
-	// E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
-	Image string `json:"image"`
 }
 
 // Set sets the values from `required` to `a`.
 func (l *MachinePool) Set(required *MachinePool) {
 	if required == nil || l == nil {
 		return
-	}
-
-	if required.ImagePool != "" {
-		l.ImagePool = required.ImagePool
-	}
-	if required.ImageVolume != "" {
-		l.ImageVolume = required.ImageVolume
-	}
-	if required.Image != "" {
-		l.Image = required.Image
 	}
 }

--- a/pkg/types/libvirt/platform.go
+++ b/pkg/types/libvirt/platform.go
@@ -12,6 +12,10 @@ type Platform struct {
 	// cluster (where the cluster-API controller pod will be running).
 	URI string `json:"URI"`
 
+	// Image is the URL to the OS image.
+	// E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
+	Image string `json:"image"`
+
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on libvirt for machine pools which do not define their
 	// own platform configuration.

--- a/pkg/types/libvirt/validation/machinepool.go
+++ b/pkg/types/libvirt/validation/machinepool.go
@@ -4,16 +4,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/libvirt"
-	"github.com/openshift/installer/pkg/validate"
 )
 
 // ValidateMachinePool checks that the specified machine pool is valid.
 func ValidateMachinePool(p *libvirt.MachinePool, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	if p.Image != "" {
-		if err := validate.URI(p.Image); err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("image"), p.Image, err.Error()))
-		}
-	}
-	return allErrs
+	return field.ErrorList{}
 }

--- a/pkg/types/libvirt/validation/machinepool_test.go
+++ b/pkg/types/libvirt/validation/machinepool_test.go
@@ -20,20 +20,6 @@ func TestValidateMachinePool(t *testing.T) {
 			pool:  &libvirt.MachinePool{},
 			valid: true,
 		},
-		{
-			name: "valid image",
-			pool: &libvirt.MachinePool{
-				Image: "https://example.com/rhcos-qemu.qcow2",
-			},
-			valid: true,
-		},
-		{
-			name: "invalid image",
-			pool: &libvirt.MachinePool{
-				Image: "bad-image",
-			},
-			valid: false,
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/types/libvirt/validation/platform.go
+++ b/pkg/types/libvirt/validation/platform.go
@@ -13,6 +13,9 @@ func ValidatePlatform(p *libvirt.Platform, fldPath *field.Path) field.ErrorList 
 	if err := validate.URI(p.URI); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("uri"), p.URI, err.Error()))
 	}
+	if err := validate.URI(p.Image); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("image"), p.Image, err.Error()))
+	}
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}

--- a/pkg/types/libvirt/validation/platform_test.go
+++ b/pkg/types/libvirt/validation/platform_test.go
@@ -11,7 +11,8 @@ import (
 
 func validPlatform() *libvirt.Platform {
 	return &libvirt.Platform{
-		URI: "qemu+tcp://192.168.122.1/system",
+		URI:   "qemu+tcp://192.168.122.1/system",
+		Image: "https://example.com/rhcos-qemu.qcow2",
 		Network: libvirt.Network{
 			IfName: "tt0",
 		},
@@ -39,6 +40,15 @@ func TestValidatePlatform(t *testing.T) {
 			valid: false,
 		},
 		{
+			name: "invalid image",
+			platform: func() *libvirt.Platform {
+				p := validPlatform()
+				p.Image = "bad-image"
+				return p
+			}(),
+			valid: false,
+		},
+		{
 			name: "missing interface name",
 			platform: func() *libvirt.Platform {
 				p := validPlatform()
@@ -55,17 +65,6 @@ func TestValidatePlatform(t *testing.T) {
 				return p
 			}(),
 			valid: true,
-		},
-		{
-			name: "invalid machine pool",
-			platform: func() *libvirt.Platform {
-				p := validPlatform()
-				p.DefaultMachinePlatform = &libvirt.MachinePool{
-					Image: "bad-image",
-				}
-				return p
-			}(),
-			valid: false,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -207,7 +207,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.Libvirt = &libvirt.Platform{}
 				return c
 			}(),
-			expectedError: `^\[platform: Invalid value: types\.Platform{AWS:\(\*aws\.Platform\)\(0x[0-9a-f]*\), Libvirt:\(\*libvirt\.Platform\)\(0x[0-9a-f]*\), None:\(\*none\.Platform\)\(nil\), OpenStack:\(\*openstack\.Platform\)\(nil\)}: must only specify a single type of platform; cannot use both "aws" and "libvirt", platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\), platform\.libvirt\.network\.if: Required value]$`,
+			expectedError: `^\[platform: Invalid value: types\.Platform{AWS:\(\*aws\.Platform\)\(0x[0-9a-f]*\), Libvirt:\(\*libvirt\.Platform\)\(0x[0-9a-f]*\), None:\(\*none\.Platform\)\(nil\), OpenStack:\(\*openstack\.Platform\)\(nil\)}: must only specify a single type of platform; cannot use both "aws" and "libvirt", platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\), platform.libvirt.image: Invalid value: "": invalid URI "" \(no scheme\), platform\.libvirt\.network\.if: Required value]$`,
 		},
 		{
 			name: "invalid aws platform",
@@ -226,7 +226,8 @@ func TestValidateInstallConfig(t *testing.T) {
 				c := validInstallConfig()
 				c.Platform = types.Platform{
 					Libvirt: &libvirt.Platform{
-						URI: "qemu+tcp://192.168.122.1/system",
+						URI:   "qemu+tcp://192.168.122.1/system",
+						Image: "https://example.com/test-image",
 						Network: libvirt.Network{
 							IfName: "tt0",
 						},
@@ -245,7 +246,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: `^\[platform: Invalid value: types\.Platform{AWS:\(\*aws\.Platform\)\(nil\), Libvirt:\(\*libvirt\.Platform\)\(0x[0-9a-f]*\), None:\(\*none\.Platform\)\(nil\), OpenStack:\(\*openstack\.Platform\)\(nil\)}: must specify one of the platforms \(aws, none, openstack\), platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\), platform\.libvirt\.network\.if: Required value]$`,
+			expectedError: `^\[platform: Invalid value: types\.Platform{AWS:\(\*aws\.Platform\)\(nil\), Libvirt:\(\*libvirt\.Platform\)\(0x[0-9a-f]*\), None:\(\*none\.Platform\)\(nil\), OpenStack:\(\*openstack\.Platform\)\(nil\)}: must specify one of the platforms \(aws, none, openstack\), platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\), platform.libvirt.image: Invalid value: "": invalid URI "" \(no scheme\), platform\.libvirt\.network\.if: Required value]$`,
 		},
 		{
 			name: "valid openstack platform",

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -82,19 +82,6 @@ func TestValidateMachinePool(t *testing.T) {
 			valid:    true,
 		},
 		{
-			name: "invalid libvirt",
-			pool: &types.MachinePool{
-				Name: "master",
-				Platform: types.MachinePoolPlatform{
-					Libvirt: &libvirt.MachinePool{
-						Image: "bad-image",
-					},
-				},
-			},
-			platform: "libvirt",
-			valid:    false,
-		},
-		{
 			name: "valid openstack",
 			pool: &types.MachinePool{
 				Name: "master",


### PR DESCRIPTION
None of the options, other than Image, that were in the Libvirt MachinePool were being used.
They have been removed. The Image has been pulled up to the Libvirt Platform, as there was no
way to use a different image for different machines pools.

For consistency with the AWS and OpenStack platforms, the Libvirt MachinePool has been retained,
event though it is empty. The DefaultMachinePlatform has been retained in the Libvirt Platform
as well.

The code in the Master Machines and Worker Machines assets that determines the configuration
to use for the machines has been adjusted for Libvirt to rectify the machine-pool-specific
configuration against the default machine-pool configuration. This is not strictly necessary
as, again, the Libvirt configuration is empty. It keeps the logic consistent with the other
platforms, though.

https://jira.coreos.com/browse/CORS-911