### PR TITLE
Add LB and DNS (service) vm

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -12,9 +12,31 @@ resource "openstack_objectstorage_tempurl_v1" "ignition_tmpurl" {
 }
 
 data "ignition_config" "redirect" {
-  replace {
+  append {
     source = "${openstack_objectstorage_tempurl_v1.ignition_tmpurl.url}"
   }
+
+  files = [
+    "${data.ignition_file.bootstrap_ifcfg.id}",
+  ]
+}
+
+data "ignition_file" "bootstrap_ifcfg" {
+    filesystem = "root"
+    mode = "420"  // 0644
+    path = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+    content {
+      content = <<EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+DNS1="${var.service_vm_fixed_ip}"
+PEERDNS="no"
+NM_CONTROLLED="yes"
+EOF
+    }
 }
 
 data "openstack_images_image_v2" "bootstrap_image" {

--- a/data/data/openstack/lb/main.tf
+++ b/data/data/openstack/lb/main.tf
@@ -1,0 +1,120 @@
+data "openstack_images_image_v2" "bootstrap_image" {
+  name        = "${var.image_name}"
+  most_recent = true
+}
+
+data "openstack_compute_flavor_v2" "bootstrap_flavor" {
+  name = "${var.flavor_name}"
+}
+
+data "ignition_systemd_unit" "haproxy_unit" {
+    name = "bootkube-haproxy.service"
+    enabled = true
+    content = <<EOF
+[Unit]
+Description=Load balancer for the OpenShift services
+
+[Service]
+ExecStartPre=/sbin/setenforce 0
+ExecStart=/bin/podman run --name haproxy --rm -ti --net=host -v /etc/haproxy:/usr/local/etc/haproxy:ro docker.io/library/haproxy:1.7
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+data "ignition_file" "haproxy_conf" {
+    filesystem = "root"
+    path = "/etc/haproxy/haproxy.cfg"
+    source {
+      source = "data:,listen%20ostest-api-80%0D%0A%20%20%20%20bind%200.0.0.0%3A80%0D%0A%20%20%20%20mode%20tcp%0D%0A%20%20%20%20stats%20enable%0D%0A%20%20%20%20stats%20uri%20%2Fhaproxy%3Fstatus%0D%0A%20%20%20%20balance%20roundrobin%0D%0A%20%20%20%20server%20ostest-bootstrap%20ostest-bootstrap.shiftstack.com%3A80%20check%0D%0A%20%20%20%20server%20ostest-master-0%20ostest-master-0.shiftstack.com%3A80%20check%0D%0A%20%20%20%20server%20ostest-master-1%20ostest-master-1.shiftstack.com%3A80%20check%0D%0A%20%20%20%20server%20ostest-master-2%20ostest-master-2.shiftstack.com%3A80%20check%0D%0A%0D%0Alisten%20ostest-api-6443%0D%0A%20%20%20%20bind%200.0.0.0%3A6443%0D%0A%20%20%20%20mode%20tcp%0D%0A%20%20%20%20stats%20enable%0D%0A%20%20%20%20stats%20uri%20%2Fhaproxy%3Fstatus%0D%0A%20%20%20%20balance%20roundrobin%0D%0A%20%20%20%20server%20ostest-bootstrap%20ostest-bootstrap.shiftstack.com%3A6443%20check%0D%0A%20%20%20%20server%20ostest-master-0%20ostest-master-0.shiftstack.com%3A6443%20check%0D%0A%20%20%20%20server%20ostest-master-1%20ostest-master-1.shiftstack.com%3A6443%20check%0D%0A%20%20%20%20server%20ostest-master-2%20ostest-master-2.shiftstack.com%3A6443%20check%0D%0A%0D%0Alisten%20ostest-api-443%0D%0A%20%20%20%20bind%200.0.0.0%3A443%0D%0A%20%20%20%20mode%20tcp%0D%0A%20%20%20%20stats%20enable%0D%0A%20%20%20%20stats%20uri%20%2Fhaproxy%3Fstatus%0D%0A%20%20%20%20balance%20roundrobin%0D%0A%20%20%20%20server%20ostest-bootstrap%20ostest-bootstrap.shiftstack.com%3A443%20check%0D%0A%20%20%20%20server%20ostest-master-0%20ostest-master-0.shiftstack.com%3A443%20check%0D%0A%20%20%20%20server%20ostest-master-1%20ostest-master-1.shiftstack.com%3A443%20check%0D%0A%20%20%20%20server%20ostest-master-2%20ostest-master-2.shiftstack.com%3A443%20check%0D%0A%0D%0Alisten%20ostest-api-49500%0D%0A%20%20%20%20bind%200.0.0.0%3A49500%0D%0A%20%20%20%20mode%20tcp%0D%0A%20%20%20%20stats%20enable%0D%0A%20%20%20%20stats%20uri%20%2Fhaproxy%3Fstatus%0D%0A%20%20%20%20balance%20roundrobin%0D%0A%20%20%20%20server%20ostest-bootstrap%20ostest-bootstrap.shiftstack.com%3A49500%20check%0D%0A%20%20%20%20server%20ostest-master-0%20ostest-master-0.shiftstack.com%3A49500%20check%0D%0A%20%20%20%20server%20ostest-master-1%20ostest-master-1.shiftstack.com%3A49500%20check%0D%0A%20%20%20%20server%20ostest-master-2%20ostest-master-2.shiftstack.com%3A49500%20check"
+    }
+}
+
+data "ignition_file" "openshift_hosts" {
+  filesystem = "root"
+  mode = "420"  // 0644
+  path = "/etc/openshift-hosts"
+  content {
+    content = <<EOF
+${replace(join("\n", formatlist("%s ${var.cluster_name}-etcd-%s.${var.cluster_domain}", var.master_ips, var.master_port_names)), "master-port-", "")}
+EOF
+  }
+}
+
+data "ignition_systemd_unit" "local_dns" {
+    name = "local-dns.service"
+      content = <<EOF
+[Unit]
+Description=Internal DNS server for running OpenShift on OpenStack
+
+[Service]
+ExecStart=/bin/podman run --name bootstrap-dns --rm -t -i -p 53:53/tcp -p 53:53/udp -v /etc/openshift-hosts:/etc/openshift-hosts:z --cap-add=NET_ADMIN docker.io/andyshinn/dnsmasq:latest --keep-in-foreground --log-facility=- --log-queries --no-resolv --addn-hosts=/etc/openshift-hosts --server=10.0.0.2 ${replace(join(" ", formatlist("--srv-host=_etcd-server-ssl._tcp.${var.cluster_name}.${var.cluster_domain},${var.cluster_name}-etcd-%s.${var.cluster_domain},2380,0,10", var.master_port_names)), "master-port-", "")}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+data "ignition_user" "core" {
+    name = "core"
+    ssh_authorized_keys = [
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDX0EAM8x9uTjYWD+yZolNDuFxDbmy1cpmDOecL7+SxwoI84LuAGQnwxFofpnmKpNa6XQlYi1OSY2NQmMhrp8dl4e7+utc7ShqjFvTXBsHtQAOsboAWq7vL6fgwwEADUiWi+aERhtNJHjOz1EPOyN40M9yEui9I3SQnOQBFPmjMhFpy561m2qDs8LyoB3XMsmkRKmrLsTmYWWtf3abMsVfPjsZfN87oKJBQbYrfvOXoQ3wOa/IXvmCB2rf360LlHh0WiV1xFLggFdj659/huoPGs2B58op7Cep1YHprBvZTivetnGYhQWbha4WUh9UzLJtvxdG5mHzPRZcg71yeH8dv root@localhost.localdomain"
+    ]
+}
+
+data "ignition_config" "config" {
+  files = [
+    "${data.ignition_file.haproxy_conf.id}",
+    "${data.ignition_file.openshift_hosts.id}",
+  ]
+
+  systemd = [
+      "${data.ignition_systemd_unit.haproxy_unit.id}",
+      "${data.ignition_systemd_unit.local_dns.id}",
+  ]
+
+  users = [
+      "${data.ignition_user.core.id}",
+  ]
+}
+
+resource "openstack_objectstorage_object_v1" "lb_ignition" {
+  container_name = "${var.swift_container}"
+  name           = "load-balancer.ign"
+  content        = "${data.ignition_config.config.rendered}"
+}
+
+resource "openstack_objectstorage_tempurl_v1" "lb_ignition_tmpurl" {
+  container = "${var.swift_container}"
+  method    = "get"
+  object    = "${openstack_objectstorage_object_v1.lb_ignition.name}"
+  ttl       = 3600
+}
+
+data "ignition_config" "lb_redirect" {
+  replace {
+    source = "${openstack_objectstorage_tempurl_v1.lb_ignition_tmpurl.url}"
+  }
+}
+
+resource "openstack_compute_instance_v2" "load_balancer" {
+  name      = "${var.cluster_name}-api"
+  flavor_id = "${data.openstack_compute_flavor_v2.bootstrap_flavor.id}"
+  image_id  = "${data.openstack_images_image_v2.bootstrap_image.id}"
+
+  user_data = "${data.ignition_config.lb_redirect.rendered}"
+
+  network {
+    port = "${var.lb_port_id}"
+  }
+
+  metadata {
+    Name = "${var.cluster_name}-bootstrap"
+
+    # "kubernetes.io/cluster/${var.cluster_name}" = "owned"
+    tectonicClusterID = "${var.cluster_id}"
+  }
+}

--- a/data/data/openstack/lb/variables.tf
+++ b/data/data/openstack/lb/variables.tf
@@ -17,6 +17,11 @@ variable "cluster_id" {
   type = "string"
 }
 
+variable "cluster_domain" {
+  type        = "string"
+  description = "The domain name of the cluster."
+}
+
 variable "ignition" {
   type        = "string"
   description = "The content of the bootstrap ignition file."
@@ -28,11 +33,15 @@ variable "flavor_name" {
   description = "The Nova flavor for the bootstrap node."
 }
 
-variable "bootstrap_port_id" {
+variable "lb_port_id" {
   type        = "string"
   description = "The subnet ID for the bootstrap node."
 }
 
-variable "service_vm_fixed_ip" {
-  type = "string"
+variable "master_ips" {
+  type = "list"
+}
+
+variable "master_port_names" {
+  type = "list"
 }

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -24,6 +24,21 @@ provider "openstack" {
   version             = ">=1.6.0"
 }
 
+module "lb" {
+  source = "./lb"
+
+  swift_container   = "${openstack_objectstorage_container_v1.container.name}"
+  cluster_name      = "${var.cluster_name}"
+  cluster_id        = "${var.cluster_id}"
+  cluster_domain    = "${var.base_domain}"
+  image_name        = "${var.openstack_base_image}"
+  flavor_name       = "${var.openstack_master_flavor_name}"
+  ignition          = "${var.ignition_bootstrap}"
+  lb_port_id        = "${module.topology.lb_port_id}"
+  master_ips        = "${module.topology.master_ips}"
+  master_port_names = "${module.topology.master_port_names}"
+}
+
 module "bootstrap" {
   source = "./bootstrap"
 
@@ -34,6 +49,7 @@ module "bootstrap" {
   flavor_name       = "${var.openstack_master_flavor_name}"
   ignition          = "${var.ignition_bootstrap}"
   bootstrap_port_id = "${module.topology.bootstrap_port_id}"
+  service_vm_fixed_ip = "${module.topology.service_vm_fixed_ip}"
 }
 
 module "masters" {
@@ -47,6 +63,7 @@ module "masters" {
   master_sg_ids  = "${concat(var.openstack_master_extra_sg_ids, list(module.topology.master_sg_id))}"
   subnet_ids     = "${module.topology.master_subnet_ids}"
   user_data_ign  = "${var.ignition_master}"
+  service_vm_fixed_ip = "${module.topology.service_vm_fixed_ip}"
 }
 
 # TODO(shadower) add a dns module here

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -7,6 +7,73 @@ data "openstack_compute_flavor_v2" "masters_flavor" {
   name = "${var.flavor_name}"
 }
 
+data "ignition_config" "master_ignition_config" {
+  append {
+    source = "data:text/plain;charset=utf-8;base64,${base64encode(var.user_data_ign)}"
+  }
+
+  files = [
+    "${data.ignition_file.master_ifcfg.id}",
+    "${data.ignition_file.master_hacks_script.id}",
+  ]
+
+  systemd = [
+    "${data.ignition_systemd_unit.master_hacks_service.id}",
+  ]
+}
+
+data "ignition_file" "master_ifcfg" {
+    filesystem = "root"
+    mode = "420"  // 0644
+    path = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+    content {
+      content = <<EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+DNS1="${var.service_vm_fixed_ip}"
+PEERDNS="no"
+NM_CONTROLLED="yes"
+EOF
+    }
+}
+
+data "ignition_file" "master_hacks_script" {
+    filesystem = "root"
+    mode = "493"  // 0755
+    path = "/opt/hacks.sh"
+    content {
+      content = <<EOF
+#!/usr/bin/env bash
+set -ex
+
+sed -i '/cloud-provider=openstack/d' /etc/systemd/system/kubelet.service
+
+# NOTE(shadower): this is run before kubelet so we don't need to restart it.
+systemctl daemon-reload
+EOF
+    }
+}
+
+data "ignition_systemd_unit" "master_hacks_service" {
+    name = "hacks.service"
+      content = <<EOF
+[Unit]
+Description=Run hacks after bootup
+Before=kubelet.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/hacks.sh
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
 resource "openstack_compute_instance_v2" "master_conf" {
   name  = "${var.cluster_name}-master-${count.index}"
   count = "${var.instance_count}"
@@ -14,11 +81,16 @@ resource "openstack_compute_instance_v2" "master_conf" {
   flavor_id       = "${data.openstack_compute_flavor_v2.masters_flavor.id}"
   image_id        = "${data.openstack_images_image_v2.masters_img.id}"
   security_groups = ["${var.master_sg_ids}"]
-  user_data       = "${var.user_data_ign}"
+  user_data       = "${data.ignition_config.master_ignition_config.rendered}"
 
   network = {
     port = "${var.subnet_ids[count.index]}"
   }
+
+  #network = {
+  #  name = "openshift"
+  #  fixed_ip_v4 = "10.3.0.${count.index == 0? 1: count.index + 2}"
+  #}
 
   metadata {
     Name               = "${var.cluster_name}-master"

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -31,3 +31,7 @@ variable "subnet_ids" {
 variable "user_data_ign" {
   type = "string"
 }
+
+variable "service_vm_fixed_ip" {
+  type = "string"
+}

--- a/data/data/openstack/topology/outputs.tf
+++ b/data/data/openstack/topology/outputs.tf
@@ -1,5 +1,21 @@
+output "lb_port_id" {
+  value = "${openstack_networking_port_v2.lb_port.id}"
+}
+
 output "bootstrap_port_id" {
   value = "${openstack_networking_port_v2.bootstrap_port.id}"
+}
+
+output "master_ips" {
+  value = "${flatten(openstack_networking_port_v2.masters.*.all_fixed_ips)}"
+}
+
+output "master_port_names" {
+  value = "${openstack_networking_port_v2.masters.*.name}"
+}
+
+output "service_vm_fixed_ip" {
+  value = "${openstack_networking_port_v2.lb_port.all_fixed_ips[0]}"
 }
 
 output "master_sg_id" {

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -9,6 +9,16 @@ resource "openstack_networking_network_v2" "openshift-private" {
   tags           = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
 
+#resource "openstack_networking_subnet_v2" "service" {
+#  name        = "service"
+#  cidr        = "10.3.0.0/17"
+#  ip_version  = 4
+#  enable_dhcp = "true"
+#  gateway_ip  = "10.3.0.254"
+#  network_id  = "${openstack_networking_network_v2.openshift-private.id}"
+#  tags        = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+#}
+
 resource "openstack_networking_subnet_v2" "masters" {
   name       = "masters"
   cidr       = "${local.new_master_cidr_range}"
@@ -24,6 +34,35 @@ resource "openstack_networking_subnet_v2" "workers" {
   network_id = "${openstack_networking_network_v2.openshift-private.id}"
   tags       = ["tectonicClusterID=${var.cluster_id}", "openshiftClusterID=${var.cluster_id}"]
 }
+
+#resource "openstack_networking_port_v2" "api_service_port" {
+#  name  = "api-service-port-${count.index}"
+#  count = "${var.masters_count}"
+#
+#  admin_state_up     = "true"
+#  network_id         = "${openstack_networking_network_v2.openshift-private.id}"
+#  security_group_ids = ["${openstack_networking_secgroup_v2.master.id}"]
+#  tags               = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+#
+#  fixed_ip {
+#    "subnet_id" = "${openstack_networking_subnet_v2.service.id}"
+#    "ip_address" = "10.3.0.${count.index+1}"
+#  }
+#}
+
+#resource "openstack_networking_port_v2" "api_service_router_port" {
+#  name  = "api-service-router-port"
+#
+#  admin_state_up     = "true"
+#  network_id         = "${openstack_networking_network_v2.openshift-private.id}"
+#  security_group_ids = ["${openstack_networking_secgroup_v2.master.id}"]
+#  tags               = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+#
+#  fixed_ip {
+#    "subnet_id" = "${openstack_networking_subnet_v2.service.id}"
+#    "ip_address" = "10.3.0.253"
+#  }
+#}
 
 resource "openstack_networking_port_v2" "masters" {
   name  = "master-port-${count.index}"
@@ -52,6 +91,19 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
   }
 }
 
+resource "openstack_networking_port_v2" "lb_port" {
+  name = "lb-port"
+
+  admin_state_up     = "true"
+  network_id         = "${openstack_networking_network_v2.openshift-private.id}"
+  security_group_ids = ["${openstack_networking_secgroup_v2.master.id}"]
+  tags               = ["${format("tectonicClusterID=%s", var.cluster_id)}"]
+
+  fixed_ip {
+    "subnet_id" = "${openstack_networking_subnet_v2.masters.id}"
+  }
+}
+
 data "openstack_networking_network_v2" "external_network" {
   name     = "${var.external_network}"
   external = true
@@ -73,3 +125,8 @@ resource "openstack_networking_router_interface_v2" "workers_router_interface" {
   router_id = "${openstack_networking_router_v2.openshift-external-router.id}"
   subnet_id = "${openstack_networking_subnet_v2.workers.id}"
 }
+
+#resource "openstack_networking_router_interface_v2" "service_router_interface" {
+#  router_id = "${openstack_networking_router_v2.openshift-external-router.id}"
+#  port_id = "${openstack_networking_port_v2.api_service_router_port.id}"
+#}

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -222,3 +222,24 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_from_c
   remote_group_id   = "${openstack_networking_secgroup_v2.console.id}"
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
+
+# NOTE(shadower): open up DNS SG on the bootstrap node so the masters can talk to it
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_tcp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}


### PR DESCRIPTION
We're adding a service VM to support 2, work in progress, features in the OpenStack platform architecture. This VM runs 2 pods: A dnsmasq one and an haproxy one.

The dnsmasq pod has been configured to serve the ETCD A and SRV records on the service VM, forwards requests to Neutron DNS and configures the bootstrap and master servers to use it.

The haproxy pod has been configured to serve requests for the `api` hostname that the installer depends on.

This VM is not meant to be put in production but rather allow for development to progress while the final architecture implementations for these 2 services are finished.

/cc @tomassedovic 
/assign @russellb @hardys 