### PR TITLE
pkg/asset/installconfig/pullsecret: Use survey.Password

### DIFF
--- a/pkg/asset/installconfig/pullsecret.go
+++ b/pkg/asset/installconfig/pullsecret.go
@@ -22,7 +22,7 @@ func (a *pullSecret) Dependencies() []asset.Asset {
 func (a *pullSecret) Generate(asset.Parents) error {
 	return survey.Ask([]*survey.Question{
 		{
-			Prompt: &survey.Input{
+			Prompt: &survey.Password{
 				Message: "Pull Secret",
 				Help:    "The container registry pull secret for this cluster, as a single line of JSON (e.g. {\"auths\": {...}}).\n\nYou can get this secret from https://try.openshift.com",
 			},


### PR DESCRIPTION
Folks are going to be pasting this in, so they won't have to see the characters to fix typos and such.  And using the `Password` input allows folks to demo the wizard (or run it where they are concerned about shoulder surfing) and not have to worry about leaking their secret.  It also reinforces the fact that this *is* a secret, which may help users remember not to post it in public places (e.g. issue reports).