### PR TITLE
asset/installconfig: fix survey for aws access key id

### DIFF
--- a/pkg/asset/installconfig/aws/aws.go
+++ b/pkg/asset/installconfig/aws/aws.go
@@ -131,7 +131,7 @@ func getCredentials() error {
 				Help:    "The AWS access key ID to use for installation (this is not your username).\nhttps://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
 			},
 		},
-	}, keyID)
+	}, &keyID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The call to survey.Ask needs to be passed a pointer to the keyID.