### PR TITLE
docs/user/azure/customization: Add azure availability zones

### DIFF
--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -15,6 +15,8 @@ The following options are available when using Azure:
 * `osDisk` (optional object):
     * `diskSizeGB` (optional integer): The size of the disk in gigabytes (GB).
 * `type` (optional string): The Azure instance type.
+* `zones` (optional string slice): List of Azure availability zones that can be used (eg. ["1", "2", "3"]).
+
 
 ## Examples
 
@@ -60,6 +62,8 @@ compute:
       type: Standard_DS4_v2
       osDisk:
         diskSizeGB: 512
+      zones:
+      - "1"
   replicas: 5
 metadata:
   name: test-cluster

--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -15,8 +15,7 @@ The following options are available when using Azure:
 * `osDisk` (optional object):
     * `diskSizeGB` (optional integer): The size of the disk in gigabytes (GB).
 * `type` (optional string): The Azure instance type.
-* `zones` (optional string slice): List of Azure availability zones that can be used (eg. ["1", "2", "3"]).
-
+* `zones` (optional string slice): List of Azure availability zones that can be used (for example, `["1", "2", "3"]`).
 
 ## Examples
 
@@ -64,6 +63,8 @@ compute:
         diskSizeGB: 512
       zones:
       - "1"
+      - "2"
+      - "3"
   replicas: 5
 metadata:
   name: test-cluster


### PR DESCRIPTION
Based on `pkg/types/azure/machinepool.go` , I am adding the availability zones customization section for machine pools and including a custom availability zone config in the custom machine pool example because it was missing.