### PR TITLE
google: create network infrastructure

### DIFF
--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -1,0 +1,18 @@
+locals {
+  compute_subnet_cidr = cidrsubnet(var.machine_cidr, 3, 1) #compute subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  control_subnet_cidr = cidrsubnet(var.machine_cidr, 3, 0) #control plane subnet is a smaller subnet within the vnet. i.e from /21 to /24
+}
+
+provider "google" {
+  region  = var.google_region
+  project = var.google_project
+}
+
+module "network" {
+  source = "./network"
+
+  cluster_id          = var.cluster_id
+  compute_subnet_cidr = local.compute_subnet_cidr
+  control_subnet_cidr = local.control_subnet_cidr
+  network_cidr        = var.machine_cidr
+}

--- a/data/data/gcp/network/common.tf
+++ b/data/data/gcp/network/common.tf
@@ -1,0 +1,11 @@
+# Canonical internal state definitions for this module.
+# read only: only locals and data source definitions allowed. No resources or module blocks in this file
+
+// Fetch a list of available AZs
+data "google_compute_zones" "available" {}
+
+// Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
+locals {
+  // List of possible AZs for each type of subnet
+  zones = "${data.google_compute_zones.available.names}"
+}

--- a/data/data/gcp/network/firewall-compute.tf
+++ b/data/data/gcp/network/firewall-compute.tf
@@ -1,0 +1,154 @@
+resource "google_compute_firewall" "compute_ingress_icmp" {
+  name    = "${var.cluster_id}-compute-ingress-icmp"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = [var.network_cidr]
+  target_tags   = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_ssh" {
+  name    = "${var.cluster_id}-compute-ingress-ssh"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = [var.network_cidr]
+  target_tags   = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_vxlan" {
+  name    = "${var.cluster_id}-compute-ingress-vxlan"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["4789"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_vxlan_from_master" {
+  name    = "${var.cluster_id}-compute-ingress-vxlan-from-master"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["4789"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_internal" {
+  name    = "${var.cluster_id}-compute-ingress-internal"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9000-9999"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_internal_from_master" {
+  name    = "${var.cluster_id}-compute-ingress-internal-from-master"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9000-9999"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_internal_udp" {
+  name    = "${var.cluster_id}-compute-ingress-udp"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["9000-9999"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_internal_from_master_udp" {
+  name    = "${var.cluster_id}-compute-ingress-udp-from-master"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["9000-9999"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_kubelet_insecure" {
+  name    = "${var.cluster_id}-compute-ingress-kubelet-insecure"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["10250"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_kubelet_insecure_from_master" {
+  name    = "${var.cluster_id}-compute-ingress-kubelet-insecure-from-master"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["10250"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_services_tcp" {
+  name    = "${var.cluster_id}-compute-ingress-services-tcp"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["30000-32767"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-worker"]
+}
+
+resource "google_compute_firewall" "compute_ingress_services_udp" {
+  name    = "${var.cluster_id}-compute-ingress-services-udp"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["30000-32767"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-worker"]
+}

--- a/data/data/gcp/network/firewall-control.tf
+++ b/data/data/gcp/network/firewall-control.tf
@@ -1,0 +1,245 @@
+resource "google_compute_firewall" "control_ingress_icmp" {
+  name    = "${var.cluster_id}-control-ingress-icmp"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "icmp"
+  }
+
+  source_ranges = [var.network_cidr]
+  target_tags   = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_ssh" {
+  name    = "${var.cluster_id}-control-ingress-ssh"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = [var.network_cidr]
+  target_tags   = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_https" {
+  name    = "${var.cluster_id}-control-ingress-https"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["6443"]
+  }
+
+  source_ranges = [var.network_cidr]
+  target_tags   = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_mcs" {
+  name    = "${var.cluster_id}-control-ingress-mcs"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22623"]
+  }
+
+  source_ranges = [var.network_cidr]
+  target_tags   = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_vxlan" {
+  name    = "${var.cluster_id}-control-ingress-vxlan"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["4789"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_vxlan_from_compute" {
+  name    = "${var.cluster_id}-control-ingress-vxlan-from-compute"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["4789"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_internal" {
+  name    = "${var.cluster_id}-control-ingress-internal"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9000-9999"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_internal_from_compute" {
+  name    = "${var.cluster_id}-control-ingress-internal-from-compute"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9000-9999"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_internal_udp" {
+  name    = "${var.cluster_id}-control-ingress-internal-udp"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["9000-9999"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_internal_from_compute_udp" {
+  name    = "${var.cluster_id}-control-ingress-internal-from-compute-udp"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["9000-9999"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_kube_scheduler" {
+  name    = "${var.cluster_id}-control-ingress-kube-scheduler"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["10259"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_kube_scheduler_from_compute" {
+  name    = "${var.cluster_id}-control-ingress-kube-scheduler-from-compute"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["10259"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_kube_controller_manager" {
+  name    = "${var.cluster_id}-control-ingress-kube-controller-manager"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["10257"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_kube_controller_manager_from_compute" {
+  name    = "${var.cluster_id}-control-ingress-kube-controller-manager-from-compute"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["10257"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_kubelet_secure" {
+  name    = "${var.cluster_id}-control-ingress-kubelet-secure"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["10250"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_kubelet_secure_from_compute" {
+  name    = "${var.cluster_id}-control-ingress-kubelet-secure-from-compute"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["10250"]
+  }
+
+  source_tags = ["${var.cluster_id}-worker"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_etcd" {
+  name    = "${var.cluster_id}-control-ingress-etcd"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["2379-2380"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_services_tcp" {
+  name    = "${var.cluster_id}-control-ingress-services-tcp"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["30000-32767"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-master"]
+}
+
+resource "google_compute_firewall" "control_ingress_services_udp" {
+  name    = "${var.cluster_id}-control-ingress-services-udp"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "udp"
+    ports    = ["30000-32767"]
+  }
+
+  source_tags = ["${var.cluster_id}-master"]
+  target_tags = ["${var.cluster_id}-master"]
+}

--- a/data/data/gcp/network/network.tf
+++ b/data/data/gcp/network/network.tf
@@ -1,0 +1,17 @@
+resource "google_compute_network" "cluster_network" {
+  name = "${var.cluster_id}-network"
+
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "compute_subnet" {
+  name          = "${var.cluster_id}-compute-subnet"
+  network       = google_compute_network.cluster_network.self_link
+  ip_cidr_range = var.compute_subnet_cidr
+}
+
+resource "google_compute_subnetwork" "control_subnet" {
+  name          = "${var.cluster_id}-control-subnet"
+  network       = google_compute_network.cluster_network.self_link
+  ip_cidr_range = var.control_subnet_cidr
+}

--- a/data/data/gcp/network/outputs.tf
+++ b/data/data/gcp/network/outputs.tf
@@ -1,0 +1,15 @@
+output "network" {
+  value = google_compute_network.cluster_network.self_link
+}
+
+output "compute_subnet" {
+  value = google_compute_subnetwork.compute_subnet.self_link
+}
+
+output "control_subnet" {
+  value = google_compute_subnetwork.control_subnet.self_link
+}
+
+output "zones" {
+  value = local.zones
+}

--- a/data/data/gcp/network/variables.tf
+++ b/data/data/gcp/network/variables.tf
@@ -1,0 +1,15 @@
+variable "cluster_id" {
+  type = string
+}
+
+variable "compute_subnet_cidr" {
+  type = string
+}
+
+variable "control_subnet_cidr" {
+  type = string
+}
+
+variable "network_cidr" {
+  type = string
+}

--- a/data/data/gcp/variables-google.tf
+++ b/data/data/gcp/variables-google.tf
@@ -1,0 +1,9 @@
+variable "google_project" {
+  type        = string
+  description = "The target GCP project for the cluster."
+}
+
+variable "google_region" {
+  type        = string
+  description = "The target GCP region for the cluster."
+}


### PR DESCRIPTION
This change adds the terraform bits to create the network infrastructure
for the google platform. It creates the control and compute networks for
the control plane and compute instances. It also creates firewall rules
to allow ingress ping and internal tcp.