### PR TITLE
Re-group the network operator crd.

### DIFF
--- a/data/data/manifests/openshift/cluster-networkconfig-crd.yaml
+++ b/data/data/manifests/openshift/cluster-networkconfig-crd.yaml
@@ -4,14 +4,14 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: networkconfigs.networkoperator.openshift.io
+  name: networks.operator.openshift.io
 spec:
-  group: networkoperator.openshift.io
+  group: operator.openshift.io
   names:
-    kind: NetworkConfig
-    listKind: NetworkConfigList
-    plural: networkconfigs
-    singular: networkconfig
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
   scope: Cluster
   versions:
   - name: v1


### PR DESCRIPTION
This has already been merged in the operator; just need to update
the installer's cache of the crd.

Someday we can get rid of this, but not yet.