### PR TITLE
data/gcp/dns: api.cluster_domain inside the VPC must point to internal LB for consistency

### DIFF
--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -4,7 +4,7 @@ resource "google_dns_managed_zone" "int" {
   visibility = "private"
   private_visibility_config {
     networks {
-      network_url = "${var.network}"
+      network_url = var.network
     }
   }
 }
@@ -13,8 +13,8 @@ resource "google_dns_record_set" "api_external" {
   name         = "api.${var.cluster_domain}."
   type         = "A"
   ttl          = "60"
-  managed_zone = "${var.public_dns_zone_name}"
-  rrdatas      = ["${var.api_external_lb_ip}"]
+  managed_zone = var.public_dns_zone_name
+  rrdatas      = [var.api_external_lb_ip]
 }
 
 resource "google_dns_record_set" "api_internal" {
@@ -22,7 +22,7 @@ resource "google_dns_record_set" "api_internal" {
   type         = "A"
   ttl          = "60"
   managed_zone = google_dns_managed_zone.int.name
-  rrdatas      = ["${var.api_internal_lb_ip}"]
+  rrdatas      = [var.api_internal_lb_ip]
 }
 
 resource "google_dns_record_set" "api_external_internal_zone" {
@@ -30,7 +30,7 @@ resource "google_dns_record_set" "api_external_internal_zone" {
   type         = "A"
   ttl          = "60"
   managed_zone = google_dns_managed_zone.int.name
-  rrdatas      = ["${var.api_external_lb_ip}"]
+  rrdatas      = [var.api_external_lb_ip]
 }
 
 resource "google_dns_record_set" "etcd_a_nodes" {

--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -30,7 +30,7 @@ resource "google_dns_record_set" "api_external_internal_zone" {
   type         = "A"
   ttl          = "60"
   managed_zone = google_dns_managed_zone.int.name
-  rrdatas      = [var.api_external_lb_ip]
+  rrdatas      = [var.api_internal_lb_ip]
 }
 
 resource "google_dns_record_set" "etcd_a_nodes" {


### PR DESCRIPTION
similar to other platforms like AWS: https://github.com/openshift/installer/blob/37f72577e0dc6debc2facc52221531e6dd62abfd/data/data/aws/route53/base.tf#L53

/cc @csrwng @jstuever 