### PR TITLE
pkg/asset/ignition/bootstrap: Bump etcd to 3.3.10

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -31,7 +31,7 @@ const (
 	rootDir              = "/opt/openshift"
 	bootstrapIgnFilename = "bootstrap.ign"
 	etcdCertSignerImage  = "quay.io/coreos/kube-etcd-signer-server:678cc8e6841e2121ebfdb6e2db568fce290b67d6"
-	etcdctlImage         = "quay.io/coreos/etcd:v3.2.14"
+	etcdctlImage         = "quay.io/coreos/etcd:v3.3.10"
 	ignitionUser         = "core"
 )
 


### PR DESCRIPTION
Catching the bootstrap's health-checker up with the masters, which were bumped to 3.3.10 in openshift/machine-config-operator@59f80967 (openshift/machine-config-operator#205).  Sam Batschelet motivated that change [with][1]:

> Currently OpenShift 4.0 installs are using an old version of etcd v3.2.14.  This PR bumps that to 3.3.10 which will be the release version.

Tangentially related to #1059, which also talks about etcd versions.

[1]: https://github.com/openshift/machine-config-operator/pull/205