### PR TITLE
Bug 1684670: data/data/bootstrap: add kube-client-agent-image flag

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -23,6 +23,7 @@ MACHINE_CONFIG_DAEMON_IMAGE=$(podman run --quiet --rm ${release} image machine-c
 MACHINE_CONFIG_OSCONTENT=$(podman run --quiet --rm ${release} image machine-os-content)
 MACHINE_CONFIG_ETCD_IMAGE=$(podman run --quiet --rm ${release} image etcd)
 MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE=$(podman run --quiet --rm ${release} image setup-etcd-environment)
+MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE=$(podman run --quiet --rm ${release} image kube-client-agent)
 MACHINE_CONFIG_INFRA_IMAGE=$(podman run --quiet --rm ${release} image pod)
 
 CONFIG_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster-config-operator)
@@ -178,6 +179,7 @@ then
 			--pull-secret=/assets/manifests/pull.json \
 			--etcd-image=${MACHINE_CONFIG_ETCD_IMAGE} \
 			--setup-etcd-env-image=${MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE} \
+			--kube-client-agent-image=${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE} \
 			--machine-config-controller-image=${MACHINE_CONFIG_CONTROLLER_IMAGE} \
 			--machine-config-server-image=${MACHINE_CONFIG_SERVER_IMAGE} \
 			--machine-config-daemon-image=${MACHINE_CONFIG_DAEMON_IMAGE} \


### PR DESCRIPTION
* adds new flag kube-client-agent-imag and populates with release image metadata
* update etcdCertSignerImage to use openshift 4.0 release image

depends on: https://github.com/openshift/machine-config-operator/pull/538

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1684670