### PR TITLE
Conditionally include the bootstrap node in the SRV record

### DIFF
--- a/data/data/aws/bootstrap/outputs.tf
+++ b/data/data/aws/bootstrap/outputs.tf
@@ -1,0 +1,4 @@
+output "ip_addresses" {
+  value = [aws_instance.bootstrap.private_ip]
+}
+

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -66,8 +66,10 @@ module "dns" {
   base_domain              = var.base_domain
   cluster_domain           = var.cluster_domain
   cluster_id               = var.cluster_id
+  etcd_pivot               = var.etcd_pivot
   etcd_count               = var.master_count
   etcd_ip_addresses        = flatten(module.masters.ip_addresses)
+  bootstrap_ip_addresses   = flatten(module.bootstrap.ip_addresses)
   tags                     = local.tags
   vpc_id                   = module.vpc.vpc_id
 }

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -3,6 +3,13 @@ variable "cluster_domain" {
   type        = string
 }
 
+variable "etcd_pivot" {
+  type    = string
+  default = "false"
+
+  description = "(internal)(temporary) Should OpenShift pivot an etcd cluster from the boostrap node."
+}
+
 variable "etcd_count" {
   description = "The number of etcd members."
   type        = string
@@ -10,6 +17,12 @@ variable "etcd_count" {
 
 variable "etcd_ip_addresses" {
   description = "List of string IPs for machines running etcd members."
+  type        = list(string)
+  default     = []
+}
+
+variable "bootstrap_ip_addresses" {
+  description = "List of string IPs for boostrap machines."
   type        = list(string)
   default     = []
 }

--- a/data/data/azure/bootstrap/outputs.tf
+++ b/data/data/azure/bootstrap/outputs.tf
@@ -1,0 +1,4 @@
+output "ip_addresses" {
+  value = [azurerm_public_ip.bootstrap_public_ip.private_ip_address]
+}
+

--- a/data/data/azure/dns/dns.tf
+++ b/data/data/azure/dns/dns.tf
@@ -36,6 +36,15 @@ resource "azurerm_dns_a_record" "etcd_a_nodes" {
   records             = [var.etcd_ip_addresses[count.index]]
 }
 
+resource "azurerm_dns_a_record" "etcd_a_bootstrap" {
+  count               = var.etcd_pivot ? 1 : 0
+  name                = "bootstrap"
+  zone_name           = var.private_dns_zone_name
+  resource_group_name = var.resource_group_name
+  ttl                 = 60
+  records             = [var.bootstrap_ip_addresses[count.index]]
+}
+
 resource "azurerm_dns_srv_record" "etcd_cluster" {
   name                = "_etcd-server-ssl._tcp"
   zone_name           = var.private_dns_zone_name
@@ -43,7 +52,7 @@ resource "azurerm_dns_srv_record" "etcd_cluster" {
   ttl                 = 60
 
   dynamic "record" {
-    for_each = azurerm_dns_a_record.etcd_a_nodes.*.name
+    for_each = concat(azurerm_dns_a_record.etcd_a_nodes.*.name, azurerm_dns_a_record.etcd_a_bootstrap.*.name)
     iterator = name
     content {
       target   = "${name.value}.${var.private_dns_zone_name}"

--- a/data/data/azure/dns/variables.tf
+++ b/data/data/azure/dns/variables.tf
@@ -34,6 +34,13 @@ variable "private_dns_zone_name" {
   type        = string
 }
 
+variable "etcd_pivot" {
+  type    = string
+  default = "false"
+
+  description = "(internal)(temporary) Should OpenShift pivot an etcd cluster from the boostrap node."
+}
+
 variable "etcd_count" {
   description = "The number of etcd members."
   type        = string
@@ -41,6 +48,12 @@ variable "etcd_count" {
 
 variable "etcd_ip_addresses" {
   description = "List of string IPs for machines running etcd members."
+  type        = list(string)
+  default     = []
+}
+
+variable "bootstrap_ip_addresses" {
+  description = "List of string IPs for boostrap machines."
   type        = list(string)
   default     = []
 }

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -84,8 +84,10 @@ module "dns" {
   resource_group_name             = azurerm_resource_group.main.name
   base_domain_resource_group_name = var.azure_base_domain_resource_group_name
   private_dns_zone_name           = azurerm_dns_zone.private.name
+  etcd_pivot                      = var.etcd_pivot
   etcd_count                      = var.master_count
   etcd_ip_addresses               = module.master.ip_addresses
+  bootstrap_ip_addresses          = module.bootstrap.ip_addresses
 }
 
 resource "random_string" "storage_suffix" {

--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -83,3 +83,13 @@ EOF
 
 }
 
+variable "etcd_pivot" {
+  type = string
+  default = "false"
+
+  description = <<EOF
+(internal)(temporary) Should OpenShift pivot an etcd cluster from the boostrap node.
+EOF
+
+}
+

--- a/data/data/gcp/bootstrap/output.tf
+++ b/data/data/gcp/bootstrap/output.tf
@@ -1,3 +1,7 @@
 output "bootstrap_instances" {
   value = google_compute_instance.bootstrap.*.self_link
 }
+
+output "bootstrap_instance_ips" {
+  value = google_compute_instance.bootstrap.*.network_interface.0.network_ip
+}

--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -42,10 +42,19 @@ resource "google_dns_record_set" "etcd_a_nodes" {
   rrdatas      = [var.etcd_ip_addresses[count.index]]
 }
 
+resource "google_dns_record_set" "etcd_a_bootstrap" {
+  count        = var.etcd_pivot ? 1 : 0
+  type         = "A"
+  ttl          = "60"
+  managed_zone = google_dns_managed_zone.int.name
+  name         = "etcd-bootstrap.${var.cluster_domain}."
+  rrdatas      = [var.bootstrap_ip_addresses[count.index]]
+}
+
 resource "google_dns_record_set" "etcd_cluster" {
   type         = "SRV"
   ttl          = "60"
   managed_zone = google_dns_managed_zone.int.name
   name         = "_etcd-server-ssl._tcp.${var.cluster_domain}."
-  rrdatas      = formatlist("0 10 2380 %s", google_dns_record_set.etcd_a_nodes.*.name)
+  rrdatas      = formatlist("0 10 2380 %s", concat(google_dns_record_set.etcd_a_nodes.*.name, google_dns_record_set.etcd_a_bootstrap.*.name))
 }

--- a/data/data/gcp/dns/variables.tf
+++ b/data/data/gcp/dns/variables.tf
@@ -8,6 +8,13 @@ variable "network" {
   type        = string
 }
 
+variable "etcd_pivot" {
+  type    = string
+  default = "false"
+
+  description = "(internal)(temporary) Should OpenShift pivot an etcd cluster from the boostrap node."
+}
+
 variable "etcd_count" {
   description = "The number of etcd members."
   type        = string
@@ -15,6 +22,12 @@ variable "etcd_count" {
 
 variable "etcd_ip_addresses" {
   description = "List of string IPs for machines running etcd members."
+  type        = list(string)
+  default     = []
+}
+
+variable "bootstrap_ip_addresses" {
+  description = "List of string IPs for boostrap machines."
   type        = list(string)
   default     = []
 }

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -65,11 +65,13 @@ module "network" {
 module "dns" {
   source = "./dns"
 
-  cluster_id           = var.cluster_id
-  public_dns_zone_name = var.gcp_public_dns_zone_name
-  network              = module.network.network
-  etcd_ip_addresses    = flatten(module.master.ip_addresses)
-  etcd_count           = var.master_count
-  cluster_domain       = var.cluster_domain
-  api_external_lb_ip   = module.network.cluster_public_ip
+  cluster_id             = var.cluster_id
+  public_dns_zone_name   = var.gcp_public_dns_zone_name
+  network                = module.network.network
+  etcd_ip_addresses      = flatten(module.master.ip_addresses)
+  bootstrap_ip_addresses = flatten(module.bootstrap.bootstrap_instance_ips)
+  etcd_count             = var.master_count
+  etcd_pivot             = var.etcd_pivot
+  cluster_domain         = var.cluster_domain
+  api_external_lb_ip     = module.network.cluster_public_ip
 }

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -54,7 +54,7 @@ resource "libvirt_network" "net" {
     local_only = true
 
     dynamic "srvs" {
-      for_each = data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered
+      for_each = concat(data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered, data.libvirt_network_dns_srv_template.etcd_bootstrap.*.rendered)
       content {
         domain   = srvs.value.domain
         port     = srvs.value.port
@@ -151,5 +151,15 @@ data "libvirt_network_dns_srv_template" "etcd_cluster" {
   port     = 2380
   weight   = 10
   target   = "etcd-${count.index}.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_srv_template" "etcd_bootstrap" {
+  count    = var.etcd_pivot ? 1 : 0
+  service  = "etcd-server-ssl"
+  protocol = "tcp"
+  domain   = var.cluster_domain
+  port     = 2380
+  weight   = 10
+  target   = "etcd-bootstrap.${var.cluster_domain}"
 }
 

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -4,7 +4,10 @@ package tfvars
 import (
 	"encoding/json"
 	"net"
+	"os"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 type config struct {
@@ -13,6 +16,7 @@ type config struct {
 	BaseDomain    string `json:"base_domain,omitempty"`
 	MachineCIDR   string `json:"machine_cidr"`
 	Masters       int    `json:"master_count,omitempty"`
+	EtcdPivot     string `json:"etcd_pivot,omitempty"`
 
 	IgnitionBootstrap string `json:"ignition_bootstrap,omitempty"`
 	IgnitionMaster    string `json:"ignition_master,omitempty"`
@@ -20,6 +24,11 @@ type config struct {
 
 // TFVars generates terraform.tfvar JSON for launching the cluster.
 func TFVars(clusterID string, clusterDomain string, baseDomain string, machineCIDR *net.IPNet, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
+	etcdPivot := "false"
+	if pivot, ok := os.LookupEnv("OPENSHIFT_INSTALL_ETCD_ENABLE_PIVOT"); ok && pivot != "" {
+		logrus.Warn("Found override for etcd provisioning style. Please be warned, this is still under development")
+		etcdPivot = pivot
+	}
 	config := &config{
 		ClusterID:         clusterID,
 		ClusterDomain:     strings.TrimSuffix(clusterDomain, "."),
@@ -28,6 +37,7 @@ func TFVars(clusterID string, clusterDomain string, baseDomain string, machineCI
 		Masters:           masterCount,
 		IgnitionBootstrap: bootstrapIgn,
 		IgnitionMaster:    masterIgn,
+		EtcdPivot:         etcdPivot,
 	}
 
 	return json.MarshalIndent(config, "", "  ")


### PR DESCRIPTION
Define a new tfvar `etcd_pivot` that is set based on the
OPENSHIFT_INSTALL_ETCD_ENABLE_PIVOT environment variable, and controls
the addition of the bootstrap node to the etcd srv record.

This work is part of the redesign of how etcd is deployed to masters,
and the existance of the bootstrap node in this record will initially
be used by bootkube.sh to determine if this new functionally should be
enabled, and like on masters is used to validate that the bootstrap node
is permitted to host etcd.

The patch includes support for AWS and libvirt

Relates to https://github.com/openshift/installer/pull/2008