### PR TITLE
 data/gcp/network: create nat-gateways per subnet for egress from private instances

### DIFF
--- a/data/data/gcp/network/network.tf
+++ b/data/data/gcp/network/network.tf
@@ -15,3 +15,32 @@ resource "google_compute_subnetwork" "master_subnet" {
   network       = google_compute_network.cluster_network.self_link
   ip_cidr_range = var.master_subnet_cidr
 }
+
+resource "google_compute_router" "router" {
+  name    = "${var.cluster_id}-router"
+  network = google_compute_network.cluster_network.self_link
+}
+
+resource "google_compute_router_nat" "master_nat" {
+  name                               = "${var.cluster_id}-nat-master"
+  router                             = google_compute_router.router.name
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  subnetwork {
+    name                    = google_compute_subnetwork.master_subnet.self_link
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+}
+
+resource "google_compute_router_nat" "worker_nat" {
+  name                               = "${var.cluster_id}-nat-worker"
+  router                             = google_compute_router.router.name
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  subnetwork {
+    name                    = google_compute_subnetwork.worker_subnet.self_link
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+}

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -116,6 +116,7 @@ func (o *ClusterUninstaller) destroyCluster() (bool, error) {
 		{name: "Health checks", destroy: o.destroyHealthChecks},
 		{name: "Cloud controller internal LBs", destroy: o.destroyCloudControllerInternalLBs},
 		{name: "Cloud controller external LBs", destroy: o.destroyCloudControllerExternalLBs},
+		{name: "Cloud routers", destroy: o.destroyRouters},
 		{name: "Subnetworks", destroy: o.destroySubNetworks},
 		{name: "Networks", destroy: o.destroyNetworks},
 	}


### PR DESCRIPTION
Based on internet-access-reqs docs [1], the private instances need Cloud-NAT [1] resources to allow egress to internet.

The Cloud NAT gateways provide an automatically scaling-ha way to access the internet, so creating one per subnet (master and worker) should be
enough.
Cloud NATs also require a Cloud Router [3] for the control-plane, no data flows through Cloud router. This change creates one Cloud Router for the cluster.

Both the resources are regional and created in the same region as the cluster.


Also adds:  pkg/destroy/gcp: add cleanup for cloud routers
the nat-gateways are automatically cleaned up on deletion of cloud routers

[1]: https://cloud.google.com/vpc/docs/vpc#internet_access_reqs
[2]: https://cloud.google.com/nat/docs/overview
[3]: https://cloud.google.com/router/docs/concepts/overview

/cc @csrwng @jstuever 