### PR TITLE
cmd/openshift-install/create: Log progressing messages

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -352,6 +352,11 @@ func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
 						cov1helpers.FindStatusCondition(cv.Status.Conditions, configv1.OperatorFailing).Message)
 					return false, nil
 				}
+				if cov1helpers.IsStatusConditionTrue(cv.Status.Conditions, configv1.OperatorProgressing) {
+					logrus.Debugf("Still waiting for the cluster to initialize: %v",
+						cov1helpers.FindStatusCondition(cv.Status.Conditions, configv1.OperatorProgressing).Message)
+					return false, nil
+				}
 			}
 			logrus.Debug("Still waiting for the cluster to initialize...")
 			return false, nil


### PR DESCRIPTION
Like:

```
Working towards 4.0.0-0.alpha-2019-03-18-091023: 64% complete
```

These seem to advance slowly, but having slowly-changing information about progress is better than having no information ;).  And with this change, we will pass along more detailed progress information if/when the cluster-version operator adds it.