### PR TITLE
BUG 1696342: pkg/asset: include kubeadmin password in the IgnitionConfig target

### DIFF
--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -87,9 +87,10 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 			}
 
 			emptyAssets := map[string]bool{
-				"Master Machines": true, // no files for the 'none' platform
-				"Worker Machines": true, // no files for the 'none' platform
-				"Metadata":        true, // read-only
+				"Master Machines":    true, // no files for the 'none' platform
+				"Worker Machines":    true, // no files for the 'none' platform
+				"Metadata":           true, // read-only
+				"Kubeadmin Password": true, // read-only
 			}
 			for _, a := range tc.targets {
 				name := a.Name()

--- a/pkg/asset/targets/targets.go
+++ b/pkg/asset/targets/targets.go
@@ -54,6 +54,7 @@ var (
 	// IgnitionConfigs are the ignition-configs targeted assets.
 	IgnitionConfigs = []asset.WritableAsset{
 		&kubeconfig.AdminClient{},
+		&password.KubeadminPassword{},
 		&machine.Master{},
 		&machine.Worker{},
 		&bootstrap.Bootstrap{},


### PR DESCRIPTION
BZ#1696342 [1] pointed out that installer was not providing the kubeadmin secret when running the `create ignition-configs` target. That target is currently the primary
means to perform UPI type installations. Missing kubeadmin password file cause error like `FATAL open /root/installation/baremetal-0404/auth/kubeadmin-password: no such file or directory`
when running the wait-for command.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1696342

/cc @wking @staebler 