### PR TITLE
data/aws/vpc/master-elb: Set thresholds back to two

### DIFF
--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -41,8 +41,8 @@ resource "aws_lb_target_group" "api_internal" {
   ), var.tags)}"
 
   health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
     interval            = 10
     port                = 6443
     protocol            = "HTTPS"
@@ -63,8 +63,8 @@ resource "aws_lb_target_group" "api_external" {
   ), var.tags)}"
 
   health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
     interval            = 10
     port                = 6443
     protocol            = "HTTPS"
@@ -85,8 +85,8 @@ resource "aws_lb_target_group" "services" {
   ), var.tags)}"
 
   health_check {
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
     interval            = 10
     port                = 22623
     protocol            = "HTTPS"


### PR DESCRIPTION
These were changes from two to three in 16dfbb3541 (#594):

```console
$ git show 16dfbb354120 | grep _threshold | sort | uniq
-    healthy_threshold   = 2
-  #   healthy_threshold   = 2
+    healthy_threshold   = 3
-    unhealthy_threshold = 2
-  #   unhealthy_threshold = 2
+    unhealthy_threshold = 3
```

@crawford doesn't remember intentionally making that change, and the lower thresholds will hopefully help mitigate some issues with continued connection attempts to API servers which are in the process of shutting down.