### PR TITLE
types/conversion: return no version provided error when trying to convert

### DIFF
--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -15,6 +15,8 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 	switch config.APIVersion {
 	case types.InstallConfigVersion, "v1beta3", "v1beta4":
 		// works
+	case "":
+		return errors.Errorf("no version was provided")
 	default:
 		return errors.Errorf("cannot upconvert from version %s", config.APIVersion)
 	}


### PR DESCRIPTION
Currently the error returned is `failed to upconvert install config: cannot upconvert from version ` and empty version is not
visible to users explicitly.

/cc @wking 