### PR TITLE
asset/templates: remove fileName field

### DIFF
--- a/pkg/asset/templates/content/bootkube/04-openshift-machine-config-operator.go
+++ b/pkg/asset/templates/content/bootkube/04-openshift-machine-config-operator.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*OpenshiftMachineConfigOperator)(nil)
 
 // OpenshiftMachineConfigOperator is the constant to represent contents of Openshift_MachineConfigOperator.yaml file
 type OpenshiftMachineConfigOperator struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *OpenshiftMachineConfigOperator) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *OpenshiftMachineConfigOperator) Generate(parents asset.Parents) error {
-	t.fileName = openshiftMachineConfigOperatorFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := openshiftMachineConfigOperatorFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/05-openshift-cluster-api-namespace.go
+++ b/pkg/asset/templates/content/bootkube/05-openshift-cluster-api-namespace.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*OpenshiftClusterAPINamespace)(nil)
 
 // OpenshiftClusterAPINamespace is the constant to represent contents of Openshift_ClusterApiNamespace.yaml file
 type OpenshiftClusterAPINamespace struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *OpenshiftClusterAPINamespace) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *OpenshiftClusterAPINamespace) Generate(parents asset.Parents) error {
-	t.fileName = openshiftClusterAPINamespaceFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := openshiftClusterAPINamespaceFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/09-openshift-service-cert-signer-namespace.go
+++ b/pkg/asset/templates/content/bootkube/09-openshift-service-cert-signer-namespace.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*OpenshiftServiceCertSignerNamespace)(nil)
 
 // OpenshiftServiceCertSignerNamespace is the constant to represent the contents of 09-openshift-service-signer-namespace.yaml
 type OpenshiftServiceCertSignerNamespace struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *OpenshiftServiceCertSignerNamespace) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *OpenshiftServiceCertSignerNamespace) Generate(parents asset.Parents) error {
-	t.fileName = openshiftServiceCertSignerNamespaceFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := openshiftServiceCertSignerNamespaceFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/cvo-overrides.go
+++ b/pkg/asset/templates/content/bootkube/cvo-overrides.go
@@ -19,7 +19,6 @@ var _ asset.WritableAsset = (*CVOOverrides)(nil)
 // with resources already owned by other operators.
 // This files can be dropped when the overrides list becomes empty.
 type CVOOverrides struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -35,14 +34,14 @@ func (t *CVOOverrides) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *CVOOverrides) Generate(parents asset.Parents) error {
-	t.fileName = cVOOverridesFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := cVOOverridesFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/etcd-service.go
+++ b/pkg/asset/templates/content/bootkube/etcd-service.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*EtcdServiceKubeSystem)(nil)
 
 // EtcdServiceKubeSystem is the constant to represent contents of etcd-service.yaml file
 type EtcdServiceKubeSystem struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *EtcdServiceKubeSystem) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *EtcdServiceKubeSystem) Generate(parents asset.Parents) error {
-	t.fileName = etcdServiceKubeSystemFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := etcdServiceKubeSystemFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/host-etcd-service-endpoints.go
+++ b/pkg/asset/templates/content/bootkube/host-etcd-service-endpoints.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*HostEtcdServiceEndpointsKubeSystem)(nil)
 
 // HostEtcdServiceEndpointsKubeSystem is the constant to represent contents of etcd-service-endpoints.yaml.template file.
 type HostEtcdServiceEndpointsKubeSystem struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *HostEtcdServiceEndpointsKubeSystem) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *HostEtcdServiceEndpointsKubeSystem) Generate(parents asset.Parents) error {
-	t.fileName = hostEtcdServiceEndpointsKubeSystemFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := hostEtcdServiceEndpointsKubeSystemFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/host-etcd-service.go
+++ b/pkg/asset/templates/content/bootkube/host-etcd-service.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*HostEtcdServiceKubeSystem)(nil)
 
 // HostEtcdServiceKubeSystem is the constant to represent contents of etcd-service.yaml file
 type HostEtcdServiceKubeSystem struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *HostEtcdServiceKubeSystem) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *HostEtcdServiceKubeSystem) Generate(parents asset.Parents) error {
-	t.fileName = hostEtcdServiceKubeSystemFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := hostEtcdServiceKubeSystemFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/kube-cloud-config.go
+++ b/pkg/asset/templates/content/bootkube/kube-cloud-config.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*KubeCloudConfig)(nil)
 
 // KubeCloudConfig is the constant to represent contents of kube_cloudconfig.yaml file
 type KubeCloudConfig struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *KubeCloudConfig) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *KubeCloudConfig) Generate(parents asset.Parents) error {
-	t.fileName = kubeCloudConfigFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := kubeCloudConfigFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/kube-system-configmap-etcd-serving-ca.go
+++ b/pkg/asset/templates/content/bootkube/kube-system-configmap-etcd-serving-ca.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*KubeSystemConfigmapEtcdServingCA)(nil)
 
 // KubeSystemConfigmapEtcdServingCA is the constant to represent contents of kube-system-configmap-etcd-serving-ca.yaml.template file.
 type KubeSystemConfigmapEtcdServingCA struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *KubeSystemConfigmapEtcdServingCA) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *KubeSystemConfigmapEtcdServingCA) Generate(parents asset.Parents) error {
-	t.fileName = kubeSystemConfigmapEtcdServingCAFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := kubeSystemConfigmapEtcdServingCAFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/kube-system-configmap-root-ca.go
+++ b/pkg/asset/templates/content/bootkube/kube-system-configmap-root-ca.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*KubeSystemConfigmapRootCA)(nil)
 
 // KubeSystemConfigmapRootCA is the constant to represent contents of kube-system-configmap-root-ca.yaml.template file.
 type KubeSystemConfigmapRootCA struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *KubeSystemConfigmapRootCA) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *KubeSystemConfigmapRootCA) Generate(parents asset.Parents) error {
-	t.fileName = kubeSystemConfigmapRootCAFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := kubeSystemConfigmapRootCAFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/kube-system-secret-etcd-client.go
+++ b/pkg/asset/templates/content/bootkube/kube-system-secret-etcd-client.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*KubeSystemSecretEtcdClient)(nil)
 
 // KubeSystemSecretEtcdClient is the constant to represent contents of kube-system-secret-etcd-client.yaml.template file.
 type KubeSystemSecretEtcdClient struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *KubeSystemSecretEtcdClient) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *KubeSystemSecretEtcdClient) Generate(parents asset.Parents) error {
-	t.fileName = kubeSystemSecretEtcdClientFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := kubeSystemSecretEtcdClientFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/machine-config-server-tls-secret.go
+++ b/pkg/asset/templates/content/bootkube/machine-config-server-tls-secret.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*MachineConfigServerTLSSecret)(nil)
 
 // MachineConfigServerTLSSecret is the constant to represent contents of machine_configservertlssecret.yaml.template file
 type MachineConfigServerTLSSecret struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *MachineConfigServerTLSSecret) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *MachineConfigServerTLSSecret) Generate(parents asset.Parents) error {
-	t.fileName = machineConfigServerTLSSecretFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := machineConfigServerTLSSecretFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/openshift-service-cert-signer-ca-secret.go
+++ b/pkg/asset/templates/content/bootkube/openshift-service-cert-signer-ca-secret.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*OpenshiftServiceCertSignerSecret)(nil)
 
 // OpenshiftServiceCertSignerSecret is the constant to represent the contents of openshift-service-signer-secret.yaml.template
 type OpenshiftServiceCertSignerSecret struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *OpenshiftServiceCertSignerSecret) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *OpenshiftServiceCertSignerSecret) Generate(parents asset.Parents) error {
-	t.fileName = openshiftServiceCertSignerSecretFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := openshiftServiceCertSignerSecretFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/bootkube/pull.go
+++ b/pkg/asset/templates/content/bootkube/pull.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*Pull)(nil)
 
 // Pull is the constant to represent contents of pull.yaml.template file
 type Pull struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *Pull) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *Pull) Generate(parents asset.Parents) error {
-	t.fileName = pullFileName
-	data, err := content.GetBootkubeTemplate(t.fileName)
+	fileName := pullFileName
+	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/openshift/binding-discovery.go
+++ b/pkg/asset/templates/content/openshift/binding-discovery.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*BindingDiscovery)(nil)
 
 // BindingDiscovery  is the variable/constant representing the contents of the respective file
 type BindingDiscovery struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *BindingDiscovery) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *BindingDiscovery) Generate(parents asset.Parents) error {
-	t.fileName = bindingDiscoveryFileName
-	data, err := content.GetOpenshiftTemplate(t.fileName)
+	fileName := bindingDiscoveryFileName
+	data, err := content.GetOpenshiftTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/openshift/cloud-creds-secret.go
+++ b/pkg/asset/templates/content/openshift/cloud-creds-secret.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*CloudCredsSecret)(nil)
 
 // CloudCredsSecret is the constant to represent contents of corresponding yaml file
 type CloudCredsSecret struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *CloudCredsSecret) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *CloudCredsSecret) Generate(parents asset.Parents) error {
-	t.fileName = cloudCredsSecretFileName
-	data, err := content.GetOpenshiftTemplate(t.fileName)
+	fileName := cloudCredsSecretFileName
+	data, err := content.GetOpenshiftTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/openshift/kubeadmin-password-secret.go
+++ b/pkg/asset/templates/content/openshift/kubeadmin-password-secret.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*KubeadminPasswordSecret)(nil)
 
 // KubeadminPasswordSecret is the constant to represent contents of kubeadmin-password-secret.yaml.template file
 type KubeadminPasswordSecret struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *KubeadminPasswordSecret) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *KubeadminPasswordSecret) Generate(parents asset.Parents) error {
-	t.fileName = kubeadminPasswordSecretFileName
-	data, err := content.GetOpenshiftTemplate(t.fileName)
+	fileName := kubeadminPasswordSecretFileName
+	data, err := content.GetOpenshiftTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}

