### PR TITLE
vendor: Fork httpcache to support streaming images

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -353,7 +353,8 @@
     "diskcache",
   ]
   pruneopts = "NUT"
-  revision = "9cad4c3443a7200dd6400aef47183728de563a38"
+  revision = "8d10353503cd5426136ad4880b523785bb76e8c7"
+  source = "https://github.com/wking/httpcache"
 
 [[projects]]
   digest = "1:c9898be5ce1ec9e8c04a85d9b83c18835c9571e36e39b989c9d3c110ad7d1817"
@@ -1242,6 +1243,7 @@
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/util/errors",
+    "k8s.io/apimachinery/pkg/util/net",
     "k8s.io/apimachinery/pkg/util/rand",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/validation",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,6 +30,11 @@ required = [
   version = "0.26.0"
 
 [[constraint]]
+  name = "github.com/gregjones/httpcache"
+  source = "https://github.com/wking/httpcache"
+  revision = "8d10353503cd5426136ad4880b523785bb76e8c7"
+
+[[constraint]]
   name = "github.com/libvirt/libvirt-go"
   version = "4.7.0"
 

--- a/vendor/github.com/gregjones/httpcache/bufferedstreamingcache.go
+++ b/vendor/github.com/gregjones/httpcache/bufferedstreamingcache.go
@@ -1,0 +1,56 @@
+package httpcache
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// BufferedStreamingCache converts a Cache into a StreamingCache by using in-memory buffers.
+type BufferedStreamingCache struct {
+	cache Cache
+}
+
+// NewBufferedStreamingCache(cache Cache) wraps a Cache in a BufferedStreamingCache.
+func NewBufferedStreamingCache(cache Cache) StreamingCache {
+	return &BufferedStreamingCache{cache: cache}
+}
+
+// Get returns the []byte representation of a cached response and a bool
+// set to true if the value isn't empty.
+func (c *BufferedStreamingCache) Get(key string) (responseBytes []byte, ok bool) {
+	return c.cache.Get(key)
+}
+
+// Set stores the []byte representation of a response against a key.
+func (c *BufferedStreamingCache) Set(key string, responseBytes []byte) {
+	c.cache.Set(key, responseBytes)
+}
+
+// Delete removes the value associated with the key.
+func (c *BufferedStreamingCache) Delete(key string) {
+	c.cache.Delete(key)
+}
+
+// GetReader streams data from the cache.  Returns os.ErrNotExist on cache misses.
+func (c *BufferedStreamingCache) GetReader(key string) (response io.ReadCloser, err error) {
+	data, ok := c.cache.Get(key)
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	reader := bytes.NewBuffer(data)
+	return ioutil.NopCloser(reader), nil
+}
+
+// SetReader streams data into the cache.
+func (c *BufferedStreamingCache) SetReader(key string, reader io.Reader) (err error) {
+	data, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return err
+	}
+
+	c.cache.Set(key, data)
+	return nil
+}

--- a/vendor/github.com/gregjones/httpcache/diskcache/diskcache.go
+++ b/vendor/github.com/gregjones/httpcache/diskcache/diskcache.go
@@ -26,10 +26,22 @@ func (c *Cache) Get(key string) (resp []byte, ok bool) {
 	return resp, true
 }
 
+// GetReader streams data from the cache.
+func (c *Cache) GetReader(key string) (reader io.ReadCloser, err error) {
+	key = keyToFilename(key)
+	return c.d.ReadStream(key, true) // FIXME: what direct value do we want?
+}
+
 // Set saves a response to the cache as key
 func (c *Cache) Set(key string, resp []byte) {
 	key = keyToFilename(key)
 	c.d.WriteStream(key, bytes.NewReader(resp), true)
+}
+
+// SetReader streams data into the cache.
+func (c *Cache) SetReader(key string, input io.Reader) (err error) {
+	key = keyToFilename(key)
+	return c.d.WriteStream(key, input, true)
 }
 
 // Delete removes the response with key from the cache

--- a/vendor/github.com/gregjones/httpcache/httpcache.go
+++ b/vendor/github.com/gregjones/httpcache/httpcache.go
@@ -10,10 +10,11 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -38,28 +39,47 @@ type Cache interface {
 	Delete(key string)
 }
 
