### PR TITLE
asset/ignition: fix error when marshaling ignition config

### DIFF
--- a/pkg/asset/ignition/machine/master.go
+++ b/pkg/asset/ignition/machine/master.go
@@ -42,7 +42,7 @@ func (a *Master) Generate(dependencies asset.Parents) error {
 
 	data, err := json.Marshal(a.Config)
 	if err != nil {
-		return errors.Wrap(err, "failed to get InstallConfig from parents")
+		return errors.Wrap(err, "failed to marshal Ignition config")
 	}
 	a.File = &asset.File{
 		Filename: masterIgnFilename,

--- a/pkg/asset/ignition/machine/worker.go
+++ b/pkg/asset/ignition/machine/worker.go
@@ -42,7 +42,7 @@ func (a *Worker) Generate(dependencies asset.Parents) error {
 
 	data, err := json.Marshal(a.Config)
 	if err != nil {
-		return errors.Wrap(err, "failed to get InstallConfig from parents")
+		return errors.Wrap(err, "failed to marshal Ignition config")
 	}
 	a.File = &asset.File{
 		Filename: workerIgnFilename,


### PR DESCRIPTION
The error returned when there is an error marshaling the ignition config for masters and workers indicated that there was a problem loading the install config. This fixes the error to state that there was a problem marshaling the ignition config.