### PR TITLE
docs/user/aws/create-infrastructure-errors: Start documenting Terraform errors

### DIFF
--- a/docs/user/aws/create-infrastructure-errors.md
+++ b/docs/user/aws/create-infrastructure-errors.md
@@ -1,0 +1,26 @@
+# Errors with Infrastructure Creation
+
+This document describes errors with infrastructure creation on AWS.
+For more troubleshooting suggestions, look [here](../troubleshooting.md).
+
+## Instances time out with `pending`
+
+The error looks like:
+
+```
+aws_instance.master.1: Error launching source instance: timeout while waiting for state to become 'success' (timeout: 30s)
+```
+
+or:
+
+```
+aws_instance.master.1: Error waiting for instance (i-0eb201c7376b6f94e) to become ready: timeout while waiting for state to become 'running' (last state: 'pending', timeout: 10m0s)"
+```
+
+This happens when AWS does not have the capacity in the target availability zone to fulfill the instance request.
+There may be multiple datacenters within a given availability zone, and the limitation may be restricted to a subset of datacenters within the affected zone.
+You probably want to destroy the failed cluster, after which you have a few choices:
+
+* You can try a fresh install with the same parameters, hoping that the capacity has become available or that you happen to be assigned to an unaffected datacenter.
+* You can configure a different region or availability zone(s) to find sufficient capacity.
+* You can configure a different instance type to find sufficient capacity.

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -87,9 +87,13 @@ Error signing CSR provided in request from agent: error parsing profile: invalid
 
 This is safe to ignore and merely indicates that the etcd bootstrapping is still in progress. etcd makes use of the CSR APIs provided by Kubernetes to issue and rotate its TLS assets, but these facilities aren't available before etcd has formed quorum. In order to break this dependency loop, a CSR service is run on the bootstrap node which only signs CSRs for etcd. When the Kubelet attempts to go through its TLS bootstrap, it is initially denied because the service it is communicating with only respects CSRs from etcd. After etcd starts and the control plane begins bootstrapping, an approver is scheduled and the Kubelet CSR requests will succeed.
 
-### Installer Fails to Create Resources
+### Installer Fails to Create Infrastructure Resources
 
 The easiest way to get more debugging information from the installer is to check the log file (`.openshift_install.log`) in the install directory. Regardless of the logging level specified, the installer will write its logs in case they need to be inspected retroactively.
+
+If the installer fails with `Error: Error applying plan` in the `Creating infrastructure resources...` phase, there are per-platform pages discussing the detailed error messages:
+
+- [AWS](aws/create-infrastructure-errors.md)
 
 ### Installer Fails to Initialize the Cluster
 


### PR DESCRIPTION
To help users decode Terraform's messages without doing that for them in Go.  This particular message is from [here][1].

[1]: https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.0/6066/build-log.txt