### PR TITLE
data/openstack/topology: Close ignition sg to outside world.

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -9,7 +9,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_mcs" {
   protocol          = "tcp"
   port_range_min    = 49500
   port_range_max    = 49500
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = "${var.cidr_block}"
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
 


### PR DESCRIPTION
Not sure why this was set like this?  I suspect we want this to only
be available to the deployment subnet.