### PR TITLE
bootkube: Add ETCD_PIVOT environment variable

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -16,6 +16,10 @@ if ! release=$( podman inspect {{.ReleaseImage}} -f '{{"{{"}} index .RepoDigests
 	release="{{.ReleaseImage}}"
 fi
 
+if host -t SRV _etcd-server-ssl._tcp.{{.ClusterDomain}} | grep -q etcd-bootstrap; then
+        ETCD_PIVOT=1
+fi
+
 MACHINE_CONFIG_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image machine-config-operator)
 MACHINE_CONFIG_OSCONTENT=$(podman run --quiet --rm ${release} image machine-os-content)
 MACHINE_CONFIG_ETCD_IMAGE=$(podman run --quiet --rm ${release} image etcd)

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -40,11 +40,12 @@ const (
 // bootstrapTemplateData is the data to use to replace values in bootstrap
 // template files.
 type bootstrapTemplateData struct {
-	EtcdCluster  string
-	PullSecret   string
-	ReleaseImage string
-	Proxy        *configv1.ProxyStatus
-	Registries   []sysregistriesv2.Registry
+	EtcdCluster   string
+	PullSecret    string
+	ReleaseImage  string
+	Proxy         *configv1.ProxyStatus
+	Registries    []sysregistriesv2.Registry
+	ClusterDomain string
 }
 
 // Bootstrap is an asset that generates the ignition config for bootstrap nodes.
@@ -217,11 +218,12 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 	}
 
 	return &bootstrapTemplateData{
-		PullSecret:   installConfig.PullSecret,
-		ReleaseImage: releaseImage,
-		EtcdCluster:  strings.Join(etcdEndpoints, ","),
-		Proxy:        &proxy.Status,
-		Registries:   registries,
+		PullSecret:    installConfig.PullSecret,
+		ReleaseImage:  releaseImage,
+		EtcdCluster:   strings.Join(etcdEndpoints, ","),
+		Proxy:         &proxy.Status,
+		Registries:    registries,
+		ClusterDomain: installConfig.ClusterDomain(),
 	}, nil
 }
 


### PR DESCRIPTION
This is a precursor to future work to bootstrap etcd on the bootstrap node and then pivot off to the masters via the cluster etcd operator.

Until this future is fully realized, we need to gate the bootstrap behavior so we can have both workflows available simultaneously for testing the pivot workflow.  The "normal" mode will continue to behave as it does presently.  The new bootstrap-and-pivot mode can be activated by adding the bootstrap node, with hostname "etcd-bootstrap", to the etcd cluster SRV record.

Any future pivot work must be guarded with ETCD_PIVOT until the process has been fully tested and vetted, at which time the pivot workflow will become the only operating mode.