### PR TITLE
openstack: Prefix all openstack resources with the cluster name

### DIFF
--- a/data/data/openstack/service/main.tf
+++ b/data/data/openstack/service/main.tf
@@ -161,9 +161,9 @@ ${length(var.lb_floating_ip) == 0 ? "" : "    file /etc/coredns/db.${var.cluster
         upstream /etc/resolv.conf
     }
 
-${replace(join("\n", formatlist("    file /etc/coredns/db.${var.cluster_domain} master-%s.${var.cluster_domain} {\n    upstream /etc/resolv.conf\n    }\n", var.master_port_names)), "master-port-", "")}
+${replace(join("\n", formatlist("    file /etc/coredns/db.${var.cluster_domain} master-%s.${var.cluster_domain} {\n    upstream /etc/resolv.conf\n    }\n", var.master_port_names)), "${var.cluster_id}-master-port-", "")}
 
-${replace(join("\n", formatlist("    file /etc/coredns/db.${var.cluster_domain} etcd-%s.${var.cluster_domain} {\n    upstream /etc/resolv.conf\n    }\n", var.master_port_names)), "master-port-", "")}
+${replace(join("\n", formatlist("    file /etc/coredns/db.${var.cluster_domain} etcd-%s.${var.cluster_domain} {\n    upstream /etc/resolv.conf\n    }\n", var.master_port_names)), "${var.cluster_id}-master-port-", "")}
 
 
     forward . /etc/resolv.conf {
@@ -204,10 +204,10 @@ ${length(var.lb_floating_ip) == 0 ? "" : "api  IN  A  ${var.lb_floating_ip}"}
 ${length(var.lb_floating_ip) == 0 ? "" : "*.apps  IN  A  ${var.lb_floating_ip}"}
 
 bootstrap.${var.cluster_domain}  IN  A  ${var.bootstrap_ip}
-${replace(join("\n", formatlist("master-%s  IN  A %s", var.master_port_names, var.master_ips)), "master-port-", "")}
+${replace(join("\n", formatlist("master-%s  IN  A %s", var.master_port_names, var.master_ips)), "${var.cluster_id}-master-port-", "")}
 
-${replace(join("\n", formatlist("etcd-%s  IN  A  %s", var.master_port_names, var.master_ips)), "master-port-", "")}
-${replace(join("\n", formatlist("_etcd-server-ssl._tcp  8640  IN  SRV  0  10  2380   etcd-%s.${var.cluster_domain}.", var.master_port_names)), "master-port-", "")}
+${replace(join("\n", formatlist("etcd-%s  IN  A  %s", var.master_port_names, var.master_ips)), "${var.cluster_id}-master-port-", "")}
+${replace(join("\n", formatlist("_etcd-server-ssl._tcp  8640  IN  SRV  0  10  2380   etcd-%s.${var.cluster_domain}.", var.master_port_names)), "${var.cluster_id}-master-port-", "")}
 EOF
   }
 }

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -4,13 +4,13 @@ locals {
 }
 
 resource "openstack_networking_network_v2" "openshift-private" {
-  name           = "openshift"
+  name           = "${var.cluster_id}-openshift"
   admin_state_up = "true"
   tags           = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_subnet_v2" "service" {
-  name       = "service"
+  name       = "${var.cluster_id}-service"
   cidr       = "${local.service_cidr_block}"
   ip_version = 4
   network_id = "${openstack_networking_network_v2.openshift-private.id}"
@@ -18,7 +18,7 @@ resource "openstack_networking_subnet_v2" "service" {
 }
 
 resource "openstack_networking_subnet_v2" "nodes" {
-  name            = "nodes"
+  name            = "${var.cluster_id}-nodes"
   cidr            = "${local.nodes_cidr_block}"
   ip_version      = 4
   network_id      = "${openstack_networking_network_v2.openshift-private.id}"
@@ -27,7 +27,7 @@ resource "openstack_networking_subnet_v2" "nodes" {
 }
 
 resource "openstack_networking_port_v2" "masters" {
-  name  = "master-port-${count.index}"
+  name  = "${var.cluster_id}-master-port-${count.index}"
   count = "${var.masters_count}"
 
   admin_state_up     = "true"
@@ -41,7 +41,7 @@ resource "openstack_networking_port_v2" "masters" {
 }
 
 resource "openstack_networking_trunk_v2" "masters" {
-  name  = "master-trunk-${count.index}"
+  name  = "${var.cluster_id}-master-trunk-${count.index}"
   count = "${var.trunk_support ? var.masters_count : 0}"
   tags  = ["openshiftClusterID=${var.cluster_id}"]
 
@@ -50,7 +50,7 @@ resource "openstack_networking_trunk_v2" "masters" {
 }
 
 resource "openstack_networking_port_v2" "bootstrap_port" {
-  name = "bootstrap-port"
+  name = "${var.cluster_id}-bootstrap-port"
 
   admin_state_up     = "true"
   network_id         = "${openstack_networking_network_v2.openshift-private.id}"
@@ -63,7 +63,7 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
 }
 
 resource "openstack_networking_port_v2" "service_port" {
-  name = "service-port"
+  name = "${var.cluster_id}-service-port"
 
   admin_state_up     = "true"
   network_id         = "${openstack_networking_network_v2.openshift-private.id}"
@@ -88,7 +88,7 @@ resource "openstack_networking_floatingip_associate_v2" "service_fip" {
 }
 
 resource "openstack_networking_router_v2" "openshift-external-router" {
-  name                = "openshift-external-router"
+  name                = "${var.cluster_id}-external-router"
   admin_state_up      = true
   external_network_id = "${data.openstack_networking_network_v2.external_network.id}"
   tags                = ["openshiftClusterID=${var.cluster_id}"]

--- a/data/data/openstack/topology/sg-lb.tf
+++ b/data/data/openstack/topology/sg-lb.tf
@@ -1,5 +1,5 @@
 resource "openstack_networking_secgroup_v2" "api" {
-  name = "api"
+  name = "${var.cluster_id}-api"
   tags = ["openshiftClusterID=${var.cluster_id}"]
 }
 

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -1,5 +1,5 @@
 resource "openstack_networking_secgroup_v2" "master" {
-  name = "master"
+  name = "${var.cluster_id}-master"
   tags = ["openshiftClusterID=${var.cluster_id}"]
 }
 

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -1,5 +1,5 @@
 resource "openstack_networking_secgroup_v2" "worker" {
-  name = "worker"
+  name = "${var.cluster_id}-worker"
   tags = ["openshiftClusterID=${var.cluster_id}"]
 }
 


### PR DESCRIPTION
This will allow for running multiple OCP clusters under the same tenant
without conflicting names and resources.