### PR TITLE
vendor(github.com/AlecAivazis/survey): switch back to version(1.8.1) constraint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -612,7 +612,7 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:44304b24a4eb0976a72f7cb3b496adcd33e3751fd637e19f7a4b7622b50c4ed9"
+  digest = "1:acce65b46e283672291c073e642b3cadbb2817d4689a2f8babc5bad08724c99c"
   name = "gopkg.in/AlecAivazis/survey.v1"
   packages = [
     ".",
@@ -620,7 +620,8 @@
     "terminal",
   ]
   pruneopts = "NUT"
-  revision = "49e2fbe5917c359f48b5e50062df01fb5554daf8"
+  revision = "3389f2f05f2f02457ea70d0cf93653543d2324e9"
+  version = "v1.8.1"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,7 +10,7 @@ ignored = [
 
 [[constraint]]
   name = "gopkg.in/AlecAivazis/survey.v1"
-  revision = "49e2fbe5917c359f48b5e50062df01fb5554daf8"
+  version = "1.8.1"
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/multiline.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/multiline.go
@@ -29,7 +29,8 @@ var MultilineQuestionTemplate = `
 {{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
 {{- color "default+hb"}}{{ .Message }} {{color "reset"}}
 {{- if .ShowAnswer}}
-  {{- "\n"}}{{color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+  {{- "\n"}}{{color "cyan"}}{{.Answer}}{{color "reset"}}
+  {{- if .Answer }}{{ "\n" }}{{ end }}
 {{- else }}
   {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
   {{- color "cyan"}}[Enter 2 empty lines to finish]{{color "reset"}}


### PR DESCRIPTION
e1f28c2e42c022f0928834c5c0817e5cf33b42cd moved to revision from a version to being in [1].
But a new release [2] includes the change from [1].

So switching back to version for dep constraint.

[1] https://github.com/AlecAivazis/survey/pull/174
[2] https://github.com/AlecAivazis/survey/releases/tag/v1.8.1