### PR TITLE
aws: conditionally open either ovn-kubernetes or openshift-sdn ports

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -86,6 +86,9 @@ module "vpc" {
   )
 
   tags = local.tags
+
+  open_ovn_ports   = var.aws_network_type == "OVNKubernetes"
+  open_vxlan_ports = var.aws_network_type != "OVNKubernetes"
 }
 
 resource "aws_ami_copy" "main" {

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -69,3 +69,8 @@ variable "aws_worker_availability_zones" {
   description = "The availability zones to provision for workers.  Worker instances are created by the machine-API operator, but this variable controls their supporting infrastructure (subnets, routing, etc.)."
 }
 
+variable "aws_network_type" {
+  type = string
+
+  description = "For OCP 4.2 only! Configured network type."
+}

--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -63,26 +63,6 @@ resource "aws_security_group_rule" "master_ingress_https" {
   to_port     = 6443
 }
 
-resource "aws_security_group_rule" "master_ingress_vxlan" {
-  type              = "ingress"
-  security_group_id = aws_security_group.master.id
-
-  protocol  = "udp"
-  from_port = 4789
-  to_port   = 4789
-  self      = true
-}
-
-resource "aws_security_group_rule" "master_ingress_vxlan_from_worker" {
-  type                     = "ingress"
-  security_group_id        = aws_security_group.master.id
-  source_security_group_id = aws_security_group.worker.id
-
-  protocol  = "udp"
-  from_port = 4789
-  to_port   = 4789
-}
-
 resource "aws_security_group_rule" "master_ingress_internal" {
   type              = "ingress"
   security_group_id = aws_security_group.master.id
@@ -213,3 +193,74 @@ resource "aws_security_group_rule" "master_ingress_services_udp" {
   self      = true
 }
 
+resource "aws_security_group_rule" "master_ingress_vxlan" {
+  count = var.open_vxlan_ports ? 1 : 0
+
+  type              = "ingress"
+  security_group_id = aws_security_group.master.id
+
+  protocol  = "udp"
+  from_port = 4789
+  to_port   = 4789
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_vxlan_from_worker" {
+  count = var.open_vxlan_ports ? 1 : 0
+
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
+
+  protocol  = "udp"
+  from_port = 4789
+  to_port   = 4789
+}
+
+resource "aws_security_group_rule" "master_ingress_geneve" {
+  count = var.open_ovn_ports ? 1 : 0
+
+  type              = "ingress"
+  security_group_id = "${aws_security_group.master.id}"
+
+  protocol  = "udp"
+  from_port = 6081
+  to_port   = 6081
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_geneve_from_worker" {
+  count = var.open_ovn_ports ? 1 : 0
+
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.master.id}"
+  source_security_group_id = "${aws_security_group.worker.id}"
+
+  protocol  = "udp"
+  from_port = 6081
+  to_port   = 6081
+}
+
+resource "aws_security_group_rule" "master_ingress_ovndb" {
+  count = var.open_ovn_ports ? 1 : 0
+
+  type              = "ingress"
+  security_group_id = "${aws_security_group.master.id}"
+
+  protocol  = "tcp"
+  from_port = 6641
+  to_port   = 6642
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_ovnsb_from_worker" {
+  count = var.open_ovn_ports ? 1 : 0
+
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.master.id}"
+  source_security_group_id = "${aws_security_group.worker.id}"
+
+  protocol  = "tcp"
+  from_port = 6641
+  to_port   = 6642
+}

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -43,26 +43,6 @@ resource "aws_security_group_rule" "worker_ingress_ssh" {
   to_port     = 22
 }
 
