### PR TITLE
gcp: use the zones from machine objects in terraform

### DIFF
--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -22,7 +22,7 @@ module "bootstrap" {
   ignition     = var.ignition_bootstrap
   network      = module.network.network
   subnet       = module.network.master_subnet
-  zone         = module.network.zones[0]
+  zone         = var.gcp_master_availability_zones[0]
 
   labels = local.labels
 }
@@ -37,7 +37,7 @@ module "master" {
   ignition       = var.ignition_master
   network        = module.network.network
   subnet         = module.network.master_subnet
-  zones          = module.network.zones
+  zones          = distinct(var.gcp_master_availability_zones)
 
   labels = local.labels
 }

--- a/data/data/gcp/network/common.tf
+++ b/data/data/gcp/network/common.tf
@@ -1,11 +1,2 @@
 # Canonical internal state definitions for this module.
 # read only: only locals and data source definitions allowed. No resources or module blocks in this file
-
-// Fetch a list of available AZs
-data "google_compute_zones" "available" {}
-
-// Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
-locals {
-  // List of possible AZs for each type of subnet
-  zones = data.google_compute_zones.available.names
-}

--- a/data/data/gcp/network/outputs.tf
+++ b/data/data/gcp/network/outputs.tf
@@ -17,7 +17,3 @@ output "worker_subnet" {
 output "master_subnet" {
   value = google_compute_subnetwork.master_subnet.self_link
 }
-
-output "zones" {
-  value = local.zones
-}

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -65,3 +65,8 @@ variable "gcp_public_dns_zone_name" {
   type = string
   description = "The name of the public DNS zone to use for this cluster"
 }
+
+variable "gcp_master_availability_zones" {
+  type = list(string)
+  description = "The availability zones in which to create the masters. The length of this list must match master_count."
+}

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -13,28 +13,34 @@ type Auth struct {
 }
 
 type config struct {
-	Auth                  `json:",inline"`
-	Region                string `json:"gcp_region,omitempty"`
-	BootstrapInstanceType string `json:"gcp_bootstrap_instance_type,omitempty"`
-	MasterInstanceType    string `json:"gcp_master_instance_type,omitempty"`
-	ImageID               string `json:"gcp_image_id,omitempty"`
-	VolumeType            string `json:"gcp_master_root_volume_type,omitempty"`
-	VolumeSize            int64  `json:"gcp_master_root_volume_size,omitempty"`
-	PublicZoneName        string `json:"gcp_public_dns_zone_name,omitempty"`
+	Auth                    `json:",inline"`
+	Region                  string   `json:"gcp_region,omitempty"`
+	BootstrapInstanceType   string   `json:"gcp_bootstrap_instance_type,omitempty"`
+	MasterInstanceType      string   `json:"gcp_master_instance_type,omitempty"`
+	MasterAvailabilityZones []string `json:"gcp_master_availability_zones"`
+	ImageID                 string   `json:"gcp_image_id,omitempty"`
+	VolumeType              string   `json:"gcp_master_root_volume_type,omitempty"`
+	VolumeSize              int64    `json:"gcp_master_root_volume_size,omitempty"`
+	PublicZoneName          string   `json:"gcp_public_dns_zone_name,omitempty"`
 }
 
 // TFVars generates gcp-specific Terraform variables launching the cluster.
 func TFVars(auth Auth, masterConfigs []*gcpprovider.GCPMachineProviderSpec, publicZoneName string) ([]byte, error) {
 	masterConfig := masterConfigs[0]
+	masterAvailabilityZones := make([]string, len(masterConfigs))
+	for i, c := range masterConfigs {
+		masterAvailabilityZones[i] = c.Zone
+	}
 	cfg := &config{
-		Auth:                  auth,
-		Region:                masterConfig.Region,
-		BootstrapInstanceType: masterConfig.MachineType,
-		MasterInstanceType:    masterConfig.MachineType,
-		VolumeType:            masterConfig.Disks[0].Type,
-		VolumeSize:            masterConfig.Disks[0].SizeGb,
-		ImageID:               masterConfig.Disks[0].Image,
-		PublicZoneName:        publicZoneName,
+		Auth:                    auth,
+		Region:                  masterConfig.Region,
+		BootstrapInstanceType:   masterConfig.MachineType,
+		MasterInstanceType:      masterConfig.MachineType,
+		MasterAvailabilityZones: masterAvailabilityZones,
+		VolumeType:              masterConfig.Disks[0].Type,
+		VolumeSize:              masterConfig.Disks[0].SizeGb,
+		ImageID:                 masterConfig.Disks[0].Image,
+		PublicZoneName:          publicZoneName,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
Currenlty the installer picks the zones for each machine when creating their Machine object, and then
terrafor code picks the zones again, this can lead to cases where the teo code-paths pick different results.

Using the zones from Machine objects and passing them to terraform directly reduce the possibility of the diff.