### PR TITLE
data/data/manifests/openshift: passthrough cloud-creds annotation

### DIFF
--- a/data/data/manifests/openshift/cloud-creds-secret.yaml.template
+++ b/data/data/manifests/openshift/cloud-creds-secret.yaml.template
@@ -6,6 +6,8 @@ metadata:
   name: aws-creds
 {{- else if .CloudCreds.Azure}}
   name: azure-credentials
+  annotations:
+    cloudcredential.openshift.io/mode: passthrough
 {{- else if .CloudCreds.OpenStack}}
   name: openstack-credentials
 {{- else if .CloudCreds.VSphere}}


### PR DESCRIPTION
Azure cred minter implementation currently only supports passthrough.
The credentials secret needs to be annotated to enable it.