### PR TITLE
Add static external ip address to GCP bootstrap node.

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -20,6 +20,10 @@ data "ignition_config" "redirect" {
   }
 }
 
+resource "google_compute_address" "bootstrap" {
+  name = "${var.cluster_id}-bootstrap-public-ip"
+}
+
 resource "google_compute_firewall" "bootstrap_ingress_ssh" {
   name    = "${var.cluster_id}-bootstrap-in-ssh"
   network = var.network
@@ -52,6 +56,7 @@ resource "google_compute_instance" "bootstrap" {
     subnetwork = var.subnet
 
     access_config {
+      nat_ip = "${google_compute_address.bootstrap.address}"
     }
   }
 


### PR DESCRIPTION
There seemed to be some concerns about using an ephemeral ip address for the bootstrap node and its effects on the gather command. Although the tests were fine, why not just give it a static address?

Replace the current ephemeral external ip address for the bootstrap node with a static one. This will prevent a new ip address from being assigned to the bootstrap node in the event that the node is stopped and restarted. 

/label platform/google