### PR TITLE
data/bootstrap: update etcd-signer-server to use certs for api and api-int

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -231,6 +231,8 @@ podman run \
 	--cakey=/opt/openshift/tls/etcd-client-ca.key \
 	--metric-cacrt=/opt/openshift/tls/etcd-metric-signer.crt \
 	--metric-cakey=/opt/openshift/tls/etcd-metric-signer.key \
+	--servcrt=/opt/openshift/tls/kube-apiserver-lb-server.crt \
+	--servkey=/opt/openshift/tls/kube-apiserver-lb-server.key \
 	--servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
 	--servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
 	--address=0.0.0.0:6443 \


### PR DESCRIPTION
Requires etcd-signer-server to support multiple certs for serving [1]

Currently the etcd-signer-server only serves request using `api-int` serving certificate which causes errors like,

```console
time="2019-04-24T13:25:11-07:00" level=debug msg="Still waiting for the Kubernetes API: Get https://api.adahiya-0.tt.testing:6443/version?timeout=32s: x509: certificate is valid for api-int.adahiya-0.tt.testing, not api.adahiya-0.tt.testing"
```

as the installer is hitting the etcd-signer-server on api.$cluster_domain.

Setting up etcd-signer-server to use multiple certs ie one for api and another for api-int allows both internal and external client to hot etcd-signer-server and not get x509 errors.

[1]: https://github.com/coreos/kubecsr/pull/28