### PR TITLE
Bug 1743840: data/bootstrap/files/usr/local/bin/bootkube.sh.template: Localhost keys for etcd-signer

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -257,6 +257,8 @@ bootkube_podman_run \
 	--servkey=/opt/openshift/tls/kube-apiserver-lb-server.key \
 	--servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
 	--servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
+	--servcrt=/opt/openshift/tls/kube-apiserver-localhost-server.crt \
+	--servkey=/opt/openshift/tls/kube-apiserver-localhost-server.key \
 	--address=0.0.0.0:6443 \
 	--insecure-health-check-address=0.0.0.0:6080 \
 	--csrdir=/tmp \


### PR DESCRIPTION
Reduce noise like:

```
Aug 20 17:36:29 localhost openshift.sh[1621]: error: unable to recognize "./90_metal3_baremetalhost_crd.yaml": Get https://localhost:6443/api?timeout=32s: x509: certificate is valid for api.ostest.test.metalkube.org, not localhost
```

from the bootkube.service logs.