### PR TITLE
bump bootstrap cert validity to 10 years to allow for disaster recovery

### DIFF
--- a/pkg/asset/tls/kubelet.go
+++ b/pkg/asset/tls/kubelet.go
@@ -181,7 +181,7 @@ func (a *KubeletClientCertKey) Generate(dependencies asset.Parents) error {
 		Subject:      pkix.Name{CommonName: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper", Organization: []string{"system:serviceaccounts:openshift-machine-config-operator"}},
 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		Validity:     ValidityOneDay,
+		Validity:     ValidityTenYears,
 	}
 
 	return a.SignedCertKey.Generate(cfg, ca, "kubelet-client", DoNotAppendParent)


### PR DESCRIPTION
By setting the bootstrap cert expiration to one day the node can only be suspended for < 24 hours. Bumping the validity to ten years allows the node to be suspended and resumed for that duration.

/cc @sjenning @deads2k 