### PR TITLE
cmd/openshift-install/create: Drop dead-code "no routes found" error

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -319,7 +319,6 @@ func waitForConsole(ctx context.Context, config *rest.Config, directory string) 
 			if silenceRemaining == 0 {
 				logrus.Debug("Still waiting for the console route...")
 				silenceRemaining = logDownsample
-				err = errors.New("no routes found in openshift-console namespace")
 			}
 		}
 	}, 2*time.Second, consoleRouteContext.Done())


### PR DESCRIPTION
This line is from 4c347524 (#859).  But while the rest of that commit fixed error handling for the no-routes-found case, this line was just dead code.  If we go around the loop again, we immediately clobber `err` [here][1].  And if we fall out of the loop because we've exceeded our timeout, we clobber `err` [here][2].

CC @sallyom.

[1]: https://github.com/openshift/installer/blob/5813f611f9078b15fc917ba51609159925e72823/cmd/openshift-install/create.go#L301
[2]: https://github.com/openshift/installer/blob/5813f611f9078b15fc917ba51609159925e72823/cmd/openshift-install/create.go#L326