### PR TITLE
openstack: fix the openstack creds secret name

### DIFF
--- a/data/data/manifests/openshift/cloud-creds-secret.yaml.template
+++ b/data/data/manifests/openshift/cloud-creds-secret.yaml.template
@@ -5,7 +5,7 @@ metadata:
 {{- if .CloudCreds.AWS}}
   name: aws-creds
 {{- else if .CloudCreds.OpenStack}}
-  name: openstack-creds
+  name: openstack-credentials
 {{- end}}
 data:
 {{- if .CloudCreds.AWS}}

--- a/data/data/manifests/openshift/role-cloud-creds-secret-reader.yaml.template
+++ b/data/data/manifests/openshift/role-cloud-creds-secret-reader.yaml.template
@@ -13,6 +13,6 @@ rules:
 {{- if .CloudCreds.AWS}}
   resourceNames: ["aws-creds"]
 {{- else if .CloudCreds.OpenStack}}
-  resourceNames: ["openstack-creds"]
+  resourceNames: ["openstack-credentials"]
 {{- end}}
   verbs: ["get"]

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -15,7 +15,10 @@ import (
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
-const cloudsSecret = "openstack-credentials"
+const (
+	cloudsSecret          = "openstack-credentials"
+	cloudsSecretNamespace = "kube-system"
+)
 
 // Machines returns a list of machines for a machinepool.
 func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]clusterapi.Machine, error) {
@@ -81,7 +84,7 @@ func provider(clusterID, clusterName string, platform *openstack.Platform, mpool
 		},*/
 		Image:          osImage,
 		CloudName:      platform.Cloud,
-		CloudsSecret:   &corev1.SecretReference{Name: cloudsSecret},
+		CloudsSecret:   &corev1.SecretReference{Name: cloudsSecret, Namespace: cloudsSecretNamespace},
 		UserDataSecret: &corev1.SecretReference{Name: userDataSecret},
 		Networks: []openstackprovider.NetworkParam{
 			{


### PR DESCRIPTION
The OpenStack MachineSets expect `cloudsSecret` to be called
`openstack-credentials`, but the one we were creating was called
`openstack-creds`.