### PR TITLE
BUG 1685704: upi/metal: add the api-int dns

### DIFF
--- a/docs/user/metal/install_upi.md
+++ b/docs/user/metal/install_upi.md
@@ -89,9 +89,9 @@ All the RHCOS machines require network in `initramfs` during boot to fetch Ignit
 
 * Kubernetes API
 
-    OpenShift 4.x requires the DNS record `api.$cluster_name.$base_domain` to point to the Load balancer targeting the control plane machines. This record must be resolvable by both clients external to the cluster and from all the nodes within the cluster.
+    OpenShift 4.x requires the DNS records `api.$cluster_name.$base_domain` and `api-int.$cluster_name.$base_domain` to point to the Load balancer targeting the control plane machines. Both records must be resolvable from all the nodes within the cluster. The `api.$cluster_name.$base_domain` must also be resolvable by clients external to the cluster.
 
-* Etcd
+* etcd
 
     For each control plane machine, OpenShift 4.x requires DNS records `etcd-$idx.$cluster_name.$base_domain` to point to `$idx`'th control plane machine. The DNS record must resolve to an unicast IPV4 address for the control plane machine and the records must be resolvable from all the nodes in the cluster.
 

--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -175,6 +175,15 @@ resource "aws_route53_record" "ctrlp" {
   records = ["${local.ctrp_records}"]
 }
 
+resource "aws_route53_record" "ctrlp_int" {
+  zone_id = "${data.aws_route53_zone.public.zone_id}"
+  type    = "A"
+  ttl     = "60"
+  name    = "api-int.${var.cluster_domain}"
+
+  records = ["${local.ctrp_records}"]
+}
+
 resource "aws_route53_record" "apps" {
   zone_id = "${data.aws_route53_zone.public.zone_id}"
   type    = "A"


### PR DESCRIPTION
Add DNS record for api-int that points to the control plane hosts.

infrastructure architecture change happening for https://bugzilla.redhat.com/show_bug.cgi?id=1685704