### PR TITLE
pkg/rhcos/builds: allow use of env var to override stream URL.

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -47,6 +47,10 @@ release)
 	then
 		LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/rhcos.buildName=${RHCOS_BUILD_NAME}"
 	fi
+	if test -n "${RHCOS_BUILD_URL}"
+	then
+		LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/rhcos.baseURL=${RHCOS_BUILD_URL}"
+	fi
 	if test "${SKIP_GENERATION}" != y
 	then
 		go generate ./data

--- a/pkg/rhcos/builds.go
+++ b/pkg/rhcos/builds.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -21,6 +22,13 @@ var (
 
 	baseURL = "https://releases-rhcos.svc.ci.openshift.org/storage/releases"
 )
+
+func init() {
+	if or, ok := os.LookupEnv("OPENSHIFT_INSTALL_COREOS_IMAGE_URL"); ok && or != "" {
+		logrus.Warn("Found override for OS BASE URL. Untrusted repository will be used. This is not advised")
+		baseURL = or
+	}
+}
 
 type metadata struct {
 	AMIs []struct {


### PR DESCRIPTION
Use of 'OPENSHIFT_INSTALL_COREOS_IMAGE_URL' environment variable will allow RHCOS developers to select different sources for RHCOS images. Also, added 'RHCOS_URL' to set the default at binary build.