### PR TITLE
openshift: update wait for kube-apiserver to correct namespace

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/openshift.sh
+++ b/data/data/bootstrap/files/usr/local/bin/openshift.sh
@@ -30,10 +30,10 @@ kubectl() {
 }
 
 wait_for_pods() {
-	echo "Waiting for pods in namespace $1..."
+	echo "Waiting for kube-apiserver pods in namespace $1..."
 	while true
 	do
-		out=$(kubectl --namespace "$1" get pods --output custom-columns=STATUS:.status.phase,NAME:.metadata.name --no-headers=true)
+		out=$(kubectl --namespace "$1" get pods --output custom-columns=STATUS:.status.phase,NAME:.metadata.name --no-headers=true | grep kube-apiserver)
 		echo "$out"
 
 		# make sure kubectl returns at least one status
@@ -56,7 +56,7 @@ wait_for_pods() {
 }
 
 # Wait for Kubernetes pods
-wait_for_pods kube-system
+wait_for_pods openshift-kube-apiserver
 
 for file in $(find . -maxdepth 1 -type f | sort)
 do


### PR DESCRIPTION
openshift.sh runs after bootkube and attemps to wait for the kube-apiserver to look healthy.
The wait is a little unusual in and of itself (you contacted the server, why wait), but
it should wait on the openshift-kube-apiserver namespace since that's the one that runs
the kube-apiserver.

You can see an example of the failing log here: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/648/pull-ci-openshift-machine-config-operator-master-e2e-aws-op/1668/artifacts/e2e-aws-op/bootstrap/openshift.service .

The grep I added should shrink the list:

```
Apr 22 17:35:04 ip-10-0-12-47 openshift.sh[1518]: Not all pods available yet. Waiting for 5 seconds...
Apr 22 17:35:09 ip-10-0-12-47 openshift.sh[1518]: Executing kubectl --namespace openshift-kube-apiserver get pods --output custom-columns=STATUS:.status.phase,NAME:.metadata.name --no-headers=true
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-1-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-2-ip-10-0-159-71.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-2-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-3-ip-10-0-140-109.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-3-ip-10-0-159-71.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Running     installer-3-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Running     kube-apiserver-ip-10-0-140-109.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Running     kube-apiserver-ip-10-0-159-71.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Pending     kube-apiserver-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-1-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-2-ip-10-0-159-71.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-2-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-3-ip-10-0-140-109.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-3-ip-10-0-159-71.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-1-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-2-ip-10-0-159-71.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-2-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-3-ip-10-0-140-109.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   installer-3-ip-10-0-159-71.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Pending     kube-apiserver-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-1-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-2-ip-10-0-159-71.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-2-ip-10-0-166-238.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-3-ip-10-0-140-109.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Succeeded   revision-pruner-3-ip-10-0-159-71.ec2.internal
Apr 22 17:35:10 ip-10-0-12-47 openshift.sh[1518]: Not all pods available yet. Waiting for 5 seconds...
```