### PR TITLE
cmd/openshift-install/create: Drop addRouterCAToClusterCA

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -173,56 +171,6 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 			logrus.Fatal(err)
 		}
 	}
-}
-
-// addRouterCAToClusterCA adds router CA to cluster CA in kubeconfig
-func addRouterCAToClusterCA(config *rest.Config, directory string) (err error) {
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return errors.Wrap(err, "creating a Kubernetes client")
-	}
-
-	// Configmap may not exist. log and accept not-found errors with configmap.
-	caConfigMap, err := client.CoreV1().ConfigMaps("openshift-config-managed").Get("router-ca", metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logrus.Infof("router-ca resource not found in cluster, perhaps you are not using default router CA")
-			return nil
-		}
-		return errors.Wrap(err, "fetching router-ca configmap from openshift-config-managed namespace")
-	}
-
-	routerCrtBytes := []byte(caConfigMap.Data["ca-bundle.crt"])
-	kubeconfig := filepath.Join(directory, "auth", "kubeconfig")
-	kconfig, err := clientcmd.LoadFromFile(kubeconfig)
-	if err != nil {
-		return errors.Wrap(err, "loading kubeconfig")
-	}
-
-	if kconfig == nil || len(kconfig.Clusters) == 0 {
-		return errors.New("kubeconfig is missing expected data")
-	}
-
-	for _, c := range kconfig.Clusters {
-		clusterCABytes := c.CertificateAuthorityData
-		if len(clusterCABytes) == 0 {
-			return errors.New("kubeconfig CertificateAuthorityData not found")
-		}
-		certPool := x509.NewCertPool()
-		if !certPool.AppendCertsFromPEM(clusterCABytes) {
-			return errors.New("cluster CA found in kubeconfig not valid PEM format")
-		}
-		if !certPool.AppendCertsFromPEM(routerCrtBytes) {
-			return errors.New("ca-bundle.crt from router-ca configmap not valid PEM format")
-		}
-
-		newCA := append(routerCrtBytes, clusterCABytes...)
-		c.CertificateAuthorityData = newCA
-	}
-	if err := clientcmd.WriteToFile(*kconfig, kubeconfig); err != nil {
-		return errors.Wrap(err, "writing kubeconfig")
-	}
-	return nil
 }
 
 // FIXME: pulling the kubeconfig and metadata out of the root
@@ -440,10 +388,6 @@ func finish(ctx context.Context, config *rest.Config, directory string) error {
 
 	consoleURL, err := waitForConsole(ctx, config, rootOpts.dir)
 	if err != nil {
-		return err
-	}
-
-	if err = addRouterCAToClusterCA(config, rootOpts.dir); err != nil {
 		return err
 	}
 

--- a/cmd/openshift-install/upi.go
+++ b/cmd/openshift-install/upi.go
@@ -27,9 +27,7 @@ provides entry points to support the following workflow:
    until the bootstrap phase has completed.
 4. Destroy the bootstrap resources.
 5. Call 'user-provided-infrastructure finish' to wait until the
-   cluster finishes deploying its initial version.  This also
-   retrieves the router certificate authority from the cluster and
-   inserts it into the admin kubeconfig.`
+   cluster finishes deploying its initial version.`
 )
 
 func newUPICmd() *cobra.Command {
@@ -76,7 +74,7 @@ func newUPIBootstrapCompleteCmd() *cobra.Command {
 func newUPIFinishCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "finish",
-		Short: "Wait for the cluster to finish updating and update local resources",
+		Short: "Wait for the cluster to finish updating",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			ctx := context.Background()


### PR DESCRIPTION
This was added in 40335776f6 (#1242), where the motivation [was][1]:

>  With users created with an identity-provider, OAuth flow goes through router and router-ca is not trusted. This prohibits the user from using `oc login` from command line...

But the admin kubeconfig is already authenticated, so folks shouldn't be using `oc login` with that kubeconfig (more in dee6929c69, #1513).  That leaves us with no use case for this modification, and making the finish code watch-only sets us up to rename away from the user-provided-infrastructure subcommand.

CC @abhinavdahiya, @sallyom

[1]: https://github.com/openshift/installer/pull/1242#issue-252678381