### PR TITLE
Bug 1722221: [release-4.1] blank api version

### DIFF
--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -15,6 +15,8 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 	switch config.APIVersion {
 	case types.InstallConfigVersion, "v1beta3", "v1beta4":
 		// works
+	case "":
+		return errors.Errorf("no version was provided")
 	default:
 		return errors.Errorf("cannot upconvert from version %s", config.APIVersion)
 	}


### PR DESCRIPTION
Currently the error returned is failed to upconvert install config: cannot upconvert from version and empty version is not visible to users explicitly.

Combines (supercedes) #1764 & #1901

4.2.0 bz: https://bugzilla.redhat.com/show_bug.cgi?id=1723565
/cc @eparis 