### PR TITLE
Adds a customize doc for libvirt with tt0 bridge customization

### DIFF
--- a/docs/dev/libvirt/README.md
+++ b/docs/dev/libvirt/README.md
@@ -2,6 +2,10 @@
 
 Launching clusters via libvirt is especially useful for operator development.
 
+**NOTE:** Some aspects of the installation can be customized through the
+`install-config.yaml` file. See
+[how to create an install-config.yaml file](docs/user/overview.md#multiple-invocations) and [the libvirt platform customization](docs/dev/libvirt/customization.md) documents.
+
 ## One-time setup
 It's expected that you will create and destroy clusters often in the course of development. These steps only need to be run once.
 

--- a/docs/dev/libvirt/customization.md
+++ b/docs/dev/libvirt/customization.md
@@ -1,0 +1,22 @@
+# Libvirt Platform Customization
+
+The following options are available when using libvirt:
+
+- `platform.libvirt.network.if` - the network bridge attached to the libvirt network (`tt0` by default)
+
+## Examples
+
+An example `install-config.yaml` is shown below. This configuration has been modified to show the customization that is possible via the install config.
+
+```yaml
+apiVersion: v1
+baseDomain: example.com
+...
+platform:
+  libvirt:
+    URI: qemu+tcp://192.168.122.1/system
+    network:
+      if: mybridge0
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```


### PR DESCRIPTION
Adds a comment about the `tt0` bridge for libvirt.

Fixes #708 