### PR TITLE
hack/build: Force disable Go modules

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+export GO111MODULE=off
+
 # shellcheck disable=SC2068
 version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}
 


### PR DESCRIPTION
The build script was failing on systems where Go modules have been
explicitly enabled.

With this change, Go modules are explicitly switched off in the build
script.

Fixes #2215