### PR TITLE
openstack: update the machine templates

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -119,6 +119,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			instances = append(instances, fmt.Sprintf("master-%d", i))
 		}
 		config := openstack.MasterConfig{
+			CloudName:   ic.Platform.OpenStack.Cloud,
 			ClusterName: ic.ObjectMeta.Name,
 			Instances:   instances,
 			Image:       ic.Platform.OpenStack.BaseImage,

--- a/pkg/asset/machines/openstack/master.go
+++ b/pkg/asset/machines/openstack/master.go
@@ -9,6 +9,7 @@ import (
 
 // MasterConfig is used to generate the machine.
 type MasterConfig struct {
+	CloudName   string
 	ClusterName string
 	Instances   []string
 	Image       string
@@ -42,31 +43,24 @@ items:
       value:
         apiVersion: openstack.cluster.k8s.io/v1alpha1
         kind: OpenStackMachineProviderConfig
-        image:
-          id: {{$c.Image}}
+        cloudName: {{$c.CloudName}}
+        cloudsSecret: "openstack-credentials"
+        image: {{$c.Image}}
         flavor: {{$c.Machine.FlavorName}}
         placement:
           region: {{$c.Region}}
-        subnet:
-          filters:
-          - name: "tag:Name"
-            values:
-            - "{{$c.ClusterName}}-master-*"
-        tags:
+        networks:
 {{- range $key,$value := $c.Tags}}
-          - name: "{{$key}}"
-            value: "{{$value}}"
+        - filter:
+            tags: "{{$key}}={{$value}}"
 {{- end}}
         securityGroups:
-          - filters:
-            - name: "tag:Name"
-              values:
-              - "{{$c.ClusterName}}_master_sg"
+          - master
         userDataSecret:
           name: master-user-data
         trunk: {{$c.Trunk}}
     versions:
-      kubelet: ""
+      kubelet: "v1.11.0"
       controlPlane: ""
 {{- end -}}
 `))

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -137,6 +137,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			numOfWorkers = *pool.Replicas
 		}
 		config := openstack.Config{
+			CloudName:   ic.Platform.OpenStack.Cloud,
 			ClusterName: ic.ObjectMeta.Name,
 			Replicas:    numOfWorkers,
 			Image:       ic.Platform.OpenStack.BaseImage,


### PR DESCRIPTION
Note that we're passing a version for kubelet, which the openstack
actuator checks on. This version, however, is completely ignored by the
CoreOS image. We'll work on removing this requirement from the openstack
actuator but, in the meantime, we should just set it to something to
avoid breaking.