### PR TITLE
hack/build: Pin to RHCOS 47.235 and quay.io/openshift-release-dev/ocp-release:4.0.0-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,53 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.8.0 - 2018-12-23
+
+### Added
+
+- The installer binary now includes all required Terraform plugins, so
+  there is no longer a need to separately download and install them.
+  This will be most noticeable on libvirt, where users used to be
+  required to install the libvirt plugin manually.  This avoids issues
+  with mismatched plugin versions (which we saw sometimes on libvirt)
+  and network-connectivity issues during `create cluster` invocations
+  (which we saw sometimes on all platforms).
+- The configured base domain is now pushed into the cluster's
+  `config.openshift.io` as a DNS custom resource.
+
+### Changed
+
+- `install-config.yml` is now `install-config.yaml` to align with our
+  usual YAML extension.  `install-config.yml` is deprecated, and
+  support for it will be removed completely in the next release.
+- On AWS, we now use a select widget for the base-domain wizard
+  prompt, making it easier to choose an existing public zone.
+- On AWS, Route 53 rate limits during `cluster destroy` are now less
+  disruptive, reducing the AWS request load in busy accounts.
+- On OpenStack, the HAProxy configuration no longer hard-codes the
+  cluster name and base domain.
+- On OpenStack, the 0.7.0 fix for:
+
+        FATAL Expected HTTP response code [202 204] when accessing [DELETE https://osp-xxxxx:13696/v2.0/routers/52093478-dcf1-4bcc-9a2c-dbb1e42da880], but got 409 instead
+        {"NeutronError": {"message": "Router 52093478-dcf1-4bcc-9a2c-dbb1e42da880 still has ports", "type": "RouterInUse", "detail": ""}}
+
+    was incorrect and has been reverted.  We'll land a real fix for
+    this issue in future work.
+- On OpenStack, the service VM from 0.7.0 now has a floating IP
+  address.
+- All libvirt functionality is behind `TAGS=libvirt` now.  Previously
+  installer builds with `TAGS=libvirt_destroy` included all libvirt
+  functionality, while builds without that tag would include `create
+  cluster` but not `destroy cluster` functionality.  With the change,
+  all users using the installer with libvirt clusters will need to set
+  the new build tag.
+- Lots of doc and internal cleanup and minor fixes.
+
+### Removed
+
+- On AWS and OpenStack, the `tectonicClusterID` tag which was
+  deprecated in 0.7.0 has been removed.
+
 ## 0.7.0 - 2018-12-14
 
 ### Added
@@ -48,9 +95,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (controller manager) have been opened to access from all machines.
   This allows Prometheus (which runs on the worker nodes) to scrape
   all machines for metrics.
-- On AWS, the installer and subsequent cluster will now tag resources
-  it creates with `openshiftClusterID`.  `tectonicClusterID` is
-  deprecated.
+- On AWS and OpenStack, the installer and subsequent cluster will now
+  tag resources it creates with `openshiftClusterID`.
+  `tectonicClusterID` is deprecated.
 - On OpenStack, only the OpenStack `clouds` entry is marshalled into
   the `openstack-creds` secret.  Previously we had injected the host's
   entire cloud configuration.

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+RELEASE_IMAGE="${RELEASE_IMAGE:-quay.io/openshift-release-dev/ocp-release:4.0.0-8}"
+RHCOS_BUILD_NAME="${RELEASE_BUILD_NAME:-47.235}"
+
 # shellcheck disable=SC2068
 version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}
 

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -144,7 +144,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig) (*bootst
 	}
 
 	releaseImage := defaultReleaseImage
-	if ri, ok := os.LookupEnv("OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"); ok && ri != "" {
+	if ri, ok := os.LookupEnv("_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"); ok && ri != "" {
 		logrus.Warn("Found override for ReleaseImage. Please be warned, this is not advised")
 		releaseImage = ri
 	}


### PR DESCRIPTION
DO NOT MERGE!

That's the latest RHCOS release:

```console
$ curl -s https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/builds.json | jq '{latest: .builds[0], timestamp}'
{
  "latest": "47.235",
  "timestamp": "2018-12-23T05:40:56Z"
}
```

And @smarterclayton just pushed a recent update payload to quay.io/openshift-release-dev/ocp-release:4.0.0-8.

Renaming `OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE` gets us CI testing of the pinned release despite openshift/release@60007df2 (openshift/release#1793).

I'd initially expected to export the pinning environment variables in `release.sh`, but I've put them in `build.sh` here because our continuous integration tests use `build.sh` directly and don't go through `release.sh`.