### PR TITLE
[gcp] pkg/destroy/gcp: Fix external and internal load balancer deletion

### DIFF
--- a/pkg/destroy/gcp/compute.go
+++ b/pkg/destroy/gcp/compute.go
@@ -40,7 +40,7 @@ func (o *ClusterUninstaller) getInstanceNameAndZone(instanceURL string) (string,
 	path := strings.TrimLeft(instanceURL, o.computeSvc.BasePath)
 	parts := strings.Split(path, "/")
 	if len(parts) >= 5 {
-		return parts[2], parts[4]
+		return parts[4], parts[2]
 	}
 	return "", ""
 }
@@ -59,7 +59,7 @@ func (o *ClusterUninstaller) listInstanceGroupsWithFilter(filter string) ([]name
 					name: ig.Name,
 					zone: zoneName,
 				})
-				o.Logger.Debugf("Found instance group %s in zone %s\n", ig.Name, zoneName)
+				o.Logger.Debugf("Found instance group %s in zone %s", ig.Name, zoneName)
 			}
 		}
 		return nil

--- a/pkg/destroy/gcp/compute.go
+++ b/pkg/destroy/gcp/compute.go
@@ -106,7 +106,7 @@ func (o *ClusterUninstaller) deleteInstanceGroup(ig nameAndZone) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("instancegroup", ig.zone, ig.name)
-		return errors.Errorf("failed to delete instance group %s in zone %s with error: %s", ig.name, ig.zone, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete instance group %s in zone %s with error: %s", ig.name, ig.zone, operationErrorMessage(op))
 	}
 	return nil
 }
@@ -148,7 +148,7 @@ func (o *ClusterUninstaller) deleteComputeInstance(instance nameAndZone) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("instance", instance.zone, instance.name)
-		return errors.Errorf("failed to delete instance %s in zone %s with error: %s", instance.name, instance.zone, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete instance %s in zone %s with error: %s", instance.name, instance.zone, operationErrorMessage(op))
 	}
 	return nil
 }
@@ -206,7 +206,7 @@ func (o *ClusterUninstaller) deleteImage(name string) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("image", name)
-		return errors.Errorf("failed to delete image %s with error: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete image %s with error: %s", name, operationErrorMessage(op))
 	}
 	return nil
 }
@@ -266,7 +266,7 @@ func (o *ClusterUninstaller) deleteDisk(disk nameAndZone) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("disk", disk.zone, disk.name)
-		return errors.Errorf("failed to delete disk %s in zone %s with error: %s", disk.name, disk.zone, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete disk %s in zone %s with error: %s", disk.name, disk.zone, operationErrorMessage(op))
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -249,3 +249,17 @@ func (t pendingItemTracker) setPendingItems(itemType string, items []string) []s
 func isErrorStatus(code int64) bool {
 	return code < 200 || code >= 300
 }
+
+func operationErrorMessage(op *compute.Operation) string {
+	errs := []string{}
+	if op.Error != nil {
+		for _, e := range op.Error.Errors {
+			errs = append(errs, fmt.Sprintf("%s: %s", e.Code, e.Message))
+		}
+	}
+	if len(errs) == 0 {
+		return op.HttpErrorMessage
+	} else {
+		return strings.Join(errs, ", ")
+	}
+}

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -259,7 +259,6 @@ func operationErrorMessage(op *compute.Operation) string {
 	}
 	if len(errs) == 0 {
 		return op.HttpErrorMessage
-	} else {
-		return strings.Join(errs, ", ")
 	}
+	return strings.Join(errs, ", ")
 }

