### PR TITLE
create cluster: change Creating cluster to Creating infrastructure resources

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -82,7 +82,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		},
 	}
 
-	logrus.Infof("Creating cluster...")
+	logrus.Infof("Creating infrastructure resources...")
 	stateFile, err := terraform.Apply(tmpDir, installConfig.Config.Platform.Name(), extraArgs...)
 	if err != nil {
 		err = errors.Wrap(err, "failed to create cluster")


### PR DESCRIPTION
Right now it seems like we are spending that time creating our cluster stuff.
In reality we are taking that time creating VMs and load balancers, and DNS
entries in the cloud. So try to say something which indicates 'this time is not
out fault!'