### PR TITLE
image: Add a RHEL7 dockerfile and standarize format

### DIFF
--- a/images/installer/Dockerfile.ci.rhel7
+++ b/images/installer/Dockerfile.ci.rhel7
@@ -1,13 +1,13 @@
 # This Dockerfile is a used by CI to publish openshift/origin-v4.0:installer
 # It builds an image containing only the openshift-install.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000

--- a/images/nested-libvirt/Dockerfile
+++ b/images/nested-libvirt/Dockerfile
@@ -7,7 +7,6 @@ RUN hack/build.sh
 
 FROM centos:7
 COPY --from=build /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
-COPY --from=build /go/src/github.com/openshift/installer/bin/terraform /bin/terraform
 COPY --from=build /go/src/github.com/openshift/installer/images/nested-libvirt/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
 COPY --from=build /go/src/github.com/openshift/installer/images/nested-libvirt/mock-nss.sh /bin/mock-nss.sh
 


### PR DESCRIPTION
This is similar to various PRs opened in openshift repos like https://github.com/openshift/machine-config-operator/pull/165
to help standarize the dockerfiles

also remove the `COPY --from builder <terraform>` instructions that were missed in aff2e983f9438717dec2d182799ba7250035912d

/cc @smarterclayton @wking 