### PR TITLE
BUG 1698573: cmd: level-driven bootstrap complete

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/report-progress.sh
+++ b/data/data/bootstrap/files/usr/local/bin/report-progress.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
 KUBECONFIG="${1}"
-NAME="${2}"
-MESSAGE="${3}"
 
 wait_for_existance() {
 	while [ ! -e "${1}" ]
@@ -16,22 +14,14 @@ wait_for_existance /opt/openshift/.bootkube.done
 wait_for_existance /opt/openshift/.openshift.done
 
 echo "Reporting install progress..."
-timestamp="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 while ! oc --config="$KUBECONFIG" create -f - <<-EOF
 	apiVersion: v1
-	kind: Event
+	kind: ConfigMap
 	metadata:
-	  name: "${NAME}"
+	  name: bootstrap
 	  namespace: kube-system
-	involvedObject:
-	  namespace: kube-system
-	message: "${MESSAGE}"
-	firstTimestamp: "${timestamp}"
-	lastTimestamp: "${timestamp}"
-	count: 1
-	source:
-	  component: cluster
-	  host: $(hostname)
+	data:
+	  status: complete
 EOF
 do
 	sleep 5

--- a/data/data/bootstrap/systemd/units/progress.service
+++ b/data/data/bootstrap/systemd/units/progress.service
@@ -5,7 +5,7 @@ Wants=bootkube.service openshift.service
 After=bootkube.service openshift.service
 
 [Service]
-ExecStart=/usr/local/bin/report-progress.sh /opt/openshift/auth/kubeconfig bootstrap-complete "cluster bootstrapping has completed"
+ExecStart=/usr/local/bin/report-progress.sh /opt/openshift/auth/kubeconfig
 
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
Modify the progress service so that it creates a configmap when bootstrapping is done rather than an event. This is done so that the installer can determining whether bootstrapping has completed even when run later, after the bootstrap-complete event would otherwise have expired and been deleted.

https://bugzilla.redhat.com/show_bug.cgi?id=1698573