### PR TITLE
data/bootstrap/files/usr/local/bin/bootkube: etcdctl from release image

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -216,8 +216,8 @@ until podman run \
 		--name etcdctl \
 		--env ETCDCTL_API=3 \
 		--volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
-		"{{.EtcdctlImage}}" \
-		/usr/local/bin/etcdctl \
+		--entrypoint etcdctl \
+		"${MACHINE_CONFIG_ETCD_IMAGE}" \
 		--dial-timeout=10m \
 		--cacert=/opt/openshift/tls/etcd-client-ca.crt \
 		--cert=/opt/openshift/tls/etcd-client.crt \

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -32,7 +32,6 @@ const (
 	rootDir              = "/opt/openshift"
 	bootstrapIgnFilename = "bootstrap.ign"
 	etcdCertSignerImage  = "quay.io/coreos/kube-etcd-signer-server:678cc8e6841e2121ebfdb6e2db568fce290b67d6"
-	etcdctlImage         = "quay.io/coreos/etcd:v3.3.10"
 	ignitionUser         = "core"
 )
 
@@ -45,7 +44,6 @@ var (
 type bootstrapTemplateData struct {
 	EtcdCertSignerImage string
 	EtcdCluster         string
-	EtcdctlImage        string
 	PullSecret          string
 	ReleaseImage        string
 }
@@ -182,7 +180,6 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig) (*bootst
 
 	return &bootstrapTemplateData{
 		EtcdCertSignerImage: etcdCertSignerImage,
-		EtcdctlImage:        etcdctlImage,
 		PullSecret:          installConfig.PullSecret,
 		ReleaseImage:        releaseImage,
 		EtcdCluster:         strings.Join(etcdEndpoints, ","),


### PR DESCRIPTION
It was added to the image via openshift/etcd@5d267b9f (openshift/etcd#4).  This way we don't have to bump our version by hand (#1060, #1304).