### PR TITLE
data/manifests: update the upstream Cincinnati URL

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -4,6 +4,6 @@ metadata:
   namespace: openshift-cluster-version
   name: version
 spec:
-  upstream: http://localhost:8080/graph
+  upstream: https://api.openshift.com/api/upgrades_info/v1/graph
   channel: fast
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
Now that Cincinnati is running in production, the CVO should refer to
that service instead of localhost. This will allow the clusters to check
for updates. Whether or not they can apply them is another story...