### PR TITLE
BUG 1670700: data/data/bootstrap: add --etcd-metric-ca to MCO bootstrap

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -174,6 +174,7 @@ then
 		"${MACHINE_CONFIG_OPERATOR_IMAGE}" \
 		bootstrap \
 			--etcd-ca=/assets/tls/etcd-client-ca.crt \
+			--etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
 			--root-ca=/assets/tls/root-ca.crt \
 			--kube-ca=/assets/tls/kube-ca.crt \
 			--config-file=/assets/manifests/cluster-config.yaml \


### PR DESCRIPTION
This PR is the last commit required to complete chicken/egg adding `--etcd-metric-ca` flag to MCO.

Flag was added to MCO via: https://github.com/openshift/machine-config-operator/pull/590