### PR TITLE
data/aws: create bootstrap machine in first public subnet

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -15,7 +15,7 @@ module "bootstrap" {
   instance_type            = "${var.aws_bootstrap_instance_type}"
   cluster_id               = "${var.cluster_id}"
   ignition                 = "${var.ignition_bootstrap}"
-  subnet_id                = "${module.vpc.az_to_private_subnet_id[var.aws_master_availability_zones[0]]}"
+  subnet_id                = "${module.vpc.az_to_public_subnet_id[var.aws_master_availability_zones[0]]}"
   target_group_arns        = "${module.vpc.aws_lb_target_group_arns}"
   target_group_arns_length = "${module.vpc.aws_lb_target_group_arns_length}"
   vpc_id                   = "${module.vpc.vpc_id}"

--- a/data/data/aws/vpc/outputs.tf
+++ b/data/data/aws/vpc/outputs.tf
@@ -6,6 +6,10 @@ output "az_to_private_subnet_id" {
   value = "${zipmap(local.new_subnet_azs, local.private_subnet_ids)}"
 }
 
+output "az_to_public_subnet_id" {
+  value = "${zipmap(local.new_subnet_azs, local.public_subnet_ids)}"
+}
+
 output "public_subnet_ids" {
   value = "${local.public_subnet_ids}"
 }


### PR DESCRIPTION
https://github.com/openshift/installer/pull/1121/commits/afa0b599b76163b08ea393bc36e94e6248042a8e had moved the bootstrap node to private
subnet based on https://github.com/openshift/installer/pull/1121#issuecomment-466563682, but we need the bootstrap node in public subnet to be able to ssh.

The bootstrap node is accesible on ssh again.
```console
$ ush core@18.215.154.240
Warning: Permanently added '18.215.154.240' (ECDSA) to the list of known hosts.
Red Hat CoreOS 4.0 Beta
WARNING: Direct SSH access to machines is not recommended.
This node has been annotated with machineconfiguration.openshift.io/ssh=accessed

---
This is the bootstrap node; it will be destroyed when the master is fully up.

The primary service is "bootkube.service". To watch its status, run e.g.

  journalctl -b -f -u bootkube.service
[core@ip-10-0-8-165 ~]$
```