### PR TITLE
*: add missing etcd-client-ca secret

### DIFF
--- a/data/data/manifests/bootkube/etcd-client-ca-secret.yaml.template
+++ b/data/data/manifests/bootkube/etcd-client-ca-secret.yaml.template
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-client-ca
+  namespace: openshift-config
+type: SecretTypeTLS
+data:
+  tls.crt: {{ .EtcdClientCaCert }}
+  tls.key: {{ .EtcdClientCaKey }}


### PR DESCRIPTION
For disaster recovery, we need to persist the etcd-client-ca.{crt,key} which allows us to regenerate etcd certificates. While the cert is persisted to disk we do not have the key. For now, this adds the secret to `openshift-config` along with the other etcd related TLS assets.

https://github.com/openshift/installer/blob/9d177305fab2300e9c833b6587b86b9f9d877031/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L230-L232

https://github.com/openshift/installer/blob/ad87acccbf601211adf40f79a86f70032c80ab2b/pkg/asset/manifests/operators.go#L176-L177

