### PR TITLE
libvirt: Add Terraform variables for bootstrap node memory/CPU

### DIFF
--- a/data/data/libvirt/bootstrap/main.tf
+++ b/data/data/libvirt/bootstrap/main.tf
@@ -11,9 +11,9 @@ resource "libvirt_ignition" "bootstrap" {
 resource "libvirt_domain" "bootstrap" {
   name = "${var.cluster_id}-bootstrap"
 
-  memory = "2048"
+  memory = "${var.libvirt_bootstrap_memory}"
 
-  vcpu = "2"
+  vcpu = "${var.libvirt_bootstrap_vcpu}"
 
   coreos_ignition = libvirt_ignition.bootstrap.id
 

--- a/data/data/libvirt/bootstrap/variables.tf
+++ b/data/data/libvirt/bootstrap/variables.tf
@@ -23,4 +23,3 @@ variable "network_id" {
   type        = string
   description = "The ID of a network resource containing the bootstrap node's addresses."
 }
-


### PR DESCRIPTION
Similar to https://github.com/openshift/installer/pull/785, but for the bootstrap node. 