### PR TITLE
Bug 1746459: destroy/aws: fix error expected when snapshot not found

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -922,7 +922,7 @@ func deleteEC2Snapshot(client *ec2.EC2, id string, logger logrus.FieldLogger) er
 		SnapshotId: &id,
 	})
 	if err != nil {
-		if err.(awserr.Error).Code() == "InvalidSnapshotID.NotFound" {
+		if err.(awserr.Error).Code() == "InvalidSnapshot.NotFound" {
 			return nil
 		}
 		return err


### PR DESCRIPTION
The destroyer is expecting that the error returned when attempting to delete a missing snapshot is "InvalidSnapshotID.NotFound". The actual error returned in "InvalidSnapshot.NotFound". [1]

https://bugzilla.redhat.com/show_bug.cgi?id=1746459

[1] https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html