### PR TITLE
OpenStack Destroy, break after matching swift container metadata

### DIFF
--- a/pkg/destroy/openstack/openstack_deprovision.go
+++ b/pkg/destroy/openstack/openstack_deprovision.go
@@ -472,6 +472,8 @@ func deleteContainers(opts *clientconfig.ClientOpts, filter Filter, logger logru
 					logger.Fatalf("%v", err)
 					os.Exit(1)
 				}
+				// If a metadata key matched, we're done so break from the loop
+				break
 			}
 		}
 	}


### PR DESCRIPTION
This worked previously since we only had one tag in the filter
but since we added both via #817 we exposed a bug which is we
should break after matching any key since we've deleted the
things and don't need to iterate over the filter keys anymore.