### PR TITLE
*: add support for journal-gatewayd

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/templates"
+	"github.com/openshift/installer/pkg/asset/tls"
 	destroybootstrap "github.com/openshift/installer/pkg/destroy/bootstrap"
 )
 
@@ -117,7 +118,7 @@ var (
 				}
 			},
 		},
-		assets: []asset.WritableAsset{&cluster.TerraformVariables{}, &kubeconfig.Admin{}, &cluster.Cluster{}},
+		assets: []asset.WritableAsset{&cluster.TerraformVariables{}, &kubeconfig.Admin{}, &tls.JournalCertKey{}, &cluster.Cluster{}},
 	}
 
 	targets = []target{installConfigTarget, manifestTemplatesTarget, manifestsTarget, ignitionConfigsTarget, clusterTarget}

--- a/data/data/bootstrap/systemd/units/systemd-journal-gatewayd.service.d/certs.conf
+++ b/data/data/bootstrap/systemd/units/systemd-journal-gatewayd.service.d/certs.conf
@@ -1,0 +1,6 @@
+[Service]
+ExecStart=
+ExecStart=/usr/lib/systemd/systemd-journal-gatewayd \
+  --key=/opt/openshift/tls/journal-gatewayd.key \
+  --cert=/opt/openshift/tls/journal-gatewayd.crt \
+  --trust=/opt/openshift/tls/root-ca.crt

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -66,11 +66,10 @@ Master nodes waiting for Ignition is indicative of problems on the bootstrap nod
 
 If the bootstrap node isn't available, first double check that it hasn't been automatically removed by the installer. If it's not being created in the first place, the installer will need to be [troubleshot](#installer-fails-to-create-resources).
 
-After using SSH to access the bootstrap node, the most important thing to look at is `bootkube.service`. The logs can be viewed with the following command:
+The most important thing to look at on the bootstrap node is `bootkube.service`. The logs can be viewed in two different ways:
 
-```sh
-journalctl --unit=bootkube.service
-```
+1. If SSH is available, the following command can be run on the bootstrap node: `journalctl --unit=bootkube.service`
+2. Regardless of whether or not SSH is available, the following command can be run: `curl --insecure --cert ${INSTALL_DIR}/tls/journal-gatewayd.crt --key ${INSTALL_DIR}/tls/journal-gatewayd.key 'https://${BOOTSTRAP_IP}:19531/entries?follow&_SYSTEMD_UNIT=bootkube.service'`
 
 ### etcd Is Not Running
 

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -207,7 +207,7 @@ func (a *Bootstrap) addStorageFiles(base string, uri string, templateData *boots
 	} else {
 		mode = 0600
 	}
-	ign := ignition.FileFromBytes(strings.TrimSuffix(base, ".template"), mode, data)
+	ign := ignition.FileFromBytes(strings.TrimSuffix(base, ".template"), "root", mode, data)
 	if filename == ".bash_history" {
 		ign.User = &igntypes.NodeUser{Name: ignitionUser}
 		ign.Group = &igntypes.NodeGroup{Name: ignitionUser}
@@ -340,11 +340,11 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 
 	a.Config.Storage.Files = append(
 		a.Config.Storage.Files,
-		ignition.FilesFromAsset(rootDir, 0644, mfsts)...,
+		ignition.FilesFromAsset(rootDir, "root", 0644, mfsts)...,
 	)
 	a.Config.Storage.Files = append(
 		a.Config.Storage.Files,
-		ignition.FilesFromAsset(rootDir, 0644, openshiftManifests)...,
+		ignition.FilesFromAsset(rootDir, "root", 0644, openshiftManifests)...,
 	)
 
 	for _, asset := range []asset.WritableAsset{
@@ -364,7 +364,7 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 		&tls.ServiceAccountKeyPair{},
 	} {
 		dependencies.Get(asset)
-		a.Config.Storage.Files = append(a.Config.Storage.Files, ignition.FilesFromAsset(rootDir, 0600, asset)...)
+		a.Config.Storage.Files = append(a.Config.Storage.Files, ignition.FilesFromAsset(rootDir, "root", 0600, asset)...)
 	}
 }
 

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -350,7 +350,6 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 	for _, asset := range []asset.WritableAsset{
 		&kubeconfig.Admin{},
 		&kubeconfig.Kubelet{},
-		&tls.RootCA{},
 		&tls.KubeCA{},
 		&tls.AggregatorCA{},
 		&tls.ServiceServingCA{},
@@ -366,6 +365,10 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 		dependencies.Get(asset)
 		a.Config.Storage.Files = append(a.Config.Storage.Files, ignition.FilesFromAsset(rootDir, "root", 0600, asset)...)
 	}
