### PR TITLE
Fix string fmt bug in saving credentials message.

### DIFF
--- a/pkg/asset/installconfig/gcp/session.go
+++ b/pkg/asset/installconfig/gcp/session.go
@@ -68,7 +68,7 @@ func getCredentials(ctx context.Context) (*googleoauth.Credentials, error) {
 	}
 
 	filePath := defaultAuthFilePath
-	logrus.Info("Saving the credentials to %q", filePath)
+	logrus.Infof("Saving the credentials to %q", filePath)
 	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes bug #2096 where we were passing formatted string, but not using the formatted string function.