### PR TITLE
pkg/asset/ignition/machine: add setazurehostname systemd unit

### DIFF
--- a/pkg/asset/ignition/machine/azure/node.go
+++ b/pkg/asset/ignition/machine/azure/node.go
@@ -1,0 +1,22 @@
+package azure
+
+import (
+	"github.com/coreos/ignition/config/util"
+	ignition "github.com/coreos/ignition/config/v2_2/types"
+)
+
+//ModifyPointerIgnitionConfig modifies the ignitionconfig pointer as per the platform requirements
+func ModifyPointerIgnitionConfig(ignitionConfig *ignition.Config) {
+	//until afterburn sets the hostname for azure
+	//and the fix is included in the azure image: https://github.com/coreos/afterburn/issues/197
+	setHostname(ignitionConfig)
+}
+
+func setHostname(ignitionConfig *ignition.Config) {
+	ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, ignition.Unit{
+		Name:     "setazurehostname.service",
+		Enabled:  util.BoolToPtr(true),
+		Enable:   true,
+		Contents: "[Service]\nType=oneshot\nExecStart=curl -H Metadata:true \"http://169.254.169.254/metadata/instance/compute/name?api-version=2017-08-01&format=text\" -o /tmp/hostname\nExecStart=mv -f /tmp/hostname /etc/hostname\n\n[Install]\nWantedBy=multi-user.target",
+	})
+}

--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/coreos/ignition/config/util"
 	ignition "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/vincent-petithory/dataurl"
 
+	azuremachine "github.com/openshift/installer/pkg/asset/ignition/machine/azure"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 )
@@ -39,18 +39,7 @@ func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, ro
 		},
 	}
 	if installConfig.Platform.Name() == azure.Name {
-		setAzureHostName(config)
+		azuremachine.ModifyPointerIgnitionConfig(config)
 	}
 	return config
-}
-
-//until hostname is set by afterburn fixed
-//and included in the azure image: https://github.com/coreos/afterburn/issues/197
-func setAzureHostName(ignitionConfig *ignition.Config) {
-	ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, ignition.Unit{
-		Name:     "setazurehostname.service",
-		Enabled:  util.BoolToPtr(true),
-		Enable:   true,
-		Contents: "[Service]\nType=oneshot\nExecStart=curl -H Metadata:true \"http://169.254.169.254/metadata/instance/compute/name?api-version=2017-08-01&format=text\" -o /tmp/hostname\nExecStart=mv -f /tmp/hostname /etc/hostname\n\n[Install]\nWantedBy=multi-user.target",
-	})
 }

--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -4,16 +4,18 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/coreos/ignition/config/util"
 	ignition "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/vincent-petithory/dataurl"
 
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/azure"
 )
 
 // pointerIgnitionConfig generates a config which references the remote config
 // served by the machine config server.
 func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, role string) *ignition.Config {
-	return &ignition.Config{
+	config := &ignition.Config{
 		Ignition: ignition.Ignition{
 			Version: ignition.MaxVersion.String(),
 			Config: ignition.IgnitionConfig{
@@ -36,4 +38,19 @@ func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, ro
 			},
 		},
 	}
+	if installConfig.Platform.Name() == azure.Name {
+		setAzureHostName(config)
+	}
+	return config
+}
+
+//until hostname is set by afterburn fixed
+//and included in the azure image: https://github.com/coreos/afterburn/issues/197
+func setAzureHostName(ignitionConfig *ignition.Config) {
+	ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, ignition.Unit{
+		Name:     "setazurehostname.service",
+		Enabled:  util.BoolToPtr(true),
+		Enable:   true,
+		Contents: "[Service]\nType=oneshot\nExecStart=curl -H Metadata:true \"http://169.254.169.254/metadata/instance/compute/name?api-version=2017-08-01&format=text\" -o /tmp/hostname\nExecStart=mv -f /tmp/hostname /etc/hostname\n\n[Install]\nWantedBy=multi-user.target",
+	})
 }


### PR DESCRIPTION
Afterburn does not set the azure hostname which is needed
for kubernetes to register the hosts with their actual names
and not `localhost.localdomain`
    
related: https://github.com/coreos/afterburn/issues/197

/cc @awesomenix