### PR TITLE
gather: update the state handling for terraform 0.12

### DIFF
--- a/pkg/terraform/exec/state.go
+++ b/pkg/terraform/exec/state.go
@@ -1,0 +1,32 @@
+package exec
+
+import (
+	"bytes"
+	"os"
+
+	"github.com/hashicorp/terraform/states/statefile"
+	"github.com/pkg/errors"
+)
+
+// ReadState reads the terraform state from file and returns the contents in bytes
+// It returns an error if reading the state was unsuccessful
+// ReadState utilizes the terraform's internal wiring to upconvert versions of terraform state to return
+// the state it currently recognizes.
+func ReadState(file string) ([]byte, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open %q", file)
+	}
+	defer f.Close()
+
+	sf, err := statefile.Read(f)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read statefile from %q", file)
+	}
+
+	out := bytes.Buffer{}
+	if err := statefile.Write(sf, &out); err != nil {
+		return nil, errors.Wrapf(err, "failed to write statefile")
+	}
+	return out.Bytes(), nil
+}

--- a/pkg/terraform/gather/aws/ip.go
+++ b/pkg/terraform/gather/aws/ip.go
@@ -1,0 +1,45 @@
+// Package aws contains utilities that help gather AWS specific
+// information from terraform state.
+package aws
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/installer/pkg/terraform"
+)
+
+// BootstrapIP returns the ip address for bootstrap host.
+func BootstrapIP(tfs *terraform.State) (string, error) {
+	br, err := terraform.LookupResource(tfs, "module.bootstrap", "aws_instance", "bootstrap")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup bootstrap")
+	}
+	if len(br.Instances) == 0 {
+		return "", errors.New("no bootstrap instance found")
+	}
+	bootstrap, _, err := unstructured.NestedString(br.Instances[0].Attributes, "public_ip")
+	if err != nil {
+		return "", errors.New("no public_ip found for bootstrap")
+	}
+	return bootstrap, nil
+}
+
+// ControlPlaneIPs returns the ip addresses for control plane hosts.
+func ControlPlaneIPs(tfs *terraform.State) ([]string, error) {
+	mrs, err := terraform.LookupResource(tfs, "module.masters", "aws_instance", "master")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to lookup masters")
+	}
+	var errs []error
+	var masters []string
+	for idx, inst := range mrs.Instances {
+		master, _, err := unstructured.NestedString(inst.Attributes, "private_ip")
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "no private_ip for master.%d", idx))
+		}
+		masters = append(masters, master)
+	}
+	return masters, utilerrors.NewAggregate(errs)
+}

--- a/pkg/terraform/gather/libvirt/ip.go
+++ b/pkg/terraform/gather/libvirt/ip.go
@@ -1,0 +1,60 @@
+// Package libvirt contains utilities that help gather Libvirt specific
+// information from terraform state.
+package libvirt
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/installer/pkg/terraform"
+)
+
+// BootstrapIP returns the ip address for bootstrap host.
+func BootstrapIP(tfs *terraform.State) (string, error) {
+	br, err := terraform.LookupResource(tfs, "module.bootstrap", "libvirt_domain", "bootstrap")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup bootstrap")
+	}
+	if len(br.Instances) == 0 {
+		return "", errors.New("no bootstrap instance found")
+	}
+	bootstrap, err := hostnameForDomain(br.Instances[0].Attributes)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup hostname")
+	}
+	return bootstrap, nil
+}
+
+// ControlPlaneIPs returns the ip addresses for control plane hosts.
+func ControlPlaneIPs(tfs *terraform.State) ([]string, error) {
+	mrs, err := terraform.LookupResource(tfs, "", "libvirt_domain", "master")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to lookup masters")
+	}
+	var errs []error
+	var masters []string
+	for idx, inst := range mrs.Instances {
+		master, err := hostnameForDomain(inst.Attributes)
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to lookup hostname for master.%d", idx))
+		}
+		masters = append(masters, master)
+	}
+	return masters, utilerrors.NewAggregate(errs)
+}
+
+func hostnameForDomain(attr map[string]interface{}) (string, error) {
+	nics, _, err := unstructured.NestedSlice(attr, "network_interface")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup network_interface")
+	}
+	if len(nics) == 0 {
+		return "", errors.New("no network_interface found")
+	}
+	hostname, _, err := unstructured.NestedString(nics[0].(map[string]interface{}), "hostname")
+	if err != nil {
+		return "", errors.New("no hostname found")
+	}
+	return hostname, nil
+}

