### PR TITLE
docs: Drop 'OPENSHIFT_INSTALL_' prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ INFO Waiting 10m0s for the openshift-console route to be created...
 INFO Install complete!
 INFO Run 'export KUBECONFIG=/path/to/auth/kubeconfig' to manage the cluster with 'oc', the OpenShift CLI.
 INFO The cluster is ready when 'oc login -u kubeadmin -p 5char-5char-5char-5char' succeeds (wait a few minutes).
-INFO Access the OpenShift web-console here: https://console-openshift-console.apps.${OPENSHIFT_INSTALL_CLUSTER_NAME}.${OPENSHIFT_INSTALL_BASE_DOMAIN}:6443
+INFO Access the OpenShift web-console here: https://console-openshift-console.apps.${CLUSTER_NAME}.${BASE_DOMAIN}:6443
 INFO Login to the console with user: kubeadmin, password: 5char-5char-5char-5char
 ```
 

--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -251,7 +251,7 @@ Some things you can do:
 The bootstrap node, e.g. `test1-bootstrap.tt.testing`, runs the bootstrap process. You can watch it:
 
 ```sh
-ssh core@$OPENSHIFT_INSTALL_CLUSTER_NAME-bootstrap.$OPENSHIFT_INSTALL_BASE_DOMAIN
+ssh "core@${CLUSTER_NAME}-bootstrap.${BASE_DOMAIN}"
 sudo journalctl -f -u bootkube -u openshift
 ```
 
@@ -261,11 +261,11 @@ Using the domain names above will only work if you [set up the DNS overlay](#set
 Alternatively, if you didn't set up DNS on the host, you can use:
 
 ```sh
-virsh -c "${OPENSHIFT_INSTALL_LIBVIRT_URI}" domifaddr "${OPENSHIFT_INSTALL_CLUSTER_NAME}-master-0"  # to get the master IP
+virsh -c "${LIBVIRT_URI}" domifaddr "${CLUSTER_NAME}-master-0"  # to get the master IP
 ssh core@$MASTER_IP
 ```
 
-Here `OPENSHIFT_INSTALL_LIBVIRT_URI` is the libvirt connection URI which you [passed to the installer](#build-and-run-the-installer).
+Here `LIBVIRT_URI` is the libvirt connection URI which you [passed to the installer](../../README.md#quick-start).
 
 ### Inspect the cluster with kubectl
 


### PR DESCRIPTION
The long forms are less likely to exist in the user's environment since 6be4c253 (#861), and we no longer need the context to distinguish from all the other environment variables on a user's system.

CC @alejovicu