### PR TITLE
openstack: delete DNS server from service VM

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -15,29 +15,6 @@ data "ignition_config" "redirect" {
   append {
     source = "${openstack_objectstorage_tempurl_v1.ignition_tmpurl.url}"
   }
-
-  files = [
-    "${data.ignition_file.bootstrap_ifcfg.id}",
-  ]
-}
-
-data "ignition_file" "bootstrap_ifcfg" {
-  filesystem = "root"
-  mode       = "420"                                       // 0644
-  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
-
-  content {
-    content = <<EOF
-DEVICE="eth0"
-BOOTPROTO="dhcp"
-ONBOOT="yes"
-TYPE="Ethernet"
-PERSISTENT_DHCLIENT="yes"
-DNS1="${var.service_vm_fixed_ip}"
-PEERDNS="no"
-NM_CONTROLLED="yes"
-EOF
-  }
 }
 
 data "openstack_images_image_v2" "bootstrap_image" {

--- a/data/data/openstack/lb/main.tf
+++ b/data/data/openstack/lb/main.tf
@@ -35,33 +35,6 @@ data "ignition_file" "haproxy_conf" {
   }
 }
 
-data "ignition_file" "openshift_hosts" {
-  filesystem = "root"
-  mode       = "420"                  // 0644
-  path       = "/etc/openshift-hosts"
-
-  content {
-    content = <<EOF
-${replace(join("\n", formatlist("%s ${var.cluster_name}-etcd-%s.${var.cluster_domain}", var.master_ips, var.master_port_names)), "master-port-", "")}
-EOF
-  }
-}
-
-data "ignition_systemd_unit" "local_dns" {
-  name = "local-dns.service"
-
-  content = <<EOF
-[Unit]
-Description=Internal DNS server for running OpenShift on OpenStack
-
-[Service]
-ExecStart=/bin/podman run --name bootstrap-dns --rm -t -i -p 53:53/tcp -p 53:53/udp -v /etc/openshift-hosts:/etc/openshift-hosts:z --cap-add=NET_ADMIN docker.io/andyshinn/dnsmasq:latest --keep-in-foreground --log-facility=- --log-queries --no-resolv --addn-hosts=/etc/openshift-hosts --server=10.0.0.2 ${replace(join(" ", formatlist("--srv-host=_etcd-server-ssl._tcp.${var.cluster_name}.${var.cluster_domain},${var.cluster_name}-etcd-%s.${var.cluster_domain},2380,0,10", var.master_port_names)), "master-port-", "")}
-
-[Install]
-WantedBy=multi-user.target
-EOF
-}
-
 data "ignition_user" "core" {
   name = "core"
 }
@@ -69,12 +42,10 @@ data "ignition_user" "core" {
 data "ignition_config" "config" {
   files = [
     "${data.ignition_file.haproxy_conf.id}",
-    "${data.ignition_file.openshift_hosts.id}",
   ]
 
   systemd = [
     "${data.ignition_systemd_unit.haproxy_unit.id}",
-    "${data.ignition_systemd_unit.local_dns.id}",
   ]
 
   users = [

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -13,32 +13,12 @@ data "ignition_config" "master_ignition_config" {
   }
 
   files = [
-    "${data.ignition_file.master_ifcfg.id}",
     "${data.ignition_file.master_hacks_script.id}",
   ]
 
   systemd = [
     "${data.ignition_systemd_unit.master_hacks_service.id}",
   ]
-}
-
-data "ignition_file" "master_ifcfg" {
-  filesystem = "root"
-  mode       = "420"                                       // 0644
-  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
-
-  content {
-    content = <<EOF
-DEVICE="eth0"
-BOOTPROTO="dhcp"
-ONBOOT="yes"
-TYPE="Ethernet"
-PERSISTENT_DHCLIENT="yes"
-DNS1="${var.service_vm_fixed_ip}"
-PEERDNS="no"
-NM_CONTROLLED="yes"
-EOF
-  }
 }
 
 data "ignition_file" "master_hacks_script" {

--- a/data/data/openstack/topology/sg-lb.tf
+++ b/data/data/openstack/topology/sg-lb.tf
@@ -23,22 +23,12 @@ resource "openstack_networking_secgroup_rule_v2" "api_https" {
   security_group_id = "${openstack_networking_secgroup_v2.api.id}"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "api_ingress_dns_udp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "udp"
-  port_range_min    = 53
-  port_range_max    = 53
-  remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.api.id}"
-}
-
-resource "openstack_networking_secgroup_rule_v2" "api_ingress_dns_tcp" {
+resource "openstack_networking_secgroup_rule_v2" "api_ingress_ssh_tcp" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 53
-  port_range_max    = 53
+  port_range_min    = 22
+  port_range_max    = 22
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = "${openstack_networking_secgroup_v2.api.id}"
 }

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -24,6 +24,34 @@ The installer assumes the following about the OpenStack cloud you run against:
   * For example: `openstack quota set --secgroups 100 --secgroup-rules 1000
     openshift`
 
+* You should add the following records to the DNS server that provides service
+  to your cluster (typically that's the one that the Neutron dns forwards to):
+
+      Dnsmasq example with three masters
+      ==================================
+
+      service-host=_etcd-server-ssl._tcp.CLUSTER_NAME.DOMAIN_NAME,CLUSTER_NAME-etcd-0.DOMAIN_NAME,2380,0,10
+      service-host=_etcd-server-ssl._tcp.CLUSTER_NAME.DOMAIN_NAME,CLUSTER_NAME-etcd-1.DOMAIN_NAME,2380,0,10
+      service-host=_etcd-server-ssl._tcp.CLUSTER_NAME.DOMAIN_NAME,CLUSTER_NAME-etcd-2.DOMAIN_NAME,2380,0,10
+      cname=CLUSTER_NAME-etcd-0,CLUSTER_NAME-master-0
+      cname=CLUSTER_NAME-etcd-1,CLUSTER_NAME-master-1
+      cname=CLUSTER_NAME-etcd-2,CLUSTER_NAME-master-2
+
+      Bind example with three masters
+      ===============================
+
+      ;                                SVC.PROTO.NAME   TTL    CLASS  PRIORITY WEIGHT PORT                           TARGET
+      _etcd-server-ssl._tcp.CLUSTER_NAME.DOMAIN_NAME.    IN      SRV         0     10 2380  CLUSTER_NAME-etcd-0.DOMAIN_NAME
+                                                         IN      SRV         0     10 2380  CLUSTER_NAME-etcd-1.DOMAIN_NAME
+                                                         IN      SRV         0     10 2380  CLUSTER_NAME-etcd-2.DOMAIN_NAME
+
+      $ORIGIN DOMAIN_NAME.
+      ;              NAME    TTL   CLASS                            CANONICAL_NAME
+      CLUSTER_NAME-etcd-0     IN   CNAME        CLUSTER_NAME-master-0.DOMAIN_NAME.
+      CLUSTER_NAME-etcd-1     IN   CNAME        CLUSTER_NAME-master-1.DOMAIN_NAME.
+      CLUSTER_NAME-etcd-2     IN   CNAME        CLUSTER_NAME-master-2.DOMAIN_NAME.
+
+
 ## Current Expected Behavior
 
 As mentioned, OpenStack support is still experimental.  The installer will


### PR DESCRIPTION
For the Openstack DNS (short-term) solution, the external DNS should be
configured with the relevant SRV and CNAME records.
This patch deletes the DNS server runs in service VM.