### PR TITLE
Delete check aws account admin rights

### DIFF
--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openshift/installer/pkg/asset"
-	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	azureconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -39,14 +38,6 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 	platform := ic.Config.Platform.Name()
 	switch platform {
 	case aws.Name:
-		ssn, err := awsconfig.GetSession()
-		if err != nil {
-			return errors.Wrap(err, "creating AWS session")
-		}
-		err = awsconfig.ValidateCreds(ssn)
-		if err != nil {
-			return errors.Wrap(err, "validate AWS credentials")
-		}
 	case openstack.Name:
 		opts := new(clientconfig.ClientOpts)
 		opts.Cloud = ic.Config.Platform.OpenStack.Cloud


### PR DESCRIPTION
Problem:
If you have a simulated admin account for AWS, the check returns the value: "false".

Solution:
Delete the Check function in platformcredscheck.go. 
A better solution were a way to create a choice between admin and simulated admin account.