### PR TITLE
plugins: include add github.com/abhinavdahiya/terraform-provider-azurerm-srv

### DIFF
--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -108,6 +108,14 @@
   version = "v2"
 
 [[projects]]
+  branch = "master"
+  digest = "1:82ebfdc7eb1a9f93e8edfaf5bc974c921364cf8dab78ca57f9b0789c386a258b"
+  name = "github.com/abhinavdahiya/terraform-provider-azurerm-srv"
+  packages = ["srv"]
+  pruneopts = "NUT"
+  revision = "b76400a3f181b7801de30c7cd6a11ac6361cf1e9"
+
+[[projects]]
   digest = "1:e6d97567e560cc54e59ca39eed9651a615ea0d31cd1b104d8a4e27043afea53b"
   name = "github.com/aws/aws-sdk-go"
   packages = [
@@ -953,6 +961,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv",
     "github.com/dmacvicar/terraform-provider-libvirt/libvirt",
     "github.com/terraform-providers/terraform-provider-aws/aws",
     "github.com/terraform-providers/terraform-provider-azurerm/azurerm",

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -46,6 +46,10 @@ ignored = [
   version = "=1.25.0"
 
 [[constraint]]
+  name = "github.com/abhinavdahiya/terraform-provider-azurerm-srv"
+  branch = "master"
+
+[[constraint]]
   name = "github.com/terraform-providers/terraform-provider-random"
   version = "2.1.1"
 

--- a/pkg/terraform/exec/plugins/azure-srv.go
+++ b/pkg/terraform/exec/plugins/azure-srv.go
@@ -1,0 +1,15 @@
+package plugins
+
+import (
+	"github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func init() {
+	azurermSrvProvider := func() {
+		plugin.Serve(&plugin.ServeOpts{
+			ProviderFunc: srv.Provider,
+		})
+	}
+	KnownPlugins["terraform-provider-azurerm-srv"] = azurermSrvProvider
+}

--- a/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/config.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/config.go
@@ -1,0 +1,133 @@
+package srv
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	az "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/authentication"
+)
+
+// armClient contains the handles to all the specific Azure Resource Manager
+// resource classes' respective clients.
+type armClient struct {
+	clientID              string
+	tenantID              string
+	subscriptionID        string
+	usingServicePrincipal bool
+	environment           az.Environment
+
+	StopContext context.Context
+
+	dnsClient   dns.RecordSetsClient
+	zonesClient dns.ZonesClient
+}
+
+// getArmClient is a helper method which returns a fully instantiated
+// *armClient based on the Config's current settings.
+func getArmClient(c *authentication.Config) (*armClient, error) {
+	env, err := authentication.DetermineEnvironment(c.Environment)
+	if err != nil {
+		return nil, err
+	}
+
+	// client declarations:
+	client := armClient{
+		clientID:              c.ClientID,
+		tenantID:              c.TenantID,
+		subscriptionID:        c.SubscriptionID,
+		environment:           *env,
+		usingServicePrincipal: c.AuthenticatedAsAServicePrincipal,
+	}
+
+	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, c.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	// OAuthConfigForTenant returns a pointer, which can be nil.
+	if oauthConfig == nil {
+		return nil, fmt.Errorf("Unable to configure OAuthConfig for tenant %s", c.TenantID)
+	}
+
+	// Resource Manager endpoints
+	endpoint := env.ResourceManagerEndpoint
+	auth, err := c.GetAuthorizationToken(oauthConfig, env.TokenAudience)
+	if err != nil {
+		return nil, err
+	}
+
+	client.registerDNSClients(endpoint, c.SubscriptionID, auth)
+	return &client, nil
+}
+
+func (c *armClient) registerDNSClients(endpoint, subscriptionId string, auth autorest.Authorizer) {
+	dn := dns.NewRecordSetsClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&dn.Client, auth)
+	c.dnsClient = dn
+
+	zo := dns.NewZonesClientWithBaseURI(endpoint, subscriptionId)
+	c.configureClient(&zo.Client, auth)
+	c.zonesClient = zo
+}
+
+func (c *armClient) configureClient(client *autorest.Client, auth autorest.Authorizer) {
+	client.Authorizer = auth
+	client.Sender = buildSender()
+	client.PollingDuration = 60 * time.Minute
+}
+
+func buildSender() autorest.Sender {
+	return autorest.DecorateSender(&http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		},
+	}, withRequestLogging())
+}
+
+func withRequestLogging() autorest.SendDecorator {
+	return func(s autorest.Sender) autorest.Sender {
+		return autorest.SenderFunc(func(r *http.Request) (*http.Response, error) {
+			// strip the authorization header prior to printing
+			authHeaderName := "Authorization"
+			auth := r.Header.Get(authHeaderName)
+			if auth != "" {
+				r.Header.Del(authHeaderName)
+			}
+
+			// dump request to wire format
+			if dump, err := httputil.DumpRequestOut(r, true); err == nil {
+				log.Printf("[DEBUG] AzureRM Request: \n%s\n", dump)
+			} else {
+				// fallback to basic message
+				log.Printf("[DEBUG] AzureRM Request: %s to %s\n", r.Method, r.URL)
+			}
+
+			// add the auth header back
+			if auth != "" {
+				r.Header.Add(authHeaderName, auth)
+			}
+
+			resp, err := s.Do(r)
+			if resp != nil {
+				// dump response to wire format
+				if dump, err2 := httputil.DumpResponse(resp, true); err2 == nil {
+					log.Printf("[DEBUG] AzureRM Response for %s: \n%s\n", r.URL, dump)
+				} else {
+					// fallback to basic message
+					log.Printf("[DEBUG] AzureRM Response: %s for %s\n", resp.Status, r.URL)
+				}
+			} else {
+				log.Printf("[DEBUG] Request to %s completed with no response", r.URL)
+			}
+			return resp, err
+		})
+	}
+}

