### PR TITLE
hack/build: Strip compiled binaries

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -38,6 +38,7 @@ export CGO_ENABLED=0
 
 case "${MODE}" in
 release)
+	LDFLAGS="${LDFLAGS} -s -w"
 	TAGS="${TAGS} release"
 	if test -n "${RELEASE_IMAGE}"
 	then


### PR DESCRIPTION
I'm not sure how portable this is, but for the GNU linker this is:

```
  -s
  --strip-all
     Omit all symbol information from the output file.
```

With this change, our compiled Linux binary (without libvirt) drops from ~240 MB to ~130 MB.  Alex was concerned about panic support, but with:

```console
$ git diff -U1
diff --git a/cmd/openshift-install/main.go b/cmd/openshift-install/main.go
index 37f7f96..fbd9889 100644
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -69,2 +69,4 @@ func newRootCmd() *cobra.Command {
 func runRootCmd(cmd *cobra.Command, args []string) {
+       panic("testing, testing")
+
        logrus.SetOutput(ioutil.Discard)
```

panics still produce useful tracebacks:

```console
$ openshift-install create install-config
panic: testing, testing

goroutine 1 [running]:
main.runRootCmd(0x8575360, 0x85d4390, 0x0, 0x0)
  /.../go/src/github.com/openshift/installer/cmd/openshift-install/main.go:70 +0x39
github.com/openshift/installer/vendor/github.com/spf13/cobra.(*Command).execute(0x8575360, 0x85d4390, 0x0, 0x0, 0x8575360, 0x85d4390)
  /.../go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:746 +0x237
github.com/openshift/installer/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc42044f180, 0x0, 0xc4209cc500, 0xc42044f2d0)
  /.../go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:852 +0x30a
github.com/openshift/installer/vendor/github.com/spf13/cobra.(*Command).Execute(0xc42044f180, 0xc420983ec0, 0x1)
  /.../go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:800 +0x2b
main.installerMain()
  /.../go/src/github.com/openshift/installer/cmd/openshift-install/main.go:50 +0x132
main.main()
  /.../go/src/github.com/openshift/installer/cmd/openshift-install/main.go:34 +0x39
```

which looks fine.

Suggested-by: @pamoedom