### PR TITLE
 gcp: reduce the length of the names of machines 

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -40,7 +40,7 @@ resource "google_compute_firewall" "bootstrap_ingress_ssh" {
 resource "google_compute_instance" "bootstrap" {
   count = var.bootstrap_enabled ? 1 : 0
 
-  name         = "${var.cluster_id}-bootstrap"
+  name         = "${var.cluster_id}-b"
   machine_type = var.machine_type
   zone         = var.zone
 

--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -26,7 +26,7 @@ resource "google_project_iam_member" "master-object-storage-admin" {
 resource "google_compute_instance" "master" {
   count = var.instance_count
 
-  name         = "${var.cluster_id}-master-${count.index}"
+  name         = "${var.cluster_id}-m-${count.index}"
   machine_type = var.machine_type
   zone         = element(var.zones, count.index)
 

--- a/pkg/asset/installconfig/clusterid_test.go
+++ b/pkg/asset/installconfig/clusterid_test.go
@@ -18,7 +18,7 @@ func Test_generateInfraID(t *testing.T) {
 		expNonRand: "qwertyuiop",
 	}, {
 		input:      "qwertyuiopasdfghjklzxcvbnm",
-		expLen:     maxBaseLen + randomLen + 1,
+		expLen:     27,
 		expNonRand: "qwertyuiopasdfghjklzx",
 	}, {
 		input:      "qwe.rty.@iop!",
@@ -27,7 +27,7 @@ func Test_generateInfraID(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			got := generateInfraID(test.input)
+			got := generateInfraID(test.input, 27)
 			t.Log("InfraID", got)
 			assert.Equal(t, test.expLen, len(got))
 			assert.Equal(t, test.expNonRand, got[:len(got)-randomLen-1])

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -45,7 +45,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "openshift-machine-api",
-				Name:      fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, idx),
+				Name:      fmt.Sprintf("%s-%s-%d", clusterID, pool.Name[:1], idx),
 				Labels: map[string]string{
 					"machine.openshift.io/cluster-api-cluster":      clusterID,
 					"machine.openshift.io/cluster-api-machine-role": role,

--- a/pkg/asset/machines/gcp/machinesets.go
+++ b/pkg/asset/machines/gcp/machinesets.go
@@ -3,6 +3,7 @@ package gcp
 
 import (
 	"fmt"
+	"strings"
 
 	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +42,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
-		name := fmt.Sprintf("%s-%s-%s", clusterID, pool.Name, az)
+		name := fmt.Sprintf("%s-%s-%s", clusterID, pool.Name[:1], strings.TrimPrefix(az, fmt.Sprintf("%s-", platform.Region)))
 		mset := &machineapi.MachineSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.openshift.io/v1beta1",


### PR DESCRIPTION
The GCE kubelet uses the `os.Hostname()` to create node names and there's a har limit on hostnames to be 64 characters. based on [1]
On GCP, the hostnames are `<instance name>.c.<project-id>.internal` and since the project ids on GCP can be of max 30 characters, an instance name can be max 22 characters.
The instances created by a machineset have the `6` character of randomness added to machineset's name, therefore the max length of machineset's name can be 16 characters. Therefore to accomodate the pool's name and zone (as we create machineset per zone) :

the mastes machines are now `<infra-id>-m-<idx>` and
the worker machinesets are now `<infra-is>-w-<zone>`, where the infra-id can be max 12 characters on GCP.

[1]: https://tools.ietf.org/html/rfc2181#section-11

/cc @csrwng @jstuever 