### PR TITLE
Revert "pkg/asset/machines/aws/machinesets: Give workers public IPs (for now)"

### DIFF
--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -6,8 +6,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
-	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1alpha1"
 	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/openshift/installer/pkg/types"
@@ -89,15 +87,4 @@ func MachineSets(config *types.InstallConfig, pool *types.MachinePool, role, use
 	}
 
 	return machinesets, nil
-}
-
-// ConfigWorkers sets the PublicIP flag for the given machine sets.
-//
-// Deprecated: We'll remove this once the e2e tests no longer require
-// worker SSH access.
-func ConfigWorkers(machineSets []clusterapi.MachineSet) {
-	for _, machineSet := range machineSets {
-		providerConfig := machineSet.Spec.Template.Spec.ProviderConfig.Value.Object.(*awsprovider.AWSMachineProviderConfig)
-		providerConfig.PublicIP = pointer.BoolPtr(true)
-	}
 }

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -100,7 +100,6 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create worker machine objects")
 		}
-		aws.ConfigWorkers(sets)
 
 		list := listFromMachineSets(sets)
 		raw, err := yaml.Marshal(list)


### PR DESCRIPTION
Reverts openshift/installer#927

We didn't quite get all the NAT settings working.  After more discussion Eric made the convincing argument to just fix the conformance tests (since he didn't have to implement it) which is what openshift/origin#21700 demonstrates.  In order for that to work, we have to revert this because the masters can't reach the workers on their external IP which the conformance tests try to look up automatically.