### PR TITLE
aws, openstack: open ports 9000-9999 between nodes on UDP too.

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -96,6 +96,26 @@ resource "aws_security_group_rule" "master_ingress_internal_from_worker" {
   to_port   = 9999
 }
 
+resource "aws_security_group_rule" "master_ingress_internal_udp" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.master.id}"
+
+  protocol  = "udp"
+  from_port = 9000
+  to_port   = 9999
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_internal_from_worker_udp" {
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.master.id}"
+  source_security_group_id = "${aws_security_group.worker.id}"
+
+  protocol  = "udp"
+  from_port = 9000
+  to_port   = 9999
+}
+
 resource "aws_security_group_rule" "master_ingress_kube_scheduler" {
   type              = "ingress"
   security_group_id = "${aws_security_group.master.id}"

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -76,6 +76,26 @@ resource "aws_security_group_rule" "worker_ingress_internal_from_master" {
   to_port   = 9999
 }
 
+resource "aws_security_group_rule" "worker_ingress_internal_udp" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.worker.id}"
+
+  protocol  = "udp"
+  from_port = 9000
+  to_port   = 9999
+  self      = true
+}
+
+resource "aws_security_group_rule" "worker_ingress_internal_from_master_udp" {
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.worker.id}"
+  source_security_group_id = "${aws_security_group.master.id}"
+
+  protocol  = "udp"
+  from_port = 9000
+  to_port   = 9999
+}
+
 resource "aws_security_group_rule" "worker_ingress_kubelet_insecure" {
   type              = "ingress"
   security_group_id = "${aws_security_group.worker.id}"

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -110,6 +110,25 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_from_w
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 9000
+  port_range_max    = 9999
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_from_worker_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 9000
+  port_range_max    = 9999
+  remote_group_id   = "${openstack_networking_secgroup_v2.worker.id}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_insecure" {
   direction         = "ingress"
   ethertype         = "IPv4"


### PR DESCRIPTION
We allow ports 9000-9999 for general-purpose system services. This change opens them up for UDP as well.