### PR TITLE
Bug 1684951: pkg/destroy/aws: Use GetSession() to prompt when missing

### DIFF
--- a/pkg/destroy/aws.go
+++ b/pkg/destroy/aws.go
@@ -1,6 +1,7 @@
 package destroy
 
 import (
+	session "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/destroy/aws"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/sirupsen/logrus"
@@ -13,11 +14,17 @@ func NewAWS(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (Destroy
 		filters = append(filters, filter)
 	}
 
+	awsSession, err := session.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
 	return &aws.ClusterUninstaller{
 		Filters:   filters,
 		Region:    metadata.ClusterPlatformMetadata.AWS.Region,
 		Logger:    logger,
 		ClusterID: metadata.InfraID,
+		Session:   awsSession,
 	}, nil
 }
 


### PR DESCRIPTION
Avoid looping forever [with][1]:

```
INFO get tagged resources: NoCredentialProviders: no valid providers in chain. Deprecated.
    For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```

and so on for all the other calls.  With this commit, I'm allowing callers to provide their own session, which they can pre-check as they like.

I'm not adjusting `pkg/destroy/aws` to use `GetSession` internally, because it would drag in a bunch of mostly-unrelated dependencies that `pkg/destroy/aws` consumers like [Hive][2] won't want.  And Hive's consumer isn't interactive anyway, so our prompting logic would not be a good fit for them.  With this commit, *we* can use our prompting `GetSession` without forcing it onto Hive.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1684951
[2]: https://github.com/openshift/hive/blob/a9ffb5af700bdc46dab2a880ec8414cd9e99242e/contrib/cmd/hiveutil/awstagdeprovision.go#L24