### PR TITLE
data/data/openstack: Open UDP 5353 (mdns) port

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -33,6 +33,16 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_ssh" {
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_mdns_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 5353
+  port_range_max    = 5353
+  remote_ip_prefix  = "${var.cidr_block}"
+  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_http" {
   direction         = "ingress"
   ethertype         = "IPv4"


### PR DESCRIPTION
The mdns port is going to be used for updating the internal DNS
records necessary for the installation to succeed (the master & etcd A
as well as the SRV records).

Some OpenStack deployments allow UDP traffic by default, but some
don't so we need to create this Security Group Rule explicitly.