### PR TITLE
pkg/asset: fix client cert key name

### DIFF
--- a/pkg/asset/tls/aggregator.go
+++ b/pkg/asset/tls/aggregator.go
@@ -161,7 +161,7 @@ func (a *AggregatorClientCertKey) Generate(dependencies asset.Parents) error {
 		Validity:     ValidityOneDay,
 	}
 
-	return a.SignedCertKey.Generate(cfg, ca, "apiserver-proxy", DoNotAppendParent)
+	return a.SignedCertKey.Generate(cfg, ca, "aggregator-client", DoNotAppendParent)
 }
 
 // Name returns the human-friendly name of the asset.


### PR DESCRIPTION
When working on the Ignition v2s3 move, we noticed that we were
generating a duplicate asset. That one had the same name
"apiserver-proxy". The correct name _should_ be "aggregator-client".
This may just have been a copy/paste error.
We're not sure how it worked _before_ because what this is doing is overwriting an already written file (the other asset wrote that already and this piece of code is re-writing it with the same name)

Signed-off-by: Antonio Murdaca <runcom@linux.com>