--- a/pkg/destroy/gcp/network.go
+++ b/pkg/destroy/gcp/network.go
@@ -50,7 +50,7 @@ func (o *ClusterUninstaller) deleteFirewall(name string, errorOnPending bool) er
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("firewall", name)
-		return errors.Errorf("failed to delete firewall %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete firewall %s with error: %s", name, operationErrorMessage(op))
 	}
 	if errorOnPending && op != nil && op.Status != "DONE" {
 		return errors.Errorf("deletion of firewall %s is pending", name)
@@ -111,7 +111,7 @@ func (o *ClusterUninstaller) deleteAddress(name string, errorOnPending bool) err
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("address", name)
-		return errors.Errorf("failed to delete address %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete address %s with error: %s", name, operationErrorMessage(op))
 	}
 	if errorOnPending && op != nil && op.Status != "DONE" {
 		return errors.Errorf("deletion of address %s is pending", name)
@@ -172,7 +172,7 @@ func (o *ClusterUninstaller) deleteForwardingRule(name string, errorOnPending bo
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("forwardingrule", name)
-		return errors.Errorf("failed to delete forwarding rule %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete forwarding rule %s with error: %s", name, operationErrorMessage(op))
 	}
 	if errorOnPending && op != nil && op.Status != "DONE" {
 		return errors.Errorf("deletion of forwarding rule %s is pending", name)
@@ -246,7 +246,7 @@ func (o *ClusterUninstaller) deleteBackendService(name string) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("backendservice", name)
-		return errors.Errorf("failed to delete backend service %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete backend service %s with error: %s", name, operationErrorMessage(op))
 	}
 	return nil
 }
@@ -273,7 +273,7 @@ func (o *ClusterUninstaller) clearBackendServiceHealthChecks(name string) error 
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("backendservice", name)
-		return errors.Errorf("failed to clear backend service %s health checks with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to clear backend service %s health checks with error: %s", name, operationErrorMessage(op))
 	}
 	if op != nil && op.Status != "DONE" {
 		return errors.Errorf("backend service pending to be cleared of health checks")
@@ -334,7 +334,7 @@ func (o *ClusterUninstaller) deleteHealthCheck(name string, errorOnPending bool)
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("healthcheck", name)
-		return errors.Errorf("failed to delete health check %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete health check %s with error: %s", name, operationErrorMessage(op))
 	}
 	if errorOnPending && op != nil && op.Status != "DONE" {
 		return errors.Errorf("deletion of forwarding rule %s is pending", name)
@@ -395,7 +395,7 @@ func (o *ClusterUninstaller) deleteHTTPHealthCheck(name string) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("httphealthcheck", name)
-		return errors.Errorf("failed to delete HTTP health check %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete HTTP health check %s with error: %s", name, operationErrorMessage(op))
 	}
 	return nil
 }
@@ -462,7 +462,7 @@ func (o *ClusterUninstaller) deleteTargetPool(name string) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("targetpool", name)
-		return errors.Errorf("failed to delete route %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete route %s with error: %s", name, operationErrorMessage(op))
 	}
 	o.Logger.Infof("Deleted target pool %s", name)
 	return nil
@@ -495,7 +495,7 @@ func (o *ClusterUninstaller) clearTargetPoolHealthChecks(name string) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("cleartargetpool", name)
-		return errors.Errorf("failed to clear target pool %s health checks with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to clear target pool %s health checks with error: %s", name, operationErrorMessage(op))
 	}
 	if op != nil && op.Status != "DONE" {
 		return errors.Errorf("target pool pending to be cleared of health checks")
@@ -557,7 +557,7 @@ func (o *ClusterUninstaller) deleteSubNetwork(name string) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("subnetwork", name)
-		return errors.Errorf("failed to delete subnetwork %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete subnetwork %s with error: %s", name, operationErrorMessage(op))
 	}
 	return nil
 }
@@ -619,7 +619,7 @@ func (o *ClusterUninstaller) deleteNetwork(name string) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("network", name)
-		return errors.Errorf("failed to delete network %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete network %s with error: %s", name, operationErrorMessage(op))
 	}
 	return nil
 }
@@ -698,7 +698,7 @@ func (o *ClusterUninstaller) deleteRoute(name string) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("route", name)
-		return errors.Errorf("failed to delete route %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete route %s with error: %s", name, operationErrorMessage(op))
 	}
 	return nil
 }
@@ -756,7 +756,7 @@ func (o *ClusterUninstaller) deleteRouter(name string) error {
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
 		o.resetRequestID("router", name)
-		return errors.Errorf("failed to delete router %s with erorr: %s", name, op.HttpErrorMessage)
+		return errors.Errorf("failed to delete router %s with error: %s", name, operationErrorMessage(op))
 	}
 	return nil
 }

--- a/pkg/destroy/gcp/network.go
+++ b/pkg/destroy/gcp/network.go
@@ -251,36 +251,6 @@ func (o *ClusterUninstaller) deleteBackendService(name string) error {
 	return nil
 }
 
