### PR TITLE
Bug 1743871: vendor: update terraform-provider-ironic to v0.1.7

### DIFF
--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -789,12 +789,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:80b145e3cfe196d8f4de68afd2632aab3cc1feb93571c0998d01e5e1ab244c52"
+  digest = "1:eba01da9d7286b80ecfb6b6ea6299b57f7a74ada8c94534e35eb9573816cfefc"
   name = "github.com/openshift-metal3/terraform-provider-ironic"
   packages = ["ironic"]
   pruneopts = "NUT"
-  revision = "c8fa7040d10d6cd0abdf6084687723517712abb1"
-  version = "v0.1.6"
+  revision = "c68a8212f13053ab7b45f66f7c6deded348bcd23"
+  version = "v0.1.7"
 
 [[projects]]
   branch = "master"

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -70,4 +70,4 @@ ignored = [
 
 [[constraint]]
   name = "github.com/openshift-metal3/terraform-provider-ironic"
-  version = "v0.1.6"
+  version = "v0.1.7"

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_deployment.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_deployment.go
@@ -70,13 +70,13 @@ func resourceDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
 	// Set instance info
 	instanceInfo := d.Get("instance_info").(map[string]interface{})
 	if instanceInfo != nil {
-		_, err := nodes.Update(client, d.Get("node_uuid").(string), nodes.UpdateOpts{
+		_, err := UpdateNode(client, d.Get("node_uuid").(string), nodes.UpdateOpts{
 			nodes.UpdateOperation{
 				Op:    nodes.AddOp,
 				Path:  "/instance_info",
 				Value: instanceInfo,
 			},
-		}).Extract()
+		})
 		if err != nil {
 			return fmt.Errorf("could not update instance info: %s", err)
 		}


### PR DESCRIPTION
This updates the terraform-provider-ironic to v0.1.7, which includes a
fix for retrying when Ironic returns a 409 Conflict error. Ironic can
return this error when it's busy talking to the hardware's baseboard
management controller (BMC) to get the power status for example, so we
should retry when that happens.