### PR TITLE
types/validation: validate cluster network CIDRs

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -85,14 +85,22 @@ func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorLis
 	if n.Type == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "network provider type required"))
 	}
-	if err := validate.SubnetCIDR(&n.MachineCIDR.IPNet); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("machineCIDR"), n.MachineCIDR.String(), err.Error()))
+	if n.MachineCIDR != nil {
+		if err := validate.SubnetCIDR(&n.MachineCIDR.IPNet); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("machineCIDR"), n.MachineCIDR.String(), err.Error()))
+		}
+	} else {
+		allErrs = append(allErrs, field.Required(fldPath.Child("machineCIDR"), "a machine CIDR is required"))
 	}
-	if err := validate.SubnetCIDR(&n.ServiceCIDR.IPNet); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceCIDR"), n.ServiceCIDR.String(), err.Error()))
-	}
-	for i, cn := range n.ClusterNetworks {
-		allErrs = append(allErrs, validateClusterNetwork(&cn, fldPath.Child("clusterNetworks").Index(i), &n.ServiceCIDR.IPNet)...)
+	if n.ServiceCIDR != nil {
+		if err := validate.SubnetCIDR(&n.ServiceCIDR.IPNet); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceCIDR"), n.ServiceCIDR.String(), err.Error()))
+		}
+		for i, cn := range n.ClusterNetworks {
+			allErrs = append(allErrs, validateClusterNetwork(&cn, fldPath.Child("clusterNetworks").Index(i), &n.ServiceCIDR.IPNet)...)
+		}
+	} else {
+		allErrs = append(allErrs, field.Required(fldPath.Child("serviceCIDR"), "a service CIDR is required"))
 	}
 	if len(n.ClusterNetworks) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("clusterNetworks"), "cluster network required"))
@@ -102,6 +110,9 @@ func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorLis
 
 func validateClusterNetwork(cn *types.ClusterNetworkEntry, fldPath *field.Path, serviceCIDR *net.IPNet) field.ErrorList {
 	allErrs := field.ErrorList{}
+	if err := validate.SubnetCIDR(&cn.CIDR.IPNet); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("cidr"), cn.CIDR.IPNet.String(), err.Error()))
+	}
 	if validate.DoCIDRsOverlap(&cn.CIDR.IPNet, serviceCIDR) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("cidr"), cn.CIDR.String(), "cluster network CIDR must not overlap with serviceCIDR"))
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -157,10 +157,10 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "invalid service cidr",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.Networking.ServiceCIDR = &ipnet.IPNet{}
+				c.Networking.ServiceCIDR = ipnet.MustParseCIDR("10.0.128.0/16")
 				return c
 			}(),
-			expectedError: `^networking\.serviceCIDR: Invalid value: "<nil>": must use IPv4$`,
+			expectedError: `^networking\.serviceCIDR: Invalid value: \"10\.0\.128\.0/16\": invalid network address. got 10\.0\.128\.0/16, expecting 10\.0\.0\.0/16$`,
 		},
 		{
 			name: "missing machine cidr",
@@ -175,21 +175,19 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "invalid machine cidr",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.Networking.MachineCIDR = &ipnet.IPNet{}
+				c.Networking.MachineCIDR = ipnet.MustParseCIDR("10.0.128.0/16")
 				return c
 			}(),
-			expectedError: `^networking\.machineCIDR: Invalid value: "<nil>": must use IPv4$`,
+			expectedError: `^networking\.machineCIDR: Invalid value: \"10\.0\.128\.0/16\": invalid network address. got 10\.0\.128\.0/16, expecting 10\.0\.0\.0/16$`,
 		},
 		{
 			name: "invalid cluster network cidr",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.Networking.ClusterNetworks = []types.ClusterNetworkEntry{
-					{},
-				}
+				c.Networking.ClusterNetworks = []types.ClusterNetworkEntry{{CIDR: *ipnet.MustParseCIDR("10.0.128.0/16")}}
 				return c
 			}(),
-			expectedError: `^networking\.clusterNetworks\[0]\.cidr: Invalid value: "<nil>": must use IPv4$`,
+			expectedError: `^networking\.clusterNetworks\[0]\.cidr: Invalid value: \"10\.0\.128\.0/16\": invalid network address. got 10\.0\.128\.0/16, expecting 10\.0\.0\.0/16$`,
 		},
 		{
 			name: "overlapping cluster network cidr",

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -145,6 +145,15 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking.type: Required value: network provider type required$`,
 		},
 		{
+			name: "missing service cidr",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.ServiceCIDR = nil
+				return c
+			}(),
+			expectedError: `^networking\.serviceCIDR: Required value: a service CIDR is required$`,
+		},
+		{
 			name: "invalid service cidr",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
@@ -152,6 +161,35 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: `^networking\.serviceCIDR: Invalid value: "<nil>": must use IPv4$`,
+		},
+		{
+			name: "missing machine cidr",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.MachineCIDR = nil
+				return c
+			}(),
+			expectedError: `^networking\.machineCIDR: Required value: a machine CIDR is required$`,
+		},
+		{
+			name: "invalid machine cidr",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.MachineCIDR = &ipnet.IPNet{}
+				return c
+			}(),
+			expectedError: `^networking\.machineCIDR: Invalid value: "<nil>": must use IPv4$`,
+		},
+		{
+			name: "invalid cluster network cidr",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.ClusterNetworks = []types.ClusterNetworkEntry{
+					{},
+				}
+				return c
+			}(),
+			expectedError: `^networking\.clusterNetworks\[0]\.cidr: Invalid value: "<nil>": must use IPv4$`,
 		},
 		{
 			name: "overlapping cluster network cidr",


### PR DESCRIPTION
Validate that cluster network CIDR in install-config.yaml are valid CIDRs. Also, add validation that the machineCIDR and serverCIDR are not nil.

https://bugzilla.redhat.com/show_bug.cgi?id=1678824