### PR TITLE
Bug 1745004: baremetal: Clarify comment in startironic.sh.template 

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -112,8 +112,9 @@ sudo podman run -d --net host --privileged --name ironic-api \
 # The alternative would be RemainAfterExit=yes but then we lose the ability to restart if something crashes.
 while true; do
     for name in ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb; do
-        # Note it would be nicer to use the --format option here but it breaks the go templating
-        # in the installer and escaping the template appears difficult
+        # Note there are two levels of go templating here, the outer braces
+        # are for the templating done in openshift-install, to escape the
+        # templating input to the --format option of podman inspect
         state=$(podman inspect ${name} --format  {{ "{{.State.Status}}" }})
         if [[ $state != "running" ]]; then
             echo "ERROR: Unexpected service status for $name"


### PR DESCRIPTION
This comment should have been adjusted following code-review
updates in #2249 but I missed it, now we are using the --format
option clarify the comment to explain the multiple templating