### PR TITLE
bootstrap: add new names for kube apiserver and controller manager pods

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -217,7 +217,7 @@ podman run \
 	--volume /etc/kubernetes:/etc/kubernetes:z \
 	--network=host \
 	"${CLUSTER_BOOTSTRAP_IMAGE}" \
-	start --asset-dir=/assets --required-pods openshift-kube-apiserver/openshift-kube-apiserver,openshift-kube-scheduler/openshift-kube-scheduler,openshift-kube-controller-manager/openshift-kube-controller-manager,openshift-cluster-version/cluster-version-operator
+	start --asset-dir=/assets --required-pods="kube-apiserver:openshift-kube-apiserver/openshift-kube-apiserver|openshift-kube-apiserver/kube-apiserver,openshift-kube-scheduler/openshift-kube-scheduler,kube-controller-manager:openshift-kube-controller-manager/openshift-kube-controller-manager|openshift-kube-controller-manager/kube-controller-manager,openshift-cluster-version/cluster-version-operator"
 
 # Workaround for https://github.com/opencontainers/runc/pull/1807
 touch /opt/openshift/.bootkube.done


### PR DESCRIPTION
This change is needed to support changing the pod names of apiserver
and controller manager pods. After these two PR's are merged:

https://github.com/openshift/cluster-kube-apiserver-operator/pull/256
https://github.com/openshift/cluster-kube-controller-manager-operator/pull/157

we can remove the openshift- prefixes from the start.