### PR TITLE
data/data/openstack: Add registry to coredns image

### DIFF
--- a/data/data/openstack/service/main.tf
+++ b/data/data/openstack/service/main.tf
@@ -235,7 +235,7 @@ data "ignition_systemd_unit" "local_dns" {
 Description=Internal DNS serving the required OpenShift records
 
 [Service]
-ExecStart=/bin/podman run --rm -i -t -m 128m --net host --cap-add=NET_ADMIN -v /etc/coredns:/etc/coredns:Z openshift/origin-coredns:v4.0 -conf /etc/coredns/Corefile
+ExecStart=/bin/podman run --rm -i -t -m 128m --net host --cap-add=NET_ADMIN -v /etc/coredns:/etc/coredns:Z quay.io/openshift/origin-coredns:v4.0 -conf /etc/coredns/Corefile
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
The OpenStack deployment started failing with the following message:

Error: error pulling image "openshift/origin-coredns:v4.0": unable to pull openshift/origin-coredns:v4.0: image name provided is a short name and no search registries are defined in the registries config file.

That caused the `local-dns` service on the Service VM to fail which
resulted in none of the nodes receiving Ignition and booting up.

Specifying the `quay.io` registry explicitly fixes this issue.