### PR TITLE
[WIP] openstack: use trunks if available

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -39,14 +39,15 @@ module "bootstrap" {
 module "masters" {
   source = "./masters"
 
-  base_image     = "${var.openstack_base_image}"
-  cluster_id     = "${var.cluster_id}"
-  cluster_name   = "${var.cluster_name}"
-  flavor_name    = "${var.openstack_master_flavor_name}"
-  instance_count = "${var.master_count}"
-  master_sg_ids  = "${concat(var.openstack_master_extra_sg_ids, list(module.topology.master_sg_id))}"
-  subnet_ids     = "${module.topology.master_subnet_ids}"
-  user_data_ign  = "${var.ignition_master}"
+  base_image      = "${var.openstack_base_image}"
+  cluster_id      = "${var.cluster_id}"
+  cluster_name    = "${var.cluster_name}"
+  flavor_name     = "${var.openstack_master_flavor_name}"
+  instance_count  = "${var.master_count}"
+  master_sg_ids   = "${concat(var.openstack_master_extra_sg_ids, list(module.topology.master_sg_id))}"
+  master_port_ids = "${module.topology.master_port_ids}"
+  user_data_ign   = "${var.ignition_master}"
+  trunk_support   = "${var.openstack_trunk_support}"
 }
 
 # TODO(shadower) add a dns module here
@@ -57,9 +58,9 @@ module "topology" {
   cidr_block                 = "${var.openstack_network_cidr_block}"
   cluster_id                 = "${var.cluster_id}"
   cluster_name               = "${var.cluster_name}"
-  external_master_subnet_ids = "${compact(var.openstack_external_master_subnet_ids)}"
   external_network           = "${var.openstack_external_network}"
   masters_count              = "${var.master_count}"
+  trunk_support              = "${var.openstack_trunk_support}"
 }
 
 resource "openstack_objectstorage_container_v1" "container" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -17,7 +17,7 @@ resource "openstack_compute_instance_v2" "master_conf" {
   user_data       = "${var.user_data_ign}"
 
   network = {
-    port = "${var.subnet_ids[count.index]}"
+    port = "${var.master_port_ids[count.index]}"
   }
 
   metadata {

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -24,8 +24,9 @@ variable "master_sg_ids" {
   description = "The security group IDs to be applied to the master nodes."
 }
 
-variable "subnet_ids" {
+variable "master_port_ids" {
   type = "list"
+  description = "List of port ids for the master nodes"
 }
 
 variable "user_data_ign" {

--- a/data/data/openstack/topology/common.tf
+++ b/data/data/openstack/topology/common.tf
@@ -1,3 +1,4 @@
 locals {
-  master_subnet_ids = ["${coalescelist(openstack_networking_port_v2.masters.*.id,var.external_master_subnet_ids)}"]
+  trunk_port_ids = "${element(concat(openstack_networking_trunk_v2.masters.*.port_id, list("")), 0)}"
+  master_port_ids = ["${coalescelist(trunk_port_ids,openstack_networking_port_v2.masters.*.id)}"]
 }

--- a/data/data/openstack/topology/outputs.tf
+++ b/data/data/openstack/topology/outputs.tf
@@ -6,6 +6,6 @@ output "master_sg_id" {
   value = "${openstack_networking_secgroup_v2.master.id}"
 }
 
-output "master_subnet_ids" {
-  value = "${local.master_subnet_ids}"
+output "master_port_ids" {
+  value = "${local.master_port_ids}"
 }

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -39,6 +39,15 @@ resource "openstack_networking_port_v2" "masters" {
   }
 }
 
+resource "openstack_networking_trunk_v2" "masters" {
+  name = "master-trunk-${count.index}"
+  count = ${var.trunk_support ? var.masters_count : 0}
+  tags  = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+
+  admin_state_up = "true"
+  port_id = "${openstack_networking_port_v2.masters[count.index].id}
+}
+
 resource "openstack_networking_port_v2" "bootstrap_port" {
   name = "bootstrap-port"
 

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -10,10 +10,6 @@ variable "cluster_name" {
   type = "string"
 }
 
-variable "external_master_subnet_ids" {
-  type = "list"
-}
-
 variable "external_network" {
   description = "UUID of the external network providing Floating IP addresses."
   type        = "string"
@@ -21,5 +17,9 @@ variable "external_network" {
 }
 
 variable "masters_count" {
+  type = "string"
+}
+
+variable "trunk_support" {
   type = "string"
 }

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -190,18 +190,6 @@ The Username to login with. If omitted, the OS_USERNAME environment variable is 
 EOF
 }
 
-variable "openstack_external_master_subnet_ids" {
-  type    = "list"
-  default = []
-
-  description = <<EOF
-(optional) List of subnet IDs within an existing VPC to deploy master nodes into.
-Required to use an existing VPC, not applicable otherwise.
-
-Example: `["subnet-111111", "subnet-222222", "subnet-333333"]`
-EOF
-}
-
 variable "openstack_external_network" {
   type    = "string"
   default = ""
@@ -251,5 +239,13 @@ variable "openstack_network_cidr_block" {
   description = <<EOF
 Block of IP addresses used by the VPC.
 This should not overlap with any other networks, such as a private datacenter connected via Direct Connect.
+EOF
+}
+
+variable "openstack_trunk_support" {
+  type = "string"
+
+  description = <<EOF
+Contains 0 if the OpenStack Neutron trunk extension is disabled and 1 if it is enabled.
 EOF
 }

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -119,6 +119,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			Image:       ic.Platform.OpenStack.BaseImage,
 			Region:      ic.Platform.OpenStack.Region,
 			Machine:     defaultOpenStackMachinePoolPlatform(),
+			Trunk:       trunkSupportBoolean(ic.Platform.OpenStack.TrunkSupport),
 		}
 
 		tags := map[string]string{

--- a/pkg/asset/machines/openstack/master.go
+++ b/pkg/asset/machines/openstack/master.go
@@ -15,6 +15,7 @@ type MasterConfig struct {
 	Tags        map[string]string
 	Region      string
 	Machine     openstack.MachinePool
+	Trunk       bool
 }
 
 // MasterMachinesTmpl is the template for master machines.
@@ -63,6 +64,7 @@ items:
               - "{{$c.ClusterName}}_master_sg"
         userDataSecret:
           name: master-user-data
+        trunk: {{.Trunk}}
     versions:
       kubelet: ""
       controlPlane: ""

--- a/pkg/asset/machines/openstack/worker.go
+++ b/pkg/asset/machines/openstack/worker.go
@@ -15,6 +15,7 @@ type Config struct {
 	Tags        map[string]string
 	Region      string
 	Machine     openstack.MachinePool
+	Trunk       bool
 }
 
 // WorkerMachineSetTmpl is template for worker machineset.
@@ -68,6 +69,7 @@ spec:
                 - "{{.ClusterName}}_worker_sg"
           userDataSecret:
             name: worker-user-data
+          trunK: {{.Trunk}}
       versions:
         kubelet: ""
         controlPlane: ""

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -37,6 +37,14 @@ func defaultOpenStackMachinePoolPlatform() openstacktypes.MachinePool {
 	}
 }
 
+func trunkSupportBoolean(trunkSupport string) (result bool) {
+	if trunkSupport == "1" {
+		result = true
+	} else {
+		result = false
+	}
+}
+
 // Worker generates the machinesets for `worker` machine pool.
 type Worker struct {
 	MachineSetRaw     []byte
@@ -130,6 +138,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			Image:       ic.Platform.OpenStack.BaseImage,
 			Region:      ic.Platform.OpenStack.Region,
 			Machine:     defaultOpenStackMachinePoolPlatform(),
+			Trunk:       trunkSupportBoolean(ic.Platform.OpenStack.TrunkSupport),
 		}
 
 		tags := map[string]string{

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -10,6 +10,7 @@ type OpenStack struct {
 	Master           `json:",inline"`
 	Region           string `json:"openstack_region,omitempty"`
 	NetworkCIDRBlock string `json:"openstack_network_cidr_block,omitempty"`
+	Trunk            string `json:"openstack_trunk_support,omitempty"`
 }
 
 // External converts external related config.

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -119,6 +119,7 @@ func TFVars(cfg *types.InstallConfig, bootstrapIgn, masterIgn string) ([]byte, e
 		}
 		config.OpenStack.Credentials.Cloud = cfg.Platform.OpenStack.Cloud
 		config.OpenStack.ExternalNetwork = cfg.Platform.OpenStack.ExternalNetwork
+		config.OpenStack.TrunkSupport = cfg.Platform.OpenStack.TrunkSupport
 	}
 
 	return json.MarshalIndent(config, "", "  ")

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -26,4 +26,8 @@ type Platform struct {
 	// ExternalNetwork
 	// The OpenStack external network to be used for installation.
 	ExternalNetwork string `json:"externalNetwork"`
+
+	// TrunkSupport
+	// Whether OpenStack ports can be trunked
+	TrunkSupport string `json:"trunkSupport"`
 }


### PR DESCRIPTION
Depending on the SDN, the openshift nodes need to be wired with
trunk ports. This patch detects when Neutron has the trunk extension
enabled and if it does, makes the cluster use trunks for its nodes.

Signed-off-by: Antoni Segura Puimedon <celebdor@gmail.com>