### PR TITLE
tls: only write etcd certs into openshift-config

### DIFF
--- a/data/data/manifests/bootkube/kube-system-configmap-etcd-serving-ca.yaml.template
+++ b/data/data/manifests/bootkube/kube-system-configmap-etcd-serving-ca.yaml.template
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: etcd-serving-ca
-  namespace: kube-system
-data:
-  ca-bundle.crt: |
-    {{.EtcdCaCert | indent 4}}

--- a/data/data/manifests/bootkube/kube-system-secret-etcd-client.yaml.template
+++ b/data/data/manifests/bootkube/kube-system-secret-etcd-client.yaml.template
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: etcd-client
-  namespace: kube-system
-type: SecretTypeTLS
-data:
-  tls.crt: {{ .EtcdClientCert }}
-  tls.key: {{ .EtcdClientKey }}

--- a/pkg/asset/templates/content/bootkube/configmap-etcd-serving-ca.go
+++ b/pkg/asset/templates/content/bootkube/configmap-etcd-serving-ca.go
@@ -9,11 +9,10 @@ import (
 )
 
 const (
-	kubeSystemConfigmapEtcdServingCAFileName      = "kube-system-configmap-etcd-serving-ca.yaml.template"
 	openshiftConfigConfigmapEtcdServingCAFileName = "openshift-config-configmap-etcd-serving-ca.yaml.template"
 )
 
-var etcdServingCAFiles = []string{kubeSystemConfigmapEtcdServingCAFileName, openshiftConfigConfigmapEtcdServingCAFileName}
+var etcdServingCAFiles = []string{openshiftConfigConfigmapEtcdServingCAFileName}
 
 var _ asset.WritableAsset = (*KubeSystemConfigmapEtcdServingCA)(nil)
 

--- a/pkg/asset/templates/content/bootkube/secret-etcd-client.go
+++ b/pkg/asset/templates/content/bootkube/secret-etcd-client.go
@@ -9,11 +9,10 @@ import (
 )
 
 const (
-	kubeSystemSecretEtcdClientFileName      = "kube-system-secret-etcd-client.yaml.template"
 	openshiftConfigSecretEtcdClientFileName = "openshift-config-secret-etcd-client.yaml.template"
 )
 
-var etcdClientCertFiles = []string{kubeSystemSecretEtcdClientFileName, openshiftConfigSecretEtcdClientFileName}
+var etcdClientCertFiles = []string{openshiftConfigSecretEtcdClientFileName}
 
 var _ asset.WritableAsset = (*KubeSystemSecretEtcdClient)(nil)
 


### PR DESCRIPTION
completes the work already done in the rest of the operators to rely on the openshift-config namespace.