### PR TITLE
bootkube: Supply machine-os-content to MCO

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -20,6 +20,7 @@ MACHINE_CONFIG_OPERATOR_IMAGE=$(podman run --rm ${release} image machine-config-
 MACHINE_CONFIG_CONTROLLER_IMAGE=$(podman run --rm ${release} image machine-config-controller)
 MACHINE_CONFIG_SERVER_IMAGE=$(podman run --rm ${release} image machine-config-server)
 MACHINE_CONFIG_DAEMON_IMAGE=$(podman run --rm ${release} image machine-config-daemon)
+MACHINE_CONFIG_OSCONTENT=$(podman run --rm ${release} image machine-os-content)
 
 KUBE_APISERVER_OPERATOR_IMAGE=$(podman run --rm ${release} image cluster-kube-apiserver-operator)
 KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(podman run --rm ${release} image cluster-kube-controller-manager-operator)
@@ -129,6 +130,7 @@ then
 			--machine-config-controller-image=${MACHINE_CONFIG_CONTROLLER_IMAGE} \
 			--machine-config-server-image=${MACHINE_CONFIG_SERVER_IMAGE} \
 			--machine-config-daemon-image=${MACHINE_CONFIG_DAEMON_IMAGE} \
+			--machine-config-oscontent-image=${MACHINE_CONFIG_OSCONTENT}
 
 	# Bootstrap MachineConfigController uses /etc/mcc/bootstrap/manifests/ dir to
 	# 1. read the controller config rendered by MachineConfigOperator


### PR DESCRIPTION
Pass through the OS image the same way we do the others, to ensure
the rendered MachineConfig includes it.

Ref: https://github.com/openshift/machine-config-operator/issues/334