### PR TITLE
data/aws: explicitly create the network interface for masters to speed up DNS

### DIFF
--- a/data/data/aws/master/outputs.tf
+++ b/data/data/aws/master/outputs.tf
@@ -1,3 +1,3 @@
 output "ip_addresses" {
-  value = "${aws_instance.master.*.private_ip}"
+  value = "${aws_network_interface.master.*.private_ips}"
 }

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -480,6 +480,8 @@ func deleteEC2(session *session.Session, arn arn.ARN, filter Filter, logger logr
 		return deleteEC2SecurityGroup(client, id, logger)
 	case "snapshot":
 		return deleteEC2Snapshot(client, id, logger)
+	case "network-interface":
+		return deleteEC2NetworkInterface(client, id, logger)
 	case "subnet":
 		return deleteEC2Subnet(client, id, logger)
 	case "volume":
@@ -796,6 +798,21 @@ func deleteEC2Snapshot(client *ec2.EC2, id string, logger logrus.FieldLogger) er
 	})
 	if err != nil {
 		if err.(awserr.Error).Code() == "InvalidSnapshotID.NotFound" {
+			return nil
+		}
+		return err
+	}
+
+	logger.Info("Deleted")
+	return nil
+}
+
+func deleteEC2NetworkInterface(client *ec2.EC2, id string, logger logrus.FieldLogger) error {
+	_, err := client.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(id),
+	})
+	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidNetworkInterfaceID.NotFound" {
 			return nil
 		}
 		return err


### PR DESCRIPTION
Today we create the network interface for master nodes implicitly as part
of the instance creation. We then use the IPs from those nodes to create
DNS records we use to set up etcd. This change creates the Network Interface
for masters explicitly instead of implicitly. Since this can be done before
the AMI copy is complete it means we can get DNS complete before we ever
launch a node. It looks like it saves at least 1m in the terraform time.

It might be more since DNS never will get an NXDOMAIN and cache that either.
I don't know about that yet