### PR TITLE
Add defaultNodeSelector annotation to openshift-etcd namespace

### DIFF
--- a/data/data/manifests/bootkube/etcd-namespace.yaml
+++ b/data/data/manifests/bootkube/etcd-namespace.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-etcd
+  annotations:
+    openshift.io/node-selector: ""
   labels:
     openshift.io/run-level: "1"


### PR DESCRIPTION
**Why this change?**
When https://github.com/openshift/cluster-kube-apiserver-operator/pull/394 merges, all the pods running openshift cluster will have a [defaultNodeSelector](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#setting-the-cluster-wide-default-node-selector) if it has been set by cluster-admin including pods running in `openshift-*` namespace. The main advantage of having that feature is in a multi-tenant environment, any new project created can be steered towards compute nodes(non-master nodes).

**What should I do?**
If you think, the pods in your namespace shouldn't have defaultNodeSelector set, please review this PR. If not feel free to close this. The annotation added as part of this PR lets all the pods created within your project to not have the defaultNodeSelector set.


/cc @deads2k @sjenning 

I see that there is also `openshift-machine-config-operator` namespace created here(https://github.com/openshift/installer/blob/master/data/data/manifests/bootkube/04-openshift-machine-config-operator.yaml) but I see that annotation is already applied to that namespace not sure which component is applying it.