### PR TITLE
bootkube.sh: fix cluster-config operator cp commands

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -67,7 +67,6 @@ then
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/config-bootstrap
 
-	cp config-bootstrap/bootstrap-manifests/* bootstrap-manifests/
 	cp config-bootstrap/manifests/* manifests/
 fi
 


### PR DESCRIPTION
There are no bootstrap manifests in cluster-config-operator.

Why does this make my local installs fail, but in CI nobody complaints?