### PR TITLE
cmd/openshift-install/create: Drop "timed out waiting for the condition"

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -353,6 +353,10 @@ func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
 	}
 
 	if lastError != "" {
+		if err == wait.ErrWaitTimeout {
+			return errors.Errorf("failed to initialize the cluster: %s", lastError)
+		}
+
 		return errors.Wrapf(err, "failed to initialize the cluster: %s", lastError)
 	}
 


### PR DESCRIPTION
The message reported by the cluster-version operator is already fairly clear on this being a timeout error.  For example, with this commit,

```
failed to initialize the cluster: Some cluster operators are still updating: console, image-registry: timed out waiting for the condition
```

will become:

```
failed to initialize the cluster: Some cluster operators are still updating: console, image-registry
```