### PR TITLE
baremetal: Add VIPs to status.platformStatus.baremetal

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -87,6 +87,11 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		}
 	case baremetal.Name:
 		config.Status.PlatformStatus.Type = configv1.BareMetalPlatformType
+		config.Status.PlatformStatus.BareMetal = &configv1.BareMetalPlatformStatus{
+			APIServerInternalIP: installConfig.Config.Platform.BareMetal.APIVIP,
+			NodeDNSIP:           installConfig.Config.Platform.BareMetal.DNSVIP,
+			IngressIP:           installConfig.Config.Platform.BareMetal.IngressVIP,
+		}
 	case gcp.Name:
 		config.Status.PlatformStatus.Type = configv1.GCPPlatformType
 		config.Status.PlatformStatus.GCP = &configv1.GCPPlatformStatus{

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -63,4 +63,7 @@ type Platform struct {
 
 	// IngressVIP is the VIP to use for ingress traffic
 	IngressVIP string `json:"ingressVIP"`
+
+	// DNSVIP is the VIP to use for internal DNS communication
+	DNSVIP string `json:"dnsVIP"`
 }

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -40,5 +40,9 @@ func ValidatePlatform(p *baremetal.Platform, fldPath *field.Path) field.ErrorLis
 	if err := validate.IP(p.IngressVIP); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressVIP"), p.IngressVIP, err.Error()))
 	}
+
+	if err := validate.IP(p.DNSVIP); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("dnsVIP"), p.DNSVIP, err.Error()))
+	}
 	return allErrs
 }


### PR DESCRIPTION
We need to have these VIPs available in platform status so they are available to the static pod configurations rendered by MCO.