### PR TITLE
pkg/asset: Annotate machines to require node drain

### DIFF
--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -54,6 +54,9 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 					"sigs.k8s.io/cluster-api-machine-role": role,
 					"sigs.k8s.io/cluster-api-machine-type": role,
 				},
+				Annotations: map[string]string{
+					"openshift.io/drain-node": "True",
+				},
 			},
 			Spec: clusterapi.MachineSpec{
 				ProviderSpec: clusterapi.ProviderSpec{

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -73,6 +73,9 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 							"sigs.k8s.io/cluster-api-machine-role": role,
 							"sigs.k8s.io/cluster-api-machine-type": role,
 						},
+						Annotations: map[string]string{
+							"openshift.io/drain-node": "True",
+						},
 					},
 					Spec: clusterapi.MachineSpec{
 						ProviderSpec: clusterapi.ProviderSpec{

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -44,6 +44,9 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 					"sigs.k8s.io/cluster-api-machine-role": role,
 					"sigs.k8s.io/cluster-api-machine-type": role,
 				},
+				Annotations: map[string]string{
+					"openshift.io/drain-node": "True",
+				},
 			},
 			Spec: clusterapi.MachineSpec{
 				ProviderSpec: clusterapi.ProviderSpec{

--- a/pkg/asset/machines/libvirt/machinesets.go
+++ b/pkg/asset/machines/libvirt/machinesets.go
@@ -64,6 +64,9 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 						"sigs.k8s.io/cluster-api-machine-role": role,
 						"sigs.k8s.io/cluster-api-machine-type": role,
 					},
+					Annotations: map[string]string{
+						"openshift.io/drain-node": "True",
+					},
 				},
 				Spec: clusterapi.MachineSpec{
 					ProviderSpec: clusterapi.ProviderSpec{


### PR DESCRIPTION
Ensure we attempt to drain nodes before deleting machines by default.

Admins are able to undo the annotation to circumvent a stuck drain.

/cc @enxebre @ingvagabund @smarterclayton 