### PR TITLE
Bug 1740543: Consolidate bootstrap resources to bootstrap module

### DIFF
--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -23,7 +23,30 @@ variable "flavor_name" {
   description = "The Nova flavor for the bootstrap node."
 }
 
-variable "bootstrap_port_id" {
-  type        = string
-  description = "The subnet ID for the bootstrap node."
+variable "api_int_ip" {
+  type = string
+}
+
+variable "node_dns_ip" {
+  type = string
+}
+
+variable "external_network" {
+  type = string
+}
+
+variable "private_network_id" {
+  type = string
+}
+
+variable "master_sg_id" {
+  type = string
+}
+
+variable "nodes_subnet_id" {
+  type = string
+}
+
+variable "cluster_domain" {
+  type = string
 }

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -25,12 +25,18 @@ provider "openstack" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  swift_container   = openstack_objectstorage_container_v1.container.name
-  cluster_id        = var.cluster_id
-  image_name        = var.openstack_base_image
-  flavor_name       = var.openstack_master_flavor_name
-  ignition          = var.ignition_bootstrap
-  bootstrap_port_id = module.topology.bootstrap_port_id
+  swift_container    = openstack_objectstorage_container_v1.container.name
+  cluster_id         = var.cluster_id
+  image_name         = var.openstack_base_image
+  flavor_name        = var.openstack_master_flavor_name
+  ignition           = var.ignition_bootstrap
+  api_int_ip         = var.openstack_api_int_ip
+  node_dns_ip        = var.openstack_node_dns_ip
+  external_network   = var.openstack_external_network
+  cluster_domain     = var.cluster_domain
+  nodes_subnet_id    = module.topology.nodes_subnet_id
+  private_network_id = module.topology.private_network_id
+  master_sg_id       = module.topology.master_sg_id
 }
 
 module "masters" {

--- a/data/data/openstack/topology/outputs.tf
+++ b/data/data/openstack/topology/outputs.tf
@@ -1,12 +1,16 @@
-output "bootstrap_port_id" {
-  value = openstack_networking_port_v2.bootstrap_port.id
-}
-
 output "master_sg_id" {
   value = openstack_networking_secgroup_v2.master.id
 }
 
 output "master_port_ids" {
   value = local.master_port_ids
+}
+
+output "private_network_id" {
+  value = openstack_networking_network_v2.openshift-private.id
+}
+
+output "nodes_subnet_id" {
+  value = openstack_networking_subnet_v2.nodes.id
 }
 

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -29,12 +29,6 @@ variable "lb_floating_ip" {
   default     = ""
 }
 
-variable "enable_bootstrap_floating_ip" {
-  description = "(optional) If true the bootstrap machine gets a floating IP address that will be used to collect logs."
-  type        = bool
-  default     = true
-}
-
 variable "masters_count" {
   type = string
 }


### PR DESCRIPTION
This patch moves the related to bootstrap machine resources from  the topology module to the bootstrap module.
This allows to destroy the bootstrap FIP along with the machine.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1740543
Fixes: #1047