### PR TITLE
data/aws/route53: Drop unused public worker A records

### DIFF
--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -13,12 +13,6 @@ variable "master_count" {
   type        = "string"
 }
 
-variable "worker_count" {
-  description = "The number of workers"
-  type        = "string"
-  default     = "0"
-}
-
 variable "master_ip_addresses" {
   description = "List of string IPs for masters"
   type        = "list"
@@ -29,18 +23,6 @@ variable "worker_ip_addresses" {
   description = "List of string IPs for workers"
   type        = "list"
   default     = []
-}
-
-variable "worker_public_ips" {
-  description = "(optional) List of string public IPs for workers"
-  type        = "list"
-  default     = []
-}
-
-// hack: worker_public_ips_enabled is a workaround for https://github.com/hashicorp/terraform/issues/10857
-variable "worker_public_ips_enabled" {
-  description = "Worker nodes have public IPs assigned. worker_public_ips must be provided if true."
-  default     = true
 }
 
 variable "extra_tags" {

--- a/data/data/aws/route53/worker.tf
+++ b/data/data/aws/route53/worker.tf
@@ -1,9 +1,0 @@
-resource "aws_route53_record" "worker_nodes_public" {
-  // hack: worker_public_ips_enabled is a workaround for https://github.com/hashicorp/terraform/issues/10857
-  count   = "${var.worker_public_ips_enabled ? var.worker_count : 0}"
-  zone_id = "${data.aws_route53_zone.base.zone_id}"
-  name    = "${var.cluster_name}-worker-${count.index}-public"
-  type    = "A"
-  ttl     = "60"
-  records = ["${var.worker_public_ips[count.index]}"]
-}


### PR DESCRIPTION
This code was added in 7cde4de2 (coreos/tectonic-installer#1875), but seems to only ever have been used on OpenStack.