### PR TITLE
make error output clearer

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -19,7 +19,7 @@ cd "$(dirname "$0")/.."
 PACKAGE_PATH="$(go list -e -f '{{.Dir}}' github.com/openshift/installer)"
 if test -z "${PACKAGE_PATH}"
 then
-	echo "build from your \${GOPATH} (${LAUNCH_PATH} is not in $(go env GOPATH))" 2>&1
+	echo "build from your \${GOPATH} (${LAUNCH_PATH} is not in $(go env GOPATH)/github.com/openshift/installer)" 2>&1
 	exit 1
 fi
 


### PR DESCRIPTION
the error like below is not clear and confuse people (new comer)
/Users/Rob 1/Programming/go/installer is not in /Users/Rob 1/Programming/go

we need make it clearer where's the wrong place

fixes: #1908 