### PR TITLE
[gcp] data/data/gcp: remove role binding to storage.objectAdmin

### DIFF
--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -23,11 +23,6 @@ resource "google_project_iam_member" "master-storage-admin" {
   member = "serviceAccount:${google_service_account.master-node-sa.email}"
 }
 
-resource "google_project_iam_member" "master-object-storage-admin" {
-  role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${google_service_account.master-node-sa.email}"
-}
-
 resource "google_project_iam_member" "master-service-account-user" {
   role   = "roles/iam.serviceAccountUser"
   member = "serviceAccount:${google_service_account.master-node-sa.email}"


### PR DESCRIPTION
The storage.admin role (which we already include) is a superset of storage.objectAdmin. This PR
removes the unnecessary additional role binding.