### PR TITLE
upi/vsphere: manage ip address reservation

### DIFF
--- a/upi/vsphere/README.md
+++ b/upi/vsphere/README.md
@@ -33,7 +33,7 @@ The bootstrap ignition config must be placed in a location that will be accessib
 5. Ensure that you have you AWS profile set and a region specified. The installation will use create AWS route53 resources for routing to the OpenShift cluster.
 
 6. Run `terraform apply -auto-approve`.
-This will create the OpenShift cluster
+This will reserve IP addresses for the VMs.
 
 7. Run `openshift-install upi bootstrap-complete`. Wait for the bootstrapping to complete.
 

--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -1,0 +1,82 @@
+locals {
+  mask = "${element(split("/", var.machine_cidr), 1)}"
+  gw   = "${cidrhost(var.machine_cidr,1)}"
+
+  ignition_encoded = "data:text/plain;charset=utf-8;base64,${base64encode(var.ignition)}"
+}
+
+data "ignition_file" "hostname" {
+  count = "${var.instance_count}"
+
+  filesystem = "root"
+  path       = "/etc/hostname"
+  mode       = "420"
+
+  content {
+    content = "${var.name}-${count.index}.${var.cluster_domain}"
+  }
+}
+
+data "ignition_file" "static_ip" {
+  count = "${var.instance_count}"
+
+  filesystem = "root"
+  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+  mode       = "420"
+
+  content {
+    content = <<EOF
+TYPE=Ethernet
+BOOTPROTO=none
+NAME=eth0
+DEVICE=eth0
+ONBOOT=yes
+IPADDR=${local.ip_addresses[count.index]}
+PREFIX=${local.mask}
+GATEWAY=${local.gw}
+DNS1=8.8.8.8
+EOF
+  }
+}
+
+data "ignition_systemd_unit" "restart" {
+  count = "${var.instance_count}"
+
+  name = "restart.service"
+
+  content = <<EOF
+[Unit]
+ConditionFirstBoot=yes
+[Service]
+Type=idle
+ExecStart=/sbin/reboot
+[Install]
+WantedBy=multi-user.target
+EOF
+}
+
+data "ignition_user" "extra_users" {
+  count = "${length(var.extra_user_names)}"
+
+  name          = "${var.extra_user_names[count.index]}"
+  password_hash = "${var.extra_user_password_hashes[count.index]}"
+}
+
+data "ignition_config" "ign" {
+  count = "${var.instance_count}"
+
+  append {
+    source = "${var.ignition_url != "" ? var.ignition_url : local.ignition_encoded}"
+  }
+
+  systemd = [
+    "${data.ignition_systemd_unit.restart.*.id[count.index]}",
+  ]
+
+  files = [
+    "${data.ignition_file.hostname.*.id[count.index]}",
+    "${data.ignition_file.static_ip.*.id[count.index]}",
+  ]
+
+  users = ["${data.ignition_user.extra_users.*.id}"]
+}

--- a/upi/vsphere/machine/ip.tf
+++ b/upi/vsphere/machine/ip.tf
@@ -1,0 +1,41 @@
+locals {
+  ip_addresses = ["${data.template_file.ip_address.*.rendered}"]
+}
+
+data "external" "ip_address" {
+  count = "${var.instance_count}"
+
+  program = ["bash", "${path.module}/cidr_to_ip.sh"]
+
+  query = {
+    hostname   = "${var.name}-${count.index}.${var.cluster_domain}"
+    ipam       = "${var.ipam}"
+    ipam_token = "${var.ipam_token}"
+  }
+
+  depends_on = ["null_resource.ip_address"]
+}
+
+data "template_file" "ip_address" {
+  count = "${var.instance_count}"
+
+  template = "${lookup(data.external.ip_address.*.result[count.index], "ip_address")}"
+}
+
+resource "null_resource" "ip_address" {
+  count = "${var.instance_count}"
+
+  provisioner "local-exec" {
+    command = <<EOF
+echo '{"cidr":"${var.machine_cidr}","hostname":"${var.name}-${count.index}.${var.cluster_domain}","ipam":"${var.ipam}","ipam_token":"${var.ipam_token}"}' | ${path.module}/cidr_to_ip.sh
+EOF
+  }
+
+  provisioner "local-exec" {
+    when = "destroy"
+
+    command = <<EOF
+curl -s "http://${var.ipam}/api/removeHost.php?apiapp=address&apitoken=${var.ipam_token}&host=${var.name}-${count.index}.${var.cluster_domain}"
+EOF
+  }
+}

