### PR TITLE
add libvirt tag to libvirt-ci Dockerfile

### DIFF
--- a/images/nested-libvirt/Dockerfile
+++ b/images/nested-libvirt/Dockerfile
@@ -3,7 +3,7 @@
 FROM openshift/origin-release:golang-1.10 AS build
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-RUN hack/build.sh
+RUN TAGS=libvirt_destroy hack/build.sh
 
 FROM centos:7
 COPY --from=build /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install


### PR DESCRIPTION
@wking ptal, working on libvirt ci job, found I need to build with libvirt tag

With this: https://github.com/openshift/release/pull/2410  we have a working ci setup for libvirt