### PR TITLE
[openstack] Remove gateway before delete router

### DIFF
--- a/pkg/destroy/openstack/openstack_deprovision.go
+++ b/pkg/destroy/openstack/openstack_deprovision.go
@@ -356,6 +356,16 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 			}
 		}
 
+		// Clean Gateway interface
+		updateOpts := routers.UpdateOpts{
+			GatewayInfo: &routers.GatewayInfo{},
+		}
+
+		_, err = routers.Update(conn, router.ID, updateOpts).Extract()
+		if err != nil {
+			logger.Fatalf("%v", err)
+		}
+
 		// Get router interface ports
 		portListOpts := ports.ListOpts{
 			DeviceID: router.ID,


### PR DESCRIPTION
platform: openstack

before delete router, we should remove gateway otherwise
a 409 (conflict) error will block the deletion of the router.

Fixes: #1859 