### PR TITLE
Adds support for leading dots in domain names

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -265,10 +265,10 @@ func validateProxy(p *types.Proxy, fldPath *field.Path) field.ErrorList {
 	if p.NoProxy != "" {
 		for _, v := range strings.Split(p.NoProxy, ",") {
 			v = strings.TrimSpace(v)
-			errDomain := validate.DomainName(v, false)
+			errDomain := validate.NoProxyDomainName(v)
 			_, _, errCIDR := net.ParseCIDR(v)
 			if errDomain != nil && errCIDR != nil {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("NoProxy"), v, "must be a CIDR or domain, without wildcard characters and without leading or trailing dots ('.')"))
+				allErrs = append(allErrs, field.Invalid(field.NewPath("NoProxy"), v, "must be a CIDR or domain, without wildcard characters and without trailing dots ('.')"))
 			}
 		}
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -616,7 +616,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.NoProxy = "good-no-proxy.com, .bad-proxy."
 				return c
 			}(),
-			expectedError: `^\QNoProxy: Invalid value: ".bad-proxy.": must be a CIDR or domain, without wildcard characters and without leading or trailing dots ('.')\E$`,
+			expectedError: `^\QNoProxy: Invalid value: ".bad-proxy.": must be a CIDR or domain, without wildcard characters and without trailing dots ('.')\E$`,
 		},
 		{
 			name: "invalid NoProxy CIDR",
@@ -625,7 +625,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.NoProxy = "good-no-proxy.com, 172.bad.CIDR.0/16"
 				return c
 			}(),
-			expectedError: `^\QNoProxy: Invalid value: "172.bad.CIDR.0/16": must be a CIDR or domain, without wildcard characters and without leading or trailing dots ('.')\E$`,
+			expectedError: `^\QNoProxy: Invalid value: "172.bad.CIDR.0/16": must be a CIDR or domain, without wildcard characters and without trailing dots ('.')\E$`,
 		},
 		{
 			name: "invalid NoProxy domain & CIDR",
@@ -634,7 +634,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.NoProxy = "good-no-proxy.com, a-good-one, .bad-proxy., another,   172.bad.CIDR.0/16, good-end"
 				return c
 			}(),
-			expectedError: `^\Q[NoProxy: Invalid value: ".bad-proxy.": must be a CIDR or domain, without wildcard characters and without leading or trailing dots ('.'), NoProxy: Invalid value: "172.bad.CIDR.0/16": must be a CIDR or domain, without wildcard characters and without leading or trailing dots ('.')]\E$`,
+			expectedError: `^\Q[NoProxy: Invalid value: ".bad-proxy.": must be a CIDR or domain, without wildcard characters and without trailing dots ('.'), NoProxy: Invalid value: "172.bad.CIDR.0/16": must be a CIDR or domain, without wildcard characters and without trailing dots ('.')]\E$`,
 		},
 		{
 			name: "valid GCP platform",

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -63,6 +63,14 @@ func DomainName(v string, acceptTrailingDot bool) error {
 	return validateSubdomain(v)
 }
 
+// NoProxyDomainName checks if the given string is a valid proxy noProxy domain name
+// and returns an error if not. Example valid noProxy domains are ".foo.com", "bar.com",
+// but not "*.foo.com", "bar.com."
+func NoProxyDomainName(v string) error {
+	v = strings.TrimPrefix(v, ".")
+	return validateSubdomain(v)
+}
+
 type imagePullSecret struct {
 	Auths map[string]map[string]interface{} `json:"auths"`
 }

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -164,6 +164,46 @@ func TestDomainName_RejectingTrailingDot(t *testing.T) {
 	}
 }
 
+func TestNoProxyDomainName(t *testing.T) {
+	cases := []struct {
+		domain string
+		valid  bool
+	}{
+		{"", false},
+		{" ", false},
+		{"a", true},
+		{".", false},
+		{"日本語", false},
+		{"日本語.com", false},
+		{"abc.日本語.com", false},
+		{"a日本語a.com", false},
+		{"abc", true},
+		{"ABC", false},
+		{"ABC123", false},
+		{"ABC123.COM123", false},
+		{"1", true},
+		{"0.0", true},
+		{"1.2.3.4", true},
+		{"1.2.3.4.", false},
+		{"abc.", false},
+		{"abc.com", true},
+		{"abc.com.", false},
+		{"a.b.c.d.e.f", true},
+		{".abc", true},
+		{".abc.com", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.domain, func(t *testing.T) {
+			err := NoProxyDomainName(tc.domain)
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestDoCIDRsOverlap(t *testing.T) {
 	cases := []struct {
 		a       string


### PR DESCRIPTION
To provide compatibility with [OCP 3.x ](https://docs.openshift.com/container-platform/3.11/install_config/http_proxies.html), the installer should allow leading `.` for `proxy.noProxy` values. This will allow subdomains preceding `.` to bypass proxy.
