### PR TITLE
data/aws: make API LBs listen on 443

### DIFF
--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -97,7 +97,7 @@ resource "aws_lb_target_group" "services" {
 resource "aws_lb_listener" "api_internal_api" {
   load_balancer_arn = "${aws_lb.api_internal.arn}"
   protocol          = "TCP"
-  port              = "6443"
+  port              = "443"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.api_internal.arn}"
@@ -121,7 +121,7 @@ resource "aws_lb_listener" "api_external_api" {
 
   load_balancer_arn = "${aws_lb.api_external.arn}"
   protocol          = "TCP"
-  port              = "6443"
+  port              = "443"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.api_external.arn}"

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -31,7 +31,7 @@ func (k *kubeconfig) generate(
 			{
 				Name: installConfig.ObjectMeta.Name,
 				Cluster: clientcmd.Cluster{
-					Server: fmt.Sprintf("https://api.%s:6443", installConfig.ClusterDomain()),
+					Server: fmt.Sprintf("https://api.%s:443", installConfig.ClusterDomain()),
 					CertificateAuthorityData: ca.Cert(),
 				},
 			},

--- a/pkg/asset/kubeconfig/kubeconfig_test.go
+++ b/pkg/asset/kubeconfig/kubeconfig_test.go
@@ -62,7 +62,7 @@ func TestKubeconfigGenerate(t *testing.T) {
 			expectedData: []byte(`clusters:
 - cluster:
     certificate-authority-data: VEhJUyBJUyBST09UIENBIENFUlQgREFUQQ==
-    server: https://api.test-cluster-name.test.example.com:6443
+    server: https://api.test-cluster-name.test.example.com:443
   name: test-cluster-name
 contexts:
 - context:
@@ -86,7 +86,7 @@ users:
 			expectedData: []byte(`clusters:
 - cluster:
     certificate-authority-data: VEhJUyBJUyBST09UIENBIENFUlQgREFUQQ==
-    server: https://api.test-cluster-name.test.example.com:6443
+    server: https://api.test-cluster-name.test.example.com:443
   name: test-cluster-name
 contexts:
 - context:
@@ -112,7 +112,7 @@ users:
 			actualFiles := kc.Files()
 			assert.Equal(t, 1, len(actualFiles), "unexpected number of files generated")
 			assert.Equal(t, tt.filename, actualFiles[0].Filename, "unexpected file name generated")
-			assert.Equal(t, tt.expectedData, actualFiles[0].Data, "unexpected config")
+			assert.Equal(t, string(tt.expectedData), string(actualFiles[0].Data), "unexpected config")
 		})
 	}
 

--- a/pkg/asset/manifests/utils.go
+++ b/pkg/asset/manifests/utils.go
@@ -34,7 +34,7 @@ func configMap(namespace, name string, data genericData) *configurationObject {
 }
 
 func getAPIServerURL(ic *types.InstallConfig) string {
-	return fmt.Sprintf("https://api.%s:6443", ic.ClusterDomain())
+	return fmt.Sprintf("https://api.%s:443", ic.ClusterDomain())
 }
 
 func getEtcdDiscoveryDomain(ic *types.InstallConfig) string {


### PR DESCRIPTION
The actual api server is still listening on 6443 on the host, but the LBs in
front of the apiservers are on 443.