### PR TITLE
installconfig: separate control plane and compute machine pools

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -140,7 +140,7 @@ func (a *Bootstrap) Files() []*asset.File {
 
 // getTemplateData returns the data to use to execute bootstrap templates.
 func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig) (*bootstrapTemplateData, error) {
-	etcdEndpoints := make([]string, installConfig.MasterCount())
+	etcdEndpoints := make([]string, *installConfig.ControlPlane.Replicas)
 	for i := range etcdEndpoints {
 		etcdEndpoints[i] = fmt.Sprintf("https://%s-etcd-%d.%s:2379", installConfig.ObjectMeta.Name, i, installConfig.BaseDomain)
 	}

--- a/pkg/asset/ignition/machine/master_test.go
+++ b/pkg/asset/ignition/machine/master_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
@@ -30,11 +31,9 @@ func TestMasterGenerate(t *testing.T) {
 					Region: "us-east",
 				},
 			},
-			Machines: []types.MachinePool{
-				{
-					Name:     "master",
-					Replicas: func(x int64) *int64 { return &x }(3),
-				},
+			ControlPlane: &types.MachinePool{
+				Name:     "master",
+				Replicas: pointer.Int64Ptr(3),
 			},
 		},
 	}

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -55,7 +55,7 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 
 	a.Config = &types.InstallConfig{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1beta2",
+			APIVersion: types.InstallConfigVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName.ClusterName,

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/mock"
@@ -74,14 +75,14 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 				},
 			},
 		},
-		Machines: []types.MachinePool{
-			{
-				Name:     "master",
-				Replicas: func(x int64) *int64 { return &x }(3),
-			},
+		ControlPlane: &types.MachinePool{
+			Name:     "master",
+			Replicas: pointer.Int64Ptr(3),
+		},
+		Compute: []types.MachinePool{
 			{
 				Name:     "worker",
-				Replicas: func(x int64) *int64 { return &x }(3),
+				Replicas: pointer.Int64Ptr(3),
 			},
 		},
 		Platform: types.Platform{
@@ -133,14 +134,14 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 						},
 					},
 				},
