### PR TITLE
Add initial docs and example implementation for UPI bare-metal

### DIFF
--- a/docs/user/metal/install_upi.md
+++ b/docs/user/metal/install_upi.md
@@ -1,0 +1,326 @@
+# Install: BareMetal User Provided Infrastructure
+
+The steps for performing a UPI-based install are outlined here. Several [Terraform][upi-metal-example] templates are provided as an example to help model your own.
+
+## Table of contents
+
+1. Minimum compute requirements
+
+2. Network topology requirements
+
+3. DNS requirements
+
+4. Getting Ignition configs for machines
+
+5. Getting OS related assets for machines
+
+6. Booting machines with RHCOS and Ignition configs
+
+7. Watching your installation (bootstrap_complete, cluster available)
+
+8. Example Bare-Metal UPI deployment
+
+## Compute
+
+The smallest OpenShift 4.x clusters require the following host:
+
+* 1 bootstrap machine.
+
+* 3 control plane machines.
+
+* at least 1 worker machine.
+
+NOTE: The cluster requires the bootstrap machine to deploy the OpenShift cluster on to the 3 control plane machines, and you can remove the bootstrap machine.
+
+The bootstrap and control plane machines must use Red Hat Enterprise Linux CoreOS (RHCOS) as the operating system.
+
+### Minimum resource requirements
+
+Processing
+Memory
+Storage
+Networking
+
+[todo-link-to-minimum-resource-requirements]
+
+## Network Topology Requirements
+
+OpenShift 4.x requires all nodes to have internet access to pull images for platform containers and provide telemetry data to Red Hat.
+
+### Load balancers
+
+Before you install OpenShift, you must provision two load balancers.
+
+* A load balancer for the control plane machines that targets port 6443 (Kubernetes APIServer) and 22623([Machine Config server][machine-config-server]). Port 6443 must be accessible to both clients external to the cluster and nodes within the cluster, and port 22623 must be accessible to nodes within the cluster.
+
+* A load balancer for the machines that run the [ingress router][openshift-router] pods that balances ports 443 and 80. Both the ports must be accessible to both clients external to the cluster and nodes within the cluster.
+
+    NOTE: A working configuration for the ingress router is required for an OpenShift 4.x cluster.
+
+    NOTE: The default configuration for Cluster Ingress Operator  deploys the ingress router to `worker` nodes in the cluster. The administrator needs to configure the [ingress][openshift-router] after the control plane has been bootstrapped.
+
+### Connectivity between machines
+
+You must configure the network connectivity between machines to allow cluster components to communicate.
+
+* Etcd
+
+    As the etcd members are located on the control plane machines. Each control plane machine requires connectivity to [etcd server][etcd-ports], [etcd peer][etcd-ports] and [etcd-metrics][etcd-ports] on every other control plane machine.
+
+    All the worker machines should have connectivity to [etcd server][etcd-ports] and [etcd-metrics][etcd-ports] ports on the control plane machines.
+
+* OpenShift SDN
+
+    All the machines require connectivity to certain reserved ports on every other machine to establish in-cluster networking. For more details refer [doc][snd-ports].
+
+* Kubernetes NodePort
+
+    All the machines require connectivity to Kubernetes NodePort range 30000-32767 on every other machine for OpenShift platform components.
+
+* OpenShift reserved
+
+    All the machines require connectivity to reserved port ranges 10250-12252 and 9000-9999 on every other machine for OpenShift platform components.
+
+### Connectivity during machine boot
+
+All the RHCOS machines require network in `initramfs` during boot to fetch Ignition config from the Machine Config Server [machine-config-server].
+
+## DNS requirements
+
+* Kubernetes API
+
+    OpenShift 4.x requires the DNS record `api.$cluster_name.$base_domain` to point to the Load balancer targeting the control plane machines. This record must be resolvable by both clients external to the cluster and from all the nodes within the cluster.
+
+* Etcd
+
+    For each control plane machine, OpenShift 4.x requires DNS records `etcd-$idx.$cluster_name.$base_domain` to point to `$idx`'th control plane machine. The DNS record must resolve to an unicast IPV4 address for the control plane machine and the records must be resolvable from all the nodes in the cluster.
+
+    For each control plane machine, OpenShift 4.x also requires a SRV DNS record for etcd server on that machine with priority `0`, weight `10` and port `2380`. For 3 control plane cluster, the records look like:
+
+    ```plain
+    # _service._proto.name.                            TTL   class SRV priority weight port target.
+    _etcd-server-ssl._tcp.$cluster_name.$base_domain   86400 IN    SRV 0        10     2380 etcd-0.$cluster_name.$base_domain.
+    _etcd-server-ssl._tcp.$cluster_name.$base_domain   86400 IN    SRV 0        10     2380 etcd-1.$cluster_name.$base_domain.
+    _etcd-server-ssl._tcp.$cluster_name.$base_domain   86400 IN    SRV 0        10     2380 etcd-2.$cluster_name.$base_domain.
+    ```
+
+* OpenShift Routes
+
+    OpenShift 4.x requires the DNS record `*.apps.$cluster_name.$base_domain` to point to the Load balancer targeting the machines running the ingress router pods. This record must be resolvable by both clients external to the cluster and from all the nodes within the cluster.
+
+## Getting ignition configs for machines
+
+The OpenShift Installer provides administrators various assets that are required to create an OpenShift cluster, namely:
+
+* Ignition configs: The OpenShift Installer provides Ignition configs that should be used to configure the RHCOS based bootstrap and control plane machines using `bootstrap.ign`  and `master.ign` respectively. The OpenShift Installer also provides `worker.ign` that can be used to configure the RHCOS based `worker` machines, but also can be used as source for configuring RHEL based machines [todo-link-to-BYO-RHEL].
+
+* Admin Kubeconfig: The OpenShift Installer provides a kubeconfig with admin level privileges to Kubernetes APIServer.
+
+    NOTE: This kubeconfig is configured to use `api.$cluster_name.$base_domain` DNS name to communicate with the Kubernetes APIServer.
+
+### Setting up install-config for installer
+
+The OpenShift installer uses an [Install Config][install-config] to drive all install time configuration.
+
+An example install config for bare-metal UPI is as follows:
+
+```yaml
+apiVersion: v1beta3
+## The base domain of the cluster. All DNS records will be sub-domains of this base and will also include the cluster name.
+baseDomain: example.com
+compute:
+- name: worker
+  replicas: 1
+controlPlane:
+  name: master
+  replicas: 1
+metadata:
+  ## The name for the cluster
+  name: test
+platform:
+  none: {}
+## The pull secret that provides components in the cluster access to images for OpenShift components.
+pullSecret: ''
+## The default SSH key that will be programmed for `core` user.
+sshKey: ''
+```
+
+Create a directory that will be used by the OpenShift installer to provide all the assets. For example `test-bare-metal`,
+
+```console
+$ mkdir test-bare-metal
+$ tree test-bare-metal
+test-bare-metal
+
+0 directories, 0 files
+```
+
+Copy *your* `install-config` to the `INSTALL_DIR`. For example using the `test-bare-metal` as our `INSTALL_DIR`,
+
+```console
+$ cp <your-instal-config> test-bare-metal/install-config.yaml
+$ tree test-bare-metal
+test-bare-metal
+└── install-config.yaml
+
+0 directories, 1 file
+```
+
+NOTE: The filename for `install-config` in the `INSTALL_DIR` must be `install-config.yaml`
+
+### Invoking the installer to get Ignition configs
+
+Given that you have setup the `INSTALL_DIR` with the appropriate `install-config`, you can create the Ignition configs by using the `create ignition-configs` target. For example,
+
+```console
+$ openshift-install --dir test-bare-metal create ignition-configs
+INFO Consuming "Install Config" from target directory
+$ tree test-bare-metal
+test-bare-metal
+├── auth
+│   └── kubeconfig
+├── bootstrap.ign
+├── master.ign
+└── worker.ign
+
+1 directory, 4 files
+```
+
+## Getting OS related assets for machines
+
+TODO RHEL CoreOS does not have assets for bare-metal.
+
+## Booting machines with RHCOS and Ignition configs
+
+### Required kernel parameters during PXE
+
+* `rd.neednet=1`: [CoreOS Installer][coreos-installer] needs internet access to fetch the OS image that needs to be installed on the machine.
+
+* CoreOS Installer [arguments][coreos-installer-args] are required to be configured to install RHCOS and setup the Ignition config file for that machine.
+
+## Watching your installation
+
+### Monitor for bootstrap-complete
+
+The administrators can use the `upi bootstrap-complete` target of the OpenShift Installer to monitor cluster bootstrapping. The command succeeds when it notices `bootstrap-complete` event from Kubernetes APIServer. This event is generated by the bootstrap machine after the Kubernetes APIServer has been bootstrapped on the control plane machines. For example,
+
+```console
+$ openshift-install --dir test-bare-metal upi bootstrap-complete
+INFO Waiting up to 30m0s for the Kubernetes API at https://api.test.example.com:6443...
+INFO API v1.12.4+c53f462 up
+INFO Waiting up to 30m0s for the bootstrap-complete event...
+```
+
+## Monitor for cluster completion
+
+The administrators can use the `upi finish` target of the OpenShift Installer to monitor cluster completion. The command succeeds when it notices that Cluster Version Operator has completed rolling out the OpenShift cluster from Kubernetes APIServer.
+
+```console
+$ openshift-install upi finish
+INFO Waiting up to 30m0s for the cluster to initialize...
+```
+
+## Example Bare-Metal UPI deployment
+
+Terraform [templates][upi-metal-example] provides an example of using OpenShift Installer to create an bare-metal UPI OpenShift cluster on Packet.net
+
+### Overview
+
+* Compute: Uses Packet.net to deploy bare-metal machines.
+    Uses [matchbox](coreos-matchbox) to serve PXE scripts and Ignition configs for bootstrap, control plane and worker machines.
+    Uses `public` IPv4 addresses for each machine, so that all the machines are accessible on the internet.
+
+* DNS and Load Balancing
+    Uses AWS [Route53](aws-route53) to configure the all the DNS records.
+    Uses Round-Robin DNS [RRDNS][rrdns] in place of load balancing solutions.
+
+Refer to the pre-requisites for using the example [here][upi-metal-example-pre-req]
+
+### Creating the cluster
+
+#### Installer assets
+
+Use the OpenShift Installer to create [Ignition configs][#getting-ignition-configs-for-machines] that will be used to create bootstrap, control plane and worker machines.
+
+#### Terraform variable file
+
+Use the [example][upi-metal-example-tfvar] Terraform variable file to create terraform variable file, and edit the `tfvars` file on your favorite editor.
+
+```sh
+cp terraform.tfvars.{example,}
+```
+
+#### Creating resources
+
+Initialize terraform to download all the required providers. For more info on terraform [init][terraform-init] and terraform [providers][terraform-providers]
+
+```sh
+terraform init
+```
+
+Create all the resources using terraform by invoking [apply][terraform-apply]
+
+```sh
+terraform apply -auto-approve
+```
+
+#### Monitoring bootstrap-complete and removing bootstrap resources
+
+Use the bootstrap [monitoring][#monitor-for-bootstrap-complete] to track when cluster bootstrapping has finished. After the Kubernetes APIServer has been bootstrapped on the control plane machines, the bootstrap machine can be removed from the API pool by following:
+
+```sh
+terraform apply -auto-approve -var=boostrap_dns="false"
+```
+
+NOTE: The bootstrap resources like the bootstrap machines currently cannot be removed using terraform. You can use the Packet.net console to remove the bootstrap machine. All the resources will be cleaned up by `terraform destroy`
+
+### Approving server certificates for nodes
+
+To allow Kube APIServer to communicate with the kubelet running on nodes for logs, rsh etc. The administrator needs to approve the CSR [requests][csr-requests] generated by each kubelet.
+
+You can approve all `Pending` CSR requests using,
+
+```sh
+oc get csr -ojson | jq -r '.items[] | select(.status == {} ) | .metadata.name' | xargs oc adm certificate approve
+```
+
+### Updating image-registry to emptyDir storage backend
+
+The Cluster Image Registry [Operator][cluster-image-registry-operator] does not pick an storage backend for `None` platform. Therefore, the cluster operator is will be stuck in progressing because it is waiting for administrator to [configure][cluster-image-registry-operator-configuration] a storage backend for the image-registry. You can pick `emptyDir` for non-production clusters by following:
+
+```sh
+oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"filesystem":{"volumeSource": {"emptyDir":{}}}}}}'
+```
+
+#### Monitoring cluster completion
+
+Use the cluster finish [monitoring][#monitor-for-cluster-completion] to track when cluster has completely finished deploying.
+
+#### Destroying the cluster
+
+Use terraform [destroy][terraform-destroy] to destroy all the resources for the cluster. For example,
+
+```console
+terraform destroy -auto-approve
+```
+
+[aws-route53]: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/Welcome.html
+[cluster-image-registry-operator-configuration]: https://github.com/openshift/cluster-image-registry-operator#registry-resource
+[cluster-image-registry-operator]: https://github.com/openshift/cluster-image-registry-operator#image-registry-operator
+[coreos-installer-args]: https://github.com/coreos/coreos-installer#kernel-command-line-options-for-coreos-installer-running-in-the-initramfs
+[coreos-installer]: https://github.com/coreos/coreos-installer#coreos-installer
+[coreos-matchbox]: https://github.com/coreos/matchbox#matchbox----
+[csr-request]: https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/#requesting-a-certificate
+[etcd-ports]: https://github.com/openshift/origin/pull/21520
+[install-config]: https://godoc.org/github.com/openshift/installer/pkg/types#InstallConfig
+[machine-config-server]: https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfigServer.md
+[openshift-router]: https://github.com/openshift/cluster-ingress-operator#openshift-ingress-operator
+[rrdns]: https://tools.ietf.org/html/rfc1794
+[sdn-ports]: https://github.com/openshift/origin/pull/21520
+[terraform-apply]: https://www.terraform.io/docs/commands/apply.html
+[terraform-destroy]: https://www.terraform.io/docs/commands/destroy.html
+[terraform-init]: https://www.terraform.io/docs/commands/init.html
+[terraform-providers]: https://www.terraform.io/docs/providers/
+[upi-metal-example-pre-req]: ../../../upi/metal/README.md#pre-requisites
+[upi-metal-example-tfvar]: ../../../upi/aws/terraform.tfvar.example
+[upi-metal-example]: ../../../upi/metal/README.md

--- a/upi/metal/.gitignore
+++ b/upi/metal/.gitignore
@@ -1,0 +1,5 @@
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup
+matchbox/tls
+packet/

--- a/upi/metal/README.md
+++ b/upi/metal/README.md
@@ -1,0 +1,50 @@
+# UPI Bare Metal
+
+## Pre-requisites
+
+### Matchbox
+
+Setup an instance of matchbox using this [guide][coreos-matchbox-getting-started] which is accessible to everybody on the internet.
+
+Store the tls assets that will be used for client authentication and the CA certificate that allows client to trust the matchbox server on the host that will run the example terraform scripts.
+
+### AWS
+
+Create a public route53 zone using this [guide][aws-create-public-route53-zone].
+
+Setup `default` AWS cli profile on the host that will run the example terraform scripts using this [guide][aws-cli-configure-creds]
+
+### Packet
+
+Setup a Project in Packet.net that will be used to deploy servers, for example using this [guide](packet-deploy-server)
+
+Setup API keys for your Project in Packet.net using this [guide][packet-api-keys]
+
+Store the API keys in `PACKET_AUTH_TOKEN` so that `terraform-provide-packet` can use it to deploy servers in the project. For more info see [this][terraform-provider-packet-auth]
+
+#### Terraform
+
+Install Terraform on the host that will run the example terraform scripts using the Getting Started [Guide][terraform-getting-started]
+
+## Generating the terraform variable example
+
+Install [terraform-examples][terraform-examples] on your host.
+
+```sh
+go get -u github.com/s-urbaniak/terraform-examples
+```
+
+Generate the `terraform.tfvars.example` using
+
+```sh
+terraform-examples config.tf > terraform.tfvars.example
+```
+
+[aws-cli-configure-creds]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
+[aws-create-public-route53-zone]: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html
+[coreos-matchbox-getting-started]: https://github.com/coreos/matchbox#matchbox----
+[packet-api-keys]: https://www.packet.com/developers/changelog/project-only-api-keys/
+[packet-deploy-server]: https://support.packet.com/kb/articles/deploy-a-server
+[terafform-examples]: https://github.com/s-urbaniak/terraform-examples#terraform-examples
+[terrafom-getting-started]: https://learn.hashicorp.com/terraform/getting-started/install.html
+[terraform-provider-packet-auth]: https://www.terraform.io/docs/providers/packet/index.html#auth_token

--- a/upi/metal/bootstrap/matchbox.tf
+++ b/upi/metal/bootstrap/matchbox.tf
@@ -1,0 +1,25 @@
+resource "matchbox_profile" "bootstrap" {
+  name   = "${var.cluster_id}-bootstrap"
+  kernel = "${var.pxe_kernel}"
+
+  initrd = [
+    "${var.pxe_initrd}",
+  ]
+
+  args = [
+    "${var.pxe_kernel_args}",
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?cluster_id=${var.cluster_id}&role=bootstrap",
+  ]
+
+  raw_ignition = "${var.igntion_config_content}"
+}
+
+resource "matchbox_group" "bootstrap" {
+  name    = "${var.cluster_id}-bootstrap"
+  profile = "${matchbox_profile.bootstrap.name}"
+
+  selector {
+    cluster_id = "${var.cluster_id}"
+    role       = "bootstrap"
+  }
+}

--- a/upi/metal/bootstrap/outputs.tf
+++ b/upi/metal/bootstrap/outputs.tf
@@ -1,0 +1,11 @@
+output "device_ip" {
+  value = "${packet_device.bootstrap.network.0.address}"
+}
+
+output "device_hostname" {
+  value = "${packet_device.bootstrap.hostname}"
+}
+
+output "device_id" {
+  value = "${packet_device.bootstrap.id}"
+}

--- a/upi/metal/bootstrap/packet.tf
+++ b/upi/metal/bootstrap/packet.tf
@@ -1,0 +1,11 @@
+resource "packet_device" "bootstrap" {
+  hostname         = "${var.cluster_id}-bootstrap"
+  plan             = "t1.small.x86"
+  facilities       = ["${var.packet_facility}"]
+  operating_system = "custom_ipxe"
+  ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=bootstrap"
+  billing_cycle    = "hourly"
+  project_id       = "${var.packet_project_id}"
+
+  depends_on = ["matchbox_group.bootstrap"]
+}

--- a/upi/metal/bootstrap/variables.tf
+++ b/upi/metal/bootstrap/variables.tf
@@ -1,0 +1,31 @@
+variable "pxe_kernel" {
+  type = "string"
+}
+
+variable "pxe_initrd" {
+  type = "string"
+}
+
+variable "pxe_kernel_args" {
+  type = "list"
+}
+
+variable "matchbox_http_endpoint" {
+  type = "string"
+}
+
+variable "cluster_id" {
+  type = "string"
+}
+
+variable "igntion_config_content" {
+  type = "string"
+}
+
+variable "packet_facility" {
+  type = "string"
+}
+
+variable "packet_project_id" {
+  type = "string"
+}

--- a/upi/metal/config.tf
+++ b/upi/metal/config.tf
@@ -1,0 +1,181 @@
+# ================COMMON=====================
+
+variable "cluster_id" {
+  type = "string"
+
+  description = <<EOF
+(internal) This is an identifier that can uniquely identify the cluster.
+
+All the resources created include `cluster_id` for uniquness purposes.
+EOF
+}
+
+variable "cluster_domain" {
+  type = "string"
+
+  description = <<EOF
+The domain of the cluster.
+All the records for the cluster are created under this domain.
+Note: This field MUST be set manually prior to creating the cluster.
+EOF
+}
+
+variable "bootstrap_ign_file" {
+  type = "string"
+
+  description = <<EOF
+The file that contains the Ignition config used to configure the RHCOS based bootstrap machine.
+EOF
+}
+
+variable "master_ign_file" {
+  type = "string"
+
+  description = <<EOF
+The file that contains the Ignition config used to configure the RHCOS based control plane machines.
+EOF
+}
+
+variable "worker_ign_file" {
+  type = "string"
+
+  description = <<EOF
+The file that contains the Ignition config used to configure the RHCOS based worker machines.
+EOF
+}
+
+variable "master_count" {
+  type    = "string"
+  default = "1"
+
+  description = <<EOF
+The number of control plane machines required.
+
+Since etcd is colocated on control plane machines, suggested number is 3 or 5.
+Default: 1
+EOF
+}
+
+variable "worker_count" {
+  type    = "string"
+  default = "1"
+
+  description = <<EOF
+The number of worker machines required.
+
+Default: 1
+EOF
+}
+
+# ================MATCHBOX=====================
+
+variable "matchbox_rpc_endpoint" {
+  type = "string"
+
+  description = <<EOF
+RPC endpoint for matchbox.
+
+For more info: https://godoc.org/github.com/coreos/matchbox/matchbox/client
+EOF
+}
+
+variable "matchbox_http_endpoint" {
+  type = "string"
+
+  description = <<EOF
+HTTPS endpoint for matchbox. This must include the scheme
+
+For more info: https://github.com/coreos/matchbox/blob/master/Documentation/api.md
+EOF
+}
+
+variable "matchbox_trusted_ca_cert" {
+  type    = "string"
+  default = "matchbox/tls/ca.crt"
+
+  description = <<EOF
+Certificate Authority certificate to trust the matchbox endpoint.
+EOF
+}
+
+variable "matchbox_client_cert" {
+  type    = "string"
+  default = "matchbox/tls/client.crt"
+
+  description = <<EOF
+Client certificate used to authenticate with the matchbox RPC API.
+
+For more info: https://github.com/coreos/matchbox/blob/master/Documentation/api.md
+EOF
+}
+
+variable "matchbox_client_key" {
+  type    = "string"
+  default = "matchbox/tls/client.key"
+
+  description = <<EOF
+Client certificate's key used to authenticate with the matchbox RPC API.
+
+For more info: https://github.com/coreos/matchbox/blob/master/Documentation/api.md
+EOF
+}
+
+variable "pxe_os_image_url" {
+  type = "string"
+
+  description = <<EOF
+URL to the OS image for RHCOS that should be installed on machines.
+
+For more info: https://github.com/coreos/coreos-installer#kernel-command-line-options-for-coreos-installer-running-in-the-initramfs
+EOF
+}
+
+variable "pxe_kernel_url" {
+  type = "string"
+
+  description = <<EOF
+URL to the kernel image that should be used to PXE machines.
+
+This can be a fully-qualified URL or URL relative to matchbox_http_endpoint to use Matchbox assets (https://github.com/coreos/matchbox/blob/master/Documentation/matchbox.md#assets).
+EOF
+}
+
+variable "pxe_initrd_url" {
+  type = "string"
+
+  description = <<EOF
+URL to the initrd image that should be used to PXE machines.
+
+This can be a fully-qualified URL or URL relative to matchbox_http_endpoint to use Matchbox assets (https://github.com/coreos/matchbox/blob/master/Documentation/matchbox.md#assets).
+EOF
+}
+
+# ================PACKET=====================
+
+variable "packet_project_id" {
+  type = "string"
+
+  description = <<EOF
+The Project ID for Packet.net where servers will be deployed.
+EOF
+}
+
+# ================AWS=====================
+
+variable "public_r53_zone" {
+  type = "string"
+
+  description = <<EOF
+The name of the public route53 zone that should be used to create DNS records for the cluster.
+EOF
+}
+
+variable "bootstrap_dns" {
+  default = true
+
+  description = <<EOF
+(internal) This defines if the bootstrap machine should be part of the API pool.
+
+Default: true
+EOF
+}

--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -1,0 +1,220 @@
+# ================MATCHBOX=====================
+
+locals {
+  kernel_args = [
+    "console=tty0",
+    "console=ttyS1,115200n8",
+    "rd.neednet=1",
+
+    # "rd.break=initqueue"
+    "coreos.inst=yes",
+
+    "coreos.inst.image_url=${var.pxe_os_image_url}",
+    "coreos.inst.install_dev=sda",
+    "coreos.inst.skip_media_check",
+  ]
+
+  pxe_kernel = "${var.pxe_kernel_url}"
+  pxe_initrd = "${var.pxe_initrd_url}"
+}
+
+provider "matchbox" {
+  endpoint    = "${var.matchbox_rpc_endpoint}"
+  client_cert = "${file(var.matchbox_client_cert)}"
+  client_key  = "${file(var.matchbox_client_key)}"
+  ca          = "${file(var.matchbox_trusted_ca_cert)}"
+}
+
+resource "matchbox_profile" "default" {
+  name = "${var.cluster_id}"
+}
+
+resource "matchbox_group" "default" {
+  name    = "${var.cluster_id}"
+  profile = "${matchbox_profile.default.name}"
+}
+
+resource "matchbox_profile" "master" {
+  name   = "${var.cluster_id}-master"
+  kernel = "${local.pxe_kernel}"
+
+  initrd = [
+    "${local.pxe_initrd}",
+  ]
+
+  args = [
+    "${local.kernel_args}",
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?cluster_id=${var.cluster_id}&role=master",
+  ]
+
+  raw_ignition = "${file(var.master_ign_file)}"
+}
+
+resource "matchbox_profile" "worker" {
+  name   = "${var.cluster_id}-worker"
+  kernel = "${local.pxe_kernel}"
+
+  initrd = [
+    "${local.pxe_initrd}",
+  ]
+
+  args = [
+    "${local.kernel_args}",
+    "coreos.inst.ignition_url=${var.matchbox_http_endpoint}/ignition?cluster_id=${var.cluster_id}&role=worker",
+  ]
+
+  raw_ignition = "${file(var.worker_ign_file)}"
+}
+
+resource "matchbox_group" "master" {
+  name    = "${var.cluster_id}-master"
+  profile = "${matchbox_profile.master.name}"
+
+  selector {
+    cluster_id = "${var.cluster_id}"
+    role       = "master"
+  }
+}
+
+resource "matchbox_group" "worker" {
+  name    = "${var.cluster_id}-worker"
+  profile = "${matchbox_profile.worker.name}"
+
+  selector {
+    cluster_id = "${var.cluster_id}"
+    role       = "worker"
+  }
+}
+
+# ================PACKET=====================
+
+provider "packet" {}
+
+locals {
+  packet_facility = "sjc1"
+}
+
+resource "packet_device" "masters" {
+  count            = "${var.master_count}"
+  hostname         = "master-${count.index}.${var.cluster_domain}"
+  plan             = "c1.small.x86"
+  facilities       = ["${local.packet_facility}"]
+  operating_system = "custom_ipxe"
+  ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=master"
+  billing_cycle    = "hourly"
+  project_id       = "${var.packet_project_id}"
+
+  depends_on = ["matchbox_group.master"]
+}
+
+resource "packet_device" "workers" {
+  count            = "${var.worker_count}"
+  hostname         = "worker-${count.index}.${var.cluster_domain}"
+  plan             = "c1.small.x86"
+  facilities       = ["${local.packet_facility}"]
+  operating_system = "custom_ipxe"
+  ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=worker"
+  billing_cycle    = "hourly"
+  project_id       = "${var.packet_project_id}"
+
+  depends_on = ["matchbox_group.worker"]
+}
+
+# ==============BOOTSTRAP=================
+
+module "bootstrap" {
+  source = "./bootstrap"
+
+  pxe_kernel             = "${local.pxe_kernel}"
+  pxe_initrd             = "${local.pxe_initrd}"
+  pxe_kernel_args        = "${local.kernel_args}"
+  matchbox_http_endpoint = "${var.matchbox_http_endpoint}"
+  igntion_config_content = "${file(var.bootstrap_ign_file)}"
+
+  cluster_id = "${var.cluster_id}"
+
+  packet_facility   = "${local.packet_facility}"
+  packet_project_id = "${var.packet_project_id}"
+}
+
+# ================AWS=====================
+
+provider aws {
+  region = "us-east-1"
+}
+
+locals {
+  master_public_ipv4_networks = "${flatten(packet_device.masters.*.network)}"
+  master_public_ipv4          = "${data.template_file.master_ips.*.rendered}"
+
+  worker_public_ipv4_networks = "${flatten(packet_device.workers.*.network)}"
+  worker_public_ipv4          = "${data.template_file.worker_ips.*.rendered}"
+  ctrp_records                = "${compact(concat(list(var.bootstrap_dns ? module.bootstrap.device_ip : ""), local.master_public_ipv4))}"
+}
+
+data "template_file" "master_ips" {
+  count    = "${var.master_count}"
+  template = "${lookup(local.master_public_ipv4_networks[count.index*3], "address")}"
+}
+
+data "template_file" "worker_ips" {
+  count    = "${var.worker_count}"
+  template = "${lookup(local.worker_public_ipv4_networks[count.index*3], "address")}"
+}
+
+data "aws_route53_zone" "public" {
+  name = "${var.public_r53_zone}"
+}
+
+resource "aws_route53_record" "ctrlp" {
+  zone_id = "${data.aws_route53_zone.public.zone_id}"
+  type    = "A"
+  ttl     = "60"
+  name    = "api.${var.cluster_domain}"
+
+  records = ["${local.ctrp_records}"]
+}
+
+resource "aws_route53_record" "apps" {
+  zone_id = "${data.aws_route53_zone.public.zone_id}"
+  type    = "A"
+  ttl     = "60"
+  name    = "*.apps.${var.cluster_domain}"
+
+  records = ["${local.worker_public_ipv4}"]
+}
+
+resource "aws_route53_record" "etcd_a_nodes" {
+  count   = "${var.master_count}"
+  zone_id = "${data.aws_route53_zone.public.zone_id}"
+  type    = "A"
+  ttl     = "60"
+  name    = "etcd-${count.index}.${var.cluster_domain}"
+  records = ["${local.master_public_ipv4[count.index]}"]
+}
+
+resource "aws_route53_record" "master_a_nodes" {
+  count   = "${var.master_count}"
+  zone_id = "${data.aws_route53_zone.public.zone_id}"
+  type    = "A"
+  ttl     = "60"
+  name    = "master-${count.index}.${var.cluster_domain}"
+  records = ["${local.master_public_ipv4[count.index]}"]
+}
+
+resource "aws_route53_record" "worker_a_nodes" {
+  count   = "${var.worker_count}"
+  zone_id = "${data.aws_route53_zone.public.zone_id}"
+  type    = "A"
+  ttl     = "60"
+  name    = "worker-${count.index}.${var.cluster_domain}"
+  records = ["${local.worker_public_ipv4[count.index]}"]
+}
+
+resource "aws_route53_record" "etcd_cluster" {
+  zone_id = "${data.aws_route53_zone.public.zone_id}"
+  type    = "SRV"
+  ttl     = "60"
+  name    = "_etcd-server-ssl._tcp.${var.cluster_domain}"
+  records = ["${formatlist("0 10 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)}"]
+}

--- a/upi/metal/outputs.tf
+++ b/upi/metal/outputs.tf
@@ -1,0 +1,15 @@
+output "master_ips" {
+  value = ["${local.master_public_ipv4}"]
+}
+
+output "worker_ips" {
+  value = ["${local.master_public_ipv4}"]
+}
+
+output "bootstrap_ip" {
+  value = "${module.bootstrap.device_ip}"
+}
+
+output "sos_consoles" {
+  value = "${zipmap(concat(list(module.bootstrap.device_hostname), packet_device.masters.*.hostname, packet_device.workers.*.hostname), formatlist("ssh %s@sos.%s.packet.net", concat(list(module.bootstrap.device_id), packet_device.masters.*.id, packet_device.workers.*.id), local.packet_facility))}"
+}

--- a/upi/metal/terraform.tfvars.example
+++ b/upi/metal/terraform.tfvars.example
@@ -1,0 +1,69 @@
+
+// The file that contains the Ignition config used to configure the RHCOS based bootstrap machine.
+bootstrap_ign_file = ""
+
+// The domain of the cluster.
+// All the records for the cluster are created under this domain.
+// Note: This field MUST be set manually prior to creating the cluster.
+cluster_domain = ""
+
+// The number of control plane machines required.
+// 
+// Since etcd is colocated on control plane machines, suggested number is 3 or 5.
+// Default: 1
+master_count = "1"
+
+// The file that contains the Ignition config used to configure the RHCOS based control plane machines.
+master_ign_file = ""
+
+// Client certificate used to authenticate with the matchbox RPC API.
+// 
+// For more info: https://github.com/coreos/matchbox/blob/master/Documentation/api.md
+matchbox_client_cert = "matchbox/tls/client.crt"
+
+// Client certificate's key used to authenticate with the matchbox RPC API.
+// 
+// For more info: https://github.com/coreos/matchbox/blob/master/Documentation/api.md
+matchbox_client_key = "matchbox/tls/client.key"
+
+// HTTPS endpoint for matchbox. This must include the scheme
+// 
+// For more info: https://github.com/coreos/matchbox/blob/master/Documentation/api.md
+matchbox_http_endpoint = ""
+
+// RPC endpoint for matchbox.
+// 
+// For more info: https://godoc.org/github.com/coreos/matchbox/matchbox/client
+matchbox_rpc_endpoint = ""
+
+// Certificate Authority certificate to trust the matchbox endpoint.
+matchbox_trusted_ca_cert = "matchbox/tls/ca.crt"
+
+// The Project ID for Packet.net where servers will be deployed.
+packet_project_id = ""
+
+// The name of the public route53 zone that should be used to create DNS records for the cluster.
+public_r53_zone = ""
+
+// URL to the initrd image that should be used to PXE machines.
+// 
+// This can be a fully-qualified URL or URL relative to matchbox_http_endpoint to use Matchbox assets (https://github.com/coreos/matchbox/blob/master/Documentation/matchbox.md#assets).
+pxe_initrd_url = ""
+
+// URL to the kernel image that should be used to PXE machines.
+// 
+// This can be a fully-qualified URL or URL relative to matchbox_http_endpoint to use Matchbox assets (https://github.com/coreos/matchbox/blob/master/Documentation/matchbox.md#assets).
+pxe_kernel_url = ""
+
+// URL to the OS image for RHCOS that should be installed on machines.
+// 
+// For more info: https://github.com/coreos/coreos-installer#kernel-command-line-options-for-coreos-installer-running-in-the-initramfs
+pxe_os_image_url = ""
+
+// The number of worker machines required.
+// 
+// Default: 1
+worker_count = "1"
+
+// The file that contains the Ignition config used to configure the RHCOS based worker machines.
+worker_ign_file = ""


### PR DESCRIPTION
* Adds an example implementation for UPI Bare Metal in `upi/metal` using Packet.net and AWS.
* Adds docs on requirements and how-to on using OpenShift Installer to create a Bare Metal cluster.