### PR TITLE
controller-manager/scheduler: switch to secure ports

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -121,8 +121,8 @@ resource "aws_security_group_rule" "master_ingress_kube_scheduler" {
   security_group_id = "${aws_security_group.master.id}"
 
   protocol  = "tcp"
-  from_port = 10251
-  to_port   = 10251
+  from_port = 10259
+  to_port   = 10259
   self      = true
 }
 
@@ -132,8 +132,8 @@ resource "aws_security_group_rule" "master_ingress_kube_scheduler_from_worker" {
   source_security_group_id = "${aws_security_group.worker.id}"
 
   protocol  = "tcp"
-  from_port = 10251
-  to_port   = 10251
+  from_port = 10259
+  to_port   = 10259
 }
 
 resource "aws_security_group_rule" "master_ingress_kube_controller_manager" {
@@ -141,8 +141,8 @@ resource "aws_security_group_rule" "master_ingress_kube_controller_manager" {
   security_group_id = "${aws_security_group.master.id}"
 
   protocol  = "tcp"
-  from_port = 10252
-  to_port   = 10252
+  from_port = 10257
+  to_port   = 10257
   self      = true
 }
 
@@ -152,8 +152,8 @@ resource "aws_security_group_rule" "master_ingress_kube_controller_manager_from_
   source_security_group_id = "${aws_security_group.worker.id}"
 
   protocol  = "tcp"
-  from_port = 10252
-  to_port   = 10252
+  from_port = 10257
+  to_port   = 10257
 }
 
 resource "aws_security_group_rule" "master_ingress_kubelet_secure" {

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -152,8 +152,8 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_scheduler"
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 10251
-  port_range_max    = 10251
+  port_range_min    = 10259
+  port_range_max    = 10259
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
 
@@ -161,8 +161,8 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_scheduler_
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 10251
-  port_range_max    = 10251
+  port_range_min    = 10259
+  port_range_max    = 10259
   remote_group_id   = "${openstack_networking_secgroup_v2.worker.id}"
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
@@ -171,8 +171,8 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_controller
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 10252
-  port_range_max    = 10252
+  port_range_min    = 10257
+  port_range_max    = 10257
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
 
@@ -180,8 +180,8 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_controller
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 10252
-  port_range_max    = 10252
+  port_range_min    = 10257
+  port_range_max    = 10257
   remote_group_id   = "${openstack_networking_secgroup_v2.worker.id}"
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -141,7 +141,7 @@ Resources:
       SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
       Description: Kubernetes kubelet, scheduler and controller manager
       FromPort: 10250
-      ToPort: 10252
+      ToPort: 10259
       IpProtocol: tcp
 
   MasterIngressWorkerKube:
@@ -151,7 +151,7 @@ Resources:
       SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
       Description: Kubernetes kubelet, scheduler and controller manager
       FromPort: 10250
-      ToPort: 10252
+      ToPort: 10259
       IpProtocol: tcp
 
   MasterIngressIngressServices:


### PR DESCRIPTION
Recently, the control plane switched to secure ports in [1] and [2].
This aligns them in the installer.

[1]
https://github.com/openshift/cluster-kube-scheduler-operator/pull/88
[2]
https://github.com/openshift/cluster-kube-controller-manager-operator/pull/207

/cc @brancz @sttts