-				Machines: []types.MachinePool{
-					{
-						Name:     "master",
-						Replicas: func(x int64) *int64 { return &x }(3),
-					},
+				ControlPlane: &types.MachinePool{
+					Name:     "master",
+					Replicas: pointer.Int64Ptr(3),
+				},
+				Compute: []types.MachinePool{
 					{
 						Name:     "worker",
-						Replicas: func(x int64) *int64 { return &x }(3),
+						Replicas: pointer.Int64Ptr(3),
 					},
 				},
 				Platform: types.Platform{

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -105,7 +105,7 @@ func TestInstallConfigLoad(t *testing.T) {
 		{
 			name: "valid InstallConfig",
 			data: `
-apiVersion: v1beta2
+apiVersion: v1beta3
 metadata:
   name: test-cluster
 baseDomain: test-domain

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -89,7 +89,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 	}
 
 	ic := installconfig.Config
-	pool := workerPool(ic.Machines)
+	pool := workerPool(ic.Compute)
 	switch ic.Platform.Name() {
 	case awstypes.Name:
 		mpool := defaultAWSMachinePoolPlatform()

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -140,7 +140,7 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		rootCA,
 	)
 
-	etcdEndpointHostnames := make([]string, installConfig.Config.MasterCount())
+	etcdEndpointHostnames := make([]string, *installConfig.Config.ControlPlane.Replicas)
 	for i := range etcdEndpointHostnames {
 		etcdEndpointHostnames[i] = fmt.Sprintf("%s-etcd-%d", installConfig.Config.ObjectMeta.Name, i)
 	}

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// InstallConfigVersion is the version supported by this package.
-	InstallConfigVersion = "v1beta2"
+	InstallConfigVersion = "v1beta3"
 )
 
 var (

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -47,11 +47,14 @@ type InstallConfig struct {
 	// Networking defines the pod network provider in the cluster.
 	*Networking `json:"networking,omitempty"`
 
-	// Machines is the list of MachinePools that need to be installed.
+	// ControlPlane is the configuration for the machines that comprise the
+	// control plane.
 	// +optional
-	// Default on AWS and OpenStack is 3 masters and 3 workers.
-	// Default on Libvirt is 1 master and 1 worker.
-	Machines []MachinePool `json:"machines,omitempty"`
+	ControlPlane *MachinePool `json:"controlPlane,omitempty"`
+
+	// Compute is the list of compute MachinePools that need to be installed.
+	// +optional
+	Compute []MachinePool `json:"compute,omitempty"`
 
 	// Platform is the configuration for the specific platform upon which to
 	// perform the installation.
@@ -59,17 +62,6 @@ type InstallConfig struct {
 
 	// PullSecret is the secret to use when pulling images.
 	PullSecret string `json:"pullSecret"`
-}
-
-// MasterCount returns the number of replicas in the master machine pool,
-// defaulting to one if no machine pool was found.
-func (c *InstallConfig) MasterCount() int {
-	for _, m := range c.Machines {
-		if m.Name == "master" && m.Replicas != nil {
-			return int(*m.Replicas)
-		}
-	}
-	return 1
 }
 
 // Platform is the configuration for the specific platform upon which to perform

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -9,6 +9,8 @@ import (
 // MachinePool is a pool of machines to be installed.
 type MachinePool struct {
 	// Name is the name of the machine pool.
+	// For the control plane machine pool, the name will always be "master".
+	// For the compute machine pools, the only valid name is "worker".
 	Name string `json:"name"`
 
 	// Replicas is the count of machines for this machine pool.

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -81,6 +81,15 @@ func TestValidateInstallConfig(t *testing.T) {
 			installConfig: validInstallConfig(),
 		},
 		{
+			name: "invalid version",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.APIVersion = "bad-version"
+				return c
+			}(),
+			expectedError: fmt.Sprintf(`^apiVersion: Invalid value: "bad-version": install-config version must be %q`, types.InstallConfigVersion),
+		},
+		{
 			name: "invalid name",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
@@ -22,15 +23,16 @@ func TestValidateMachinePool(t *testing.T) {
 		{
 			name: "minimal",
 			pool: &types.MachinePool{
-				Name: "master",
+				Name:     "master",
+				Replicas: pointer.Int64Ptr(1),
 			},
 			platform: "aws",
 			valid:    true,
 		},
 		{
-			name: "invalid name",
+			name: "missing replicas",
 			pool: &types.MachinePool{
-				Name: "bad-name",
+				Name: "master",
 			},
 			platform: "aws",
 			valid:    false,
@@ -47,7 +49,8 @@ func TestValidateMachinePool(t *testing.T) {
 		{
 			name: "valid aws",
 			pool: &types.MachinePool{
-				Name: "master",
+				Name:     "master",
+				Replicas: pointer.Int64Ptr(1),
 				Platform: types.MachinePoolPlatform{
 					AWS: &aws.MachinePool{},
 				},
@@ -58,7 +61,8 @@ func TestValidateMachinePool(t *testing.T) {
 		{
 			name: "invalid aws",
 			pool: &types.MachinePool{
-				Name: "master",
+				Name:     "master",
+				Replicas: pointer.Int64Ptr(1),
 				Platform: types.MachinePoolPlatform{
 					AWS: &aws.MachinePool{
 						EC2RootVolume: aws.EC2RootVolume{
@@ -73,7 +77,8 @@ func TestValidateMachinePool(t *testing.T) {
 		{
 			name: "valid libvirt",
 			pool: &types.MachinePool{
-				Name: "master",
+				Name:     "master",
+				Replicas: pointer.Int64Ptr(1),
 				Platform: types.MachinePoolPlatform{
 					Libvirt: &libvirt.MachinePool{},
 				},
@@ -84,7 +89,8 @@ func TestValidateMachinePool(t *testing.T) {
 		{
 			name: "valid openstack",
 			pool: &types.MachinePool{
-				Name: "master",
+				Name:     "master",
+				Replicas: pointer.Int64Ptr(1),
 				Platform: types.MachinePoolPlatform{
 					OpenStack: &openstack.MachinePool{},
 				},
@@ -95,7 +101,8 @@ func TestValidateMachinePool(t *testing.T) {
 		{
 			name: "mis-matched platform",
 			pool: &types.MachinePool{
-				Name: "master",
+				Name:     "master",
+				Replicas: pointer.Int64Ptr(1),
 				Platform: types.MachinePoolPlatform{
 					AWS: &aws.MachinePool{},
 				},
@@ -106,7 +113,8 @@ func TestValidateMachinePool(t *testing.T) {
 		{
 			name: "multiple platforms",
 			pool: &types.MachinePool{
-				Name: "master",
+				Name:     "master",
+				Replicas: pointer.Int64Ptr(1),
 				Platform: types.MachinePoolPlatform{
 					AWS:     &aws.MachinePool{},
 					Libvirt: &libvirt.MachinePool{},


### PR DESCRIPTION
There should always be a control plane machine pool, so the declaration is moved from a generic `machines` field to a specific `controlPlane` field. The `machines` field contains only `compute` machines, so it is renamed to `compute`.

This is the first step in replacing references to master and worker with references to control plane and compute throughout the installer.
