### PR TITLE
Bug 1741930: allow to define OpenStack image name

### DIFF
--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -78,7 +78,7 @@ func osImage(config *types.InstallConfig) (string, error) {
 	case libvirt.Name:
 		osimage, err = rhcos.QEMU(ctx)
 	case openstack.Name:
-		osimage = "rhcos"
+		osimage = config.Platform.OpenStack.BaseImage
 	case azure.Name:
 		osimage, err = rhcos.VHD(ctx)
 	case baremetal.Name:

--- a/pkg/types/openstack/defaults/platform.go
+++ b/pkg/types/openstack/defaults/platform.go
@@ -23,6 +23,10 @@ func SetPlatformDefaults(p *openstack.Platform) {
 			p.Cloud = DefaultCloudName
 		}
 	}
+
+	if p.BaseImage == "" {
+		p.BaseImage = "rhcos"
+	}
 }
 
 // APIVIP returns the internal virtual IP address (VIP) put in front

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -28,6 +28,10 @@ type Platform struct {
 	// Existing Floating IP to associate with the OpenStack load balancer.
 	LbFloatingIP string `json:"lbFloatingIP"`
 
+	// BaseImage
+	// Name of the Red Hat CoreOS image in Glance.
+	BaseImage string `json:"baseImage"`
+
 	// TrunkSupport
 	// Whether OpenStack ports can be trunked
 	TrunkSupport string `json:"trunkSupport"`


### PR DESCRIPTION
This commit adds a new option to the install config: BaseImage, that allows to set a custom RHCOS image name in Glance.
By default it is still "rhcos".

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1741930