### PR TITLE
libvirt: Pass correct InfraID prefix to destroy

### DIFF
--- a/pkg/destroy/libvirt/libvirt.go
+++ b/pkg/destroy/libvirt/libvirt.go
@@ -215,7 +215,7 @@ func deleteNetwork(conn *libvirt.Connect, filter filterFunc, logger logrus.Field
 func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (destroy.Destroyer, error) {
 	return &ClusterUninstaller{
 		LibvirtURI: metadata.ClusterPlatformMetadata.Libvirt.URI,
-		Filter:     ClusterIDPrefixFilter(metadata.ClusterID),
+		Filter:     ClusterIDPrefixFilter(metadata.InfraID),
 		Logger:     logger,
 	}, nil
 }


### PR DESCRIPTION
Otherwise we don't clean up anything.

Fixes: d137c801ca419b00418348fe652425bae4b71ae3