### PR TITLE
OpenStack: Fix Octavia support detection

### DIFF
--- a/pkg/types/openstack/validation/realvalidvaluesfetcher.go
+++ b/pkg/types/openstack/validation/realvalidvaluesfetcher.go
@@ -167,7 +167,7 @@ func (f realValidValuesFetcher) GetServiceCatalog(cloud string) ([]string, error
 
 	domainName := cloudConfig.AuthInfo.DomainName
 	if domainName == "" {
-		domainName = "default"
+		domainName = cloudConfig.AuthInfo.UserDomainName
 	}
 
 	scope := tokens.Scope{


### PR DESCRIPTION
In order to detect if Octavia service is enabled in the cloud
the service catalog must be retrieved. Right now, we rely on
the project domain to authenticate, and if this parameter
is not provided we set it as default. However, other clouds
could have another value for that parameter resulting in failure
when retrieving the catalog list. This commit fixes the issue by
using the user domain when no project domain is defined.