### PR TITLE
WIP Add fcos flag which transpiles ignition files from spec2 to spec3

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -139,7 +139,7 @@ func newCreateCmd() *cobra.Command {
 }
 
 func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args []string) {
-	runner := func(directory string) error {
+	runner := func(fcos bool, directory string) error {
 		assetStore, err := assetstore.NewStore(directory)
 		if err != nil {
 			return errors.Wrap(err, "failed to create asset store")
@@ -151,7 +151,7 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 				err = errors.Wrapf(err, "failed to fetch %s", a.Name())
 			}
 
-			if err2 := asset.PersistToFile(a, directory); err2 != nil {
+			if err2 := asset.PersistToFile(a, directory, fcos); err2 != nil {
 				err2 = errors.Wrapf(err2, "failed to write asset (%s) to disk", a.Name())
 				if err != nil {
 					logrus.Error(err2)
@@ -171,7 +171,7 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 		cleanup := setupFileHook(rootOpts.dir)
 		defer cleanup()
 
-		err := runner(rootOpts.dir)
+		err := runner(rootOpts.fcos, rootOpts.dir)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -19,6 +19,7 @@ var (
 	rootOpts struct {
 		dir      string
 		logLevel string
+		fcos     bool
 	}
 )
 
@@ -71,6 +72,7 @@ func newRootCmd() *cobra.Command {
 	}
 	cmd.PersistentFlags().StringVar(&rootOpts.dir, "dir", ".", "assets directory")
 	cmd.PersistentFlags().StringVar(&rootOpts.logLevel, "log-level", "info", "log level (e.g. \"debug | info | warn | error\")")
+	cmd.PersistentFlags().BoolVar(&rootOpts.fcos, "fcos", false, "set to true to generate ignition v3 configs")
 	return cmd
 }
 

--- a/pkg/asset/asset_test.go
+++ b/pkg/asset/asset_test.go
@@ -41,22 +41,47 @@ func TestPersistToFile(t *testing.T) {
 	cases := []struct {
 		name      string
 		filenames []string
+		fcos      bool
 	}{
 		{
 			name:      "no files",
 			filenames: []string{},
+			fcos:      false,
 		},
 		{
 			name:      "single file",
 			filenames: []string{"file1"},
+			fcos:      false,
 		},
 		{
 			name:      "multiple files",
 			filenames: []string{"file1", "file2"},
+			fcos:      false,
 		},
 		{
 			name:      "new directory",
 			filenames: []string{"dir1/file1"},
+			fcos:      false,
+		},
+		{
+			name:      "no files spec3",
+			filenames: []string{},
+			fcos:      true,
+		},
+		{
+			name:      "single file spec3",
+			filenames: []string{"file1"},
+			fcos:      true,
+		},
+		{
+			name:      "multiple files spec3",
+			filenames: []string{"file1", "file2"},
+			fcos:      true,
+		},
+		{
+			name:      "new directory",
+			filenames: []string{"dir1/file1"},
+			fcos:      true,
 		},
 	}
 	for _, tc := range cases {
@@ -79,7 +104,7 @@ func TestPersistToFile(t *testing.T) {
 				}
 				expectedFiles[filepath.Join(dir, filename)] = data
 			}
-			err = PersistToFile(asset, dir)
+			err = PersistToFile(asset, dir, tc.fcos)
 			assert.NoError(t, err, "unexpected error persisting state to file")
 			verifyFilesCreated(t, dir, expectedFiles)
 		})

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -36,22 +36,27 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 	cases := []struct {
 		name    string
 		targets []asset.WritableAsset
+		fcos    bool
 	}{
 		{
 			name:    "install config",
 			targets: targets.InstallConfig,
+			fcos:    false,
 		},
 		{
 			name:    "manifest templates",
 			targets: targets.ManifestTemplates,
+			fcos:    false,
 		},
 		{
 			name:    "manifests",
 			targets: targets.Manifests,
+			fcos:    false,
 		},
 		{
 			name:    "ignition configs",
 			targets: targets.IgnitionConfigs,
+			fcos:    false,
 		},
 	}
 	for _, tc := range cases {
@@ -76,7 +81,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 					t.Fatalf("failed to fetch %q: %v", a.Name(), err)
 				}
 
-				if err := asset.PersistToFile(a, tempDir); err != nil {
+				if err := asset.PersistToFile(a, tempDir, tc.fcos); err != nil {
 					t.Fatalf("failed to write asset %q to disk: %v", a.Name(), err)
 				}
 			}

--- a/pkg/asset/store/store_test.go
+++ b/pkg/asset/store/store_test.go
@@ -409,7 +409,7 @@ func TestStoreFetchIdempotency(t *testing.T) {
 			if !assert.NoError(t, err, "(loop %d) unexpected error fetching asset %q", a.Name()) {
 				t.Fatal()
 			}
-			err = asset.PersistToFile(a, tempDir)
+			err = asset.PersistToFile(a, tempDir, false)
 			if !assert.NoError(t, err, "(loop %d) unexpected error persisting asset %q", a.Name()) {
 				t.Fatal()
 			}


### PR DESCRIPTION
This PR would add a new `--fcos` flag to installer, which would quickly patch ignition files to be compatible with spec3

TODO:
* [ ] Convert configs in IPI mode
* [ ] Make sure default FCOS bootstrap image boots with this config
* [ ] Fix unit tests