### PR TITLE
pkg/destroy/gcp: ensure nextPageToken is present in response to correctly handle pages

### DIFF
--- a/pkg/destroy/gcp/compute.go
+++ b/pkg/destroy/gcp/compute.go
@@ -50,7 +50,7 @@ func (o *ClusterUninstaller) listInstanceGroupsWithFilter(filter string) ([]name
 	result := []nameAndZone{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.InstanceGroups.AggregatedList(o.ProjectID).Fields("items/*/instanceGroups(name,zone)").Filter(filter)
+	req := o.computeSvc.InstanceGroups.AggregatedList(o.ProjectID).Fields("items/*/instanceGroups(name,zone),nextPageToken").Filter(filter)
 	err := req.Pages(ctx, func(list *compute.InstanceGroupAggregatedList) error {
 		for _, scopedList := range list.Items {
 			for _, ig := range scopedList.InstanceGroups {
@@ -75,7 +75,7 @@ func (o *ClusterUninstaller) listInstanceGroupInstances(ig nameAndZone) ([]nameA
 	result := []nameAndZone{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.InstanceGroups.ListInstances(o.ProjectID, ig.zone, ig.name, &compute.InstanceGroupsListInstancesRequest{}).Fields("items(instance)")
+	req := o.computeSvc.InstanceGroups.ListInstances(o.ProjectID, ig.zone, ig.name, &compute.InstanceGroupsListInstancesRequest{}).Fields("items(instance),nextPageToken")
 	err := req.Pages(ctx, func(list *compute.InstanceGroupsListInstances) error {
 		for _, item := range list.Items {
 			name, zone := o.getInstanceNameAndZone(item.Instance)
@@ -114,7 +114,7 @@ func (o *ClusterUninstaller) deleteInstanceGroup(ig nameAndZone) error {
 func (o *ClusterUninstaller) listComputeInstances() ([]nameAndZone, error) {
 	o.Logger.Debugf("Listing compute instances")
 	result := []nameAndZone{}
-	req := o.computeSvc.Instances.AggregatedList(o.ProjectID).Filter(o.clusterIDFilter()).Fields("items/*/instances(name,zone,status)")
+	req := o.computeSvc.Instances.AggregatedList(o.ProjectID).Filter(o.clusterIDFilter()).Fields("items/*/instances(name,zone,status),nextPageToken")
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
 	err := req.Pages(ctx, func(list *compute.InstanceAggregatedList) error {
@@ -180,7 +180,7 @@ func (o *ClusterUninstaller) listImages() ([]string, error) {
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.Images.List(o.ProjectID).Fields("items(name)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.Images.List(o.ProjectID).Fields("items(name),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(imageList *compute.ImageList) error {
 		for _, image := range imageList.Items {
 			result = append(result, image.Name)
@@ -238,7 +238,7 @@ func (o *ClusterUninstaller) listDisks() ([]nameAndZone, error) {
 	result := []nameAndZone{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.Disks.AggregatedList(o.ProjectID).Fields("items/*/disks(name,zone)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.Disks.AggregatedList(o.ProjectID).Fields("items/*/disks(name,zone),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(aggregatedList *compute.DiskAggregatedList) error {
 		for _, scopedList := range aggregatedList.Items {
 			for _, disk := range scopedList.Disks {

--- a/pkg/destroy/gcp/dns.go
+++ b/pkg/destroy/gcp/dns.go
@@ -20,7 +20,7 @@ func (o *ClusterUninstaller) listDNSZones() (private *dnsZone, public []dnsZone,
 	o.Logger.Debugf("Listing DNS Zones")
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.dnsSvc.ManagedZones.List(o.ProjectID).Fields("managedZones(name,dnsName,visibility)")
+	req := o.dnsSvc.ManagedZones.List(o.ProjectID).Fields("managedZones(name,dnsName,visibility),nextPageToken")
 	err = req.Pages(ctx, func(response *dns.ManagedZonesListResponse) error {
 		for _, zone := range response.ManagedZones {
 			switch zone.Visibility {

--- a/pkg/destroy/gcp/iam.go
+++ b/pkg/destroy/gcp/iam.go
@@ -18,7 +18,7 @@ func (o *ClusterUninstaller) listServiceAccounts() ([]string, error) {
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.iamSvc.Projects.ServiceAccounts.List(fmt.Sprintf("projects/%s", o.ProjectID)).Fields("accounts(name,email)")
+	req := o.iamSvc.Projects.ServiceAccounts.List(fmt.Sprintf("projects/%s", o.ProjectID)).Fields("accounts(name,email),nextPageToken")
 	err := req.Pages(ctx, func(response *iam.ListServiceAccountsResponse) error {
 		for _, account := range response.Accounts {
 			if o.isClusterResource(account.Email) {

--- a/pkg/destroy/gcp/network.go
+++ b/pkg/destroy/gcp/network.go
@@ -25,7 +25,7 @@ func (o *ClusterUninstaller) listFirewalls() ([]string, error) {
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.Firewalls.List(o.ProjectID).Fields("items(name)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.Firewalls.List(o.ProjectID).Fields("items(name),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(list *compute.FirewallList) error {
 		for _, firewall := range list.Items {
 			o.Logger.Debugf("Found firewall rule: %s", firewall.Name)
@@ -86,7 +86,7 @@ func (o *ClusterUninstaller) listAddresses() ([]string, error) {
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.Addresses.List(o.ProjectID, o.Region).Fields("items(name)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.Addresses.List(o.ProjectID, o.Region).Fields("items(name),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(list *compute.AddressList) error {
 		for _, address := range list.Items {
 			o.Logger.Debugf("Found address: %s", address.Name)
@@ -147,7 +147,7 @@ func (o *ClusterUninstaller) listForwardingRules() ([]string, error) {
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.ForwardingRules.List(o.ProjectID, o.Region).Fields("items(name)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.ForwardingRules.List(o.ProjectID, o.Region).Fields("items(name),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(list *compute.ForwardingRuleList) error {
 		for _, forwardingRule := range list.Items {
 			o.Logger.Debugf("Found forwarding rule: %s", forwardingRule.Name)
@@ -279,7 +279,7 @@ func (o *ClusterUninstaller) listHealthChecks() ([]string, error) {
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.HealthChecks.List(o.ProjectID).Fields("items(name)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.HealthChecks.List(o.ProjectID).Fields("items(name),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(list *compute.HealthCheckList) error {
 		for _, healthCheck := range list.Items {
 			o.Logger.Debugf("Found health check: %s", healthCheck.Name)
@@ -340,7 +340,7 @@ func (o *ClusterUninstaller) listHTTPHealthChecks() ([]string, error) {
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.HttpHealthChecks.List(o.ProjectID).Fields("items(name)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.HttpHealthChecks.List(o.ProjectID).Fields("items(name),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(list *compute.HttpHealthCheckList) error {
 		for _, healthCheck := range list.Items {
 			o.Logger.Debugf("Found HTTP health check: %s", healthCheck.Name)
@@ -503,7 +503,7 @@ func (o *ClusterUninstaller) listSubNetworks() ([]string, error) {
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.Subnetworks.List(o.ProjectID, o.Region).Fields("items(name)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.Subnetworks.List(o.ProjectID, o.Region).Fields("items(name),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(list *compute.SubnetworkList) error {
 		for _, subNetwork := range list.Items {
 			o.Logger.Debugf("Found subnetwork: %s", subNetwork.Name)
@@ -561,7 +561,7 @@ func (o *ClusterUninstaller) listNetworks() ([]nameAndURL, error) {
 	result := []nameAndURL{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.Networks.List(o.ProjectID).Fields("items(name,selfLink)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.Networks.List(o.ProjectID).Fields("items(name,selfLink),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(list *compute.NetworkList) error {
 		for _, network := range list.Items {
 			o.Logger.Debugf("Found network: %s", network.Name)
@@ -644,7 +644,7 @@ func (o *ClusterUninstaller) listRoutesWithFilter(filter string) ([]string, erro
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.Routes.List(o.ProjectID).Fields("items(name)").Filter(filter)
+	req := o.computeSvc.Routes.List(o.ProjectID).Fields("items(name),nextPageToken").Filter(filter)
 	err := req.Pages(ctx, func(list *compute.RouteList) error {
 		for _, route := range list.Items {
 			o.Logger.Debugf("Found route: %s", route.Name)
@@ -702,7 +702,7 @@ func (o *ClusterUninstaller) listRouters() ([]string, error) {
 	result := []string{}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.computeSvc.Routers.List(o.ProjectID, o.Region).Fields("items(name)").Filter(o.clusterIDFilter())
+	req := o.computeSvc.Routers.List(o.ProjectID, o.Region).Fields("items(name),nextPageToken").Filter(o.clusterIDFilter())
 	err := req.Pages(ctx, func(list *compute.RouterList) error {
 		for _, router := range list.Items {
 			o.Logger.Debugf("Found router: %s", router.Name)

--- a/pkg/destroy/gcp/storage.go
+++ b/pkg/destroy/gcp/storage.go
@@ -10,7 +10,7 @@ func (o *ClusterUninstaller) listStorageBuckets() ([]string, error) {
 	o.Logger.Debug("Listing storage buckets")
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.storageSvc.Buckets.List(o.ProjectID).Fields("items(name)").Prefix(o.ClusterID + "-")
+	req := o.storageSvc.Buckets.List(o.ProjectID).Fields("items(name),nextPageToken").Prefix(o.ClusterID + "-")
 	result := []string{}
 	err := req.Pages(ctx, func(buckets *storage.Buckets) error {
 		for _, bucket := range buckets.Items {
@@ -30,7 +30,7 @@ func (o *ClusterUninstaller) listBucketObjects(bucket string) ([]string, error) 
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
 	result := []string{}
-	req := o.storageSvc.Objects.List(bucket).Fields("items(name)")
+	req := o.storageSvc.Objects.List(bucket).Fields("items(name),nextPageToken")
 	err := req.Pages(ctx, func(objects *storage.Objects) error {
 		for _, object := range objects.Items {
 			o.Logger.Debugf("Found storage object %s/%s", bucket, object.Name)


### PR DESCRIPTION
LIST operations in GCP provide `nextPageToken` field in response for clients to loop through multiple pages.
Using the `fields` options while making the response only returns the requested fields ie. if the `nextPageToken` is not explicitly mentioned in the request it is not returned by the API.

Missing the `nextPageToken` causes the `req.Pages` to only work for the first page. This ensures we are looping through all pages.

Note:

- we didn't see this for most resources because most List support server side filtering and therefore we covered all resources for the clusters as the count converges to 0, just across multiple requests.
- serviceaccount list doesn't support server-side list and therefore not being able to correctly loop over all the service accounts caused us to leak all those.