### PR TITLE
*: support no worker nodes

### DIFF
--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]machineapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]*machineapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != aws.Name {
 		return nil, fmt.Errorf("non-AWS configuration: %q", configPlatform)
 	}
@@ -31,7 +31,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		total = *pool.Replicas
 	}
 	numOfAZs := int64(len(azs))
-	var machinesets []machineapi.MachineSet
+	var machinesets []*machineapi.MachineSet
 	for idx, az := range azs {
 		replicas := int32(total / numOfAZs)
 		if int64(idx) < total%numOfAZs {
@@ -43,7 +43,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
 		name := fmt.Sprintf("%s-%s-%s", clustername, pool.Name, az)
-		mset := machineapi.MachineSet{
+		mset := &machineapi.MachineSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.openshift.io/v1beta1",
 				Kind:       "MachineSet",

--- a/pkg/asset/machines/libvirt/machinesets.go
+++ b/pkg/asset/machines/libvirt/machinesets.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]machineapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, role, userDataSecret string) ([]*machineapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != libvirt.Name {
 		return nil, fmt.Errorf("non-Libvirt configuration: %q", configPlatform)
 	}
@@ -34,7 +34,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 
 	provider := provider(clustername, config.Networking.MachineCIDR.String(), platform, userDataSecret)
 	name := fmt.Sprintf("%s-%s-%d", clustername, pool.Name, 0)
-	mset := machineapi.MachineSet{
+	mset := &machineapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cluster.k8s.io/v1alpha1",
 			Kind:       "MachineSet",
@@ -75,5 +75,5 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		},
 	}
 
-	return []machineapi.MachineSet{mset}, nil
+	return []*machineapi.MachineSet{mset}, nil
 }

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]clusterapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]*clusterapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != openstack.Name {
 		return nil, fmt.Errorf("non-OpenStack configuration: %q", configPlatform)
 	}
@@ -31,7 +31,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	}
 
 	// TODO(flaper87): Add support for availability zones
