### PR TITLE
restrict clustername validation to include DNS subdomain and DNS label requirements.

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -49,7 +49,7 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 			allErrs = append(allErrs, field.Invalid(field.NewPath("sshKey"), c.SSHKey, err.Error()))
 		}
 	}
-	nameErr := validate.DomainName(c.ObjectMeta.Name, false)
+	nameErr := validate.ClusterName(c.ObjectMeta.Name)
 	if nameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, nameErr.Error()))
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -123,11 +123,11 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "overly long cluster domain",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.ObjectMeta.Name = fmt.Sprintf("test-cluster%050d", 0)
-				c.BaseDomain = fmt.Sprintf("test-domain%050d.a%060d.b%060d.c%060d", 0, 0, 0, 0)
+				c.ObjectMeta.Name = fmt.Sprintf("test-cluster%042d", 0)
+				c.BaseDomain = fmt.Sprintf("test-domain%056d.a%060d.b%060d.c%060d", 0, 0, 0, 0)
 				return c
 			}(),
-			expectedError: `^baseDomain: Invalid value: "` + fmt.Sprintf("test-cluster%050d.test-domain%050d.a%060d.b%060d.c%060d", 0, 0, 0, 0, 0) + `": must be no more than 253 characters$`,
+			expectedError: `^baseDomain: Invalid value: "` + fmt.Sprintf("test-cluster%042d.test-domain%056d.a%060d.b%060d.c%060d", 0, 0, 0, 0, 0) + `": must be no more than 253 characters$`,
 		},
 		{
 			name: "missing networking",

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -68,7 +68,13 @@ func ImagePullSecret(secret string) error {
 }
 
 // ClusterName checks if the given string is a valid name for a cluster and returns an error if not.
+// The max length of the DNS label is `DNS1123LabelMaxLength + 9` because the public DNS zones have records
+// `api.clustername`, `*.apps.clustername`, and *.apps is rendered as the nine-character \052.apps in DNS records.
 func ClusterName(v string) error {
+	maxlen := validation.DNS1123LabelMaxLength - 9
+	if len(v) > maxlen {
+		return errors.New(validation.MaxLenError(maxlen))
+	}
 	return validateSubdomain(v)
 }
 

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestClusterName(t *testing.T) {
-	maxSizeName := strings.Repeat("123456789.", 25) + "123"
+	maxSizeName := strings.Repeat("123456789.", 5) + "1234"
 
 	cases := []struct {
 		name        string


### PR DESCRIPTION
the clustername is a subdomain [1] when we create the private DNS zone ie `clustername.basedomain`
but when creating the public records, clustername is a dns label [1] as we create records under the `basedomain`

So the clustername needs to be valid subdomain but can be max 63 bytes, compared to currently allowed 255 bytes.

[1]: https://tools.ietf.org/html/rfc1123

/cc @openshift/openshift-team-installer @csrwng 