### PR TITLE
openstack: Retrieve namespaced credentials

### DIFF
--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -20,8 +20,8 @@ const (
 	// the environment more predictable. We expect there to a secret
 	// named `openstack-credentials` and a cloud named `openstack` in
 	// the clouds file stored in this secret.
-	cloudsSecret          = "openstack-credentials"
-	cloudsSecretNamespace = "kube-system"
+	cloudsSecret          = "openstack-cloud-credentials"
+	cloudsSecretNamespace = "openshift-machine-api"
 
 	// CloudName is a constant containing the name of the cloud used in the internal cloudsSecret
 	CloudName = "openstack"


### PR DESCRIPTION
With openshift/machine-api-operator#315 the Machine API Operator
doesn't have access to the `kube-system` namespace anymore.

We now need to issue a CredentialsRequest in MAO and retrieve it from
the `openshift-machine-api` namespace here.

Needs openshift/machine-api-operator#324