### PR TITLE
Bump worker resources

### DIFF
--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -64,7 +64,7 @@ func provider(clusterID string, networkInterfaceAddress string, platform *libvir
 			Kind:       "LibvirtMachineProviderConfig",
 		},
 		DomainMemory: 6144,
-		DomainVcpu:   2,
+		DomainVcpu:   4,
 		Ignition: &libvirtprovider.Ignition{
 			UserDataSecret: userDataSecret,
 		},

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -63,7 +63,7 @@ func provider(clusterID string, networkInterfaceAddress string, platform *libvir
 			APIVersion: "libvirtproviderconfig.openshift.io/v1beta1",
 			Kind:       "LibvirtMachineProviderConfig",
 		},
-		DomainMemory: 4096,
+		DomainMemory: 6144,
 		DomainVcpu:   2,
 		Ignition: &libvirtprovider.Ignition{
 			UserDataSecret: userDataSecret,


### PR DESCRIPTION
Bump up worker resources so that all the prometheus pods can start.

Fixes #1860.