### PR TITLE
data/data/aws: use vpc configuration block for route53 zone `int`

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -96,9 +96,12 @@ resource "aws_route53_record" "etcd_cluster" {
 }
 
 resource "aws_route53_zone" "int" {
-  vpc_id        = "${module.vpc.vpc_id}"
   name          = "${var.base_domain}"
   force_destroy = true
+
+  vpc {
+    vpc_id = "${module.vpc.vpc_id}"
+  }
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}_int",


### PR DESCRIPTION
Seeing this error when running on AWS.
```console
ERROR
ERROR Warning: aws_route53_zone.int: "vpc_id": [DEPRECATED] use 'vpc' attribute instead
ERROR
ERROR
```

https://www.terraform.io/docs/providers/aws/r/route53_zone.html#vpc_id states the `vpc_id` field is deprecated.
here are the fields supported by `vpc` configuration block https://github.com/terraform-providers/terraform-provider-aws/blob/v1.51.0/aws/resource_aws_route53_zone.go#L43

Fixes #950 
at least the cause ;)

/cc @wking 