### PR TITLE
data/data/manifests/bootkube/cvo-overrides: Move to stable-4.1

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -5,5 +5,5 @@ metadata:
   name: version
 spec:
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph
-  channel: stable-4.0
+  channel: stable-4.1
   clusterID: {{.CVOClusterID}}

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -109,7 +109,7 @@ The installer uses the [cluster-version-operator] to create all the components o
       selfLink: /apis/config.openshift.io/v1/clusterversions/version
       uid: 6e0f4cf8-3ade-11e9-9034-0a923b47ded4
     spec:
-      channel: stable-4.0
+      channel: stable-4.1
       clusterID: 5ec312f9-f729-429d-a454-61d4906896ca
       upstream: https://api.openshift.com/api/upgrades_info/v1/graph
     status:


### PR DESCRIPTION
This is the channel that the beta4 drop and later will be in.

CC @abhinavdahiya, @smarterclayton, @steveeJ.  We may need to wait on the production Cincinnati to also switch.

/hold