### PR TITLE
Rename openstackproviderconfig.k8s.io to openstackproviderconfig.openshift.io

### DIFF
--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -82,7 +82,7 @@ func provider(clusterID string, platform *openstack.Platform, mpool *openstack.M
 
 	return &openstackprovider.OpenstackProviderSpec{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "openstackproviderconfig.k8s.io/v1alpha1",
+			APIVersion: "openstackproviderconfig.openshift.io/v1alpha1",
 			Kind:       "OpenstackProviderSpec",
 		},
 		Flavor: mpool.FlavorName,


### PR DESCRIPTION
All good openshift citizens live under openshift.io sufixed group.