### PR TITLE
data: add approve-csr service to approve CSRs until bootstrap is complete

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
+++ b/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+KUBECONFIG="${1}"
+
+echo "Approving all CSR requests until bootstrapping is complete..."
+while [ ! -f /opt/openshift/bootkube.done ]
+do
+    oc --config="$KUBECONFIG" get csr --no-headers | grep Pending | \
+        awk '{print $1}' | \
+        xargs --no-run-if-empty oc --config="$KUBECONFIG" adm certificate approve
+	sleep 20
+done

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -4,7 +4,7 @@ ARTIFACTS="/tmp/artifacts"
 
 echo "Gathering bootstrap journals ..."
 mkdir -p "${ARTIFACTS}/bootstrap/journals"
-for service in bootkube openshift kubelet crio
+for service in bootkube openshift kubelet crio approve-csr
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"
 done

--- a/data/data/bootstrap/systemd/units/approve-csr.service
+++ b/data/data/bootstrap/systemd/units/approve-csr.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Approve CSRs during bootstrap phase
+Wants=bootkube.service
+After=bootkube.service
+
+[Service]
+ExecStart=/usr/local/bin/approve-csr.sh /opt/openshift/auth/kubeconfig
+
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -248,6 +248,7 @@ func (a *Bootstrap) addSystemdUnits(uri string, templateData *bootstrapTemplateD
 		"kubelet.service":                 {},
 		"chown-gatewayd-key.service":      {},
 		"systemd-journal-gatewayd.socket": {},
+		"approve-csr.service":             {},
 	}
 
 	directory, err := data.Assets.Open(uri)


### PR DESCRIPTION
PR for cluster-machine-approver [1] is taking over the approval of CSRs for client certificates for Machines that end up
as Nodes in Openshift clusters.

But during bootstrapping, cluster-machine-approver is not available and therefore, this service is required to approve CSRs until
we have successfully bootstrapped the control plane, after which cluster-machine-approver or users take over the role of approving any new CSRs.

Currently, all CSRs are automatically approved without any condition, this PR scopes it to only during bootstrapping phase, securing the endpoint for later use.

[1]: https://github.com/openshift/cluster-machine-approver/pull/26