### PR TITLE
Bug 1744532: proxy: add .svc and .cluster.local to default noProxy

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -122,6 +122,8 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 	set := sets.NewString(
 		"127.0.0.1",
 		"localhost",
+		".svc",
+		".cluster.local",
 		network.Config.Spec.ServiceNetwork[0],
 		apiServerURL.Hostname(),
 		internalAPIServer.Hostname(),


### PR DESCRIPTION
Proxy controller (I think) changed this https://github.com/openshift/cluster-network-operator/pull/295 but the installer isn't doing the same. This is causing a different proxy config being generated between bootstrap and in-cluster which in turn causes the MCO to generates different machineconfigs and resulting in https://bugzilla.redhat.com/show_bug.cgi?id=1744532#c13

Signed-off-by: Antonio Murdaca <runcom@linux.com>