### PR TITLE
docs/user: Drop compute access to etcd server from UPI docs

### DIFF
--- a/docs/user/metal/install_upi.md
+++ b/docs/user/metal/install_upi.md
@@ -69,8 +69,6 @@ You must configure the network connectivity between machines to allow cluster co
 
     As the etcd members are located on the control plane machines. Each control plane machine requires connectivity to [etcd server][etcd-ports], [etcd peer][etcd-ports] and [etcd-metrics][etcd-ports] on every other control plane machine.
 
-    All the worker machines should have connectivity to [etcd server][etcd-ports] and [etcd-metrics][etcd-ports] ports on the control plane machines.
-
 * OpenShift SDN
 
     All the machines require connectivity to certain reserved ports on every other machine to establish in-cluster networking. For more details refer [doc][snd-ports].

--- a/docs/user/vsphere/install_upi.md
+++ b/docs/user/vsphere/install_upi.md
@@ -71,8 +71,6 @@ You must configure the network connectivity between machines to allow cluster co
 
     As the etcd members are located on the control plane machines, each control plane machine requires connectivity to [etcd server][etcd-ports], [etcd peer][etcd-ports] and [etcd-metrics][etcd-ports] on every other control plane machine.
 
-    All the worker machines should have connectivity to [etcd server][etcd-ports] and [etcd-metrics][etcd-ports] ports on the control plane machines.
-
 * OpenShift SDN
 
     All the machines require connectivity to certain reserved ports on every other machine to establish in-cluster networking. For more details refer [doc][snd-ports].


### PR DESCRIPTION
This was added out of an abundance of caution about how etcd metrics were being scraped, because the Prometheus scrapers can run on compute nodes.  We've now confirmed that etcd-metrics are being scraped from port 9979, which is part of the existing "OpenShift reserved" and so does not need a specific call-out.

CC @abhinavdahiya, @hexfusion