### PR TITLE
pkg/types/validation: Drop v1beta1 backwards compat hack

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -38,7 +38,7 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 	switch v := c.APIVersion; v {
 	case types.InstallConfigVersion:
 		// Current version
-	case "v1beta1", "v1beta2":
+	case "v1beta2":
 		logrus.Warnf("install-config.yaml is using a deprecated version %q. The expected version is %q.", v, types.InstallConfigVersion)
 	default:
 		return field.ErrorList{field.Invalid(field.NewPath("apiVersion"), c.TypeMeta.APIVersion, fmt.Sprintf("install-config version must be %q", types.InstallConfigVersion))}


### PR DESCRIPTION
I'd kept this in 3b393da8 (#1154) to support CI.  But with openshift/release@d31f601e (openshift/release#2772) landed, we no longer need the workaround.