### PR TITLE
OpenStack: update troubleshooting docs

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -289,7 +289,7 @@ oc get pods -A
 
 ### Destroying The Cluster
 
-Destroying the cluster has been noticed to [sometimes fail](https://github.com/openshift/installer/issues/1985). We are working on patching this, but in a mean time the workaround is to simply run it again. To do so, point it to your cluster with this command:
+To destroy the cluster, point it to your cluster with this command:
 
 ```sh
 ./openshift-install --log-level debug destroy cluster --dir ostest

--- a/docs/user/openstack/troubleshooting.md
+++ b/docs/user/openstack/troubleshooting.md
@@ -11,10 +11,15 @@ OpenStack CLI tools should be installed, then:
 
 `openstack console log show <instance>`
 
+## Cluster destroying fails
+
+Destroying the cluster has been noticed to [sometimes fail](https://github.com/openshift/installer/issues/1985). We are working on patching this, but in a mean time the workaround is to simply restart the destroying process of the cluster.
+
 ## SSH access to the instances
 
 Get the IP address of the node on the private network:
-```
+
+```sh
 openstack server list | grep master
 | 0dcd756b-ad80-42f1-987a-1451b1ae95ba | cluster-wbzrr-master-1     | ACTIVE    | cluster-wbzrr-openshift=172.24.0.21                | rhcos           | m1.s2.xlarge |
 | 3b455e43-729b-4e64-b3bd-1d4da9996f27 | cluster-wbzrr-master-2     | ACTIVE    | cluster-wbzrr-openshift=172.24.0.18                | rhcos           | m1.s2.xlarge |
@@ -23,6 +28,6 @@ openstack server list | grep master
 
 And connect to it using the master currently holding the API VIP (and hence the API FIP) as a jumpbox:
 
-```
+```sh
 ssh -J core@${FIP} core@<host>
 ```


### PR DESCRIPTION
Add info that if cluster deletion fails, users should try it again.

Related bug: https://bugzilla.redhat.com/show_bug.cgi?id=1746748