### PR TITLE
cmd/openshift-install/waitfor: Replace --help with runnable gather suggestion

### DIFF
--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -46,8 +47,13 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 
 			err = waitForBootstrapComplete(ctx, config, rootOpts.dir)
 			if err != nil {
-				logrus.Info("Use the following commands to gather logs from the cluster")
-				logrus.Info("openshift-install gather bootstrap --help")
+				_, _, err2 := getGatherBootstrapIPs(rootOpts.dir)
+				if err2 == nil {
+					logrus.Infof("Gather logs from the cluster with: %q --dir %q gather bootstrap", os.Args[0], rootOpts.dir)
+				} else {
+					logrus.Infof("Gather logs from the cluster with: %q gather bootstrap --bootstrap PUBLIC_BOOTSTRAP_IP [--master MASTER_IP ...]", os.Args[0])
+					logrus.Infof("See also: %q gather bootstrap --help", os.Args[0])
+				}
 				logrus.Fatal(err)
 			}
 


### PR DESCRIPTION
Because:

```
INFO Use the following command to gather logs from the cluster: "openshift-install" --dir "wking" gather bootstrap
```

is more helpful than:

```
INFO Use the following commands to gather logs from the cluster
INFO openshift-install gather bootstrap --help
```

The new suggestion:

* No longer splits the advice across multiple log entries, which is good if these are ever fed into a log aggregator that treats log entries as stand-alone objects.
* No longer points users at `--help`, but instead points them at a command they can run directly without having to read docs.

I'm using `os.Args`, because `cobra.Command` doesn't seem to expose `Args[0]` directly, although there is a [`CalledAs`][1] which may include the full stack.

I'm quoting both strings, because it's possible that they both contain paths with whitespace.  It's a bit ugly, but it's safer ;).

[1]: https://godoc.org/github.com/spf13/cobra#Command.CalledAs