### PR TITLE
baremetal: Remove spurious Type from ironic.service

### DIFF
--- a/data/data/bootstrap/baremetal/systemd/units/ironic.service
+++ b/data/data/bootstrap/baremetal/systemd/units/ironic.service
@@ -5,7 +5,6 @@ Wants=network-online.target crio.service
 After=network-online.target crio.service release-image.service
 
 [Service]
-Type=exec
 ExecStart=/usr/local/bin/startironic.sh
 ExecStop=/usr/local/bin/stopironic.sh
 


### PR DESCRIPTION
This is a mistake, and results in a warning from systemd then the type
is ignored (defaulting to "simple" due to the ExecStart), so lets remove
it to avoid the warning.

Fixes: #2309