### PR TITLE
openstack: add tag and desc to bootstrap floating IP

### DIFF
--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -88,9 +88,11 @@ resource "openstack_networking_floatingip_associate_v2" "service_fip" {
 }
 
 resource "openstack_networking_floatingip_v2" "bootstrap_fip" {
-  count   = var.enable_bootstrap_floating_ip ? 1 : 0
-  pool    = "${var.external_network}"
-  port_id = "${openstack_networking_port_v2.bootstrap_port.id}"
+  description = "${var.cluster_id}-bootstrap-fip"
+  count       = var.enable_bootstrap_floating_ip ? 1 : 0
+  pool        = "${var.external_network}"
+  port_id     = "${openstack_networking_port_v2.bootstrap_port.id}"
+  tags        = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_router_v2" "openshift-external-router" {


### PR DESCRIPTION
Tag the floating IP with the cluster ID. Without it we are leaking floating IPs.