### PR TITLE
data/manifests: update the default update channel

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -5,5 +5,5 @@ metadata:
   name: version
 spec:
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph
-  channel: fast
+  channel: stable-4.0
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
This changes the default from "fast" (a name I made up a while ago) to
"stable-4.0", which will actually be used by the product. We aren't
going with "stable" because the upgrade from 4.0 to 4.1 won't be an
automatic update (the user will have to click the button in the
console). After everything has stabilized further, we may introduce a
"stable" channel which transitions across minor/Y releases in addition
to patch/Z releases.