### PR TITLE
data/aws/vpc: Create DHCP options

### DIFF
--- a/data/data/aws/vpc/vpc.tf
+++ b/data/data/aws/vpc/vpc.tf
@@ -18,3 +18,15 @@ resource "aws_vpc_endpoint" "s3" {
   service_name    = "com.amazonaws.${var.region}.s3"
   route_table_ids = ["${concat(aws_route_table.private_routes.*.id, aws_route_table.default.*.id)}"]
 }
+
+resource "aws_vpc_dhcp_options" "main" {
+  domain_name         = "${var.region == "us-east-1" ? "ec2.internal" : format("%s.compute.internal", var.region)}"
+  domain_name_servers = ["AmazonProvidedDNS"]
+
+  tags = "${var.tags}"
+}
+
+resource "aws_vpc_dhcp_options_association" "main" {
+  vpc_id          = "${aws_vpc.new_vpc.id}"
+  dhcp_options_id = "${aws_vpc_dhcp_options.main.id}"
+}

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -410,6 +410,8 @@ func deleteEC2(session *session.Session, arn arn.ARN, logger logrus.FieldLogger)
 	logger = logger.WithField("id", id)
 
 	switch resourceType {
+	case "dhcp-options":
+		return deleteEC2DHCPOptions(client, id, logger)
 	case "elastic-ip":
 		return deleteEC2ElasticIP(client, id, logger)
 	case "instance":
@@ -431,6 +433,21 @@ func deleteEC2(session *session.Session, arn arn.ARN, logger logrus.FieldLogger)
 	default:
 		return errors.Errorf("unrecognized EC2 resource type %s", resourceType)
 	}
+}
+
+func deleteEC2DHCPOptions(client *ec2.EC2, id string, logger logrus.FieldLogger) error {
+	_, err := client.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{
+		DhcpOptionsId: &id,
+	})
+	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidDhcpOptionsID.NotFound" {
+			return nil
+		}
+		return err
+	}
+
+	logger.Info("Deleted")
+	return nil
 }
 
 func deleteEC2ElasticIP(client *ec2.EC2, id string, logger logrus.FieldLogger) error {


### PR DESCRIPTION
With the default values.  This should [avoid][1]:

```console
$ oc rsh -t openshift-tests-1-rrgd6
Error from server: error dialing backend: dial tcp: lookup ip-10-0-143-162 on > 10.0.0.2:53: no such host
```

for accounts which do not correctly configure their default DHCP options.  From [the AWS docs][2]:

> domain-name:
>
> If you're using AmazonProvidedDNS in us-east-1, specify ec2.internal.  If you're using AmazonProvidedDNS in another region, specify region.compute.internal (for example, ap-northeast-1.compute.internal).  Otherwise, specify a domain name (for example, example.com).  This value is used to complete unqualified DNS hostnames.  For more information about DNS hostnames and DNS support in your VPC, see Using DNS with Your VPC.

The ternary operator is documented [here][3] and `format` is documented [here][4].  The new AWS-provider properties are documented [here][5] and [here][6].

From [the `DeleteDhcpOptions` docs][7]:

> You must disassociate the set of DHCP options before you can delete it.  You can disassociate the set of DHCP options by associating either a new set of options or the default set of options with the VPC.

but I haven't bothered with that, because dissociation [requires the associated VPC ID][8]:

```go
input := &ec2.AssociateDhcpOptionsInput{
    DhcpOptionsId: aws.String("default"),
    VpcId:         aws.String("vpc-a01106c2"),
}
```

and I didn't see a way to list associations to find those VPC IDs.  As it stands, the VPC will be deleted via its existing tag entry, and then we'll be free to delete the DHCP options.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1665341
[2]: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_DHCP_Options.html#DHCPOptionSets
[3]: https://www.terraform.io/docs/configuration/interpolation.html#conditionals
[4]: https://www.terraform.io/docs/configuration/interpolation.html#format-format-args-
[5]: https://www.terraform.io/docs/providers/aws/r/vpc_dhcp_options.html
[6]: https://www.terraform.io/docs/providers/aws/r/vpc_dhcp_options_association.html
[7]: https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DeleteDhcpOptions
[8]: https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.AssociateDhcpOptions