### PR TITLE
 types/azure: allow specifying the disk size for pools 

### DIFF
--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -84,7 +84,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		},
 		OSDisk: azureprovider.OSDisk{
 			OSType:     "Linux",
-			DiskSizeGB: 64,
+			DiskSizeGB: mpool.OSDisk.DiskSizeGB,
 			ManagedDisk: azureprovider.ManagedDisk{
 				StorageAccountType: "Premium_LRS",
 			},

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -68,7 +68,11 @@ func defaultLibvirtMachinePoolPlatform() libvirttypes.MachinePool {
 }
 
 func defaultAzureMachinePoolPlatform() azuretypes.MachinePool {
-	return azuretypes.MachinePool{}
+	return azuretypes.MachinePool{
+		OSDisk: azuretypes.OSDisk{
+			DiskSizeGB: 128,
+		},
+	}
 }
 
 func defaultOpenStackMachinePoolPlatform(flavor string) openstacktypes.MachinePool {

--- a/pkg/types/azure/machinepool.go
+++ b/pkg/types/azure/machinepool.go
@@ -6,6 +6,15 @@ type MachinePool struct {
 	// InstanceType defines the azure instance type.
 	// eg. Standard_DS_V2
 	InstanceType string `json:"type"`
+
+	// OSDisk defines the storage for instance.
+	OSDisk `json:"osDisk"`
+}
+
+// OSDisk defines the disk for machines on Azure.
+type OSDisk struct {
+	// DiskSizeGB defines the size of disk in GB.
+	DiskSizeGB int32 `json:"diskSizeGB"`
 }
 
 // Set sets the values from `required` to `a`.
@@ -16,5 +25,9 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.InstanceType != "" {
 		a.InstanceType = required.InstanceType
+	}
+
+	if required.OSDisk.DiskSizeGB != 0 {
+		a.OSDisk.DiskSizeGB = required.OSDisk.DiskSizeGB
 	}
 }

--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -7,7 +7,10 @@ import (
 
 // ValidateMachinePool checks that the specified machine pool is valid.
 func ValidateMachinePool(p *azure.MachinePool, fldPath *field.Path) field.ErrorList {
-	//TODO: implement machine pool validation
 	allErrs := field.ErrorList{}
+
+	if p.OSDisk.DiskSizeGB < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), p.OSDisk.DiskSizeGB, "Storage DiskSizeGB must be positive"))
+	}
 	return allErrs
 }

--- a/pkg/types/azure/validation/machinepool_test.go
+++ b/pkg/types/azure/validation/machinepool_test.go
@@ -10,23 +10,39 @@ import (
 
 func TestValidateMachinePool(t *testing.T) {
 	cases := []struct {
-		name  string
-		pool  *azure.MachinePool
-		valid bool
+		name     string
+		pool     *azure.MachinePool
+		expected string
 	}{
 		{
-			name:  "empty",
-			pool:  &azure.MachinePool{},
-			valid: true,
+			name: "empty",
+			pool: &azure.MachinePool{},
+		},
+		{
+			name: "valid iops",
+			pool: &azure.MachinePool{
+				OSDisk: azure.OSDisk{
+					DiskSizeGB: 120,
+				},
+			},
+		},
+		{
+			name: "invalid iops",
+			pool: &azure.MachinePool{
+				OSDisk: azure.OSDisk{
+					DiskSizeGB: -120,
+				},
+			},
+			expected: `^test-path\.diskSizeGB: Invalid value: -120: Storage DiskSizeGB must be positive$`,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidateMachinePool(tc.pool, field.NewPath("test-path")).ToAggregate()
-			if tc.valid {
+			if tc.expected == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				assert.Regexp(t, tc.expected, err)
 			}
 		})
 	}


### PR DESCRIPTION
This also updates the default disk size for Azure to 128 GB

This brings up the IOPS to 500 and through-put to 100 MB/second [1] to get it closer to AWS defaults.

[1]: https://azure.microsoft.com/en-us/pricing/details/managed-disks/

/cc @jhixson74 @smarterclayton 