### PR TITLE
Add `libvirt-devel` dependency for building

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -2,6 +2,7 @@
 # It builds an image containing only the openshift-install.
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+RUN yum install -y libvirt-devel
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN TAGS="libvirt baremetal" hack/build.sh


### PR DESCRIPTION
On the first stage of the **baremetal** build, the command `go build ...` already requires `libvirt-devel` to be present, otherwise it fails horribly with the following message:

```
Package libvirt was not found in the pkg-config search path.
Perhaps you should add the directory containing `libvirt.pc'
to the PKG_CONFIG_PATH environment variable
No package 'libvirt' found
pkg-config: exit status 1
```