### PR TITLE
BUG 1695860: upi/aws: Removing hardcoded names on TargetGroup resources

### DIFF
--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -131,7 +131,6 @@ Resources:
   ExternalApiTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: ExternalApiTargetGroup
       Port: 6443
       Protocol: TCP
       TargetType: ip
@@ -156,7 +155,6 @@ Resources:
   InternalApiTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: InternalApiTargetGroup
       Port: 6443
       Protocol: TCP
       TargetType: ip
@@ -181,7 +179,6 @@ Resources:
   InternalServiceTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: InternalServiceTargetGroup
       Port: 22623
       Protocol: TCP
       TargetType: ip


### PR DESCRIPTION
Names for ELBv2 TargetGroup names must be unique per region [1]. With the name hardcoded in this file, it doesn't allow more than one of these stacks to be created in a region (per account). We desire multiple clusters created this way per region.

[1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-name