### PR TITLE
Bug 1754542: Destroy Script works before bootstrap complete

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -121,6 +121,7 @@ func deleteRunner(deleteFuncName string, dFunction deleteFunc, opts *clientconfi
 // populateDeleteFuncs is the list of functions that will be launched as
 // goroutines.
 func populateDeleteFuncs(funcs map[string]deleteFunc) {
+	funcs["deleteFloatingIPs"] = deleteFloatingIPs
 	funcs["deleteServers"] = deleteServers
 	funcs["deleteTrunks"] = deleteTrunks
 	funcs["deleteLoadBalancers"] = deleteLoadBalancers
@@ -132,7 +133,6 @@ func populateDeleteFuncs(funcs map[string]deleteFunc) {
 	funcs["deleteNetworks"] = deleteNetworks
 	funcs["deleteContainers"] = deleteContainers
 	funcs["deleteVolumes"] = deleteVolumes
-	funcs["deleteFloatingIPs"] = deleteFloatingIPs
 }
 
 // filterObjects will do client-side filtering given an appropriately filled out


### PR DESCRIPTION
The Destroy script fails when run before bootstrap complete. This fix resolves the issue. 