### PR TITLE
docs/user/gcp/install: Link to the UPI install docs

### DIFF
--- a/docs/user/gcp/install.md
+++ b/docs/user/gcp/install.md
@@ -1,9 +1,12 @@
 # Cluster Installation
 
-At this point, you are ready to perform the OpenShift installation. See below for an example of an
-IPI install.
+At this point, you are ready to perform the OpenShift installation.
+You have two choices for installing your cluster on GCP, installer-provided infrastructure or user-provided infrastructure.
+See below for an example of an installer-provided infrastructure install.
 
-## Example: Installer-Provided Infrastructure (IPI)
+To see a guided example of a user-provided infrastructure install, please see [Install: User-Provided Infrastructure](install_upi.md)
+
+## Example: Installer-Provided Infrastructure
 
 The steps for performing an IPI-based install are outlined [here][cloud-install]. Following this guide you may begin at
 Step 3: Download the Installer.

--- a/docs/user/gcp/install_upi.md
+++ b/docs/user/gcp/install_upi.md
@@ -1,6 +1,6 @@
-# Install: User Provided Infrastructure (UPI)
+# Install: User-Provided Infrastructure
 
-The steps for performing a UPI-based install are outlined here. Several
+The steps for performing a user-provided infrastructure install are outlined here. Several
 [Deployment Manager][deploymentmanager] templates are provided to assist in
 completing these steps or to help model your own. You are also free to create
 the required resources through other methods; the templates are just an


### PR DESCRIPTION
Broadly following the analogous AWS wording, but I've removed the "IPI" and "UPI" acronyms based on [rhbz#1706179][1].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1706179