### PR TITLE
[FIX #1006] destroy/libvirt: cannot destroy domain if it is already shutoff

### DIFF
--- a/pkg/destroy/libvirt/libvirt.go
+++ b/pkg/destroy/libvirt/libvirt.go
@@ -104,10 +104,16 @@ func deleteDomainsSinglePass(conn *libvirt.Connect, filter filterFunc, logger lo
 		}
 
 		nothingToDelete = false
-		if err := domain.Destroy(); err != nil {
-			return false, errors.Wrapf(err, "destroy domain %q", dName)
+		dState, _, err := domain.GetState()
+		if err != nil {
+			return false, errors.Wrapf(err, "get domain state %d", dName)
 		}
 
+		if dState != libvirt.DOMAIN_SHUTOFF && dState != libvirt.DOMAIN_SHUTDOWN {
+			if err := domain.Destroy(); err != nil {
+				return false, errors.Wrapf(err, "destroy domain %q", dName)
+			}
+		}
 		if err := domain.Undefine(); err != nil {
 			return false, errors.Wrapf(err, "undefine domain %q", dName)
 		}


### PR DESCRIPTION
https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainDestroy
```
Destroy the domain object. The running instance is shutdown if not down already and all resources used by it are given back to the hypervisor.
```

Calling destroy on a shutoff/shutdown domain returns `Requested operation is not valid: domain is not running` error.
Therefore, skipping calling destroy when domain is already in those 2 states.

Fixes #1006