### PR TITLE
gcp: limit internal load balancer during bootstrap 

### DIFF
--- a/data/data/gcp/network/internal-lb.tf
+++ b/data/data/gcp/network/internal-lb.tf
@@ -15,7 +15,7 @@ resource "google_compute_region_backend_service" "api_internal" {
   timeout_sec           = 120
 
   dynamic "backend" {
-    for_each = var.bootstrap_lb ? concat(var.master_instance_groups, var.bootstrap_instance_groups) : var.master_instance_groups
+    for_each = var.bootstrap_lb ? var.bootstrap_instance_groups : var.master_instance_groups
 
     content {
       group = backend.value


### PR DESCRIPTION
This change limits the internal load balancer to only have the bootstrap
instance during bootstrap (before bootstrap destroy). This resolves a
bug where the masters are redirecting to themselves during this time.

Depends on #1993