### PR TITLE
openstack:update doc link

### DIFF
--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -29,7 +29,7 @@ variable "openstack_credentials_cloud" {
   default = ""
 
   description = <<EOF
-required if auth_url is not specified) An entry in a clouds.yaml file. See the OpenStack os-client-config documentation for more information about clouds.yaml files. If omitted, the OS_CLOUD environment variable is used.
+required if auth_url is not specified) An entry in a clouds.yaml file. See the openstacksdk(https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html#config-files) documentation for more information about clouds.yaml files. If omitted, the OS_CLOUD environment variable is used.
 EOF
 
 }

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -12,7 +12,7 @@ The installer assumes the following about the OpenStack cloud you run against:
 * You must create a `clouds.yaml` file with the auth URL and credentials
     necessary to access the OpenStack cloud you want to use.  Information on
     this file can be found at
-    https://docs.openstack.org/os-client-config/latest/user/configuration.html
+    https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html#config-files
     and it looks like:
 ```
 clouds:


### PR DESCRIPTION
openstack: update the doc link for up to date info

https://docs.openstack.org/os-client-config/latest
has been superceded by openstacksdk, also, add a link
for OS_CLOUD setting as well.