### PR TITLE
Bug 1751905: data/data/azure/bootstrap: ensure pool is only updated after machine is terminated

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -144,6 +144,11 @@ resource "azurerm_virtual_machine" "bootstrap" {
     enabled     = true
     storage_uri = var.storage_account.primary_blob_endpoint
   }
+
+  depends_on = [
+    azurerm_network_interface_backend_address_pool_association.public_lb_bootstrap,
+    azurerm_network_interface_backend_address_pool_association.internal_lb_bootstrap
+  ]
 }
 
 resource "azurerm_network_security_rule" "bootstrap_ssh_in" {


### PR DESCRIPTION
It looks like an internal Azure race is causing a cryptic message like

```
Error: Error waiting for removal of Backend Address Pool Association for NIC \"ci-op-8qv3w054-282fe-2222c-bootstrap-nic\" (Resource Group \"ci-op-8qv3w054-282fe-2222c-rg\"): Code=\"OperationNotAllowed\" Message=\"Operation 'startTenantUpdate' is not allowed on VM 'ci-op-8qv3w054-282fe-2222c-bootstrap' since the VM is marked for deletion. You can only retry the Delete operation (or wait for an ongoing one to complete).\" Details=[]
```
when we update the NIC and the machine attached to it.

`azurerm_network_interface_backend_address_pool_association.` depends on NIC but is not related to the machine NIC is attached to, the VM might be shutting down while this update is happeninig. This depends_on makes sure that VM is destroyed before we try to delete this association, preventing the race.

Similar error seen by people like https://github.com/Azure/azure-rest-api-specs/issues/7207

This is affecting all Azure installs since 09/12

https://prow.k8s.io/view/gcs/origin-ci-test/logs/canary-openshift-ocp-installer-e2e-azure-4.2/253#0:build-log.txt%3A55
https://prow.k8s.io/view/gcs/origin-ci-test/logs/canary-openshift-ocp-installer-e2e-azure-4.2/254#0:build-log.txt%3A51
https://prow.k8s.io/view/gcs/origin-ci-test/logs/canary-openshift-ocp-installer-e2e-azure-4.2/255#0:build-log.txt%3A59


Fixes: https://github.com/openshift/installer/issues/2354