### PR TITLE
Use .yaml throughout

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -102,7 +102,7 @@ then
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-apiserver-bootstrap \
 		--config-output-file=/assets/kube-apiserver-bootstrap/config \
-		--cluster-config-file=/assets/manifests/cluster-network-02-config.yml
+		--cluster-config-file=/assets/manifests/cluster-network-02-config.yaml
 
 	cp kube-apiserver-bootstrap/config /etc/kubernetes/bootstrap-configs/kube-apiserver-config.yaml
 	cp kube-apiserver-bootstrap/bootstrap-manifests/* bootstrap-manifests/
@@ -127,7 +127,7 @@ then
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-controller-manager-bootstrap \
 		--config-output-file=/assets/kube-controller-manager-bootstrap/config \
-		--cluster-config-file=/assets/manifests/cluster-network-02-config.yml
+		--cluster-config-file=/assets/manifests/cluster-network-02-config.yaml
 
 	cp kube-controller-manager-bootstrap/config /etc/kubernetes/bootstrap-configs/kube-controller-manager-config.yaml
 	cp kube-controller-manager-bootstrap/bootstrap-manifests/* bootstrap-manifests/

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -67,11 +67,11 @@ For example:
     total 68
     -rw-r--r--. 1 xxxxx xxxxx  169 Feb 28 10:54 04-openshift-machine-config-operator.yaml
     -rw-r--r--. 1 xxxxx xxxxx 1589 Feb 28 10:54 cluster-config.yaml
-    -rw-r--r--. 1 xxxxx xxxxx  149 Feb 28 10:54 cluster-dns-02-config.yml
-    -rw-r--r--. 1 xxxxx xxxxx  243 Feb 28 10:54 cluster-infrastructure-02-config.yml
-    -rw-r--r--. 1 xxxxx xxxxx  154 Feb 28 10:54 cluster-ingress-02-config.yml
-    -rw-r--r--. 1 xxxxx xxxxx  557 Feb 28 10:54 cluster-network-01-crd.yml
-    -rw-r--r--. 1 xxxxx xxxxx  327 Feb 28 10:54 cluster-network-02-config.yml
+    -rw-r--r--. 1 xxxxx xxxxx  149 Feb 28 10:54 cluster-dns-02-config.yaml
+    -rw-r--r--. 1 xxxxx xxxxx  243 Feb 28 10:54 cluster-infrastructure-02-config.yaml
+    -rw-r--r--. 1 xxxxx xxxxx  154 Feb 28 10:54 cluster-ingress-02-config.yaml
+    -rw-r--r--. 1 xxxxx xxxxx  557 Feb 28 10:54 cluster-network-01-crd.yaml
+    -rw-r--r--. 1 xxxxx xxxxx  327 Feb 28 10:54 cluster-network-02-config.yaml
     -rw-r--r--. 1 xxxxx xxxxx  264 Feb 28 10:54 cvo-overrides.yaml
     -rw-r--r--. 1 xxxxx xxxxx  275 Feb 28 10:54 etcd-service.yaml
     -rw-r--r--. 1 xxxxx xxxxx  283 Feb 28 10:54 host-etcd-service-endpoints.yaml

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -24,10 +24,10 @@ import (
 )
 
 var (
-	dnsCfgFilename = filepath.Join(manifestDir, "cluster-dns-02-config.yml")
+	dnsCfgFilename = filepath.Join(manifestDir, "cluster-dns-02-config.yaml")
 )
 
-// DNS generates the cluster-dns-*.yml files.
+// DNS generates the cluster-dns-*.yaml files.
 type DNS struct {
 	FileList []*asset.File
 }

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -21,10 +21,10 @@ import (
 
 var (
 	infraCrdFilename = filepath.Join(manifestDir, "cluster-infrastructure-01-crd.yaml")
-	infraCfgFilename = filepath.Join(manifestDir, "cluster-infrastructure-02-config.yml")
+	infraCfgFilename = filepath.Join(manifestDir, "cluster-infrastructure-02-config.yaml")
 )
 
-// Infrastructure generates the cluster-infrastructure-*.yml files.
+// Infrastructure generates the cluster-infrastructure-*.yaml files.
 type Infrastructure struct {
 	FileList []*asset.File
 }

--- a/pkg/asset/manifests/ingress.go
+++ b/pkg/asset/manifests/ingress.go
@@ -14,10 +14,10 @@ import (
 )
 
 var (
-	ingCfgFilename = filepath.Join(manifestDir, "cluster-ingress-02-config.yml")
+	ingCfgFilename = filepath.Join(manifestDir, "cluster-ingress-02-config.yaml")
 )
 
-// Ingress generates the cluster-ingress-*.yml files.
+// Ingress generates the cluster-ingress-*.yaml files.
 type Ingress struct {
 	FileList []*asset.File
 }

--- a/pkg/asset/manifests/network.go
+++ b/pkg/asset/manifests/network.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	noCrdFilename = filepath.Join(manifestDir, "cluster-network-01-crd.yml")
-	noCfgFilename = filepath.Join(manifestDir, "cluster-network-02-config.yml")
+	noCrdFilename = filepath.Join(manifestDir, "cluster-network-01-crd.yaml")
+	noCfgFilename = filepath.Join(manifestDir, "cluster-network-02-config.yaml")
 )
 
 // We need to manually create our CRDs first, so we can create the
@@ -29,7 +29,7 @@ var (
 // network in a more detailed manner with the operator-specific CR, which
 // also needs to be done before the installer is run, so we provide both.
 
-// Networking generates the cluster-network-*.yml files.
+// Networking generates the cluster-network-*.yaml files.
 type Networking struct {
 	Config   *configv1.Network
 	FileList []*asset.File

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -55,7 +55,7 @@ func (o *Openshift) Dependencies() []asset.Asset {
 	}
 }
 
-// Generate generates the respective operator config.yml files
+// Generate generates the respective operator config.yaml files
 func (o *Openshift) Generate(dependencies asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	clusterID := &installconfig.ClusterID{}

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -88,7 +88,7 @@ func (m *Manifests) Dependencies() []asset.Asset {
 	}
 }
 
-// Generate generates the respective operator config.yml files
+// Generate generates the respective operator config.yaml files
 func (m *Manifests) Generate(dependencies asset.Parents) error {
 	ingress := &Ingress{}
 	dns := &DNS{}

--- a/pkg/asset/manifests/scheduler.go
+++ b/pkg/asset/manifests/scheduler.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	schedulerCfgFilename = filepath.Join(manifestDir, "cluster-scheduler-02-config.yml")
+	schedulerCfgFilename = filepath.Join(manifestDir, "cluster-scheduler-02-config.yaml")
 )
 
-// Scheduler generates the cluster-scheduler-*.yml files.
+// Scheduler generates the cluster-scheduler-*.yaml files.
 type Scheduler struct {
 	FileList []*asset.File
 }

--- a/pkg/destroy/openstack/openstack_deprovision.go
+++ b/pkg/destroy/openstack/openstack_deprovision.go
@@ -46,7 +46,7 @@ type deleteFunc func(opts *clientconfig.ClientOpts, filter Filter, logger logrus
 
 // ClusterUninstaller holds the various options for the cluster we want to delete.
 type ClusterUninstaller struct {
-	// Cloud is the cloud name as set in clouds.yml
+	// Cloud is the cloud name as set in clouds.yaml
 	Cloud string
 	// Filter contains the openshiftClusterID to filter tags
 	Filter Filter

--- a/tests/bdd-smoke/utils/libvirt_install_yaml_file_validator.go
+++ b/tests/bdd-smoke/utils/libvirt_install_yaml_file_validator.go
@@ -60,7 +60,7 @@ func (c *installConf) readInstallConf(filePath string) *installConf {
 
 //ValidateInstallConfig check that the file content is the same of the env variables
 func ValidateInstallConfig(filePath string, expectedData DataToValidate) {
-	fileName := "install-config.yml"
+	fileName := "install-config.yaml"
 	var installConfiguration installConf
 	installConfiguration.readInstallConf(filePath)
 


### PR DESCRIPTION
This changes all remaining .yml extensions to .yaml, following the
pattern set by 869cbb67bad763c4bbfce3e19d359b3014dc0c66 for
install-config.yaml.

Fixes https://github.com/openshift/installer/issues/1501

Signed-off-by: Stephen Kitt <skitt@redhat.com>