### PR TITLE
data/aws: Tag IAM roles

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -63,6 +63,8 @@ resource "aws_iam_role" "bootstrap" {
     ]
 }
 EOF
+
+  tags = "${var.tags}"
 }
 
 resource "aws_iam_role_policy" "bootstrap" {

--- a/data/data/aws/iam/main.tf
+++ b/data/data/aws/iam/main.tf
@@ -36,6 +36,8 @@ resource "aws_iam_role" "worker_role" {
     ]
 }
 EOF
+
+  tags = "${var.tags}"
 }
 
 resource "aws_iam_role_policy" "worker_policy" {

--- a/data/data/aws/iam/variables.tf
+++ b/data/data/aws/iam/variables.tf
@@ -7,3 +7,9 @@ variable "worker_iam_role" {
   default     = ""
   description = "IAM role to use for the instance profiles of worker nodes."
 }
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "AWS tags to be applied to created resources."
+}

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -57,6 +57,10 @@ module "iam" {
 
   cluster_name    = "${var.cluster_name}"
   worker_iam_role = "${var.aws_worker_iam_role_name}"
+
+  tags = "${merge(map(
+      "kubernetes.io/cluster/${var.cluster_name}", "owned",
+    ), local.tags)}"
 }
 
 module "dns" {

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -36,6 +36,8 @@ resource "aws_iam_role" "master_role" {
     ]
 }
 EOF
