### PR TITLE
GCP client: pass scope when using default credentials.

### DIFF
--- a/pkg/asset/installconfig/gcp/session.go
+++ b/pkg/asset/installconfig/gcp/session.go
@@ -145,7 +145,7 @@ func (f *contentLoader) String() string {
 type cliLoader struct{}
 
 func (c *cliLoader) Load(ctx context.Context) (*googleoauth.Credentials, error) {
-	return googleoauth.FindDefaultCredentials(ctx)
+	return googleoauth.FindDefaultCredentials(ctx, compute.CloudPlatformScope)
 }
 
 func (c *cliLoader) String() string {


### PR DESCRIPTION
The function that creates a GCP session when using default credentials needs to pass a scope, just as the function for using JSON service account keys already does.

This fixes a bug when users have default gcloud credentials set to a valid service account which results in this error:

```
oauth2: cannot fetch token: 400 Bad Request
Response: {
  "error": "invalid_scope",
  "error_description": "Empty or missing scope not allowed."
}
```
Default credentials are:
```

1. A JSON file whose path is specified by the GOOGLE_APPLICATION_CREDENTIALS environment variable.
2. A JSON file in a location known to the gcloud command-line tool. On Windows, this is %APPDATA%/gcloud/application_default_credentials.json. On other systems, $HOME/.config/gcloud/application_default_credentials.json.
3. On Google App Engine standard first generation runtimes (<= Go 1.9) it uses the appengine.AccessToken function.
4. On Google Compute Engine, Google App Engine standard second generation runtimes (>= Go 1.11), and Google App Engine flexible environment, it fetches credentials from the metadata server. (In this final case any provided scopes are ignored.)
```

/label platform/google