### PR TITLE
Add more conservative permissions to files and directories

### DIFF
--- a/cmd/openshift-install/log.go
+++ b/cmd/openshift-install/log.go
@@ -47,11 +47,11 @@ func (h *fileHook) Fire(entry *logrus.Entry) error {
 }
 
 func setupFileHook(baseDir string) func() {
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
+	if err := os.MkdirAll(baseDir, 0750); err != nil {
 		logrus.Fatal(errors.Wrap(err, "failed to create base directory for logs"))
 	}
 
-	logfile, err := os.OpenFile(filepath.Join(baseDir, ".openshift_install.log"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
+	logfile, err := os.OpenFile(filepath.Join(baseDir, ".openshift_install.log"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0660)
 	if err != nil {
 		logrus.Fatal(errors.Wrap(err, "failed to open log file"))
 	}

--- a/data/unpack.go
+++ b/data/unpack.go
@@ -21,7 +21,7 @@ func Unpack(base string, uri string) (err error) {
 	}
 
 	if info.IsDir() {
-		os.Mkdir(base, 0777)
+		os.Mkdir(base, 0750)
 		children, err := file.Readdir(0)
 		if err != nil {
 			return err
@@ -38,7 +38,7 @@ func Unpack(base string, uri string) (err error) {
 		return nil
 	}
 
-	out, err := os.OpenFile(base, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	out, err := os.OpenFile(base, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0660)
 	if err != nil {
 		return err
 	}

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -49,7 +49,7 @@ type File struct {
 func PersistToFile(asset WritableAsset, directory string) error {
 	for _, f := range asset.Files() {
 		path := filepath.Join(directory, f.Filename)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 			return errors.Wrap(err, "failed to create dir")
 		}
 		if err := ioutil.WriteFile(path, f.Data, 0644); err != nil {

--- a/pkg/asset/state.go
+++ b/pkg/asset/state.go
@@ -31,7 +31,7 @@ func (s *State) PersistToFile(directory string) error {
 			continue
 		}
 		path := filepath.Join(directory, c.Name)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 			return errors.Wrap(err, "failed to create dir")
 		}
 		if err := ioutil.WriteFile(path, c.Data, 0644); err != nil {

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -181,7 +181,7 @@ func (s *storeImpl) saveStateFile() error {
 	}
 
 	path := filepath.Join(s.directory, stateFileName)
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 		return err
 	}
 	if err := ioutil.WriteFile(path, data, 0644); err != nil {

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -139,7 +139,7 @@ func setupEmbeddedPlugins(dir string) error {
 	}
 
 	pdir := filepath.Join(dir, "plugins")
-	if err := os.MkdirAll(pdir, 0777); err != nil {
+	if err := os.MkdirAll(pdir, 0750); err != nil {
 		return err
 	}
 	for name := range plugins.KnownPlugins {

--- a/pkg/tfvars/libvirt/cache.go
+++ b/pkg/tfvars/libvirt/cache.go
@@ -60,7 +60,7 @@ func cachedImage(uri string) (string, error) {
 	}
 
 	imageCacheDir := filepath.Join(cacheDir, "image")
-	err = os.MkdirAll(imageCacheDir, 0777)
+	err = os.MkdirAll(imageCacheDir, 0750)
 	if err != nil {
 		return uri, err
 	}


### PR DESCRIPTION
The files and directories created by the installer had quite open permissions. Changing them to be more restrictive is generally a good security practice.

When doing a deployment, specially in more restrictive environments, having your deployment files be world readable is something that you want to avoid. And running security scanners will tend to mark this as a low impact vulnerability (since it's easily fixable), so we want to avoid this noise as well.