### PR TITLE
azure: pass credentials provided to installer to terraform 

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -10,6 +10,13 @@ locals {
   node_subnet_cidr   = cidrsubnet(var.machine_cidr, 3, 1) #node subnet is a smaller subnet within the vnet. i.e from /21 to /24
 }
 
+provider "azurerm" {
+  subscription_id = var.azure_subscription_id
+  client_id       = var.azure_client_id
+  client_secret   = var.azure_client_secret
+  tenant_id       = var.azure_tenant_id
+}
+
 module "bootstrap" {
   source                  = "./bootstrap"
   resource_group_name     = azurerm_resource_group.main.name

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -51,3 +51,22 @@ type        = string
 description = "The resource id of the vm image used for all node."
 }
 
+variable "azure_subscription_id" {
+  type        = string
+  description = "The subscription that should be used to interact with Azure API"
+}
+
+variable "azure_client_id" {
+  type        = string
+  description = "The app ID that should be used to interact with Azure API"
+}
+
+variable "azure_client_secret" {
+  type        = string
+  description = "The password that should be used to interact with Azure API"
+}
+
+variable "azure_tenant_id" {
+  type        = string
+  description = "The tenant ID that should be used to interact with Azure API"
+}

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -7,7 +7,16 @@ import (
 	azureprovider "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1"
 )
 
+// Auth is the collection of credentials that will be used by terrform.
+type Auth struct {
+	SubscriptionID string `json:"azure_subscription_id,omitempty"`
+	ClientID       string `json:"azure_client_id,omitempty"`
+	ClientSecret   string `json:"azure_client_secret,omitempty"`
+	TenantID       string `json:"azure_tenant_id,omitempty"`
+}
+
 type config struct {
+	Auth                        `json:",inline"`
 	ExtraTags                   map[string]string `json:"azure_extra_tags,omitempty"`
 	BootstrapInstanceType       string            `json:"azure_bootstrap_vm_type,omitempty"`
 	MasterInstanceType          string            `json:"azure_master_vm_type,omitempty"`
@@ -18,10 +27,11 @@ type config struct {
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
-func TFVars(baseDomainResourceGroupName string, masterConfigs []*azureprovider.AzureMachineProviderSpec) ([]byte, error) {
+func TFVars(auth Auth, baseDomainResourceGroupName string, masterConfigs []*azureprovider.AzureMachineProviderSpec) ([]byte, error) {
 	masterConfig := masterConfigs[0]
 	region := masterConfig.Location
 	cfg := &config{
+		Auth:   auth,
 		Region: region,
 		BaseDomainResourceGroupName: baseDomainResourceGroupName,
 		BootstrapInstanceType:       defaults.InstanceClass(region),


### PR DESCRIPTION
Terraform azurerm provider supports supports 4 kinds of authentication methods [here][1].
The installer uses the `Service Principal and a Client Secret` [here][2] method because it best suites the requirement for installer as this type of auth methods can be passed into the cluster as secret.

By default when no authentication is specified for Azurerm provider, the ordering followed is (service principal + client secret) > (service principal + client secret) > (msi) > (azure cli token) [here][3]

Currently since the provider is not setup with any authentication in the templates, it usually falls back to the azure cli method.

Now since installer sets up the creds for users, there is no way to use the ENV input for (service principal + client secret) and terraform
Azurerm provider doesn't support file based source for creds.

Therefore, they need to be explicitly provided by the installer to the templates.

[1]: https://www.terraform.io/docs/providers/azurerm/#authenticating-to-azure
[2]: https://www.terraform.io/docs/providers/azurerm/auth/service_principal_client_secret.html
[3]: https://github.com/hashicorp/go-azure-helpers/blob/5e51ac013932f1c9434224349e74d77be738739c/authentication/builder.go#L49-L56

/cc @wking @jstuever 