### PR TITLE
Remove the double @sha256 in case the image name is already digest base

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -11,7 +11,7 @@ fi
 # convert the release image pull spec to an "absolute" form if a digest is available - this is
 # safe to resolve after the actions above because podman will not pull the image once it is
 # locally available
-if ! release=$( podman inspect {{.ReleaseImage}} -f '{{"{{"}} index .RepoDigests 0 {{"}}"}}' ) || [[ -z "${release}" ]]; then
+if ! release=$( podman inspect {{.ReleaseImage}} -f '{{"{{"}} index .RepoDigests 0 {{"}}"}}' | sed s/@sha256@sha256/@sha256/ ) || [[ -z "${release}" ]]; then
 	echo "Warning: Could not resolve release image to pull by digest" 2>&1
 	release="{{.ReleaseImage}}"
 fi


### PR DESCRIPTION
Due to the issue in podman it seems to incorrectly return digests with
double @sha256 in the name.

This patch fixes the issue in the bootkube.sh to remove double occurances
of @256 and replace it with single occurence, as normally expected.

I.e.
quay.io/openshift-release-dev/ocp-release@sha256@sha256:e237499d3b118e25890550daad8b17274af93baf855914a9c6f8f07ebc095dea

Reference to the issue:
https://github.com/openshift/installer/issues/933

Signed-off-by: Lev Veyde <lveyde@redhat.com>