### PR TITLE
pkg/asset/manifests/azure: leave cloud-provider identity empty

### DIFF
--- a/pkg/asset/manifests/azure/cloudproviderconfig.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig.go
@@ -3,7 +3,6 @@ package azure
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 )
 
 //CloudProviderConfig is the azure cloud provider config
@@ -24,10 +23,12 @@ func (params CloudProviderConfig) JSON() (string, error) {
 			TenantID:                    params.TenantID,
 			SubscriptionID:              params.SubscriptionID,
 			UseManagedIdentityExtension: true,
-			UserAssignedIdentityID: fmt.Sprintf("/subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s",
-				params.SubscriptionID,
-				resourceGroupName,
-				params.ResourcePrefix+"-identity"),
+			// The cloud provider needs the clientID which is only known after terraform has run.
+			// When left empty, the existing managed identity on the VM will be used.
+			// By leaving it empty, we don't have to create the identity before running the installer.
+			// We only need to know that there will be one assigned to the VM, and we control this.
+			// ref: https://github.com/kubernetes/kubernetes/blob/4b7c607ba47928a7be77fadef1550d6498397a4c/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go#L69
+			UserAssignedIdentityID: "",
 		},
 		ResourceGroup:          resourceGroupName,
 		Location:               params.GroupLocation,

--- a/pkg/asset/manifests/azure/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig_test.go
@@ -22,7 +22,7 @@ func TestCloudProviderConfig(t *testing.T) {
 	"aadClientCertPath": "",
 	"aadClientCertPassword": "",
 	"useManagedIdentityExtension": true,
-	"userAssignedIdentityID": "/subscriptions/subID/resourcegroups/clusterid-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/clusterid-identity",
+	"userAssignedIdentityID": "",
 	"subscriptionId": "subID",
 	"resourceGroup": "clusterid-rg",
 	"location": "westeurope",


### PR DESCRIPTION
The cloud provider needs the clientID which is only known after terraform has run.
When left empty, the existing managed identity on the VM will be used.
By leaving it empty, we don't have to create the identity before running the installer.
We only need to know that there will be one assigned to the VM, and we control this.

ref: https://github.com/kubernetes/kubernetes/blob/4b7c607ba47928a7be77fadef1550d6498397a4c/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go#L69