### PR TITLE
aws: Increase the default master instance size to reduce etcd timeouts

### DIFF
--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -12,7 +12,7 @@ variable "aws_master_ec2_type" {
   description = "Instance size for the master node(s). Example: `m4.large`."
 
   # FIXME: get this wired up to the machine default
-  default = "m4.large"
+  default = "m4.xlarge"
 }
 
 variable "aws_ec2_ami_override" {

--- a/docs/user/aws/limits.md
+++ b/docs/user/aws/limits.md
@@ -58,8 +58,14 @@ to be created.
 
 ## Instance Limits
 
-By default, a cluster will create 6 nodes (3 masters and 3 workers). Currently, these are m4.large and within a new
-account's default limit. If you intend to start with a higher number of workers, enable autoscaling and large workloads
+By default, a cluster will create:
+
+* One m4.large bootstrap machine (removed after install)
+* Three m4.xlarge master nodes.
+* Three m4.large worker nodes.
+
+Currently, these instance type counts are within a new account's default limit.
+If you intend to start with a higher number of workers, enable autoscaling and large workloads
 or a different instance type, please ensure you have the necessary remaining instance count within the instance type's
 limit to satisfy the need. If not, please ask AWS to increase the limit via a support case.
 

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -67,6 +67,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	switch ic.Platform.Name() {
 	case awstypes.Name:
 		mpool := defaultAWSMachinePoolPlatform()
+		mpool.InstanceType = "m4.xlarge"
 		mpool.Set(ic.Platform.AWS.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.AWS)
 		if len(mpool.Zones) == 0 {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -26,9 +26,7 @@ import (
 )
 
 func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
-	return awstypes.MachinePool{
-		InstanceType: "m4.large",
-	}
+	return awstypes.MachinePool{}
 }
 
 func defaultLibvirtMachinePoolPlatform() libvirttypes.MachinePool {
@@ -94,6 +92,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 	switch ic.Platform.Name() {
 	case awstypes.Name:
 		mpool := defaultAWSMachinePoolPlatform()
+		mpool.InstanceType = "m4.large"
 		mpool.Set(ic.Platform.AWS.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.AWS)
 		if len(mpool.Zones) == 0 {


### PR DESCRIPTION
After experimenting with disks we determined that we were CPU starved, not IO starved (later comments).  This PR sets default master size to m4.xlarge which performs more consistently against 1.11 kube.

https://openshift-gce-devel.appspot.com/build/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.0/3155/ is representative, many timeouts.

The CPU use in 1.11 kube is excessive due to two bugs that will be fixed in the rebase, after which we can try stepping back down to m4.large.