### PR TITLE
 vendor: fix inconsistent state 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1125,7 +1125,7 @@
     "pkg/apis/azureprovider/v1alpha1",
   ]
   pruneopts = "NUT"
-  revision = "b49363c5b3247da8d7345904a3c95d4a28c66a61"
+  revision = "5d24bf040dbd469e149dc54d938698a7be71e7c9"
   source = "https://github.com/awesomenix/cluster-api-provider-azure.git"
 
 [[projects]]
@@ -1238,6 +1238,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/fields",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/serializer",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,7 +61,7 @@ required = [
   name = "k8s.io/client-go"
   version = "9.0.0"
 
-[[constraint]]
+[[override]]
   name = "github.com/openshift/cluster-api"
   revision = "d8958b539e331bf5ebb056b7f872541e13fb8e01"
 

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+if [ "$IS_CONTAINER" != "" ]; then
+  if [ ! "$(command -v dep >/dev/null)" ]; then
+    go get -u github.com/golang/dep/cmd/dep
+  fi
+
+  dep check
+  dep ensure
+  git diff --exit-code
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
+    --workdir /go/src/github.com/openshift/installer \
+    docker.io/openshift/origin-release:golang-1.10 \
+    ./hack/verify-vendor.sh "${@}"
+fi


### PR DESCRIPTION
#1688 updated the vendor that left the master vedoring in inconsistent.

```console
$ git --no-pager log --pretty=oneline -1 -U

30e4f71 (HEAD -> master, upstream/master) Merge pull request #1696 from patrickdillon/update-owners

$ dep ensure

Solving failure: No versions of github.com/openshift/cluster-api-provider-libvirt met constraints:

        c23986b36a2521cd69ac22d7adb74a22bca9f7aa: Could not introduce github.com/openshift/cluster-api-provider-libvirt@c23986b36a2521cd69ac22d7adb74a22bca9f7aa, as it has a dependency on github.com/openshift/cluster-api with constraint 91fca585a85b163ddfd119fd09c128c9feadddca, which has no overlap with existing constraint d8958b539e331bf5ebb056b7f872541e13fb8e01 from (root)

        v0.2.0: Could not introduce github.com/openshift/cluster-api-provider-libvirt@v0.2.0, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        v0.1.0: Could not introduce github.com/openshift/cluster-api-provider-libvirt@v0.1.0, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        v0: Could not introduce github.com/openshift/cluster-api-provider-libvirt@v0, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        master: Could not introduce github.com/openshift/cluster-api-provider-libvirt@master, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        bump-k8s-to-1.12: Could not introduce github.com/openshift/cluster-api-provider-libvirt@bump-k8s-to-1.12, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        crd: Could not introduce github.com/openshift/cluster-api-provider-libvirt@crd, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        e2e: Could not introduce github.com/openshift/cluster-api-provider-libvirt@e2e, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        paulfantom-patch-1: Could not introduce github.com/openshift/cluster-api-provider-libvirt@paulfantom-patch-1, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        paulfantom-patch-2: Could not introduce github.com/openshift/cluster-api-provider-libvirt@paulfantom-patch-2, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        release-4.0: Could not introduce github.com/openshift/cluster-api-provider-libvirt@release-4.0, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        release-4.1: Could not introduce github.com/openshift/cluster-api-provider-libvirt@release-4.1, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.

        revert-82-remove_log_level: Could not introduce github.com/openshift/cluster-api-provider-libvirt@revert-82-remove_log_level, as it is not allowed by constraint c23986b36a2521cd69ac22d7adb74a22bca9f7aa from project github.com/openshift/installer.
```

/cc @wking @enxebre 