### PR TITLE
openstack: document shifting to external load balancer.

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -101,6 +101,92 @@ handle the request (get routes.route.openshift.io)
 FATAL waiting for openshift-console URL: context deadline exceeded
 ```
 
+## Using an External Load Balancer
+
+This documents how to shift from the API VM load balancer, which is
+intended for initial cluster deployment and not highly available, to an
+external load balancer.
+
+The load balancer must serve ports 6443, 443, and 80 to any users of
+the system.  Port 49500 is for serving ignition startup configurations
+to the OpenShift nodes and should not be reachable outside of the cluster.
+
+The first step is to add floating IPs to all the master nodes:
+
+* `openstack floating ip create --port master-port-0 <public network>`
+* `openstack floating ip create --port master-port-1 <public network>`
+* `openstack floating ip create --port master-port-2 <public network>`
+
+Once complete you can see your floating IPs using:
+
+* `openstack server list`
+
+These floating IPs can then be used by the load balancer to access
+the cluster.  An example haproxy configuration for port 6443 is below.
+The other port configurations are identical.
+
+```
+listen <cluster name>-api-6443
+    bind 0.0.0.0:6443
+    mode tcp
+    balance roundrobin
+    server <cluster name>-master-2 <floating ip>:6443 check
+    server <cluster name>-master-0 <floating ip>:6443 check
+    server <cluster name>-master-1 <floating ip>:6443 check
+```
+
+The next step is to allow network access from the load balancer network
+to the master nodes:
+
+* `openstack security group rule create master --remote-ip <load balancer CIDR> --ingress --protocol tcp --dst-port 6443`
+* `openstack security group rule create master --remote-ip <load balancer CIDR> --ingress --protocol tcp --dst-port 443`
+* `openstack security group rule create master --remote-ip <load balancer CIDR> --ingress --protocol tcp --dst-port 80`
+
+You could also specify a specific IP address with /32 if you wish.
+
+You can verify the operation of the load balancer now if you wish, using the
+curl commands given below.
+
+Now the DNS entry for <cluster name>-api.<base domain> needs to be updated
+to point to the new load balancer:
+
+* `<load balancer ip> <cluster-name>-api.<base domain>`
+
+The external load balancer should now be operational along with your own
+DNS solution. It's best to test this configuration before removing
+the API. The following curl command is an example of how
+to check functionality:
+
+`curl https://<loadbalancer-ip>:6443/version --insecure`
+
+Result:
+
+```json
+{
+  "major": "1",
+  "minor": "11+",
+  "gitVersion": "v1.11.0+ad103ed",
+  "gitCommit": "ad103ed",
+  "gitTreeState": "clean",
+  "buildDate": "2019-01-09T06:44:10Z",
+  "goVersion": "go1.10.3",
+  "compiler": "gc",
+  "platform": "linux/amd64"
+}
+```
+
+Another useful thing to check is that the ignition configurations are
+only available from within the deployment. The following command should
+only succeed from a node in the OpenShift cluster:
+
+* `curl https://<loadbalancer ip>:49500/config/master --insecure`
+
+Now that the DNS and load balancer has been moved, we can take down the existing
+api VM:
+
+* `openstack server delete <cluster name>-api`
+
+
 ## Reporting Issues
 
 Please see the [Issue Tracker][issues_openstack] for current known issues.


### PR DESCRIPTION
We've documented the steps to shift to an external load balancer here.
I did not cover specifically how to configure the DNS, only that the -api
record needs to be changed.  I'll leave this for the DNS folks or fix
it after they submit their documentation.

Co-Authored-By: egarcia@redhat.com