-resource "aws_security_group_rule" "worker_ingress_vxlan" {
-  type              = "ingress"
-  security_group_id = aws_security_group.worker.id
-
-  protocol  = "udp"
-  from_port = 4789
-  to_port   = 4789
-  self      = true
-}
-
-resource "aws_security_group_rule" "worker_ingress_vxlan_from_master" {
-  type                     = "ingress"
-  security_group_id        = aws_security_group.worker.id
-  source_security_group_id = aws_security_group.master.id
-
-  protocol  = "udp"
-  from_port = 4789
-  to_port   = 4789
-}
-
 resource "aws_security_group_rule" "worker_ingress_internal" {
   type              = "ingress"
   security_group_id = aws_security_group.worker.id
@@ -143,3 +123,50 @@ resource "aws_security_group_rule" "worker_ingress_services_udp" {
   self      = true
 }
 
+resource "aws_security_group_rule" "worker_ingress_vxlan" {
+  count = var.open_vxlan_ports ? 1 : 0
+
+  type              = "ingress"
+  security_group_id = aws_security_group.worker.id
+
+  protocol  = "udp"
+  from_port = 4789
+  to_port   = 4789
+  self      = true
+}
+
+resource "aws_security_group_rule" "worker_ingress_vxlan_from_master" {
+  count = var.open_vxlan_ports ? 1 : 0
+
+  type                     = "ingress"
+  security_group_id        = aws_security_group.worker.id
+  source_security_group_id = aws_security_group.master.id
+
+  protocol  = "udp"
+  from_port = 4789
+  to_port   = 4789
+}
+
+resource "aws_security_group_rule" "worker_ingress_geneve" {
+  count = var.open_ovn_ports ? 1 : 0
+
+  type              = "ingress"
+  security_group_id = "${aws_security_group.worker.id}"
+
+  protocol  = "udp"
+  from_port = 6081
+  to_port   = 6081
+  self      = true
+}
+
+resource "aws_security_group_rule" "worker_ingress_geneve_from_master" {
+  count = var.open_ovn_ports ? 1 : 0
+
+  type                     = "ingress"
+  security_group_id        = "${aws_security_group.worker.id}"
+  source_security_group_id = "${aws_security_group.master.id}"
+
+  protocol  = "udp"
+  from_port = 6081
+  to_port   = 6081
+}

--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -32,3 +32,14 @@ variable "tags" {
   description = "AWS tags to be applied to created resources."
 }
 
+variable "open_vxlan_ports" {
+  type = bool
+
+  description = "For OCP 4.2 only! Causes VXLAN ports to be opened."
+}
+
+variable "open_ovn_ports" {
+  type = bool
+
+  description = "For OCP 4.2 only! Causes ovn-kubernetes-related ports to be opened."
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -140,7 +140,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		for i, m := range workers {
 			workerConfigs[i] = m.Spec.Template.Spec.ProviderSpec.Value.Object.(*awsprovider.AWSMachineProviderConfig)
 		}
-		data, err := awstfvars.TFVars(masterConfigs, workerConfigs)
+		data, err := awstfvars.TFVars(masterConfigs, workerConfigs, installConfig.Config.Networking.NetworkType)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -21,10 +21,13 @@ type config struct {
 	Size                    int64             `json:"aws_master_root_volume_size,omitempty"`
 	Type                    string            `json:"aws_master_root_volume_type,omitempty"`
 	Region                  string            `json:"aws_region,omitempty"`
+
+	// Hack for 4.2 only
+	NetworkType string `json:"aws_network_type"`
 }
 
 // TFVars generates AWS-specific Terraform variables launching the cluster.
-func TFVars(masterConfigs []*v1beta1.AWSMachineProviderConfig, workerConfigs []*v1beta1.AWSMachineProviderConfig) ([]byte, error) {
+func TFVars(masterConfigs []*v1beta1.AWSMachineProviderConfig, workerConfigs []*v1beta1.AWSMachineProviderConfig, networkType string) ([]byte, error) {
 	masterConfig := masterConfigs[0]
 
 	tags := make(map[string]string, len(masterConfig.Tags))
@@ -80,6 +83,7 @@ func TFVars(masterConfigs []*v1beta1.AWSMachineProviderConfig, workerConfigs []*
 		MasterInstanceType:      masterConfig.InstanceType,
 		Size:                    *rootVolume.EBS.VolumeSize,
 		Type:                    *rootVolume.EBS.VolumeType,
+		NetworkType:             networkType,
 	}
 
 	if rootVolume.EBS.Iops != nil {


### PR DESCRIPTION
alternative to #1563; this makes the behavior conditional on `networkType` (and adds a bunch of notes pointing out that this is just for 4.2; for 4.3 the plan is that cluster-network-operator will do this). It works, though the implementation may not be ideal; I was figuring out terraform as I went.

/cc @dcbw @squeed 