### PR TITLE
Text edits for the CloudFormation templates

### DIFF
--- a/upi/aws/cloudformation/01_vpc.yaml
+++ b/upi/aws/cloudformation/01_vpc.yaml
@@ -4,19 +4,19 @@ Description: Template for Best Practice VPC with 1-3 AZs
 Parameters:
   VpcCidr:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
     Default: 10.0.0.0/16
-    Description: CIDR block for VPC
+    Description: CIDR block for VPC.
     Type: String
   AvailabilityZoneCount:
-    ConstraintDescription: "The number of availability zones (Min: 1, Max: 3)"
+    ConstraintDescription: "The number of availability zones. (Min: 1, Max: 3)"
     MinValue: 1
     MaxValue: 3
     Default: 1
-    Description: "How many AZs to create VPC subnets for (Min: 1, Max: 3)"
+    Description: "How many AZs to create VPC subnets for. (Min: 1, Max: 3)"
     Type: Number
   SubnetBits:
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/19-27
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/19-27.
     MinValue: 5
     MaxValue: 13
     Default: 12
@@ -351,17 +351,17 @@ Resources:
 
 Outputs:
   VpcId:
-    Description: ID of the newly created VPC
+    Description: ID of the new VPC.
     Value: !Ref VPC
   PublicSubnetIds:
-    Description: Subnet IDs of the public subnets
+    Description: Subnet IDs of the public subnets.
     Value:
       !Join [
         ",",
         [!Ref PublicSubnet, !If [DoAz2, !Ref PublicSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PublicSubnet3, !Ref "AWS::NoValue"]]
       ]
   PrivateSubnetIds:
