### PR TITLE
OpenStack Destroy, tolerate temporary router delete failure

### DIFF
--- a/pkg/destroy/openstack/openstack_deprovision.go
+++ b/pkg/destroy/openstack/openstack_deprovision.go
@@ -335,8 +335,8 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 		logger.Debugf("Deleting Router: %+v\n", router.ID)
 		err = routers.Delete(conn, router.ID).ExtractErr()
 		if err != nil {
-			logger.Fatalf("%v", err)
-			os.Exit(1)
+			// This can fail when port is still in use
+			return false, nil
 		}
 	}
 	return len(allRouters) == 0, nil


### PR DESCRIPTION
As reported in issue #891 this can fail until assigned ports
are deleted, so return such that a deletion may be re-tried.

Closes: #891