### PR TITLE
pkg/tfvars/baremetal: don't hardcode external and provision interfaces

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -339,8 +339,8 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			installConfig.Config.Platform.BareMetal.LibvirtURI,
 			installConfig.Config.Platform.BareMetal.BootstrapProvisioningIP,
 			string(*rhcosBootstrapImage),
-			"baremetal",
-			"provisioning",
+			installConfig.Config.Platform.BareMetal.ExternalBridge,
+			installConfig.Config.Platform.BareMetal.ProvisioningBridge,
 			installConfig.Config.Platform.BareMetal.Hosts,
 			string(*rhcosImage),
 		)


### PR DESCRIPTION
Baremetal: get external and provision from configuration