### PR TITLE
libvirt: fix DNS docs

### DIFF
--- a/docs/dev/libvirt-howto.md
+++ b/docs/dev/libvirt-howto.md
@@ -205,6 +205,12 @@ This step allows installer and users to resolve cluster-internal hostnames from 
     ```sh
     echo server=/tt.testing/192.168.126.1 | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
     ```
+
+    Bump the maximum number of DNS requests:
+    ```sh
+    echo dns-forward-max=1000 | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
+    ```
+
 3. Reload NetworkManager to pick up the `dns` configuration change: `sudo systemctl reload NetworkManager`
 
 
@@ -242,10 +248,10 @@ Some things you can do:
 
 ### SSH access
 
-The bootstrap node, e.g. `test1-bootstrap.tt.testing`, runs the bootstrap process. You can watch it:
+The bootstrap node, e.g. `test1-bootstrap.test1.tt.testing`, runs the bootstrap process. You can watch it:
 
 ```sh
-ssh "core@${CLUSTER_NAME}-bootstrap.${BASE_DOMAIN}"
+ssh "core@${CLUSTER_NAME}-bootstrap.${CLUSTER_NAME}.${BASE_DOMAIN}"
 sudo journalctl -f -u bootkube -u openshift
 ```
 


### PR DESCRIPTION
On my quest to debug some libvirt issues, I found the following:

* The bootstrap node is starved of resources. Bump the memory requirements to 4096.
* dnsmasq is returning a maximum limit of 150 parallel requests at a time. Bumps the DNS limit to 1000.

After these tweaks the master is returning:

```
Feb 19 23:05:59 test1-master-0 hyperkube[3159]: E0219 23:05:59.772111    3159 file.go:187] Can't process manifest file "/etc/kubernetes/manifests/kube-apiserver-pod.yaml": /etc/kubernetes/manifests/kube-apiserver-pod.yaml: couldn't parse as pod(Object 'Kind' is missing in 'null'), please check config file.
```

/etc/kubernetes/manifests/kube-apiserver-pod.yam:
```yaml
{
  "kind": "Pod",
  "apiVersion": "v1",
  "metadata": {
    "name": "kube-apiserver",
    "namespace": "openshift-kube-apiserver",
    "creationTimestamp": null,
    "deletionGracePeriodSeconds": 65,
    "labels": {
      "apiserver": "true",
      "app": "openshift-kube-apiserver",
      "revision": "2"
    }
  },
  "spec": {
    "volumes": [
      {
        "name": "resource-dir",
        "hostPath": {
          "path": "/etc/kubernetes/static-pod-resources/kube-apiserver-pod-2"
        }
      },
      {
        "name": "audit-dir",
        "hostPath": {
          "path": "/var/log/kube-apiserver"
        }
      }
    ],
    "containers": [
      {
        "name": "kube-apiserver-2",
        "image": "registry.svc.ci.openshift.org/openshift/origin-v4.0-2019-02-18-164603@sha256:7facb4d66aa9f9b69cf79accee60898407a800dd8150fa846452c3fd39c22b89",
        "command": [
          "/bin/bash",
          "-xec"
        ],
        "args": [
          "mkdir -p /var/log/kube-apiserver\nchmod 0700 /var/log/kube-apiserver\nexec hypershift openshift-kube-apiserver  --config=/etc/kubernetes/static-pod-resources/configmaps/config/config.yaml\n",
          "-v=2"
        ],
        "ports": [
          {
            "containerPort": 6443
          }
        ],
        "resources": {
          "requests": {
            "cpu": "150m",
            "memory": "1Gi"
          }
        },
        "volumeMounts": [
          {
            "name": "resource-dir",
            "mountPath": "/etc/kubernetes/static-pod-resources"
          },
          {
            "name": "audit-dir",
            "mountPath": "/var/log/kube-apiserver"
          }
        ],
        "livenessProbe": {
          "httpGet": {
            "path": "healthz",
            "port": 6443,
            "scheme": "HTTPS"
          },
          "initialDelaySeconds": 45,
          "timeoutSeconds": 10
        },
        "readinessProbe": {
          "httpGet": {
            "path": "healthz",
            "port": 6443,
            "scheme": "HTTPS"
          },
          "initialDelaySeconds": 10,
          "timeoutSeconds": 10
        },
        "terminationMessagePolicy": "FallbackToLogsOnError",
        "imagePullPolicy": "Always"
      }
    ],
    "hostNetwork": true,
    "tolerations": [
      {
        "operator": "Exists"
      }
    ],
    "priorityClassName": "system-node-critical"
  },
  "status": {}
}
```