### PR TITLE
terraform: remove tectonicClusterID tag on resources

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -21,7 +21,6 @@ module "bootstrap" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}-bootstrap",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.aws_extra_tags)}"
 }
@@ -105,7 +104,6 @@ resource "aws_route53_zone" "int" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_int",
       "KubernetesCluster", "${var.cluster_name}",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.aws_extra_tags)}"
 }

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -96,7 +96,6 @@ resource "aws_instance" "master" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}-master-${count.index}",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}",
       "clusterid", "${var.cluster_name}"
     ), var.extra_tags)}"
@@ -110,7 +109,6 @@ resource "aws_instance" "master" {
   volume_tags = "${merge(map(
     "Name", "${var.cluster_name}-master-${count.index}-vol",
     "kubernetes.io/cluster/${var.cluster_name}", "owned",
-    "tectonicClusterID", "${var.cluster_id}",
     "openshiftClusterID", "${var.cluster_id}"
   ), var.extra_tags)}"
 }

--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -8,7 +8,6 @@ resource "aws_lb" "api_internal" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
@@ -23,7 +22,6 @@ resource "aws_lb" "api_external" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
@@ -38,7 +36,6 @@ resource "aws_lb_target_group" "api_internal" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 
@@ -61,7 +58,6 @@ resource "aws_lb_target_group" "api_external" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 
@@ -84,7 +80,6 @@ resource "aws_lb_target_group" "services" {
 
   tags = "${merge(map(
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 

--- a/data/data/aws/vpc/sg-elb.tf
+++ b/data/data/aws/vpc/sg-elb.tf
@@ -4,7 +4,6 @@ resource "aws_security_group" "api" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_api_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
@@ -45,7 +44,6 @@ resource "aws_security_group" "console" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_console_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }

--- a/data/data/aws/vpc/sg-etcd.tf
+++ b/data/data/aws/vpc/sg-etcd.tf
@@ -4,7 +4,6 @@ resource "aws_security_group" "etcd" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_etcd_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }

--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -4,7 +4,6 @@ resource "aws_security_group" "master" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_master_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -4,7 +4,6 @@ resource "aws_security_group" "worker" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}_worker_sg",
       "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }

--- a/data/data/aws/vpc/vpc-private.tf
+++ b/data/data/aws/vpc/vpc-private.tf
@@ -5,7 +5,6 @@ resource "aws_route_table" "private_routes" {
   tags = "${merge(map(
       "Name","${var.cluster_name}-private-${local.new_subnet_azs[count.index]}",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
@@ -31,7 +30,6 @@ resource "aws_subnet" "worker_subnet" {
     "Name", "${var.cluster_name}-worker-${local.new_subnet_azs[count.index]}",
     "kubernetes.io/cluster/${var.cluster_name}","shared",
     "kubernetes.io/role/internal-elb", "",
-    "tectonicClusterID", "${var.cluster_id}",
     "openshiftClusterID", "${var.cluster_id}"
     ),
     var.extra_tags)}"

--- a/data/data/aws/vpc/vpc-public.tf
+++ b/data/data/aws/vpc/vpc-public.tf
@@ -4,7 +4,6 @@ resource "aws_internet_gateway" "igw" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}-igw",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
@@ -15,7 +14,6 @@ resource "aws_route_table" "default" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}-public",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
@@ -42,7 +40,6 @@ resource "aws_subnet" "master_subnet" {
   tags = "${merge(map(
     "Name", "${var.cluster_name}-master-${local.new_subnet_azs[count.index]}",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }
@@ -58,7 +55,6 @@ resource "aws_eip" "nat_eip" {
   vpc   = true
 
   tags = "${merge(map(
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 
@@ -74,7 +70,6 @@ resource "aws_nat_gateway" "nat_gw" {
   subnet_id     = "${aws_subnet.master_subnet.*.id[count.index]}"
 
   tags = "${merge(map(
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }

--- a/data/data/aws/vpc/vpc.tf
+++ b/data/data/aws/vpc/vpc.tf
@@ -11,7 +11,6 @@ resource "aws_vpc" "new_vpc" {
   tags = "${merge(map(
       "Name", "${var.cluster_name}.${var.base_domain}",
       "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.extra_tags)}"
 }

--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -64,7 +64,6 @@ resource "openstack_compute_instance_v2" "bootstrap" {
     Name = "${var.cluster_name}-bootstrap"
 
     # "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-    tectonicClusterID  = "${var.cluster_id}"
     openshiftClusterID = "${var.cluster_id}"
   }
 }

