### PR TITLE
Bug 1719808: openstack: change bootstrap_fip module for gather

### DIFF
--- a/pkg/terraform/gather/openstack/ip.go
+++ b/pkg/terraform/gather/openstack/ip.go
@@ -15,7 +15,7 @@ func BootstrapIP(tfs *terraform.State) (string, error) {
 
 	// Floating IPs aren't required but we try them first. If one
 	// exists it would be the best means to access the bootstrap instance
-	fip, err := terraform.LookupResource(tfs, "module.topology", "openstack_networking_floatingip_v2", "bootstrap_fip")
+	fip, err := terraform.LookupResource(tfs, "module.bootstrap", "openstack_networking_floatingip_v2", "bootstrap_fip")
 	if err == nil && fip != nil {
 		bootstrap, _, err := unstructured.NestedString(fip.Instances[0].Attributes, "address")
 		if err == nil {


### PR DESCRIPTION
Patch #2128 moved this resource from topology to bootstrap module. We have to change the gather part accordingly.