### PR TITLE
pkg/types/validation/installconfig: Drop nominal v1beta2 support

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -38,8 +38,6 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 	switch v := c.APIVersion; v {
 	case types.InstallConfigVersion:
 		// Current version
-	case "v1beta2":
-		logrus.Warnf("install-config.yaml is using a deprecated version %q. The expected version is %q.", v, types.InstallConfigVersion)
 	default:
 		return field.ErrorList{field.Invalid(field.NewPath("apiVersion"), c.TypeMeta.APIVersion, fmt.Sprintf("install-config version must be %q", types.InstallConfigVersion))}
 	}


### PR DESCRIPTION
When we pivoted to `v1beta3` in ccdc32e3 (#1157), we dropped support for the old `machines` JSON property.  Instead of silently ignoring that property in `v1beta2` configs, error out to avoid surprising users later when they notice us not picking up their `machines` configuration.

Or internal consumers pivoted to `v1beta3` in openshift/release@e1d729c6 (openshift/release#2787) and openshift/hive@3eda6d12 (openshift/hive#228).

CC @staebler