### PR TITLE
[azure] rollback azure UserTags

### DIFF
--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -14,6 +14,11 @@ type Platform struct {
 	// installing on Azure for machine pools which do not define their own
 	// platform configuration.
 	// +optional
+
+	// UserTags specifies additional tags for Azure resources created for the cluster.
+	// +optional
+	UserTags map[string]string `json:"userTags,omitempty"`
+
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
 }
 


### PR DESCRIPTION
Rollack `Platform.UserTags` for Azure Platform. 

This brings back UserTags in Azure Platform definition.

