### PR TITLE
Bug 1734539: Openstack: Option to set multiple external DNS IP Addresses

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -70,6 +70,7 @@ module "topology" {
   api_int_ip          = var.openstack_api_int_ip
   node_dns_ip         = var.openstack_node_dns_ip
   ingress_ip          = var.openstack_ingress_ip
+  external_dns        = var.openstack_external_dns
   trunk_support       = var.openstack_trunk_support
   octavia_support     = var.openstack_octavia_support
 }

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -15,11 +15,12 @@ resource "openstack_networking_network_v2" "openshift-private" {
 }
 
 resource "openstack_networking_subnet_v2" "nodes" {
-  name       = "${var.cluster_id}-nodes"
-  cidr       = local.nodes_cidr_block
-  ip_version = 4
-  network_id = openstack_networking_network_v2.openshift-private.id
-  tags       = ["openshiftClusterID=${var.cluster_id}"]
+  name            = "${var.cluster_id}-nodes"
+  cidr            = local.nodes_cidr_block
+  ip_version      = 4
+  network_id      = openstack_networking_network_v2.openshift-private.id
+  tags            = ["openshiftClusterID=${var.cluster_id}"]
+  dns_nameservers = var.external_dns
 
   # We reserve some space at the beginning of the CIDR to use for the VIPs
   # It would be good to make this more dynamic by calculating the number of

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -45,6 +45,10 @@ variable "ingress_ip" {
   type = string
 }
 
+variable "external_dns" {
+  type = list(string)
+}
+
 variable "trunk_support" {
   type = string
 }

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -301,6 +301,12 @@ variable "openstack_ingress_ip" {
   description = "IP on the nodes subnet reserved for the ingress VIP."
 }
 
+variable "openstack_external_dns" {
+  type        = list(string)
+  description = "IP addresses of exernal dns servers to add to networks."
+  default     = []
+}
+
 variable "openstack_master_flavor_name" {
   type        = string
   description = "Instance size for the master node(s). Example: `m1.medium`."

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -317,6 +317,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			masters[0].Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec),
 			installConfig.Config.Platform.OpenStack.Cloud,
 			installConfig.Config.Platform.OpenStack.ExternalNetwork,
+			installConfig.Config.Platform.OpenStack.ExternalDNS,
 			installConfig.Config.Platform.OpenStack.LbFloatingIP,
 			apiVIP.String(),
 			dnsVIP.String(),

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -14,24 +14,25 @@ import (
 )
 
 type config struct {
-	BaseImageName   string `json:"openstack_base_image_name,omitempty"`
-	BaseImageURL    string `json:"openstack_base_image_url,omitempty"`
-	ExternalNetwork string `json:"openstack_external_network,omitempty"`
-	Cloud           string `json:"openstack_credentials_cloud,omitempty"`
-	FlavorName      string `json:"openstack_master_flavor_name,omitempty"`
-	LbFloatingIP    string `json:"openstack_lb_floating_ip,omitempty"`
-	APIVIP          string `json:"openstack_api_int_ip,omitempty"`
-	DNSVIP          string `json:"openstack_node_dns_ip,omitempty"`
-	IngressVIP      string `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport    string `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport  string `json:"openstack_octavia_support,omitempty"`
-	RootVolumeSize  int    `json:"openstack_master_root_volume_size,omitempty"`
-	RootVolumeType  string `json:"openstack_master_root_volume_type,omitempty"`
-	SwiftPublicURL  string `json:"openstack_swift_public_url,omitempty"`
+	BaseImageName   string   `json:"openstack_base_image_name,omitempty"`
+	BaseImageURL    string   `json:"openstack_base_image_url,omitempty"`
+	ExternalNetwork string   `json:"openstack_external_network,omitempty"`
+	Cloud           string   `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName      string   `json:"openstack_master_flavor_name,omitempty"`
+	LbFloatingIP    string   `json:"openstack_lb_floating_ip,omitempty"`
+	APIVIP          string   `json:"openstack_api_int_ip,omitempty"`
+	DNSVIP          string   `json:"openstack_node_dns_ip,omitempty"`
+	IngressVIP      string   `json:"openstack_ingress_ip,omitempty"`
+	TrunkSupport    string   `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport  string   `json:"openstack_octavia_support,omitempty"`
+	RootVolumeSize  int      `json:"openstack_master_root_volume_size,omitempty"`
+	RootVolumeType  string   `json:"openstack_master_root_volume_type,omitempty"`
+	SwiftPublicURL  string   `json:"openstack_swift_public_url,omitempty"`
+	ExternalDNS     []string `json:"openstack_external_dns,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string) ([]byte, error) {
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string) ([]byte, error) {
 	swiftPublicURL, err := getSwiftPublicURL(cloud)
 	if err != nil {
 		return nil, err
@@ -45,6 +46,7 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 		APIVIP:          apiVIP,
 		DNSVIP:          dnsVIP,
 		IngressVIP:      ingressVIP,
+		ExternalDNS:     externalDNS,
 		TrunkSupport:    trunkSupport,
 		OctaviaSupport:  octaviaSupport,
 		SwiftPublicURL:  swiftPublicURL,

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -29,9 +29,8 @@ type Platform struct {
 	// Existing Floating IP to associate with the OpenStack load balancer.
 	LbFloatingIP string `json:"lbFloatingIP"`
 
-	// ExternalDNS
-	// IP addresses of dns servers that will be added to the nodes
-	// subnet managed by the installer
+	// ExternalDNS holds the IP addresses of dns servers that will
+	// be added to the dns resolution of all instances in the cluster.
 	// +optional
 	ExternalDNS []string `json:"externalDNS"`
 

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -29,6 +29,12 @@ type Platform struct {
 	// Existing Floating IP to associate with the OpenStack load balancer.
 	LbFloatingIP string `json:"lbFloatingIP"`
 
+	// ExternalDNS
+	// IP addresses of dns servers that will be added to the nodes
+	// subnet managed by the installer
+	// +optional
+	ExternalDNS []string `json:"externalDNS"`
+
 	// TrunkSupport
 	// Whether OpenStack ports can be trunked
 	TrunkSupport string `json:"trunkSupport"`

--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/openstack"
+	"github.com/openshift/installer/pkg/validate"
 )
 
 // ValidatePlatform checks that the specified platform is valid.
@@ -57,6 +58,12 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field
 
 	if len(c.ObjectMeta.Name) > 14 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, "metadata name is too long, please restrict it to 14 characters"))
+	}
+
+	for _, ip := range p.ExternalDNS {
+		if err := validate.IP(ip); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("ExternalDNS"), p.ExternalDNS, err.Error()))
+		}
 	}
 
 	return allErrs

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -65,6 +65,28 @@ func TestValidatePlatform(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "non IP external dns",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.ExternalDNS = []string{
+					"invalid",
+				}
+				return p
+			}(),
+			valid: false,
+		},
+		{
+			name: "valid external dns",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.ExternalDNS = []string{
+					"192.168.1.1",
+				}
+				return p
+			}(),
+			valid: true,
+		},
+		{
 			name:     "clouds fetch failure",
 			platform: validPlatform(),
 			noClouds: true,


### PR DESCRIPTION
Adds an option in the installer that allows users to add the ip addresses of dns servers. These IP's will be added to the nodes subnet. 

Bug Fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1734539