### PR TITLE
asset/bootstrap: Remove ~core/.bash_history

### DIFF
--- a/data/data/bootstrap/files/home/core/.bash_history
+++ b/data/data/bootstrap/files/home/core/.bash_history
@@ -1,1 +1,0 @@
-journalctl -b -f -u bootkube.service

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -209,10 +209,6 @@ func (a *Bootstrap) addStorageFiles(base string, uri string, templateData *boots
 		mode = 0600
 	}
 	ign := ignition.FileFromBytes(strings.TrimSuffix(base, ".template"), "root", mode, data)
-	if filename == ".bash_history" {
-		ign.User = &igntypes.NodeUser{Name: ignitionUser}
-		ign.Group = &igntypes.NodeGroup{Name: ignitionUser}
-	}
 	ign.Append = appendToFile
 	a.Config.Storage.Files = append(a.Config.Storage.Files, ign)
 


### PR DESCRIPTION
This creates a dependency on this user's existence which may not be
present on RHEL nodes.

In the future CI jobs that validate scale-up on RHEL nodes will prevent
introduction of breaking changes but those weren't in place when this
went in.

/cc @cgwalters @wking 