### PR TITLE
network: block ExternalIPs by default.

### DIFF
--- a/pkg/asset/manifests/network.go
+++ b/pkg/asset/manifests/network.go
@@ -89,6 +89,10 @@ func (no *Networking) Generate(dependencies asset.Parents) error {
 			ClusterNetwork: clusterNet,
 			ServiceNetwork: serviceNet,
 			NetworkType:    netConfig.NetworkType,
+			// Block all Service.ExternalIPs by default
+			ExternalIP: &configv1.ExternalIPConfig{
+				Policy: &configv1.ExternalIPPolicy{},
+			},
 		},
 	}
 


### PR DESCRIPTION
In OpenShift 3.x, Service.ExternalIP was not allowed to be set by default. Administrators had to explicitly whitelist network blocks.

4.1 allowed all ExternalIP values. We re-added the ability to restrict ExternalIP in 4.2. Correspondingly, new clusters should be initialized in a default-deny state.

(API PR: https://github.com/openshift/api/pull/347)