### PR TITLE
bootkube: stop passing temporary image flag to kas

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -111,7 +111,6 @@ then
 		--manifest-etcd-serving-ca=etcd-ca-bundle.crt \
 		--manifest-etcd-server-urls={{.EtcdCluster}} \
 		--manifest-image=${OPENSHIFT_HYPERKUBE_IMAGE} \
-		--new-image=${OPENSHIFT_HYPERKUBE_IMAGE} \
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/kube-apiserver-bootstrap \
 		--config-output-file=/assets/kube-apiserver-bootstrap/config \


### PR DESCRIPTION
To swap images used by the kas-o, we needed a temporary flag.  We no longer need to pass that flag.

This is part 6 of the 7 part plan.

/assign @abhinavdahiya 

cleaning cruft as promised.