### PR TITLE
tls: increase validity of client cert used for boostrapping masters to 1 day

### DIFF
--- a/pkg/asset/tls/kubeletcertkey.go
+++ b/pkg/asset/tls/kubeletcertkey.go
@@ -32,7 +32,7 @@ func (a *KubeletCertKey) Generate(dependencies asset.Parents) error {
 		Subject:      pkix.Name{CommonName: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper", Organization: []string{"system:serviceaccounts:openshift-machine-config-operator"}},
 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		Validity:     ValidityThirtyMinutes,
+		Validity:     ValidityOneDay,
 	}
 
 	return a.CertKey.Generate(cfg, kubeCA, "kubelet", DoNotAppendParent)

--- a/pkg/asset/tls/tls.go
+++ b/pkg/asset/tls/tls.go
@@ -24,9 +24,9 @@ const (
 	// ValidityTenYears sets the validity of a cert to 10 years.
 	ValidityTenYears = time.Hour * 24 * 365 * 10
 
-	// ValidityThirtyMinutes sets the validity of a cert to 30 minutes.
+	// ValidityOneDay sets the validity of a cert to 24 hours.
 	// This is for the kubelet bootstrap.
-	ValidityThirtyMinutes = time.Minute * 30
+	ValidityOneDay = time.Hour * 24
 )
 
 // CertCfg contains all needed fields to configure a new certificate


### PR DESCRIPTION
The 30 minutes validity was necessary as before https://github.com/openshift/installer/pull/879 the client certificate provided
cluster admin rights. But after https://github.com/openshift/installer/pull/879 the client certificate only has access to CSR endpoint.

Therefore, we can safely increase the validity to something longer.

/cc @crawford 

Fixes #650.