### PR TITLE
Bug 1734157: data/bootstrap: Remove the unwanted backslash newline escape char

### DIFF
--- a/data/data/bootstrap/systemd/units/kubelet.service.template
+++ b/data/data/bootstrap/systemd/units/kubelet.service.template
@@ -21,7 +21,7 @@ ExecStart=/usr/bin/hyperkube \
     --cgroup-driver=systemd \
     --serialize-image-pulls=false \
     --v=2 \
-    --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+    --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec
 
 Restart=always
 RestartSec=10


### PR DESCRIPTION
## What I did
Removed the unwanted backslash newline escape char from the service file

## Description for the changelog

While testing on the fedora coreos, have seen these extra backslash newline escape chars were creating issues and couldn't start the service, hence removing them anyways which aren't required here.

Fixes: #2080