### PR TITLE
[gcp] pkg/destroy: handle async call results, log delete info messages

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -7,8 +7,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	compute "google.golang.org/api/compute/v1"
@@ -40,6 +43,9 @@ type ClusterUninstaller struct {
 	iamSvc     *iam.Service
 	dnsSvc     *dns.Service
 	storageSvc *storage.Service
+
+	requestIDTracker
+	pendingItemTracker
 }
 
 // New returns an AWS destroyer from ClusterMetadata.
@@ -50,6 +56,9 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 		ProjectID: metadata.ClusterPlatformMetadata.GCP.ProjectID,
 		ClusterID: metadata.InfraID,
 		Context:   context.Background(),
+
+		requestIDTracker:   newRequestIDTracker(),
+		pendingItemTracker: newPendingItemTracker(),
 	}, nil
 }
 
@@ -120,15 +129,15 @@ func (o *ClusterUninstaller) destroyCluster() (bool, error) {
 		{name: "Subnetworks", destroy: o.destroySubNetworks},
 		{name: "Networks", destroy: o.destroyNetworks},
 	}
-	hasErr := false
+	done := true
 	for _, f := range destroyFuncs {
 		err := f.destroy()
 		if err != nil {
-			hasErr = true
 			o.Logger.Debugf("%s: %v", f.name, err)
+			done = false
 		}
 	}
-	return !hasErr, nil
+	return done, nil
 }
 
 func (o *ClusterUninstaller) isClusterResource(name string) bool {
@@ -147,6 +156,81 @@ func isNoOp(err error) bool {
 	return ok && (ae.Code == http.StatusNotFound || ae.Code == http.StatusNotModified)
 }
 
+// aggregateError is a utility function that takes a slice of errors and an
+// optional pending argument, and returns an error or nil
+func aggregateError(errs []error, pending ...int) error {
+	if len(errs) > 0 {
+		return utilerrors.NewAggregate(errs)
+	}
+	if len(pending) > 0 && pending[0] > 0 {
+		return errors.Errorf("%d items pending", pending[0])
+	}
+	return nil
+}
+
 func (o *ClusterUninstaller) contextWithTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(o.Context, defaultTimeout)
+}
+
+// requestIDTracker keeps track of a set of request IDs mapped to a unique resource
+// identifier
+type requestIDTracker struct {
+	requestIDs map[string]string
+}
+
+func newRequestIDTracker() requestIDTracker {
+	return requestIDTracker{
+		requestIDs: map[string]string{},
+	}
+}
+
+// requestID returns a UID for a given item identifier. Unless the ID is reset, the
+// same requestID will be returned every time for a given item.
+func (t requestIDTracker) requestID(identifier ...string) string {
+	key := strings.Join(identifier, "/")
+	id, exists := t.requestIDs[key]
+	if !exists {
+		id = uuid.New()
+		t.requestIDs[key] = id
+	}
+	return id
+}
+
+// resetRequestID resets the request ID used for a particular item. This
+// should be called whenever a request fails, and a brand new request should be
+// sent.
+func (t requestIDTracker) resetRequestID(identifier ...string) {
+	key := strings.Join(identifier, "/")
+	if _, exists := t.requestIDs[key]; exists {
+		delete(t.requestIDs, key)
+	}
+}
+
+// pendingItemTracker tracks a set of pending item names for a given type of resource
+type pendingItemTracker struct {
+	pendingItems map[string]sets.String
+}
+
+func newPendingItemTracker() pendingItemTracker {
+	return pendingItemTracker{
+		pendingItems: map[string]sets.String{},
+	}
+}
+
+// setPendingItems sets the list of items pending deletion for a particular item type.
+// It returns items that were previously pending that are no longer in the list
+// of pending items. These are items that have been deleted.
+func (t pendingItemTracker) setPendingItems(itemType string, items []string) []string {
+	found := sets.NewString(items...)
+	lastFound, exists := t.pendingItems[itemType]
+	if !exists {
+		lastFound = sets.NewString()
+	}
+	deletedItems := lastFound.Difference(found)
+	t.pendingItems[itemType] = found
+	return deletedItems.List()
+}
+
+func isErrorStatus(code int64) bool {
+	return code < 200 || code >= 300
 }

--- a/pkg/destroy/gcp/iam.go
+++ b/pkg/destroy/gcp/iam.go
@@ -39,6 +39,7 @@ func (o *ClusterUninstaller) deleteServiceAccount(serviceAccount string) error {
 	if err != nil && !isNoOp(err) {
 		return errors.Wrapf(err, "failed to delete service account %s", serviceAccount)
 	}
+	o.Logger.Infof("Deleted service account %s", serviceAccount)
 	return nil
 }
 
@@ -49,11 +50,12 @@ func (o *ClusterUninstaller) destroyServiceAccounts() error {
 	if err != nil {
 		return err
 	}
+	errs := []error{}
 	for _, serviceAccount := range serviceAccounts {
 		err := o.deleteServiceAccount(serviceAccount)
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return aggregateError(errs)
 }

--- a/pkg/destroy/gcp/storage.go
+++ b/pkg/destroy/gcp/storage.go
@@ -52,6 +52,9 @@ func (o *ClusterUninstaller) deleteStorageObject(bucket, object string) error {
 	if err != nil && !isNoOp(err) {
 		return errors.Wrapf(err, "failed to delete bucket object %s/%s", bucket, object)
 	}
+	if err == nil {
+		o.Logger.Infof("Deleted storage object %s/%s", bucket, object)
+	}
 	return nil
 }
 
@@ -63,6 +66,9 @@ func (o *ClusterUninstaller) deleteStorageBucket(bucket string) error {
 	if err != nil && !isNoOp(err) {
 		return errors.Wrapf(err, "failed to delete bucket %s", bucket)
 	}
+	if err == nil {
+		o.Logger.Infof("Deleted storage bucket %s", bucket)
+	}
 	return nil
 }
 
@@ -73,21 +79,23 @@ func (o *ClusterUninstaller) destroyObjectStorage() error {
 	if err != nil {
 		return err
 	}
+	errs := []error{}
 	for _, bucket := range buckets {
 		objects, err := o.listBucketObjects(bucket)
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 		for _, object := range objects {
 			err = o.deleteStorageObject(bucket, object)
 			if err != nil {
-				return err
+				errs = append(errs, err)
 			}
 		}
 		err = o.deleteStorageBucket(bucket)
 		if err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-	return nil
+	return aggregateError(errs, len(buckets))
 }


### PR DESCRIPTION
Updates GCP destroy to handle async call results by using the same
request id every time a particular item is deleted. The resulting
operation should return the latest results of the particular request.
It updates the destroy function interface to return a boolean indicating
whether there are items still pending to be deleted. It also returns a
slice of errors instead of a single error so that all items of a
particular type are attempted instead of up to the first failure.
Info log statements are now logged when an item is successfully deleted.