### PR TITLE
BUG 1670700: data/data/bootstrap: set metric-ca flags for kube-etcd-signer-server

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -228,12 +228,15 @@ podman run \
 	serve \
 	--cacrt=/opt/openshift/tls/etcd-client-ca.crt \
 	--cakey=/opt/openshift/tls/etcd-client-ca.key \
+	--metric-cacrt=/opt/openshift/tls/etcd-metric-signer.crt \
+	--metric-cakey=/opt/openshift/tls/etcd-metric-signer.key \
 	--servcrt=/opt/openshift/tls/apiserver.crt \
 	--servkey=/opt/openshift/tls/apiserver.key \
 	--address=0.0.0.0:6443 \
 	--csrdir=/tmp \
 	--peercertdur=26280h \
-	--servercertdur=26280h
+	--servercertdur=26280h \
+	--metriccertdur=26280h
 
 echo "Waiting for etcd cluster..."
 


### PR DESCRIPTION
This PR adds metric-signer CA's to kube-etcd-signer-server as part of voyage to etcd metrics by default. The eventual result is the etcd static pod procuring TLS certs with a separate chain of trust vs `Peer` and `Server` .