### PR TITLE
pkg/destroy/aws: do not fail uninstall on absent s3 bucket

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -1597,7 +1597,7 @@ func deleteS3(session *session.Session, arn arn.ARN, logger logrus.FieldLogger) 
 		Bucket: aws.String(arn.Resource),
 	})
 	err := s3manager.NewBatchDeleteWithClient(client).Delete(aws.BackgroundContext(), iter)
-	if err != nil {
+	if err != nil && !isBucketNotFound(err) {
 		return err
 	}
 	logger.Debug("Emptied")
@@ -1605,10 +1605,32 @@ func deleteS3(session *session.Session, arn arn.ARN, logger logrus.FieldLogger) 
 	_, err = client.DeleteBucket(&s3.DeleteBucketInput{
 		Bucket: aws.String(arn.Resource),
 	})
-	if err != nil {
+	if err != nil && !isBucketNotFound(err) {
 		return err
 	}
 
 	logger.Info("Deleted")
 	return nil
+}
+
+func isBucketNotFound(err interface{}) bool {
+	switch s3Err := err.(type) {
+	case awserr.Error:
+		if s3Err.Code() == "NoSuchBucket" {
+			return true
+		}
+		origErr := s3Err.OrigErr()
+		if origErr != nil {
+			return isBucketNotFound(origErr)
+		}
+	case s3manager.Error:
+		if s3Err.OrigErr != nil {
+			return isBucketNotFound(s3Err.OrigErr)
+		}
+	case s3manager.Errors:
+		if len(s3Err) == 1 {
+			return isBucketNotFound(s3Err[0])
+		}
+	}
+	return false
 }


### PR DESCRIPTION
We ran into the situation that the call to get resources by tag was returning an s3 bucket arn, however, when querying the s3 api directly, the bucket didn't exist. The uninstaller should not fail a delete when the item it's trying to delete doesn't exist.

Fixes https://github.com/openshift/installer/issues/1886