### PR TITLE
Revert "image: Take explicit dependency on util-linux for uuidgen and gzip"

### DIFF
--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -9,8 +9,7 @@ RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
-RUN yum install -y util-linux gzip && yum clean all && rm -rf /var/cache/yum/* && \
-    mkdir /output && chown 1000:1000 /output
+RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output

--- a/images/installer/Dockerfile.ci.rhel7
+++ b/images/installer/Dockerfile.ci.rhel7
@@ -9,8 +9,7 @@ RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
-RUN yum install -y util-linux gzip && yum clean all && rm -rf /var/cache/yum/* && \
-    mkdir /output && chown 1000:1000 /output
+RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output


### PR DESCRIPTION
This reverts commit 71d199c55e0e897801765d4283049486562beb92, #1262

Since openshift/release@00d7b3f31 (openshift/release#2911), the release repository no longer users the installer image for the teardown containers.