### PR TITLE
Add gather support for gcp

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -17,11 +17,13 @@ import (
 	"github.com/openshift/installer/pkg/terraform"
 	gatheraws "github.com/openshift/installer/pkg/terraform/gather/aws"
 	gatherazure "github.com/openshift/installer/pkg/terraform/gather/azure"
+	gathergcp "github.com/openshift/installer/pkg/terraform/gather/gcp"
 	gatherlibvirt "github.com/openshift/installer/pkg/terraform/gather/libvirt"
 	gatheropenstack "github.com/openshift/installer/pkg/terraform/gather/openstack"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
+	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
 	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
 )
@@ -142,6 +144,15 @@ func extractHostAddresses(config *types.InstallConfig, tfstate *terraform.State)
 			return bootstrap, port, masters, err
 		}
 		masters, err = gatherazure.ControlPlaneIPs(tfstate)
+		if err != nil {
+			logrus.Error(err)
+		}
+	case gcptypes.Name:
+		bootstrap, err = gathergcp.BootstrapIP(tfstate)
+		if err != nil {
+			return bootstrap, port, masters, err
+		}
+		masters, err = gathergcp.ControlPlaneIPs(tfstate)
 		if err != nil {
 			logrus.Error(err)
 		}

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -112,7 +112,9 @@ func runGatherBootstrapCmd(directory string) error {
 func logGatherBootstrap(bootstrap string, port int, masters []string, directory string) error {
 	logrus.Info("Pulling debug logs from the bootstrap machine")
 	client, err := ssh.NewClient("core", fmt.Sprintf("%s:%d", bootstrap, port), gatherBootstrapOpts.sshKeys)
-	if err != nil {
+	if err != nil && len(gatherBootstrapOpts.sshKeys) == 0 {
+		return errors.Wrap(err, "failed to create SSH client, ensure the proper ssh key is in your keyring or specify with --key")
+	} else if err != nil {
 		return errors.Wrap(err, "failed to create SSH client")
 	}
 	if err := ssh.Run(client, fmt.Sprintf("/usr/local/bin/installer-gather.sh %s", strings.Join(masters, " "))); err != nil {

--- a/pkg/terraform/gather/gcp/ip.go
+++ b/pkg/terraform/gather/gcp/ip.go
@@ -1,0 +1,74 @@
+package gcp
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/installer/pkg/terraform"
+)
+
+// BootstrapIP returns the ip address for bootstrap host.
+func BootstrapIP(tfs *terraform.State) (string, error) {
+	br, err := terraform.LookupResource(tfs, "module.bootstrap", "google_compute_instance", "bootstrap")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup bootstrap")
+	}
+	if len(br.Instances) == 0 {
+		return "", errors.New("no bootstrap instance found")
+	}
+
+	networkInterfaces, found, err := unstructured.NestedSlice(br.Instances[0].Attributes, "network_interface")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup network interface")
+	}
+	if !found {
+		return "", errors.New("bootstrap does not contain network_interface")
+	}
+
+	accessConfigs, found, err := unstructured.NestedSlice(networkInterfaces[0].(map[string]interface{}), "access_config")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup access config")
+	}
+	if !found {
+		return "", errors.New("bootstrap's network interface does not contain access_config")
+	}
+
+	bootstrap, found, err := unstructured.NestedString(accessConfigs[0].(map[string]interface{}), "nat_ip")
+	if err != nil {
+		return "", errors.New("failed to lookup public ip address")
+	}
+	if !found {
+		return "", errors.New("access config does not contain nat_ip")
+	}
+	return bootstrap, nil
+}
+
+// ControlPlaneIPs returns the ip addresses for control plane hosts.
+func ControlPlaneIPs(tfs *terraform.State) ([]string, error) {
+	mrs, err := terraform.LookupResource(tfs, "module.master", "google_compute_instance", "master")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to lookup masters")
+	}
+	var errs []error
+	var masters []string
+	for idx, inst := range mrs.Instances {
+		networkInterfaces, found, err := unstructured.NestedSlice(inst.Attributes, "network_interface")
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to lookup network interface for master.%d", idx))
+		}
+		if !found {
+			errs = append(errs, errors.Errorf("no network_interface found for master.%d", idx))
+		}
+
+		master, found, err := unstructured.NestedString(networkInterfaces[0].(map[string]interface{}), "network_ip")
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "no network_ip for master.%d", idx))
+		}
+		if !found {
+			errs = append(errs, errors.Errorf("no network_ip found for master.%d", idx))
+		}
+		masters = append(masters, master)
+	}
+	return masters, utilerrors.NewAggregate(errs)
+}


### PR DESCRIPTION
Adds support for the gather command for the GCP platform. 

There might be a more elegant way to parse the terraform state file for GCP using the unstructured package, but this implementation works and has error checking at each step.

[CORS-1123](https://jira.coreos.com/browse/CORS-1123)

/label platform/google