### PR TITLE
 Bug 1749714: OpenStack: Open port 1936 on compute and tighten security groups

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -9,26 +9,30 @@ resource "openstack_networking_secgroup_rule_v2" "master_mcs" {
   protocol          = "tcp"
   port_range_min    = 22623
   port_range_max    = 22623
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
+#
+# TODO(mandre) Explicitely enable egress
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "icmp"
-  port_range_min    = 0
-  port_range_max    = 0
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "icmp"
+  port_range_min = 0
+  port_range_max = 0
+  # FIXME(mandre) AWS only allows ICMP from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ssh" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 22
-  port_range_max    = 22
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "tcp"
+  port_range_min = 22
+  port_range_max = 22
+  # FIXME(mandre) AWS only allows SSH from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
@@ -39,7 +43,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_tcp" {
   protocol          = "tcp"
   port_range_min    = 53
   port_range_max    = 53
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -49,7 +53,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
   protocol          = "udp"
   port_range_min    = 53
   port_range_max    = 53
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -64,11 +68,12 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_mdns_udp" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 6443
-  port_range_max    = 6443
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "tcp"
+  port_range_min = 6443
+  port_range_max = 6443
+  # FIXME(mandre) AWS only allows API port from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
@@ -79,6 +84,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_vxlan" {
   protocol          = "udp"
   port_range_min    = 4789
   port_range_max    = 4789
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -98,6 +104,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_geneve" {
   protocol          = "udp"
   port_range_min    = 6081
   port_range_max    = 6081
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -117,6 +124,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_ovndb" {
   protocol          = "tcp"
   port_range_min    = 6641
   port_range_max    = 6642
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -136,6 +144,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal" {
   protocol          = "tcp"
   port_range_min    = 9000
   port_range_max    = 9999
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -155,6 +164,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_udp" {
   protocol          = "udp"
   port_range_min    = 9000
   port_range_max    = 9999
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -174,6 +184,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_scheduler"
   protocol          = "tcp"
   port_range_min    = 10259
   port_range_max    = 10259
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -193,6 +204,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_controller
   protocol          = "tcp"
   port_range_min    = 10257
   port_range_max    = 10257
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -212,6 +224,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure"
   protocol          = "tcp"
   port_range_min    = 10250
   port_range_max    = 10250
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -231,6 +244,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_etcd" {
   protocol          = "tcp"
   port_range_min    = 2379
   port_range_max    = 2380
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -240,6 +254,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_tcp" {
   protocol          = "tcp"
   port_range_min    = 30000
   port_range_max    = 32767
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
@@ -249,13 +264,15 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp" {
   protocol          = "udp"
   port_range_min    = 30000
   port_range_max    = 32767
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp" {
   direction         = "ingress"
   ethertype         = "IPv4"
-  protocol          = 112
+  protocol          = "vrrp"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -3,22 +3,26 @@ resource "openstack_networking_secgroup_v2" "worker" {
   tags = ["openshiftClusterID=${var.cluster_id}"]
 }
 
+# TODO(mandre) Explicitely enable egress
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "icmp"
-  port_range_min    = 0
-  port_range_max    = 0
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "icmp"
+  port_range_min = 0
+  port_range_max = 0
+  # FIXME(mandre) AWS only allows ICMP from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 22
-  port_range_max    = 22
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "tcp"
+  port_range_min = 22
+  port_range_max = 22
+  # FIXME(mandre) AWS only allows SSH from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
@@ -69,6 +73,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan" {
   protocol          = "udp"
   port_range_min    = 4789
   port_range_max    = 4789
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
@@ -88,6 +93,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_geneve" {
   protocol          = "udp"
   port_range_min    = 6081
   port_range_max    = 6081
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
@@ -107,6 +113,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal" {
   protocol          = "tcp"
   port_range_min    = 9000
   port_range_max    = 9999
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
@@ -126,6 +133,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_udp" {
   protocol          = "udp"
   port_range_min    = 9000
   port_range_max    = 9999
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
@@ -145,6 +153,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecur
   protocol          = "tcp"
   port_range_min    = 10250
   port_range_max    = 10250
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
@@ -164,6 +173,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp" {
   protocol          = "tcp"
   port_range_min    = 30000
   port_range_max    = 32767
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
@@ -173,12 +183,14 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
   protocol          = "udp"
   port_range_min    = 30000
   port_range_max    = 32767
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp" {
   direction         = "ingress"
   ethertype         = "IPv4"
-  protocol          = 112
+  protocol          = "vrrp"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }


### PR DESCRIPTION
The port 1936 is used to get metrics from the router. Also noticed the security groups were too widely open so tighten them to match AWS.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1749714