### PR TITLE
add ec2:DeregisterImage permission to pre-flight checks

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -32,6 +32,7 @@ var installPermissions = []string{
 	"ec2:CreateVpc",
 	"ec2:CreateVpcEndpoint",
 	"ec2:CreateVolume",
+	"ec2:DeregisterImage",
 	"ec2:DescribeAccountAttributes",
 	"ec2:DescribeAddresses",
 	"ec2:DescribeAvailabilityZones",


### PR DESCRIPTION
Now that the installer creates the encrypted AMI, we also need the ability to delete the AMI on cluster destroy. Otherwise we get these errors:

DEBUG deleting arn:aws:ec2:us-east-1:125931421481:image/ami-0c82315f404e184a8: UnauthorizedOperation: You are not authorized to perform this operation.
        status code: 403, request id: b57ae4d9-5c9c-4e69-a7de-81f03eea3b15

Add ec2:DeregisterImage to the list of permissions the installer needs.