### PR TITLE
docs/user: Bump vSphere and metal from v1beta4 to v1

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -108,7 +108,7 @@ include:
   https://github.com/metal3-io/baremetal-operator/blob/master/pkg/hardware/profile.go#L48
 
 ```yaml
-apiVersion: v1beta4
+apiVersion: v1
 baseDomain: test.metalkube.org
 metadata:
   name: ostest

--- a/docs/user/vsphere/install_upi.md
+++ b/docs/user/vsphere/install_upi.md
@@ -127,7 +127,7 @@ The OpenShift installer uses an [Install Config][install-config] to drive all in
 An example install config for vSphere UPI is as follows:
 
 ```yaml
-apiVersion: v1beta4
+apiVersion: v1
 ## The base domain of the cluster. All DNS records will be sub-domains of this base and will also include the cluster name.
 baseDomain: example.com
 compute:


### PR DESCRIPTION
Most of our docs were bumped in befde3c232 (#1589), but these v1beta4 references snuck in with 0ec07d0769 (#1545) and 0055065143 (#1873).