### PR TITLE
WIP [gcp] Use a tcp proxy for the internal load balancer

### DIFF
--- a/data/data/bootstrap/gcp/files/usr/local/bin/redirect-ports.sh.template
+++ b/data/data/bootstrap/gcp/files/usr/local/bin/redirect-ports.sh.template
@@ -1,0 +1,32 @@
+#/bin/bash
+
+# Script to redirect API traffic from<->to load balancer ports to internal ports on GCP
+
+# On control plane nodes:
+# Requests coming in to port 5222 will be redirected to port 6443
+
+# On all nodes:
+# Outgoing requests to the internal load balancer IP on port 6443 will be redirected to port 5222
+
+
+run() {
+  {{ if .ControlPlane }}
+  if ! iptables -t nat -C PREROUTING -i ens4 -p tcp -m tcp --dport 5222 -j REDIRECT --to-ports 6443 &> /dev/null; then
+    echo "Adding rule to redirect incoming traffic on port 5222 to port 6443"
+    iptables -t nat -A PREROUTING -i ens4 -p tcp -m tcp --dport 5222 -j REDIRECT --to-ports 6443
+  fi
+  {{ end }}
+
+  if getent hosts api-int.{{.ClusterDomain}} &> /dev/null; then
+    lb_ip="$(getent hosts api-int.{{.ClusterDomain}} | awk '{ print $1 }')"
+    if ! iptables -t nat -C OUTPUT -d ${lb_ip} -p tcp -m tcp --dport 6443 -j DNAT --to-destination ${lb_ip}:5222 &> /dev/null; then
+      echo "Adding rule to redirect outgoing traffic from ${lb_ip}:6443 to ${lb_ip}:5222"
+      iptables -t nat -A OUTPUT -d ${lb_ip} -p tcp -m tcp --dport 6443 -j DNAT --to-destination ${lb_ip}:5222
+    fi
+  fi
+}
+
+while :; do
+  run
+  sleep 30
+done

