### PR TITLE
Set the default AWS disk size to 120Gb across both workers and masters

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -72,7 +72,6 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	case awstypes.Name:
 		mpool := defaultAWSMachinePoolPlatform()
 		mpool.InstanceType = "m4.xlarge"
-		mpool.EC2RootVolume.Size = 120
 		mpool.Set(ic.Platform.AWS.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.AWS)
 		if len(mpool.Zones) == 0 {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -29,7 +29,7 @@ func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
 	return awstypes.MachinePool{
 		EC2RootVolume: awstypes.EC2RootVolume{
 			Type: "gp2",
-			Size: 32,
+			Size: 120,
 		},
 	}
 }


### PR DESCRIPTION
Workers often have similar IO needs as masters for container images, and
may be used for empty disk. For maximum out of the box flexibility, set
the node sizes for both masters and workers to 120Gb.

Will improve e2e test performance, also make builds quite a bit snappier
as they are often IO limited.