### PR TITLE
[gcp] pkg/asset/machines - add project id to machines

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -624,14 +624,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b0a79e04b1f18b94b52c77000c119f0abdf6400ad8a13fbe8decdf79c179281e"
+  digest = "1:dae599d7d65acefd73adebcfa2631c447da94ec9b1047beb2d887bbdd173ba27"
   name = "github.com/openshift/cluster-api-provider-gcp"
   packages = [
     "pkg/apis",
     "pkg/apis/gcpprovider/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "cb0305f3b986e67ff8d5bb0b375dd7bbb835db01"
+  revision = "f5146705932b14d468b59d90443d127c9003142b"
 
 [[projects]]
   branch = "master"

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -93,6 +93,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 		MachineType: mpool.InstanceType,
 		Region:      platform.Region,
 		Zone:        az,
+		ProjectID:   platform.ProjectID,
 	}, nil
 }
 

--- a/vendor/github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
+++ b/vendor/github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
@@ -33,6 +33,7 @@ type GCPMachineProviderSpec struct {
 	MachineType        string                 `json:"machineType"`
 	Region             string                 `json:"region"`
 	Zone               string                 `json:"zone"`
+	ProjectID          string                 `json:"projectID,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -59,6 +60,7 @@ type GCPMetadata struct {
 
 // GCPNetworkInterface describes network interfaces for GCP
 type GCPNetworkInterface struct {
+	PublicIP   bool   `json:"publicIP,omitempty"`
 	Network    string `json:"network,omitempty"`
 	Subnetwork string `json:"subnetwork,omitempty"`
 }


### PR DESCRIPTION
Adds the GCP project ID to the machine provider spec to ensure that
machines are created in the project where the cluster is being
installed.