### PR TITLE
upi/vsphere: use ens192 nic name

### DIFF
--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -21,15 +21,15 @@ data "ignition_file" "static_ip" {
   count = "${var.instance_count}"
 
   filesystem = "root"
-  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+  path       = "/etc/sysconfig/network-scripts/ifcfg-ens192"
   mode       = "420"
 
   content {
     content = <<EOF
 TYPE=Ethernet
 BOOTPROTO=none
-NAME=eth0
-DEVICE=eth0
+NAME=ens192
+DEVICE=ens192
 ONBOOT=yes
 IPADDR=${local.ip_addresses[count.index]}
 PREFIX=${local.mask}


### PR DESCRIPTION
RHCOS has changed the name of the NIC from eth0 to ens192 [1]. The ifcfg file laid down to set the static IP address of the machines needs to be updated to reflect the new name of the NIC.

[1] https://github.com/coreos/coreos-assembler/pull/442