### PR TITLE
openstack: have gather bootstrap look for FIP

### DIFF
--- a/pkg/terraform/gather/openstack/ip.go
+++ b/pkg/terraform/gather/openstack/ip.go
@@ -12,6 +12,17 @@ import (
 
 // BootstrapIP returns the ip address for bootstrap host.
 func BootstrapIP(tfs *terraform.State) (string, error) {
+
+	// Floating IPs aren't required but we try them first. If one
+	// exists it would be the best means to access the bootstrap instance
+	fip, err := terraform.LookupResource(tfs, "module.topology", "openstack_networking_floatingip_v2", "bootstrap_fip")
+	if err == nil && fip != nil {
+		bootstrap, _, err := unstructured.NestedString(fip.Instances[0].Attributes, "address")
+		if err == nil {
+			return bootstrap, nil
+		}
+	}
+
 	br, err := terraform.LookupResource(tfs, "module.bootstrap", "openstack_compute_instance_v2", "bootstrap")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to lookup bootstrap")


### PR DESCRIPTION
OpenStack installations may have floating IPs that get used for
bootstrap nodes. This patch updates the bootstrap IP code so that
it looks for the floating IP first. If found it will be used.
Otherwised it can be silently ignored in favor of direct
access via the openstack instances access_ipv4 address.

As OpenShift CI for OpenStack uses floating IPs this should resolve
issues in obtaining bootstrap logs in our CI scripts.