### PR TITLE
pkg/ipnet: fix Unmarshal to match ParseCIDR output

### DIFF
--- a/pkg/ipnet/ipnet.go
+++ b/pkg/ipnet/ipnet.go
@@ -50,7 +50,7 @@ func (ipnet *IPNet) UnmarshalJSON(b []byte) (err error) {
 		return errors.Wrap(err, "failed to Unmarshal string")
 	}
 
-	ip, net, err := net.ParseCIDR(cidr)
+	_, net, err := net.ParseCIDR(cidr)
 	if err != nil {
 		return errors.Wrap(err, "failed to Parse cidr string to net.IPNet")
 	}
@@ -61,7 +61,7 @@ func (ipnet *IPNet) UnmarshalJSON(b []byte) (err error) {
 	// which is what some libraries (e.g. github.com/apparentlymart/go-cidr)
 	// assume. By forcing the address to be the expected length, we can work
 	// around these bugs.
-	if ip.To4() != nil {
+	if ip := net.IP; ip.To4() != nil {
 		ipnet.IP = ip.To4()
 	} else {
 		ipnet.IP = ip

--- a/pkg/ipnet/ipnet_test.go
+++ b/pkg/ipnet/ipnet_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func assertJSON(t *testing.T, data interface{}, expected string) {
@@ -31,27 +33,39 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestUnmarshal(t *testing.T) {
-	for _, ipNetIn := range []*IPNet{
-		nil,
-		{IPNet: net.IPNet{
-			IP:   net.IP{192, 168, 0, 10},
-			Mask: net.IPv4Mask(255, 255, 255, 0),
-		}},
-	} {
-		t.Run(ipNetIn.String(), func(t *testing.T) {
-			data, err := json.Marshal(ipNetIn)
-			if err != nil {
-				t.Fatal(err)
-			}
+	tests := []struct {
+		input string
 
-			var ipNetOut *IPNet
-			err = json.Unmarshal(data, &ipNetOut)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if ipNetOut.String() != ipNetIn.String() {
-				t.Fatalf("%v != %v", ipNetOut, ipNetIn)
+		exp    *IPNet
+		expErr string
+	}{{
+		input:  `""`,
+		expErr: "failed to Parse cidr string to net.IPNet: invalid CIDR address: ",
+	}, {
+		input:  ``,
+		expErr: "unexpected end of JSON input",
+	}, {
+		input: `null`,
+		exp:   &IPNet{net.IPNet{IP: net.IP{}, Mask: net.IPMask{}}},
+	}, {
+		input:  `"null"`,
+		expErr: "failed to Parse cidr string to net.IPNet: invalid CIDR address: null",
+	}, {
+		input: `"192.168.0.10/24"`,
+		exp:   &IPNet{net.IPNet{IP: net.IP{0xc0, 0xa8, 0x0, 0x0}, Mask: net.IPMask{0xff, 0xff, 0xff, 0x0}}},
+	}, {
+		input: `"fe80::c0a8:a/120"`,
+		exp:   &IPNet{net.IPNet{IP: net.IP{0xfe, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0, 0xa8, 0x0, 0x0}, Mask: net.IPMask{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0}}},
+	}}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			var ipNetOut IPNet
+			err := json.Unmarshal([]byte(test.input), &ipNetOut)
+			if test.expErr == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, test.exp, &ipNetOut)
+			} else {
+				assert.EqualError(t, err, test.expErr)
 			}
 		})
 	}


### PR DESCRIPTION
Moved into separate PR as this as not required for https://github.com/openshift/installer/pull/1065 and @wking can reservations on this change https://github.com/openshift/installer/pull/1065#discussion_r247736304

The stdlib's implementation [1] of parsing cidr string into `net.IPNet` [2] converts cidrs like `192.168.0.10/24`,
which are using an IP that only belongs to a network rather than using network IPs (usually the first IP in a network), to a `192.168.0.1/24`.

This is more clearer from the comment [3], that `IP` field in `net.IPNet` is intended to be a network IP.

example,
```go
_, net, _ := net.ParseCIDR("192.168.0.10/24")
println(net.String()) // prints "192.168.0.1/24"
```

As of master [4], installer's wrapper implementation for unmarshalling cidr from `JSON string` to `net.IPNet` actually keeps the non network IP.

example,
```go
var net ipnet.IPNet
json.Unmarshal([]byte(`"192.168.0.10/24"`), &net)
println(net.String()) // prints "192.168.0.10/24"
```

This PR fixes the json.Unmarshal for `pkg/ipnet/IPNet` to match behavior of `net.ParseCIDR`

[1] https://golang.org/pkg/net/#ParseCIDR
[2] https://golang.org/pkg/net/#IPNet
[3] https://golang.org/src/net/ip.go?s=1063:1144#L28
[4] https://github.com/openshift/installer/blob/54737c4f9bcb8a73f1695e8c23d2c74394ae0af9/pkg/ipnet/ipnet.go

/cc @wking @crawford 