### PR TITLE
hack: create & set GOPATH if not already set

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,6 +2,10 @@
 
 set -ex
 
+# shellcheck source=hack/init.sh
+. "$(dirname "${BASH_SOURCE[0]}")/init.sh"
+setup_env
+
 # shellcheck disable=SC2068
 version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}
 
@@ -13,20 +17,13 @@ if [ "$(version "${current_go_version#go}")" -lt "$(version "$minimum_go_version
      exit 1
 fi
 
-LAUNCH_PATH="${PWD}"
-cd "$(dirname "$0")/.."
+# Go to the root of the repo
+cd "${INSTALLER_ROOT}"
 
 PACKAGE_PATH="$(go list -e -f '{{.Dir}}' github.com/openshift/installer)"
 if test -z "${PACKAGE_PATH}"
 then
 	echo "build from your \${GOPATH} (${LAUNCH_PATH} is not in $(go env GOPATH))" 2>&1
-	exit 1
-fi
-
-LOCAL_PATH="${PWD}"
-if test "${PACKAGE_PATH}" != "${LOCAL_PATH}"
-then
-	echo "build from your \${GOPATH} (${PACKAGE_PATH}, not ${LAUNCH_PATH})" 2>&1
 	exit 1
 fi
 
@@ -47,7 +44,7 @@ release)
 	fi
 	if test "${SKIP_GENERATION}" != y
 	then
-		go generate ./data
+		go generate "${INSTALLER_GO_PKG}/data"
 	fi
 	;;
 dev)
@@ -62,4 +59,4 @@ then
 	export CGO_ENABLED=1
 fi
 
-go build -ldflags "${LDFLAGS}" -tags "${TAGS}" -o "${OUTPUT}" ./cmd/openshift-install
+go build -ldflags "${LDFLAGS}" -tags "${TAGS}" -o "${OUTPUT}" "${INSTALLER_GO_PKG}/cmd/openshift-install"

--- a/hack/init.sh
+++ b/hack/init.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+eval "$(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")"
+
+export GOOS=${GOOS:-${GOHOSTOS}}
+export GOARCH=${GOACH:-${GOHOSTARCH}}
+OUT_DIR=${OUT_DIR:-_output}
+
+function setup_env() {
+  local init_source
+
+  init_source="$( dirname "${BASH_SOURCE[0]}" )/.."
+  INSTALLER_ROOT="$( absolute_path "${init_source}" )"
+  export INSTALLER_ROOT
+  INSTALLER_GO_PKG="github.com/openshift/installer"
+  export INSTALLER_GO_PKG
+
+  if [[ -z "${GOPATH+a}" ]]; then
+    unset GOBIN
+    # create a local GOPATH in _output
+    GOPATH="${INSTALLER_ROOT}/${OUT_DIR}/go"
+    local go_pkg_dir="${GOPATH}/src/${INSTALLER_GO_PKG}"
+
+    mkdir -p "$(dirname "${go_pkg_dir}")"
+    rm -f "${go_pkg_dir}"
+    ln -s "${INSTALLER_ROOT}" "${go_pkg_dir}"
+
+    export GOPATH
+  fi
+
+  if [[ -z "${INSTALLER_BIN_PATH+a}" ]]; then
+    export INSTALLER_BIN_PATH="${INSTALLER_ROOT}/${OUT_DIR}/${GOOS}/${GOARCH}"
+  fi
+  mkdir -p "${INSTALLER_BIN_PATH}"
+}
+readonly -f setup_env
+
+# absolute_path returns the absolute path to the directory provided
+function absolute_path() {
+        local relative_path="$1"
+        local absolute_path
+
+        pushd "${relative_path}" >/dev/null || exit
+        relative_path="$( pwd )"
+        if [[ -h "${relative_path}" ]]; then
+                absolute_path="$( readlink "${relative_path}" )"
+        else
+                absolute_path="${relative_path}"
+        fi
+        popd >/dev/null || exit
+
+	echo "${absolute_path}"
+}
+readonly -f absolute_path


### PR DESCRIPTION
As with other OpenShift projects (origin, others), don't require that
GOPATH is set before running hack/build.sh. If the user doesn't set
one then create a default one so that people can simply run:

hack/build.sh

and the installer will build.