### PR TITLE
BUG 1702050: Add aws role labels back (revert #1474)

### DIFF
--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -49,7 +49,9 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				Namespace: "openshift-machine-api",
 				Name:      fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, idx),
 				Labels: map[string]string{
-					"machine.openshift.io/cluster-api-cluster": clusterID,
+					"machine.openshift.io/cluster-api-cluster":      clusterID,
+					"machine.openshift.io/cluster-api-machine-role": role,
+					"machine.openshift.io/cluster-api-machine-type": role,
 				},
 			},
 			Spec: machineapi.MachineSpec{

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -58,15 +58,19 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 				Replicas: &replicas,
 				Selector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"machine.openshift.io/cluster-api-machineset": name,
-						"machine.openshift.io/cluster-api-cluster":    clusterID,
+						"machine.openshift.io/cluster-api-machineset":   name,
+						"machine.openshift.io/cluster-api-cluster":      clusterID,
+						"machine.openshift.io/cluster-api-machine-role": role,
+						"machine.openshift.io/cluster-api-machine-type": role,
 					},
 				},
 				Template: machineapi.MachineTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							"machine.openshift.io/cluster-api-machineset": name,
-							"machine.openshift.io/cluster-api-cluster":    clusterID,
+							"machine.openshift.io/cluster-api-machineset":   name,
+							"machine.openshift.io/cluster-api-cluster":      clusterID,
+							"machine.openshift.io/cluster-api-machine-role": role,
+							"machine.openshift.io/cluster-api-machine-type": role,
 						},
 					},
 					Spec: machineapi.MachineSpec{


### PR DESCRIPTION
We dropped aws role labels in https://github.com/openshift/installer/pull/1474 to reduce the surface to what's actually needed by our core controllers. However having this lables provides better UX and searchability for end users and consumers like machineAutoscaler resource so we are putting them back