### PR TITLE
 [gcp] pkg/destroy: delete disks

### DIFF
--- a/pkg/destroy/gcp/compute.go
+++ b/pkg/destroy/gcp/compute.go
@@ -233,3 +233,63 @@ func (o *ClusterUninstaller) destroyImages() error {
 	}
 	return aggregateError(errs, len(found))
 }
+
+func (o *ClusterUninstaller) listDisks() ([]nameAndZone, error) {
+	o.Logger.Debug("Listing disks")
+	result := []nameAndZone{}
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
+	req := o.computeSvc.Disks.AggregatedList(o.ProjectID).Fields("items(name,zone)").Filter(o.clusterIDFilter())
+	err := req.Pages(ctx, func(aggregatedList *compute.DiskAggregatedList) error {
+		for _, scopedList := range aggregatedList.Items {
+			for _, disk := range scopedList.Disks {
+				result = append(result, nameAndZone{name: disk.Name, zone: disk.Zone})
+				o.Logger.Debugf("Found disk %s in zone %s", disk.Name, disk.Zone)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to fetch images")
+	}
+	return result, nil
+}
+
+func (o *ClusterUninstaller) deleteDisk(disk nameAndZone) error {
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
+	o.Logger.Debugf("Deleting disk %s in zone %s", disk.name, disk.zone)
+	op, err := o.computeSvc.Disks.Delete(o.ProjectID, disk.zone, disk.name).RequestId(o.requestID("disk", disk.zone, disk.name)).Context(ctx).Do()
+	if err != nil && !isNoOp(err) {
+		o.resetRequestID("disk", disk.zone, disk.name)
+		return errors.Wrapf(err, "failed to delete disk %s in zone %s", disk.name, disk.zone)
+	}
+	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
+		o.resetRequestID("disk", disk.zone, disk.name)
+		return errors.Errorf("failed to delete disk %s in zone %s with error: %s", disk.name, disk.zone, op.HttpErrorMessage)
+	}
+	return nil
+}
+
+// destroyDisks searches for disks across all zones that have a name that starts with
+// the infra ID prefix. It then deletes each disk found.
+func (o *ClusterUninstaller) destroyDisks() error {
+	disks, err := o.listDisks()
+	if err != nil {
+		return err
+	}
+	errs := []error{}
+	found := make([]string, 0, len(disks))
+	for _, disk := range disks {
+		found = append(found, fmt.Sprintf("%s/%s", disk.zone, disk.name))
+		err := o.deleteDisk(disk)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	deletedItems := o.setPendingItems("disk", found)
+	for _, item := range deletedItems {
+		o.Logger.Infof("Deleted disk %s", item)
+	}
+	return aggregateError(errs, len(found))
+}

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -111,6 +111,7 @@ func (o *ClusterUninstaller) destroyCluster() (bool, error) {
 		destroy func() error
 	}{
 		{name: "Compute instances", destroy: o.destroyComputeInstances},
+		{name: "Disks", destroy: o.destroyDisks},
 		{name: "Service accounts", destroy: o.destroyServiceAccounts},
 		{name: "Images", destroy: o.destroyImages},
 		{name: "DNS", destroy: o.destroyDNS},


### PR DESCRIPTION
Adds code to delete disks that are prefixed with the cluster's infra
ID. Disks that are dynamically created should get this prefix when the
controller-manager is passed the infra ID as the --cluster-name
argument.