### PR TITLE
types: move vsphere out of tui

### DIFF
--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -25,7 +25,6 @@ var (
 	// platforms presented to the user in the interactive wizard.
 	PlatformNames = []string{
 		aws.Name,
-		vsphere.Name,
 	}
 	// HiddenPlatformNames is a slice with all the
 	// hidden-but-supported platform names. This list isn't presented
@@ -33,6 +32,7 @@ var (
 	HiddenPlatformNames = []string{
 		none.Name,
 		openstack.Name,
+		vsphere.Name,
 	}
 )
 


### PR DESCRIPTION
PR 1498 [1] include vsphere in the platfoms that show up in TUI.

```console
$ ./openshift-install create cluster
? SSH Public Key /home/adahiya/.ssh/id_rsa_aws.pub
? Platform  [Use arrows to move, type to filter]
> aws
  vsphere
```

all UPI platforms are install-config only. These should not show up in TUI for installer.

[1]: https://github.com/openshift/installer/pull/1458

/cc @staebler 