### PR TITLE
WIP: master-elb: switch to target type instance

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -134,7 +134,7 @@ resource "aws_lb_target_group_attachment" "bootstrap" {
   count = "${var.target_group_arns_length}"
 
   target_group_arn = "${var.target_group_arns[count.index]}"
-  target_id        = "${aws_instance.bootstrap.private_ip}"
+  target_id        = "${aws_instance.bootstrap.id}"
 }
 
 resource "aws_security_group" "bootstrap" {

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -120,5 +120,5 @@ resource "aws_lb_target_group_attachment" "master" {
   count = "${var.instance_count * var.target_group_arns_length}"
 
   target_group_arn = "${var.target_group_arns[count.index % var.target_group_arns_length]}"
-  target_id        = "${aws_instance.master.*.private_ip[count.index / var.target_group_arns_length]}"
+  target_id        = "${aws_instance.master.*.id[count.index / var.target_group_arns_length]}"
 }

--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -34,7 +34,7 @@ resource "aws_lb_target_group" "api_internal" {
   port     = 6443
   vpc_id   = "${local.vpc_id}"
 
-  target_type = "ip"
+  target_type = "instance"
 
   tags = "${merge(map(
     "Name", "${var.cluster_id}-aint",
@@ -56,7 +56,7 @@ resource "aws_lb_target_group" "api_external" {
   port     = 6443
   vpc_id   = "${local.vpc_id}"
 
-  target_type = "ip"
+  target_type = "instance"
 
   tags = "${merge(map(
     "Name", "${var.cluster_id}-aext",
@@ -78,7 +78,7 @@ resource "aws_lb_target_group" "services" {
   port     = 22623
   vpc_id   = "${local.vpc_id}"
 
-  target_type = "ip"
+  target_type = "instance"
 
   tags = "${merge(map(
     "Name", "${var.cluster_id}-sint",


### PR DESCRIPTION
This allows to preserve source IPs, important for auditing.