### PR TITLE
asset/cluster: inject installer info when creating

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -1,11 +1,21 @@
 package cluster
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/user"
 
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	libvirtprovider "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
+	azureprovider "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1"
+	openstackprovider "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
+
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
@@ -23,11 +33,7 @@ import (
 	"github.com/openshift/installer/pkg/types/none"
 	"github.com/openshift/installer/pkg/types/openstack"
 	"github.com/openshift/installer/pkg/types/vsphere"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
-	azureprovider "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1"
-	openstackprovider "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
+	"github.com/openshift/installer/pkg/version"
 )
 
 const (
@@ -86,8 +92,11 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		return errors.Errorf("cannot create the cluster because %q is a UPI platform", platform)
 	}
 
-	bootstrapIgn := string(bootstrapIgnAsset.Files()[0].Data)
 	masterIgn := string(masterIgnAsset.Files()[0].Data)
+	bootstrapIgn, err := injectInstallInfo(bootstrapIgnAsset.Files()[0].Data)
+	if err != nil {
+		return errors.Wrap(err, "unable to inject installation info")
+	}
 
 	masterCount := len(mastersAsset.MachineFiles)
 	data, err := tfvars.TFVars(
@@ -238,4 +247,41 @@ func (t *TerraformVariables) Load(f asset.FileFetcher) (found bool, err error) {
 	t.FileList = append(t.FileList, fileList...)
 
 	return true, nil
+}
+
+// injectInstallInfo adds information about the installer and its invoker as a
+// ConfigMap to the provided bootstrap Ignition config.
+func injectInstallInfo(bootstrap []byte) (string, error) {
+	config := &igntypes.Config{}
+	if err := json.Unmarshal(bootstrap, &config); err != nil {
+		return "", errors.Wrap(err, "failed to unmarshal bootstrap Ignition config")
+	}
+
+	var invoker string
+	if env, ok := os.LookupEnv("OPENSHIFT_INSTALL_INVOKER"); ok {
+		invoker = env
+	} else if user, err := user.Current(); err == nil {
+		invoker = user.Username
+	} else {
+		logrus.Warnf("Unable to determine username: %v", err)
+		invoker = "<unknown>"
+	}
+
+	config.Storage.Files = append(config.Storage.Files, ignition.FileFromString("/opt/openshift/manifests/openshift-install.yml", "root", 0644, fmt.Sprintf(`---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openshift-install
+  namespace: openshift-config
+data:
+  version: "%s"
+  invoker: "%s"
+`, version.Raw, invoker)))
+
+	ign, err := json.Marshal(config)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal bootstrap Ignition config")
+	}
+
+	return string(ign), nil
 }


### PR DESCRIPTION
OpenShift telemetry is currently unable to report _how_ a cluster was
installed (i.e. user-provisioned vs installer-provisioned). We currently
use a heuristic to try to determine this information.

This patch adds a ConfigMap immediately before cluster creation with
information about the installer. This ConfigMap is not present when the
user provisions the cluster themselves since it isn't injected until the
Terraform variables are generated. This ConfipMap contains the installer
version and the name of the invoker (can be overridden with the
OPENSHIFT_INSTALL_INVOKER environment variable). This will allow us to
determine whether a cluster was user-provisioned or installer-
provisioned, whether or not a custom build of the installer was used,
and who created the cluster (e.g. Hive, CI).