### PR TITLE
rhcos: Support channels

### DIFF
--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -55,9 +55,9 @@ func (i *Image) Generate(p asset.Parents) error {
 	defer cancel()
 	switch config.Platform.Name() {
 	case aws.Name:
-		osimage, err = rhcos.AMI(ctx, rhcos.DefaultChannel, config.Platform.AWS.Region)
+		osimage, err = rhcos.AMI(ctx, config.Platform.AWS.Region)
 	case libvirt.Name:
-		osimage, err = rhcos.QEMU(ctx, rhcos.DefaultChannel)
+		osimage, err = rhcos.QEMU(ctx)
 	case openstack.Name:
 		osimage = "rhcos"
 	case none.Name:

--- a/pkg/rhcos/ami.go
+++ b/pkg/rhcos/ami.go
@@ -7,8 +7,8 @@ import (
 )
 
 // AMI fetches the HVM AMI ID of the latest Red Hat Enterprise Linux CoreOS release.
-func AMI(ctx context.Context, channel, region string) (string, error) {
-	meta, err := fetchLatestMetadata(ctx, channel)
+func AMI(ctx context.Context, region string) (string, error) {
+	meta, err := fetchLatestMetadata(ctx)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to fetch RHCOS metadata")
 	}

--- a/pkg/rhcos/qemu.go
+++ b/pkg/rhcos/qemu.go
@@ -8,11 +8,11 @@ import (
 )
 
 // QEMU fetches the URL of the latest Red Hat Enterprise Linux CoreOS release.
-func QEMU(ctx context.Context, channel string) (string, error) {
-	meta, err := fetchLatestMetadata(ctx, channel)
+func QEMU(ctx context.Context) (string, error) {
+	meta, err := fetchLatestMetadata(ctx)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to fetch RHCOS metadata")
 	}
 
-	return fmt.Sprintf("%s/%s/%s/%s", baseURL, channel, meta.OSTreeVersion, meta.Images.QEMU.Path), nil
+	return fmt.Sprintf("%s/%s/%s/%s", baseURL, getChannel(), meta.OSTreeVersion, meta.Images.QEMU.Path), nil
 }


### PR DESCRIPTION
The code was hardcoded to `DefaultChannel`; add an environment variable
so people (and CI) can use the other channels.