### PR TITLE
pkg/asset/machines/aws/machinesets: Give workers public IPs (for now)

### DIFF
--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -6,6 +6,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
 	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/openshift/installer/pkg/types"
@@ -87,4 +89,15 @@ func MachineSets(config *types.InstallConfig, pool *types.MachinePool, role, use
 	}
 
 	return machinesets, nil
+}
+
+// ConfigWorkers sets the PublicIP flag for the given machine sets.
+//
+// Deprecated: We'll remove this once the e2e tests no longer require
+// worker SSH access.
+func ConfigWorkers(machineSets []clusterapi.MachineSet) {
+	for _, machineSet := range machineSets {
+		providerConfig := machineSet.Spec.Template.Spec.ProviderConfig.Value.Object.(*awsprovider.AWSMachineProviderConfig)
+		providerConfig.PublicIP = pointer.BoolPtr(true)
+	}
 }

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -100,6 +100,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create worker machine objects")
 		}
+		aws.ConfigWorkers(sets)
 
 		list := listFromMachineSets(sets)
 		raw, err := yaml.Marshal(list)


### PR DESCRIPTION
Workers have not had public IPs since (at least) we moved them to cluster-API creation in e2dc9550 (#468).  But it turns out a number of e2e tests assume SSH access to workers (e.g. [here][1]), and we don't have time to fix those tests now.  We'll remove this once the tests have been fixed.

CC @abhinavdahiya, @crawford, @smarterclayton

[1]: https://github.com/kubernetes/kubernetes/blob/v1.13.1/test/e2e/node/ssh.go#L43