### PR TITLE
link to ansible role for setting up libvirt dev environment

### DIFF
--- a/docs/dev/libvirt/README.md
+++ b/docs/dev/libvirt/README.md
@@ -2,6 +2,13 @@
 
 Launching clusters via libvirt is especially useful for operator development.
 
+## Ansible role
+
+For environments managed via ansible, there is a
+[role](https://github.com/dhellmann/ansible-openshift-libvirt) to
+implement the system configuration steps below. The installer source
+code is not downloaded or built automatically.
+
 ## One-time setup
 It's expected that you will create and destroy clusters often in the course of development. These steps only need to be run once.
 


### PR DESCRIPTION
Add a section to the libvirt howto that points to an ansible role for
managing the system configuration steps automatically.

Signed-off-by: Doug Hellmann <doug@doughellmann.com>