### PR TITLE
openstack: name swift container according to cluster_id

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -81,7 +81,7 @@ module "topology" {
 }
 
 resource "openstack_objectstorage_container_v1" "container" {
-  name = "${var.cluster_domain}"
+  name = "${var.cluster_id}"
 
   # "kubernetes.io/cluster/${var.cluster_id}" = "owned"
   metadata = "${merge(map(


### PR DESCRIPTION
We currently name the swift container according to cluster_domain.
However, swift container names are global scope, and cluster_domain
may not be unique in an entire openstack cloud. Instead, we should
use cluster_id, which is also in line with how other resources are
named.