### PR TITLE
Setup ownership of libvirt code

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,6 +13,12 @@ aliases:
     - mtnbikenc
     - patrickdillon
     - sdodson
+  libvirt-approvers:
+    - abhinavdahiya
+    - enxebre
+    - praveenkumar
+    - zeenix
+  libvirt-reviewers:
   openstack-approvers:
     - flaper87
     - tomassedovic

--- a/data/data/libvirt/OWNERS
+++ b/data/data/libvirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - libvirt-approvers
+reviewers:
+  - libvirt-reviewers

--- a/docs/dev/libvirt/OWNERS
+++ b/docs/dev/libvirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - libvirt-approvers
+reviewers:
+  - libvirt-reviewers

--- a/pkg/asset/cluster/libvirt/OWNERS
+++ b/pkg/asset/cluster/libvirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - libvirt-approvers
+reviewers:
+  - libvirt-reviewers

--- a/pkg/asset/installconfig/libvirt/OWNERS
+++ b/pkg/asset/installconfig/libvirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - libvirt-approvers
+reviewers:
+  - libvirt-reviewers

--- a/pkg/asset/machines/libvirt/OWNERS
+++ b/pkg/asset/machines/libvirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - libvirt-approvers
+reviewers:
+  - libvirt-reviewers

--- a/pkg/destroy/libvirt/OWNERS
+++ b/pkg/destroy/libvirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - libvirt-approvers
+reviewers:
+  - libvirt-reviewers

--- a/pkg/tfvars/libvirt/OWNERS
+++ b/pkg/tfvars/libvirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - libvirt-approvers
+reviewers:
+  - libvirt-reviewers

--- a/pkg/types/libvirt/OWNERS
+++ b/pkg/types/libvirt/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+reviewers:
+  - libvirt-reviewers

--- a/tests/bdd-smoke/suites/config/libvirt/OWNERS
+++ b/tests/bdd-smoke/suites/config/libvirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - libvirt-approvers
+reviewers:
+  - libvirt-reviewers


### PR DESCRIPTION
This is to give ownership of libvirt backend of Installer to CRC team. For now I've only added two members from CRC team (myself and Praveen). I also added two members of Installer team who seem to have been the most active devs developing the relevant code.