### PR TITLE
[FIX] Validate provided addresses are network addresses

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -62,10 +62,10 @@ func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorLis
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("type"), n.Type, validate.ValidNetworkTypeValues))
 	}
 	if err := validate.SubnetCIDR(&n.MachineCIDR.IPNet); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("machineCIDR"), n.MachineCIDR, err.Error()))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("machineCIDR"), n.MachineCIDR.String(), err.Error()))
 	}
 	if err := validate.SubnetCIDR(&n.ServiceCIDR.IPNet); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceCIDR"), n.ServiceCIDR, err.Error()))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceCIDR"), n.ServiceCIDR.String(), err.Error()))
 	}
 	for i, cn := range n.ClusterNetworks {
 		allErrs = append(allErrs, validateClusterNetwork(&cn, fldPath.Child("clusterNetworks").Index(i), &n.ServiceCIDR.IPNet)...)

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -129,7 +129,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Networking.ServiceCIDR = &ipnet.IPNet{}
 				return c
 			}(),
-			expectedError: `^networking\.serviceCIDR: Invalid value: ipnet\.IPNet{IPNet:net\.IPNet{IP:net\.IP\(nil\), Mask:net\.IPMask\(nil\)}}: must use IPv4$`,
+			expectedError: `^networking\.serviceCIDR: Invalid value: "<nil>": must use IPv4$`,
 		},
 		{
 			name: "invalid cluster network cidr",

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -93,13 +93,17 @@ func ClusterName(v string) error {
 	return validateSubdomain(v)
 }
 
-// SubnetCIDR checks if the given IP net is a valid CIDR for a master nodes or worker nodes subnet and returns an error if not.
+// SubnetCIDR checks if the given IP net is a valid CIDR.
 func SubnetCIDR(cidr *net.IPNet) error {
 	if cidr.IP.To4() == nil {
 		return errors.New("must use IPv4")
 	}
 	if cidr.IP.IsUnspecified() {
 		return errors.New("address must be specified")
+	}
+	nip := cidr.IP.Mask(cidr.Mask)
+	if nip.String() != cidr.IP.String() {
+		return fmt.Errorf("invalid network address. got %s, expecting %s", cidr.String(), (&net.IPNet{IP: nip, Mask: cidr.Mask}).String())
 	}
 	if DoCIDRsOverlap(cidr, dockerBridgeCIDR) {
 		return fmt.Errorf("overlaps with default Docker Bridge subnet (%v)", cidr.String())


### PR DESCRIPTION
Before this change validation allowed CIDRs with network IP set to any IP address in the range.
This change enforces that CIDR notation use network IP.

example,
```yaml
...
networking:
  machineCIDR: 192.168.126.10/24
...
```

The installer now errors on `create cluster`
```console
FATAL failed to fetch Terraform Variables: failed to load asset "Install Config": invalid "install-config.yaml" file: networking.machineCIDR: Invalid value: "192.168.126.10/24": invalid network address. got 192.168.126.10/24, expecting 192.168.126.0/24
```

/cc @crawford @wking 
xref: https://jira.coreos.com/browse/CORS-961
Fixes #1023 