### PR TITLE
Bug 1696085: Allow using "-" in ClusterName parameter

### DIFF
--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -3,7 +3,7 @@ Description: Template for Openshift Cluster UPI Network Elements (Route53 & LBs)
 
 Parameters:
   ClusterName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9]{0,31})$
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
     ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 32 characters
     Description: A short, representative cluster name to use for hostnames, etc.
     Type: String

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -3,7 +3,7 @@ Description: Template for Openshift Cluster UPI Security Elements (Security Grou
 
 Parameters:
   ClusterName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9]{0,31})$
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
     ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 32 characters
     Description: A short, representative cluster name to use for hostnames, etc.
     Type: String

--- a/upi/aws/cloudformation/04_cluster_bootstrap.yaml
+++ b/upi/aws/cloudformation/04_cluster_bootstrap.yaml
@@ -3,7 +3,7 @@ Description: Template for Openshift Cluster UPI Bootstrap (EC2 Instance, Securit
 
 Parameters:
   ClusterName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9]{0,31})$
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
     ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 32 characters
     Description: A short, representative cluster name to use for hostnames, etc.
     Type: String

--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -3,7 +3,7 @@ Description: Template for Openshift Cluster UPI Node Launch (EC2 master instance
 
 Parameters:
   ClusterName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9]{0,31})$
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
     ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 32 characters
     Description: A short, representative cluster name to use for hostnames, etc.
     Type: String

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -3,7 +3,7 @@ Description: Template for Openshift Cluster UPI Node Launch (EC2 worker instance
 
 Parameters:
   ClusterName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9]{0,31})$
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
     ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 32 characters
     Description: A short, representative cluster name to use for hostnames, etc.
     Type: String


### PR DESCRIPTION
Fixes bugzilla by allowing hyphen as part of the cluster name. Verified the ClusterName is only used in tags and other names where a hyphen is okay (or also being used to generate names).