### PR TITLE
upi/vsphere: remove dependency on ipcalc

### DIFF
--- a/upi/vsphere/machine/cidr_to_ip.sh
+++ b/upi/vsphere/machine/cidr_to_ip.sh
@@ -3,7 +3,7 @@
 #  https://www.terraform.io/docs/providers/external/data_source.html
 #  Based on info from here: https://gist.github.com/irvingpop/968464132ded25a206ced835d50afa6b
 #  This script takes requests an IP address from an IPAM server
-#  echo '{"cidr": "139.178.89.192/26", "hostname": "control-plane-0.dphillip.devcluster.openshift.com", "ipam": "ipam_address", "ipam_token", "api_token" }' | ./cidr_to_ip.sh
+#  echo '{"network": "139.178.89.192", "hostname": "control-plane-0.dphillip.devcluster.openshift.com", "ipam": "ipam_address", "ipam_token", "api_token" }' | ./cidr_to_ip.sh
 function error_exit() {
   echo "$1" 1>&2
   exit 1
@@ -11,13 +11,12 @@ function error_exit() {
 
 function check_deps() {
   test -f "$(command -v jq)" || error_exit "jq command not detected in path, please install it"
-  test -f "$(command -v ipcalc)" || error_exit "ipcalc command not detected in path, please install it"
 
 }
 
 function parse_input() {
   input=$(jq .)
-  CIDR=$(echo "$input" | jq -r .cidr)
+  network=$(echo "$input" | jq -r .network)
   hostname=$(echo "$input" | jq -r .hostname)
   ipam=$(echo "$input" | jq -r .ipam)
   ipam_token=$(echo "$input" | jq -r .ipam_token)
@@ -43,7 +42,7 @@ get_reservation() {
 }
 
 function produce_output() {
-  if [[ "${CIDR}" == "null" ]]
+  if [[ "${network}" == "null" ]]
   then
     jq -n \
       --arg ip_address "$(get_reservation)" \
@@ -51,18 +50,13 @@ function produce_output() {
 	exit 0
   fi
 
-  cidr=$CIDR
-
-  # Build the curl and run it
-  lo=$(ipcalc -n "$cidr" | cut -f2 -d=)
-  
   # Request an IP address. Verify that the IP address reserved matches the IP
   # address returned. Loop until the reservation matches the address returned.
   # The verification and looping is a crude way of overcoming the lack of
   # currency safety in the IPAM server.
   while true
   do 
-    ip_address=$(curl -s "http://$ipam/api/getFreeIP.php?apiapp=address&apitoken=$ipam_token&subnet=$lo&host=${hostname}")
+    ip_address=$(curl -s "http://$ipam/api/getFreeIP.php?apiapp=address&apitoken=$ipam_token&subnet=${network}&host=${hostname}")
 
     if [[ "$(is_ip_address "${ip_address}")" != "true" ]]; then error_exit "could not reserve an IP address: ${ip_address}"; fi
 	

--- a/upi/vsphere/machine/ip.tf
+++ b/upi/vsphere/machine/ip.tf
@@ -1,4 +1,5 @@
 locals {
+  network      = "${cidrhost(var.machine_cidr,0)}"
   ip_addresses = ["${data.template_file.ip_address.*.rendered}"]
 }
 
@@ -27,7 +28,7 @@ resource "null_resource" "ip_address" {
 
   provisioner "local-exec" {
     command = <<EOF
-echo '{"cidr":"${var.machine_cidr}","hostname":"${var.name}-${count.index}.${var.cluster_domain}","ipam":"${var.ipam}","ipam_token":"${var.ipam_token}"}' | ${path.module}/cidr_to_ip.sh
+echo '{"network":"${local.network}","hostname":"${var.name}-${count.index}.${var.cluster_domain}","ipam":"${var.ipam}","ipam_token":"${var.ipam_token}"}' | ${path.module}/cidr_to_ip.sh
 EOF
   }
 


### PR DESCRIPTION
The cidr_to_ip.sh script used to reserve IP addresses uses ipcalc to determine the subnet from the CIDR. The CIDR is not used for anything else. These changes pass in the subnet to the script rather than the CIDR so that ipcalc is not needed. The motivation for this is that ipcalc is not available on RHEL7, which is the base image for the image used in CI.