### PR TITLE
pkg/asset/ignition/bootstrap/release_image: Fix 'v4.1' -> '4.1'

### DIFF
--- a/pkg/asset/ignition/bootstrap/release_image.go
+++ b/pkg/asset/ignition/bootstrap/release_image.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:v4.1"
+	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:4.1"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
A similar v-dropping happened for 4.2 back in c88d2ebda5 (#1756).

This should only matter for folks building 4.1 from source and deciding not to pin a particular 4.1 release image.  Folks seem to do this sometimes (#2268), although pinning to a particular release would be a much more reliable approach.

Fixes #2268.