### PR TITLE
Add RHCOSBaseURI to templating for bootstrap files

### DIFF
--- a/pkg/rhcos/baseuri.go
+++ b/pkg/rhcos/baseuri.go
@@ -1,0 +1,23 @@
+package rhcos
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+// BaseURI fetches the BaseURI where images can be downloaded from
+func BaseURI() (string, error) {
+	meta, err := fetchRHCOSBuild(context.TODO())
+	if err != nil {
+		return "", errors.Wrap(err, "failed to fetch RHCOS metadata")
+	}
+
+	base, err := url.Parse(meta.BaseURI)
+	if err != nil {
+		return "", err
+	}
+
+	return base.String(), nil
+}


### PR DESCRIPTION
This allows us to template in the baseURI from data/data/rhcos.json
when needed for boostrap files (the baremetal platform will soon require
this to download the appropriate image to provision the masters ref
https://github.com/openshift-metal3/kni-installer/pull/100