### PR TITLE
pkg/destroy/aws: Ignore missing instances

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -487,6 +487,9 @@ func deleteEC2Instance(ec2Client *ec2.EC2, iamClient *iam.IAM, id string, logger
 		},
 	})
 	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidInstanceID.NotFound" {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Count these as successes to make instance deletion idempotent (and robust against racing termination from other users, etc.).  There's an example [here][1], where `destroy cluster` does not exit because the destroyer is stuck trying to re-delete some already-deleted instances.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1674440#c0