### PR TITLE
add ec2:CopyImage as a required permission

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -20,6 +20,7 @@ var installPermissions = []string{
 	"ec2:AttachInternetGateway",
 	"ec2:AuthorizeSecurityGroupEgress",
 	"ec2:AuthorizeSecurityGroupIngress",
+	"ec2:CopyImage",
 	"ec2:CreateDhcpOptions",
 	"ec2:CreateInternetGateway",
 	"ec2:CreateNatGateway",


### PR DESCRIPTION
@csrwng reporting earlier today that the latest master branch cluster installs are failing with:

ERROR
ERROR Error: Error applying plan:
ERROR
ERROR 1 error occurred:
ERROR     * aws_ami_copy.main: 1 error occurred:
ERROR     * aws_ami_copy.main: UnauthorizedOperation: You are not authorized to perform this operation.
ERROR     status code: 403, request id: 96aa0046-aea7-447f-b03d-3dd5550e1dc9
ERROR

this was resolved by granting the AWS user the ec2:CopyImage permission/capability. add ec2:CopyImage to the pre-flight permission checks.