### PR TITLE
Create temporary service VM and document the current state of experimental OpenStack support

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -12,8 +12,31 @@ resource "openstack_objectstorage_tempurl_v1" "ignition_tmpurl" {
 }
 
 data "ignition_config" "redirect" {
-  replace {
+  append {
     source = "${openstack_objectstorage_tempurl_v1.ignition_tmpurl.url}"
+  }
+
+  files = [
+    "${data.ignition_file.bootstrap_ifcfg.id}",
+  ]
+}
+
+data "ignition_file" "bootstrap_ifcfg" {
+  filesystem = "root"
+  mode       = "420"                                       // 0644
+  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+
+  content {
+    content = <<EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+DNS1="${var.service_vm_fixed_ip}"
+PEERDNS="no"
+NM_CONTROLLED="yes"
+EOF
   }
 }
 

--- a/data/data/openstack/lb/main.tf
+++ b/data/data/openstack/lb/main.tf
@@ -1,0 +1,122 @@
+data "openstack_images_image_v2" "bootstrap_image" {
+  name        = "${var.image_name}"
+  most_recent = true
+}
+
+data "openstack_compute_flavor_v2" "bootstrap_flavor" {
+  name = "${var.flavor_name}"
+}
+
+data "ignition_systemd_unit" "haproxy_unit" {
+  name    = "bootkube-haproxy.service"
+  enabled = true
+
+  content = <<EOF
+[Unit]
+Description=Load balancer for the OpenShift services
+
+[Service]
+ExecStartPre=/sbin/setenforce 0
+ExecStart=/bin/podman run --name haproxy --rm -ti --net=host -v /etc/haproxy:/usr/local/etc/haproxy:ro docker.io/library/haproxy:1.7
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+data "ignition_file" "haproxy_conf" {
+  filesystem = "root"
+  path       = "/etc/haproxy/haproxy.cfg"
+
+  source {
+    source = "data:,listen%20ostest-api-80%0D%0A%20%20%20%20bind%200.0.0.0%3A80%0D%0A%20%20%20%20mode%20tcp%0D%0A%20%20%20%20stats%20enable%0D%0A%20%20%20%20stats%20uri%20%2Fhaproxy%3Fstatus%0D%0A%20%20%20%20balance%20roundrobin%0D%0A%20%20%20%20server%20ostest-bootstrap%20ostest-bootstrap.shiftstack.com%3A80%20check%0D%0A%20%20%20%20server%20ostest-master-0%20ostest-master-0.shiftstack.com%3A80%20check%0D%0A%20%20%20%20server%20ostest-master-1%20ostest-master-1.shiftstack.com%3A80%20check%0D%0A%20%20%20%20server%20ostest-master-2%20ostest-master-2.shiftstack.com%3A80%20check%0D%0A%0D%0Alisten%20ostest-api-6443%0D%0A%20%20%20%20bind%200.0.0.0%3A6443%0D%0A%20%20%20%20mode%20tcp%0D%0A%20%20%20%20stats%20enable%0D%0A%20%20%20%20stats%20uri%20%2Fhaproxy%3Fstatus%0D%0A%20%20%20%20balance%20roundrobin%0D%0A%20%20%20%20server%20ostest-bootstrap%20ostest-bootstrap.shiftstack.com%3A6443%20check%0D%0A%20%20%20%20server%20ostest-master-0%20ostest-master-0.shiftstack.com%3A6443%20check%0D%0A%20%20%20%20server%20ostest-master-1%20ostest-master-1.shiftstack.com%3A6443%20check%0D%0A%20%20%20%20server%20ostest-master-2%20ostest-master-2.shiftstack.com%3A6443%20check%0D%0A%0D%0Alisten%20ostest-api-443%0D%0A%20%20%20%20bind%200.0.0.0%3A443%0D%0A%20%20%20%20mode%20tcp%0D%0A%20%20%20%20stats%20enable%0D%0A%20%20%20%20stats%20uri%20%2Fhaproxy%3Fstatus%0D%0A%20%20%20%20balance%20roundrobin%0D%0A%20%20%20%20server%20ostest-bootstrap%20ostest-bootstrap.shiftstack.com%3A443%20check%0D%0A%20%20%20%20server%20ostest-master-0%20ostest-master-0.shiftstack.com%3A443%20check%0D%0A%20%20%20%20server%20ostest-master-1%20ostest-master-1.shiftstack.com%3A443%20check%0D%0A%20%20%20%20server%20ostest-master-2%20ostest-master-2.shiftstack.com%3A443%20check%0D%0A%0D%0Alisten%20ostest-api-49500%0D%0A%20%20%20%20bind%200.0.0.0%3A49500%0D%0A%20%20%20%20mode%20tcp%0D%0A%20%20%20%20stats%20enable%0D%0A%20%20%20%20stats%20uri%20%2Fhaproxy%3Fstatus%0D%0A%20%20%20%20balance%20roundrobin%0D%0A%20%20%20%20server%20ostest-bootstrap%20ostest-bootstrap.shiftstack.com%3A49500%20check%0D%0A%20%20%20%20server%20ostest-master-0%20ostest-master-0.shiftstack.com%3A49500%20check%0D%0A%20%20%20%20server%20ostest-master-1%20ostest-master-1.shiftstack.com%3A49500%20check%0D%0A%20%20%20%20server%20ostest-master-2%20ostest-master-2.shiftstack.com%3A49500%20check"
+  }
+}
+
+data "ignition_file" "openshift_hosts" {
+  filesystem = "root"
+  mode       = "420"                  // 0644
+  path       = "/etc/openshift-hosts"
+
+  content {
+    content = <<EOF
+${replace(join("\n", formatlist("%s ${var.cluster_name}-etcd-%s.${var.cluster_domain}", var.master_ips, var.master_port_names)), "master-port-", "")}
+EOF
+  }
+}
+
+data "ignition_systemd_unit" "local_dns" {
+  name = "local-dns.service"
+
+  content = <<EOF
+[Unit]
+Description=Internal DNS server for running OpenShift on OpenStack
+
+[Service]
+ExecStart=/bin/podman run --name bootstrap-dns --rm -t -i -p 53:53/tcp -p 53:53/udp -v /etc/openshift-hosts:/etc/openshift-hosts:z --cap-add=NET_ADMIN docker.io/andyshinn/dnsmasq:latest --keep-in-foreground --log-facility=- --log-queries --no-resolv --addn-hosts=/etc/openshift-hosts --server=10.0.0.2 ${replace(join(" ", formatlist("--srv-host=_etcd-server-ssl._tcp.${var.cluster_name}.${var.cluster_domain},${var.cluster_name}-etcd-%s.${var.cluster_domain},2380,0,10", var.master_port_names)), "master-port-", "")}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+data "ignition_user" "core" {
+  name = "core"
+}
+
+data "ignition_config" "config" {
+  files = [
+    "${data.ignition_file.haproxy_conf.id}",
+    "${data.ignition_file.openshift_hosts.id}",
+  ]
+
+  systemd = [
+    "${data.ignition_systemd_unit.haproxy_unit.id}",
+    "${data.ignition_systemd_unit.local_dns.id}",
+  ]
+
+  users = [
+    "${data.ignition_user.core.id}",
+  ]
+}
+
+resource "openstack_objectstorage_object_v1" "lb_ignition" {
+  container_name = "${var.swift_container}"
+  name           = "load-balancer.ign"
+  content        = "${data.ignition_config.config.rendered}"
+}
+
+resource "openstack_objectstorage_tempurl_v1" "lb_ignition_tmpurl" {
+  container = "${var.swift_container}"
+  method    = "get"
+  object    = "${openstack_objectstorage_object_v1.lb_ignition.name}"
+  ttl       = 3600
+}
+
+data "ignition_config" "lb_redirect" {
+  replace {
+    source = "${openstack_objectstorage_tempurl_v1.lb_ignition_tmpurl.url}"
+  }
+}
+
+resource "openstack_compute_instance_v2" "load_balancer" {
+  name      = "${var.cluster_name}-api"
+  flavor_id = "${data.openstack_compute_flavor_v2.bootstrap_flavor.id}"
+  image_id  = "${data.openstack_images_image_v2.bootstrap_image.id}"
+
+  user_data = "${data.ignition_config.lb_redirect.rendered}"
+
+  network {
+    port = "${var.lb_port_id}"
+  }
+
+  metadata {
+    Name = "${var.cluster_name}-bootstrap"
+
+    # "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+    tectonicClusterID  = "${var.cluster_id}"
+    openshiftClusterID = "${var.cluster_id}"
+  }
+}

--- a/data/data/openstack/lb/variables.tf
+++ b/data/data/openstack/lb/variables.tf
@@ -17,6 +17,11 @@ variable "cluster_id" {
   type = "string"
 }
 
+variable "cluster_domain" {
+  type        = "string"
+  description = "The domain name of the cluster."
+}
+
 variable "ignition" {
   type        = "string"
   description = "The content of the bootstrap ignition file."
@@ -28,11 +33,15 @@ variable "flavor_name" {
   description = "The Nova flavor for the bootstrap node."
 }
 
-variable "bootstrap_port_id" {
+variable "lb_port_id" {
   type        = "string"
   description = "The subnet ID for the bootstrap node."
 }
 
-variable "service_vm_fixed_ip" {
-  type = "string"
+variable "master_ips" {
+  type = "list"
+}
+
+variable "master_port_names" {
+  type = "list"
 }

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -24,29 +24,46 @@ provider "openstack" {
   version             = ">=1.6.0"
 }
 
-module "bootstrap" {
-  source = "./bootstrap"
+module "lb" {
+  source = "./lb"
 
   swift_container   = "${openstack_objectstorage_container_v1.container.name}"
   cluster_name      = "${var.cluster_name}"
   cluster_id        = "${var.cluster_id}"
+  cluster_domain    = "${var.base_domain}"
   image_name        = "${var.openstack_base_image}"
   flavor_name       = "${var.openstack_master_flavor_name}"
   ignition          = "${var.ignition_bootstrap}"
-  bootstrap_port_id = "${module.topology.bootstrap_port_id}"
+  lb_port_id        = "${module.topology.lb_port_id}"
+  master_ips        = "${module.topology.master_ips}"
+  master_port_names = "${module.topology.master_port_names}"
+}
+
+module "bootstrap" {
+  source = "./bootstrap"
+
+  swift_container     = "${openstack_objectstorage_container_v1.container.name}"
+  cluster_name        = "${var.cluster_name}"
+  cluster_id          = "${var.cluster_id}"
+  image_name          = "${var.openstack_base_image}"
+  flavor_name         = "${var.openstack_master_flavor_name}"
+  ignition            = "${var.ignition_bootstrap}"
+  bootstrap_port_id   = "${module.topology.bootstrap_port_id}"
+  service_vm_fixed_ip = "${module.topology.service_vm_fixed_ip}"
 }
 
 module "masters" {
   source = "./masters"
 
-  base_image     = "${var.openstack_base_image}"
-  cluster_id     = "${var.cluster_id}"
-  cluster_name   = "${var.cluster_name}"
-  flavor_name    = "${var.openstack_master_flavor_name}"
-  instance_count = "${var.master_count}"
-  master_sg_ids  = "${concat(var.openstack_master_extra_sg_ids, list(module.topology.master_sg_id))}"
-  subnet_ids     = "${module.topology.master_subnet_ids}"
-  user_data_ign  = "${var.ignition_master}"
+  base_image          = "${var.openstack_base_image}"
+  cluster_id          = "${var.cluster_id}"
+  cluster_name        = "${var.cluster_name}"
+  flavor_name         = "${var.openstack_master_flavor_name}"
+  instance_count      = "${var.master_count}"
+  master_sg_ids       = "${concat(var.openstack_master_extra_sg_ids, list(module.topology.master_sg_id))}"
+  subnet_ids          = "${module.topology.master_subnet_ids}"
+  user_data_ign       = "${var.ignition_master}"
+  service_vm_fixed_ip = "${module.topology.service_vm_fixed_ip}"
 }
 
 # TODO(shadower) add a dns module here

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -7,6 +7,76 @@ data "openstack_compute_flavor_v2" "masters_flavor" {
   name = "${var.flavor_name}"
 }
 
+data "ignition_config" "master_ignition_config" {
+  append {
+    source = "data:text/plain;charset=utf-8;base64,${base64encode(var.user_data_ign)}"
+  }
+
+  files = [
+    "${data.ignition_file.master_ifcfg.id}",
+    "${data.ignition_file.master_hacks_script.id}",
+  ]
+
+  systemd = [
+    "${data.ignition_systemd_unit.master_hacks_service.id}",
+  ]
+}
+
+data "ignition_file" "master_ifcfg" {
+  filesystem = "root"
+  mode       = "420"                                       // 0644
+  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+
+  content {
+    content = <<EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+DNS1="${var.service_vm_fixed_ip}"
+PEERDNS="no"
+NM_CONTROLLED="yes"
+EOF
+  }
+}
+
+data "ignition_file" "master_hacks_script" {
+  filesystem = "root"
+  mode       = "493"           // 0755
+  path       = "/opt/hacks.sh"
+
+  content {
+    content = <<EOF
+#!/usr/bin/env bash
+set -ex
+
+sed -i '/cloud-provider=openstack/d' /etc/systemd/system/kubelet.service
+
+# NOTE(shadower): this is run before kubelet so we don't need to restart it.
+systemctl daemon-reload
+EOF
+  }
+}
+
+data "ignition_systemd_unit" "master_hacks_service" {
+  name = "hacks.service"
+
+  content = <<EOF
+[Unit]
+Description=Run hacks after bootup
+Before=kubelet.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/hacks.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
 resource "openstack_compute_instance_v2" "master_conf" {
   name  = "${var.cluster_name}-master-${count.index}"
   count = "${var.instance_count}"
@@ -14,7 +84,7 @@ resource "openstack_compute_instance_v2" "master_conf" {
   flavor_id       = "${data.openstack_compute_flavor_v2.masters_flavor.id}"
   image_id        = "${data.openstack_images_image_v2.masters_img.id}"
   security_groups = ["${var.master_sg_ids}"]
-  user_data       = "${var.user_data_ign}"
+  user_data       = "${data.ignition_config.master_ignition_config.rendered}"
 
   network = {
     port = "${var.subnet_ids[count.index]}"

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -31,3 +31,7 @@ variable "subnet_ids" {
 variable "user_data_ign" {
   type = "string"
 }
+
+variable "service_vm_fixed_ip" {
+  type = "string"
+}

--- a/data/data/openstack/topology/outputs.tf
+++ b/data/data/openstack/topology/outputs.tf
@@ -1,5 +1,21 @@
+output "lb_port_id" {
+  value = "${openstack_networking_port_v2.lb_port.id}"
+}
+
 output "bootstrap_port_id" {
   value = "${openstack_networking_port_v2.bootstrap_port.id}"
+}
+
+output "master_ips" {
+  value = "${flatten(openstack_networking_port_v2.masters.*.all_fixed_ips)}"
+}
+
+output "master_port_names" {
+  value = "${openstack_networking_port_v2.masters.*.name}"
+}
+
+output "service_vm_fixed_ip" {
+  value = "${openstack_networking_port_v2.lb_port.all_fixed_ips[0]}"
 }
 
 output "master_sg_id" {

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -52,6 +52,19 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
   }
 }
 
+resource "openstack_networking_port_v2" "lb_port" {
+  name = "lb-port"
+
+  admin_state_up     = "true"
+  network_id         = "${openstack_networking_network_v2.openshift-private.id}"
+  security_group_ids = ["${openstack_networking_secgroup_v2.api.id}"]
+  tags               = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+
+  fixed_ip {
+    "subnet_id" = "${openstack_networking_subnet_v2.masters.id}"
+  }
+}
+
 data "openstack_networking_network_v2" "external_network" {
   name     = "${var.external_network}"
   external = true

--- a/data/data/openstack/topology/sg-lb.tf
+++ b/data/data/openstack/topology/sg-lb.tf
@@ -1,21 +1,16 @@
-resource "openstack_networking_secgroup_v2" "mcs" {
-  name = "mcs"
+resource "openstack_networking_secgroup_v2" "api" {
+  name = "api"
   tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
-resource "openstack_networking_secgroup_rule_v2" "mcs_https" {
+resource "openstack_networking_secgroup_rule_v2" "api_mcs" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 49500
   port_range_max    = 49500
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.mcs.id}"
-}
-
-resource "openstack_networking_secgroup_v2" "api" {
-  name = "api"
-  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+  security_group_id = "${openstack_networking_secgroup_v2.api.id}"
 }
 
 resource "openstack_networking_secgroup_rule_v2" "api_https" {
@@ -28,27 +23,32 @@ resource "openstack_networking_secgroup_rule_v2" "api_https" {
   security_group_id = "${openstack_networking_secgroup_v2.api.id}"
 }
 
-resource "openstack_networking_secgroup_v2" "console" {
-  name = "console"
-  tags = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
+resource "openstack_networking_secgroup_rule_v2" "api_ingress_dns_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.api.id}"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "console_http" {
+resource "openstack_networking_secgroup_rule_v2" "api_ingress_dns_tcp" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 80
-  port_range_max    = 80
+  port_range_min    = 53
+  port_range_max    = 53
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.console.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.api.id}"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "console_https" {
+resource "openstack_networking_secgroup_rule_v2" "api_ingress_icmp" {
   direction         = "ingress"
   ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 443
-  port_range_max    = 443
+  protocol          = "icmp"
+  port_range_min    = 0
+  port_range_max    = 0
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.console.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.api.id}"
 }

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -212,13 +212,3 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_services" {
   port_range_max    = 32767
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
-
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_from_console" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 30000
-  port_range_max    = 32767
-  remote_group_id   = "${openstack_networking_secgroup_v2.console.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
-}

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -146,13 +146,3 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services" {
   port_range_max    = 32767
   security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
 }
-
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_from_console" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 30000
-  port_range_max    = 32767
-  remote_group_id   = "${openstack_networking_secgroup_v2.console.id}"
-  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
-}

--- a/docs/dev/openstack-howto.md
+++ b/docs/dev/openstack-howto.md
@@ -1,0 +1,13 @@
+# OpenStack Development Environment
+
+First, see if you have access to an OpenStack cloud that meets the
+[requirements](../user/openstack/README.md).  If so, you may just point the
+installer at that cloud.
+
+If you would like to set up an isolated development environment, you may use a
+bare metal host running CentOS 7.  The following repository includes some
+instructions and scripts to help with creating a single-node OpenStack
+development environment for running the installer.  Please refer to the
+documentation in that repository for further details.
+
+* https://github.com/imain/ocp-doit

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -1,0 +1,58 @@
+# OpenStack Platform Support
+
+Support for launching clusters on OpenStack is **experimental**.
+
+This document discusses the requirements, current expected behavior, and how to
+try out what exists so far.
+
+## OpenStack Requirements
+
+The installer assumes the following about the OpenStack cloud you run against:
+
+* You must create a `clouds.yaml` file with the auth URL and credentials
+    necessary to access the OpenStack cloud you want to use.  Information on
+    this file can be found at
+    https://docs.openstack.org/os-client-config/latest/user/configuration.html
+
+* Swift must be enabled.  The user must have `swiftoperator` permissions and
+  `temp-url` support must be enabled.
+  * `openstack role add --user <user> --project <project> swiftoperator`
+  * `openstack object store account set --property Temp-URL-Key=superkey`
+
+* You may need to increase the security group related quotas from their default
+  values.
+  * For example: `openstack quota set --secgroups 100 --secgroup-rules 1000
+    openshift`
+
+## Current Expected Behavior
+
+As mentioned, OpenStack support is still experimental.  The installer will
+launch a cluster on an isolated tenant network.  To access your cluster, you
+can create a floating IP address and assign it to the load balancer service VM.
+
+* `openstack floating ip create ${EXTERNAL_NETWORK}`
+* `openstack floating ip set --port lb-port ${FLOATING_IP_ADDRESS}`
+
+The service VM also hosts a DNS server that has enough records to bring up the
+cluster.  If you add the `${FLOATING_IP_ADDRESS}` as your first `nameserver`
+entry in `/etc/resolv.conf`, the installer will be able to look up the address
+needed to reach the API.
+
+If you don’t expose the cluster and add a hosts entry, the installer will hang
+trying to reach the API.  However, the cluster should still come up
+successfully within the isolated network.
+
+If you do expose the cluster, the installer should make it far enough along to
+bring up the HA control plane and tear down the bootstrap node.  It will then
+hang waiting for the console to come up.
+
+`DEBUG Still waiting for the console route: the server is currently unable to
+handle the request (get routes.route.openshift.io)`
+
+## Reporting Issues
+
+Please see the [Issue Tracker][issues_openstack] for current known issues.
+Please report a new issue if you do not find an issue related to any trouble
+you’re having.
+
+[issues_openstack]: https://github.com/openshift/installer/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+openstack


### PR DESCRIPTION
OpenStack support is still experimental and requires some hacks to get the cluster up and running.  This patch merges those hacks so that people can get a better experience that are giving it a try.  The service VM is temporary and will be removed before OpenStack is supported.

This PR also includes a doc where we can keep notes on the state of OpenStack support.