### PR TITLE
data/aws/vpc: Add explicit dependencies on aws_internet_gateway.igw to aws_lb

### DIFF
--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -7,6 +7,8 @@ resource "aws_lb" "api_internal" {
   idle_timeout                     = 3600
 
   tags = "${var.tags}"
+
+  depends_on = ["aws_internet_gateway.igw"]
 }
 
 resource "aws_lb" "api_external" {
@@ -18,6 +20,8 @@ resource "aws_lb" "api_external" {
   idle_timeout                     = 3600
 
   tags = "${var.tags}"
+
+  depends_on = ["aws_internet_gateway.igw"]
 }
 
 resource "aws_lb_target_group" "api_internal" {


### PR DESCRIPTION
[Avoiding][1]:

```
* module.vpc.aws_lb.api_external: 1 error occurred:
* aws_lb.api_external: Error creating Application Load Balancer: InvalidSubnet: VPC vpc-0765c67bbc82a1b7d has no internet gateway
status code: 400, request id: 5a6dc8ec-1d89-11e9-9f6f-bd4a7391f4d5
```

This sort of explicitly-declared dependency is unfortunate, but see terraform-providers/terraform-provider-aws#3494 and terraform-providers/terraform-provider-aws#3580 for upstream precedent.

Fixes #1110.

[1]: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/operator-framework_operator-lifecycle-manager/666/pull-ci-operator-framework-operator-lifecycle-manager-master-e2e-aws-olm/792/artifacts/e2e-aws-olm/installer/.openshift_install.log