### PR TITLE
Revert "OpenStack Destroy, tolerate temporary router delete failure"

### DIFF
--- a/pkg/destroy/openstack/openstack_deprovision.go
+++ b/pkg/destroy/openstack/openstack_deprovision.go
@@ -335,8 +335,8 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 		logger.Debugf("Deleting Router: %+v\n", router.ID)
 		err = routers.Delete(conn, router.ID).ExtractErr()
 		if err != nil {
-			// This can fail when port is still in use
-			return false, nil
+			logger.Fatalf("%v", err)
+			os.Exit(1)
 		}
 	}
 	return len(allRouters) == 0, nil


### PR DESCRIPTION
As reported in #891 this is not the right fix and can result in a
loop if the router delete fails.  Instead we need to remove interfaces
from the router before attempting deletion.  For now revert the
incorrect fix and I'll push a follow-up with revised solution
pending further local testing.

Related: #891

This reverts commit fb73b45ca90d9ffe5d2428841444580a039c2614.