### PR TITLE
pkg/asset/manifests/proxy: Do not inject empty-string noProxy

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -142,7 +142,9 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 	}
 
 	for _, userValue := range strings.Split(installConfig.Config.Proxy.NoProxy, ",") {
-		set.Insert(userValue)
+		if userValue != "" {
+			set.Insert(userValue)
+		}
 	}
 
 	return strings.Join(set.List(), ","), nil


### PR DESCRIPTION
Splitting an empty string:

```
len(strings.Split("", ",")))
```

returns a slice with a single empty string in it.  No need to inject an empty string in the noProxy set.  This will also protect us from install-config entries that begin or end with a comma, giving us a cleaner in-cluster config in those cases.