### PR TITLE
Destroy should remove install-config from state file

### DIFF
--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -60,6 +60,11 @@ func runDestroyCmd(directory string) error {
 			return errors.Wrapf(err, "failed to destroy asset %q", asset.Name())
 		}
 	}
+	for _, asset := range installConfigTarget.assets {
+		if err := store.Destroy(asset); err != nil {
+			return errors.Wrapf(err, "failed to destroy asset %q", asset.Name())
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
If destroy would not delete install-config asset (from both state file and the disk), and the user wants to re-use the directory for creating another cluster, there is trouble with the text user interface as no more questions are asked about the new cluster and a lot of information is just assumed that cause failures later.
See https://jira.coreos.com/browse/CORS-943

Alternative solution (not in this PR): destroy the state file completely on 'destroy cluster' command.