### PR TITLE
Change awsproviderconfig.k8s.io/v1alpha1 API version to awsproviderconfig.openshift.io/v1beta1

### DIFF
--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -78,7 +78,7 @@ func provider(clusterID, clusterName string, platform *aws.Platform, mpool *aws.
 	}
 	return &awsprovider.AWSMachineProviderConfig{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "awsproviderconfig.k8s.io/v1alpha1",
+			APIVersion: "awsproviderconfig.openshift.io/v1beta1",
 			Kind:       "AWSMachineProviderConfig",
 		},
 		InstanceType: mpool.InstanceType,


### PR DESCRIPTION
As part of migrating from upstream k8s.io group (cluster API) into openshift.io group (machine API),
we are changing all upstream API versions into our openshift machine API implementation.
This change allows us to interate more quickly over machine API implementation.

PR changing the API version in aws actuator: https://github.com/openshift/cluster-api-provider-aws/pull/152