### PR TITLE
Update error message when automatic gather boostrap fails on cluster fail.

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -97,9 +97,9 @@ var (
 				err = waitForBootstrapComplete(ctx, config, rootOpts.dir)
 				if err != nil {
 					if err2 := runGatherBootstrapCmd(rootOpts.dir); err2 != nil {
-						logrus.Error(err2)
+						logrus.Error("Attempted to gather debug logs after installation failure: ", err2)
 					}
-					logrus.Fatal(err)
+					logrus.Fatal("Bootstrap failed to complete: ", err)
 				}
 
 				logrus.Info("Destroying the bootstrap resources...")


### PR DESCRIPTION
Many users seem to misinterpret the failure of the gather command to collect logs as the error message for why their cluster failed to install. An example error message looks like this:

```
ERROR failed to create SSH client, ensure the proper ssh key is in your keyring or specify with --key: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
FATAL waiting for Kubernetes API: context deadline exceeded
```
This change will switch the error prefix to INFO. I have opted to hide the error message entirely. I think this is the best approach here, but am definitely open to other ideas.

Here are some examples from internal slack channel where users have been confused:

- August 20: @here Having a problem bringing up aws cluster. Getting ERROR failed to create SSH client, ensure the proper ssh key, I have rebuilt tokens and new are the same as previous.
- July 16: Trying to install OpenShift 4.2 AWS cluster from my laptop. I am getting repeated
````
ERROR failed to create SSH client: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain 
FATAL waiting for Kubernetes API: context deadline exceeded 
````
- July 29: Hello, when I try to spin up a 4.2 cluster today for myself, Its failing to create an SSH client - how can I get it to prompt me for my ssh key when it starts up again?

- August 3: ```INFO Pulling debug logs from the bootstrap machine ************************************************************
ERROR failed to create SSH client, ensure the proper ssh key is in your keyring or specify with --key: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain```

Which setup step could I be missing? (edited) 

- July 25: hey folks! I'm trying to setup a libvirt install, I've thus far gotten for the wait for bootstrap step, and failed on this
```INFO Waiting up to 30m0s for bootstrapping to complete... 
cdku    INFO Pulling debug logs from the bootstrap machine 
ERROR failed to create SSH client, ensure the proper ssh key is in your keyring or specify with --key: dial tcp: lookup test1-rnrgr-bootstrap on 127.0.0.1:53:
 no such host 
FATAL failed to wait for bootstrapping to complete: timed out waiting for the condition```
did I mess up a step in this doc (https://github.com/openshift/installer/blob/master/docs/dev/libvirt/README.md#install-and-enable-libvirt)/am I missing something?
- July 22: @installer, is an SSH key required to install a cluster in 4.2, or have I hit a weird bug?




