### PR TITLE
bootkube: new image for kube-apiserver

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -111,6 +111,7 @@ then
 		--manifest-etcd-serving-ca=etcd-ca-bundle.crt \
 		--manifest-etcd-server-urls={{.EtcdCluster}} \
 		--manifest-image=${OPENSHIFT_HYPERSHIFT_IMAGE} \
+		--new-image=${OPENSHIFT_HYPERKUBE_IMAGE} \
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-apiserver-bootstrap \
 		--config-output-file=/assets/kube-apiserver-bootstrap/config \


### PR DESCRIPTION
The kube-apiserver is switching to use hyperkube, but we cannot break in the interim,
so we need to pass old and new image, then switch the flag back

We want to use hyperkube instead of hypershift. To do so in an orderly fashion will take a few steps with pulls to different repos.

--newImage allows us to change our image to one with a different binary without breaking functionality at intermediate steps

1. allow --newImage
1. installer passes --image=old and --new-image=new
1. operator render uses --new-image only
1. installer passes --image=new and --new-image=new
1. operator switches back to --image
1. installer passes --image=new
1. operator removes --new-image

This is step 2