### PR TITLE
[AWS] Correcting UPI gp2 volumes to match IPI sizes

### DIFF
--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -90,6 +90,10 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
     - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
         default: "Host Information"
       Parameters:
       - MasterInstanceType
@@ -121,6 +125,8 @@ Metadata:
       - InternalApiTargetGroupArn
       - InternalServiceTargetGroupArn
     ParameterLabels:
+      InfrastructureName:
+        default: "Infrastructure Name"
       VpcId:
         default: "VPC ID"
       Master0Subnet:
@@ -159,6 +165,11 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref RhcosAmi
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
       IamInstanceProfile: !Ref MasterInstanceProfileName
       InstanceType: !Ref MasterInstanceType
       NetworkInterfaces:
@@ -206,6 +217,11 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref RhcosAmi
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
       IamInstanceProfile: !Ref MasterInstanceProfileName
       InstanceType: !Ref MasterInstanceType
       NetworkInterfaces:
@@ -253,6 +269,11 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref RhcosAmi
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
       IamInstanceProfile: !Ref MasterInstanceProfileName
       InstanceType: !Ref MasterInstanceType
       NetworkInterfaces:

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -56,6 +56,10 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
     - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
         default: "Host Information"
       Parameters:
       - WorkerInstanceType
@@ -71,6 +75,8 @@ Metadata:
     ParameterLabels:
       Subnet:
         default: "Subnet"
+      InfrastructureName:
+        default: "Infrastructure Name"
       WorkerInstanceType:
         default: "Worker Instance Type"
       WorkerInstanceProfileName:
@@ -89,6 +95,11 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref RhcosAmi
+      BlockDeviceMappings:
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
       IamInstanceProfile: !Ref WorkerInstanceProfileName
       InstanceType: !Ref WorkerInstanceType
       NetworkInterfaces:


### PR DESCRIPTION
Noticed when researching the io1 volumes and configurability of root volumes the installer overrides the default 16G size of the root RHCOS volume to 120G. Changing the CloudFormation templates to match for both masters and workers.