### PR TITLE
images: add rhcos.json to the upi ci image

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -16,6 +16,7 @@ COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/bin/terraform-provider-matchbox /bin/terraform-provider-matchbox
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
+COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json /var/lib/openshift-install/rhcos.json
 
 ## epel-release is required for jq
 ## gettext is required for envsubst


### PR DESCRIPTION
The vSphere e2e tests need to create a VM template from an OVA. The location from which to download the OVA is in the rhcos.json file. This change makes the rhcos.json file available to the CI tests.