### PR TITLE
image: Add a production "installer-artifacts" image for Mac binary

### DIFF
--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -1,0 +1,10 @@
+# This Dockerfile builds an image containing the Mac version of the installer layered
+# on top of the Linux installer image.
+
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN SKIP_GENERATION=y GOOS=darwin GOARCH=amd64 hack/build.sh
+
+FROM registry.svc.ci.openshift.org/ocp/4.0:installer
+COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac/openshift-install


### PR DESCRIPTION
To ensure the payload is reproducible, we will include images for both cli
and installer commands for non linux platforms that allow users to get the
correct tools to install the release image. Since the installer binary is
not small and we don't want to take the cost to pull it on each node when
in use from hive, create a new image installer-artifacts that layers on top
of installer (inheriting the default installer Linux binary) and places the
darwin binary into
/usr/share/openshift/mac/openshift-install. This directory structure is
kept deliberately simple for end users - if we do in the future need to
deal with multi-arch concerns we'll do that at a higher level and in
practice neither 32bit nor arm will be "supported" as part of the core
distro yet.

The dockerfile matches the desired final form from the release team
(Dockerfile.rhel) and will be used in both CI and publishing.

Used by https://github.com/openshift/origin/pull/22439