### PR TITLE
data/bootstrap: retry when reporting progress

### DIFF
--- a/data/data/bootstrap/systemd/units/progress.service
+++ b/data/data/bootstrap/systemd/units/progress.service
@@ -5,9 +5,6 @@ Wants=bootkube.service openshift.service
 After=bootkube.service openshift.service
 
 [Service]
-# Workaround for https://github.com/systemd/systemd/issues/1312 and https://github.com/opencontainers/runc/pull/1807
-ExecStartPre=/usr/bin/test -f /opt/openshift/.bootkube.done
-ExecStartPre=/usr/bin/test -f /opt/openshift/.openshift.done
 ExecStart=/usr/local/bin/report-progress.sh /opt/openshift/auth/kubeconfig bootstrap-complete "cluster bootstrapping has completed"
 
 Restart=on-failure


### PR DESCRIPTION
Previously, report-progress.sh relied on systemd to perform its retry
logic. Unfortunately, this causes the logs to fill up with entries like
the following:

    systemd[1]: progress.service holdoff time over, scheduling restart.
    systemd[1]: Stopped Report the completion of the cluster bootstrap
                process.
    systemd[1]: Starting Report the completion of the cluster bootstrap
                process...
    systemd[1]: Stopped Report the completion of the cluster bootstrap
    systemd[1]: progress.service: control process exited, code=exited
                status=1
    systemd[1]: Failed to start Report the completion of the cluster
                bootstrap process.
    systemd[1]: Unit progress.service entered failed state.
    systemd[1]: progress.service failed.

By adding the retry logic to report-progress.sh, these verbose logs are
avoided.