### PR TITLE
[gcp] data/data: give bootstrap machine an external IP

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -1,3 +1,16 @@
+resource "google_compute_firewall" "bootstrap_ingress_ssh" {
+  name    = "${var.cluster_id}-bootstrap-ingress-ssh"
+  network = var.network
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["${var.cluster_id}-bootstrap"]
+}
+
 resource "google_compute_instance" "bootstrap" {
   name         = "${var.cluster_id}-bootstrap"
   machine_type = var.machine_type
@@ -13,13 +26,16 @@ resource "google_compute_instance" "bootstrap" {
 
   network_interface {
     subnetwork = var.subnet
+
+    access_config {
+    }
   }
 
   metadata = {
     user-data = var.ignition
   }
 
-  tags = ["${var.cluster_id}-master"]
+  tags = ["${var.cluster_id}-master", "${var.cluster_id}-bootstrap"]
 
   labels = var.labels
 }


### PR DESCRIPTION
Enables an external IP for the bootstrap machine for ssh access