--- a/upi/vsphere/machine/main.tf
+++ b/upi/vsphere/machine/main.tf
@@ -1,10 +1,3 @@
-locals {
-  mask = "${element(split("/", var.machine_cidr), 1)}"
-  gw   = "${cidrhost(var.machine_cidr,1)}"
-
-  ignition_encoded = "data:text/plain;charset=utf-8;base64,${base64encode(var.ignition)}"
-}
-
 data "vsphere_datastore" "datastore" {
   name          = "${var.datastore}"
   datacenter_id = "${var.datacenter_id}"
@@ -20,95 +13,6 @@ data "vsphere_virtual_machine" "template" {
   datacenter_id = "${var.datacenter_id}"
 }
 
-data "external" "ip_address" {
-  count = "${var.instance_count}"
-
-  program = ["bash", "${path.module}/cidr_to_ip.sh"]
-
-  query = {
-    cidr       = "${var.machine_cidr}"
-    hostname   = "${var.name}-${count.index}.${var.cluster_domain}"
-    ipam       = "${var.ipam}"
-    ipam_token = "${var.ipam_token}"
-  }
-}
-
-data "ignition_file" "hostname" {
-  count = "${var.instance_count}"
-
-  filesystem = "root"
-  path       = "/etc/hostname"
-  mode       = "420"
-
-  content {
-    content = "${var.name}-${count.index}.${var.cluster_domain}"
-  }
-}
-
-data "ignition_file" "static_ip" {
-  count = "${var.instance_count}"
-
-  filesystem = "root"
-  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
-  mode       = "420"
-
-  content {
-    content = <<EOF
-TYPE=Ethernet
-BOOTPROTO=none
-NAME=eth0
-DEVICE=eth0
-ONBOOT=yes
-IPADDR=${data.external.ip_address.*.result.ip_address[count.index]}
-PREFIX=${local.mask}
-GATEWAY=${local.gw}
-DNS1=8.8.8.8
-EOF
-  }
-}
-
-data "ignition_systemd_unit" "restart" {
-  count = "${var.instance_count}"
-
-  name = "restart.service"
-
-  content = <<EOF
-[Unit]
-ConditionFirstBoot=yes
-[Service]
-Type=idle
-ExecStart=/sbin/reboot
-[Install]
-WantedBy=multi-user.target
-EOF
-}
-
-data "ignition_user" "extra_users" {
-  count = "${length(var.extra_user_names)}"
-
-  name          = "${var.extra_user_names[count.index]}"
-  password_hash = "${var.extra_user_password_hashes[count.index]}"
-}
-
-data "ignition_config" "ign" {
-  count = "${var.instance_count}"
-
-  append {
-    source = "${var.ignition_url != "" ? var.ignition_url : local.ignition_encoded}"
-  }
-
-  systemd = [
-    "${data.ignition_systemd_unit.restart.*.id[count.index]}",
-  ]
-
-  files = [
-    "${data.ignition_file.hostname.*.id[count.index]}",
-    "${data.ignition_file.static_ip.*.id[count.index]}",
-  ]
-
-  users = ["${data.ignition_user.extra_users.*.id}"]
-}
-
 resource "vsphere_virtual_machine" "vm" {
   count = "${var.instance_count}"
 
@@ -120,6 +24,9 @@ resource "vsphere_virtual_machine" "vm" {
   guest_id         = "other26xLinux64Guest"
   folder           = "${var.folder}"
   enable_disk_uuid = "true"
+
+  wait_for_guest_net_timeout  = "0"
+  wait_for_guest_net_routable = "false"
 
   network_interface {
     network_id = "${data.vsphere_network.network.id}"
@@ -140,13 +47,5 @@ resource "vsphere_virtual_machine" "vm" {
       "guestinfo.ignition.config.data"          = "${base64encode(data.ignition_config.ign.*.rendered[count.index])}"
       "guestinfo.ignition.config.data.encoding" = "base64"
     }
-  }
-
-  provisioner "local-exec" {
-    when = "destroy"
-
-    command = <<EOF
-curl "http://${var.ipam}/api/removeHost.php?apiapp=address&apitoken=${var.ipam_token}&host=${var.name}-${count.index}.${var.cluster_domain}"
-EOF
   }
 }

--- a/upi/vsphere/machine/output.tf
+++ b/upi/vsphere/machine/output.tf
@@ -1,3 +1,3 @@
 output "ip_addresses" {
-  value = "${data.external.ip_address.*.result.ip_address}"
+  value = ["${local.ip_addresses}"]
 }

--- a/upi/vsphere/machine/variables.tf
+++ b/upi/vsphere/machine/variables.tf
@@ -52,14 +52,14 @@ variable "template" {
   type = "string"
 }
 
+variable "machine_cidr" {
+  type = "string"
+}
+
 variable "ipam" {
   type = "string"
 }
 
 variable "ipam_token" {
-  type = "string"
-}
-
-variable "machine_cidr" {
   type = "string"
 }

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -90,9 +90,12 @@ module "compute" {
 module "dns" {
   source = "./route53"
 
-  base_domain       = "${var.base_domain}"
-  cluster_domain    = "${var.cluster_domain}"
-  bootstrap_ips     = ["${module.bootstrap.ip_addresses}"]
-  control_plane_ips = ["${module.control_plane.ip_addresses}"]
-  compute_ips       = ["${module.compute.ip_addresses}"]
+  base_domain         = "${var.base_domain}"
+  cluster_domain      = "${var.cluster_domain}"
+  bootstrap_count     = "${var.bootstrap_complete ? 0 : 1}"
+  bootstrap_ips       = ["${module.bootstrap.ip_addresses}"]
+  control_plane_count = "${var.control_plane_count}"
+  control_plane_ips   = ["${module.control_plane.ip_addresses}"]
+  compute_count       = "${var.compute_count}"
+  compute_ips         = ["${module.compute.ip_addresses}"]
 }

--- a/upi/vsphere/route53/main.tf
+++ b/upi/vsphere/route53/main.tf
@@ -33,13 +33,13 @@ resource "aws_route53_record" "api" {
 }
 
 resource "aws_route53_record" "etcd_a_nodes" {
-  count = "${length(var.control_plane_ips)}"
+  count = "${var.control_plane_count}"
 
   type    = "A"
   ttl     = "60"
   zone_id = "${aws_route53_zone.cluster.zone_id}"
   name    = "etcd-${count.index}.${var.cluster_domain}"
-  records = ["${var.control_plane_ips[count.index]}"]
+  records = ["${element(var.control_plane_ips, count.index)}"]
 }
 
 resource "aws_route53_record" "etcd_cluster" {
@@ -59,21 +59,21 @@ resource "aws_route53_record" "ingress" {
 }
 
 resource "aws_route53_record" "control_plane_nodes" {
-  count = "${length(var.control_plane_ips)}"
+  count = "${var.control_plane_count}"
 
   type    = "A"
   ttl     = "60"
   zone_id = "${aws_route53_zone.cluster.zone_id}"
   name    = "control-plane-${count.index}.${var.cluster_domain}"
-  records = ["${var.control_plane_ips[count.index]}"]
+  records = ["${element(var.control_plane_ips, count.index)}"]
 }
 
 resource "aws_route53_record" "compute_nodes" {
-  count = "${length(var.compute_ips)}"
+  count = "${var.compute_count}"
 
   type    = "A"
   ttl     = "60"
   zone_id = "${aws_route53_zone.cluster.zone_id}"
   name    = "compute-${count.index}.${var.cluster_domain}"
-  records = ["${var.compute_ips[count.index]}"]
+  records = ["${element(var.compute_ips, count.index)}"]
 }

--- a/upi/vsphere/route53/variables.tf
+++ b/upi/vsphere/route53/variables.tf
@@ -3,19 +3,31 @@ variable "cluster_domain" {
   type        = "string"
 }
 
+variable "base_domain" {
+  description = "The base domain used for public records."
+  type        = "string"
+}
+
+variable "bootstrap_count" {
+  type = "string"
+}
+
 variable "bootstrap_ips" {
   type = "list"
+}
+
+variable "control_plane_count" {
+  type = "string"
 }
 
 variable "control_plane_ips" {
   type = "list"
 }
 
-variable "compute_ips" {
-  type = "list"
+variable "compute_count" {
+  type = "string"
 }
 
-variable "base_domain" {
-  description = "The base domain used for public records."
-  type        = "string"
+variable "compute_ips" {
+  type = "list"
 }


### PR DESCRIPTION
The ip address reservation has been changed so that the ip address reservation is done by a resource instead of a data source. This prevents ip addresses from being reserved when doing terraform plan
and destroy. The ip address query is still done by a data source, since there is no way to get output from a null resource. And because data sources are run before resources are created, the ip addresses are not available on the first terraform apply. The user needs to run terraform apply twice.

The machines module has also been refactored to separate the ignition and ip address portions into their own separate files.