### PR TITLE
pkg/asset/tls: self-sign kube-ca

### DIFF
--- a/pkg/asset/kubeconfig/admin.go
+++ b/pkg/asset/kubeconfig/admin.go
@@ -22,7 +22,7 @@ var _ asset.WritableAsset = (*Admin)(nil)
 // Dependencies returns the dependency of the kubeconfig.
 func (k *Admin) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		&tls.RootCA{},
+		&tls.KubeCA{},
 		&tls.AdminCertKey{},
 		&installconfig.InstallConfig{},
 	}
@@ -30,13 +30,13 @@ func (k *Admin) Dependencies() []asset.Asset {
 
 // Generate generates the kubeconfig.
 func (k *Admin) Generate(parents asset.Parents) error {
-	rootCA := &tls.RootCA{}
+	kubeCA := &tls.KubeCA{}
 	adminCertKey := &tls.AdminCertKey{}
 	installConfig := &installconfig.InstallConfig{}
-	parents.Get(rootCA, adminCertKey, installConfig)
+	parents.Get(kubeCA, adminCertKey, installConfig)
 
 	return k.kubeconfig.generate(
-		rootCA,
+		kubeCA,
 		adminCertKey,
 		installConfig.Config,
 		"admin",

--- a/pkg/asset/kubeconfig/kubelet.go
+++ b/pkg/asset/kubeconfig/kubelet.go
@@ -22,7 +22,7 @@ var _ asset.WritableAsset = (*Kubelet)(nil)
 // Dependencies returns the dependency of the kubeconfig.
 func (k *Kubelet) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		&tls.RootCA{},
+		&tls.KubeCA{},
 		&tls.KubeletCertKey{},
 		&installconfig.InstallConfig{},
 	}
@@ -30,13 +30,13 @@ func (k *Kubelet) Dependencies() []asset.Asset {
 
 // Generate generates the kubeconfig.
 func (k *Kubelet) Generate(parents asset.Parents) error {
-	rootCA := &tls.RootCA{}
+	kubeCA := &tls.KubeCA{}
 	kubeletCertKey := &tls.KubeletCertKey{}
 	installConfig := &installconfig.InstallConfig{}
-	parents.Get(rootCA, kubeletCertKey, installConfig)
+	parents.Get(kubeCA, kubeletCertKey, installConfig)
 
 	return k.kubeconfig.generate(
-		rootCA,
+		kubeCA,
 		kubeletCertKey,
 		installConfig.Config,
 		"kubelet",

--- a/pkg/asset/tls/apiservercertkey.go
+++ b/pkg/asset/tls/apiservercertkey.go
@@ -54,7 +54,7 @@ func (a *APIServerCertKey) Generate(dependencies asset.Parents) error {
 		IPAddresses: []net.IP{net.ParseIP(apiServerAddress), net.ParseIP("127.0.0.1")},
 	}
 
-	return a.CertKey.Generate(cfg, kubeCA, "apiserver", AppendParent)
+	return a.CertKey.Generate(cfg, kubeCA, "apiserver", DoNotAppendParent)
 }
 
 // Name returns the human-friendly name of the asset.


### PR DESCRIPTION
This PR turns the kube-ca into a self-signed CA rather than intermediate from the root CA. Detaching it from the root CA trust chain gives us a proper separation of the trust domain while making it possible to accommodate non-golang clients without compromising the intended trust separation. 