### PR TITLE
Bug 1752979: data/data/gcp/network: increase the NAT ports for control plane to 7168

### DIFF
--- a/data/data/gcp/network/network.tf
+++ b/data/data/gcp/network/network.tf
@@ -30,7 +30,7 @@ resource "google_compute_router_nat" "master_nat" {
   router                             = google_compute_router.router.name
   nat_ip_allocate_option             = "MANUAL_ONLY"
   nat_ips                            = [google_compute_address.master_nat_ip.self_link]
-  min_ports_per_vm                   = 256
+  min_ports_per_vm                   = 7168
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {


### PR DESCRIPTION
The control-plane subnet is used for control-plane nodes, which are usually 3 (recommended) and we don't expect more than single digit nodes
in this subnet, and currently we only use single NAT IP.

So increasing the minimum ports per VM allows control-plane to access the Internet with much higher resiliency.

/cc @squeed @sdodson 