### PR TITLE
Revert "Revert "data/aws: Switch to m4.large""

### DIFF
--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -26,7 +26,7 @@ variable "ignition" {
 
 variable "instance_type" {
   type        = "string"
-  default     = "t3.medium"
+  default     = "m4.large"
   description = "The EC2 instance type for the bootstrap node."
 }
 

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -9,10 +9,10 @@ EOF
 
 variable "aws_master_ec2_type" {
   type        = "string"
-  description = "Instance size for the master node(s). Example: `t3.medium`."
+  description = "Instance size for the master node(s). Example: `m4.large`."
 
   # FIXME: get this wired up to the machine default
-  default = "t3.medium"
+  default = "m4.large"
 }
 
 variable "aws_ec2_ami_override" {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -27,7 +27,7 @@ import (
 
 func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
 	return awstypes.MachinePool{
-		InstanceType: "t3.medium",
+		InstanceType: "m4.large",
 	}
 }
 


### PR DESCRIPTION
Reverts openshift/installer#858

Even though we got our AWS quota increased, it looks like AWS just doesn't have the physical capacity for these machines in us-east-1. We are seeing a lot of failures in CI:

```
Error: Error applying plan:

1 error occurred:
    * module.masters.aws_instance.master[0]: 1 error occurred:
    * aws_instance.master.0: Error launching source instance: timeout while waiting for state to become 'success' (timeout: 30s)
```

Looking at CloudTrail, I see the following error, which corresponds to that failure:

> We currently do not have sufficient t3.medium capacity in the Availability Zone you requested (us-east-1a). Our system will be working on provisioning additional capacity. You can currently get t3.medium capacity by not specifying an Availability Zone in your request or choosing us-east-1d, us-east-1b, us-east-1c, us-east-1f.