### PR TITLE
*: Wrapf(err, "...") -> Wrap(err, "...")

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -156,7 +156,7 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 	runner := func(directory string) error {
 		assetStore, err := assetstore.NewStore(directory)
 		if err != nil {
-			return errors.Wrapf(err, "failed to create asset store")
+			return errors.Wrap(err, "failed to create asset store")
 		}
 
 		for _, a := range targets {

--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -54,7 +54,7 @@ func runDestroyCmd(directory string) error {
 
 	store, err := assetstore.NewStore(directory)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create asset store")
+		return errors.Wrap(err, "failed to create asset store")
 	}
 	for _, asset := range clusterTarget.assets {
 		if err := store.Destroy(asset); err != nil {

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -447,7 +447,7 @@ func (a *Bootstrap) Load(f asset.FileFetcher) (found bool, err error) {
 
 	config := &igntypes.Config{}
 	if err := json.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrapf(err, "failed to unmarshal")
+		return false, errors.Wrap(err, "failed to unmarshal")
 	}
 
 	a.File, a.Config = file, config

--- a/pkg/asset/ignition/machine/master.go
+++ b/pkg/asset/ignition/machine/master.go
@@ -77,7 +77,7 @@ func (a *Master) Load(f asset.FileFetcher) (found bool, err error) {
 
 	config := &igntypes.Config{}
 	if err := json.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrapf(err, "failed to unmarshal")
+		return false, errors.Wrap(err, "failed to unmarshal")
 	}
 
 	a.File, a.Config = file, config

--- a/pkg/asset/ignition/machine/worker.go
+++ b/pkg/asset/ignition/machine/worker.go
@@ -77,7 +77,7 @@ func (a *Worker) Load(f asset.FileFetcher) (found bool, err error) {
 
 	config := &igntypes.Config{}
 	if err := json.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrapf(err, "failed to unmarshal")
+		return false, errors.Wrap(err, "failed to unmarshal")
 	}
 
 	a.File, a.Config = file, config

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -71,7 +71,7 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 	a.Config.OpenStack = platform.OpenStack
 
 	if err := a.setDefaults(); err != nil {
-		return errors.Wrapf(err, "failed to set defaults for install config")
+		return errors.Wrap(err, "failed to set defaults for install config")
 	}
 
 	if err := validation.ValidateInstallConfig(a.Config, openstackvalidation.NewValidValuesFetcher()).ToAggregate(); err != nil {
@@ -114,12 +114,12 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 
 	config := &types.InstallConfig{}
 	if err := yaml.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrapf(err, "failed to unmarshal")
+		return false, errors.Wrap(err, "failed to unmarshal")
 	}
 	a.Config = config
 
 	if err := a.setDefaults(); err != nil {
-		return false, errors.Wrapf(err, "failed to set defaults for install config")
+		return false, errors.Wrap(err, "failed to set defaults for install config")
 	}
 
 	if err := validation.ValidateInstallConfig(a.Config, openstackvalidation.NewValidValuesFetcher()).ToAggregate(); err != nil {

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -90,7 +90,7 @@ func (k *kubeconfig) load(f asset.FileFetcher, name string) (found bool, err err
 
 	config := &clientcmd.Config{}
 	if err := yaml.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrapf(err, "failed to unmarshal")
+		return false, errors.Wrap(err, "failed to unmarshal")
 	}
 
 	k.File, k.Config = file, config

--- a/pkg/asset/manifests/cluster_k8s_io.go
+++ b/pkg/asset/manifests/cluster_k8s_io.go
@@ -41,7 +41,7 @@ func (c *ClusterK8sIO) Generate(dependencies asset.Parents) error {
 	dependencies.Get(clusterID, net)
 	clusterNet, err := net.ClusterNetwork()
 	if err != nil {
-		return errors.Wrapf(err, "Could not generate ClusterNetworkingConfig")
+		return errors.Wrap(err, "failed to generate ClusterNetworkingConfig")
 	}
 
 	cluster := clusterv1a1.Cluster{

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -229,7 +229,7 @@ func (m *Manifests) Load(f asset.FileFetcher) (bool, error) {
 	for _, file := range fileList {
 		if file.Filename == kubeSysConfigPath {
 			if err := yaml.Unmarshal(file.Data, kubeSysConfig); err != nil {
-				return false, errors.Wrapf(err, "failed to unmarshal cluster-config.yaml")
+				return false, errors.Wrap(err, "failed to unmarshal cluster-config.yaml")
 			}
 			found = true
 		}

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -77,10 +77,10 @@ func (s *storeImpl) Fetch(a asset.Asset) error {
 		return err
 	}
 	if err := s.saveStateFile(); err != nil {
-		return errors.Wrapf(err, "failed to save state")
+		return errors.Wrap(err, "failed to save state")
 	}
 	if wa, ok := a.(asset.WritableAsset); ok {
-		return errors.Wrapf(s.purge(wa), "failed to purge asset")
+		return errors.Wrap(s.purge(wa), "failed to purge asset")
 	}
 	return nil
 }

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -144,7 +144,7 @@ func (o *ClusterUninstaller) Run() error {
 					},
 				)
 				if err != nil {
-					err = errors.Wrapf(err, "get tagged resources")
+					err = errors.Wrap(err, "get tagged resources")
 					o.Logger.Info(err)
 					matched = true
 					loopError = err


### PR DESCRIPTION
No need for formatting in these cases.  I've also adjusted the "Could not {attempted thing}" message to be more consistent with our other "failed to {attempted thing}" messages.

Personally I prefer "{attempted thing}", because the fact that we're returning an error sufficiently expresses our failure.  But that's been occasionally contentious before, so I'm punting on it while touching these lines ;).