### PR TITLE
types/validation: add version to install-config

### DIFF
--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -54,6 +54,9 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 	)
 
 	a.Config = &types.InstallConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1beta1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName.ClusterName,
 		},

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -20,6 +20,9 @@ import (
 
 func validInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1beta1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
 		},
@@ -54,6 +57,9 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 		t.Errorf("unexpected error generating install config: %v", err)
 	}
 	expected := &types.InstallConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1beta1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
 		},
@@ -99,6 +105,7 @@ func TestInstallConfigLoad(t *testing.T) {
 		{
 			name: "valid InstallConfig",
 			data: `
+apiVersion: v1beta1
 metadata:
   name: test-cluster
 baseDomain: test-domain
@@ -109,6 +116,9 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: true,
 			expectedConfig: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1beta1",
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -19,9 +19,19 @@ import (
 	"github.com/openshift/installer/pkg/validate"
 )
 
+const (
+	installConfigVersion = "v1beta1"
+)
+
 // ValidateInstallConfig checks that the specified install config is valid.
 func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher openstackvalidation.ValidValuesFetcher) field.ErrorList {
 	allErrs := field.ErrorList{}
+	if c.TypeMeta.APIVersion == "" {
+		return field.ErrorList{field.Required(field.NewPath("apiVersion"), "install-config version required")}
+	}
+	if c.TypeMeta.APIVersion != installConfigVersion {
+		return field.ErrorList{field.Invalid(field.NewPath("apiVersion"), c.TypeMeta.APIVersion, fmt.Sprintf("install-config version must be %q", installConfigVersion))}
+	}
 	if c.ObjectMeta.Name == "" {
 		allErrs = append(allErrs, field.Required(field.NewPath("metadata", "name"), "cluster name required"))
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -18,6 +18,9 @@ import (
 
 func validInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1beta1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
 		},


### PR DESCRIPTION
The install-config needs to be versioned in order to allow the installer
to make changes, breaking or otherwise. Since the install-config is
already a valid Kubernetes object, it adopts the same versioning scheme.

cc @dgoodwin @wking @abhinavdahiya @smarterclayton 