### PR TITLE
azure: generate loopback kubeconfig to access API locally

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -61,6 +61,7 @@ func (a *Bootstrap) Dependencies() []asset.Asset {
 		&installconfig.InstallConfig{},
 		&kubeconfig.AdminClient{},
 		&kubeconfig.Kubelet{},
+		&kubeconfig.LoopbackClient{},
 		&machines.Master{},
 		&machines.Worker{},
 		&manifests.Manifests{},
@@ -418,6 +419,7 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 	for _, asset := range []asset.WritableAsset{
 		&kubeconfig.AdminClient{},
 		&kubeconfig.Kubelet{},
+		&kubeconfig.LoopbackClient{},
 		&tls.AdminKubeConfigCABundle{},
 		&tls.AggregatorCA{},
 		&tls.AggregatorCABundle{},

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -105,3 +105,7 @@ func getExtAPIServerURL(ic *types.InstallConfig) string {
 func getIntAPIServerURL(ic *types.InstallConfig) string {
 	return fmt.Sprintf("https://api-int.%s:6443", ic.ClusterDomain())
 }
+
+func getLoopbackAPIServerURL(ic *types.InstallConfig) string {
+	return fmt.Sprintf("https://localhost:6443")
+}

--- a/pkg/asset/kubeconfig/loopback.go
+++ b/pkg/asset/kubeconfig/loopback.go
@@ -1,0 +1,56 @@
+package kubeconfig
+
+import (
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/tls"
+)
+
+var (
+	kubeconfigLoopbackPath = filepath.Join("auth", "kubeconfig-loopback")
+)
+
+// LoopbackClient is the asset for the admin kubeconfig.
+type LoopbackClient struct {
+	kubeconfig
+}
+
+var _ asset.WritableAsset = (*LoopbackClient)(nil)
+
+// Dependencies returns the dependency of the kubeconfig.
+func (k *LoopbackClient) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&tls.AdminKubeConfigClientCertKey{},
+		&tls.KubeAPIServerLocalhostCABundle{},
+		&installconfig.InstallConfig{},
+	}
+}
+
+// Generate generates the kubeconfig.
+func (k *LoopbackClient) Generate(parents asset.Parents) error {
+	ca := &tls.KubeAPIServerLocalhostCABundle{}
+	clientCertKey := &tls.AdminKubeConfigClientCertKey{}
+	installConfig := &installconfig.InstallConfig{}
+	parents.Get(ca, clientCertKey, installConfig)
+
+	return k.kubeconfig.generate(
+		ca,
+		clientCertKey,
+		getLoopbackAPIServerURL(installConfig.Config),
+		installConfig.Config.GetName(),
+		"loopback",
+		kubeconfigLoopbackPath,
+	)
+}
+
+// Name returns the human-friendly name of the asset.
+func (k *LoopbackClient) Name() string {
+	return "Kubeconfig Admin Client (Loopback)"
+}
+
+// Load returns the kubeconfig from disk.
+func (k *LoopbackClient) Load(f asset.FileFetcher) (found bool, err error) {
+	return k.load(f, kubeconfigLoopbackPath)
+}


### PR DESCRIPTION
This code generates a kubeconfig that uses localhost for API access. 

This is necessary due to a limitation with Azure internal load balancers. See limitation #2 here: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview#limitations

"Unlike public Load Balancers which provide outbound connections when transitioning from private IP addresses inside the virtual network to public IP addresses, internal Load Balancers do not translate outbound originated connections to the frontend of an internal Load Balancer as both are in private IP address space. This avoids potential for SNAT port exhaustion inside unique internal IP address space where translation is not required. The side effect is that if an outbound flow from a VM in the backend pool attempts a flow to frontend of the internal Load Balancer in which pool it resides and is mapped back to itself, both legs of the flow don't match and the flow will fail."

https://jira.coreos.com/browse/CORS-1094