--- a/pkg/asset/templates/content/openshift/role-cloud-creds-secret-reader.go
+++ b/pkg/asset/templates/content/openshift/role-cloud-creds-secret-reader.go
@@ -16,7 +16,6 @@ var _ asset.WritableAsset = (*RoleCloudCredsSecretReader)(nil)
 
 // RoleCloudCredsSecretReader is the variable to represent contents of corresponding file
 type RoleCloudCredsSecretReader struct {
-	fileName string
 	FileList []*asset.File
 }
 
@@ -32,14 +31,14 @@ func (t *RoleCloudCredsSecretReader) Name() string {
 
 // Generate generates the actual files by this asset
 func (t *RoleCloudCredsSecretReader) Generate(parents asset.Parents) error {
-	t.fileName = roleCloudCredsSecretReaderFileName
-	data, err := content.GetOpenshiftTemplate(t.fileName)
+	fileName := roleCloudCredsSecretReaderFileName
+	data, err := content.GetOpenshiftTemplate(fileName)
 	if err != nil {
 		return err
 	}
 	t.FileList = []*asset.File{
 		{
-			Filename: filepath.Join(content.TemplateDir, t.fileName),
+			Filename: filepath.Join(content.TemplateDir, fileName),
 			Data:     []byte(data),
 		},
 	}


### PR DESCRIPTION
The fileName field is not needed. The template assets do not need to store this information.

This change is part of work that is on-going to add tests to ensure that targeted assets are not assessed as dirty when read back in without being modified. The problem with the fileName field is that it is not set when the asset is loaded from the state file or from on-disk. This causes road-trip tests that compare a generated asset to a read asset to fail.