### PR TITLE
aws/defaults/platform: Default to m5 in ap-east-1

### DIFF
--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -6,6 +6,7 @@ import (
 
 var (
 	defaultMachineClass = map[string]string{
+		"ap-east-1":     "m5",
 		"eu-north-1":    "m5",
 		"eu-west-3":     "m5",
 		"us-gov-east-1": "m5",

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -13,6 +13,7 @@ var (
 	// the short name of the region. The value of the map is the long
 	// name of the region.
 	Regions = map[string]string{
+		//"ap-east-1":      "Hong Kong",
 		"ap-northeast-1": "Tokyo",
 		"ap-northeast-2": "Seoul",
 		//"ap-northeast-3": "Osaka-Local",

--- a/platformtests/aws/default_instance_class_test.go
+++ b/platformtests/aws/default_instance_class_test.go
@@ -72,8 +72,12 @@ func TestGetDefaultInstanceClass(t *testing.T) {
 	}
 
 	regions := map[string]string{ // seed with locations that don't match AWS's usual names
-		"South America (Sao Paulo)": "sa-east-1",
-		"AWS GovCloud (US)":         "us-gov-west-1",
+		"AWS GovCloud (US)":          "us-gov-west-1",
+		"AWS GovCloud (US-East)":     "us-gov-east-1",
+		"Asia Pacific (Hong Kong)":   "ap-east-1",
+		"Asia Pacific (Osaka-Local)": "ap-northeast-3",
+		"EU (Stockholm)":             "eu-north-1",
+		"South America (Sao Paulo)":  "sa-east-1",
 	}
 
 	for location, classes := range instanceClasses {


### PR DESCRIPTION
The Hong Kong region is [new 2019-04-25][1] and does not support the older m4 types.  This pull-request adds it (commented out in validation, because we don't push RHCOS AMIs there, see also #1528).  It also expands the seeded regions in `TestGetDefaultInstanceClass` to gets the tests to pass:

```console
platformtests/aws$ AWS_PROFILE=openshift-dev go test .
ok  							 github.com/openshift/installer/platformtests/aws			26.282s
```

[1]: https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-hong-kong-region/