### PR TITLE
log,return error if console URL is not obtained

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -313,14 +313,16 @@ func waitForConsole(ctx context.Context, config *rest.Config, directory string) 
 			if silenceRemaining == 0 {
 				logrus.Debug("Still waiting for the console route...")
 				silenceRemaining = logDownsample
+				err = errors.New("no routes found in openshift-console namespace")
 			}
 		}
 	}, 2*time.Second, consoleRouteContext.Done())
-	if err != nil {
-		return "", errors.Wrap(err, "waiting for console route to be created")
+	err = consoleRouteContext.Err()
+	if err != nil && err != context.Canceled {
+		return url, errors.Wrap(err, "waiting for openshift-console URL")
 	}
 	if url == "" {
-		return url, errors.Wrap(err, "could not obtain openshift-console URL from route")
+		return url, errors.New("could not get openshift-console URL")
 	}
 	return url, nil
 }


### PR DESCRIPTION
@wking I hit a bug where the installer finished, with no errors logged, but the console URL was returned as " ".  The reason was that the install did not create any workers, but I _thought_ I had a solid check to error out if the consoleURL was " ".  This PR  creates an error in the wait if there are no routes found in -n openshift-console.  That way, when/if the context.WithTimeout... Done() times out, the error is not nil.  Also, I'll be adding some tests to the openshift/smoke-4 origin conformance suite to catch this in the future.