### PR TITLE
Reduce kube-apiserver ELB (un)healthy_threshold to be <= minimal server termination time

### DIFF
--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -41,8 +41,9 @@ resource "aws_lb_target_group" "api_internal" {
   ), var.tags)}"
 
   health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    # 2+1 times interval must be smaller than 35 sec the kube-apiserver waits
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
     interval            = 10
     port                = 6443
     protocol            = "HTTPS"
@@ -63,8 +64,9 @@ resource "aws_lb_target_group" "api_external" {
   ), var.tags)}"
 
   health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    # 2+1 times interval must be smaller than 35 sec the kube-apiserver waits
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
     interval            = 10
     port                = 6443
     protocol            = "HTTPS"


### PR DESCRIPTION
The kube-apiserver waits 35 sec to start termination. It will signal unreadiness via /readyz from the start of those 35 sec. The ELB has to notice this with its 10 sec interval pings. This means that in the worst case it takes `(unhealthy_threshold + 1) * interval` to take a target out of the loop. With the old setting this was 40 secs, more than the kube-apiserver guarantees to stay up (35 sec).