### PR TITLE
openstack: use static .repo file for openstack client

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,6 +1,5 @@
 # This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
-
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
@@ -8,11 +7,11 @@ RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=builder images/openstack/rdo-stein.repo /etc/yum.repos.d/rdo-stein.repo
 COPY --from=registry.svc.ci.openshift.org/openshift/origin-v4.0:cli /usr/bin/oc /bin/oc
 
 RUN yum install --setopt=tsflags=nodocs -y \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
-    https://www.rdoproject.org/repos/rdo-release.rpm && \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &&\
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     python-openstackclient && \

--- a/images/openstack/rdo-stein.repo
+++ b/images/openstack/rdo-stein.repo
@@ -1,0 +1,6 @@
+[openstack-stein]
+name=OpenStack Stein Repository
+baseurl=http://mirror.centos.org/centos/7/cloud/$basearch/openstack-stein/
+#mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=cloud-openstack-stein
+gpgcheck=0
+enabled=1


### PR DESCRIPTION
The openstack repo provided by the release rpm was providing a broken .repo file. Instead, we can use our own static .repo file.