### PR TITLE
pkg/destroy/aws: remove un-used cluster_name field

### DIFF
--- a/pkg/destroy/aws.go
+++ b/pkg/destroy/aws.go
@@ -14,10 +14,9 @@ func NewAWS(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (Destroy
 	}
 
 	return &aws.ClusterUninstaller{
-		Filters:     filters,
-		Region:      metadata.ClusterPlatformMetadata.AWS.Region,
-		ClusterName: metadata.ClusterName,
-		Logger:      logger,
+		Filters: filters,
+		Region:  metadata.ClusterPlatformMetadata.AWS.Region,
+		Logger:  logger,
 	}, nil
 }
 

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -47,18 +47,14 @@ type ClusterUninstaller struct {
 	//   }
 	//
 	// will match resources with (a:b and c:d) or d:e.
-	Filters     []Filter // filter(s) we will be searching for
-	Logger      logrus.FieldLogger
-	Region      string
-	ClusterName string
+	Filters []Filter // filter(s) we will be searching for
+	Logger  logrus.FieldLogger
+	Region  string
 }
 
 func (o *ClusterUninstaller) validate() error {
 	if len(o.Filters) == 0 {
 		return errors.Errorf("you must specify at least one tag filter")
-	}
-	if len(o.ClusterName) == 0 {
-		return errors.Errorf("you must specify cluster-name")
 	}
 	return nil
 }


### PR DESCRIPTION
We used to use this for AWS teardown too, but e24c7dc4 (#1039) removed the last consumer there.  Now, only libvirt needs the cluster name for deletion.