### PR TITLE
pkg/destroy/aws: Add deleteEC2NetworkInterfaceByVPC

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -782,6 +782,9 @@ func deleteEC2SecurityGroup(client *ec2.EC2, id string, logger logrus.FieldLogge
 		GroupIds: []*string{aws.String(id)},
 	})
 	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidGroup.NotFound" {
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -760,7 +760,7 @@ func deleteEC2RouteTablesByVPC(client *ec2.EC2, vpc string, logger logrus.FieldL
 		},
 		func(results *ec2.DescribeRouteTablesOutput, lastPage bool) bool {
 			for _, table := range results.RouteTables {
-				lastError := deleteEC2RouteTableObject(client, table, logger.WithField("table", *table.RouteTableId))
+				lastError = deleteEC2RouteTableObject(client, table, logger.WithField("table", *table.RouteTableId))
 				if lastError != nil {
 					lastError = errors.Wrapf(lastError, "deleting EC2 route table %s", *table.RouteTableId)
 					logger.Info(lastError)
@@ -1254,7 +1254,8 @@ func deleteIAMRole(client *iam.IAM, roleARN arn.ARN, logger logrus.FieldLogger) 
 		&iam.ListInstanceProfilesForRoleInput{RoleName: &name},
 		func(results *iam.ListInstanceProfilesForRoleOutput, lastPage bool) bool {
 			for _, profile := range results.InstanceProfiles {
-				parsed, lastError := arn.Parse(*profile.Arn)
+				var parsed arn.ARN
+				parsed, lastError = arn.Parse(*profile.Arn)
 				if lastError != nil {
 					lastError = errors.Wrap(lastError, "parse ARN for IAM instance profile")
 					logger.Info(lastError)
@@ -1320,7 +1321,7 @@ func deleteIAMUser(client *iam.IAM, id string, logger logrus.FieldLogger) error 
 		&iam.ListAccessKeysInput{UserName: &id},
 		func(results *iam.ListAccessKeysOutput, lastPage bool) bool {
 			for _, key := range results.AccessKeyMetadata {
-				_, lastError := client.DeleteAccessKey(&iam.DeleteAccessKeyInput{
+				_, lastError = client.DeleteAccessKey(&iam.DeleteAccessKeyInput{
 					UserName:    &id,
 					AccessKeyId: key.AccessKeyId,
 				})


### PR DESCRIPTION
We've been explicitly creating and tagging network interfaces since 4fcdc1cb (#1361).  But sometimes Terraform errors halt creation between creation and tagging, leading to destroy loops like:

```
...
time="2019-03-18T09:57:08-07:00" level=debug msg="search for and delete matching resources by tag in us-east-1 matching aws.Filter{\"openshiftClusterID\":\"null\"}"
time="2019-03-18T09:57:08-07:00" level=debug msg="search for and delete matching resources by tag in us-east-1 matching aws.Filter{\"kubernetes.io/cluster/ci-op-7dc8l67n-28622-nxrw2\":\"owned\"}"
time="2019-03-18T09:57:09-07:00" level=debug msg="deleting arn:aws:ec2:us-east-1:460538899914:dhcp-options/dopt-07f625baad68c14fe: DependencyViolation: The dhcpOptions 'dopt-07f625baad68c14fe' has dependencies and cannot be deleted.\n\tstatus code: 400, request id: 627395f8-0be9-4908-9059-9ef52613799c"
time="2019-03-18T09:57:11-07:00" level=debug msg="deleting arn:aws:ec2:us-east-1:460538899914:security-group/sg-0cdb3da1fb4ade884: DependencyViolation: resource sg-0cdb3da1fb4ade884 has a dependent object\n\tstatus code: 400, request id: 9dcc1f38-9d50-46fe-a3b6-e546bbf57c07"
time="2019-03-18T09:57:16-07:00" level=debug msg="deleting arn:aws:ec2:us-east-1:460538899914:vpc/vpc-04bde0fe7f82b58d1: DependencyViolation: The vpc 'vpc-04bde0fe7f82b58d1' has dependencies and cannot be deleted.\n\tstatus code: 400, request id: 49ac66fe-b72c-4edb-ac29-001e350338ab"
time="2019-03-18T09:57:16-07:00" level=debug msg="search for IAM roles"
time="2019-03-18T09:57:17-07:00" level=debug msg="search for IAM users"
time="2019-03-18T09:57:18-07:00" level=debug msg="search for and delete matching resources by tag in us-east-1 matching aws.Filter{\"openshiftClusterID\":\"null\"}"
time="2019-03-18T09:57:18-07:00" level=debug msg="search for and delete matching resources by tag in us-east-1 matching aws.Filter{\"kubernetes.io/cluster/ci-op-7dc8l67n-28622-nxrw2\":\"owned\"}"
time="2019-03-18T09:57:20-07:00" level=debug msg="deleting arn:aws:ec2:us-east-1:460538899914:dhcp-options/dopt-07f625baad68c14fe: DependencyViolation: The dhcpOptions 'dopt-07f625baad68c14fe' has dependencies and cannot be deleted.\n\tstatus code: 400, request id: 3cb61be5-4d46-49c2-9407-b19d160c2f66"
time="2019-03-18T09:57:21-07:00" level=debug msg="deleting arn:aws:ec2:us-east-1:460538899914:security-group/sg-0cdb3da1fb4ade884: DependencyViolation: resource sg-0cdb3da1fb4ade884 has a dependent object\n\tstatus code: 400, request id: f9264377-392e-4f46-9882-f39890bb81c6"
time="2019-03-18T09:57:29-07:00" level=debug msg="deleting arn:aws:ec2:us-east-1:460538899914:vpc/vpc-04bde0fe7f82b58d1: DependencyViolation: The vpc 'vpc-04bde0fe7f82b58d1' has dependencies and cannot be deleted.\n\tstatus code: 400, request id: a1b7aa8d-5a2a-4c74-a425-6cba0d0e5f2b"
time="2019-03-18T09:57:29-07:00" level=debug msg="search for IAM roles"
time="2019-03-18T09:57:29-07:00" level=debug msg="search for IAM users"
...
```

where the tagged security group is blocked by an untagged network interface.

With this pull request, we add network interfaces to the set of resource types that belong to VPCs and which need not be tagged to get deleted.  We don't need to worry about shared resources within cluster-owned VPCs, so the lack of tagging is not a problem in that respect.

I've also added two orthogonal fixup commits for other issues that I turned up when seeding `deleteEC2NetworkInterfaceByVPC` from our existing `deleteEC2*ByVPC` helpers.  I can split those out into separate pull requests if it makes review easier.