### PR TITLE
Bug 1752135: data/aws: Set 20m creation timeouts for instances

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -144,6 +144,10 @@ resource "aws_instance" "bootstrap" {
     },
     var.tags,
   )
+
+  timeouts {
+    create = "20m"
+  }
 }
 
 resource "aws_lb_target_group_attachment" "bootstrap" {

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -125,6 +125,10 @@ resource "aws_instance" "master" {
     },
     var.tags,
   )
+
+  timeouts {
+    create = "20m"
+  }
 }
 
 resource "aws_lb_target_group_attachment" "master" {


### PR DESCRIPTION
We've been hitting the default 10m timeout recently, starting around [here][1].  Use [the creation timeout knob][2] to wait a bit longer before giving up on AWS.  20m matches the value we've used bumping this timeout for other resources in 1ec27580b2 (#2279) and previous.  There's no guarantee that 20m will be sufficient, the issue could be due to internal AWS issues like a shortage of on-demand instances of the requested type in the requested availability zone.  But it gives AWS an even easier target to hit ;).

[1]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_console/2708/pull-ci-openshift-console-master-e2e-aws-console-olm/8584
[2]: https://www.terraform.io/docs/providers/aws/r/instance.html#timeouts