### PR TITLE
azure: reduce the install-config api to smallest set

### DIFF
--- a/pkg/types/azure/machinepool.go
+++ b/pkg/types/azure/machinepool.go
@@ -3,9 +3,6 @@ package azure
 // MachinePool stores the configuration for a machine pool installed
 // on Azure.
 type MachinePool struct {
-	// Zones is list of availability zones that can be used.
-	Zones []string `json:"zones,omitempty"`
-
 	// InstanceType defines the azure instance type.
 	// eg. Standard_DS_V2
 	InstanceType string `json:"type"`
@@ -15,10 +12,6 @@ type MachinePool struct {
 func (a *MachinePool) Set(required *MachinePool) {
 	if required == nil || a == nil {
 		return
-	}
-
-	if len(required.Zones) > 0 {
-		a.Zones = required.Zones
 	}
 
 	if required.InstanceType != "" {

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -10,11 +10,6 @@ type Platform struct {
 
 	// BaseDomainResourceGroupName specifies the resource group where the azure DNS zone for the base domain is found
 	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
-
-	// UserTags specifies additional tags for Azure resources created for the cluster.
-	// +optional
-	UserTags map[string]string `json:"userTags,omitempty"`
-
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on Azure for machine pools which do not define their own
 	// platform configuration.


### PR DESCRIPTION
We are not currently using UserTags or Zones in Azure. This PR removed them. 

https://jira.coreos.com/browse/CORS-1090 