### PR TITLE
Revert "data/data/azure/dns: use public ip behind internal apis"

### DIFF
--- a/data/data/azure/dns/dns.tf
+++ b/data/data/azure/dns/dns.tf
@@ -3,20 +3,20 @@ locals {
   api_external_name = "api.${replace(var.cluster_domain, ".${var.base_domain}", "")}"
 }
 
-resource "azurerm_dns_cname_record" "apiint_internal" {
+resource "azurerm_dns_a_record" "apiint_internal" {
   name                = "api-int"
   zone_name           = var.private_dns_zone_name
   resource_group_name = var.resource_group_name
   ttl                 = 300
-  record              = var.external_lb_fqdn
+  records             = [var.internal_lb_ipaddress]
 }
 
-resource "azurerm_dns_cname_record" "api_internal" {
+resource "azurerm_dns_a_record" "api_internal" {
   name                = "api"
   zone_name           = var.private_dns_zone_name
   resource_group_name = var.resource_group_name
   ttl                 = 300
-  record              = var.external_lb_fqdn
+  records             = [var.internal_lb_ipaddress]
 }
 
 resource "azurerm_dns_cname_record" "api_external" {

--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -59,8 +59,7 @@ resource "azurerm_lb_probe" "internal_lb_probe_sint" {
   number_of_probes    = 3
   loadbalancer_id     = azurerm_lb.internal.id
   port                = 22623
-  request_path        = "/healthz"
-  protocol            = "Https"
+  protocol            = "TCP"
 }
 
 resource "azurerm_lb_probe" "internal_lb_probe_api_internal" {
@@ -70,7 +69,6 @@ resource "azurerm_lb_probe" "internal_lb_probe_api_internal" {
   number_of_probes    = 3
   loadbalancer_id     = azurerm_lb.internal.id
   port                = 6443
-  request_path        = "/readyz"
-  protocol            = "Https"
+  protocol            = "TCP"
 }
 

--- a/data/data/azure/vnet/nsg.tf
+++ b/data/data/azure/vnet/nsg.tf
@@ -33,17 +33,3 @@ resource "azurerm_network_security_rule" "apiserver_in" {
   resource_group_name         = var.resource_group_name
   network_security_group_name = azurerm_network_security_group.master.name
 }
-
-resource "azurerm_network_security_rule" "sint_in" {
-  name                        = "sint_in"
-  priority                    = 102
-  direction                   = "Inbound"
-  access                      = "Allow"
-  protocol                    = "Tcp"
-  source_port_range           = "*"
-  destination_port_range      = "22623"
-  source_address_prefix       = "*"
-  destination_address_prefix  = "*"
-  resource_group_name         = var.resource_group_name
-  network_security_group_name = azurerm_network_security_group.master.name
-}

--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -49,21 +49,6 @@ resource "azurerm_lb_rule" "public_lb_rule_api_internal" {
   probe_id                       = azurerm_lb_probe.public_lb_probe_api_internal.id
 }
 
-resource "azurerm_lb_rule" "public_lb_rule_sint_internal" {
-  name                           = "sint-internal"
-  resource_group_name            = var.resource_group_name
-  protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool.id
-  loadbalancer_id                = azurerm_lb.public.id
-  frontend_port                  = 22623
-  backend_port                   = 22623
-  frontend_ip_configuration_name = local.public_lb_frontend_ip_configuration_name
-  enable_floating_ip             = false
-  idle_timeout_in_minutes        = 30
-  load_distribution              = "Default"
-  probe_id                       = azurerm_lb_probe.public_lb_sint.id
-}
-
 resource "azurerm_lb_probe" "public_lb_probe_api_internal" {
   name                = "api-internal-probe"
   resource_group_name = var.resource_group_name
@@ -71,15 +56,5 @@ resource "azurerm_lb_probe" "public_lb_probe_api_internal" {
   number_of_probes    = 3
   loadbalancer_id     = azurerm_lb.public.id
   port                = 6443
-  protocol            = "TCP"
-}
-
-resource "azurerm_lb_probe" "public_lb_sint" {
-  name                = "sint-probe"
-  resource_group_name = var.resource_group_name
-  interval_in_seconds = 10
-  number_of_probes    = 3
-  loadbalancer_id     = azurerm_lb.public.id
-  port                = 22623
   protocol            = "TCP"
 }


### PR DESCRIPTION
This reverts commit 619d0b28f377ab0c397b1a8b169dac5429599a38.

xref: https://jira.coreos.com/browse/CORS-1095