### PR TITLE
BUG 1686943: asset/store: purge consumed assets for all targeted assets at once

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -142,26 +142,7 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 			return errors.Wrap(err, "failed to create asset store")
 		}
 
-		for _, a := range targets {
-			err := assetStore.Fetch(a)
-			if err != nil {
-				err = errors.Wrapf(err, "failed to fetch %s", a.Name())
-			}
-
-			if err2 := asset.PersistToFile(a, directory); err2 != nil {
-				err2 = errors.Wrapf(err2, "failed to write asset (%s) to disk", a.Name())
-				if err != nil {
-					logrus.Error(err2)
-					return err
-				}
-				return err2
-			}
-
-			if err != nil {
-				return err
-			}
-		}
-		return nil
+		return assetStore.Fetch(targets...)
 	}
 
 	return func(cmd *cobra.Command, args []string) {

--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -2,9 +2,9 @@ package asset
 
 // Store is a store for the states of assets.
 type Store interface {
-	// Fetch retrieves the state of the given asset, generating it and its
+	// Fetch retrieves the state of the given assets, generating them and their
 	// dependencies if necessary.
-	Fetch(Asset) error
+	Fetch(...WritableAsset) error
 
 	// Destroy removes the asset from all its internal state and also from
 	// disk if possible.

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -71,14 +71,8 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 				t.Fatalf("failed to create asset store: %v", err)
 			}
 
-			for _, a := range tc.targets {
-				if err := assetStore.Fetch(a); err != nil {
-					t.Fatalf("failed to fetch %q: %v", a.Name(), err)
-				}
-
-				if err := asset.PersistToFile(a, tempDir); err != nil {
-					t.Fatalf("failed to write asset %q to disk: %v", a.Name(), err)
-				}
+			if err := assetStore.Fetch(tc.targets...); err != nil {
+				t.Fatalf("failed to fetch targets: %v", err)
 			}
 
 			newAssetStore, err := newStore(tempDir)


### PR DESCRIPTION
When the user of the asset store fetches an asset, all of the assets that the store thinks are on-disk are purged from the disk. When the user is fetching multiple assets, the behavior should be that
all of the fetched assets are retained on disk. However, if one of the fetched assets already existed on disk prior to the user fetching the assets, then that asset will be purged from the disk when the other assets are fetched.

For example, if the user runs the `create manifests` command, then the Common Manifests and the OpenShift Manifests assets are both fetched and written to disk. If the user then runs the `create manifests` command again, then the fetch of the OpenShift Manifests asset will cause the Common Manifests asset to be purged from the disk.

The changes in this commit modify the Fetch function so that it takes all of the assets being fetched at once instead of requiring the user of the asset store to call Fetch for each asset. This allows the asset store to make a more informed decision about which assets should be retained on disk and which  assets are eligible to be purged.

Additionally, the responsibility for persisting asset files to disk has been given to the asset store. The asset store is responsible for everything else related to the maintenance and lifetime of the asset files. Why should it not be responsible for persisting the asset files to disk as well?

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1686943