### PR TITLE
Current aws customization page is outdated. `machines` section has been replaced by `controlPlane` for `masters` and `compute` for `worker` nodes

### DIFF
--- a/docs/user/aws/customization.md
+++ b/docs/user/aws/customization.md
@@ -17,14 +17,16 @@ An example `install-config.yaml` is shown below. This configuration has been mod
 ```yaml
 apiVersion: v1beta1
 baseDomain: example.com
-machines:
-- name: master
+controlPlane:
+  name: master
   platform:
     aws:
       zones:
       - us-west-2a
       - us-west-2b
+      type: m5.xlarge
   replicas: 3
+compute:
 - name: worker
   platform:
     aws:


### PR DESCRIPTION
Current aws customization page is outdated. `machines` section has been replaced by `controlPlane` for `masters` and `compute` for `worker` nodes