### PR TITLE
pkg/terraform/exec/plugins/vendor: Roll back libvirt to 2ad0228349

### DIFF
--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -199,12 +199,11 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:ca3102cf764b03e3a79f7cc0762567ea29f8f65959c7f5d20c15f795287506ee"
+  digest = "1:e101085bd88d5999c0cc346c222d4afb3aebc169c23f3126fa8987fb92badaec"
   name = "github.com/dmacvicar/terraform-provider-libvirt"
   packages = ["libvirt"]
   pruneopts = "NUT"
-  revision = "d5e60df0007a7f861af6e0282a4c1b3f9be3da23"
-  version = "v0.5.1"
+  revision = "2ad0228349b2d3b487a2ada25d1a0eb40d73b7d1"
 
 [[projects]]
   digest = "1:54d36727a1d852a38be8b8dbcfbae6aa99130d793d63dabc865f150b690144af"

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -10,7 +10,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/dmacvicar/terraform-provider-libvirt"
-  version = "0.5.1"
+  revision = "2ad0228349b2d3b487a2ada25d1a0eb40d73b7d1"
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-aws"

--- a/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/cloudinit_def.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/cloudinit_def.go
@@ -60,6 +60,9 @@ func (ci *defCloudInit) UploadIso(client *Client, iso string) (string, error) {
 	}
 	defer pool.Free()
 
+	client.poolMutexKV.Lock(ci.PoolName)
+	defer client.poolMutexKV.Unlock(ci.PoolName)
+
 	// Refresh the pool of the volume so that libvirt knows it is
 	// not longer in use.
 	waitForSuccess("Error refreshing pool for volume", func() error {

--- a/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/config.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/config.go
@@ -1,9 +1,9 @@
 package libvirt
 
 import (
-	"log"
-
+	"github.com/hashicorp/terraform/helper/mutexkv"
 	libvirt "github.com/libvirt/libvirt-go"
+	"log"
 )
 
 // Config struct for the libvirt-provider
@@ -13,7 +13,8 @@ type Config struct {
 
 // Client libvirt
 type Client struct {
-	libvirt *libvirt.Connect
+	libvirt     *libvirt.Connect
+	poolMutexKV *mutexkv.MutexKV
 }
 
 // Client libvirt, generate libvirt client given URI
@@ -25,7 +26,8 @@ func (c *Config) Client() (*Client, error) {
 	log.Println("[INFO] Created libvirt client")
 
 	client := &Client{
-		libvirt: libvirtClient,
+		libvirt:     libvirtClient,
+		poolMutexKV: mutexkv.NewMutexKV(),
 	}
 
 	return client, nil

--- a/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/coreos_ignition_def.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/coreos_ignition_def.go
@@ -38,6 +38,9 @@ func (ign *defIgnition) CreateAndUpload(client *Client) (string, error) {
 	}
 	defer pool.Free()
 
+	client.poolMutexKV.Lock(ign.PoolName)
+	defer client.poolMutexKV.Unlock(ign.PoolName)
+
 	// Refresh the pool of the volume so that libvirt knows it is
 	// not longer in use.
 	waitForSuccess("Error refreshing pool for volume", func() error {

--- a/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/resource_libvirt_volume.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/resource_libvirt_volume.go
@@ -91,6 +91,9 @@ func resourceLibvirtVolumeCreate(d *schema.ResourceData, meta interface{}) error
 		poolName = d.Get("pool").(string)
 	}
 
+	client.poolMutexKV.Lock(poolName)
+	defer client.poolMutexKV.Unlock(poolName)
+
 	pool, err := client.libvirt.LookupStoragePoolByName(poolName)
 	if err != nil {
 		return fmt.Errorf("can't find storage pool '%s'", poolName)

--- a/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/utils_volume.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/utils_volume.go
@@ -294,6 +294,14 @@ func removeVolume(client *Client, key string) error {
 	}
 	defer volPool.Free()
 
+	poolName, err := volPool.GetName()
+	if err != nil {
+		return fmt.Errorf("Error retrieving name of volume: %s", err)
+	}
+
+	client.poolMutexKV.Lock(poolName)
+	defer client.poolMutexKV.Unlock(poolName)
+
 	waitForSuccess("Error refreshing pool for volume", func() error {
 		return volPool.Refresh(0)
 	})


### PR DESCRIPTION
The final pull request landing in the provider's v0.5.1 [broke the installer on my libvirt 3.9.0][1]:

```
libvirt_ignition.master: Creating...
  ...
module.volume.libvirt_volume.coreos_base: Creating...
  ...
libvirt_network.net: Creating...
  ...
module.bootstrap.libvirt_ignition.bootstrap: Creating...
  ...
libvirt_ignition.master: Creation complete after 0s (ID: /home/trking/VirtualMachines/wking-mast...n;5c1b382d-27af-08b2-1fff-8dafabae17c3)
module.bootstrap.libvirt_ignition.bootstrap: Still creating... (10s elapsed)
module.bootstrap.libvirt_ignition.bootstrap: Still creating... (20s elapsed)
module.bootstrap.libvirt_ignition.bootstrap: Still creating... (30s elapsed)
...
module.bootstrap.libvirt_ignition.bootstrap: Still creating... (5m0s elapsed)

Error: Error applying plan:

3 error(s) occurred:

* libvirt_network.net: 1 error(s) occurred:

* libvirt_network.net: Error clearing libvirt network: virError(Code=38, Domain=7, Message='End of file while reading data: Input/output error')
* module.volume.libvirt_volume.coreos_base: 1 error(s) occurred:

* libvirt_volume.coreos_base: Error creating libvirt volume: virError(Code=38, Domain=7, Message='End of file while reading data: Input/output error')
* module.bootstrap.libvirt_ignition.bootstrap: 1 error(s) occurred:

* libvirt_ignition.bootstrap: Error creating libvirt volume for Ignition wking-bootstrap.ign: virError(Code=1, Domain=7, Message='internal error: client socket is closed')
```

Roll back to keep the lock that was dropped upstream until we understand this better.

[1]: https://github.com/dmacvicar/terraform-provider-libvirt/pull/495#issuecomment-448891285