### PR TITLE
data/azure: create an explicit dependency on private zone before VMs are created

### DIFF
--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -64,3 +64,7 @@ variable "tags" {
   description = "tags to be applied to created resources."
 }
 
+variable "private_dns_zone_id" {
+  type        = string
+  description = "This is to create explicit dependency on private zone to exist before VMs are created in the vnet. https://github.com/MicrosoftDocs/azure-docs/issues/13728"
+}

--- a/data/data/azure/dns/dns.tf
+++ b/data/data/azure/dns/dns.tf
@@ -3,16 +3,9 @@ locals {
   api_external_name = "api.${replace(var.cluster_domain, ".${var.base_domain}", "")}"
 }
 
-resource "azurerm_dns_zone" "private" {
-  name                           = var.cluster_domain
-  resource_group_name            = var.resource_group_name
-  zone_type                      = "Private"
-  resolution_virtual_network_ids = [var.internal_dns_resolution_vnet_id]
-}
-
 resource "azurerm_dns_cname_record" "apiint_internal" {
   name                = "api-int"
-  zone_name           = azurerm_dns_zone.private.name
+  zone_name           = var.private_dns_zone_name
   resource_group_name = var.resource_group_name
   ttl                 = 300
   record              = var.external_lb_fqdn
@@ -20,7 +13,7 @@ resource "azurerm_dns_cname_record" "apiint_internal" {
 
 resource "azurerm_dns_cname_record" "api_internal" {
   name                = "api"
-  zone_name           = azurerm_dns_zone.private.name
+  zone_name           = var.private_dns_zone_name
   resource_group_name = var.resource_group_name
   ttl                 = 300
   record              = var.external_lb_fqdn
@@ -37,7 +30,7 @@ resource "azurerm_dns_cname_record" "api_external" {
 resource "azurerm_dns_a_record" "etcd_a_nodes" {
   count               = var.etcd_count
   name                = "etcd-${count.index}"
-  zone_name           = azurerm_dns_zone.private.name
+  zone_name           = var.private_dns_zone_name
   resource_group_name = var.resource_group_name
   ttl                 = 60
   records             = [var.etcd_ip_addresses[count.index]]
@@ -45,7 +38,7 @@ resource "azurerm_dns_a_record" "etcd_a_nodes" {
 
 resource "azurerm_dns_srv_record" "etcd_cluster" {
   name                = "_etcd-server-ssl._tcp"
-  zone_name           = azurerm_dns_zone.private.name
+  zone_name           = var.private_dns_zone_name
   resource_group_name = var.resource_group_name
   ttl                 = 60
 
@@ -53,7 +46,7 @@ resource "azurerm_dns_srv_record" "etcd_cluster" {
     for_each = azurerm_dns_a_record.etcd_a_nodes.*.name
     iterator = name
     content {
-      target   = "${name.value}.${azurerm_dns_zone.private.name}"
+      target   = "${name.value}.${var.private_dns_zone_name}"
       priority = 10
       weight   = 10
       port     = 2380

--- a/data/data/azure/dns/variables.tf
+++ b/data/data/azure/dns/variables.tf
@@ -29,8 +29,8 @@ variable "internal_lb_ipaddress" {
   type        = string
 }
 
-variable "internal_dns_resolution_vnet_id" {
-  description = "the vnet id to be attached to the private DNS zone"
+variable "private_dns_zone_name" {
+  description = "private DNS zone name that should be used for records"
   type        = string
 }
 

--- a/data/data/azure/master/variables.tf
+++ b/data/data/azure/master/variables.tf
@@ -88,3 +88,7 @@ variable "ssh_nat_rule_ids" {
   description = "ssh nat rule to make the master nodes reachable"
 }
 
+variable "private_dns_zone_id" {
+  type        = string
+  description = "This is to create explicit dependency on private zone to exist before VMs are created in the vnet. https://github.com/MicrosoftDocs/azure-docs/issues/13728"
+}


### PR DESCRIPTION
From the Private DNS Overview Doc [here][1]

```
The virtual network needs to be empty (that is, no VM records exist) when it initially (that is, for the first time) links to a private zone as a registration or resolution virtual network. However, the virtual network can then be non-empty for future linking as a registration or resolution virtual network, to other private zones.
```

Therefore, it looks like there needs to be an explicit dependency between private zone and VMs being created in the VNET.

Moving the private zone resource to main.tf and making bootstrap, masters, dns module consume a variable with value from private zone resource, makes terraform create the DNS Zone before creating any resources from those modules.

There is hope that the constraint might be lifted when private DNS zones become publicly GA. [here][2]

[1]: https://docs.microsoft.com/en-us/azure/dns/private-dns-overview
[2]: https://feedback.azure.com/forums/217313-networking/suggestions/35340511-create-private-dns-zone-in-virtual-network-which-a

/cc @wking @jstuever 