### PR TITLE
bootkube: fix indentation of mco image option

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -198,7 +198,7 @@ then
 			--machine-config-controller-image=${MACHINE_CONFIG_CONTROLLER_IMAGE} \
 			--machine-config-server-image=${MACHINE_CONFIG_SERVER_IMAGE} \
 			--machine-config-daemon-image=${MACHINE_CONFIG_DAEMON_IMAGE} \
-                        --machine-config-operator-image=${MACHINE_CONFIG_OPERATOR_IMAGE} \
+			--machine-config-operator-image=${MACHINE_CONFIG_OPERATOR_IMAGE} \
 			--machine-config-oscontent-image=${MACHINE_CONFIG_OSCONTENT} \
 			--infra-image=${MACHINE_CONFIG_INFRA_IMAGE} \
 			--cloud-config-file=/assets/manifests/cloud-provider-config.yaml


### PR DESCRIPTION
The command line option for mco image to `podman run bootstrap` is
indented incorrectly. 

Really nitpicky, but I noticed it when rebasing kni-installer