### PR TITLE
gcp: Create public and private load balancers

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -23,3 +23,21 @@ resource "google_compute_instance" "bootstrap" {
 
   labels = var.labels
 }
+
+resource "google_compute_instance_group" "bootstrap" {
+  name    = "${var.cluster_id}-bootstrap"
+  network = var.network
+  zone    = var.zone
+
+  named_port {
+    name = "ignition"
+    port = "22623"
+  }
+
+  named_port {
+    name = "https"
+    port = "6443"
+  }
+
+  instances = [google_compute_instance.bootstrap.self_link]
+}

--- a/data/data/gcp/bootstrap/output.tf
+++ b/data/data/gcp/bootstrap/output.tf
@@ -1,0 +1,7 @@
+output "bootstrap_instance" {
+  value = google_compute_instance.bootstrap.self_link
+}
+
+output "bootstrap_instance_group" {
+  value = google_compute_instance_group.bootstrap.self_link
+}

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -15,7 +15,7 @@ module "bootstrap" {
   source = "./bootstrap"
 
   image_name   = var.gcp_image_id
-  machine_type = var.gcp_bootstrap_machine_type
+  machine_type = var.gcp_bootstrap_instance_type
   cluster_id   = var.cluster_id
   ignition     = var.ignition_bootstrap
   network      = module.network.network
@@ -30,7 +30,7 @@ module "master" {
 
   image_name     = var.gcp_image_id
   instance_count = var.master_count
-  machine_type   = var.gcp_master_machine_type
+  machine_type   = var.gcp_master_instance_type
   cluster_id     = var.cluster_id
   ignition       = var.ignition_master
   network        = module.network.network
@@ -47,4 +47,10 @@ module "network" {
   master_subnet_cidr = local.master_subnet_cidr
   worker_subnet_cidr = local.worker_subnet_cidr
   network_cidr       = var.machine_cidr
+
+  bootstrap_instance = module.bootstrap.bootstrap_instance
+  master_instances   = module.master.master_instances
+
+  bootstrap_instance_group = module.bootstrap.bootstrap_instance_group
+  master_instance_groups   = module.master.master_instance_groups
 }

--- a/data/data/gcp/master/outputs.tf
+++ b/data/data/gcp/master/outputs.tf
@@ -1,3 +1,7 @@
 output "master_instances" {
   value = google_compute_instance.master.*.self_link
 }
+
+output "master_instance_groups" {
+  value = google_compute_instance_group.master.*.self_link
+}

--- a/data/data/gcp/network/external-lb.tf
+++ b/data/data/gcp/network/external-lb.tf
@@ -1,0 +1,25 @@
+resource "google_compute_address" "cluster_public_ip" {
+  name = "${var.cluster_id}-cluster-public-ip"
+}
+
+resource "google_compute_http_health_check" "api_external" {
+  name = "${var.cluster_id}-api-external"
+
+  port         = 6443
+  request_path = "/readyz"
+}
+
+resource "google_compute_target_pool" "api_external" {
+  name = "${var.cluster_id}-api-external"
+
+  instances     = concat(var.master_instances, [var.bootstrap_instance])
+  health_checks = [google_compute_http_health_check.api_external.self_link]
+}
+
+resource "google_compute_forwarding_rule" "api_external" {
+  name = "${var.cluster_id}-api-external"
+
+  ip_address = google_compute_address.cluster_public_ip.address
+  target     = google_compute_target_pool.api_external.self_link
+  port_range = "6443"
+}

--- a/data/data/gcp/network/firewall-control.tf
+++ b/data/data/gcp/network/firewall-control.tf
@@ -36,6 +36,19 @@ resource "google_compute_firewall" "master_ingress_https" {
   target_tags   = ["${var.cluster_id}-master"]
 }
 
+resource "google_compute_firewall" "master_ingress_https_from_health_checks" {
+  name    = "${var.cluster_id}-master-ingress-https-from-health-checks"
+  network = google_compute_network.cluster_network.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["6443"]
+  }
+
+  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22"]
+  target_tags   = ["${var.cluster_id}-master"]
+}
+
 resource "google_compute_firewall" "master_ingress_mcs" {
   name    = "${var.cluster_id}-master-ingress-mcs"
   network = google_compute_network.cluster_network.self_link

--- a/data/data/gcp/network/internal-lb.tf
+++ b/data/data/gcp/network/internal-lb.tf
@@ -1,0 +1,36 @@
+resource "google_compute_health_check" "api_internal" {
+  name = "${var.cluster_id}-api-internal"
+
+  https_health_check {
+    port         = 6443
+    request_path = "/readyz"
+  }
+}
+
+resource "google_compute_region_backend_service" "api_internal" {
+  name = "${var.cluster_id}-api-internal"
+
+  load_balancing_scheme = "INTERNAL"
+  protocol              = "TCP"
+  timeout_sec           = 120
+
+  dynamic "backend" {
+    for_each = concat(var.master_instance_groups, [var.bootstrap_instance_group])
+
+    content {
+      group = backend.value
+    }
+  }
+
+  health_checks = [google_compute_health_check.api_internal.self_link]
+}
+
+resource "google_compute_forwarding_rule" "api_internal" {
+  name = "${var.cluster_id}-api-internal"
+
+  backend_service = google_compute_region_backend_service.api_internal.self_link
+  ports           = ["6443", "22623"]
+  subnetwork      = google_compute_subnetwork.master_subnet.self_link
+
+  load_balancing_scheme = "INTERNAL"
+}

--- a/data/data/gcp/network/outputs.tf
+++ b/data/data/gcp/network/outputs.tf
@@ -1,3 +1,11 @@
+output "cluster_public_ip" {
+  value = google_compute_forwarding_rule.api_external.ip_address
+}
+
+output "cluster_private_ip" {
+  value = google_compute_forwarding_rule.api_internal.ip_address
+}
+
 output "network" {
   value = google_compute_network.cluster_network.self_link
 }

--- a/data/data/gcp/network/variables.tf
+++ b/data/data/gcp/network/variables.tf
@@ -1,9 +1,29 @@
+variable "bootstrap_instance" {
+  type        = string
+  description = "The bootstrap instance."
+}
+
+variable "bootstrap_instance_group" {
+  type        = string
+  description = "The instance group that hold the bootstrap instance in this region."
+}
+
 variable "cluster_id" {
   type = string
 }
 
 variable "worker_subnet_cidr" {
   type = string
+}
+
+variable "master_instances" {
+  type        = list
+  description = "The master instances."
+}
+
+variable "master_instance_groups" {
+  type        = list
+  description = "The instance groups that hold the master instances in this region."
 }
 
 variable "master_subnet_cidr" {


### PR DESCRIPTION
This change adds internal and external load balancers to the google
provider. Due to the nature of gcp load balancing, there are a few
challenges to consider:

- The internal balancer uses backend services. It will be difficult to
maintain their memberships.
- The external balancer uses target pools, which only supports legacy
google_compute_http_health_check.