### PR TITLE
data/data/openstack: Remove cluster name from servers

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -49,7 +49,7 @@ data "ignition_file" "hostname" {
 
   content {
     content = <<EOF
-${var.cluster_id}-bootstrap
+bootstrap
 EOF
 
   }

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -15,7 +15,7 @@ data "ignition_file" "hostname" {
 
   content {
     content = <<EOF
-${var.cluster_id}-master-${count.index}
+master-${count.index}
 EOF
 
   }


### PR DESCRIPTION
The convention for the fully-qualified names is
`master-$index.$cluster_name.$domain_name`, but the hostnames we were
setting were in the `$cluster_name-master-$index` format.

The master and bootstrap Ignition configs now drop the `$cluster_name`
prefix and only set the `master-$index` / `bootstrap` part.