### PR TITLE
google: create virtual machines

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -1,0 +1,25 @@
+resource "google_compute_instance" "bootstrap" {
+  name         = "${var.cluster_id}-bootstrap"
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      type  = var.root_volume_type
+      size  = var.root_volume_size
+      image = var.image_name
+    }
+  }
+
+  network_interface {
+    subnetwork = var.subnet
+  }
+
+  metadata = {
+    user-data = var.ignition
+  }
+
+  tags = ["${var.cluster_id}-master"]
+
+  labels = var.labels
+}

--- a/data/data/gcp/bootstrap/variables.tf
+++ b/data/data/gcp/bootstrap/variables.tf
@@ -1,0 +1,52 @@
+variable "cluster_id" {
+  type        = string
+  description = "The name of the cluster."
+}
+
+variable "ignition" {
+  type        = string
+  description = "The content of the bootstrap ignition file."
+}
+
+variable "image_name" {
+  type        = string
+  description = "The image for the bootstrap node."
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "GCP labels to be applied to created resources."
+  default     = {}
+}
+
+variable "machine_type" {
+  type        = string
+  description = "Machine type for the bootstrap node."
+}
+
+variable "network" {
+  type        = string
+  description = "The network the bootstrap node will be added to."
+}
+
+variable "subnet" {
+  type        = string
+  description = "The subnetwork the bootstrap node will be added to."
+}
+
+variable "root_volume_size" {
+  type        = string
+  description = "The volume size (in gibibytes) for the bootstrap node's root volume."
+  default     = "128"
+}
+
+variable "root_volume_type" {
+  type        = string
+  description = "The volume type for the bootstrap node's root volume."
+  default     = "pd-standard"
+}
+
+variable "zone" {
+  type        = string
+  description = "The zone for the bootstrap node."
+}

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -1,18 +1,49 @@
 locals {
-  compute_subnet_cidr = cidrsubnet(var.machine_cidr, 3, 1) #compute subnet is a smaller subnet within the vnet. i.e from /21 to /24
-  control_subnet_cidr = cidrsubnet(var.machine_cidr, 3, 0) #control plane subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  labels = var.gcp_extra_labels
+
+  master_subnet_cidr = cidrsubnet(var.machine_cidr, 3, 0) #master subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  worker_subnet_cidr = cidrsubnet(var.machine_cidr, 3, 1) #worker subnet is a smaller subnet within the vnet. i.e from /21 to /24
 }
 
 provider "google" {
-  region  = var.google_region
-  project = var.google_project
+  region  = var.gcp_region
+  project = var.gcp_project
+}
+
+module "bootstrap" {
+  source = "./bootstrap"
+
+  image_name   = var.gcp_image_name_override
+  machine_type = var.gcp_bootstrap_machine_type
+  cluster_id   = var.cluster_id
+  ignition     = var.ignition_bootstrap
+  network      = module.network.network
+  subnet       = module.network.master_subnet
+  zone         = module.network.zones[0]
+
+  labels = local.labels
+}
+
+module "master" {
+  source = "./master"
+
+  image_name     = var.gcp_image_name_override
+  instance_count = var.master_count
+  machine_type   = var.gcp_master_machine_type
+  cluster_id     = var.cluster_id
+  ignition       = var.ignition_master
+  network        = module.network.network
+  subnet         = module.network.master_subnet
+  zones          = module.network.zones
+
+  labels = local.labels
 }
 
 module "network" {
   source = "./network"
 
-  cluster_id          = var.cluster_id
-  compute_subnet_cidr = local.compute_subnet_cidr
-  control_subnet_cidr = local.control_subnet_cidr
-  network_cidr        = var.machine_cidr
+  cluster_id         = var.cluster_id
+  master_subnet_cidr = local.master_subnet_cidr
+  worker_subnet_cidr = local.worker_subnet_cidr
+  network_cidr       = var.machine_cidr
 }

--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -1,0 +1,27 @@
+resource "google_compute_instance" "master" {
+  count = var.instance_count
+
+  name         = "${var.cluster_id}-master-${count.index}"
+  machine_type = var.machine_type
+  zone         = var.zones[count.index]
+
+  boot_disk {
+    initialize_params {
+      type  = var.root_volume_type
+      size  = var.root_volume_size
+      image = var.image_name
+    }
+  }
+
+  network_interface {
+    subnetwork = var.subnet
+  }
+
+  metadata = {
+    user-data = var.ignition
+  }
+
+  tags = ["${var.cluster_id}-master"]
+
+  labels = var.labels
+}

