### PR TITLE
Fix the Kubelet certificate short validity issue

### DIFF
--- a/pkg/asset/tls/kubeletcertkey.go
+++ b/pkg/asset/tls/kubeletcertkey.go
@@ -32,7 +32,7 @@ func (a *KubeletCertKey) Generate(dependencies asset.Parents) error {
 		Subject:      pkix.Name{CommonName: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper", Organization: []string{"system:serviceaccounts:openshift-machine-config-operator"}},
 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		Validity:     ValidityThirtyMinutes,
+		Validity:     ValidityTenYears,
 	}
 
 	return a.CertKey.Generate(cfg, kubeCA, "kubelet", DoNotAppendParent)


### PR DESCRIPTION
The default validity period is set to just 30 minutes, which is
just too short.

This patch increases the validity period to 10 years, to be the
same as the default validity period of the admin certificate.

Signed-off-by: Lev Veyde <lveyde@redhat.com>