### PR TITLE
BZ1697262: Add infrastructure ID to private HostedZone

### DIFF
--- a/docs/user/aws/install_upi.md
+++ b/docs/user/aws/install_upi.md
@@ -32,6 +32,21 @@ $ tree
 └── worker.ign
 ```
 
+### Extract Infrastructure ID from Ignition Metadata
+
+Many of the operators and functions within OpenShift rely on tagging AWS resources. By default, Ignition
+generates a unique cluster identifier comprised of the cluster name specified during the invocation of the installer
+and a short string known internally as the infrastructure ID. These values are seeded in the initial manifests within
+the Ignition configuration. To use the output of the default, generated 
+`ignition-configs` extracting the internal infrastructure ID is necessary.
+
+An example of a way to get this is below (`vw9j6` is the infrastructure ID): 
+
+```
+$ jq -r .infraID metadata.json 
+openshift-vw9j6
+```
+
 ## Create/Identify the VPC to be Used
 
 You may create a VPC with various desirable characteristics for your situation (VPN, route tables, etc.). The
@@ -253,9 +268,47 @@ The CSR can be approved by using
 oc adm certificate approve <csr_name>
 ```
 
-## Configure Router for UPI DNS
+## Configure Router for UPI
 
-TODO: Identify changes needed to Router or Ingress for DNS `*.apps` registration or LoadBalancer creation.
+The Ingress operator manages DNS and LoadBalancers. It makes use of tags on HostedZones to identify which public and 
+private zones are to be updated from the cluster by the operator as objects are created in the cluster. 
+
+The tags used for finding HostedZones used by the operator
+are fulfilled by the CloudFormation template [here](../../../upi/aws/cloudformation/02_cluster_infra.yaml).
+
+An example of the `spec` for DNS configuration is below:
+
+```
+$ oc get dns -o yaml
+apiVersion: v1
+items:
+- apiVersion: config.openshift.io/v1
+  kind: DNS
+  metadata:
+    creationTimestamp: 2019-03-28T12:31:10Z
+    generation: 1
+    name: cluster
+    namespace: ""
+    resourceVersion: "395"
+    selfLink: /apis/config.openshift.io/v1/dnses/cluster
+    uid: 5e51dd25-5155-11e9-befc-02d75ce1a902
+  spec:
+    baseDomain: test.example.com
+    privateZone:
+      tags:
+        Name: test-r69hh-int
+        kubernetes.io/cluster/test-r69hh: owned
+    publicZone:
+      id: Z21IZ5YJJMZ2A4
+  status: {}
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""
+
+```
+
+TODO: Identify changes needed to Router or Ingress for automatic LoadBalancer creation.
 
 ## Monitor for Cluster Completion
 

--- a/docs/user/aws/install_upi.md
+++ b/docs/user/aws/install_upi.md
@@ -60,8 +60,10 @@ A created VPC via the template or manually should approximate a setup similar to
 
 The DNS and load balancer configuration within a CloudFormation template is provided
 [here](../../../upi/aws/cloudformation/02_cluster_infra.yaml). It uses a public hosted zone and creates a private hosted
-zone similar to the IPI installation method. It also creates load balancers and listeners the same way as the IPI
-installation method. This template can be run multiple times within a single VPC and in combination with the VPC
+zone similar to the IPI installation method. 
+It also creates load balancers, listeners, as well as hosted zone and subnet tags the same way as the IPI
+installation method. 
+This template can be run multiple times within a single VPC and in combination with the VPC
 template provided above.
 
 ### Optional: Manually Create Load Balancer Configuration
@@ -271,7 +273,8 @@ oc adm certificate approve <csr_name>
 ## Configure Router for UPI
 
 The Ingress operator manages DNS and LoadBalancers. It makes use of tags on HostedZones to identify which public and 
-private zones are to be updated from the cluster by the operator as objects are created in the cluster. 
+private zones are to be updated from the cluster by the operator as objects are created in the cluster. It makes use
+of tags on subnets to identify those to associate with Service objects of type LoadBalancer created in the cluster.
 
 The tags used for finding HostedZones used by the operator
 are fulfilled by the CloudFormation template [here](../../../upi/aws/cloudformation/02_cluster_infra.yaml).
@@ -307,8 +310,6 @@ metadata:
   selfLink: ""
 
 ```
-
-TODO: Identify changes needed to Router or Ingress for automatic LoadBalancer creation.
 
 ## Monitor for Cluster Completion
 

--- a/docs/user/aws/install_upi.md
+++ b/docs/user/aws/install_upi.md
@@ -32,15 +32,15 @@ $ tree
 └── worker.ign
 ```
 
