### PR TITLE
Remove S3 access privilege from worker iam-instance-role

### DIFF
--- a/data/data/aws/iam/main.tf
+++ b/data/data/aws/iam/main.tf
@@ -43,13 +43,6 @@ resource "aws_iam_role_policy" "worker_policy" {
       "Effect": "Allow",
       "Action": "ec2:Describe*",
       "Resource": "*"
-    },
-    {
-      "Action" : [
-        "s3:GetObject"
-      ],
-      "Resource": "arn:${local.arn}:s3:::*",
-      "Effect": "Allow"
     }
   ]
 }


### PR DESCRIPTION
Running through kubelet code, the cloudprovider uses S3 only for load balancer
logs by learning through the annotation. And load balancers are not called from
kubelet, so we can safely remove s3 access from compute nodes.
Follow up to #1200 

@wking  PTAL