### PR TITLE
libvirt/cache: Display target OS version

### DIFF
--- a/pkg/tfvars/libvirt/cache.go
+++ b/pkg/tfvars/libvirt/cache.go
@@ -28,7 +28,7 @@ func (libvirt *Libvirt) UseCachedImage() (err error) {
 		return nil
 	}
 
-	logrus.Infof("Fetching OS image...")
+	logrus.Infof("Fetching OS image: %s", filepath.Base(libvirt.Image))
 
 	// FIXME: Use os.UserCacheDir() once we bump to Go 1.11
 	// baseCacheDir, err := os.UserCacheDir()


### PR DESCRIPTION
This is a trival subset of
https://github.com/openshift/installer/pull/856

As I was arguing in this PR:

The result of an install run is currently a function of the 3-tuple:
(installer, RHCOS, release payload)

I'd actually like to print out all 3 clearly in the logs; this is
a first step to show the RHCOS version.