-func (o *ClusterUninstaller) clearBackendServiceHealthChecks(name string) error {
-	o.Logger.Debugf("Clearing backend service %s health checks", name)
-	ctx, cancel := o.contextWithTimeout()
-	defer cancel()
-	backendService, err := o.computeSvc.RegionBackendServices.Get(o.ProjectID, o.Region, name).Context(ctx).Do()
-	if isNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return errors.Wrapf(err, "cannot retrieve backend service %s", name)
-	}
-	if len(backendService.HealthChecks) == 0 {
-		o.Logger.Debugf("Backend service %s has no health checks to clear", name)
-	}
-	backendService.HealthChecks = []string{}
-	op, err := o.computeSvc.RegionBackendServices.Patch(o.ProjectID, o.Region, name, backendService).Context(ctx).RequestId(o.requestID("clearbackendservice", name)).Context(ctx).Do()
-	if err != nil && !isNoOp(err) {
-		o.resetRequestID("clearbackendservice", name)
-		return errors.Wrapf(err, "failed to clear backend service %s health checks", name)
-	}
-	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {
-		o.resetRequestID("backendservice", name)
-		return errors.Errorf("failed to clear backend service %s health checks with error: %s", name, operationErrorMessage(op))
-	}
-	if op != nil && op.Status != "DONE" {
-		return errors.Errorf("backend service pending to be cleared of health checks")
-	}
-	return nil
-}
-
 // destroyBackendServices removes backend services with a name prefixed by the
 // cluster's infra ID.
 func (o *ClusterUninstaller) destroyBackendServices() error {
@@ -480,7 +450,8 @@ func (o *ClusterUninstaller) clearTargetPoolHealthChecks(name string) error {
 		return errors.Wrapf(err, "cannot retrieve target pool %s", name)
 	}
 	if len(targetPool.HealthChecks) == 0 {
-		o.Logger.Debugf("Backend service %s has no health checks to clear", name)
+		o.Logger.Debugf("Target pool %s has no health checks to clear", name)
+		return nil
 	}
 	hcRemoveRequest := &compute.TargetPoolsRemoveHealthCheckRequest{}
 	for _, hc := range targetPool.HealthChecks {
@@ -857,6 +828,7 @@ func (o *ClusterUninstaller) listBackendServicesForInstanceGroups(igs []nameAndZ
 				return false
 			}
 		}
+		o.Logger.Debugf("Found backend service %s", item.Name)
 		return true
 	})
 }
@@ -865,14 +837,6 @@ func (o *ClusterUninstaller) listBackendServicesForInstanceGroups(igs []nameAndZ
 // https://github.com/openshift/kubernetes/blob/1e5983903742f64bca36a464582178c940353e9a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go#L222
 // TODO: add cleanup for shared mode resources (determine if it's supported in 4.2)
 func (o *ClusterUninstaller) deleteInternalLoadBalancer(loadBalancerName string) error {
-
-	// First, remove backend service health checks so that we can delete health checks first
-	// without having to delete the backend service. The backend service is the resource
-	// that tells us that there is an internal load balancer pending deletion. It should be
-	// deleted last.
-	if err := o.clearBackendServiceHealthChecks(loadBalancerName); err != nil {
-		return err
-	}
 	if err := o.deleteAddress(loadBalancerName, true); err != nil {
 		return err
 	}
@@ -1006,6 +970,7 @@ func (o *ClusterUninstaller) getExternalLBTargetPools() ([]string, error) {
 				return false
 			}
 		}
+		o.Logger.Debugf("Found external load balancer target pool: %s", pool.Name)
 		return true
 	})
 }
@@ -1037,7 +1002,7 @@ func (o *ClusterUninstaller) destroyCloudControllerExternalLBs() error {
 		if err := o.deleteHealthCheck(fmt.Sprintf("k8s-%s-node-hc", o.cloudControllerUID), true); err != nil {
 			return err
 		}
-		if err := o.deleteFirewall(fmt.Sprintf("k8s-%s-node--hc", o.cloudControllerUID), true); err != nil {
+		if err := o.deleteFirewall(fmt.Sprintf("k8s-%s-node-hc", o.cloudControllerUID), true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Improves logging of errors coming from failed operations

Fixes bugs related to deleting internal and external load balancers created by the Kubernetes cloud  controller.