### PR TITLE
bootkube: pass --kube-ca to MCO

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -144,6 +144,7 @@ then
 		bootstrap \
 			--etcd-ca=/assets/tls/etcd-client-ca.crt \
 			--root-ca=/assets/tls/root-ca.crt \
+			--kube-ca=/assets/tls/kube-ca.crt \
 			--config-file=/assets/manifests/cluster-config.yaml \
 			--dest-dir=/assets/mco-bootstrap \
 			--pull-secret=/assets/manifests/pull.json \


### PR DESCRIPTION
This follow-up for https://github.com/openshift/machine-config-operator/pull/420#issuecomment-463721284 will allow us to remove the installer-specific default in the MCO options.
/cc @abhinavdahiya @cgwalters 