### PR TITLE
set the cloud-provider-config for GCP

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	"github.com/openshift/installer/pkg/asset/manifests/azure"
+	gcpmanifests "github.com/openshift/installer/pkg/asset/manifests/gcp"
 	openstackmanifests "github.com/openshift/installer/pkg/asset/manifests/openstack"
 	vspheremanifests "github.com/openshift/installer/pkg/asset/manifests/vsphere"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
@@ -79,7 +80,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 	}
 
 	switch installConfig.Config.Platform.Name() {
-	case awstypes.Name, libvirttypes.Name, nonetypes.Name, baremetaltypes.Name, gcptypes.Name:
+	case awstypes.Name, libvirttypes.Name, nonetypes.Name, baremetaltypes.Name:
 		return nil
 	case openstacktypes.Name:
 		cm.Data[cloudProviderConfigDataKey] = openstackmanifests.CloudProviderConfig()
@@ -98,6 +99,12 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			return errors.Wrap(err, "could not create cloud provider config")
 		}
 		cm.Data[cloudProviderConfigDataKey] = azureConfig
+	case gcptypes.Name:
+		gcpConfig, err := gcpmanifests.CloudProviderConfig(clusterID.InfraID, installConfig.Config.GCP.ProjectID)
+		if err != nil {
+			return errors.Wrap(err, "could not create cloud provider config")
+		}
+		cm.Data[cloudProviderConfigDataKey] = gcpConfig
 	case vspheretypes.Name:
 		vsphereConfig, err := vspheremanifests.CloudProviderConfig(
 			installConfig.Config.ObjectMeta.Name,

--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -1,0 +1,48 @@
+package gcp
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/pkg/errors"
+	ini "gopkg.in/ini.v1"
+)
+
+// https://github.com/kubernetes/kubernetes/blob/368ee4bb8ee7a0c18431cd87ee49f0c890aa53e5/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go#L188
+type config struct {
+	Global global `ini:"global"`
+}
+
+type global struct {
+	ProjectID string `ini:"project-id"`
+
+	Regional  bool `ini:"regional"`
+	Multizone bool `ini:"multizone"`
+
+	NodeTags []string `ini:"node-tags"`
+}
+
+// CloudProviderConfig generates the cloud provider config for the GCP platform.
+func CloudProviderConfig(infraID, projectID string) (string, error) {
+	file := ini.Empty()
+	config := &config{
+		Global: global{
+			ProjectID: projectID,
+
+			// To make sure k8s cloud provider is looking for instances in all zones.
+			Regional:  true,
+			Multizone: true,
+
+			// To make sure k8s cloud provide has tags for firewal for load balancer.
+			NodeTags: []string{fmt.Sprintf("%s-worker", infraID)},
+		},
+	}
+	if err := file.ReflectFrom(config); err != nil {
+		return "", errors.Wrap(err, "failed to reflect from config")
+	}
+	buf := &bytes.Buffer{}
+	if _, err := file.WriteTo(buf); err != nil {
+		return "", errors.Wrap(err, "failed to write out cloud provider config")
+	}
+	return buf.String(), nil
+}

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -1,0 +1,20 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudProviderConfig(t *testing.T) {
+	expectedConfig := `[global]
+project-id = test-project-id
+regional   = true
+multizone  = true
+node-tags  = uid-master,uid-worker
+
+`
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id")
+	assert.NoError(t, err, "failed to create cloud provider config")
+	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
+}

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -11,7 +11,7 @@ func TestCloudProviderConfig(t *testing.T) {
 project-id = test-project-id
 regional   = true
 multizone  = true
-node-tags  = uid-master,uid-worker
+node-tags  = uid-worker
 
 `
 	actualConfig, err := CloudProviderConfig("uid", "test-project-id")


### PR DESCRIPTION
GCP cloud provider needs to be configured to be Regional and MultiZone so that it is looking for resources like instances in all Zones for the region it's deployed in.

/cc @csrwng 
/label platform/google