### PR TITLE
cmd/openshift-install: Stricter argument parsing

### DIFF
--- a/cmd/openshift-install/completions.go
+++ b/cmd/openshift-install/completions.go
@@ -50,6 +50,7 @@ func newCompletionCmd() *cobra.Command {
 		Use:     "bash",
 		Short:   "Outputs the bash shell completions",
 		Example: completionExampleBash,
+		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Root().GenBashCompletion(os.Stdout)
 		},

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -134,6 +134,7 @@ func newCreateCmd() *cobra.Command {
 	}
 
 	for _, t := range targets {
+		t.command.Args = cobra.ExactArgs(0)
 		t.command.Run = runTargetCmd(t.assets...)
 		cmd.AddCommand(t.command)
 	}

--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -30,6 +30,7 @@ func newDestroyClusterCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "cluster",
 		Short: "Destroy an OpenShift cluster",
+		Args:  cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, _ []string) {
 			cleanup := setupFileHook(rootOpts.dir)
 			defer cleanup()
@@ -73,6 +74,7 @@ func newDestroyBootstrapCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "bootstrap",
 		Short: "Destroy the bootstrap resources",
+		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cleanup := setupFileHook(rootOpts.dir)
 			defer cleanup()

--- a/cmd/openshift-install/graph.go
+++ b/cmd/openshift-install/graph.go
@@ -24,6 +24,7 @@ func newGraphCmd() *cobra.Command {
 		Use:   "graph",
 		Short: "Outputs the internal dependency graph for installer",
 		Long:  "",
+		Args:  cobra.ExactArgs(0),
 		RunE:  runGraphCmd,
 	}
 	cmd.PersistentFlags().StringVar(&graphOpts.outputFile, "output-file", "", "file where the graph is written, if empty prints the graph to Stdout.")

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -54,25 +54,25 @@ func installerMain() {
 
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "openshift-install",
-		Short:             "Creates OpenShift clusters",
-		Long:              "",
-		PersistentPreRunE: runRootCmd,
-		SilenceErrors:     true,
-		SilenceUsage:      true,
+		Use:              "openshift-install",
+		Short:            "Creates OpenShift clusters",
+		Long:             "",
+		PersistentPreRun: runRootCmd,
+		SilenceErrors:    true,
+		SilenceUsage:     true,
 	}
 	cmd.PersistentFlags().StringVar(&rootOpts.dir, "dir", ".", "assets directory")
 	cmd.PersistentFlags().StringVar(&rootOpts.logLevel, "log-level", "info", "log level (e.g. \"debug | info | warn | error\")")
 	return cmd
 }
 
-func runRootCmd(cmd *cobra.Command, args []string) error {
+func runRootCmd(cmd *cobra.Command, args []string) {
 	logrus.SetOutput(ioutil.Discard)
 	logrus.SetLevel(logrus.TraceLevel)
 
 	level, err := logrus.ParseLevel(rootOpts.logLevel)
 	if err != nil {
-		return errors.Wrap(err, "invalid log-level")
+		level = logrus.InfoLevel
 	}
 
 	logrus.AddHook(newFileHook(os.Stderr, level, &logrus.TextFormatter{
@@ -86,5 +86,7 @@ func runRootCmd(cmd *cobra.Command, args []string) error {
 		DisableLevelTruncation: true,
 	}))
 
-	return nil
+	if err != nil {
+		logrus.Fatal(errors.Wrap(err, "invalid log-level"))
+	}
 }

--- a/cmd/openshift-install/version.go
+++ b/cmd/openshift-install/version.go
@@ -16,6 +16,7 @@ func newVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version information",
 		Long:  "",
+		Args:  cobra.ExactArgs(0),
 		RunE:  runVersionCmd,
 	}
 }


### PR DESCRIPTION
If we can't parse the value, wait until we've setup stderr logging before complaining about it.  With this pull-request:

```console
$ openshift-install --log-level destroy create cluster
FATAL invalid log-level: not a valid logrus Level: "destroy"
$ echo $?
1
```

while previously:

```console
$ openshift-install --log-level destroy create cluster
$ echo $?
1
```