### PR TITLE
libvirt-howto: Less intrusive NetworkManager setup

### DIFF
--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -192,7 +192,12 @@ sudo virsh pool-autostart default
 ### Set up NetworkManager DNS overlay
 
 This step allows installer and users to resolve cluster-internal hostnames from your host.
-1. Edit `/etc/NetworkManager/NetworkManager.conf` and set `dns=dnsmasq` in section `[main]`
+1. Tell NetworkManager to use `dnsmasq`:
+
+    ```sh
+    echo -e "[main]\ndns=dnsmasq" | sudo tee /etc/NetworkManager/conf.d/openshift.conf
+    ```
+
 2. Tell dnsmasq to use your cluster. The syntax is `server=/<baseDomain>/<firstIP>`.
 
     For this example:


### PR DESCRIPTION
Instead of modifying the main NetworkManager configuration, let's add a separate configuration file for our purposes.

Based on a patch from Colin Walters: https://github.com/code-ready/osp4/pull/36