### PR TITLE
machines: fix machine asset for None, VSphere platform

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -134,8 +134,6 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		}
 		openstack.ConfigMasters(machines, clusterID.InfraID)
 	case nonetypes.Name, vspheretypes.Name:
-		// machines are managed directly by users
-		return nil
 	default:
 		return fmt.Errorf("invalid Platform")
 	}
@@ -208,10 +206,6 @@ func (m *Master) Load(f asset.FileFetcher) (found bool, err error) {
 	fileList, err := f.FetchByPattern(filepath.Join(directory, masterMachineFileNamePattern))
 	if err != nil {
 		return true, err
-	}
-
-	if len(fileList) == 0 {
-		return true, errors.Errorf("master machine manifests are required if you also provide %s", m.UserDataFile.Filename)
 	}
 
 	m.MachineFiles = fileList


### PR DESCRIPTION
for each machinepool (install-config), we have 3 things that make it up: <RHCOS only>
- userdata-secret with stub ignition that can be used to start machines...
- machineconfigs with configuration like sshAuthorizedKeys, hyperthreading options
- machine-api resources..

for UPI based platforms the asset must include:
- userdata-secret,  because it is harmless allows users to fetch the ignition configs from inside their cluster (can be used for automation in machine-api supported UPIs)
- machineconfigs, these are always required.