### PR TITLE
hack/build: Bump RHCOS from 47.245 to 47.249

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.9.1 - 2019-01-07
+
+### Changed
+
+- Bumped the pinned RHCOS from 47.245 to 47.249 to fix a bug where
+  Ignition was run on every boot (when it should only run on the first
+  boot).
+
 ## 0.9.0 - 2019-01-05
 
 ### Added

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -3,7 +3,7 @@
 set -ex
 
 RELEASE_IMAGE="${RELEASE_IMAGE:-quay.io/openshift-release-dev/ocp-release:4.0.0-9}"
-RHCOS_BUILD_NAME="${RELEASE_BUILD_NAME:-47.245}"
+RHCOS_BUILD_NAME="${RELEASE_BUILD_NAME:-47.249}"
 
 # shellcheck disable=SC2068
 version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}


### PR DESCRIPTION
To fix a bug where Ignition was run on every boot (when it should only run on the first boot).

[The 47.249 build][1] is still running, but I thought I'd push this up so it's ready when the build goes out.

CC @crawford

[1]: https://continuous-infra-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/redhat-coreos-maipo/3613/console