### PR TITLE
Refresh troubleshooting doc to use machine api

### DIFF
--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -21,16 +21,16 @@ If the API is unavailable, that will need to be [investigated first](#kubernetes
 The previous command should yield output similar to the following:
 
 ```
-NAME                             DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-cluster-autoscaler-operator      1         1         1            1           1d
-clusterapi-manager-controllers   1         1         1            1           1d
-machine-api-operator             1         1         1            1           1d
+NAME                          READY   UP-TO-DATE   AVAILABLE   AGE
+cluster-autoscaler-operator   1/1     1            1           86m
+machine-api-controllers       1/1     1            1           85m
+machine-api-operator          1/1     1            1           86m
 ```
 
 Check the machine controller logs with the following command.
 
 ```sh
-oc --config=${INSTALL_DIR}/auth/kubeconfig --namespace=openshift-machine-api logs deployments/clusterapi-manager-controllers --container=machine-controller
+oc --config=${INSTALL_DIR}/auth/kubeconfig --namespace=openshift-machine-api logs deployments/machine-api-controllers --container=machine-controller
 ```
 
 ### Kubernetes API is Unavailable


### PR DESCRIPTION
`machine-api-controllers` should now be used instead of
`clusterapi-manager-controllers`