### PR TITLE
Install sshuttle in openstack CI image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -15,7 +15,8 @@ RUN yum install --setopt=tsflags=nodocs -y \
     https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &&\
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    python-openstackclient && \
+    python-openstackclient \
+    sshuttle && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /output && chown 1000:1000 /output

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -18,6 +18,7 @@ RUN yum install --setopt=tsflags=nodocs -y \
     yum install --setopt=tsflags=nodocs -y \
     python-openstackclient \
     python-pip \
+    iptables \
     shadow-utils \
     sudo && \
     yum clean all && rm -rf /var/cache/yum/*

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -17,11 +17,13 @@ RUN yum install --setopt=tsflags=nodocs -y \
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     python-openstackclient \
+    shadow-utils \
     sshuttle \
     sudo && \
     yum clean all && rm -rf /var/cache/yum/*
 
-RUN mkdir /output && chown 1000:1000 /output
+RUN useradd -u 1000 -d /output ci && \
+    chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -9,6 +9,7 @@ FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/images/openstack/rdo-stein.repo /etc/yum.repos.d/rdo-stein.repo
 COPY --from=builder /go/src/github.com/openshift/installer/images/openstack/rdo-stein.gpg /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
+COPY --from=builder /go/src/github.com/openshift/installer/images/openstack/sudoers_sshuttle /etc/sudoers.d/sshuttle
 COPY --from=registry.svc.ci.openshift.org/origin/4.1:cli /usr/bin/oc /bin/oc
 
 RUN yum install --setopt=tsflags=nodocs -y \
@@ -16,7 +17,8 @@ RUN yum install --setopt=tsflags=nodocs -y \
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     python-openstackclient \
-    sshuttle && \
+    sshuttle \
+    sudo && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /output && chown 1000:1000 /output

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -17,10 +17,12 @@ RUN yum install --setopt=tsflags=nodocs -y \
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     python-openstackclient \
+    python-pip \
     shadow-utils \
-    sshuttle \
     sudo && \
     yum clean all && rm -rf /var/cache/yum/*
+
+RUN pip install sshuttle
 
 RUN useradd -u 1000 -d /output ci && \
     chown 1000:1000 /output

--- a/images/openstack/sudoers_sshuttle
+++ b/images/openstack/sudoers_sshuttle
@@ -1,0 +1,1 @@
+#1000  ALL = (root) NOPASSWD: /bin/sshuttle


### PR DESCRIPTION
The node that runs the installer need to access a DNS resolver that has
the A api records for the CI provisioned clusters. This resolver is
currently hosted in MOC and wide open but will likely need to be locked
down. `sshuttle` can capture the DNS queries and forward them to the
CI-DNS VM on MOC, provided it has SSH access.

https://sshuttle.readthedocs.io/en/stable/manpage.html#cmdoption-sshuttle-dns