### PR TITLE
uninstaller: fix endless loop when no public route53 zone found

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -1239,19 +1239,23 @@ func deleteRoute53(session *session.Session, arn arn.ARN, logger logrus.FieldLog
 	}
 
 	sharedEntries := map[string]*route53.ResourceRecordSet{}
-	err = client.ListResourceRecordSetsPages(
-		&route53.ListResourceRecordSetsInput{HostedZoneId: aws.String(sharedZoneID)},
-		func(results *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
-			for _, recordSet := range results.ResourceRecordSets {
-				key := recordSetKey(recordSet)
-				sharedEntries[key] = recordSet
-			}
+	if len(sharedZoneID) != 0 {
+		err = client.ListResourceRecordSetsPages(
+			&route53.ListResourceRecordSetsInput{HostedZoneId: aws.String(sharedZoneID)},
+			func(results *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
+				for _, recordSet := range results.ResourceRecordSets {
+					key := recordSetKey(recordSet)
+					sharedEntries[key] = recordSet
+				}
 
-			return !lastPage
-		},
-	)
-	if err != nil {
-		return err
+				return !lastPage
+			},
+		)
+		if err != nil {
+			return err
+		}
+	} else {
+		logger.Debug("shared public zone not found")
 	}
 
 	var lastError error


### PR DESCRIPTION
When the uninstaller no longer finds an associated public zone
(because the records associating the public zone to the private zone no longer exist),
it currently loops endlessly because the query to retrieve records of the public zone
always fails. It never reaches the part that deletes the private zone.

This fix checks that the public zone id is not empty in order to query
its records.