### PR TITLE
pkg/version: Include the commit hash

### DIFF
--- a/cmd/openshift-install/log.go
+++ b/cmd/openshift-install/log.go
@@ -68,6 +68,9 @@ func setupFileHook(baseDir string) func() {
 	}))
 
 	logrus.Debugf(version.String)
+	if version.Commit != "" {
+		logrus.Debugf("Built from commit %s", version.Commit)
+	}
 
 	return func() {
 		logfile.Close()

--- a/cmd/openshift-install/version.go
+++ b/cmd/openshift-install/version.go
@@ -21,5 +21,8 @@ func newVersionCmd() *cobra.Command {
 
 func runVersionCmd(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s %s\n", os.Args[0], version.Raw)
+	if version.Commit != "" {
+		fmt.Printf("built from commit %s\n", version.Commit)
+	}
 	return nil
 }

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -31,7 +31,7 @@ then
 fi
 
 MODE="${MODE:-release}"
-LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=$(git describe --always --abbrev=40 --dirty)"
+LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=$(git describe --always --abbrev=40 --dirty) -X github.com/openshift/installer/pkg/version.Commit=$(git rev-parse --verify 'HEAD^{commit}')"
 TAGS="${TAGS:-}"
 OUTPUT="${OUTPUT:-bin/openshift-install}"
 export CGO_ENABLED=0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,4 +11,8 @@ var (
 
 	// String is the human-friendly representation of the version.
 	String = fmt.Sprintf("OpenShift Installer %s", Raw)
+
+	// Commit is the commit hash from which the installer was built.
+	// Set in hack/build.sh.
+	Commit = ""
 )


### PR DESCRIPTION
And include that hash in the `openshift version` and log output. This makes it easier to troubleshoot reports from official builds, which currently reference internal tags:

```console
$ RELEASE=quay.io/openshift-release-dev/ocp-release:4.0.0-0.7
$ INSTALLER="$(oc adm release info "${RELEASE}" --image-for installer)"
$ oc image extract "${INSTALLER}" --file=/usr/bin/openshift-install
$ chmod +x openshift-install
$ ./openshift-install version
./openshift-install v4.0.15-1-dirty
```

although you can currently extract the commit given the pullspec and access to the backing registry:

```console
$ oc image info --output=json "${INSTALLER}" | jq -r '.config.config.Labels["io.openshift.build.commit.id"]'
c8b3b5532694c7713efe300a636108174d623c52
```