### PR TITLE
data/bootstrap/files/usr/local/bin/bootkube.sh.template: Drop OPENSHIFT_HYPERSHIFT_IMAGE

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -29,7 +29,6 @@ KUBE_APISERVER_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster
 KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster-kube-controller-manager-operator)
 KUBE_SCHEDULER_OPERATOR_IMAGE=$(podman run --quiet --rm ${release} image cluster-kube-scheduler-operator)
 
-OPENSHIFT_HYPERSHIFT_IMAGE=$(podman run --quiet --rm ${release} image hypershift)
 OPENSHIFT_HYPERKUBE_IMAGE=$(podman run --quiet --rm ${release} image hyperkube)
 
 CLUSTER_BOOTSTRAP_IMAGE=$(podman run --quiet --rm ${release} image cluster-bootstrap)


### PR DESCRIPTION
The last consumer was removed in 8c58a999f7 (#1885).