### PR TITLE
Add Proxy to InstallConfig

### DIFF
--- a/pkg/asset/manifests/network.go
+++ b/pkg/asset/manifests/network.go
@@ -25,7 +25,7 @@ var (
 // their CRD created by the CVO, but we need to create the corresponding
 // CRs in the installer, so we need the CRD to be there.
 // The first CRD is the high-level Network.config.openshift.io object,
-// which is stable ahd minimal. Administrators can override configure the
+// which is stable and minimal. Administrators can configure the
 // network in a more detailed manner with the operator-specific CR, which
 // also needs to be done before the installer is run, so we provide both.
 

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -70,6 +70,11 @@ type InstallConfig struct {
 
 	// PullSecret is the secret to use when pulling images.
 	PullSecret string `json:"pullSecret"`
+
+	// Proxy defines the proxy settings for the cluster.
+	// If unset, the cluster will not be configured to use a proxy.
+	// +optional
+	Proxy *Proxy `json:"proxy,omitempty"`
 }
 
 // ClusterDomain returns the DNS domain that all records for a cluster must belong to.
@@ -181,4 +186,20 @@ type ClusterNetworkEntry struct {
 	// The size of blocks to allocate from the larger pool.
 	// This is the length in bits - so a 9 here will allocate a /23.
 	DeprecatedHostSubnetLength int32 `json:"hostSubnetLength,omitempty"`
+}
+
+// Proxy defines the proxy settings for the cluster.
+// At least one of HTTPProxy or HTTPSProxy is required.
+type Proxy struct {
+	// HTTPProxy is the URL of the proxy for HTTP requests.
+	// +optional
+	HTTPProxy string `json:"httpProxy,omitempty"`
+
+	// HTTPSProxy is the URL of the proxy for HTTPS requests.
+	// +optional
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+
+	// NoProxy is a comma-separated list of domains and CIDRs for which the proxy should not be used.
+	// +optional
+	NoProxy string `json:"noProxy,omitempty"`
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -113,3 +113,16 @@ func URI(uri string) error {
 	}
 	return nil
 }
+
+// URIWithProtocol validates that the URI specifies a certain
+// protocol scheme (e.g. "https")
+func URIWithProtocol(uri string, protocol string) error {
+	parsed, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != protocol {
+		return fmt.Errorf("must use %s protocol", protocol)
+	}
+	return nil
+}


### PR DESCRIPTION
As a step toward cluster proxies, add support for proxies to the InstallConfig. This PR creates the `Proxy` type struct and adds it to the InstallConfig. It also adds validation and unit tests for the validation.

Jira: [CORS-1075](https://jira.coreos.com/browse/CORS-1075)
Related PRS: openshift/api#335, openshift/cluster-config-operator#66

This is a work in progress but I am looking for feedback:

- I think this is close so I need to know what is missing
- Confirm: httpProxy & httpsProxy must include scheme, i.e. start with http:// or https://
- Do we need further validation?
- Suggestions on how to validate NoProxy. Currently "bad-proxy" receives no error when passed to validate.DomainName

Just realized I also need to fill in the commit messages.