### PR TITLE
README: remove experimental designation for bare metal and vSphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ## Supported Platforms
 
 * [AWS](docs/user/aws/README.md)
-* [Bare-metal (experimental)](docs/user/metal/install_upi.md)
+* [Bare-metal](docs/user/metal/install_upi.md)
 * [Libvirt with KVM](docs/dev/libvirt/README.md) (development only)
 * [OpenStack (experimental)](docs/user/openstack/README.md)
-* [vSphere (experimental)](docs/user/vsphere/install_upi.md)
+* [vSphere](docs/user/vsphere/install_upi.md)
 
 ## Quick Start
 


### PR DESCRIPTION
The Bare Metal and vSphere platforms are no longer experimental. They should not be listed as experimental in the README.