### PR TITLE
data/approve-csr.sh: fix the exit condition to use correct file path for bootkube done

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
+++ b/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
@@ -3,7 +3,7 @@
 KUBECONFIG="${1}"
 
 echo "Approving all CSR requests until bootstrapping is complete..."
-while [ ! -f /opt/openshift/bootkube.done ]
+while [ ! -f /opt/openshift/.bootkube.done ]
 do
     oc --config="$KUBECONFIG" get csr --no-headers | grep Pending | \
         awk '{print $1}' | \


### PR DESCRIPTION
`touch /opt/openshift/.bootkube.done` [1] from bootkube.service creates the file on successful completion.

The approve-csr needs to stop approving CSRs after bootkube has finshed successfully, but PR 1747 [2] has wrong file location in the while condition.

[1]: https://github.com/openshift/installer/blob/1723ee626f17c479d14841d167f45a2e5d03bc7f/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L299
[2]: https://github.com/openshift/installer/commit/c5d4d0f3ab3b0e65cb8d6af3ff6dfb3162dfa1d6

/cc @wking 
/cc @sjenning 
^^ as he noticed this behavior that approve-csr was active after bootkube completed.

Previous discussion why systemd constructs wouldn't work very well https://github.com/openshift/installer/pull/1747#discussion_r284525835