### PR TITLE
 tfvars/libvirt: fix installer keeping RHCOS OS Image in memory 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -883,6 +883,7 @@
     "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1alpha1",
     "github.com/openshift/cluster-network-operator/pkg/apis/networkoperator/v1",
     "github.com/pborman/uuid",
+    "github.com/peterbourgon/diskv",
     "github.com/pkg/errors",
     "github.com/shurcooL/vfsgen",
     "github.com/sirupsen/logrus",

--- a/pkg/tfvars/libvirt/cache.go
+++ b/pkg/tfvars/libvirt/cache.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gregjones/httpcache"
 	"github.com/gregjones/httpcache/diskcache"
+	"github.com/peterbourgon/diskv"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -44,7 +45,10 @@ func (libvirt *Libvirt) UseCachedImage() (err error) {
 		return err
 	}
 
-	cache := diskcache.New(httpCacheDir)
+	cache := diskcache.NewWithDiskv(diskv.New(diskv.Options{
+		BasePath:     httpCacheDir,
+		CacheSizeMax: 0, // This stops the diskcache from caching the resp in memory.
+	}))
 	transport := httpcache.NewTransport(cache)
 	resp, err := transport.Client().Get(libvirt.Image)
 	if err != nil {


### PR DESCRIPTION
The default diskv backend in diskcache is intialized with non-zero `CacheSizeMax` [1].
Non-zero `CacheSizeMax` causes the diskv backend to load the cached responses from disk into memory [2] for faster returns on future calls.
This behavior causes the diskv backend to load up entire RHCOs image contents into internal map.

But as installer has no use for optimizing the sunsequent read for RHCOS image , switching to `CacheSizeMax` => 0, makes diskv backend to directly return the reader for file from disk and diesn't store the contents to internal map.

[1] https://github.com/gregjones/httpcache/blob/master/diskcache/diskcache.go#L48-L55
[2] https://github.com/peterbourgon/diskv/blob/v2.0.1/diskv.go#L322-L327

Fixes #610 

/cc @wking @squeed 

/hold