### PR TITLE
Add required GCP types

### DIFF
--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -5,6 +5,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
 	azuredefaults "github.com/openshift/installer/pkg/types/azure/defaults"
+	gcpdefaults "github.com/openshift/installer/pkg/types/gcp/defaults"
 	libvirtdefaults "github.com/openshift/installer/pkg/types/libvirt/defaults"
 	nonedefaults "github.com/openshift/installer/pkg/types/none/defaults"
 	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
@@ -60,6 +61,8 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		awsdefaults.SetPlatformDefaults(c.Platform.AWS)
 	case c.Platform.Azure != nil:
 		azuredefaults.SetPlatformDefaults(c.Platform.Azure)
+	case c.Platform.GCP != nil:
+		gcpdefaults.SetPlatformDefaults(c.Platform.GCP)
 	case c.Platform.Libvirt != nil:
 		libvirtdefaults.SetPlatformDefaults(c.Platform.Libvirt)
 	case c.Platform.OpenStack != nil:

--- a/pkg/types/gcp/defaults/platform.go
+++ b/pkg/types/gcp/defaults/platform.go
@@ -1,0 +1,7 @@
+package defaults
+
+import "github.com/openshift/installer/pkg/types/gcp"
+
+// SetPlatformDefaults sets the defaults for the platform.
+func SetPlatformDefaults(p *gcp.Platform) {
+}

