### PR TITLE
pkg/types: Add cross-platform Networking.MachineCIDR

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -70,7 +70,7 @@ module "vpc" {
   source = "./vpc"
 
   base_domain  = "${var.base_domain}"
-  cidr_block   = "${var.aws_vpc_cidr_block}"
+  cidr_block   = "${var.machine_cidr}"
   cluster_id   = "${var.cluster_id}"
   cluster_name = "${var.cluster_name}"
   region       = "${var.aws_region}"

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -21,15 +21,6 @@ variable "aws_ec2_ami_override" {
   default     = ""
 }
 
-variable "aws_vpc_cidr_block" {
-  type = "string"
-
-  description = <<EOF
-Block of IP addresses used by the VPC.
-This should not overlap with any other networks, such as a private datacenter connected via Direct Connect.
-EOF
-}
-
 variable "aws_extra_tags" {
   type = "map"
 

--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -2,6 +2,14 @@ terraform {
   required_version = ">= 0.10.7"
 }
 
+variable "machine_cidr" {
+  type = "string"
+
+  description = <<EOF
+The IP address space from which to assign machine IPs.
+EOF
+}
+
 variable "master_count" {
   type    = "string"
   default = "1"

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -39,7 +39,7 @@ resource "libvirt_network" "net" {
   domain = "${var.base_domain}"
 
   addresses = [
-    "${var.libvirt_ip_range}",
+    "${var.machine_cidr}",
   ]
 
   dns = [{

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -13,11 +13,6 @@ variable "libvirt_network_if" {
   description = "The name of the bridge to use"
 }
 
-variable "libvirt_ip_range" {
-  type        = "string"
-  description = "IP range for the libvirt machines"
-}
-
 variable "os_image" {
   type        = "string"
   description = "The URL of the OS disk image"

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -70,7 +70,7 @@ module "masters" {
 module "topology" {
   source = "./topology"
 
-  cidr_block                 = "${var.openstack_network_cidr_block}"
+  cidr_block                 = "${var.machine_cidr}"
   cluster_id                 = "${var.cluster_id}"
   cluster_name               = "${var.cluster_name}"
   external_master_subnet_ids = "${compact(var.openstack_external_master_subnet_ids)}"

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -243,12 +243,3 @@ variable "openstack_region" {
   type        = "string"
   description = "The target OpenStack region for the cluster."
 }
-
-variable "openstack_network_cidr_block" {
-  type = "string"
-
-  description = <<EOF
-Block of IP addresses used by the VPC.
-This should not overlap with any other networks, such as a private datacenter connected via Direct Connect.
-EOF
-}

--- a/pkg/asset/installconfig/aws/aws.go
+++ b/pkg/asset/installconfig/aws/aws.go
@@ -16,13 +16,8 @@ import (
 	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
-	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/aws/validation"
-)
-
-var (
-	defaultVPCCIDR = ipnet.MustParseCIDR("10.0.0.0/16")
 )
 
 // Platform collects AWS-specific configuration.
@@ -86,8 +81,7 @@ func Platform() (*aws.Platform, error) {
 	}
 
 	return &aws.Platform{
-		VPCCIDRBlock: defaultVPCCIDR,
-		Region:       region,
+		Region: region,
 	}, nil
 }
 

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/mock"
-	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 )
@@ -27,7 +26,8 @@ func validInstallConfig() *types.InstallConfig {
 		BaseDomain: "test-domain",
 		Networking: types.Networking{
 			Type:        "OpenshiftSDN",
-			ServiceCIDR: *ipnet.MustParseCIDR("10.0.0.0/16"),
+			MachineCIDR: *defaultMachineCIDR,
+			ServiceCIDR: *defaultServiceCIDR,
 			ClusterNetworks: []netopv1.ClusterNetwork{
 				{
 					CIDR:             "192.168.1.0/24",

--- a/pkg/asset/installconfig/libvirt/libvirt.go
+++ b/pkg/asset/installconfig/libvirt/libvirt.go
@@ -18,7 +18,9 @@ const (
 )
 
 var (
-	defaultNetworkIPRange = ipnet.MustParseCIDR("192.168.126.0/24")
+	// DefaultMachineCIDR is the libvirt default IP address space from
+	// which to assign machine IPs.
+	DefaultMachineCIDR = ipnet.MustParseCIDR("192.168.126.0/24")
 )
 
 // Platform collects libvirt-specific configuration.
@@ -45,8 +47,7 @@ func Platform() (*libvirt.Platform, error) {
 
 	return &libvirt.Platform{
 		Network: libvirt.Network{
-			IfName:  defaultNetworkIfName,
-			IPRange: *defaultNetworkIPRange,
+			IfName: defaultNetworkIfName,
 		},
 		DefaultMachinePlatform: &libvirt.MachinePool{
 			Image: qcowImage,

--- a/pkg/asset/installconfig/openstack/openstack.go
+++ b/pkg/asset/installconfig/openstack/openstack.go
@@ -8,13 +8,8 @@ import (
 	"github.com/pkg/errors"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
-	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/openstack"
 	openstackvalidation "github.com/openshift/installer/pkg/types/openstack/validation"
-)
-
-var (
-	defaultNetworkCIDR = ipnet.MustParseCIDR("10.0.0.0/16")
 )
 
 // Platform collects OpenStack-specific configuration.
@@ -160,11 +155,10 @@ func Platform() (*openstack.Platform, error) {
 	}
 
 	return &openstack.Platform{
-		NetworkCIDRBlock: *defaultNetworkCIDR,
-		Region:           region,
-		BaseImage:        image,
-		Cloud:            cloud,
-		ExternalNetwork:  extNet,
-		FlavorName:       flavor,
+		Region:          region,
+		BaseImage:       image,
+		Cloud:           cloud,
+		ExternalNetwork: extNet,
+		FlavorName:      flavor,
 	}, nil
 }

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -31,7 +31,7 @@ func Machines(config *types.InstallConfig, pool *types.MachinePool, role, userDa
 	if pool.Replicas != nil {
 		total = *pool.Replicas
 	}
-	provider := provider(clustername, platform, userDataSecret)
+	provider := provider(clustername, config.Networking.MachineCIDR.String(), platform, userDataSecret)
 	var machines []clusterapi.Machine
 	for idx := int64(0); idx < total; idx++ {
 		machine := clusterapi.Machine{
@@ -61,7 +61,7 @@ func Machines(config *types.InstallConfig, pool *types.MachinePool, role, userDa
 	return machines, nil
 }
 
-func provider(clusterName string, platform *libvirt.Platform, userDataSecret string) *libvirtprovider.LibvirtMachineProviderConfig {
+func provider(clusterName string, networkInterfaceAddress string, platform *libvirt.Platform, userDataSecret string) *libvirtprovider.LibvirtMachineProviderConfig {
 	return &libvirtprovider.LibvirtMachineProviderConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "libvirtproviderconfig.k8s.io/v1alpha1",
@@ -77,7 +77,7 @@ func provider(clusterName string, platform *libvirt.Platform, userDataSecret str
 			BaseVolumeID: fmt.Sprintf("/var/lib/libvirt/images/%s-base", clusterName),
 		},
 		NetworkInterfaceName:    clusterName,
-		NetworkInterfaceAddress: platform.Network.IPRange.String(),
+		NetworkInterfaceAddress: networkInterfaceAddress,
 		Autostart:               false,
 		URI:                     platform.URI,
 	}

--- a/pkg/asset/machines/libvirt/machinesets.go
+++ b/pkg/asset/machines/libvirt/machinesets.go
@@ -32,7 +32,7 @@ func MachineSets(config *types.InstallConfig, pool *types.MachinePool, role, use
 		total = *pool.Replicas
 	}
 
-	provider := provider(clustername, platform, userDataSecret)
+	provider := provider(clustername, config.Networking.MachineCIDR.String(), platform, userDataSecret)
 	name := fmt.Sprintf("%s-%s-%d", clustername, pool.Name, 0)
 	mset := clusterapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -6,7 +6,6 @@ type AWS struct {
 	ExtraTags      map[string]string `json:"aws_extra_tags,omitempty"`
 	Master         `json:",inline"`
 	Region         string `json:"aws_region,omitempty"`
-	VPCCIDRBlock   string `json:"aws_vpc_cidr_block"`
 	Worker         `json:",inline"`
 }
 

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -18,19 +18,13 @@ type Libvirt struct {
 
 // Network describes a libvirt network configuration.
 type Network struct {
-	IfName  string `json:"libvirt_network_if"`
-	IPRange string `json:"libvirt_ip_range"`
+	IfName string `json:"libvirt_network_if"`
 }
 
 // TFVars fills in computed Terraform variables.
-func (l *Libvirt) TFVars(masterCount int) error {
-	_, network, err := net.ParseCIDR(l.Network.IPRange)
-	if err != nil {
-		return fmt.Errorf("failed to parse libvirt network ipRange: %v", err)
-	}
-
+func (l *Libvirt) TFVars(machineCIDR *net.IPNet, masterCount int) error {
 	if l.BootstrapIP == "" {
-		ip, err := cidr.Host(network, 10)
+		ip, err := cidr.Host(machineCIDR, 10)
 		if err != nil {
 			return fmt.Errorf("failed to generate bootstrap IP: %v", err)
 		}
@@ -42,7 +36,7 @@ func (l *Libvirt) TFVars(masterCount int) error {
 			return fmt.Errorf("length of MasterIPs doesn't match master count")
 		}
 	} else {
-		if ips, err := generateIPs("master", network, masterCount, 11); err == nil {
+		if ips, err := generateIPs("master", machineCIDR, masterCount, 11); err == nil {
 			l.MasterIPs = ips
 		} else {
 			return err

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -2,14 +2,13 @@ package openstack
 
 // OpenStack converts OpenStack related config.
 type OpenStack struct {
-	BaseImage        string `json:"openstack_base_image,omitempty"`
-	Credentials      `json:",inline"`
-	External         `json:",inline"`
-	ExternalNetwork  string            `json:"openstack_external_network,omitempty"`
-	ExtraTags        map[string]string `json:"openstack_extra_tags,omitempty"`
-	Master           `json:",inline"`
-	Region           string `json:"openstack_region,omitempty"`
-	NetworkCIDRBlock string `json:"openstack_network_cidr_block,omitempty"`
+	BaseImage       string `json:"openstack_base_image,omitempty"`
+	Credentials     `json:",inline"`
+	External        `json:",inline"`
+	ExternalNetwork string            `json:"openstack_external_network,omitempty"`
+	ExtraTags       map[string]string `json:"openstack_extra_tags,omitempty"`
+	Master          `json:",inline"`
+	Region          string `json:"openstack_region,omitempty"`
 }
 
 // External converts external related config.

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -1,9 +1,5 @@
 package aws
 
-import (
-	"github.com/openshift/installer/pkg/ipnet"
-)
-
 // Platform stores all the global configuration that all machinesets
 // use.
 type Platform struct {
@@ -17,8 +13,4 @@ type Platform struct {
 	// installing on AWS for machine pools which do not define their own
 	// platform configuration.
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
-
-	// VPCCIDRBlock
-	// +optional
-	VPCCIDRBlock *ipnet.IPNet `json:"vpcCIDRBlock,omitempty"`
 }

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/aws"
-	"github.com/openshift/installer/pkg/validate"
 )
 
 var (
@@ -54,11 +53,6 @@ func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
 	}
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
-	}
-	if p.VPCCIDRBlock != nil {
-		if err := validate.SubnetCIDR(&p.VPCCIDRBlock.IPNet); err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("vpcCIDRBlock"), p.VPCCIDRBlock, err.Error()))
-		}
 	}
 	return allErrs
 }

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/aws"
 )
 
@@ -47,22 +46,6 @@ func TestValidatePlatform(t *testing.T) {
 						IOPS: -10,
 					},
 				},
-			},
-			valid: false,
-		},
-		{
-			name: "valid CIDR",
-			platform: &aws.Platform{
-				Region:       "us-east-1",
-				VPCCIDRBlock: ipnet.MustParseCIDR("192.168.0.0/16"),
-			},
-			valid: true,
-		},
-		{
-			name: "invalid CIDR",
-			platform: &aws.Platform{
-				Region:       "us-east-1",
-				VPCCIDRBlock: ipnet.MustParseCIDR("0.0.0.0/16"),
 			},
 			valid: false,
 		},

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -108,10 +108,13 @@ func (p *Platform) Name() string {
 
 // Networking defines the pod network provider in the cluster.
 type Networking struct {
+	// MachineCIDR is the IP address space from which to assign machine IPs.
+	MachineCIDR ipnet.IPNet `json:"machineCIDR"`
+
 	// Type is the network type to install
 	Type netopv1.NetworkType `json:"type"`
 
-	// ServiceCIDR is the ip block from which to assign service IPs
+	// ServiceCIDR is the IP address space from which to assign service IPs.
 	ServiceCIDR ipnet.IPNet `json:"serviceCIDR"`
 
 	// ClusterNetworks is the IP address space from which to assign pod IPs.

--- a/pkg/types/libvirt/network.go
+++ b/pkg/types/libvirt/network.go
@@ -1,13 +1,7 @@
 package libvirt
 
-import (
-	"github.com/openshift/installer/pkg/ipnet"
-)
-
 // Network is the configuration of the libvirt network.
 type Network struct {
 	// IfName is the name of the network interface.
 	IfName string `json:"if"`
-	// IPRange is the range of IPs to use.
-	IPRange ipnet.IPNet `json:"ipRange"`
 }

--- a/pkg/types/libvirt/validation/platform.go
+++ b/pkg/types/libvirt/validation/platform.go
@@ -19,8 +19,5 @@ func ValidatePlatform(p *libvirt.Platform, fldPath *field.Path) field.ErrorList 
 	if p.Network.IfName == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("network").Child("if"), p.Network.IfName))
 	}
-	if err := validate.SubnetCIDR(&p.Network.IPRange.IPNet); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("network").Child("ipRange"), p.Network.IPRange, err.Error()))
-	}
 	return allErrs
 }

--- a/pkg/types/libvirt/validation/platform_test.go
+++ b/pkg/types/libvirt/validation/platform_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/libvirt"
 )
 
@@ -14,8 +13,7 @@ func validPlatform() *libvirt.Platform {
 	return &libvirt.Platform{
 		URI: "qemu+tcp://192.168.122.1/system",
 		Network: libvirt.Network{
-			IfName:  "tt0",
-			IPRange: *ipnet.MustParseCIDR("10.0.0.0/16"),
+			IfName: "tt0",
 		},
 	}
 }
@@ -45,15 +43,6 @@ func TestValidatePlatform(t *testing.T) {
 			platform: func() *libvirt.Platform {
 				p := validPlatform()
 				p.Network.IfName = ""
-				return p
-			}(),
-			valid: false,
-		},
-		{
-			name: "missing ip range",
-			platform: func() *libvirt.Platform {
-				p := validPlatform()
-				p.Network.IPRange = ipnet.IPNet{}
 				return p
 			}(),
 			valid: false,

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -1,9 +1,5 @@
 package openstack
 
-import (
-	"github.com/openshift/installer/pkg/ipnet"
-)
-
 // Platform stores all the global configuration that all
 // machinesets use.
 type Platform struct {
@@ -14,9 +10,6 @@ type Platform struct {
 	// installing on OpenStack for machine pools which do not define their own
 	// platform configuration.
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
-
-	// NetworkCIDRBlock
-	NetworkCIDRBlock ipnet.IPNet `json:"NetworkCIDRBlock"`
 
 	// BaseImage
 	// Name of image to use from OpenStack cloud

--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -6,7 +6,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/openstack"
-	"github.com/openshift/installer/pkg/validate"
 )
 
 // ValidatePlatform checks that the specified platform is valid.
@@ -45,9 +44,6 @@ func ValidatePlatform(p *openstack.Platform, fldPath *field.Path, fetcher ValidV
 	}
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
-	}
-	if err := validate.SubnetCIDR(&p.NetworkCIDRBlock.IPNet); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("NetworkCIDRBlock"), p.NetworkCIDRBlock, err.Error()))
 	}
 	return allErrs
 }

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -8,19 +8,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/openstack"
 	"github.com/openshift/installer/pkg/types/openstack/validation/mock"
 )
 
 func validPlatform() *openstack.Platform {
 	return &openstack.Platform{
-		Region:           "test-region",
-		NetworkCIDRBlock: *ipnet.MustParseCIDR("10.0.0.0/16"),
-		BaseImage:        "test-image",
-		Cloud:            "test-cloud",
-		ExternalNetwork:  "test-network",
-		FlavorName:       "test-flavor",
+		Region:          "test-region",
+		BaseImage:       "test-image",
+		Cloud:           "test-cloud",
+		ExternalNetwork: "test-network",
+		FlavorName:      "test-flavor",
 	}
 }
 

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -50,6 +50,9 @@ func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorLis
 	if !validate.ValidNetworkTypes[n.Type] {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), n.Type, validate.ValidNetworkTypeValues))
 	}
+	if err := validate.SubnetCIDR(&n.MachineCIDR.IPNet); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("machineCIDR"), n.MachineCIDR, err.Error()))
+	}
 	if err := validate.SubnetCIDR(&n.ServiceCIDR.IPNet); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceCIDR"), n.ServiceCIDR, err.Error()))
 	}


### PR DESCRIPTION
The concept was not platform-specific, and it's simpler to track the cross-platform value in a single, generic location.

Spun off from #792; see the thread starting [here][1].

CC @abhinavdahiya.

[1]: https://github.com/openshift/installer/pull/792#discussion_r239234304