### PR TITLE
[gcp] add dns resources

### DIFF
--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -41,7 +41,9 @@ variable "cluster_domain" {
   type = string
 
   description = <<EOF
-The domain of the cluster.
+The domain of the cluster. It must NOT contain a trailing period. Some
+DNS providers will automatically add this if necessary.
+
 All the records for the cluster are created under this domain.
 
 Note: This field MUST be set manually prior to creating the cluster.

--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -1,0 +1,51 @@
+resource "google_dns_managed_zone" "int" {
+  name       = "${var.cluster_id}-int"
+  dns_name   = "${var.cluster_domain}."
+  visibility = "private"
+  private_visibility_config {
+    networks {
+      network_url = "${var.network}"
+    }
+  }
+}
+
+resource "google_dns_record_set" "api_external" {
+  name         = "api.${var.cluster_domain}."
+  type         = "A"
+  ttl          = "60"
+  managed_zone = "${var.public_dns_zone_name}"
+  rrdatas      = ["${var.api_external_lb_ip}"]
+}
+
+resource "google_dns_record_set" "api_internal" {
+  name         = "api-int.${var.cluster_domain}."
+  type         = "A"
+  ttl          = "60"
+  managed_zone = google_dns_managed_zone.int.name
+  rrdatas      = ["${var.api_internal_lb_ip}"]
+}
+
+resource "google_dns_record_set" "api_external_internal_zone" {
+  name         = "api.${var.cluster_domain}."
+  type         = "A"
+  ttl          = "60"
+  managed_zone = google_dns_managed_zone.int.name
+  rrdatas      = ["${var.api_external_lb_ip}"]
+}
+
+resource "google_dns_record_set" "etcd_a_nodes" {
+  count        = var.etcd_count
+  type         = "A"
+  ttl          = "60"
+  managed_zone = google_dns_managed_zone.int.name
+  name         = "etcd-${count.index}.${var.cluster_domain}."
+  rrdatas      = [var.etcd_ip_addresses[count.index]]
+}
+
+resource "google_dns_record_set" "etcd_cluster" {
+  type         = "SRV"
+  ttl          = "60"
+  managed_zone = google_dns_managed_zone.int.name
+  name         = "_etcd-server-ssl._tcp.${var.cluster_domain}."
+  rrdatas      = formatlist("0 10 2380 %s", google_dns_record_set.etcd_a_nodes.*.name)
+}

--- a/data/data/gcp/dns/variables.tf
+++ b/data/data/gcp/dns/variables.tf
@@ -1,0 +1,40 @@
+variable "public_dns_zone_name" {
+  description = "The name of the public managed DNS zone"
+  type        = string
+}
+
+variable "network" {
+  description = "URL of the VPC network resource for the cluster"
+  type        = string
+}
+
+variable "etcd_count" {
+  description = "The number of etcd members."
+  type        = string
+}
+
+variable "etcd_ip_addresses" {
+  description = "List of string IPs for machines running etcd members."
+  type        = list(string)
+  default     = []
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "The identifier for the cluster."
+}
+
+variable "api_external_lb_ip" {
+  description = "External API's LB IP"
+  type        = string
+}
+
+variable "api_internal_lb_ip" {
+  description = "Internal API's LB IP"
+  type        = string
+}
+
+variable "cluster_domain" {
+  description = "The domain for the cluster that all DNS records must belong"
+  type        = string
+}

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -54,3 +54,16 @@ module "network" {
   bootstrap_instance_group = module.bootstrap.bootstrap_instance_group
   master_instance_groups   = module.master.master_instance_groups
 }
+
+module "dns" {
+  source = "./dns"
+
+  cluster_id           = var.cluster_id
+  public_dns_zone_name = var.gcp_public_dns_zone_name
+  network              = module.network.network
+  etcd_ip_addresses    = flatten(module.master.ip_addresses)
+  etcd_count           = var.master_count
+  cluster_domain       = var.cluster_domain
+  api_external_lb_ip   = module.network.cluster_public_ip
+  api_internal_lb_ip   = module.network.cluster_private_ip
+}

--- a/data/data/gcp/master/outputs.tf
+++ b/data/data/gcp/master/outputs.tf
@@ -5,3 +5,7 @@ output "master_instances" {
 output "master_instance_groups" {
   value = google_compute_instance_group.master.*.self_link
 }
+
+output "ip_addresses" {
+  value = google_compute_instance.master.*.network_interface.0.network_ip
+}

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -49,3 +49,8 @@ variable "gcp_master_root_volume_size" {
   type = string
   description = "The size of the volume in gigabytes for the root block device of master nodes."
 }
+
+variable "gcp_public_dns_zone_name" {
+  type = string
+  description = "The name of the public DNS zone to use for this cluster"
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -201,9 +201,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		for i, m := range masters {
 			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*gcpprovider.GCPMachineProviderSpec)
 		}
+		publicZone, err := gcpconfig.GetPublicZone(context.TODO(), installConfig.Config.GCP.ProjectID, installConfig.Config.BaseDomain)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get GCP public zone")
+		}
 		data, err := gcptfvars.TFVars(
 			auth,
 			masterConfigs,
+			publicZone.Name,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -20,10 +20,11 @@ type config struct {
 	ImageID               string `json:"gcp_image_id,omitempty"`
 	VolumeType            string `json:"gcp_master_root_volume_type,omitempty"`
 	VolumeSize            int64  `json:"gcp_master_root_volume_size,omitempty"`
+	PublicZoneName        string `json:"gcp_public_dns_zone_name,omitempty"`
 }
 
 // TFVars generates gcp-specific Terraform variables launching the cluster.
-func TFVars(auth Auth, masterConfigs []*gcpprovider.GCPMachineProviderSpec) ([]byte, error) {
+func TFVars(auth Auth, masterConfigs []*gcpprovider.GCPMachineProviderSpec, publicZoneName string) ([]byte, error) {
 	masterConfig := masterConfigs[0]
 	cfg := &config{
 		Auth:                  auth,
@@ -33,6 +34,7 @@ func TFVars(auth Auth, masterConfigs []*gcpprovider.GCPMachineProviderSpec) ([]b
 		VolumeType:            masterConfig.Disks[0].Type,
 		VolumeSize:            masterConfig.Disks[0].SizeGb,
 		ImageID:               masterConfig.Disks[0].Image,
+		PublicZoneName:        publicZoneName,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -4,6 +4,7 @@ package tfvars
 import (
 	"encoding/json"
 	"net"
+	"strings"
 )
 
 type config struct {
@@ -21,8 +22,8 @@ type config struct {
 func TFVars(clusterID string, clusterDomain string, baseDomain string, machineCIDR *net.IPNet, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
 	config := &config{
 		ClusterID:         clusterID,
-		ClusterDomain:     clusterDomain,
-		BaseDomain:        baseDomain,
+		ClusterDomain:     strings.TrimSuffix(clusterDomain, "."),
+		BaseDomain:        strings.TrimSuffix(baseDomain, "."),
 		MachineCIDR:       machineCIDR.String(),
 		Masters:           masterCount,
 		IgnitionBootstrap: bootstrapIgn,


### PR DESCRIPTION
Adds resources for the internal DNS managed zone, its records and API record in the public zone.

Depends on https://github.com/openshift/installer/pull/1971