### PR TITLE
 hack: remove compile time RELEASE_IMAGE override

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -41,10 +41,6 @@ case "${MODE}" in
 release)
 	LDFLAGS="${LDFLAGS} -s -w"
 	TAGS="${TAGS} release"
-	if test -n "${RELEASE_IMAGE}"
-	then
-		LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/asset/ignition/bootstrap.defaultReleaseImageOriginal=${RELEASE_IMAGE}"
-	fi
 	if test "${SKIP_GENERATION}" != y
 	then
 		go generate ./data


### PR DESCRIPTION
The location of the defaultReleaseImage variable has moved to
pkg/asset/releaseimage, and this doesn't currently work. It also appears
nothing is relying on this feature so we can remove it.  If you want to
override the release image, you can do at run time with
OPENSHIFT_RELEASE_IMAGE_OVERRIDE, which functions the same other than
not being embedded in the produced openshift-install binary.