### PR TITLE
Bug 1751375: Azure: bump disk size to 1TB for control plane 

### DIFF
--- a/docs/user/azure/limits.md
+++ b/docs/user/azure/limits.md
@@ -45,10 +45,18 @@ allows for many clusters to be created. The network security groups which exist 
 By default, a cluster will create:
 
 * One Standard_D4s_v3 bootstrap machine (removed after install)
-* Three Standard_D4s_v3 master nodes.
+* Three Standard_D8s_v3 master nodes.
 * Three Standard_D2s_v3 worker nodes.
 
 The specs for the VM sizes (Dsv3-series) are as follows:
+
+* Standard_D8s_v3
+   * 8 vCPU's, 32GiB ram
+   * IOPs / Throughput (Mbps): (cached) 16000 / 128
+   * IOPs / Throughput (Mbps): (uncached) 12800 / 192
+   * NICs / Bandwidth (Mbps): 4 / 4000
+   * 64 GiB temp storage (SSD)
+   * 16 data disks max
 
 * Standard_D4s_v3
    * 4 vCPU's, 16GiB ram

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -190,6 +190,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	case azuretypes.Name:
 		mpool := defaultAzureMachinePoolPlatform()
 		mpool.InstanceType = azuredefaults.ControlPlaneInstanceType(installconfig.Config.Platform.Azure.Region)
+		mpool.OSDisk.DiskSizeGB = 1024
 		mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Azure)
 		if len(mpool.Zones) == 0 {

--- a/pkg/types/azure/defaults/machines.go
+++ b/pkg/types/azure/defaults/machines.go
@@ -14,10 +14,11 @@ func BootstrapInstanceType(region string) string {
 
 // ControlPlaneInstanceType sets the defaults for control plane instances.
 // Minimum requirements are 4 CPU's, 16GiB of ram, and 120GiB storage.
-// D4s v3 gives us 4 CPU's, 16GiB ram and 32GiB of temporary storage
+// D8s v3 gives us 8 CPU's, 32GiB ram and 64GiB of temporary storage
+// This extra bump is done to prevent etcd from overloading
 func ControlPlaneInstanceType(region string) string {
 	instanceClass := getInstanceClass(region)
-	return fmt.Sprintf("%s_D4s_v3", instanceClass)
+	return fmt.Sprintf("%s_D8s_v3", instanceClass)
 }
 
 // ComputeInstanceType sets the defaults for compute instances.


### PR DESCRIPTION
To support the throughput for uncached writes to 1024 GB Preimum SSD disks [P30 200MB/second](https://azure.microsoft.com/en-us/pricing/details/managed-disks/) the instance size also need to be bumped to `D8s_v3` [192Mb/second](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes-general#dsv3-series-1)

This increases the default vCPU requirement for default single cluster to `34` from `22`, and the default disk requirements for deafult single cluster to `4480 GB` from `896GB`