### PR TITLE
upi/vsphere: create apps dns entry

### DIFF
--- a/upi/vsphere/route53/main.tf
+++ b/upi/vsphere/route53/main.tf
@@ -61,3 +61,13 @@ resource "aws_route53_record" "etcd_cluster" {
   name    = "_etcd-server-ssl._tcp"
   records = ["${formatlist("0 10 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)}"]
 }
+
+resource "aws_route53_record" "ingress" {
+  count = "${var.compute_instance_count == "0" ? "0" : "1"}"
+
+  type    = "A"
+  ttl     = "60"
+  zone_id = "${aws_route53_zone.cluster.zone_id}"
+  name    = "*.apps.${var.cluster_domain}"
+  records = ["${var.compute_ips}"]
+}


### PR DESCRIPTION
Create wildcard `*.apps` for VSphere UPI so that authentication and console operators would work