### PR TITLE
images/installer: add matchbox provider to upi image

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -7,12 +7,14 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
+RUN GOBIN=$(pwd)/bin go get -u github.com/coreos/terraform-provider-matchbox
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:cli as cli
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=builder /go/src/github.com/openshift/installer/bin/terraform-provider-matchbox /bin/terraform-provider-matchbox
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
 
 ## epel-release is required for jq


### PR DESCRIPTION
CI for bare-matal uses [`terraform-provider-matchbox`](https://github.com/coreos/terraform-provider-matchbox) and since it is not part of the official providers for terraform it cannot be downloaded on the fly.

This builds and include the binary for terraform-provider-matchox in the upi image.

/cc @wking @sdodson 