### PR TITLE
bootstrap: update default release image to track 4.2 origin

### DIFF
--- a/pkg/asset/ignition/bootstrap/release_image.go
+++ b/pkg/asset/ignition/bootstrap/release_image.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:v4.1"
+	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:4.2"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
The master branch is now tracking 4.2 work and therefore tracking 4.2 release image stream [2] is more appropiate.

[1]: https://origin-release.svc.ci.openshift.org/
[2]: `registry.svc.ci.openshift.org/origin/release:4.2`

/cc @smarterclayton @wking 