### PR TITLE
Set GCP to pull boot images from RHCOS pipeline.

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -48,7 +48,7 @@ resource "google_compute_instance" "bootstrap" {
     initialize_params {
       type  = var.root_volume_type
       size  = var.root_volume_size
-      image = var.image_name
+      image = var.image
     }
   }
 

--- a/data/data/gcp/bootstrap/variables.tf
+++ b/data/data/gcp/bootstrap/variables.tf
@@ -14,7 +14,7 @@ variable "ignition" {
   description = "The content of the bootstrap ignition file."
 }
 
-variable "image_name" {
+variable "image" {
   type        = string
   description = "The image for the bootstrap node."
 }

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -16,7 +16,7 @@ module "bootstrap" {
 
   bootstrap_enabled = var.gcp_bootstrap_enabled
 
-  image_name   = var.gcp_image_id
+  image        = google_compute_image.cluster.self_link
   machine_type = var.gcp_bootstrap_instance_type
   cluster_id   = var.cluster_id
   ignition     = var.ignition_bootstrap
@@ -30,7 +30,7 @@ module "bootstrap" {
 module "master" {
   source = "./master"
 
-  image_name     = var.gcp_image_id
+  image          = google_compute_image.cluster.self_link
   instance_count = var.master_count
   machine_type   = var.gcp_master_instance_type
   cluster_id     = var.cluster_id
@@ -72,4 +72,12 @@ module "dns" {
   etcd_count           = var.master_count
   cluster_domain       = var.cluster_domain
   api_external_lb_ip   = module.network.cluster_public_ip
+}
+
+resource "google_compute_image" "cluster" {
+  name = "${var.cluster_id}-rhcos-image"
+
+  raw_disk {
+    source = var.gcp_image_uri
+  }
 }

--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -34,7 +34,7 @@ resource "google_compute_instance" "master" {
     initialize_params {
       type  = var.root_volume_type
       size  = var.root_volume_size
-      image = var.image_name
+      image = var.image
     }
   }
 

--- a/data/data/gcp/master/variables.tf
+++ b/data/data/gcp/master/variables.tf
@@ -8,7 +8,7 @@ variable "ignition" {
   description = "The content of the masters ignition file."
 }
 
-variable "image_name" {
+variable "image" {
   type        = string
   description = "The image for the master instances."
 }

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -40,7 +40,7 @@ variable "gcp_master_instance_type" {
   description = "Instance type for the master node(s). Example: `n1-standard-4`"
 }
 
-variable "gcp_image_id" {
+variable "gcp_image_uri" {
   type = string
   description = "Image for all nodes."
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -210,6 +210,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		data, err := gcptfvars.TFVars(
 			auth,
 			masterConfigs,
+			string(*rhcosImage),
 			publicZone.Name,
 		)
 		if err != nil {

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -79,7 +79,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 			Boot:   true,
 			SizeGb: 128,
 			Type:   "pd-ssd",
-			Image:  osImage,
+			Image:  fmt.Sprintf("%s-rhcos-image", clusterID),
 		}},
 		NetworkInterfaces: []*gcpprovider.GCPNetworkInterface{{
 			Network:    fmt.Sprintf("%s-network", clusterID),

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -65,6 +65,7 @@ func (i *Image) Generate(p asset.Parents) error {
 		}
 		osimage, err = rhcos.AMI(ctx, config.Platform.AWS.Region)
 	case gcp.Name:
+		osimage, err = rhcos.GCP(ctx)
 	case libvirt.Name:
 		osimage, err = rhcos.QEMU(ctx)
 	case openstack.Name:

--- a/pkg/rhcos/gcp.go
+++ b/pkg/rhcos/gcp.go
@@ -1,0 +1,22 @@
+package rhcos
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// GCP fetches the URL of the public GCP storage bucket containing the RHCOS image
+func GCP(ctx context.Context) (string, error) {
+	meta, err := fetchRHCOSBuild(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to fetch RHCOS metadata")
+	}
+
+	url := meta.GCP.URL
+	if url == "" {
+		return "", errors.New("no RHCOS GCP URL found")
+	}
+
+	return url, nil
+}

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -18,14 +18,14 @@ type config struct {
 	BootstrapInstanceType   string   `json:"gcp_bootstrap_instance_type,omitempty"`
 	MasterInstanceType      string   `json:"gcp_master_instance_type,omitempty"`
 	MasterAvailabilityZones []string `json:"gcp_master_availability_zones"`
-	ImageID                 string   `json:"gcp_image_id,omitempty"`
+	ImageURI                string   `json:"gcp_image_uri,omitempty"`
 	VolumeType              string   `json:"gcp_master_root_volume_type,omitempty"`
 	VolumeSize              int64    `json:"gcp_master_root_volume_size,omitempty"`
 	PublicZoneName          string   `json:"gcp_public_dns_zone_name,omitempty"`
 }
 
 // TFVars generates gcp-specific Terraform variables launching the cluster.
-func TFVars(auth Auth, masterConfigs []*gcpprovider.GCPMachineProviderSpec, publicZoneName string) ([]byte, error) {
+func TFVars(auth Auth, masterConfigs []*gcpprovider.GCPMachineProviderSpec, imageURI, publicZoneName string) ([]byte, error) {
 	masterConfig := masterConfigs[0]
 	masterAvailabilityZones := make([]string, len(masterConfigs))
 	for i, c := range masterConfigs {
@@ -39,7 +39,7 @@ func TFVars(auth Auth, masterConfigs []*gcpprovider.GCPMachineProviderSpec, publ
 		MasterAvailabilityZones: masterAvailabilityZones,
 		VolumeType:              masterConfig.Disks[0].Type,
 		VolumeSize:              masterConfig.Disks[0].SizeGb,
-		ImageID:                 masterConfig.Disks[0].Image,
+		ImageURI:                imageURI,
 		PublicZoneName:          publicZoneName,
 	}
 


### PR DESCRIPTION
Specifies a URL which points to a gcp storage bucket where the RHCOS pipeline publishes an RHCOS image for gcp (coreos/coreos-assembler#650). Use that tar.gz file to create a compute image for the cluster and boot the instances from that.

JIRA: [CORS-1164](https://jira.coreos.com/browse/CORS-1164)
/label platform/google