### PR TITLE
upi/vsphere: complete install-config.yaml example in README

### DIFF
--- a/upi/vsphere/README.md
+++ b/upi/vsphere/README.md
@@ -1,15 +1,25 @@
 1. Create an install-config.yaml.
-The machine CIDR for the dev cluster is 139.178.89.192/26.
+The following example uses the settings for the dev cluster.
 
 ```
 apiVersion: v1beta4
 baseDomain: devcluster.openshift.com
 metadata:
-  name: mstaeble
+  name: ${YOUR_OPENSHIFT_CLUSTER_NAME}
 networking:
   machineCIDR: "139.178.89.192/26"
 platform:
-  vsphere: {}
+  vsphere:
+    virtualCenters:
+    - name: vcsa.vmware.devcluster.openshift.com
+      username: ${YOUR_VSPHERE_USER}
+      password: ${YOUR_VSPHERE_PASSWORD}
+      datacenters:
+      - dc1
+    workspace:
+      defaultDatastore: nvme-ds1
+    scsiControllerType: pvscsi
+    publicNetwork: VM Network
 pullSecret: YOUR_PULL_SECRET
 sshKey: YOUR_SSH_KEY
 ```
@@ -18,15 +28,14 @@ sshKey: YOUR_SSH_KEY
 
 3. Fill out a terraform.tfvars file with the ignition configs generated.
 There is an example terraform.tfvars file in this directory named terraform.tfvars.example. The example file is set up for use with the dev cluster running at vcsa.vmware.devcluster.openshift.com. At a minimum, you need to set values for the following variables.
-* cluster_id
-* cluster_domain
-* vsphere_user
-* vsphere_password
-* ipam_token
-* bootstrap_ignition_url
-* control_plane_ignition
-* compute_ignition
-The bootstrap ignition config must be placed in a location that will be accessible by the bootstrap machine. For example, you could store the bootstrap ignition config in a gist.
+* *cluster_id*. This must match the name used in install-config.yaml.
+* *cluster_domain*. This must be ${cluster_id}.${base_domain}.
+* *vsphere_user*
+* *vsphere_password*
+* *ipam_token*
+* *bootstrap_ignition_url*. This must be accessible by the bootstrap machine. For example, you could store the bootstrap ignition config in a gist.
+* *control_plane_ignition*
+* *compute_ignition*
 
 4. Run `terraform init`.
 


### PR DESCRIPTION
Update the README to provide a complete install-config.yaml example that has the vsphere platform filled out.