### PR TITLE
upi/vsphere: support rhcos-latest template

### DIFF
--- a/upi/vsphere/machine/variables.tf
+++ b/upi/vsphere/machine/variables.tf
@@ -20,15 +20,11 @@ variable "resource_pool_id" {
   type = "string"
 }
 
-variable "datastore_id" {
+variable "datastore" {
   type = "string"
 }
 
-variable "network_id" {
-  type = "string"
-}
-
-variable "vm_template_id" {
+variable "network" {
   type = "string"
 }
 
@@ -42,4 +38,12 @@ variable "extra_user_names" {
 
 variable "extra_user_password_hashes" {
   type = "list"
+}
+
+variable "datacenter_id" {
+  type = "string"
+}
+
+variable "template" {
+  type = "string"
 }

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -1,8 +1,3 @@
-locals {
-  network_prefix = "${element(split("/", var.machine_cidr), 1)}"
-  gateway        = "${cidrhost(var.machine_cidr,1)}"
-}
-
 provider "vsphere" {
   user                 = "${var.vsphere_user}"
   password             = "${var.vsphere_password}"
@@ -12,26 +7,6 @@ provider "vsphere" {
 
 data "vsphere_datacenter" "dc" {
   name = "${var.vsphere_datacenter}"
-}
-
-data "vsphere_compute_cluster" "compute_cluster" {
-  name          = "${var.vsphere_cluster}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
-}
-
-data "vsphere_datastore" "datastore" {
-  name          = "${var.vsphere_datastore}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
-}
-
-data "vsphere_network" "network" {
-  name          = "${var.vm_network}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
-}
-
-data "vsphere_virtual_machine" "template" {
-  name          = "${var.vm_template}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
 module "resource_pool" {
@@ -49,9 +24,10 @@ module "bootstrap" {
   instance_count   = "${var.bootstrap_complete ? 0 : 1}"
   ignition_url     = "${var.bootstrap_ignition_url}"
   resource_pool_id = "${module.resource_pool.pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
-  network_id       = "${data.vsphere_network.network.id}"
-  vm_template_id   = "${data.vsphere_virtual_machine.template.id}"
+  datastore        = "${var.vsphere_datastore}"
+  network          = "${var.vm_network}"
+  datacenter_id    = "${data.vsphere_datacenter.dc.id}"
+  template         = "${var.vm_template}"
   cluster_domain   = "${var.cluster_domain}"
 
   extra_user_names           = ["${var.extra_user_names}"]
@@ -65,9 +41,10 @@ module "control_plane" {
   instance_count   = "${var.control_plane_instance_count}"
   ignition         = "${var.control_plane_ignition}"
   resource_pool_id = "${module.resource_pool.pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
-  network_id       = "${data.vsphere_network.network.id}"
-  vm_template_id   = "${data.vsphere_virtual_machine.template.id}"
+  datastore        = "${var.vsphere_datastore}"
+  network          = "${var.vm_network}"
+  datacenter_id    = "${data.vsphere_datacenter.dc.id}"
+  template         = "${var.vm_template}"
   cluster_domain   = "${var.cluster_domain}"
 
   extra_user_names           = ["${var.extra_user_names}"]
@@ -81,9 +58,10 @@ module "compute" {
   instance_count   = "${var.compute_instance_count}"
   ignition         = "${var.compute_ignition}"
   resource_pool_id = "${module.resource_pool.pool_id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
-  network_id       = "${data.vsphere_network.network.id}"
-  vm_template_id   = "${data.vsphere_virtual_machine.template.id}"
+  datastore        = "${var.vsphere_datastore}"
+  network          = "${var.vm_network}"
+  datacenter_id    = "${data.vsphere_datacenter.dc.id}"
+  template         = "${var.vm_template}"
   cluster_domain   = "${var.cluster_domain}"
 
   extra_user_names           = ["${var.extra_user_names}"]

--- a/upi/vsphere/terraform.tfvars.example
+++ b/upi/vsphere/terraform.tfvars.example
@@ -40,10 +40,11 @@ vsphere_datacenter = "dc1"
 // Name of the vSphere data store to use for the VMs. The dev cluster uses "nvme-ds1".
 vsphere_datastore = "nvme-ds1"
 
-// CIDR block for the VMs. The dev cluster uses "139.178.89.192/26".
-machine_cidr = "139.178.89.192/26"
-
-// Name of the VM template to clone to create VMs for the cluster. The dev cluster has a template named "rchos-davis-no-ig".
+// Name of the VM template to clone to create VMs for the cluster. The dev cluster has templates named "rhcos-latest" and "rhcos-davis-no-ig".
+// The "rhcos-latest" template is a recent version of rhcos. There is an issue running the journald gateway on the bootstrap machine with the rhel8 rchos.
+// If you want to use the latest rhcos, you should remove the systemd-journal-gatewayd systemd units from the bootstrap ignition config for the
+// time being.
+// The "rhcos-davis-no-ig" template is a rhel7 rchos.
 vm_template = "rhcos-davis-no-ig"
 
 // URL of the bootstrap ignition. This needs to be publicly accessible so that the bootstrap machine can pull the ignition.

--- a/upi/vsphere/variables.tf
+++ b/upi/vsphere/variables.tf
@@ -72,11 +72,6 @@ variable "cluster_domain" {
   description = "The base DNS zone to add the sub zone to."
 }
 
-variable "machine_cidr" {
-  type        = "string"
-  description = "This is the public network netmask."
-}
-
 /////////
 // Bootstrap machine variables
 /////////


### PR DESCRIPTION
Add support for rchos template that use thin provisioning.

Update terraform.tfvars.example to give details about the rchos-latest
template.

This also removed some unused variables and commented out code around setting static IP addresses for the machines. Static IP addresses are not working yet.