### PR TITLE
Bug 1755073: docs/user/*/install_upi: Drop compute replicas zeroing

### DIFF
--- a/docs/user/aws/install_upi.md
+++ b/docs/user/aws/install_upi.md
@@ -18,19 +18,6 @@ $ openshift-install create install-config
 ? Pull Secret [? for help]
 ```
 
-### Empty Compute Pools
-
-We'll be providing the control-plane and compute machines ourselves, so edit the resulting `install-config.yaml` to set `replicas` to 0 for the `compute` pool:
-
-```sh
-python -c '
-import yaml;
-path = "install-config.yaml";
-data = yaml.load(open(path));
-data["compute"][0]["replicas"] = 0;
-open(path, "w").write(yaml.dump(data, default_flow_style=False))'
-```
-
 ## Edit Manifests
 
 Use [a staged install](../overview.md#multiple-invocations) to make some adjustments which are not exposed via the install configuration.

--- a/docs/user/gcp/install_upi.md
+++ b/docs/user/gcp/install_upi.md
@@ -39,19 +39,6 @@ $ openshift-install create install-config
 ? Pull Secret [? for help]
 ```
 
-### Empty the compute pool (optional)
-
-If you do not want the cluster to provision compute machines, edit the resulting `install-config.yaml` to set `replicas` to 0 for the `compute` pool.
-
-```sh
-python -c '
-import yaml;
-path = "install-config.yaml";
-data = yaml.full_load(open(path));
-data["compute"][0]["replicas"] = 0;
-open(path, "w").write(yaml.dump(data, default_flow_style=False))'
-```
-
 ### Create manifests
 
 Create manifest to enable customizations which are not exposed via the install configuration.


### PR DESCRIPTION
We grew this in c22d042fe1 (#1649) to set the stage for changing the `replicas: 0` semantics from "we'll make you some dummy MachineSets" to "we won't make you MachineSets".  But that hasn't happened yet, and since 64f96df25f (#2004) `replicas: 0` for compute has also meant "add the `worker` role to control-plane nodes".  That leads to racy problems when ingress comes through a load balancer, because Kubernetes load balancers exclude control-plane nodes from their target set (see [here][1] and kubernetes/kubernetes#65618, although this [may get relaxed soonish][3]).  If the router pods get scheduled on the control plane machines due to the `worker` role, they are not reachable from the load balancer and [ingress routing breaks][4].  @sjenning says:

> pod `nodeSelectors` are not like taints/tolerations.  They only have effect at scheduling time.  They are not continually enforced.

which means that attempting to address this issue as a day-2 operation would mean removing the `worker` role from the control-plane nodes and then manually evicting the router pods to force rescheduling.  So until we get the changes from [here][3], it's easier to just drop this section and keep the `worker` role off the control-plane machines entirely.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1671136#c1
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=1744370#c6
[4]: https://bugzilla.redhat.com/show_bug.cgi?id=1755073