### PR TITLE
docs/metal: worker host should have role 'worker'

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -162,8 +162,8 @@ platform:
           password: password
         bootMACAddress: 00:11:07:4e:f6:70
         hardwareProfile: default
-    - name: openshift-worker-0
-        role: master
+      - name: openshift-worker-0
+        role: worker
         bmc:
           address: ipmi://192.168.111.1:6233
           username: admin


### PR DESCRIPTION
This fixes a copy/paste error in the docs for the baremetal
install-config. A worker host should have the 'worker' role,
not 'master'.