### PR TITLE
azure: create an image for booting machines for the cluster from vhd blob

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -99,9 +99,6 @@ resource "azurerm_network_interface_backend_address_pool_association" "internal_
   ip_configuration_name   = local.bootstrap_nic_ip_configuration_name
 }
 
-data "azurerm_subscription" "current" {
-}
-
 resource "azurerm_virtual_machine" "bootstrap" {
   name                  = "${var.cluster_id}-bootstrap"
   location              = var.region
@@ -126,7 +123,7 @@ resource "azurerm_virtual_machine" "bootstrap" {
   }
 
   storage_image_reference {
-    id = "${data.azurerm_subscription.current.id}${var.vm_image}"
+    id = var.vm_image
   }
 
   os_profile {

--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -48,9 +48,9 @@ variable "ilb_backend_pool_id" {
   description = "The internal load balancer bakend pool id. used to attach the bootstrap NIC"
 }
 
-variable "boot_diag_blob_endpoint" {
-  type        = string
-  description = "the blob endpoint where machines should store their boot diagnostics."
+variable "storage_account" {
+  type        = any
+  description = "the storage account for the cluster. It can be used for boot diagnostics."
 }
 
 variable "tags" {

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -22,7 +22,7 @@ module "bootstrap" {
   resource_group_name = azurerm_resource_group.main.name
   region              = var.azure_region
   vm_size             = var.azure_bootstrap_vm_type
-  vm_image            = var.azure_image_id
+  vm_image            = azurerm_image.cluster.id
   identity            = azurerm_user_assigned_identity.main.id
   cluster_id          = var.cluster_id
   ignition            = var.ignition_bootstrap
@@ -59,7 +59,7 @@ module "master" {
   region              = var.azure_region
   availability_zones  = var.azure_master_availability_zones
   vm_size             = var.azure_master_vm_type
-  vm_image            = var.azure_image_id
+  vm_image            = azurerm_image.cluster.id
   identity            = azurerm_user_assigned_identity.main.id
   ignition            = var.ignition_master
   external_lb_id      = module.vnet.public_lb_id
@@ -134,4 +134,34 @@ resource "azurerm_virtual_network" "cluster_vnet" {
   resource_group_name = azurerm_resource_group.main.name
   location            = var.azure_region
   address_space       = [var.machine_cidr]
+}
+
+# copy over the vhd to cluster resource group and create an image using that
+resource "azurerm_storage_container" "vhd" {
+  name                 = "vhd"
+  resource_group_name  = azurerm_resource_group.main.name
+  storage_account_name = azurerm_storage_account.cluster.name
+}
+
+resource "azurerm_storage_blob" "rhcos_image" {
+  name                   = "rhcos${random_string.storage_suffix.result}.vhd"
+  resource_group_name    = azurerm_resource_group.main.name
+  storage_account_name   = azurerm_storage_account.cluster.name
+  storage_container_name = azurerm_storage_container.vhd.name
+  type                   = "block"
+  source_uri             = var.azure_image_url
+  metadata               = map("source_uri", "var.azure_image_url")
+  attempts               = 2
+}
+
+resource "azurerm_image" "cluster" {
+  name                = var.cluster_id
+  resource_group_name = azurerm_resource_group.main.name
+  location            = var.azure_region
+
+  os_disk {
+    os_type  = "Linux"
+    os_state = "Generalized"
+    blob_uri = azurerm_storage_blob.rhcos_image.url
+  }
 }

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -18,20 +18,20 @@ provider "azurerm" {
 }
 
 module "bootstrap" {
-  source                  = "./bootstrap"
-  resource_group_name     = azurerm_resource_group.main.name
-  region                  = var.azure_region
-  vm_size                 = var.azure_bootstrap_vm_type
-  vm_image                = var.azure_image_id
-  identity                = azurerm_user_assigned_identity.main.id
-  cluster_id              = var.cluster_id
-  ignition                = var.ignition_bootstrap
-  subnet_id               = module.vnet.public_subnet_id
-  elb_backend_pool_id     = module.vnet.public_lb_backend_pool_id
-  ilb_backend_pool_id     = module.vnet.internal_lb_backend_pool_id
-  tags                    = local.tags
-  boot_diag_blob_endpoint = azurerm_storage_account.bootdiag.primary_blob_endpoint
-  nsg_name                = module.vnet.master_nsg_name
+  source              = "./bootstrap"
+  resource_group_name = azurerm_resource_group.main.name
+  region              = var.azure_region
+  vm_size             = var.azure_bootstrap_vm_type
+  vm_image            = var.azure_image_id
+  identity            = azurerm_user_assigned_identity.main.id
+  cluster_id          = var.cluster_id
+  ignition            = var.ignition_bootstrap
+  subnet_id           = module.vnet.public_subnet_id
+  elb_backend_pool_id = module.vnet.public_lb_backend_pool_id
+  ilb_backend_pool_id = module.vnet.internal_lb_backend_pool_id
+  tags                = local.tags
+  storage_account     = azurerm_storage_account.cluster
+  nsg_name            = module.vnet.master_nsg_name
 
   # This is to create explicit dependency on private zone to exist before VMs are created in the vnet. https://github.com/MicrosoftDocs/azure-docs/issues/13728
   private_dns_zone_id = azurerm_dns_zone.private.id
@@ -53,23 +53,23 @@ module "vnet" {
 }
 
 module "master" {
-  source                  = "./master"
-  resource_group_name     = azurerm_resource_group.main.name
-  cluster_id              = var.cluster_id
-  region                  = var.azure_region
-  availability_zones      = var.azure_master_availability_zones
-  vm_size                 = var.azure_master_vm_type
-  vm_image                = var.azure_image_id
-  identity                = azurerm_user_assigned_identity.main.id
-  ignition                = var.ignition_master
-  external_lb_id          = module.vnet.public_lb_id
-  elb_backend_pool_id     = module.vnet.public_lb_backend_pool_id
-  ilb_backend_pool_id     = module.vnet.internal_lb_backend_pool_id
-  subnet_id               = module.vnet.public_subnet_id
-  master_subnet_cidr      = local.master_subnet_cidr
-  instance_count          = var.master_count
-  boot_diag_blob_endpoint = azurerm_storage_account.bootdiag.primary_blob_endpoint
-  os_volume_size          = var.azure_master_root_volume_size
+  source              = "./master"
+  resource_group_name = azurerm_resource_group.main.name
+  cluster_id          = var.cluster_id
+  region              = var.azure_region
+  availability_zones  = var.azure_master_availability_zones
+  vm_size             = var.azure_master_vm_type
+  vm_image            = var.azure_image_id
+  identity            = azurerm_user_assigned_identity.main.id
+  ignition            = var.ignition_master
+  external_lb_id      = module.vnet.public_lb_id
+  elb_backend_pool_id = module.vnet.public_lb_backend_pool_id
+  ilb_backend_pool_id = module.vnet.internal_lb_backend_pool_id
+  subnet_id           = module.vnet.public_subnet_id
+  master_subnet_cidr  = local.master_subnet_cidr
+  instance_count      = var.master_count
+  storage_account     = azurerm_storage_account.cluster
+  os_volume_size      = var.azure_master_root_volume_size
 
   # This is to create explicit dependency on private zone to exist before VMs are created in the vnet. https://github.com/MicrosoftDocs/azure-docs/issues/13728
   private_dns_zone_id = azurerm_dns_zone.private.id
@@ -100,8 +100,8 @@ resource "azurerm_resource_group" "main" {
   tags     = local.tags
 }
 
-resource "azurerm_storage_account" "bootdiag" {
-  name                     = "bootdiagmasters${random_string.storage_suffix.result}"
+resource "azurerm_storage_account" "cluster" {
+  name                     = "cluster${random_string.storage_suffix.result}"
   resource_group_name      = azurerm_resource_group.main.name
   location                 = var.azure_region
   account_tier             = "Standard"

--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -80,7 +80,7 @@ resource "azurerm_virtual_machine" "master" {
 
   boot_diagnostics {
     enabled     = true
-    storage_uri = var.boot_diag_blob_endpoint
+    storage_uri = var.storage_account.primary_blob_endpoint
   }
 }
 

--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -31,9 +31,6 @@ resource "azurerm_network_interface_backend_address_pool_association" "master_in
   ip_configuration_name   = local.ip_configuration_name #must be the same as nic's ip configuration name.
 }
 
-data "azurerm_subscription" "current" {
-}
-
 resource "azurerm_virtual_machine" "master" {
   count                 = var.instance_count
   name                  = "${var.cluster_id}-master-${count.index}"
@@ -59,7 +56,7 @@ resource "azurerm_virtual_machine" "master" {
   }
 
   storage_image_reference {
-    id = "${data.azurerm_subscription.current.id}${var.vm_image}"
+    id = var.vm_image
   }
 
   //we don't provide a ssh key, because it is set with ignition. 

--- a/data/data/azure/master/variables.tf
+++ b/data/data/azure/master/variables.tf
@@ -69,9 +69,9 @@ variable "tags" {
   description = "tags to be applied to created resources."
 }
 
-variable "boot_diag_blob_endpoint" {
-  type        = string
-  description = "the blob endpoint where machines should store their boot diagnostics."
+variable "storage_account" {
+  type        = any
+  description = "the storage account for the cluster. It can be used for boot diagnostics."
 }
 
 variable "ignition" {

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -46,9 +46,9 @@ type        = string
 description = "The resource group that contains the dns zone used as base domain for the cluster."
 }
 
-variable "azure_image_id" {
+variable "azure_image_url" {
 type        = string
-description = "The resource id of the vm image used for all node."
+description = "The URL of the vm image used for all nodes."
 }
 
 variable "azure_subscription_id" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -177,6 +177,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		data, err := azuretfvars.TFVars(
 			auth,
 			installConfig.Config.Azure.BaseDomainResourceGroupName,
+			string(*rhcosImage),
 			masterConfigs,
 		)
 		if err != nil {

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -94,7 +94,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		Location:          platform.Region,
 		VMSize:            mpool.InstanceType,
 		Image: azureprovider.Image{
-			ResourceID: osImage,
+			ResourceID: fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/images/%s", clusterID+"-rg", clusterID),
 		},
 		OSDisk: azureprovider.OSDisk{
 			OSType:     "Linux",

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -70,7 +70,7 @@ func (i *Image) Generate(p asset.Parents) error {
 	case openstack.Name:
 		osimage = "rhcos"
 	case azure.Name:
-		osimage = "https://openshifttechpreview.blob.core.windows.net/rhcos/rhcos-410.8.20190504.0-azure.vhd"
+		osimage = "https://rhcospipelineimages2.blob.core.windows.net/imagebucket/rhcos-420devel.8.20190719.0.vhd"
 	case baremetal.Name:
 		osimage, err = rhcos.QEMU(ctx)
 	case none.Name, vsphere.Name:

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -70,8 +70,7 @@ func (i *Image) Generate(p asset.Parents) error {
 	case openstack.Name:
 		osimage = "rhcos"
 	case azure.Name:
-		//TODO(serbrech): change to right image once available.
-		osimage = "/resourceGroups/rhcos_images/providers/Microsoft.Compute/images/rhcostestimage"
+		osimage = "https://openshifttechpreview.blob.core.windows.net/rhcos/rhcos-410.8.20190504.0-azure.vhd"
 	case baremetal.Name:
 		osimage, err = rhcos.QEMU(ctx)
 	case none.Name, vsphere.Name:

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -22,15 +22,15 @@ type config struct {
 	ExtraTags                   map[string]string `json:"azure_extra_tags,omitempty"`
 	BootstrapInstanceType       string            `json:"azure_bootstrap_vm_type,omitempty"`
 	MasterInstanceType          string            `json:"azure_master_vm_type,omitempty"`
+	MasterAvailabilityZones     []string          `json:"azure_master_availability_zones"`
 	VolumeSize                  int32             `json:"azure_master_root_volume_size,omitempty"`
-	VMImageID                   string            `json:"azure_image_id,omitempty"`
+	ImageURL                    string            `json:"azure_image_url,omitempty"`
 	Region                      string            `json:"azure_region,omitempty"`
 	BaseDomainResourceGroupName string            `json:"azure_base_domain_resource_group_name,omitempty"`
-	MasterAvailabilityZones     []string          `json:"azure_master_availability_zones"`
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
-func TFVars(auth Auth, baseDomainResourceGroupName string, masterConfigs []*azureprovider.AzureMachineProviderSpec) ([]byte, error) {
+func TFVars(auth Auth, baseDomainResourceGroupName string, imageURL string, masterConfigs []*azureprovider.AzureMachineProviderSpec) ([]byte, error) {
 	masterConfig := masterConfigs[0]
 	region := masterConfig.Location
 
@@ -45,9 +45,9 @@ func TFVars(auth Auth, baseDomainResourceGroupName string, masterConfigs []*azur
 		BaseDomainResourceGroupName: baseDomainResourceGroupName,
 		BootstrapInstanceType:       defaults.BootstrapInstanceType(region),
 		MasterInstanceType:          masterConfig.VMSize,
-		VolumeSize:                  masterConfig.OSDisk.DiskSizeGB,
-		VMImageID:                   masterConfig.Image.ResourceID,
 		MasterAvailabilityZones:     masterAvailabilityZones,
+		VolumeSize:                  masterConfig.OSDisk.DiskSizeGB,
+		ImageURL:                    imageURL,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
previously the terraform expected an Azure Image [1] provided to the cluster, but that approach had some disadvantages:
* the image needed to be created before creating the cluster
* the image location was hardcoded to a specific resource-group

And since RHCOS isn't avaiable on the Public Registry of images, the new flow is using the vhd blob from Azure storage and creating an Azure Image from it for the cluster.