### PR TITLE
move etcd connection information to openshift-config

### DIFF
--- a/data/data/manifests/bootkube/openshift-config-configmap-etcd-serving-ca.yaml.template
+++ b/data/data/manifests/bootkube/openshift-config-configmap-etcd-serving-ca.yaml.template
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-serving-ca
+  namespace: openshift-config
+data:
+  ca-bundle.crt: |
+    {{.EtcdCaCert | indent 4}}

--- a/data/data/manifests/bootkube/openshift-config-secret-etcd-client.yaml.template
+++ b/data/data/manifests/bootkube/openshift-config-secret-etcd-client.yaml.template
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-client
+  namespace: openshift-config
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .EtcdClientCert }}
+  tls.key: {{ .EtcdClientKey }}


### PR DESCRIPTION
To get to API freeze, we need to ensure that all shared configmaps and secrets are in openshift-config or openshift-config-managed.  This moves the interlock for etcd to kas-o to openshift-config.  We have to ratchet these in, so this creates the new, but does not remove the old.

/assign @hexfusion 