### PR TITLE
Bug 1737802: openstack: move swift container to the bootstrap module

### DIFF
--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -3,23 +3,30 @@ variable "image_name" {
   description = "The name of the Glance image for the bootstrap node."
 }
 
-variable "swift_container" {
-  type        = string
-  description = "The Swift container name for bootstrap ignition file."
+variable "extra_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOF
+(optional) Extra tags to be applied to created resources.
+
+Example: `{ "key" = "value", "foo" = "bar" }`
+EOF
+
 }
 
 variable "cluster_id" {
-  type        = string
+  type = string
   description = "The identifier for the cluster."
 }
 
 variable "ignition" {
-  type        = string
+  type = string
   description = "The content of the bootstrap ignition file."
 }
 
 variable "flavor_name" {
-  type        = string
+  type = string
   description = "The Nova flavor for the bootstrap node."
 }
 

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -25,8 +25,8 @@ provider "openstack" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  swift_container    = openstack_objectstorage_container_v1.container.name
   cluster_id         = var.cluster_id
+  extra_tags         = var.openstack_extra_tags
   image_name         = var.openstack_base_image
   flavor_name        = var.openstack_master_flavor_name
   ignition           = var.ignition_bootstrap
@@ -70,19 +70,3 @@ module "topology" {
   trunk_support       = var.openstack_trunk_support
   octavia_support     = var.openstack_octavia_support
 }
-
-resource "openstack_objectstorage_container_v1" "container" {
-  name = var.cluster_id
-
-  # "kubernetes.io/cluster/${var.cluster_id}" = "owned"
-  metadata = merge(
-    {
-      "Name"               = "${var.cluster_id}-ignition"
-      "openshiftClusterID" = var.cluster_id
-    },
-    # FIXME(mandre) the openstack_extra_tags should be applied to all resources
-    # created
-    var.openstack_extra_tags,
-  )
-}
-


### PR DESCRIPTION
When bootstrapping is completed we no longer need the container with the ignition file.

This commit moves the container Terraform resource to the bootstrap module, so that it can be deleted along with the rest of the resources.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1737802