### PR TITLE
Azure: Restrict all clients on bootstrap host to localhost for k8s API access

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -66,7 +66,7 @@ then
 	cp cvo-bootstrap/bootstrap/* bootstrap-manifests/
 	cp cvo-bootstrap/manifests/* manifests/
 	## FIXME: CVO should use `/etc/kubernetes/bootstrap-secrets/kubeconfig` instead
-	cp auth/kubeconfig /etc/kubernetes/kubeconfig
+	cp auth/kubeconfig-loopback /etc/kubernetes/kubeconfig
 
 	touch cvo-bootstrap.done
 fi

--- a/data/data/bootstrap/systemd/units/approve-csr.service
+++ b/data/data/bootstrap/systemd/units/approve-csr.service
@@ -4,7 +4,7 @@ Wants=bootkube.service
 After=bootkube.service
 
 [Service]
-ExecStart=/usr/local/bin/approve-csr.sh /opt/openshift/auth/kubeconfig
+ExecStart=/usr/local/bin/approve-csr.sh /opt/openshift/auth/kubeconfig-loopback
 
 Restart=on-failure
 RestartSec=5s

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -61,6 +61,7 @@ func (a *Bootstrap) Dependencies() []asset.Asset {
 		&installconfig.InstallConfig{},
 		&kubeconfig.AdminClient{},
 		&kubeconfig.Kubelet{},
+		&kubeconfig.LoopbackClient{},
 		&machines.Master{},
 		&machines.Worker{},
 		&manifests.Manifests{},
@@ -418,6 +419,7 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 	for _, asset := range []asset.WritableAsset{
 		&kubeconfig.AdminClient{},
 		&kubeconfig.Kubelet{},
+		&kubeconfig.LoopbackClient{},
 		&tls.AdminKubeConfigCABundle{},
 		&tls.AggregatorCA{},
 		&tls.AggregatorCABundle{},

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -105,3 +105,7 @@ func getExtAPIServerURL(ic *types.InstallConfig) string {
 func getIntAPIServerURL(ic *types.InstallConfig) string {
 	return fmt.Sprintf("https://api-int.%s:6443", ic.ClusterDomain())
 }
+
+func getLoopbackAPIServerURL(ic *types.InstallConfig) string {
+	return fmt.Sprintf("https://localhost:6443")
+}

--- a/pkg/asset/kubeconfig/loopback.go
+++ b/pkg/asset/kubeconfig/loopback.go
@@ -1,0 +1,56 @@
+package kubeconfig
+
+import (
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/tls"
+)
+
+var (
+	kubeconfigLoopbackPath = filepath.Join("auth", "kubeconfig-loopback")
+)
+
+// LoopbackClient is the asset for the admin kubeconfig.
+type LoopbackClient struct {
+	kubeconfig
+}
+
+var _ asset.WritableAsset = (*LoopbackClient)(nil)
+
+// Dependencies returns the dependency of the kubeconfig.
+func (k *LoopbackClient) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&tls.AdminKubeConfigClientCertKey{},
+		&tls.KubeAPIServerLocalhostCABundle{},
+		&installconfig.InstallConfig{},
+	}
+}
+
+// Generate generates the kubeconfig.
+func (k *LoopbackClient) Generate(parents asset.Parents) error {
+	ca := &tls.KubeAPIServerLocalhostCABundle{}
+	clientCertKey := &tls.AdminKubeConfigClientCertKey{}
+	installConfig := &installconfig.InstallConfig{}
+	parents.Get(ca, clientCertKey, installConfig)
+
+	return k.kubeconfig.generate(
+		ca,
+		clientCertKey,
+		getLoopbackAPIServerURL(installConfig.Config),
+		installConfig.Config.GetName(),
+		"loopback",
+		kubeconfigLoopbackPath,
+	)
+}
+
+// Name returns the human-friendly name of the asset.
+func (k *LoopbackClient) Name() string {
+	return "Kubeconfig Admin Client (Loopback)"
+}
+
+// Load returns the kubeconfig from disk.
+func (k *LoopbackClient) Load(f asset.FileFetcher) (found bool, err error) {
+	return k.load(f, kubeconfigLoopbackPath)
+}


### PR DESCRIPTION
This code attempts to coerce bootstrap operators to use localhost for API access. This avoids clients getting blackholed by hitting the load balancer which is is only in front of the bootstrap node during bootstrapping. 

A kubeconfig is generated that accesses the API server locally. The following
operators are affected by this:

cluster-bootstrap
bootstrap cluster-version-operator
bootstrap kube-controller-manager
bootstrap kube-scheduler

https://jira.coreos.com/browse/CORS-1094