### PR TITLE
pkg/types/aws: allow specifying AMI ID for machines

### DIFF
--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -58,6 +58,10 @@ func (i *Image) Generate(p asset.Parents) error {
 	defer cancel()
 	switch config.Platform.Name() {
 	case aws.Name:
+		if len(config.Platform.AWS.AMIID) > 0 {
+			osimage = config.Platform.AWS.AMIID
+			break
+		}
 		osimage, err = rhcos.AMI(ctx, config.Platform.AWS.Region)
 	case gcp.Name:
 	case libvirt.Name:

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -3,6 +3,10 @@ package aws
 // Platform stores all the global configuration that all machinesets
 // use.
 type Platform struct {
+	// AMIID is the AMI that should be used to boot machines for the cluster.
+	// If set, the AMI should belong to the same region as the cluster.
+	AMIID string `json:"amiID,omitempty"`
+
 	// Region specifies the AWS region where the cluster will be created.
 	Region string `json:"region"`
 


### PR DESCRIPTION
ref: https://jira.coreos.com/browse/CORS-1103

for aws the new order for osImage is:
- env OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE
- platform.aws.amiID
- embedded ami for the region

/cc @crawford @openshift/openshift-team-installer 