### PR TITLE
baremetal: rename os_image to bootstrap_os_image

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -11,7 +11,7 @@ module "bootstrap" {
   source = "./bootstrap"
 
   cluster_id          = var.cluster_id
-  image               = var.os_image
+  image               = var.bootstrap_os_image
   ignition            = var.ignition_bootstrap
   external_bridge     = var.external_bridge
   provisioning_bridge = var.provisioning_bridge

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -8,9 +8,9 @@ variable "libvirt_uri" {
   description = "libvirt connection URI"
 }
 
-variable "os_image" {
+variable "bootstrap_os_image" {
   type        = string
-  description = "The URL of the OS disk image"
+  description = "The URL of the bootstrap OS disk image"
 }
 
 variable "external_bridge" {

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -13,7 +13,7 @@ import (
 type config struct {
 	LibvirtURI         string `json:"libvirt_uri,omitempty"`
 	IronicURI          string `json:"ironic_uri,omitempty"`
-	Image              string `json:"os_image,omitempty"`
+	BootstrapOSImage   string `json:"bootstrap_os_image,omitempty"`
 	ExternalBridge     string `json:"external_bridge,omitempty"`
 	ProvisioningBridge string `json:"provisioning_bridge,omitempty"`
 
@@ -26,10 +26,10 @@ type config struct {
 }
 
 // TFVars generates bare metal specific Terraform variables.
-func TFVars(libvirtURI, ironicURI, osImage, externalBridge, provisioningBridge string, platformHosts []*baremetal.Host, image baremetal.Image) ([]byte, error) {
-	osImage, err := libvirttfvars.CachedImage(osImage)
+func TFVars(libvirtURI, ironicURI, bootstrapOSImage, externalBridge, provisioningBridge string, platformHosts []*baremetal.Host, image baremetal.Image) ([]byte, error) {
+	bootstrapOSImage, err := libvirttfvars.CachedImage(bootstrapOSImage)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to use cached libvirt image")
+		return nil, errors.Wrap(err, "failed to use cached bootstrap libvirt image")
 	}
 
 	var hosts, rootDevices, properties, driverInfos, instanceInfos []map[string]interface{}
@@ -96,7 +96,7 @@ func TFVars(libvirtURI, ironicURI, osImage, externalBridge, provisioningBridge s
 	cfg := &config{
 		LibvirtURI:         libvirtURI,
 		IronicURI:          ironicURI,
-		Image:              osImage,
+		BootstrapOSImage:   bootstrapOSImage,
 		ExternalBridge:     externalBridge,
 		ProvisioningBridge: provisioningBridge,
 		Hosts:              hosts,


### PR DESCRIPTION
Rename the terraform os_image variable to bootstrap_os_image to make it clear that this boot image is only used for the bootstrap VM.

Related to openshift/installer#2037