### PR TITLE
Bump libvirt resource from 6GB to 7GB

### DIFF
--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -63,7 +63,7 @@ func provider(clusterID string, networkInterfaceAddress string, platform *libvir
 			APIVersion: "libvirtproviderconfig.openshift.io/v1beta1",
 			Kind:       "LibvirtMachineProviderConfig",
 		},
-		DomainMemory: 6144,
+		DomainMemory: 7168,
 		DomainVcpu:   4,
 		Ignition: &libvirtprovider.Ignition{
 			UserDataSecret: userDataSecret,


### PR DESCRIPTION
With current resource, the extended tests which are part of CI are failing
because of resource constraint.

```
event for s2i-build-quota-1-build: {default-scheduler } FailedScheduling: 0/2 nodes are available: 1 Insufficient memory, 1 node(s) had taints that the pod didn't tolerate.
```