### PR TITLE
Move DNS records from base_domain to cluster_domain

### DIFF
--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -6,11 +6,13 @@ locals {
   public_zone_id = "${data.aws_route53_zone.base.zone_id}"
 
   zone_id = "${var.private_zone_id}"
+
+  cluster_domain = "${var.cluster_name}.${var.base_domain}"
 }
 
 resource "aws_route53_record" "api_external" {
   zone_id = "${local.public_zone_id}"
-  name    = "${var.cluster_name}-api.${var.base_domain}"
+  name    = "api.${local.cluster_domain}"
   type    = "A"
 
   alias {
@@ -22,7 +24,7 @@ resource "aws_route53_record" "api_external" {
 
 resource "aws_route53_record" "api_internal" {
   zone_id = "${var.private_zone_id}"
-  name    = "${var.cluster_name}-api.${var.base_domain}"
+  name    = "api.${local.cluster_domain}"
   type    = "A"
 
   alias {

--- a/data/data/aws/vpc/vpc.tf
+++ b/data/data/aws/vpc/vpc.tf
@@ -1,6 +1,8 @@
 locals {
   new_private_cidr_range = "${cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block,1,1)}"
   new_public_cidr_range  = "${cidrsubnet(data.aws_vpc.cluster_vpc.cidr_block,1,0)}"
+
+  cluster_domain = "${var.cluster_name}.${var.base_domain}"
 }
 
 resource "aws_vpc" "new_vpc" {
@@ -9,7 +11,7 @@ resource "aws_vpc" "new_vpc" {
   enable_dns_support   = true
 
   tags = "${merge(map(
-      "Name", "${var.cluster_name}.${var.base_domain}",
+      "Name", "${local.cluster_domain}",
     ), var.tags)}"
 }
 

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -1,3 +1,7 @@
+locals {
+  cluster_domain = "${var.cluster_name}.${var.base_domain}"
+}
+
 provider "openstack" {
   auth_url            = "${var.openstack_credentials_auth_url}"
   cert                = "${var.openstack_credentials_cert}"
@@ -81,7 +85,7 @@ module "topology" {
 }
 
 resource "openstack_objectstorage_container_v1" "container" {
-  name = "${lower(var.cluster_name)}.${var.base_domain}"
+  name = "${local.cluster_domain}"
 
   metadata = "${merge(map(
       "Name", "${var.cluster_name}-ignition-master",

--- a/data/data/openstack/service/main.tf
+++ b/data/data/openstack/service/main.tf
@@ -134,19 +134,19 @@ data "ignition_file" "corefile" {
     errors
     reload 10s
 
-${length(var.lb_floating_ip) == 0 ? "" : "    file /etc/coredns/db.${var.cluster_domain} ${var.cluster_name}-api.${var.cluster_domain} {\n    }\n"}
+${length(var.lb_floating_ip) == 0 ? "" : "    file /etc/coredns/db.${var.cluster_domain} api.${var.cluster_domain} {\n    }\n"}
 
 
-    file /etc/coredns/db.${var.cluster_domain} _etcd-server-ssl._tcp.${var.cluster_name}.${var.cluster_domain} {
+    file /etc/coredns/db.${var.cluster_domain} _etcd-server-ssl._tcp.${var.cluster_domain} {
     }
 
-${replace(join("\n", formatlist("    file /etc/coredns/db.${var.cluster_domain} ${var.cluster_name}-etcd-%s.${var.cluster_domain} {\n    upstream /etc/resolv.conf\n    }\n", var.master_port_names)), "master-port-", "")}
+${replace(join("\n", formatlist("    file /etc/coredns/db.${var.cluster_domain} etcd-%s.${var.cluster_domain} {\n    upstream /etc/resolv.conf\n    }\n", var.master_port_names)), "master-port-", "")}
 
     forward . /etc/resolv.conf {
     }
 }
 
-${var.cluster_name}.${var.cluster_domain} {
+${var.cluster_domain} {
     log
     errors
     reload 10s
@@ -168,7 +168,7 @@ data "ignition_file" "coredb" {
   content {
     content = <<EOF
 $ORIGIN ${var.cluster_domain}.
-@    3600 IN SOA host-${var.cluster_name}.${var.cluster_domain}. hostmaster (
+@    3600 IN SOA host.${var.cluster_domain}. hostmaster (
                                 2017042752 ; serial
                                 7200       ; refresh (2 hours)
                                 3600       ; retry (1 hour)
@@ -176,12 +176,12 @@ $ORIGIN ${var.cluster_domain}.
                                 3600       ; minimum (1 hour)
                                 )
 
-${length(var.lb_floating_ip) == 0 ? "" : "${var.cluster_name}-api  IN  A  ${var.lb_floating_ip}"}
-${length(var.lb_floating_ip) == 0 ? "" : "*.apps.${var.cluster_name}  IN  A  ${var.lb_floating_ip}"}
+${length(var.lb_floating_ip) == 0 ? "" : "api  IN  A  ${var.lb_floating_ip}"}
+${length(var.lb_floating_ip) == 0 ? "" : "*.apps  IN  A  ${var.lb_floating_ip}"}
 
-${replace(join("\n", formatlist("${var.cluster_name}-etcd-%s  IN  CNAME  ${var.cluster_name}-master-%s", var.master_port_names, var.master_port_names)), "master-port-", "")}
+${replace(join("\n", formatlist("etcd-%s  IN  CNAME  master-%s", var.master_port_names, var.master_port_names)), "master-port-", "")}
 
-${replace(join("\n", formatlist("_etcd-server-ssl._tcp.${var.cluster_name}  8640  IN  SRV  0  10  2380   ${var.cluster_name}-etcd-%s.${var.cluster_domain}.", var.master_port_names)), "master-port-", "")}
+${replace(join("\n", formatlist("_etcd-server-ssl._tcp.${var.cluster_domain}  8640  IN  SRV  0  10  2380   etcd-%s.${var.cluster_domain}.", var.master_port_names)), "master-port-", "")}
 EOF
   }
 }

--- a/data/data/openstack/service/variables.tf
+++ b/data/data/openstack/service/variables.tf
@@ -19,7 +19,7 @@ variable "cluster_id" {
 
 variable "cluster_domain" {
   type        = "string"
-  description = "The domain name of the cluster."
+  description = "The domain name of the cluster. All DNS records must be under this domain."
 }
 
 variable "ignition" {

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -142,7 +142,7 @@ func (a *Bootstrap) Files() []*asset.File {
 func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig) (*bootstrapTemplateData, error) {
 	etcdEndpoints := make([]string, *installConfig.ControlPlane.Replicas)
 	for i := range etcdEndpoints {
-		etcdEndpoints[i] = fmt.Sprintf("https://%s-etcd-%d.%s:2379", installConfig.ObjectMeta.Name, i, installConfig.BaseDomain)
+		etcdEndpoints[i] = fmt.Sprintf("https://etcd-%d.%s:2379", i, installConfig.ClusterDomain())
 	}
 
 	releaseImage := defaultReleaseImage

--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -21,7 +21,7 @@ func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, ro
 					Source: func() *url.URL {
 						return &url.URL{
 							Scheme: "https",
-							Host:   fmt.Sprintf("%s-api.%s:22623", installConfig.ObjectMeta.Name, installConfig.BaseDomain),
+							Host:   fmt.Sprintf("api.%s:22623", installConfig.ClusterDomain()),
 							Path:   fmt.Sprintf("/config/%s", role),
 						}
 					}().String(),

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -31,7 +31,7 @@ func (k *kubeconfig) generate(
 			{
 				Name: installConfig.ObjectMeta.Name,
 				Cluster: clientcmd.Cluster{
-					Server: fmt.Sprintf("https://%s-api.%s:6443", installConfig.ObjectMeta.Name, installConfig.BaseDomain),
+					Server: fmt.Sprintf("https://api.%s:6443", installConfig.ClusterDomain()),
 					CertificateAuthorityData: []byte(rootCA.Cert()),
 				},
 			},

--- a/pkg/asset/kubeconfig/kubeconfig_test.go
+++ b/pkg/asset/kubeconfig/kubeconfig_test.go
@@ -62,7 +62,7 @@ func TestKubeconfigGenerate(t *testing.T) {
 			expectedData: []byte(`clusters:
 - cluster:
     certificate-authority-data: VEhJUyBJUyBST09UIENBIENFUlQgREFUQQ==
-    server: https://test-cluster-name-api.test.example.com:6443
+    server: https://api.test-cluster-name.test.example.com:6443
   name: test-cluster-name
 contexts:
 - context:
@@ -86,7 +86,7 @@ users:
 			expectedData: []byte(`clusters:
 - cluster:
     certificate-authority-data: VEhJUyBJUyBST09UIENBIENFUlQgREFUQQ==
-    server: https://test-cluster-name-api.test.example.com:6443
+    server: https://api.test-cluster-name.test.example.com:6443
   name: test-cluster-name
 contexts:
 - context:

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -65,7 +65,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 			// not namespaced
 		},
 		Spec: configv1.DNSSpec{
-			BaseDomain: installConfig.Config.BaseDomain,
+			BaseDomain: installConfig.Config.ClusterDomain(),
 		},
 	}
 

--- a/pkg/asset/manifests/ingress.go
+++ b/pkg/asset/manifests/ingress.go
@@ -52,7 +52,7 @@ func (ing *Ingress) Generate(dependencies asset.Parents) error {
 			// not namespaced
 		},
 		Spec: configv1.IngressSpec{
-			Domain: fmt.Sprintf("apps.%s.%s", installConfig.Config.ObjectMeta.Name, installConfig.Config.BaseDomain),
+			Domain: fmt.Sprintf("apps.%s", installConfig.Config.ClusterDomain()),
 		},
 	}
 

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -142,7 +142,7 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 
 	etcdEndpointHostnames := make([]string, *installConfig.Config.ControlPlane.Replicas)
 	for i := range etcdEndpointHostnames {
-		etcdEndpointHostnames[i] = fmt.Sprintf("%s-etcd-%d", installConfig.Config.ObjectMeta.Name, i)
+		etcdEndpointHostnames[i] = fmt.Sprintf("etcd-%d", i)
 	}
 
 	templateData := &bootkubeTemplateData{
@@ -158,7 +158,7 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		RootCaCert:                      string(rootCA.Cert()),
 		CVOClusterID:                    clusterID.ClusterID,
 		EtcdEndpointHostnames:           etcdEndpointHostnames,
-		EtcdEndpointDNSSuffix:           installConfig.Config.BaseDomain,
+		EtcdEndpointDNSSuffix:           installConfig.Config.ClusterDomain(),
 	}
 
 	kubeCloudConfig := &bootkube.KubeCloudConfig{}

--- a/pkg/asset/manifests/utils.go
+++ b/pkg/asset/manifests/utils.go
@@ -34,9 +34,9 @@ func configMap(namespace, name string, data genericData) *configurationObject {
 }
 
 func getAPIServerURL(ic *types.InstallConfig) string {
-	return fmt.Sprintf("https://%s-api.%s:6443", ic.ObjectMeta.Name, ic.BaseDomain)
+	return fmt.Sprintf("https://api.%s:6443", ic.ClusterDomain())
 }
 
 func getEtcdDiscoveryDomain(ic *types.InstallConfig) string {
-	return fmt.Sprintf("%s.%s", ic.ObjectMeta.Name, ic.BaseDomain)
+	return ic.ClusterDomain()
 }

--- a/pkg/asset/tls/helper.go
+++ b/pkg/asset/tls/helper.go
@@ -19,7 +19,7 @@ func assetFilePath(filename string) string {
 }
 
 func apiAddress(cfg *types.InstallConfig) string {
-	return fmt.Sprintf("%s-api.%s", cfg.ObjectMeta.Name, cfg.BaseDomain)
+	return fmt.Sprintf("api.%s", cfg.ClusterDomain())
 }
 
 func cidrhost(network net.IPNet, hostNum int) (string, error) {

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -62,6 +64,11 @@ type InstallConfig struct {
 
 	// PullSecret is the secret to use when pulling images.
 	PullSecret string `json:"pullSecret"`
+}
+
+// ClusterDomain returns the DNS domain that all records for a cluster must belong to.
+func (c *InstallConfig) ClusterDomain() string {
+	return fmt.Sprintf("%s.%s", c.ObjectMeta.Name, c.BaseDomain)
 }
 
 // Platform is the configuration for the specific platform upon which to perform


### PR DESCRIPTION
The issue was reported in https://github.com/openshift/installer/issues/1136

On AWS, we are currently creating a private zone for `base_domain` and create all the necessary records in that private zone. when users create a new cluster under the same domain, we create a new private zone for the `base_domain` again. This setup creates 2 zones each with authority on `base_domain` and therefore each cluster cannot resolve the api or other endpoints for the other cluster.

A solution is that we create private zones for a cluster with authority on `cluster_domain = cluster_name.base_domain`. This allows each cluster to maintain authority on subdomain of basedomain and allows each to resolve the other.

some of our current dns records look like:
`cluster_name-api.base_domain` -> for api and ignition server.
`cluster_name-etcd-{idx}.base_domain` -> for each master with etcd.

To make sure when moving records from base_domain to cluster_domain, we do not make our dns names very long. the new records look like:
`api.cluster_domain` -> for api and ignition server. 
`etcd-{idx}.cluster_domain` -> for each master with etcd.
This keeps all the records exactly the same length as before, as we are moving cluster_name and replacing `-` with a `.`

tasks:

- [x] move libvirt records from `base_domain` to be under `cluster_domain` with new schema
- [x] move aws records from `base_domain` to be under `cluster_domain` with new schema
- [x] move openstack records from `base_domain` to be under `cluster_domain` with new schema
- [x] changes are required in Machine Config Operator to use the new api server url
- [x] changes are required in Ingress Operator to make sure it can create the `*.app.cluster_domain`
- [ ] possible changes required in [`DNS.config.openshift.io`](https://github.com/openshift/api/blob/4912e102a00fa8bb4bf27f83808dce6ef1b6887d/config/v1/types_dns.go#L22-L29) and consumers.