### PR TITLE
bootkube.sh: suppress podman output when pulling images

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -5,7 +5,7 @@ mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests
 
 if ! podman inspect {{.ReleaseImage}} &>/dev/null; then
     echo "Pulling release image..."
-    podman pull {{.ReleaseImage}}
+    podman pull --quiet {{.ReleaseImage}}
 fi
 
 # convert the release image pull spec to an "absolute" form if a digest is available - this is
@@ -16,23 +16,23 @@ if ! release=$( podman inspect {{.ReleaseImage}} -f '{{"{{"}} index .RepoDigests
 	release="{{.ReleaseImage}}"
 fi
 
-MACHINE_CONFIG_OPERATOR_IMAGE=$(podman run --rm ${release} image machine-config-operator)
-MACHINE_CONFIG_CONTROLLER_IMAGE=$(podman run --rm ${release} image machine-config-controller)
-MACHINE_CONFIG_SERVER_IMAGE=$(podman run --rm ${release} image machine-config-server)
-MACHINE_CONFIG_DAEMON_IMAGE=$(podman run --rm ${release} image machine-config-daemon)
-MACHINE_CONFIG_OSCONTENT=$(podman run --rm ${release} image machine-os-content)
-MACHINE_CONFIG_ETCD_IMAGE=$(podman run --rm ${release} image etcd)
-MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE=$(podman run --rm ${release} image setup-etcd-environment)
+MACHINE_CONFIG_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image machine-config-operator)
+MACHINE_CONFIG_CONTROLLER_IMAGE=$(podman run --quiet --rm ${release} image machine-config-controller)
+MACHINE_CONFIG_SERVER_IMAGE=$(podman run --quiet --rm ${release} image machine-config-server)
+MACHINE_CONFIG_DAEMON_IMAGE=$(podman run --quiet --rm ${release} image machine-config-daemon)
+MACHINE_CONFIG_OSCONTENT=$(podman run --quiet --rm ${release} image machine-os-content)
+MACHINE_CONFIG_ETCD_IMAGE=$(podman run --quiet --rm ${release} image etcd)
+MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE=$(podman run --quiet --rm ${release} image setup-etcd-environment)
 
-CONFIG_OPERATOR_IMAGE=$(podman run --rm ${release} image cluster-config-operator)
-KUBE_APISERVER_OPERATOR_IMAGE=$(podman run --rm ${release} image cluster-kube-apiserver-operator)
-KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(podman run --rm ${release} image cluster-kube-controller-manager-operator)
-KUBE_SCHEDULER_OPERATOR_IMAGE=$(podman run --rm ${release} image cluster-kube-scheduler-operator)
+CONFIG_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster-config-operator)
+KUBE_APISERVER_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster-kube-apiserver-operator)
+KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster-kube-controller-manager-operator)
+KUBE_SCHEDULER_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster-kube-scheduler-operator)
 
-OPENSHIFT_HYPERSHIFT_IMAGE=$(podman run --rm ${release} image hypershift)
-OPENSHIFT_HYPERKUBE_IMAGE=$(podman run --rm ${release} image hyperkube)
+OPENSHIFT_HYPERSHIFT_IMAGE=$(podman run --quiet --rm ${release} image hypershift)
+OPENSHIFT_HYPERKUBE_IMAGE=$(podman run --quiet --rm ${release} image hyperkube)
 
-CLUSTER_BOOTSTRAP_IMAGE=$(podman run --rm ${release} image cluster-bootstrap)
+CLUSTER_BOOTSTRAP_IMAGE=$(podman run --quiet --rm ${release} image cluster-bootstrap)
 
 mkdir --parents ./{bootstrap-manifests,manifests}
 
@@ -42,6 +42,7 @@ then
 
 	# shellcheck disable=SC2154
 	podman run \
+		--quiet \
 		--volume "$PWD:/assets:z" \
 		"${release}" \
 		render \
@@ -60,6 +61,7 @@ then
 
 	# shellcheck disable=SC2154
 	podman run \
+		--quiet \
 		--volume "$PWD:/assets:z" \
 		"${CONFIG_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-config-operator render \
@@ -77,6 +79,7 @@ then
 
 	# shellcheck disable=SC2154
 	podman run \
