### PR TITLE
cmd: fix some copy in the help text

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -49,7 +49,7 @@ var (
 func newGatherBootstrapCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
-		Short: "Gather debugging data for a failing to bootstrap control plane",
+		Short: "Gather debugging data for a failing-to-bootstrap control plane",
 		Args:  cobra.ExactArgs(0),
 		Run: func(_ *cobra.Command, _ []string) {
 			cleanup := setupFileHook(rootOpts.dir)


### PR DESCRIPTION
Compound adjectives are seperated by hyphens. The copy as-is is a little
hard to parse.