### PR TITLE
baremetal: Add validation for provisioning network IPs 

### DIFF
--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -17,6 +17,13 @@ func validateIPinMachineCIDR(vip string, n *types.Networking) error {
 	return nil
 }
 
+func validateIPNotinMachineCIDR(ip string, n *types.Networking) error {
+	if n.MachineCIDR.Contains(net.ParseIP(ip)) {
+		return fmt.Errorf("the IP must not be in %s subnet", n.MachineCIDR.String())
+	}
+	return nil
+}
+
 // ValidatePlatform checks that the specified platform is valid.
 func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -70,6 +77,12 @@ func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field
 
 	if err := validateIPinMachineCIDR(p.DNSVIP, n); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("dnsVIP"), p.DNSVIP, err.Error()))
+	}
+	if err := validateIPNotinMachineCIDR(p.ClusterProvisioningIP, n); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("provisioningHostIP"), p.ClusterProvisioningIP, err.Error()))
+	}
+	if err := validateIPNotinMachineCIDR(p.BootstrapProvisioningIP, n); err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("bootstrapHostIP"), p.BootstrapProvisioningIP, err.Error()))
 	}
 
 	return allErrs

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -1,0 +1,162 @@
+package validation
+
+import (
+	"net"
+	"testing"
+
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidatePlatform(t *testing.T) {
+	iface, _ := net.Interfaces()
+	network := &types.Networking{MachineCIDR: ipnet.MustParseCIDR("192.168.111.0/24")}
+	cases := []struct {
+		name     string
+		platform *baremetal.Platform
+		network  *types.Networking
+		expected string
+	}{
+		{
+			name: "valid",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.111.2",
+				DNSVIP:                  "192.168.111.3",
+				IngressVIP:              "192.168.111.4",
+				Hosts:                   []*baremetal.Host{},
+				LibvirtURI:              "qemu://system",
+				ClusterProvisioningIP:   "172.22.0.3",
+				BootstrapProvisioningIP: "172.22.0.2",
+				ExternalBridge:          iface[0].Name,
+				ProvisioningBridge:      iface[0].Name,
+			},
+			network: network,
+		},
+		{
+			name: "invalid_apivip",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.222.2",
+				DNSVIP:                  "192.168.111.3",
+				IngressVIP:              "192.168.111.4",
+				Hosts:                   []*baremetal.Host{},
+				LibvirtURI:              "qemu://system",
+				ClusterProvisioningIP:   "172.22.0.3",
+				BootstrapProvisioningIP: "172.22.0.2",
+				ExternalBridge:          iface[0].Name,
+				ProvisioningBridge:      iface[0].Name,
+			},
+			network:  network,
+			expected: "Invalid value: \"192.168.222.2\": the virtual IP is expected to be in 192.168.111.0/24 subnet",
+		},
+		{
+			name: "invalid_dnsvip",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.111.2",
+				DNSVIP:                  "192.168.222.3",
+				IngressVIP:              "192.168.111.4",
+				Hosts:                   []*baremetal.Host{},
+				LibvirtURI:              "qemu://system",
+				ClusterProvisioningIP:   "172.22.0.3",
+				BootstrapProvisioningIP: "172.22.0.2",
+				ExternalBridge:          iface[0].Name,
+				ProvisioningBridge:      iface[0].Name,
+			},
+			network:  network,
+			expected: "Invalid value: \"192.168.222.3\": the virtual IP is expected to be in 192.168.111.0/24 subnet",
+		},
+		{
+			name: "invalid_ingressvip",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.111.2",
+				DNSVIP:                  "192.168.111.3",
+				IngressVIP:              "192.168.222.4",
+				Hosts:                   []*baremetal.Host{},
+				LibvirtURI:              "qemu://system",
+				ClusterProvisioningIP:   "172.22.0.3",
+				BootstrapProvisioningIP: "172.22.0.2",
+				ExternalBridge:          iface[0].Name,
+				ProvisioningBridge:      iface[0].Name,
+			},
+			network:  network,
+			expected: "Invalid value: \"192.168.222.4\": the virtual IP is expected to be in 192.168.111.0/24 subnet",
+		},
+		{
+			name: "invalid_hosts",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.111.2",
+				DNSVIP:                  "192.168.111.3",
+				IngressVIP:              "192.168.111.4",
+				Hosts:                   nil,
+				LibvirtURI:              "qemu://system",
+				ClusterProvisioningIP:   "172.22.0.3",
+				BootstrapProvisioningIP: "172.22.0.2",
+				ExternalBridge:          iface[0].Name,
+				ProvisioningBridge:      iface[0].Name,
+			},
+			network:  network,
+			expected: "bare metal hosts are missing",
+		},
+		{
+			name: "invalid_libvirturi",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.111.2",
+				DNSVIP:                  "192.168.111.3",
+				IngressVIP:              "192.168.111.4",
+				Hosts:                   []*baremetal.Host{},
+				LibvirtURI:              "",
+				ClusterProvisioningIP:   "172.22.0.3",
+				BootstrapProvisioningIP: "172.22.0.2",
+				ExternalBridge:          iface[0].Name,
+				ProvisioningBridge:      iface[0].Name,
+			},
+			network:  network,
+			expected: "invalid URI \"\"",
+		},
+		{
+			name: "invalid_extbridge",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.111.2",
+				DNSVIP:                  "192.168.111.3",
+				IngressVIP:              "192.168.111.4",
+				Hosts:                   []*baremetal.Host{},
+				LibvirtURI:              "qemu://system",
+				ClusterProvisioningIP:   "172.22.0.3",
+				BootstrapProvisioningIP: "172.22.0.2",
+				ExternalBridge:          "noexist",
+				ProvisioningBridge:      iface[0].Name,
+			},
+			network:  network,
+			expected: "Invalid value: \"noexist\": noexist is not a valid network interface",
+		},
+		{
+			name: "invalid_provbridge",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.111.2",
+				DNSVIP:                  "192.168.111.3",
+				IngressVIP:              "192.168.111.4",
+				Hosts:                   []*baremetal.Host{},
+				LibvirtURI:              "qemu://system",
+				ClusterProvisioningIP:   "172.22.0.3",
+				BootstrapProvisioningIP: "172.22.0.2",
+				ExternalBridge:          iface[0].Name,
+				ProvisioningBridge:      "noexist",
+			},
+			network:  network,
+			expected: "Invalid value: \"noexist\": noexist is not a valid network interface",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePlatform(tc.platform, tc.network, field.NewPath("test-path")).ToAggregate()
+			if tc.expected == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, tc.expected, err)
+			}
+		})
+	}
+}

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -147,6 +147,38 @@ func TestValidatePlatform(t *testing.T) {
 			network:  network,
 			expected: "Invalid value: \"noexist\": noexist is not a valid network interface",
 		},
