### PR TITLE
Bug 1753187: OpenStack: Permit choosing the volume type for instances

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -52,6 +52,8 @@ module "masters" {
     var.openstack_master_extra_sg_ids,
     [module.topology.master_sg_id],
   )
+  root_volume_size = var.openstack_master_root_volume_size
+  root_volume_type = var.openstack_master_root_volume_type
 }
 
 module "topology" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -32,17 +32,37 @@ data "ignition_config" "master_ignition_config" {
   ]
 }
 
+resource "openstack_blockstorage_volume_v3" "master_volume" {
+  name = "${var.cluster_id}-master-${count.index}"
+  count = var.root_volume_size == null ? 0 : var.instance_count
+
+  size = var.root_volume_size
+  volume_type = var.root_volume_type
+  image_id = data.openstack_images_image_v2.masters_img.id
+}
+
 resource "openstack_compute_instance_v2" "master_conf" {
   name = "${var.cluster_id}-master-${count.index}"
   count = var.instance_count
 
   flavor_id = data.openstack_compute_flavor_v2.masters_flavor.id
-  image_id = data.openstack_images_image_v2.masters_img.id
+  image_id = var.root_volume_size == null ? data.openstack_images_image_v2.masters_img.id : null
   security_groups = var.master_sg_ids
   user_data = element(
     data.ignition_config.master_ignition_config.*.rendered,
     count.index,
   )
+
+  dynamic block_device {
+    for_each = var.root_volume_size == null ? [] : [openstack_blockstorage_volume_v3.master_volume[count.index].id]
+    content {
+      uuid = block_device.value
+      source_type = "volume"
+      boot_index = 0
+      destination_type = "volume"
+      delete_on_termination = true
+    }
+  }
 
   network {
     port = var.master_port_ids[count.index]
@@ -55,4 +75,3 @@ resource "openstack_compute_instance_v2" "master_conf" {
     openshiftClusterID = var.cluster_id
   }
 }
-

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -29,3 +29,13 @@ variable "master_port_ids" {
 variable "user_data_ign" {
   type = string
 }
+
+variable "root_volume_size" {
+  type        = number
+  description = "The size of the volume in gigabytes for the root block device."
+}
+
+variable "root_volume_type" {
+  type        = string
+  description = "The type of volume for the root block device."
+}

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -1,3 +1,15 @@
+variable "openstack_master_root_volume_type" {
+  type        = string
+  default     = null
+  description = "The type of volume for the root block device of master nodes."
+}
+
+variable "openstack_master_root_volume_size" {
+  type        = number
+  default     = null
+  description = "The size of the volume in gigabytes for the root block device of master nodes."
+}
+
 variable "openstack_base_image" {
   type        = string
   default     = "rhcos"


### PR DESCRIPTION
This is a stop gap solution to allow using a faster storage (if there
is a more performant storage type in cinder) than the default ephemeral
disk. This setting will later be reworked to be exposed as under the
machinepool as it is for other platforms.