### PR TITLE
pkg/asset/machines/aws: Only return available zones

### DIFF
--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -3,7 +3,9 @@
 data "aws_region" "current" {}
 
 // Fetch a list of available AZs
-data "aws_availability_zones" "azs" {}
+data "aws_availability_zones" "azs" {
+  state = "available"
+}
 
 // Only reference data sources which are gauranteed to exist at any time (above) in this locals{} block
 locals {

--- a/pkg/asset/machines/aws/zones.go
+++ b/pkg/asset/machines/aws/zones.go
@@ -32,12 +32,17 @@ func ec2Client(region string) (*ec2.EC2, error) {
 }
 
 func fetchAvailabilityZones(client *ec2.EC2, region string) ([]string, error) {
-	zoneFilter := &ec2.Filter{
-		Name:   aws.String("region-name"),
-		Values: []*string{aws.String(region)},
-	}
 	req := &ec2.DescribeAvailabilityZonesInput{
-		Filters: []*ec2.Filter{zoneFilter},
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("region-name"),
+				Values: []*string{aws.String(region)},
+			},
+			{
+				Name:   aws.String("state"),
+				Values: []*string{aws.String("available")},
+			},
+		},
 	}
 	resp, err := client.DescribeAvailabilityZones(req)
 	if err != nil {


### PR DESCRIPTION
Zones can also be impaired, unavailable, or "information" (docs [here][1] and [here][2]).  I dunno what that last one is about.  But we only want to put machines in available zones ;).

This is a bit racy, because we could get different responses at both call-sites.  Moving forward, we'll want to shift this request into a single available-zones asset.

Fixes #1209.

[1]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html
[2]: https://www.terraform.io/docs/providers/aws/d/availability_zones.html#state