### PR TITLE
ISSUE_TEMPLATE.md: List baremetal and none as paltform types

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ $ openshift-install version
 
 # Platform:
 <!--
-Please specify below either aws, libvirt or openstack below.
+Please specify the platform type: aws, libvirt, openstack, baremetal, or none (UPI)
 -->
 
 # What happened?


### PR DESCRIPTION
Instead of updating this comment to list "baremetal" as a valid
platform type, just reference the README.md, which lists the platforms
currently supported by the installer.  That saves one more place to
update each time a platform is updated.