### PR TITLE
Add infra-image to MCO bootstrap

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -23,6 +23,7 @@ MACHINE_CONFIG_DAEMON_IMAGE=$(podman run --quiet --rm ${release} image machine-c
 MACHINE_CONFIG_OSCONTENT=$(podman run --quiet --rm ${release} image machine-os-content)
 MACHINE_CONFIG_ETCD_IMAGE=$(podman run --quiet --rm ${release} image etcd)
 MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE=$(podman run --quiet --rm ${release} image setup-etcd-environment)
+MACHINE_CONFIG_INFRA_IMAGE=$(podman run --quiet --rm ${release} image pod)
 
 CONFIG_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster-kube-apiserver-operator)
@@ -158,7 +159,8 @@ then
 			--machine-config-controller-image=${MACHINE_CONFIG_CONTROLLER_IMAGE} \
 			--machine-config-server-image=${MACHINE_CONFIG_SERVER_IMAGE} \
 			--machine-config-daemon-image=${MACHINE_CONFIG_DAEMON_IMAGE} \
-			--machine-config-oscontent-image=${MACHINE_CONFIG_OSCONTENT}
+			--machine-config-oscontent-image=${MACHINE_CONFIG_OSCONTENT} \
+			--infra-image=${MACHINE_CONFIG_INFRA_IMAGE}
 
 	# Bootstrap MachineConfigController uses /etc/mcc/bootstrap/manifests/ dir to
 	# 1. read the controller config rendered by MachineConfigOperator


### PR DESCRIPTION
Need to get the pod image for the MCO so that it can be set
in crio.conf.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>