### PR TITLE
hack/release: Compute release.sha256(.sig)

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -18,4 +18,8 @@ do
 	OUTPUT="bin/openshift-install-${GOOS}-${GOARCH}"
 	GOOS="${GOOS}" GOARCH="${GOARCH}" OUTPUT="${OUTPUT}" SKIP_GENERATION=y ./build.sh
 done
-(cd ../bin && sha256sum openshift-install-*)
+(
+	cd ../bin
+	sha256sum openshift-install-* >release.sha256
+	gpg --output release.sha256.sig --detach-sig release.sha256
+)


### PR DESCRIPTION
I've been working these up by hand for the last several releases to give users who trust my key but not GitHub (possibly an empty set ;) a way to verify the authenticity of downloaded installers.  This commit just institutionalizes the procedure.