### PR TITLE
data/data/bootstrap: use loopback kubeconfig for API access

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -71,7 +71,7 @@ then
 	cp cvo-bootstrap/bootstrap/* bootstrap-manifests/
 	cp cvo-bootstrap/manifests/* manifests/
 	## FIXME: CVO should use `/etc/kubernetes/bootstrap-secrets/kubeconfig` instead
-	cp auth/kubeconfig /etc/kubernetes/kubeconfig
+	cp auth/kubeconfig-loopback /etc/kubernetes/kubeconfig
 
 	touch cvo-bootstrap.done
 fi

--- a/data/data/bootstrap/systemd/units/approve-csr.service
+++ b/data/data/bootstrap/systemd/units/approve-csr.service
@@ -4,7 +4,7 @@ Wants=bootkube.service
 After=bootkube.service
 
 [Service]
-ExecStart=/usr/local/bin/approve-csr.sh /opt/openshift/auth/kubeconfig
+ExecStart=/usr/local/bin/approve-csr.sh /opt/openshift/auth/kubeconfig-loopback
 
 Restart=on-failure
 RestartSec=5s

--- a/data/data/bootstrap/systemd/units/openshift.service
+++ b/data/data/bootstrap/systemd/units/openshift.service
@@ -6,7 +6,7 @@ ConditionPathExists=!/opt/openshift/.openshift.done
 
 [Service]
 WorkingDirectory=/opt/openshift/openshift
-ExecStart=/usr/local/bin/openshift.sh /opt/openshift/auth/kubeconfig
+ExecStart=/usr/local/bin/openshift.sh /opt/openshift/auth/kubeconfig-loopback
 
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
This code copies the loopback kubeconfig into the kubernetes configuration so that static pods can use it. approve-csr is also modified to use it in its service script. 

This is necessary due to a limitation with Azure internal load balancers. See limitation #2 here: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview#limitations

"Unlike public Load Balancers which provide outbound connections when transitioning from private IP addresses inside the virtual network to public IP addresses, internal Load Balancers do not translate outbound originated connections to the frontend of an internal Load Balancer as both are in private IP address space. This avoids potential for SNAT port exhaustion inside unique internal IP address space where translation is not required. The side effect is that if an outbound flow from a VM in the backend pool attempts a flow to frontend of the internal Load Balancer in which pool it resides and is mapped back to itself, both legs of the flow don't match and the flow will fail."

https://jira.coreos.com/browse/CORS-1094