### PR TITLE
openstack: open port 443 on the load balancer

### DIFF
--- a/data/data/openstack/topology/sg-lb.tf
+++ b/data/data/openstack/topology/sg-lb.tf
@@ -23,6 +23,16 @@ resource "openstack_networking_secgroup_rule_v2" "api_https" {
   security_group_id = "${openstack_networking_secgroup_v2.api.id}"
 }
 
+resource "openstack_networking_secgroup_rule_v2" "console_https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.api.id}"
+}
+
 resource "openstack_networking_secgroup_rule_v2" "api_ingress_dns_udp" {
   direction         = "ingress"
   ethertype         = "IPv4"


### PR DESCRIPTION
This is necessary to provide the access to the openshift-console.