### PR TITLE
data/data/baremetal: disable introspection on masters

### DIFF
--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -3,7 +3,6 @@ resource "ironic_node_v1" "openshift-master-host" {
   name           = var.hosts[count.index]["name"]
   resource_class = "baremetal"
 
-  inspect   = true
   clean     = true
   available = true
 


### PR DESCRIPTION
Currently, ironic inspection data from the masters isn't used anywhere,
and increases deployment time. We can re-enable it if and when the data
is used.