### PR TITLE
fix: Gopkg.lock after running dep ensure on pkg/terraform/exec

### DIFF
--- a/pkg/terraform/exec/Gopkg.lock
+++ b/pkg/terraform/exec/Gopkg.lock
@@ -1326,7 +1326,6 @@
     "github.com/hashicorp/logutils",
     "github.com/hashicorp/terraform/command",
     "github.com/hashicorp/terraform/helper/logging",
-    "github.com/hashicorp/terraform/version",
     "github.com/mitchellh/cli",
   ]
   solver-name = "gps-cdcl"


### PR DESCRIPTION
See linked issue for details.

fixes #1471