### PR TITLE
bootkube: pass the hyperkube image as main image

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -110,7 +110,7 @@ then
 		/usr/bin/cluster-kube-apiserver-operator render \
 		--manifest-etcd-serving-ca=etcd-ca-bundle.crt \
 		--manifest-etcd-server-urls={{.EtcdCluster}} \
-		--manifest-image=${OPENSHIFT_HYPERSHIFT_IMAGE} \
+		--manifest-image=${OPENSHIFT_HYPERKUBE_IMAGE} \
 		--new-image=${OPENSHIFT_HYPERKUBE_IMAGE} \
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-apiserver-bootstrap \


### PR DESCRIPTION
In order to switch to using hyperkube, we have a little dance of rachets to move through.
This updates the existing flag name to match the temporary flag.  Step 4.

Next from https://github.com/openshift/installer/pull/1881

We want to use hyperkube instead of hypershift. To do so in an orderly fashion will take a few steps with pulls to different repos.

--newImage allows us to change our image to one with a different binary without breaking functionality at intermediate steps

1. allow --newImage
1. installer passes --image=old and --new-image=new
1. operator render uses --new-image only
1. installer passes --image=new and --new-image=new
1. operator switches back to --image
1. installer passes --image=new
1. operator removes --new-image