### PR TITLE
hack/build.sh: check for vfsgen before `go generate`

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -41,6 +41,12 @@ release)
 	TAGS="${TAGS} release"
 	if test "${SKIP_GENERATION}" != y
 	then
+		if ! $(go list github.com/shurcooL/vfsgen &> /dev/null);
+		then
+			echo "cannot find github.com/shurcooL/vfsgen, needed by 'go generate ./data'"
+			echo "maybe run 'go get github.com/shurcooL/vfsgen' and retry"
+			exit 1
+		fi
 		go generate ./data
 	fi
 	;;


### PR DESCRIPTION
hack/build.sh: check for vfsgen before `go generate`

./data/assets_generate.go requires github.com/shurcooL/vfsgen
but nothing checks that it exists before trying to run
`go generate ./data`. This should check it and let the user
know if it doesn't exist.
