### PR TITLE
openstack: make the local DNS service more robust

### DIFF
--- a/data/data/openstack/lb/main.tf
+++ b/data/data/openstack/lb/main.tf
@@ -55,7 +55,9 @@ data "ignition_systemd_unit" "local_dns" {
 Description=Internal DNS server for running OpenShift on OpenStack
 
 [Service]
-ExecStart=/bin/podman run --name bootstrap-dns --rm -t -i -p 53:53/tcp -p 53:53/udp -v /etc/openshift-hosts:/etc/openshift-hosts:z --cap-add=NET_ADMIN docker.io/andyshinn/dnsmasq:latest --keep-in-foreground --log-facility=- --log-queries --no-resolv --addn-hosts=/etc/openshift-hosts --server=10.0.0.2 ${replace(join(" ", formatlist("--srv-host=_etcd-server-ssl._tcp.${var.cluster_name}.${var.cluster_domain},${var.cluster_name}-etcd-%s.${var.cluster_domain},2380,0,10", var.master_port_names)), "master-port-", "")}
+ExecStart=/bin/podman run --rm -t -i -p 53:53/tcp -p 53:53/udp -v /etc/openshift-hosts:/etc/openshift-hosts:z --cap-add=NET_ADMIN docker.io/andyshinn/dnsmasq:latest --keep-in-foreground --log-facility=- --log-queries --no-resolv --addn-hosts=/etc/openshift-hosts --server=10.0.0.2 ${replace(join(" ", formatlist("--srv-host=_etcd-server-ssl._tcp.${var.cluster_name}.${var.cluster_domain},${var.cluster_name}-etcd-%s.${var.cluster_domain},2380,0,10", var.master_port_names)), "master-port-", "")}
+Restart=always
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The `local-dns` service will now restart on failure (e.g. when the
initial image pull fails) and it no longer sets the name of the
container (so we can always re-run it without running into duplicate
name issues).