### PR TITLE
Add new `rhcos-metadata` command

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -49,6 +49,7 @@ func installerMain() {
 		newWaitForCmd(),
 		newGatherCmd(),
 		newVersionCmd(),
+		newRhcosMetadataCmd(),
 		newGraphCmd(),
 		newCompletionCmd(),
 	} {

--- a/cmd/openshift-install/rhcos-metadata.go
+++ b/cmd/openshift-install/rhcos-metadata.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/installer/data"
+)
+
+func newRhcosMetadataCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "rhcos-metadata",
+		Short: "Output Red Hat Enterprise Linux CoreOS metaadata",
+		Long:  "",
+		Args:  cobra.ExactArgs(0),
+		RunE:  runRhcosMetadata,
+	}
+}
+
+// runRhcosMetadata simply dumps the embedded RHCOS metadata to
+// stdout. See also https://github.com/openshift/installer/issues/1399
+func runRhcosMetadata(cmd *cobra.Command, args []string) error {
+	file, err := data.Assets.Open("rhcos.json")
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = io.Copy(os.Stdout, file)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Today the installer pins RHCOS, and that's not likely
to change.  The embedded version isn't easy to know in
pre-release/development scenarios.

Further, the way we do releases via CI, we don't know
what the "re-branded OpenShift version" (e.g. 4.1.0)
will be until it's released.

For other things like the AMIs, today the documentation
writers copy them into the docs manually.

Since the installer is the canonical source of this data,
let's make it easy to extract.

We're not documenting this much yet, but having this
data easily available is going to be extremely helpful
for the variety of cases mentioned above and allow
other teams to have a canonical way to get it.

Related: https://github.com/openshift/installer/issues/1399