### PR TITLE
pkg/gather/ssh: Attempt to use existing SSH agents

### DIFF
--- a/pkg/gather/ssh/ssh.go
+++ b/pkg/gather/ssh/ssh.go
@@ -20,7 +20,7 @@ import (
 //
 // if keys list is empty, it tries to load the keys from the user's environment.
 func NewClient(user, address string, keys []string) (*ssh.Client, error) {
-	ag, err := newAgent(keys)
+	ag, err := getAgent(keys)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize the SSH agent")
 	}


### PR DESCRIPTION
This attempts to use the user's existing SSH agent when gathering
diagnostics -- if the SSH_AUTH_SOCK environment variable is set and no
keys are explicitly given.  This is important as some users may not
have their private keys available on disk.

Fixes: #1865