-	var machinesets []clusterapi.MachineSet
+	var machinesets []*clusterapi.MachineSet
 	az := ""
 	provider, err := provider(clusterID, clustername, platform, mpool, osImage, az, role, userDataSecret)
 	if err != nil {
@@ -40,7 +40,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	// TODO(flaper87): Implement AZ support sometime soon
 	//name := fmt.Sprintf("%s-%s-%s", clustername, pool.Name, az)
 	name := fmt.Sprintf("%s-%s", clustername, pool.Name)
-	mset := clusterapi.MachineSet{
+	mset := &clusterapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machine.openshift.io/v1beta1",
 			Kind:       "MachineSet",

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -6,11 +6,9 @@ import (
 	"text/template"
 
 	"github.com/ghodss/yaml"
-	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	clusterapi "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
@@ -19,7 +17,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines/libvirt"
 	"github.com/openshift/installer/pkg/asset/machines/openstack"
 	"github.com/openshift/installer/pkg/asset/rhcos"
-	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
 	nonetypes "github.com/openshift/installer/pkg/types/none"
@@ -88,83 +85,79 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		return errors.Wrap(err, "failed to create user-data secret for worker machines")
 	}
 
+	machineSets := []runtime.Object{}
+
 	ic := installconfig.Config
-	pool := workerPool(ic.Compute)
-	switch ic.Platform.Name() {
-	case awstypes.Name:
-		mpool := defaultAWSMachinePoolPlatform()
-		mpool.InstanceType = "m4.large"
-		mpool.Set(ic.Platform.AWS.DefaultMachinePlatform)
-		mpool.Set(pool.Platform.AWS)
-		if len(mpool.Zones) == 0 {
-			azs, err := aws.AvailabilityZones(ic.Platform.AWS.Region)
-			if err != nil {
-				return errors.Wrap(err, "failed to fetch availability zones")
+	for _, pool := range ic.Compute {
+		switch ic.Platform.Name() {
+		case awstypes.Name:
+			mpool := defaultAWSMachinePoolPlatform()
+			mpool.InstanceType = "m4.large"
+			mpool.Set(ic.Platform.AWS.DefaultMachinePlatform)
+			mpool.Set(pool.Platform.AWS)
+			if len(mpool.Zones) == 0 {
+				azs, err := aws.AvailabilityZones(ic.Platform.AWS.Region)
+				if err != nil {
+					return errors.Wrap(err, "failed to fetch availability zones")
+				}
+				mpool.Zones = azs
 			}
-			mpool.Zones = azs
-		}
-		pool.Platform.AWS = &mpool
-		sets, err := aws.MachineSets(clusterID.ClusterID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data")
-		if err != nil {
-			return errors.Wrap(err, "failed to create worker machine objects")
-		}
+			pool.Platform.AWS = &mpool
+			sets, err := aws.MachineSets(clusterID.ClusterID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data")
+			if err != nil {
+				return errors.Wrap(err, "failed to create worker machine objects")
+			}
+			for _, set := range sets {
+				machineSets = append(machineSets, set)
+			}
+		case libvirttypes.Name:
+			mpool := defaultLibvirtMachinePoolPlatform()
+			mpool.Set(ic.Platform.Libvirt.DefaultMachinePlatform)
+			mpool.Set(pool.Platform.Libvirt)
+			pool.Platform.Libvirt = &mpool
+			sets, err := libvirt.MachineSets(clusterID.ClusterID, ic, &pool, "worker", "worker-user-data")
+			if err != nil {
+				return errors.Wrap(err, "failed to create worker machine objects")
+			}
+			for _, set := range sets {
+				machineSets = append(machineSets, set)
+			}
+		case nonetypes.Name:
+		case openstacktypes.Name:
+			mpool := defaultOpenStackMachinePoolPlatform(ic.Platform.OpenStack.FlavorName)
+			mpool.Set(ic.Platform.OpenStack.DefaultMachinePlatform)
+			mpool.Set(pool.Platform.OpenStack)
+			pool.Platform.OpenStack = &mpool
 
-		list := listFromMachineSets(sets)
-		raw, err := yaml.Marshal(list)
-		if err != nil {
-			return errors.Wrap(err, "failed to marshal")
+			sets, err := openstack.MachineSets(clusterID.ClusterID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data")
+			if err != nil {
+				return errors.Wrap(err, "failed to create master machine objects")
+			}
+			for _, set := range sets {
+				machineSets = append(machineSets, set)
+			}
+		default:
+			return fmt.Errorf("invalid Platform")
 		}
-		w.MachineSetRaw = raw
-	case libvirttypes.Name:
-		mpool := defaultLibvirtMachinePoolPlatform()
-		mpool.Set(ic.Platform.Libvirt.DefaultMachinePlatform)
-		mpool.Set(pool.Platform.Libvirt)
-		pool.Platform.Libvirt = &mpool
-		sets, err := libvirt.MachineSets(clusterID.ClusterID, ic, &pool, "worker", "worker-user-data")
-		if err != nil {
-			return errors.Wrap(err, "failed to create worker machine objects")
-		}
-
-		list := listFromMachineSets(sets)
-		raw, err := yaml.Marshal(list)
-		if err != nil {
-			return errors.Wrap(err, "failed to marshal")
-		}
-		w.MachineSetRaw = raw
-	case nonetypes.Name:
-		// This is needed to ensure that roundtrip generate-load tests pass when
-		// comparing this value. Otherwise, generate will use a nil value while
-		// load will use an empty byte slice.
-		w.MachineSetRaw = []byte{}
-	case openstacktypes.Name:
-		mpool := defaultOpenStackMachinePoolPlatform(ic.Platform.OpenStack.FlavorName)
-		mpool.Set(ic.Platform.OpenStack.DefaultMachinePlatform)
-		mpool.Set(pool.Platform.OpenStack)
-		pool.Platform.OpenStack = &mpool
-
-		sets, err := openstack.MachineSets(clusterID.ClusterID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data")
-		if err != nil {
-			return errors.Wrap(err, "failed to create master machine objects")
-		}
-
-		list := listFromMachineSetsDeprecated(sets)
-		w.MachineSetRaw, err = yaml.Marshal(list)
-		if err != nil {
-			return errors.Wrap(err, "failed to marshal")
-		}
-	default:
-		return fmt.Errorf("invalid Platform")
 	}
+
+	list := &metav1.List{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "List",
+		},
+		Items: make([]runtime.RawExtension, len(machineSets)),
+	}
+	for i, set := range machineSets {
+		list.Items[i] = runtime.RawExtension{Object: set}
+	}
+	raw, err := yaml.Marshal(list)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal")
+	}
+	w.MachineSetRaw = raw
+
 	return nil
-}
-
-func workerPool(pools []types.MachinePool) types.MachinePool {
-	for idx, pool := range pools {
-		if pool.Name == "worker" {
-			return pools[idx]
-		}
-	}
-	return types.MachinePool{}
 }
 
 func applyTemplateData(template *template.Template, templateData interface{}) []byte {
@@ -173,30 +166,4 @@ func applyTemplateData(template *template.Template, templateData interface{}) []
 		panic(err)
 	}
 	return buf.Bytes()
-}
-
-func listFromMachineSets(objs []machineapi.MachineSet) *metav1.List {
-	list := &metav1.List{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "List",
-		},
-	}
-	for idx := range objs {
-		list.Items = append(list.Items, runtime.RawExtension{Object: &objs[idx]})
-	}
-	return list
-}
-
-func listFromMachineSetsDeprecated(objs []clusterapi.MachineSet) *metav1.List {
-	list := &metav1.List{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "List",
-		},
-	}
-	for idx := range objs {
-		list.Items = append(list.Items, runtime.RawExtension{Object: &objs[idx]})
-	}
-	return list
 }

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -206,7 +206,6 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Compute = nil
 				return c
 			}(),
-			expectedError: `^compute: Required value: there must be at least one compute machine pool$`,
 		},
 		{
 			name: "empty compute",
@@ -215,7 +214,6 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Compute = []types.MachinePool{}
 				return c
 			}(),
-			expectedError: `^compute: Required value: there must be at least one compute machine pool$`,
 		},
 		{
 			name: "duplicate compute",
@@ -236,20 +234,6 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^compute\[1\]\.name: Duplicate value: "worker"$`,
 		},
 		{
-			name: "compute with invalid name",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Compute = []types.MachinePool{
-					{
-						Name:     "bad-name",
-						Replicas: pointer.Int64Ptr(1),
-					},
-				}
-				return c
-			}(),
-			expectedError: `^compute\[0\]\.name: Unsupported value: "bad-name": supported values: "worker"$`,
-		},
-		{
 			name: "no compute replicas",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
@@ -261,7 +245,6 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: `^compute\[0\]\.replicas: Invalid value: 0: at least one compute machine pool must have a positive replicas count$`,
 		},
 		{
 			name: "invalid compute",

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
+func validMachinePool() *types.MachinePool {
+	return &types.MachinePool{
+		Name:     "test-pool",
+		Replicas: pointer.Int64Ptr(1),
+	}
+}
+
 func TestValidateMachinePool(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -21,105 +28,105 @@ func TestValidateMachinePool(t *testing.T) {
 		valid    bool
 	}{
 		{
-			name: "minimal",
-			pool: &types.MachinePool{
-				Name:     "master",
-				Replicas: pointer.Int64Ptr(1),
-			},
+			name:     "minimal",
+			pool:     validMachinePool(),
 			platform: "aws",
 			valid:    true,
 		},
 		{
 			name: "missing replicas",
-			pool: &types.MachinePool{
-				Name: "master",
-			},
+			pool: func() *types.MachinePool {
+				p := validMachinePool()
+				p.Replicas = nil
+				return p
+			}(),
 			platform: "aws",
 			valid:    false,
 		},
 		{
 			name: "invalid replicas",
-			pool: &types.MachinePool{
-				Name:     "master",
-				Replicas: func(x int64) *int64 { return &x }(-1),
-			},
+			pool: func() *types.MachinePool {
+				p := validMachinePool()
+				p.Replicas = pointer.Int64Ptr(-1)
+				return p
+			}(),
 			platform: "aws",
 			valid:    false,
 		},
 		{
 			name: "valid aws",
-			pool: &types.MachinePool{
-				Name:     "master",
-				Replicas: pointer.Int64Ptr(1),
-				Platform: types.MachinePoolPlatform{
+			pool: func() *types.MachinePool {
+				p := validMachinePool()
+				p.Platform = types.MachinePoolPlatform{
 					AWS: &aws.MachinePool{},
-				},
-			},
+				}
+				return p
+			}(),
 			platform: "aws",
 			valid:    true,
 		},
 		{
 			name: "invalid aws",
-			pool: &types.MachinePool{
-				Name:     "master",
-				Replicas: pointer.Int64Ptr(1),
-				Platform: types.MachinePoolPlatform{
+			pool: func() *types.MachinePool {
+				p := validMachinePool()
+				p.Platform = types.MachinePoolPlatform{
 					AWS: &aws.MachinePool{
 						EC2RootVolume: aws.EC2RootVolume{
 							IOPS: -10,
 						},
 					},
-				},
-			},
+				}
+				return p
+			}(),
 			platform: "aws",
 			valid:    false,
 		},
 		{
 			name: "valid libvirt",
-			pool: &types.MachinePool{
-				Name:     "master",
-				Replicas: pointer.Int64Ptr(1),
-				Platform: types.MachinePoolPlatform{
+			pool: func() *types.MachinePool {
+				p := validMachinePool()
+				p.Platform = types.MachinePoolPlatform{
 					Libvirt: &libvirt.MachinePool{},
-				},
-			},
+				}
+				return p
+			}(),
 			platform: "libvirt",
 			valid:    true,
 		},
 		{
 			name: "valid openstack",
-			pool: &types.MachinePool{
-				Name:     "master",
-				Replicas: pointer.Int64Ptr(1),
-				Platform: types.MachinePoolPlatform{
+			pool: func() *types.MachinePool {
+				p := validMachinePool()
+				p.Platform = types.MachinePoolPlatform{
 					OpenStack: &openstack.MachinePool{},
-				},
-			},
+				}
+				return p
+			}(),
 			platform: "openstack",
 			valid:    true,
 		},
 		{
 			name: "mis-matched platform",
-			pool: &types.MachinePool{
-				Name:     "master",
-				Replicas: pointer.Int64Ptr(1),
-				Platform: types.MachinePoolPlatform{
+			pool: func() *types.MachinePool {
+				p := validMachinePool()
+				p.Platform = types.MachinePoolPlatform{
 					AWS: &aws.MachinePool{},
-				},
-			},
+				}
+				return p
+			}(),
 			platform: "libvirt",
 			valid:    false,
 		},
 		{
 			name: "multiple platforms",
-			pool: &types.MachinePool{
-				Name:     "master",
-				Replicas: pointer.Int64Ptr(1),
-				Platform: types.MachinePoolPlatform{
+			pool: func() *types.MachinePool {
+				p := validMachinePool()
+				p.Platform = types.MachinePoolPlatform{
 					AWS:     &aws.MachinePool{},
 					Libvirt: &libvirt.MachinePool{},
-				},
-			},
+				}
+				return p
+			}(),
 			platform: "aws",
 			valid:    false,
 		},


### PR DESCRIPTION
* The user will be allowed to configure no compute machine pools. To do this, the user must explicitly specify the "master" machine pool. If the user does not specify any machine pools, then the installer will apply the default of a single "master" machine pool and a single "worker" machine pool.
* The user will be allowed to configure a compute machine pool with 0 replicas. To do this, the user must explicitly specify a replica count of 0 for the machine pool. If the `replicas` field is omitted, then the installer will apply the default replica count, which depends upon the platform selected.
* The user will be allowed to configure multiple compute machine pools. Every compute machine pool will use the same ignition config.
* The installer will warn the user if there are no compute nodes configured. The installer will not block the user from using such a configuration.

Fix for https://jira.coreos.com/browse/CORS-988