### PR TITLE
data/azure: create explicit deps to internal dns zone before any resource in vnet

### DIFF
--- a/data/data/azure/vnet/common.tf
+++ b/data/data/azure/vnet/common.tf
@@ -3,8 +3,6 @@
 
 // Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
 locals {
-  vnet_id = azurerm_virtual_network.cluster_vnet.id
-
   subnet_ids = azurerm_subnet.master_subnet.id
 
   lb_fqdn = azurerm_lb.public.id

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -1,7 +1,3 @@
-output "vnet_id" {
-  value = local.vnet_id
-}
-
 output "cluster-pip" {
   value = azurerm_public_ip.cluster_public_ip.ip_address
 }

--- a/data/data/azure/vnet/variables.tf
+++ b/data/data/azure/vnet/variables.tf
@@ -1,3 +1,7 @@
+variable "vnet_name" {
+  type = string
+}
+
 variable "vnet_cidr" {
   type = string
 }
@@ -53,3 +57,7 @@ variable "master_count" {
   default     = "3"
 }
 
+variable "private_dns_zone_id" {
+  type        = string
+  description = "This is to create explicit dependency on private zone to exist before VMs are created in the vnet. https://github.com/MicrosoftDocs/azure-docs/issues/13728"
+}

--- a/data/data/azure/vnet/vnet.tf
+++ b/data/data/azure/vnet/vnet.tf
@@ -1,10 +1,3 @@
-resource "azurerm_virtual_network" "cluster_vnet" {
-  name                = "${var.cluster_id}-vnet"
-  resource_group_name = var.resource_group_name
-  location            = var.region
-  address_space       = [var.vnet_cidr]
-}
-
 resource "azurerm_route_table" "route_table" {
   name                = "${var.cluster_id}-node-routetable"
   location            = var.region
@@ -14,14 +7,14 @@ resource "azurerm_route_table" "route_table" {
 resource "azurerm_subnet" "master_subnet" {
   resource_group_name  = var.resource_group_name
   address_prefix       = var.master_subnet_cidr
-  virtual_network_name = azurerm_virtual_network.cluster_vnet.name
+  virtual_network_name = var.vnet_name
   name                 = "${var.cluster_id}-controlplane-subnet"
 }
 
 resource "azurerm_subnet" "node_subnet" {
   resource_group_name  = var.resource_group_name
   address_prefix       = var.node_subnet_cidr
-  virtual_network_name = azurerm_virtual_network.cluster_vnet.name
+  virtual_network_name = var.vnet_name
   name                 = "${var.cluster_id}-node-subnet"
 }
 


### PR DESCRIPTION
Previous commit [1] created explicit deps to make sure VMs were not created before internal DNS zone and VNET attachement.
There is still cases where LBs etc like resources in VNET block the internal DNS zone creation because of azure issues [2]

[1]: https://github.com/openshift/installer/commit/08c8bc55881197210f162b1587c38f352759a73f
[2]: https://github.com/MicrosoftDocs/azure-docs/issues/13728

/cc @jstuever @wking