### PR TITLE
upi/vsphere: add dns for control plane and compute hostnames

### DIFF
--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -75,4 +75,5 @@ module "dns" {
   cluster_domain    = "${var.cluster_domain}"
   bootstrap_ip      = "${var.bootstrap_complete ? "" : var.bootstrap_ip}"
   control_plane_ips = "${var.control_plane_ips}"
+  compute_ips       = "${var.compute_ips}"
 }

--- a/upi/vsphere/route53/main.tf
+++ b/upi/vsphere/route53/main.tf
@@ -71,3 +71,23 @@ resource "aws_route53_record" "ingress" {
   name    = "*.apps.${var.cluster_domain}"
   records = ["${var.compute_ips}"]
 }
+
+resource "aws_route53_record" "control_plane_nodes" {
+  count = "${length(var.control_plane_ips)}"
+
+  type    = "A"
+  ttl     = "60"
+  zone_id = "${aws_route53_zone.cluster.zone_id}"
+  name    = "control-plane-${count.index}.${var.cluster_domain}"
+  records = ["${var.control_plane_ips[count.index]}"]
+}
+
+resource "aws_route53_record" "compute_nodes" {
+  count = "${length(var.compute_ips)}"
+
+  type    = "A"
+  ttl     = "60"
+  zone_id = "${aws_route53_zone.cluster.zone_id}"
+  name    = "compute-${count.index}.${var.cluster_domain}"
+  records = ["${var.compute_ips[count.index]}"]
+}

--- a/upi/vsphere/route53/variables.tf
+++ b/upi/vsphere/route53/variables.tf
@@ -11,6 +11,10 @@ variable "control_plane_ips" {
   type = "list"
 }
 
+variable "compute_ips" {
+  type = "list"
+}
+
 variable "base_domain" {
   description = "The base domain used for public records."
   type        = "string"

--- a/upi/vsphere/variables.tf
+++ b/upi/vsphere/variables.tf
@@ -124,3 +124,8 @@ variable "compute_instance_count" {
 variable "compute_ignition" {
   type = "string"
 }
+
+variable "compute_ips" {
+  type    = "list"
+  default = []
+}


### PR DESCRIPTION
Add DNS records for the control plane and compute hostnames so that they are resolvable from within the cluster.