### PR TITLE
Make `terraform fmt` output diff

### DIFF
--- a/hack/tf-fmt.sh
+++ b/hack/tf-fmt.sh
@@ -3,7 +3,7 @@
 # in prow, already in container, so no 'podman run'
 if [ "$IS_CONTAINER" != "" ]; then
   if [ "${#N}" -eq 0 ]; then
-    set -- -list -check -write=false -recursive data/data/
+    set -- -list -check -diff -write=false -recursive data/data/
   fi
   set -x
   terraform fmt "${@}"


### PR DESCRIPTION
So that the output is more useful and actionable. Otherwise, you just see the list of files in the CI job (or any other users of this script) output and that's not great.