### PR TITLE
release: Allow release image to be directly substituted into binary

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -35,10 +35,6 @@ const (
 	ignitionUser         = "core"
 )
 
-var (
-	defaultReleaseImage = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
-)
-
 // bootstrapTemplateData is the data to use to replace values in bootstrap
 // template files.
 type bootstrapTemplateData struct {
@@ -174,10 +170,17 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig) (*bootst
 		etcdEndpoints[i] = fmt.Sprintf("https://etcd-%d.%s:2379", i, installConfig.ClusterDomain())
 	}
 
-	releaseImage := defaultReleaseImage
+	var releaseImage string
 	if ri, ok := os.LookupEnv("OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"); ok && ri != "" {
 		logrus.Warn("Found override for ReleaseImage. Please be warned, this is not advised")
 		releaseImage = ri
+	} else {
+		var err error
+		releaseImage, err = defaultReleaseImage()
+		if err != nil {
+			return nil, err
+		}
+		logrus.Debugf("Using internal constant for release image %s", releaseImage)
 	}
 
 	return &bootstrapTemplateData{

--- a/pkg/asset/ignition/bootstrap/release_image.go
+++ b/pkg/asset/ignition/bootstrap/release_image.go
@@ -1,0 +1,54 @@
+package bootstrap
+
+import (
+	"fmt"
+	"strings"
+)
+
+// This file handles correctly identifying the default release image, which is expected to be
+// replaced in the binary post-compile after being extracted from a payload. The expected modification is:
+//
+// 1. Extract a release binary from the installer image referenced within the release image
+// 2. Identify the release image pull spec, add a NUL terminator byte (0x00) to the end, calculate length
+// 3. Length must be less than 300 bytes
+// 4. Search through the installer binary looking for `\x00_RELEASE_IMAGE_LOCATION_\x00<PADDING_TO_LENGTH>`
+//    where padding is the ASCII character X and length is the total length of the image
+// 5. Overwrite that chunk of the bytes if found, otherwise return error.
+//
+// On start the installer examines the constant and if it has been modified from the default the installer
+// will use that image.
+
+var (
+	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
+	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
+	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
+	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
+	// location without having to rebuild the source.
+	defaultReleaseImagePadded = "\x00_RELEASE_IMAGE_LOCATION_\x00XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\x00"
+	defaultReleaseImagePrefix = "\x00_RELEASE_IMAGE_LOCATION_\x00"
+	defaultReleaseImageLength = len(defaultReleaseImagePadded)
+)
+
+// defaultReleaseImage abstracts how the binary loads the default release payload. We want to lock the binary
+// to the
+func defaultReleaseImage() (string, error) {
+	if strings.HasPrefix(defaultReleaseImagePadded, defaultReleaseImagePrefix) {
+		// the defaultReleaseImagePadded constant hasn't been altered in the binary, fall back to the default
+		return defaultReleaseImageOriginal, nil
+	}
+	nullTerminator := strings.IndexByte(defaultReleaseImagePadded, '\x00')
+	if nullTerminator == -1 {
+		// the binary has been altered, but we didn't find a null terminator within the constant which is an error
+		return "", fmt.Errorf("release image location was replaced but without a null terminator before %d bytes", defaultReleaseImageLength)
+	}
+	if nullTerminator > len(defaultReleaseImagePadded) {
+		// the binary has been altered, but the null terminator is *longer* than the constant encoded in the binary
+		return "", fmt.Errorf("release image location contains no null-terminator and constant is corrupted")
+	}
+	pullspec := defaultReleaseImagePadded[:nullTerminator]
+	if len(pullspec) == 0 {
+		// the binary has been altered, but the replaced image is empty which is incorrect
+		return "", fmt.Errorf("release image location is empty, this binary was incorrectly generated")
+	}
+	return pullspec, nil
+}


### PR DESCRIPTION
As part of our release process we build container images for installer
that are added to the release image (which has a cryptographic
relationship to the images it contains, giving strong integrity). A
consumer should be able to download and install a locked installer
binary that uses the payload. However, we would prefer to not
rebuild the binary outside of the image, but instead have:

1. a source for the binary from the payload
2. the binary be locked to the payload it comes from

This commit allows a build system above the payload to extract the
installer binary for linux from the image (other platforms later)
and perform a replacement on the binary itself, patching:

```
_RELEASE_IMAGE_LOCATION_XXXXXXXXXXX
```

with

```
quay.io/openshift/ocp-release:v4.0\x00
```

without requiring a recompilation of the binary. The internal code
checks the constant and verifies bounds (panicking if necessary)
and then returns the updated constant. This allows a simpler
replacement process to customize a binary for both external use
and offline use that is locked to a payload.

Chose this over a few other options:

1. rebuilding outside the payload (loses reproducibility)
2. not locking payload (loses simplicity for test and users)

Steps after this:

1. `oc` can stream back either this binary or a tar from a payload with the proper locking
2. release-controller can serve that
3. ART creates the tar as the last step in the promotion flow and sends it to the mirror

/assign @wking