### PR TITLE
Bug 1709869: tls: add openshift service to DNS names

### DIFF
--- a/pkg/asset/tls/apiserver.go
+++ b/pkg/asset/tls/apiserver.go
@@ -293,6 +293,9 @@ func (a *KubeAPIServerServiceNetworkServerCertKey) Generate(dependencies asset.P
 			"kubernetes", "kubernetes.default",
 			"kubernetes.default.svc",
 			"kubernetes.default.svc.cluster.local",
+			"openshift", "openshift.default",
+			"openshift.default.svc",
+			"openshift.default.svc.cluster.local",
 		},
 		IPAddresses: []net.IP{net.ParseIP(serviceAddress)},
 	}


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1709869

We can't break legacy apps using the "openshift" service hostname.

/cc @smarterclayton 
/cc @wking 