### PR TITLE
Add g+w /etc/passwd to be able to collect proxy access logs in teardown

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -23,7 +23,8 @@ RUN yum install --setopt=tsflags=nodocs -y \
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     unzip gzip jq util-linux && \
-    yum clean all && rm -rf /var/cache/yum/*
+    yum clean all && rm -rf /var/cache/yum/* && \
+    chmod g+w /etc/passwd
 
 ENV TERRAFORM_VERSION=0.11.11
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \


### PR DESCRIPTION
Similar to https://github.com/openshift/origin/pull/22592

Addresses being able to add a user entry for container user id to be able to ssh to squid proxy
```
Agent pid 90
Identity added: /etc/openshift-installer/ssh-privatekey (/etc/openshift-installer/ssh-privatekey)
No user exists for uid 1451760000
```

