### PR TITLE
Bug 1698210: aws: allow udp services as well

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -186,11 +186,21 @@ resource "aws_security_group_rule" "master_ingress_etcd" {
   self      = true
 }
 
-resource "aws_security_group_rule" "master_ingress_services" {
+resource "aws_security_group_rule" "master_ingress_services_tcp" {
   type              = "ingress"
   security_group_id = "${aws_security_group.master.id}"
 
   protocol  = "tcp"
+  from_port = 30000
+  to_port   = 32767
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_services_udp" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.master.id}"
+
+  protocol  = "udp"
   from_port = 30000
   to_port   = 32767
   self      = true

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -116,11 +116,21 @@ resource "aws_security_group_rule" "worker_ingress_kubelet_insecure_from_master"
   to_port   = 10250
 }
 
-resource "aws_security_group_rule" "worker_ingress_services" {
+resource "aws_security_group_rule" "worker_ingress_services_tcp" {
   type              = "ingress"
   security_group_id = "${aws_security_group.worker.id}"
 
   protocol  = "tcp"
+  from_port = 30000
+  to_port   = 32767
+  self      = true
+}
+
+resource "aws_security_group_rule" "worker_ingress_services_udp" {
+  type              = "ingress"
+  security_group_id = "${aws_security_group.worker.id}"
+
+  protocol  = "udp"
   from_port = 30000
   to_port   = 32767
   self      = true


### PR DESCRIPTION
We open port 30000-32767 for NodePort services. We need to allow this for UDP too.

Fixes [bz1698210](https://bugzilla.redhat.com/show_bug.cgi?id=1698210).