### PR TITLE
pkg/asset/ignition/bootstrap/release_image: Bump default to v4.1

### DIFF
--- a/pkg/asset/ignition/bootstrap/release_image.go
+++ b/pkg/asset/ignition/bootstrap/release_image.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
+	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:v4.1"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
On Mon, Apr 15, 2019 at 10:07 AM @smarterclayton wrote:
> Install team developers:
>
> Can continue building the installer locally, but the location we publish origin to has been updated to registry.svc.ci.openshift.org/origin/release:v4.1 and this is only if you are hacking the installer.