### PR TITLE
Bug 1737660: data/azure/master: use ReadOnly caching for OSDisk

### DIFF
--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -49,7 +49,7 @@ resource "azurerm_virtual_machine" "master" {
 
   storage_os_disk {
     name              = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
-    caching           = "ReadWrite"
+    caching           = "ReadOnly"
     create_option     = "FromImage"
     managed_disk_type = "Premium_LRS"
     disk_size_gb      = var.os_volume_size


### PR DESCRIPTION
In search for find the performance bottleneck for etcd on control-plane host, I contacted the Microsoft Support with the FIO results. They mentioned that the Disks for the control-plane were using Read/Write caches and for Premium SSDs certain applications can benefit from switching to Read-only cache.

`Azure Red Hat Openshift` deployments already use Read-only cache for etcd data disks [1][1]

Switching to read-only has provided definite speed ups. This is still not comparable to AWS/GCP but I think this is definitely required as we optimize more.

[1]: https://github.com/openshift/openshift-azure/blob/ced59421d8f8122315d5b649ba89c43b52c5e183/pkg/arm/v5/resources.go#L475