### PR TITLE
data/aws/vpc: Sanitize cluster name for aws_lb and aws_lb_target_group

### DIFF
--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -7,6 +7,8 @@ data "aws_availability_zones" "azs" {}
 
 // Only reference data sources which are gauranteed to exist at any time (above) in this locals{} block
 locals {
+  lb_base_name = "${replace(var.cluster_name, "/[^A-Za-z0-9-]/", "-")}"
+
   // List of possible AZs for each type of subnet
   new_subnet_azs = "${data.aws_availability_zones.azs.names}"
 

--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "api_internal" {
-  name                             = "${var.cluster_name}-int"
+  name                             = "${local.lb_base_name}-int"
   load_balancer_type               = "network"
   subnets                          = ["${local.master_subnet_ids}"]
   internal                         = true
@@ -10,7 +10,7 @@ resource "aws_lb" "api_internal" {
 }
 
 resource "aws_lb" "api_external" {
-  name                             = "${var.cluster_name}-ext"
+  name                             = "${local.lb_base_name}-ext"
   load_balancer_type               = "network"
   subnets                          = ["${local.master_subnet_ids}"]
   internal                         = false
@@ -21,7 +21,7 @@ resource "aws_lb" "api_external" {
 }
 
 resource "aws_lb_target_group" "api_internal" {
-  name     = "${var.cluster_name}-api-int"
+  name     = "${local.lb_base_name}-api-int"
   protocol = "TCP"
   port     = 6443
   vpc_id   = "${local.vpc_id}"
@@ -41,7 +41,7 @@ resource "aws_lb_target_group" "api_internal" {
 }
 
 resource "aws_lb_target_group" "api_external" {
-  name     = "${var.cluster_name}-api-ext"
+  name     = "${local.lb_base_name}-api-ext"
   protocol = "TCP"
   port     = 6443
   vpc_id   = "${local.vpc_id}"
@@ -61,7 +61,7 @@ resource "aws_lb_target_group" "api_external" {
 }
 
 resource "aws_lb_target_group" "services" {
-  name     = "${var.cluster_name}-services"
+  name     = "${local.lb_base_name}-services"
   protocol = "TCP"
   port     = 49500
   vpc_id   = "${local.vpc_id}"


### PR DESCRIPTION
For folks who use multi-component cluster names like `jliu-beta1.test20190117`, this change avoids raising [errors like][1]:

```
ERROR Error: module.vpc.aws_lb.api_external: only alphanumeric characters and hyphens allowed in "name": "jliu-beta1.test20190117-ext"
ERROR
ERROR Error: module.vpc.aws_lb.api_internal: only alphanumeric characters and hyphens allowed in "name": "jliu-beta1.test20190117-int"
ERROR
ERROR Error: module.vpc.aws_lb_target_group.api_external: only alphanumeric characters and hyphens allowed in "name"
ERROR
ERROR Error: module.vpc.aws_lb_target_group.api_internal: only alphanumeric characters and hyphens allowed in "name"
ERROR
ERROR Error: module.vpc.aws_lb_target_group.services: only alphanumeric characters and hyphens allowed in "name"
```

I'm using [HCL's `replace` function][2] with a regular expression to replace everything except the characters the error message claims are supported.  I've allowed both upper and lower case, because [RFC 952][3] has:

> A "name" (Net, Host, Gateway, or Domain name) is a text string up to 24 characters drawn from the alphabet (`A-Z`), digits (`0-9`), minus sign (`-`), and period (`.`).  Note that periods are only allowed when they serve to delimit components of "domain style names". (See RFC-921, "Domain Name System Implementation Schedule", for background).  No blank or space characters are permitted as part of a name.  No distinction is made between upper and lower case.

But I haven't checked `IsDNS1123Subdomain` to see how it handles case.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1666956#c0
[2]: https://www.terraform.io/docs/configuration/interpolation.html#replace-string-search-replace-
[3]: https://tools.ietf.org/html/rfc952