### PR TITLE
hack/build: Use SOURCE_GIT_COMMIT if set

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -31,7 +31,8 @@ then
 fi
 
 MODE="${MODE:-release}"
-LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=$(git describe --always --abbrev=40 --dirty) -X github.com/openshift/installer/pkg/version.Commit=$(git rev-parse --verify 'HEAD^{commit}')"
+GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}"
+LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=$(git describe --always --abbrev=40 --dirty) -X github.com/openshift/installer/pkg/version.Commit=${GIT_COMMIT}"
 TAGS="${TAGS:-}"
 OUTPUT="${OUTPUT:-bin/openshift-install}"
 export CGO_ENABLED=0


### PR DESCRIPTION
ART copies occasional snapshots from upstream repositories like this one into dist-git repositories for their builds.  That means their commit hashes diverge from ours, because they have a different history behind them.  Tree hashes should still match, but we don't want to have to explain the difference between commits and trees to users.  ART is going to set the `SOURCE_GIT_COMMIT` environment variable for us with the associated upstream commit.  With this commit, we'll use that when it's set, and fall back to querying the local repository when it isn't.