+		{
+			name: "invalid_clusterprovip",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.111.2",
+				DNSVIP:                  "192.168.111.3",
+				IngressVIP:              "192.168.111.4",
+				Hosts:                   []*baremetal.Host{},
+				LibvirtURI:              "qemu://system",
+				ClusterProvisioningIP:   "192.168.111.5",
+				BootstrapProvisioningIP: "172.22.0.2",
+				ExternalBridge:          iface[0].Name,
+				ProvisioningBridge:      iface[0].Name,
+			},
+			network:  network,
+			expected: "Invalid value: \"192.168.111.5\": the IP must not be in 192.168.111.0/24 subnet",
+		},
+		{
+			name: "invalid_bootstrapprovip",
+			platform: &baremetal.Platform{
+				APIVIP:                  "192.168.111.2",
+				DNSVIP:                  "192.168.111.3",
+				IngressVIP:              "192.168.111.4",
+				Hosts:                   []*baremetal.Host{},
+				LibvirtURI:              "qemu://system",
+				ClusterProvisioningIP:   "172.22.0.3",
+				BootstrapProvisioningIP: "192.168.111.5",
+				ExternalBridge:          iface[0].Name,
+				ProvisioningBridge:      iface[0].Name,
+			},
+			network:  network,
+			expected: "Invalid value: \"192.168.111.5\": the IP must not be in 192.168.111.0/24 subnet",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
As mentioned in #2079 we should validate these IPs as they must
be on a different subnet than the machine CIDR, these IPs are used
to configure a dedicated network for provisioning machines via pxe.

This also adds some tests for the existing validation as a pre-requisite to adding tests for the new validation.

Closes: #2210