### PR TITLE
libvirt: Assign fully-qualified domain names to master & bootstrap nodes

### DIFF
--- a/data/data/libvirt/bootstrap/main.tf
+++ b/data/data/libvirt/bootstrap/main.tf
@@ -34,7 +34,7 @@ resource "libvirt_domain" "bootstrap" {
 
   network_interface {
     network_id = var.network_id
-    hostname   = "${var.cluster_id}-bootstrap"
+    hostname   = "${var.cluster_id}-bootstrap.${var.cluster_domain}"
     addresses  = var.addresses
   }
 }

--- a/data/data/libvirt/bootstrap/variables.tf
+++ b/data/data/libvirt/bootstrap/variables.tf
@@ -14,6 +14,11 @@ variable "cluster_id" {
   description = "The identifier for the cluster."
 }
 
+variable "cluster_domain" {
+  type        = string
+  description = "The domain for the cluster that all DNS records must belong"
+}
+
 variable "ignition" {
   type        = string
   description = "The content of the bootstrap ignition file."

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -19,6 +19,7 @@ module "volume" {
 module "bootstrap" {
   source = "./bootstrap"
 
+  cluster_domain = var.cluster_domain
   addresses      = [var.libvirt_bootstrap_ip]
   base_volume_id = module.volume.coreos_base_volume_id
   cluster_id     = var.cluster_id
@@ -108,7 +109,7 @@ resource "libvirt_domain" "master" {
 
   network_interface {
     network_id = libvirt_network.net.id
-    hostname   = "${var.cluster_id}-master-${count.index}"
+    hostname   = "${var.cluster_id}-master-${count.index}.${var.cluster_domain}"
     addresses  = [var.libvirt_master_ips[count.index]]
   }
 }


### PR DESCRIPTION
This is needed for gather logs from the nodes.

Related: https://github.com/openshift/release/pull/4395