### PR TITLE
Bug 1754452: OpenStack: reduce the timeout for deleting the cluster

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -99,9 +99,9 @@ func (o *ClusterUninstaller) Run() error {
 
 func deleteRunner(deleteFuncName string, dFunction deleteFunc, opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger, channel chan string) {
 	backoffSettings := wait.Backoff{
-		Duration: time.Second * 10,
+		Duration: time.Second * 15,
 		Factor:   1.3,
-		Steps:    100,
+		Steps:    10,
 	}
 
 	err := wait.ExponentialBackoff(backoffSettings, func() (bool, error) {


### PR DESCRIPTION
Now we use ExponentialBackoff timeout with 100 steps, which gives us approx. 262000 years of waiting.

Although it is quite obvious that the cluster will be destroyed during this time, we must terminate the process earlier than this time frame.

This commit increases the initial duration from 10 to 15 seconds and also reduces the number of steps from 100 to 10. So the timeout will be 10 minutes after that.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1754452