### PR TITLE
[4.3] data/gcp: Drop unused defaults for control-plane/bootstrap volumes

### DIFF
--- a/data/data/gcp/bootstrap/variables.tf
+++ b/data/data/gcp/bootstrap/variables.tf
@@ -43,13 +43,11 @@ variable "subnet" {
 variable "root_volume_size" {
   type        = string
   description = "The volume size (in gibibytes) for the bootstrap node's root volume."
-  default     = "128"
 }
 
 variable "root_volume_type" {
   type        = string
   description = "The volume type for the bootstrap node's root volume."
-  default     = "pd-standard"
 }
 
 variable "zone" {

--- a/data/data/gcp/master/variables.tf
+++ b/data/data/gcp/master/variables.tf
@@ -42,13 +42,11 @@ variable "subnet" {
 variable "root_volume_size" {
   type        = string
   description = "The size of the volume in gigabytes for the root block device."
-  default     = "128"
 }
 
 variable "root_volume_type" {
   type        = string
   description = "The type of volume for the root block device."
-  default     = "pd-standard"
 }
 
 variable "zones" {

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -19,8 +19,8 @@ type config struct {
 	MasterInstanceType      string   `json:"gcp_master_instance_type,omitempty"`
 	MasterAvailabilityZones []string `json:"gcp_master_availability_zones"`
 	ImageURI                string   `json:"gcp_image_uri,omitempty"`
-	VolumeType              string   `json:"gcp_master_root_volume_type,omitempty"`
-	VolumeSize              int64    `json:"gcp_master_root_volume_size,omitempty"`
+	VolumeType              string   `json:"gcp_master_root_volume_type"`
+	VolumeSize              int64    `json:"gcp_master_root_volume_size"`
 	PublicZoneName          string   `json:"gcp_public_dns_zone_name,omitempty"`
 }
 


### PR DESCRIPTION
We've clobbered these with values exported from Go since ca3580146d (#2192).  Remove the distracting, unused strings from Terraform.