### PR TITLE
WIP *: fix etcd ca mismatch

### DIFF
--- a/data/data/manifests/bootkube/etcd-serving-ca-configmap.yaml.template
+++ b/data/data/manifests/bootkube/etcd-serving-ca-configmap.yaml.template
@@ -5,4 +5,4 @@ metadata:
   namespace: openshift-config
 data:
   ca-bundle.crt: |
-    {{.EtcdCaCert | indent 4}}
+    {{.EtcdSignerClientCert | indent 4}}

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -172,7 +172,6 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 	templateData := &bootkubeTemplateData{
 		CVOClusterID:               clusterID.UUID,
 		EtcdCaBundle:               base64.StdEncoding.EncodeToString(etcdCABundle.Cert()),
-		EtcdCaCert:                 string(etcdCA.Cert()),
 		EtcdClientCaCert:           base64.StdEncoding.EncodeToString(etcdCA.Cert()),
 		EtcdClientCaKey:            base64.StdEncoding.EncodeToString(etcdCA.Key()),
 		EtcdClientCert:             base64.StdEncoding.EncodeToString(etcdClientCertKey.Cert()),

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -39,7 +39,6 @@ type cloudCredsSecretData struct {
 type bootkubeTemplateData struct {
 	CVOClusterID               string
 	EtcdCaBundle               string
-	EtcdCaCert                 string
 	EtcdClientCaCert           string
 	EtcdClientCaKey            string
 	EtcdClientCert             string


### PR DESCRIPTION
While doing disaster recovery I noticed that the etcd CA cert on disk was not the same that was used to sign the certs. This PR is a test to see if it's possible to fix that.