--- a/data/data/gcp/master/outputs.tf
+++ b/data/data/gcp/master/outputs.tf
@@ -1,0 +1,3 @@
+output "master_instances" {
+  value = google_compute_instance.master.*.self_link
+}

--- a/data/data/gcp/master/variables.tf
+++ b/data/data/gcp/master/variables.tf
@@ -1,0 +1,56 @@
+variable "cluster_id" {
+  type        = string
+  description = "The name of the cluster."
+}
+
+variable "ignition" {
+  type        = string
+  description = "The content of the masters ignition file."
+}
+
+variable "image_name" {
+  type        = string
+  description = "The image for the master instances."
+}
+
+variable "instance_count" {
+  type        = string
+  description = "The number of master instances to launch."
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "GCP labels to be applied to created resources."
+  default     = {}
+}
+
+variable "machine_type" {
+  type        = string
+  description = "The machine type for the master instances."
+}
+
+variable "network" {
+  type        = string
+  description = "The network the master instances will be added to."
+}
+
+variable "subnet" {
+  type        = string
+  description = "The subnetwork the master instances will be added to."
+}
+
+variable "root_volume_size" {
+  type        = string
+  description = "The size of the volume in gigabytes for the root block device."
+  default     = "128"
+}
+
+variable "root_volume_type" {
+  type        = string
+  description = "The type of volume for the root block device."
+  default     = "pd-standard"
+}
+
+variable "zones" {
+  type = list
+}

--- a/data/data/gcp/network/common.tf
+++ b/data/data/gcp/network/common.tf
@@ -7,5 +7,5 @@ data "google_compute_zones" "available" {}
 // Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
 locals {
   // List of possible AZs for each type of subnet
-  zones = "${data.google_compute_zones.available.names}"
+  zones = data.google_compute_zones.available.names
 }

