### PR TITLE
openstack: remove SRV records from service VM

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -18,25 +18,33 @@ data "ignition_config" "redirect" {
 
   files = [
     data.ignition_file.hostname.id,
-    data.ignition_file.bootstrap_ifcfg.id,
+    data.ignition_file.dns_conf.id,
+    data.ignition_file.dhcp_conf.id,
   ]
 }
 
-data "ignition_file" "bootstrap_ifcfg" {
+data "ignition_file" "dhcp_conf" {
   filesystem = "root"
-  mode       = "420" // 0644
-  path       = "/etc/sysconfig/network-scripts/ifcfg-eth0"
+  mode       = "420"
+  path       = "/etc/NetworkManager/conf.d/dhcp-client.conf"
 
   content {
     content = <<EOF
-DEVICE="eth0"
-BOOTPROTO="dhcp"
-ONBOOT="yes"
-TYPE="Ethernet"
-PERSISTENT_DHCLIENT="yes"
-DNS1="${var.service_vm_fixed_ip}"
-PEERDNS="no"
-NM_CONTROLLED="yes"
+[main]
+dhcp=dhclient
+EOF
+  }
+}
+
+data "ignition_file" "dns_conf" {
+  filesystem = "root"
+  mode = "420"
+  path = "/etc/dhcp/dhclient.conf"
+
+  content {
+    content = <<EOF
+send dhcp-client-identifier = hardware;
+prepend domain-name-servers ${var.master_vm_fixed_ip};
 EOF
 
   }
@@ -44,8 +52,8 @@ EOF
 
 data "ignition_file" "hostname" {
   filesystem = "root"
-  mode = "420" // 0644
-  path = "/etc/hostname"
+  mode       = "420" // 0644
+  path       = "/etc/hostname"
 
   content {
     content = <<EOF
@@ -56,7 +64,7 @@ EOF
 }
 
 data "openstack_images_image_v2" "bootstrap_image" {
-  name        = var.image_name
+  name = var.image_name
   most_recent = true
 }
 
@@ -65,9 +73,9 @@ data "openstack_compute_flavor_v2" "bootstrap_flavor" {
 }
 
 resource "openstack_compute_instance_v2" "bootstrap" {
-  name      = "${var.cluster_id}-bootstrap"
+  name = "${var.cluster_id}-bootstrap"
   flavor_id = data.openstack_compute_flavor_v2.bootstrap_flavor.id
-  image_id  = data.openstack_images_image_v2.bootstrap_image.id
+  image_id = data.openstack_images_image_v2.bootstrap_image.id
 
   user_data = data.ignition_config.redirect.rendered
 

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -37,3 +37,7 @@ variable "service_vm_fixed_ip" {
   type = string
 }
 
+variable "master_vm_fixed_ip" {
+  type        = "string"
+  description = "Fixed IP for a master node to provide DNS to bootstrap during clustering."
+}

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -50,6 +50,7 @@ module "bootstrap" {
   ignition            = var.ignition_bootstrap
   bootstrap_port_id   = module.topology.bootstrap_port_id
   service_vm_fixed_ip = module.topology.service_vm_fixed_ip
+  master_vm_fixed_ip  = module.topology.master_ips[0]
 }
 
 module "masters" {

--- a/data/data/openstack/service/main.tf
+++ b/data/data/openstack/service/main.tf
@@ -216,12 +216,6 @@ ${length(var.lb_floating_ip) == 0 ? "*.apps  IN  A  ${var.service_port_ip}" : "*
 api-int  IN  A  ${var.service_port_ip}
 
 bootstrap.${var.cluster_domain}  IN  A  ${var.bootstrap_ip}
-${replace(join("\n", formatlist("%s  IN  A %s", var.master_port_names, var.master_ips)), "port-", "")}
-${replace(join("\n", formatlist("master-%s  IN  A %s", var.master_port_names, var.master_ips)), "${var.cluster_id}-master-port-", "")}
-
-${replace(join("\n", formatlist("etcd-%s  IN  A  %s", var.master_port_names, var.master_ips)), "${var.cluster_id}-master-port-", "")}
-${replace(join("\n", formatlist("_etcd-server-ssl._tcp  8640  IN  SRV  0  10  2380   etcd-%s.${var.cluster_domain}.", var.master_port_names)), "${var.cluster_id}-master-port-", "")}
-
 EOF
 
   }

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -33,6 +33,26 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_ssh" {
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_tcp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = "${var.cidr_block}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 53
+  port_range_max    = 53
+  remote_ip_prefix  = "${var.cidr_block}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_http" {
   direction         = "ingress"
   ethertype         = "IPv4"


### PR DESCRIPTION
This is part of the work to remove the service VM from the
openstack architecture. This relies on the coredns/mdns static
pods setup in: openshift/machine-config-operator/pull/740