### PR TITLE
[WIP] [Do Not Merge] pkg/validate: 'Raw' is a valid type of network

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -28,6 +28,7 @@ var (
 		netopv1.NetworkTypeOVNKubernetes: true,
 		netopv1.NetworkTypeCalico:        true,
 		netopv1.NetworkTypeKuryr:         true,
+		netopv1.NetworkTypeRaw:           true,
 	}
 
 	// ValidNetworkTypeValues is a slice filled with the valid network types as


### PR DESCRIPTION
Playing with the proposal that network type could be 'raw'. 

This will allow us to inject a cni-vendor's operator manifests (managed by OLM, hopefully), so that the default/known networking plugins can be swapped shut nicely. Changes will be needed in the network operator such that it can take the main network to be of this none/raw type.