--- a/pkg/types/gcp/doc.go
+++ b/pkg/types/gcp/doc.go
@@ -1,0 +1,6 @@
+// Package gcp contains GCP-specific structures for installer
+// configuration and management.
+package gcp
+
+// Name is name for the gcp platform.
+const Name string = "gcp"

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -1,0 +1,11 @@
+package gcp
+
+// MachinePool stores the configuration for a machine pool installed on GCP.
+type MachinePool struct {
+	// Zones is list of availability zones that can be used.
+	Zones []string `json:"zones,omitempty"`
+
+	// InstanceType defines the GCP instance type.
+	// eg. n1-standard-4
+	InstanceType string `json:"type"`
+}

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -1,0 +1,17 @@
+package gcp
+
+// Platform stores all the global configuration that all machinesets
+// use.
+type Platform struct {
+	// ProjectID is the the project that will be used for the cluster.
+	ProjectID string `json:"projectID"`
+
+	// Region specifies the GCP region where the cluster will be created.
+	Region string `json:"region"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on GCP for machine pools which do not define their own
+	// platform configuration.
+	// +optional
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+}

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -1,0 +1,21 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/installer/pkg/types/gcp"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ValidateMachinePool checks that the specified machine pool is valid.
+func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for i, zone := range p.Zones {
+		if !strings.HasPrefix(zone, platform.Region) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("zones").Index(i), zone, fmt.Sprintf("Zone not in configured region (%s)", platform.Region)))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -1,0 +1,47 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types/gcp"
+)
+
+func TestValidateMachinePool(t *testing.T) {
+	platform := &gcp.Platform{Region: "us-east1"}
+	cases := []struct {
+		name     string
+		pool     *gcp.MachinePool
+		expected string
+	}{
+		{
+			name: "empty",
+			pool: &gcp.MachinePool{},
+		},
+		{
+			name: "valid zone",
+			pool: &gcp.MachinePool{
+				Zones: []string{"us-east1-b", "us-east1-c"},
+			},
+		},
+		{
+			name: "invalid zone",
+			pool: &gcp.MachinePool{
+				Zones: []string{"us-east1-b", "us-central1-f"},
+			},
+			expected: `^test-path\.zones\[1]: Invalid value: "us-central1-f": Zone not in configured region \(us-east1\)$`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateMachinePool(platform, tc.pool, field.NewPath("test-path")).ToAggregate()
+			if tc.expected == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, tc.expected, err)
+			}
+		})
+	}
+}

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -1,0 +1,53 @@
+package validation
+
+import (
+	"sort"
+
+	"github.com/openshift/installer/pkg/types/gcp"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var (
+	// Regions is a map of known GCP regions. The key of the map is
+	// the short name of the region. The value of the map is the long
+	// name of the region.
+	Regions = map[string]string{
+		"northamerica-northeast1": "Montréal",
+		"us-central":              "Iowa",
+		"us-west2":                "Los Angeles",
+		"us-east1":                "South Carolina",
+		"us-east4":                "Northern Virginia",
+		"southamerica-east1":      "São Paulo",
+		"europe-west":             "Belgium",
+		"europe-west2":            "London",
+		"europe-west3":            "Frankfurt",
+		"europe-west6":            "Zürich",
+		"asia-northeast1":         "Tokyo",
+		"asia-northeast2":         "Osaka",
+		"asia-east2":              "Hong Kong",
+		"asia-south1":             "Mumbai",
+		"australia-southeast1":    "Sydney",
+	}
+	validRegionValues = func() []string {
+		validValues := make([]string, len(Regions))
+		i := 0
+		for r := range Regions {
+			validValues[i] = r
+			i++
+		}
+		sort.Strings(validValues)
+		return validValues
+	}()
+)
+
+// ValidatePlatform checks that the specified platform is valid.
+func ValidatePlatform(p *gcp.Platform, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if _, ok := Regions[p.Region]; !ok {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("region"), p.Region, validRegionValues))
+	}
+	if p.DefaultMachinePlatform != nil {
+		allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
+	}
+	return allErrs
+}

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -1,0 +1,51 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types/gcp"
+)
+
+func TestValidatePlatform(t *testing.T) {
+	cases := []struct {
+		name     string
+		platform *gcp.Platform
+		valid    bool
+	}{
+		{
+			name: "minimal",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+			},
+			valid: true,
+		},
+		{
+			name: "invalid region",
+			platform: &gcp.Platform{
+				Region: "bad-region",
+			},
+			valid: false,
+		},
+		{
+			name: "valid machine pool",
+			platform: &gcp.Platform{
+				Region:                 "us-east1",
+				DefaultMachinePlatform: &gcp.MachinePool{},
+			},
+			valid: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePlatform(tc.platform, field.NewPath("test-path")).ToAggregate()
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/none"
 	"github.com/openshift/installer/pkg/types/openstack"
@@ -27,6 +28,7 @@ var (
 	PlatformNames = []string{
 		aws.Name,
 		azure.Name,
+		gcp.Name,
 	}
 	// HiddenPlatformNames is a slice with all the
 	// hidden-but-supported platform names. This list isn't presented
@@ -89,6 +91,14 @@ type Platform struct {
 	// +optional
 	AWS *aws.Platform `json:"aws,omitempty"`
 
+	// Azure is the configuration used when installing on Azure.
+	// +optional
+	Azure *azure.Platform `json:"azure,omitempty"`
+
+	// GCP is the configuration used when installing on Google Cloud Platform.
+	// +optional
+	GCP *gcp.Platform `json:"gcp,omitempty"`
+
 	// Libvirt is the configuration used when installing on libvirt.
 	// +optional
 	Libvirt *libvirt.Platform `json:"libvirt,omitempty"`
@@ -104,10 +114,6 @@ type Platform struct {
 	// VSphere is the configuration used when installing on vSphere.
 	// +optional
 	VSphere *vsphere.Platform `json:"vsphere,omitempty"`
-
-	// Azure is the configuration used when installing on Azure.
-	// +optional
-	Azure *azure.Platform `json:"azure,omitempty"`
 }
 
 // Name returns a string representation of the platform (e.g. "aws" if
@@ -119,6 +125,10 @@ func (p *Platform) Name() string {
 		return ""
 	case p.AWS != nil:
 		return aws.Name
+	case p.Azure != nil:
+		return azure.Name
+	case p.GCP != nil:
+		return gcp.Name
 	case p.Libvirt != nil:
 		return libvirt.Name
 	case p.None != nil:
@@ -127,8 +137,6 @@ func (p *Platform) Name() string {
 		return openstack.Name
 	case p.VSphere != nil:
 		return vsphere.Name
-	case p.Azure != nil:
-		return azure.Name
 	default:
 		return ""
 	}

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/openstack"
 	"github.com/openshift/installer/pkg/types/vsphere"
@@ -44,6 +45,12 @@ type MachinePoolPlatform struct {
 	// AWS is the configuration used when installing on AWS.
 	AWS *aws.MachinePool `json:"aws,omitempty"`
 
+	// Azure is the configuration used when installing on OpenStack.
+	Azure *azure.MachinePool `json:"azure,omitempty"`
+
+	// GCP is the configuration used when installing on GCP
+	GCP *gcp.MachinePool `json:"gcp,omitempty"`
+
 	// Libvirt is the configuration used when installing on libvirt.
 	Libvirt *libvirt.MachinePool `json:"libvirt,omitempty"`
 
@@ -52,9 +59,6 @@ type MachinePoolPlatform struct {
 
 	// VSphere is the configuration used when installing on vSphere.
 	VSphere *vsphere.MachinePool `json:"vsphere,omitempty"`
-
-	// Azure is the configuration used when installing on OpenStack.
-	Azure *azure.MachinePool `json:"azure,omitempty"`
 }
 
 // Name returns a string representation of the platform (e.g. "aws" if
@@ -66,14 +70,16 @@ func (p *MachinePoolPlatform) Name() string {
 		return ""
 	case p.AWS != nil:
 		return aws.Name
+	case p.Azure != nil:
+		return azure.Name
+	case p.GCP != nil:
+		return gcp.Name
 	case p.Libvirt != nil:
 		return libvirt.Name
 	case p.OpenStack != nil:
 		return openstack.Name
 	case p.VSphere != nil:
 		return vsphere.Name
-	case p.Azure != nil:
-		return azure.Name
 	default:
 		return ""
 	}

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -14,6 +14,8 @@ import (
 	awsvalidation "github.com/openshift/installer/pkg/types/aws/validation"
 	"github.com/openshift/installer/pkg/types/azure"
 	azurevalidation "github.com/openshift/installer/pkg/types/azure/validation"
+	"github.com/openshift/installer/pkg/types/gcp"
+	gcpvalidation "github.com/openshift/installer/pkg/types/gcp/validation"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	libvirtvalidation "github.com/openshift/installer/pkg/types/libvirt/validation"
 	"github.com/openshift/installer/pkg/types/openstack"
@@ -219,6 +221,9 @@ func validatePlatform(platform *types.Platform, fldPath *field.Path, openStackVa
 	}
 	if platform.Azure != nil {
 		validate(azure.Name, platform.Azure, func(f *field.Path) field.ErrorList { return azurevalidation.ValidatePlatform(platform.Azure, f) })
+	}
+	if platform.GCP != nil {
+		validate(gcp.Name, platform.GCP, func(f *field.Path) field.ErrorList { return gcpvalidation.ValidatePlatform(platform.GCP, f) })
 	}
 	if platform.Libvirt != nil {
 		validate(libvirt.Name, platform.Libvirt, func(f *field.Path) field.ErrorList { return libvirtvalidation.ValidatePlatform(platform.Libvirt, f) })

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/none"
 	"github.com/openshift/installer/pkg/types/openstack"
@@ -59,6 +60,13 @@ func validAWSPlatform() *aws.Platform {
 	}
 }
 
+func validGCPPlatform() *gcp.Platform {
+	return &gcp.Platform{
+		ProjectID: "myProject",
+		Region:    "us-east1",
+	}
+}
+
 func validLibvirtPlatform() *libvirt.Platform {
 	return &libvirt.Platform{
 		URI: "qemu+tcp://192.168.122.1/system",
@@ -77,6 +85,7 @@ func validVSpherePlatform() *vsphere.Platform {
 		DefaultDatastore: "test-datastore",
 	}
 }
+
 func TestValidateInstallConfig(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -352,7 +361,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform = types.Platform{}
 				return c
 			}(),
-			expectedError: `^platform: Invalid value: types\.Platform{((, )?\w+:\(\*\w+\.Platform\)\(nil\))+}: must specify one of the platforms \(aws, azure, none, openstack, vsphere\)$`,
+			expectedError: `^platform: Invalid value: types\.Platform{((, )?\w+:\(\*\w+\.Platform\)\(nil\))+}: must specify one of the platforms \(aws, azure, gcp, none, openstack, vsphere\)$`,
 		},
 		{
 			name: "multiple platforms",
@@ -383,7 +392,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: `^platform: Invalid value: types\.Platform{((, )?(\w+:\(\*\w+\.Platform\)\(nil\)|Libvirt:\(\*libvirt\.Platform\)\(0x[0-9a-f]*\)))+}: must specify one of the platforms \(aws, azure, none, openstack, vsphere\)$`,
+			expectedError: `^platform: Invalid value: types\.Platform{((, )?(\w+:\(\*\w+\.Platform\)\(nil\)|Libvirt:\(\*libvirt\.Platform\)\(0x[0-9a-f]*\)))+}: must specify one of the platforms \(aws, azure, gcp, none, openstack, vsphere\)$`,
 		},
 		{
 			name: "invalid libvirt platform",
@@ -395,7 +404,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.Libvirt.URI = ""
 				return c
 			}(),
-			expectedError: `^\[platform: Invalid value: types\.Platform{((, )?(\w+:\(\*\w+\.Platform\)\(nil\)|Libvirt:\(\*libvirt\.Platform\)\(0x[0-9a-f]*\)))+}: must specify one of the platforms \(aws, azure, none, openstack, vsphere\), platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\)]$`,
+			expectedError: `^\[platform: Invalid value: types\.Platform{((, )?(\w+:\(\*\w+\.Platform\)\(nil\)|Libvirt:\(\*libvirt\.Platform\)\(0x[0-9a-f]*\)))+}: must specify one of the platforms \(aws, azure, gcp, none, openstack, vsphere\), platform\.libvirt\.uri: Invalid value: "": invalid URI "" \(no scheme\)]$`,
 		},
 		{
 			name: "valid none platform",
@@ -510,6 +519,16 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: `^\Q[NoProxy: Invalid value: ".bad-proxy.": must be a CIDR or domain, without wildcard characters and without leading or trailing dots ('.'), NoProxy: Invalid value: "172.bad.CIDR.0/16": must be a CIDR or domain, without wildcard characters and without leading or trailing dots ('.')]\E$`,
+		},
+		{
+			name: "valid GCP platform",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{
+					GCP: validGCPPlatform(),
+				}
+				return c
+			}(),
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Adds required types for creating the GCP platform from the install config, including validation and tests.

Does not include defaults, but has a stub placeholder.

Jira: CORS-1114