### PR TITLE
docs: use v1 format in install-config examples

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -108,7 +108,7 @@ include:
   https://github.com/metal3-io/baremetal-operator/blob/master/pkg/hardware/profile.go#L48
 
 ```yaml
-apiVersion: v1beta4
+apiVersion: v1
 baseDomain: test.metalkube.org
 metadata:
   name: ostest

--- a/docs/user/vsphere/install_upi.md
+++ b/docs/user/vsphere/install_upi.md
@@ -127,7 +127,7 @@ The OpenShift installer uses an [Install Config][install-config] to drive all in
 An example install config for vSphere UPI is as follows:
 
 ```yaml
-apiVersion: v1beta4
+apiVersion: v1
 ## The base domain of the cluster. All DNS records will be sub-domains of this base and will also include the cluster name.
 baseDomain: example.com
 compute:


### PR DESCRIPTION
Since openshift/installer#1589 users should be using v1.