### PR TITLE
[gcp] pkg/assets/machine: specify full URL for machine image

### DIFF
--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -79,7 +79,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 			Boot:   true,
 			SizeGb: 128,
 			Type:   "pd-ssd",
-			Image:  osImage,
+			Image:  fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/global/images/%s", platform.ProjectID, osImage),
 		}},
 		NetworkInterfaces: []*gcpprovider.GCPNetworkInterface{{
 			Network:    fmt.Sprintf("%s-network", clusterID),


### PR DESCRIPTION
The call to create a new instance requires a URL for the image to use. This changes the image spec on machines/machinesets to a URL.