### PR TITLE
pkg/types/aws/validation: Require machine-pool zones in platform region

### DIFF
--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -1,14 +1,23 @@
 package validation
 
 import (
+	"fmt"
+	"strings"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/aws"
 )
 
 // ValidateMachinePool checks that the specified machine pool is valid.
-func ValidateMachinePool(p *aws.MachinePool, fldPath *field.Path) field.ErrorList {
+func ValidateMachinePool(platform *aws.Platform, p *aws.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	for i, zone := range p.Zones {
+		if !strings.HasPrefix(zone, platform.Region) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("zones").Index(i), zone, fmt.Sprintf("Zone not in configured region (%s)", platform.Region)))
+		}
+	}
+
 	if p.IOPS < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("iops"), p.IOPS, "Storage IOPS must be positive"))
 	}

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -55,7 +55,7 @@ func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("region"), p.Region, validRegionValues))
 	}
 	if p.DefaultMachinePlatform != nil {
-		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
+		allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}
 	return allErrs
 }

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -23,38 +23,39 @@ func validMachinePool() *types.MachinePool {
 func TestValidateMachinePool(t *testing.T) {
 	cases := []struct {
 		name     string
+		platform *types.Platform
 		pool     *types.MachinePool
-		platform string
 		valid    bool
 	}{
 		{
 			name:     "minimal",
+			platform: &types.Platform{AWS: &aws.Platform{Region: "us-east-1"}},
 			pool:     validMachinePool(),
-			platform: "aws",
 			valid:    true,
 		},
 		{
-			name: "missing replicas",
+			name:     "missing replicas",
+			platform: &types.Platform{AWS: &aws.Platform{Region: "us-east-1"}},
 			pool: func() *types.MachinePool {
 				p := validMachinePool()
 				p.Replicas = nil
 				return p
 			}(),
-			platform: "aws",
-			valid:    false,
+			valid: false,
 		},
 		{
-			name: "invalid replicas",
+			name:     "invalid replicas",
+			platform: &types.Platform{AWS: &aws.Platform{Region: "us-east-1"}},
 			pool: func() *types.MachinePool {
 				p := validMachinePool()
 				p.Replicas = pointer.Int64Ptr(-1)
 				return p
 			}(),
-			platform: "aws",
-			valid:    false,
+			valid: false,
 		},
 		{
-			name: "valid aws",
+			name:     "valid aws",
+			platform: &types.Platform{AWS: &aws.Platform{Region: "us-east-1"}},
 			pool: func() *types.MachinePool {
 				p := validMachinePool()
 				p.Platform = types.MachinePoolPlatform{
@@ -62,11 +63,11 @@ func TestValidateMachinePool(t *testing.T) {
 				}
 				return p
 			}(),
-			platform: "aws",
-			valid:    true,
+			valid: true,
 		},
 		{
-			name: "invalid aws",
+			name:     "invalid aws",
+			platform: &types.Platform{AWS: &aws.Platform{Region: "us-east-1"}},
 			pool: func() *types.MachinePool {
 				p := validMachinePool()
 				p.Platform = types.MachinePoolPlatform{
@@ -78,11 +79,11 @@ func TestValidateMachinePool(t *testing.T) {
 				}
 				return p
 			}(),
-			platform: "aws",
-			valid:    false,
+			valid: false,
 		},
 		{
-			name: "valid libvirt",
+			name:     "valid libvirt",
+			platform: &types.Platform{Libvirt: &libvirt.Platform{}},
 			pool: func() *types.MachinePool {
 				p := validMachinePool()
 				p.Platform = types.MachinePoolPlatform{
@@ -90,11 +91,11 @@ func TestValidateMachinePool(t *testing.T) {
 				}
 				return p
 			}(),
-			platform: "libvirt",
-			valid:    true,
+			valid: true,
 		},
 		{
-			name: "valid openstack",
+			name:     "valid openstack",
+			platform: &types.Platform{OpenStack: &openstack.Platform{}},
 			pool: func() *types.MachinePool {
 				p := validMachinePool()
 				p.Platform = types.MachinePoolPlatform{
@@ -102,11 +103,11 @@ func TestValidateMachinePool(t *testing.T) {
 				}
 				return p
 			}(),
-			platform: "openstack",
-			valid:    true,
+			valid: true,
 		},
 		{
-			name: "mis-matched platform",
+			name:     "mis-matched platform",
+			platform: &types.Platform{Libvirt: &libvirt.Platform{}},
 			pool: func() *types.MachinePool {
 				p := validMachinePool()
 				p.Platform = types.MachinePoolPlatform{
@@ -114,11 +115,11 @@ func TestValidateMachinePool(t *testing.T) {
 				}
 				return p
 			}(),
-			platform: "libvirt",
-			valid:    false,
+			valid: false,
 		},
 		{
-			name: "multiple platforms",
+			name:     "multiple platforms",
+			platform: &types.Platform{AWS: &aws.Platform{Region: "us-east-1"}},
 			pool: func() *types.MachinePool {
 				p := validMachinePool()
 				p.Platform = types.MachinePoolPlatform{
@@ -127,13 +128,12 @@ func TestValidateMachinePool(t *testing.T) {
 				}
 				return p
 			}(),
-			platform: "aws",
-			valid:    false,
+			valid: false,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateMachinePool(tc.pool, field.NewPath("test-path"), tc.platform).ToAggregate()
+			err := ValidateMachinePool(tc.platform, tc.pool, field.NewPath("test-path")).ToAggregate()
 			if tc.valid {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
In the excitement of a zone outage, this one [bit me][1], leading to [errors like][2]:

```
ERROR  * module.masters.aws_network_interface.master[1]: key "us-east-1c" does not exist in map var.az_to_subnet_id in:
ERROR
ERROR ${var.az_to_subnet_id[var.availability_zones[count.index]]}
ERROR  * module.masters.aws_network_interface.master[2]: key "us-east-1d" does not exist in map var.az_to_subnet_id in:
ERROR
ERROR ${var.az_to_subnet_id[var.availability_zones[count.index]]}
ERROR  * module.masters.aws_network_interface.master[0]: key "us-east-1a" does not exist in map var.az_to_subnet_id in:
ERROR
ERROR ${var.az_to_subnet_id[var.availability_zones[count.index]]}
ERROR  * module.bootstrap.var.subnet_id: key "us-east-1a" does not exist in map module.vpc.az_to_public_subnet_id in:
ERROR
ERROR ${module.vpc.az_to_public_subnet_id[var.aws_master_availability_zones[0]]}
```

With this commit, we require zones in the configured region before getting into Terraform, and we describe the mismatch with words that are hopefully more obvious to jumpy users ;).

[1]: https://github.com/openshift/release/pull/3204#issuecomment-475750104
[2]: https://github.com/openshift/release/pull/3204#issue-263731522