+
+	rootCA := &tls.RootCA{}
+	dependencies.Get(rootCA)
+	a.Config.Storage.Files = append(a.Config.Storage.Files, ignition.FileFromBytes(filepath.Join(rootDir, rootCA.CertFile().Filename), "root", 0644, rootCA.Cert()))
 }
 
 func applyTemplateData(template *template.Template, templateData interface{}) string {

--- a/pkg/asset/ignition/node.go
+++ b/pkg/asset/ignition/node.go
@@ -11,25 +11,28 @@ import (
 
 // FilesFromAsset creates ignition files for each of the files in the specified
 // asset.
-func FilesFromAsset(pathPrefix string, mode int, asset asset.WritableAsset) []ignition.File {
+func FilesFromAsset(pathPrefix string, username string, mode int, asset asset.WritableAsset) []ignition.File {
 	var files []ignition.File
 	for _, f := range asset.Files() {
-		files = append(files, FileFromBytes(filepath.Join(pathPrefix, f.Filename), mode, f.Data))
+		files = append(files, FileFromBytes(filepath.Join(pathPrefix, f.Filename), username, mode, f.Data))
 	}
 	return files
 }
 
 // FileFromString creates an ignition-config file with the given contents.
-func FileFromString(path string, mode int, contents string) ignition.File {
-	return FileFromBytes(path, mode, []byte(contents))
+func FileFromString(path string, username string, mode int, contents string) ignition.File {
+	return FileFromBytes(path, username, mode, []byte(contents))
 }
 
 // FileFromBytes creates an ignition-config file with the given contents.
-func FileFromBytes(path string, mode int, contents []byte) ignition.File {
+func FileFromBytes(path string, username string, mode int, contents []byte) ignition.File {
 	return ignition.File{
 		Node: ignition.Node{
 			Filesystem: "root",
 			Path:       path,
+			User: &ignition.NodeUser{
+				Name: username,
+			},
 		},
 		FileEmbedded1: ignition.FileEmbedded1{
 			Mode: &mode,

--- a/pkg/asset/tls/certkey.go
+++ b/pkg/asset/tls/certkey.go
@@ -90,6 +90,11 @@ func (c *CertKey) Files() []*asset.File {
 	return c.FileList
 }
 
+// CertFile returns the certificate file.
+func (c *CertKey) CertFile() *asset.File {
+	return c.FileList[1]
+}
+
 func (c *CertKey) generateFiles(filenameBase string) {
 	c.FileList = []*asset.File{
 		{

--- a/pkg/asset/tls/journalcertkey.go
+++ b/pkg/asset/tls/journalcertkey.go
@@ -1,0 +1,45 @@
+package tls
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+
+	"github.com/openshift/installer/pkg/asset"
+)
+
+// JournalCertKey is the asset that generates the key/cert pair that is used to
+// authenticate with journal-gatewayd on the bootstrap node.
+type JournalCertKey struct {
+	CertKey
+}
+
+var _ asset.WritableAsset = (*JournalCertKey)(nil)
+
+// Dependencies returns the dependency of the the cert/key pair, which includes
+// the parent CA, and install config if it depends on the install config for
+// DNS names, etc.
+func (a *JournalCertKey) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&RootCA{},
+	}
+}
+
+// Generate generates the cert/key pair based on its dependencies.
+func (a *JournalCertKey) Generate(dependencies asset.Parents) error {
+	ca := &RootCA{}
+	dependencies.Get(ca)
+
+	cfg := &CertCfg{
+		Subject:      pkix.Name{CommonName: "journal-gatewayd", Organization: []string{"OpenShift Bootstrap"}},
+		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		Validity:     ValidityTenYears,
+	}
+
+	return a.CertKey.Generate(cfg, ca, "journal-gatewayd", DoNotAppendParent)
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *JournalCertKey) Name() string {
+	return "Certificate (journal-gatewayd)"
+}


### PR DESCRIPTION
This allows the user to stream logs from the bootstrap node without the
need for SSH. This read-only view into the bootstrap process is
convenient for those who wish not to use SSH in their cluster. Right
now, this requires the user to manually invoke curl to fetch the logs,
but this could be done automatically by the installer in the future.

