### PR TITLE
image: Take explicit dependency on util-linux for uuidgen and gzip

### DIFF
--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -9,7 +9,8 @@ RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
-RUN mkdir /output && chown 1000:1000 /output
+RUN yum install -y util-linux gzip && yum clean all && rm -rf /var/cache/yum/* && \
+    mkdir /output && chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output

--- a/images/installer/Dockerfile.ci.rhel7
+++ b/images/installer/Dockerfile.ci.rhel7
@@ -9,7 +9,8 @@ RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
-RUN mkdir /output && chown 1000:1000 /output
+RUN yum install -y util-linux gzip && yum clean all && rm -rf /var/cache/yum/* && \
+    mkdir /output && chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output


### PR DESCRIPTION
uuidgen is moderately useful to a consumer to generate a unique
cluster id, but we are in the process of removing util-linux which
contains uuidgen from the base image because it brings in about
30M of compressed dependencies above what the new minimal base
includes (timezone data, systemd libs, a few others). For now,
update the image to make the dependency explicit, although we
may want to remove uuidgen in the future or make it a subcommand
of the install.

Explicitly references gzip as well for convenience in gzipping logs.