### PR TITLE
baremetal: Add dns vip to install-config

### DIFF
--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -63,4 +63,7 @@ type Platform struct {
 
 	// IngressVIP is the VIP to use for ingress traffic
 	IngressVIP string `json:"ingressVIP"`
+
+	// DNSVIP is the VIP to use for internal DNS communication
+	DNSVIP     string `json:"dnsVIP"`
 }

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -40,5 +40,9 @@ func ValidatePlatform(p *baremetal.Platform, fldPath *field.Path) field.ErrorLis
 	if err := validate.IP(p.IngressVIP); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressVIP"), p.IngressVIP, err.Error()))
 	}
+
+	if err := validate.IP(p.DNSVIP); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("dnsVIP"), p.DNSVIP, err.Error()))
+	}
 	return allErrs
 }


### PR DESCRIPTION
Currently the DNS VIP is being looked up from an external DNS record,
but because we don't want to have unnecessary external dependencies
we need to have it specified in the install-config. This adds the
DNS VIP as a configuration item like the API and ingress VIPs.

Co-Authored-By: Yossi Boaron <yboaron@redhat.com>