### PR TITLE
[gcp] data/data: add service user role to masters

### DIFF
--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -28,6 +28,11 @@ resource "google_project_iam_member" "master-object-storage-admin" {
   member = "serviceAccount:${google_service_account.master-node-sa.email}"
 }
 
+resource "google_project_iam_member" "master-service-account-user" {
+  role   = "roles/iam.serviceAccountUser"
+  member = "serviceAccount:${google_service_account.master-node-sa.email}"
+}
+
 resource "google_compute_instance" "master" {
   count = var.instance_count
 


### PR DESCRIPTION
The service user role is required for the control plane to be able to attach a
disk to an instance running as a different role.
See https://cloud.google.com/compute/docs/disks/add-persistent-disk
(Under permissions required for this task for mounting a disk):
```
If you are connecting to a VM instance that can run as a service account, you must also grant the roles/iam.serviceAccountUser role.
```
In 3.x we accomplished this via scopes and the default service account:
https://github.com/openshift/openshift-ansible/blob/release-3.11/roles/openshift_gcp/templates/provision.j2.sh#L109