### PR TITLE
libvirt: Delete volumes & storage pool directory

### DIFF
--- a/pkg/destroy/libvirt/libvirt.go
+++ b/pkg/destroy/libvirt/libvirt.go
@@ -178,6 +178,10 @@ func deleteStoragePool(conn *libvirt.Connect, filter filterFunc, logger logrus.F
 			return errors.Wrapf(err, "destroy pool %q", pname)
 		}
 
+		if err := pool.Delete(0); err != nil {
+			return errors.Wrapf(err, "delete pool %q", pname)
+		}
+
 		if err := pool.Undefine(); err != nil {
 			return errors.Wrapf(err, "undefine pool %q", pname)
 		}

--- a/pkg/destroy/libvirt/libvirt.go
+++ b/pkg/destroy/libvirt/libvirt.go
@@ -164,9 +164,6 @@ func deleteStoragePool(conn *libvirt.Connect, filter filterFunc, logger logrus.F
 			if err != nil {
 				return errors.Wrapf(err, "get volume names in %q", pname)
 			}
-			if !filter(vName) {
-				continue
-			}
 			if err := vol.Delete(0); err != nil {
 				return errors.Wrapf(err, "delete volume %q from %q", vName, pname)
 			}


### PR DESCRIPTION
Two patches that ensures we delete the volumes and storage pool when destroying the relevant cluster.

Fixes #2074.