### PR TITLE
Add terminal prompts for GCP: region, project id, & base domain.

### DIFF
--- a/pkg/asset/installconfig/gcp/dns.go
+++ b/pkg/asset/installconfig/gcp/dns.go
@@ -3,20 +3,18 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	dns "google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
+	survey "gopkg.in/AlecAivazis/survey.v1"
 )
 
-// GetPublicZone returns a DNS managed zone from the provided project which matches the baseDomain
-// If multiple zones match the basedomain, it uses the last public zone in the list as provided by the GCP API.
-func GetPublicZone(ctx context.Context, project, baseDomain string) (managedZone *dns.ManagedZone, err error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
-	defer cancel()
-
+func getDNSService(ctx context.Context) (*dns.Service, error) {
 	ssn, err := GetSession(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get session")
@@ -25,6 +23,19 @@ func GetPublicZone(ctx context.Context, project, baseDomain string) (managedZone
 	svc, err := dns.NewService(ctx, option.WithCredentials(ssn.Credentials))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create compute service")
+	}
+	return svc, nil
+}
+
+// GetPublicZone returns a DNS managed zone from the provided project which matches the baseDomain
+// If multiple zones match the basedomain, it uses the last public zone in the list as provided by the GCP API.
+func GetPublicZone(ctx context.Context, project, baseDomain string) (*dns.ManagedZone, error) {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	svc, err := getDNSService(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if !strings.HasSuffix(baseDomain, ".") {
@@ -35,7 +46,7 @@ func GetPublicZone(ctx context.Context, project, baseDomain string) (managedZone
 	var res *dns.ManagedZone
 	if err := req.Pages(ctx, func(page *dns.ManagedZonesListResponse) error {
 		for idx, v := range page.ManagedZones {
-			if v.Visibility == "public" {
+			if v.Visibility != "private" {
 				res = page.ManagedZones[idx]
 			}
 		}
@@ -47,4 +58,62 @@ func GetPublicZone(ctx context.Context, project, baseDomain string) (managedZone
 		return nil, errors.New("no matching public DNS Zone found")
 	}
 	return res, nil
+}
+
+// GetBaseDomain returns a base domain chosen from among the project's public DNS zones.
+func GetBaseDomain(project string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
+	defer cancel()
+
+	svc, err := getDNSService(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	var publicZones []string
+	req := svc.ManagedZones.List(project).Context(ctx)
+	if err := req.Pages(ctx, func(page *dns.ManagedZonesListResponse) error {
+		for _, v := range page.ManagedZones {
+			if v.Visibility != "private" {
+				publicZones = append(publicZones, strings.TrimSuffix(v.DnsName, "."))
+			}
+		}
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	if len(publicZones) == 0 {
+		return "", errors.New("no domain names found in project")
+	}
+
+	var domain string
+	if err := survey.AskOne(&survey.Select{
+		Message: "Base Domain",
+		Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base and will also include the cluster name.\n\nIf you don't see you intended base-domain listed, create a new public hosted zone and rerun the installer.",
+		Options: publicZones,
+	}, &domain, func(ans interface{}) error {
+		choice := ans.(string)
+		i := sort.SearchStrings(publicZones, choice)
+		if i == len(publicZones) || publicZones[i] != choice {
+			return errors.Errorf("invalid base domain %q", choice)
+		}
+		return nil
+	}); err != nil {
+		return "", errors.Wrap(err, "failed UserInput for base domain")
+	}
+
+	return domain, nil
+}
+
+// IsForbidden checks whether a response from the GPC API was forbidden,
+// indicating that a given service account cannot access the specified project.
+func IsForbidden(err error) bool {
+	gErr, ok := err.(*googleapi.Error)
+	return ok && gErr.Code == 403
+}
+
+// IsThrottled checks whether a response from the GPC API returns Too Many Requests
+func IsThrottled(err error) bool {
+	gErr, ok := err.(*googleapi.Error)
+	return ok && gErr.Code == 429
 }

--- a/pkg/asset/installconfig/gcp/gcp.go
+++ b/pkg/asset/installconfig/gcp/gcp.go
@@ -1,10 +1,93 @@
 package gcp
 
 import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
 	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/gcp/validation"
+	"github.com/pkg/errors"
+	"gopkg.in/AlecAivazis/survey.v1"
 )
 
 // Platform collects GCP-specific configuration.
 func Platform() (*gcp.Platform, error) {
-	return &gcp.Platform{}, nil
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	project, err := selectProject(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	region, err := selectRegion(project)
+
+	return &gcp.Platform{
+		ProjectID: project,
+		Region:    region,
+	}, nil
+}
+
+func selectProject(ctx context.Context) (string, error) {
+	ssn, err := GetSession(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get session")
+	}
+	defaultProject := ssn.Credentials.ProjectID
+
+	var selectedProject string
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Project ID",
+				Help:    "The project id where the cluster will be provisioned. The default is taken from the provided service account.",
+				Default: defaultProject,
+			},
+		},
+	}, &selectedProject)
+	return selectedProject, nil
+}
+
+func selectRegion(project string) (string, error) {
+	longRegions := make([]string, 0, len(validation.Regions))
+	shortRegions := make([]string, 0, len(validation.Regions))
+	for id, location := range validation.Regions {
+		longRegions = append(longRegions, fmt.Sprintf("%s (%s)", id, location))
+		shortRegions = append(shortRegions, id)
+	}
+	regionTransform := survey.TransformString(func(s string) string {
+		return strings.SplitN(s, " ", 2)[0]
+	})
+
+	sort.Strings(longRegions)
+	sort.Strings(shortRegions)
+
+	defaultRegion := "us-central1"
+	var selectedRegion string
+	err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Select{
+				Message: "Region",
+				Help:    "The GCP region to be used for installation.",
+				Default: fmt.Sprintf("%s (%s)", defaultRegion, validation.Regions[defaultRegion]),
+				Options: longRegions,
+			},
+			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				choice := regionTransform(ans).(string)
+				i := sort.SearchStrings(shortRegions, choice)
+				if i == len(shortRegions) || shortRegions[i] != choice {
+					return errors.Errorf("invalid region %q", choice)
+				}
+				return nil
+			}),
+			Transform: regionTransform,
+		},
+	}, &selectedRegion)
+	if err != nil {
+		return "", err
+	}
+
+	return selectedRegion, nil
 }

--- a/pkg/asset/installconfig/gcp/session.go
+++ b/pkg/asset/installconfig/gcp/session.go
@@ -54,7 +54,6 @@ func loadCredentials(ctx context.Context) (*googleoauth.Credentials, error) {
 	for _, l := range loaders {
 		creds, err := l.Load(ctx)
 		if err != nil {
-			logrus.Debug(errors.Wrapf(err, "failed to load credentials from %s", l))
 			continue
 		}
 		return creds, nil
@@ -160,8 +159,9 @@ func (u *userLoader) Load(ctx context.Context) (*googleoauth.Credentials, error)
 	err := survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Multiline{
-				Message: "service account",
-				Help:    "The location to file that contains the service account in JSON, or the service account in JSON format",
+				Message: "Service Account (absolute path to file or JSON content)",
+				// Due to a bug in survey pkg, help message is not rendered
+				Help: "The location to file that contains the service account in JSON, or the service account in JSON format",
 			},
 		},
 	}, &content)

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -72,6 +72,7 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 	a.Config.OpenStack = platform.OpenStack
 	a.Config.VSphere = platform.VSphere
 	a.Config.Azure = platform.Azure
+	a.Config.GCP = platform.GCP
 
 	if err := a.setDefaults(); err != nil {
 		return errors.Wrap(err, "failed to set defaults for install config")

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -12,21 +12,27 @@ var (
 	// the short name of the region. The value of the map is the long
 	// name of the region.
 	Regions = map[string]string{
-		"northamerica-northeast1": "Montréal",
-		"us-central":              "Iowa",
-		"us-west2":                "Los Angeles",
-		"us-east1":                "South Carolina",
-		"us-east4":                "Northern Virginia",
-		"southamerica-east1":      "São Paulo",
-		"europe-west":             "Belgium",
-		"europe-west2":            "London",
-		"europe-west3":            "Frankfurt",
-		"europe-west6":            "Zürich",
-		"asia-northeast1":         "Tokyo",
-		"asia-northeast2":         "Osaka",
+		// List from: https://cloud.google.com/compute/docs/regions-zones/
+		"asia-east1":              "Changhua County, Taiwan",
 		"asia-east2":              "Hong Kong",
-		"asia-south1":             "Mumbai",
-		"australia-southeast1":    "Sydney",
+		"asia-northeast1":         "Tokyo, Japan",
+		"asia-northeast2":         "Osaka, Japan",
+		"asia-south1":             "Mumbai, India",
+		"asia-southeast1":         "Jurong West, Singapore",
+		"australia-southeast1":    "Sydney, Australia",
+		"europe-north1":           "Hamina, Finland",
+		"europe-west1":            "St. Ghislain, Belgium",
+		"europe-west2":            "London, England, UK",
+		"europe-west3":            "Frankfurt, Germany",
+		"europe-west4":            "Eemshaven, Netherlands",
+		"europe-west6":            "Zürich, Switzerland",
+		"northamerica-northeast1": "Montréal, Québec, Canada",
+		"southamerica-east1":      "São Paulo, Brazil",
+		"us-central1":             "Council Bluffs, Iowa, USA",
+		"us-east1":                "Moncks Corner, South Carolina, USA",
+		"us-east4":                "Ashburn, Northern Virginia, USA",
+		"us-west1":                "The Dalles, Oregon, USA",
+		"us-west2":                "Los Angeles, California, USA",
 	}
 	validRegionValues = func() []string {
 		validValues := make([]string, len(Regions))


### PR DESCRIPTION
Add interactive terminal prompts to allow users to select region, project id and base domain when using the GCP platform. Automatically populate available regions and base domains based on project. Validate project ID.

WIP: Working on completing regions, considering moving region validation to work in both install config and terminal prompts. 

[CORS-1115](https://jira.coreos.com/browse/CORS-1115)