### PR TITLE
 Bug 1725524: types/aws/default: move ap-northeast-2 to m5 instance class 

### DIFF
--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -6,11 +6,12 @@ import (
 
 var (
 	defaultMachineClass = map[string]string{
-		"ap-east-1":     "m5",
-		"eu-north-1":    "m5",
-		"eu-west-3":     "m5",
-		"us-gov-east-1": "m5",
-		"us-west-2":     "m5",
+		"ap-east-1":      "m5",
+		"ap-northeast-2": "m5",
+		"eu-north-1":     "m5",
+		"eu-west-3":      "m5",
+		"us-gov-east-1":  "m5",
+		"us-west-2":      "m5",
 	}
 )
 

--- a/platformtests/aws/default_instance_class_test.go
+++ b/platformtests/aws/default_instance_class_test.go
@@ -128,7 +128,7 @@ func TestGetDefaultInstanceClass(t *testing.T) {
 			}
 
 			available := make(map[string]map[string]struct{}, len(preferredInstanceClasses))
-			var match string
+			var allowed []string
 
 			for _, instanceClass := range preferredInstanceClasses {
 				if _, ok := classes[instanceClass]; !ok {
@@ -164,17 +164,16 @@ func TestGetDefaultInstanceClass(t *testing.T) {
 				}
 
 				if reflect.DeepEqual(available[instanceClass], zones) {
-					match = instanceClass
-					break
+					allowed = append(allowed, instanceClass)
 				}
 			}
 
-			if match == "" {
+			if len(allowed) == 0 {
 				t.Fatalf("none of the preferred instance classes are fully supported: %v", available)
 			}
 
 			t.Log(available)
-			assert.Equal(t, defaults.InstanceClass(region), match)
+			assert.Contains(t, allowed, defaults.InstanceClass(region))
 		})
 	}
 }


### PR DESCRIPTION
AWS allows m4 class for reserved instances in all AZs for ap-northeast-2

```console
aws --region ap-northeast-2 ec2 describe-reserved-instances-offerings --instance-tenancy default --instance-type m4.large --product-description 'Linux/UNIX' --filters Name=scope,Values='Availability Zone' | jq -r '[.ReservedInstancesOfferings[].AvailabilityZone] | sort | unique[]'
ap-northeast-2a
ap-northeast-2b
ap-northeast-2c
```

But the on-demand instances in ap-norteast-2b was failing with error
```
Unsupported: Your requested instance type (m4.xlarge) is not supported in your requested Availability Zone (ap-northeast-2b). Please retry your request by not specifying an Availability Zone or choosing ap-northeast-2a, ap-northeast-2c.
```

So moving to m5 class for ap-northeast-2 should allow creating control plane instances in all Zones. (the default configuration)

/cc @openshift/openshift-team-installer @eparis 