### PR TITLE
Bug 1746230: Add target pools to gcp masters

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -625,14 +625,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dae599d7d65acefd73adebcfa2631c447da94ec9b1047beb2d887bbdd173ba27"
+  digest = "1:b64f317f57589e7b683e4d48415da851914c7ffb8d75cf4cf36d550afadcb6e2"
   name = "github.com/openshift/cluster-api-provider-gcp"
   packages = [
     "pkg/apis",
     "pkg/apis/gcpprovider/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "f5146705932b14d468b59d90443d127c9003142b"
+  revision = "0cd5daa07e0d829061206e211fec12bd6585e83e"
 
 [[projects]]
   branch = "master"

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -100,4 +100,11 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 
 // ConfigMasters assigns a set of load balancers to the given machines
 func ConfigMasters(machines []machineapi.Machine, clusterID string) {
+	for _, machine := range machines {
+		providerSpec := machine.Spec.ProviderSpec.Value.Object.(*gcpprovider.GCPMachineProviderSpec)
+		providerSpec.TargetPools = []string{
+			fmt.Sprintf("%s-ign", clusterID),
+			fmt.Sprintf("%s-api", clusterID),
+		}
+	}
 }

--- a/vendor/github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
+++ b/vendor/github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderconfig_types.go
@@ -30,6 +30,7 @@ type GCPMachineProviderSpec struct {
 	NetworkInterfaces  []*GCPNetworkInterface `json:"networkInterfaces,omitempty"`
 	ServiceAccounts    []GCPServiceAccount    `json:"serviceAccounts"`
 	Tags               []string               `json:"tags,omitempty"`
+	TargetPools        []string               `json:"targetPools,omitempty"`
 	MachineType        string                 `json:"machineType"`
 	Region             string                 `json:"region"`
 	Zone               string                 `json:"zone"`

--- a/vendor/github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1/zz_generated.deepcopy.go
@@ -133,6 +133,11 @@ func (in *GCPMachineProviderSpec) DeepCopyInto(out *GCPMachineProviderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.TargetPools != nil {
+		in, out := &in.TargetPools, &out.TargetPools
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
This commit adds masters to targetPools on gcp.

This commit also updates cluster-api-provider-gcp dep.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1746230