### PR TITLE
.github/ISSUE_TEMPLATE: Explicitly mention .openshift_install.log

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -24,6 +24,7 @@ Enter text here.
 
 Enter text here.
 See [the troubleshooting documentation](https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md) for ideas about what information to collect.
+For example, if the installer [fails to create resources](https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md#installer-fails-to-create-resources), attach the relevant portions of your `.openshift_install.log`.
 
 # What you expected to happen?
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /bin/
-.openshift-install.log
+.openshift_install.log

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -88,7 +88,7 @@ This is safe to ignore and merely indicates that the etcd bootstrapping is still
 
 ### Installer Fails to Create Resources
 
-The easiest way to get more debugging information from the installer is to check the log file (`.openshift-install.log`) in the install directory. Regardless of the logging level specified, the installer will write its logs in case they need to be inspected retroactively.
+The easiest way to get more debugging information from the installer is to check the log file (`.openshift_install.log`) in the install directory. Regardless of the logging level specified, the installer will write its logs in case they need to be inspected retroactively.
 
 ## Generic Troubleshooting
 


### PR DESCRIPTION
We're still getting issue reports about installer crashes that attempt to summarize the issue but do not include copies of the actual error messages.  While summaries can be accurate, they're usually not much more compact than a copy/paste of the errors from the logs, and it's a lot easier to find existing reports for a given error if those reports include the error you're looking for.

Also fix some `.openshift-install.log` -> `.openshift_install.log` typos from #689.

CC @crawford