### PR TITLE
scheduler: Allow configuration of schedulable masters.

### DIFF
--- a/pkg/asset/manifests/scheduler.go
+++ b/pkg/asset/manifests/scheduler.go
@@ -8,6 +8,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -30,7 +31,9 @@ func (*Scheduler) Name() string {
 // Dependencies returns all of the dependencies directly needed to generate
 // the asset.
 func (*Scheduler) Dependencies() []asset.Asset {
-	return []asset.Asset{}
+	return []asset.Asset{
+		&installconfig.InstallConfig{},
+	}
 }
 
 // Generate generates the scheduler config and its CRD.
@@ -47,6 +50,12 @@ func (s *Scheduler) Generate(dependencies asset.Parents) error {
 		Spec: configv1.SchedulerSpec{
 			MastersSchedulable: false,
 		},
+	}
+
+	installConfig := &installconfig.InstallConfig{}
+	dependencies.Get(installConfig)
+	if installConfig.Config.ControlPlane.Schedulable == true {
+		config.Spec.MastersSchedulable = true
 	}
 
 	configData, err := yaml.Marshal(config)

--- a/pkg/asset/manifests/scheduler.go
+++ b/pkg/asset/manifests/scheduler.go
@@ -44,7 +44,9 @@ func (s *Scheduler) Generate(dependencies asset.Parents) error {
 			Name: "cluster",
 			// not namespaced
 		},
-		Spec: configv1.SchedulerSpec{},
+		Spec: configv1.SchedulerSpec{
+			MastersSchedulable: false,
+		},
 	}
 
 	configData, err := yaml.Marshal(config)

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -38,6 +38,13 @@ type MachinePool struct {
 	// +optional
 	// Default is for hyperthreading to be enabled.
 	Hyperthreading HyperthreadingMode `json:"hyperthreading,omitempty"`
+
+	// Schedulable determines whether workloads can be scheduled to the
+	// machines in this MachinePool.  This option is only used for the "master"
+	// MachinePool and will be ignored for "worker" MachinePools.
+	// +optional
+	// Default for "master" MachinePool is "false".
+	Schedulable bool `json:"schedulable,omitempty"`
 }
 
 // MachinePoolPlatform is the platform-specific configuration for a machine


### PR DESCRIPTION
This change makes use of a new configuration item on the scheduler CR
that specifies that control plane hosts should be able to run
workloads.  This option is off by default, but can be changed through
a new install-config option under controlPlane.
    
The justification for a new install-config option for this is that
this is a required tunable for some clusters to have a successful
install.  A 3-node cluster on bare metal for example will need
schedulable masters.
