### PR TITLE
bootstrap: don't make openshift unit wait for kas

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/openshift.sh
+++ b/data/data/bootstrap/files/usr/local/bin/openshift.sh
@@ -29,35 +29,6 @@ kubectl() {
 	done
 }
 
-wait_for_pods() {
-	echo "Waiting for pods in namespace $1..."
-	while true
-	do
-		out=$(kubectl --namespace "$1" get pods --output custom-columns=STATUS:.status.phase,NAME:.metadata.name --no-headers=true)
-		echo "$out"
-
-		# make sure kubectl returns at least one status
-		if [ "$(wc --lines <<< "$out")" -eq 0 ]
-		then
-			echo "No pods were found. Waiting for 5 seconds..."
-			sleep 5
-			continue
-		fi
-
-		if ! grep --invert-match '^Running' <<< "$out"
-		then
-			return
-		fi
-
-		echo "Not all pods available yet. Waiting for 5 seconds..."
-		sleep 5
-	done
-	set -e
-}
-
-# Wait for Kubernetes pods
-wait_for_pods kube-system
-
 for file in $(find . -maxdepth 1 -type f | sort)
 do
 	echo "Creating object from file: $file ..."


### PR DESCRIPTION
The openshift unit runs after the bootkube unit, so the control plane is up.
We no longer have any need to wait.

Alternative https://github.com/openshift/installer/pull/1658
/assign @wking 