### PR TITLE
types: validate cluster name in InstallConfig

### DIFF
--- a/pkg/asset/installconfig/basedomain.go
+++ b/pkg/asset/installconfig/basedomain.go
@@ -46,7 +46,7 @@ func (a *baseDomain) Generate(parents asset.Parents) error {
 				Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base and will also include the cluster name.",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
-				return validate.DomainName(ans.(string))
+				return validate.DomainName(ans.(string), true)
 			}),
 		},
 	}, &a.BaseDomain)

--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -4,6 +4,7 @@ import (
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/types/validation"
 	"github.com/openshift/installer/pkg/validate"
 )
 
@@ -15,11 +16,16 @@ var _ asset.Asset = (*clusterName)(nil)
 
 // Dependencies returns no dependencies.
 func (a *clusterName) Dependencies() []asset.Asset {
-	return []asset.Asset{}
+	return []asset.Asset{
+		&baseDomain{},
+	}
 }
 
 // Generate queries for the cluster name from the user.
-func (a *clusterName) Generate(asset.Parents) error {
+func (a *clusterName) Generate(parents asset.Parents) error {
+	bd := &baseDomain{}
+	parents.Get(bd)
+
 	return survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Input{
@@ -27,7 +33,7 @@ func (a *clusterName) Generate(asset.Parents) error {
 				Help:    "The name of the cluster.  This will be used when generating sub-domains.\n\nFor libvirt, choose a name that is unique enough to be used as a prefix during cluster deletion.  For example, if you use 'demo' as your cluster name, `openshift-install destroy cluster` may destroy all domains, networks, pools, and volumes that begin with 'demo'.",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
-				return validate.DomainName(ans.(string))
+				return validate.DomainName(validation.ClusterDomain(bd.BaseDomain, ans.(string)), false)
 			}),
 		},
 	}, &a.ClusterName)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -35,9 +35,11 @@ func validateSubdomain(v string) error {
 }
 
 // DomainName checks if the given string is a valid domain name and returns an error if not.
-func DomainName(v string) error {
-	// Trailing dot is OK
-	return validateSubdomain(strings.TrimSuffix(v, "."))
+func DomainName(v string, acceptTrailingDot bool) error {
+	if acceptTrailingDot {
+		v = strings.TrimSuffix(v, ".")
+	}
+	return validateSubdomain(v)
 }
 
 type imagePullSecret struct {

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -82,7 +82,7 @@ func TestSubnetCIDR(t *testing.T) {
 	}
 }
 
-func TestDomainName(t *testing.T) {
+func TestDomainName_AcceptingTrailingDot(t *testing.T) {
 	cases := []struct {
 		domain string
 		valid  bool
@@ -113,7 +113,48 @@ func TestDomainName(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.domain, func(t *testing.T) {
-			err := DomainName(tc.domain)
+			err := DomainName(tc.domain, true)
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestDomainName_RejectingTrailingDot(t *testing.T) {
+	cases := []struct {
+		domain string
+		valid  bool
+	}{
+		{"", false},
+		{" ", false},
+		{"a", true},
+		{".", false},
+		{"日本語", false},
+		{"日本語.com", false},
+		{"abc.日本語.com", false},
+		{"a日本語a.com", false},
+		{"abc", true},
+		{"ABC", false},
+		{"ABC123", false},
+		{"ABC123.COM123", false},
+		{"1", true},
+		{"0.0", true},
+		{"1.2.3.4", true},
+		{"1.2.3.4.", false},
+		{"abc.", false},
+		{"abc.com", true},
+		{"abc.com.", false},
+		{"a.b.c.d.e.f", true},
+		{".abc", false},
+		{".abc.com", false},
+		{".abc.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.domain, func(t *testing.T) {
+			err := DomainName(tc.domain, false)
 			if tc.valid {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
Validate that the cluster name in an InstallConfig is a valid DNS subdomain.

Validate that `<cluster-name>.<base-domain>` is a valid DNS subdomain.

The DomainName function in pkg/validate now takes a parameter specifying whether the domain name being validated is permitted to have a trailing dot. The base domain is allowed to have a trailing dot, but the cluster name is not allowed to have a trailing dot.

Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1663447