### PR TITLE
metadata: include openshiftClusterID on AWS

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -9,11 +9,13 @@ import (
 )
 
 // Metadata converts an install configuration to AWS metadata.
-func Metadata(infraID string, config *types.InstallConfig) *aws.Metadata {
+func Metadata(clusterID, infraID string, config *types.InstallConfig) *aws.Metadata {
 	return &aws.Metadata{
 		Region: config.Platform.AWS.Region,
 		Identifier: []map[string]string{{
 			fmt.Sprintf("kubernetes.io/cluster/%s", infraID): "owned",
+		}, {
+			"openshiftClusterID": clusterID,
 		}},
 	}
 }

--- a/pkg/asset/cluster/metadata.go
+++ b/pkg/asset/cluster/metadata.go
@@ -57,7 +57,7 @@ func (m *Metadata) Generate(parents asset.Parents) (err error) {
 
 	switch {
 	case installConfig.Config.Platform.AWS != nil:
-		metadata.ClusterPlatformMetadata.AWS = aws.Metadata(clusterID.InfraID, installConfig.Config)
+		metadata.ClusterPlatformMetadata.AWS = aws.Metadata(clusterID.UUID, clusterID.InfraID, installConfig.Config)
 	case installConfig.Config.Platform.Libvirt != nil:
 		metadata.ClusterPlatformMetadata.Libvirt = libvirt.Metadata(installConfig.Config)
 	case installConfig.Config.Platform.OpenStack != nil:


### PR DESCRIPTION
image-registry-operator is using the ID from clusterversion object in the cluster to tag s3 buckets [1].

```
$ AWS_PROFILE=ci aws s3api get-bucket-tagging  --bucket image-registry-us-east-1-f23dc729905144e6b844ab3d76a42ed7-a306
{
    "TagSet": [
        {
            "Key": "openshiftClusterID",
            "Value": "f23dc729-9051-44e6-b844-ab3d76a42ed7"
        },
        {
            "Key": "expirationDate",
            "Value": "2019-02-23T05:39+0000"
        }
    ]
}
```

Therefore the destroy code is leaking registry s3 buckets. Adding the `openshiftClusterID` tag to AWS metadata back to make sure we don't
leak resources.

Installer tried to move to single tag for AWS clusters here [2].

[1]: https://github.com/openshift/cluster-image-registry-operator/blob/7228534c826c92dee38d578445c93f2537f0b775/pkg/storage/s3/s3.go#L288
[2]: https://github.com/openshift/installer/pull/1280