### PR TITLE
vendor: bump survey to fix slow input issue

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -612,7 +612,7 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:3f36ff57a1033b3e4eb2c03c311b23c9da6890fd94ddd56dc05c57b4214eb782"
+  digest = "1:44304b24a4eb0976a72f7cb3b496adcd33e3751fd637e19f7a4b7622b50c4ed9"
   name = "gopkg.in/AlecAivazis/survey.v1"
   packages = [
     ".",
@@ -620,8 +620,7 @@
     "terminal",
   ]
   pruneopts = "NUT"
-  revision = "0be4439d90f533f1ea2e0adddd5b1a405e6f5559"
-  version = "v1.6.3"
+  revision = "49e2fbe5917c359f48b5e50062df01fb5554daf8"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,7 +10,7 @@ ignored = [
 
 [[constraint]]
   name = "gopkg.in/AlecAivazis/survey.v1"
-  version = "1.6.2"
+  revision = "49e2fbe5917c359f48b5e50062df01fb5554daf8"
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/core/template.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/core/template.go
@@ -19,7 +19,7 @@ var (
 	ErrorIcon = "X"
 
 	// HelpIcon will be shown before more detailed question help
-	HelpIcon = "????"
+	HelpIcon = "?"
 	// QuestionIcon will be shown before a question Message
 	QuestionIcon = "?"
 

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/editor.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/editor.go
@@ -72,7 +72,20 @@ func init() {
 	}
 }
 
+func (e *Editor) PromptAgain(invalid interface{}, err error) (interface{}, error) {
+	initialValue := invalid.(string)
+	return e.prompt(initialValue)
+}
+
 func (e *Editor) Prompt() (interface{}, error) {
+	initialValue := ""
+	if e.Default != "" && e.AppendDefault {
+		initialValue = e.Default
+	}
+	return e.prompt(initialValue)
+}
+
+func (e *Editor) prompt(initialValue string) (interface{}, error) {
 	// render the template
 	err := e.Render(
 		EditorQuestionTemplate,
@@ -134,11 +147,9 @@ func (e *Editor) Prompt() (interface{}, error) {
 		return "", err
 	}
 
-	// write default value
-	if e.Default != "" && e.AppendDefault {
-		if _, err := f.WriteString(e.Default); err != nil {
-			return "", err
-		}
+	// write initial value
+	if _, err := f.WriteString(initialValue); err != nil {
+		return "", err
 	}
 
 	// close the fd to prevent the editor unable to save file

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/filter.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/filter.go
@@ -1,0 +1,13 @@
+package survey
+
+import "strings"
+
+var DefaultFilterFn = func(filter string, options []string) (answer []string) {
+	filter = strings.ToLower(filter)
+	for _, o := range options {
+		if strings.Contains(strings.ToLower(o), filter) {
+			answer = append(answer, o)
+		}
+	}
+	return answer
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/multiline.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/multiline.go
@@ -1,0 +1,103 @@
+package survey
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+type Multiline struct {
+	core.Renderer
+	Message string
+	Default string
+	Help    string
+}
+
+// data available to the templates when processing
+type MultilineTemplateData struct {
+	Multiline
+	Answer     string
+	ShowAnswer bool
+	ShowHelp   bool
+}
+
+// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
+var MultilineQuestionTemplate = `
+{{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+  {{- "\n"}}{{color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
+  {{- color "cyan"}}[Enter 2 empty lines to finish]{{color "reset"}}
+{{- end}}`
+
+func (i *Multiline) Prompt() (interface{}, error) {
+	// render the template
+	err := i.Render(
+		MultilineQuestionTemplate,
+		MultilineTemplateData{Multiline: *i},
+	)
+	if err != nil {
+		return "", err
+	}
+	fmt.Println()
+
+	// start reading runes from the standard in
+	rr := i.NewRuneReader()
+	rr.SetTermMode()
+	defer rr.RestoreTermMode()
+
+	cursor := i.NewCursor()
+
+	multiline := make([]string, 0)
+
+	emptyOnce := false
+	// get the next line
+	for {
+		line := []rune{}
+		line, err = rr.ReadLine(0)
+		if err != nil {
+			return string(line), err
+		}
+
+		if string(line) == "" {
+			if emptyOnce {
+				numLines := len(multiline) + 2
+				cursor.PreviousLine(numLines)
+				for j := 0; j < numLines; j++ {
+					terminal.EraseLine(i.Stdio().Out, terminal.ERASE_LINE_ALL)
+					cursor.NextLine(1)
+				}
+				cursor.PreviousLine(numLines)
+				break
+			}
+			emptyOnce = true
+		} else {
+			emptyOnce = false
+		}
+		multiline = append(multiline, string(line))
+	}
+
+	val := strings.Join(multiline, "\n")
+	val = strings.TrimSpace(val)
+
+	// if the line is empty
+	if len(val) == 0 {
+		// use the default value
+		return i.Default, err
+	}
+
+	// we're done
+	return val, err
+}
+
+func (i *Multiline) Cleanup(val interface{}) error {
+	return i.Render(
+		MultilineQuestionTemplate,
+		MultilineTemplateData{Multiline: *i, Answer: val.(string), ShowAnswer: true},
+	)
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/multiselect.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/multiselect.go
@@ -28,6 +28,7 @@ type MultiSelect struct {
 	PageSize      int
 	VimMode       bool
 	FilterMessage string
+	FilterFn      func(string, []string) []string
 	filter        string
 	selectedIndex int
 	checked       map[string]bool
@@ -94,6 +95,7 @@ func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, 
 				// otherwise just invert the current value
 				m.checked[options[m.selectedIndex]] = !old
 			}
+			m.filter = ""
 		}
 		// only show the help message if we have one to show
 	} else if key == core.HelpInputRune && m.Help != "" {
@@ -145,17 +147,13 @@ func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, 
 }
 
 func (m *MultiSelect) filterOptions() []string {
-	filter := strings.ToLower(m.filter)
-	if filter == "" {
+	if m.filter == "" {
 		return m.Options
 	}
-	answer := []string{}
-	for _, o := range m.Options {
-		if strings.Contains(strings.ToLower(o), filter) {
-			answer = append(answer, o)
-		}
+	if m.FilterFn != nil {
+		return m.FilterFn(m.filter, m.Options)
 	}
-	return answer
+	return DefaultFilterFn(m.filter, m.Options)
 }
 
 func (m *MultiSelect) Prompt() (interface{}, error) {
@@ -165,7 +163,7 @@ func (m *MultiSelect) Prompt() (interface{}, error) {
 	if len(m.Default) > 0 {
 		for _, dflt := range m.Default {
 			for _, opt := range m.Options {
-				// if the option correponds to the default
+				// if the option corresponds to the default
 				if opt == dflt {
 					// we found our initial value
 					m.checked[opt] = true

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/survey.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/survey.go
@@ -49,6 +49,11 @@ type Prompt interface {
 	Error(error) error
 }
 
+// PromptAgainer Interface for Prompts that support prompting again after invalid input
+type PromptAgainer interface {
+	PromptAgain(invalid interface{}, err error) (interface{}, error)
+}
+
 // AskOpt allows setting optional ask options.
 type AskOpt func(options *AskOptions) error
 
@@ -157,7 +162,11 @@ func Ask(qs []*Question, response interface{}, opts ...AskOpt) error {
 				}
 
 				// ask for more input
-				ans, err = q.Prompt.Prompt()
+				if promptAgainer, ok := q.Prompt.(PromptAgainer); ok {
+					ans, err = promptAgainer.PromptAgain(ans, invalid)
+				} else {
+					ans, err = q.Prompt.Prompt()
+				}
 				// if there was a problem
 				if err != nil {
 					return err

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader.go
@@ -41,14 +41,18 @@ func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
 
 	// we get the terminal width and height (if resized after this point the property might become invalid)
 	terminalSize, _ := cursor.Size(rr.Buffer())
+	// we set the current location of the cursor once
+	cursorCurrent, _ := cursor.Location(rr.Buffer())
+
 	for {
 		// wait for some input
 		r, _, err := rr.ReadRune()
 		if err != nil {
 			return line, err
 		}
-		// we set the current location of the cursor and update it after every key press
-		cursorCurrent, err := cursor.Location(rr.Buffer())
+		// increment cursor location
+		cursorCurrent.X++
+
 		// if the user pressed enter or some other newline/termination like ctrl+d
 		if r == '\r' || r == '\n' || r == KeyEndTransmission {
 			// delete what's printed out on the console screen (cleanup)


### PR DESCRIPTION
When copying and pasting large values into the installer prompts, the
installer sometimes took a long time to accept the input (as if the user
were typing very slowly). This has been fixed upstream [1].

[1]: https://github.com/AlecAivazis/survey/pull/174

Fixes #628