### PR TITLE
machines/libvirt: Drop volume paths

### DIFF
--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -70,7 +70,7 @@ func provider(clusterID string, networkInterfaceAddress string, platform *libvir
 		},
 		Volume: &libvirtprovider.Volume{
 			PoolName:     "default",
-			BaseVolumeID: fmt.Sprintf("/var/lib/libvirt/images/%s-base", clusterID),
+			BaseVolumeID: fmt.Sprintf("%s-base", clusterID),
 		},
 		NetworkInterfaceName:    clusterID,
 		NetworkInterfaceAddress: networkInterfaceAddress,


### PR DESCRIPTION
Volume should be identified by their names and their paths should be left to their container pools. This change is needed to allow for custom storage locations.

This is the needed update in Installer for the actual change in the libvirt actuator: https://github.com/openshift/cluster-api-provider-libvirt/pull/144

Fixes #308.