### PR TITLE
openstack: Update machines namespace for OpenStack

### DIFF
--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -56,7 +56,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				Kind:       "Machine",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "openshift-cluster-api",
+				Namespace: "openshift-machine-api",
 				Name:      fmt.Sprintf("%s-%s-%d", clustername, pool.Name, idx),
 				Labels: map[string]string{
 					"sigs.k8s.io/cluster-api-cluster":      clustername,

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -46,7 +46,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			Kind:       "MachineSet",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "openshift-cluster-api",
+			Namespace: "openshift-machine-api",
 			Name:      name,
 			Labels: map[string]string{
 				"sigs.k8s.io/cluster-api-cluster":      clustername,


### PR DESCRIPTION
PR #1215  changed namespaces for machines and machinesets for all providers, except OpenStack. 
This commit fixes the remaining parts.