### PR TITLE
asset/manifests: network and ingress equal from state file and on-disk

### DIFF
--- a/pkg/asset/manifests/ingress.go
+++ b/pkg/asset/manifests/ingress.go
@@ -23,7 +23,6 @@ var (
 
 // Ingress generates the cluster-ingress-*.yml files.
 type Ingress struct {
-	config   *configv1.Ingress
 	FileList []*asset.File
 }
 
@@ -47,7 +46,7 @@ func (ing *Ingress) Generate(dependencies asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	dependencies.Get(installConfig)
 
-	ing.config = &configv1.Ingress{
+	config := &configv1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: configv1.SchemeGroupVersion.String(),
 			Kind:       "Ingress",
@@ -61,7 +60,7 @@ func (ing *Ingress) Generate(dependencies asset.Parents) error {
 		},
 	}
 
-	configData, err := yaml.Marshal(ing.config)
+	configData, err := yaml.Marshal(config)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create %s manifests from InstallConfig", ing.Name())
 	}
@@ -116,7 +115,7 @@ func (ing *Ingress) Load(f asset.FileFetcher) (bool, error) {
 
 	fileList := []*asset.File{crdFile, cfgFile}
 
-	ing.FileList, ing.config = fileList, ingressConfig
+	ing.FileList = fileList
 
 	return true, nil
 }

--- a/pkg/asset/manifests/network.go
+++ b/pkg/asset/manifests/network.go
@@ -48,7 +48,7 @@ spec:
 
 // Networking generates the cluster-network-*.yml files.
 type Networking struct {
-	config   *netopv1.NetworkConfig
+	Config   *netopv1.NetworkConfig
 	FileList []*asset.File
 }
 
@@ -104,7 +104,7 @@ func (no *Networking) Generate(dependencies asset.Parents) error {
 		}
 	}
 
-	no.config = &netopv1.NetworkConfig{
+	no.Config = &netopv1.NetworkConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: netopv1.SchemeGroupVersion.String(),
 			Kind:       "NetworkConfig",
@@ -121,7 +121,7 @@ func (no *Networking) Generate(dependencies asset.Parents) error {
 		},
 	}
 
-	configData, err := yaml.Marshal(no.config)
+	configData, err := yaml.Marshal(no.Config)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create %s manifests from InstallConfig", no.Name())
 	}
@@ -149,19 +149,19 @@ func (no *Networking) Files() []*asset.File {
 // object. This is called by ClusterK8sIO, which captures generalized cluster
 // state but shouldn't need to be fully networking aware.
 func (no *Networking) ClusterNetwork() (*clusterv1a1.ClusterNetworkingConfig, error) {
-	if no.config == nil {
+	if no.Config == nil {
 		// should be unreachable.
 		return nil, errors.Errorf("ClusterNetwork called before initialization")
 	}
 
 	pods := []string{}
-	for _, cn := range no.config.Spec.ClusterNetworks {
+	for _, cn := range no.Config.Spec.ClusterNetworks {
 		pods = append(pods, cn.CIDR)
 	}
 
 	cn := &clusterv1a1.ClusterNetworkingConfig{
 		Services: clusterv1a1.NetworkRanges{
-			CIDRBlocks: []string{no.config.Spec.ServiceNetwork},
+			CIDRBlocks: []string{no.Config.Spec.ServiceNetwork},
 		},
 		Pods: clusterv1a1.NetworkRanges{
 			CIDRBlocks: pods,
@@ -196,7 +196,7 @@ func (no *Networking) Load(f asset.FileFetcher) (bool, error) {
 
 	fileList := []*asset.File{crdFile, cfgFile}
 
-	no.FileList, no.config = fileList, netConfig
+	no.FileList, no.Config = fileList, netConfig
 
 	return true, nil
 }


### PR DESCRIPTION
The on-disk and in-state-file versions of the Network and Ingress manifest assets are not evaluating as equal when read into the store. Consequently, they are being marked as dirty, even when the user has not made any changes to them. This propagates to the Operators and Openshift manifest assets, making them dirty as well.

For both assets, the underlying issue is that the `config` field is not stored in the state file but it is populated when loading from on-disk. The `config` field in `manifests.Network` has been made public, allowing it to be stored in the state file. The `config` field in `manifests.Ingress` has been removed, since it is not being used.

Fixes https://jira.coreos.com/browse/CORS-938

https://jira.coreos.com/browse/CORS-940 has been created to add tests to ensure that there are not more assets that have this same problem.