### PR TITLE
BUG 1686943: asset/store: include all assets to preserve when doing a fetch

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -143,7 +143,7 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 		}
 
 		for _, a := range targets {
-			err := assetStore.Fetch(a)
+			err := assetStore.Fetch(a, targets...)
 			if err != nil {
 				err = errors.Wrapf(err, "failed to fetch %s", a.Name())
 			}

--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -3,8 +3,9 @@ package asset
 // Store is a store for the states of assets.
 type Store interface {
 	// Fetch retrieves the state of the given asset, generating it and its
-	// dependencies if necessary.
-	Fetch(Asset) error
+	// dependencies if necessary. When purging consumed assets, none of the
+	// assets in assetsToPreserve will be purged.
+	Fetch(assetToFetch Asset, assetsToPreserve ...WritableAsset) error
 
 	// Destroy removes the asset from all its internal state and also from
 	// disk if possible.

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -72,7 +72,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 			}
 
 			for _, a := range tc.targets {
-				if err := assetStore.Fetch(a); err != nil {
+				if err := assetStore.Fetch(a, tc.targets...); err != nil {
 					t.Fatalf("failed to fetch %q: %v", a.Name(), err)
 				}
 
@@ -94,7 +94,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 			for _, a := range tc.targets {
 				name := a.Name()
 				newAsset := reflect.New(reflect.TypeOf(a).Elem()).Interface().(asset.WritableAsset)
-				if err := newAssetStore.Fetch(newAsset); err != nil {
+				if err := newAssetStore.Fetch(newAsset, tc.targets...); err != nil {
 					t.Fatalf("failed to fetch %q in new store: %v", a.Name(), err)
 				}
 				assetState := newAssetStore.assets[reflect.TypeOf(a)]


### PR DESCRIPTION
Pass in to the Fetch function all of the assets that should not be consumed when purging.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1686943