### PR TITLE
data/gcp/dns: fix resource name for internal dns zone

### DIFF
--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -1,5 +1,5 @@
 resource "google_dns_managed_zone" "int" {
-  name       = "${var.cluster_id}-int"
+  name       = "${var.cluster_id}-private-zone"
   dns_name   = "${var.cluster_domain}."
   visibility = "private"
   private_visibility_config {


### PR DESCRIPTION
The internal zone name expected by the cluster is `<cluster-id>-private-zone` [1]

[1]: https://github.com/openshift/installer/blob/0055065143ee52ee6252cd7896d551e374500a59/pkg/asset/manifests/dns.go#L109

/cc @jstuever @csrwng 