### PR TITLE
azure: set default machine types by region

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -143,7 +143,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		openstack.ConfigMasters(machines, clusterID.InfraID)
 	case azuretypes.Name:
 		mpool := defaultAzureMachinePoolPlatform()
-		mpool.InstanceType = azuredefaults.InstanceClass(installconfig.Config.Platform.Azure.Region)
+		mpool.InstanceType = azuredefaults.ControlPlaneInstanceType(installconfig.Config.Platform.Azure.Region)
 		mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Azure)
 		pool.Platform.Azure = &mpool

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -178,7 +178,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			}
 		case azuretypes.Name:
 			mpool := defaultAzureMachinePoolPlatform()
-			mpool.InstanceType = azuredefaults.InstanceClass(installconfig.Config.Platform.Azure.Region)
+			mpool.InstanceType = azuredefaults.ComputeInstanceType(installconfig.Config.Platform.Azure.Region)
 			mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.Azure)
 			pool.Platform.Azure = &mpool

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -34,7 +34,7 @@ func TFVars(auth Auth, baseDomainResourceGroupName string, masterConfigs []*azur
 		Auth:   auth,
 		Region: region,
 		BaseDomainResourceGroupName: baseDomainResourceGroupName,
-		BootstrapInstanceType:       defaults.InstanceClass(region),
+		BootstrapInstanceType:       defaults.BootstrapInstanceType(region),
 		MasterInstanceType:          masterConfig.VMSize,
 		VolumeSize:                  masterConfig.OSDisk.DiskSizeGB,
 		VMImageID:                   masterConfig.Image.ResourceID,

--- a/pkg/types/azure/defaults/machines.go
+++ b/pkg/types/azure/defaults/machines.go
@@ -1,0 +1,29 @@
+package defaults
+
+import (
+	"fmt"
+)
+
+// BootstrapInstanceType sets the defaults for bootstrap instances.
+// Minimum requirements are 4 CPU's, 16GiB of ram, and 120GiB storage.
+// D4s v3 gives us 4 CPU's, 16GiB ram and 32GiB of temporary storage
+func BootstrapInstanceType(region string) string {
+	instanceClass := getInstanceClass(region)
+	return fmt.Sprintf("%s_D4s_v3", instanceClass)
+}
+
+// ControlPlaneInstanceType sets the defaults for control plane instances.
+// Minimum requirements are 4 CPU's, 16GiB of ram, and 120GiB storage.
+// D4s v3 gives us 4 CPU's, 16GiB ram and 32GiB of temporary storage
+func ControlPlaneInstanceType(region string) string {
+	instanceClass := getInstanceClass(region)
+	return fmt.Sprintf("%s_D4s_v3", instanceClass)
+}
+
+// ComputeInstanceType sets the defaults for compute instances.
+// Minimum requirements are 2 CPU's, 8GiB of ram, and 120GiB storage.
+// D4s v3 gives us 2 CPU's, 8GiB ram and 16GiB of temporary storage
+func ComputeInstanceType(region string) string {
+	instanceClass := getInstanceClass(region)
+	return fmt.Sprintf("%s_D2s_v3", instanceClass)
+}

--- a/pkg/types/azure/defaults/platform.go
+++ b/pkg/types/azure/defaults/platform.go
@@ -4,12 +4,20 @@ import (
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
+var (
+	// Overrides
+	defaultMachineClass = map[string]string{}
+)
+
 // SetPlatformDefaults sets the defaults for the platform.
 func SetPlatformDefaults(p *azure.Platform) {
 }
 
-// InstanceClass returns the instance "class" we should use for a given
-// region.
-func InstanceClass(region string) string {
-	return "Standard_DS4_v2"
+// getInstanceClass returns the instance "class" we should use for a given region.
+func getInstanceClass(region string) string {
+	if class, ok := defaultMachineClass[region]; ok {
+		return class
+	}
+
+	return "Standard"
 }


### PR DESCRIPTION
This PR attempts to set the default machine type by region. According to Microsoft documentation, the Dsv3-Series is generally available across all regions. Master nodes are assigned Standard_D4s_v3 while worker nodes and default machine type is set to Standard_D2s_v3.

https://jira.coreos.com/browse/CORS-1091