### PR TITLE
machines/azure: Set subnets for control plane and compute machines 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1120,14 +1120,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1ec43d1093555bc7a4f63f0cec39c215d1c5754b90bd9741d7ded6c2110fc465"
+  digest = "1:4271f208cbd48a3758384d61ae02c7fddb6b8dc8f8c01b946614e891709c9349"
   name = "sigs.k8s.io/cluster-api-provider-azure"
   packages = [
     "pkg/apis",
     "pkg/apis/azureprovider/v1alpha1",
   ]
   pruneopts = "NUT"
-  revision = "106e77fea15a9a0a39776b3edbc5666aa337ca70"
+  revision = "702ef3a407263373a619b4df1be7fda77ef2a7e5"
   source = "https://github.com/openshift/cluster-api-provider-azure.git"
 
 [[projects]]

--- a/data/data/azure/vnet/vnet.tf
+++ b/data/data/azure/vnet/vnet.tf
@@ -8,13 +8,13 @@ resource "azurerm_subnet" "master_subnet" {
   resource_group_name  = var.resource_group_name
   address_prefix       = var.master_subnet_cidr
   virtual_network_name = var.vnet_name
-  name                 = "${var.cluster_id}-controlplane-subnet"
+  name                 = "${var.cluster_id}-master-subnet"
 }
 
 resource "azurerm_subnet" "node_subnet" {
   resource_group_name  = var.resource_group_name
   address_prefix       = var.node_subnet_cidr
   virtual_network_name = var.vnet_name
-  name                 = "${var.cluster_id}-node-subnet"
+  name                 = "${var.cluster_id}-worker-subnet"
 }
 

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -37,7 +37,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	}
 	var machines []machineapi.Machine
 	for idx := int64(0); idx < total; idx++ {
-		provider, err := provider(platform, mpool, osImage, userDataSecret)
+		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
@@ -69,7 +69,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	return machines, nil
 }
 
-func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string, userDataSecret string) (*azureprovider.AzureMachineProviderSpec, error) {
+func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string, userDataSecret string, clusterID string, role string) (*azureprovider.AzureMachineProviderSpec, error) {
 	return &azureprovider.AzureMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "azureprovider.k8s.io/v1alpha1",
@@ -89,6 +89,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 				StorageAccountType: "Premium_LRS",
 			},
 		},
+		Subnet: fmt.Sprintf("%s-%s-subnet", clusterID, role),
 	}, nil
 }
 

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	cloudsSecret          = "azure-credentials"
-	cloudsSecretNamespace = "kube-system"
+	cloudsSecret          = "azure-cloud-credentials"
+	cloudsSecretNamespace = "openshift-machine-api"
 )
 
 // Machines returns a list of machines for a machinepool.

--- a/pkg/asset/machines/azure/machinesets.go
+++ b/pkg/asset/machines/azure/machinesets.go
@@ -29,7 +29,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	}
 
 	var machinesets []*clusterapi.MachineSet
-	provider, err := provider(platform, mpool, osImage, userDataSecret)
+	provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create provider")
 	}

--- a/vendor/sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1/azuremachineproviderconfig_types.go
@@ -47,6 +47,19 @@ type AzureMachineProviderSpec struct {
 	OSDisk        OSDisk `json:"osDisk"`
 	SSHPublicKey  string `json:"sshPublicKey"`
 	SSHPrivateKey string `json:"sshPrivateKey"`
+	PublicIP      bool   `json:"publicIP"`
+
+	// Subnet to use for this instance
+	Subnet string `json:"subnet"`
+
+	// PublicLoadBalancer to use for this instance
+	PublicLoadBalancer string `json:"publicLoadBalancer"`
+
+	// InternalLoadBalancerName to use for this instance
+	InternalLoadBalancer string `json:"internalLoadBalancer"`
+
+	// NatRule to set inbound NAT rule of the load balancer
+	NatRule *int `json:"natRule"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
With changes in the cluster-api-provider-azure from https://github.com/openshift/cluster-api-provider-azure/pull/35, the Azure IPI fails to create worker VMs like
https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/4006/rehearse-4006-pull-ci-openshift-origin-master-e2e-azure/1/artifacts/e2e-azure/must-gather/namespaces/openshift-machine-api/pods/machine-api-controllers-c95fb75b5-rzjks/machine-controller/machine-controller/logs/current.log
```console
2019-06-07T19:38:06.7703507Z E0607 19:38:06.770317       1 actuator.go:79] failed to reconcile machine ci-op-pqj0zh18-849ce-9765f-worker-qg7fj: failed to create nic ci-op-pqj0zh18-849ce-9765f-worker-qg7fj-nic for machine ci-op-pqj0zh18-849ce-9765f-worker-qg7fj: MachineConfig subnet is missing on machine ci-op-pqj0zh18-849ce-9765f-worker-qg7fj, skipping machine creation
```

This changes the installer to set the subnet names based on the role of the MachinePool.

/cc @enxebre @ingvagabund 