### PR TITLE
openstack: Add a floating IP to bootstrap node for must-gather

### DIFF
--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -88,6 +88,7 @@ resource "openstack_networking_floatingip_associate_v2" "service_fip" {
 }
 
 resource "openstack_networking_floatingip_v2" "bootstrap_fip" {
+  count   = var.enable_bootstrap_floating_ip ? 1 : 0
   pool    = "${var.external_network}"
   port_id = "${openstack_networking_port_v2.bootstrap_port.id}"
 }

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -87,6 +87,11 @@ resource "openstack_networking_floatingip_associate_v2" "service_fip" {
   floating_ip = var.lb_floating_ip
 }
 
+resource "openstack_networking_floatingip_v2" "bootstrap_fip" {
+  pool    = "${var.external_network}"
+  port_id = "${openstack_networking_port_v2.bootstrap_port.id}"
+}
+
 resource "openstack_networking_router_v2" "openshift-external-router" {
   name                = "${var.cluster_id}-external-router"
   admin_state_up      = true

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -24,6 +24,12 @@ variable "lb_floating_ip" {
   default     = ""
 }
 
+variable "enable_bootstrap_floating_ip" {
+  description = "(optional) If true the bootstrap machine gets a floating IP address that will be used to collect logs."
+  type        = bool
+  default     = true
+}
+
 variable "masters_count" {
   type = string
 }


### PR DESCRIPTION
In order to collect logs from the bootstrap node during CI, we
need to have a floating IP attached to the node. Otherwise, there
is no way for the installer to run must-gather against the
bootstrap node.

Note: we also need to pass a private-key in CI. Handled by:
https://github.com/openshift/release/pull/4504