### PR TITLE
data/aws: try to make startup faster by eliminating dependencies in DNS record creation

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -52,8 +52,8 @@ module "iam" {
   tags = "${local.tags}"
 }
 
-module "dns" {
-  source = "./route53"
+module "dns-api" {
+  source = "./route53/api"
 
   api_external_lb_dns_name = "${module.vpc.aws_lb_api_external_dns_name}"
   api_external_lb_zone_id  = "${module.vpc.aws_lb_api_external_zone_id}"
@@ -62,10 +62,18 @@ module "dns" {
   base_domain              = "${var.base_domain}"
   cluster_domain           = "${var.cluster_domain}"
   cluster_id               = "${var.cluster_id}"
-  etcd_count               = "${var.master_count}"
-  etcd_ip_addresses        = "${module.masters.ip_addresses}"
   tags                     = "${local.tags}"
   vpc_id                   = "${module.vpc.vpc_id}"
+}
+
+module "dns-etcd" {
+  source = "./route53/etcd"
+
+  zone_id        = "${module.dns-api.int_zone_id}"
+  cluster_domain = "${var.cluster_domain}"
+
+  etcd_count        = "${var.master_count}"
+  etcd_ip_addresses = "${module.masters.ip_addresses}"
 }
 
 module "vpc" {

--- a/data/data/aws/route53/api/base.tf
+++ b/data/data/aws/route53/api/base.tf
@@ -38,20 +38,3 @@ resource "aws_route53_record" "api_internal" {
     evaluate_target_health = false
   }
 }
-
-resource "aws_route53_record" "etcd_a_nodes" {
-  count   = "${var.etcd_count}"
-  type    = "A"
-  ttl     = "60"
-  zone_id = "${aws_route53_zone.int.zone_id}"
-  name    = "etcd-${count.index}.${var.cluster_domain}"
-  records = ["${var.etcd_ip_addresses[count.index]}"]
-}
-
-resource "aws_route53_record" "etcd_cluster" {
-  type    = "SRV"
-  ttl     = "60"
-  zone_id = "${aws_route53_zone.int.zone_id}"
-  name    = "_etcd-server-ssl._tcp"
-  records = ["${formatlist("0 10 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)}"]
-}

--- a/data/data/aws/route53/api/outputs.tf
+++ b/data/data/aws/route53/api/outputs.tf
@@ -1,0 +1,3 @@
+output "int_zone_id" {
+  value = "${aws_route53_zone.int.zone_id}"
+}

--- a/data/data/aws/route53/api/variables.tf
+++ b/data/data/aws/route53/api/variables.tf
@@ -3,17 +3,6 @@ variable "cluster_domain" {
   type        = "string"
 }
 
-variable "etcd_count" {
-  description = "The number of etcd members."
-  type        = "string"
-}
-
-variable "etcd_ip_addresses" {
-  description = "List of string IPs for machines running etcd members."
-  type        = "list"
-  default     = []
-}
-
 variable "base_domain" {
   description = "The base domain used for public records."
   type        = "string"

--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -23,7 +23,7 @@ resource "aws_route53_record" "api_external" {
   alias {
     name                   = "${var.api_external_lb_dns_name}"
     zone_id                = "${var.api_external_lb_zone_id}"
-    evaluate_target_health = true
+    evaluate_target_health = false
   }
 }
 
@@ -35,7 +35,7 @@ resource "aws_route53_record" "api_internal" {
   alias {
     name                   = "${var.api_internal_lb_dns_name}"
     zone_id                = "${var.api_internal_lb_zone_id}"
-    evaluate_target_health = true
+    evaluate_target_health = false
   }
 }
 

--- a/data/data/aws/route53/etcd/base.tf
+++ b/data/data/aws/route53/etcd/base.tf
@@ -1,0 +1,16 @@
+resource "aws_route53_record" "etcd_a_nodes" {
+  count   = "${var.etcd_count}"
+  type    = "A"
+  ttl     = "60"
+  zone_id = "${var.zone_id}"
+  name    = "etcd-${count.index}.${var.cluster_domain}"
+  records = ["${var.etcd_ip_addresses[count.index]}"]
+}
+
+resource "aws_route53_record" "etcd_cluster" {
+  type    = "SRV"
+  ttl     = "60"
+  zone_id = "${var.zone_id}"
+  name    = "_etcd-server-ssl._tcp"
+  records = ["${formatlist("0 10 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)}"]
+}

--- a/data/data/aws/route53/etcd/output.tf
+++ b/data/data/aws/route53/etcd/output.tf
@@ -1,0 +1,3 @@
+output "internal_lb_route" {
+  value = "aws_route53_record.api_internal"
+}

--- a/data/data/aws/route53/etcd/variables.tf
+++ b/data/data/aws/route53/etcd/variables.tf
@@ -1,0 +1,20 @@
+variable "cluster_domain" {
+  description = "The domain for the cluster that all DNS records must belong"
+  type        = "string"
+}
+
+variable "zone_id" {
+  description = "The zone_id of the internal route53 zone"
+  type        = "string"
+}
+
+variable "etcd_count" {
+  description = "The number of etcd members."
+  type        = "string"
+}
+
+variable "etcd_ip_addresses" {
+  description = "List of string IPs for machines running etcd members."
+  type        = "list"
+  default     = []
+}


### PR DESCRIPTION
We need the API DNS records in order for ignition to run on the masters. But today we need the master's IP addresses to create the etcd DNS records. This PR splits the creation of the API DNS record (which doesn't need to know the master IPs) from the etcd records. In this way the api dns records are created much sooner.
