### PR TITLE
BUG 1685704: data/aws: create an api-int dns name

### DIFF
--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -31,6 +31,18 @@ resource "aws_route53_record" "api_external" {
 
 resource "aws_route53_record" "api_internal" {
   zone_id = "${aws_route53_zone.int.zone_id}"
+  name    = "api-int.${var.cluster_domain}"
+  type    = "A"
+
+  alias {
+    name                   = "${var.api_internal_lb_dns_name}"
+    zone_id                = "${var.api_internal_lb_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "api_external_internal_zone" {
+  zone_id = "${aws_route53_zone.int.zone_id}"
   name    = "api.${var.cluster_domain}"
   type    = "A"
 

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -101,6 +101,18 @@ data "libvirt_network_dns_host_template" "masters" {
   hostname = "api.${var.cluster_domain}"
 }
 
+data "libvirt_network_dns_host_template" "bootstrap" {
+  count    = "${var.bootstrap_dns ? 1 : 0}"
+  ip       = "${var.libvirt_bootstrap_ip}"
+  hostname = "api-int.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_host_template" "masters" {
+  count    = "${var.master_count}"
+  ip       = "${var.libvirt_master_ips[count.index]}"
+  hostname = "api-int.${var.cluster_domain}"
+}
+
 data "libvirt_network_dns_host_template" "etcds" {
   count    = "${var.master_count}"
   ip       = "${var.libvirt_master_ips[count.index]}"


### PR DESCRIPTION
wired to the same load balancer. But does mean you can change the certs
and CA for the apiserver on the public name, but let us continue to own
certs for the -int name used by kubelets