### PR TITLE
assets/installconfig: apply defaults to install config

### DIFF
--- a/pkg/asset/ignition/machine/master_test.go
+++ b/pkg/asset/ignition/machine/master_test.go
@@ -22,8 +22,8 @@ func TestMasterGenerate(t *testing.T) {
 				Name: "test-cluster",
 			},
 			BaseDomain: "test-domain",
-			Networking: types.Networking{
-				ServiceCIDR: *ipnet.MustParseCIDR("10.0.1.0/24"),
+			Networking: &types.Networking{
+				ServiceCIDR: ipnet.MustParseCIDR("10.0.1.0/24"),
 			},
 			Platform: types.Platform{
 				AWS: &aws.Platform{

--- a/pkg/asset/ignition/machine/worker_test.go
+++ b/pkg/asset/ignition/machine/worker_test.go
@@ -17,8 +17,8 @@ import (
 func TestWorkerGenerate(t *testing.T) {
 	installConfig := &installconfig.InstallConfig{
 		Config: &types.InstallConfig{
-			Networking: types.Networking{
-				ServiceCIDR: *ipnet.MustParseCIDR("10.0.1.0/24"),
+			Networking: &types.Networking{
+				ServiceCIDR: ipnet.MustParseCIDR("10.0.1.0/24"),
 			},
 			Platform: types.Platform{
 				AWS: &aws.Platform{

--- a/pkg/asset/installconfig/libvirt/libvirt.go
+++ b/pkg/asset/installconfig/libvirt/libvirt.go
@@ -4,19 +4,9 @@ package libvirt
 import (
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
-	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/libvirt"
+	libvirtdefaults "github.com/openshift/installer/pkg/types/libvirt/defaults"
 	"github.com/openshift/installer/pkg/validate"
-)
-
-const (
-	defaultNetworkIfName = "tt0"
-)
-
-var (
-	// DefaultMachineCIDR is the libvirt default IP address space from
-	// which to assign machine IPs.
-	DefaultMachineCIDR = ipnet.MustParseCIDR("192.168.126.0/24")
 )
 
 // Platform collects libvirt-specific configuration.
@@ -27,7 +17,7 @@ func Platform() (*libvirt.Platform, error) {
 			Prompt: &survey.Input{
 				Message: "Libvirt Connection URI",
 				Help:    "The libvirt connection URI to be used. This must be accessible from the running cluster.",
-				Default: "qemu+tcp://192.168.122.1/system",
+				Default: libvirtdefaults.DefaultURI,
 			},
 			Validate: survey.ComposeValidators(survey.Required, uriValidator),
 		},
@@ -37,9 +27,6 @@ func Platform() (*libvirt.Platform, error) {
 	}
 
 	return &libvirt.Platform{
-		Network: libvirt.Network{
-			IfName: defaultNetworkIfName,
-		},
 		URI: uri,
 	}, nil
 }

--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -1,0 +1,9 @@
+package defaults
+
+import (
+	"github.com/openshift/installer/pkg/types/aws"
+)
+
+// SetPlatformDefaults sets the defaults for the platform.
+func SetPlatformDefaults(p *aws.Platform) {
+}

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -7,10 +7,12 @@ type Platform struct {
 	Region string `json:"region"`
 
 	// UserTags specifies additional tags for AWS resources created for the cluster.
+	// +optional
 	UserTags map[string]string `json:"userTags,omitempty"`
 
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on AWS for machine pools which do not define their own
 	// platform configuration.
+	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
 }

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -1,0 +1,74 @@
+package defaults
+
+import (
+	netopv1 "github.com/openshift/cluster-network-operator/pkg/apis/networkoperator/v1"
+
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
+	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
+	libvirtdefaults "github.com/openshift/installer/pkg/types/libvirt/defaults"
+	nonedefaults "github.com/openshift/installer/pkg/types/none/defaults"
+	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
+)
+
+var (
+	defaultMachineCIDR      = ipnet.MustParseCIDR("10.0.0.0/16")
+	defaultServiceCIDR      = ipnet.MustParseCIDR("172.30.0.0/16")
+	defaultClusterCIDR      = "10.128.0.0/14"
+	defaultHostSubnetLength = 9 // equivalent to a /23 per node
+)
+
+// SetInstallConfigDefaults sets the defaults for the install config.
+func SetInstallConfigDefaults(c *types.InstallConfig) {
+	if c.Networking == nil {
+		c.Networking = &types.Networking{}
+	}
+	if c.Networking.MachineCIDR == nil {
+		c.Networking.MachineCIDR = defaultMachineCIDR
+		if c.Platform.Libvirt != nil {
+			c.Networking.MachineCIDR = libvirtdefaults.DefaultMachineCIDR
+		}
+	}
+	if c.Networking.Type == "" {
+		c.Networking.Type = netopv1.NetworkTypeOpenshiftSDN
+	}
+	if c.Networking.ServiceCIDR == nil {
+		c.Networking.ServiceCIDR = defaultServiceCIDR
+	}
+	if len(c.Networking.ClusterNetworks) == 0 && c.Networking.PodCIDR == nil {
+		c.Networking.ClusterNetworks = []netopv1.ClusterNetwork{
+			{
+				CIDR:             defaultClusterCIDR,
+				HostSubnetLength: uint32(defaultHostSubnetLength),
+			},
+		}
+	}
+	if len(c.Machines) == 0 {
+		numberOfMasters := int64(3)
+		numberOfWorkers := int64(3)
+		if c.Platform.Libvirt != nil {
+			numberOfMasters = 1
+			numberOfWorkers = 1
+		}
+		c.Machines = []types.MachinePool{
+			{
+				Name:     "master",
+				Replicas: func(x int64) *int64 { return &x }(numberOfMasters),
+			},
+			{
+				Name:     "worker",
+				Replicas: func(x int64) *int64 { return &x }(numberOfWorkers),
+			},
+		}
+	}
+	switch {
+	case c.Platform.AWS != nil:
+		awsdefaults.SetPlatformDefaults(c.Platform.AWS)
+	case c.Platform.Libvirt != nil:
+		libvirtdefaults.SetPlatformDefaults(c.Platform.Libvirt)
+	case c.Platform.OpenStack != nil:
+		openstackdefaults.SetPlatformDefaults(c.Platform.OpenStack)
+	case c.Platform.None != nil:
+		nonedefaults.SetPlatformDefaults(c.Platform.None)
+	}
+}

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -1,0 +1,257 @@
+package defaults
+
+import (
+	"testing"
+
+	netopv1 "github.com/openshift/cluster-network-operator/pkg/apis/networkoperator/v1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/aws"
+	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	libvirtdefaults "github.com/openshift/installer/pkg/types/libvirt/defaults"
+	"github.com/openshift/installer/pkg/types/none"
+	nonedefaults "github.com/openshift/installer/pkg/types/none/defaults"
+	"github.com/openshift/installer/pkg/types/openstack"
+	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
+)
+
+func defaultInstallConfig() *types.InstallConfig {
+	return &types.InstallConfig{
+		Networking: &types.Networking{
+			MachineCIDR: defaultMachineCIDR,
+			Type:        netopv1.NetworkTypeOpenshiftSDN,
+			ServiceCIDR: defaultServiceCIDR,
+			ClusterNetworks: []netopv1.ClusterNetwork{
+				{
+					CIDR:             defaultClusterCIDR,
+					HostSubnetLength: uint32(defaultHostSubnetLength),
+				},
+			},
+		},
+		Machines: []types.MachinePool{
+			{
+				Name:     "master",
+				Replicas: func(x int64) *int64 { return &x }(3),
+			},
+			{
+				Name:     "worker",
+				Replicas: func(x int64) *int64 { return &x }(3),
+			},
+		},
+	}
+}
+
+func defaultAWSInstallConfig() *types.InstallConfig {
+	c := defaultInstallConfig()
+	c.Platform.AWS = &aws.Platform{}
+	awsdefaults.SetPlatformDefaults(c.Platform.AWS)
+	return c
+}
+
+func defaultLibvirtInstallConfig() *types.InstallConfig {
+	c := defaultInstallConfig()
+	c.Networking.MachineCIDR = libvirtdefaults.DefaultMachineCIDR
+	c.Platform.Libvirt = &libvirt.Platform{}
+	libvirtdefaults.SetPlatformDefaults(c.Platform.Libvirt)
+	for i, m := range c.Machines {
+		m.Replicas = func(x int64) *int64 { return &x }(1)
+		c.Machines[i] = m
+	}
+	return c
+}
+
+func defaultOpenStackInstallConfig() *types.InstallConfig {
+	c := defaultInstallConfig()
+	c.Platform.OpenStack = &openstack.Platform{}
+	openstackdefaults.SetPlatformDefaults(c.Platform.OpenStack)
+	return c
+}
+
+func defaultNoneInstallConfig() *types.InstallConfig {
+	c := defaultInstallConfig()
+	c.Platform.None = &none.Platform{}
+	nonedefaults.SetPlatformDefaults(c.Platform.None)
+	return c
+}
+
+func TestSetInstallConfigDefaults(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   *types.InstallConfig
+		expected *types.InstallConfig
+	}{
+		{
+			name:     "empty",
+			config:   &types.InstallConfig{},
+			expected: defaultInstallConfig(),
+		},
+		{
+			name: "empty AWS",
+			config: &types.InstallConfig{
+				Platform: types.Platform{
+					AWS: &aws.Platform{},
+				},
+			},
+			expected: defaultAWSInstallConfig(),
+		},
+		{
+			name: "empty Libvirt",
+			config: &types.InstallConfig{
+				Platform: types.Platform{
+					Libvirt: &libvirt.Platform{},
+				},
+			},
+			expected: defaultLibvirtInstallConfig(),
+		},
+		{
+			name: "empty OpenStack",
+			config: &types.InstallConfig{
+				Platform: types.Platform{
+					OpenStack: &openstack.Platform{},
+				},
+			},
+			expected: defaultOpenStackInstallConfig(),
+		},
+		{
+			name: "Networking present",
+			config: &types.InstallConfig{
+				Networking: &types.Networking{},
+			},
+			expected: defaultInstallConfig(),
+		},
+		{
+			name: "Networking types present",
+			config: &types.InstallConfig{
+				Networking: &types.Networking{
+					Type: netopv1.NetworkType("test-networking-type"),
+				},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultInstallConfig()
+				c.Networking.Type = netopv1.NetworkType("test-networking-type")
+				return c
+			}(),
+		},
+		{
+			name: "Service CIDR present",
+			config: &types.InstallConfig{
+				Networking: &types.Networking{
+					ServiceCIDR: ipnet.MustParseCIDR("1.2.3.4/8"),
+				},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultInstallConfig()
+				c.Networking.ServiceCIDR = ipnet.MustParseCIDR("1.2.3.4/8")
+				return c
+			}(),
+		},
+		{
+			name: "Cluster Networks present",
+			config: &types.InstallConfig{
+				Networking: &types.Networking{
+					ClusterNetworks: []netopv1.ClusterNetwork{
+						{
+							CIDR:             "test-cidr",
+							HostSubnetLength: 10,
+						},
+					},
+				},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultInstallConfig()
+				c.Networking.ClusterNetworks = []netopv1.ClusterNetwork{
+					{
+						CIDR:             "test-cidr",
+						HostSubnetLength: 10,
+					},
+				}
+				return c
+			}(),
+		},
+		{
+			name: "Pod CIDR present",
+			config: &types.InstallConfig{
+				Networking: &types.Networking{
+					PodCIDR: ipnet.MustParseCIDR("1.2.3.4/8"),
+				},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultInstallConfig()
+				c.Networking.ClusterNetworks = nil
+				c.Networking.PodCIDR = ipnet.MustParseCIDR("1.2.3.4/8")
+				return c
+			}(),
+		},
+		{
+			name: "Machines present",
+			config: &types.InstallConfig{
+				Machines: []types.MachinePool{{Name: "test-machine"}},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultInstallConfig()
+				c.Machines = []types.MachinePool{{Name: "test-machine"}}
+				return c
+			}(),
+		},
+		{
+			name: "AWS platform present",
+			config: &types.InstallConfig{
+				Platform: types.Platform{
+					AWS: &aws.Platform{},
+				},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultAWSInstallConfig()
+				return c
+			}(),
+		},
+		{
+			name: "Libvirt platform present",
+			config: &types.InstallConfig{
+				Platform: types.Platform{
+					Libvirt: &libvirt.Platform{
+						URI: "test-uri",
+					},
+				},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultLibvirtInstallConfig()
+				c.Platform.Libvirt.URI = "test-uri"
+				return c
+			}(),
+		},
+		{
+			name: "OpenStack platform present",
+			config: &types.InstallConfig{
+				Platform: types.Platform{
+					OpenStack: &openstack.Platform{},
+				},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultOpenStackInstallConfig()
+				return c
+			}(),
+		},
+		{
+			name: "None platform present",
+			config: &types.InstallConfig{
+				Platform: types.Platform{
+					None: &none.Platform{},
+				},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultNoneInstallConfig()
+				return c
+			}(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetInstallConfigDefaults(tc.config)
+			assert.Equal(t, tc.expected, tc.config, "unexpected install config")
+		})
+	}
+}

--- a/pkg/types/libvirt/defaults/network.go
+++ b/pkg/types/libvirt/defaults/network.go
@@ -1,0 +1,24 @@
+package defaults
+
+import (
+	"github.com/openshift/installer/pkg/ipnet"
+
+	"github.com/openshift/installer/pkg/types/libvirt"
+)
+
+const (
+	defaultIfName = "tt0"
+)
+
+var (
+	// DefaultMachineCIDR is the libvirt default IP address space from
+	// which to assign machine IPs.
+	DefaultMachineCIDR = ipnet.MustParseCIDR("192.168.126.0/24")
+)
+
+// SetNetworkDefaults sets the defaults for the network.
+func SetNetworkDefaults(n *libvirt.Network) {
+	if n.IfName == "" {
+		n.IfName = defaultIfName
+	}
+}

--- a/pkg/types/libvirt/defaults/network_test.go
+++ b/pkg/types/libvirt/defaults/network_test.go
@@ -1,0 +1,46 @@
+package defaults
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/installer/pkg/types/libvirt"
+)
+
+func defaultNetwork() *libvirt.Network {
+	return &libvirt.Network{
+		IfName: defaultIfName,
+	}
+}
+
+func TestSetNetworkDefaults(t *testing.T) {
+	cases := []struct {
+		name     string
+		network  *libvirt.Network
+		expected *libvirt.Network
+	}{
+		{
+			name:     "empty",
+			network:  &libvirt.Network{},
+			expected: defaultNetwork(),
+		},
+		{
+			name: "IfName present",
+			network: &libvirt.Network{
+				IfName: "test-if",
+			},
+			expected: func() *libvirt.Network {
+				n := defaultNetwork()
+				n.IfName = "test-if"
+				return n
+			}(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetNetworkDefaults(tc.network)
+			assert.Equal(t, tc.expected, tc.network, "unexpected network")
+		})
+	}
+}

--- a/pkg/types/libvirt/defaults/platform.go
+++ b/pkg/types/libvirt/defaults/platform.go
@@ -1,0 +1,21 @@
+package defaults
+
+import (
+	"github.com/openshift/installer/pkg/types/libvirt"
+)
+
+const (
+	// DefaultURI is the default URI of the libvirtd connection.
+	DefaultURI = "qemu+tcp://192.168.122.1/system"
+)
+
+// SetPlatformDefaults sets the defaults for the platform.
+func SetPlatformDefaults(p *libvirt.Platform) {
+	if p.URI == "" {
+		p.URI = DefaultURI
+	}
+	if p.Network == nil {
+		p.Network = &libvirt.Network{}
+	}
+	SetNetworkDefaults(p.Network)
+}

--- a/pkg/types/libvirt/defaults/platform_test.go
+++ b/pkg/types/libvirt/defaults/platform_test.go
@@ -1,0 +1,67 @@
+package defaults
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/installer/pkg/types/libvirt"
+)
+
+func defaultPlatform() *libvirt.Platform {
+	n := &libvirt.Network{}
+	SetNetworkDefaults(n)
+	return &libvirt.Platform{
+		URI:     DefaultURI,
+		Network: n,
+	}
+}
+
+func TestSetPlatformDefaults(t *testing.T) {
+	cases := []struct {
+		name     string
+		platform *libvirt.Platform
+		expected *libvirt.Platform
+	}{
+		{
+			name:     "empty",
+			platform: &libvirt.Platform{},
+			expected: defaultPlatform(),
+		},
+		{
+			name: "URI present",
+			platform: &libvirt.Platform{
+				URI: "test-uri",
+			},
+			expected: func() *libvirt.Platform {
+				p := defaultPlatform()
+				p.URI = "test-uri"
+				return p
+			}(),
+		},
+		{
+			name: "Network present",
+			platform: &libvirt.Platform{
+				Network: func() *libvirt.Network {
+					n := &libvirt.Network{}
+					SetNetworkDefaults(n)
+					n.IfName = "test-if"
+					return n
+				}(),
+			},
+			expected: func() *libvirt.Platform {
+				p := defaultPlatform()
+				p.Network = &libvirt.Network{}
+				SetNetworkDefaults(p.Network)
+				p.Network.IfName = "test-if"
+				return p
+			}(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetPlatformDefaults(tc.platform)
+			assert.Equal(t, tc.expected, tc.platform, "unexpected platform")
+		})
+	}
+}

--- a/pkg/types/libvirt/network.go
+++ b/pkg/types/libvirt/network.go
@@ -2,6 +2,7 @@ package libvirt
 
 // Network is the configuration of the libvirt network.
 type Network struct {
-	// IfName is the name of the network interface.
-	IfName string `json:"if"`
+	// +optional
+	// Default is tt0.
+	IfName string `json:"if,omitempty"`
 }

--- a/pkg/types/libvirt/platform.go
+++ b/pkg/types/libvirt/platform.go
@@ -10,16 +10,22 @@ type Platform struct {
 	// URI is the identifier for the libvirtd connection.  It must be
 	// reachable from both the host (where the installer is run) and the
 	// cluster (where the cluster-API controller pod will be running).
-	URI string `json:"URI"`
+	// +optional
+	// Default is qemu+tcp://192.168.122.1/system
+	URI string `json:"URI,omitempty"`
 
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on libvirt for machine pools which do not define their
 	// own platform configuration.
+	// +optional
+	// Default will set the image field to the latest RHCOS image.
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
 
 	// Network
-	Network Network `json:"network"`
+	// +optional
+	Network *Network `json:"network,omitempty"`
 
 	// MasterIPs
+	// +optional
 	MasterIPs []net.IP `json:"masterIPs,omitempty"`
 }

--- a/pkg/types/libvirt/validation/platform.go
+++ b/pkg/types/libvirt/validation/platform.go
@@ -16,8 +16,12 @@ func ValidatePlatform(p *libvirt.Platform, fldPath *field.Path) field.ErrorList 
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}
-	if p.Network.IfName == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("network").Child("if"), p.Network.IfName))
+	if p.Network != nil {
+		if p.Network.IfName == "" {
+			allErrs = append(allErrs, field.Required(fldPath.Child("network").Child("if"), p.Network.IfName))
+		}
+	} else {
+		allErrs = append(allErrs, field.Required(fldPath.Child("network"), "network is required"))
 	}
 	return allErrs
 }

--- a/pkg/types/libvirt/validation/platform_test.go
+++ b/pkg/types/libvirt/validation/platform_test.go
@@ -12,7 +12,7 @@ import (
 func validPlatform() *libvirt.Platform {
 	return &libvirt.Platform{
 		URI: "qemu+tcp://192.168.122.1/system",
-		Network: libvirt.Network{
+		Network: &libvirt.Network{
 			IfName: "tt0",
 		},
 	}
@@ -34,6 +34,15 @@ func TestValidatePlatform(t *testing.T) {
 			platform: func() *libvirt.Platform {
 				p := validPlatform()
 				p.URI = "bad-uri"
+				return p
+			}(),
+			valid: false,
+		},
+		{
+			name: "missing network",
+			platform: func() *libvirt.Platform {
+				p := validPlatform()
+				p.Network = nil
 				return p
 			}(),
 			valid: false,

--- a/pkg/types/none/defaults/platform.go
+++ b/pkg/types/none/defaults/platform.go
@@ -1,0 +1,9 @@
+package defaults
+
+import (
+	"github.com/openshift/installer/pkg/types/none"
+)
+
+// SetPlatformDefaults sets the defaults for the platform.
+func SetPlatformDefaults(p *none.Platform) {
+}

--- a/pkg/types/openstack/defaults/platform.go
+++ b/pkg/types/openstack/defaults/platform.go
@@ -1,0 +1,9 @@
+package defaults
+
+import (
+	"github.com/openshift/installer/pkg/types/openstack"
+)
+
+// SetPlatformDefaults sets the defaults for the platform.
+func SetPlatformDefaults(p *openstack.Platform) {
+}

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -9,6 +9,7 @@ type Platform struct {
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on OpenStack for machine pools which do not define their own
 	// platform configuration.
+	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
 
 	// Cloud

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -33,7 +33,11 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 	if err := validate.DomainName(c.BaseDomain); err != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("baseDomain"), c.BaseDomain, err.Error()))
 	}
-	allErrs = append(allErrs, validateNetworking(&c.Networking, field.NewPath("networking"))...)
+	if c.Networking != nil {
+		allErrs = append(allErrs, validateNetworking(c.Networking, field.NewPath("networking"))...)
+	} else {
+		allErrs = append(allErrs, field.Required(field.NewPath("networking"), "networking is required"))
+	}
 	allErrs = append(allErrs, validateMachinePools(c.Machines, field.NewPath("machines"), c.Platform.Name())...)
 	allErrs = append(allErrs, validatePlatform(&c.Platform, field.NewPath("platform"), openStackValidValuesFetcher)...)
 	if err := validate.ImagePullSecret(c.PullSecret); err != nil {


### PR DESCRIPTION
The Install Config asset will apply defaults to fields for which there are reasonable defaults. This applies to a generated Install Config asset and to an Install Config asset loaded from disk.

Carrying #902 onto #1057.  CC @staebler, @abhinavdahiya, @crawford.  Hold until #1057 lands:

/hold