### PR TITLE
Fix /usr/local/bin/haproxy-watch.sh if-conditionals

### DIFF
--- a/data/data/openstack/service/main.tf
+++ b/data/data/openstack/service/main.tf
@@ -87,7 +87,7 @@ WORKERS=$(oc get nodes -l node-role.kubernetes.io/worker -ogo-template="$TEMPLAT
 update_cfg_and_restart() {
     CHANGED=$(diff /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.new)
 
-    if [[ ! -f /etc/haproxy/haproxy.cfg ]] || [[ ! $CHANGED -eq "" ]];
+    if [[ ! -f /etc/haproxy/haproxy.cfg ]] || [[ ! -z "$CHANGED" ]];
     then
         cp /etc/haproxy/haproxy.cfg /etc/haproxy/haproxy.cfg.backup || true
         cp /etc/haproxy/haproxy.cfg.new /etc/haproxy/haproxy.cfg
@@ -95,7 +95,7 @@ update_cfg_and_restart() {
     fi
 }
 
-if [[ $MASTERS -eq "" ]];
+if [[ -z "$MASTERS" ]];
 then
 cat > /etc/haproxy/haproxy.cfg.new << EOF
 listen ${var.cluster_id}-api-masters


### PR DESCRIPTION
Two checks within the haproxy-watcher.sh script use the following conditionals:

`if [[ $MASTERS -eq "" ]]`
`if [[ ! $CHANGED -eq "" ]]`

These are apparently invalid expressions, as the following errors are generated when the script is run, respectively:

`./haproxy-watcher.sh: line 29: [[: 192.168.126.24 : syntax error: invalid arithmetic operator (error token is ".168.126.24 ")`
`./haproxy-watcher.sh: line 20: [[: 6,13c6: value too great for base (error token is "13c6")`

Changing the conditionals to use the `-z` operator appears to fix the errors and preserve the intended functionality.
