### PR TITLE
openstack: set up `docs/design/openstack` OWNERS

### DIFF
--- a/docs/design/openstack/OWNERS
+++ b/docs/design/openstack/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers


### PR DESCRIPTION
This adds a new directory for documents about the design of the
OpenStack platform and sets up `openstack-approvers` as its owners.

For example content see the existing Bare Metal folder:

https://github.com/openshift/installer/tree/master/docs/design/baremetal

Or this pull request:

https://github.com/openshift/installer/pull/2148