### PR TITLE
cvo: remove packages apiserver override

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -7,7 +7,3 @@ spec:
   upstream: http://localhost:8080/graph
   channel: fast
   clusterID: {{.CVOClusterID}}
-  overrides:
-  - kind: APIService                    # packages.apps.redhat.com fails to start properly
-    name: v1alpha1.packages.apps.redhat.com
-    unmanaged: true

--- a/data/data/manifests/bootkube/legacy-cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/legacy-cvo-overrides.yaml.template
@@ -6,7 +6,3 @@ metadata:
 upstream: http://localhost:8080/graph
 channel: fast
 clusterID: {{.CVOClusterID}}
-overrides:
-- kind: APIService                    # packages.apps.redhat.com fails to start properly
-  name: v1alpha1.packages.apps.redhat.com
-  unmanaged: true


### PR DESCRIPTION
The packages server was previously disabled in CVO config. 

Since then, we've fixed the problem causing the apiserver to flag, and we have also switched to self-hosting the packages api in OLM (so this override is doing nothing right now).

(In the future it would be helpful to get bug reports about OLM components instead of having them disabled in the installer/cvo)