### PR TITLE
issue-template: Make it easy to remove irrelevant platforms

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,9 +14,10 @@ $ openshift-install version
 <your output here>
 ```
 
-# Platform (aws|libvirt|openstack):
-
-Enter text here.
+# Platform:
+<!--
+Please specify below either aws, libvirt or openstack below.
+-->
 
 # What happened?
 


### PR DESCRIPTION
With the current template, people just fill in the name of their platform, leaving the list of platforms as is. This makes it a bit hard to label issues. Let's modify the template a bit so reporters simply remove the irrelevant platforms from the list and the issue description only mentions the relevant platform.