### PR TITLE
openstack: Copy openshift-tests into CI installer image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -10,6 +10,7 @@ COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/images/openstack/rdo-stein.repo /etc/yum.repos.d/rdo-stein.repo
 COPY --from=builder /go/src/github.com/openshift/installer/images/openstack/rdo-stein.gpg /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
 COPY --from=registry.svc.ci.openshift.org/origin/4.1:cli /usr/bin/oc /bin/oc
+COPY --from=registry.svc.ci.openshift.org/origin/4.1:tests /usr/bin/openshift-tests /bin/openshift-tests
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \


### PR DESCRIPTION
Some 'parallel' OpenShift storage tests require openstack-client
libraries. Simply adding openshift-tests into this container will
allow us to re-use it for testing as well.