### PR TITLE
Switch api ELBs to /readyz for healthz checks

### DIFF
--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -46,7 +46,7 @@ resource "aws_lb_target_group" "api_internal" {
     interval            = 10
     port                = 6443
     protocol            = "HTTPS"
-    path                = "/healthz"
+    path                = "/readyz"
   }
 }
 
@@ -68,7 +68,7 @@ resource "aws_lb_target_group" "api_external" {
     interval            = 10
     port                = 6443
     protocol            = "HTTPS"
-    path                = "/healthz"
+    path                = "/readyz"
   }
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/openshift/origin/pull/22322.

Goal: make the ELB notice termination of kube-apiserver early in order to have time to take the node out of the loop.

`/healthz` in contrast to `/readyz` only fails when the pod was actually gone, not when the termination process (which now takes 30+ seconds) has been started.

Prerequisite: https://github.com/openshift/origin/pull/22322