### PR TITLE
OWNERS_ALIASES: Add vsphere-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,3 +16,7 @@ aliases:
     - tomassedovic
     - hardys
     - russellb
+  vsphere-approvers:
+    - abhinavdahiya
+    - dav1x
+    - staebler

--- a/pkg/asset/installconfig/vsphere/OWNERS
+++ b/pkg/asset/installconfig/vsphere/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers

--- a/pkg/asset/manifests/vsphere/OWNERS
+++ b/pkg/asset/manifests/vsphere/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers

--- a/pkg/types/vsphere/OWNERS
+++ b/pkg/types/vsphere/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers

--- a/upi/vsphere/OWNERS
+++ b/upi/vsphere/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers


### PR DESCRIPTION
These directories are vSphere-specific, and the set of vSphere maintainers does not need to exactly match the folks maintaining the core, cross-platform installer components.  Add a new alias to make it easy to manage that distinction.

CC @abhinavdahiya, @staebler.  Also in this space: Azure approvers: #1569