### PR TITLE
openstack: allow external LB FIP

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -26,17 +26,17 @@ provider "openstack" {
 module "service" {
   source = "./service"
 
-  swift_container        = "${openstack_objectstorage_container_v1.container.name}"
-  cluster_name           = "${var.cluster_name}"
-  cluster_id             = "${var.cluster_id}"
-  cluster_domain         = "${var.base_domain}"
-  image_name             = "${var.openstack_base_image}"
-  flavor_name            = "${var.openstack_master_flavor_name}"
-  ignition               = "${var.ignition_bootstrap}"
-  service_port_id        = "${module.topology.service_port_id}"
-  master_ips             = "${module.topology.master_ips}"
-  master_port_names      = "${module.topology.master_port_names}"
-  service_vm_floating_ip = "${module.topology.service_vm_floating_ip}"
+  swift_container   = "${openstack_objectstorage_container_v1.container.name}"
+  cluster_name      = "${var.cluster_name}"
+  cluster_id        = "${var.cluster_id}"
+  cluster_domain    = "${var.base_domain}"
+  image_name        = "${var.openstack_base_image}"
+  flavor_name       = "${var.openstack_master_flavor_name}"
+  ignition          = "${var.ignition_bootstrap}"
+  lb_floating_ip    = "${var.openstack_lb_floating_ip}"
+  service_port_id   = "${module.topology.service_port_id}"
+  master_ips        = "${module.topology.master_ips}"
+  master_port_names = "${module.topology.master_port_names}"
 }
 
 module "bootstrap" {
@@ -76,6 +76,7 @@ module "topology" {
   cluster_name     = "${var.cluster_name}"
   external_network = "${var.openstack_external_network}"
   masters_count    = "${var.master_count}"
+  lb_floating_ip   = "${var.openstack_lb_floating_ip}"
   trunk_support    = "${var.openstack_trunk_support}"
 }
 

--- a/data/data/openstack/service/main.tf
+++ b/data/data/openstack/service/main.tf
@@ -134,8 +134,8 @@ data "ignition_file" "corefile" {
     errors
     reload 10s
 
-    file /etc/coredns/db.${var.cluster_domain} ${var.cluster_name}-api.${var.cluster_domain} {
-    }
+${length(var.lb_floating_ip) == 0 ? "" : "    file /etc/coredns/db.${var.cluster_domain} ${var.cluster_name}-api.${var.cluster_domain} {\n    }\n"}
+
 
     file /etc/coredns/db.${var.cluster_domain} _etcd-server-ssl._tcp.${var.cluster_name}.${var.cluster_domain} {
     }
@@ -176,8 +176,8 @@ $ORIGIN ${var.cluster_domain}.
                                 3600       ; minimum (1 hour)
                                 )
 
-${var.cluster_name}-api  IN  A  ${var.service_vm_floating_ip}
-*.apps.${var.cluster_name}  IN  A  ${var.service_vm_floating_ip}
+${length(var.lb_floating_ip) == 0 ? "" : "${var.cluster_name}-api  IN  A  ${var.lb_floating_ip}"}
+${length(var.lb_floating_ip) == 0 ? "" : "*.apps.${var.cluster_name}  IN  A  ${var.lb_floating_ip}"}
 
 ${replace(join("\n", formatlist("${var.cluster_name}-etcd-%s  IN  CNAME  ${var.cluster_name}-master-%s", var.master_port_names, var.master_port_names)), "master-port-", "")}
 

--- a/data/data/openstack/service/variables.tf
+++ b/data/data/openstack/service/variables.tf
@@ -46,6 +46,6 @@ variable "master_port_names" {
   type = "list"
 }
 
-variable "service_vm_floating_ip" {
+variable "lb_floating_ip" {
   type = "string"
 }

--- a/data/data/openstack/topology/outputs.tf
+++ b/data/data/openstack/topology/outputs.tf
@@ -18,10 +18,6 @@ output "service_vm_fixed_ip" {
   value = "${openstack_networking_port_v2.service_port.all_fixed_ips[0]}"
 }
 
-output "service_vm_floating_ip" {
-  value = "${openstack_networking_floatingip_v2.service_fip.address}"
-}
-
 output "master_sg_id" {
   value = "${openstack_networking_secgroup_v2.master.id}"
 }

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -80,9 +80,10 @@ data "openstack_networking_network_v2" "external_network" {
   external = true
 }
 
-resource "openstack_networking_floatingip_v2" "service_fip" {
-  pool    = "${var.external_network}"
-  port_id = "${openstack_networking_port_v2.service_port.id}"
+resource "openstack_networking_floatingip_associate_v2" "service_fip" {
+  count       = "${length(var.lb_floating_ip) == 0 ? 0 : 1}"
+  port_id     = "${openstack_networking_port_v2.service_port.id}"
+  floating_ip = "${var.lb_floating_ip}"
 }
 
 resource "openstack_networking_router_v2" "openshift-external-router" {

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -16,6 +16,12 @@ variable "external_network" {
   default     = ""
 }
 
+variable "lb_floating_ip" {
+  description = "(optional) Existing floating IP address to attach to the load balancer created by the installer."
+  type        = "string"
+  default     = ""
+}
+
 variable "masters_count" {
   type = "string"
 }

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -222,6 +222,15 @@ Example: `["sg-51530134", "sg-b253d7cc"]`
 EOF
 }
 
+variable "openstack_lb_floating_ip" {
+  type    = "string"
+  default = ""
+
+  description = <<EOF
+(optional) Existing Floating IP to attach to the load balancer created by the installer.
+EOF
+}
+
 variable "openstack_master_flavor_name" {
   type        = "string"
   description = "Instance size for the master node(s). Example: `m1.medium`."

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -146,6 +146,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			masters[0].Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec),
 			installConfig.Config.Platform.OpenStack.Region,
 			installConfig.Config.Platform.OpenStack.ExternalNetwork,
+			installConfig.Config.Platform.OpenStack.LbFloatingIP,
 			installConfig.Config.Platform.OpenStack.TrunkSupport,
 		)
 		if err != nil {

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -13,17 +13,19 @@ type config struct {
 	ExternalNetwork string `json:"openstack_external_network,omitempty"`
 	Cloud           string `json:"openstack_credentials_cloud,omitempty"`
 	FlavorName      string `json:"openstack_master_flavor_name,omitempty"`
+	LbFloatingIP    string `json:"openstack_lb_floating_ip,omitempty"`
 	TrunkSupport    string `json:"openstack_trunk_support,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, region string, externalNetwork string, trunkSupport string) ([]byte, error) {
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, region string, externalNetwork string, lbFloatingIP string, trunkSupport string) ([]byte, error) {
 	cfg := &config{
 		Region:          region,
 		BaseImage:       masterConfig.Image,
 		ExternalNetwork: externalNetwork,
 		Cloud:           masterConfig.CloudName,
 		FlavorName:      masterConfig.Flavor,
+		LbFloatingIP:    lbFloatingIP,
 		TrunkSupport:    trunkSupport,
 	}
 

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -24,6 +24,10 @@ type Platform struct {
 	// The OpenStack compute flavor to use for servers.
 	FlavorName string `json:"computeFlavor"`
 
+	// LbFloatingIP
+	// Existing Floating IP to associate with the OpenStack load balancer.
+	LbFloatingIP string `json:"lbFloatingIP"`
+
 	// TrunkSupport
 	// Whether OpenStack ports can be trunked
 	TrunkSupport string `json:"trunkSupport"`


### PR DESCRIPTION
The OpenStack provider now does not create any floating IP addresses.
Instead, the user is expected to create one themselves ahead of time
and pass it in.

This lets us support non-FIP deployments and it is the final step
towards a completely unattended installation.

Since the external API DNS records have to be created out-of-band and
since the floating IP address could not be determined ahead of time,
this was something the deployers had to do as the installation was
happening.

Now they can create the FIP, create the DNS records, add the IP to the
install config (under `platform.openstack.lbFloatingIp`) and have the
start the installation and let it complete on its own.

If the `lbFloatingIp` value is not specified, no floating IP will be
created. This will likely make the installer fail (unless the deployer
configured their networking and DNS such that the API is externally
accessible), but this was true even before this change.

This should still result in a successful deployment, the installer
just won't be able to tell.
