### PR TITLE
[4.3] Increase the amount of memory for control plane nodes on vsphere upi

### DIFF
--- a/upi/vsphere/machine/main.tf
+++ b/upi/vsphere/machine/main.tf
@@ -20,7 +20,7 @@ resource "vsphere_virtual_machine" "vm" {
   resource_pool_id = "${var.resource_pool_id}"
   datastore_id     = "${data.vsphere_datastore.datastore.id}"
   num_cpus         = "4"
-  memory           = "8192"
+  memory           = "${var.memory}"
   guest_id         = "${data.vsphere_virtual_machine.template.guest_id}"
   folder           = "${var.folder}"
   enable_disk_uuid = "true"

--- a/upi/vsphere/machine/variables.tf
+++ b/upi/vsphere/machine/variables.tf
@@ -59,3 +59,6 @@ variable "ipam_token" {
 variable "ip_addresses" {
   type = "list"
 }
+variable "memory" {
+  type = "string"
+}

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -41,6 +41,7 @@ module "bootstrap" {
   ipam_token       = "${var.ipam_token}"
   ip_addresses     = ["${compact(list(var.bootstrap_ip))}"]
   machine_cidr     = "${var.machine_cidr}"
+  memory           = "8192"
 }
 
 module "control_plane" {
@@ -60,6 +61,7 @@ module "control_plane" {
   ipam_token       = "${var.ipam_token}"
   ip_addresses     = ["${var.control_plane_ips}"]
   machine_cidr     = "${var.machine_cidr}"
+  memory           = "16384"
 }
 
 module "compute" {
@@ -79,6 +81,7 @@ module "compute" {
   ipam_token       = "${var.ipam_token}"
   ip_addresses     = ["${var.compute_ips}"]
   machine_cidr     = "${var.machine_cidr}"
+  memory           = "8192"
 }
 
 module "dns" {


### PR DESCRIPTION
Modified the machine module to take memory as an option.
Modified main adding memory values per type.