### PR TITLE
pkg/asset/ignition/bootstrap: bump etcdctl binary to 3.3.10

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -32,7 +32,7 @@ const (
 	rootDir              = "/opt/openshift"
 	bootstrapIgnFilename = "bootstrap.ign"
 	etcdCertSignerImage  = "quay.io/coreos/kube-etcd-signer-server:678cc8e6841e2121ebfdb6e2db568fce290b67d6"
-	etcdctlImage         = "quay.io/coreos/etcd:v3.2.14"
+	etcdctlImage         = "quay.io/coreos/etcd:v3.3.10"
 	ignitionUser         = "core"
 )
 


### PR DESCRIPTION
We are using etcd server image 3.3.10 this PR bring the client binary  `etcdctl ` up to the same version. Although [endpoint health](https://github.com/openshift/installer/blob/7fec739ee1ffbeda02789fece6a4feb0484fc69c/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L218) Is somewhat trivial, it is still a gRPC call.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>