### PR TITLE
upi/metal: remove domain from hostname

### DIFF
--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -96,7 +96,7 @@ locals {
 
 resource "packet_device" "masters" {
   count            = "${var.master_count}"
-  hostname         = "master-${count.index}.${var.cluster_domain}"
+  hostname         = "master-${count.index}"
   plan             = "c1.small.x86"
   facilities       = ["any"]
   operating_system = "custom_ipxe"
@@ -109,7 +109,7 @@ resource "packet_device" "masters" {
 
 resource "packet_device" "workers" {
   count            = "${var.worker_count}"
-  hostname         = "worker-${count.index}.${var.cluster_domain}"
+  hostname         = "worker-${count.index}"
   plan             = "c1.small.x86"
   facilities       = ["any"]
   operating_system = "custom_ipxe"


### PR DESCRIPTION
In baremetal installs, we define hostname as FQDN. Because of this `hostname`  will report FQDN vs actual hostname. I feel this should be a standard across all installers. Is there a reason we need this defined in this way for metal?

```sh
[core@heavy-metal-001 bin]$ hostname
heavy-metal-001.my.bare.metal.deployment.com
[core@heavy-metal-001 bin]$ hostname -d
my.bare.metal.deployment.com
```

/cc @abhinavdahiya @celebdor 

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1714457