### PR TITLE
Azure assets: set machine vnet and managed identity explicitly

### DIFF
--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -89,7 +89,9 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 				StorageAccountType: "Premium_LRS",
 			},
 		},
-		Subnet: fmt.Sprintf("%s-%s-subnet", clusterID, role),
+		Subnet:          fmt.Sprintf("%s-%s-subnet", clusterID, role),
+		ManagedIdentity: fmt.Sprintf("%s-identity", clusterID),
+		Vnet:            fmt.Sprintf("%s-vnet", clusterID),
 	}, nil
 }
 


### PR DESCRIPTION
Azure actuator already allows to set both vnet and managed identity
explicitly. Once the installer does the same, logic of implicit naming
of both resources can be dropped from the actuator. Installer can
then choose any name for the resource.