### PR TITLE
gcp: move external health_check to http port 6080

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -242,6 +242,7 @@ podman run \
 	--servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
 	--servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
 	--address=0.0.0.0:6443 \
+	--insecure-health-check-address=0.0.0.0:6080 \
 	--csrdir=/tmp \
 	--peercertdur=26280h \
 	--servercertdur=26280h \

--- a/data/data/gcp/network/external-lb.tf
+++ b/data/data/gcp/network/external-lb.tf
@@ -5,7 +5,7 @@ resource "google_compute_address" "cluster_public_ip" {
 resource "google_compute_http_health_check" "api_external" {
   name = "${var.cluster_id}-api-external"
 
-  port         = 6443
+  port         = 6080
   request_path = "/readyz"
 }
 

--- a/data/data/gcp/network/firewall-control.tf
+++ b/data/data/gcp/network/firewall-control.tf
@@ -32,7 +32,7 @@ resource "google_compute_firewall" "master_ingress_https" {
     ports    = ["6443"]
   }
 
-  source_ranges = [var.network_cidr]
+  source_ranges = ["0.0.0.0/0"]
   target_tags   = ["${var.cluster_id}-master"]
 }
 

--- a/data/data/gcp/network/firewall-control.tf
+++ b/data/data/gcp/network/firewall-control.tf
@@ -42,7 +42,7 @@ resource "google_compute_firewall" "master_ingress_https_from_health_checks" {
 
   allow {
     protocol = "tcp"
-    ports    = ["6443"]
+    ports    = ["6443", "6080"]
   }
 
   source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22"]


### PR DESCRIPTION
Before this change, the internal health check was using an unencrypted
google_compute_http_health_check while trying to access the cluster over
an encrypted https port: 6443.

This change moves to the port 6080 where the api/readyz should be
available unencrypted for this use case.

This change also opens up 6443 on the masters through the load balancers.

Depends on openshift/cluster-kube-apiserver-operator#525