### PR TITLE
bootstrap: Work around systemd-journal-gateway DynamicUser=yes

### DIFF
--- a/data/data/bootstrap/systemd/units/chown-gatewayd-key.service
+++ b/data/data/bootstrap/systemd/units/chown-gatewayd-key.service
@@ -1,0 +1,15 @@
+# In RHEL8 the service uses DynamicUser=yes; we need to work both ways, so hence
+# we hack this by adding the user if it doesn't exist and chown the file, rather
+# than doing it in Ignition.
+# https://github.com/openshift/installer/pull/1445
+[Unit]
+Description=Change ownership of journal-gatewayd.key
+Before=systemd-journal-gatewayd.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "if ! getent passwd systemd-journal-gateway &>/dev/null; then useradd -r systemd-journal-gateway; fi && chown systemd-journal-gateway: /opt/openshift/tls/journal-gatewayd.{crt,key}"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
In RHEL8 journald switched to `DynamicUser=yes`, we can't reference
the user at Ignition time.  Let's hack around this by adding a fixed
version of the user and doing the chown.