### PR TITLE
pkg/destroy/aws: Fix zone id in debug output

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -1206,7 +1206,7 @@ func r53ZonesToAWSObjects(zones []*route53.HostedZone, r53Client *route53.Route5
 			})
 			if err != nil {
 				if request.IsErrorThrottle(err) {
-					logger.Debugf("sleeping before trying to resolve tags for zone %s: %v", zone.Id, err)
+					logger.Debugf("sleeping before trying to resolve tags for zone %s: %v", *zone.Id, err)
 					time.Sleep(time.Second)
 					continue
 				}


### PR DESCRIPTION
Before this commit, when the installer requested tags for the zone from the AWS API and the request was throttled, the installer printed a message with the string pointer value of the zone id:

    DEBUG sleeping before trying to resolve tags for zone %!s(*string=0xc420e7fdc8): Throttling: Rate exceeded

After this commit, the installer prints the string value:

    DEBUG sleeping before trying to resolve tags for zone /hostedzone/Z2J66YWY5ZGE1: Throttling: Rate exceeded

* `pkg/destroy/aws/aws.go` (`r53ZonesToAWSObject`): Dereference `zone.Id` when printing it.