### PR TITLE
pkg/asset/installconfig/aws: Suppress "Unrecognized" for empty region

### DIFF
--- a/pkg/asset/installconfig/aws/aws.go
+++ b/pkg/asset/installconfig/aws/aws.go
@@ -82,7 +82,7 @@ func Platform() (*aws.Platform, error) {
 	}
 
 	defaultRegionPointer := ssn.Config.Region
-	if defaultRegionPointer != nil {
+	if defaultRegionPointer != nil && *defaultRegionPointer != "" {
 		_, ok := validAWSRegions[*defaultRegionPointer]
 		if ok {
 			defaultRegion = *defaultRegionPointer


### PR DESCRIPTION
We want to warn when the user has configured a region that we don't recognize.  But it's fine if the user hasn't configured a region at all.  We'll fall back to us-east-1 in either case, but dropping the warning from the "no configured region" case [avoids spooking users][1].

Fixes #828.

[1]: https://github.com/openshift/installer/issues/828#issue-388767930