### PR TITLE
OpenStack: change provider API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1250,14 +1250,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:218907e65c91aef95d8f29a1bab723bf810d2fdc20e5e13400a9295d2bfefb87"
+  digest = "1:7580b2faadd6de6748de7a43a16d9223a70411973d549287c4cf0128a9b42389"
   name = "sigs.k8s.io/cluster-api-provider-openstack"
   packages = [
     "pkg/apis",
     "pkg/apis/openstackproviderconfig/v1alpha1",
   ]
   pruneopts = "NUT"
-  revision = "bedbef13faf2f0539164a8a19d755e59a905367b"
+  revision = "076f2c35a0307178f4d6c32bd2f185d8e35d5a84"
   source = "https://github.com/openshift/cluster-api-provider-openstack.git"
 
 [[projects]]

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -82,7 +82,7 @@ func provider(clusterID string, platform *openstack.Platform, mpool *openstack.M
 
 	return &openstackprovider.OpenstackProviderSpec{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "openstackproviderconfig.k8s.io/v1alpha1",
+			APIVersion: openstackprovider.SchemeGroupVersion.String(),
 			Kind:       "OpenstackProviderSpec",
 		},
 		Flavor: mpool.FlavorName,

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/doc.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/doc.go
@@ -18,5 +18,5 @@ limitations under the License.
 // +k8s:conversion-gen=github.com/openshift/cluster-api/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=openstackproviderconfig.k8s.io
+// +groupName=openstackproviderconfig.openshift.io
 package v1alpha1

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/register.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/register.go
@@ -33,7 +33,7 @@ const GroupName = "openstackproviderconfig"
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "openstackproviderconfig.k8s.io", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "openstackproviderconfig.openshift.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -220,12 +220,6 @@ type OpenstackClusterProviderStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// CACertificate is a PEM encoded CA Certificate for the control plane nodes.
-	CACertificate []byte
-
-	// CAPrivateKey is a PEM encoded PKCS1 CA PrivateKey for the control plane nodes.
-	CAPrivateKey []byte
-
 	// Network contains all information about the created OpenStack Network.
 	// It includes Subnets and Router.
 	Network *Network `json:"network,omitempty"`

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/zz_generated.deepcopy.go
@@ -111,6 +111,11 @@ func (in *OpenstackClusterProviderSpec) DeepCopyInto(out *OpenstackClusterProvid
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -137,16 +142,6 @@ func (in *OpenstackClusterProviderStatus) DeepCopyInto(out *OpenstackClusterProv
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.CACertificate != nil {
-		in, out := &in.CACertificate, &out.CACertificate
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
-	if in.CAPrivateKey != nil {
-		in, out := &in.CAPrivateKey, &out.CAPrivateKey
-		*out = make([]byte, len(*in))
-		copy(*out, *in)
-	}
 	if in.Network != nil {
 		in, out := &in.Network, &out.Network
 		*out = new(Network)
@@ -210,15 +205,27 @@ func (in *OpenstackProviderSpec) DeepCopyInto(out *OpenstackProviderSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
-	out.RootVolume = in.RootVolume
-	out.Tags = in.Tags
-
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.ServerMetadata != nil {
 		in, out := &in.ServerMetadata, &out.ServerMetadata
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.ConfigDrive != nil {
+		in, out := &in.ConfigDrive, &out.ConfigDrive
+		*out = new(bool)
+		**out = **in
+	}
+	if in.RootVolume != nil {
+		in, out := &in.RootVolume, &out.RootVolume
+		*out = new(RootVolume)
+		**out = **in
 	}
 	return
 }


### PR DESCRIPTION
This patch changes OpenStack provider API from openstackproviderconfig.k8s.io/v1alpha1
to openstackproviderconfig.openshift.io/v1alpha1