### PR TITLE
types: rename network type to match Network.config.openshift.io.

### DIFF
--- a/docs/user/aws/customization.md
+++ b/docs/user/aws/customization.md
@@ -15,7 +15,7 @@ The following options are available when using AWS:
 An example `install-config.yaml` is shown below. This configuration has been modified to show the customization that is possible via the install config.
 
 ```yaml
-apiVersion: v1beta3
+apiVersion: v1beta4
 baseDomain: example.com
 controlPlane:
   name: master

--- a/pkg/asset/ignition/machine/master_test.go
+++ b/pkg/asset/ignition/machine/master_test.go
@@ -24,7 +24,7 @@ func TestMasterGenerate(t *testing.T) {
 			},
 			BaseDomain: "test-domain",
 			Networking: &types.Networking{
-				ServiceCIDR: ipnet.MustParseCIDR("10.0.1.0/24"),
+				ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("10.0.1.0/24")},
 			},
 			Platform: types.Platform{
 				AWS: &aws.Platform{

--- a/pkg/asset/ignition/machine/worker_test.go
+++ b/pkg/asset/ignition/machine/worker_test.go
@@ -18,7 +18,7 @@ func TestWorkerGenerate(t *testing.T) {
 	installConfig := &installconfig.InstallConfig{
 		Config: &types.InstallConfig{
 			Networking: &types.Networking{
-				ServiceCIDR: ipnet.MustParseCIDR("10.0.1.0/24"),
+				ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("10.0.1.0/24")},
 			},
 			Platform: types.Platform{
 				AWS: &aws.Platform{

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -120,7 +120,9 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 	a.Config = config
 
 	// Upconvert any deprecated fields
-	a.convert()
+	if err := a.convert(); err != nil {
+		return false, errors.Wrap(err, "failed to upconvert install config")
+	}
 
 	if err := a.setDefaults(); err != nil {
 		return false, errors.Wrap(err, "failed to set defaults for install config")
@@ -149,6 +151,6 @@ func (a *InstallConfig) setDefaults() error {
 
 // convert converts possibly older versions of the install config to
 // the current version, relocating deprecated fields.
-func (a *InstallConfig) convert() {
-	conversion.ConvertInstallConfig(a.Config)
+func (a *InstallConfig) convert() error {
+	return conversion.ConvertInstallConfig(a.Config)
 }

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/conversion"
 	"github.com/openshift/installer/pkg/types/defaults"
 	openstackvalidation "github.com/openshift/installer/pkg/types/openstack/validation"
 	"github.com/openshift/installer/pkg/types/validation"
@@ -118,6 +119,9 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 	}
 	a.Config = config
 
+	// Upconvert any deprecated fields
+	a.convert()
+
 	if err := a.setDefaults(); err != nil {
 		return false, errors.Wrap(err, "failed to set defaults for install config")
 	}
@@ -141,4 +145,10 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 func (a *InstallConfig) setDefaults() error {
 	defaults.SetInstallConfigDefaults(a.Config)
 	return nil
+}
+
+// convert converts possibly older versions of the install config to
+// the current version, relocating deprecated fields.
+func (a *InstallConfig) convert() {
+	conversion.ConvertInstallConfig(a.Config)
 }

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -65,13 +65,13 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 		},
 		BaseDomain: "test-domain",
 		Networking: &types.Networking{
-			MachineCIDR: ipnet.MustParseCIDR("10.0.0.0/16"),
-			Type:        "OpenShiftSDN",
-			ServiceCIDR: ipnet.MustParseCIDR("172.30.0.0/16"),
-			ClusterNetworks: []types.ClusterNetworkEntry{
+			MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
+			NetworkType:    "OpenShiftSDN",
+			ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
+			ClusterNetwork: []types.ClusterNetworkEntry{
 				{
-					CIDR:             *ipnet.MustParseCIDR("10.128.0.0/14"),
-					HostSubnetLength: 9,
+					CIDR:       *ipnet.MustParseCIDR("10.128.0.0/14"),
+					HostPrefix: 23,
 				},
 			},
 		},
@@ -124,13 +124,13 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				},
 				BaseDomain: "test-domain",
 				Networking: &types.Networking{
-					MachineCIDR: ipnet.MustParseCIDR("10.0.0.0/16"),
-					Type:        "OpenShiftSDN",
-					ServiceCIDR: ipnet.MustParseCIDR("172.30.0.0/16"),
-					ClusterNetworks: []types.ClusterNetworkEntry{
+					MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
+					NetworkType:    "OpenShiftSDN",
+					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
+					ClusterNetwork: []types.ClusterNetworkEntry{
 						{
-							CIDR:             *ipnet.MustParseCIDR("10.128.0.0/14"),
-							HostSubnetLength: 9,
+							CIDR:       *ipnet.MustParseCIDR("10.128.0.0/14"),
+							HostPrefix: 23,
 						},
 					},
 				},

--- a/pkg/asset/manifests/network.go
+++ b/pkg/asset/manifests/network.go
@@ -61,16 +61,20 @@ func (no *Networking) Generate(dependencies asset.Parents) error {
 	netConfig := installConfig.Config.Networking
 
 	clusterNet := []configv1.ClusterNetworkEntry{}
-	if len(netConfig.ClusterNetworks) > 0 {
-		for _, net := range netConfig.ClusterNetworks {
-			_, size := net.CIDR.Mask.Size()
+	if len(netConfig.ClusterNetwork) > 0 {
+		for _, net := range netConfig.ClusterNetwork {
 			clusterNet = append(clusterNet, configv1.ClusterNetworkEntry{
 				CIDR:       net.CIDR.String(),
-				HostPrefix: uint32(size) - uint32(net.HostSubnetLength),
+				HostPrefix: uint32(net.HostPrefix),
 			})
 		}
 	} else {
 		return errors.Errorf("ClusterNetworks must be specified")
+	}
+
+	serviceNet := []string{}
+	for _, sn := range netConfig.ServiceNetwork {
+		serviceNet = append(serviceNet, sn.String())
 	}
 
 	no.Config = &configv1.Network{
@@ -84,8 +88,8 @@ func (no *Networking) Generate(dependencies asset.Parents) error {
 		},
 		Spec: configv1.NetworkSpec{
 			ClusterNetwork: clusterNet,
-			ServiceNetwork: []string{netConfig.ServiceCIDR.String()},
-			NetworkType:    netConfig.Type,
+			ServiceNetwork: serviceNet,
+			NetworkType:    netConfig.NetworkType,
 		},
 	}
 

--- a/pkg/asset/tls/apiserver.go
+++ b/pkg/asset/tls/apiserver.go
@@ -34,7 +34,7 @@ func (a *APIServerCertKey) Generate(dependencies asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	dependencies.Get(kubeCA, installConfig)
 
-	apiServerAddress, err := cidrhost(installConfig.Config.Networking.ServiceCIDR.IPNet, 1)
+	apiServerAddress, err := cidrhost(installConfig.Config.Networking.ServiceNetwork[0].IPNet, 1)
 	if err != nil {
 		return errors.Wrap(err, "failed to get API Server address from InstallConfig")
 	}
@@ -331,7 +331,7 @@ func (a *KubeAPIServerServiceNetworkServerCertKey) Generate(dependencies asset.P
 	ca := &KubeAPIServerServiceNetworkSignerCertKey{}
 	installConfig := &installconfig.InstallConfig{}
 	dependencies.Get(ca, installConfig)
-	serviceAddress, err := cidrhost(installConfig.Config.Networking.ServiceCIDR.IPNet, 1)
+	serviceAddress, err := cidrhost(installConfig.Config.Networking.ServiceNetwork[0].IPNet, 1)
 	if err != nil {
 		return errors.Wrap(err, "failed to get service address for kube-apiserver from InstallConfig")
 	}

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -3,12 +3,25 @@ package conversion
 import (
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/pkg/errors"
 )
 
 // ConvertInstallConfig is modeled after the k8s conversion schemes, which is
 // how deprecated values are upconverted.
-func ConvertInstallConfig(config *types.InstallConfig) {
+// This updates the APIVersion to reflect the fact that we've internally
+// upconverted.
+func ConvertInstallConfig(config *types.InstallConfig) error {
+	// check that the version is convertible
+	switch config.APIVersion {
+	case types.InstallConfigVersion, "v1beta3":
+		// works
+	default:
+		return errors.Errorf("cannot upconvert from version %s", config.APIVersion)
+	}
 	ConvertNetworking(config)
+
+	config.APIVersion = types.InstallConfigVersion
+	return nil
 }
 
 // ConvertNetworking upconverts deprecated fields in networking

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -1,0 +1,42 @@
+package conversion
+
+import (
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
+)
+
+// ConvertInstallConfig is modeled after the k8s conversion schemes, which is
+// how deprecated values are upconverted.
+func ConvertInstallConfig(config *types.InstallConfig) {
+	ConvertNetworking(config)
+}
+
+// ConvertNetworking upconverts deprecated fields in networking
+func ConvertNetworking(config *types.InstallConfig) {
+	if config.Networking == nil {
+		return
+	}
+
+	netconf := config.Networking
+
+	if len(netconf.ClusterNetwork) == 0 {
+		netconf.ClusterNetwork = netconf.DeprecatedClusterNetworks
+	}
+
+	if len(netconf.ServiceNetwork) == 0 && netconf.DeprecatedServiceCIDR != nil {
+		netconf.ServiceNetwork = []ipnet.IPNet{*netconf.DeprecatedServiceCIDR}
+	}
+
+	// Convert type to networkType if the latter is missing
+	if netconf.NetworkType == "" {
+		netconf.NetworkType = netconf.DeprecatedType
+	}
+
+	// Convert hostSubnetLength to hostPrefix
+	for i, entry := range netconf.ClusterNetwork {
+		if entry.HostPrefix == 0 && entry.DeprecatedHostSubnetLength != 0 {
+			_, size := entry.CIDR.Mask.Size()
+			netconf.ClusterNetwork[i].HostPrefix = int32(size) - entry.DeprecatedHostSubnetLength
+		}
+	}
+}

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
@@ -16,16 +17,30 @@ func TestConvertInstallConfig(t *testing.T) {
 		expected *types.InstallConfig
 	}{
 		{
-			name:     "empty",
-			config:   &types.InstallConfig{},
-			expected: &types.InstallConfig{},
+			name: "empty",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+			},
 		},
 		{
 			name: "empty networking",
 			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
 				Networking: &types.Networking{},
 			},
 			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
 				Networking: &types.Networking{},
 			},
 		},
@@ -33,6 +48,9 @@ func TestConvertInstallConfig(t *testing.T) {
 			// all deprecated fields
 			name: "old networking",
 			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1beta3",
+				},
 				Networking: &types.Networking{
 					MachineCIDR:           ipnet.MustParseCIDR("1.1.1.1/24"),
 					DeprecatedType:        "foo",
@@ -46,6 +64,9 @@ func TestConvertInstallConfig(t *testing.T) {
 				},
 			},
 			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
 				Networking: &types.Networking{
 					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
 					NetworkType:    "foo",
@@ -76,6 +97,9 @@ func TestConvertInstallConfig(t *testing.T) {
 		{
 			name: "new networking",
 			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
 				Networking: &types.Networking{
 					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
 					NetworkType:    "foo",
@@ -89,6 +113,9 @@ func TestConvertInstallConfig(t *testing.T) {
 				},
 			},
 			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
 				Networking: &types.Networking{
 					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
 					NetworkType:    "foo",
@@ -106,7 +133,10 @@ func TestConvertInstallConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ConvertInstallConfig(tc.config)
+			err := ConvertInstallConfig(tc.config)
+			if err != nil {
+				t.Fatal("unexpected error", err)
+			}
 			assert.Equal(t, tc.expected, tc.config, "unexpected install config")
 		})
 	}

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -1,0 +1,113 @@
+package conversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
+)
+
+func TestConvertInstallConfig(t *testing.T) {
+	cases := []struct {
+		name     string
+		config   *types.InstallConfig
+		expected *types.InstallConfig
+	}{
+		{
+			name:     "empty",
+			config:   &types.InstallConfig{},
+			expected: &types.InstallConfig{},
+		},
+		{
+			name: "empty networking",
+			config: &types.InstallConfig{
+				Networking: &types.Networking{},
+			},
+			expected: &types.InstallConfig{
+				Networking: &types.Networking{},
+			},
+		},
+		{
+			// all deprecated fields
+			name: "old networking",
+			config: &types.InstallConfig{
+				Networking: &types.Networking{
+					MachineCIDR:           ipnet.MustParseCIDR("1.1.1.1/24"),
+					DeprecatedType:        "foo",
+					DeprecatedServiceCIDR: ipnet.MustParseCIDR("1.2.3.4/32"),
+					DeprecatedClusterNetworks: []types.ClusterNetworkEntry{
+						{
+							CIDR: *ipnet.MustParseCIDR("1.2.3.5/32"),
+							DeprecatedHostSubnetLength: 8,
+						},
+					},
+				},
+			},
+			expected: &types.InstallConfig{
+				Networking: &types.Networking{
+					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
+					NetworkType:    "foo",
+					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/32")},
+					ClusterNetwork: []types.ClusterNetworkEntry{
+						{
+							CIDR: *ipnet.MustParseCIDR("1.2.3.5/32"),
+
+							HostPrefix:                 24,
+							DeprecatedHostSubnetLength: 8,
+						},
+					},
+
+					// deprecated fields are preserved
+					DeprecatedType:        "foo",
+					DeprecatedServiceCIDR: ipnet.MustParseCIDR("1.2.3.4/32"),
+					DeprecatedClusterNetworks: []types.ClusterNetworkEntry{
+						{
+							CIDR: *ipnet.MustParseCIDR("1.2.3.5/32"),
+
+							HostPrefix:                 24,
+							DeprecatedHostSubnetLength: 8,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "new networking",
+			config: &types.InstallConfig{
+				Networking: &types.Networking{
+					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
+					NetworkType:    "foo",
+					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/32")},
+					ClusterNetwork: []types.ClusterNetworkEntry{
+						{
+							CIDR:       *ipnet.MustParseCIDR("1.2.3.5/32"),
+							HostPrefix: 24,
+						},
+					},
+				},
+			},
+			expected: &types.InstallConfig{
+				Networking: &types.Networking{
+					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
+					NetworkType:    "foo",
+					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/32")},
+					ClusterNetwork: []types.ClusterNetworkEntry{
+						{
+							CIDR:       *ipnet.MustParseCIDR("1.2.3.5/32"),
+							HostPrefix: 24,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ConvertInstallConfig(tc.config)
+			assert.Equal(t, tc.expected, tc.config, "unexpected install config")
+		})
+	}
+}

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -10,11 +10,11 @@ import (
 )
 
 var (
-	defaultMachineCIDR      = ipnet.MustParseCIDR("10.0.0.0/16")
-	defaultServiceCIDR      = ipnet.MustParseCIDR("172.30.0.0/16")
-	defaultClusterCIDR      = ipnet.MustParseCIDR("10.128.0.0/14")
-	defaultHostSubnetLength = 9 // equivalent to a /23 per node
-	defaultNetworkPlugin    = "OpenShiftSDN"
+	defaultMachineCIDR    = ipnet.MustParseCIDR("10.0.0.0/16")
+	defaultServiceNetwork = ipnet.MustParseCIDR("172.30.0.0/16")
+	defaultClusterNetwork = ipnet.MustParseCIDR("10.128.0.0/14")
+	defaultHostPrefix     = 23
+	defaultNetworkType    = "OpenShiftSDN"
 )
 
 // SetInstallConfigDefaults sets the defaults for the install config.
@@ -28,17 +28,17 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 			c.Networking.MachineCIDR = libvirtdefaults.DefaultMachineCIDR
 		}
 	}
-	if c.Networking.Type == "" {
-		c.Networking.Type = defaultNetworkPlugin
+	if c.Networking.NetworkType == "" {
+		c.Networking.NetworkType = defaultNetworkType
 	}
-	if c.Networking.ServiceCIDR == nil {
-		c.Networking.ServiceCIDR = defaultServiceCIDR
+	if len(c.Networking.ServiceNetwork) == 0 {
+		c.Networking.ServiceNetwork = []ipnet.IPNet{*defaultServiceNetwork}
 	}
-	if len(c.Networking.ClusterNetworks) == 0 {
-		c.Networking.ClusterNetworks = []types.ClusterNetworkEntry{
+	if len(c.Networking.ClusterNetwork) == 0 {
+		c.Networking.ClusterNetwork = []types.ClusterNetworkEntry{
 			{
-				CIDR:             *defaultClusterCIDR,
-				HostSubnetLength: int32(defaultHostSubnetLength),
+				CIDR:       *defaultClusterNetwork,
+				HostPrefix: int32(defaultHostPrefix),
 			},
 		}
 	}

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -21,13 +21,13 @@ import (
 func defaultInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
-			MachineCIDR: defaultMachineCIDR,
-			Type:        defaultNetworkPlugin,
-			ServiceCIDR: defaultServiceCIDR,
-			ClusterNetworks: []types.ClusterNetworkEntry{
+			MachineCIDR:    defaultMachineCIDR,
+			NetworkType:    defaultNetworkType,
+			ServiceNetwork: []ipnet.IPNet{*defaultServiceNetwork},
+			ClusterNetwork: []types.ClusterNetworkEntry{
 				{
-					CIDR:             *defaultClusterCIDR,
-					HostSubnetLength: int32(defaultHostSubnetLength),
+					CIDR:       *defaultClusterNetwork,
+					HostPrefix: int32(defaultHostPrefix),
 				},
 			},
 		},
@@ -124,46 +124,46 @@ func TestSetInstallConfigDefaults(t *testing.T) {
 			name: "Networking types present",
 			config: &types.InstallConfig{
 				Networking: &types.Networking{
-					Type: "test-networking-type",
+					NetworkType: "test-networking-type",
 				},
 			},
 			expected: func() *types.InstallConfig {
 				c := defaultInstallConfig()
-				c.Networking.Type = "test-networking-type"
+				c.Networking.NetworkType = "test-networking-type"
 				return c
 			}(),
 		},
 		{
-			name: "Service CIDR present",
+			name: "Service network present",
 			config: &types.InstallConfig{
 				Networking: &types.Networking{
-					ServiceCIDR: ipnet.MustParseCIDR("1.2.3.4/8"),
+					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/8")},
 				},
 			},
 			expected: func() *types.InstallConfig {
 				c := defaultInstallConfig()
-				c.Networking.ServiceCIDR = ipnet.MustParseCIDR("1.2.3.4/8")
+				c.Networking.ServiceNetwork[0] = *ipnet.MustParseCIDR("1.2.3.4/8")
 				return c
 			}(),
 		},
 		{
-			name: "Cluster Networks present",
+			name: "Cluster network present",
 			config: &types.InstallConfig{
 				Networking: &types.Networking{
-					ClusterNetworks: []types.ClusterNetworkEntry{
+					ClusterNetwork: []types.ClusterNetworkEntry{
 						{
-							CIDR:             *ipnet.MustParseCIDR("8.8.0.0/18"),
-							HostSubnetLength: 10,
+							CIDR:       *ipnet.MustParseCIDR("8.8.0.0/18"),
+							HostPrefix: 22,
 						},
 					},
 				},
 			},
 			expected: func() *types.InstallConfig {
 				c := defaultInstallConfig()
-				c.Networking.ClusterNetworks = []types.ClusterNetworkEntry{
+				c.Networking.ClusterNetwork = []types.ClusterNetworkEntry{
 					{
-						CIDR:             *ipnet.MustParseCIDR("8.8.0.0/18"),
-						HostSubnetLength: 10,
+						CIDR:       *ipnet.MustParseCIDR("8.8.0.0/18"),
+						HostPrefix: 22,
 					},
 				}
 				return c

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -121,21 +121,35 @@ type Networking struct {
 	// For Libvirt, the default is 192.168.126.0/24.
 	MachineCIDR *ipnet.IPNet `json:"machineCIDR,omitempty"`
 
-	// Type is the network type to install
+	// NetworkType is the type of network to install.
 	// +optional
 	// Default is OpenShiftSDN.
-	Type string `json:"type,omitempty"`
+	NetworkType string `json:"networkType,omitempty"`
 
-	// ServiceCIDR is the IP address space from which to assign service IPs.
+	// ClusterNetwork is the IP address pool to use for pod IPs.
 	// +optional
-	// Default is 172.30.0.0/16.
-	ServiceCIDR *ipnet.IPNet `json:"serviceCIDR,omitempty"`
+	// Default is 10.128.0.0/14 and a host prefix of /23
+	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork,omitempty"`
 
