### PR TITLE
data/aws/vpc/master-elb: Drop idle_timeout from aws_lb resources

### DIFF
--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -4,7 +4,6 @@ resource "aws_lb" "api_internal" {
   subnets                          = local.private_subnet_ids
   internal                         = true
   enable_cross_zone_load_balancing = true
-  idle_timeout                     = 3600
 
   tags = merge(
     {
@@ -22,7 +21,6 @@ resource "aws_lb" "api_external" {
   subnets                          = local.public_subnet_ids
   internal                         = false
   enable_cross_zone_load_balancing = true
-  idle_timeout                     = 3600
 
   tags = merge(
     {


### PR DESCRIPTION
It is [not valid for network load balancers][1].  We've been setting this in our Terraform config since 0a96415026 (coreos/tectonic-installer#725) when we were using classic load balancers and should have dropped it in 16dfbb3541 (#594).

Spun off from #2279 at @abhinavdahiya's [request][2].

[1]: https://github.com/terraform-providers/terraform-provider-aws/commit/d25a227e639d770ecec3a50aaae6191d68f17c98#diff-f4b0dbdc7e3eede6ba70cd286c834f37R78
[2]: https://github.com/openshift/installer/pull/2279#issuecomment-525589712