### PR TITLE
data/gcp/masters: add roles/compute.securityAdmin to masters

### DIFF
--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -13,6 +13,11 @@ resource "google_project_iam_member" "master-network-admin" {
   member = "serviceAccount:${google_service_account.master-node-sa.email}"
 }
 
+resource "google_project_iam_member" "master-compute-security" {
+  role   = "roles/compute.securityAdmin"
+  member = "serviceAccount:${google_service_account.master-node-sa.email}"
+}
+
 resource "google_project_iam_member" "master-storage-admin" {
   role   = "roles/storage.admin"
   member = "serviceAccount:${google_service_account.master-node-sa.email}"


### PR DESCRIPTION
This provides master machines access to compute.firewalls.* as it is required by the k8s cloud provider

/cc @csrwng 
/label platform/google