### PR TITLE
Bug 1725524: types/aws/default: move ap-northeast-2 to m5 instance class

### DIFF
--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -6,10 +6,11 @@ import (
 
 var (
 	defaultMachineClass = map[string]string{
-		"eu-north-1":    "m5",
-		"eu-west-3":     "m5",
-		"us-gov-east-1": "m5",
-		"us-west-2":     "m5",
+		"eu-north-1":     "m5",
+		"ap-northeast-2": "m5",
+		"eu-west-3":      "m5",
+		"us-gov-east-1":  "m5",
+		"us-west-2":      "m5",
 	}
 )
 

--- a/platformtests/aws/default_instance_class_test.go
+++ b/platformtests/aws/default_instance_class_test.go
@@ -124,7 +124,7 @@ func TestGetDefaultInstanceClass(t *testing.T) {
 			}
 
 			available := make(map[string]map[string]struct{}, len(preferredInstanceClasses))
-			var match string
+			var allowed []string
 
 			for _, instanceClass := range preferredInstanceClasses {
 				if _, ok := classes[instanceClass]; !ok {
@@ -160,17 +160,16 @@ func TestGetDefaultInstanceClass(t *testing.T) {
 				}
 
 				if reflect.DeepEqual(available[instanceClass], zones) {
-					match = instanceClass
-					break
+					allowed = append(allowed, instanceClass)
 				}
 			}
 
-			if match == "" {
+			if len(allowed) == 0 {
 				t.Fatalf("none of the preferred instance classes are fully supported: %v", available)
 			}
 
 			t.Log(available)
-			assert.Equal(t, defaults.InstanceClass(region), match)
+			assert.Contains(t, allowed, defaults.InstanceClass(region))
 		})
 	}
 }


### PR DESCRIPTION
This PR cherry-picks #1935 back to release-4.1.  It's not a clean cherry-pick, because we [decided][1] to not backport the ap-east-1 addition from #1755 to 4.1.z.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1734136#c4