### PR TITLE
*: increase resources for libvirt machines

### DIFF
--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -32,7 +32,7 @@ variable "libvirt_master_ips" {
 variable "libvirt_master_memory" {
   type        = "string"
   description = "RAM in MiB allocated to masters"
-  default     = "4096"
+  default     = "6144"
 }
 
 # At some point this one is likely to default to the number
@@ -41,5 +41,5 @@ variable "libvirt_master_memory" {
 variable "libvirt_master_vcpu" {
   type        = "string"
   description = "CPUs allocated to masters"
-  default     = "2"
+  default     = "4"
 }

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -64,7 +64,7 @@ func provider(clusterName string, networkInterfaceAddress string, platform *libv
 			APIVersion: "libvirtproviderconfig.k8s.io/v1alpha1",
 			Kind:       "LibvirtMachineProviderConfig",
 		},
-		DomainMemory: 2048,
+		DomainMemory: 4096,
 		DomainVcpu:   2,
 		Ignition: &libvirtprovider.Ignition{
 			UserDataSecret: userDataSecret,


### PR DESCRIPTION
OpenShift has picked up a little weight over the past few months. Two
and four gibibytes of RAM for the control plane and compute machines,
respectively, is no longer enough. This bumps the machines to four and
six gibibytes.