### PR TITLE
openstack: Fix rhcos version wrong info in doc

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -45,7 +45,7 @@ enough to store the ignition config files, so they are served by swift instead.
   values. For example (as an OpenStack admin) `openstack quota set --secgroups 100 --secgroup-rules 1000 <project>`
 
 * The installer requires a proper RHCOS image in the OpenStack cluster or project:
-`openstack image create --container-format=bare --disk-format=qcow2 --file rhcos-${RHCOSVERSION}-openstack.qcow2 rhcos-${RHCOSVERSION}`
+`openstack image create --container-format=bare --disk-format=qcow2 --file rhcos-${RHCOSVERSION}-openstack.qcow2 rhcos`
 
 **NOTE:** Depending on your OpenStack environment you can upload the RHCOS image
 as `raw` or `qcow2`. See [Disk and container formats for images](https://docs.openstack.org/image-guide/image-formats.html) for more information. The installer looks for an image named rhcos. This could be overridden via the `OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE` environment variable if for instance your cloud operator provides the image under a different name.


### PR DESCRIPTION
current doc contains wrong info
https://github.com/openshift/installer/blob/master/pkg/asset/rhcos/image.go#L64
only support rhcos

and per test, change image name to rhcos-xxx such as rhcos-112
ERROR
ERROR Error: Your query returned no results. Please change your search criteria and try again.
ERROR
ERROR   on ../../../../../../tmp/openshift-install-590981577/bootstrap/main.tf line 58, in data "openstack_images_image_v2" "bootstrap_image":
ERROR   58: data "openstack_images_image_v2" "bootstrap_image" {