### PR TITLE
gcp: Ensure terraform object names have max length 63

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -21,7 +21,7 @@ data "ignition_config" "redirect" {
 }
 
 resource "google_compute_firewall" "bootstrap_ingress_ssh" {
-  name    = "${var.cluster_id}-bootstrap-ingress-ssh"
+  name    = "${var.cluster_id}-bootstrap-in-ssh"
   network = var.network
 
   allow {

--- a/data/data/gcp/network/firewall-compute.tf
+++ b/data/data/gcp/network/firewall-compute.tf
@@ -1,5 +1,5 @@
 resource "google_compute_firewall" "worker_ingress_icmp" {
-  name    = "${var.cluster_id}-worker-ingress-icmp"
+  name    = "${var.cluster_id}-worker-in-icmp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -11,7 +11,7 @@ resource "google_compute_firewall" "worker_ingress_icmp" {
 }
 
 resource "google_compute_firewall" "worker_ingress_ssh" {
-  name    = "${var.cluster_id}-worker-ingress-ssh"
+  name    = "${var.cluster_id}-worker-in-ssh"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -24,7 +24,7 @@ resource "google_compute_firewall" "worker_ingress_ssh" {
 }
 
 resource "google_compute_firewall" "worker_ingress_vxlan" {
-  name    = "${var.cluster_id}-worker-ingress-vxlan"
+  name    = "${var.cluster_id}-worker-in-vxlan"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -37,7 +37,7 @@ resource "google_compute_firewall" "worker_ingress_vxlan" {
 }
 
 resource "google_compute_firewall" "worker_ingress_vxlan_from_master" {
-  name    = "${var.cluster_id}-worker-ingress-vxlan-from-master"
+  name    = "${var.cluster_id}-worker-in-vxlan-from-master"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -50,7 +50,7 @@ resource "google_compute_firewall" "worker_ingress_vxlan_from_master" {
 }
 
 resource "google_compute_firewall" "worker_ingress_internal" {
-  name    = "${var.cluster_id}-worker-ingress-internal"
+  name    = "${var.cluster_id}-worker-in-internal"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -63,7 +63,7 @@ resource "google_compute_firewall" "worker_ingress_internal" {
 }
 
 resource "google_compute_firewall" "worker_ingress_internal_from_master" {
-  name    = "${var.cluster_id}-worker-ingress-internal-from-master"
+  name    = "${var.cluster_id}-worker-in-internal-from-master"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -76,7 +76,7 @@ resource "google_compute_firewall" "worker_ingress_internal_from_master" {
 }
 
 resource "google_compute_firewall" "worker_ingress_internal_udp" {
-  name    = "${var.cluster_id}-worker-ingress-udp"
+  name    = "${var.cluster_id}-worker-in-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -89,7 +89,7 @@ resource "google_compute_firewall" "worker_ingress_internal_udp" {
 }
 
 resource "google_compute_firewall" "worker_ingress_internal_from_master_udp" {
-  name    = "${var.cluster_id}-worker-ingress-from-master-udp"
+  name    = "${var.cluster_id}-worker-in-from-master-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -102,7 +102,7 @@ resource "google_compute_firewall" "worker_ingress_internal_from_master_udp" {
 }
 
 resource "google_compute_firewall" "worker_ingress_kubelet_insecure" {
-  name    = "${var.cluster_id}-worker-ingress-kubelet-insecure"
+  name    = "${var.cluster_id}-worker-in-kubelet-insecure"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -115,7 +115,7 @@ resource "google_compute_firewall" "worker_ingress_kubelet_insecure" {
 }
 
 resource "google_compute_firewall" "worker_ingress_kubelet_insecure_from_master" {
-  name    = "${var.cluster_id}-worker-ingress-kubelet-insecure-from-master"
+  name    = "${var.cluster_id}-worker-in-kubelet-insecure-fr-mast"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -128,7 +128,7 @@ resource "google_compute_firewall" "worker_ingress_kubelet_insecure_from_master"
 }
 
 resource "google_compute_firewall" "worker_ingress_services_tcp" {
-  name    = "${var.cluster_id}-worker-ingress-services-tcp"
+  name    = "${var.cluster_id}-worker-in-services-tcp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -141,7 +141,7 @@ resource "google_compute_firewall" "worker_ingress_services_tcp" {
 }
 
 resource "google_compute_firewall" "worker_ingress_services_udp" {
-  name    = "${var.cluster_id}-worker-ingress-services-udp"
+  name    = "${var.cluster_id}-worker-in-services-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {

--- a/data/data/gcp/network/firewall-control.tf
+++ b/data/data/gcp/network/firewall-control.tf
@@ -1,5 +1,5 @@
 resource "google_compute_firewall" "master_ingress_icmp" {
-  name    = "${var.cluster_id}-master-ingress-icmp"
+  name    = "${var.cluster_id}-master-in-icmp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -11,7 +11,7 @@ resource "google_compute_firewall" "master_ingress_icmp" {
 }
 
 resource "google_compute_firewall" "master_ingress_ssh" {
-  name    = "${var.cluster_id}-master-ingress-ssh"
+  name    = "${var.cluster_id}-master-in-ssh"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -24,7 +24,7 @@ resource "google_compute_firewall" "master_ingress_ssh" {
 }
 
 resource "google_compute_firewall" "master_ingress_https" {
-  name    = "${var.cluster_id}-master-ingress-https"
+  name    = "${var.cluster_id}-master-in-https"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -37,7 +37,7 @@ resource "google_compute_firewall" "master_ingress_https" {
 }
 
 resource "google_compute_firewall" "master_ingress_https_from_health_checks" {
-  name    = "${var.cluster_id}-master-ingress-https-from-health-checks"
+  name    = "${var.cluster_id}-master-in-https-from-health-checks"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -50,7 +50,7 @@ resource "google_compute_firewall" "master_ingress_https_from_health_checks" {
 }
 
 resource "google_compute_firewall" "master_ingress_mcs" {
-  name    = "${var.cluster_id}-master-ingress-mcs"
+  name    = "${var.cluster_id}-master-in-mcs"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -63,7 +63,7 @@ resource "google_compute_firewall" "master_ingress_mcs" {
 }
 
 resource "google_compute_firewall" "master_ingress_vxlan" {
-  name    = "${var.cluster_id}-master-ingress-vxlan"
+  name    = "${var.cluster_id}-master-in-vxlan"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -76,7 +76,7 @@ resource "google_compute_firewall" "master_ingress_vxlan" {
 }
 
 resource "google_compute_firewall" "master_ingress_vxlan_from_worker" {
-  name    = "${var.cluster_id}-master-ingress-vxlan-from-worker"
+  name    = "${var.cluster_id}-master-in-vxlan-from-worker"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -89,7 +89,7 @@ resource "google_compute_firewall" "master_ingress_vxlan_from_worker" {
 }
 
 resource "google_compute_firewall" "master_ingress_internal" {
-  name    = "${var.cluster_id}-master-ingress-internal"
+  name    = "${var.cluster_id}-master-in-internal"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -102,7 +102,7 @@ resource "google_compute_firewall" "master_ingress_internal" {
 }
 
 resource "google_compute_firewall" "master_ingress_internal_from_worker" {
-  name    = "${var.cluster_id}-master-ingress-internal-from-worker"
+  name    = "${var.cluster_id}-master-in-internal-from-worker"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -115,7 +115,7 @@ resource "google_compute_firewall" "master_ingress_internal_from_worker" {
 }
 
 resource "google_compute_firewall" "master_ingress_internal_udp" {
-  name    = "${var.cluster_id}-master-ingress-internal-udp"
+  name    = "${var.cluster_id}-master-in-internal-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -128,7 +128,7 @@ resource "google_compute_firewall" "master_ingress_internal_udp" {
 }
 
 resource "google_compute_firewall" "master_ingress_internal_from_worker_udp" {
-  name    = "${var.cluster_id}-master-ingress-internal-from-worker-udp"
+  name    = "${var.cluster_id}-master-in-internal-from-worker-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -141,7 +141,7 @@ resource "google_compute_firewall" "master_ingress_internal_from_worker_udp" {
 }
 
 resource "google_compute_firewall" "master_ingress_kube_scheduler" {
-  name    = "${var.cluster_id}-master-ingress-kube-scheduler"
+  name    = "${var.cluster_id}-master-in-kube-scheduler"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -154,7 +154,7 @@ resource "google_compute_firewall" "master_ingress_kube_scheduler" {
 }
 
 resource "google_compute_firewall" "master_ingress_kube_scheduler_from_worker" {
-  name    = "${var.cluster_id}-master-ingress-kube-scheduler-from-worker"
+  name    = "${var.cluster_id}-master-in-kube-scheduler-fr-worker"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -166,8 +166,8 @@ resource "google_compute_firewall" "master_ingress_kube_scheduler_from_worker" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "master_ingress_kube_masterler_manager" {
-  name    = "${var.cluster_id}-master-ingress-kube-masterler-manager"
+resource "google_compute_firewall" "master_ingress_kube_master_manager" {
+  name    = "${var.cluster_id}-master-in-kube-master-manager"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -179,8 +179,8 @@ resource "google_compute_firewall" "master_ingress_kube_masterler_manager" {
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "master_ingress_kube_masterler_manager_from_worker" {
-  name    = "${var.cluster_id}-master-ingress-kube-masterler-manager-from-worker"
+resource "google_compute_firewall" "master_ingress_kube_master_manager_from_worker" {
+  name    = "${var.cluster_id}-master-in-kube-master-mgr-fr-work"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -193,7 +193,7 @@ resource "google_compute_firewall" "master_ingress_kube_masterler_manager_from_w
 }
 
 resource "google_compute_firewall" "master_ingress_kubelet_secure" {
-  name    = "${var.cluster_id}-master-ingress-kubelet-secure"
+  name    = "${var.cluster_id}-master-in-kubelet-secure"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -206,7 +206,7 @@ resource "google_compute_firewall" "master_ingress_kubelet_secure" {
 }
 
 resource "google_compute_firewall" "master_ingress_kubelet_secure_from_worker" {
-  name    = "${var.cluster_id}-master-ingress-kubelet-secure-from-worker"
+  name    = "${var.cluster_id}-master-in-kubelet-secure-fr-worker"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -219,7 +219,7 @@ resource "google_compute_firewall" "master_ingress_kubelet_secure_from_worker" {
 }
 
 resource "google_compute_firewall" "master_ingress_etcd" {
-  name    = "${var.cluster_id}-master-ingress-etcd"
+  name    = "${var.cluster_id}-master-in-etcd"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -232,7 +232,7 @@ resource "google_compute_firewall" "master_ingress_etcd" {
 }
 
 resource "google_compute_firewall" "master_ingress_services_tcp" {
-  name    = "${var.cluster_id}-master-ingress-services-tcp"
+  name    = "${var.cluster_id}-master-in-services-tcp"
   network = google_compute_network.cluster_network.self_link
 
   allow {
@@ -245,7 +245,7 @@ resource "google_compute_firewall" "master_ingress_services_tcp" {
 }
 
 resource "google_compute_firewall" "master_ingress_services_udp" {
-  name    = "${var.cluster_id}-master-ingress-services-udp"
+  name    = "${var.cluster_id}-master-in-services-udp"
   network = google_compute_network.cluster_network.self_link
 
   allow {


### PR DESCRIPTION
This change ensures all of the "Name" fields in the terraform google
provider templates adhere to the max length of 63.