--- a/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/provider.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/provider.go
@@ -1,0 +1,91 @@
+package srv
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/authentication"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Provider returns a terraform.ResourceProvider.
+func Provider() terraform.ResourceProvider {
+	p := &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"subscription_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_SUBSCRIPTION_ID", ""),
+			},
+
+			"client_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_ID", ""),
+			},
+
+			"tenant_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_TENANT_ID", ""),
+			},
+
+			"environment": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_ENVIRONMENT", "public"),
+			},
+
+			"client_secret": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_SECRET", ""),
+			},
+		},
+
+		DataSourcesMap: map[string]*schema.Resource{},
+
+		ResourcesMap: map[string]*schema.Resource{
+			"azurerm-srv_dns_srv_record": resourceArmDnsSrvRecord(),
+		},
+	}
+
+	p.ConfigureFunc = providerConfigure(p)
+
+	return p
+}
+
+func providerConfigure(p *schema.Provider) schema.ConfigureFunc {
+	return func(d *schema.ResourceData) (interface{}, error) {
+		builder := &authentication.Builder{
+			SubscriptionID: d.Get("subscription_id").(string),
+			ClientID:       d.Get("client_id").(string),
+			ClientSecret:   d.Get("client_secret").(string),
+			TenantID:       d.Get("tenant_id").(string),
+			Environment:    d.Get("environment").(string),
+
+			// Feature Toggles
+			SupportsClientSecretAuth: true,
+			SupportsAzureCliToken:    true,
+		}
+
+		config, err := builder.Build()
+		if err != nil {
+			return nil, fmt.Errorf("Error building AzureRM Client: %s", err)
+		}
+
+		client, err := getArmClient(config)
+		if err != nil {
+			return nil, err
+		}
+
+		client.StopContext = p.StopContext()
+
+		// replaces the context between tests
+		p.MetaReset = func() error {
+			client.StopContext = p.StopContext()
+			return nil
+		}
+		return client, nil
+	}
+}

