### PR TITLE
[AWS] Remove unused/legacy boostrap etcd ports in master security group

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -186,16 +186,6 @@ resource "aws_security_group_rule" "master_ingress_etcd" {
   self      = true
 }
 
-resource "aws_security_group_rule" "master_ingress_bootstrap_etcd" {
-  type              = "ingress"
-  security_group_id = "${aws_security_group.master.id}"
-
-  protocol  = "tcp"
-  from_port = 12379
-  to_port   = 12380
-  self      = true
-}
-
 resource "aws_security_group_rule" "master_ingress_services" {
   type              = "ingress"
   security_group_id = "${aws_security_group.master.id}"


### PR DESCRIPTION
Noticed extra ports exposed on master security group. Nothing listening on these ports during or after the install. Appears there used to be a temporary etcd used by the bootstrap, but sitting in the master security group still. Removed the unnecessary rule.