### PR TITLE
asset/targets: add JournalCertKey to ignition-configs target for UPI troubleshooting

### DIFF
--- a/pkg/asset/targets/targets.go
+++ b/pkg/asset/targets/targets.go
@@ -54,6 +54,7 @@ var (
 		&machine.Master{},
 		&machine.Worker{},
 		&bootstrap.Bootstrap{},
+		&tls.JournalCertKey{},
 		&cluster.Metadata{},
 	}
 


### PR DESCRIPTION
UPI based installs are recommended to invoke `create ignition-configs` to get the necessary assets for bootstrapping the cluster.

JournalCertKey is a useful asset to debug any bootstrap node errors on UPI like AWS.

/cc @openshift/installer @cuppett 