### PR TITLE
Updating main.tf for terraform version 0.12

### DIFF
--- a/upi/vsphere/machine/main.tf
+++ b/upi/vsphere/machine/main.tf
@@ -43,7 +43,7 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   vapp {
-    properties {
+    properties = {
       "guestinfo.ignition.config.data"          = "${base64encode(data.ignition_config.ign.*.rendered[count.index])}"
       "guestinfo.ignition.config.data.encoding" = "base64"
     }


### PR DESCRIPTION
Fix vSphere main.tf file for compatibility with terraform 0.12

Documented in this issue: https://github.com/hashicorp/terraform/issues/19575 , Terraform 0.12 requires having the `=` symbol in certain places where previous versions did not. 

