### PR TITLE
upi/vsphere: delay creation of control plane machines until etcd dns

### DIFF
--- a/upi/vsphere/README.md
+++ b/upi/vsphere/README.md
@@ -33,15 +33,18 @@ The bootstrap ignition config must be placed in a location that will be accessib
 5. Ensure that you have you AWS profile set and a region specified. The installation will use create AWS route53 resources for routing to the OpenShift cluster.
 
 6. Run `terraform apply -auto-approve`.
+This will reserve IP addresses for the VMs.
+
+7. Run `terraform apply -auto-approve`.
 This will create the OpenShift cluster
 
-7. Run `openshift-install upi bootstrap-complete`. Wait for the bootstrapping to complete.
+8. Run `openshift-install upi bootstrap-complete`. Wait for the bootstrapping to complete.
 
-8. Run `terraform apply -auto-approve -var 'bootstrap_complete=true'`.
+9. Run `terraform apply -auto-approve -var 'bootstrap_complete=true'`.
 This will destroy the bootstrap VM.
 
-9. Run `openshift-install upi finish`. Wait for the cluster install to finish.
+10. Run `openshift-install upi finish`. Wait for the cluster install to finish.
 
-10. Enjoy your new OpenShift cluster.
+11. Enjoy your new OpenShift cluster.
 
-11. Run `terraform destroy -auto-approve`.
+12. Run `terraform destroy -auto-approve`.