-// cacheKey returns the cache key for req.
-func cacheKey(req *http.Request) string {
-	if req.Method == http.MethodGet {
-		return req.URL.String()
-	} else {
-		return req.Method + " " + req.URL.String()
-	}
+// A StreamingCache interface is used by the Transport to store and retrieve responses.
+type StreamingCache interface {
+	Cache
+
+	// GetReader streams data from the cache.  Returns os.ErrNotExist on cache misses.
+	GetReader(key string) (response io.ReadCloser, err error)
+
+	// SetReader streams data into the cache.
+	SetReader(key string, input io.Reader) error
+}
+
+// cacheKey returns the cache keys for req.
+func cacheKey(req *http.Request) (header string, body string) {
+	key := fmt.Sprintf("%s-%s", req.Method, req.URL.String())
+	return fmt.Sprintf("header-%s", key), fmt.Sprintf("body-%s", key)
 }
 
 // CachedResponse returns the cached http.Response for req if present, and nil
 // otherwise.
-func CachedResponse(c Cache, req *http.Request) (resp *http.Response, err error) {
-	cachedVal, ok := c.Get(cacheKey(req))
+func CachedResponse(c StreamingCache, req *http.Request) (resp *http.Response, err error) {
+	headerKey, bodyKey := cacheKey(req)
+	header, ok := c.Get(headerKey)
 	if !ok {
 		return
 	}
 
-	b := bytes.NewBuffer(cachedVal)
-	return http.ReadResponse(bufio.NewReader(b), req)
+	body, err := c.GetReader(bodyKey)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	b := bytes.NewBuffer(header)
+	resp, err = http.ReadResponse(bufio.NewReader(b), req)
+	resp.Body = body
+	return resp, err
 }
 
-// MemoryCache is an implemtation of Cache that stores responses in an in-memory map.
+// MemoryCache is an implementation of Cache that stores responses in an in-memory map.
 type MemoryCache struct {
 	mu    sync.RWMutex
 	items map[string][]byte
@@ -100,15 +120,21 @@ type Transport struct {
 	// The RoundTripper interface actually used to make requests
 	// If nil, http.DefaultTransport is used
 	Transport http.RoundTripper
-	Cache     Cache
+	Cache     StreamingCache
 	// If true, responses returned from the cache will be given an extra header, X-From-Cache
 	MarkCachedResponses bool
+
+	clock timer
 }
 
 // NewTransport returns a new Transport with the
 // provided Cache implementation and MarkCachedResponses set to true
-func NewTransport(c Cache) *Transport {
-	return &Transport{Cache: c, MarkCachedResponses: true}
+func NewTransport(c StreamingCache) *Transport {
+	return &Transport{
+		Cache:               c,
+		MarkCachedResponses: true,
+		clock:               &realClock{},
+	}
 }
 
 // Client returns an *http.Client that caches responses.
@@ -137,29 +163,43 @@ func varyMatches(cachedResp *http.Response, req *http.Request) bool {
 // to give the server a chance to respond with NotModified. If this happens, then the cached Response
 // will be returned.
 func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
-	cacheKey := cacheKey(req)
-	cacheable := (req.Method == "GET" || req.Method == "HEAD") && req.Header.Get("range") == ""
-	var cachedResp *http.Response
-	if cacheable {
-		cachedResp, err = CachedResponse(t.Cache, req)
-	} else {
-		// Need to invalidate an existing value
-		t.Cache.Delete(cacheKey)
-	}
+	headerKey, bodyKey := cacheKey(req)
 
 	transport := t.Transport
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
 
-	if cacheable && cachedResp != nil && err == nil {
+	cacheable := (req.Method == "GET" || req.Method == "HEAD") && req.Header.Get("range") == ""
+	if !cacheable {
+		t.Cache.Delete(headerKey)
+		t.Cache.Delete(bodyKey)
+		return transport.RoundTrip(req)
+	}
+
+	cachedResp, err := CachedResponse(t.Cache, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if cachedResp == nil {
+		reqCacheControl := parseCacheControl(req.Header)
+		if _, ok := reqCacheControl["only-if-cached"]; ok {
+			resp = newGatewayTimeoutResponse(req)
+		} else {
+			resp, err = transport.RoundTrip(req)
+			if err != nil {
+				return resp, err
+			}
+		}
+	} else {
 		if t.MarkCachedResponses {
 			cachedResp.Header.Set(XFromCache, "1")
 		}
 
 		if varyMatches(cachedResp, req) {
 			// Can only use cached value if the new request doesn't Vary significantly
-			freshness := getFreshness(cachedResp.Header, req.Header)
+			freshness := getFreshness(t.clock, cachedResp.Header, req.Header)
 			if freshness == fresh {
 				return cachedResp, nil
 			}
@@ -186,70 +226,61 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		}
 
 		resp, err = transport.RoundTrip(req)
-		if err == nil && req.Method == "GET" && resp.StatusCode == http.StatusNotModified {
+		if err != nil {
+			if cachedResp != nil && canStaleOnError(t.clock, req, cachedResp.Header) {
+				// In case of transport failure and stale-if-error activated, returns cached content
+				// when available
+				return cachedResp, nil
+			}
+			t.Cache.Delete(headerKey)
+			t.Cache.Delete(bodyKey)
+			return resp, err
+		}
+
+		if req.Method == "GET" && resp.StatusCode == http.StatusNotModified {
 			// Replace the 304 response with the one from cache, but update with some new headers
 			endToEndHeaders := getEndToEndHeaders(resp.Header)
 			for _, header := range endToEndHeaders {
 				cachedResp.Header[header] = resp.Header[header]
 			}
 			resp = cachedResp
-		} else if (err != nil || (cachedResp != nil && resp.StatusCode >= 500)) &&
-			req.Method == "GET" && canStaleOnError(cachedResp.Header, req.Header) {
+		} else if cachedResp != nil && resp.StatusCode >= 500 && canStaleOnError(t.clock, req, cachedResp.Header) {
 			// In case of transport failure and stale-if-error activated, returns cached content
 			// when available
 			return cachedResp, nil
-		} else {
-			if err != nil || resp.StatusCode != http.StatusOK {
-				t.Cache.Delete(cacheKey)
-			}
-			if err != nil {
-				return nil, err
-			}
-		}
-	} else {
-		reqCacheControl := parseCacheControl(req.Header)
-		if _, ok := reqCacheControl["only-if-cached"]; ok {
-			resp = newGatewayTimeoutResponse(req)
-		} else {
-			resp, err = transport.RoundTrip(req)
-			if err != nil {
-				return nil, err
-			}
+		} else if resp.StatusCode != http.StatusOK {
+			t.Cache.Delete(headerKey)
+			t.Cache.Delete(bodyKey)
 		}
 	}
 
-	if cacheable && canStore(parseCacheControl(req.Header), parseCacheControl(resp.Header)) {
-		for _, varyKey := range headerAllCommaSepValues(resp.Header, "vary") {
-			varyKey = http.CanonicalHeaderKey(varyKey)
-			fakeHeader := "X-Varied-" + varyKey
-			reqValue := req.Header.Get(varyKey)
-			if reqValue != "" {
-				resp.Header.Set(fakeHeader, reqValue)
-			}
-		}
-		switch req.Method {
-		case "GET":
-			// Delay caching until EOF is reached.
-			resp.Body = &cachingReadCloser{
-				R: resp.Body,
-				OnEOF: func(r io.Reader) {
-					resp := *resp
-					resp.Body = ioutil.NopCloser(r)
-					respBytes, err := httputil.DumpResponse(&resp, true)
-					if err == nil {
-						t.Cache.Set(cacheKey, respBytes)
-					}
-				},
-			}
-		default:
-			respBytes, err := httputil.DumpResponse(resp, true)
-			if err == nil {
-				t.Cache.Set(cacheKey, respBytes)
-			}
-		}
-	} else {
-		t.Cache.Delete(cacheKey)
+	if !canStore(parseCacheControl(req.Header), parseCacheControl(resp.Header)) {
+		t.Cache.Delete(headerKey)
+		t.Cache.Delete(bodyKey)
+		return resp, nil
 	}
+
+	for _, varyKey := range headerAllCommaSepValues(resp.Header, "vary") {
+		varyKey = http.CanonicalHeaderKey(varyKey)
+		fakeHeader := "X-Varied-" + varyKey
+		reqValue := req.Header.Get(varyKey)
+		if reqValue != "" {
+			resp.Header.Set(fakeHeader, reqValue)
+		}
+	}
+
+	t.Cache.Delete(headerKey)
+	t.Cache.Delete(bodyKey)
+	headerBytes, err := httputil.DumpResponse(resp, false)
+	if err != nil {
+		return resp, err
+	}
+	t.Cache.Set(headerKey, headerBytes)
+
+	resp.Body = stream(resp.Body, func(pipeReader io.ReadCloser) error {
+		return t.Cache.SetReader(bodyKey, pipeReader)
+	})
+
 	return resp, nil
 }
 
@@ -277,8 +308,6 @@ type timer interface {
 	since(d time.Time) time.Duration
 }
 
-var clock timer = &realClock{}
-
 // getFreshness will return one of fresh/stale/transparent based on the cache-control
 // values of the request and the response
 //
@@ -288,7 +317,7 @@ var clock timer = &realClock{}
 //
 // Because this is only a private cache, 'public' and 'private' in cache-control aren't
 // signficant. Similarly, smax-age isn't used.
-func getFreshness(respHeaders, reqHeaders http.Header) (freshness int) {
+func getFreshness(clock timer, respHeaders, reqHeaders http.Header) (freshness int) {
 	respCacheControl := parseCacheControl(respHeaders)
 	reqCacheControl := parseCacheControl(reqHeaders)
 	if _, ok := reqCacheControl["no-cache"]; ok {
@@ -304,6 +333,9 @@ func getFreshness(respHeaders, reqHeaders http.Header) (freshness int) {
 	date, err := Date(respHeaders)
 	if err != nil {
 		return stale
+	}
+	if clock == nil {
+		clock = &realClock{}
 	}
 	currentAge := clock.since(date)
 
@@ -371,9 +403,13 @@ func getFreshness(respHeaders, reqHeaders http.Header) (freshness int) {
 
 // Returns true if either the request or the response includes the stale-if-error
 // cache control extension: https://tools.ietf.org/html/rfc5861
-func canStaleOnError(respHeaders, reqHeaders http.Header) bool {
+func canStaleOnError(clock timer, req *http.Request, respHeaders http.Header) bool {
+	if req.Method != "HEAD" && req.Method != "GET" {
+		return false
+	}
+
 	respCacheControl := parseCacheControl(respHeaders)
-	reqCacheControl := parseCacheControl(reqHeaders)
+	reqCacheControl := parseCacheControl(req.Header)
 
 	var err error
 	lifetime := time.Duration(-1)
@@ -404,6 +440,9 @@ func canStaleOnError(respHeaders, reqHeaders http.Header) bool {
 		if err != nil {
 			return false
 		}
+		if clock == nil {
+			clock = &realClock{}
+		}
 		currentAge := clock.since(date)
 		if lifetime > currentAge {
 			return true
@@ -416,14 +455,14 @@ func canStaleOnError(respHeaders, reqHeaders http.Header) bool {
 func getEndToEndHeaders(respHeaders http.Header) []string {
 	// These headers are always hop-by-hop
 	hopByHopHeaders := map[string]struct{}{
-		"Connection":          struct{}{},
-		"Keep-Alive":          struct{}{},
-		"Proxy-Authenticate":  struct{}{},
-		"Proxy-Authorization": struct{}{},
-		"Te":                struct{}{},
-		"Trailers":          struct{}{},
-		"Transfer-Encoding": struct{}{},
-		"Upgrade":           struct{}{},
+		"Connection":          {},
+		"Keep-Alive":          {},
+		"Proxy-Authenticate":  {},
+		"Proxy-Authorization": {},
+		"Te":                  {},
+		"Trailers":            {},
+		"Transfer-Encoding":   {},
+		"Upgrade":             {},
 	}
 
 	for _, extra := range strings.Split(respHeaders.Get("connection"), ",") {
@@ -433,7 +472,7 @@ func getEndToEndHeaders(respHeaders http.Header) []string {
 		}
 	}
 	endToEndHeaders := []string{}
-	for respHeader, _ := range respHeaders {
+	for respHeader := range respHeaders {
 		if _, ok := hopByHopHeaders[respHeader]; !ok {
 			endToEndHeaders = append(endToEndHeaders, respHeader)
 		}
@@ -514,38 +553,9 @@ func headerAllCommaSepValues(headers http.Header, name string) []string {
 	return vals
 }
 
-// cachingReadCloser is a wrapper around ReadCloser R that calls OnEOF
-// handler with a full copy of the content read from R when EOF is
-// reached.
-type cachingReadCloser struct {
-	// Underlying ReadCloser.
-	R io.ReadCloser
-	// OnEOF is called with a copy of the content of R when EOF is reached.
-	OnEOF func(io.Reader)
-
-	buf bytes.Buffer // buf stores a copy of the content of R.
-}
-
-// Read reads the next len(p) bytes from R or until R is drained. The
-// return value n is the number of bytes read. If R has no data to
-// return, err is io.EOF and OnEOF is called with a full copy of what
-// has been read so far.
-func (r *cachingReadCloser) Read(p []byte) (n int, err error) {
-	n, err = r.R.Read(p)
-	r.buf.Write(p[:n])
-	if err == io.EOF {
-		r.OnEOF(bytes.NewReader(r.buf.Bytes()))
-	}
-	return n, err
-}
-
-func (r *cachingReadCloser) Close() error {
-	return r.R.Close()
-}
-
 // NewMemoryCacheTransport returns a new Transport using the in-memory cache implementation
 func NewMemoryCacheTransport() *Transport {
-	c := NewMemoryCache()
+	c := NewBufferedStreamingCache(NewMemoryCache())
 	t := NewTransport(c)
 	return t
 }

--- a/vendor/github.com/gregjones/httpcache/streamreader.go
+++ b/vendor/github.com/gregjones/httpcache/streamreader.go
@@ -1,0 +1,73 @@
+package httpcache
+
+import (
+	"errors"
+	"io"
+)
+
+// streamReader fans out a source ReadCloser into two consumers.
+//
+// https://github.com/golang/go/issues/9051#issue-51289031
+type streamReader struct {
+	sourceCloser  io.Closer
+	teeReader     io.Reader
+	pipeReader    *io.PipeReader
+	pipeWriter    *io.PipeWriter
+	handlerErrors chan error
+}
+
+var closedEarly = errors.New("closed before EOF")
+
+// Read pulls data from the source reader.  Besides being returned
+// here, it will also be pushed into the pipe for the handler to pick
+// up.
+func (r *streamReader) Read(data []byte) (n int, err error) {
+	n, err = r.teeReader.Read(data)
+	if err == io.EOF {
+		r.pipeWriter.Close()
+		r.pipeWriter = nil
+		err = <-r.handlerErrors
+		if err != nil {
+			return n, err
+		}
+		return n, io.EOF
+	}
+	return n, err
+}
+
+// Close closes the source reader and the pipe.  The handler reader FIXME
+func (r *streamReader) Close() (err error) {
+	err = r.sourceCloser.Close()
+	if err != nil {
+		if r.pipeWriter != nil {
+			r.pipeWriter.CloseWithError(err)
+		}
+		return err
+	}
+
+	if r.pipeWriter != nil {
+		err = r.pipeWriter.CloseWithError(closedEarly)
+		if err != nil {
+			return err
+		}
+
+		return <-r.handlerErrors
+	}
+
+	return nil
+}
+
+func stream(readCloser io.ReadCloser, handler func(io.ReadCloser) error) *streamReader {
+	pipeReader, pipeWriter := io.Pipe()
+	handlerErrors := make(chan error, 1)
+	go func() {
+		handlerErrors <- handler(pipeReader)
+	}()
+	return &streamReader{
+		sourceCloser:  readCloser,
+		teeReader:     io.TeeReader(readCloser, pipeWriter),
+		pipeReader:    pipeReader,
+		pipeWriter:    pipeWriter,
+		handlerErrors: handlerErrors,
+	}
+}


### PR DESCRIPTION
Recent RHCOS images are ~1.6 GiB, which is a lot to hold in memory at
once (#610).  I've submitted [a patch upstream](https://github.com/gregjones/httpcache/pull/93) to support streaming,
but upstream rejected it because it introduces an API change.
Reworking the patch to make it acceptable upstream would probably
involve a significant amount of effort.

This patch reduces the memory requirements for the download and unpack
phase from over 20 GiB down to less than 150 MiB, with
`rhcos-410.8.20190412.1`.