### PR TITLE
asset/manifests: Load Openshift asset from disk

### DIFF
--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -146,5 +146,6 @@ func (o *Openshift) Load(f asset.FileFetcher) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	o.FileList = fileList
 	return len(fileList) > 0, nil
 }


### PR DESCRIPTION
The Openshift manifests asset does not load its files from disk. It reads the files but does not store them in the object. This was changed in commit ac11b74cc513fbf9362de72c84e09bb524cbc55c, presumably by mistake.

Fixes https://jira.coreos.com/browse/CORS-939