### PR TITLE
Marshal and compare strings instead of DeepEqual

### DIFF
--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -297,8 +297,11 @@ func (s *StoreImpl) load(asset Asset, indent string) (*assetState, error) {
 
 			// If the on-disk asset is the same as the one in the state file, there
 			// is no need to consider the one on disk and to mark the asset dirty.
-			onDiskMatchesStateFile = reflect.DeepEqual(onDiskAsset, stateFileAsset)
-			if onDiskMatchesStateFile {
+			// DeepEqual does not always work because the asset may have private fields populated by 'Load'
+			onDiskData, _ := json.Marshal(onDiskAsset)
+			stateFileData, _ := json.Marshal(stateFileAsset)
+			if string(onDiskData) == string(stateFileData) {
+				onDiskMatchesStateFile = true
 				logrus.Debugf("%sOn-disk %q matches asset in state file", indent, asset.Name())
 			}
 		}


### PR DESCRIPTION
reflect.DeepEqual between the stateFileAsset and onDiskAsset did not work as intended because onDiskAsset used the 'Load' function which populates some internal private fields also (see dns asset). Though possibly inefficient, we have to unfortunately marshal the assets back to strings to be able to check equality.

reflect.DeepEqual was always returning not matched for dns asset as an example, even if the on disk files stay untouched.

/kind bug

@staebler PTAL