### PR TITLE
data/aws/bootstrap: Restore global SSH access

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -145,6 +145,16 @@ resource "aws_security_group" "bootstrap" {
   ), var.tags)}"
 }
 
+resource "aws_security_group_rule" "ssh" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.bootstrap.id}"
+
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+  from_port   = 22
+  to_port     = 22
+}
+
 resource "aws_security_group_rule" "bootstrap_journald_gateway" {
   type              = "ingress"
   security_group_id = "${aws_security_group.bootstrap.id}"


### PR DESCRIPTION
In 6c10827b (#1306), we restricted master SSH access to the cluster, catching up with 6add0ab4 (#1045).  But the bootstrap node is a useful SSH bastion for debugging hung installs (until we get far enough along to tear down the bootstrap resources).  This commit restores global SSH access to the bootstrap node, now that it is no longer provided by the master security group.