### PR TITLE
Bug 1737102: vSphere UPI - Use template guest_id for machines guest_id

### DIFF
--- a/upi/vsphere/machine/main.tf
+++ b/upi/vsphere/machine/main.tf
@@ -21,7 +21,7 @@ resource "vsphere_virtual_machine" "vm" {
   datastore_id     = "${data.vsphere_datastore.datastore.id}"
   num_cpus         = "4"
   memory           = "8192"
-  guest_id         = "other26xLinux64Guest"
+  guest_id         = "${data.vsphere_virtual_machine.template.guest_id}"
   folder           = "${var.folder}"
   enable_disk_uuid = "true"
 


### PR DESCRIPTION
RHCOS switch from using other26xLinux64Guest to rhel7_64guest.
This changes uses the templates guest_id for use within the machine creation.