### PR TITLE
docs/user/aws: update network type string

### DIFF
--- a/docs/user/aws/customization.md
+++ b/docs/user/aws/customization.md
@@ -46,7 +46,7 @@ networking:
     hostSubnetLength: 9
   machineCIDR: 10.0.0.0/16
   serviceCIDR: 172.30.0.0/16
-  type: OpenshiftSDN
+  type: OpenShiftSDN
 platform:
   aws:
     region: us-west-2


### PR DESCRIPTION
The network operator recently removed support for the older string, so
this exampled needed to be updated. The default string was updated back
in dafc79f, but these docs weren't updated.