### PR TITLE
data/data/openstack: set correct hostnames for machines during bootstrap

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -49,7 +49,7 @@ data "ignition_file" "hostname" {
 
   content {
     content = <<EOF
-bootstrap
+${var.cluster_id}-bootstrap
 EOF
 
   }

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -15,7 +15,7 @@ data "ignition_file" "hostname" {
 
   content {
     content = <<EOF
-master-${count.index}
+${var.cluster_id}-master-${count.index}
 EOF
 
   }


### PR DESCRIPTION
According to https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#node-name-4 to enable OpenStack cloud provider hostnames, node names & nova names must match.

This patch sets correct hostnames for masters and the bootstrap machine during the initial deployment.
To set hostnames for workers and masters that are added later we also need: https://github.com/openshift/machine-config-operator/pull/964

Reverts: #1820