### PR TITLE
libvirt: use host-passthrough CPU type for libvirt VMs

### DIFF
--- a/data/data/libvirt/bootstrap/main.tf
+++ b/data/data/libvirt/bootstrap/main.tf
@@ -26,6 +26,10 @@ resource "libvirt_domain" "bootstrap" {
     target_port = 0
   }
 
+  cpu {
+    mode = "host-passthrough"
+  }
+
   network_interface {
     network_id = "${var.network_id}"
     hostname   = "${var.cluster_name}-bootstrap"

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -78,6 +78,10 @@ resource "libvirt_domain" "master" {
     target_port = 0
   }
 
+  cpu {
+    mode = "host-passthrough"
+  }
+
   network_interface {
     network_id = "${libvirt_network.net.id}"
     hostname   = "${var.cluster_name}-master-${count.index}"


### PR DESCRIPTION
libvirt: use host-passthrough CPU type

Should be slightly faster, I hope.

From https://wiki.openstack.org/wiki/LibvirtXMLCPUModel :
host-passthrough" - this causes libvirt to tell KVM to passthrough the host CPU with no modifications.
The difference to host-model, instead of just matching feature flags, every last detail of the host CPU is matched.
This gives absolutely best performance, and can be important to some apps which check low level CPU details, but it comes at a cost wrt migration.
The guest can only be migrated to an exactly matching host CPU.