### PR TITLE
pkg/asset/machines/worker: Default to MachineSets only where we need them

### DIFF
--- a/docs/user/aws/limits.md
+++ b/docs/user/aws/limits.md
@@ -30,20 +30,20 @@ additional clusters and deployed workloads.
 
 ## Elastic IP (EIP)
 
-By default, the installer distributes control-plane and compute machines across [all availability zones within a region][availability-zones] to provision the cluster in a highly available configuration.
+By default, the installer distributes control-plane and compute machines across [availability zones within a region][availability-zones] to provision the cluster in a highly available configuration.
 Please see [this map][az-map] for a current region map with availability zone count.
 We recommend selecting regions with 3 or more availability zones.
 You can [provide an install-config](../overview.md#multiple-invocations) to [configure](customization.md) the installer to use specific zones to override that default.
 
-The installer creates a public and private subnet for each configured availability zone.
-In each private subnet, a separate [NAT Gateway][nat-gateways] is created and requires a separate [EC2-VPC Elastic IP (EIP)][elastic-ip].
+The installer creates a public and private subnet for each availability zone that will contain machines.
+For each private subnet, a separate [NAT Gateway][nat-gateways] is created and requires a separate [EC2-VPC Elastic IP (EIP)][elastic-ip].
 The default limit of 5 is sufficient for a single cluster, unless you have configured your cluster to use more than five zones.
 For multiple clusters, a higher limit will likely be required (and will certainly be required to support more than five clusters, even if they are each single-zone clusters).
 
 ### Example: Using North Virginia (us-east-1)
 
-North Virginia (us-east-1) has six availablity zones, so a higher limit is required unless you configure your cluster to use fewer zones.
-To support the default, all-zone installation, please submit a limit increase for VPC Elastic IPs similar to the following in the support dashboard (to create more than one cluster, a higher limit will be necessary):
+North Virginia (us-east-1) has six availablity zones, so you will need to request a higher limit if you configure your cluster to use all of those zones.
+You can submit a limit increase for VPC Elastic IPs similar to the following in the support dashboard (to create more than one cluster, a higher limit may be necessary):
 
 ![Increase Elastic IP limit in AWS](images/support_increase_elastic_ip.png)
 


### PR DESCRIPTION
Builds on #1481, I'll rebase after that lands.

And not for additional zones.  This will keep us from consuming more NAT gateways and associated EIPs than we need, once subsequent work ties those resources to Machine(Set) consumption.  This means that pools where `replicas` is unset or zero will receive no MachineSets (unless the user explicitly configured `zones` for the pool), but creating MachineSets later on is something we want to be easy anyway, so I don't see a need to require the installer to inject a template MachineSet into the cluster.

The "In each private subnet" -> "For each private subnet" change is because the NAT gateways currently live *in* the public subnet, but their purpose is to handle egress from machines in the private subnets.

Spun off from #1481, where this change [was contentious][1].  The difference is mostly for folks who run `openshift-install create cluster` without providing an `install-config.yaml`.  With this approach, that would work in us-east-1, although the users will have to add additional zone infra later if they decide they actually do want something in, say, us-east-1e.  With the approach taken in #1481, those users will need to get their EIP limits bumped (or change to using an `install-config.yaml`) before the install will go through, but they won't have to worry about adding more zone infra on day-2.  Personally, I'd rather prioritize out-of-the-box success, and leave it to folks who for some reason need many zones to explicitly configure them (or set them up as day-2 operations).

[1]: https://github.com/openshift/installer/pull/1481#issuecomment-477657591