### PR TITLE
pkg/types/defaults/installconfig: Set defaults for null replicas

### DIFF
--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -16,6 +16,7 @@ import (
 	nonedefaults "github.com/openshift/installer/pkg/types/none/defaults"
 	"github.com/openshift/installer/pkg/types/openstack"
 	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
+	"k8s.io/utils/pointer"
 )
 
 func defaultInstallConfig() *types.InstallConfig {
@@ -192,7 +193,10 @@ func TestSetInstallConfigDefaults(t *testing.T) {
 			},
 			expected: func() *types.InstallConfig {
 				c := defaultInstallConfig()
-				c.Machines = []types.MachinePool{{Name: "test-machine"}}
+				c.Machines = []types.MachinePool{{
+					Name:     "test-machine",
+					Replicas: pointer.Int64Ptr(0),
+				}}
 				return c
 			}(),
 		},

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -12,8 +12,7 @@ type MachinePool struct {
 	Name string `json:"name"`
 
 	// Replicas is the count of machines for this machine pool.
-	// Default is 1.
-	Replicas *int64 `json:"replicas"`
+	Replicas *int64 `json:"replicas,omitempty"`
 
 	// Platform is configuration for machine pool specific to the platfrom.
 	Platform MachinePoolPlatform `json:"platform"`


### PR DESCRIPTION
We don't currently support configuring zero workers (#958), largely because some key operators still do not tolerate masters.  Still, some users are attempting to [work around our checks by leaving `replicas` unset][2] (which ends up as nil in Go).  This pull-request adjusts our install-config defaulting to fill in the default `replicas` when the user provides machine-pool entries but leaves `replicas` unset.

[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1670005#c1