### PR TITLE
Bug 1717604: data/aws/vpc/master-elb: Bump load-balancer timeouts to 20m

### DIFF
--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -13,6 +13,10 @@ resource "aws_lb" "api_internal" {
     var.tags,
   )
 
+  timeouts {
+    create = "20m"
+  }
+
   depends_on = [aws_internet_gateway.igw]
 }
 
@@ -30,6 +34,10 @@ resource "aws_lb" "api_external" {
     },
     var.tags,
   )
+
+  timeouts {
+    create = "20m"
+  }
 
   depends_on = [aws_internet_gateway.igw]
 }


### PR DESCRIPTION
Up from their default 10 minutes, using the knob that [dates back to the original network load balancer support][1].  This should help us [avoid][2]:

    Error: timeout while waiting for state to become 'active' (last state: 'provisioning', timeout: 10m0s)

that cropped up again this week, while still generally keeping us under the 30m timeout we set for the whole infrastructure-provisioning step.  Sometimes [even 20m will not be enough][3], but should make us a bit more resilient anyway.

While I was comparing [the docs][4] with our config, I also noticed that we should have dropped `idle_timeout` (which [does not apply to network load balancers][4]) when we made the shift from classic to network load balancers in 16dfbb3541 (#594), so I'm doing that too.

[1]: https://github.com/terraform-providers/terraform-provider-aws/commit/1af53b1a47172733e1d6e233c29db6311107078d#diff-f4b0dbdc7e3eede6ba70cd286c834f37R92
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1717604
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1717604#c15
[4]: https://www.terraform.io/docs/providers/aws/r/lb.html
[5]: https://github.com/terraform-providers/terraform-provider-aws/commit/d25a227e639d770ecec3a50aaae6191d68f17c98#diff-f4b0dbdc7e3eede6ba70cd286c834f37R78