### PR TITLE
Modify kubeadmin usage message, admins should not use kubeadmin via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Example output:
 ```sh
 INFO Waiting 10m0s for the openshift-console route to be created...
 INFO Install complete!
-INFO Run 'export KUBECONFIG=/path/to/auth/kubeconfig' to manage the cluster with 'oc', the OpenShift CLI.
-INFO The cluster is ready when 'oc login -u kubeadmin -p 5char-5char-5char-5char' succeeds (wait a few minutes).
+INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/path/to/installer/auth/kubeconfig'
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.${CLUSTER_NAME}.${BASE_DOMAIN}:6443
 INFO Login to the console with user: kubeadmin, password: 5char-5char-5char-5char
 ```

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -427,8 +427,7 @@ func logComplete(directory, consoleURL string) error {
 		return err
 	}
 	logrus.Info("Install complete!")
-	logrus.Infof("Run 'export KUBECONFIG=%s' to manage the cluster with 'oc', the OpenShift CLI.", kubeconfig)
-	logrus.Infof("The cluster is ready when 'oc login -u kubeadmin -p %s' succeeds (wait a few minutes).", pw)
+	logrus.Infof("To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=%s'", kubeconfig)
 	logrus.Infof("Access the OpenShift web-console here: %s", consoleURL)
 	logrus.Infof("Login to the console with user: kubeadmin, password: %s", pw)
 	return nil

--- a/docs/user/aws/install.md
+++ b/docs/user/aws/install.md
@@ -34,10 +34,9 @@ INFO Destroying the bootstrap resources...
 INTO Waiting up to 30m0s for the cluster at https://api.test.example.com:6443 to initialize...
 INFO Waiting up to 10m0s for the openshift-console route to be created...
 INFO Install complete!
-INFO Run 'export KUBECONFIG=/home/user/auth/kubeconfig' to manage the cluster with 'oc', the OpenShift CLI.
-INFO The cluster is ready when 'oc login -u kubeadmin -p XXXX' succeeds (wait a few minutes).
+INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/user/auth/kubeconfig'
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.test.example.com
-INFO Login to the console with user: kubeadmin, password: XXXX
+INFO Login to the console with user: kubeadmin, password: 5char-5char-5char-5char
 ```
 
 ### Running Cluster

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -188,10 +188,9 @@ It will print the console URL, username and password and you should be able to g
 
 ```
 INFO Install complete!
-INFO Run 'export KUBECONFIG=/home/thomas/go/src/github.com/openshift/installer/ostest/auth/kubeconfig' to manage the cluster with 'oc', the OpenShift CLI.
-INFO The cluster is ready when 'oc login -u kubeadmin -p siDhh-STMU3-hWDPW-jM4co' succeeds (wait a few minutes).
+INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/path/to/installer/auth/kubeconfig'
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.ostest.shiftstack.com
-INFO Login to the console with user: kubeadmin, password: siDhh-STMU3-hWDPW-jM4co
+INFO Login to the console with user: kubeadmin, password: 5char-5char-5char-5char
 ```
 
 ## Using an External Load Balancer


### PR DESCRIPTION
The kubeadmin user should only be used to temporarily access the
console, and only until an admin configures a proper Identity Provider.
There is no reason to login as the kubeadmin user via CLI.  If oauth
is broken in a cluster, an admin can still access via CLI as system:admin,
but will not be able to access via kube:admin.

@enj https://jira.coreos.com/browse/AUTH-293