### PR TITLE
add Tags Name for Master and Worker Nodes in the Cloudformation UPI AWS

### DIFF
--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -68,6 +68,11 @@ Resources:
         ToPort: 22623
         CidrIp: !Ref VpcCidr
       VpcId: !Ref VpcId
+      Tags:
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "shared"
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "sg-master"]]
 
   WorkerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -83,6 +88,11 @@ Resources:
         ToPort: 22
         CidrIp: !Ref VpcCidr
       VpcId: !Ref VpcId
+      Tags:
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "shared"
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "sg-worker"]]
 
   MasterIngressEtcd:
     Type: AWS::EC2::SecurityGroupIngress

--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -177,6 +177,8 @@ Resources:
       Tags:
       - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
         Value: "shared"
+      - Key: "Name"
+        Value: !Join ["", [!Ref InfrastructureName, "-master-1"]]
 
   RegisterMaster0:
     Condition: DoRegistration
@@ -224,6 +226,8 @@ Resources:
       Tags:
       - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
         Value: "shared"
+      - Key: "Name"
+        Value: !Join ["", [!Ref InfrastructureName, "-master-2"]]
 
   RegisterMaster1:
     Condition: DoRegistration
@@ -271,6 +275,8 @@ Resources:
       Tags:
       - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
         Value: "shared"
+      - Key: "Name"
+        Value: !Join ["", [!Ref InfrastructureName, "-master-3"]]
 
   RegisterMaster2:
     Condition: DoRegistration

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -107,6 +107,8 @@ Resources:
       Tags:
       - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
         Value: "shared"
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "worker", "1"]]
 
 Outputs:
   PrivateIP:


### PR DESCRIPTION
**What is this PR for?**

When a OCP 4.x is deployed in UPI mode using the AWS Cloudformations templates, there is not the proper Tag Names for the Workers and Masters Nodes deployed (ec2 instances tag names).
Furthermore, there isn't tagged the security groups. 

For this reason is complicated to identify which one are the masters or the workers nodes deployed (and also who is the master1, 2 or 3). Same thing for the security groups of master/worker nodes. 

**What is this PR About?**

This PR add the tag name for the worker / master nodes (ec2 instances vm), giving a describing name for each one of them. Furthermore, also define the tag names for the security groups attached to master/worker nodes.

**How is this PR tested?**

The code pull requested is tested in OCP upi 4.1.3/4.1.4 and worked perfectly. The ec2 instances for masters/workers were identified easily, as same as the security groups attached to them.