--- a/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/resource.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/resource.go
@@ -1,0 +1,136 @@
+package srv
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// resourceID represents a parsed long-form Azure Resource Manager ID
+// with the Subscription ID, Resource Group and the Provider as top-
+// level fields, and other key-value pairs available via a map in the
+// Path field.
+type resourceID struct {
+	SubscriptionID string
+	ResourceGroup  string
+	Provider       string
+	Path           map[string]string
+}
+
+// parseAzureResourceID converts a long-form Azure Resource Manager ID
+// into a ResourceID. We make assumptions about the structure of URLs,
+// which is obviously not good, but the best thing available given the
+// SDK.
+func parseAzureResourceID(id string) (*resourceID, error) {
+	idURL, err := url.ParseRequestURI(id)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot parse Azure Id: %s", err)
+	}
+
+	path := idURL.Path
+
+	path = strings.TrimSpace(path)
+	if strings.HasPrefix(path, "/") {
+		path = path[1:]
+	}
+
+	if strings.HasSuffix(path, "/") {
+		path = path[:len(path)-1]
+	}
+
+	components := strings.Split(path, "/")
+
+	// We should have an even number of key-value pairs.
+	if len(components)%2 != 0 {
+		return nil, fmt.Errorf("The number of path segments is not divisible by 2 in %q", path)
+	}
+
+	var subscriptionID string
+
+	// Put the constituent key-value pairs into a map
+	componentMap := make(map[string]string, len(components)/2)
+	for current := 0; current < len(components); current += 2 {
+		key := components[current]
+		value := components[current+1]
+
+		// Check key/value for empty strings.
+		if key == "" || value == "" {
+			return nil, fmt.Errorf("Key/Value cannot be empty strings. Key: '%s', Value: '%s'", key, value)
+		}
+
+		// Catch the subscriptionID before it can be overwritten by another "subscriptions"
+		// value in the ID which is the case for the Service Bus subscription resource
+		if key == "subscriptions" && subscriptionID == "" {
+			subscriptionID = value
+		} else {
+			componentMap[key] = value
+		}
+	}
+
+	// Build up a resourceID from the map
+	idObj := &resourceID{}
+	idObj.Path = componentMap
+
+	if subscriptionID != "" {
+		idObj.SubscriptionID = subscriptionID
+	} else {
+		return nil, fmt.Errorf("No subscription ID found in: %q", path)
+	}
+
+	if resourceGroup, ok := componentMap["resourceGroups"]; ok {
+		idObj.ResourceGroup = resourceGroup
+		delete(componentMap, "resourceGroups")
+	} else {
+		// Some Azure APIs are weird and provide things in lower case...
+		// However it's not clear whether the casing of other elements in the URI
+		// matter, so we explicitly look for that case here.
+		if resourceGroup, ok := componentMap["resourcegroups"]; ok {
+			idObj.ResourceGroup = resourceGroup
+			delete(componentMap, "resourcegroups")
+		} else {
+			return nil, fmt.Errorf("No resource group name found in: %q", path)
+		}
+	}
+
+	// It is OK not to have a provider in the case of a resource group
+	if provider, ok := componentMap["providers"]; ok {
+		idObj.Provider = provider
+		delete(componentMap, "providers")
+	}
+
+	return idObj, nil
+}
+
+func composeAzureResourceID(idObj *resourceID) (id string, err error) {
+	if idObj.SubscriptionID == "" || idObj.ResourceGroup == "" {
+		return "", fmt.Errorf("SubscriptionID and ResourceGroup cannot be empty")
+	}
+
+	id = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s", idObj.SubscriptionID, idObj.ResourceGroup)
+
+	if idObj.Provider != "" {
+		if len(idObj.Path) < 1 {
+			return "", fmt.Errorf("ResourceID.Path should have at least one item when ResourceID.Provider is specified")
+		}
+
+		id += fmt.Sprintf("/providers/%s", idObj.Provider)
+
+		// sort the path keys so our output is deterministic
+		var pathKeys []string
+		for k := range idObj.Path {
+			pathKeys = append(pathKeys, k)
+		}
+		sort.Strings(pathKeys)
+
+		for _, k := range pathKeys {
+			v := idObj.Path[k]
+			if k == "" || v == "" {
+				return "", fmt.Errorf("resourceID.Path cannot contain empty strings")
+			}
+			id += fmt.Sprintf("/%s/%s", k, v)
+		}
+	}
+
+	return
+}

