### PR TITLE
asset/cluster: clean up logging messages

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -111,10 +111,10 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		return fmt.Errorf("no known platform")
 	}
 
-	logrus.Infof("Using Terraform to create cluster...")
+	logrus.Infof("Creating cluster...")
 	stateFile, err := terraform.Apply(tmpDir, installConfig.Config.Platform.Name())
 	if err != nil {
-		err = errors.Wrap(err, "failed to run terraform")
+		err = errors.Wrap(err, "failed to create cluster")
 	}
 
 	data, err2 := ioutil.ReadFile(stateFile)

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/cluster"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // Destroy uses Terraform to remove bootstrap resources.
@@ -50,7 +49,6 @@ func Destroy(dir string) (err error) {
 		}
 	}
 
-	logrus.Infof("Using Terraform to destroy bootstrap resources...")
 	if platform == "libvirt" {
 		_, err = terraform.Apply(tempDir, platform)
 		if err != nil {


### PR DESCRIPTION
This removes explicit mention of Terraform in the log messages. We
received feedback that this was confusing users and product requested
that we remove it.