--- a/data/data/gcp/network/firewall-compute.tf
+++ b/data/data/gcp/network/firewall-compute.tf
@@ -1,5 +1,5 @@
-resource "google_compute_firewall" "compute_ingress_icmp" {
-  name    = "${var.cluster_id}-compute-ingress-icmp"
+resource "google_compute_firewall" "worker_ingress_icmp" {
+  name    = "${var.cluster_id}-worker-ingress-icmp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -10,8 +10,8 @@ resource "google_compute_firewall" "compute_ingress_icmp" {
   target_tags   = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_ssh" {
-  name    = "${var.cluster_id}-compute-ingress-ssh"
+resource "google_compute_firewall" "worker_ingress_ssh" {
+  name    = "${var.cluster_id}-worker-ingress-ssh"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -23,8 +23,8 @@ resource "google_compute_firewall" "compute_ingress_ssh" {
   target_tags   = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_vxlan" {
-  name    = "${var.cluster_id}-compute-ingress-vxlan"
+resource "google_compute_firewall" "worker_ingress_vxlan" {
+  name    = "${var.cluster_id}-worker-ingress-vxlan"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -36,8 +36,8 @@ resource "google_compute_firewall" "compute_ingress_vxlan" {
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_vxlan_from_master" {
-  name    = "${var.cluster_id}-compute-ingress-vxlan-from-master"
+resource "google_compute_firewall" "worker_ingress_vxlan_from_master" {
+  name    = "${var.cluster_id}-worker-ingress-vxlan-from-master"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -49,8 +49,8 @@ resource "google_compute_firewall" "compute_ingress_vxlan_from_master" {
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_internal" {
-  name    = "${var.cluster_id}-compute-ingress-internal"
+resource "google_compute_firewall" "worker_ingress_internal" {
+  name    = "${var.cluster_id}-worker-ingress-internal"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -62,8 +62,8 @@ resource "google_compute_firewall" "compute_ingress_internal" {
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_internal_from_master" {
-  name    = "${var.cluster_id}-compute-ingress-internal-from-master"
+resource "google_compute_firewall" "worker_ingress_internal_from_master" {
+  name    = "${var.cluster_id}-worker-ingress-internal-from-master"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -75,8 +75,8 @@ resource "google_compute_firewall" "compute_ingress_internal_from_master" {
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_internal_udp" {
-  name    = "${var.cluster_id}-compute-ingress-udp"
+resource "google_compute_firewall" "worker_ingress_internal_udp" {
+  name    = "${var.cluster_id}-worker-ingress-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -88,8 +88,8 @@ resource "google_compute_firewall" "compute_ingress_internal_udp" {
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_internal_from_master_udp" {
-  name    = "${var.cluster_id}-compute-ingress-udp-from-master"
+resource "google_compute_firewall" "worker_ingress_internal_from_master_udp" {
+  name    = "${var.cluster_id}-worker-ingress-from-master-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -101,8 +101,8 @@ resource "google_compute_firewall" "compute_ingress_internal_from_master_udp" {
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_kubelet_insecure" {
-  name    = "${var.cluster_id}-compute-ingress-kubelet-insecure"
+resource "google_compute_firewall" "worker_ingress_kubelet_insecure" {
+  name    = "${var.cluster_id}-worker-ingress-kubelet-insecure"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -114,8 +114,8 @@ resource "google_compute_firewall" "compute_ingress_kubelet_insecure" {
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_kubelet_insecure_from_master" {
-  name    = "${var.cluster_id}-compute-ingress-kubelet-insecure-from-master"
+resource "google_compute_firewall" "worker_ingress_kubelet_insecure_from_master" {
+  name    = "${var.cluster_id}-worker-ingress-kubelet-insecure-from-master"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -127,8 +127,8 @@ resource "google_compute_firewall" "compute_ingress_kubelet_insecure_from_master
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_services_tcp" {
-  name    = "${var.cluster_id}-compute-ingress-services-tcp"
+resource "google_compute_firewall" "worker_ingress_services_tcp" {
+  name    = "${var.cluster_id}-worker-ingress-services-tcp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -140,8 +140,8 @@ resource "google_compute_firewall" "compute_ingress_services_tcp" {
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "compute_ingress_services_udp" {
-  name    = "${var.cluster_id}-compute-ingress-services-udp"
+resource "google_compute_firewall" "worker_ingress_services_udp" {
+  name    = "${var.cluster_id}-worker-ingress-services-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {

--- a/data/data/gcp/network/firewall-control.tf
+++ b/data/data/gcp/network/firewall-control.tf
@@ -1,5 +1,5 @@
-resource "google_compute_firewall" "control_ingress_icmp" {
-  name    = "${var.cluster_id}-control-ingress-icmp"
+resource "google_compute_firewall" "master_ingress_icmp" {
+  name    = "${var.cluster_id}-master-ingress-icmp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -10,8 +10,8 @@ resource "google_compute_firewall" "control_ingress_icmp" {
   target_tags   = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_ssh" {
-  name    = "${var.cluster_id}-control-ingress-ssh"
+resource "google_compute_firewall" "master_ingress_ssh" {
+  name    = "${var.cluster_id}-master-ingress-ssh"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -23,8 +23,8 @@ resource "google_compute_firewall" "control_ingress_ssh" {
   target_tags   = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_https" {
-  name    = "${var.cluster_id}-control-ingress-https"
+resource "google_compute_firewall" "master_ingress_https" {
+  name    = "${var.cluster_id}-master-ingress-https"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -36,8 +36,8 @@ resource "google_compute_firewall" "control_ingress_https" {
   target_tags   = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_mcs" {
-  name    = "${var.cluster_id}-control-ingress-mcs"
+resource "google_compute_firewall" "master_ingress_mcs" {
+  name    = "${var.cluster_id}-master-ingress-mcs"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -49,8 +49,8 @@ resource "google_compute_firewall" "control_ingress_mcs" {
   target_tags   = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_vxlan" {
-  name    = "${var.cluster_id}-control-ingress-vxlan"
+resource "google_compute_firewall" "master_ingress_vxlan" {
+  name    = "${var.cluster_id}-master-ingress-vxlan"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -62,8 +62,8 @@ resource "google_compute_firewall" "control_ingress_vxlan" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_vxlan_from_compute" {
-  name    = "${var.cluster_id}-control-ingress-vxlan-from-compute"
+resource "google_compute_firewall" "master_ingress_vxlan_from_worker" {
+  name    = "${var.cluster_id}-master-ingress-vxlan-from-worker"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -75,8 +75,8 @@ resource "google_compute_firewall" "control_ingress_vxlan_from_compute" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_internal" {
-  name    = "${var.cluster_id}-control-ingress-internal"
+resource "google_compute_firewall" "master_ingress_internal" {
+  name    = "${var.cluster_id}-master-ingress-internal"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -88,8 +88,8 @@ resource "google_compute_firewall" "control_ingress_internal" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_internal_from_compute" {
-  name    = "${var.cluster_id}-control-ingress-internal-from-compute"
+resource "google_compute_firewall" "master_ingress_internal_from_worker" {
+  name    = "${var.cluster_id}-master-ingress-internal-from-worker"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -101,8 +101,8 @@ resource "google_compute_firewall" "control_ingress_internal_from_compute" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_internal_udp" {
-  name    = "${var.cluster_id}-control-ingress-internal-udp"
+resource "google_compute_firewall" "master_ingress_internal_udp" {
+  name    = "${var.cluster_id}-master-ingress-internal-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -114,8 +114,8 @@ resource "google_compute_firewall" "control_ingress_internal_udp" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_internal_from_compute_udp" {
-  name    = "${var.cluster_id}-control-ingress-internal-from-compute-udp"
+resource "google_compute_firewall" "master_ingress_internal_from_worker_udp" {
+  name    = "${var.cluster_id}-master-ingress-internal-from-worker-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -127,8 +127,8 @@ resource "google_compute_firewall" "control_ingress_internal_from_compute_udp" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_kube_scheduler" {
-  name    = "${var.cluster_id}-control-ingress-kube-scheduler"
+resource "google_compute_firewall" "master_ingress_kube_scheduler" {
+  name    = "${var.cluster_id}-master-ingress-kube-scheduler"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -140,8 +140,8 @@ resource "google_compute_firewall" "control_ingress_kube_scheduler" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_kube_scheduler_from_compute" {
-  name    = "${var.cluster_id}-control-ingress-kube-scheduler-from-compute"
+resource "google_compute_firewall" "master_ingress_kube_scheduler_from_worker" {
+  name    = "${var.cluster_id}-master-ingress-kube-scheduler-from-worker"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -153,8 +153,8 @@ resource "google_compute_firewall" "control_ingress_kube_scheduler_from_compute"
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_kube_controller_manager" {
-  name    = "${var.cluster_id}-control-ingress-kube-controller-manager"
+resource "google_compute_firewall" "master_ingress_kube_masterler_manager" {
+  name    = "${var.cluster_id}-master-ingress-kube-masterler-manager"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -166,8 +166,8 @@ resource "google_compute_firewall" "control_ingress_kube_controller_manager" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_kube_controller_manager_from_compute" {
-  name    = "${var.cluster_id}-control-ingress-kube-controller-manager-from-compute"
+resource "google_compute_firewall" "master_ingress_kube_masterler_manager_from_worker" {
+  name    = "${var.cluster_id}-master-ingress-kube-masterler-manager-from-worker"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -179,8 +179,8 @@ resource "google_compute_firewall" "control_ingress_kube_controller_manager_from
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_kubelet_secure" {
-  name    = "${var.cluster_id}-control-ingress-kubelet-secure"
+resource "google_compute_firewall" "master_ingress_kubelet_secure" {
+  name    = "${var.cluster_id}-master-ingress-kubelet-secure"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -192,8 +192,8 @@ resource "google_compute_firewall" "control_ingress_kubelet_secure" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_kubelet_secure_from_compute" {
-  name    = "${var.cluster_id}-control-ingress-kubelet-secure-from-compute"
+resource "google_compute_firewall" "master_ingress_kubelet_secure_from_worker" {
+  name    = "${var.cluster_id}-master-ingress-kubelet-secure-from-worker"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -205,8 +205,8 @@ resource "google_compute_firewall" "control_ingress_kubelet_secure_from_compute"
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_etcd" {
-  name    = "${var.cluster_id}-control-ingress-etcd"
+resource "google_compute_firewall" "master_ingress_etcd" {
+  name    = "${var.cluster_id}-master-ingress-etcd"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -218,8 +218,8 @@ resource "google_compute_firewall" "control_ingress_etcd" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_services_tcp" {
-  name    = "${var.cluster_id}-control-ingress-services-tcp"
+resource "google_compute_firewall" "master_ingress_services_tcp" {
+  name    = "${var.cluster_id}-master-ingress-services-tcp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -231,8 +231,8 @@ resource "google_compute_firewall" "control_ingress_services_tcp" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "control_ingress_services_udp" {
-  name    = "${var.cluster_id}-control-ingress-services-udp"
+resource "google_compute_firewall" "master_ingress_services_udp" {
+  name    = "${var.cluster_id}-master-ingress-services-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {

--- a/data/data/gcp/network/network.tf
+++ b/data/data/gcp/network/network.tf
@@ -4,14 +4,14 @@ resource "google_compute_network" "cluster_network" {
   auto_create_subnetworks = false
 }
 
-resource "google_compute_subnetwork" "compute_subnet" {
-  name          = "${var.cluster_id}-compute-subnet"
+resource "google_compute_subnetwork" "worker_subnet" {
+  name          = "${var.cluster_id}-worker-subnet"
   network       = google_compute_network.cluster_network.self_link
-  ip_cidr_range = var.compute_subnet_cidr
+  ip_cidr_range = var.worker_subnet_cidr
 }
 
-resource "google_compute_subnetwork" "control_subnet" {
-  name          = "${var.cluster_id}-control-subnet"
+resource "google_compute_subnetwork" "master_subnet" {
+  name          = "${var.cluster_id}-master-subnet"
   network       = google_compute_network.cluster_network.self_link
-  ip_cidr_range = var.control_subnet_cidr
+  ip_cidr_range = var.master_subnet_cidr
 }

--- a/data/data/gcp/network/outputs.tf
+++ b/data/data/gcp/network/outputs.tf
@@ -2,12 +2,12 @@ output "network" {
   value = google_compute_network.cluster_network.self_link
 }
 
-output "compute_subnet" {
-  value = google_compute_subnetwork.compute_subnet.self_link
+output "worker_subnet" {
+  value = google_compute_subnetwork.worker_subnet.self_link
 }
 
-output "control_subnet" {
-  value = google_compute_subnetwork.control_subnet.self_link
+output "master_subnet" {
+  value = google_compute_subnetwork.master_subnet.self_link
 }
 
 output "zones" {

--- a/data/data/gcp/network/variables.tf
+++ b/data/data/gcp/network/variables.tf
@@ -2,11 +2,11 @@ variable "cluster_id" {
   type = string
 }
 
-variable "compute_subnet_cidr" {
+variable "worker_subnet_cidr" {
   type = string
 }
 
-variable "control_subnet_cidr" {
+variable "master_subnet_cidr" {
   type = string
 }
 

--- a/data/data/gcp/variables-google.tf
+++ b/data/data/gcp/variables-google.tf
@@ -1,9 +1,36 @@
-variable "google_project" {
+variable "gcp_bootstrap_machine_type" {
   type        = string
+  description = "Machine type for the bootstrap node. Example: `n1-standard-2`."
+}
+
+variable "gcp_master_machine_type" {
+  type        = string
+  description = "Machine type for the master node(s). Example: `n1-standard-2`."
+}
+
+variable "gcp_extra_labels" {
+  type = map(string)
+
+  description = <<EOF
+(optional) Extra GCP labels to be applied to created resources.
+Example: `{ "key" = "value", "foo" = "bar" }`
+EOF
+
+  default = {}
+}
+
+variable "gcp_image_name_override" {
+  type = string
+  description = "(optional) Image name override for all nodes. Example: `image-foobar123`."
+  default = ""
+}
+
+variable "gcp_project" {
+  type = string
   description = "The target GCP project for the cluster."
 }
 
-variable "google_region" {
-  type        = string
+variable "gcp_region" {
+  type = string
   description = "The target GCP region for the cluster."
 }


### PR DESCRIPTION
This change adds the terraform bits to create the bootstrap and control
plane virtual machines for the google platform. It also creates groups
for use by the load balancers with one for bootstrap and one for each
control plane zone.