### PR TITLE
Add a cloud credentials checker asset

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -38,6 +38,10 @@ func (c *Cluster) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.ClusterID{},
 		&installconfig.InstallConfig{},
+		// PlatformCredsCheck just checks the creds (and asks, if needed)
+		// We do not actually use it in this asset directly, hence
+		// it is put in the dependencies but not fetched in Generate
+		&installconfig.PlatformCredsCheck{},
 		&TerraformVariables{},
 		&password.KubeadminPassword{},
 	}

--- a/pkg/asset/installconfig/aws/aws.go
+++ b/pkg/asset/installconfig/aws/aws.go
@@ -38,7 +38,7 @@ func Platform() (*aws.Platform, error) {
 		panic(fmt.Sprintf("installer bug: invalid default AWS region %q", defaultRegion))
 	}
 
-	ssn, err := getSession()
+	ssn, err := GetSession()
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,9 @@ func Platform() (*aws.Platform, error) {
 	}, nil
 }
 
-func getSession() (*session.Session, error) {
+// GetSession returns an AWS session by checking credentials
+// and, if no creds are found, asks for them and stores them on disk in a config file
+func GetSession() (*session.Session, error) {
 	ssn := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))

--- a/pkg/asset/installconfig/aws/basedomain.go
+++ b/pkg/asset/installconfig/aws/basedomain.go
@@ -22,7 +22,7 @@ func IsForbidden(err error) bool {
 // GetBaseDomain returns a base domain chosen from among the account's
 // public routes.
 func GetBaseDomain() (string, error) {
-	session, err := getSession()
+	session, err := GetSession()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -1,0 +1,55 @@
+package installconfig
+
+import (
+	"fmt"
+
+	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/openshift/installer/pkg/asset"
+	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/none"
+	"github.com/openshift/installer/pkg/types/openstack"
+)
+
+// PlatformCredsCheck is an asset that checks the platform credentials, asks for them or errors out if invalid
+// the cluster.
+type PlatformCredsCheck struct {
+}
+
+var _ asset.Asset = (*PlatformCredsCheck)(nil)
+
+// Dependencies returns the dependencies for PlatformCredsCheck
+func (a *PlatformCredsCheck) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&InstallConfig{},
+	}
+}
+
+// Generate queries for input from the user.
+func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
+	ic := &InstallConfig{}
+	dependencies.Get(ic)
+
+	var err error
+	platform := ic.Config.Platform.Name()
+	switch platform {
+	case aws.Name:
+		_, err = awsconfig.GetSession()
+	case libvirt.Name:
+	case none.Name:
+	case openstack.Name:
+		opts := new(clientconfig.ClientOpts)
+		opts.Cloud = ic.Config.Platform.OpenStack.Cloud
+		_, err = clientconfig.GetCloudFromYAML(opts)
+	default:
+		err = fmt.Errorf("unknown platform type %q", platform)
+	}
+
+	return err
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *PlatformCredsCheck) Name() string {
+	return "Platform Credentials Check"
+}

--- a/pkg/asset/machines/aws/zones.go
+++ b/pkg/asset/machines/aws/zones.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	awsutil "github.com/openshift/installer/pkg/asset/installconfig/aws"
 )
 
 // AvailabilityZones retrieves a list of availability zones for the given region.
 func AvailabilityZones(region string) ([]string, error) {
-	ec2Client := ec2Client(region)
+	ec2Client, err := ec2Client(region)
+	if err != nil {
+		return nil, err
+	}
 	zones, err := fetchAvailabilityZones(ec2Client, region)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch availability zones: %v", err)
@@ -18,14 +21,14 @@ func AvailabilityZones(region string) ([]string, error) {
 	return zones, nil
 }
 
-func ec2Client(region string) *ec2.EC2 {
-	ssn := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-		Config: aws.Config{
-			Region: aws.String(region),
-		},
-	}))
-	return ec2.New(ssn)
+func ec2Client(region string) (*ec2.EC2, error) {
+	ssn, err := awsutil.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	client := ec2.New(ssn, aws.NewConfig().WithRegion(region))
+	return client, nil
 }
 
 func fetchAvailabilityZones(client *ec2.EC2, region string) ([]string, error) {

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -41,6 +41,10 @@ func (m *Master) Name() string {
 func (m *Master) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.ClusterID{},
+		// PlatformCredsCheck just checks the creds (and asks, if needed)
+		// We do not actually use it in this asset directly, hence
+		// it is put in the dependencies but not fetched in Generate
+		&installconfig.PlatformCredsCheck{},
 		&installconfig.InstallConfig{},
 		new(rhcos.Image),
 		&machine.Master{},

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -71,6 +71,10 @@ func (w *Worker) Name() string {
 func (w *Worker) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.ClusterID{},
+		// PlatformCredsCheck just checks the creds (and asks, if needed)
+		// We do not actually use it in this asset directly, hence
+		// it is put in the dependencies but not fetched in Generate
+		&installconfig.PlatformCredsCheck{},
 		&installconfig.InstallConfig{},
 		new(rhcos.Image),
 		&machine.Worker{},


### PR DESCRIPTION
A cloud creds checker asset just checks upon the credentials. The 'cluster' target
can then depend on it and, thus, cloud creds will be checked again before the
cluster is finally created.
The reason for a double check is that a cluster can be created through an
imported install-config and the credentials may be missing then.
If the cluster were to be created in one go (i.e. no install-config generation
as a sub-step), then the asset creation ensures that they are checked upon only once.
Or rather asked about the creds only once.

Solves: https://jira.coreos.com/projects/CORS/issues/CORS-949
