### PR TITLE
libvirt/main.tf: Add correct entry for *api-int* hostname

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -51,7 +51,9 @@ resource "libvirt_network" "net" {
 
     hosts = ["${flatten(list(
       data.libvirt_network_dns_host_template.bootstrap.*.rendered,
+      data.libvirt_network_dns_host_template.bootstrap_int.*.rendered,
       data.libvirt_network_dns_host_template.masters.*.rendered,
+      data.libvirt_network_dns_host_template.masters_int.*.rendered,
       data.libvirt_network_dns_host_template.etcds.*.rendered,
     ))}"]
   }]
@@ -101,13 +103,13 @@ data "libvirt_network_dns_host_template" "masters" {
   hostname = "api.${var.cluster_domain}"
 }
 
-data "libvirt_network_dns_host_template" "bootstrap" {
+data "libvirt_network_dns_host_template" "bootstrap_int" {
   count    = "${var.bootstrap_dns ? 1 : 0}"
   ip       = "${var.libvirt_bootstrap_ip}"
   hostname = "api-int.${var.cluster_domain}"
 }
 
-data "libvirt_network_dns_host_template" "masters" {
+data "libvirt_network_dns_host_template" "masters_int" {
   count    = "${var.master_count}"
   ip       = "${var.libvirt_master_ips[count.index]}"
   hostname = "api-int.${var.cluster_domain}"


### PR DESCRIPTION
   libvirt breaks api-int changes due to commit 60526fe3760d10b561ca99f46a9e2afec30f801b

   Error: data.libvirt_network_dns_host_template.bootstrap: resource repeated multiple times

cc @wking @abhinavdahiya 