### PR TITLE
Bug 1733867: openstack: Open mdns port for workers

### DIFF
--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -23,6 +23,16 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_mdns_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 5353
+  port_range_max    = 5353
+  remote_ip_prefix  = "${var.cidr_block}"
+  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_http" {
   direction         = "ingress"
   ethertype         = "IPv4"


### PR DESCRIPTION
The worker security group did not have the mDNS port (UDP 5353) open.
This means that in OpenStack environments that block it by default,
the worker nodes' names were not resolvable via the CoreDNS static
pods running on the masters.

Fixes #2291