### PR TITLE
pkg/tfvars: Respect install-config AWS machine pools

### DIFF
--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -73,11 +73,9 @@ func TFVars(clusterID string, cfg *types.InstallConfig, osImage, bootstrapIgn, m
 	}
 
 	if cfg.Platform.AWS != nil {
-		config.AWS = aws.AWS{
-			Region:         cfg.Platform.AWS.Region,
-			ExtraTags:      cfg.Platform.AWS.UserTags,
-			EC2AMIOverride: osImage,
-		}
+		config.AWS.Region = cfg.Platform.AWS.Region
+		config.AWS.ExtraTags = cfg.Platform.AWS.UserTags
+		config.AWS.EC2AMIOverride = osImage
 	} else if cfg.Platform.Libvirt != nil {
 		masterIPs := make([]string, len(cfg.Platform.Libvirt.MasterIPs))
 		for i, ip := range cfg.Platform.Libvirt.MasterIPs {


### PR DESCRIPTION
Before this commit, this section would clobber any `config.AWS` properties which had been set up while iterating over machine pools.  I'd introduced that bug in 619db925 (#412), before which this section ran before the machine-pool iteration, so there had been nothing to clobber.

We'll need this fixed if we want to take the CI-special-case approach in #1069 (e.g. [here][1]).  #792 will probably obsolete this code anyway, but this was a pretty straightforward stopgap, and it's good to acknowledge the bug.

CC @abhinavdahiya, @crawford, @smarterclayton, @staebler

[1]: https://github.com/openshift/installer/pull/1069#issuecomment-454631465