### PR TITLE
pkg/asset: Add filenames to "failed to unmarshal" errors

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -446,7 +446,7 @@ func (a *Bootstrap) Load(f asset.FileFetcher) (found bool, err error) {
 
 	config := &igntypes.Config{}
 	if err := json.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrap(err, "failed to unmarshal")
+		return false, errors.Wrapf(err, "failed to unmarshal %s", bootstrapIgnFilename)
 	}
 
 	a.File, a.Config = file, config

--- a/pkg/asset/ignition/machine/master.go
+++ b/pkg/asset/ignition/machine/master.go
@@ -77,7 +77,7 @@ func (a *Master) Load(f asset.FileFetcher) (found bool, err error) {
 
 	config := &igntypes.Config{}
 	if err := json.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrap(err, "failed to unmarshal")
+		return false, errors.Wrapf(err, "failed to unmarshal %s", masterIgnFilename)
 	}
 
 	a.File, a.Config = file, config

--- a/pkg/asset/ignition/machine/worker.go
+++ b/pkg/asset/ignition/machine/worker.go
@@ -77,7 +77,7 @@ func (a *Worker) Load(f asset.FileFetcher) (found bool, err error) {
 
 	config := &igntypes.Config{}
 	if err := json.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrap(err, "failed to unmarshal")
+		return false, errors.Wrapf(err, "failed to unmarshal %s", workerIgnFilename)
 	}
 
 	a.File, a.Config = file, config

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -117,7 +117,7 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 
 	config := &types.InstallConfig{}
 	if err := yaml.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrap(err, "failed to unmarshal")
+		return false, errors.Wrapf(err, "failed to unmarshal %s", installConfigFilename)
 	}
 	a.Config = config
 

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -91,7 +91,7 @@ func (k *kubeconfig) load(f asset.FileFetcher, name string) (found bool, err err
 
 	config := &clientcmd.Config{}
 	if err := yaml.Unmarshal(file.Data, config); err != nil {
-		return false, errors.Wrap(err, "failed to unmarshal")
+		return false, errors.Wrapf(err, "failed to unmarshal %s", name)
 	}
 
 	k.File, k.Config = file, config

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -237,7 +237,7 @@ func (m *Manifests) Load(f asset.FileFetcher) (bool, error) {
 	for _, file := range fileList {
 		if file.Filename == kubeSysConfigPath {
 			if err := yaml.Unmarshal(file.Data, kubeSysConfig); err != nil {
-				return false, errors.Wrap(err, "failed to unmarshal cluster-config.yaml")
+				return false, errors.Wrapf(err, "failed to unmarshal %s", kubeSysConfigPath)
 			}
 			found = true
 		}


### PR DESCRIPTION
Before this commit, errors looked like:

```
failed to fetch Terraform Variables: failed to load asset "Install Config": failed to unmarshal: error converting YAML to JSON: yaml: line 39: could not find expected ':'
```

With this commit, they will look like:

```
failed to fetch Terraform Variables: failed to load asset "Install Config": failed to unmarshal install-config.yaml: error converting YAML to JSON: yaml: line 39: could not find expected ':'
```

The filename was already implicit in the asset name (e.g. "Install Config"), but it makes it slightly easier on users if we go ahead and spell out the filename for them.

CC @umohnani8