### PR TITLE
baremetal: Note short-term requirement for ns1 DNS record.

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -56,6 +56,8 @@ purposes:
     server is appropriate for this environment.
     * `api.<cluster-name>.<base-domain>` - pointing to the API VIP
     * `*.apps.<cluster-name>.<base-domain>` - pointing to the Ingress VIP
+    * `ns1.<cluster-name>.<base-domain>` - pointing to the DNS VIP. *Note: work
+      is underway to remove this required DNS entry.*
 
 * **NIC #2 - Provisioning Network**
   * A private, non-routed network, used for PXE based provisioning.


### PR DESCRIPTION
The "ns1" DNS record is currently required.  The intention is for this
to go away and be replaced by reading this VIP out of the
platformstatus field of the infrastructure resource.  That work is
underway, but this doc change reflects the current state of code.