### PR TITLE
WIP: Bug 1737660: pkg/asset/machines/worker: Bump Azure default to 256 GiB (P15) disks

### DIFF
--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -78,7 +78,7 @@ func defaultLibvirtMachinePoolPlatform() libvirttypes.MachinePool {
 func defaultAzureMachinePoolPlatform() azuretypes.MachinePool {
 	return azuretypes.MachinePool{
 		OSDisk: azuretypes.OSDisk{
-			DiskSizeGB: 128,
+			DiskSizeGB: 256,
 		},
 	}
 }

--- a/pkg/types/azure/defaults/machines.go
+++ b/pkg/types/azure/defaults/machines.go
@@ -17,7 +17,7 @@ func BootstrapInstanceType(region string) string {
 // D4s v3 gives us 4 CPU's, 16GiB ram and 32GiB of temporary storage
 func ControlPlaneInstanceType(region string) string {
 	instanceClass := getInstanceClass(region)
-	return fmt.Sprintf("%s_D4s_v3", instanceClass)
+	return fmt.Sprintf("%s_D8s_v3", instanceClass)
 }
 
 // ComputeInstanceType sets the defaults for compute instances.


### PR DESCRIPTION
We're having [latency issues with etcd on Azure's current disks][1]. Going from [the 128 GiB P10 to the 256 GiB P15][2] should bump IOPS from 0.5 to 1.1 k, throughput from 100 to 125 MB/s, and price from 19.71 to 38.02 $/month (in East US).  If this plays out well, we can take a look at separating the disk defaults for compute and control-plane nodes.

CC @hexfusion, @kikisdeliveryservice

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1737660
[2]: https://azure.microsoft.com/en-us/pricing/details/managed-disks/