+		--quiet \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_APISERVER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-apiserver-operator render \
@@ -99,6 +102,7 @@ then
 
 	# shellcheck disable=SC2154
 	podman run \
+		--quiet \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-controller-manager-operator render \
@@ -119,6 +123,7 @@ then
 
 	# shellcheck disable=SC2154
 	podman run \
+		--quiet \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_SCHEDULER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-scheduler-operator render \
@@ -138,6 +143,7 @@ then
 
 	# shellcheck disable=SC2154
 	podman run \
+		--quiet \
 		--user 0 \
 		--volume "$PWD:/assets:z" \
 		"${MACHINE_CONFIG_OPERATOR_IMAGE}" \
@@ -184,6 +190,7 @@ trap "podman rm --force etcd-signer" ERR
 
 # shellcheck disable=SC2154
 podman run \
+	--quiet \
 	--name etcd-signer \
 	--detach \
 	--volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
@@ -204,6 +211,7 @@ echo "Waiting for etcd cluster..."
 # Wait for the etcd cluster to come up.
 # shellcheck disable=SC2154,SC2086
 until podman run \
+		--quiet \
 		--rm \
 		--network host \
 		--name etcdctl \
@@ -231,6 +239,7 @@ echo "Starting cluster-bootstrap..."
 
 # shellcheck disable=SC2154
 podman run \
+	--quiet \
 	--rm \
 	--volume "$PWD:/assets:z" \
 	--volume /etc/kubernetes:/etc/kubernetes:z \


### PR DESCRIPTION
Currently the bootkube.sh logs have quite a few of pulling images logs like [1]

```console
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 68cddb23acfe: 0 B / 72.31 MiB
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob b1ae8487cc2f: 0 B / 975 B
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 897e36f3fc47: 0 B / 471 B
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 9b3f2521a69b: 0 B / 7.15 MiB
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 1214db883504: 0 B / 10.15 MiB
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob f203276ea9f1: 0 B / 47.75 KiB
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: [52B blob data]
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob b1ae8487cc2f: 975 B / 975 B  0s
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 897e36f3fc47: 471 B / 471 B  0s
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 9b3f2521a69b: 2.97 MiB / 7.15 MiB
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 1214db883504: 249.91 KiB / 10.15 MiB
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob f203276ea9f1: 47.75 KiB / 47.75 KiB  0s
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: [52B blob data]
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob b1ae8487cc2f: 975 B / 975 B  0s
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 897e36f3fc47: 471 B / 471 B  0s
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 9b3f2521a69b: 4.45 MiB / 7.15 MiB
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 1214db883504: 1.67 MiB / 10.15 MiB
Feb 21 23:11:36 ip-10-0-2-183 bootkube.sh[4511]: Copying blob f203276ea9f1: 47.75 KiB / 47.75 KiB  0s
Feb 21 23:11:37 ip-10-0-2-183 bootkube.sh[4511]: [52B blob data]
Feb 21 23:11:37 ip-10-0-2-183 bootkube.sh[4511]: Copying blob b1ae8487cc2f: 975 B / 975 B  1s
Feb 21 23:11:37 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 897e36f3fc47: 471 B / 471 B  1s
Feb 21 23:11:37 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 9b3f2521a69b: 7.15 MiB / 7.15 MiB  1s
Feb 21 23:11:37 ip-10-0-2-183 bootkube.sh[4511]: Copying blob 1214db883504: 3.73 MiB / 10.15 MiB
Feb 21 23:11:37 ip-10-0-2-183 bootkube.sh[4511]: Copying blob f203276ea9f1: 47.75 KiB / 47.75 KiB  1s
Feb 21 23:11:37 ip-10-0-2-183 bootkube.sh[4511]: [52B blob data]
...
```

```console
$ podman run --help | rg quiet
   --quiet, -q                                   Suppress output information when pulling images
$ podman pull --help | rg quiet
   --quiet, -q                  Suppress output information when pulling images
```

using `-q` flag reduces the noise in the bootkube.sh logs.

[1]: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/471/pull-ci-openshift-machine-config-operator-master-e2e-aws-op/721/artifacts/e2e-aws-op/bootstrap/bootkube.service