### PR TITLE
Fixed link to terraform/upi template

### DIFF
--- a/docs/user/vsphere/install_upi.md
+++ b/docs/user/vsphere/install_upi.md
@@ -448,5 +448,5 @@ terraform destroy -auto-approve
 [terraform-init]: https://www.terraform.io/docs/commands/init.html
 [terraform-providers]: https://www.terraform.io/docs/providers/
 [upi-vsphere-example-pre-req]: ../../../upi/vsphere/README.md#pre-requisites
-[upi-vsphere-example-tfvar]: ../../../upi/vsphere/terraform.tfvar.example
+[upi-vsphere-example-tfvar]: ../../../upi/vsphere/terraform.tfvars.example
 [upi-vsphere-example]: ../../../upi/vsphere/README.md


### PR DESCRIPTION
docs: fixed broken link

The link to the terraform example file was broken:
 upi/vsphere/terraform.tfvar.example -> upi/vsphere/terraform.tfvars.example 