-    Description: Subnet IDs of the private subnets
+    Description: Subnet IDs of the private subnets.
     Value:
       !Join [
         ",",

--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -1,36 +1,36 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Template for Openshift Cluster UPI Network Elements (Route53 & LBs)
+Description: Template for OpenShift Cluster Network Elements (Route53 & LBs)
 
 Parameters:
   ClusterName:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Cluster name must be alphanumeric, start with a letter and a maximum of 27 characters
-    Description: A short, representative cluster name to use for hostnames, etc.
+    ConstraintDescription: Cluster name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, representative cluster name to use for host names and other identifying names.
     Type: String
   InfrastructureName:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
-    Description: A short, unique cluster ID used to tag cloud resources and identify items owned/used by the cluster.
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster.
     Type: String
   HostedZoneId:
-    Description: The Route53 public zone ID to register the targets with (e.g Z21IXYZABCZ2A4)
+    Description: The Route53 public zone ID to register the targets with, such as Z21IXYZABCZ2A4.
     Type: String
   HostedZoneName:
-    Description: The Route53 zone to register the targets with (No trailing dot - e.g. mycorp.com)
+    Description: The Route53 zone to register the targets with, such as example.com. Omit the trailing period.
     Type: String
     Default: "example.com"
   PublicSubnets:
-    Description: The internet-facing subnets
+    Description: The internet-facing subnets.
     Type: List<AWS::EC2::Subnet::Id>
   PrivateSubnets:
-    Description: The internal subnets
+    Description: The internal subnets.
     Type: List<AWS::EC2::Subnet::Id>
   VpcId:
-    Description: The VPC created resources will belong.
+    Description: The VPC-scoped resources will belong to this VPC.
     Type: AWS::EC2::VPC::Id
 
 Metadata:
@@ -355,7 +355,7 @@ Resources:
 
 Outputs:
   PrivateHostedZoneId:
-    Description: Hosted zone ID for the private DNS - needed for private records
+    Description: Hosted zone ID for the private DNS, which is required for private records.
     Value: !Ref IntDns
   ExternalApiLoadBalancerName:
     Description: Full name of the External API load balancer created.
@@ -364,17 +364,17 @@ Outputs:
     Description: Full name of the Internal API load balancer created.
     Value: !GetAtt IntApiElb.LoadBalancerFullName
   ApiServerDnsName:
-    Description: Full hostname of the API server - Needed for ignition configs
+    Description: Full hostname of the API server, which is required for the Ignition config files.
     Value: !Join [".", ["api-int", !Ref ClusterName, !Ref HostedZoneName]]
   RegisterNlbIpTargetsLambda:
-    Description: Lambda ARN useful to help register/deregister IP targets for these load balancers
+    Description: Lambda ARN useful to help register or deregister IP targets for these load balancers.
     Value: !GetAtt RegisterNlbIpTargets.Arn
   ExternalApiTargetGroupArn:
-    Description: ARN of External API target group
+    Description: ARN of External API target group.
     Value: !Ref ExternalApiTargetGroup
   InternalApiTargetGroupArn:
-    Description: ARN of Internal API target group
+    Description: ARN of Internal API target group.
     Value: !Ref InternalApiTargetGroup
   InternalServiceTargetGroupArn:
-    Description: ARN of internal service target group
+    Description: ARN of internal service target group.
     Value: !Ref InternalServiceTargetGroup

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -1,25 +1,25 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Template for Openshift Cluster UPI Security Elements (Security Groups & IAM)
+Description: Template for OpenShift Cluster Security Elements (Security Groups & IAM)
 
 Parameters:
   InfrastructureName:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
-    Description: A short, unique cluster ID used to tag cloud resources and identify items owned/used by the cluster.
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster.
     Type: String
   VpcCidr:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
     Default: 10.0.0.0/16
-    Description: CIDR block for VPC
+    Description: CIDR block for VPC.
     Type: String
   VpcId:
-    Description: The VPC created resources will belong.
+    Description: The VPC-scoped resources will belong to this VPC.
     Type: AWS::EC2::VPC::Id
   PrivateSubnets:
-    Description: The internal subnets
+    Description: The internal subnets.
     Type: List<AWS::EC2::Subnet::Id>
 
 Metadata:

--- a/upi/aws/cloudformation/04_cluster_bootstrap.yaml
+++ b/upi/aws/cloudformation/04_cluster_bootstrap.yaml
@@ -1,54 +1,54 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Template for Openshift Cluster UPI Bootstrap (EC2 Instance, Security Groups and IAM)
+Description: Template for OpenShift Cluster Bootstrap (EC2 Instance, Security Groups and IAM)
 
 Parameters:
   InfrastructureName:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
-    Description: A short, unique cluster ID used to tag cloud resources and identify items owned/used by the cluster.
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster.
     Type: String
   RhcosAmi:
-    Description: Current RHEL CoreOS AMI to use for boostrap
+    Description: Current Red Hat Enterprise Linux CoreOS AMI to use for boostrap.
     Type: AWS::EC2::Image::Id
   AllowedBootstrapSshCidr:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|1[0-9]|2[0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/0-32
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/0-32.
     Default: 0.0.0.0/0
-    Description: CIDR block to allow SSH access to the bootstrap node
+    Description: CIDR block to allow SSH access to the bootstrap node.
     Type: String
   PublicSubnet:
-    Description: The public subnet to launch the bootstrap node into
+    Description: The public subnet to launch the bootstrap node into.
     Type: AWS::EC2::Subnet::Id
   MasterSecurityGroupId:
-    Description: The master security group ID (for registering temporary rules)
+    Description: The master security group ID for registering temporary rules.
     Type: AWS::EC2::SecurityGroup::Id
   VpcId:
-    Description: The VPC created resources will belong.
+    Description: The VPC-scoped resources will belong to this VPC.
     Type: AWS::EC2::VPC::Id
   BootstrapIgnitionLocation:
     Default: s3://my-s3-bucket/bootstrap.ign
-    Description: Location to fetch bootstrap ignition from. (Recommend to use the autocreated cf-templates bucket.)
+    Description: Ignition config file location.
     Type: String
   AutoRegisterELB:
     Default: "yes"
     AllowedValues:
     - "yes"
     - "no"
-    Description: Do you want to invoke NLB registration (requires Lambda ARN parameter to be supplied)?
+    Description: Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
     Type: String
   RegisterNlbIpTargetsLambdaArn:
-    Description: ARN for NLB IP target registration lambda
+    Description: ARN for NLB IP target registration lambda.
     Type: String
   ExternalApiTargetGroupArn:
-    Description: ARN for external API load balancer target group
+    Description: ARN for external API load balancer target group.
     Type: String
   InternalApiTargetGroupArn:
-    Description: ARN for internal API load balancer target group
+    Description: ARN for internal API load balancer target group.
     Type: String
   InternalServiceTargetGroupArn:
-    Description: ARN for internal service load balancer target group
+    Description: ARN for internal service load balancer target group.
     Type: String
 
 Metadata:
@@ -88,7 +88,7 @@ Metadata:
       PublicSubnet:
         default: "Public Subnet"
       RhcosAmi:
-        default: "RHEL CoreOS AMI ID"
+        default: "Red Hat Enterprise Linux CoreOS AMI ID"
       BootstrapIgnitionLocation:
         default: "Bootstrap Ignition Source"
       MasterSecurityGroupId:
@@ -199,13 +199,13 @@ Resources:
 
 Outputs:
   BootstrapInstanceId:
-    Description: Bootstrap Instance ID
+    Description: Bootstrap Instance ID.
     Value: !Ref BootstrapInstance
 
   BootstrapPublicIp:
-    Description: The bootstrap node public IP address
+    Description: The bootstrap node public IP address.
     Value: !GetAtt BootstrapInstance.PublicIp
 
   BootstrapPrivateIp:
-    Description: The bootstrap node private IP address
+    Description: The bootstrap node private IP address.
     Value: !GetAtt BootstrapInstance.PrivateIp

--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -1,45 +1,45 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Template for Openshift Cluster UPI Node Launch (EC2 master instances)
+Description: Template for OpenShift Cluster Node Launch (EC2 master instances)
 
 Parameters:
   InfrastructureName:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
     Description: A short, unique cluster ID used to tag nodes for the kubelet cloud provider.
     Type: String
   RhcosAmi:
-    Description: Current RHEL CoreOS AMI to use for boostrap
+    Description: Current Red Hat Enterprise Linux CoreOS AMI to use for boostrap.
     Type: AWS::EC2::Image::Id
   AutoRegisterDNS:
     Default: "yes"
     AllowedValues:
     - "yes"
     - "no"
-    Description: Do you want to invoke DNS etcd registration (requires Hosted Zone info provided)?
+    Description: Do you want to invoke DNS etcd registration, which requires Hosted Zone information?
     Type: String
   PrivateHostedZoneId:
-    Description: The Route53 private zone ID to register the etcd targets with (e.g Z21IXYZABCZ2A4)
+    Description: The Route53 private zone ID to register the etcd targets with, such as Z21IXYZABCZ2A4.
     Type: String
   PrivateHostedZoneName:
-    Description: The Route53 zone to register the targets with (No trailing dot - e.g. cluster.mycorp.com)
+    Description: The Route53 zone to register the targets with, such as cluster.example.com. Omit the trailing period.
     Type: String
   Master0Subnet:
-    Description: The subnets (recommend private) to launch the master nodes into
+    Description: The subnets, recommend private, to launch the master nodes into.
     Type: AWS::EC2::Subnet::Id
   Master1Subnet:
-    Description: The subnets (recommend private) to launch the master nodes into
+    Description: The subnets, recommend private, to launch the master nodes into.
     Type: AWS::EC2::Subnet::Id
   Master2Subnet:
-    Description: The subnets (recommend private) to launch the master nodes into
+    Description: The subnets, recommend private, to launch the master nodes into.
     Type: AWS::EC2::Subnet::Id
   MasterSecurityGroupId:
     Description: The master security group ID to associate with master nodes.
     Type: AWS::EC2::SecurityGroup::Id
   IgnitionLocation:
     Default: https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/master
-    Description: Location to fetch bootstrap ignition from. (Recommend to use the autocreated ignition config location.)
+    Description: Ignition config file location.
     Type: String
   CertificateAuthorities:
     Default: data:text/plain;charset=utf-8;base64,ABC...xYz==
@@ -71,19 +71,19 @@ Parameters:
     AllowedValues:
     - "yes"
     - "no"
-    Description: Do you want to invoke NLB registration (requires Lambda ARN parameter to be supplied)?
+    Description: Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
     Type: String
   RegisterNlbIpTargetsLambdaArn:
-    Description: ARN for NLB IP target registration lambda (from cluster_infra_upi.yaml; otherwise select "no" for AutoRegisterELB)
+    Description: ARN for NLB IP target registration lambda. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
     Type: String
   ExternalApiTargetGroupArn:
-    Description: ARN for external API load balancer target group (from cluster_infra_upi.yaml; otherwise select "no" for AutoRegisterELB)
+    Description: ARN for external API load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
     Type: String
   InternalApiTargetGroupArn:
-    Description: ARN for internal API load balancer target group (from cluster_infra_upi.yaml; otherwise select "no" for AutoRegisterELB)
+    Description: ARN for internal API load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
     Type: String
   InternalServiceTargetGroupArn:
-    Description: ARN for internal service load balancer target group (from cluster_infra_upi.yaml; otherwise select "no" for AutoRegisterELB)
+    Description: ARN for internal service load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
     Type: String
 
 Metadata:
@@ -134,7 +134,7 @@ Metadata:
       MasterInstanceProfileName:
         default: "Master Instance Profile Name"
       RhcosAmi:
-        default: "RHEL CoreOS AMI ID"
+        default: "Red Hat Enterprise Linux CoreOS AMI ID"
       BootstrapIgnitionLocation:
         default: "Master Ignition Source"
       CertificateAuthorities:
@@ -353,7 +353,7 @@ Resources:
 
 Outputs:
   PrivateIPs:
-    Description: The control-plane node private IP addresses
+    Description: The control-plane node private IP addresses.
     Value:
       !Join [
         ",",

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -1,26 +1,26 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Template for Openshift Cluster UPI Node Launch (EC2 worker instance)
+Description: Template for OpenShift Cluster Node Launch (EC2 worker instance)
 
 Parameters:
   InfrastructureName:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter and a maximum of 27 characters
+    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
     Description: A short, unique cluster ID used to tag nodes for the kubelet cloud provider.
     Type: String
   RhcosAmi:
-    Description: Current RHEL CoreOS AMI to use for boostrap
+    Description: Current Red Hat Enterprise Linux CoreOS AMI to use for boostrap.
     Type: AWS::EC2::Image::Id
-  WorkerSubnet:
-    Description: The subnets (recommend private) to launch the master nodes into
+  Subnet:
+    Description: The subnets, recommend private, to launch the master nodes into.
     Type: AWS::EC2::Subnet::Id
   WorkerSecurityGroupId:
     Description: The master security group ID to associate with master nodes.
     Type: AWS::EC2::SecurityGroup::Id
   IgnitionLocation:
     Default: https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/worker
-    Description: Location to fetch bootstrap ignition from. (Recommend to use the autocreated ignition config location.)
+    Description: Ignition config file location.
     Type: String
   CertificateAuthorities:
     Default: data:text/plain;charset=utf-8;base64,ABC...xYz==
@@ -67,16 +67,16 @@ Metadata:
     - Label:
         default: "Network Configuration"
       Parameters:
-      - WorkerSubnet
+      - Subnet
     ParameterLabels:
-      WorkerSubnet:
-        default: "Worker Subnet"
+      Subnet:
+        default: "Subnet"
       WorkerInstanceType:
         default: "Worker Instance Type"
       WorkerInstanceProfileName:
         default: "Worker Instance Profile Name"
       RhcosAmi:
-        default: "RHEL CoreOS AMI ID"
+        default: "Red Hat Enterprise Linux CoreOS AMI ID"
       IgnitionLocation:
         default: "Worker Ignition Source"
       CertificateAuthorities:
@@ -96,7 +96,7 @@ Resources:
         DeviceIndex: "0"
         GroupSet:
         - !Ref "WorkerSecurityGroupId"
-        SubnetId: !Ref "WorkerSubnet"
+        SubnetId: !Ref "Subnet"
       UserData:
         Fn::Base64: !Sub
         - '{"ignition":{"config":{"append":[{"source":"${SOURCE}","verification":{}}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}","verification":{}}]}},"timeouts":{},"version":"2.2.0"},"networkd":{},"passwd":{},"storage":{},"systemd":{}}'
@@ -110,5 +110,5 @@ Resources:
 
 Outputs:
   PrivateIP:
-    Description: The compute node private IP address
+    Description: The compute node private IP address.
     Value: !GetAtt Worker0.PrivateIp


### PR DESCRIPTION
Because we can no longer use "UPI" in customer-facing documentation and the CloudFormation templates in /installer are published in /openshift-docs, I want to change the source templates instead of having to always reproduce the fix in the docs repo.

I'm making a few other style and changes to the parameter descriptions.