### PR TITLE
upi/vsphere: remove extra users

### DIFF
--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -55,13 +55,6 @@ WantedBy=multi-user.target
 EOF
 }
 
-data "ignition_user" "extra_users" {
-  count = "${length(var.extra_user_names)}"
-
-  name          = "${var.extra_user_names[count.index]}"
-  password_hash = "${var.extra_user_password_hashes[count.index]}"
-}
-
 data "ignition_config" "ign" {
   count = "${var.instance_count}"
 
@@ -77,6 +70,4 @@ data "ignition_config" "ign" {
     "${data.ignition_file.hostname.*.id[count.index]}",
     "${data.ignition_file.static_ip.*.id[count.index]}",
   ]
-
-  users = ["${data.ignition_user.extra_users.*.id}"]
 }

--- a/upi/vsphere/machine/variables.tf
+++ b/upi/vsphere/machine/variables.tf
@@ -36,14 +36,6 @@ variable "cluster_domain" {
   type = "string"
 }
 
-variable "extra_user_names" {
-  type = "list"
-}
-
-variable "extra_user_password_hashes" {
-  type = "list"
-}
-
 variable "datacenter_id" {
   type = "string"
 }

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -40,9 +40,6 @@ module "bootstrap" {
   ipam             = "${var.ipam}"
   ipam_token       = "${var.ipam_token}"
   machine_cidr     = "${var.machine_cidr}"
-
-  extra_user_names           = ["${var.extra_user_names}"]
-  extra_user_password_hashes = ["${var.extra_user_password_hashes}"]
 }
 
 module "control_plane" {
@@ -61,9 +58,6 @@ module "control_plane" {
   ipam             = "${var.ipam}"
   ipam_token       = "${var.ipam_token}"
   machine_cidr     = "${var.machine_cidr}"
-
-  extra_user_names           = ["${var.extra_user_names}"]
-  extra_user_password_hashes = ["${var.extra_user_password_hashes}"]
 }
 
 module "compute" {
@@ -82,9 +76,6 @@ module "compute" {
   ipam             = "${var.ipam}"
   ipam_token       = "${var.ipam_token}"
   machine_cidr     = "${var.machine_cidr}"
-
-  extra_user_names           = ["${var.extra_user_names}"]
-  extra_user_password_hashes = ["${var.extra_user_password_hashes}"]
 }
 
 module "dns" {

--- a/upi/vsphere/terraform.tfvars.example
+++ b/upi/vsphere/terraform.tfvars.example
@@ -7,10 +7,6 @@ cluster_domain = "example-cluster.devcluster.openshift.com"
 // Base domain from which the cluster domain is a subdomain.
 base_domain = "devcluster.openshift.com"
 
-// Set extra users helpful for logging into the machines from the vSphere web UI.
-//extra_user_names = ["me"]
-//extra_user_password_hashes = ["$1$d51URPHU$NQGWywqfyGHYJrKK7GsOQ1"]
-
 // Name of the vSphere server. The dev cluster is on "vcsa.vmware.devcluster.openshift.com".
 vsphere_server = "vcsa.vmware.devcluster.openshift.com"
 

--- a/upi/vsphere/variables.tf
+++ b/upi/vsphere/variables.tf
@@ -43,16 +43,6 @@ variable "vm_network" {
   default     = "VM Network"
 }
 
-variable "extra_user_names" {
-  type    = "list"
-  default = []
-}
-
-variable "extra_user_password_hashes" {
-  type    = "list"
-  default = []
-}
-
 variable "ipam" {
   type        = "string"
   description = "The IPAM server to use for IP management."


### PR DESCRIPTION
The extra users were helpful when ramping up on booting rhcos on vsphere. The boot process is more stable now so the extra users are no longer needed. If problems do arise in the future where having a user that can log in with a password is helpful, that can easily be added manually to the ignition configs.