### PR TITLE
asset/ignition: remove SSH key from pointer config

### DIFF
--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -35,12 +35,5 @@ func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, ro
 				},
 			},
 		},
-		// XXX: Remove this once MCO supports injecting SSH keys.
-		Passwd: ignition.Passwd{
-			Users: []ignition.PasswdUser{{
-				Name:              "core",
-				SSHAuthorizedKeys: []ignition.SSHAuthorizedKey{ignition.SSHAuthorizedKey(installConfig.SSHKey)},
-			}},
-		},
 	}
 }


### PR DESCRIPTION
Now that the MachineConfigOperator is capable of managing SSH keys,
there is no need to include them in the pointer Ignition Configs. In
fact, it's desirable to remove them since these configs are not managed
by the cluster. The SSH key will remain in the bootstrap config.