### PR TITLE
Remove global logger

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -103,7 +103,7 @@ var (
 				}
 
 				logrus.Info("Destroying the bootstrap resources...")
-				err = destroybootstrap.Destroy(rootOpts.dir)
+				err = destroybootstrap.Destroy(logrus.NewEntry(logrus.StandardLogger()), rootOpts.dir)
 				if err != nil {
 					logrus.Fatal(err)
 				}
@@ -140,7 +140,7 @@ func newCreateCmd() *cobra.Command {
 
 func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args []string) {
 	runner := func(directory string) error {
-		assetStore, err := assetstore.NewStore(directory)
+		assetStore, err := assetstore.NewStore(logrus.NewEntry(logrus.StandardLogger()), directory)
 		if err != nil {
 			return errors.Wrap(err, "failed to create asset store")
 		}

--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -46,15 +46,14 @@ func newDestroyClusterCmd() *cobra.Command {
 }
 
 func runDestroyCmd(directory string) error {
-	destroyer, err := destroy.New(logrus.StandardLogger(), directory)
+	destroyer, err := destroy.New(logrus.NewEntry(logrus.StandardLogger()), directory)
 	if err != nil {
 		return errors.Wrap(err, "Failed while preparing to destroy cluster")
 	}
 	if err := destroyer.Run(); err != nil {
 		return errors.Wrap(err, "Failed to destroy cluster")
 	}
-
-	store, err := assetstore.NewStore(directory)
+	store, err := assetstore.NewStore(logrus.NewEntry(logrus.StandardLogger()), directory)
 	if err != nil {
 		return errors.Wrap(err, "failed to create asset store")
 	}
@@ -81,7 +80,7 @@ func newDestroyBootstrapCmd() *cobra.Command {
 			cleanup := setupFileHook(rootOpts.dir)
 			defer cleanup()
 
-			err := bootstrap.Destroy(rootOpts.dir)
+			err := bootstrap.Destroy(logrus.NewEntry(logrus.StandardLogger()), rootOpts.dir)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -81,7 +81,7 @@ func runGatherBootstrapCmd(directory string) error {
 		return err
 	}
 
-	assetStore, err := assetstore.NewStore(directory)
+	assetStore, err := assetstore.NewStore(logrus.NewEntry(logrus.StandardLogger()), directory)
 	if err != nil {
 		return errors.Wrap(err, "failed to create asset store")
 	}

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -17,7 +17,7 @@ type Asset interface {
 	Dependencies() []Asset
 
 	// Generate generates this asset given the states of its parent assets.
-	Generate(Parents) error
+	Generate(*logrus.Entry, Parents) error
 
 	// Name returns the human-friendly name of the asset.
 	Name() string
@@ -61,8 +61,8 @@ func PersistToFile(asset WritableAsset, directory string) error {
 
 // DeleteAssetFromDisk removes all the files for asset from disk.
 // this is function is not safe for calling concurrently on the same directory.
-func DeleteAssetFromDisk(asset WritableAsset, directory string) error {
-	logrus.Debugf("Purging asset %q from disk", asset.Name())
+func DeleteAssetFromDisk(log *logrus.Entry, asset WritableAsset, directory string) error {
+	log.Debugf("Purging asset %q from disk", asset.Name())
 	for _, f := range asset.Files() {
 		path := filepath.Join(directory, f.Filename)
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {

--- a/pkg/asset/asset_test.go
+++ b/pkg/asset/asset_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +21,7 @@ func (a *persistAsset) Dependencies() []Asset {
 	return []Asset{}
 }
 
-func (a *persistAsset) Generate(Parents) error {
+func (a *persistAsset) Generate(*logrus.Entry, Parents) error {
 	return nil
 }
 

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -44,7 +44,7 @@ func (c *Cluster) Dependencies() []asset.Asset {
 }
 
 // Generate launches the cluster and generates the terraform state file on disk.
-func (c *Cluster) Generate(parents asset.Parents) (err error) {
+func (c *Cluster) Generate(log *logrus.Entry, parents asset.Parents) (err error) {
 	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
 	terraformVariables := &TerraformVariables{}
@@ -69,8 +69,8 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		extraArgs = append(extraArgs, fmt.Sprintf("-var-file=%s", filepath.Join(tmpDir, file.Filename)))
 	}
 
-	logrus.Infof("Creating infrastructure resources...")
-	stateFile, err := terraform.Apply(tmpDir, installConfig.Config.Platform.Name(), extraArgs...)
+	log.Infof("Creating infrastructure resources...")
+	stateFile, err := terraform.Apply(log, tmpDir, installConfig.Config.Platform.Name(), extraArgs...)
 	if err != nil {
 		err = errors.Wrap(err, "failed to create cluster")
 		if stateFile == "" {
@@ -90,7 +90,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	} else if err == nil {
 		err = err2
 	} else {
-		logrus.Errorf("Failed to read tfstate: %v", err2)
+		log.Errorf("Failed to read tfstate: %v", err2)
 	}
 
 	return err

--- a/pkg/asset/cluster/metadata.go
+++ b/pkg/asset/cluster/metadata.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/cluster/aws"
 	"github.com/openshift/installer/pkg/asset/cluster/azure"
@@ -47,7 +49,7 @@ func (m *Metadata) Dependencies() []asset.Asset {
 }
 
 // Generate generates the metadata asset.
-func (m *Metadata) Generate(parents asset.Parents) (err error) {
+func (m *Metadata) Generate(log *logrus.Entry, parents asset.Parents) (err error) {
 	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
 	parents.Get(clusterID, installConfig)

--- a/pkg/asset/ignition/machine/master.go
+++ b/pkg/asset/ignition/machine/master.go
@@ -6,6 +6,7 @@ import (
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
@@ -33,10 +34,10 @@ func (a *Master) Dependencies() []asset.Asset {
 }
 
 // Generate generates the ignition config for the Master asset.
-func (a *Master) Generate(dependencies asset.Parents) error {
+func (a *Master) Generate(log *logrus.Entry, parents asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	rootCA := &tls.RootCA{}
-	dependencies.Get(installConfig, rootCA)
+	parents.Get(installConfig, rootCA)
 
 	a.Config = pointerIgnitionConfig(installConfig.Config, rootCA.Cert(), "master")
 

--- a/pkg/asset/ignition/machine/master_test.go
+++ b/pkg/asset/ignition/machine/master_test.go
@@ -39,14 +39,14 @@ func TestMasterGenerate(t *testing.T) {
 	}
 
 	rootCA := &tls.RootCA{}
-	err := rootCA.Generate(nil)
+	err := rootCA.Generate(nil, nil)
 	assert.NoError(t, err, "unexpected error generating root CA")
 
 	parents := asset.Parents{}
 	parents.Add(installConfig, rootCA)
 
 	master := &Master{}
-	err = master.Generate(parents)
+	err = master.Generate(nil, parents)
 	assert.NoError(t, err, "unexpected error generating master asset")
 	expectedIgnitionConfigNames := []string{
 		"master.ign",

--- a/pkg/asset/ignition/machine/worker.go
+++ b/pkg/asset/ignition/machine/worker.go
@@ -6,6 +6,7 @@ import (
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
@@ -33,10 +34,10 @@ func (a *Worker) Dependencies() []asset.Asset {
 }
 
 // Generate generates the ignition config for the Worker asset.
-func (a *Worker) Generate(dependencies asset.Parents) error {
+func (a *Worker) Generate(log *logrus.Entry, parents asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	rootCA := &tls.RootCA{}
-	dependencies.Get(installConfig, rootCA)
+	parents.Get(installConfig, rootCA)
 
 	a.Config = pointerIgnitionConfig(installConfig.Config, rootCA.Cert(), "worker")
 

--- a/pkg/asset/ignition/machine/worker_test.go
+++ b/pkg/asset/ignition/machine/worker_test.go
@@ -29,14 +29,14 @@ func TestWorkerGenerate(t *testing.T) {
 	}
 
 	rootCA := &tls.RootCA{}
-	err := rootCA.Generate(nil)
+	err := rootCA.Generate(nil, nil)
 	assert.NoError(t, err, "unexpected error generating root CA")
 
 	parents := asset.Parents{}
 	parents.Add(installConfig, rootCA)
 
 	worker := &Worker{}
-	err = worker.Generate(parents)
+	err = worker.Generate(nil, parents)
 	assert.NoError(t, err, "unexpected error generating worker asset")
 
 	actualFiles := worker.Files()

--- a/pkg/asset/installconfig/aws/basedomain.go
+++ b/pkg/asset/installconfig/aws/basedomain.go
@@ -22,13 +22,13 @@ func IsForbidden(err error) bool {
 
 // GetBaseDomain returns a base domain chosen from among the account's
 // public routes.
-func GetBaseDomain() (string, error) {
+func GetBaseDomain(log *logrus.Entry) (string, error) {
 	session, err := GetSession()
 	if err != nil {
 		return "", err
 	}
 
-	logrus.Debugf("listing AWS hosted zones")
+	log.Debugf("listing AWS hosted zones")
 	client := route53.New(session)
 	publicZoneMap := map[string]struct{}{}
 	exists := struct{}{}

--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -189,7 +189,7 @@ var installPermissions = []string{
 // are sufficient to perform an installation, and that they can be used for cluster runtime
 // as either capable of creating new credentials for components that interact with the cloud or
 // being able to be passed through as-is to the components that need cloud credentials
-func ValidateCreds(ssn *session.Session) error {
+func ValidateCreds(log *logrus.Entry, ssn *session.Session) error {
 	creds, err := ssn.Config.Credentials.Get()
 	if err != nil {
 		return errors.Wrap(err, "getting creds from session")
@@ -201,8 +201,7 @@ func ValidateCreds(ssn *session.Session) error {
 	}
 
 	// Check whether we can do an installation
-	logger := logrus.StandardLogger()
-	canInstall, err := ccaws.CheckPermissionsAgainstActions(client, installPermissions, logger)
+	canInstall, err := ccaws.CheckPermissionsAgainstActions(client, installPermissions, log)
 	if err != nil {
 		return errors.Wrap(err, "checking install permissions")
 	}
@@ -211,7 +210,7 @@ func ValidateCreds(ssn *session.Session) error {
 	}
 
 	// Check whether we can mint new creds for cluster services needing to interact with the cloud
-	canMint, err := ccaws.CheckCloudCredCreation(client, logger)
+	canMint, err := ccaws.CheckCloudCredCreation(client, log)
 	if err != nil {
 		return errors.Wrap(err, "mint credentials check")
 	}
@@ -221,7 +220,7 @@ func ValidateCreds(ssn *session.Session) error {
 
 	// Check whether we can use the current credentials in passthrough mode to satisfy
 	// cluster services needing to interact with the cloud
-	canPassthrough, err := ccaws.CheckCloudCredPassthrough(client, logger)
+	canPassthrough, err := ccaws.CheckCloudCredPassthrough(client, log)
 	if err != nil {
 		return errors.Wrap(err, "passthrough credentials check")
 	}

--- a/pkg/asset/installconfig/azure/azure.go
+++ b/pkg/asset/installconfig/azure/azure.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/types/azure"
 
@@ -22,8 +23,8 @@ const (
 )
 
 // Platform collects azure-specific configuration.
-func Platform() (*azure.Platform, error) {
-	regions, err := getRegions()
+func Platform(log *logrus.Entry) (*azure.Platform, error) {
+	regions, err := getRegions(log)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get list of regions")
 	}
@@ -74,8 +75,8 @@ func Platform() (*azure.Platform, error) {
 	}, nil
 }
 
-func getRegions() (map[string]string, error) {
-	session, err := GetSession()
+func getRegions(log *logrus.Entry) (map[string]string, error) {
+	session, err := GetSession(log)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/installconfig/azure/dns.go
+++ b/pkg/asset/installconfig/azure/dns.go
@@ -8,6 +8,7 @@ import (
 	azdns "github.com/Azure/azure-sdk-for-go/profiles/latest/dns/mgmt/dns"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 )
 
@@ -99,8 +100,8 @@ func (config DNSConfig) GetDNSZone() (*Zone, error) {
 //NewDNSConfig returns a new DNSConfig struct that helps configuring the DNS
 //by querying your subscription and letting you choose
 //which domain you wish to use for the cluster
-func NewDNSConfig() (*DNSConfig, error) {
-	session, err := GetSession()
+func NewDNSConfig(log *logrus.Entry) (*DNSConfig, error) {
+	session, err := GetSession(log)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve session information")
 	}

--- a/pkg/asset/installconfig/basedomain.go
+++ b/pkg/asset/installconfig/basedomain.go
@@ -3,6 +3,7 @@ package installconfig
 import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -27,21 +28,21 @@ func (a *baseDomain) Dependencies() []asset.Asset {
 }
 
 // Generate queries for the base domain from the user.
-func (a *baseDomain) Generate(parents asset.Parents) error {
+func (a *baseDomain) Generate(log *logrus.Entry, parents asset.Parents) error {
 	platform := &platform{}
 	parents.Get(platform)
 
 	switch platform.CurrentName() {
 	case aws.Name:
 		var err error
-		a.BaseDomain, err = awsconfig.GetBaseDomain()
+		a.BaseDomain, err = awsconfig.GetBaseDomain(log)
 		cause := errors.Cause(err)
 		if !(awsconfig.IsForbidden(cause) || request.IsErrorThrottle(cause)) {
 			return err
 		}
 	case azure.Name:
 		var err error
-		azureDNS, _ := azureconfig.NewDNSConfig()
+		azureDNS, _ := azureconfig.NewDNSConfig(log)
 		zone, err := azureDNS.GetDNSZone()
 		if err != nil {
 			return err

--- a/pkg/asset/installconfig/clusterid.go
+++ b/pkg/asset/installconfig/clusterid.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 
 	"github.com/pborman/uuid"
+	"github.com/sirupsen/logrus"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -37,9 +38,9 @@ func (a *ClusterID) Dependencies() []asset.Asset {
 }
 
 // Generate generates a new ClusterID
-func (a *ClusterID) Generate(dep asset.Parents) error {
+func (a *ClusterID) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ica := &InstallConfig{}
-	dep.Get(ica)
+	parents.Get(ica)
 
 	// add random chars to the end to randomize
 	a.InfraID = generateInfraID(ica.Config.ObjectMeta.Name)

--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -1,6 +1,7 @@
 package installconfig
 
 import (
+	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -22,7 +23,7 @@ func (a *clusterName) Dependencies() []asset.Asset {
 }
 
 // Generate queries for the cluster name from the user.
-func (a *clusterName) Generate(parents asset.Parents) error {
+func (a *clusterName) Generate(log *logrus.Entry, parents asset.Parents) error {
 	bd := &baseDomain{}
 	parents.Get(bd)
 

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -40,7 +41,7 @@ func (a *InstallConfig) Dependencies() []asset.Asset {
 }
 
 // Generate generates the install-config.yaml file.
-func (a *InstallConfig) Generate(parents asset.Parents) error {
+func (a *InstallConfig) Generate(log *logrus.Entry, parents asset.Parents) error {
 	sshPublicKey := &sshPublicKey{}
 	baseDomain := &baseDomain{}
 	clusterName := &clusterName{}

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -53,7 +53,7 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 		pullSecret,
 		platform,
 	)
-	if err := installConfig.Generate(parents); err != nil {
+	if err := installConfig.Generate(nil, parents); err != nil {
 		t.Errorf("unexpected error generating install config: %v", err)
 	}
 	expected := &types.InstallConfig{

--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -36,7 +37,7 @@ func (a *platform) Dependencies() []asset.Asset {
 }
 
 // Generate queries for input from the user.
-func (a *platform) Generate(asset.Parents) error {
+func (a *platform) Generate(log *logrus.Entry, parents asset.Parents) error {
 	platform, err := a.queryUserForPlatform()
 	if err != nil {
 		return err
@@ -54,7 +55,7 @@ func (a *platform) Generate(asset.Parents) error {
 			return err
 		}
 	case azure.Name:
-		a.Azure, err = azureconfig.Platform()
+		a.Azure, err = azureconfig.Platform(log)
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/installconfig/pullsecret.go
+++ b/pkg/asset/installconfig/pullsecret.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/validate"
+	"github.com/sirupsen/logrus"
 )
 
 type pullSecret struct {
@@ -19,7 +20,7 @@ func (a *pullSecret) Dependencies() []asset.Asset {
 }
 
 // Generate queries for the pull secret from the user.
-func (a *pullSecret) Generate(asset.Parents) error {
+func (a *pullSecret) Generate(log *logrus.Entry, parents asset.Parents) error {
 	return survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Password{

--- a/pkg/asset/installconfig/ssh.go
+++ b/pkg/asset/installconfig/ssh.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -46,7 +47,7 @@ func readSSHKey(path string) (string, error) {
 }
 
 // Generate generates the SSH public key asset.
-func (a *sshPublicKey) Generate(asset.Parents) error {
+func (a *sshPublicKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	pubKeys := map[string]string{
 		noSSHKey: "",
 	}

--- a/pkg/asset/kubeconfig/admin.go
+++ b/pkg/asset/kubeconfig/admin.go
@@ -3,6 +3,8 @@ package kubeconfig
 import (
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/tls"
@@ -29,7 +31,7 @@ func (k *AdminClient) Dependencies() []asset.Asset {
 }
 
 // Generate generates the kubeconfig.
-func (k *AdminClient) Generate(parents asset.Parents) error {
+func (k *AdminClient) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &tls.KubeAPIServerCompleteCABundle{}
 	clientCertKey := &tls.AdminKubeConfigClientCertKey{}
 	installConfig := &installconfig.InstallConfig{}

--- a/pkg/asset/kubeconfig/kubelet.go
+++ b/pkg/asset/kubeconfig/kubelet.go
@@ -3,6 +3,8 @@ package kubeconfig
 import (
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/tls"
@@ -29,7 +31,7 @@ func (k *Kubelet) Dependencies() []asset.Asset {
 }
 
 // Generate generates the kubeconfig.
-func (k *Kubelet) Generate(parents asset.Parents) error {
+func (k *Kubelet) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &tls.KubeAPIServerCompleteCABundle{}
 	clientcertkey := &tls.KubeletClientCertKey{}
 	installConfig := &installconfig.InstallConfig{}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -11,6 +11,7 @@ import (
 	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	awsapi "sigs.k8s.io/cluster-api-provider-aws/pkg/apis"
@@ -90,12 +91,12 @@ func awsDefaultMasterMachineType(installconfig *installconfig.InstallConfig) str
 }
 
 // Generate generates the Master asset.
-func (m *Master) Generate(dependencies asset.Parents) error {
+func (m *Master) Generate(log *logrus.Entry, parents asset.Parents) error {
 	clusterID := &installconfig.ClusterID{}
 	installconfig := &installconfig.InstallConfig{}
 	rhcosImage := new(rhcos.Image)
 	mign := &machine.Master{}
-	dependencies.Get(clusterID, installconfig, rhcosImage, mign)
+	parents.Get(clusterID, installconfig, rhcosImage, mign)
 
 	ic := installconfig.Config
 

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -194,7 +194,7 @@ spec:
 				},
 			)
 			master := &Master{}
-			if err := master.Generate(parents); err != nil {
+			if err := master.Generate(nil, parents); err != nil {
 				t.Fatalf("failed to generate master machines: %v", err)
 			}
 			if tc.expectedMachineConfig != "" {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -11,6 +11,7 @@ import (
 	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	awsapi "sigs.k8s.io/cluster-api-provider-aws/pkg/apis"
@@ -111,12 +112,12 @@ func awsDefaultWorkerMachineType(installconfig *installconfig.InstallConfig) str
 }
 
 // Generate generates the Worker asset.
-func (w *Worker) Generate(dependencies asset.Parents) error {
+func (w *Worker) Generate(log *logrus.Entry, parents asset.Parents) error {
 	clusterID := &installconfig.ClusterID{}
 	installconfig := &installconfig.InstallConfig{}
 	rhcosImage := new(rhcos.Image)
 	wign := &machine.Worker{}
-	dependencies.Get(clusterID, installconfig, rhcosImage, wign)
+	parents.Get(clusterID, installconfig, rhcosImage, wign)
 
 	machineConfigs := []*mcfgv1.MachineConfig{}
 	machineSets := []runtime.Object{}

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -196,7 +196,7 @@ spec:
 				},
 			)
 			worker := &Worker{}
-			if err := worker.Generate(parents); err != nil {
+			if err := worker.Generate(nil, parents); err != nil {
 				t.Fatalf("failed to generate worker machines: %v", err)
 			}
 			if tc.expectedMachineConfig != "" {

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,10 +60,10 @@ func (*CloudProviderConfig) Dependencies() []asset.Asset {
 }
 
 // Generate generates the CloudProviderConfig.
-func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
+func (cpc *CloudProviderConfig) Generate(log *logrus.Entry, parents asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	clusterID := &installconfig.ClusterID{}
-	dependencies.Get(installConfig, clusterID)
+	parents.Get(installConfig, clusterID)
 
 	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -82,7 +83,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 	case openstacktypes.Name:
 		cm.Data[cloudProviderConfigDataKey] = openstackmanifests.CloudProviderConfig()
 	case azuretypes.Name:
-		session, err := icazure.GetSession()
+		session, err := icazure.GetSession(log)
 		if err != nil {
 			return errors.Wrap(err, "could not get azure session")
 		}

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,10 +54,10 @@ func (*DNS) Dependencies() []asset.Asset {
 }
 
 // Generate generates the DNS config and its CRD.
-func (d *DNS) Generate(dependencies asset.Parents) error {
+func (d *DNS) Generate(log *logrus.Entry, parents asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	clusterID := &installconfig.ClusterID{}
-	dependencies.Get(installConfig, clusterID)
+	parents.Get(installConfig, clusterID)
 
 	config := &configv1.DNS{
 		TypeMeta: metav1.TypeMeta{
@@ -84,7 +85,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 			"Name": fmt.Sprintf("%s-int", clusterID.InfraID),
 		}}
 	case azuretypes.Name:
-		dnsConfig, err := icazure.NewDNSConfig()
+		dnsConfig, err := icazure.NewDNSConfig(log)
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
@@ -47,11 +48,11 @@ func (*Infrastructure) Dependencies() []asset.Asset {
 }
 
 // Generate generates the Infrastructure config and its CRD.
-func (i *Infrastructure) Generate(dependencies asset.Parents) error {
+func (i *Infrastructure) Generate(log *logrus.Entry, parents asset.Parents) error {
 	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
 	cloudproviderconfig := &CloudProviderConfig{}
-	dependencies.Get(clusterID, installConfig, cloudproviderconfig)
+	parents.Get(clusterID, installConfig, cloudproviderconfig)
 
 	var platform configv1.PlatformType
 	switch installConfig.Config.Platform.Name() {

--- a/pkg/asset/manifests/ingress.go
+++ b/pkg/asset/manifests/ingress.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
@@ -38,9 +39,9 @@ func (*Ingress) Dependencies() []asset.Asset {
 }
 
 // Generate generates the ingress config and its CRD.
-func (ing *Ingress) Generate(dependencies asset.Parents) error {
+func (ing *Ingress) Generate(log *logrus.Entry, parents asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
-	dependencies.Get(installConfig)
+	parents.Get(installConfig)
 
 	config := &configv1.Ingress{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/asset/manifests/network.go
+++ b/pkg/asset/manifests/network.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
@@ -52,10 +53,10 @@ func (no *Networking) Dependencies() []asset.Asset {
 }
 
 // Generate generates the network operator config and its CRD.
-func (no *Networking) Generate(dependencies asset.Parents) error {
+func (no *Networking) Generate(log *logrus.Entry, parents asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	crds := &openshift.NetworkCRDs{}
-	dependencies.Get(installConfig, crds)
+	parents.Get(installConfig, crds)
 
 	netConfig := installConfig.Config.Networking
 

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
 
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openshift/installer/pkg/asset"
@@ -57,11 +58,11 @@ func (o *Openshift) Dependencies() []asset.Asset {
 }
 
 // Generate generates the respective operator config.yml files
-func (o *Openshift) Generate(dependencies asset.Parents) error {
+func (o *Openshift) Generate(log *logrus.Entry, parents asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	clusterID := &installconfig.ClusterID{}
 	kubeadminPassword := &password.KubeadminPassword{}
-	dependencies.Get(installConfig, kubeadminPassword, clusterID)
+	parents.Get(installConfig, kubeadminPassword, clusterID)
 	var cloudCreds cloudCredsSecretData
 	platform := installConfig.Config.Platform.Name()
 	switch platform {
@@ -82,7 +83,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 
 	case azuretypes.Name:
 		resourceGroupName := clusterID.InfraID + "-rg"
-		session, err := azure.GetSession()
+		session, err := azure.GetSession(log)
 		if err != nil {
 			return err
 		}
@@ -147,7 +148,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 	kubeadminPasswordSecret := &openshift.KubeadminPasswordSecret{}
 	roleCloudCredsSecretReader := &openshift.RoleCloudCredsSecretReader{}
 	roleBindingCloudCredsSecretReader := &openshift.RoleBindingCloudCredsSecretReader{}
-	dependencies.Get(
+	parents.Get(
 		cloudCredsSecret,
 		kubeadminPasswordSecret,
 		roleCloudCredsSecretReader,

--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ghodss/yaml"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -41,10 +42,10 @@ func (*Proxy) Dependencies() []asset.Asset {
 }
 
 // Generate generates the Proxy config and its CRD.
-func (p *Proxy) Generate(dependencies asset.Parents) error {
+func (p *Proxy) Generate(log *logrus.Entry, parents asset.Parents) error {
 	installConfig := &installconfig.InstallConfig{}
 	network := &Networking{}
-	dependencies.Get(installConfig, network)
+	parents.Get(installConfig, network)
 
 	p.Config = &configv1.Proxy{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/asset/manifests/scheduler.go
+++ b/pkg/asset/manifests/scheduler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
@@ -34,7 +35,7 @@ func (*Scheduler) Dependencies() []asset.Asset {
 }
 
 // Generate generates the scheduler config and its CRD.
-func (s *Scheduler) Generate(dependencies asset.Parents) error {
+func (s *Scheduler) Generate(log *logrus.Entry, parents asset.Parents) error {
 	config := &configv1.Scheduler{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: configv1.SchemeGroupVersion.String(),

--- a/pkg/asset/parents_test.go
+++ b/pkg/asset/parents_test.go
@@ -3,6 +3,7 @@ package asset
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +19,7 @@ func (a *parentsAsset) Dependencies() []Asset {
 	return []Asset{}
 }
 
-func (a *parentsAsset) Generate(Parents) error {
+func (a *parentsAsset) Generate(*logrus.Entry, Parents) error {
 	return nil
 }
 

--- a/pkg/asset/password/password.go
+++ b/pkg/asset/password/password.go
@@ -5,8 +5,10 @@ import (
 	"math/big"
 	"path/filepath"
 
-	"github.com/openshift/installer/pkg/asset"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/bcrypt"
+
+	"github.com/openshift/installer/pkg/asset"
 )
 
 var (
@@ -29,7 +31,7 @@ func (a *KubeadminPassword) Dependencies() []asset.Asset {
 }
 
 // Generate the kubeadmin password
-func (a *KubeadminPassword) Generate(asset.Parents) error {
+func (a *KubeadminPassword) Generate(log *logrus.Entry, parents asset.Parents) error {
 	err := a.generateRandomPasswordHash(23)
 	if err != nil {
 		return err

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -40,15 +40,15 @@ func (i *Image) Dependencies() []asset.Asset {
 }
 
 // Generate the RHCOS image location.
-func (i *Image) Generate(p asset.Parents) error {
+func (i *Image) Generate(log *logrus.Entry, parents asset.Parents) error {
 	if oi, ok := os.LookupEnv("OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE"); ok && oi != "" {
-		logrus.Warn("Found override for OS Image. Please be warned, this is not advised")
+		log.Warn("Found override for OS Image. Please be warned, this is not advised")
 		*i = Image(oi)
 		return nil
 	}
 
 	ic := &installconfig.InstallConfig{}
-	p.Get(ic)
+	parents.Get(ic)
 	config := ic.Config
 
 	var osimage string

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -65,8 +66,8 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 			if err := ioutil.WriteFile(filepath.Join(tempDir, stateFileName), []byte(userProvidedAssets), 0666); err != nil {
 				t.Fatalf("could not write the state file: %v", err)
 			}
-
-			assetStore, err := newStore(tempDir)
+			log := logrus.NewEntry(logrus.StandardLogger())
+			assetStore, err := newStore(log, tempDir)
 			if err != nil {
 				t.Fatalf("failed to create asset store: %v", err)
 			}
@@ -81,7 +82,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 				}
 			}
 
-			newAssetStore, err := newStore(tempDir)
+			newAssetStore, err := newStore(log, tempDir)
 			if err != nil {
 				t.Fatalf("failed to create new asset store: %v", err)
 			}

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -104,7 +104,7 @@ func (s *storeImpl) Destroy(a asset.Asset) error {
 	}
 
 	if wa, ok := a.(asset.WritableAsset); ok {
-		if err := asset.DeleteAssetFromDisk(wa, s.directory); err != nil {
+		if err := asset.DeleteAssetFromDisk(s.log, wa, s.directory); err != nil {
 			return err
 		}
 	}
@@ -227,7 +227,7 @@ func (s *storeImpl) fetch(a asset.Asset, indent string) error {
 		parents.Add(d)
 	}
 	s.log.Debugf("%sGenerating %q...", indent, a.Name())
-	if err := a.Generate(parents); err != nil {
+	if err := a.Generate(s.log, parents); err != nil {
 		return errors.Wrapf(err, "failed to generate asset %q", a.Name())
 	}
 	assetState.asset = a
@@ -349,7 +349,7 @@ func (s *storeImpl) purge(excluded []asset.WritableAsset) error {
 			continue
 		}
 		s.log.Infof("Consuming %q from target directory", assetState.asset.Name())
-		if err := asset.DeleteAssetFromDisk(assetState.asset.(asset.WritableAsset), s.directory); err != nil {
+		if err := asset.DeleteAssetFromDisk(s.log, assetState.asset.(asset.WritableAsset), s.directory); err != nil {
 			return err
 		}
 		assetState.presentOnDisk = false

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -46,6 +46,8 @@ type assetState struct {
 
 // storeImpl is the implementation of Store.
 type storeImpl struct {
+	log *logrus.Entry
+
 	directory       string
 	assets          map[reflect.Type]*assetState
 	stateFileAssets map[string]json.RawMessage
@@ -53,12 +55,13 @@ type storeImpl struct {
 }
 
 // NewStore returns an asset store that implements the asset.Store interface.
-func NewStore(dir string) (asset.Store, error) {
-	return newStore(dir)
+func NewStore(log *logrus.Entry, dir string) (asset.Store, error) {
+	return newStore(log, dir)
 }
 
-func newStore(dir string) (*storeImpl, error) {
+func newStore(log *logrus.Entry, dir string) (*storeImpl, error) {
 	store := &storeImpl{
+		log:         log,
 		directory:   dir,
 		fileFetcher: &fileFetcher{directory: dir},
 		assets:      map[reflect.Type]*assetState{},
@@ -194,7 +197,7 @@ func (s *storeImpl) saveStateFile() error {
 // necessary, and returns whether or not the asset had to be regenerated and
 // any errors.
 func (s *storeImpl) fetch(a asset.Asset, indent string) error {
-	logrus.Debugf("%sFetching %q...", indent, a.Name())
+	s.log.Debugf("%sFetching %q...", indent, a.Name())
 
 	assetState, ok := s.assets[reflect.TypeOf(a)]
 	if !ok {
@@ -209,7 +212,7 @@ func (s *storeImpl) fetch(a asset.Asset, indent string) error {
 	// that we always fetch the parent before children, so we don't need
 	// to worry about invalidating anything in the cache.
 	if assetState.source != unfetched {
-		logrus.Debugf("%sReusing previously-fetched %q", indent, a.Name())
+		s.log.Debugf("%sReusing previously-fetched %q", indent, a.Name())
 		reflect.ValueOf(a).Elem().Set(reflect.ValueOf(assetState.asset).Elem())
 		return nil
 	}
@@ -223,7 +226,7 @@ func (s *storeImpl) fetch(a asset.Asset, indent string) error {
 		}
 		parents.Add(d)
 	}
-	logrus.Debugf("%sGenerating %q...", indent, a.Name())
+	s.log.Debugf("%sGenerating %q...", indent, a.Name())
 	if err := a.Generate(parents); err != nil {
 		return errors.Wrapf(err, "failed to generate asset %q", a.Name())
 	}
@@ -234,7 +237,7 @@ func (s *storeImpl) fetch(a asset.Asset, indent string) error {
 
 // load loads the asset and all of its ancestors from on-disk and the state file.
 func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
-	logrus.Debugf("%sLoading %q...", indent, a.Name())
+	s.log.Debugf("%sLoading %q...", indent, a.Name())
 
 	// Stop descent if the asset has already been loaded.
 	if state, ok := s.assets[reflect.TypeOf(a)]; ok {
@@ -285,13 +288,13 @@ func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
 		}
 
 		if foundOnDisk && foundInStateFile {
-			logrus.Debugf("%sLoading %q from both state file and target directory", indent, a.Name())
+			s.log.Debugf("%sLoading %q from both state file and target directory", indent, a.Name())
 
 			// If the on-disk asset is the same as the one in the state file, there
 			// is no need to consider the one on disk and to mark the asset dirty.
 			onDiskMatchesStateFile = reflect.DeepEqual(onDiskAsset, stateFileAsset)
 			if onDiskMatchesStateFile {
-				logrus.Debugf("%sOn-disk %q matches asset in state file", indent, a.Name())
+				s.log.Debugf("%sOn-disk %q matches asset in state file", indent, a.Name())
 			}
 		}
 	}
@@ -304,18 +307,18 @@ func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
 	// A parent is dirty. The asset must be re-generated.
 	case anyParentsDirty:
 		if foundOnDisk {
-			logrus.Warningf("%sDiscarding the %q that was provided in the target directory because its dependencies are dirty and it needs to be regenerated", indent, a.Name())
+			s.log.Warningf("%sDiscarding the %q that was provided in the target directory because its dependencies are dirty and it needs to be regenerated", indent, a.Name())
 		}
 		source = unfetched
 	// The asset is on disk and that differs from what is in the source file.
 	// The asset is sourced from on disk.
 	case foundOnDisk && !onDiskMatchesStateFile:
-		logrus.Debugf("%sUsing %q loaded from target directory", indent, a.Name())
+		s.log.Debugf("%sUsing %q loaded from target directory", indent, a.Name())
 		assetToStore = onDiskAsset
 		source = onDiskSource
 	// The asset is in the state file. The asset is sourced from state file.
 	case foundInStateFile:
-		logrus.Debugf("%sUsing %q loaded from state file", indent, a.Name())
+		s.log.Debugf("%sUsing %q loaded from state file", indent, a.Name())
 		assetToStore = stateFileAsset
 		source = stateFileSource
 	// There is no existing source for the asset. The asset will be generated.
@@ -345,7 +348,7 @@ func (s *storeImpl) purge(excluded []asset.WritableAsset) error {
 		if !assetState.presentOnDisk || excl[reflect.TypeOf(assetState.asset)] {
 			continue
 		}
-		logrus.Infof("Consuming %q from target directory", assetState.asset.Name())
+		s.log.Infof("Consuming %q from target directory", assetState.asset.Name())
 		if err := asset.DeleteAssetFromDisk(assetState.asset.(asset.WritableAsset), s.directory); err != nil {
 			return err
 		}

--- a/pkg/asset/store/store_test.go
+++ b/pkg/asset/store/store_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -54,7 +55,7 @@ func (a *testStoreAssetA) Dependencies() []asset.Asset {
 	return dependenciesTestStoreAsset(a)
 }
 
-func (a *testStoreAssetA) Generate(asset.Parents) error {
+func (a *testStoreAssetA) Generate(*logrus.Entry, asset.Parents) error {
 	return generateTestStoreAsset(a)
 }
 
@@ -76,7 +77,7 @@ func (a *testStoreAssetB) Dependencies() []asset.Asset {
 	return dependenciesTestStoreAsset(a)
 }
 
-func (a *testStoreAssetB) Generate(asset.Parents) error {
+func (a *testStoreAssetB) Generate(*logrus.Entry, asset.Parents) error {
 	return generateTestStoreAsset(a)
 }
 
@@ -98,7 +99,7 @@ func (a *testStoreAssetC) Dependencies() []asset.Asset {
 	return dependenciesTestStoreAsset(a)
 }
 
-func (a *testStoreAssetC) Generate(asset.Parents) error {
+func (a *testStoreAssetC) Generate(*logrus.Entry, asset.Parents) error {
 	return generateTestStoreAsset(a)
 }
 
@@ -120,7 +121,7 @@ func (a *testStoreAssetD) Dependencies() []asset.Asset {
 	return dependenciesTestStoreAsset(a)
 }
 
-func (a *testStoreAssetD) Generate(asset.Parents) error {
+func (a *testStoreAssetD) Generate(*logrus.Entry, asset.Parents) error {
 	return generateTestStoreAsset(a)
 }
 
@@ -266,6 +267,7 @@ func TestStoreFetch(t *testing.T) {
 			}
 			defer os.RemoveAll(dir)
 			store := &storeImpl{
+				log:       logrus.NewEntry(logrus.StandardLogger()),
 				directory: dir,
 				assets:    map[reflect.Type]*assetState{},
 			}
@@ -365,6 +367,7 @@ func TestStoreFetchOnDiskAssets(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			clearAssetBehaviors()
 			store := &storeImpl{
+				log:    logrus.NewEntry(logrus.StandardLogger()),
 				assets: map[reflect.Type]*assetState{},
 			}
 			assets := make(map[string]asset.Asset, len(tc.assets))
@@ -399,7 +402,7 @@ func TestStoreFetchIdempotency(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	for i := 0; i < 2; i++ {
-		store, err := newStore(tempDir)
+		store, err := newStore(logrus.NewEntry(logrus.StandardLogger()), tempDir)
 		if !assert.NoError(t, err, "(loop %d) unexpected error creating store", i) {
 			t.Fatal()
 		}

--- a/pkg/asset/templates/content/bootkube/04-openshift-machine-config-operator.go
+++ b/pkg/asset/templates/content/bootkube/04-openshift-machine-config-operator.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *OpenshiftMachineConfigOperator) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *OpenshiftMachineConfigOperator) Generate(parents asset.Parents) error {
+func (t *OpenshiftMachineConfigOperator) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := openshiftMachineConfigOperatorFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/cvo-overrides.go
+++ b/pkg/asset/templates/content/bootkube/cvo-overrides.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -33,7 +35,7 @@ func (t *CVOOverrides) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *CVOOverrides) Generate(parents asset.Parents) error {
+func (t *CVOOverrides) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := cVOOverridesFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-ca-bundle-configmap.go
+++ b/pkg/asset/templates/content/bootkube/etcd-ca-bundle-configmap.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdCAConfigMap) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdCAConfigMap) Generate(parents asset.Parents) error {
+func (t *EtcdCAConfigMap) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdCAConfigMapFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-client-secret.go
+++ b/pkg/asset/templates/content/bootkube/etcd-client-secret.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdClientSecret) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdClientSecret) Generate(parents asset.Parents) error {
+func (t *EtcdClientSecret) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdClientSecretFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-host-service-endpoints.go
+++ b/pkg/asset/templates/content/bootkube/etcd-host-service-endpoints.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdHostServiceEndpoints) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdHostServiceEndpoints) Generate(parents asset.Parents) error {
+func (t *EtcdHostServiceEndpoints) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdHostServiceEndpointsFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-host-service.go
+++ b/pkg/asset/templates/content/bootkube/etcd-host-service.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdHostService) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdHostService) Generate(parents asset.Parents) error {
+func (t *EtcdHostService) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdHostServiceFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-metric-client-secret.go
+++ b/pkg/asset/templates/content/bootkube/etcd-metric-client-secret.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdMetricClientSecret) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdMetricClientSecret) Generate(parents asset.Parents) error {
+func (t *EtcdMetricClientSecret) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdMetricClientSecretFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-metric-serving-ca-configmap.go
+++ b/pkg/asset/templates/content/bootkube/etcd-metric-serving-ca-configmap.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdMetricServingCAConfigMap) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdMetricServingCAConfigMap) Generate(parents asset.Parents) error {
+func (t *EtcdMetricServingCAConfigMap) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdMetricServingCAConfigMapFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-metric-signer-secret.go
+++ b/pkg/asset/templates/content/bootkube/etcd-metric-signer-secret.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdMetricSignerSecret) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdMetricSignerSecret) Generate(parents asset.Parents) error {
+func (t *EtcdMetricSignerSecret) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdMetricSignerSecretFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-namespace.go
+++ b/pkg/asset/templates/content/bootkube/etcd-namespace.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdNamespace) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdNamespace) Generate(parents asset.Parents) error {
+func (t *EtcdNamespace) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdNamespaceFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-service.go
+++ b/pkg/asset/templates/content/bootkube/etcd-service.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdService) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdService) Generate(parents asset.Parents) error {
+func (t *EtcdService) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdServiceFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/etcd-serving-ca-configmap.go
+++ b/pkg/asset/templates/content/bootkube/etcd-serving-ca-configmap.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -32,7 +34,7 @@ func (t *EtcdServingCAConfigMap) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdServingCAConfigMap) Generate(parents asset.Parents) error {
+func (t *EtcdServingCAConfigMap) Generate(log *logrus.Entry, parents asset.Parents) error {
 	t.FileList = []*asset.File{}
 	for _, fileName := range etcdServingCAFiles {
 		data, err := content.GetBootkubeTemplate(fileName)

--- a/pkg/asset/templates/content/bootkube/etcd-signer-secret.go
+++ b/pkg/asset/templates/content/bootkube/etcd-signer-secret.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *EtcdSignerSecret) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *EtcdSignerSecret) Generate(parents asset.Parents) error {
+func (t *EtcdSignerSecret) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := etcdSignerSecretFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/kube-cloud-config.go
+++ b/pkg/asset/templates/content/bootkube/kube-cloud-config.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *KubeCloudConfig) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *KubeCloudConfig) Generate(parents asset.Parents) error {
+func (t *KubeCloudConfig) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := kubeCloudConfigFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/kube-system-configmap-root-ca.go
+++ b/pkg/asset/templates/content/bootkube/kube-system-configmap-root-ca.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *KubeSystemConfigmapRootCA) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *KubeSystemConfigmapRootCA) Generate(parents asset.Parents) error {
+func (t *KubeSystemConfigmapRootCA) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := kubeSystemConfigmapRootCAFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/machine-config-server-tls-secret.go
+++ b/pkg/asset/templates/content/bootkube/machine-config-server-tls-secret.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *MachineConfigServerTLSSecret) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *MachineConfigServerTLSSecret) Generate(parents asset.Parents) error {
+func (t *MachineConfigServerTLSSecret) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := machineConfigServerTLSSecretFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/bootkube/pull.go
+++ b/pkg/asset/templates/content/bootkube/pull.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *OpenshiftConfigSecretPullSecret) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *OpenshiftConfigSecretPullSecret) Generate(parents asset.Parents) error {
+func (t *OpenshiftConfigSecretPullSecret) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := openshiftConfigSecretPullSecretFileName
 	data, err := content.GetBootkubeTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/openshift/cloud-creds-secret.go
+++ b/pkg/asset/templates/content/openshift/cloud-creds-secret.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *CloudCredsSecret) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *CloudCredsSecret) Generate(parents asset.Parents) error {
+func (t *CloudCredsSecret) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := cloudCredsSecretFileName
 	data, err := content.GetOpenshiftTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/openshift/cluster-network-crds.go
+++ b/pkg/asset/templates/content/openshift/cluster-network-crds.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -31,7 +33,7 @@ func (t *NetworkCRDs) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *NetworkCRDs) Generate(parents asset.Parents) error {
+func (t *NetworkCRDs) Generate(log *logrus.Entry, parents asset.Parents) error {
 	data, err := content.GetOpenshiftTemplate(netopCRDfilename)
 	if err != nil {
 		return err

--- a/pkg/asset/templates/content/openshift/kubeadmin-password-secret.go
+++ b/pkg/asset/templates/content/openshift/kubeadmin-password-secret.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *KubeadminPasswordSecret) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *KubeadminPasswordSecret) Generate(parents asset.Parents) error {
+func (t *KubeadminPasswordSecret) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := kubeadminPasswordSecretFileName
 	data, err := content.GetOpenshiftTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/openshift/role-cloud-creds-secret-reader.go
+++ b/pkg/asset/templates/content/openshift/role-cloud-creds-secret-reader.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *RoleCloudCredsSecretReader) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *RoleCloudCredsSecretReader) Generate(parents asset.Parents) error {
+func (t *RoleCloudCredsSecretReader) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := roleCloudCredsSecretReaderFileName
 	data, err := content.GetOpenshiftTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/templates/content/openshift/rolebinding-cloud-creds-secret-reader.go
+++ b/pkg/asset/templates/content/openshift/rolebinding-cloud-creds-secret-reader.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/templates/content"
 )
@@ -30,7 +32,7 @@ func (t *RoleBindingCloudCredsSecretReader) Name() string {
 }
 
 // Generate generates the actual files by this asset
-func (t *RoleBindingCloudCredsSecretReader) Generate(parents asset.Parents) error {
+func (t *RoleBindingCloudCredsSecretReader) Generate(log *logrus.Entry, parents asset.Parents) error {
 	fileName := roleBindingCloudCredsSecretReaderFileName
 	data, err := content.GetOpenshiftTemplate(fileName)
 	if err != nil {

--- a/pkg/asset/tls/adminkubeconfig.go
+++ b/pkg/asset/tls/adminkubeconfig.go
@@ -4,6 +4,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 )
 
@@ -20,7 +22,7 @@ func (c *AdminKubeConfigSignerCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the root-ca key and cert pair.
-func (c *AdminKubeConfigSignerCertKey) Generate(parents asset.Parents) error {
+func (c *AdminKubeConfigSignerCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	cfg := &CertCfg{
 		Subject:   pkix.Name{CommonName: "admin-kubeconfig-signer", OrganizationalUnit: []string{"openshift"}},
 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -52,10 +54,10 @@ func (a *AdminKubeConfigCABundle) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert bundle based on its dependencies.
-func (a *AdminKubeConfigCABundle) Generate(deps asset.Parents) error {
+func (a *AdminKubeConfigCABundle) Generate(log *logrus.Entry, parents asset.Parents) error {
 	var certs []CertInterface
 	for _, asset := range a.Dependencies() {
-		deps.Get(asset)
+		parents.Get(asset)
 		certs = append(certs, asset.(CertInterface))
 	}
 	return a.CertBundle.Generate("admin-kubeconfig-ca-bundle", certs...)
@@ -83,9 +85,9 @@ func (a *AdminKubeConfigClientCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (a *AdminKubeConfigClientCertKey) Generate(dependencies asset.Parents) error {
+func (a *AdminKubeConfigClientCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &AdminKubeConfigSignerCertKey{}
-	dependencies.Get(ca)
+	parents.Get(ca)
 
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: "system:admin", Organization: []string{"system:masters"}},

--- a/pkg/asset/tls/certkey_test.go
+++ b/pkg/asset/tls/certkey_test.go
@@ -45,7 +45,7 @@ func TestSignedCertKeyGenerate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rootCA := &RootCA{}
-			err := rootCA.Generate(nil)
+			err := rootCA.Generate(nil, nil)
 			assert.NoError(t, err, "failed to generate root CA")
 
 			certKey := &SignedCertKey{}

--- a/pkg/asset/tls/etcd.go
+++ b/pkg/asset/tls/etcd.go
@@ -4,6 +4,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 )
 
@@ -20,7 +22,7 @@ func (c *EtcdSignerCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the root-ca key and cert pair.
-func (c *EtcdSignerCertKey) Generate(parents asset.Parents) error {
+func (c *EtcdSignerCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	cfg := &CertCfg{
 		Subject:   pkix.Name{CommonName: "etcd-signer", OrganizationalUnit: []string{"openshift"}},
 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -52,10 +54,10 @@ func (a *EtcdCABundle) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert bundle based on its dependencies.
-func (a *EtcdCABundle) Generate(deps asset.Parents) error {
+func (a *EtcdCABundle) Generate(log *logrus.Entry, parents asset.Parents) error {
 	var certs []CertInterface
 	for _, asset := range a.Dependencies() {
-		deps.Get(asset)
+		parents.Get(asset)
 		certs = append(certs, asset.(CertInterface))
 	}
 	return a.CertBundle.Generate("etcd-ca-bundle", certs...)
@@ -83,9 +85,9 @@ func (a *EtcdSignerClientCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (a *EtcdSignerClientCertKey) Generate(dependencies asset.Parents) error {
+func (a *EtcdSignerClientCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &EtcdSignerCertKey{}
-	dependencies.Get(ca)
+	parents.Get(ca)
 
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: "etcd", OrganizationalUnit: []string{"etcd"}},

--- a/pkg/asset/tls/etcdmetrics.go
+++ b/pkg/asset/tls/etcdmetrics.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509/pkix"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/sirupsen/logrus"
 )
 
 // EtcdMetricSignerCertKey is a key/cert pair that signs the etcd-metrics client and server certs.
@@ -20,7 +21,7 @@ func (c *EtcdMetricSignerCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the root-ca key and cert pair.
-func (c *EtcdMetricSignerCertKey) Generate(parents asset.Parents) error {
+func (c *EtcdMetricSignerCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	cfg := &CertCfg{
 		Subject:   pkix.Name{CommonName: "etcd-metric-signer", OrganizationalUnit: []string{"openshift"}},
 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -52,10 +53,10 @@ func (a *EtcdMetricCABundle) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert bundle based on its dependencies.
-func (a *EtcdMetricCABundle) Generate(deps asset.Parents) error {
+func (a *EtcdMetricCABundle) Generate(log *logrus.Entry, parents asset.Parents) error {
 	var certs []CertInterface
 	for _, asset := range a.Dependencies() {
-		deps.Get(asset)
+		parents.Get(asset)
 		certs = append(certs, asset.(CertInterface))
 	}
 	return a.CertBundle.Generate("etcd-metric-ca-bundle", certs...)
@@ -83,9 +84,9 @@ func (a *EtcdMetricSignerClientCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (a *EtcdMetricSignerClientCertKey) Generate(dependencies asset.Parents) error {
+func (a *EtcdMetricSignerClientCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &EtcdMetricSignerCertKey{}
-	dependencies.Get(ca)
+	parents.Get(ca)
 
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: "etcd-metric", OrganizationalUnit: []string{"etcd-metric"}},

--- a/pkg/asset/tls/journalcertkey.go
+++ b/pkg/asset/tls/journalcertkey.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509/pkix"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/sirupsen/logrus"
 )
 
 // JournalCertKey is the asset that generates the key/cert pair that is used to
@@ -25,9 +26,9 @@ func (a *JournalCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (a *JournalCertKey) Generate(dependencies asset.Parents) error {
+func (a *JournalCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &RootCA{}
-	dependencies.Get(ca)
+	parents.Get(ca)
 
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: "journal-gatewayd", Organization: []string{"OpenShift Bootstrap"}},

--- a/pkg/asset/tls/kubecontrolplane.go
+++ b/pkg/asset/tls/kubecontrolplane.go
@@ -4,6 +4,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 )
 
@@ -20,7 +22,7 @@ func (c *KubeControlPlaneSignerCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the root-ca key and cert pair.
-func (c *KubeControlPlaneSignerCertKey) Generate(parents asset.Parents) error {
+func (c *KubeControlPlaneSignerCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	cfg := &CertCfg{
 		Subject:   pkix.Name{CommonName: "kube-control-plane-signer", OrganizationalUnit: []string{"openshift"}},
 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -55,10 +57,10 @@ func (a *KubeControlPlaneCABundle) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert bundle based on its dependencies.
-func (a *KubeControlPlaneCABundle) Generate(deps asset.Parents) error {
+func (a *KubeControlPlaneCABundle) Generate(log *logrus.Entry, parents asset.Parents) error {
 	var certs []CertInterface
 	for _, asset := range a.Dependencies() {
-		deps.Get(asset)
+		parents.Get(asset)
 		certs = append(certs, asset.(CertInterface))
 	}
 	return a.CertBundle.Generate("kube-control-plane-ca-bundle", certs...)
@@ -84,9 +86,9 @@ func (a *KubeControlPlaneKubeControllerManagerClientCertKey) Dependencies() []as
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (a *KubeControlPlaneKubeControllerManagerClientCertKey) Generate(dependencies asset.Parents) error {
+func (a *KubeControlPlaneKubeControllerManagerClientCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &KubeControlPlaneSignerCertKey{}
-	dependencies.Get(ca)
+	parents.Get(ca)
 
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: "system:admin", Organization: []string{"system:masters"}},
@@ -118,9 +120,9 @@ func (a *KubeControlPlaneKubeSchedulerClientCertKey) Dependencies() []asset.Asse
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (a *KubeControlPlaneKubeSchedulerClientCertKey) Generate(dependencies asset.Parents) error {
+func (a *KubeControlPlaneKubeSchedulerClientCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &KubeControlPlaneSignerCertKey{}
-	dependencies.Get(ca)
+	parents.Get(ca)
 
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: "system:admin", Organization: []string{"system:masters"}},

--- a/pkg/asset/tls/kubelet.go
+++ b/pkg/asset/tls/kubelet.go
@@ -4,6 +4,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 )
 
@@ -20,7 +22,7 @@ func (c *KubeletCSRSignerCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the root-ca key and cert pair.
-func (c *KubeletCSRSignerCertKey) Generate(parents asset.Parents) error {
+func (c *KubeletCSRSignerCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	cfg := &CertCfg{
 		Subject:   pkix.Name{CommonName: "kubelet-signer", OrganizationalUnit: []string{"openshift"}},
 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -52,10 +54,10 @@ func (a *KubeletClientCABundle) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert bundle based on its dependencies.
-func (a *KubeletClientCABundle) Generate(deps asset.Parents) error {
+func (a *KubeletClientCABundle) Generate(log *logrus.Entry, parents asset.Parents) error {
 	var certs []CertInterface
 	for _, asset := range a.Dependencies() {
-		deps.Get(asset)
+		parents.Get(asset)
 		certs = append(certs, asset.(CertInterface))
 	}
 	return a.CertBundle.Generate("kubelet-client-ca-bundle", certs...)
@@ -82,10 +84,10 @@ func (a *KubeletServingCABundle) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert bundle based on its dependencies.
-func (a *KubeletServingCABundle) Generate(deps asset.Parents) error {
+func (a *KubeletServingCABundle) Generate(log *logrus.Entry, parents asset.Parents) error {
 	var certs []CertInterface
 	for _, asset := range a.Dependencies() {
-		deps.Get(asset)
+		parents.Get(asset)
 		certs = append(certs, asset.(CertInterface))
 	}
 	return a.CertBundle.Generate("kubelet-serving-ca-bundle", certs...)
@@ -110,7 +112,7 @@ func (c *KubeletBootstrapCertSigner) Dependencies() []asset.Asset {
 }
 
 // Generate generates the root-ca key and cert pair.
-func (c *KubeletBootstrapCertSigner) Generate(parents asset.Parents) error {
+func (c *KubeletBootstrapCertSigner) Generate(log *logrus.Entry, parents asset.Parents) error {
 	cfg := &CertCfg{
 		Subject:   pkix.Name{CommonName: "kubelet-bootstrap-kubeconfig-signer", OrganizationalUnit: []string{"openshift"}},
 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
@@ -142,10 +144,10 @@ func (a *KubeletBootstrapCABundle) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert bundle based on its dependencies.
-func (a *KubeletBootstrapCABundle) Generate(deps asset.Parents) error {
+func (a *KubeletBootstrapCABundle) Generate(log *logrus.Entry, parents asset.Parents) error {
 	var certs []CertInterface
 	for _, asset := range a.Dependencies() {
-		deps.Get(asset)
+		parents.Get(asset)
 		certs = append(certs, asset.(CertInterface))
 	}
 	return a.CertBundle.Generate("kubelet-bootstrap-kubeconfig-ca-bundle", certs...)
@@ -173,9 +175,9 @@ func (a *KubeletClientCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (a *KubeletClientCertKey) Generate(dependencies asset.Parents) error {
+func (a *KubeletClientCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &KubeletBootstrapCertSigner{}
-	dependencies.Get(ca)
+	parents.Get(ca)
 
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper", Organization: []string{"system:serviceaccounts:openshift-machine-config-operator"}},

--- a/pkg/asset/tls/mcscertkey.go
+++ b/pkg/asset/tls/mcscertkey.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/sirupsen/logrus"
 )
 
 // MCSCertKey is the asset that generates the MCS key/cert pair.
@@ -26,10 +27,10 @@ func (a *MCSCertKey) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (a *MCSCertKey) Generate(dependencies asset.Parents) error {
+func (a *MCSCertKey) Generate(log *logrus.Entry, parents asset.Parents) error {
 	ca := &RootCA{}
 	installConfig := &installconfig.InstallConfig{}
-	dependencies.Get(ca, installConfig)
+	parents.Get(ca, installConfig)
 
 	hostname := internalAPIAddress(installConfig.Config)
 

--- a/pkg/asset/tls/root.go
+++ b/pkg/asset/tls/root.go
@@ -4,6 +4,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset"
 )
 
@@ -21,7 +23,7 @@ func (c *RootCA) Dependencies() []asset.Asset {
 }
 
 // Generate generates the root-ca key and cert pair.
-func (c *RootCA) Generate(parents asset.Parents) error {
+func (c *RootCA) Generate(log *logrus.Entry, parents asset.Parents) error {
 	cfg := &CertCfg{
 		Subject:   pkix.Name{CommonName: "root-ca", OrganizationalUnit: []string{"openshift"}},
 		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,

--- a/pkg/asset/tls/serviceaccountkeypair.go
+++ b/pkg/asset/tls/serviceaccountkeypair.go
@@ -1,6 +1,9 @@
 package tls
 
-import "github.com/openshift/installer/pkg/asset"
+import (
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/sirupsen/logrus"
+)
 
 // ServiceAccountKeyPair is the asset that generates the service-account public/private key pair.
 type ServiceAccountKeyPair struct {
@@ -17,7 +20,7 @@ func (a *ServiceAccountKeyPair) Dependencies() []asset.Asset {
 }
 
 // Generate generates the cert/key pair based on its dependencies.
-func (a *ServiceAccountKeyPair) Generate(dependencies asset.Parents) error {
+func (a *ServiceAccountKeyPair) Generate(log *logrus.Entry, parents asset.Parents) error {
 	return a.KeyPair.Generate("service-account")
 }
 

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/installer/pkg/asset/cluster"
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -15,7 +17,7 @@ import (
 )
 
 // Destroy uses Terraform to remove bootstrap resources.
-func Destroy(dir string) (err error) {
+func Destroy(log *logrus.Entry, dir string) (err error) {
 	metadata, err := cluster.LoadMetadata(dir)
 	if err != nil {
 		return err
@@ -63,14 +65,14 @@ func Destroy(dir string) (err error) {
 	}
 
 	if platform == libvirt.Name {
-		_, err = terraform.Apply(tempDir, platform, extraArgs...)
+		_, err = terraform.Apply(log, tempDir, platform, extraArgs...)
 		if err != nil {
 			return errors.Wrap(err, "Terraform apply")
 		}
 	}
 
 	extraArgs = append(extraArgs, "-target=module.bootstrap")
-	err = terraform.Destroy(tempDir, platform, extraArgs...)
+	err = terraform.Destroy(log, tempDir, platform, extraArgs...)
 	if err != nil {
 		return errors.Wrap(err, "Terraform destroy")
 	}

--- a/pkg/destroy/destroyer.go
+++ b/pkg/destroy/destroyer.go
@@ -15,13 +15,13 @@ type Destroyer interface {
 }
 
 // NewFunc is an interface for creating platform-specific destroyers.
-type NewFunc func(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (Destroyer, error)
+type NewFunc func(log *logrus.Entry, metadata *types.ClusterMetadata) (Destroyer, error)
 
 // Registry maps ClusterMetadata.Platform() to per-platform Destroyer creators.
 var Registry = make(map[string]NewFunc)
 
 // New returns a Destroyer based on `metadata.json` in `rootDir`.
-func New(logger logrus.FieldLogger, rootDir string) (Destroyer, error) {
+func New(log *logrus.Entry, rootDir string) (Destroyer, error) {
 	metadata, err := cluster.LoadMetadata(rootDir)
 	if err != nil {
 		return nil, err
@@ -36,5 +36,5 @@ func New(logger logrus.FieldLogger, rootDir string) (Destroyer, error) {
 	if !ok {
 		return nil, errors.Errorf("no destroyers registered for %q", platform)
 	}
-	return creator(logger, metadata)
+	return creator(log, metadata)
 }

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -9,6 +9,7 @@ import (
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type config struct {
@@ -20,7 +21,7 @@ type config struct {
 }
 
 // TFVars generates libvirt-specific Terraform variables.
-func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, machineCIDR *net.IPNet, bridge string, masterCount int) ([]byte, error) {
+func TFVars(log *logrus.Entry, masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, machineCIDR *net.IPNet, bridge string, masterCount int) ([]byte, error) {
 	bootstrapIP, err := cidr.Host(machineCIDR, 10)
 	if err != nil {
 		return nil, errors.Errorf("failed to generate bootstrap IP: %v", err)
@@ -31,7 +32,7 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, 
 		return nil, err
 	}
 
-	osImage, err = cachedImage(osImage)
+	osImage, err = cachedImage(log, osImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to use cached libvirt image")
 	}

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -194,6 +194,7 @@ func validateCompute(platform *types.Platform, pools []types.MachinePool, fldPat
 		allErrs = append(allErrs, ValidateMachinePool(platform, &p, poolFldPath)...)
 	}
 	if !foundPositiveReplicas {
+		// FIXME: This is using global logger. Should report an error instead.
 		logrus.Warnf("There are no compute nodes specified. The cluster will not fully initialize without compute nodes.")
 	}
 	return allErrs


### PR DESCRIPTION
Removes global logrus logger object and replaces it with customer provided one.

Enables to consume installer as a package and provide custom logrus Entry object with fields for request tracking. 
Moves logger parameter to beginning of the function calls to match pattern `func([ctx], logger, args...)`
Aligns all assets generates functions to have the same variable names and parameters.
Changes `Generate` interface to accept `*logrus.Entry` as an arg

Part of: https://github.com/openshift/installer/issues/1864 