### PR TITLE
Bug 1741637: openstack: Add API Floating IP survey question

### DIFF
--- a/pkg/types/openstack/validation/mock/validvaluesfetcher_generated.go
+++ b/pkg/types/openstack/validation/mock/validvaluesfetcher_generated.go
@@ -121,3 +121,18 @@ func (mr *MockValidValuesFetcherMockRecorder) GetServiceCatalog(cloud interface{
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceCatalog", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetServiceCatalog), cloud)
 }
+
+// GetFloatingIPNames mocks base method
+func (m *MockValidValuesFetcher) GetFloatingIPNames(cloud, floatingNetwork string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFloatingIPNames", cloud, floatingNetwork)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFloatingIPNames indicates an expected call of GetFloatingIPNames
+func (mr *MockValidValuesFetcherMockRecorder) GetFloatingIPNames(cloud, floatingNetwork interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFloatingIPNames", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetFloatingIPNames), cloud, floatingNetwork)
+}

--- a/pkg/types/openstack/validation/validvaluesfetcher.go
+++ b/pkg/types/openstack/validation/validvaluesfetcher.go
@@ -16,4 +16,6 @@ type ValidValuesFetcher interface {
 	GetNetworkExtensionsAliases(cloud string) ([]string, error)
 	// GetServiceCatalog gets the catalog service names
 	GetServiceCatalog(cloud string) ([]string, error)
+	// GetFloatingIPNames gets the floating IPs
+	GetFloatingIPNames(cloud string, floatingNetwork string) ([]string, error)
 }


### PR DESCRIPTION
Without a floating IP address, the cluster will not be accessible from
the outside, which means the installer will fail when it tries to
communicate with the OpenShift API.

This adds the necessary prompt that lists all floating IPs that are
available on the previously selected external network.