### PR TITLE
cmd/openshift-install/gather: Guard against cluster-side artifact collisions

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -113,11 +113,12 @@ func logGatherBootstrap(bootstrap string, port int, masters []string, directory 
 	if err != nil {
 		return errors.Wrap(err, "failed to create SSH client")
 	}
-	if err := ssh.Run(client, fmt.Sprintf("/usr/local/bin/installer-gather.sh %s", strings.Join(masters, " "))); err != nil {
+	gatherID := time.Now().Format("20060102150405")
+	if err := ssh.Run(client, fmt.Sprintf("/usr/local/bin/installer-gather.sh --id %s %s", gatherID, strings.Join(masters, " "))); err != nil {
 		return errors.Wrap(err, "failed to run remote command")
 	}
-	file := filepath.Join(directory, fmt.Sprintf("log-bundle-%s.tar.gz", time.Now().Format("20060102150405")))
-	if err := ssh.PullFileTo(client, "/home/core/log-bundle.tar.gz", file); err != nil {
+	file := filepath.Join(directory, fmt.Sprintf("log-bundle-%s.tar.gz", gatherID))
+	if err := ssh.PullFileTo(client, fmt.Sprintf("/home/core/log-bundle-%s.tar.gz", gatherID), file); err != nil {
 		return errors.Wrap(err, "failed to pull log file from remote")
 	}
 	logrus.Infof("Bootstrap gather logs captured here %q", file)

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-ARTIFACTS="/tmp/artifacts"
+if test "x${1}" = 'x--id'
+then
+	GATHER_ID="${2}"
+	shift 2
+fi
+
+ARTIFACTS="/tmp/artifacts-${GATHER_ID}"
 
 echo "Gathering bootstrap journals ..."
 mkdir -p "${ARTIFACTS}/bootstrap/journals"
@@ -112,8 +118,9 @@ do
   echo "Collecting info from ${master}"
   scp -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -q /usr/local/bin/installer-masters-gather.sh "core@${master}:"
   mkdir -p "${ARTIFACTS}/control-plane/${master}"
-  ssh -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null "core@${master}" -C 'sudo ./installer-masters-gather.sh' </dev/null
-  scp -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -r -q "core@${master}:/tmp/artifacts/*" "${ARTIFACTS}/control-plane/${master}/"
+  ssh -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null "core@${master}" -C "sudo ./installer-masters-gather.sh --id '${GATHER_ID}'" </dev/null
+  scp -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -r -q "core@${master}:/tmp/artifacts-${GATHER_ID}/*" "${ARTIFACTS}/control-plane/${master}/"
 done
-tar cz -C /tmp/artifacts . > ~/log-bundle.tar.gz
-echo "Log bundle written to ~/log-bundle.tar.gz"
+TAR_FILE="${TAR_FILE:-${HOME}/log-bundle-${GATHER_ID}.tar.gz}"
+tar cz -C "${ARTIFACTS}" . >"${TAR_FILE}"
+echo "Log bundle written to ${TAR_FILE}"

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-ARTIFACTS="${1:-/tmp/artifacts}"
+if test "x${1}" = 'x--id'
+then
+	GATHER_ID="${2}"
+	shift 2
+fi
+
+ARTIFACTS="/tmp/artifacts-${GATHER_ID}"
 mkdir -p "${ARTIFACTS}"
 
 echo "Gathering master journals ..."


### PR DESCRIPTION
Support running multiple gather commands without cluster-side collisions. For example:

1. Alice runs `gather bootstrap`, her command writes a tarball on the bootstrap machine and starts downloading it.
2. Bob runs `gather bootstrap`, his command starts writing to the same tarball on the bootstrap machine.
3. Alice's download croaks on the truncated file.

But maybe Alice's download already has an open file descriptor, so Bob's clobber doesn't break the download?  I guess it depends on the specifics of how `installer-gather.sh`'s `> ~/log-bundle.tar.gz` worked.  With this pull request, we avoid potential issues by passing in an optional gather ID which the cluster-side scripts use to uniquify their collection directories.  We still race if multiple gathers are launched in the same second, but that's at least a narrower window, and we can close it later by using a better source of random characters.