### PR TITLE
openstack: Remove hacks script from masters

### DIFF
--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -14,11 +14,6 @@ data "ignition_config" "master_ignition_config" {
 
   files = [
     "${data.ignition_file.master_ifcfg.id}",
-    "${data.ignition_file.master_hacks_script.id}",
-  ]
-
-  systemd = [
-    "${data.ignition_systemd_unit.master_hacks_service.id}",
   ]
 }
 
@@ -39,42 +34,6 @@ PEERDNS="no"
 NM_CONTROLLED="yes"
 EOF
   }
-}
-
-data "ignition_file" "master_hacks_script" {
-  filesystem = "root"
-  mode       = "493"           // 0755
-  path       = "/opt/hacks.sh"
-
-  content {
-    content = <<EOF
-#!/usr/bin/env bash
-set -ex
-
-sed -i '/cloud-provider=openstack/d' /etc/systemd/system/kubelet.service
-
-# NOTE(shadower): this is run before kubelet so we don't need to restart it.
-systemctl daemon-reload
-EOF
-  }
-}
-
-data "ignition_systemd_unit" "master_hacks_service" {
-  name = "hacks.service"
-
-  content = <<EOF
-[Unit]
-Description=Run hacks after bootup
-Before=kubelet.service
-
-[Service]
-Type=oneshot
-ExecStart=/opt/hacks.sh
-RemainAfterExit=true
-
-[Install]
-WantedBy=multi-user.target
-EOF
 }
 
 resource "openstack_compute_instance_v2" "master_conf" {


### PR DESCRIPTION
The hack script should not be required now that we've disabled
openstack's cloud provider directly in MAO and MCO.