### PR TITLE
baremetal: Add ingressVIP to sample install config.

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -139,6 +139,7 @@ controlPlane:
 platform:
   baremetal:
     apiVIP: 192.168.111.5
+    ingressVIP: 192.168.111.4
     hosts:
       - name: openshift-master-0
         role: master


### PR DESCRIPTION
The ingress VIP is discussed both in docs/user/metal/install_ipi.md
and docs/design/baremetal/networking-architecture.md.  This option
already exists, but was not included in the sample configuration.