### PR TITLE
BUG 1685704: assets: use internal apiserver name for all internal clients

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -231,8 +231,8 @@ podman run \
 	--cakey=/opt/openshift/tls/etcd-client-ca.key \
 	--metric-cacrt=/opt/openshift/tls/etcd-metric-signer.crt \
 	--metric-cakey=/opt/openshift/tls/etcd-metric-signer.key \
-	--servcrt=/opt/openshift/tls/kube-apiserver-lb-server.crt \
-	--servkey=/opt/openshift/tls/kube-apiserver-lb-server.key \
+	--servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
+	--servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
 	--address=0.0.0.0:6443 \
 	--csrdir=/tmp \
 	--peercertdur=26280h \

--- a/pkg/asset/kubeconfig/admin.go
+++ b/pkg/asset/kubeconfig/admin.go
@@ -38,7 +38,8 @@ func (k *AdminClient) Generate(parents asset.Parents) error {
 	return k.kubeconfig.generate(
 		ca,
 		clientCertKey,
-		installConfig.Config,
+		getExtAPIServerURL(installConfig.Config),
+		installConfig.Config.GetName(),
 		"admin",
 		kubeconfigAdminPath,
 	)

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -22,16 +22,17 @@ type kubeconfig struct {
 func (k *kubeconfig) generate(
 	ca tls.CertInterface,
 	clientCertKey tls.CertKeyInterface,
-	installConfig *types.InstallConfig,
+	apiURL string,
+	cluster string,
 	userName string,
 	kubeconfigPath string,
 ) error {
 	k.Config = &clientcmd.Config{
 		Clusters: []clientcmd.NamedCluster{
 			{
-				Name: installConfig.ObjectMeta.Name,
+				Name: cluster,
 				Cluster: clientcmd.Cluster{
-					Server: fmt.Sprintf("https://api.%s:6443", installConfig.ClusterDomain()),
+					Server: apiURL,
 					CertificateAuthorityData: ca.Cert(),
 				},
 			},
@@ -49,7 +50,7 @@ func (k *kubeconfig) generate(
 			{
 				Name: userName,
 				Context: clientcmd.Context{
-					Cluster:  installConfig.ObjectMeta.Name,
+					Cluster:  cluster,
 					AuthInfo: userName,
 				},
 			},
@@ -95,4 +96,12 @@ func (k *kubeconfig) load(f asset.FileFetcher, name string) (found bool, err err
 
 	k.File, k.Config = file, config
 	return true, nil
+}
+
+func getExtAPIServerURL(ic *types.InstallConfig) string {
+	return fmt.Sprintf("https://api.%s:6443", ic.ClusterDomain())
+}
+
+func getIntAPIServerURL(ic *types.InstallConfig) string {
+	return fmt.Sprintf("https://api-int.%s:6443", ic.ClusterDomain())
 }

--- a/pkg/asset/kubeconfig/kubeconfig_test.go
+++ b/pkg/asset/kubeconfig/kubeconfig_test.go
@@ -52,6 +52,7 @@ func TestKubeconfigGenerate(t *testing.T) {
 		userName     string
 		filename     string
 		clientCert   tls.CertKeyInterface
+		apiURL       string
 		expectedData []byte
 	}{
 		{
@@ -59,10 +60,11 @@ func TestKubeconfigGenerate(t *testing.T) {
 			userName:   "admin",
 			filename:   "auth/kubeconfig",
 			clientCert: adminCert,
+			apiURL:     "https://api-int.test-cluster-name.test.example.com:6443",
 			expectedData: []byte(`clusters:
 - cluster:
     certificate-authority-data: VEhJUyBJUyBST09UIENBIENFUlQgREFUQQ==
-    server: https://api.test-cluster-name.test.example.com:6443
+    server: https://api-int.test-cluster-name.test.example.com:6443
   name: test-cluster-name
 contexts:
 - context:
@@ -83,10 +85,11 @@ users:
 			userName:   "kubelet",
 			filename:   "auth/kubeconfig-kubelet",
 			clientCert: kubeletCert,
+			apiURL:     "https://api-int.test-cluster-name.test.example.com:6443",
 			expectedData: []byte(`clusters:
 - cluster:
     certificate-authority-data: VEhJUyBJUyBST09UIENBIENFUlQgREFUQQ==
-    server: https://api.test-cluster-name.test.example.com:6443
+    server: https://api-int.test-cluster-name.test.example.com:6443
   name: test-cluster-name
 contexts:
 - context:
@@ -107,7 +110,7 @@ users:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			kc := &kubeconfig{}
-			err := kc.generate(rootCA, tt.clientCert, installConfig, tt.userName, tt.filename)
+			err := kc.generate(rootCA, tt.clientCert, tt.apiURL, installConfig.GetName(), tt.userName, tt.filename)
 			assert.NoError(t, err, "unexpected error generating config")
 			actualFiles := kc.Files()
 			assert.Equal(t, 1, len(actualFiles), "unexpected number of files generated")

--- a/pkg/asset/kubeconfig/kubelet.go
+++ b/pkg/asset/kubeconfig/kubelet.go
@@ -38,7 +38,8 @@ func (k *Kubelet) Generate(parents asset.Parents) error {
 	return k.kubeconfig.generate(
 		ca,
 		clientcertkey,
-		installConfig.Config,
+		getIntAPIServerURL(installConfig.Config),
+		installConfig.Config.GetName(),
 		"kubelet",
 		kubeconfigKubeletPath,
 	)

--- a/pkg/asset/manifests/utils.go
+++ b/pkg/asset/manifests/utils.go
@@ -34,7 +34,7 @@ func configMap(namespace, name string, data genericData) *configurationObject {
 }
 
 func getAPIServerURL(ic *types.InstallConfig) string {
-	return fmt.Sprintf("https://api.%s:6443", ic.ClusterDomain())
+	return fmt.Sprintf("https://api-int.%s:6443", ic.ClusterDomain())
 }
 
 func getEtcdDiscoveryDomain(ic *types.InstallConfig) string {


### PR DESCRIPTION
BZ1685704 requires that all internal client ie openshift cluster-infra clients inside the cluster that talk to the apiserver on LB needs to move to using `api-int.$cluster_domain` so that customers can modify the external LB URL for apiserver without affecting the internal clients.

*  `data/data/bootstrap/files/usr/local/bin/bootkube.sh.template`

All the internal clients which includes the etcd cert agent moved to contacting the apiserver on `api-int.$cluster_domain` therefore the etcd signer on the bootstrap node needs to use the serving cert for the `api-int`

*  `pkg/asset/kubeconfig/`

The admin kubeconfig that installer provides its users needs to continue the apiserver on `api.$cluster_domain`

The kubelet kubeconfig is moved to use `api-int.$cluster_domain` as kubelets are internal clients to apiserver as kubelets are internal clients to apiserver.

* `pkg/asset/manifests`

This change changes the `.status.apiServerURL` for `cluster` `infrastructures.config.openshift.io` [1] to point all internal client to use `api-int.$cluster_domain` for contacting apiserver.

[1]: https://github.com/openshift/api/blob/13b403bfb6ce84ddc053bd3b401b5d67bf175efa/config/v1/types_infrastructure.go#L55-L58

@deads2k @abhinavdahiya @wking 

see if this works now that the groundwork is laid
xref https://bugzilla.redhat.com/show_bug.cgi?id=1685704