### PR TITLE
description typo in data/data/libvirt/bootstrap/variables.tf

### DIFF
--- a/data/data/libvirt/bootstrap/variables.tf
+++ b/data/data/libvirt/bootstrap/variables.tf
@@ -1,7 +1,7 @@
 variable "addresses" {
   type        = "list"
   default     = []
-  description = "IP addresses to assign to the boostrap node."
+  description = "IP addresses to assign to the bootstrap node."
 }
 
 variable "base_volume_id" {


### PR DESCRIPTION
found while wondering why `git grep "boostrap node"` only returned one reference. (Answer: because I can't type.)