### PR TITLE
Bug 1746119: GCP Terraform ignore changes to min_cpu_platform

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -67,4 +67,11 @@ resource "google_compute_instance" "bootstrap" {
   tags = ["${var.cluster_id}-master", "${var.cluster_id}-bootstrap"]
 
   labels = var.labels
+
+  lifecycle {
+    # In GCP TF apply is run a second time to remove bootstrap node from LB.
+    # If machine_type = n2-standard series, install will error as TF tries to
+    # switch min_cpu_platform = "Intel Cascade Lake" -> null. BZ-1746119.
+    ignore_changes = [min_cpu_platform]
+  }
 }

--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -59,4 +59,11 @@ resource "google_compute_instance" "master" {
     email  = google_service_account.master-node-sa.email
     scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
+
+  lifecycle {
+    # In GCP TF apply is run a second time to remove bootstrap node from LB.
+    # If machine_type = n2-standard series, install will error as TF tries to
+    # switch min_cpu_platform = "Intel Cascade Lake" -> null. BZ-1746119.
+    ignore_changes = [min_cpu_platform]
+  }
 }


### PR DESCRIPTION
In GCP, terraform apply is run during bootstrap destroy to remove the bootstrap node from the LB. If control plane machine_type is set to the n2-standard series, master & bootstrap instances are created with min_cpu_platform = "Intel Cascade Lake," but the terraform configuration has min_cpu_platform = null. As terraform tries to switch min_cpu_platform back to null, installer will error with:

>level=error msg="Error: Changing the machine_type, min_cpu_platform, or service_account on an instance requires stopping it. To acknowledge this, please set allow_stopping_for_update = true in your config."

By using lifecycle ignore_changes we can prevent TF from mistakenly trying to switch min_cpu_platform back to null.