### PR TITLE
Revert "openshift: update wait for kube-apiserver to correct namespace"

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/openshift.sh
+++ b/data/data/bootstrap/files/usr/local/bin/openshift.sh
@@ -56,7 +56,7 @@ wait_for_pods() {
 }
 
 # Wait for Kubernetes pods
-wait_for_pods openshift-kube-apiserver
+wait_for_pods kube-system
 
 for file in $(find . -maxdepth 1 -type f | sort)
 do


### PR DESCRIPTION
This reverts commit 989839e2e661374c88b815a744e6524bd081cc0e.

the prior merge job looks to be missing the entire directory. This is probably the failure, but it's not obvious why CI failed.