### PR TITLE
Fix bug where list of masters contain all same object

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -138,11 +138,12 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	}}
 
 	machinesAll := []runtime.Object{}
-	for _, machine := range machines {
-		machinesAll = append(machinesAll, &machine)
+	for i := range machines {
+		machinesAll = append(machinesAll, &machines[i])
 	}
-	for _, machine := range machinesDeprecated {
-		machinesAll = append(machinesAll, &machine)
+
+	for i := range machinesDeprecated {
+		machinesAll = append(machinesAll, &machinesDeprecated[i])
 	}
 
 	count := len(machinesAll)


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/openshift/installer/commit/0f8e6b8b0bef8f6bf55d7053000cf66fd005490c#diff-66b4febb36af0238bb6c09e72c1c44ecR141 which makes `machinesAll` to contain the same address in every index: `machinesAll: [0xc0008d2000 0xc0008d2000 0xc0008d2000]
`
Hence the masters machine manifests rendered to disk all contain the same spec and so the same object name, hence only **one** machine master object is instantiated in the cluster, making the expectations of "each node having a backing machine" to fail in all our repos https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/203/pull-ci-openshift-machine-api-operator-master-e2e-aws-operator/269

Right now all our CI validations are failing because of this issue. We need to get https://github.com/openshift/origin/pull/22015 merged asap to run against the installer and narrow down the window for introducing this kind of bugs and make the boundaries and integration between the tools more solid.

~~The programatic reasoning behind the golang issue/fix/gotcha is still not clear to me.~~ Golang gotcha golang/go#20733

This can be easily reproduced by running `./bin/openshift-install create manifests` and check the master machines manifests

@wking @abhinavdahiya @derekwaynecarr @frobware @ingvagabund @crawford 