### PR TITLE
Seed the random number generator

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"flag"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -27,6 +29,8 @@ func main() {
 	// to log anything. Nobody likes you, glog. Go away.
 	flag.CommandLine.Parse([]string{})
 	flag.CommandLine.Set("stderrthreshold", "4")
+
+	rand.Seed(time.Now().UTC().UnixNano())
 
 	if len(os.Args) > 0 {
 		base := filepath.Base(os.Args[0])


### PR DESCRIPTION
Ensure operations requiring random data get it, calls
to randomMACAddress() were providing the same mac address
in multiple environments and in some cases getting the same
IP address if not isolated.