### PR TITLE
libvirt CI Dockerfile fix

### DIFF
--- a/images/nested-libvirt/Dockerfile
+++ b/images/nested-libvirt/Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y \
     epel-release \
     gettext \
     google-cloud-sdk \
-    openssh-clients && \
-    yum --enablerepo=epel-testing install -y nss_wrapper && \
+    openssh-clients \
+    nss_wrapper && \
     yum -y update && \
     yum clean all


### PR DESCRIPTION
This PR updates the Dockerfile used in CI to build the libvirt image.  Repo epel-testing is not available, so build errors out.  We don't need this so I've removed it. 
I'm working to get the libvirt CI job running, with CRC team.