### PR TITLE
scheduler: Use schedulable masters if no compute hosts defined.

### DIFF
--- a/pkg/asset/manifests/scheduler.go
+++ b/pkg/asset/manifests/scheduler.go
@@ -44,7 +44,9 @@ func (s *Scheduler) Generate(dependencies asset.Parents) error {
 			Name: "cluster",
 			// not namespaced
 		},
-		Spec: configv1.SchedulerSpec{},
+		Spec: configv1.SchedulerSpec{
+			MastersSchedulable: false,
+		},
 	}
 
 	configData, err := yaml.Marshal(config)

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -8,7 +8,6 @@ import (
 
 	dockerref "github.com/containers/image/docker/reference"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -183,7 +182,6 @@ func validateControlPlane(platform *types.Platform, pool *types.MachinePool, fld
 func validateCompute(platform *types.Platform, pools []types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	poolNames := map[string]bool{}
-	foundPositiveReplicas := false
 	for i, p := range pools {
 		poolFldPath := fldPath.Index(i)
 		if p.Name != "worker" {
@@ -193,13 +191,7 @@ func validateCompute(platform *types.Platform, pools []types.MachinePool, fldPat
 			allErrs = append(allErrs, field.Duplicate(poolFldPath.Child("name"), p.Name))
 		}
 		poolNames[p.Name] = true
-		if p.Replicas != nil && *p.Replicas > 0 {
-			foundPositiveReplicas = true
-		}
 		allErrs = append(allErrs, ValidateMachinePool(platform, &p, poolFldPath)...)
-	}
-	if !foundPositiveReplicas {
-		logrus.Warnf("There are no compute nodes specified. The cluster will not fully initialize without compute nodes.")
 	}
 	return allErrs
 }


### PR DESCRIPTION
This change makes use of a new configuration item on the scheduler CR
that specifies that control plane hosts should be able to run
workloads.  This option is off by default, but will now be turned on
if there are no compute machine pools with non-zero replicas defined.
    
This change also removes a validation and warning when no compute
hosts are defined, as an install with this configuration will now
complete successfully.
