### PR TITLE
pkg: Pin to RHCOS 47.198 and quay.io/openshift-release-dev/ocp-release:4.0.0-4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.6.0 - 2018-12-07
+
+### Added
+
+- We now push a `kubeadmin` user (with an internally-generated
+  password) into the cluster for the new [bootstrap identity
+  provider][bootstrap-identity-provider].  This gives users a way to
+  access the web console, Prometheus, etc. without needing to
+  configure a full-fledged identity provider or install `oc`.  The
+  `create cluster` subcommand now blocks until the web-console route
+  is available and then exits after printing instructions for using
+  the new credentials.
+
+### Changed
+
+- The SSH public key configuration has moved a level up in the install
+  config, now that the `admin` structure has been removed.
+- `build.sh` now checks to make sure you have a new enough `go`,
+  instead of erroring out partway through the build.
+- We now resolve the update payload to a digest on the bootstrap node,
+  so [the cluster-version-operator][cluster-version-operator] can
+  figure out exactly which image we used.
+- Creation logging has been overhauled to increase it's
+  signal-to-noise while waiting for the Kubernetes API to come up.
+- On AWS, the installer will now prompt you for an access key and
+  secret if it cannot find your AWS credentials in the usual places.
+- On AWS, the installer will look at `AWS_DEFAULT_REGION` and in other
+  usual places when picking a default for the region prompt.  You
+  still have to set `OPENSHIFT_INSTALL_AWS_REGION` if you want to skip
+  the prompt entirely.
+- On libvirt, we've bumped masters from 3 GiB of memory to 4 GiB to
+  address out-of-memory issues we had been seeing at 3 GiB.
+- Lots of doc and internal cleanup and minor fixes.
+
+### Removed
+
+- The old admin username and password inputs have been removed.  They
+  weren't being used anyway, and their intended role has been replaced
+  by the newly-added `kubeadmin` user and bootstrap identity provider.
+- The old `openshift-web-console` namespace is gone.  The new console
+  is in the `openshift-console` namespace.
+
 ## 0.5.0 - 2018-12-03
 
 ### Added
@@ -351,6 +393,7 @@ the new `openshift-install` command instead.
 [aws-elb-latency]: https://github.com/openshift/installer/pull/594#issue-227786691
 [aws-instance-types]: https://aws.amazon.com/ec2/instance-types/
 [aws-nlb]: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html
+[bootstrap-identity-provider]: https://github.com/openshift/origin/pull/21580
 [checkpointer-operator]: https://github.com/openshift/pod-checkpointer-operator
 [cluster-api-provider-aws]: https://github.com/openshift/cluster-api-provider-aws
 [cluster-api-provider-aws-012575c1-AWSMachineProviderConfig]: https://github.com/openshift/cluster-api-provider-aws/blob/012575c1c8d758f81c979b0b2354950a2193ec1a/pkg/apis/awsproviderconfig/v1alpha1/awsmachineproviderconfig_types.go#L86-L139

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	rootDir              = "/opt/openshift"
-	defaultReleaseImage  = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
+	defaultReleaseImage  = "quay.io/openshift-release-dev/ocp-release:4.0.0-4"
 	bootstrapIgnFilename = "bootstrap.ign"
 )
 
@@ -141,7 +141,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, adminKub
 	}
 
 	releaseImage := defaultReleaseImage
-	if ri, ok := os.LookupEnv("OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"); ok && ri != "" {
+	if ri, ok := os.LookupEnv("_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"); ok && ri != "" {
 		logrus.Warn("Found override for ReleaseImage. Please be warned, this is not advised")
 		releaseImage = ri
 	}

--- a/pkg/rhcos/builds.go
+++ b/pkg/rhcos/builds.go
@@ -33,9 +33,15 @@ type metadata struct {
 }
 
 func fetchLatestMetadata(ctx context.Context, channel string) (metadata, error) {
-	build, err := fetchLatestBuild(ctx, channel)
-	if err != nil {
-		return metadata{}, errors.Wrap(err, "failed to fetch latest build")
+	var build string
+	var err error
+	if channel == DefaultChannel {
+		build = "47.198"
+	} else {
+		build, err = fetchLatestBuild(ctx, channel)
+		if err != nil {
+			return metadata{}, errors.Wrap(err, "failed to fetch latest build")
+		}
 	}
 
 	url := fmt.Sprintf("%s/%s/%s/meta.json", baseURL, channel, build)


### PR DESCRIPTION
DO NOT MERGE!

That's the latest RHCOS release:

```console
$ curl -s https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/builds.json | jq '{latest: .builds[0], timestamp}'
{
  "latest": "47.198",
  "timestamp": "2018-12-08T23:13:22Z"
}
```

And @smarterclayton just pushed 4.0.0-alpha.0-2018-12-07-090414 to quay.io/openshift-release-dev/ocp-release:4.0.0-4.  That's not the most recent release, but it's the most-recent stable release ;).

Renaming `OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE` gets us CI testing of the pinned release despite openshift/release@60007df2 (openshift/release#1793).