### PR TITLE
upi/vsphere/machine: add missing = for attribute in map

### DIFF
--- a/upi/vsphere/machine/main.tf
+++ b/upi/vsphere/machine/main.tf
@@ -43,7 +43,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   vapp {
-    properties {
+    properties = {
       "guestinfo.ignition.config.data"          = "${base64encode(data.ignition_config.ign.*.rendered[count.index])}"
       "guestinfo.ignition.config.data.encoding" = "base64"
     }


### PR DESCRIPTION
terraform v0.12.0+ `terraform init` will generate error.
```
$ terraform init
Initializing modules...
There are some problems with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Invalid argument name

  on machine/main.tf line 47, in resource "vsphere_virtual_machine" "vm":
  47:       "guestinfo.ignition.config.data"          = "${base64encode(data.ignition_config.ign.*.rendered[count.index])}"

Argument names must not be quoted.
```

ref: https://github.com/hashicorp/terraform/issues/21402