### PR TITLE
fix: user platform validation expects sorted list of platforms

### DIFF
--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -82,6 +82,7 @@ func (a *platform) queryUserForPlatform() (platform string, err error) {
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 				choice := ans.(string)
+				sort.Strings(types.PlatformNames)
 				i := sort.SearchStrings(types.PlatformNames, choice)
 				if i == len(types.PlatformNames) || types.PlatformNames[i] != choice {
 					return errors.Errorf("invalid platform %q", choice)


### PR DESCRIPTION
if the list of platform is not sorted, the validation will fail, as the index returned by SearchString will not match the index of the platform string found, and the equality check will fail.