### PR TITLE
Stop using deprecated options in documentation examples

### DIFF
--- a/docs/user/aws/customization.md
+++ b/docs/user/aws/customization.md
@@ -41,12 +41,13 @@ compute:
 metadata:
   name: test-cluster
 networking:
-  clusterNetworks:
+  clusterNetwork:
   - cidr: 10.128.0.0/14
-    hostSubnetLength: 9
+    hostPrefix: 23
   machineCIDR: 10.0.0.0/16
-  serviceCIDR: 172.30.0.0/16
-  type: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+  networkType: OpenShiftSDN
 platform:
   aws:
     region: us-west-2

--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -28,12 +28,13 @@ compute:
 metadata:
   name: test-cluster
 networking:
-  clusterNetworks:
+  clusterNetwork:
   - cidr: 10.128.0.0/14
-    hostSubnetLength: 9
+    hostPrefix: 23
   machineCIDR: 10.0.0.0/16
-  serviceCIDR: 172.30.0.0/16
-  type: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+  networkType: OpenShiftSDN
 platform:
   azure:
     region: centralus


### PR DESCRIPTION
API version v1beta4 of install-config deprecated a few options names. While
not dramatic -- the installer knows how to update to the new format --
we should stop using deprecated options in the configuration examples
we provide.