### PR TITLE
 aws: include installer version in AWS api calls 

### DIFF
--- a/cmd/openshift-install/log.go
+++ b/cmd/openshift-install/log.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/installer/pkg/version"
 )
 
 type fileHook struct {
@@ -65,7 +67,7 @@ func setupFileHook(baseDir string) func() {
 		DisableLevelTruncation: false,
 	}))
 
-	logrus.Debugf("OpenShift Installer %s", version)
+	logrus.Debugf(version.String)
 
 	return func() {
 		logfile.Close()

--- a/cmd/openshift-install/version.go
+++ b/cmd/openshift-install/version.go
@@ -5,10 +5,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-)
 
-var (
-	version = "was not built correctly" // set in hack/build.sh
+	"github.com/openshift/installer/pkg/version"
 )
 
 func newVersionCmd() *cobra.Command {
@@ -22,6 +20,6 @@ func newVersionCmd() *cobra.Command {
 }
 
 func runVersionCmd(cmd *cobra.Command, args []string) error {
-	fmt.Printf("%s %s\n", os.Args[0], version)
+	fmt.Printf("%s %s\n", os.Args[0], version.Raw)
 	return nil
 }

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -31,7 +31,7 @@ then
 fi
 
 MODE="${MODE:-release}"
-LDFLAGS="${LDFLAGS} -X main.version=$(git describe --always --abbrev=40 --dirty)"
+LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=$(git describe --always --abbrev=40 --dirty)"
 TAGS="${TAGS:-}"
 OUTPUT="${OUTPUT:-bin/openshift-install}"
 export CGO_ENABLED=0

--- a/pkg/asset/installconfig/aws/aws.go
+++ b/pkg/asset/installconfig/aws/aws.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/aws/validation"
+	"github.com/openshift/installer/pkg/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
@@ -101,7 +103,10 @@ func GetSession() (*session.Session, error) {
 			return nil, err
 		}
 	}
-
+	ssn.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "openshiftInstaller.OpenshiftInstallerUserAgentHandler",
+		Fn:   request.MakeAddToUserAgentHandler("OpenShift/4.x Installer", version.Raw),
+	})
 	return ssn, nil
 }
 

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
@@ -18,6 +19,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/installer/pkg/version"
 )
 
 var (
@@ -73,6 +76,10 @@ func (o *ClusterUninstaller) Run() error {
 	if err != nil {
 		return err
 	}
+	awsSession.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "openshiftInstaller.OpenshiftInstallerUserAgentHandler",
+		Fn:   request.MakeAddToUserAgentHandler("OpenShift/4.x Destroyer", version.Raw),
+	})
 
 	tagClients := []*resourcegroupstaggingapi.ResourceGroupsTaggingAPI{
 		resourcegroupstaggingapi.New(awsSession),

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,14 @@
+// Package version includes the version information for installer.
+package version
+
+import "fmt"
+
+var (
+	// Raw is the string representation of the version. This will be replaced
+	// with the calculated version at build time.
+	// set in hack/build.sh
+	Raw = "was not built correctly"
+
+	// String is the human-friendly representation of the version.
+	String = fmt.Sprintf("OpenShift Installer %s", Raw)
+)


### PR DESCRIPTION
Terraform currently includes similar information in UserAgent [1].

Separate installer and destroyer UserAgents will help us differentiate cloudtrail events.

[1]: https://github.com/terraform-providers/terraform-provider-aws/blob/98f11aecb078d82fd7d9b59e5307874797d8f359/aws/config.go#L420

/cc @crawford @wking 