### PR TITLE
data/aws/master: drop un-used base_domain

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -31,7 +31,6 @@ module "bootstrap" {
 module "masters" {
   source = "./master"
 
-  base_domain  = "${var.base_domain}"
   cluster_id   = "${var.cluster_id}"
   cluster_name = "${var.cluster_name}"
   ec2_type     = "${var.aws_master_ec2_type}"

--- a/data/data/aws/master/variables.tf
+++ b/data/data/aws/master/variables.tf
@@ -1,8 +1,3 @@
-variable "base_domain" {
-  type        = "string"
-  description = "Domain on which the ELB records will be created"
-}
-
 variable "cluster_id" {
   type = "string"
 }


### PR DESCRIPTION
There are no comsumers for base_domain in this master module.
/cc @wking