### PR TITLE
data/azure: clarify that the password isn't used

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -144,7 +144,10 @@ resource "azurerm_virtual_machine" "bootstrap" {
   os_profile {
     computer_name  = "${var.cluster_id}-bootstrap-vm"
     admin_username = "core"
-    admin_password = "P@ssword1234!"
+    # The password is normally applied by WALA (the Azure agent), but this
+    # isn't installed in RHCOS. As a result, this password is never set. It is
+    # included here because it is required by the Azure ARM API.
+    admin_password = "NotActuallyApplied!"
     custom_data    = data.ignition_config.redirect.rendered
   }
 

--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -73,7 +73,10 @@ resource "azurerm_virtual_machine" "master" {
   os_profile {
     computer_name  = "${var.cluster_id}-master-${count.index}"
     admin_username = "core"
-    admin_password = "P@ssword1234!"
+    # The password is normally applied by WALA (the Azure agent), but this
+    # isn't installed in RHCOS. As a result, this password is never set. It is
+    # included here because it is required by the Azure ARM API.
+    admin_password = "NotActuallyApplied!"
     custom_data    = var.ignition
   }
 


### PR DESCRIPTION
The Azure ARM API requires that a username and password are provided
when creating a VM, even if it isn't going to be used. RHCOS doesn't
actually apply this password because WALA (the Azure Linux agent) isn't
shipped in the OS. This change just aims to make this fact more clear to
future readers.