### PR TITLE
[gcp] pkg/destroy/gcp: Fix orphan service accounts

### DIFF
--- a/pkg/destroy/gcp/compute.go
+++ b/pkg/destroy/gcp/compute.go
@@ -114,8 +114,7 @@ func (o *ClusterUninstaller) deleteInstanceGroup(ig nameAndZone) error {
 func (o *ClusterUninstaller) listComputeInstances() ([]nameAndZone, error) {
 	o.Logger.Debugf("Listing compute instances")
 	result := []nameAndZone{}
-	filter := fmt.Sprintf("(status ne TERMINATED)(%s)", o.clusterIDFilter())
-	req := o.computeSvc.Instances.AggregatedList(o.ProjectID).Filter(filter).Fields("items/*/instances(name,zone,status)")
+	req := o.computeSvc.Instances.AggregatedList(o.ProjectID).Filter(o.clusterIDFilter()).Fields("items/*/instances(name,zone,status)")
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
 	err := req.Pages(ctx, func(list *compute.InstanceAggregatedList) error {

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -182,8 +182,9 @@ func isNotFound(err error) bool {
 // aggregateError is a utility function that takes a slice of errors and an
 // optional pending argument, and returns an error or nil
 func aggregateError(errs []error, pending ...int) error {
-	if len(errs) > 0 {
-		return utilerrors.NewAggregate(errs)
+	err := utilerrors.NewAggregate(errs)
+	if err != nil {
+		return err
 	}
 	if len(pending) > 0 && pending[0] > 0 {
 		return errors.Errorf("%d items pending", pending[0])


### PR DESCRIPTION
- Changes service account and IAM policy deletion code to only declare success if
no items are returned when queried.
- Removes filter for list of instances
- Fixes aggregateError utility function
- Fixes prefix used to clear IAM policy bindings