### PR TITLE
images: Drop epel-release

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -16,10 +16,8 @@ COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
 COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json /var/lib/openshift-install/rhcos.json
 
-## epel-release is required for jq
 ## gettext is required for envsubst
 RUN yum install --setopt=tsflags=nodocs -y \
-    epel-release \
     gettext \
     openssh-clients && \
     yum update -y && \

--- a/images/nested-libvirt/Dockerfile
+++ b/images/nested-libvirt/Dockerfile
@@ -11,7 +11,6 @@ COPY --from=builder /go/src/github.com/openshift/installer/images/nested-libvirt
 COPY --from=builder /go/src/github.com/openshift/installer/images/nested-libvirt/mock-nss.sh /bin/mock-nss.sh
 
 RUN yum install -y \
-    epel-release \
     gettext \
     google-cloud-sdk \
     openssh-clients \

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -11,9 +11,7 @@ COPY --from=builder /go/src/github.com/openshift/installer/images/openstack/rdo-
 COPY --from=builder /go/src/github.com/openshift/installer/images/openstack/rdo-stein.gpg /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
 COPY --from=registry.svc.ci.openshift.org/origin/4.1:cli /usr/bin/oc /bin/oc
 
-RUN yum install --setopt=tsflags=nodocs -y \
-    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &&\
-    yum update -y && \
+RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     python-openstackclient && \
     yum clean all && rm -rf /var/cache/yum/*


### PR DESCRIPTION
[Recent CI builds][1] have been failing with:

```
No package epel-release available.
```

despite [the slightly earlier builds succeeding][2].  I'm dropping them in this commit to see how that plays in CI, although I'm not sure what caused the recent change of behavior.

[1]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_installer/2205/pull-ci-openshift-installer-master-images/5465
[2]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_installer/2073/pull-ci-openshift-installer-master-images/5464