--- a/data/data/bootstrap/gcp/systemd/units/redirect-ports.service
+++ b/data/data/bootstrap/gcp/systemd/units/redirect-ports.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Redirect load balancer port to internal port
+ConditionKernelCommandLine=ignition.platform.id=gce
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /usr/local/bin/redirect-ports.sh
+User=root
+RestartSec=30
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -38,7 +38,7 @@ resource "google_compute_firewall" "bootstrap_ingress_ssh" {
 }
 
 resource "google_compute_instance" "bootstrap" {
-  count = var.bootstrap_enabled ? 1 : 0
+  count = var.bootstrap_present ? 1 : 0
 
   name         = "${var.cluster_id}-b"
   machine_type = var.machine_type
@@ -67,4 +67,18 @@ resource "google_compute_instance" "bootstrap" {
   tags = ["${var.cluster_id}-master", "${var.cluster_id}-bootstrap"]
 
   labels = var.labels
+}
+
+resource "google_compute_instance_group" "bootstrap" {
+  count = var.bootstrap_present ? 1 : 0
+
+  name = "${var.cluster_id}-bootstrap"
+  zone = var.zone
+
+  named_port {
+    name = "tcp5222"
+    port = "5222"
+  }
+
+  instances = google_compute_instance.bootstrap.*.self_link
 }

--- a/data/data/gcp/bootstrap/output.tf
+++ b/data/data/gcp/bootstrap/output.tf
@@ -1,3 +1,7 @@
 output "bootstrap_instances" {
   value = google_compute_instance.bootstrap.*.self_link
 }
+
+output "bootstrap_instance_groups" {
+  value = google_compute_instance_group.bootstrap.*.self_link
+}

--- a/data/data/gcp/bootstrap/variables.tf
+++ b/data/data/gcp/bootstrap/variables.tf
@@ -3,7 +3,7 @@ variable "cluster_id" {
   description = "The name of the cluster."
 }
 
-variable "bootstrap_enabled" {
+variable "bootstrap_present" {
   type        = bool
   description = "If the bootstrap instance and instance_group should exist."
   default     = true

--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -22,7 +22,7 @@ resource "google_dns_record_set" "api_internal" {
   type         = "A"
   ttl          = "60"
   managed_zone = google_dns_managed_zone.int.name
-  rrdatas      = [var.api_external_lb_ip]
+  rrdatas      = [var.api_internal_lb_ip]
 }
 
 resource "google_dns_record_set" "api_external_internal_zone" {

--- a/data/data/gcp/dns/variables.tf
+++ b/data/data/gcp/dns/variables.tf
@@ -29,6 +29,11 @@ variable "api_external_lb_ip" {
   type        = string
 }
 
+variable "api_internal_lb_ip" {
+  description = "Internal API's LB IP"
+  type        = string
+}
+
 variable "cluster_domain" {
   description = "The domain for the cluster that all DNS records must belong"
   type        = string

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -14,7 +14,7 @@ provider "google" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  bootstrap_enabled = var.gcp_bootstrap_enabled
+  bootstrap_present = var.gcp_bootstrap_present
 
   image        = google_compute_image.cluster.self_link
   machine_type = var.gcp_bootstrap_instance_type
@@ -56,10 +56,12 @@ module "network" {
   worker_subnet_cidr = local.worker_subnet_cidr
   network_cidr       = var.machine_cidr
 
-  bootstrap_lb        = var.gcp_bootstrap_enabled
-  bootstrap_instances = module.bootstrap.bootstrap_instances
+  bootstrap_lb              = var.gcp_bootstrap_enabled && var.gcp_bootstrap_present
+  bootstrap_instances       = module.bootstrap.bootstrap_instances
+  bootstrap_instance_groups = module.bootstrap.bootstrap_instance_groups
 
-  master_instances = module.master.master_instances
+  master_instances       = module.master.master_instances
+  master_instance_groups = module.master.master_instance_groups
 }
 
 module "dns" {
@@ -72,6 +74,7 @@ module "dns" {
   etcd_count           = var.master_count
   cluster_domain       = var.cluster_domain
   api_external_lb_ip   = module.network.cluster_public_ip
+  api_internal_lb_ip   = module.network.cluster_private_ip
 }
 
 resource "google_compute_image" "cluster" {

--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -65,3 +65,17 @@ resource "google_compute_instance" "master" {
     scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
 }
+
+resource "google_compute_instance_group" "master" {
+  count = length(var.zones)
+
+  name = "${var.cluster_id}-master-${element(var.zones, count.index)}"
+  zone = var.zones[count.index]
+
+  named_port {
+    name = "tcp5222"
+    port = "5222"
+  }
+
+  instances = [for instance in google_compute_instance.master.* : instance.self_link if instance.zone == var.zones[count.index]]
+}

--- a/data/data/gcp/master/outputs.tf
+++ b/data/data/gcp/master/outputs.tf
@@ -5,3 +5,7 @@ output "master_instances" {
 output "ip_addresses" {
   value = google_compute_instance.master.*.network_interface.0.network_ip
 }
+
+output "master_instance_groups" {
+  value = google_compute_instance_group.master.*.self_link
+}

--- a/data/data/gcp/network/firewall-control.tf
+++ b/data/data/gcp/network/firewall-control.tf
@@ -42,7 +42,7 @@ resource "google_compute_firewall" "master_ingress_from_health_checks" {
 
   allow {
     protocol = "tcp"
-    ports    = ["6080", "22624"]
+    ports    = ["6080", "22624", "5222"]
   }
 
   source_ranges = ["35.191.0.0/16", "130.211.0.0/22"]

--- a/data/data/gcp/network/lb.tf
+++ b/data/data/gcp/network/lb.tf
@@ -2,6 +2,49 @@ resource "google_compute_address" "cluster_public_ip" {
   name = "${var.cluster_id}-cluster-public-ip"
 }
 
+resource "google_compute_global_address" "cluster_private_ip" {
+  name = "${var.cluster_id}-cluster-private-ip"
+}
+
+resource "google_compute_health_check" "api_internal" {
+  name = "${var.cluster_id}-ign-internal"
+
+  tcp_health_check {
+    port = "5222"
+  }
+}
+
+resource "google_compute_backend_service" "api_internal" {
+  name = "${var.cluster_id}-api-internal"
+
+  protocol    = "TCP"
+  port_name   = "tcp5222"
+  timeout_sec = 120
+
+  dynamic "backend" {
+    for_each = var.bootstrap_lb ? var.bootstrap_instance_groups : var.master_instance_groups
+
+    content {
+      group = backend.value
+    }
+  }
+
+  health_checks = [google_compute_health_check.api_internal.self_link]
+}
+
+resource "google_compute_target_tcp_proxy" "api_internal" {
+  name            = "${var.cluster_id}-api-internal"
+  backend_service = google_compute_backend_service.api_internal.self_link
+}
+
+resource "google_compute_global_forwarding_rule" "api_internal" {
+  name                  = "${var.cluster_id}-api-internal"
+  target                = google_compute_target_tcp_proxy.api_internal.self_link
+  port_range            = "5222"
+  load_balancing_scheme = "EXTERNAL"
+  ip_address            = google_compute_global_address.cluster_private_ip.address
+}
+
 resource "google_compute_http_health_check" "api" {
   name = "${var.cluster_id}-api"
 

--- a/data/data/gcp/network/outputs.tf
+++ b/data/data/gcp/network/outputs.tf
@@ -13,3 +13,7 @@ output "worker_subnet" {
 output "master_subnet" {
   value = google_compute_subnetwork.master_subnet.self_link
 }
+
+output "cluster_private_ip" {
+  value = google_compute_global_address.cluster_private_ip.address
+}

--- a/data/data/gcp/network/variables.tf
+++ b/data/data/gcp/network/variables.tf
@@ -29,3 +29,13 @@ variable "network_cidr" {
 variable "worker_subnet_cidr" {
   type = string
 }
+
+variable "bootstrap_instance_groups" {
+  type        = list
+  description = "The instance group that hold the bootstrap instance in this region."
+}
+
+variable "master_instance_groups" {
+  type        = list
+  description = "The instance groups that hold the master instances in this region."
+}

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -30,6 +30,12 @@ variable "gcp_bootstrap_enabled" {
   default = true
 }
 
+variable "gcp_bootstrap_present" {
+  type = bool
+  description = "Setting this to false allows the bootstrap instance and instance group to be removed."
+  default = true
+}
+
 variable "gcp_bootstrap_instance_type" {
   type = string
   description = "Instance type for the bootstrap node. Example: `n1-standard-4`"

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -40,6 +40,8 @@ const (
 // bootstrapTemplateData is the data to use to replace values in bootstrap
 // template files.
 type bootstrapTemplateData struct {
+	ControlPlane          bool
+	ClusterDomain         string
 	AdditionalTrustBundle string
 	EtcdCluster           string
 	PullSecret            string
@@ -218,6 +220,8 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 	}
 
 	return &bootstrapTemplateData{
+		ControlPlane:          true,
+		ClusterDomain:         installConfig.ClusterDomain(),
 		AdditionalTrustBundle: installConfig.AdditionalTrustBundle,
 		PullSecret:            installConfig.PullSecret,
 		ReleaseImage:          releaseImage,
@@ -293,6 +297,8 @@ func (a *Bootstrap) addSystemdUnits(uri string, templateData *bootstrapTemplateD
 		// baremetal platform services
 		"keepalived.service": {},
 		"coredns.service":    {},
+		// gcp platform services
+		"redirect-ports.service": {},
 	}
 
 	directory, err := data.Assets.Open(uri)

--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/installer/pkg/types"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 )
 
 // pointerIgnitionConfig generates a config which references the remote config
@@ -20,6 +21,9 @@ func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, ro
 		// Baremetal needs to point directly at the VIP because we don't have a
 		// way to configure DNS before Ignition runs.
 		ignitionHost = fmt.Sprintf("%s:22623", installConfig.BareMetal.APIVIP)
+	case gcptypes.Name:
+		// For GCP we are using the public IP endpoint for ignition.
+		ignitionHost = fmt.Sprintf("api.%s:22623", installConfig.ClusterDomain())
 	default:
 		ignitionHost = fmt.Sprintf("api-int.%s:22623", installConfig.ClusterDomain())
 	}

--- a/pkg/asset/machines/machineconfig/gcp/redirectports.go
+++ b/pkg/asset/machines/machineconfig/gcp/redirectports.go
@@ -1,0 +1,99 @@
+package gcp
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"text/template"
+
+	"github.com/pkg/errors"
+
+	"github.com/coreos/ignition/config/util"
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	"github.com/openshift/installer/data"
+	"github.com/openshift/installer/pkg/asset/ignition"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	scriptTemplate = "bootstrap/gcp/files/usr/local/bin/redirect-ports.sh.template"
+	scriptFile     = "/usr/local/bin/redirect-ports.sh"
+	unitFile       = "bootstrap/gcp/systemd/units/redirect-ports.service"
+)
+
+// ForPortRedirection creates the MachineConfig that adds a port redirection systemd unit
+// to machines on GCP. For masters, it redirects incoming traffic. For all nodes it redirects
+// outgoing traffic to the internal control plane load balancer.
+func ForPortRedirection(role string, clusterDomain string) (*mcfgv1.MachineConfig, error) {
+	templateData := map[string]interface{}{
+		"ClusterDomain": clusterDomain,
+		"ControlPlane":  (role == "master"),
+	}
+	script, err := readTemplate(scriptTemplate, templateData)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot read %s", scriptFile)
+	}
+	unit, err := readFile(unitFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot read %s", unitFile)
+	}
+	return &mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("99-%s-redirect-lb-ports", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: igntypes.Config{
+				Ignition: igntypes.Ignition{
+					Version: igntypes.MaxVersion.String(),
+				},
+				Storage: igntypes.Storage{
+					Files: []igntypes.File{
+						ignition.FileFromBytes(scriptFile, "root", 0555, script),
+					},
+				},
+				Systemd: igntypes.Systemd{
+					Units: []igntypes.Unit{
+						{
+							Name:     "redirect-ports.service",
+							Enabled:  util.BoolToPtr(true),
+							Contents: string(unit),
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func readFile(name string) ([]byte, error) {
+	file, err := data.Assets.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return ioutil.ReadAll(file)
+}
+
+func readTemplate(name string, data map[string]interface{}) ([]byte, error) {
+	content, err := readFile(name)
+	if err != nil {
+		return nil, err
+	}
+	t, err := template.New(name).Parse(string(content))
+	if err != nil {
+		return nil, err
+	}
+	buf := &bytes.Buffer{}
+	if err = t.Execute(buf, data); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines/gcp"
 	"github.com/openshift/installer/pkg/asset/machines/libvirt"
 	"github.com/openshift/installer/pkg/asset/machines/machineconfig"
+	gcpmachineconfig "github.com/openshift/installer/pkg/asset/machines/machineconfig/gcp"
 	"github.com/openshift/installer/pkg/asset/machines/openstack"
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/types"
@@ -229,6 +230,11 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			for _, set := range sets {
 				machineSets = append(machineSets, set)
 			}
+			cfg, err := gcpmachineconfig.ForPortRedirection("worker", ic.ClusterDomain())
+			if err != nil {
+				return errors.Wrap(err, "failed to create port redirection machine config")
+			}
+			machineConfigs = append(machineConfigs, cfg)
 		case libvirttypes.Name:
 			mpool := defaultLibvirtMachinePoolPlatform()
 			mpool.Set(ic.Platform.Libvirt.DefaultMachinePlatform)

--- a/pkg/asset/tls/mcscertkey.go
+++ b/pkg/asset/tls/mcscertkey.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 )
 
 // MCSCertKey is the asset that generates the MCS key/cert pair.
@@ -34,6 +35,7 @@ func (a *MCSCertKey) Generate(dependencies asset.Parents) error {
 	dependencies.Get(ca, installConfig)
 
 	hostname := internalAPIAddress(installConfig.Config)
+	publicHostname := apiAddress(installConfig.Config)
 
 	cfg := &CertCfg{
 		Subject:      pkix.Name{CommonName: hostname},
@@ -45,6 +47,8 @@ func (a *MCSCertKey) Generate(dependencies asset.Parents) error {
 	case baremetaltypes.Name:
 		cfg.IPAddresses = []net.IP{net.ParseIP(installConfig.Config.BareMetal.APIVIP)}
 		cfg.DNSNames = []string{hostname, installConfig.Config.BareMetal.APIVIP}
+	case gcptypes.Name:
+		cfg.DNSNames = []string{publicHostname}
 	default:
 		cfg.DNSNames = []string{hostname}
 	}

--- a/pkg/destroy/gcp/compute.go
+++ b/pkg/destroy/gcp/compute.go
@@ -45,6 +45,10 @@ func (o *ClusterUninstaller) getInstanceNameAndZone(instanceURL string) (string,
 	return "", ""
 }
 
+func (o *ClusterUninstaller) listInstanceGroups() ([]nameAndZone, error) {
+	return o.listInstanceGroupsWithFilter(o.clusterIDFilter())
+}
+
 func (o *ClusterUninstaller) listInstanceGroupsWithFilter(filter string) ([]nameAndZone, error) {
 	o.Logger.Debugf("Listing instance groups")
 	result := []nameAndZone{}
@@ -68,6 +72,22 @@ func (o *ClusterUninstaller) listInstanceGroupsWithFilter(filter string) ([]name
 		return nil, errors.Wrapf(err, "failed to fetch compute instance groups")
 	}
 	return result, nil
+}
+
+// destroyInstanceGroups removes any instance group with a name that starts with
+// the cluster's infra ID.
+func (o *ClusterUninstaller) destroyInstanceGroups() error {
+	instanceGroups, err := o.listInstanceGroups()
+	if err != nil {
+		return err
+	}
+	for _, ig := range instanceGroups {
+		err := o.deleteInstanceGroup(ig)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (o *ClusterUninstaller) listInstanceGroupInstances(ig nameAndZone) ([]nameAndZone, error) {

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -117,6 +117,7 @@ func (o *ClusterUninstaller) destroyCluster() (bool, error) {
 		destroy func() error
 	}{
 		{name: "Compute instances", destroy: o.destroyComputeInstances},
+		{name: "Instance groups", destroy: o.destroyInstanceGroups},
 		{name: "Disks", destroy: o.destroyDisks},
 		{name: "Service accounts", destroy: o.destroyServiceAccounts},
 		{name: "Images", destroy: o.destroyImages},
@@ -125,9 +126,13 @@ func (o *ClusterUninstaller) destroyCluster() (bool, error) {
 		{name: "Routes", destroy: o.destroyRoutes},
 		{name: "Firewalls", destroy: o.destroyFirewalls},
 		{name: "Addresses", destroy: o.destroyAddresses},
+		{name: "Global addresses", destroy: o.destroyGlobalAddresses},
 		{name: "Target Pools", destroy: o.destroyTargetPools},
+		{name: "TCP proxies", destroy: o.destroyTargetTCPProxies},
 		{name: "Forwarding rules", destroy: o.destroyForwardingRules},
+		{name: "Global forwarding rules", destroy: o.destroyGlobalForwardingRules},
 		{name: "Backend services", destroy: o.destroyBackendServices},
+		{name: "Regional backend services", destroy: o.destroyRegionBackendServices},
 		{name: "Health checks", destroy: o.destroyHealthChecks},
 		{name: "HTTP Health checks", destroy: o.destroyHTTPHealthChecks},
 		{name: "Cloud controller internal LBs", destroy: o.destroyCloudControllerInternalLBs},


### PR DESCRIPTION
Changes:
- Adds systemd unit to redirect ports for incoming requests on control plane machines. And outgoing requests on all machines.
- Adds TCP proxy for the internal API endpoint with a new global address. Some notes about this:
  - We cannot use the same public IP as the public API's endpoint because for a TCP proxy, it needs to be a global IP. For the network load balancer, you need a regional IP.
  - We cannot use a TCP proxy for the MCS endpoint because there is no way to limit access to a TCP proxy via firewall rules. It would be publicly exposed.
- Changes ignition URL and corresponding MCS cert to use the public DNS endpoint for the cluster, since the internal API IP now points to the TCP proxy.
- Adds destroy code for the new resource types that we're adding.
- Reverts to 3-step destroy of bootstrap resources because new instance group causes a RESOURCE_IN_USE error when deleting it without first removing it from the tcp proxy backend service.

