### PR TITLE
Revert "data/aws: Switch to m4.large"

### DIFF
--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -26,7 +26,7 @@ variable "ignition" {
 
 variable "instance_type" {
   type        = "string"
-  default     = "m4.large"
+  default     = "t3.medium"
   description = "The EC2 instance type for the bootstrap node."
 }
 

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -9,10 +9,10 @@ EOF
 
 variable "aws_master_ec2_type" {
   type        = "string"
-  description = "Instance size for the master node(s). Example: `m4.large`."
+  description = "Instance size for the master node(s). Example: `t3.medium`."
 
   # FIXME: get this wired up to the machine default
-  default = "m4.large"
+  default = "t3.medium"
 }
 
 variable "aws_ec2_ami_override" {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -27,7 +27,7 @@ import (
 
 func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
 	return awstypes.MachinePool{
-		InstanceType: "m4.large",
+		InstanceType: "t3.medium",
 	}
 }
 


### PR DESCRIPTION
This reverts commit a2303766 (#765), now that we've bumped our t3.medium limits in the CI and dev accounts to cover our expected loads.  Moving from m4.large to t3.medium also reduces memory from [8 GiB][1] to [4 GiB][2], but after a recent run of end-to-end tests, the master consumption was:

```console
$ free -m
              total        used        free      shared  buff/cache   available
Mem:           7980        2263         794           8        4922        5259
Swap:             0           0           0
```

so 4 GiB should be sufficient.  And it also matches our libvirt setup since e59513fc (#785).

CC @abhinavdahiya, @crawford, @smarterclayton, @cuppett 

[1]: https://aws.amazon.com/ec2/instance-types/#General_Purpose
[2]: https://aws.amazon.com/ec2/instance-types/t3/#Product_Details