### PR TITLE
pkg/asset/targets: Render the metadata asset before cluster

### DIFF
--- a/pkg/asset/targets/targets.go
+++ b/pkg/asset/targets/targets.go
@@ -61,7 +61,7 @@ var (
 		&cluster.TerraformVariables{},
 		&kubeconfig.Admin{},
 		&tls.JournalCertKey{},
-		&cluster.Cluster{},
 		&cluster.Metadata{},
+		&cluster.Cluster{},
 	}
 )


### PR DESCRIPTION
Otherwise Terraform failures will lead to exits without `metadata.json`, which makes it harder for users to reap any resources from the possibly-partially-created cluster.  Before this commit:

```console
$ git diff -U1 | cat
diff --git a/pkg/terraform/terraform.go b/pkg/terraform/terraform.go
index f566d34..bad05e5 100644
--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -53,2 +53,3 @@ func Apply(dir string, platform string, extraArgs ...string) (path string, err e

+				return sf, errors.New("faking a Terraform failure")
 				if exitCode := texec.Apply(dir, args, lpDebug, lpError); exitCode != 0 {
$ hack/build.sh
$ openshift-install --dir=wking create cluster
INFO Consuming "Install Config" from target directory
INFO Creating cluster...
ERROR Failed to read tfstate: open /tmp/openshift-install-655768368/terraform.tfstate: no such file or directory
FATAL failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: faking a Terraform failure
$ ls wking
auth  terraform.tfvars  tls
```

With this commit, we get `metadata.json` too.  Fixes a bug introduced by the re-order in 75ab1060 (#890, v0.12.0).