### PR TITLE
Adding openssl for proxy ci work

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -18,7 +18,8 @@ COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json 
 
 RUN yum install --setopt=tsflags=nodocs -y \
     gettext \
-    openssh-clients && \
+    openssh-clients \
+    openssl && \
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     unzip gzip jq util-linux && \


### PR DESCRIPTION
As part of the proxy ci work contained within the VPC we need to generate certs and the proxy password file using `openssl`