### PR TITLE
openstack: Bump recommended memory in prompt doc

### DIFF
--- a/pkg/asset/installconfig/openstack/openstack.go
+++ b/pkg/asset/installconfig/openstack/openstack.go
@@ -108,7 +108,7 @@ func Platform() (*openstack.Platform, error) {
 		{
 			Prompt: &survey.Select{
 				Message: "FlavorName",
-				Help:    "The OpenStack compute flavor to use for servers. A flavor with at least 4 GB RAM is recommended.",
+				Help:    "The OpenStack flavor to use for control-plane and compute nodes. A flavor with at least 16 GB RAM is recommended.",
 				Options: flavorNames,
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {


### PR DESCRIPTION
We now recommend at least 16GB RAM for masters, and 8GB for workers.