### PR TITLE
tls: fix SubjectKeyId on CA-signed certs

### DIFF
--- a/pkg/asset/tls/tls.go
+++ b/pkg/asset/tls/tls.go
@@ -115,7 +115,7 @@ func SignedCertificate(
 		Version:               3,
 		BasicConstraintsValid: true,
 	}
-	pub := caCert.PublicKey.(*rsa.PublicKey)
+	pub := key.Public()
 	certTmpl.SubjectKeyId, err = generateSubjectKeyID(pub)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set subject key identifier")


### PR DESCRIPTION
We appear to be setting the SubjectKeyId on CA-signed certs to the ID
of the issuer, not the subject.

Before this change:

```
 $ openssl x509 -in t-ocp/root-ca.crt -noout -text | grep -A 2 'Key Id'
    ...
    X509v3 Subject Key Identifier:
      E7:95:53:74:D5:06:71:46:49:49:58:71:55:E4:B7:DB:2F:0D:C3:8E
    ...
 $ openssl x509 -in machine-config-server.crt -noout -text | grep -A 2 'Key Id'
    ...
    X509v3 Subject Key Identifier:
      E7:95:53:74:D5:06:71:46:49:49:58:71:55:E4:B7:DB:2F:0D:C3:8E
    X509v3 Authority Key Identifier:
      keyid:E7:95:53:74:D5:06:71:46:49:49:58:71:55:E4:B7:DB:2F:0D:C3:8E
    ...
```

And after:

```
 $ openssl x509 -in t-ocp/root-ca.crt -noout -text
    ...
    X509v3 Subject Key Identifier:
      FD:E0:5F:3A:D6:7B:CC:B0:7A:BA:10:57:D0:E2:20:38:85:F3:B9:54
    ...
 $ openssl x509 -in t-ocp/machine-config-server.crt -noout -text | grep -A 2 'Key Id'
    ...
    X509v3 Subject Key Identifier:
      89:A9:B0:52:31:25:DB:F5:9C:90:6D:97:53:B1:86:2C:A0:C9:35:3C
    X509v3 Authority Key Identifier:
      keyid:FD:E0:5F:3A:D6:7B:CC:B0:7A:BA:10:57:D0:E2:20:38:85:F3:B9:54
    ...
```