### PR TITLE
openstack: Remove FQDN from node hostnames

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -48,7 +48,7 @@ data "ignition_file" "hostname" {
 
   content {
     content = <<EOF
-${var.cluster_id}-bootstrap.${var.cluster_domain}
+${var.cluster_id}-bootstrap
 EOF
   }
 }

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -15,7 +15,7 @@ data "ignition_file" "hostname" {
 
   content {
     content = <<EOF
-${var.cluster_id}-master-${count.index}.${var.cluster_domain}
+${var.cluster_id}-master-${count.index}
 EOF
   }
 }

--- a/data/data/openstack/service/main.tf
+++ b/data/data/openstack/service/main.tf
@@ -83,7 +83,7 @@ WORKERS=$(oc get nodes -l node-role.kubernetes.io/worker -ogo-template="$TEMPLAT
 
 update_cfg_and_restart() {
     CHANGED=$(diff /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.new)
-    
+
     if [[ ! -f /etc/haproxy/haproxy.cfg ]] || [[ ! $CHANGED -eq "" ]];
     then
         cp /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.backup || true
@@ -152,6 +152,11 @@ data "ignition_file" "corefile" {
     reload 10s
 
 ${length(var.lb_floating_ip) == 0 ? "" : "    file /etc/coredns/db.${var.cluster_domain} api.${var.cluster_domain} {\n    }\n"}
+
+    hosts {
+        ${replace(join("\n", formatlist("%s %s", var.master_ips, var.master_port_names)), "port-", "")}
+        fallthrough
+    }
 
 
     file /etc/coredns/db.${var.cluster_domain} _etcd-server-ssl._tcp.${var.cluster_domain} {
@@ -237,7 +242,7 @@ data "ignition_file" "hostname" {
 
   content {
     content = <<EOF
-${var.cluster_id}-api.${var.cluster_domain}
+${var.cluster_id}-api
 EOF
   }
 }


### PR DESCRIPTION
The terraform-created OpenStack hostnames now have the short name rather than
FQDN. This is consistent with the worker nodes and makes sure the actuator's
nodelink-controller is able to match the names and sync the nodes.

The node names without FQDN are now resolvable as well.