### PR TITLE
Gopkg: Lock aws/request

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -836,6 +836,7 @@
     "github.com/aws/aws-sdk-go/aws/awserr",
     "github.com/aws/aws-sdk-go/aws/credentials",
     "github.com/aws/aws-sdk-go/aws/defaults",
+    "github.com/aws/aws-sdk-go/aws/request",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/autoscaling",
     "github.com/aws/aws-sdk-go/service/ec2",


### PR DESCRIPTION
Generated with:

```console
$ dep ensure
```

I hadn't realized I'd need this after 6447e9c4 (#940) added a direct consumer of this package.