### PR TITLE
OpenStack: fix cluster destroy

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -609,8 +609,8 @@ func deleteLoadBalancers(opts *clientconfig.ClientOpts, filter Filter, logger lo
 
 	conn, err := clientconfig.NewServiceClient("load-balancer", opts)
 	if err != nil {
-		logger.Fatalf("%v", err)
-		os.Exit(1)
+		logger.Debugf("%v", err)
+		return true, nil
 	}
 
 	newallPages, err := apiversions.List(conn).AllPages()


### PR DESCRIPTION
The load balancer destroy step on the cluster destroy is expecting
for the cloud to have octavia service enabled, in case it is not
enabled the destroy command will fail. This commit fixes the issue
by skipping load balancers deletion in case no octavia endpoints
are enabled, which avoids a fatal error.

Fixes #1919