### PR TITLE
types: hide OpenStack in the list of platforms

### DIFF
--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -16,13 +16,13 @@ var (
 	// platforms presented to the user in the interactive wizard.
 	PlatformNames = []string{
 		aws.Name,
-		openstack.Name,
 	}
 	// HiddenPlatformNames is a slice with all the
 	// hidden-but-supported platform names. This list isn't presented
 	// to the user in the interactive wizard.
 	HiddenPlatformNames = []string{
 		none.Name,
+		openstack.Name,
 	}
 )
 


### PR DESCRIPTION
Since OpenStack isn't going to be fully supported in 4.0, it needs to be
hidden to prevent users from accidentally choosing it. This still leaves
the platform prompt in the UI with just a single choice, but this is
nice because it makes it clear that more platforms will be supported by
this tool in the future.