### PR TITLE
Introduce a destroy state function that will clean up statefile

### DIFF
--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -60,6 +60,12 @@ func runDestroyCmd(directory string) error {
 			return errors.Wrapf(err, "failed to destroy asset %q", asset.Name())
 		}
 	}
+	// delete the state file as well
+	err = store.DestroyState()
+	if err != nil {
+		return errors.Wrap(err, "failed to remove state file")
+	}
+
 	return nil
 }
 

--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -24,6 +24,10 @@ type Store interface {
 	// Destroy removes the asset from all its internal state and also from
 	// disk if possible.
 	Destroy(Asset) error
+
+	// DestroyState removes everything from the internal state and the internal
+	// state file
+	DestroyState() error
 }
 
 // assetSource indicates from where the asset was fetched
@@ -113,6 +117,20 @@ func (s *StoreImpl) Destroy(asset Asset) error {
 	delete(s.assets, reflect.TypeOf(asset))
 	delete(s.stateFileAssets, reflect.TypeOf(asset).String())
 	return s.saveStateFile()
+}
+
+// DestroyState removes the state file from disk
+func (s *StoreImpl) DestroyState() error {
+	s.stateFileAssets = nil
+	path := filepath.Join(s.directory, stateFileName)
+	err := os.Remove(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // loadStateFile retrieves the state from the state file present in the given directory


### PR DESCRIPTION

Used when 'destroy cluster' is called, the DestroyState function will clean up the state file so that a subsequent run of 'create cluster' on the same directory does not conflict with an imported (brought in by user)  install-config file.

This is an alternate implementation to PR #1071 
The drawback of this one is the ugly appearance of the DestroyState function on the Store interface (the state was supposed to be an internal thing to its implementation).

@staebler, PTAL 