--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -1,0 +1,82 @@
+locals {
+  mask = "${element(split("/", var.machine_cidr), 1)}"
+  gw   = "${cidrhost(var.machine_cidr,1)}"
+
+  ignition_encoded = "data:text/plain;charset=utf-8;base64,${base64encode(var.ignition)}"
+}
+
+data "ignition_file" "hostname" {
+  count = "${var.instance_count}"
+
+  filesystem = "root"
+  path       = "/etc/hostname"
+  mode       = "420"
+
+  content {
+    content = "${var.name}-${count.index}.${var.cluster_domain}"
+  }
+}
+
+data "ignition_file" "static_ip" {
+  count = "${var.instance_count}"
+
+  filesystem = "root"
+  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+  mode       = "420"
+
+  content {
+    content = <<EOF
+TYPE=Ethernet
+BOOTPROTO=none
+NAME=eth0
+DEVICE=eth0
+ONBOOT=yes
+IPADDR=${local.ip_addresses[count.index]}
+PREFIX=${local.mask}
+GATEWAY=${local.gw}
+DNS1=8.8.8.8
+EOF
+  }
+}
+
+data "ignition_systemd_unit" "restart" {
+  count = "${var.instance_count}"
+
+  name = "restart.service"
+
+  content = <<EOF
+[Unit]
+ConditionFirstBoot=yes
+[Service]
+Type=idle
+ExecStart=/sbin/reboot
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+data "ignition_user" "extra_users" {
+  count = "${length(var.extra_user_names)}"
+
+  name          = "${var.extra_user_names[count.index]}"
+  password_hash = "${var.extra_user_password_hashes[count.index]}"
+}
+
+data "ignition_config" "ign" {
+  count = "${var.instance_count}"
+
+  append {
+    source = "${var.ignition_url != "" ? var.ignition_url : local.ignition_encoded}"
+  }
+
+  systemd = [
+    "${data.ignition_systemd_unit.restart.*.id[count.index]}",
+  ]
+
+  files = [
+    "${data.ignition_file.hostname.*.id[count.index]}",
+    "${data.ignition_file.static_ip.*.id[count.index]}",
+  ]
+
+  users = ["${data.ignition_user.extra_users.*.id}"]
+}

--- a/upi/vsphere/machine/ip.tf
+++ b/upi/vsphere/machine/ip.tf
@@ -1,0 +1,34 @@
+locals {
+  ip_addresses = ["${data.external.ip_address.*.result.ip_address}"]
+  ips_exist    = "${length(compact(local.ip_addresses)) == var.instance_count}"
+}
+
+data "external" "ip_address" {
+  count = "${var.instance_count}"
+
+  program = ["bash", "${path.module}/cidr_to_ip.sh"]
+
+  query = {
+    hostname   = "${var.name}-${count.index}.${var.cluster_domain}"
+    ipam       = "${var.ipam}"
+    ipam_token = "${var.ipam_token}"
+  }
+}
+
+resource "null_resource" "ip_address" {
+  count = "${var.instance_count}"
+
+  provisioner "local-exec" {
+    command = <<EOF
+echo '{"cidr":"${var.machine_cidr}","hostname":"${var.name}-${count.index}.${var.cluster_domain}","ipam":"${var.ipam}","ipam_token":"${var.ipam_token}"}' | ${path.module}/cidr_to_ip.sh
+EOF
+  }
+
+  provisioner "local-exec" {
+    when = "destroy"
+
+    command = <<EOF
+curl -s "http://${var.ipam}/api/removeHost.php?apiapp=address&apitoken=${var.ipam_token}&host=${var.name}-${count.index}.${var.cluster_domain}"
+EOF
+  }
+}

--- a/upi/vsphere/machine/output.tf
+++ b/upi/vsphere/machine/output.tf
@@ -1,3 +1,7 @@
 output "ip_addresses" {
-  value = "${data.external.ip_address.*.result.ip_address}"
+  value = ["${local.ip_addresses}"]
+}
+
+output "ips_exist" {
+  value = "${local.ips_exist}"
 }

--- a/upi/vsphere/machine/variables.tf
+++ b/upi/vsphere/machine/variables.tf
@@ -52,6 +52,10 @@ variable "template" {
   type = "string"
 }
 
+variable "machine_cidr" {
+  type = "string"
+}
+
 variable "ipam" {
   type = "string"
 }
@@ -60,6 +64,12 @@ variable "ipam_token" {
   type = "string"
 }
 
-variable "machine_cidr" {
-  type = "string"
+variable "dns_names" {
+  type    = "list"
+  default = []
+}
+
+variable "wait_for_dns_names" {
+  type    = "string"
+  default = "false"
 }

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -64,6 +64,9 @@ module "control_plane" {
 
   extra_user_names           = ["${var.extra_user_names}"]
   extra_user_password_hashes = ["${var.extra_user_password_hashes}"]
+
+  dns_names          = ["${module.dns.etcd_names}"]
+  wait_for_dns_names = "true"
 }
 
 module "compute" {
@@ -90,9 +93,12 @@ module "compute" {
 module "dns" {
   source = "./route53"
 
-  base_domain       = "${var.base_domain}"
-  cluster_domain    = "${var.cluster_domain}"
-  bootstrap_ips     = ["${module.bootstrap.ip_addresses}"]
-  control_plane_ips = ["${module.control_plane.ip_addresses}"]
-  compute_ips       = ["${module.compute.ip_addresses}"]
+  base_domain             = "${var.base_domain}"
+  cluster_domain          = "${var.cluster_domain}"
+  bootstrap_ips           = ["${module.bootstrap.ip_addresses}"]
+  bootstrap_ips_exist     = "${module.bootstrap.ips_exist}"
+  control_plane_ips       = ["${module.control_plane.ip_addresses}"]
+  control_plane_ips_exist = "${module.control_plane.ips_exist}"
+  compute_ips             = ["${module.compute.ip_addresses}"]
+  compute_ips_exist       = "${module.compute.ips_exist}"
 }

--- a/upi/vsphere/route53/main.tf
+++ b/upi/vsphere/route53/main.tf
@@ -20,6 +20,8 @@ resource "aws_route53_record" "name_server" {
 }
 
 resource "aws_route53_record" "api" {
+  count = "${var.bootstrap_ips_exist && var.control_plane_ips_exist ? 1 : 0}"
+
   type           = "A"
   ttl            = "60"
   zone_id        = "${aws_route53_zone.cluster.zone_id}"
@@ -33,7 +35,7 @@ resource "aws_route53_record" "api" {
 }
 
 resource "aws_route53_record" "etcd_a_nodes" {
-  count = "${length(var.control_plane_ips)}"
+  count = "${var.control_plane_ips_exist ? length(var.control_plane_ips) : 0}"
 
   type    = "A"
   ttl     = "60"
@@ -43,6 +45,8 @@ resource "aws_route53_record" "etcd_a_nodes" {
 }
 
 resource "aws_route53_record" "etcd_cluster" {
+  count = "${var.control_plane_ips_exist ? 1 : 0}"
+
   type    = "SRV"
   ttl     = "60"
   zone_id = "${aws_route53_zone.cluster.zone_id}"
@@ -51,6 +55,8 @@ resource "aws_route53_record" "etcd_cluster" {
 }
 
 resource "aws_route53_record" "ingress" {
+  count = "${var.compute_ips_exist ? 1 : 0}"
+
   type    = "A"
   ttl     = "60"
   zone_id = "${aws_route53_zone.cluster.zone_id}"
@@ -59,7 +65,7 @@ resource "aws_route53_record" "ingress" {
 }
 
 resource "aws_route53_record" "control_plane_nodes" {
-  count = "${length(var.control_plane_ips)}"
+  count = "${var.control_plane_ips_exist ? length(var.control_plane_ips) : 0}"
 
   type    = "A"
   ttl     = "60"
@@ -69,7 +75,7 @@ resource "aws_route53_record" "control_plane_nodes" {
 }
 
 resource "aws_route53_record" "compute_nodes" {
-  count = "${length(var.compute_ips)}"
+  count = "${var.compute_ips_exist ? length(var.compute_ips) : 0}"
 
   type    = "A"
   ttl     = "60"

--- a/upi/vsphere/route53/output.tf
+++ b/upi/vsphere/route53/output.tf
@@ -1,0 +1,3 @@
+output "etcd_names" {
+  value = ["${concat(aws_route53_record.etcd_a_nodes.*.fqdn)}"]
+}

--- a/upi/vsphere/route53/variables.tf
+++ b/upi/vsphere/route53/variables.tf
@@ -7,12 +7,24 @@ variable "bootstrap_ips" {
   type = "list"
 }
 
+variable "bootstrap_ips_exist" {
+  type = "string"
+}
+
 variable "control_plane_ips" {
   type = "list"
 }
 
+variable "control_plane_ips_exist" {
+  type = "string"
+}
+
 variable "compute_ips" {
   type = "list"
+}
+
+variable "compute_ips_exist" {
+  type = "string"
 }
 
 variable "base_domain" {


### PR DESCRIPTION
There is a problem with etcd where it does not become quorate when the
control plane machines are started prior to the etcd dns records being
set and propagated. These changes attempt to lessen the impact of that
problem by delaying the creation of the control plane machines until
after the etcd dns records are able to be resolved locally.

The ip address reservation has been changed so that the ip address
reservation is done by a resource instead of a data source. This
prevents ip addresses from being reserved when doing terraform plan
and destroy. The ip address query is still done by a data source,
since there is no way to get output from a null resource. And because
data sources are run before resources are created, the ip addresses
are not available on the first terraform apply. The user needs to
run terraform apply twice.

The machines module has also been refactored to separate the ignition
and ip address portions into their own separate files.