### PR TITLE
cmd/openshift-install/waitfor: Rename cluster-ready to install-complete

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -105,7 +105,7 @@ var (
 					logrus.Fatal(err)
 				}
 
-				err = waitForClusterReady(ctx, config, rootOpts.dir)
+				err = waitForInstallComplete(ctx, config, rootOpts.dir)
 				if err != nil {
 					logrus.Fatal(err)
 				}
@@ -433,7 +433,7 @@ func logComplete(directory, consoleURL string) error {
 	return nil
 }
 
-func waitForClusterReady(ctx context.Context, config *rest.Config, directory string) error {
+func waitForInstallComplete(ctx context.Context, config *rest.Config, directory string) error {
 	if err := waitForInitializedCluster(ctx, config); err != nil {
 		return err
 	}

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -24,7 +24,7 @@ them directly.`,
 		},
 	}
 	cmd.AddCommand(newWaitForBootstrapCompleteCmd())
-	cmd.AddCommand(newWaitForClusterReadyCmd())
+	cmd.AddCommand(newWaitForInstallCompleteCmd())
 	return cmd
 }
 
@@ -54,9 +54,9 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 	}
 }
 
-func newWaitForClusterReadyCmd() *cobra.Command {
+func newWaitForInstallCompleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "cluster-ready",
+		Use:   "install-complete",
 		Short: "Wait until the cluster is ready",
 		Args:  cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -70,7 +70,7 @@ func newWaitForClusterReadyCmd() *cobra.Command {
 				logrus.Fatal(errors.Wrap(err, "loading kubeconfig"))
 			}
 
-			err = waitForClusterReady(ctx, config, rootOpts.dir)
+			err = waitForInstallComplete(ctx, config, rootOpts.dir)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/docs/user/aws/install_upi.md
+++ b/docs/user/aws/install_upi.md
@@ -248,7 +248,7 @@ TODO: Identify changes needed to Router or Ingress for DNS `*.apps` registration
 ## Monitor for Cluster Completion
 
 ```console
-$ bin/openshift-install wait-for cluster-ready
+$ bin/openshift-install wait-for install-complete
 INFO Waiting up to 30m0s for the cluster to initialize...
 ```
 

--- a/docs/user/metal/install_upi.md
+++ b/docs/user/metal/install_upi.md
@@ -213,10 +213,10 @@ INFO Waiting up to 30m0s for the bootstrap-complete event...
 
 ## Monitor for cluster completion
 
-The administrators can use the `wait-for cluster-ready` target of the OpenShift Installer to monitor cluster completion. The command succeeds when it notices that Cluster Version Operator has completed rolling out the OpenShift cluster from Kubernetes APIServer.
+The administrators can use the `wait-for install-complete` target of the OpenShift Installer to monitor cluster completion. The command succeeds when it notices that Cluster Version Operator has completed rolling out the OpenShift cluster from Kubernetes APIServer.
 
 ```console
-$ openshift-install wait-for cluster-ready
+$ openshift-install wait-for install-complete
 INFO Waiting up to 30m0s for the cluster to initialize...
 ```
 


### PR DESCRIPTION
@crawford, @smarterclayton, @derekwaynecarr, @eparis, and @sdodson got together to hash out naming, and they feel that `install-complete` is more intuitive than `cluster-ready`.