### PR TITLE
gather rendered assets as part of install-gather

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -25,6 +25,17 @@ do
     sudo podman inspect "${container}" >& "${ARTIFACTS}/bootstrap/pods/${container}.inspect"
 done
 
+echo "Gathering rendered assets..."
+mkdir -p "${ARTIFACTS}/rendered-assets"
+cp -r /var/opt/openshift/ "${ARTIFACTS}/rendered-assets"
+# remove sensitive information
+# TODO leave tls.crt inside of secret yaml files
+find "${ARTIFACTS}/rendered-assets" -name "*secret*" -print0 | xargs -0 rm
+find "${ARTIFACTS}/rendered-assets" -name "*kubeconfig*" -print0 | xargs -0 rm
+find "${ARTIFACTS}/rendered-assets" -name "*.key" -print0 | xargs -0 rm
+find "${ARTIFACTS}/rendered-assets" -name ".kube" -print0 | xargs -0 rm -rf
+
+
 # Collect cluster data
 function queue() {
     local TARGET="${ARTIFACTS}/${1}"


### PR DESCRIPTION
I've got a broken pull https://github.com/openshift/machine-config-operator/pull/626, but in general, any future asset rendering error requires the rendered assets to make a determination of the failure.  This gathers those.

@sdodson 
/assign @vrutkovs 