### PR TITLE
 rhcos: Bump bootimage to 410.8.20190325.0

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-RHCOS_BUILD_NAME="${RHCOS_BUILD_NAME:-400.7.20190306.0}"
+RHCOS_BUILD_NAME="${RHCOS_BUILD_NAME:-410.8.20190325.0}"
 
 # shellcheck disable=SC2068
 version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}

--- a/pkg/rhcos/builds.go
+++ b/pkg/rhcos/builds.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// DefaultChannel is the default RHCOS channel for the cluster.
-	DefaultChannel = "maipo"
+	DefaultChannel = "ootpa"
 
 	// buildName is the name of the build in the channel that will be picked up
 	// empty string means the first one in the build list (latest) will be used


### PR DESCRIPTION

The "bootimage" is the one we use before pivoting.  Bump this
so we don't need to support RHEL7 anymore even there.

This rolls in #1423