### PR TITLE
Bug 1659970: data/aws/route53: Block private Route 53 zone on public record

### DIFF
--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -13,6 +13,8 @@ resource "aws_route53_zone" "int" {
   tags = "${merge(map(
     "Name", "${var.cluster_id}-int",
   ), var.tags)}"
+
+  depends_on = ["aws_route53_record.api_external"]
 }
 
 resource "aws_route53_record" "api_external" {


### PR DESCRIPTION
We've been using the tagged private zone to look up the public zone since the non-Terraform destroy code landed in a8fc89bec1 (#324).  When there's an existing cluster with a given domain, that can lead to false-positive removals [like][1]:

1. Cluster 1 comes up like usual.
2. Cluster 2 creates a private zone.
3. Cluster 2 dies when its public record conflicts with cluster 1 (new since d1c17b7f83, #1442).
4. 'destroy cluster' on cluster 2's metadata.json removes cluster 2 resources (good) and cluster 1's public record (bad).

With the explicit dependency in this commit, we ensure that we only ever create the private zone after we have successfully claimed ownership of the public record.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1659970#c7