### PR TITLE
Re-add support for trunk ports

### DIFF
--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -45,7 +45,8 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	var machines []machineapi.Machine
 	for idx := int64(0); idx < total; idx++ {
 		az := ""
-		provider, err := provider(clusterID, platform, mpool, osImage, az, role, userDataSecret)
+		trunk := config.Platform.OpenStack.TrunkSupport
+		provider, err := provider(clusterID, platform, mpool, osImage, az, role, userDataSecret, trunk)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
@@ -77,7 +78,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	return machines, nil
 }
 
-func provider(clusterID string, platform *openstack.Platform, mpool *openstack.MachinePool, osImage string, az string, role, userDataSecret string) (*openstackprovider.OpenstackProviderSpec, error) {
+func provider(clusterID string, platform *openstack.Platform, mpool *openstack.MachinePool, osImage string, az string, role, userDataSecret string, trunk string) (*openstackprovider.OpenstackProviderSpec, error) {
 
 	return &openstackprovider.OpenstackProviderSpec{
 		TypeMeta: metav1.TypeMeta{
@@ -111,8 +112,17 @@ func provider(clusterID string, platform *openstack.Platform, mpool *openstack.M
 				Name: fmt.Sprintf("%s-%s", clusterID, role),
 			},
 		},
-		// TODO(flaper87): Trunk support missing. Need to add it back
+		Trunk: trunkSupportBoolean(trunk),
 	}, nil
+}
+
+func trunkSupportBoolean(trunkSupport string) (result bool) {
+	if trunkSupport == "1" {
+		result = true
+	} else {
+		result = false
+	}
+	return
 }
 
 // ConfigMasters sets the PublicIP flag and assigns a set of load balancers to the given machines

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -32,7 +32,8 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	// TODO(flaper87): Add support for availability zones
 	var machinesets []*clusterapi.MachineSet
 	az := ""
-	provider, err := provider(clusterID, platform, mpool, osImage, az, role, userDataSecret)
+	trunk := config.Platform.OpenStack.TrunkSupport
+	provider, err := provider(clusterID, platform, mpool, osImage, az, role, userDataSecret, trunk)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create provider")
 	}


### PR DESCRIPTION
This PR adds back the support to create machines and machinesets
with trunk support enabled.