### PR TITLE
data: route53 A records with SimplePolicy should not use health check

### DIFF
--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -23,7 +23,7 @@ resource "aws_route53_record" "api_external" {
   alias {
     name                   = "${var.api_external_lb_dns_name}"
     zone_id                = "${var.api_external_lb_zone_id}"
-    evaluate_target_health = true
+    evaluate_target_health = false
   }
 }
 
@@ -35,7 +35,7 @@ resource "aws_route53_record" "api_internal" {
   alias {
     name                   = "${var.api_internal_lb_dns_name}"
     zone_id                = "${var.api_internal_lb_zone_id}"
-    evaluate_target_health = true
+    evaluate_target_health = false
   }
 }
 


### PR DESCRIPTION
masters appear to take 3-5m to resolve their ignition config due to timeout.

according to https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-alias.html#rrsets-values-alias-alias-target , aws docs claim we should not enable health checking if using simple policy.

testing this out to see if it helps drop ignition config time.
