### PR TITLE
upi: update the registry patch command

### DIFF
--- a/docs/user/metal/install_upi.md
+++ b/docs/user/metal/install_upi.md
@@ -291,7 +291,7 @@ oc get csr -ojson | jq -r '.items[] | select(.status == {} ) | .metadata.name' |
 The Cluster Image Registry [Operator][cluster-image-registry-operator] does not pick an storage backend for `None` platform. Therefore, the cluster operator is will be stuck in progressing because it is waiting for administrator to [configure][cluster-image-registry-operator-configuration] a storage backend for the image-registry. You can pick `emptyDir` for non-production clusters by following:
 
 ```sh
-oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"filesystem":{"volumeSource": {"emptyDir":{}}}}}}'
+oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}}}}'
 ```
 
 #### Monitoring cluster completion

--- a/docs/user/vsphere/install_upi.md
+++ b/docs/user/vsphere/install_upi.md
@@ -422,7 +422,7 @@ oc get csr -ojson | jq -r '.items[] | select(.status == {} ) | .metadata.name' |
 The Cluster Image Registry [Operator][cluster-image-registry-operator] does not pick an storage backend for `vSphere` platform. Therefore, the cluster operator will be stuck in progressing because it is waiting for administrator to [configure][cluster-image-registry-operator-configuration] a storage backend for the image-registry. You can pick `emptyDir` for non-production clusters by following:
 
 ```sh
-oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"filesystem":{"volumeSource": {"emptyDir":{}}}}}}'
+oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}}}}'
 ```
 
 #### Monitoring cluster completion


### PR DESCRIPTION
image-registry operator modified the opertor config object to reduce the supported storage options [1].
This commit updates the docs to follow the new structure

[1]: https://github.com/openshift/cluster-image-registry-operator/pull/257