### PR TITLE
[gcp] pkg/destroy/gcp - use debug for error logging

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -124,7 +124,7 @@ func (o *ClusterUninstaller) destroyCluster() (bool, error) {
 		err := f.destroy()
 		if err != nil {
 			hasErr = true
-			o.Logger.Errorf("%s: %v", f.name, err)
+			o.Logger.Debugf("%s: %v", f.name, err)
 		}
 	}
 	return !hasErr, nil

--- a/pkg/destroy/gcp/network.go
+++ b/pkg/destroy/gcp/network.go
@@ -413,7 +413,7 @@ func (o *ClusterUninstaller) destroyNetworks() error {
 		}
 		for _, route := range routes {
 			if err = o.deleteRoute(route); err != nil {
-				o.Logger.Debug("error deleting route %s: %v", route, err)
+				o.Logger.Debugf("Failed to delete route %s: %v", route, err)
 			}
 		}
 


### PR DESCRIPTION
Other destroyers only output errors at the debug level. This makes the
gcp destroyer behave the same way.