### PR TITLE
[gcp] pkg/assets/manifest: add subnetwork name to cloud config

### DIFF
--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -20,6 +20,8 @@ type global struct {
 	Multizone bool `ini:"multizone"`
 
 	NodeTags []string `ini:"node-tags"`
+
+	SubnetworkName string `ini:"subnetwork-name"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the GCP platform.
@@ -35,6 +37,9 @@ func CloudProviderConfig(infraID, projectID string) (string, error) {
 
 			// To make sure k8s cloud provide has tags for firewal for load balancer.
 			NodeTags: []string{fmt.Sprintf("%s-worker", infraID)},
+
+			// Used for internal load balancers
+			SubnetworkName: fmt.Sprintf("%s-worker-subnet", infraID),
 		},
 	}
 	if err := file.ReflectFrom(config); err != nil {

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -8,10 +8,11 @@ import (
 
 func TestCloudProviderConfig(t *testing.T) {
 	expectedConfig := `[global]
-project-id = test-project-id
-regional   = true
-multizone  = true
-node-tags  = uid-worker
+project-id      = test-project-id
+regional        = true
+multizone       = true
+node-tags       = uid-worker
+subnetwork-name = uid-worker-subnet
 
 `
 	actualConfig, err := CloudProviderConfig("uid", "test-project-id")


### PR DESCRIPTION
Adds subnetwork name to cloud config so that the cloud controller knows where to create internal load balancers.