### PR TITLE
bootkube.sh: Print a final success message

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -239,3 +239,4 @@ podman run \
 
 # Workaround for https://github.com/opencontainers/runc/pull/1807
 touch /opt/openshift/.bootkube.done
+echo "bootkube.service complete"


### PR DESCRIPTION
Today the way we gather artifacts via the journal gateway doesn't
include the systemd unit status.  Let's print a final success message
to be very clear that we were successful.