### PR TITLE
openshift-install: add version string to logs

### DIFF
--- a/cmd/openshift-install/log.go
+++ b/cmd/openshift-install/log.go
@@ -65,6 +65,8 @@ func setupFileHook(baseDir string) func() {
 		DisableLevelTruncation: false,
 	}))
 
+	logrus.Debugf("OpenShift Installer %s", version)
+
 	return func() {
 		logfile.Close()
 		logrus.StandardLogger().ReplaceHooks(originalHooks)


### PR DESCRIPTION
Including the version in the logs should make debugging a little easier
since we'll definitively know which version of the installer produced
them. This log entry was added under `setupFileHook()` since it felt
natural to include it as part of the logfile setup: ensure the logging
directory exists, ensure the logfile exists, append the current version.