### PR TITLE
increase wait for console route (for libvirt)

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -288,7 +288,7 @@ func waitForConsole(ctx context.Context, config *rest.Config, directory string) 
 		return "", errors.Wrap(err, "creating a route client")
 	}
 
-	consoleRouteTimeout := 10 * time.Minute
+	consoleRouteTimeout := 20 * time.Minute
 	logrus.Infof("Waiting up to %v for the openshift-console route to be created...", consoleRouteTimeout)
 	consoleRouteContext, cancel := context.WithTimeout(ctx, consoleRouteTimeout)
 	defer cancel()


### PR DESCRIPTION
This PR increases the wait timeout from 10 minutes to 20 minutes for the console route post-install.

@wking I've been seeing this timeout when installing with libvirt, pretty consistently.  