### PR TITLE
cmd/openshift-install/create: remove templates

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -65,16 +65,6 @@ var (
 		assets: targetassets.Manifests,
 	}
 
-	manifestTemplatesTarget = target{
-		name: "Manifest templates",
-		command: &cobra.Command{
-			Use:   "manifest-templates",
-			Short: "Generates the unrendered Kubernetes manifest templates",
-			Long:  "",
-		},
-		assets: targetassets.ManifestTemplates,
-	}
-
 	ignitionConfigsTarget = target{
 		name: "Ignition Configs",
 		command: &cobra.Command{
@@ -124,7 +114,7 @@ var (
 		assets: targetassets.Cluster,
 	}
 
-	targets = []target{installConfigTarget, manifestTemplatesTarget, manifestsTarget, ignitionConfigsTarget, clusterTarget}
+	targets = []target{installConfigTarget, manifestsTarget, ignitionConfigsTarget, clusterTarget}
 )
 
 func newCreateCmd() *cobra.Command {


### PR DESCRIPTION
The templates target didn't quite end up being what we had in mind. To
avoid confusing users, this target is being removed from the set of
available targets. It may be reintroduced later.

This is what the help text looks like after this change:

    Available Commands:
      cluster          Create an OpenShift cluster
      ignition-configs Generates the Ignition Config asset
      install-config   Generates the Install Config asset
      manifests        Generates the Kubernetes manifests