### PR TITLE
destroy/bootstrap: explicit pass `disable-bootstrap.tfvars` for libvirt

### DIFF
--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -2,6 +2,7 @@
 package bootstrap
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -26,14 +27,14 @@ func Destroy(dir string) (err error) {
 	copyNames := []string{terraform.StateFileName, cluster.TfVarsFileName}
 
 	if platform == "libvirt" {
-		err = ioutil.WriteFile(filepath.Join(dir, "disable-bootstrap.auto.tfvars"), []byte(`{
+		err = ioutil.WriteFile(filepath.Join(dir, "disable-bootstrap.tfvars"), []byte(`{
   "bootstrap_dns": false
 }
 `), 0666)
 		if err != nil {
 			return err
 		}
-		copyNames = append(copyNames, "disable-bootstrap.auto.tfvars")
+		copyNames = append(copyNames, "disable-bootstrap.tfvars")
 	}
 
 	tempDir, err := ioutil.TempDir("", "openshift-install-")
@@ -50,7 +51,7 @@ func Destroy(dir string) (err error) {
 	}
 
 	if platform == "libvirt" {
-		_, err = terraform.Apply(tempDir, platform)
+		_, err = terraform.Apply(tempDir, platform, fmt.Sprintf("-var-file=%s", filepath.Join(tempDir, "disable-bootstrap.tfvars")))
 		if err != nil {
 			return errors.Wrap(err, "Terraform apply")
 		}


### PR DESCRIPTION
The old implementation depended on terraform auto picking up `*.auto.tfvars` in the current directory.
And since we ran terraform as separate process we changes the CWD of that to the `tempDir`.

With https://github.com/openshift/installer/pull/822 terraform in run as part of installer so var and state files need to be explicit to the `tempDir`

Fixes https://github.com/openshift/installer/issues/878