--- a/pkg/terraform/gather/openstack/ip.go
+++ b/pkg/terraform/gather/openstack/ip.go
@@ -1,0 +1,45 @@
+// Package openstack contains utilities that help gather Openstack specific
+// information from terraform state.
+package openstack
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/installer/pkg/terraform"
+)
+
+// BootstrapIP returns the ip address for bootstrap host.
+func BootstrapIP(tfs *terraform.State) (string, error) {
+	br, err := terraform.LookupResource(tfs, "module.bootstrap", "openstack_compute_instance_v2", "bootstrap")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup bootstrap")
+	}
+	if len(br.Instances) == 0 {
+		return "", errors.New("no bootstrap instance found")
+	}
+	bootstrap, _, err := unstructured.NestedString(br.Instances[0].Attributes, "access_ip_v4")
+	if err != nil {
+		return "", errors.New("no public_ip found for bootstrap")
+	}
+	return bootstrap, nil
+}
+
+// ControlPlaneIPs returns the ip addresses for control plane hosts.
+func ControlPlaneIPs(tfs *terraform.State) ([]string, error) {
+	mrs, err := terraform.LookupResource(tfs, "module.masters", "openstack_compute_instance_v2", "master_conf")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to lookup masters")
+	}
+	var errs []error
+	var masters []string
+	for idx, inst := range mrs.Instances {
+		master, _, err := unstructured.NestedString(inst.Attributes, "access_ip_v4")
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "no access_ip_v4 for master_conf.%d", idx))
+		}
+		masters = append(masters, master)
+	}
+	return masters, utilerrors.NewAggregate(errs)
+}

--- a/pkg/terraform/state.go
+++ b/pkg/terraform/state.go
@@ -1,0 +1,61 @@
+package terraform
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	tfexec "github.com/openshift/installer/pkg/terraform/exec"
+)
+
+// State in local sparse representation of terraform state that includes
+// the fields important to installer.
+type State struct {
+	Resources []StateResource `json:"resources"`
+}
+
+// StateResource is local sparse representation of terraform state resource that includes
+// the fields most important to installer.
+type StateResource struct {
+	Module    string                  `json:"module"`
+	Name      string                  `json:"name"`
+	Type      string                  `json:"type"`
+	Instances []StateResourceInstance `json:"instances"`
+}
+
+// StateResourceInstance is an instance of terraform state resource.
+type StateResourceInstance struct {
+	Attributes map[string]interface{} `json:"attributes"`
+}
+
+// ErrResourceNotFound is an error that instructs that requested resource was not found.
+var ErrResourceNotFound = errors.New("resource not found")
+
+// LookupResource finds a resource for a given module, type and name from the state.
+// If module is "root", it is treated as ""
+// If no resource is found for the triplet, ErrResourceNotFound error is returned.
+func LookupResource(state *State, module, t, name string) (*StateResource, error) {
+	if module == "root" {
+		module = ""
+	}
+	for idx, r := range state.Resources {
+		if module == r.Module && t == r.Type && name == r.Name {
+			return &state.Resources[idx], nil
+		}
+	}
+	return nil, ErrResourceNotFound
+}
+
+// ReadState returns that terraform state from the file.
+func ReadState(file string) (*State, error) {
+	sfRaw, err := tfexec.ReadState(file)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read %q", file)
+	}
+
+	var tfstate State
+	if err := json.Unmarshal(sfRaw, &tfstate); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal %q", file)
+	}
+	return &tfstate, nil
+}


### PR DESCRIPTION
- pkg/terraform: utilize the vendored terraform to read tfstate

    Utilizing the vendored statefile serialize/deserialize helps installer to no worry about the statefile
    version conversions. Installer can always assume to use the latest/chosen version of state file from vendored code.

    For example, terraform 0.12 moves the terraform state to version 4, compared to version 3. With this change installer can assume the terraform state
    deserialized for use will always be version 4, as it will be upconverted by vendored terraform statefile package.

- pkg/terraform: add gather package to store platform specific code from terraform

    This adds bootstrap and control plane hosts ip gather from state file for platforms.

- cmd/openshift-install: update gather code to utilize new terraform packages

/cc @wking @jstuever 