### PR TITLE
data/openstack/topology: update security groups

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -63,16 +63,6 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_mdns_udp" {
   security_group_id = "${openstack_networking_secgroup_v2.master.id}"
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_http" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 80
-  port_range_max    = 80
-  remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = openstack_networking_secgroup_v2.master.id
-}
-
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
   direction         = "ingress"
   ethertype         = "IPv4"
@@ -80,25 +70,6 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
   port_range_min    = 6443
   port_range_max    = 6443
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = openstack_networking_secgroup_v2.master.id
-}
-
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_heapster" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 4194
-  port_range_max    = 4194
-  security_group_id = openstack_networking_secgroup_v2.master.id
-}
-
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_heapster_from_worker" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 4194
-  port_range_max    = 4194
-  remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -260,15 +231,6 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_etcd" {
   protocol          = "tcp"
   port_range_min    = 2379
   port_range_max    = 2380
-  security_group_id = openstack_networking_secgroup_v2.master.id
-}
-
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_bootstrap_etcd" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 12379
-  port_range_max    = 12380
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -59,7 +59,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_mdns_udp" {
   protocol          = "udp"
   port_range_min    = 5353
   port_range_max    = 5353
-  remote_ip_prefix  = "${var.cidr_block}"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -40,7 +40,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_tcp" {
   port_range_min    = 53
   port_range_max    = 53
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+  security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
@@ -50,7 +50,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
   port_range_min    = 53
   port_range_max    = 53
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+  security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_mdns_udp" {
@@ -60,7 +60,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_mdns_udp" {
   port_range_min    = 5353
   port_range_max    = 5353
   remote_ip_prefix  = "${var.cidr_block}"
-  security_group_id = "${openstack_networking_secgroup_v2.master.id}"
+  security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -78,7 +78,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 6443
-  port_range_max    = 6445
+  port_range_max    = 6443
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
@@ -102,7 +102,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_heapster_from_w
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_flannel" {
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_vxlan" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
@@ -111,12 +111,50 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_flannel" {
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_flannel_from_worker" {
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_vxlan_from_worker" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 4789
   port_range_max    = 4789
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.master.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_geneve" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 6081
+  port_range_max    = 6081
+  security_group_id = openstack_networking_secgroup_v2.master.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_geneve_from_worker" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 6081
+  port_range_max    = 6081
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.master.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_ovndb" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6641
+  port_range_max    = 6642
+  security_group_id = openstack_networking_secgroup_v2.master.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_ovndb_from_worker" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6641
+  port_range_max    = 6642
   remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
@@ -155,25 +193,6 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_from_w
   protocol          = "udp"
   port_range_min    = 9000
   port_range_max    = 9999
-  remote_group_id   = openstack_networking_secgroup_v2.worker.id
-  security_group_id = openstack_networking_secgroup_v2.master.id
-}
-
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_insecure" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 10250
-  port_range_max    = 10250
-  security_group_id = openstack_networking_secgroup_v2.master.id
-}
-
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_insecure_from_worker" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 10250
-  port_range_max    = 10250
   remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
@@ -220,8 +239,8 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure"
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 10255
-  port_range_max    = 10255
+  port_range_min    = 10250
+  port_range_max    = 10250
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -229,8 +248,8 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure_
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 10255
-  port_range_max    = 10255
+  port_range_min    = 10250
+  port_range_max    = 10250
   remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
@@ -253,10 +272,19 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_bootstrap_etcd"
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_services" {
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_tcp" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  security_group_id = openstack_networking_secgroup_v2.master.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
   port_range_min    = 30000
   port_range_max    = 32767
   security_group_id = openstack_networking_secgroup_v2.master.id

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -29,7 +29,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_mdns_udp" {
   protocol          = "udp"
   port_range_min    = 5353
   port_range_max    = 5353
-  remote_ip_prefix  = "${var.cidr_block}"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -53,25 +53,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_https" {
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_heapster" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  port_range_min    = 4194
-  port_range_max    = 4194
-  protocol          = "tcp"
-  security_group_id = openstack_networking_secgroup_v2.worker.id
-}
-
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_heapster_from_master" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 4194
-  port_range_max    = 4194
-  remote_group_id   = openstack_networking_secgroup_v2.master.id
-  security_group_id = openstack_networking_secgroup_v2.worker.id
-}
-
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan" {
   direction         = "ingress"
   ethertype         = "IPv4"
@@ -163,25 +144,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecur
   protocol          = "tcp"
   port_range_min    = 10250
   port_range_max    = 10250
-  remote_group_id   = openstack_networking_secgroup_v2.master.id
-  security_group_id = openstack_networking_secgroup_v2.worker.id
-}
-
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_secure" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 10255
-  port_range_max    = 10255
-  security_group_id = openstack_networking_secgroup_v2.worker.id
-}
-
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_secure_from_master" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 10255
-  port_range_max    = 10255
   remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -72,7 +72,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_heapster_from_m
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_flannel" {
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
@@ -81,7 +81,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_flannel" {
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_flannel_from_master" {
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan_from_master" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
@@ -91,21 +91,59 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_flannel_from_ma
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_node_exporter" {
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_geneve" {
   direction         = "ingress"
   ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 9100
-  port_range_max    = 9100
+  protocol          = "udp"
+  port_range_min    = 6081
+  port_range_max    = 6081
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_node_exporter_from_master" {
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_geneve_from_master" {
   direction         = "ingress"
-  protocol          = "tcp"
   ethertype         = "IPv4"
-  port_range_min    = 9100
-  port_range_max    = 9100
+  protocol          = "udp"
+  port_range_min    = 6081
+  port_range_max    = 6081
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9000
+  port_range_max    = 9999
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_from_master" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9000
+  port_range_max    = 9999
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 9000
+  port_range_max    = 9999
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_from_master_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 9000
+  port_range_max    = 9999
   remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
@@ -148,10 +186,19 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_secure_
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services" {
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
   port_range_min    = 30000
   port_range_max    = 32767
   security_group_id = openstack_networking_secgroup_v2.worker.id

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -30,7 +30,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_mdns_udp" {
   port_range_min    = 5353
   port_range_max    = 5353
   remote_ip_prefix  = "${var.cidr_block}"
-  security_group_id = "${openstack_networking_secgroup_v2.worker.id}"
+  security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_http" {


### PR DESCRIPTION
The OpenStack security groups have diverged from AWS. Some of these
cause real problems. This makes sure that all the SGs open in AWS are
also open for OpenStack.

This also fixes some obvious typos and updates some of the names to
match AWS.