### PR TITLE
libvirt-howto: reload NetworkManager for dns configuration changes

### DIFF
--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -196,7 +196,7 @@ This step allows installer and users to resolve cluster-internal hostnames from 
     ```sh
     echo server=/tt.testing/192.168.126.1 | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
     ```
-3. `systemctl restart NetworkManager`
+3. Reload NetworkManager to pick up the `dns` configuration change: `sudo systemctl reload NetworkManager`
 
 
 ## Build and run the installer


### PR DESCRIPTION
NM has been able to switch DNS plugins on the fly for years. Quoting from the NM manpage:

```
       SIGHUP
           The signal causes a reload of NetworkManager's configuration. Note that not all configuration parameters can be changed at runtime and therefore some changes may be applied only after the next
           restart of the daemon. A SIGHUP also involves further reloading actions, like doing a DNS update and restarting the DNS plugin. The latter can be useful for example when using the dnsmasq plugin
           and changing its configuration in /etc/NetworkManager/dnsmasq.d. However, it also means this will shortly interrupt name resolution. In the future, there may be further actions added. A SIGHUP
           means to update NetworkManager configuration and reload everything that is supported. Note that this does not reload connections from disk. For that there is a D-Bus API and nmcli's reload
           action
```