### PR TITLE
Set resource group explicitly for machines

### DIFF
--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -107,6 +107,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		Subnet:          fmt.Sprintf("%s-%s-subnet", clusterID, role),
 		ManagedIdentity: fmt.Sprintf("%s-identity", clusterID),
 		Vnet:            fmt.Sprintf("%s-vnet", clusterID),
+		ResourceGroup:   fmt.Sprintf("%s-rg", clusterID),
 	}, nil
 }
 


### PR DESCRIPTION
This sets resource group explicitly for machines. We should remove unnecessary assumptions coming from the secret and be API input driven or fail otherwise.
Unless there's a reason to keep it we might drop location and rg requirement from the secret in follow ups for https://github.com/openshift/cluster-api-provider-azure/pull/55