### PR TITLE
Decouple Destroyer interface and registry from destroy command

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	awssession "github.com/openshift/installer/pkg/asset/installconfig/aws"
-	"github.com/openshift/installer/pkg/destroy"
+	"github.com/openshift/installer/pkg/destroy/providers"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/version"
 )
@@ -67,7 +67,7 @@ type ClusterUninstaller struct {
 }
 
 // New returns an AWS destroyer from ClusterMetadata.
-func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (destroy.Destroyer, error) {
+func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.Destroyer, error) {
 	filters := make([]Filter, 0, len(metadata.ClusterPlatformMetadata.AWS.Identifier))
 	for _, filter := range metadata.ClusterPlatformMetadata.AWS.Identifier {
 		filters = append(filters, filter)

--- a/pkg/destroy/aws/register.go
+++ b/pkg/destroy/aws/register.go
@@ -1,7 +1,7 @@
 package aws
 
-import "github.com/openshift/installer/pkg/destroy"
+import "github.com/openshift/installer/pkg/destroy/providers"
 
 func init() {
-	destroy.Registry["aws"] = New
+	providers.Registry["aws"] = New
 }

--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	azuresession "github.com/openshift/installer/pkg/asset/installconfig/azure"
-	"github.com/openshift/installer/pkg/destroy"
+	"github.com/openshift/installer/pkg/destroy/providers"
 	"github.com/openshift/installer/pkg/types"
 )
 
@@ -48,7 +48,7 @@ func (o *ClusterUninstaller) configureClients() {
 }
 
 // New returns an Azure destroyer from ClusterMetadata.
-func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (destroy.Destroyer, error) {
+func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.Destroyer, error) {
 	session, err := azuresession.GetSession()
 	if err != nil {
 		return nil, err

--- a/pkg/destroy/azure/register.go
+++ b/pkg/destroy/azure/register.go
@@ -1,9 +1,9 @@
 package azure
 
 import (
-	"github.com/openshift/installer/pkg/destroy"
+	"github.com/openshift/installer/pkg/destroy/providers"
 )
 
 func init() {
-	destroy.Registry["azure"] = New
+	providers.Registry["azure"] = New
 }

--- a/pkg/destroy/destroyer.go
+++ b/pkg/destroy/destroyer.go
@@ -5,23 +5,11 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset/cluster"
-	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/destroy/providers"
 )
 
-// Destroyer allows multiple implementations of destroy
-// for different platforms.
-type Destroyer interface {
-	Run() error
-}
-
-// NewFunc is an interface for creating platform-specific destroyers.
-type NewFunc func(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (Destroyer, error)
-
-// Registry maps ClusterMetadata.Platform() to per-platform Destroyer creators.
-var Registry = make(map[string]NewFunc)
-
 // New returns a Destroyer based on `metadata.json` in `rootDir`.
-func New(logger logrus.FieldLogger, rootDir string) (Destroyer, error) {
+func New(logger logrus.FieldLogger, rootDir string) (providers.Destroyer, error) {
 	metadata, err := cluster.LoadMetadata(rootDir)
 	if err != nil {
 		return nil, err
@@ -32,7 +20,7 @@ func New(logger logrus.FieldLogger, rootDir string) (Destroyer, error) {
 		return nil, errors.New("no platform configured in metadata")
 	}
 
-	creator, ok := Registry[platform]
+	creator, ok := providers.Registry[platform]
 	if !ok {
 		return nil, errors.Errorf("no destroyers registered for %q", platform)
 	}

--- a/pkg/destroy/libvirt/libvirt.go
+++ b/pkg/destroy/libvirt/libvirt.go
@@ -9,8 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/openshift/installer/pkg/destroy"
-	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/destroy/providers"
 )
 
 // filterFunc allows filtering based on names.
@@ -48,7 +47,7 @@ type ClusterUninstaller struct {
 }
 
 // New returns libvirt Uninstaller from ClusterMetadata.
-func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (destroy.Destroyer, error) {
+func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.Destroyer, error) {
 	return &ClusterUninstaller{
 		LibvirtURI: metadata.ClusterPlatformMetadata.Libvirt.URI,
 		Filter:     ClusterIDPrefixFilter(metadata.InfraID),

--- a/pkg/destroy/libvirt/register.go
+++ b/pkg/destroy/libvirt/register.go
@@ -3,9 +3,9 @@
 package libvirt
 
 import (
-	"github.com/openshift/installer/pkg/destroy"
+	"github.com/openshift/installer/pkg/providers"
 )
 
 func init() {
-	destroy.Registry["libvirt"] = New
+	providers.Registry["libvirt"] = New
 }

--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/installer/pkg/destroy"
+	"github.com/openshift/installer/pkg/destroy/providers"
 	"github.com/openshift/installer/pkg/types"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -60,7 +60,7 @@ type ClusterUninstaller struct {
 }
 
 // New returns an OpenStack destroyer from ClusterMetadata.
-func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (destroy.Destroyer, error) {
+func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.Destroyer, error) {
 	return &ClusterUninstaller{
 		Cloud:  metadata.ClusterPlatformMetadata.OpenStack.Cloud,
 		Filter: metadata.ClusterPlatformMetadata.OpenStack.Identifier,

--- a/pkg/destroy/openstack/register.go
+++ b/pkg/destroy/openstack/register.go
@@ -2,9 +2,9 @@
 package openstack
 
 import (
-	"github.com/openshift/installer/pkg/destroy"
+	"github.com/openshift/installer/pkg/destroy/providers"
 )
 
 func init() {
-	destroy.Registry["openstack"] = New
+	providers.Registry["openstack"] = New
 }

--- a/pkg/destroy/providers/registry.go
+++ b/pkg/destroy/providers/registry.go
@@ -1,0 +1,4 @@
+package providers
+
+// Registry maps ClusterMetadata.Platform() to per-platform Destroyer creators.
+var Registry = make(map[string]NewFunc)

--- a/pkg/destroy/providers/types.go
+++ b/pkg/destroy/providers/types.go
@@ -1,0 +1,16 @@
+package providers
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+// Destroyer allows multiple implementations of destroy
+// for different platforms.
+type Destroyer interface {
+	Run() error
+}
+
+// NewFunc is an interface for creating platform-specific destroyers.
+type NewFunc func(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (Destroyer, error)


### PR DESCRIPTION
Moves the destroyer registry to its own package. This decouples individual destroyers from their parent destroy package which has a dependency on pkg/asset/cluster which ends up having a dependency on a lot of the pkg/terraform/* code. These dependencies make it much harder to vendor installer code in hive.