### PR TITLE
images: Update Go version in the mock image

### DIFF
--- a/images/mock/Dockerfile
+++ b/images/mock/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 
 RUN go get github.com/golang/mock/gomock github.com/golang/mock/mockgen


### PR DESCRIPTION
Running `hack/go-genmock.sh` was failing with:

    2019/08/09 14:05:31 Loading input failed: unsupported version of go: exit status 2: flag provided but not defined: -compiled
    usage: list [-e] [-f format] [-json] [build flags] [packages]
    Run 'go help list' for details.

Updating the builder to `release:golang-1.11` fixes it.