### PR TITLE
Sort GCP basedomains in installer prompts.

### DIFF
--- a/pkg/asset/installconfig/gcp/dns.go
+++ b/pkg/asset/installconfig/gcp/dns.go
@@ -85,6 +85,7 @@ func GetBaseDomain(project string) (string, error) {
 	if len(publicZones) == 0 {
 		return "", errors.New("no domain names found in project")
 	}
+	sort.Strings(publicZones)
 
 	var domain string
 	if err := survey.AskOne(&survey.Select{


### PR DESCRIPTION
Fixes bug in GCP installer prompts where validation fails on valid choices, because validation expects domains to be sorted. This would also be better UI on a long list of domains.

Installer prompts were only working by chance.

This fixes bug that looks like this: 
```
X Sorry, your reply was invalid: invalid base domain "gcp.devcluster.openshift.com"
```
where gcp.devcluster.openshift.com was a valid domain.

/label platform/google