-### Extract Infrastructure ID from Ignition Metadata
+### Extract Infrastructure Name from Ignition Metadata
 
 Many of the operators and functions within OpenShift rely on tagging AWS resources. By default, Ignition
 generates a unique cluster identifier comprised of the cluster name specified during the invocation of the installer
-and a short string known internally as the infrastructure ID. These values are seeded in the initial manifests within
+and a short string known internally as the infrastructure name. These values are seeded in the initial manifests within
 the Ignition configuration. To use the output of the default, generated 
-`ignition-configs` extracting the internal infrastructure ID is necessary.
+`ignition-configs` extracting the internal infrastructure name is necessary.
 
-An example of a way to get this is below (`vw9j6` is the infrastructure ID): 
+An example of a way to get this is below: 
 
 ```
 $ jq -r .infraID metadata.json 

--- a/upi/aws/cloudformation/01_vpc.yaml
+++ b/upi/aws/cloudformation/01_vpc.yaml
@@ -247,6 +247,8 @@ Resources:
         Value: !Ref "AWS::StackName"
       - Key: Network
         Value: Private
+      - Key: kubernetes.io/role/internal-elb
+        Value: ""
   PrivateRouteTable:
     Type: "AWS::EC2::RouteTable"
     Properties:
@@ -297,6 +299,8 @@ Resources:
         Value: !Ref "AWS::StackName"
       - Key: Network
         Value: Private
+      - Key: kubernetes.io/role/internal-elb
+        Value: ""
   PrivateRouteTable2:
     Type: "AWS::EC2::RouteTable"
     Condition: DoAz2
@@ -352,6 +356,8 @@ Resources:
         Value: !Ref "AWS::StackName"
       - Key: Network
         Value: Private
+      - Key: kubernetes.io/role/internal-elb
+        Value: ""
   PrivateRouteTable3:
     Type: "AWS::EC2::RouteTable"
     Condition: DoAz3

--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -4,11 +4,17 @@ Description: Template for Openshift Cluster UPI Network Elements (Route53 & LBs)
 Parameters:
   ClusterName:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
+    MaxLength: 32
+    MinLength: 1
     ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 32 characters
     Description: A short, representative cluster name to use for hostnames, etc.
     Type: String
-  InfrastructureID:
-    Description: Infrastructure ID must be alphanumeric and match the manifests generated for your cluster.
+  InfrastructureName:
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
+    MaxLength: 32
+    MinLength: 1
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 32 characters
+    Description: A short, unique cluster ID used to tag cloud resources and identify items owned/used by the cluster.
     Type: String
   HostedZoneId:
     Description: The Route53 public zone ID to register the targets with (e.g Z21IXYZABCZ2A4)
@@ -34,7 +40,7 @@ Metadata:
         default: "Cluster Information"
       Parameters:
       - ClusterName
-      - InfrastructureID
+      - InfrastructureName
     - Label:
         default: "Network Configuration"
       Parameters:
@@ -49,8 +55,8 @@ Metadata:
     ParameterLabels:
       ClusterName:
         default: "Cluster Name"
-      InfrastructureID:
-        default: "Infrastructure ID"
+      InfrastructureName:
+        default: "Infrastructure Name"
       VpcId:
         default: "VPC ID"
       PublicSubnets:
@@ -88,8 +94,8 @@ Resources:
       Name: !Join [".", [!Ref ClusterName, !Ref HostedZoneName]]
       HostedZoneTags:
       - Key: Name
-        Value: !Join ["-", [!Ref ClusterName, !Ref InfrastructureID, "int"]]
-      - Key: !Join ["", ["kubernetes.io/cluster/", !Join ["-", [!Ref ClusterName, !Ref InfrastructureID]]]]
+        Value: !Join ["-", [!Ref InfrastructureName, "int"]]
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
         Value: "owned"
       VPCs:
       - VPCId: !Ref VpcId
@@ -315,12 +321,12 @@ Resources:
             ec2_client = boto3.client('ec2')
             if event['RequestType'] == 'Delete':
               for subnet_id in event['ResourceProperties']['Subnets']:
-                ec2_client.delete_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['ClusterID']}]);
+                ec2_client.delete_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName']}]);
             elif event['RequestType'] == 'Create':
               for subnet_id in event['ResourceProperties']['Subnets']:
-                ec2_client.create_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['ClusterID'], 'Value': 'shared'}]);
+                ec2_client.create_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName'], 'Value': 'shared'}]);
             responseData = {}
-            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['ClusterID']+event['ResourceProperties']['Subnets'][0])
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['InfrastructureName']+event['ResourceProperties']['Subnets'][0])
       Runtime: "python3.7"
       Timeout: 120
 
@@ -328,14 +334,14 @@ Resources:
     Type: Custom::SubnetRegister
     Properties:
       ServiceToken: !GetAtt RegisterSubnetTags.Arn
-      ClusterID: !Join ["-", [!Ref ClusterName, !Ref InfrastructureID]]
+      InfrastructureName: !Ref InfrastructureName
       Subnets: !Ref PublicSubnets
 
   RegisterPrivateSubnetTags:
     Type: Custom::SubnetRegister
     Properties:
       ServiceToken: !GetAtt RegisterSubnetTags.Arn
-      ClusterID: !Join ["-", [!Ref ClusterName, !Ref InfrastructureID]]
+      InfrastructureName: !Ref InfrastructureName
       Subnets: !Ref PrivateSubnets
 
 Outputs:

--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -7,6 +7,9 @@ Parameters:
     ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 32 characters
     Description: A short, representative cluster name to use for hostnames, etc.
     Type: String
+  InfrastructureID:
+    Description: Infrastructure ID must be alphanumeric and match the manifests generated for your cluster.
+    Type: String
   HostedZoneId:
     Description: The Route53 public zone ID to register the targets with (e.g Z21IXYZABCZ2A4)
     Type: String
@@ -31,6 +34,7 @@ Metadata:
         default: "Cluster Information"
       Parameters:
       - ClusterName
+      - InfrastructureID
     - Label:
         default: "Network Configuration"
       Parameters:
@@ -45,6 +49,8 @@ Metadata:
     ParameterLabels:
       ClusterName:
         default: "Cluster Name"
+      InfrastructureID:
+        default: "Infrastructure ID"
       VpcId:
         default: "VPC ID"
       PublicSubnets:
@@ -80,6 +86,11 @@ Resources:
       HostedZoneConfig:
         Comment: "Managed by CloudFormation"
       Name: !Join [".", [!Ref ClusterName, !Ref HostedZoneName]]
+      HostedZoneTags:
+      - Key: Name
+        Value: !Join ["-", [!Ref ClusterName, !Ref InfrastructureID, "int"]]
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Join ["-", [!Ref ClusterName, !Ref InfrastructureID]]]]
+        Value: "owned"
       VPCs:
       - VPCId: !Ref VpcId
         VPCRegion: !Ref "AWS::Region"

--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -264,6 +264,80 @@ Resources:
       Runtime: "python3.7"
       Timeout: 120
 
+  RegisterSubnetTagsLambdaIamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ["-", [!Ref ClusterName, "subnet-tags-lambda-role"]]
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "lambda.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
+      Path: "/"
+      Policies:
+      - PolicyName: !Join ["-", [!Ref ClusterName, "subnet-tagging-policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+              [
+                "ec2:DeleteTags",
+                "ec2:CreateTags"
+              ]
+            Resource: "arn:aws:ec2:*:*:subnet/*"
+          - Effect: "Allow"
+            Action:
+              [
+                "ec2:DescribeSubnets",
+                "ec2:DescribeTags"
+              ]
+            Resource: "*"
+
+  RegisterSubnetTags:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Handler: "index.handler"
+      Role:
+        Fn::GetAtt:
+        - "RegisterSubnetTagsLambdaIamRole"
+        - "Arn"
+      Code:
+        ZipFile: |
+          import json
+          import boto3
+          import cfnresponse
+          def handler(event, context):
+            ec2_client = boto3.client('ec2')
+            if event['RequestType'] == 'Delete':
+              for subnet_id in event['ResourceProperties']['Subnets']:
+                ec2_client.delete_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['ClusterID']}]);
+            elif event['RequestType'] == 'Create':
+              for subnet_id in event['ResourceProperties']['Subnets']:
+                ec2_client.create_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['ClusterID'], 'Value': 'shared'}]);
+            responseData = {}
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['ClusterID']+event['ResourceProperties']['Subnets'][0])
+      Runtime: "python3.7"
+      Timeout: 120
+
+  RegisterPublicSubnetTags:
+    Type: Custom::SubnetRegister
+    Properties:
+      ServiceToken: !GetAtt RegisterSubnetTags.Arn
+      ClusterID: !Join ["-", [!Ref ClusterName, !Ref InfrastructureID]]
+      Subnets: !Ref PublicSubnets
+
+  RegisterPrivateSubnetTags:
+    Type: Custom::SubnetRegister
+    Properties:
+      ServiceToken: !GetAtt RegisterSubnetTags.Arn
+      ClusterID: !Join ["-", [!Ref ClusterName, !Ref InfrastructureID]]
+      Subnets: !Ref PrivateSubnets
+
 Outputs:
   PrivateHostedZoneId:
     Description: Hosted zone ID for the private DNS - needed for private records


### PR DESCRIPTION
This PR resolves the DNS portion of the network edge UPI configuration. It ensures the Hosted Zone matches what the default Ignition configuration generates and updates the doc to explain how the user may extract the infrastructure ID. 

Will handle the subnet portion for BZ1697236 in a separate PR.