### PR TITLE
Revert "openstack: Del DNS from service VM update docs"

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -15,6 +15,29 @@ data "ignition_config" "redirect" {
   append {
     source = "${openstack_objectstorage_tempurl_v1.ignition_tmpurl.url}"
   }
+
+  files = [
+    "${data.ignition_file.bootstrap_ifcfg.id}",
+  ]
+}
+
+data "ignition_file" "bootstrap_ifcfg" {
+  filesystem = "root"
+  mode       = "420"                                       // 0644
+  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+
+  content {
+    content = <<EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+DNS1="${var.service_vm_fixed_ip}"
+PEERDNS="no"
+NM_CONTROLLED="yes"
+EOF
+  }
 }
 
 data "openstack_images_image_v2" "bootstrap_image" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -13,12 +13,32 @@ data "ignition_config" "master_ignition_config" {
   }
 
   files = [
+    "${data.ignition_file.master_ifcfg.id}",
     "${data.ignition_file.master_hacks_script.id}",
   ]
 
   systemd = [
     "${data.ignition_systemd_unit.master_hacks_service.id}",
   ]
+}
+
+data "ignition_file" "master_ifcfg" {
+  filesystem = "root"
+  mode       = "420"                                       // 0644
+  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+
+  content {
+    content = <<EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+DNS1="${var.service_vm_fixed_ip}"
+PEERDNS="no"
+NM_CONTROLLED="yes"
+EOF
+  }
 }
 
 data "ignition_file" "master_hacks_script" {

--- a/data/data/openstack/topology/sg-lb.tf
+++ b/data/data/openstack/topology/sg-lb.tf
@@ -23,6 +23,26 @@ resource "openstack_networking_secgroup_rule_v2" "api_https" {
   security_group_id = "${openstack_networking_secgroup_v2.api.id}"
 }
 
+resource "openstack_networking_secgroup_rule_v2" "api_ingress_dns_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.api.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "api_ingress_dns_tcp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.api.id}"
+}
+
 resource "openstack_networking_secgroup_rule_v2" "api_ingress_ssh_tcp" {
   direction         = "ingress"
   ethertype         = "IPv4"

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -60,34 +60,6 @@ openstack network list --long -c ID -c Name -c "Router Type"
 +--------------------------------------+----------------+-------------+
 ```
 
-* You should add the following records to the DNS server that provides service
-  to your cluster (typically that's the one that the Neutron dns forwards to):
-
-      Dnsmasq example with three masters
-      ==================================
-
-      service-host=_etcd-server-ssl._tcp.CLUSTER_NAME.DOMAIN_NAME,CLUSTER_NAME-etcd-0.DOMAIN_NAME,2380,0,10
-      service-host=_etcd-server-ssl._tcp.CLUSTER_NAME.DOMAIN_NAME,CLUSTER_NAME-etcd-1.DOMAIN_NAME,2380,0,10
-      service-host=_etcd-server-ssl._tcp.CLUSTER_NAME.DOMAIN_NAME,CLUSTER_NAME-etcd-2.DOMAIN_NAME,2380,0,10
-      cname=CLUSTER_NAME-etcd-0,CLUSTER_NAME-master-0
-      cname=CLUSTER_NAME-etcd-1,CLUSTER_NAME-master-1
-      cname=CLUSTER_NAME-etcd-2,CLUSTER_NAME-master-2
-
-      Bind example with three masters
-      ===============================
-
-      ;                                SVC.PROTO.NAME   TTL    CLASS  PRIORITY WEIGHT PORT                           TARGET
-      _etcd-server-ssl._tcp.CLUSTER_NAME.DOMAIN_NAME.    IN      SRV         0     10 2380  CLUSTER_NAME-etcd-0.DOMAIN_NAME
-                                                         IN      SRV         0     10 2380  CLUSTER_NAME-etcd-1.DOMAIN_NAME
-                                                         IN      SRV         0     10 2380  CLUSTER_NAME-etcd-2.DOMAIN_NAME
-
-      $ORIGIN DOMAIN_NAME.
-      ;              NAME    TTL   CLASS                            CANONICAL_NAME
-      CLUSTER_NAME-etcd-0     IN   CNAME        CLUSTER_NAME-master-0.DOMAIN_NAME.
-      CLUSTER_NAME-etcd-1     IN   CNAME        CLUSTER_NAME-master-1.DOMAIN_NAME.
-      CLUSTER_NAME-etcd-2     IN   CNAME        CLUSTER_NAME-master-2.DOMAIN_NAME.
-
-
 ## Current Expected Behavior
 
 As mentioned, OpenStack support is still experimental. Currently:


### PR DESCRIPTION
This reverts commit ae54392948cccff9b33abf49522547b3746127f8.

The proposed solution (including the exact same CoreDNS configuration)
does not work for several of our developers deployments causing a
regression (i.e. we're not able to get the etcd cluster started).

It appears that the DNS requests are getting the CNAME values for the
etcd records, but they never resolve to an IP address.

We've not figured out why that is yet, so reverting this change lets us
unblock the OpenStack deployments.