### PR TITLE
openshift: update wait for kube-apiserver to correct namespace

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/openshift.sh
+++ b/data/data/bootstrap/files/usr/local/bin/openshift.sh
@@ -56,7 +56,7 @@ wait_for_pods() {
 }
 
 # Wait for Kubernetes pods
-wait_for_pods kube-system
+wait_for_pods openshift-kube-apiserver
 
 for file in $(find . -maxdepth 1 -type f | sort)
 do


### PR DESCRIPTION
openshift.sh runs after bootkube and attemps to wait for the kube-apiserver to look healthy.
The wait is a little unusual in and of itself (you contacted the server, why wait), but
it should wait on the openshift-kube-apiserver namespace since that's the one that runs
the kube-apiserver.

/assign @wking 