### PR TITLE
aws: allow GENEVE (6081) and OVN database ports (6641 & 6642)

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -83,6 +83,46 @@ resource "aws_security_group_rule" "master_ingress_vxlan_from_worker" {
   to_port   = 4789
 }
 
+resource "aws_security_group_rule" "master_ingress_geneve" {
+  type              = "ingress"
+  security_group_id = aws_security_group.master.id
+
+  protocol  = "udp"
+  from_port = 6081
+  to_port   = 6081
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_geneve_from_worker" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
+
+  protocol  = "udp"
+  from_port = 6081
+  to_port   = 6081
+}
+
+resource "aws_security_group_rule" "master_ingress_ovndb" {
+  type              = "ingress"
+  security_group_id = aws_security_group.master.id
+
+  protocol  = "tcp"
+  from_port = 6641
+  to_port   = 6642
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_ovndb_from_worker" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
+
+  protocol  = "tcp"
+  from_port = 6641
+  to_port   = 6642
+}
+
 resource "aws_security_group_rule" "master_ingress_internal" {
   type              = "ingress"
   security_group_id = aws_security_group.master.id

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -63,6 +63,26 @@ resource "aws_security_group_rule" "worker_ingress_vxlan_from_master" {
   to_port   = 4789
 }
 
+resource "aws_security_group_rule" "worker_ingress_geneve" {
+  type              = "ingress"
+  security_group_id = aws_security_group.worker.id
+
+  protocol  = "udp"
+  from_port = 6081
+  to_port   = 6081
+  self      = true
+}
+
+resource "aws_security_group_rule" "worker_ingress_geneve_from_master" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.worker.id
+  source_security_group_id = aws_security_group.master.id
+
+  protocol  = "udp"
+  from_port = 6081
+  to_port   = 6081
+}
+
 resource "aws_security_group_rule" "worker_ingress_internal" {
   type              = "ingress"
   security_group_id = aws_security_group.worker.id


### PR DESCRIPTION
1) Allow GENEVE (6081) between all nodes (masters & workers)
2) Allow OVN databases (6641 & 6642) between all masters
3) Allow OVN databases (6641 & 6642) between masters and workers, but not between workers themselves

@squeed  @pecameron @danwinship @JacobTanenbaum @rcarrillocruz

[question: should these be enabled by default even if the install isn't using ovn-kubernetes? Or, how do SG rules get selectively added based on specific network plugin requirements? eg when running ovn-kubernetes we don't need VXLAN between nodes, and when running openshift-sdn we don't need GENEVE...]