### PR TITLE
Bug 1732858: unhardcode the cloud name for openstack

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -261,6 +261,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		data, err = openstacktfvars.TFVars(
 			masters[0].Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec),
+			installConfig.Config.Platform.OpenStack.Cloud,
 			installConfig.Config.Platform.OpenStack.Region,
 			installConfig.Config.Platform.OpenStack.ExternalNetwork,
 			installConfig.Config.Platform.OpenStack.LbFloatingIP,

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -22,12 +22,12 @@ type config struct {
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, region string, externalNetwork string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string) ([]byte, error) {
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, region string, externalNetwork string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string) ([]byte, error) {
 	cfg := &config{
 		Region:          region,
 		BaseImage:       masterConfig.Image,
 		ExternalNetwork: externalNetwork,
-		Cloud:           masterConfig.CloudName,
+		Cloud:           cloud,
 		FlavorName:      masterConfig.Flavor,
 		LbFloatingIP:    lbFloatingIP,
 		APIVIP:          apiVIP,

--- a/pkg/types/openstack/defaults/platform.go
+++ b/pkg/types/openstack/defaults/platform.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"net"
+	"os"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 
@@ -9,8 +10,19 @@ import (
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
+const (
+	// DefaultCloudName is the default name of the cloud in clouds.yaml file.
+	DefaultCloudName = "openstack"
+)
+
 // SetPlatformDefaults sets the defaults for the platform.
 func SetPlatformDefaults(p *openstack.Platform) {
+	if p.Cloud == "" {
+		p.Cloud = os.Getenv("OS_CLOUD")
+		if p.Cloud == "" {
+			p.Cloud = DefaultCloudName
+		}
+	}
 }
 
 // APIVIP returns the internal virtual IP address (VIP) put in front


### PR DESCRIPTION
To allow users to provide custom cloud names in the install config we need to remove hardcoded 'openstack' name.

To do so and to keep the compatibility with the current behavior, we read cloud name from the install config first, and if it's empty, set it to the value of OS_CLOUD env variable. If both values are not specified, then cloud name defaults to "openstack".

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1732858