### PR TITLE
version: Output RHEL CoreOS bootimage version

### DIFF
--- a/cmd/openshift-install/version.go
+++ b/cmd/openshift-install/version.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
+	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/version"
 )
 
@@ -27,6 +28,9 @@ func runVersionCmd(cmd *cobra.Command, args []string) error {
 	}
 	if image, err := bootstrap.DefaultReleaseImage(); err == nil {
 		fmt.Printf("release image %s\n", image)
+	}
+	if rhcosver, err := rhcos.FetchVersion(); err == nil {
+		fmt.Printf("Red Hat Enterprise Linux CoreOS bootimage %s\n", rhcosver)
 	}
 	return nil
 }

--- a/pkg/rhcos/builds.go
+++ b/pkg/rhcos/builds.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// metadata is a subset of the `meta.json` generated
+// by https://github.com/coreos/coreos-assembler
 type metadata struct {
 	AMIs map[string]struct {
 		HVM string `json:"hvm"`
@@ -23,6 +25,7 @@ type metadata struct {
 	OSTreeVersion string `json:"ostree-version"`
 }
 
+// fetchRHCOSBuild retrieves the pinned RHEL CoreOS metadata.
 func fetchRHCOSBuild(ctx context.Context) (*metadata, error) {
 	file, err := data.Assets.Open("rhcos.json")
 	if err != nil {
@@ -41,4 +44,13 @@ func fetchRHCOSBuild(ctx context.Context) (*metadata, error) {
 	}
 
 	return meta, nil
+}
+
+// FetchVersion retrives the pinned RHCOS version.
+func FetchVersion() (string, error) {
+	meta, err := fetchRHCOSBuild(context.TODO())
+	if err != nil {
+		return "", err
+	}
+	return meta.OSTreeVersion, nil
 }


### PR DESCRIPTION
There are a lot of reasons to want to know the RHCOS bootimage version
associated with an installer - the installer pins it today, but doesn't
make the information easy to find particularly in a CI/development
environment.

This is a very small step towards something like:
https://github.com/openshift/installer/issues/1399