### PR TITLE
Add proxy configuration to bootstrap node

### DIFF
--- a/data/data/bootstrap/files/etc/profile.d/proxy.sh.template
+++ b/data/data/bootstrap/files/etc/profile.d/proxy.sh.template
@@ -1,0 +1,11 @@
+{{if .Proxy -}}
+{{if .Proxy.HTTPProxy -}}
+export HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+{{end -}}
+{{if .Proxy.HTTPSProxy -}}
+export HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+{{end -}}
+{{if .Proxy.NoProxy -}}
+export NO_PROXY="{{.Proxy.NoProxy}}"
+{{end -}}
+{{end -}}

--- a/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env.conf.template
+++ b/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env.conf.template
@@ -1,0 +1,12 @@
+{{if .Proxy -}}
+[Manager]
+{{if .Proxy.HTTPProxy -}}
+DefaultEnvironment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+{{end -}}
+{{if .Proxy.HTTPSProxy -}}
+DefaultEnvironment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+{{end -}}
+{{if .Proxy.NoProxy -}}
+DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"
+{{end -}}
+{{end -}}

--- a/docs/dev/proxy.md
+++ b/docs/dev/proxy.md
@@ -1,0 +1,51 @@
+### Proxy Testing
+
+This will create an extremely basic configuration of squid to support
+the testing of authenticated proxy with `openshift-install`.
+
+NOTE: Make sure TCP/3128 is open
+
+
+- Create directories and configuration files
+```
+mkdir -p /srv/squid/{etc,cache}
+htpasswd -c /srv/squid/etc/passwords <username>
+
+cat << EOF > /srv/squid/etc/squid.conf
+auth_param basic program /usr/lib/squid3/basic_ncsa_auth /etc/squid/passwords
+auth_param basic realm proxy
+acl authenticated proxy_auth REQUIRED
+http_access allow authenticated
+http_port 3128
+cache_dir ufs /var/spool/squid 100 16 256
+coredump_dir /var/spool/squid
+EOF
+
+chcon -Rt svirt_sandbox_file_t /srv/squid/
+```
+
+- Start container
+```
+URL=docker.io/datadog/squid:latest
+SQUID_CACHE_PATH=/srv/squid/cache
+SQUID_ETC_PATH=/srv/squid/etc
+
+podman pull ${URL}
+podman rm -f squid
+
+podman run --name squid -d -p 3128:3128 \
+        --volume ${SQUID_CACHE_PATH}:/var/spool/squid:Z \
+        --volume ${SQUID_ETC_PATH}:/etc/squid:Z \
+        ${URL}
+```
+
+- install-config.yaml snipit
+
+```yaml
+---
+apiVersion: v1
+baseDomain: devcluster.openshift.com
+proxy:
+  httpsProxy:  "http://username:password@proxy:port"
+  httpProxy: "http://username:password@proxy:port"
+```


### PR DESCRIPTION
Modification of `bootstrapTemplateData` struct to include proxy requirements.
Modification of `getTemplateData` and `addStorageFiles` to support proxy

Added:
- /etc/profile.d/proxy.sh.template
- /etc/systemd/system.conf.d/10-default-env.conf.template