### PR TITLE
openstack: Always set the api DNS entry 

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -34,6 +34,7 @@ module "service" {
   ignition          = "${var.ignition_bootstrap}"
   lb_floating_ip    = "${var.openstack_lb_floating_ip}"
   service_port_id   = "${module.topology.service_port_id}"
+  service_port_ip   = "${module.topology.service_port_ip}"
   master_ips        = "${module.topology.master_ips}"
   master_port_names = "${module.topology.master_port_names}"
   bootstrap_ip      = "${module.topology.bootstrap_port_ip}"

--- a/data/data/openstack/service/main.tf
+++ b/data/data/openstack/service/main.tf
@@ -200,8 +200,8 @@ $ORIGIN ${var.cluster_domain}.
                                 3600       ; minimum (1 hour)
                                 )
 
-${length(var.lb_floating_ip) == 0 ? "" : "api  IN  A  ${var.lb_floating_ip}"}
-${length(var.lb_floating_ip) == 0 ? "" : "*.apps  IN  A  ${var.lb_floating_ip}"}
+${length(var.lb_floating_ip) == 0 ? "api  IN  A  ${var.service_port_ip}" : "api  IN  A  ${var.lb_floating_ip}"}
+${length(var.lb_floating_ip) == 0 ? "*.apps  IN  A  ${var.service_port_ip}" : "*.apps  IN  A  ${var.lb_floating_ip}"}
 
 bootstrap.${var.cluster_domain}  IN  A  ${var.bootstrap_ip}
 ${replace(join("\n", formatlist("%s  IN  A %s", var.master_port_names, var.master_ips)), "port-", "")}

--- a/data/data/openstack/service/variables.tf
+++ b/data/data/openstack/service/variables.tf
@@ -31,7 +31,12 @@ variable "flavor_name" {
 
 variable "service_port_id" {
   type        = "string"
-  description = "The subnet ID for the bootstrap node."
+  description = "The subnet ID for the service node."
+}
+
+variable "service_port_ip" {
+  type        = "string"
+  description = "The subnet IP for the service node."
 }
 
 variable "master_ips" {

--- a/data/data/openstack/topology/outputs.tf
+++ b/data/data/openstack/topology/outputs.tf
@@ -2,6 +2,10 @@ output "service_port_id" {
   value = "${openstack_networking_port_v2.service_port.id}"
 }
 
+output "service_port_ip" {
+  value = "${openstack_networking_port_v2.service_port.all_fixed_ips[0]}"
+}
+
 output "bootstrap_port_id" {
   value = "${openstack_networking_port_v2.bootstrap_port.id}"
 }


### PR DESCRIPTION
We used to set the API entry in the DNS to point only to the floating
IP. We should set it to the internal IP if a fIP for the API service
doesn't exist.

The deployment should be able to move forward even in a scenario like
this.