### PR TITLE
Bug 1743873: data/bootstrap: extract ironic images from release image

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -1,13 +1,12 @@
 #!/bin/bash
-
 set -ex
 
-# We should switch to openshift builds of these images when ready ref
-# https://github.com/openshift/installer/issues/2090
-IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metal3-io/ironic:master"}
-IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metal3-io/ironic-inspector:master"}
-IPA_DOWNLOADER_IMAGE=${IPA_DOWNLOADER_IMAGE:-"quay.io/metal3-io/ironic-ipa-downloader:master"}
-COREOS_DOWNLOADER_IMAGE=${COREOS_DOWNLOADER_IMAGE:-"quay.io/openshift-metal3/rhcos-downloader:master"}
+. /usr/local/bin/release-image.sh
+
+IRONIC_IMAGE=$(image_for ironic)
+IRONIC_INSPECTOR_IMAGE=$(image_for ironic-inspector)
+IPA_DOWNLOADER_IMAGE=$(image_for ironic-ipa-downloader)
+COREOS_DOWNLOADER_IMAGE=$(image_for ironic-rhcos-downloader)
 
 # This image is templated in via the installer pkg/asset/ignition/bootstrap/bootstrap.go
 RHCOS_BOOT_IMAGE_URL="{{.BootImage}}"
@@ -87,7 +86,6 @@ podman wait -i 1000 ipa-downloader
 podman wait -i 1000 coreos-downloader
 while ! curl --fail http://localhost/images/rhcos-ootpa-latest.qcow2.md5sum ; do sleep 1; done
 while ! curl --fail --head http://localhost/images/ironic-python-agent.initramfs ; do sleep 1; done
-while ! curl --fail --head http://localhost/images/ironic-python-agent.tar.headers ; do sleep 1; done
 while ! curl --fail --head http://localhost/images/ironic-python-agent.kernel ; do sleep 1; done
 
 sudo podman run -d --net host --privileged --name ironic-conductor \

--- a/data/data/bootstrap/baremetal/systemd/units/ironic.service
+++ b/data/data/bootstrap/baremetal/systemd/units/ironic.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Baremetal Deployment Ironic Services
+Requires=release-image.service
 Wants=network-online.target crio.service
-After=network-online.target crio.service
+After=network-online.target crio.service release-image.service
 
 [Service]
 Type=exec

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -1,29 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
+. /usr/local/bin/release-image.sh
+
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
-
-if ! podman inspect {{.ReleaseImage}} &>/dev/null; then
-    echo "Pulling release image..."
-    podman pull --quiet {{.ReleaseImage}}
-fi
-
-# convert the release image pull spec to an "absolute" form if a digest is available - this is
-# safe to resolve after the actions above because podman will not pull the image once it is
-# locally available
-if ! release=$( podman inspect {{.ReleaseImage}} --format '{{"{{"}} index .RepoDigests 0 {{"}}"}}' ) || [[ -z "${release}" ]]; then
-	echo "Warning: Could not resolve release image to pull by digest" 2>&1
-	release="{{.ReleaseImage}}"
-fi
 
 bootkube_podman_run() {
     # we run all commands in the host-network to prevent IP conflicts with
     # end-user infrastructure.
     podman run --quiet --net=host "${@}"
-}
-
-image_for() {
-    podman run --quiet --rm --net=none "${release}" image "${1}"
 }
 
 MACHINE_CONFIG_OPERATOR_IMAGE=$(image_for machine-config-operator)
@@ -71,10 +56,10 @@ then
 
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
-		"${release}" \
+		"${RELEASE_IMAGE_DIGEST}" \
 		render \
 			--output-dir=/assets/cvo-bootstrap \
-			--release-image="${release}"
+			--release-image="${RELEASE_IMAGE_DIGEST}"
 
 	cp cvo-bootstrap/bootstrap/* bootstrap-manifests/
 	cp cvo-bootstrap/manifests/* manifests/

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -4,7 +4,7 @@ ARTIFACTS="/tmp/artifacts"
 
 echo "Gathering bootstrap journals ..."
 mkdir -p "${ARTIFACTS}/bootstrap/journals"
-for service in bootkube openshift kubelet crio approve-csr
+for service in release-image bootkube openshift kubelet crio approve-csr
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"
 done

--- a/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Download the release image. This script is executed as a oneshot
+# service by systemd, because we cannot make use of Requires and a
+# simple service: https://github.com/systemd/systemd/issues/1312.
+#
+# This script continues trying to download the release image until
+# successful because we cannot use Restart=on-failure with a oneshot
+# service: https://github.com/systemd/systemd/issues/2582.
+#
+
+RELEASE_IMAGE={{.ReleaseImage}}
+
+echo "Pulling $RELEASE_IMAGE..."
+while ! podman pull --quiet "$RELEASE_IMAGE"
+do
+    echo "Pull failed. Retrying $RELEASE_IMAGE..."
+done

--- a/data/data/bootstrap/files/usr/local/bin/release-image.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/release-image.sh.template
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# This library provides an `image_for` helper function which can get the
+# pull spec for a specific image in a release.
+
+# Convert the release image pull spec to an "absolute" form if a digest is available
+if ! RELEASE_IMAGE_DIGEST=$( podman inspect {{.ReleaseImage}} --format '{{"{{"}} index .RepoDigests 0 {{"}}"}}' ) || [[ -z "${RELEASE_IMAGE_DIGEST}" ]]; then
+	echo "Warning: Could not resolve release image to pull by digest" 2>&1
+	RELEASE_IMAGE_DIGEST="{{.ReleaseImage}}"
+fi
+
+image_for() {
+    podman run --quiet --rm --net=none "${RELEASE_IMAGE_DIGEST}" image "${1}"
+}

--- a/data/data/bootstrap/systemd/units/bootkube.service
+++ b/data/data/bootstrap/systemd/units/bootkube.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Bootstrap a Kubernetes cluster
+Requires=release-image.service
 Wants=kubelet.service
-After=kubelet.service
+After=kubelet.service release-image.service
 ConditionPathExists=!/opt/openshift/.bootkube.done
 
 [Service]

--- a/data/data/bootstrap/systemd/units/release-image.service.template
+++ b/data/data/bootstrap/systemd/units/release-image.service.template
@@ -1,0 +1,9 @@
+[Unit]
+Description=Download the OpenShift Release Image
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/release-image-download.sh
+RemainAfterExit=true


### PR DESCRIPTION
startironic.sh now uses the ironic images specified in the release. In
order to do that, this change pulls out the code from bootkube to
get the images to it's own script, and adds a service that downloads the
release image so it only happens once.

fixes #2090