### PR TITLE
 reduce permissions on bootstrap kubeconfig used by masters 

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -46,6 +46,8 @@ then
 
 	cp cvo-bootstrap/bootstrap/* bootstrap-manifests/
 	cp cvo-bootstrap/manifests/* manifests/
+	## FIXME: CVO should use `/etc/kubernetes/bootstrap-secrets/kubeconfig` instead
+	cp auth/kubeconfig /etc/kubernetes/kubeconfig
 fi
 
 if [ ! -d kube-apiserver-bootstrap ]
@@ -136,9 +138,12 @@ then
 	# 1. read the controller config rendered by MachineConfigOperator
 	# 2. read the default MachineConfigPools rendered by MachineConfigOperator
 	# 3. read any additional MachineConfigs that are needed for the default MachineConfigPools.
-	mkdir --parents /etc/mcc/bootstrap/manifests /etc/kubernetes/manifests/
-	cp mco-bootstrap/manifests/* /etc/mcc/bootstrap/manifests/
-	cp mco-bootstrap/machineconfigoperator-bootstrap-pod.yaml /etc/kubernetes/manifests/
+	mkdir --parents /etc/mcc/bootstrap /etc/mcs/bootstrap /etc/kubernetes/manifests
+	cp mco-bootstrap/bootstrap/manifests/* /etc/mcc/bootstrap/
+	cp openshift/* /etc/mcc/bootstrap/
+	cp auth/kubeconfig-kubelet /etc/mcs/kubeconfig
+	cp mco-bootstrap/bootstrap/machineconfigoperator-bootstrap-pod.yaml /etc/kubernetes/manifests/
+	cp mco-bootstrap/manifests/* manifests/
 
 	# /etc/ssl/mcs/tls.{crt, key} are locations for MachineConfigServer's tls assets.
 	mkdir --parents /etc/ssl/mcs/

--- a/data/data/bootstrap/systemd/units/kubelet.service.template
+++ b/data/data/bootstrap/systemd/units/kubelet.service.template
@@ -5,7 +5,6 @@ Wants=rpc-statd.service
 [Service]
 Type=notify
 ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
-ExecStartPre=/usr/bin/bash -c "gawk '/certificate-authority-data/ {print $2}' /etc/kubernetes/kubeconfig | base64 --decode > /etc/kubernetes/ca.crt"
 Environment=KUBELET_RUNTIME_REQUEST_TIMEOUT=10m
 EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -18,8 +17,6 @@ ExecStart=/usr/bin/hyperkube \
     --allow-privileged \
     --minimum-container-ttl-duration=6m0s \
     --cluster-domain=cluster.local \
-    --client-ca-file=/etc/kubernetes/ca.crt \
-    --anonymous-auth=false \
     --cgroup-driver=systemd \
     --serialize-image-pulls=false \
     --v=2 \

--- a/pkg/asset/tls/kubeletcertkey.go
+++ b/pkg/asset/tls/kubeletcertkey.go
@@ -29,9 +29,7 @@ func (a *KubeletCertKey) Generate(dependencies asset.Parents) error {
 	dependencies.Get(kubeCA)
 
 	cfg := &CertCfg{
-		// system:masters is a hack to get the kubelet up without kube-core
-		// TODO(node): make kubelet bootstrapping secure with minimal permissions eventually switching to system:node:* CommonName
-		Subject:      pkix.Name{CommonName: "system:serviceaccount:kube-system:default", Organization: []string{"system:serviceaccounts:kube-system", "system:masters"}},
+		Subject:      pkix.Name{CommonName: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper", Organization: []string{"system:serviceaccounts:openshift-machine-config-operator"}},
 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		Validity:     ValidityThirtyMinutes,


### PR DESCRIPTION
Currently the master nodes have a kubeconfig served from bootstrap node that has `admin` priviledges, but only for 30 mins. This PR reduces the permissions on that kubeconfig to only allow CSR creation.

Addition of clusterrolebindings from https://github.com/openshift/machine-config-operator/pull/226 ( `csr-approver-role-binding.yaml` and `csr-bootstrapper-role-binding.yaml`) allow kubelets to create a CSR and get that CSR autoapproved from the controller manager.


Requires https://github.com/openshift/machine-config-operator/pull/226

/cc @wking @aaronlevy 