### PR TITLE
data/bootstrap: update the mco bootstrap to include the cloudconf file path

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -187,7 +187,8 @@ then
 			--machine-config-server-image=${MACHINE_CONFIG_SERVER_IMAGE} \
 			--machine-config-daemon-image=${MACHINE_CONFIG_DAEMON_IMAGE} \
 			--machine-config-oscontent-image=${MACHINE_CONFIG_OSCONTENT} \
-			--infra-image=${MACHINE_CONFIG_INFRA_IMAGE}
+			--infra-image=${MACHINE_CONFIG_INFRA_IMAGE} \
+			--cloud-config-file=/assets/manifests/cloud-provider-config.yaml
 
 	# Bootstrap MachineConfigController uses /etc/mcc/bootstrap/manifests/ dir to
 	# 1. read the controller config rendered by MachineConfigOperator


### PR DESCRIPTION
Catching up to MCO supporting reading the cloud conf file on bootstrap node only when the infrastructures.config.openshift.io
has the cloud provider config location set [1]

[1]: https://github.com/openshift/machine-config-operator/pull/591

/cc @staebler @wking 