### PR TITLE
data/manifests: fill out cloud creds role for vsphere platform

### DIFF
--- a/data/data/manifests/openshift/role-cloud-creds-secret-reader.yaml.template
+++ b/data/data/manifests/openshift/role-cloud-creds-secret-reader.yaml.template
@@ -6,6 +6,8 @@ metadata:
   name: aws-creds-secret-reader
 {{- else if .CloudCreds.OpenStack}}
   name: openstack-creds-secret-reader
+{{- else if .CloudCreds.VSphere}}
+  name: vsphere-creds-secret-reader
 {{- end}}
 rules:
 - apiGroups: [""]
@@ -14,5 +16,7 @@ rules:
   resourceNames: ["aws-creds"]
 {{- else if .CloudCreds.OpenStack}}
   resourceNames: ["openstack-credentials"]
+{{- else if .CloudCreds.VSphere}}
+  resourceNames: ["vsphere-creds"]
 {{- end}}
   verbs: ["get"]


### PR DESCRIPTION
Fill out role-cloud-creds-secret-reader.yaml when the platform is vsphere so that there is proper rbac to the cloud creds secret.