### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,11 @@
 /bin/
-.openshift_install.log
+/.project
+/.vscode
+/.settings
+*.swp
+.vimrc
+.DS_Store
+.idea
+.project
+*.go~
+.envrc


### PR DESCRIPTION
This PR updates `.gitignore` to ignore most of known editor settings file (copied from origin) as well as all the default data files the installer creates. 