### PR TITLE
 Generate kubeconfigs during `create ignition-configs` 

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -80,7 +80,7 @@ var (
 			// FIXME: add longer descriptions for our commands with examples for better UX.
 			// Long:  "",
 		},
-		assets: []asset.WritableAsset{&bootstrap.Bootstrap{}, &machine.Master{}, &machine.Worker{}},
+		assets: []asset.WritableAsset{&bootstrap.Bootstrap{}, &machine.Master{}, &machine.Worker{}, &kubeconfig.Admin{}},
 	}
 
 	clusterTarget = target{


### PR DESCRIPTION
When performing BYO RHEL installations we only call `create ignition-configs` and we'd like to have the generated kubeconfig created at that point as well. I had initially proposed moving it but it was suggested to add it rather than move it.