### PR TITLE
Bug 1715001: hack/build: Use BUILD_VERSION if non-empty

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -32,7 +32,8 @@ fi
 
 MODE="${MODE:-release}"
 GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}"
-LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=$(git describe --always --abbrev=40 --dirty) -X github.com/openshift/installer/pkg/version.Commit=${GIT_COMMIT}"
+GIT_TAG="${BUILD_VERSION:-$(git describe --always --abbrev=40 --dirty)}"
+LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=${GIT_TAG} -X github.com/openshift/installer/pkg/version.Commit=${GIT_COMMIT}"
 TAGS="${TAGS:-}"
 OUTPUT="${OUTPUT:-bin/openshift-install}"
 export CGO_ENABLED=0


### PR DESCRIPTION
Like 3313c08266 (#1744), but for tags.  This should fix #1828:

```console
$ ./openshift-install version
./openshift-install v4.1.0-201905212232-dirty
...
```

Doozer [sets `SOURCE_GIT_TAG`][2] just like it sets `SOURCE_GIT_COMMIT`.

Fixes #1828.

[1]: https://github.com/openshift/installer/issues/1828
[2]: https://github.com/openshift/doozer/blob/a36e072a87d403c09519a1d0c9be4757f8bee941/doozerlib/distgit.py#L1229