### PR TITLE
assets: no worker machinesets file for None

### DIFF
--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -93,7 +93,6 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 	}
 
 	machineSets := []runtime.Object{}
-
 	ic := installconfig.Config
 	for _, pool := range ic.Compute {
 		switch ic.Platform.Name() {
@@ -148,6 +147,9 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		}
 	}
 
+	if len(machineSets) == 0 {
+		return nil
+	}
 	list := &metav1.List{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -163,7 +165,6 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		return errors.Wrap(err, "failed to marshal")
 	}
 	w.MachineSetRaw = raw
-
 	return nil
 }
 

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -131,6 +131,9 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 
 	o.FileList = []*asset.File{}
 	for name, data := range assetData {
+		if len(data) == 0 {
+			continue
+		}
 		o.FileList = append(o.FileList, &asset.File{
 			Filename: filepath.Join(openshiftManifestDir, name),
 			Data:     data,


### PR DESCRIPTION
When the platform is none, there should be no worker machineset object created.
Currently when using the None platform, following file is created:

```console
$ ls -l dev-metal/openshift
total 20
-rw-r--r--. 1 adahiya adahiya  293 Mar  7 16:11 99_binding-discovery.yaml
-rw-r--r--. 1 adahiya adahiya  181 Mar  7 16:11 99_kubeadmin-password-secret.yaml
-rw-r--r--. 1 adahiya adahiya  330 Mar  7 16:11 99_openshift-cluster-api_cluster.yaml
-rw-r--r--. 1 adahiya adahiya   49 Mar  7 16:11 99_openshift-cluster-api_worker-machineset.yaml
-rw-r--r--. 1 adahiya adahiya 2689 Mar  7 16:11 99_openshift-cluster-api_worker-user-data-secret.yaml
```

The contents of the 99_openshift-cluster-api_worker-machineset.yaml are:
```console
$ cat dev-metal/openshift/99_openshift-cluster-api_worker-machineset.yaml
apiVersion: v1
items: []
kind: List
metadata: {}
```

`99_openshift-cluster-api_worker-machineset.yaml` should not be created when there are no machinesets to be created, either in 0 compute
required or None platform case.