--- a/data/data/openstack/lb/main.tf
+++ b/data/data/openstack/lb/main.tf
@@ -116,7 +116,6 @@ resource "openstack_compute_instance_v2" "load_balancer" {
     Name = "${var.cluster_name}-bootstrap"
 
     # "kubernetes.io/cluster/${var.cluster_name}" = "owned"
-    tectonicClusterID  = "${var.cluster_id}"
     openshiftClusterID = "${var.cluster_id}"
   }
 }

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -85,7 +85,6 @@ resource "openstack_objectstorage_container_v1" "container" {
   metadata = "${merge(map(
       "Name", "${var.cluster_name}-ignition-master",
       "KubernetesCluster", "${var.cluster_name}",
-      "tectonicClusterID", "${var.cluster_id}",
       "openshiftClusterID", "${var.cluster_id}"
     ), var.openstack_extra_tags)}"
 }

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -93,7 +93,6 @@ resource "openstack_compute_instance_v2" "master_conf" {
   metadata {
     Name               = "${var.cluster_name}-master"
     owned              = "kubernetes.io/cluster/${var.cluster_name}"
-    tectonicClusterID  = "${var.cluster_id}"
     openshiftClusterID = "${var.cluster_id}"
   }
 }

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -6,7 +6,7 @@ locals {
 resource "openstack_networking_network_v2" "openshift-private" {
   name           = "openshift"
   admin_state_up = "true"
-  tags           = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  tags           = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_subnet_v2" "masters" {
@@ -14,7 +14,7 @@ resource "openstack_networking_subnet_v2" "masters" {
   cidr       = "${local.new_master_cidr_range}"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.openshift-private.id}"
-  tags       = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  tags       = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_subnet_v2" "workers" {
@@ -22,7 +22,7 @@ resource "openstack_networking_subnet_v2" "workers" {
   cidr       = "${local.new_worker_cidr_range}"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.openshift-private.id}"
-  tags       = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  tags       = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_port_v2" "masters" {
@@ -32,7 +32,7 @@ resource "openstack_networking_port_v2" "masters" {
   admin_state_up     = "true"
   network_id         = "${openstack_networking_network_v2.openshift-private.id}"
   security_group_ids = ["${openstack_networking_secgroup_v2.master.id}"]
-  tags               = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  tags               = ["openshiftClusterID=${var.cluster_id}"]
 
   fixed_ip {
     "subnet_id" = "${openstack_networking_subnet_v2.masters.id}"
@@ -45,7 +45,7 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
   admin_state_up     = "true"
   network_id         = "${openstack_networking_network_v2.openshift-private.id}"
   security_group_ids = ["${openstack_networking_secgroup_v2.master.id}"]
-  tags               = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  tags               = ["openshiftClusterID=${var.cluster_id}"]
 
   fixed_ip {
     "subnet_id" = "${openstack_networking_subnet_v2.masters.id}"
@@ -58,7 +58,7 @@ resource "openstack_networking_port_v2" "lb_port" {
   admin_state_up     = "true"
   network_id         = "${openstack_networking_network_v2.openshift-private.id}"
   security_group_ids = ["${openstack_networking_secgroup_v2.api.id}"]
-  tags               = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+  tags               = ["openshiftClusterID=${var.cluster_id}"]
 
   fixed_ip {
     "subnet_id" = "${openstack_networking_subnet_v2.masters.id}"
@@ -74,7 +74,7 @@ resource "openstack_networking_router_v2" "openshift-external-router" {
   name                = "openshift-external-router"
   admin_state_up      = true
   external_network_id = "${data.openstack_networking_network_v2.external_network.id}"
-  tags                = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  tags                = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_router_interface_v2" "masters_router_interface" {

--- a/data/data/openstack/topology/sg-lb.tf
+++ b/data/data/openstack/topology/sg-lb.tf
@@ -1,6 +1,6 @@
 resource "openstack_networking_secgroup_v2" "api" {
   name = "api"
-  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  tags = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "api_mcs" {

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -1,6 +1,6 @@
 resource "openstack_networking_secgroup_v2" "master" {
   name = "master"
-  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  tags = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_mcs" {

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -1,6 +1,6 @@
 resource "openstack_networking_secgroup_v2" "worker" {
   name = "worker"
-  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  tags = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {

--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -14,9 +14,6 @@ func Metadata(config *types.InstallConfig) *aws.Metadata {
 		Region: config.Platform.AWS.Region,
 		Identifier: []map[string]string{
 			{
-				"tectonicClusterID": config.ClusterID,
-			},
-			{
 				"openshiftClusterID": config.ClusterID,
 			},
 			{

--- a/pkg/asset/cluster/openstack/openstack.go
+++ b/pkg/asset/cluster/openstack/openstack.go
@@ -13,7 +13,6 @@ func Metadata(config *types.InstallConfig) *openstack.Metadata {
 		Region: config.Platform.OpenStack.Region,
 		Cloud:  config.Platform.OpenStack.Cloud,
 		Identifier: map[string]string{
-			"tectonicClusterID":  config.ClusterID,
 			"openshiftClusterID": config.ClusterID,
 		},
 	}

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -103,7 +103,6 @@ func provider(clusterID, clusterName string, platform *aws.Platform, mpool *aws.
 
 func tagsFromUserTags(clusterID, clusterName string, usertags map[string]string) ([]awsprovider.TagSpecification, error) {
 	tags := []awsprovider.TagSpecification{
-		{Name: "tectonicClusterID", Value: clusterID},
 		{Name: "openshiftClusterID", Value: clusterID},
 		{Name: fmt.Sprintf("kubernetes.io/cluster/%s", clusterName), Value: "owned"},
 	}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -122,7 +122,6 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		}
 
 		tags := map[string]string{
-			"tectonicClusterID":  ic.ClusterID,
 			"openshiftClusterID": ic.ClusterID,
 		}
 		config.Tags = tags

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -133,7 +133,6 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		}
 
 		tags := map[string]string{
-			"tectonicClusterID":  ic.ClusterID,
 			"openshiftClusterID": ic.ClusterID,
 		}
 		config.Tags = tags


### PR DESCRIPTION
The tectonicClusterID tag is replaced with openshiftClusterID.

https://jira.coreos.com/browse/CORS-878

/hold
https://github.com/openshift/installer/pull/817
https://github.com/openshift/machine-api-operator/pull/147
https://github.com/openshift/cluster-ingress-operator/pull/83
https://github.com/openshift/cluster-image-registry-operator/pull/114
https://github.com/openshift/hive/pull/126
https://github.com/openshift/master-dns-operator/pull/8