+
+  tags = "${var.tags}"
 }
 
 resource "aws_iam_role_policy" "master_policy" {

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -95,10 +95,8 @@ resource "aws_instance" "master" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}-master-${count.index}",
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}",
       "clusterid", "${var.cluster_name}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 
   root_block_device {
     volume_type = "${var.root_volume_type}"
@@ -108,9 +106,7 @@ resource "aws_instance" "master" {
 
   volume_tags = "${merge(map(
     "Name", "${var.cluster_name}-master-${count.index}-vol",
-    "kubernetes.io/cluster/${var.cluster_name}", "owned",
-    "openshiftClusterID", "${var.cluster_id}"
-  ), var.extra_tags)}"
+  ), var.tags)}"
 }
 
 resource "aws_lb_target_group_attachment" "master" {

--- a/data/data/aws/master/variables.tf
+++ b/data/data/aws/master/variables.tf
@@ -20,12 +20,6 @@ variable "ec2_type" {
   type = "string"
 }
 
-variable "extra_tags" {
-  description = "Extra AWS tags to be applied to created resources."
-  type        = "map"
-  default     = {}
-}
-
 variable "ec2_ami" {
   type    = "string"
   default = ""
@@ -69,6 +63,12 @@ variable "root_volume_type" {
 
 variable "subnet_ids" {
   type = "list"
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "AWS tags to be applied to created resources."
 }
 
 variable "target_group_arns" {

--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -6,10 +6,7 @@ resource "aws_lb" "api_internal" {
   enable_cross_zone_load_balancing = true
   idle_timeout                     = 3600
 
-  tags = "${merge(map(
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+  tags = "${var.tags}"
 }
 
 resource "aws_lb" "api_external" {
@@ -20,10 +17,7 @@ resource "aws_lb" "api_external" {
   enable_cross_zone_load_balancing = true
   idle_timeout                     = 3600
 
-  tags = "${merge(map(
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+  tags = "${var.tags}"
 }
 
 resource "aws_lb_target_group" "api_internal" {
@@ -34,10 +28,7 @@ resource "aws_lb_target_group" "api_internal" {
 
   target_type = "ip"
 
-  tags = "${merge(map(
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+  tags = "${var.tags}"
 
   health_check {
     healthy_threshold   = 3
@@ -57,10 +48,7 @@ resource "aws_lb_target_group" "api_external" {
 
   target_type = "ip"
 
-  tags = "${merge(map(
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+  tags = "${var.tags}"
 
   health_check {
     healthy_threshold   = 3
@@ -80,10 +68,7 @@ resource "aws_lb_target_group" "services" {
 
   target_type = "ip"
 
-  tags = "${merge(map(
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+  tags = "${var.tags}"
 
   health_check {
     healthy_threshold   = 3

--- a/data/data/aws/vpc/sg-elb.tf
+++ b/data/data/aws/vpc/sg-elb.tf
@@ -3,9 +3,7 @@ resource "aws_security_group" "api" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}_api_sg",
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 }
 
 resource "aws_security_group_rule" "api_egress" {
@@ -43,9 +41,7 @@ resource "aws_security_group" "console" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}_console_sg",
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 }
 
 resource "aws_security_group_rule" "console_egress" {

--- a/data/data/aws/vpc/sg-etcd.tf
+++ b/data/data/aws/vpc/sg-etcd.tf
@@ -3,9 +3,7 @@ resource "aws_security_group" "etcd" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}_etcd_sg",
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 }
 
 resource "aws_security_group_rule" "etcd_egress" {

--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -3,9 +3,7 @@ resource "aws_security_group" "master" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}_master_sg",
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 }
 
 resource "aws_security_group_rule" "master_mcs" {

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -3,9 +3,7 @@ resource "aws_security_group" "worker" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}_worker_sg",
-      "kubernetes.io/cluster/${var.cluster_name}", "owned",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 }
 
 resource "aws_security_group_rule" "worker_egress" {

--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -14,12 +14,6 @@ variable "cluster_name" {
   type = "string"
 }
 
-variable "extra_tags" {
-  description = "Extra AWS tags to be applied to created resources."
-  type        = "map"
-  default     = {}
-}
-
 variable "private_master_endpoints" {
   description = "If set to true, private-facing ingress resources are created."
   default     = true
@@ -33,4 +27,10 @@ variable "public_master_endpoints" {
 variable "region" {
   type        = "string"
   description = "The target AWS region for the cluster."
+}
+
+variable "tags" {
+  type        = "map"
+  default     = {}
+  description = "AWS tags to be applied to created resources."
 }

--- a/data/data/aws/vpc/vpc-private.tf
+++ b/data/data/aws/vpc/vpc-private.tf
@@ -4,9 +4,7 @@ resource "aws_route_table" "private_routes" {
 
   tags = "${merge(map(
       "Name","${var.cluster_name}-private-${local.new_subnet_azs[count.index]}",
-      "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 }
 
 resource "aws_route" "to_nat_gw" {
@@ -27,12 +25,9 @@ resource "aws_subnet" "worker_subnet" {
   availability_zone = "${local.new_subnet_azs[count.index]}"
 
   tags = "${merge(map(
-    "Name", "${var.cluster_name}-worker-${local.new_subnet_azs[count.index]}",
-    "kubernetes.io/cluster/${var.cluster_name}","shared",
-    "kubernetes.io/role/internal-elb", "",
-    "openshiftClusterID", "${var.cluster_id}"
-    ),
-    var.extra_tags)}"
+      "Name", "${var.cluster_name}-worker-${local.new_subnet_azs[count.index]}",
+      "kubernetes.io/role/internal-elb", "",
+    ), var.tags)}"
 }
 
 resource "aws_route_table_association" "worker_routing" {

--- a/data/data/aws/vpc/vpc-public.tf
+++ b/data/data/aws/vpc/vpc-public.tf
@@ -3,9 +3,7 @@ resource "aws_internet_gateway" "igw" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}-igw",
-      "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 }
 
 resource "aws_route_table" "default" {
@@ -13,9 +11,7 @@ resource "aws_route_table" "default" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}-public",
-      "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 }
 
 resource "aws_main_route_table_association" "main_vpc_routes" {
@@ -38,10 +34,8 @@ resource "aws_subnet" "master_subnet" {
   availability_zone = "${local.new_subnet_azs[count.index]}"
 
   tags = "${merge(map(
-    "Name", "${var.cluster_name}-master-${local.new_subnet_azs[count.index]}",
-      "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+      "Name", "${var.cluster_name}-master-${local.new_subnet_azs[count.index]}",
+    ), var.tags)}"
 }
 
 resource "aws_route_table_association" "route_net" {
@@ -54,9 +48,7 @@ resource "aws_eip" "nat_eip" {
   count = "${local.new_az_count}"
   vpc   = true
 
-  tags = "${merge(map(
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+  tags = "${var.tags}"
 
   # Terraform does not declare an explicit dependency towards the internet gateway.
   # this can cause the internet gateway to be deleted/detached before the EIPs.
@@ -69,7 +61,5 @@ resource "aws_nat_gateway" "nat_gw" {
   allocation_id = "${aws_eip.nat_eip.*.id[count.index]}"
   subnet_id     = "${aws_subnet.master_subnet.*.id[count.index]}"
 
-  tags = "${merge(map(
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+  tags = "${var.tags}"
 }

--- a/data/data/aws/vpc/vpc.tf
+++ b/data/data/aws/vpc/vpc.tf
@@ -10,9 +10,7 @@ resource "aws_vpc" "new_vpc" {
 
   tags = "${merge(map(
       "Name", "${var.cluster_name}.${var.base_domain}",
-      "kubernetes.io/cluster/${var.cluster_name}", "shared",
-      "openshiftClusterID", "${var.cluster_id}"
-    ), var.extra_tags)}"
+    ), var.tags)}"
 }
 
 resource "aws_vpc_endpoint" "s3" {


### PR DESCRIPTION
As reported by in #1000, we're currently deleting these roles based on cluster name, when we'd ideally be deleting them based on the more-specific cluster ID.  Tagging the roles is a step in that direction, although as of this commit we still delete roles by name.  In coming work, I'll pivot to deleting these based on their tags.

The tag property is documented [here][2].  Unfortunately, [instance profiles are not tag-able][3].

[1]: https://github.com/openshift/installer/issues/1000
[2]: https://www.terraform.io/docs/providers/aws/r/iam_role.html#tags
[3]: https://www.terraform.io/docs/providers/aws/r/iam_instance_profile.html