### PR TITLE
Install cinder client in OpenStack CI image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -13,6 +13,7 @@ COPY --from=registry.svc.ci.openshift.org/origin/4.1:cli /usr/bin/oc /bin/oc
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
+    python2-cinderclient \
     python-openstackclient && \
     yum clean all && rm -rf /var/cache/yum/*
 


### PR DESCRIPTION
The `cinder` executable is required for some of the sig-storage tests.