### PR TITLE
libvirt: let memory/vcpus be configurable

### DIFF
--- a/pkg/asset/machines/libvirt/machinesets.go
+++ b/pkg/asset/machines/libvirt/machinesets.go
@@ -23,15 +23,14 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		return nil, fmt.Errorf("non-Libvirt machine-pool: %q", poolPlatform)
 	}
 	platform := config.Platform.Libvirt
-	// FIXME: libvirt actuator does not support any options from machinepool.
-	// mpool := pool.Platform.Libvirt
+	mpool := pool.Platform.Libvirt
 
 	total := int64(0)
 	if pool.Replicas != nil {
 		total = *pool.Replicas
 	}
 
-	provider := provider(clusterID, config.Networking.MachineCIDR.String(), platform, userDataSecret)
+	provider := provider(clusterID, config.Networking.MachineCIDR.String(), platform, mpool, userDataSecret)
 	name := fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, 0)
 	mset := &machineapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -72,7 +72,12 @@ func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
 }
 
 func defaultLibvirtMachinePoolPlatform() libvirttypes.MachinePool {
-	return libvirttypes.MachinePool{}
+	return libvirttypes.MachinePool{
+		// legacy defaults up until 605fa00f7 included, preserved
+		// for backward compatibility.
+		DomainMemoryMiB: 6144,
+		DomainVcpuCount: 4,
+	}
 }
 
 func defaultAzureMachinePoolPlatform() azuretypes.MachinePool {

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1"
@@ -12,11 +13,13 @@ import (
 )
 
 type config struct {
-	URI         string   `json:"libvirt_uri,omitempty"`
-	Image       string   `json:"os_image,omitempty"`
-	IfName      string   `json:"libvirt_network_if"`
-	MasterIPs   []string `json:"libvirt_master_ips,omitempty"`
-	BootstrapIP string   `json:"libvirt_bootstrap_ip,omitempty"`
+	URI          string   `json:"libvirt_uri,omitempty"`
+	Image        string   `json:"os_image,omitempty"`
+	IfName       string   `json:"libvirt_network_if"`
+	MasterIPs    []string `json:"libvirt_master_ips,omitempty"`
+	BootstrapIP  string   `json:"libvirt_bootstrap_ip,omitempty"`
+	MasterMemory string   `json:"libvirt_master_memory,omitempty"`
+	MasterVcpu   string   `json:"libvirt_master_vcpu,omitempty"`
 }
 
 // TFVars generates libvirt-specific Terraform variables.
@@ -37,11 +40,13 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, 
 	}
 
 	cfg := &config{
-		URI:         masterConfig.URI,
-		Image:       osImage,
-		IfName:      bridge,
-		BootstrapIP: bootstrapIP.String(),
-		MasterIPs:   masterIPs,
+		URI:          masterConfig.URI,
+		Image:        osImage,
+		IfName:       bridge,
+		BootstrapIP:  bootstrapIP.String(),
+		MasterIPs:    masterIPs,
+		MasterMemory: strconv.Itoa(masterConfig.DomainMemory),
+		MasterVcpu:   strconv.Itoa(masterConfig.DomainVcpu),
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/libvirt/machinepool.go
+++ b/pkg/types/libvirt/machinepool.go
@@ -3,11 +3,23 @@ package libvirt
 // MachinePool stores the configuration for a machine pool installed
 // on libvirt.
 type MachinePool struct {
+	// DomainMemoryMiB is the amount of RAM each VM will have.
+	DomainMemoryMiB int `json:"memory"`
+
+	// DomainVcpCount is the number of VCPUs each VM will have.
+	DomainVcpuCount int `json:"vcpus"`
 }
 
 // Set sets the values from `required` to `a`.
 func (l *MachinePool) Set(required *MachinePool) {
 	if required == nil || l == nil {
 		return
+	}
+
+	if required.DomainMemoryMiB != 0 {
+		l.DomainMemoryMiB = required.DomainMemoryMiB
+	}
+	if required.DomainVcpuCount != 0 {
+		l.DomainVcpuCount = required.DomainVcpuCount
 	}
 }

--- a/pkg/types/libvirt/validation/machinepool.go
+++ b/pkg/types/libvirt/validation/machinepool.go
@@ -8,5 +8,14 @@ import (
 
 // ValidateMachinePool checks that the specified machine pool is valid.
 func ValidateMachinePool(p *libvirt.MachinePool, fldPath *field.Path) field.ErrorList {
-	return field.ErrorList{}
+	allErrs := field.ErrorList{}
+
+	if p.DomainMemoryMiB < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("DomainMemory"), p.DomainMemoryMiB, "Domain Memory (MiB) must be non-negative"))
+	}
+	if p.DomainVcpuCount < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("DomainVcpu"), p.DomainVcpuCount, "Domain VCPU count must be positive"))
+	}
+	return allErrs
+
 }


### PR DESCRIPTION
This patch exposes domain{memory,vcpu} as tunables in the `install-config.yaml`;
we propagate them to the terraform variables. Example usage:
```json
...
platform:
  libvirt:
    URI: qemu+tcp://192.168.122.1/system
    defaultMachinePlatform:
      memory: 12288
      vcpus: 6
    network:
      if: tt0
...
```

Signed-off-by: Francesco Romani <fromani@redhat.com>