### PR TITLE
image: Asset generation is required

### DIFF
--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -4,7 +4,8 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-RUN SKIP_GENERATION=y GOOS=darwin GOARCH=amd64 hack/build.sh
+RUN go generate ./data && \
+    SKIP_GENERATION=y GOOS=darwin GOARCH=amd64 hack/build.sh
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:installer
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac/openshift-install


### PR DESCRIPTION
Assets are required to build, but hack/build-go.sh cannot handle
cross architecture asset generation. Explicitly generate before
invoking the script.

Failed when CI tried to build:

```
+ go build ... ./cmd/openshift-install
data/unpack.go:12:15: undefined: Assets
```

in https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_release/3321/rehearse-3321-pull-ci-openshift-installer-master-images/1