### PR TITLE
Make it clearer where azure auth is cached

### DIFF
--- a/pkg/asset/installconfig/azure/azure.go
+++ b/pkg/asset/installconfig/azure/azure.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/openshift/installer/pkg/types/azure"
@@ -25,6 +26,12 @@ const (
 func Platform() (*azure.Platform, error) {
 	regions, err := getRegions()
 	if err != nil {
+		if dErr, ok := err.(autorest.DetailedError); ok {
+			if dErr.StatusCode == 401 {
+				return nil, errors.Wrapf(err, "auth failed whilst getting a list of regions, please check %s", getAuthFilePath())
+			}
+		}
+
 		return nil, errors.Wrap(err, "failed to get list of regions")
 	}
 	longRegions := make([]string, 0, len(regions))

--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -35,11 +35,15 @@ type Credentials struct {
 // GetSession returns an azure session by using credentials found in ~/.azure/osServicePrincipal.json
 // and, if no creds are found, asks for them and stores them on disk in a config file
 func GetSession() (*Session, error) {
+	return newSessionFromFile(getAuthFilePath())
+}
+
+func getAuthFilePath() string {
 	authFile := defaultAuthFilePath
 	if f := os.Getenv(azureAuthEnv); len(f) > 0 {
 		authFile = f
 	}
-	return newSessionFromFile(authFile)
+	return authFile
 }
 
 func newSessionFromFile(authFilePath string) (*Session, error) {


### PR DESCRIPTION
If ~/.azure/osServicePrincipal.json exists before install, but is old and incorrect azure commands will fail
with a non obvious error. This PR attempts to clarify what is going on and how to fix the issue by:

- adding a debug log to indicate where it is getting read from
- if there is an auth error include the path to the file in the error message

closes #2237