### PR TITLE
data/data/openstack: Generate master clustervars

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -55,18 +55,22 @@ module "bootstrap" {
 module "masters" {
   source = "./masters"
 
-  base_image     = var.openstack_base_image
-  cluster_id     = var.cluster_id
-  cluster_domain = var.cluster_domain
-  flavor_name    = var.openstack_master_flavor_name
-  instance_count = var.master_count
+  base_image          = var.openstack_base_image
+  bootstrap_ip        = module.topology.bootstrap_port_ip
+  cluster_id          = var.cluster_id
+  cluster_domain      = var.cluster_domain
+  flavor_name         = var.openstack_master_flavor_name
+  instance_count      = var.master_count
+  lb_floating_ip      = var.openstack_lb_floating_ip
+  master_ips          = module.topology.master_ips
+  master_port_ids     = module.topology.master_port_ids
+  master_port_names   = module.topology.master_port_names
+  user_data_ign       = var.ignition_master
+  service_vm_fixed_ip = module.topology.service_vm_fixed_ip
   master_sg_ids = concat(
     var.openstack_master_extra_sg_ids,
     [module.topology.master_sg_id],
   )
-  master_port_ids     = module.topology.master_port_ids
-  user_data_ign       = var.ignition_master
-  service_vm_fixed_ip = module.topology.service_vm_fixed_ip
 }
 
 # TODO(shadower) add a dns module here

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -21,6 +21,20 @@ EOF
   }
 }
 
+data "ignition_file" "clustervars" {
+  filesystem = "root"
+  mode = "420" // 0644
+  path = "/etc/kubernetes/static-pod-resources/clustervars"
+
+  content {
+    content = <<EOF
+export FLOATING_IP=${var.lb_floating_ip}
+export BOOTSTRAP_IP=${var.bootstrap_ip}
+${replace(join("\n", formatlist("export MASTER_FIXED_IPS_%s=%s", var.master_port_names, var.master_ips)), "${var.cluster_id}-master-port-", "")}
+EOF
+  }
+}
+
 data "ignition_config" "master_ignition_config" {
   count = var.instance_count
 
@@ -30,15 +44,16 @@ data "ignition_config" "master_ignition_config" {
 
   files = [
     element(data.ignition_file.hostname.*.id, count.index),
+    data.ignition_file.clustervars.id,
   ]
 }
 
 resource "openstack_compute_instance_v2" "master_conf" {
-  name = "${var.cluster_id}-master-${count.index}"
+  name  = "${var.cluster_id}-master-${count.index}"
   count = var.instance_count
 
-  flavor_id = data.openstack_compute_flavor_v2.masters_flavor.id
-  image_id = data.openstack_images_image_v2.masters_img.id
+  flavor_id       = data.openstack_compute_flavor_v2.masters_flavor.id
+  image_id        = data.openstack_images_image_v2.masters_img.id
   security_groups = var.master_sg_ids
   user_data = element(
     data.ignition_config.master_ignition_config.*.rendered,

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -2,6 +2,10 @@ variable "base_image" {
   type = string
 }
 
+variable "bootstrap_ip" {
+  type = string
+}
+
 variable "cluster_id" {
   type        = string
   description = "The identifier for the cluster."
@@ -20,6 +24,14 @@ variable "instance_count" {
   type = string
 }
 
+variable "lb_floating_ip" {
+  type = string
+}
+
+variable "master_ips" {
+  type = list(string)
+}
+
 variable "master_sg_ids" {
   type        = list(string)
   default     = ["default"]
@@ -31,6 +43,10 @@ variable "master_port_ids" {
   description = "List of port ids for the master nodes"
 }
 
+variable "master_port_names" {
+  type = list(string)
+}
+
 variable "user_data_ign" {
   type = string
 }
@@ -38,4 +54,3 @@ variable "user_data_ign" {
 variable "service_vm_fixed_ip" {
   type = string
 }
-


### PR DESCRIPTION
These variables are going to be used by the machine-config-operator to
seed the initial DNS and LB static pod configuration on each master.