### PR TITLE
OpenStack: Add subnet pools destroy

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -314,7 +314,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fafce8bcd6b10bcf75556a9649010fbfed5772302c1bf24fbc347558ccfa9c63"
+  digest = "1:c75010dd8aa8622064eb44b7639e0b80b2aaf031c6462219fc94391c3fb6a303"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -339,6 +339,7 @@
     "openstack/networking/v2/extensions/layer3/routers",
     "openstack/networking/v2/extensions/security/groups",
     "openstack/networking/v2/extensions/security/rules",
+    "openstack/networking/v2/extensions/subnetpools",
     "openstack/networking/v2/extensions/trunks",
     "openstack/networking/v2/networks",
     "openstack/networking/v2/ports",
@@ -1240,6 +1241,7 @@
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups",
+    "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/networks",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/doc.go
@@ -1,0 +1,72 @@
+/*
+Package subnetpools provides the ability to retrieve and manage subnetpools through the Neutron API.
+
+Example of Listing Subnetpools
+
+	listOpts := subnets.ListOpts{
+		IPVersion: 6,
+	}
+
+	allPages, err := subnetpools.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allSubnetpools, err := subnetpools.ExtractSubnetPools(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, subnetpools := range allSubnetpools {
+		fmt.Printf("%+v\n", subnetpools)
+	}
+
+Example to Get a Subnetpool
+
+	subnetPoolID = "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
+	subnetPool, err := subnetpools.Get(networkClient, subnetPoolID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Create a new Subnetpool
+
+	subnetPoolName := "private_pool"
+	subnetPoolPrefixes := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+	}
+	subnetPoolOpts := subnetpools.CreateOpts{
+		Name: subnetPoolName,
+		Prefixes: subnetPoolPrefixes,
+	}
+	subnetPool, err := subnetpools.Create(networkClient, subnetPoolOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Subnetpool
+
+	subnetPoolID := "099546ca-788d-41e5-a76d-17d8cd282d3e"
+	updateOpts := networks.UpdateOpts{
+		Prefixes: []string{
+		  "fdf7:b13d:dead:beef::/64",
+	  },
+		MaxPrefixLen: 72,
+	}
+
+	subnetPool, err := subnetpools.Update(networkClient, subnetPoolID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Subnetpool
+
+	subnetPoolID := "23d5d3f7-9dfa-4f73-b72b-8b0b0063ec55"
+	err := subnetpools.Delete(networkClient, subnetPoolID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package subnetpools

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/requests.go
@@ -1,0 +1,225 @@
+package subnetpools
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToSubnetPoolListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the Neutron API. Filtering is achieved by passing in struct field values
+// that map to the subnetpool attributes you want to see returned.
+// SortKey allows you to sort by a particular subnetpool attribute.
+// SortDir sets the direction, and is either `asc' or `desc'.
+// Marker and Limit are used for the pagination.
+type ListOpts struct {
+	ID               string `q:"id"`
+	Name             string `q:"name"`
+	DefaultQuota     int    `q:"default_quota"`
+	TenantID         string `q:"tenant_id"`
+	ProjectID        string `q:"project_id"`
+	DefaultPrefixLen int    `q:"default_prefixlen"`
+	MinPrefixLen     int    `q:"min_prefixlen"`
+	MaxPrefixLen     int    `q:"max_prefixlen"`
+	AddressScopeID   string `q:"address_scope_id"`
+	IPVersion        int    `q:"ip_version"`
+	Shared           *bool  `q:"shared"`
+	Description      string `q:"description"`
+	IsDefault        *bool  `q:"is_default"`
+	RevisionNumber   int    `q:"revision_number"`
+	Limit            int    `q:"limit"`
+	Marker           string `q:"marker"`
+	SortKey          string `q:"sort_key"`
+	SortDir          string `q:"sort_dir"`
+	Tags             string `q:"tags"`
+	TagsAny          string `q:"tags-any"`
+	NotTags          string `q:"not-tags"`
+	NotTagsAny       string `q:"not-tags-any"`
+}
+
+// ToSubnetPoolListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToSubnetPoolListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// subnetpools. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only the subnetpools owned by the project
+// of the user submitting the request, unless the user has the administrative role.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToSubnetPoolListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return SubnetPoolPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific subnetpool based on its ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSubnetPoolCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new subnetpool.
+type CreateOpts struct {
+	// Name is the human-readable name of the subnetpool.
+	Name string `json:"name"`
+
+	// DefaultQuota is the per-project quota on the prefix space
+	// that can be allocated from the subnetpool for project subnets.
+	DefaultQuota int `json:"default_quota,omitempty"`
+
+	// TenantID is the id of the Identity project.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the id of the Identity project.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Prefixes is the list of subnet prefixes to assign to the subnetpool.
+	// Neutron API merges adjacent prefixes and treats them as a single prefix.
+	// Each subnet prefix must be unique among all subnet prefixes in all subnetpools
+	// that are associated with the address scope.
+	Prefixes []string `json:"prefixes"`
+
+	// DefaultPrefixLen is the size of the prefix to allocate when the cidr
+	// or prefixlen attributes are omitted when you create the subnet.
+	// Defaults to the MinPrefixLen.
+	DefaultPrefixLen int `json:"default_prefixlen,omitempty"`
+
+	// MinPrefixLen is the smallest prefix that can be allocated from a subnetpool.
+	// For IPv4 subnetpools, default is 8.
+	// For IPv6 subnetpools, default is 64.
+	MinPrefixLen int `json:"min_prefixlen,omitempty"`
+
+	// MaxPrefixLen is the maximum prefix size that can be allocated from the subnetpool.
+	// For IPv4 subnetpools, default is 32.
+	// For IPv6 subnetpools, default is 128.
+	MaxPrefixLen int `json:"max_prefixlen,omitempty"`
+
+	// AddressScopeID is the Neutron address scope to assign to the subnetpool.
+	AddressScopeID string `json:"address_scope_id,omitempty"`
+
+	// Shared indicates whether this network is shared across all projects.
+	Shared bool `json:"shared,omitempty"`
+
+	// Description is the human-readable description for the resource.
+	Description string `json:"description,omitempty"`
+
+	// IsDefault indicates if the subnetpool is default pool or not.
+	IsDefault bool `json:"is_default,omitempty"`
+}
+
+// ToSubnetPoolCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToSubnetPoolCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "subnetpool")
+}
+
+// Create requests the creation of a new subnetpool on the server.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSubnetPoolCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{201},
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToSubnetPoolUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents options used to update a network.
+type UpdateOpts struct {
+	// Name is the human-readable name of the subnetpool.
+	Name string `json:"name,omitempty"`
+
+	// DefaultQuota is the per-project quota on the prefix space
+	// that can be allocated from the subnetpool for project subnets.
+	DefaultQuota *int `json:"default_quota,omitempty"`
+
+	// TenantID is the id of the Identity project.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the id of the Identity project.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Prefixes is the list of subnet prefixes to assign to the subnetpool.
+	// Neutron API merges adjacent prefixes and treats them as a single prefix.
+	// Each subnet prefix must be unique among all subnet prefixes in all subnetpools
+	// that are associated with the address scope.
+	Prefixes []string `json:"prefixes,omitempty"`
+
+	// DefaultPrefixLen is yhe size of the prefix to allocate when the cidr
+	// or prefixlen attributes are omitted when you create the subnet.
+	// Defaults to the MinPrefixLen.
+	DefaultPrefixLen int `json:"default_prefixlen,omitempty"`
+
+	// MinPrefixLen is the smallest prefix that can be allocated from a subnetpool.
+	// For IPv4 subnetpools, default is 8.
+	// For IPv6 subnetpools, default is 64.
+	MinPrefixLen int `json:"min_prefixlen,omitempty"`
+
+	// MaxPrefixLen is the maximum prefix size that can be allocated from the subnetpool.
+	// For IPv4 subnetpools, default is 32.
+	// For IPv6 subnetpools, default is 128.
+	MaxPrefixLen int `json:"max_prefixlen,omitempty"`
+
+	// AddressScopeID is the Neutron address scope to assign to the subnetpool.
+	AddressScopeID *string `json:"address_scope_id,omitempty"`
+
+	// Description is thehuman-readable description for the resource.
+	Description *string `json:"description,omitempty"`
+
+	// IsDefault indicates if the subnetpool is default pool or not.
+	IsDefault *bool `json:"is_default,omitempty"`
+}
+
+// ToSubnetPoolUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToSubnetPoolUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "subnetpool")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing subnetpool using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, subnetPoolID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToSubnetPoolUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, subnetPoolID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete accepts a unique ID and deletes the subnetpool associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/results.go
@@ -1,0 +1,203 @@
+package subnetpools
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a subnetpool resource.
+func (r commonResult) Extract() (*SubnetPool, error) {
+	var s struct {
+		SubnetPool *SubnetPool `json:"subnetpool"`
+	}
+	err := r.ExtractInto(&s)
+	return s.SubnetPool, err
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a SubnetPool.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a SubnetPool.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a SubnetPool.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// SubnetPool represents a Neutron subnetpool.
+// A subnetpool is a pool of addresses from which subnets can be allocated.
+type SubnetPool struct {
+	// ID is the id of the subnetpool.
+	ID string `json:"id"`
+
+	// Name is the human-readable name of the subnetpool.
+	Name string `json:"name"`
+
+	// DefaultQuota is the per-project quota on the prefix space
+	// that can be allocated from the subnetpool for project subnets.
+	DefaultQuota int `json:"default_quota"`
+
+	// TenantID is the id of the Identity project.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the id of the Identity project.
+	ProjectID string `json:"project_id"`
+
+	// CreatedAt is the time at which subnetpool has been created.
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is the time at which subnetpool has been created.
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// Prefixes is the list of subnet prefixes to assign to the subnetpool.
+	// Neutron API merges adjacent prefixes and treats them as a single prefix.
+	// Each subnet prefix must be unique among all subnet prefixes in all subnetpools
+	// that are associated with the address scope.
+	Prefixes []string `json:"prefixes"`
+
+	// DefaultPrefixLen is yhe size of the prefix to allocate when the cidr
+	// or prefixlen attributes are omitted when you create the subnet.
+	// Defaults to the MinPrefixLen.
+	DefaultPrefixLen int `json:"-"`
+
+	// MinPrefixLen is the smallest prefix that can be allocated from a subnetpool.
+	// For IPv4 subnetpools, default is 8.
+	// For IPv6 subnetpools, default is 64.
+	MinPrefixLen int `json:"-"`
+
+	// MaxPrefixLen is the maximum prefix size that can be allocated from the subnetpool.
+	// For IPv4 subnetpools, default is 32.
+	// For IPv6 subnetpools, default is 128.
+	MaxPrefixLen int `json:"-"`
+
+	// AddressScopeID is the Neutron address scope to assign to the subnetpool.
+	AddressScopeID string `json:"address_scope_id"`
+
+	// IPversion is the IP protocol version.
+	// Valid value is 4 or 6. Default is 4.
+	IPversion int `json:"ip_version"`
+
+	// Shared indicates whether this network is shared across all projects.
+	Shared bool `json:"shared"`
+
+	// Description is thehuman-readable description for the resource.
+	Description string `json:"description"`
+
+	// IsDefault indicates if the subnetpool is default pool or not.
+	IsDefault bool `json:"is_default"`
+
+	// RevisionNumber is the revision number of the subnetpool.
+	RevisionNumber int `json:"revision_number"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
+}
+
+func (r *SubnetPool) UnmarshalJSON(b []byte) error {
+	type tmp SubnetPool
+	var s struct {
+		tmp
+		DefaultPrefixLen interface{} `json:"default_prefixlen"`
+		MinPrefixLen     interface{} `json:"min_prefixlen"`
+		MaxPrefixLen     interface{} `json:"max_prefixlen"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = SubnetPool(s.tmp)
+
+	switch t := s.DefaultPrefixLen.(type) {
+	case string:
+		if r.DefaultPrefixLen, err = strconv.Atoi(t); err != nil {
+			return err
+		}
+	case float64:
+		r.DefaultPrefixLen = int(t)
+	default:
+		return fmt.Errorf("DefaultPrefixLen has unexpected type: %T", t)
+	}
+
+	switch t := s.MinPrefixLen.(type) {
+	case string:
+		if r.MinPrefixLen, err = strconv.Atoi(t); err != nil {
+			return err
+		}
+	case float64:
+		r.MinPrefixLen = int(t)
+	default:
+		return fmt.Errorf("MinPrefixLen has unexpected type: %T", t)
+	}
+
+	switch t := s.MaxPrefixLen.(type) {
+	case string:
+		if r.MaxPrefixLen, err = strconv.Atoi(t); err != nil {
+			return err
+		}
+	case float64:
+		r.MaxPrefixLen = int(t)
+	default:
+		return fmt.Errorf("MaxPrefixLen has unexpected type: %T", t)
+	}
+
+	return nil
+}
+
+// SubnetPoolPage stores a single page of SubnetPools from a List() API call.
+type SubnetPoolPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of subnetpools has reached
+// the end of a page and the pager seeks to traverse over a new one.
+// In order to do this, it needs to construct the next page's URL.
+func (r SubnetPoolPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"subnetpools_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty determines whether or not a SubnetPoolPage is empty.
+func (r SubnetPoolPage) IsEmpty() (bool, error) {
+	subnetpools, err := ExtractSubnetPools(r)
+	return len(subnetpools) == 0, err
+}
+
+// ExtractSubnetPools interprets the results of a single page from a List() API call,
+// producing a slice of SubnetPools structs.
+func ExtractSubnetPools(r pagination.Page) ([]SubnetPool, error) {
+	var s struct {
+		SubnetPools []SubnetPool `json:"subnetpools"`
+	}
+	err := (r.(SubnetPoolPage)).ExtractInto(&s)
+	return s.SubnetPools, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools/urls.go
@@ -1,0 +1,33 @@
+package subnetpools
+
+import "github.com/gophercloud/gophercloud"
+
+const resourcePath = "subnetpools"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(resourcePath)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
This PR adds support for subnet pool deletion on cluster destroy. It uses tags to filter the subnet pools and delete them.