### PR TITLE
pkg/asset/installconfig/pullsecret: Point to cloud.openshift.com

### DIFF
--- a/pkg/asset/installconfig/pullsecret.go
+++ b/pkg/asset/installconfig/pullsecret.go
@@ -24,7 +24,7 @@ func (a *pullSecret) Generate(asset.Parents) error {
 		{
 			Prompt: &survey.Input{
 				Message: "Pull Secret",
-				Help:    "The container registry pull secret for this cluster, as a single line of JSON (e.g. {\"auths\": {...}}).\n\nYou can get this secret from https://try.openshift.com",
+				Help:    "The container registry pull secret for this cluster, as a single line of JSON (e.g. {\"auths\": {...}}).\n\nYou can get this secret from https://cloud.openshift.com/clusters/install#pull-secret",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 				return validate.JSON([]byte(ans.(string)))


### PR DESCRIPTION
try.openshift.com used to be an HTML redirect to cloud.openshift.com, but now it's a page in its own right talking about what OpenShift 4 is.  Folks who are trying to find a pull secret for the installer are already pretty interested, so they shouldn't have to dig too hard to get the JSON they need.

This will also help avoid confusion like we saw for [the CoreOS flow][1], where the pull secret was not immediately obvious to several users due to an undocumented "register for a Tectonic plan" intermediate (#677, #691).

Currently the JavaScript on `/clusters/install` is stripping the `#pull-secret` fragment.  Hopefully we'll get that sorted out soon and we'll be able to link directly to the section with the pull-secret.  CC @kbsingh

The environment file tweak will conflict with #861, but it should be easy to rebase whichever branch lands second.  CC @crawford

[1]: https://github.com/openshift/installer/pull/663#discussion_r234345693