### PR TITLE
baremetal: Add dnsVIP to sample install-config.

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -56,8 +56,6 @@ purposes:
     server is appropriate for this environment.
     * `api.<cluster-name>.<base-domain>` - pointing to the API VIP
     * `*.apps.<cluster-name>.<base-domain>` - pointing to the Ingress VIP
-    * `ns1.<cluster-name>.<base-domain>` - pointing to the DNS VIP. *Note: work
-      is underway to remove this required DNS entry.*
 
 * **NIC #2 - Provisioning Network**
   * A private, non-routed network, used for PXE based provisioning.
@@ -140,6 +138,7 @@ platform:
   baremetal:
     apiVIP: 192.168.111.5
     ingressVIP: 192.168.111.4
+    dnsVIP: 192.168.111.3
     hosts:
       - name: openshift-master-0
         role: master


### PR DESCRIPTION
This is described in the network prerequisites section earlier in the
doc, but was not reflected in the sample install-config.

The ns1 DNS record is also no longer required.