### PR TITLE
images/installer: add image that can be used to instal UPI platforms

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -1,0 +1,35 @@
+# This Dockerfile is a used by CI to test UPI platforms for OpenShift Installer
+# It builds an image containing binaries like jq, terraform, awscli, oc, etc. to allow bringing up UPI infrastructure.
+# It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
+
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN hack/build.sh
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:cli /usr/bin/oc /bin/oc
+COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
+
+## epel-release is required for jq
+## gettext is required for envsubst
+RUN yum install --setopt=tsflags=nodocs -y \
+    epel-release \
+    gettext \
+    openssh-clients && \
+    yum update -y && \
+    yum install --setopt=tsflags=nodocs -y \
+    unzip gzip jq awscli util-linux && \
+    yum clean all && rm -rf /var/cache/yum/*
+
+ENV TERRAFORM_VERSION=0.11.11
+RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin/
+
+RUN mkdir /output && chown 1000:1000 /output
+USER 1000:1000
+ENV PATH /bin
+ENV HOME /output
+WORKDIR /output
+


### PR DESCRIPTION
It builds an image containing binaries like jq, terraform, awscli, oc, etc. to allow bringing up UPI infrastructure.
It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.

```console
$ docker run --user 0 -ti --entrypoint /bin/bash abhinavdahiya/upi-installer:latest
bash-4.2# oc
OpenShift Client

This client helps you develop, build, deploy, and run your applications on any OpenShift or Kubernetes compatible
platform. It also includes the administrative commands for managing a cluster under the 'adm' subcommand.

To create a new application, login to your server and then run new-app:

  oc login https://mycluster.mycompany.com
  oc new-app centos/ruby-25-centos7~https://github.com/sclorg/ruby-ex.git
  oc logs -f bc/ruby-ex

This will create an application based on the Docker image 'centos/ruby-25-centos7' that builds the source code from
GitHub. A build will start automatically, push the resulting image to the registry, and a deployment will roll that
change out in your project.

Once your application is deployed, use the status, describe, and get commands to see more about the created components:

  oc status
  oc describe deploymentconfig ruby-ex
  oc get pods

To make this application visible outside of the cluster, use the expose command on the service we just created to create
a 'route' (which will connect your application over the HTTP port to a public domain name).

  oc expose svc/ruby-ex
  oc status

You should now see the URL the application can be reached at.

To see the full list of commands supported, run 'oc --help'.
bash-4.2# terraform
Usage: terraform [-version] [-help] <command> [args]

The available commands for execution are listed below.
The most common, useful commands are shown first, followed by
less common or more advanced commands. If you're just getting
started with Terraform, stick with the common commands. For the
other commands, please read the help and docs before usage.

Common commands:
    apply              Builds or changes infrastructure
    console            Interactive console for Terraform interpolations
    destroy            Destroy Terraform-managed infrastructure
    env                Workspace management
    fmt                Rewrites config files to canonical format
    get                Download and install modules for the configuration
    graph              Create a visual graph of Terraform resources
    import             Import existing infrastructure into Terraform
    init               Initialize a Terraform working directory
    output             Read an output from a state file
    plan               Generate and show an execution plan
    providers          Prints a tree of the providers used in the configuration
    push               Upload this Terraform module to Atlas to run
    refresh            Update local state file against real resources
    show               Inspect Terraform state or plan
    taint              Manually mark a resource for recreation
    untaint            Manually unmark a resource as tainted
    validate           Validates the Terraform files
    version            Prints the Terraform version
    workspace          Workspace management

All other commands:
    debug              Debug output management (experimental)
    force-unlock       Manually unlock the terraform state
    state              Advanced state management
bash-4.2# opens
openshift-install  openssl
bash-4.2# opens
openshift-install  openssl
bash-4.2# opens
openshift-install  openssl
bash-4.2# opens
openshift-install  openssl
bash-4.2# openshift-install
Creates OpenShift clusters

Usage:
  openshift-install [command]

Available Commands:
  completion                   Outputs shell completions for the openshift-install command
  create                       Create part of an OpenShift cluster
  destroy                      Destroy part of an OpenShift cluster
  graph                        Outputs the internal dependency graph for installer
  help                         Help about any command
  user-provided-infrastructure Entry-points for user-provided infrastructure
  version                      Print version information

Flags:
      --dir string         assets directory (default ".")
  -h, --help               help for openshift-install
      --log-level string   log level (e.g. "debug | info | warn | error") (default "info")

Use "openshift-install [command] --help" for more information about a command.
bash-4.2# jq
jq - commandline JSON processor [version 1.5]
Usage: jq [options] <jq filter> [file...]

        jq is a tool for processing JSON inputs, applying the
        given filter to its JSON text inputs and producing the
        filter's results as JSON on standard output.
        The simplest filter is ., which is the identity filter,
        copying jq's input to its output unmodified (except for
        formatting).
        For more advanced filters see the jq(1) manpage ("man jq")
        and/or https://stedolan.github.io/jq

        Some of the options include:
         -c             compact instead of pretty-printed output;
         -n             use `null` as the single input value;
         -e             set the exit status code based on the output;
         -s             read (slurp) all inputs into an array; apply filter to it;
         -r             output raw strings, not JSON texts;
         -R             read raw strings, not JSON texts;
         -C             colorize JSON;
         -M             monochrome (don't colorize JSON);
         -S             sort keys of objects on output;
         --tab  use tabs for indentation;
         --arg a v      set variable $a to value <v>;
         --argjson a v  set variable $a to JSON value <v>;
         --slurpfile a f        set variable $a to an array of JSON texts read from <f>;
        See the manpage for more options.
bash-4.2# aws
usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: too few arguments
bash-4.2# ls /var/lib/openshift-install/upi/
aws  metal  vsphere
```

/cc @wking 