### PR TITLE
Bug 1748162: Open GENEVE wherever possible

### DIFF
--- a/data/data/gcp/network/firewall-compute.tf
+++ b/data/data/gcp/network/firewall-compute.tf
@@ -23,26 +23,28 @@ resource "google_compute_firewall" "worker_ingress_ssh" {
   target_tags   = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "worker_ingress_vxlan" {
-  name    = "${var.cluster_id}-worker-in-vxlan"
+resource "google_compute_firewall" "worker_ingress_overlay" {
+  name    = "${var.cluster_id}-worker-in-overlay"
   network = google_compute_network.cluster_network.self_link
 
+  # allow VXLAN and GENEVE
   allow {
     protocol = "udp"
-    ports    = ["4789"]
+    ports    = ["4789", "6081"]
   }
 
   source_tags = ["${var.cluster_id}-worker"]
   target_tags = ["${var.cluster_id}-worker"]
 }
 
-resource "google_compute_firewall" "worker_ingress_vxlan_from_master" {
-  name    = "${var.cluster_id}-worker-in-vxlan-from-master"
+resource "google_compute_firewall" "worker_ingress_overlay_from_master" {
+  name    = "${var.cluster_id}-worker-in-overlay-from-master"
   network = google_compute_network.cluster_network.self_link
 
+  # allow VXLAN and GENEVE
   allow {
     protocol = "udp"
-    ports    = ["4789"]
+    ports    = ["4789", "6081"]
   }
 
   source_tags = ["${var.cluster_id}-master"]

--- a/data/data/gcp/network/firewall-control.tf
+++ b/data/data/gcp/network/firewall-control.tf
@@ -62,26 +62,28 @@ resource "google_compute_firewall" "master_ingress_mcs" {
   target_tags   = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "master_ingress_vxlan" {
-  name    = "${var.cluster_id}-master-in-vxlan"
+resource "google_compute_firewall" "master_ingress_overlay" {
+  name    = "${var.cluster_id}-master-in-overlay"
   network = google_compute_network.cluster_network.self_link
 
+  # allow VXLAN and GENEVE
   allow {
     protocol = "udp"
-    ports    = ["4789"]
+    ports    = ["4789", "6081"]
   }
 
   source_tags = ["${var.cluster_id}-master"]
   target_tags = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "master_ingress_vxlan_from_worker" {
-  name    = "${var.cluster_id}-master-in-vxlan-from-worker"
+resource "google_compute_firewall" "master_ingress_overlay_from_worker" {
+  name    = "${var.cluster_id}-master-in-overlay-from-worker"
   network = google_compute_network.cluster_network.self_link
 
+  # allow VXLAN and GENEVE
   allow {
     protocol = "udp"
-    ports    = ["4789"]
+    ports    = ["4789", "6081"]
   }
 
   source_tags = ["${var.cluster_id}-worker"]

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -114,6 +114,26 @@ Resources:
       ToPort: 4789
       IpProtocol: udp
 
+  MasterIngressGeneve:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Geneve packets
+      FromPort: 6081
+      ToPort: 6081
+      IpProtocol: udp
+
+  MasterIngressWorkerGeneve:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Geneve packets
+      FromPort: 6081
+      ToPort: 6081
+      IpProtocol: udp
+
   MasterIngressInternal:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -184,7 +204,7 @@ Resources:
       ToPort: 4789
       IpProtocol: udp
 
-  WorkerIngressWorkerVxlan:
+  WorkerIngressMasterVxlan:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt WorkerSecurityGroup.GroupId
@@ -192,6 +212,26 @@ Resources:
       Description: Vxlan packets
       FromPort: 4789
       ToPort: 4789
+      IpProtocol: udp
+
+  WorkerIngressGeneve:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Geneve packets
+      FromPort: 6081
+      ToPort: 6081
+      IpProtocol: udp
+
+  WorkerIngressMasterGeneve:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Geneve packets
+      FromPort: 6081
+      ToPort: 6081
       IpProtocol: udp
 
   WorkerIngressInternal:

--- a/upi/gcp/03_security.py
+++ b/upi/gcp/03_security.py
@@ -64,25 +64,25 @@ def GenerateConfig(context):
             'targetTags': [context.properties['infra_id'] + '-master']
         }
     }, {
-        'name': context.properties['infra_id'] + '-master-in-vxlan',
+        'name': context.properties['infra_id'] + '-master-in-overlay',
         'type': 'compute.v1.firewall',
         'properties': {
             'network': context.properties['cluster_network'],
             'allowed': [{
                 'IPProtocol': 'udp',
-                'ports': ['4789']
+                'ports': ['4789', '6081']
             }],
             'sourceTags': [context.properties['infra_id'] + '-master'],
             'targetTags': [context.properties['infra_id'] + '-master']
         }
     }, {
-        'name': context.properties['infra_id'] + '-master-in-vxlan-from-worker',
+        'name': context.properties['infra_id'] + '-master-in-overlay-from-worker',
         'type': 'compute.v1.firewall',
         'properties': {
             'network': context.properties['cluster_network'],
             'allowed': [{
                 'IPProtocol': 'udp',
-                'ports': ['4789']
+                'ports': ['4789', '6081']
             }],
             'sourceTags': [context.properties['infra_id'] + '-worker'],
             'targetTags': [context.properties['infra_id'] + '-master']
@@ -267,25 +267,25 @@ def GenerateConfig(context):
             'targetTags': [context.properties['infra_id'] + '-worker']
         }
     }, {
-        'name': context.properties['infra_id'] + '-worker-in-vxlan',
+        'name': context.properties['infra_id'] + '-worker-in-overlay',
         'type': 'compute.v1.firewall',
         'properties': {
             'network': context.properties['cluster_network'],
             'allowed': [{
                 'IPProtocol': 'udp',
-                'ports': ['4789']
+                'ports': ['4789', '6081']
             }],
             'sourceTags': [context.properties['infra_id'] + '-worker'],
             'targetTags': [context.properties['infra_id'] + '-worker']
         }
     }, {
-        'name': context.properties['infra_id'] + '-worker-in-vxlan-from-master',
+        'name': context.properties['infra_id'] + '-worker-in-overlay-from-master',
         'type': 'compute.v1.firewall',
         'properties': {
             'network': context.properties['cluster_network'],
             'allowed': [{
                 'IPProtocol': 'udp',
-                'ports': ['4789']
+                'ports': ['4789', '6081']
             }],
             'sourceTags': [context.properties['infra_id'] + '-master'],
             'targetTags': [context.properties['infra_id'] + '-worker']


### PR DESCRIPTION
We already opened the GENEVE port for AWS IPI. This opens it for GCP IPI and AWS + GCP UPI.

The other platforms (Vsphere, Azure) do not have intra-cluster firewalls.