### PR TITLE
pkg/destroy/aws: Set 'matched' on tag-pagination errors

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -143,6 +143,7 @@ func (o *ClusterUninstaller) Run() error {
 				if err != nil {
 					err = errors.Wrapf(err, "get tagged resources")
 					o.Logger.Info(err)
+					matched = true
 					loopError = err
 				}
 			}


### PR DESCRIPTION
Fixing a bug from e24c7dc4 (#1039).  Before this commit, we were setting `loopError`, so we'd still take another pass through the loop.  But we weren't setting `matched`, because fetch errors (e.g. because the caller lacked `tag:GetResources`) would not have returned *any* resources.  The deletion code would wrongly assume that there were no matching resources behind that `tagClient` and remove the client from `tagClients`.  `Run` would end up exiting non-zero despite having abandoned the resources behind that `tagClient`.

With this commit, we no longer prune the `tagClient`.  And since we don't distinguish between fatal and non-fatal errors, we'll just loop forever until the caller notices the problem and kills us.  That's not great, but with permission pre-checks in the pipe via install-time credential operator calls, I don't know if it's worth putting in a fatal/nonfatal distinction now.

CC @dgoodwin