### PR TITLE
cmd: drop terraform version from version subcommand

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -149,9 +148,6 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 		for _, a := range targets {
 			err := assetStore.Fetch(a)
 			if err != nil {
-				if exitError, ok := errors.Cause(err).(*exec.ExitError); ok && len(exitError.Stderr) > 0 {
-					logrus.Error(strings.Trim(string(exitError.Stderr), "\n"))
-				}
 				err = errors.Wrapf(err, "failed to fetch %s", a.Name())
 			}
 

--- a/cmd/openshift-install/version.go
+++ b/cmd/openshift-install/version.go
@@ -3,14 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
-	"github.com/openshift/installer/pkg/terraform"
 )
 
 var (
@@ -28,14 +22,5 @@ func newVersionCmd() *cobra.Command {
 
 func runVersionCmd(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s %s\n", os.Args[0], version)
-	terraformVersion, err := terraform.Version()
-	if err != nil {
-		exitError, ok := err.(*exec.ExitError)
-		if ok && len(exitError.Stderr) > 0 {
-			logrus.Error(strings.Trim(string(exitError.Stderr), "\n"))
-		}
-		return errors.Wrap(err, "Failed to calculate Terraform version")
-	}
-	fmt.Println(terraformVersion)
 	return nil
 }


### PR DESCRIPTION
We no longer need to report terraform version as `openshift-install version` as terraform is not vendored.
Also dropped the check for PathError check as we are no longer execing terraform.

/cc @wking @crawford 