### PR TITLE
Revert "Add OpenStack team as reviewers"

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,5 @@
 
 approvers:
   - installer-approvers
-  - openstack-approvers
 reviewers:
   - installer-reviewers


### PR DESCRIPTION
This reverts commit c1aa02274f3d64760f1d177f87ecac581c0238cc, #618.

We've made a lot of progress separating out the per-platform components since that went in, so take another run at formally separating approval for per-platform and core changes.

CC @flaper87, @tomassedovic, @hardys: any concerns about this?  If so, point me at the code you're concerned about not being able to bump independently, and as long as it's not `vendor/`, I'll see if I can make the core/platform separation cleaner there.