### PR TITLE
bootkube.sh: remove image refs for mco components

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -17,12 +17,8 @@ if ! release=$( podman inspect {{.ReleaseImage}} -f '{{"{{"}} index .RepoDigests
 fi
 
 MACHINE_CONFIG_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image machine-config-operator)
-MACHINE_CONFIG_CONTROLLER_IMAGE=$(podman run --quiet --rm ${release} image machine-config-controller)
-MACHINE_CONFIG_SERVER_IMAGE=$(podman run --quiet --rm ${release} image machine-config-server)
-MACHINE_CONFIG_DAEMON_IMAGE=$(podman run --quiet --rm ${release} image machine-config-daemon)
 MACHINE_CONFIG_OSCONTENT=$(podman run --quiet --rm ${release} image machine-os-content)
 MACHINE_CONFIG_ETCD_IMAGE=$(podman run --quiet --rm ${release} image etcd)
-MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE=$(podman run --quiet --rm ${release} image setup-etcd-environment)
 MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE=$(podman run --quiet --rm ${release} image kube-client-agent)
 MACHINE_CONFIG_INFRA_IMAGE=$(podman run --quiet --rm ${release} image pod)
 
@@ -194,11 +190,7 @@ then
 			--dest-dir=/assets/mco-bootstrap \
 			--pull-secret=/assets/manifests/openshift-config-secret-pull-secret.yaml \
 			--etcd-image=${MACHINE_CONFIG_ETCD_IMAGE} \
-			--setup-etcd-env-image=${MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE} \
 			--kube-client-agent-image=${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE} \
-			--machine-config-controller-image=${MACHINE_CONFIG_CONTROLLER_IMAGE} \
-			--machine-config-server-image=${MACHINE_CONFIG_SERVER_IMAGE} \
-			--machine-config-daemon-image=${MACHINE_CONFIG_DAEMON_IMAGE} \
 			--machine-config-operator-image=${MACHINE_CONFIG_OPERATOR_IMAGE} \
 			--machine-config-oscontent-image=${MACHINE_CONFIG_OSCONTENT} \
 			--infra-image=${MACHINE_CONFIG_INFRA_IMAGE} \


### PR DESCRIPTION
Remove references to mcc/mcd/mcs and setupetcd images now that the MCO has 1
super-image containing all of the sub-images

Requires: openshift/machine-config-operator#850
Related-to: openshift/machine-config-operator#739