### PR TITLE
Add role label to the Spec.Selector.MatchLables for azure machinesets

### DIFF
--- a/pkg/asset/machines/azure/machinesets.go
+++ b/pkg/asset/machines/azure/machinesets.go
@@ -63,8 +63,10 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 				Replicas: &replicas,
 				Selector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"machine.openshift.io/cluster-api-machineset": name,
-						"machine.openshift.io/cluster-api-cluster":    clusterID,
+						"machine.openshift.io/cluster-api-machineset":   name,
+						"machine.openshift.io/cluster-api-cluster":      clusterID,
+						"machine.openshift.io/cluster-api-machine-role": role,
+						"machine.openshift.io/cluster-api-machine-type": role,
 					},
 				},
 				Template: clusterapi.MachineTemplateSpec{


### PR DESCRIPTION
This change is required for making labels on azure machinesets consistent with aws and gcp machineset labels.

There is an e2e for verifying [machinesets scaling which gets skipped ](https://github.com/openshift/origin/blob/master/test/extended/machines/scale.go#L47-L49)because of this inconsistency for azure clusters at CI. 