### PR TITLE
azure: source Azure OS bootimage from RHCOS pipeline

### DIFF
--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -71,7 +71,7 @@ func (i *Image) Generate(p asset.Parents) error {
 	case openstack.Name:
 		osimage = "rhcos"
 	case azure.Name:
-		osimage = "https://rhcospipelineimages2.blob.core.windows.net/imagebucket/rhcos-420devel.8.20190719.0.vhd"
+		osimage, err = rhcos.VHD(ctx)
 	case baremetal.Name:
 		osimage, err = rhcos.QEMU(ctx)
 	case none.Name, vsphere.Name:

--- a/pkg/rhcos/azure.go
+++ b/pkg/rhcos/azure.go
@@ -1,0 +1,22 @@
+package rhcos
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// VHD fetches the URL of the public Azure storage bucket containing the RHCOS image
+func VHD(ctx context.Context) (string, error) {
+	meta, err := fetchRHCOSBuild(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to fetch RHCOS metadata")
+	}
+
+	url := meta.Azure.URL
+	if url == "" {
+		return "", errors.New("no RHCOS Azure URL found")
+	}
+
+	return url, nil
+}


### PR DESCRIPTION
Use bootimage artifact from the data/data/rhcos.json file rather than hard coding path. 