### PR TITLE
OWNERS: Add to `pkg/destroy/openstack`

### DIFF
--- a/pkg/destroy/openstack/OWNERS
+++ b/pkg/destroy/openstack/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers


### PR DESCRIPTION
This creates the `OWNERS` file with `openstack-approvers` in
`pkg/destroy/openstack`.