### PR TITLE
*: mirror tectonicClusterID as openshiftClusterID

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -29,7 +29,8 @@ module "bootstrap" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}-bootstrap",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.aws_extra_tags)}"
 }
 
@@ -127,6 +128,7 @@ resource "aws_route53_zone" "int" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_int",
       "KubernetesCluster", "${var.cluster_name}",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.aws_extra_tags)}"
 }

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -97,6 +97,7 @@ resource "aws_instance" "master" {
       "Name", "${var.cluster_name}-master-${count.index}",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
       "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}",
       "clusterid", "${var.cluster_name}"
     ), var.extra_tags)}"
 
@@ -109,7 +110,8 @@ resource "aws_instance" "master" {
   volume_tags = "${merge(map(
     "Name", "${var.cluster_name}-master-${count.index}-vol",
     "kubernetes.io/cluster/${var.cluster_name}", "owned",
-    "tectonicClusterID", "${var.cluster_id}"
+    "tectonicClusterID", "${var.cluster_id}",
+    "openshiftClusterID", "${var.cluster_id}"
   ), var.extra_tags)}"
 }
 

--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -10,7 +10,8 @@ resource "aws_lb" "api_internal" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 
@@ -26,7 +27,8 @@ resource "aws_lb" "api_external" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 
@@ -42,7 +44,8 @@ resource "aws_lb_target_group" "api_internal" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 
   health_check {
@@ -66,7 +69,8 @@ resource "aws_lb_target_group" "api_external" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 
   health_check {
@@ -88,7 +92,8 @@ resource "aws_lb_target_group" "services" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 
   health_check {

--- a/data/data/aws/vpc/sg-elb.tf
+++ b/data/data/aws/vpc/sg-elb.tf
@@ -4,7 +4,8 @@ resource "aws_security_group" "api" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_api_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 
@@ -44,7 +45,8 @@ resource "aws_security_group" "console" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_console_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 

--- a/data/data/aws/vpc/sg-etcd.tf
+++ b/data/data/aws/vpc/sg-etcd.tf
@@ -4,7 +4,8 @@ resource "aws_security_group" "etcd" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_etcd_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 

--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -4,7 +4,8 @@ resource "aws_security_group" "master" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_master_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -4,7 +4,8 @@ resource "aws_security_group" "worker" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_worker_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 

--- a/data/data/aws/vpc/vpc-private.tf
+++ b/data/data/aws/vpc/vpc-private.tf
@@ -5,7 +5,8 @@ resource "aws_route_table" "private_routes" {
   tags = "${merge(map(
       "Name","${var.cluster_name}-private-${local.new_worker_subnet_azs[count.index]}",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 
@@ -34,6 +35,7 @@ resource "aws_subnet" "worker_subnet" {
     "kubernetes.io/cluster/${var.cluster_name}","shared",
     "kubernetes.io/role/internal-elb", "",
     "tectonicClusterID", "${var.cluster_id}",
+    "openshiftClusterID", "${var.cluster_id}"
     ),
     var.extra_tags)}"
 }

--- a/data/data/aws/vpc/vpc-public.tf
+++ b/data/data/aws/vpc/vpc-public.tf
@@ -5,7 +5,8 @@ resource "aws_internet_gateway" "igw" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}-igw",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 
@@ -17,6 +18,7 @@ resource "aws_route_table" "default" {
       "Name", "${var.cluster_name}-public",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
       "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 
@@ -47,7 +49,8 @@ resource "aws_subnet" "master_subnet" {
   tags = "${merge(map(
     "Name", "${var.cluster_name}-master-${local.new_master_subnet_azs[count.index]}",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
 
@@ -62,7 +65,8 @@ resource "aws_eip" "nat_eip" {
   vpc   = true
 
   tags = "${merge(map(
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 
   # Terraform does not declare an explicit dependency towards the internet gateway.
@@ -77,6 +81,7 @@ resource "aws_nat_gateway" "nat_gw" {
   subnet_id     = "${aws_subnet.master_subnet.*.id[count.index]}"
 
   tags = "${merge(map(
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }

--- a/data/data/aws/vpc/vpc.tf
+++ b/data/data/aws/vpc/vpc.tf
@@ -12,6 +12,7 @@ resource "aws_vpc" "new_vpc" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}.${var.base_domain}",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }

--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -41,6 +41,7 @@ resource "openstack_compute_instance_v2" "bootstrap" {
     Name = "${var.cluster_name}-bootstrap"
 
     # "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-    tectonicClusterID = "${var.cluster_id}"
+    tectonicClusterID  = "${var.cluster_id}"
+    openshiftClusterID = "${var.cluster_id}"
   }
 }

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -68,6 +68,7 @@ resource "openstack_objectstorage_container_v1" "container" {
   metadata = "${merge(map(
       "Name", "${var.cluster_name}-ignition-master",
       "KubernetesCluster", "${var.cluster_name}",
-      "tectonicClusterID", "${var.cluster_id}"
+      "tectonicClusterID", "${var.cluster_id}",
+      "openshiftClusterID", "${var.cluster_id}"
     ), var.openstack_extra_tags)}"
 }

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -21,8 +21,9 @@ resource "openstack_compute_instance_v2" "master_conf" {
   }
 
   metadata {
-    Name              = "${var.cluster_name}-master"
-    owned             = "kubernetes.io/cluster/${var.cluster_name}"
-    tectonicClusterID = "${var.cluster_id}"
+    Name               = "${var.cluster_name}-master"
+    owned              = "kubernetes.io/cluster/${var.cluster_name}"
+    tectonicClusterID  = "${var.cluster_id}"
+    openshiftClusterID = "${var.cluster_id}"
   }
 }

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -6,7 +6,7 @@ locals {
 resource "openstack_networking_network_v2" "openshift-private" {
   name           = "openshift"
   admin_state_up = "true"
-  tags           = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags           = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_subnet_v2" "masters" {
@@ -14,7 +14,7 @@ resource "openstack_networking_subnet_v2" "masters" {
   cidr       = "${local.new_master_cidr_range}"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.openshift-private.id}"
-  tags       = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags       = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_subnet_v2" "workers" {
@@ -22,7 +22,7 @@ resource "openstack_networking_subnet_v2" "workers" {
   cidr       = "${local.new_worker_cidr_range}"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.openshift-private.id}"
-  tags       = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags       = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_port_v2" "masters" {
@@ -32,7 +32,7 @@ resource "openstack_networking_port_v2" "masters" {
   admin_state_up     = "true"
   network_id         = "${openstack_networking_network_v2.openshift-private.id}"
   security_group_ids = ["${openstack_networking_secgroup_v2.master.id}"]
-  tags               = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags               = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 
   fixed_ip {
     "subnet_id" = "${openstack_networking_subnet_v2.masters.id}"
@@ -45,7 +45,7 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
   admin_state_up     = "true"
   network_id         = "${openstack_networking_network_v2.openshift-private.id}"
   security_group_ids = ["${openstack_networking_secgroup_v2.master.id}"]
-  tags               = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags               = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 
   fixed_ip {
     "subnet_id" = "${openstack_networking_subnet_v2.masters.id}"
@@ -61,7 +61,7 @@ resource "openstack_networking_router_v2" "openshift-external-router" {
   name                = "openshift-external-router"
   admin_state_up      = true
   external_network_id = "${data.openstack_networking_network_v2.external_network.id}"
-  tags                = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags                = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_router_interface_v2" "masters_router_interface" {

--- a/data/data/openstack/topology/sg-lb.tf
+++ b/data/data/openstack/topology/sg-lb.tf
@@ -1,6 +1,6 @@
 resource "openstack_networking_secgroup_v2" "mcs" {
   name = "mcs"
-  tags = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "mcs_https" {
@@ -15,7 +15,7 @@ resource "openstack_networking_secgroup_rule_v2" "mcs_https" {
 
 resource "openstack_networking_secgroup_v2" "api" {
   name = "api"
-  tags = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "api_https" {
@@ -30,7 +30,7 @@ resource "openstack_networking_secgroup_rule_v2" "api_https" {
 
 resource "openstack_networking_secgroup_v2" "console" {
   name = "console"
-  tags = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "console_http" {

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -1,6 +1,6 @@
 resource "openstack_networking_secgroup_v2" "master" {
   name = "master"
-  tags = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_mcs" {

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -1,6 +1,6 @@
 resource "openstack_networking_secgroup_v2" "worker" {
   name = "worker"
-  tags = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {

--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -17,6 +17,9 @@ func Metadata(config *types.InstallConfig) *aws.Metadata {
 				"tectonicClusterID": config.ClusterID,
 			},
 			{
+				"openshiftClusterID": config.ClusterID,
+			},
+			{
 				fmt.Sprintf("kubernetes.io/cluster/%s", config.ObjectMeta.Name): "owned",
 			},
 		},

--- a/pkg/asset/cluster/openstack/openstack.go
+++ b/pkg/asset/cluster/openstack/openstack.go
@@ -13,7 +13,8 @@ func Metadata(config *types.InstallConfig) *openstack.Metadata {
 		Region: config.Platform.OpenStack.Region,
 		Cloud:  config.Platform.OpenStack.Cloud,
 		Identifier: map[string]string{
-			"tectonicClusterID": config.ClusterID,
+			"tectonicClusterID":  config.ClusterID,
+			"openshiftClusterID": config.ClusterID,
 		},
 	}
 }

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -104,6 +104,7 @@ func provider(clusterID, clusterName string, platform *aws.Platform, mpool *aws.
 func tagsFromUserTags(clusterID, clusterName string, usertags map[string]string) ([]awsprovider.TagSpecification, error) {
 	tags := []awsprovider.TagSpecification{
 		{Name: "tectonicClusterID", Value: clusterID},
+		{Name: "openshiftClusterID", Value: clusterID},
 		{Name: fmt.Sprintf("kubernetes.io/cluster/%s", clusterName), Value: "owned"},
 	}
 	forbiddenTags := sets.NewString()

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -122,7 +122,8 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		}
 
 		tags := map[string]string{
-			"tectonicClusterID": ic.ClusterID,
+			"tectonicClusterID":  ic.ClusterID,
+			"openshiftClusterID": ic.ClusterID,
 		}
 		config.Tags = tags
 

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -133,7 +133,8 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		}
 
 		tags := map[string]string{
-			"tectonicClusterID": ic.ClusterID,
+			"tectonicClusterID":  ic.ClusterID,
+			"openshiftClusterID": ic.ClusterID,
 		}
 		config.Tags = tags
 

--- a/pkg/destroy/openstack/openstack_deprovision.go
+++ b/pkg/destroy/openstack/openstack_deprovision.go
@@ -46,7 +46,7 @@ type deleteFunc func(opts *clientconfig.ClientOpts, filter Filter, logger logrus
 type ClusterUninstaller struct {
 	// Cloud is the cloud name as set in clouds.yml
 	Cloud string
-	// Filter contains the tectonicClusterID to filter tags
+	// Filter contains the openshiftClusterID to filter tags
 	Filter Filter
 	Logger logrus.FieldLogger
 }
@@ -443,8 +443,8 @@ func deleteContainers(opts *clientconfig.ClientOpts, filter Filter, logger logru
 			os.Exit(1)
 		}
 		for key, val := range filter {
-			// Swift mangles the case so tectonicClusterID becomes
-			// Tectonicclusterid in the X-Container-Meta- HEAD output
+			// Swift mangles the case so openshiftClusterID becomes
+			// Openshiftclusterid in the X-Container-Meta- HEAD output
 			titlekey := strings.Title(strings.ToLower(key))
 			if metadata[titlekey] == val {
 				listOpts := objects.ListOpts{Full: false}


### PR DESCRIPTION
As part of removing references to tectonic, the tectonicClusterID tags will
be changed to openshiftClusterID. This is the first part of that. This
creates the openshiftClusterID tag that will be laid down alongside the
tectonicClusterID tag. After all of the usages of tectonicClusterID in other
repos are removed, then the tectonicClusterID will be removed, leaving only
the openshiftClusterID.

https://jira.coreos.com/browse/CORS-878