### PR TITLE
data/aws/variables-aws: Drop aws_master_ec2_type and similar defaults

### DIFF
--- a/data/data/aws/master/variables.tf
+++ b/data/data/aws/master/variables.tf
@@ -36,7 +36,6 @@ variable "master_sg_ids" {
 
 variable "root_volume_iops" {
   type        = "string"
-  default     = "100"
   description = "The amount of provisioned IOPS for the root block device."
 }
 

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -10,9 +10,6 @@ EOF
 variable "aws_master_ec2_type" {
   type        = "string"
   description = "Instance size for the master node(s). Example: `m4.large`."
-
-  # FIXME: get this wired up to the machine default
-  default = "m4.xlarge"
 }
 
 variable "aws_ec2_ami_override" {
@@ -35,19 +32,16 @@ EOF
 
 variable "aws_master_root_volume_type" {
   type        = "string"
-  default     = "gp2"
   description = "The type of volume for the root block device of master nodes."
 }
 
 variable "aws_master_root_volume_size" {
   type        = "string"
-  default     = "120"
   description = "The size of the volume in gigabytes for the root block device of master nodes."
 }
 
 variable "aws_master_root_volume_iops" {
-  type    = "string"
-  default = "400"
+  type = "string"
 
   description = <<EOF
 The amount of provisioned IOPS for the root block device of master nodes.

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -12,7 +12,7 @@ type config struct {
 	EC2AMIOverride string            `json:"aws_ec2_ami_override,omitempty"`
 	ExtraTags      map[string]string `json:"aws_extra_tags,omitempty"`
 	EC2Type        string            `json:"aws_master_ec2_type,omitempty"`
-	IOPS           int64             `json:"aws_master_root_volume_iops,omitempty"`
+	IOPS           int64             `json:"aws_master_root_volume_iops"`
 	Size           int64             `json:"aws_master_root_volume_size,omitempty"`
 	Type           string            `json:"aws_master_root_volume_type,omitempty"`
 	Region         string            `json:"aws_region,omitempty"`


### PR DESCRIPTION
Since 9a9cd6de (#1076) and cbad1a41 (#1079), we should always be providing these in the Terraform variables generated by the asset graph.