### PR TITLE
Revert "Remove the double @sha256 in case the image name is already digest base"

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -11,7 +11,7 @@ fi
 # convert the release image pull spec to an "absolute" form if a digest is available - this is
 # safe to resolve after the actions above because podman will not pull the image once it is
 # locally available
-if ! release=$( podman inspect {{.ReleaseImage}} -f '{{"{{"}} index .RepoDigests 0 {{"}}"}}' | sed s/@sha256@sha256/@sha256/ ) || [[ -z "${release}" ]]; then
+if ! release=$( podman inspect {{.ReleaseImage}} -f '{{"{{"}} index .RepoDigests 0 {{"}}"}}' ) || [[ -z "${release}" ]]; then
 	echo "Warning: Could not resolve release image to pull by digest" 2>&1
 	release="{{.ReleaseImage}}"
 fi


### PR DESCRIPTION
This reverts commit bc59aaf7f8618fb2c99ca6962425fbc1b80a8c30, #1032.

We don't need this any more after Podman was bumped to 1.0.1 in RHCOS 47.317:

```console
$ curl -s https://releases-redhat-coreos.cloud.paas.upshift.redhat.com/storage/releases/maipo/47.317/meta.json | jq .pkgdiff
[
  [
    "podman",
    2,
    {
      "NewPackage": [
        "podman",
        "1.0.1-2.git921f98f.el7",
        "x86_64"
      ],
      "PreviousPackage": [
        "podman",
        "1.0.0-3.git921f98f.el7",
        "x86_64"
      ]
    }
  ]
]
```

pulling in containers/libpod@53e70e26 (containers/libpod#2251).