### PR TITLE
data/manifests: fill out cloud creds role for azure platform 

### DIFF
--- a/data/data/manifests/openshift/cloud-creds-secret.yaml.template
+++ b/data/data/manifests/openshift/cloud-creds-secret.yaml.template
@@ -4,6 +4,8 @@ metadata:
   namespace: kube-system
 {{- if .CloudCreds.AWS}}
   name: aws-creds
+{{- else if .CloudCreds.Azure}}
+  name: azure-credentials
 {{- else if .CloudCreds.OpenStack}}
   name: openstack-credentials
 {{- else if .CloudCreds.VSphere}}
@@ -13,6 +15,14 @@ data:
 {{- if .CloudCreds.AWS}}
   aws_access_key_id: {{.CloudCreds.AWS.Base64encodeAccessKeyID}}
   aws_secret_access_key: {{.CloudCreds.AWS.Base64encodeSecretAccessKey}}
+{{- else if .CloudCreds.Azure}}
+  azure_subscription_id: {{.CloudCreds.Azure.Base64encodeSubscriptionID}}
+  azure_client_id: {{.CloudCreds.Azure.Base64encodeClientID}}
+  azure_client_secret: {{.CloudCreds.Azure.Base64encodeClientSecret}}
+  azure_tenant_id: {{.CloudCreds.Azure.Base64encodeTenantID}}
+  azure_resource_prefix: {{.CloudCreds.Azure.Base64encodeResourcePrefix}}
+  azure_resourcegroup: {{.CloudCreds.Azure.Base64encodeResourceGroup}}
+  azure_region: {{.CloudCreds.Azure.Base64encodeRegion}}
 {{- else if .CloudCreds.OpenStack}}
   clouds.yaml: {{.CloudCreds.OpenStack.Base64encodeCloudCreds}}
 {{- else if .CloudCreds.VSphere}}

--- a/data/data/manifests/openshift/role-cloud-creds-secret-reader.yaml.template
+++ b/data/data/manifests/openshift/role-cloud-creds-secret-reader.yaml.template
@@ -4,6 +4,8 @@ metadata:
   namespace: kube-system
 {{- if .CloudCreds.AWS}}
   name: aws-creds-secret-reader
+{{- else if .CloudCreds.Azure}}
+  name: azure-creds-secret-reader
 {{- else if .CloudCreds.OpenStack}}
   name: openstack-creds-secret-reader
 {{- else if .CloudCreds.VSphere}}
@@ -14,6 +16,8 @@ rules:
   resources: ["secrets"]
 {{- if .CloudCreds.AWS}}
   resourceNames: ["aws-creds"]
+{{- else if .CloudCreds.Azure}}
+  resourceNames: ["azure-credentials"]
 {{- else if .CloudCreds.OpenStack}}
   resourceNames: ["openstack-credentials"]
 {{- else if .CloudCreds.VSphere}}


### PR DESCRIPTION
Fill out role-cloud-creds-secret-reader.yaml when the platform is vsphere so that there is proper rbac to the cloud creds secret.

```console
$ > cat install-config.yaml                                                                                   
apiVersion: v1beta4
baseDomain: basename.com
compute:
- name: worker
  platform: {}
  replicas: 3
controlPlane:
  name: master
  platform: {}
  replicas: 3
metadata:
  creationTimestamp: null
  name: mycluster
networking:
  clusterNetwork:
  - cidr: 10.128.0.0/14
    hostPrefix: 23
  machineCIDR: 10.0.0.0/16
  networkType: OpenShiftSDN
  serviceNetwork:
  - 172.30.0.0/16
platform:
  azure:
    baseDomainResourceGroupName: os_domain
    region: eastus
pullSecret: '...'
sshKey: |
  ssh-rsa AAAAB3NzaC1yc2EAA...

$ > cat 99_role-cloud-creds-secret-reader.yaml
kind: Role
apiVersion: rbac.authorization.k8s.io/v1beta1
metadata:
  namespace: kube-system
  name: azure-creds-secret-reader
rules:
- apiGroups: [""]
  resources: ["secrets"]
  resourceNames: ["azure-credentials"]
  verbs: ["get"]

$ > cat 99_cloud-creds-secret.yaml
kind: Secret
apiVersion: v1
metadata:
  namespace: kube-system
  name: azure-credentials
data:
  azure_subscription_id: OTVh...
  azure_client_id: ZTU4M2M2...
  azure_client_secret: MWFiN...
  azure_tenant_id: NzJmO...
  azure_resource_prefix: dGVzd...
  azure_resourcegroup: dGVzd...
  azure_region: ZWFzdHVz
```