### PR TITLE
pkg/types/azure/OWNERS: Delegate to Azure owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,6 +11,9 @@ aliases:
     - wking
   installer-reviewers:
     - vikramsk
+  azure-approvers:
+    - abhinavdahiya
+    - serbrech
   openstack-approvers:
     - flaper87
     - tomassedovic

--- a/pkg/types/azure/OWNERS
+++ b/pkg/types/azure/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - azure-approvers


### PR DESCRIPTION
This sub-package is Azure-specific, and the set of Azure maintainers does not need to exactly match the folks maintaining the core, cross-platform installer components.  Add a new alias to make it easy to manage that distinction.

CC @abhinavdahiya, @serbrech, who belongs under this new alias?