### PR TITLE
startironic.sh uses wrong route IP for CACHEURL

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -73,7 +73,7 @@ podman run -d --net host --privileged --name httpd \
 # Set CACHEURL to the default route, so we try to consume any images cached on the host
 # running the VM (dev-scripts configures a cache here), if none is found then the
 # downloader containers just skip and download from the internet location
-CACHEURL="http://$(ip r | grep default | head -n1 | awk '{print $3}')/images"
+CACHEURL="http://$(ip r | grep $PROVISIONING_NIC | head -n1 | awk '{print $3}')/images"
 podman run -d --net host --name ipa-downloader \
      --env CACHEURL=${CACHEURL} \
      -v $IRONIC_SHARED_VOLUME:/shared:z ${IPA_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh


### PR DESCRIPTION
Updated the CACHEURL env variable to utilise $PROVISIONING_NIC
instead of default. The default route works in virtualised
environments but typically not in baremetal ones. This should
resolve for both.

Closes #2232