### PR TITLE
Set Kuryr as default NetworkType if platform supports it

### DIFF
--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -66,7 +66,7 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 		BaseDomain: "test-domain",
 		Networking: &types.Networking{
 			MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
-			NetworkType:    "OpenShiftSDN",
+			NetworkType:    "DefaultNetworkType",
 			ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 			ClusterNetwork: []types.ClusterNetworkEntry{
 				{
@@ -127,7 +127,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				BaseDomain: "test-domain",
 				Networking: &types.Networking{
 					MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
-					NetworkType:    "OpenShiftSDN",
+					NetworkType:    "DefaultNetworkType",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
 						{
@@ -208,7 +208,7 @@ network:
 				BaseDomain: "test-domain",
 				Networking: &types.Networking{
 					MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
-					NetworkType:    "OpenShiftSDN",
+					NetworkType:    "DefaultNetworkType",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
 						{

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -18,7 +18,10 @@ var (
 	defaultServiceNetwork = ipnet.MustParseCIDR("172.30.0.0/16")
 	defaultClusterNetwork = ipnet.MustParseCIDR("10.128.0.0/14")
 	defaultHostPrefix     = 23
-	defaultNetworkType    = "OpenShiftSDN"
+	// DefaultNetworkType is just a token meaning that user haven't specified preference for NetworkType. This is
+	// because for OpenStack installations Kuryr should be configured if possible and we are unable to know if cloud
+	// fulfills all the Kuryr requirements at the point SetInstallConfigDefaults() is called.
+	DefaultNetworkType = "DefaultNetworkType"
 )
 
 // SetInstallConfigDefaults sets the defaults for the install config.
@@ -33,7 +36,7 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		}
 	}
 	if c.Networking.NetworkType == "" {
-		c.Networking.NetworkType = defaultNetworkType
+		c.Networking.NetworkType = DefaultNetworkType
 	}
 	if len(c.Networking.ServiceNetwork) == 0 {
 		c.Networking.ServiceNetwork = []ipnet.IPNet{*defaultServiceNetwork}

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -24,7 +24,7 @@ func defaultInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
 			MachineCIDR:    defaultMachineCIDR,
-			NetworkType:    defaultNetworkType,
+			NetworkType:    DefaultNetworkType,
 			ServiceNetwork: []ipnet.IPNet{*defaultServiceNetwork},
 			ClusterNetwork: []types.ClusterNetworkEntry{
 				{


### PR DESCRIPTION
This commit makes sure that the default NetworkType will be set to
"Kuryr" for OpenStack clouds that have Neuron trunk ports enabled and
are running Octavia loadbalancing service. For any other platform
OpenShiftSDN will be used. Please note that this does not override any
choice that might have been made by the deployer in the InstallConfig.

The detection and choice of the default value is done in
config.v1.Network's Generate() as at the point of
SetInstallConfigDefaults() we don't know anything about the target
platform capabilities.

This bases on and supersedes #1500 approach.