### PR TITLE
upi/metal: update the instance location and size

### DIFF
--- a/upi/metal/bootstrap/packet.tf
+++ b/upi/metal/bootstrap/packet.tf
@@ -1,6 +1,6 @@
 resource "packet_device" "bootstrap" {
   hostname         = "${var.cluster_id}-bootstrap"
-  plan             = "t1.small.x86"
+  plan             = "c1.small.x86"
   facilities       = ["${var.packet_facility}"]
   operating_system = "custom_ipxe"
   ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=bootstrap"

--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -98,7 +98,7 @@ resource "packet_device" "masters" {
   count            = "${var.master_count}"
   hostname         = "master-${count.index}.${var.cluster_domain}"
   plan             = "c1.small.x86"
-  facilities       = ["${local.packet_facility}"]
+  facilities       = ["any"]
   operating_system = "custom_ipxe"
   ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=master"
   billing_cycle    = "hourly"
@@ -111,7 +111,7 @@ resource "packet_device" "workers" {
   count            = "${var.worker_count}"
   hostname         = "worker-${count.index}.${var.cluster_domain}"
   plan             = "c1.small.x86"
-  facilities       = ["${local.packet_facility}"]
+  facilities       = ["any"]
   operating_system = "custom_ipxe"
   ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=worker"
   billing_cycle    = "hourly"
@@ -133,7 +133,7 @@ module "bootstrap" {
 
   cluster_id = "${var.cluster_id}"
 
-  packet_facility   = "${local.packet_facility}"
+  packet_facility   = "any"
   packet_project_id = "${var.packet_project_id}"
 }
 

--- a/upi/metal/outputs.tf
+++ b/upi/metal/outputs.tf
@@ -3,13 +3,9 @@ output "master_ips" {
 }
 
 output "worker_ips" {
-  value = ["${local.master_public_ipv4}"]
+  value = ["${local.worker_public_ipv4}"]
 }
 
 output "bootstrap_ip" {
   value = "${module.bootstrap.device_ip}"
-}
-
-output "sos_consoles" {
-  value = "${zipmap(concat(list(module.bootstrap.device_hostname), packet_device.masters.*.hostname, packet_device.workers.*.hostname), formatlist("ssh %s@sos.%s.packet.net", concat(list(module.bootstrap.device_id), packet_device.masters.*.id, packet_device.workers.*.id), local.packet_facility))}"
 }


### PR DESCRIPTION
Bootstrap node is failing to uncompress the bios image with `t1.small` capacity.
and also packet seems to be failing to deploy servers in SJC1. Using `any` allows terraform to create the servers in any available datacenter.

/cc @wking @sdodson 