### PR TITLE
gcp: increase the ports per VM for NAT

### DIFF
--- a/data/data/gcp/network/network.tf
+++ b/data/data/gcp/network/network.tf
@@ -30,6 +30,7 @@ resource "google_compute_router_nat" "master_nat" {
   router                             = google_compute_router.router.name
   nat_ip_allocate_option             = "MANUAL_ONLY"
   nat_ips                            = [google_compute_address.master_nat_ip.self_link]
+  min_ports_per_vm                   = 256
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {
@@ -47,6 +48,7 @@ resource "google_compute_router_nat" "worker_nat" {
   router                             = google_compute_router.router.name
   nat_ip_allocate_option             = "MANUAL_ONLY"
   nat_ips                            = [google_compute_address.worker_nat_ip.self_link]
+  min_ports_per_vm                   = 128
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {


### PR DESCRIPTION
The number of concurrent connections to single host:port depends on the minimum number of ports per VM configuration of the cloud NAT [1]. This esp important for pulling images, as those are pulled in parallel by CRI-O

Increasing the default from 64 to 256 for control-plane for better bootstrapping throughput, and increasing the default from 64 to 128 for compute for better baseline.

[1]: https://cloud.google.com/nat/docs/overview#number_of_nat_ports_and_connections

/cc @csrwng 