### PR TITLE
Trim down the worker iam role

### DIFF
--- a/data/data/aws/iam/main.tf
+++ b/data/data/aws/iam/main.tf
@@ -45,21 +45,6 @@ resource "aws_iam_role_policy" "worker_policy" {
       "Resource": "*"
     },
     {
-      "Effect": "Allow",
-      "Action": "ec2:AttachVolume",
-      "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": "ec2:DetachVolume",
-      "Resource": "*"
-    },
-    {
-      "Action": "elasticloadbalancing:*",
-      "Resource": "*",
-      "Effect": "Allow"
-    },
-    {
       "Action" : [
         "s3:GetObject"
       ],


### PR DESCRIPTION
The kubelet was suspected to use attach/detach volume and load balancer apis, but
apparently not. We can trim the privileges down to minimum now.
The last big one remaining is DescribeInstances that is stuck because of instance 'tags'.

The cluster comes up just fine, now hoping I didn't miscalculate on actual workloads.. time for the virtuous e2e to shine.

Part 2: Try removing s3 access also and see what gives.