### PR TITLE
docs: include `dep version` command in Go section

### DIFF
--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -20,7 +20,8 @@ Dependencies are managed with [dep](https://golang.github.io/dep/) but committed
 
 We require atleast following version for dep:
 
-```
+```console
+$ dep version
 dep:
  version     : v0.5.0
  build date  : 2018-07-26


### PR DESCRIPTION
The original fix was from [here](https://github.com/openshift/installer/pull/808/files#diff-eaa921eb2eb55c28750c89b6461e4d23R24)

/cc @wking  