### PR TITLE
Bug 1713374: Do not use machine role and in machineset matching labels

### DIFF
--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -58,10 +58,8 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 				Replicas: &replicas,
 				Selector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"machine.openshift.io/cluster-api-machineset":   name,
-						"machine.openshift.io/cluster-api-cluster":      clusterID,
-						"machine.openshift.io/cluster-api-machine-role": role,
-						"machine.openshift.io/cluster-api-machine-type": role,
+						"machine.openshift.io/cluster-api-machineset": name,
+						"machine.openshift.io/cluster-api-cluster":    clusterID,
 					},
 				},
 				Template: machineapi.MachineTemplateSpec{

--- a/pkg/asset/machines/gcp/machinesets.go
+++ b/pkg/asset/machines/gcp/machinesets.go
@@ -59,10 +59,8 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 				Replicas: &replicas,
 				Selector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"machine.openshift.io/cluster-api-machineset":   name,
-						"machine.openshift.io/cluster-api-cluster":      clusterID,
-						"machine.openshift.io/cluster-api-machine-role": role,
-						"machine.openshift.io/cluster-api-machine-type": role,
+						"machine.openshift.io/cluster-api-machineset": name,
+						"machine.openshift.io/cluster-api-cluster":    clusterID,
 					},
 				},
 				Template: machineapi.MachineTemplateSpec{


### PR DESCRIPTION
Both 'machine.openshift.io/cluster-api-machine-role' and 'machine.openshift.io/cluster-api-machine-type' labels
in machineset matching labels are redundant. Only machineset name is needed. Given all other providers
set only cluster ID and machineset name in the matchine labels, let's honor the set of two items only.