### PR TITLE
Bug 1746748: OpenStack: idempotent cluster deletion

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1317,6 +1317,7 @@
     "github.com/coreos/ignition/config/v2_2/types",
     "github.com/ghodss/yaml",
     "github.com/golang/mock/gomock",
+    "github.com/gophercloud/gophercloud",
     "github.com/gophercloud/gophercloud/openstack/common/extensions",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",


### PR DESCRIPTION
Now we delete OpenStack resources in parallel using goroutines. It can lead to the fact that a resource can already been deleted when another goroutine sends a request.

Instead of returning an error in this case and quitting the installer we should tolerate this type of errors and continue to remove resources.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1746748