### PR TITLE
openstack: Set hostnames for nodes

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -17,6 +17,7 @@ data "ignition_config" "redirect" {
   }
 
   files = [
+    "${data.ignition_file.hostname.id}",
     "${data.ignition_file.bootstrap_ifcfg.id}",
   ]
 }
@@ -36,6 +37,18 @@ PERSISTENT_DHCLIENT="yes"
 DNS1="${var.service_vm_fixed_ip}"
 PEERDNS="no"
 NM_CONTROLLED="yes"
+EOF
+  }
+}
+
+data "ignition_file" "hostname" {
+  filesystem = "root"
+  mode       = "420"           // 0644
+  path       = "/etc/hostname"
+
+  content {
+    content = <<EOF
+${var.cluster_id}-bootstrap.${var.cluster_domain}
 EOF
   }
 }

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -13,6 +13,11 @@ variable "cluster_id" {
   description = "The identifier for the cluster."
 }
 
+variable "cluster_domain" {
+  type        = "string"
+  description = "The domain name of the cluster. All DNS records must be under this domain."
+}
+
 variable "ignition" {
   type        = "string"
   description = "The content of the bootstrap ignition file."

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -44,6 +44,7 @@ module "bootstrap" {
 
   swift_container     = "${openstack_objectstorage_container_v1.container.name}"
   cluster_id          = "${var.cluster_id}"
+  cluster_domain      = "${var.cluster_domain}"
   image_name          = "${var.openstack_base_image}"
   flavor_name         = "${var.openstack_master_flavor_name}"
   ignition            = "${var.ignition_bootstrap}"
@@ -56,6 +57,7 @@ module "masters" {
 
   base_image          = "${var.openstack_base_image}"
   cluster_id          = "${var.cluster_id}"
+  cluster_domain      = "${var.cluster_domain}"
   flavor_name         = "${var.openstack_master_flavor_name}"
   instance_count      = "${var.master_count}"
   master_sg_ids       = "${concat(var.openstack_master_extra_sg_ids, list(module.topology.master_sg_id))}"

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -7,10 +7,29 @@ data "openstack_compute_flavor_v2" "masters_flavor" {
   name = "${var.flavor_name}"
 }
 
+data "ignition_file" "hostname" {
+  count      = "${var.instance_count}"
+  filesystem = "root"
+  mode       = "420"                   // 0644
+  path       = "/etc/hostname"
+
+  content {
+    content = <<EOF
+${var.cluster_id}-master-${count.index}.${var.cluster_domain}
+EOF
+  }
+}
+
 data "ignition_config" "master_ignition_config" {
+  count = "${var.instance_count}"
+
   append {
     source = "data:text/plain;charset=utf-8;base64,${base64encode(var.user_data_ign)}"
   }
+
+  files = [
+    "${element(data.ignition_file.hostname.*.id, count.index)}",
+  ]
 }
 
 resource "openstack_compute_instance_v2" "master_conf" {
@@ -20,7 +39,7 @@ resource "openstack_compute_instance_v2" "master_conf" {
   flavor_id       = "${data.openstack_compute_flavor_v2.masters_flavor.id}"
   image_id        = "${data.openstack_images_image_v2.masters_img.id}"
   security_groups = ["${var.master_sg_ids}"]
-  user_data       = "${data.ignition_config.master_ignition_config.rendered}"
+  user_data       = "${element(data.ignition_config.master_ignition_config.*.rendered, count.index)}"
 
   network = {
     port = "${var.master_port_ids[count.index]}"

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -7,6 +7,11 @@ variable "cluster_id" {
   description = "The identifier for the cluster."
 }
 
+variable "cluster_domain" {
+  type        = "string"
+  description = "The domain name of the cluster. All DNS records must be under this domain."
+}
+
 variable "flavor_name" {
   type = "string"
 }


### PR DESCRIPTION
Now that we're not using neutron DNS anymore, we must set the hostnames
on the nodes so that it's possible to communicate between VMs