### PR TITLE
cmd/openshift-install: suppress glog output

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -22,6 +23,11 @@ var (
 )
 
 func main() {
+	// This attempts to configure glog (used by vendored Kubernetes code) not
+	// to log anything. Nobody likes you, glog. Go away.
+	flag.CommandLine.Parse([]string{})
+	flag.CommandLine.Set("stderrthreshold", "4")
+
 	if len(os.Args) > 0 {
 		base := filepath.Base(os.Args[0])
 		cname := strings.TrimSuffix(base, filepath.Ext(base))


### PR DESCRIPTION
glog is polluting the output of the installer with messages like the
following:

    ERROR: logging before flag.Parse: E0201 13:56:32.940927

By telling the flag parser to parse nothing, the "logging before
flag.Parse" portion is removed. By setting 'stderrthreshold', the rest
of the error message is also suppressed.