### PR TITLE
OWNERS_ALIASES: Create a new aws-owners alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,6 +11,11 @@ aliases:
     - wking
   installer-reviewers:
     - vikramsk
+  aws-approvers:
+    - abhinavdahiya
+    - crawford
+    - staebler
+    - wking
   openstack-approvers:
     - flaper87
     - tomassedovic

--- a/data/data/aws/OWNERS
+++ b/data/data/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers

--- a/docs/user/aws/OWNERS
+++ b/docs/user/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers

--- a/pkg/asset/cluster/aws/OWNERS
+++ b/pkg/asset/cluster/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers

--- a/pkg/asset/installconfig/aws/OWNERS
+++ b/pkg/asset/installconfig/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers

--- a/pkg/asset/machines/aws/OWNERS
+++ b/pkg/asset/machines/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers

--- a/pkg/destroy/aws/OWNERS
+++ b/pkg/destroy/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers

--- a/pkg/tfvars/aws/OWNERS
+++ b/pkg/tfvars/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers

--- a/pkg/types/aws/OWNERS
+++ b/pkg/types/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers

--- a/platformtests/aws/OWNERS
+++ b/platformtests/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers

--- a/upi/aws/OWNERS
+++ b/upi/aws/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers


### PR DESCRIPTION
No need to assume that this overlaps with the core team.  The core team will still inherit approver powers down into these subdirectories, but I've selected frequent AWS maintainers so Prow can be smarter about auto-assigning pull requests.

CC @abhinavdahiya