--- a/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/resource_arm_dns_srv_record.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/resource_arm_dns_srv_record.go
@@ -1,0 +1,223 @@
+package srv
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/dns/mgmt/2018-03-01-preview/dns"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmDnsSrvRecord() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmDnsSrvRecordCreateUpdate,
+		Read:   resourceArmDnsSrvRecordRead,
+		Update: resourceArmDnsSrvRecordCreateUpdate,
+		Delete: resourceArmDnsSrvRecordDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": schemaResourceGroupName(),
+
+			"zone_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"record": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"priority": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"weight": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"target": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+
+			"ttl": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceArmDnsSrvRecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*armClient).dnsClient
+	ctx := meta.(*armClient).StopContext
+
+	name := d.Get("name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	zoneName := d.Get("zone_name").(string)
+
+	if d.IsNewResource() {
+		existing, err := client.Get(ctx, resGroup, zoneName, name, dns.SRV)
+		if err != nil {
+			if !responseWasNotFound(existing.Response) {
+				return fmt.Errorf("Error checking for presence of existing DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+			}
+		}
+
+		if existing.ID != nil && *existing.ID != "" {
+			return fmt.Errorf("resource azurerm_dns_srv_record %q already exists, cannot create new", *existing.ID)
+		}
+	}
+
+	ttl := int64(d.Get("ttl").(int))
+	tags := d.Get("tags").(map[string]interface{})
+
+	parameters := dns.RecordSet{
+		Name: &name,
+		RecordSetProperties: &dns.RecordSetProperties{
+			Metadata:   expandTags(tags),
+			TTL:        &ttl,
+			SrvRecords: expandAzureRmDnsSrvRecords(d),
+		},
+	}
+
+	eTag := ""
+	ifNoneMatch := "" // set to empty to allow updates to records after creation
+	if _, err := client.CreateOrUpdate(ctx, resGroup, zoneName, name, dns.SRV, parameters, eTag, ifNoneMatch); err != nil {
+		return fmt.Errorf("Error creating/updating DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.SRV)
+	if err != nil {
+		return fmt.Errorf("Error retrieving DNS SRV Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	}
+
+	if resp.ID == nil {
+		return fmt.Errorf("Cannot read DNS SRV Record %s (resource group %s) ID", name, resGroup)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmDnsSrvRecordRead(d, meta)
+}
+
+func resourceArmDnsSrvRecordRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*armClient).dnsClient
+	ctx := meta.(*armClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resGroup := id.ResourceGroup
+	name := id.Path["SRV"]
+	zoneName := id.Path["dnszones"]
+
+	resp, err := client.Get(ctx, resGroup, zoneName, name, dns.SRV)
+	if err != nil {
+		if responseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error reading DNS SRV record %s: %v", name, err)
+	}
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("zone_name", zoneName)
+	d.Set("ttl", resp.TTL)
+
+	if err := d.Set("record", flattenAzureRmDnsSrvRecords(resp.SrvRecords)); err != nil {
+		return err
+	}
+	flattenAndSetTags(d, resp.Metadata)
+
+	return nil
+}
+
+func resourceArmDnsSrvRecordDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*armClient).dnsClient
+	ctx := meta.(*armClient).StopContext
+
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resGroup := id.ResourceGroup
+	name := id.Path["SRV"]
+	zoneName := id.Path["dnszones"]
+
+	resp, err := client.Delete(ctx, resGroup, zoneName, name, dns.SRV, "")
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Error deleting DNS SRV Record %s: %+v", name, err)
+	}
+
+	return nil
+}
+
+func flattenAzureRmDnsSrvRecords(records *[]dns.SrvRecord) []map[string]interface{} {
+	results := make([]map[string]interface{}, 0, len(*records))
+
+	if records != nil {
+		for _, record := range *records {
+			results = append(results, map[string]interface{}{
+				"priority": *record.Priority,
+				"weight":   *record.Weight,
+				"port":     *record.Port,
+				"target":   *record.Target,
+			})
+		}
+	}
+
+	return results
+}
+
+func expandAzureRmDnsSrvRecords(d *schema.ResourceData) *[]dns.SrvRecord {
+	recordStrings := d.Get("record").([]interface{})
+	records := make([]dns.SrvRecord, len(recordStrings))
+
+	for i, v := range recordStrings {
+		record := v.(map[string]interface{})
+		priority := int32(record["priority"].(int))
+		weight := int32(record["weight"].(int))
+		port := int32(record["port"].(int))
+		target := record["target"].(string)
+
+		srvRecord := dns.SrvRecord{
+			Priority: &priority,
+			Weight:   &weight,
+			Port:     &port,
+			Target:   &target,
+		}
+
+		records[i] = srvRecord
+	}
+
+	return &records
+}

--- a/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/resource_group.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/resource_group.go
@@ -1,0 +1,36 @@
+package srv
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func schemaResourceGroupName() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validateResourceGroupName,
+	}
+}
+func validateResourceGroupName(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	if len(value) > 80 {
+		errors = append(errors, fmt.Errorf("%q may not exceed 80 characters in length", k))
+	}
+
+	if strings.HasSuffix(value, ".") {
+		errors = append(errors, fmt.Errorf("%q may not end with a period", k))
+	}
+
+	// regex pulled from https://docs.microsoft.com/en-us/rest/api/resources/resourcegroups/createorupdate
+	if matched := regexp.MustCompile(`^[-\w\._\(\)]+$`).Match([]byte(value)); !matched {
+		errors = append(errors, fmt.Errorf("%q may only contain alphanumeric characters, dash, underscores, parentheses and periods", k))
+	}
+
+	return warnings, errors
+}

--- a/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/response.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/response.go
@@ -1,0 +1,21 @@
+package srv
+
+import (
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+func responseWasNotFound(resp autorest.Response) bool {
+	return responseWasStatusCode(resp, http.StatusNotFound)
+}
+
+func responseWasStatusCode(resp autorest.Response, statusCode int) bool {
+	if r := resp.Response; r != nil {
+		if r.StatusCode == statusCode {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/tags.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/abhinavdahiya/terraform-provider-azurerm-srv/srv/tags.go
@@ -1,0 +1,74 @@
+package srv
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func tagsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:         schema.TypeMap,
+		Optional:     true,
+		Computed:     true,
+		ValidateFunc: validateAzureRMTags,
+	}
+}
+
+func validateAzureRMTags(v interface{}, _ string) (warnings []string, errors []error) {
+	tagsMap := v.(map[string]interface{})
+
+	if len(tagsMap) > 15 {
+		errors = append(errors, fmt.Errorf("a maximum of 15 tags can be applied to each ARM resource"))
+	}
+
+	for k, v := range tagsMap {
+		if len(k) > 512 {
+			errors = append(errors, fmt.Errorf("the maximum length for a tag key is 512 characters: %q is %d characters", k, len(k)))
+		}
+
+		value, err := tagValueToString(v)
+		if err != nil {
+			errors = append(errors, err)
+		} else if len(value) > 256 {
+			errors = append(errors, fmt.Errorf("the maximum length for a tag value is 256 characters: the value for %q is %d characters", k, len(value)))
+		}
+	}
+
+	return warnings, errors
+}
+
+func tagValueToString(v interface{}) (string, error) {
+	switch value := v.(type) {
+	case string:
+		return value, nil
+	case int:
+		return fmt.Sprintf("%d", value), nil
+	default:
+		return "", fmt.Errorf("unknown tag type %T in tag value", value)
+	}
+}
+
+func expandTags(tagsMap map[string]interface{}) map[string]*string {
+	output := make(map[string]*string, len(tagsMap))
+
+	for i, v := range tagsMap {
+		//Validate should have ignored this error already
+		value, _ := tagValueToString(v)
+		output[i] = &value
+	}
+
+	return output
+}
+
+func flattenAndSetTags(d *schema.ResourceData, tagMap map[string]*string) {
+
+	// If tagsMap is nil, len(tagsMap) will be 0.
+	output := make(map[string]interface{}, len(tagMap))
+
+	for i, v := range tagMap {
+		output[i] = *v
+	}
+
+	d.Set("tags", output)
+}


### PR DESCRIPTION
This plugin [1] is almost same upstream azurerm provider [2], with the only exception that the
`record` field is a `TypeList` compared to `TypeSet` for `dns_srv_record` resource.

The `TypeList` allows users to create the list of records in the SRV record dynamically, which is not possible with upstream unless
we wait for `terraform 0.12` to become generally available with `foreach` semanctics and all our other vendored plugins have also moved to 0.12
compatibility.

This allows users to create SRV record  like

```tf
provider "azurerm" {}
provider "azurerm-srv" {}

resource "azurerm_resource_group" "main" {
  name     = "example"
  location = "westus2"
}

resource "azurerm_virtual_network" "main" {
  name                = "example"
  resource_group_name = "${azurerm_resource_group.main.name}"
  location            = "westus2"
  address_space       = ["10.0.0.0/16"]
}

resource "azurerm_dns_zone" "private" {
  name                           = "thisistest.com"
  resource_group_name            = "${azurerm_resource_group.main.name}"
  zone_type                      = "Private"
  resolution_virtual_network_ids = ["${azurerm_virtual_network.main.id}"]
}

resource "null_resource" "etcd_mappings" {
  count = 4

  triggers {
    priority = 10
    weight   = 10
    port     = 2380
    target   = "etcd-${count.index}.${azurerm_dns_zone.private.name}"
  }
}

resource "azurerm-srv_dns_srv_record" "etcd_cluster" {
  name                = "_etcd-server-ssl._tcp"
  zone_name           = "${azurerm_dns_zone.private.name}"
  resource_group_name = "${azurerm_resource_group.main.name}"
  ttl                 = 60

  record = ["${null_resource.etcd_mappings.*.triggers}"]
}
```
[1]: https://github.com/abhinavdahiya/terraform-provider-azurerm-srv
[2]: https://github.com/terraform-providers/terraform-provider-azurerm


This was created from offline discussion with @serbrech who is working on azure initial support, especially https://github.com/openshift/installer/pull/1454/files#diff-764adb23dcc0edbbebc09192eb233e9aR41 which hardcodes the number of masters because of the upstream's inability.

Since terraform 0.12 is going to be released soon, the upstream is moving users to `foreach`.
the installer can only move to 0.12 after it is generally available, all plugins have moved to newer codebase (currently ignition, libvirt are trailing) and we have done the internal work to make changes to our terraform templates based on https://www.terraform.io/upgrade-guides/0-12.html. 

Therefore moving to 0.12 is going to be a lot of work and this lightweight plugin should help us move ahead on azure without all that effort.