### PR TITLE
bootkube: add mco image

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -198,6 +198,7 @@ then
 			--machine-config-controller-image=${MACHINE_CONFIG_CONTROLLER_IMAGE} \
 			--machine-config-server-image=${MACHINE_CONFIG_SERVER_IMAGE} \
 			--machine-config-daemon-image=${MACHINE_CONFIG_DAEMON_IMAGE} \
+                        --machine-config-operator-image=${MACHINE_CONFIG_OPERATOR_IMAGE} \
 			--machine-config-oscontent-image=${MACHINE_CONFIG_OSCONTENT} \
 			--infra-image=${MACHINE_CONFIG_INFRA_IMAGE} \
 			--cloud-config-file=/assets/manifests/cloud-provider-config.yaml


### PR DESCRIPTION
This is a prep step for folding all mco component images into one mco image.
A corresponding mco image flag has been added in the MCO repo via openshift/machine-config-operator#847

Related-to: openshift/machine-config-operator#739
Related-to: openshift/machine-config-operator#847
Required-by: openshift/machine-config-operator#850

cc: @runcom 