### PR TITLE
upi/aws/cloudformation: Cap InfrastructureName at 27 chars

### DIFF
--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -3,17 +3,17 @@ Description: Template for Openshift Cluster UPI Network Elements (Route53 & LBs)
 
 Parameters:
   ClusterName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
-    MaxLength: 32
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 32 characters
+    ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 27 characters
     Description: A short, representative cluster name to use for hostnames, etc.
     Type: String
   InfrastructureName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
-    MaxLength: 32
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 32 characters
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
     Description: A short, unique cluster ID used to tag cloud resources and identify items owned/used by the cluster.
     Type: String
   HostedZoneId:
@@ -72,7 +72,7 @@ Resources:
   ExtApiElb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: !Join ["-", ["api-ext", !Ref ClusterName, !Ref "AWS::Region"]]
+      Name: !Join ["-", [!Ref InfrastructureName, "ext"]]
       IpAddressType: ipv4
       Subnets: !Ref PublicSubnets
       Type: network
@@ -80,7 +80,7 @@ Resources:
   IntApiElb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: !Join ["-", ["api-int", !Ref ClusterName, !Ref "AWS::Region"]]
+      Name: !Join ["-", [!Ref InfrastructureName, "int"]]
       Scheme: internal
       IpAddressType: ipv4
       Subnets: !Ref PrivateSubnets

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -3,10 +3,10 @@ Description: Template for Openshift Cluster UPI Security Elements (Security Grou
 
 Parameters:
   InfrastructureName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
-    MaxLength: 32
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 32 characters
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
     Description: A short, unique cluster ID used to tag cloud resources and identify items owned/used by the cluster.
     Type: String
   VpcCidr:

--- a/upi/aws/cloudformation/04_cluster_bootstrap.yaml
+++ b/upi/aws/cloudformation/04_cluster_bootstrap.yaml
@@ -3,10 +3,10 @@ Description: Template for Openshift Cluster UPI Bootstrap (EC2 Instance, Securit
 
 Parameters:
   InfrastructureName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
-    MaxLength: 32
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 32 characters
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
     Description: A short, unique cluster ID used to tag cloud resources and identify items owned/used by the cluster.
     Type: String
   RhcosAmi:

--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -3,10 +3,10 @@ Description: Template for Openshift Cluster UPI Node Launch (EC2 master instance
 
 Parameters:
   InfrastructureName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
-    MaxLength: 32
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 32 characters
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
     Description: A short, unique cluster ID used to tag nodes for the kubelet cloud provider.
     Type: String
   RhcosAmi:

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -3,10 +3,10 @@ Description: Template for Openshift Cluster UPI Node Launch (EC2 worker instance
 
 Parameters:
   InfrastructureName:
-    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,31})$
-    MaxLength: 32
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 32 characters
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
     Description: A short, unique cluster ID used to tag nodes for the kubelet cloud provider.
     Type: String
   RhcosAmi:


### PR DESCRIPTION
So we can still add a few chars and stay under the AWS limits, avoiding stuff like:

```
The load balancer name 'api-int-ci-op-mk19233w-38af6-us-east-1' cannot be longer than '32' characters (Service: AmazonElasticLoadBalancingV2; Status Code: 400; Error Code: ValidationError; Request ID: 2acccf34-6d74-11e9-ac17-cf3d0e8e1c6d)
```

This brings us in line with [`InfrastructureStatus.InfrastructureStatus`][1].

[1]: https://github.com/openshift/api/blob/168fd4e3c55217ad0042c4ee1ec79e9ce40d5c21/config/v1/types_infrastructure.go#L36