### PR TITLE
Proposal for BYO deployment

### DIFF
--- a/pkg/asset/byo/byo.go
+++ b/pkg/asset/byo/byo.go
@@ -1,0 +1,68 @@
+package byo
+
+import (
+	"github.com/openshift/installer/pkg/asset"
+	"path/filepath"
+)
+
+const (
+	PluginsDir = "plugins"
+)
+
+type Deployment struct {
+	FileList []*asset.File
+}
+
+var _ asset.Asset = (*Deployment)(nil)
+
+func (d *Deployment) Name() string {
+	return "BYO Deployment"
+}
+
+func (d *Deployment) Dependencies() []asset.Asset {
+	return []asset.Asset{}
+}
+
+func (d *Deployment) Generate(asset.Parents) error {
+	return nil
+}
+
+func (d *Deployment) Files() []*asset.File {
+	return d.FileList
+}
+
+// Load returns the deployment asset from disk.
+func (d *Deployment) Load(f asset.FileFetcher) (bool, error) {
+	var fileList []*asset.File
+
+	// get the main.tf
+	mainFile, err := f.FetchByName("main.tf")
+	if err != nil {
+		return false, err
+	}
+	fileList = append(fileList, mainFile)
+
+	// get the variables-*.tf
+	variablesFile, err := f.FetchByPattern("variables-*.tf")
+	if err != nil {
+		return false, err
+	}
+	fileList = append(fileList, variablesFile...)
+
+	// get all modules
+	modulesFileList, err := f.FetchByPattern(filepath.Join("**/*.tf"))
+	if err != nil {
+		return false, err
+	}
+	fileList = append(fileList, modulesFileList...)
+
+	// get plugins
+	pluginsFileList, _ := f.FetchByPattern(filepath.Join(PluginsDir, "**/*"))
+	fileList = append(fileList, pluginsFileList...)
+
+	d.FileList = fileList
+
+	asset.SortFiles(d.FileList)
+
+	return true, nil
+}

--- a/pkg/asset/cluster/metadata.go
+++ b/pkg/asset/cluster/metadata.go
@@ -53,6 +53,7 @@ func (m *Metadata) Generate(parents asset.Parents) (err error) {
 		ClusterName: installConfig.Config.ObjectMeta.Name,
 		ClusterID:   clusterID.UUID,
 		InfraID:     clusterID.InfraID,
+		BYO:         installConfig.Config.BYO,
 	}
 
 	switch {

--- a/pkg/asset/targets/targets.go
+++ b/pkg/asset/targets/targets.go
@@ -2,6 +2,7 @@ package targets
 
 import (
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/byo"
 	"github.com/openshift/installer/pkg/asset/cluster"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
@@ -63,6 +64,7 @@ var (
 		&kubeconfig.AdminClient{},
 		&tls.JournalCertKey{},
 		&cluster.Metadata{},
+		&byo.Deployment{},
 		&cluster.Cluster{},
 	}
 )

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -27,8 +27,8 @@ const (
 // given directory and then runs 'terraform init' and 'terraform
 // apply'.  It returns the absolute path of the tfstate file, rooted
 // in the specified directory, along with any errors from Terraform.
-func Apply(dir string, platform string, extraArgs ...string) (path string, err error) {
-	err = unpackAndInit(dir, platform)
+func Apply(dir string, platform string, byo bool, extraArgs ...string) (path string, err error) {
+	err = unpackAndInit(dir, platform, byo)
 	if err != nil {
 		return "", err
 	}
@@ -59,8 +59,8 @@ func Apply(dir string, platform string, extraArgs ...string) (path string, err e
 // Destroy unpacks the platform-specific Terraform modules into the
 // given directory and then runs 'terraform init' and 'terraform
 // destroy'.
-func Destroy(dir string, platform string, extraArgs ...string) (err error) {
-	err = unpackAndInit(dir, platform)
+func Destroy(dir string, platform string, byo bool, extraArgs ...string) (err error) {
+	err = unpackAndInit(dir, platform, byo)
 	if err != nil {
 		return err
 	}
@@ -89,10 +89,13 @@ func Destroy(dir string, platform string, extraArgs ...string) (err error) {
 
 // unpack unpacks the platform-specific Terraform modules into the
 // given directory.
-func unpack(dir string, platform string) (err error) {
-	err = data.Unpack(dir, platform)
-	if err != nil {
-		return err
+func unpack(dir string, platform string, byo bool) (err error) {
+
+	if !byo {
+		err = data.Unpack(dir, platform,)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = data.Unpack(filepath.Join(dir, "config.tf"), "config.tf")
@@ -105,8 +108,8 @@ func unpack(dir string, platform string) (err error) {
 
 // unpackAndInit unpacks the platform-specific Terraform modules into
 // the given directory and then runs 'terraform init'.
-func unpackAndInit(dir string, platform string) (err error) {
-	err = unpack(dir, platform)
+func unpackAndInit(dir string, platform string, byo bool) (err error) {
+	err = unpack(dir, platform, byo)
 	if err != nil {
 		return errors.Wrap(err, "failed to unpack Terraform modules")
 	}

--- a/pkg/types/clustermetadata.go
+++ b/pkg/types/clustermetadata.go
@@ -16,6 +16,8 @@ type ClusterMetadata struct {
 	// infraID is an ID that is used to identify cloud resources created by the installer.
 	InfraID                 string `json:"infraID"`
 	ClusterPlatformMetadata `json:",inline"`
+	// Bring your own terraform platform deployment
+	BYO bool `json:"byo,omitempty"`
 }
 
 // ClusterPlatformMetadata contains metadata for platfrom.

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -62,6 +62,9 @@ type InstallConfig struct {
 	// perform the installation.
 	Platform `json:"platform"`
 
+	// Bring your own terraform platform deployment
+	BYO bool `json:"byo,omitempty"`
+
 	// PullSecret is the secret to use when pulling images.
 	PullSecret string `json:"pullSecret"`
 }


### PR DESCRIPTION
The motivation behind this PR is to be able to solve our security requirements by using our own Terraform files and plugins for the supported platforms.
The use of self defined Terraform files should always respecting the boundaries given by the installer.
If the byo is set via the install-config.yaml then the installer will not unpack the platform specific files and expects them in the specified installer directory.