### PR TITLE
docs/user/aws/install: openshift-install-linux-amd64 -> openshift-install

### DIFF
--- a/docs/user/aws/install.md
+++ b/docs/user/aws/install.md
@@ -14,7 +14,7 @@ Step 3: Download the Installer.
 ### Create Configuration
 
 ```console
-[~]$ openshift-install-linux-amd64 create install-config
+$ openshift-install create install-config
 ? SSH Public Key /home/user_id/.ssh/id_rsa.pub
 ? Platform aws
 ? Region us-east-1
@@ -26,7 +26,7 @@ Step 3: Download the Installer.
 ### Create Cluster
 
 ```console
-[~]$ openshift-install-linux-amd64 create cluster
+$ openshift-install create cluster
 INFO Waiting up to 30m0s for the Kubernetes API at https://api.test.example.com:6443...
 INFO API v1.11.0+85a0623 up
 INFO Waiting up to 30m0s for the bootstrap-complete event...


### PR DESCRIPTION
The OS/arch suffix was an artifact of our GitHub release approach (e.g. [here][1]).  With the new mirror approach, the flow is going to be more like:

```console
$ wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-install-linux-4.1.0-rc.5.tar.gz
$ tar xf openshift-install-linux-4.1.0-rc.5.tar.gz
$ ./openshift-install ...

But folks could install into their `PATH`, and our current docs prefer the in-the-`PATH` form, so that's what I've gone with here.

[1]: https://github.com/openshift/installer/releases/tag/v0.16.1