### PR TITLE
data/data/bootstrap: add etcd metrics flags

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -171,6 +171,9 @@ then
 		"${MACHINE_CONFIG_OPERATOR_IMAGE}" \
 		bootstrap \
 			--etcd-ca=/assets/tls/etcd-client-ca.crt \
+			--etcd-metrics-ca=/assets/tls/etcd-metrics-ca-bundle.crt \
+			--etcd-metrics-server-crt=/assets/tls/etcd-metrics-signer-server.crt \
+			--etcd-metrics-server-key=/assets/tls/etcd-metrics-signer-server.key \
 			--root-ca=/assets/tls/root-ca.crt \
 			--kube-ca=/assets/tls/kube-ca.crt \
 			--config-file=/assets/manifests/cluster-config.yaml \


### PR DESCRIPTION
This PR adds the TLS file paths to bootstrap for metrics assets created in https://github.com/openshift/installer/pull/1291.

Depends on https://github.com/openshift/machine-config-operator/pull/517