### PR TITLE
Update machines namespace

### DIFF
--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -47,7 +47,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				Kind:       "Machine",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "openshift-cluster-api",
+				Namespace: "openshift-machine-api",
 				Name:      fmt.Sprintf("%s-%s-%d", clustername, pool.Name, idx),
 				Labels: map[string]string{
 					"sigs.k8s.io/cluster-api-cluster":      clustername,

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -49,7 +49,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 				Kind:       "MachineSet",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "openshift-cluster-api",
+				Namespace: "openshift-machine-api",
 				Name:      name,
 				Labels: map[string]string{
 					"sigs.k8s.io/cluster-api-cluster":      clustername,

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -37,7 +37,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				Kind:       "Machine",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "openshift-cluster-api",
+				Namespace: "openshift-machine-api",
 				Name:      fmt.Sprintf("%s-%s-%d", clustername, pool.Name, idx),
 				Labels: map[string]string{
 					"sigs.k8s.io/cluster-api-cluster":      clustername,

--- a/pkg/asset/machines/libvirt/machinesets.go
+++ b/pkg/asset/machines/libvirt/machinesets.go
@@ -40,7 +40,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			Kind:       "MachineSet",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "openshift-cluster-api",
+			Namespace: "openshift-machine-api",
 			Name:      name,
 			Labels: map[string]string{
 				"sigs.k8s.io/cluster-api-cluster":      clustername,

--- a/pkg/asset/machines/userdata.go
+++ b/pkg/asset/machines/userdata.go
@@ -20,7 +20,7 @@ items:
   kind: Secret
   metadata:
     name: {{$name}}
-    namespace: openshift-cluster-api
+    namespace: openshift-machine-api
   type: Opaque
   data:
     userData: {{$content}}


### PR DESCRIPTION
Since we are pivoting machines API towards machine.openshift.io we want to be consistent with namespace name
For reference:
https://github.com/openshift/machine-api-operator/pull/202
blocks:
https://github.com/openshift/cluster-autoscaler-operator/pull/43
https://github.com/openshift/kubernetes-autoscaler/pull/33
https://github.com/openshift/machine-api-operator/pull/203