### PR TITLE
Fix reference links in GCP quota limit docs.

### DIFF
--- a/docs/user/gcp/limits.md
+++ b/docs/user/gcp/limits.md
@@ -8,7 +8,7 @@ A vanilla IPI installation will result in 24 CPUs, 3 Static IPs and 768 GB of st
 Be sure to consider cluster growth and consumption from other clusters if using a shared projectd.  The most likely areas of contention are CPU, Static IPs and Storage (SSD) quota.  Whenever an installation fails the installer CLI will return the relevant error message stating which quota was exceeded in a particular region.
 
 ## Increasing limits
-To adjust quotas visit the [GCP console](gcp-console-quota) and make necessary changes.  This will likely involve filing a support ticket so it's best to plan ahead as this is often the most time consuming barrier to your first running cluster.  For more detailed information please refer to the [GCP documentation](gcp-docs-quota).
+To adjust quotas visit the [GCP console][gcp-console-quota] and make necessary changes.  This will likely involve filing a support ticket so it's best to plan ahead as this is often the most time consuming barrier to your first running cluster.  For more detailed information please refer to the [GCP documentation][gcp-docs-quota].
 
 [gcp-console-quota]: https://console.cloud.google.com/iam-admin/quotas
 [gcp-docs-quota]: https://cloud.google.com/compute/quotas


### PR DESCRIPTION
I could combine this into the update I will do of GCP docs later this week with [CORS--1192](https://jira.coreos.com/browse/CORS-1192) but link is currently broken so perhaps we want to merge immediately.