### PR TITLE
cmd: Report locked release image pull spec in `version` command

### DIFF
--- a/cmd/openshift-install/version.go
+++ b/cmd/openshift-install/version.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/version"
 )
 
@@ -23,6 +24,9 @@ func runVersionCmd(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s %s\n", os.Args[0], version.Raw)
 	if version.Commit != "" {
 		fmt.Printf("built from commit %s\n", version.Commit)
+	}
+	if image, err := bootstrap.DefaultReleaseImage(); err == nil {
+		fmt.Printf("release image %s\n", image)
 	}
 	return nil
 }

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -175,7 +175,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig) (*bootst
 		releaseImage = ri
 	} else {
 		var err error
-		releaseImage, err = defaultReleaseImage()
+		releaseImage, err = DefaultReleaseImage()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/asset/ignition/bootstrap/release_image.go
+++ b/pkg/asset/ignition/bootstrap/release_image.go
@@ -29,9 +29,11 @@ var (
 	defaultReleaseImageLength = len(defaultReleaseImagePadded)
 )
 
-// defaultReleaseImage abstracts how the binary loads the default release payload. We want to lock the binary
-// to the
-func defaultReleaseImage() (string, error) {
+// DefaultReleaseImage abstracts how the binary loads the default release payload. We want to lock the binary
+// to the pull spec of the payload we test it with, and since a payload contains an installer image we can't
+// know that at build time. Instead, we make it possible to replace the release string after build via a
+// known constant in the binary.
+func DefaultReleaseImage() (string, error) {
 	if strings.HasPrefix(defaultReleaseImagePadded, defaultReleaseImagePrefix) {
 		// the defaultReleaseImagePadded constant hasn't been altered in the binary, fall back to the default
 		return defaultReleaseImageOriginal, nil


### PR DESCRIPTION
When the installer is updated to have the locked release version
the version command should show that info to assist in debugging.

Identified while testing the transformation - I wanted to see what
the binary was locked to as the bootstrap code would see it.

Related to https://github.com/openshift/origin/pull/22439