### PR TITLE
data/azure: make machine object name and VM name created by terraform same

### DIFF
--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -43,7 +43,7 @@ data "azurerm_subscription" "current" {
 
 resource "azurerm_virtual_machine" "master" {
   count                 = var.instance_count
-  name                  = "${var.cluster_id}-master${count.index}"
+  name                  = "${var.cluster_id}-master-${count.index}"
   location              = var.region
   resource_group_name   = var.resource_group_name
   network_interface_ids = [element(azurerm_network_interface.master.*.id, count.index)]


### PR DESCRIPTION
Master Machines are named `<id>-master-<idx>`, while the terraform creates VMs with name `<id>-master<idx>`. Equality is required for adoption in the cluster.

/cc @wking @jstuever 