### PR TITLE
openstack: Always set opts.Cloud

### DIFF
--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -84,6 +84,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		}
 	case "openstack":
 		opts := new(clientconfig.ClientOpts)
+		opts.Cloud = installConfig.Config.Platform.OpenStack.Cloud
 		cloud, err := clientconfig.GetCloudFromYAML(opts)
 		if err != nil {
 			return err


### PR DESCRIPTION
If OS_CLOUD is not set in the environment, this part of the code will
fail with a NPE because neither OS_CLOUD nor opts.Cloud are set. Set
opts.Cloud to the value in Platform.