### PR TITLE
images: Clean up image FROM to be consistent

### DIFF
--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -7,5 +7,5 @@ COPY . .
 RUN go generate ./data && \
     SKIP_GENERATION=y GOOS=darwin GOARCH=amd64 hack/build.sh
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:installer
+FROM registry.svc.ci.openshift.org/ocp/4.1:installer
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac/openshift-install

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -1,4 +1,4 @@
-# This Dockerfile is a used by CI to publish openshift/origin-v4.0:installer
+# This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
@@ -7,7 +7,7 @@ COPY . .
 RUN hack/build.sh
 
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000

--- a/images/installer/Dockerfile.ci.rhel7
+++ b/images/installer/Dockerfile.ci.rhel7
@@ -1,4 +1,4 @@
-# This Dockerfile is a used by CI to publish openshift/origin-v4.0:installer
+# This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
@@ -7,7 +7,7 @@ COPY . .
 RUN hack/build.sh
 
 
-FROM registry.svc.ci.openshift.org/ocp/4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -1,17 +1,17 @@
-# This Dockerfile is a used by CI to test UPI platforms for OpenShift Installer
+# This Dockerfile is used by CI to test UPI platforms for OpenShift Installer
 # It builds an image containing binaries like jq, terraform, awscli, oc, etc. to allow bringing up UPI infrastructure.
 # It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
 
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 RUN GOBIN=$(pwd)/bin go get -u github.com/coreos/terraform-provider-matchbox
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:cli as cli
+FROM registry.svc.ci.openshift.org/ocp/4.1:cli as cli
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.svc.ci.openshift.org/ocp/4.1:base
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/bin/terraform-provider-matchbox /bin/terraform-provider-matchbox

--- a/images/mock/Dockerfile
+++ b/images/mock/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/openshift/origin-release:golang-1.10
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 
 RUN go get github.com/golang/mock/gomock github.com/golang/mock/mockgen

--- a/images/nested-libvirt/Dockerfile
+++ b/images/nested-libvirt/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is a used by CI to test a libvirt cluster launched in a gce instance
 # It builds an image containing google-cloud-sdk, ns_wrapper and scripts to launch a VM for a libvirt install.
-FROM openshift/origin-release:golang-1.10 AS build
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN TAGS=libvirt hack/build.sh

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,13 +1,12 @@
-# This Dockerfile is a used by CI to test using OpenShift Installer against an OpenStack cloud.
+# This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
-
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:cli /usr/bin/oc /bin/oc
 


### PR DESCRIPTION
The images in use should be consistent across all components, and
pointing to the right versions. Doing this will allow the installer
CI repo to benefit from binary build reuse in ci-operator. Prevent
local dev builders from grabbing the wrong images.