### PR TITLE
images/installer/Dockerfile.*: Set LABEL

### DIFF
--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -15,3 +15,8 @@ ENV PATH /bin
 ENV HOME /output
 WORKDIR /output
 ENTRYPOINT ["/bin/openshift-install"]
+
+LABEL License= \
+      io.k8s.description="The OpenShift Installer installs OpenShift clusters." \
+      io.k8s.display-name="OpenShift Installer" \
+      summary="The OpenShift Installer installs OpenShift clusters."

--- a/images/installer/Dockerfile.ci.rhel7
+++ b/images/installer/Dockerfile.ci.rhel7
@@ -15,3 +15,8 @@ ENV PATH /bin
 ENV HOME /output
 WORKDIR /output
 ENTRYPOINT ["/bin/openshift-install"]
+
+LABEL License= \
+      io.k8s.description="The OpenShift Installer installs OpenShift clusters." \
+      io.k8s.display-name="OpenShift Installer" \
+      summary="The OpenShift Installer installs OpenShift clusters."


### PR DESCRIPTION
Labels are [inherited from parent images][1], and we are currently inheriting values that don't apply to the installer image:

```console
$ oc adm release info --pullspecs  registry.svc.ci.openshift.org/ocp/release:4.0.0-0.nightly-2019-01-21-005139 | grep installer
  installer                                     registry.svc.ci.openshift.org/ocp/4.0-art-latest-2019-01-21-005139@sha256:d83a72f680ab0332dae578380d0fe63fe5e1b2b037a618090096f2b0bd85425b
$ oc image info registry.svc.ci.openshift.org/ocp/4.0-art-latest-2019-01-21-005139@sha256:d83a72f680ab0332dae578380d0fe63fe5e1b2b037a618090096f2b0bd85425b
Name:        registry.svc.ci.openshift.org/ocp/4.0-art-latest-2019-01-21-005139@sha256:d83a72f680ab0332dae578380d0fe63fe5e1b2b037a618090096f2b0bd85425b
Media Type:  application/vnd.docker.distribution.manifest.v1+prettyjws
Created:     4d ago
Image Size:  0B in 4 layers
Layers:      0B sha256:23113ae36f8e9d98b1423e44673979132dec59db2805e473e931d83548b0be82
             0B sha256:d134b18b98b0d113b7b1194a60efceaa2c06eff41386d6c14b0e44bfe557eee8
             0B sha256:9f6608e94e3498ea7e3c316f591913f347bdf4dfa40faa69c9548a715275eefc
             0B sha256:a4aebe76c4b11292ea0cd9d941869fbb9e61e60ae17f1c36b2a2a9aced546442
OS:          linux
Arch:        amd64
Entrypoint:  /bin/openshift-install
Working Dir: /output
User:        1000:1000
Environment: PATH=/bin
             HOME=/output
             container=oci
Labels:      License=GPLv2+
             architecture=x86_64
             authoritative-source-url=registry.access.redhat.com
             build-date=2019-01-18T11:57:03.270111
             com.redhat.build-host=cpt-0008.osbs.prod.upshift.rdu2.redhat.com
             com.redhat.component=ose-installer-container
             description=This is the base image from which all OpenShift Container Platform images inherit.
             distribution-scope=public
             io.k8s.description=This is the base image from which all OpenShift Container Platform images inherit.
             io.k8s.display-name=OpenShift Container Platform RHEL 7 Base
             io.openshift.build.commit.id=0ec07f34105f0083d4224acda347a45f8da9a4f7
             io.openshift.build.commit.url=https://github.com/openshift/installer/commit/0ec07f34105f0083d4224acda347a45f8da9a4f7
             io.openshift.build.source-location=https://github.com/openshift/installer
             io.openshift.tags=openshift,base
             name=openshift/ose-installer
             release=0.143.0.0
             summary=Provides the latest release of Red Hat Enterprise Linux 7 in a fully featured and supported base image.
             url=https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-installer/images/v4.0.0-0.143.0.0
             vcs-ref=8b7d00d70f68a57c3283544f05964afa53ca3249
             vcs-type=git
             vendor=Red Hat, Inc.
             version=v4.0.0
```

Licensing is complicated.  I'm not sure what the license for the RHEL and origin base images are, but I expect they're complicated on their own.  And whatever they are, we're layering in Apache 2.0 installer code, MPL 2.0 Terraform code, BSD-3-Clause golang.org/x code, etc., etc.  Until someone does a full audit, it seems best to clear the field.  And because there doesn't seem to be Dockerfile syntax for "clear a label", I've just set it to an empty string.

I'm assuming that setting `io.k8s.description` is sufficient to also get `description` populated, since that seems to work for other repositories.  I guess we'll see once this goes live ;).

[1]: https://docs.docker.com/engine/reference/builder/#label