### PR TITLE
image: fix invalid yum commands in images

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -10,10 +10,8 @@ RUN TAGS="libvirt baremetal" hack/build.sh
 FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 
-RUN yum install --setopt=tsflags=nodocs -y \
-    yum update -y && \
-    yum install --setopt=tsflags=nodocs -y \
-    libvirt-libs && \
+RUN yum update -y && \
+    yum install --setopt=tsflags=nodocs -y libvirt-libs && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /output && chown 1000:1000 /output

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -16,15 +16,12 @@ COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
 COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json /var/lib/openshift-install/rhcos.json
 
-## epel-release is required for jq
-## gettext is required for envsubst
 RUN yum install --setopt=tsflags=nodocs -y \
-    epel-release \
     gettext \
     openssh-clients && \
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    unzip gzip jq awscli util-linux && \
+    unzip gzip jq util-linux && \
     yum clean all && rm -rf /var/cache/yum/*
 
 ENV TERRAFORM_VERSION=0.11.11

--- a/images/nested-libvirt/Dockerfile
+++ b/images/nested-libvirt/Dockerfile
@@ -11,7 +11,6 @@ COPY --from=builder /go/src/github.com/openshift/installer/images/nested-libvirt
 COPY --from=builder /go/src/github.com/openshift/installer/images/nested-libvirt/mock-nss.sh /bin/mock-nss.sh
 
 RUN yum install -y \
-    epel-release \
     gettext \
     google-cloud-sdk \
     openssh-clients \

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -11,9 +11,7 @@ COPY --from=builder /go/src/github.com/openshift/installer/images/openstack/rdo-
 COPY --from=builder /go/src/github.com/openshift/installer/images/openstack/rdo-stein.gpg /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
 COPY --from=registry.svc.ci.openshift.org/origin/4.1:cli /usr/bin/oc /bin/oc
 
-RUN yum install --setopt=tsflags=nodocs -y \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &&\
-    yum update -y && \
+RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     python-openstackclient && \
     yum clean all && rm -rf /var/cache/yum/*


### PR DESCRIPTION
This fixes the failing yum commands in the installer images.  It looks like yum's `skip_missing_names_on_install` is now False, which errors on invalid `yum install` commands. baremetal had an isuse where it had a yum install without arguments, the others were installing various unnecessary and unavailable packages: epel-release, awscli, etc.