### PR TITLE
gcp: workaround terraform dependencies with bootstrap destroy

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -34,6 +34,8 @@ resource "google_compute_firewall" "bootstrap_ingress_ssh" {
 }
 
 resource "google_compute_instance" "bootstrap" {
+  count = var.bootstrap_enabled ? 1 : 0
+
   name         = "${var.cluster_id}-bootstrap"
   machine_type = var.machine_type
   zone         = var.zone
@@ -63,6 +65,8 @@ resource "google_compute_instance" "bootstrap" {
 }
 
 resource "google_compute_instance_group" "bootstrap" {
+  count = var.bootstrap_enabled ? 1 : 0
+
   name    = "${var.cluster_id}-bootstrap"
   network = var.network
   zone    = var.zone
@@ -77,5 +81,5 @@ resource "google_compute_instance_group" "bootstrap" {
     port = "6443"
   }
 
-  instances = [google_compute_instance.bootstrap.self_link]
+  instances = google_compute_instance.bootstrap.*.self_link
 }

--- a/data/data/gcp/bootstrap/output.tf
+++ b/data/data/gcp/bootstrap/output.tf
@@ -1,7 +1,7 @@
-output "bootstrap_instance" {
-  value = google_compute_instance.bootstrap.self_link
+output "bootstrap_instances" {
+  value = google_compute_instance.bootstrap.*.self_link
 }
 
-output "bootstrap_instance_group" {
-  value = google_compute_instance_group.bootstrap.self_link
+output "bootstrap_instance_groups" {
+  value = google_compute_instance_group.bootstrap.*.self_link
 }

--- a/data/data/gcp/bootstrap/variables.tf
+++ b/data/data/gcp/bootstrap/variables.tf
@@ -3,6 +3,12 @@ variable "cluster_id" {
   description = "The name of the cluster."
 }
 
+variable "bootstrap_enabled" {
+  type        = bool
+  description = "If the bootstrap instance and instance_group should exist."
+  default     = true
+}
+
 variable "ignition" {
   type        = string
   description = "The content of the bootstrap ignition file."

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -14,6 +14,8 @@ provider "google" {
 module "bootstrap" {
   source = "./bootstrap"
 
+  bootstrap_enabled = var.gcp_bootstrap_enabled
+
   image_name   = var.gcp_image_id
   machine_type = var.gcp_bootstrap_instance_type
   cluster_id   = var.cluster_id
@@ -48,11 +50,12 @@ module "network" {
   worker_subnet_cidr = local.worker_subnet_cidr
   network_cidr       = var.machine_cidr
 
-  bootstrap_instance = module.bootstrap.bootstrap_instance
-  master_instances   = module.master.master_instances
+  bootstrap_lb              = var.gcp_bootstrap_enabled && var.gcp_bootstrap_lb
+  bootstrap_instances       = module.bootstrap.bootstrap_instances
+  bootstrap_instance_groups = module.bootstrap.bootstrap_instance_groups
 
-  bootstrap_instance_group = module.bootstrap.bootstrap_instance_group
-  master_instance_groups   = module.master.master_instance_groups
+  master_instances       = module.master.master_instances
+  master_instance_groups = module.master.master_instance_groups
 }
 
 module "dns" {

--- a/data/data/gcp/network/external-lb.tf
+++ b/data/data/gcp/network/external-lb.tf
@@ -12,7 +12,7 @@ resource "google_compute_http_health_check" "api_external" {
 resource "google_compute_target_pool" "api_external" {
   name = "${var.cluster_id}-api-external"
 
-  instances     = concat(var.master_instances, [var.bootstrap_instance])
+  instances     = var.bootstrap_lb ? concat(var.master_instances, var.bootstrap_instances) : var.master_instances
   health_checks = [google_compute_http_health_check.api_external.self_link]
 }
 

--- a/data/data/gcp/network/internal-lb.tf
+++ b/data/data/gcp/network/internal-lb.tf
@@ -15,7 +15,7 @@ resource "google_compute_region_backend_service" "api_internal" {
   timeout_sec           = 120
 
   dynamic "backend" {
-    for_each = concat(var.master_instance_groups, [var.bootstrap_instance_group])
+    for_each = var.bootstrap_lb ? concat(var.master_instance_groups, var.bootstrap_instance_groups) : var.master_instance_groups
 
     content {
       group = backend.value

--- a/data/data/gcp/network/variables.tf
+++ b/data/data/gcp/network/variables.tf
@@ -1,18 +1,20 @@
-variable "bootstrap_instance" {
-  type        = string
+variable "bootstrap_instances" {
+  type        = list
   description = "The bootstrap instance."
 }
 
-variable "bootstrap_instance_group" {
-  type        = string
+variable "bootstrap_instance_groups" {
+  type        = list
   description = "The instance group that hold the bootstrap instance in this region."
 }
 
-variable "cluster_id" {
-  type = string
+variable "bootstrap_lb" {
+  type        = bool
+  description = "If the bootstrap instance should be in the load balancers."
+  default     = true
 }
 
-variable "worker_subnet_cidr" {
+variable "cluster_id" {
   type = string
 }
 
@@ -31,5 +33,9 @@ variable "master_subnet_cidr" {
 }
 
 variable "network_cidr" {
+  type = string
+}
+
+variable "worker_subnet_cidr" {
   type = string
 }

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -24,6 +24,17 @@ EOF
   default = {}
 }
 
+variable "gcp_bootstrap_enabled" {
+  type = bool
+  description = "Setting this to false allows the bootstrap instance and instance_group to be destroyed."
+  default = true
+}
+
+variable "gcp_bootstrap_lb" {
+  type = bool
+  description = "Setting this to false allows the bootstrap resources to be removed from the cluster load balancers."
+  default = true
+}
 
 variable "gcp_bootstrap_instance_type" {
   type = string


### PR DESCRIPTION
This changes removes the bootstrap instance from the cluster's load
balancers and then deletes the bootstrap instance and instance_group
prior to destroying bootstrap module. This removes the dependencies
of the bootstrap assets so that terraform does not destroy the load
balancers.