### PR TITLE
aws: fix ICMP ACL

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -32,8 +32,8 @@ resource "aws_security_group_rule" "master_ingress_icmp" {
 
   protocol    = "icmp"
   cidr_blocks = ["${data.aws_vpc.cluster_vpc.cidr_block}"]
-  from_port   = 0
-  to_port     = 0
+  from_port   = -1
+  to_port     = -1
 }
 
 resource "aws_security_group_rule" "master_ingress_ssh" {

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -21,9 +21,9 @@ resource "aws_security_group_rule" "worker_ingress_icmp" {
   security_group_id = "${aws_security_group.worker.id}"
 
   protocol    = "icmp"
-  cidr_blocks = ["0.0.0.0/0"]
-  from_port   = 0
-  to_port     = 0
+  cidr_blocks = ["${data.aws_vpc.cluster_vpc.cidr_block}"]
+  from_port   = -1
+  to_port     = -1
 }
 
 resource "aws_security_group_rule" "worker_ingress_ssh" {


### PR DESCRIPTION
There was a typo in the rule that allowed icmp - it accidentally blocked all icmp.
    
Also, fix the ip block to match for both master and workers.

Fixes  https://bugzilla.redhat.com/show_bug.cgi?id=1689857