### PR TITLE
data/aws/vpc/sg-master: Fix 9990 -> 9999 metrics to_port

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -122,7 +122,7 @@ resource "aws_security_group_rule" "master_ingress_internal" {
 
   protocol  = "tcp"
   from_port = 9000
-  to_port   = 9990
+  to_port   = 9999
   self      = true
 }
 
@@ -133,7 +133,7 @@ resource "aws_security_group_rule" "master_ingress_internal_from_worker" {
 
   protocol  = "tcp"
   from_port = 9000
-  to_port   = 9990
+  to_port   = 9999
 }
 
 resource "aws_security_group_rule" "master_ingress_kube_scheduler" {


### PR DESCRIPTION
These were added in 3248996d (#683) with a commit message that claimed the range should be through 9999.  Catch the code up with that message.

CC @smarterclayton