### PR TITLE
openstack: Use user provided cloud value instead of hardcode

### DIFF
--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -91,7 +91,7 @@ func provider(clusterID string, platform *openstack.Platform, mpool *openstack.M
 			Size:       pointer.Int64Ptr(int64(mpool.Size)),
 		},*/
 		Image:          osImage,
-		CloudName:      CloudName,
+		CloudName:      platform.Cloud,
 		CloudsSecret:   &corev1.SecretReference{Name: cloudsSecret, Namespace: cloudsSecretNamespace},
 		UserDataSecret: &corev1.SecretReference{Name: userDataSecret},
 		Networks: []openstackprovider.NetworkParam{

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines"
 	openstackmanifests "github.com/openshift/installer/pkg/asset/manifests/openstack"
 
-	osmachine "github.com/openshift/installer/pkg/asset/machines/openstack"
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/templates/content/openshift"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
@@ -107,7 +106,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		}
 		clouds := make(map[string]map[string]*clientconfig.Cloud)
 		clouds["clouds"] = map[string]*clientconfig.Cloud{
-			osmachine.CloudName: cloud,
+			opts.Cloud: cloud,
 		}
 
 		marshalled, err := yaml.Marshal(clouds)


### PR DESCRIPTION
now the cloud is hardcoded to 'openstack' and we need
honor the input value or it will lead to potential error
as bug descriped

Fixes Bug: #1857