-	// ClusterNetworks is the IP address space from which to assign pod IPs.
+	// ServiceNetwork is the IP address pool to use for service IPs.
 	// +optional
-	// Default is a single cluster network with a CIDR of 10.128.0.0/14
-	// and a host subnet length of 9.
-	ClusterNetworks []ClusterNetworkEntry `json:"clusterNetworks,omitempty"`
+	// Default is 172.30.0.0/16
+	// NOTE: currently only one entry is supported.
+	ServiceNetwork []ipnet.IPNet `json:"serviceNetwork,omitempty"`
+
+	// Deprected types, scheduled to be removed
+
+	// Deprecated name for NetworkType
+	// +optional
+	DeprecatedType string `json:"type,omitempty"`
+
+	// Depcreated name for ServiceNetwork
+	// +optional
+	DeprecatedServiceCIDR *ipnet.IPNet `json:"serviceCIDR,omitempty"`
+
+	// Deprecated name for ClusterNetwork
+	// +optional
+	DeprecatedClusterNetworks []ClusterNetworkEntry `json:"clusterNetworks,omitempty"`
 }
 
 // ClusterNetworkEntry is a single IP address block for pod IP blocks. IP blocks
@@ -144,7 +158,11 @@ type ClusterNetworkEntry struct {
 	// The IP block address pool
 	CIDR ipnet.IPNet `json:"cidr"`
 
+	// HostPrefix is the prefix size to allocate to each node from the CIDR.
+	// For example, 24 would allocate 2^8=256 adresses to each node.
+	HostPrefix int32 `json:"hostPrefix"`
+
 	// The size of blocks to allocate from the larger pool.
 	// This is the length in bits - so a 9 here will allocate a /23.
-	HostSubnetLength int32 `json:"hostSubnetLength"`
+	DeprecatedHostSubnetLength int32 `json:"hostSubnetLength,omitempty"`
 }

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -13,7 +13,9 @@ import (
 
 const (
 	// InstallConfigVersion is the version supported by this package.
-	InstallConfigVersion = "v1beta3"
+	// If you bump this, you must also update the list of convertable values in
+	// pkg/conversion/installconfig.go
+	InstallConfigVersion = "v1beta4"
 )
 
 var (


### PR DESCRIPTION
Renames:
- serviceCIDR -> serviceNetwork
- clusterNetworks -> clusterNetwork
- type -> networkType
- hostSubnetLength -> hostPrefix

Add significantly more network validation, especially around overlapping cidrs.

This adds an upconversion step to loading install config. It will convert any deprecated install configs to the latest version.