### PR TITLE
network: add the network.cluster.openshift.io CRD

### DIFF
--- a/pkg/asset/manifests/network.go
+++ b/pkg/asset/manifests/network.go
@@ -43,6 +43,24 @@ spec:
     - name: v1
       served: true
       storage: true
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networks.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
 `
 )
 


### PR DESCRIPTION
This will be used to configure the network operator in lieu of the current operator-specific CRD. I'll submit a follow-up PR once the network operator PR is merged, but this needs to go first.

ref: https://github.com/openshift/cluster-network-operator/pull/47