### PR TITLE
destroy: delete snapshots used in ami copies

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -32,6 +32,7 @@ var installPermissions = []string{
 	"ec2:CreateVpc",
 	"ec2:CreateVpcEndpoint",
 	"ec2:CreateVolume",
+	"ec2:DeleteSnapshot",
 	"ec2:DeregisterImage",
 	"ec2:DescribeAccountAttributes",
 	"ec2:DescribeAddresses",

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -130,7 +130,7 @@ func (o *ClusterUninstaller) Run() error {
 							arn := *resource.ResourceARN
 							if _, ok := deleted[arn]; !ok {
 								matched = true
-								err := deleteARN(awsSession, arn, o.Logger)
+								err := deleteARN(awsSession, arn, filter, o.Logger)
 								if err != nil {
 									err = errors.Wrapf(err, "deleting %s", arn)
 									o.Logger.Debug(err)
@@ -179,7 +179,7 @@ func (o *ClusterUninstaller) Run() error {
 		}
 		for _, arn := range arns {
 			if _, ok := deleted[arn]; !ok {
-				err = deleteARN(awsSession, arn, o.Logger)
+				err = deleteARN(awsSession, arn, nil, o.Logger)
 				if err != nil {
 					err = errors.Wrapf(err, "deleting %s", arn)
 					o.Logger.Debug(err)
@@ -221,6 +221,17 @@ func tagMatch(filters []Filter, tags map[string]string) bool {
 		}
 	}
 	return len(filters) == 0
+}
+
+func tagsForFilter(filter Filter) []*ec2.Tag {
+	tags := make([]*ec2.Tag, 0, len(filter))
+	for key, value := range filter {
+		tags = append(tags, &ec2.Tag{
+			Key:   aws.String(key),
+			Value: aws.String(value),
+		})
+	}
+	return tags
 }
 
 type iamRoleSearch struct {
@@ -417,7 +428,7 @@ func findPublicRoute53(client *route53.Route53, dnsName string, logger logrus.Fi
 	return "", nil
 }
 
-func deleteARN(session *session.Session, arnString string, logger logrus.FieldLogger) error {
+func deleteARN(session *session.Session, arnString string, filter Filter, logger logrus.FieldLogger) error {
 	logger = logger.WithField("arn", arnString)
 
 	parsed, err := arn.Parse(arnString)
@@ -427,7 +438,7 @@ func deleteARN(session *session.Session, arnString string, logger logrus.FieldLo
 
 	switch parsed.Service {
 	case "ec2":
-		return deleteEC2(session, parsed, logger)
+		return deleteEC2(session, parsed, filter, logger)
 	case "elasticloadbalancing":
 		return deleteElasticLoadBalancing(session, parsed, logger)
 	case "iam":
@@ -441,7 +452,7 @@ func deleteARN(session *session.Session, arnString string, logger logrus.FieldLo
 	}
 }
 
-func deleteEC2(session *session.Session, arn arn.ARN, logger logrus.FieldLogger) error {
+func deleteEC2(session *session.Session, arn arn.ARN, filter Filter, logger logrus.FieldLogger) error {
 	client := ec2.New(session)
 
 	resourceType, id, err := splitSlash("resource", arn.Resource)
@@ -456,7 +467,7 @@ func deleteEC2(session *session.Session, arn arn.ARN, logger logrus.FieldLogger)
 	case "elastic-ip":
 		return deleteEC2ElasticIP(client, id, logger)
 	case "image":
-		return deleteEC2Image(client, id, logger)
+		return deleteEC2Image(client, id, filter, logger)
 	case "instance":
 		return deleteEC2Instance(client, iam.New(session), id, logger)
 	case "internet-gateway":
@@ -467,6 +478,8 @@ func deleteEC2(session *session.Session, arn arn.ARN, logger logrus.FieldLogger)
 		return deleteEC2RouteTable(client, id, logger)
 	case "security-group":
 		return deleteEC2SecurityGroup(client, id, logger)
+	case "snapshot":
+		return deleteEC2Snapshot(client, id, logger)
 	case "subnet":
 		return deleteEC2Subnet(client, id, logger)
 	case "volume":
@@ -493,8 +506,35 @@ func deleteEC2DHCPOptions(client *ec2.EC2, id string, logger logrus.FieldLogger)
 	return nil
 }
 
-func deleteEC2Image(client *ec2.EC2, id string, logger logrus.FieldLogger) error {
-	_, err := client.DeregisterImage(&ec2.DeregisterImageInput{
+func deleteEC2Image(client *ec2.EC2, id string, filter Filter, logger logrus.FieldLogger) error {
+	// tag the snapshots used by the AMI so that the snapshots are matched
+	// by the filter and deleted
+	response, err := client.DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: []*string{&id},
+	})
+	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidAMIID.NotFound" {
+			return nil
+		}
+		return err
+	}
+	snapshots := []*string{}
+	for _, image := range response.Images {
+		for _, bdm := range image.BlockDeviceMappings {
+			if bdm.Ebs != nil && bdm.Ebs.SnapshotId != nil {
+				snapshots = append(snapshots, bdm.Ebs.SnapshotId)
+			}
+		}
+	}
+	_, err = client.CreateTags(&ec2.CreateTagsInput{
+		Resources: snapshots,
+		Tags:      tagsForFilter(filter),
+	})
+	if err != nil {
+		err = errors.Wrapf(err, "tagging snapshots for %s", id)
+	}
+
+	_, err = client.DeregisterImage(&ec2.DeregisterImageInput{
 		ImageId: &id,
 	})
 	if err != nil {
@@ -741,6 +781,21 @@ func deleteEC2SecurityGroup(client *ec2.EC2, id string, logger logrus.FieldLogge
 	})
 	if err != nil {
 		if err.(awserr.Error).Code() == "InvalidGroup.NotFound" {
+			return nil
+		}
+		return err
+	}
+
+	logger.Info("Deleted")
+	return nil
+}
+
+func deleteEC2Snapshot(client *ec2.EC2, id string, logger logrus.FieldLogger) error {
+	_, err := client.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+		SnapshotId: &id,
+	})
+	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidSnapshotID.NotFound" {
 			return nil
 		}
 		return err


### PR DESCRIPTION
When the encrypted AMI used by the cluster is created, a snapshot is created as well. This snapshot needs to be explicitly deleted when the cluster is destroyed to avoid leaking resources. Unfortunately,
the snapshot does not have any tags when it is created. The snapshot can be found from the AMI's block device mappings, though. When the destroyer finds an AMI to delete, the destroyer will tag the snapshots used by the AMI with tags that match the filter used to find the AMI. This will allow the destroyer to find the snapshots on subsequent queries using that filter.

It would be preferably if the snapshot were tagged during the cluster creation. There is no way that I see to tag the snapshot when the AMI is created, using the terraform aws provider. There may be a way to have terraform assume ownership of the snapshot after the AMI is created and modify the tags of the snapshot after that. Or there may be a way to run some shell code from within terraform to modify the tags (although that would necessitate having the AWS CLI installed, which I think is a non-starter). In any event, those are things that could be looked into as a follow-on. But for now, the destroyer needs to stop leaking the snapshots, and these changes accomplish that.

Fixes #1342