### PR TITLE
data/aws: Explicitly set ebs_optimized true

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -110,6 +110,7 @@ resource "aws_instance" "bootstrap" {
   user_data                   = "${data.ignition_config.redirect.rendered}"
   vpc_security_group_ids      = ["${var.vpc_security_group_ids}"]
   associate_public_ip_address = "${var.associate_public_ip_address}"
+  ebs_optimized               = true
 
   lifecycle {
     # Ignore changes in the AMI which force recreation of the resource. This

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -82,6 +82,7 @@ resource "aws_instance" "master" {
   instance_type        = "${var.ec2_type}"
   subnet_id            = "${element(var.subnet_ids, count.index)}"
   user_data            = "${var.user_data_ign}"
+  ebs_optimized        = true
 
   vpc_security_group_ids      = ["${var.master_sg_ids}"]
   associate_public_ip_address = "${var.public_endpoints}"


### PR DESCRIPTION
I'd have expected this to be the default for instance types where EBS-optimized is the default ([like m4.large][1]).  But apparently not:

```console
$ AWS_PROFILE=ci aws ec2 describe-instances --instance-ids i-076622e249b75a673 --query 'Reservations[0].Instances[0].{InstanceType: InstanceType, EbsOptimized: EbsOptimized}' --output json
{
    "EbsOptimized": false,
    "InstanceType": "m4.large"
}
```

Docs for the Terraform property are [here][2].

[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html
[2]: https://www.terraform.io/docs/providers/aws/r/instance.html#ebs_optimized