### PR TITLE
upi/vsphere: script to fill out terraform.tfvars

### DIFF
--- a/upi/vsphere/README.md
+++ b/upi/vsphere/README.md
@@ -6,13 +6,13 @@
 # Build a Cluster
 
 1. Create an install-config.yaml.
-The machine CIDR for the dev cluster is 139.178.89.192/26.
+The following example uses the settings for the dev cluster.
 
 ```
 apiVersion: v1beta4
 baseDomain: devcluster.openshift.com
 metadata:
-  name: mstaeble
+  name: YOUR_CLUSTER_NAME
 networking:
   machineCIDR: "139.178.89.192/26"
 platform:
@@ -28,16 +28,8 @@ sshKey: YOUR_SSH_KEY
 
 2. Run `openshift-install create ignition-configs`.
 
-3. Fill out a terraform.tfvars file with the ignition configs generated.
-There is an example terraform.tfvars file in this directory named terraform.tfvars.example. The example file is set up for use with the dev cluster running at vcsa.vmware.devcluster.openshift.com. At a minimum, you need to set values for the following variables.
-* cluster_id
-* cluster_domain
-* vsphere_user
-* vsphere_password
-* ipam_token
-* bootstrap_ignition_url
-* control_plane_ignition
-* compute_ignition
+3. Run `IPAM_TOKEN=YOUR_TOKEN BOOTSTRAP_IGNITION_URL=YOUR_URL create_tfvars.sh`
+This needs to be run in your asset directory so that the results from the installer can be used to fill out terraform.tfvars.
 The bootstrap ignition config must be placed in a location that will be accessible by the bootstrap machine. For example, you could store the bootstrap ignition config in a gist.
 
 4. Run `terraform init`.

--- a/upi/vsphere/create_tfvars.sh
+++ b/upi/vsphere/create_tfvars.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+cat <<EOF > terraform.tfvars
+vsphere_cluster = "${VSPHERE_CLUSTER:-devel}"
+
+vsphere_network = "${VSPHERE_NETWORK:-VM Network}"
+
+vm_template = "${VM_TEMPLATE:-rhcos-latest}"
+
+ipam = "${IPAM:-139.178.89.254}"
+
+ipam_token = "${IPAM_TOKEN}"
+
+bootstrap_ignition_url = "${BOOTSTRAP_IGNITION_URL}"
+
+
+## The rest of the variables are all taken from the installer. You should not need to change any of these.
+
+cluster_name = $(jq '.["*installconfig.InstallConfig"].config.metadata.name' .openshift_install_state.json)
+vsphere_server = $(jq '.["*installconfig.InstallConfig"].config.platform.vsphere.vCenter' .openshift_install_state.json)
+vsphere_user = $(jq '.["*installconfig.InstallConfig"].config.platform.vsphere.username' .openshift_install_state.json)
+vsphere_password = $(jq '.["*installconfig.InstallConfig"].config.platform.vsphere.password' .openshift_install_state.json)
+vsphere_datacenter = $(jq '.["*installconfig.InstallConfig"].config.platform.vsphere.datacenter' .openshift_install_state.json)
+vsphere_datastore = $(jq '.["*installconfig.InstallConfig"].config.platform.vsphere.defaultDatastore' .openshift_install_state.json)
+machine_cidr = $(jq '.["*installconfig.InstallConfig"].config.networking.machineCIDR' .openshift_install_state.json)
+base_domain = $(jq '.["*installconfig.InstallConfig"].config.baseDomain' .openshift_install_state.json)
+control_plane_ignition = <<END_OF_CONTROL_PLANE_IGNITION
+$(jq . master.ign)
+END_OF_CONTROL_PLANE_IGNITION
+compute_ignition = <<END_OF_COMPUTE_IGNITION
+$(jq . worker.ign)
+END_OF_COMPUTE_IGNITION
+EOF

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -1,3 +1,7 @@
+locals {
+  cluster_domain = "${var.cluster_name}.${var.base_domain}"
+}
+
 provider "vsphere" {
   user                 = "${var.vsphere_user}"
   password             = "${var.vsphere_password}"
@@ -12,14 +16,14 @@ data "vsphere_datacenter" "dc" {
 module "folder" {
   source = "./folder"
 
-  path          = "${var.cluster_id}"
+  path          = "${var.cluster_name}"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
 module "resource_pool" {
   source = "./resource_pool"
 
-  name            = "${var.cluster_id}"
+  name            = "${var.cluster_name}"
   datacenter_id   = "${data.vsphere_datacenter.dc.id}"
   vsphere_cluster = "${var.vsphere_cluster}"
 }
@@ -36,7 +40,7 @@ module "bootstrap" {
   network          = "${var.vm_network}"
   datacenter_id    = "${data.vsphere_datacenter.dc.id}"
   template         = "${var.vm_template}"
-  cluster_domain   = "${var.cluster_domain}"
+  cluster_domain   = "${local.cluster_domain}"
   ipam             = "${var.ipam}"
   ipam_token       = "${var.ipam_token}"
   ip_addresses     = ["${compact(list(var.bootstrap_ip))}"]
@@ -55,7 +59,7 @@ module "control_plane" {
   network          = "${var.vm_network}"
   datacenter_id    = "${data.vsphere_datacenter.dc.id}"
   template         = "${var.vm_template}"
-  cluster_domain   = "${var.cluster_domain}"
+  cluster_domain   = "${local.cluster_domain}"
   ipam             = "${var.ipam}"
   ipam_token       = "${var.ipam_token}"
   ip_addresses     = ["${var.control_plane_ips}"]
@@ -74,7 +78,7 @@ module "compute" {
   network          = "${var.vm_network}"
   datacenter_id    = "${data.vsphere_datacenter.dc.id}"
   template         = "${var.vm_template}"
-  cluster_domain   = "${var.cluster_domain}"
+  cluster_domain   = "${local.cluster_domain}"
   ipam             = "${var.ipam}"
   ipam_token       = "${var.ipam_token}"
   ip_addresses     = ["${var.compute_ips}"]
@@ -85,7 +89,7 @@ module "dns" {
   source = "./route53"
 
   base_domain         = "${var.base_domain}"
-  cluster_domain      = "${var.cluster_domain}"
+  cluster_domain      = "${local.cluster_domain}"
   bootstrap_count     = "${var.bootstrap_complete ? 0 : 1}"
   bootstrap_ips       = ["${module.bootstrap.ip_addresses}"]
   control_plane_count = "${var.control_plane_count}"

--- a/upi/vsphere/terraform.tfvars.example
+++ b/upi/vsphere/terraform.tfvars.example
@@ -1,8 +1,5 @@
-// ID identifying the cluster to create. Use your username so that resources created can be tracked back to you.
-cluster_id = "example-cluster"
-
-// Domain of the cluster. This should be "${cluster_id}.${base_domain}".
-cluster_domain = "example-cluster.devcluster.openshift.com"
+// Name of the cluster to create. Use your username so that resources created can be tracked back to you.
+cluster_name = "example-cluster"
 
 // Base domain from which the cluster domain is a subdomain.
 base_domain = "devcluster.openshift.com"

--- a/upi/vsphere/variables.tf
+++ b/upi/vsphere/variables.tf
@@ -59,17 +59,12 @@ variable "ipam_token" {
 // OpenShift cluster variables
 /////////
 
-variable "cluster_id" {
+variable "cluster_name" {
   type        = "string"
-  description = "This cluster id must be of max length 27 and must have only alphanumeric or hyphen characters."
+  description = "The name of the OpenShift cluster."
 }
 
 variable "base_domain" {
-  type        = "string"
-  description = "The base DNS zone to add the sub zone to."
-}
-
-variable "cluster_domain" {
   type        = "string"
   description = "The base DNS zone to add the sub zone to."
 }


### PR DESCRIPTION
There have been a few instances where users have not kept the terraform.tfvars and install-config.yaml updated in concert. These changes add a script to fill out terraform.tfvars from the outputs of the installer, so that everything in kept in-sync.