### PR TITLE
pkg/types/aws/validation: Move ValidRegions into this package

### DIFF
--- a/pkg/asset/installconfig/aws/aws.go
+++ b/pkg/asset/installconfig/aws/aws.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/aws/validation"
 )
 
 var (
@@ -26,9 +27,9 @@ var (
 
 // Platform collects AWS-specific configuration.
 func Platform() (*aws.Platform, error) {
-	longRegions := make([]string, 0, len(aws.ValidRegions))
-	shortRegions := make([]string, 0, len(aws.ValidRegions))
-	for id, location := range aws.ValidRegions {
+	longRegions := make([]string, 0, len(validation.Regions))
+	shortRegions := make([]string, 0, len(validation.Regions))
+	for id, location := range validation.Regions {
 		longRegions = append(longRegions, fmt.Sprintf("%s (%s)", id, location))
 		shortRegions = append(shortRegions, id)
 	}
@@ -37,7 +38,7 @@ func Platform() (*aws.Platform, error) {
 	})
 
 	defaultRegion := "us-east-1"
-	_, ok := aws.ValidRegions[defaultRegion]
+	_, ok := validation.Regions[defaultRegion]
 	if !ok {
 		panic(fmt.Sprintf("installer bug: invalid default AWS region %q", defaultRegion))
 	}
@@ -59,7 +60,7 @@ func Platform() (*aws.Platform, error) {
 
 	defaultRegionPointer := ssn.Config.Region
 	if defaultRegionPointer != nil && *defaultRegionPointer != "" {
-		_, ok := aws.ValidRegions[*defaultRegionPointer]
+		_, ok := validation.Regions[*defaultRegionPointer]
 		if ok {
 			defaultRegion = *defaultRegionPointer
 		} else {
@@ -76,7 +77,7 @@ func Platform() (*aws.Platform, error) {
 			Prompt: &survey.Select{
 				Message: "Region",
 				Help:    "The AWS region to be used for installation.",
-				Default: fmt.Sprintf("%s (%s)", defaultRegion, aws.ValidRegions[defaultRegion]),
+				Default: fmt.Sprintf("%s (%s)", defaultRegion, validation.Regions[defaultRegion]),
 				Options: longRegions,
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -4,32 +4,6 @@ import (
 	"github.com/openshift/installer/pkg/ipnet"
 )
 
-var (
-	// ValidRegions is a map of the known AWS regions. The key of the map is
-	// the short name of the region. The value of the map is the long name of
-	// the region.
-	ValidRegions = map[string]string{
-		"ap-northeast-1": "Tokyo",
-		"ap-northeast-2": "Seoul",
-		"ap-northeast-3": "Osaka-Local",
-		"ap-south-1":     "Mumbai",
-		"ap-southeast-1": "Singapore",
-		"ap-southeast-2": "Sydney",
-		"ca-central-1":   "Central",
-		"cn-north-1":     "Beijing",
-		"cn-northwest-1": "Ningxia",
-		"eu-central-1":   "Frankfurt",
-		"eu-west-1":      "Ireland",
-		"eu-west-2":      "London",
-		"eu-west-3":      "Paris",
-		"sa-east-1":      "São Paulo",
-		"us-east-1":      "N. Virginia",
-		"us-east-2":      "Ohio",
-		"us-west-1":      "N. California",
-		"us-west-2":      "Oregon",
-	}
-)
-
 // Platform stores all the global configuration that all machinesets
 // use.
 type Platform struct {

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -8,10 +8,34 @@ import (
 )
 
 var (
+	// Regions is a map of the known AWS regions. The key of the map is
+	// the short name of the region. The value of the map is the long
+	// name of the region.
+	Regions = map[string]string{
+		"ap-northeast-1": "Tokyo",
+		"ap-northeast-2": "Seoul",
+		"ap-northeast-3": "Osaka-Local",
+		"ap-south-1":     "Mumbai",
+		"ap-southeast-1": "Singapore",
+		"ap-southeast-2": "Sydney",
+		"ca-central-1":   "Central",
+		"cn-north-1":     "Beijing",
+		"cn-northwest-1": "Ningxia",
+		"eu-central-1":   "Frankfurt",
+		"eu-west-1":      "Ireland",
+		"eu-west-2":      "London",
+		"eu-west-3":      "Paris",
+		"sa-east-1":      "São Paulo",
+		"us-east-1":      "N. Virginia",
+		"us-east-2":      "Ohio",
+		"us-west-1":      "N. California",
+		"us-west-2":      "Oregon",
+	}
+
 	validRegionValues = func() []string {
-		validValues := make([]string, len(aws.ValidRegions))
+		validValues := make([]string, len(Regions))
 		i := 0
-		for r := range aws.ValidRegions {
+		for r := range Regions {
 			validValues[i] = r
 			i++
 		}
@@ -22,7 +46,7 @@ var (
 // ValidatePlatform checks that the specified platform is valid.
 func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if _, ok := aws.ValidRegions[p.Region]; !ok {
+	if _, ok := Regions[p.Region]; !ok {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("region"), p.Region, validRegionValues))
 	}
 	if p.DefaultMachinePlatform != nil {


### PR DESCRIPTION
And rename to `Regions`, since the target package is already about validation.  `ValidRegions` was added to the aws package in b2d6fa40 (#711), but it's just used for validation and it isn't a type defintion.

CC @staebler