### PR TITLE
GCP: Add install-config and terraform support for BYO VPC

### DIFF
--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -2,6 +2,7 @@ resource "google_dns_managed_zone" "int" {
   name       = "${var.cluster_id}-private-zone"
   dns_name   = "${var.cluster_domain}."
   visibility = "private"
+
   private_visibility_config {
     networks {
       network_url = var.network

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -38,7 +38,6 @@ module "master" {
   machine_type   = var.gcp_master_instance_type
   cluster_id     = var.cluster_id
   ignition       = var.ignition_master
-  network        = module.network.network
   subnet         = module.network.master_subnet
   zones          = distinct(var.gcp_master_availability_zones)
 
@@ -66,6 +65,11 @@ module "network" {
   bootstrap_instances = module.bootstrap.bootstrap_instances
 
   master_instances = module.master.master_instances
+
+  preexisting_network = var.gcp_preexisting_network
+  cluster_network     = var.gcp_cluster_network
+  master_subnet       = var.gcp_control_plane_subnet
+  worker_subnet       = var.gcp_compute_subnet
 }
 
 module "dns" {

--- a/data/data/gcp/master/variables.tf
+++ b/data/data/gcp/master/variables.tf
@@ -29,11 +29,6 @@ variable "machine_type" {
   description = "The machine type for the master instances."
 }
 
-variable "network" {
-  type        = string
-  description = "The network the master instances will be added to."
-}
-
 variable "subnet" {
   type        = string
   description = "The subnetwork the master instances will be added to."

--- a/data/data/gcp/network/common.tf
+++ b/data/data/gcp/network/common.tf
@@ -1,2 +1,24 @@
 # Canonical internal state definitions for this module.
 # read only: only locals and data source definitions allowed. No resources or module blocks in this file
+
+data "google_compute_network" "preexisting_cluster_network" {
+  count = var.preexisting_network ? 1 : 0
+
+  name = var.cluster_network
+}
+
+data "google_compute_subnetwork" "preexisting_master_subnet" {
+  count = var.preexisting_network ? 1 : 0
+
+  name = var.master_subnet
+}
+
+data "google_compute_subnetwork" "preexisting_worker_subnet" {
+  count = var.preexisting_network ? 1 : 0
+
+  name = var.worker_subnet
+}
+
+locals {
+  cluster_network = var.preexisting_network ? data.google_compute_network.preexisting_cluster_network[0].self_link : google_compute_network.cluster_network[0].self_link
+}

--- a/data/data/gcp/network/firewall-compute.tf
+++ b/data/data/gcp/network/firewall-compute.tf
@@ -1,6 +1,6 @@
 resource "google_compute_firewall" "worker_ingress_icmp" {
   name    = "${var.cluster_id}-worker-in-icmp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "icmp"
@@ -12,7 +12,7 @@ resource "google_compute_firewall" "worker_ingress_icmp" {
 
 resource "google_compute_firewall" "worker_ingress_ssh" {
   name    = "${var.cluster_id}-worker-in-ssh"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -25,7 +25,7 @@ resource "google_compute_firewall" "worker_ingress_ssh" {
 
 resource "google_compute_firewall" "worker_ingress_overlay" {
   name    = "${var.cluster_id}-worker-in-overlay"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   # allow VXLAN and GENEVE
   allow {
@@ -39,7 +39,7 @@ resource "google_compute_firewall" "worker_ingress_overlay" {
 
 resource "google_compute_firewall" "worker_ingress_overlay_from_master" {
   name    = "${var.cluster_id}-worker-in-overlay-from-master"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   # allow VXLAN and GENEVE
   allow {
@@ -53,7 +53,7 @@ resource "google_compute_firewall" "worker_ingress_overlay_from_master" {
 
 resource "google_compute_firewall" "worker_ingress_internal" {
   name    = "${var.cluster_id}-worker-in-internal"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -66,7 +66,7 @@ resource "google_compute_firewall" "worker_ingress_internal" {
 
 resource "google_compute_firewall" "worker_ingress_internal_from_master" {
   name    = "${var.cluster_id}-worker-in-internal-from-master"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -79,7 +79,7 @@ resource "google_compute_firewall" "worker_ingress_internal_from_master" {
 
 resource "google_compute_firewall" "worker_ingress_internal_udp" {
   name    = "${var.cluster_id}-worker-in-udp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "udp"
@@ -92,7 +92,7 @@ resource "google_compute_firewall" "worker_ingress_internal_udp" {
 
 resource "google_compute_firewall" "worker_ingress_internal_from_master_udp" {
   name    = "${var.cluster_id}-worker-in-from-master-udp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "udp"
@@ -105,7 +105,7 @@ resource "google_compute_firewall" "worker_ingress_internal_from_master_udp" {
 
 resource "google_compute_firewall" "worker_ingress_kubelet_insecure" {
   name    = "${var.cluster_id}-worker-in-kubelet-insecure"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -118,7 +118,7 @@ resource "google_compute_firewall" "worker_ingress_kubelet_insecure" {
 
 resource "google_compute_firewall" "worker_ingress_kubelet_insecure_from_master" {
   name    = "${var.cluster_id}-worker-in-kubelet-insecure-fr-mast"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -131,7 +131,7 @@ resource "google_compute_firewall" "worker_ingress_kubelet_insecure_from_master"
 
 resource "google_compute_firewall" "worker_ingress_services_tcp" {
   name    = "${var.cluster_id}-worker-in-services-tcp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -144,7 +144,7 @@ resource "google_compute_firewall" "worker_ingress_services_tcp" {
 
 resource "google_compute_firewall" "worker_ingress_services_udp" {
   name    = "${var.cluster_id}-worker-in-services-udp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "udp"

--- a/data/data/gcp/network/firewall-control.tf
+++ b/data/data/gcp/network/firewall-control.tf
@@ -1,6 +1,6 @@
 resource "google_compute_firewall" "master_ingress_icmp" {
   name    = "${var.cluster_id}-master-in-icmp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "icmp"
@@ -12,7 +12,7 @@ resource "google_compute_firewall" "master_ingress_icmp" {
 
 resource "google_compute_firewall" "master_ingress_ssh" {
   name    = "${var.cluster_id}-master-in-ssh"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -25,7 +25,7 @@ resource "google_compute_firewall" "master_ingress_ssh" {
 
 resource "google_compute_firewall" "master_ingress_https" {
   name    = "${var.cluster_id}-master-in-https"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -38,7 +38,7 @@ resource "google_compute_firewall" "master_ingress_https" {
 
 resource "google_compute_firewall" "master_ingress_from_health_checks" {
   name    = "${var.cluster_id}-master-in-from-health-checks"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -51,20 +51,20 @@ resource "google_compute_firewall" "master_ingress_from_health_checks" {
 
 resource "google_compute_firewall" "master_ingress_mcs" {
   name    = "${var.cluster_id}-master-in-mcs"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
     ports    = ["22623"]
   }
 
-  source_ranges = [var.network_cidr, google_compute_address.master_nat_ip.address, google_compute_address.worker_nat_ip.address]
+  source_ranges = var.preexisting_network ? ["0.0.0.0/0"] : [var.network_cidr, google_compute_address.master_nat_ip[0].address, google_compute_address.worker_nat_ip[0].address]
   target_tags   = ["${var.cluster_id}-master"]
 }
 
 resource "google_compute_firewall" "master_ingress_overlay" {
   name    = "${var.cluster_id}-master-in-overlay"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   # allow VXLAN and GENEVE
   allow {
@@ -78,7 +78,7 @@ resource "google_compute_firewall" "master_ingress_overlay" {
 
 resource "google_compute_firewall" "master_ingress_overlay_from_worker" {
   name    = "${var.cluster_id}-master-in-overlay-from-worker"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   # allow VXLAN and GENEVE
   allow {
@@ -92,7 +92,7 @@ resource "google_compute_firewall" "master_ingress_overlay_from_worker" {
 
 resource "google_compute_firewall" "master_ingress_internal" {
   name    = "${var.cluster_id}-master-in-internal"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -105,7 +105,7 @@ resource "google_compute_firewall" "master_ingress_internal" {
 
 resource "google_compute_firewall" "master_ingress_internal_from_worker" {
   name    = "${var.cluster_id}-master-in-internal-from-worker"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -118,7 +118,7 @@ resource "google_compute_firewall" "master_ingress_internal_from_worker" {
 
 resource "google_compute_firewall" "master_ingress_internal_udp" {
   name    = "${var.cluster_id}-master-in-internal-udp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "udp"
@@ -131,7 +131,7 @@ resource "google_compute_firewall" "master_ingress_internal_udp" {
 
 resource "google_compute_firewall" "master_ingress_internal_from_worker_udp" {
   name    = "${var.cluster_id}-master-in-internal-from-worker-udp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "udp"
@@ -144,7 +144,7 @@ resource "google_compute_firewall" "master_ingress_internal_from_worker_udp" {
 
 resource "google_compute_firewall" "master_ingress_kube_scheduler" {
   name    = "${var.cluster_id}-master-in-kube-scheduler"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -157,7 +157,7 @@ resource "google_compute_firewall" "master_ingress_kube_scheduler" {
 
 resource "google_compute_firewall" "master_ingress_kube_scheduler_from_worker" {
   name    = "${var.cluster_id}-master-in-kube-scheduler-fr-worker"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -170,7 +170,7 @@ resource "google_compute_firewall" "master_ingress_kube_scheduler_from_worker" {
 
 resource "google_compute_firewall" "master_ingress_kube_master_manager" {
   name    = "${var.cluster_id}-master-in-kube-master-manager"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -183,7 +183,7 @@ resource "google_compute_firewall" "master_ingress_kube_master_manager" {
 
 resource "google_compute_firewall" "master_ingress_kube_master_manager_from_worker" {
   name    = "${var.cluster_id}-master-in-kube-master-mgr-fr-work"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -196,7 +196,7 @@ resource "google_compute_firewall" "master_ingress_kube_master_manager_from_work
 
 resource "google_compute_firewall" "master_ingress_kubelet_secure" {
   name    = "${var.cluster_id}-master-in-kubelet-secure"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -209,7 +209,7 @@ resource "google_compute_firewall" "master_ingress_kubelet_secure" {
 
 resource "google_compute_firewall" "master_ingress_kubelet_secure_from_worker" {
   name    = "${var.cluster_id}-master-in-kubelet-secure-fr-worker"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -222,7 +222,7 @@ resource "google_compute_firewall" "master_ingress_kubelet_secure_from_worker" {
 
 resource "google_compute_firewall" "master_ingress_etcd" {
   name    = "${var.cluster_id}-master-in-etcd"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -235,7 +235,7 @@ resource "google_compute_firewall" "master_ingress_etcd" {
 
 resource "google_compute_firewall" "master_ingress_services_tcp" {
   name    = "${var.cluster_id}-master-in-services-tcp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "tcp"
@@ -248,7 +248,7 @@ resource "google_compute_firewall" "master_ingress_services_tcp" {
 
 resource "google_compute_firewall" "master_ingress_services_udp" {
   name    = "${var.cluster_id}-master-in-services-udp"
-  network = google_compute_network.cluster_network.self_link
+  network = local.cluster_network
 
   allow {
     protocol = "udp"

--- a/data/data/gcp/network/network.tf
+++ b/data/data/gcp/network/network.tf
@@ -1,58 +1,74 @@
 resource "google_compute_network" "cluster_network" {
-  name = "${var.cluster_id}-network"
+  count = var.preexisting_network ? 0 : 1
+
+  name = var.cluster_network
 
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "worker_subnet" {
-  name          = "${var.cluster_id}-worker-subnet"
-  network       = google_compute_network.cluster_network.self_link
+  count = var.preexisting_network ? 0 : 1
+
+  name          = var.worker_subnet
+  network       = google_compute_network.cluster_network[0].self_link
   ip_cidr_range = var.worker_subnet_cidr
 }
 
 resource "google_compute_subnetwork" "master_subnet" {
-  name          = "${var.cluster_id}-master-subnet"
-  network       = google_compute_network.cluster_network.self_link
+  count = var.preexisting_network ? 0 : 1
+
+  name          = var.master_subnet
+  network       = google_compute_network.cluster_network[0].self_link
   ip_cidr_range = var.master_subnet_cidr
 }
 
 resource "google_compute_router" "router" {
+  count = var.preexisting_network ? 0 : 1
+
   name    = "${var.cluster_id}-router"
-  network = google_compute_network.cluster_network.self_link
+  network = google_compute_network.cluster_network[0].self_link
 }
 
 resource "google_compute_address" "master_nat_ip" {
+  count = var.preexisting_network ? 0 : 1
+
   name = "${var.cluster_id}-master-nat-ip"
 }
 
 resource "google_compute_router_nat" "master_nat" {
+  count = var.preexisting_network ? 0 : 1
+
   name                               = "${var.cluster_id}-nat-master"
-  router                             = google_compute_router.router.name
+  router                             = google_compute_router.router[0].name
   nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = [google_compute_address.master_nat_ip.self_link]
+  nat_ips                            = [google_compute_address.master_nat_ip[0].self_link]
   min_ports_per_vm                   = 7168
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {
-    name                    = google_compute_subnetwork.master_subnet.self_link
+    name                    = google_compute_subnetwork.master_subnet[0].self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }
 
 resource "google_compute_address" "worker_nat_ip" {
+  count = var.preexisting_network ? 0 : 1
+
   name = "${var.cluster_id}-worker-nat-ip"
 }
 
 resource "google_compute_router_nat" "worker_nat" {
+  count = var.preexisting_network ? 0 : 1
+
   name                               = "${var.cluster_id}-nat-worker"
-  router                             = google_compute_router.router.name
+  router                             = google_compute_router.router[0].name
   nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = [google_compute_address.worker_nat_ip.self_link]
+  nat_ips                            = [google_compute_address.worker_nat_ip[0].self_link]
   min_ports_per_vm                   = 128
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {
-    name                    = google_compute_subnetwork.worker_subnet.self_link
+    name                    = google_compute_subnetwork.worker_subnet[0].self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }

--- a/data/data/gcp/network/outputs.tf
+++ b/data/data/gcp/network/outputs.tf
@@ -3,13 +3,13 @@ output "cluster_public_ip" {
 }
 
 output "network" {
-  value = google_compute_network.cluster_network.self_link
+  value = local.cluster_network
 }
 
 output "worker_subnet" {
-  value = google_compute_subnetwork.worker_subnet.self_link
+  value = var.preexisting_network ? data.google_compute_subnetwork.preexisting_worker_subnet[0].self_link : google_compute_subnetwork.worker_subnet[0].self_link
 }
 
 output "master_subnet" {
-  value = google_compute_subnetwork.master_subnet.self_link
+  value = var.preexisting_network ? data.google_compute_subnetwork.preexisting_master_subnet[0].self_link : google_compute_subnetwork.master_subnet[0].self_link
 }

--- a/data/data/gcp/network/variables.tf
+++ b/data/data/gcp/network/variables.tf
@@ -29,3 +29,20 @@ variable "network_cidr" {
 variable "worker_subnet_cidr" {
   type = string
 }
+
+variable "cluster_network" {
+  type = string
+}
+
+variable "master_subnet" {
+  type = string
+}
+
+variable "worker_subnet" {
+  type = string
+}
+
+variable "preexisting_network" {
+  type    = bool
+  default = false
+}

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -64,3 +64,26 @@ variable "gcp_master_availability_zones" {
   type = list(string)
   description = "The availability zones in which to create the masters. The length of this list must match master_count."
 }
+
+variable "gcp_preexisting_network" {
+  type = bool
+  default = false
+  description = "Specifies whether an existing network should be used or a new one created for installation."
+}
+
+variable "gcp_cluster_network" {
+  type = string
+  description = "The name of the cluster network, either existing or to be created."
+}
+
+variable "gcp_control_plane_subnet" {
+  type = string
+  description = "The name of the subnet for the control plane, either existing or to be created."
+}
+
+variable "gcp_compute_subnet" {
+  type = string
+  description = "The name of the subnet for worker nodes, either existing or to be created"
+}
+
+

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -108,7 +109,11 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 		}
 		cm.Data[cloudProviderConfigDataKey] = azureConfig
 	case gcptypes.Name:
-		gcpConfig, err := gcpmanifests.CloudProviderConfig(clusterID.InfraID, installConfig.Config.GCP.ProjectID)
+		subnet := fmt.Sprintf("%s-worker-subnet", clusterID.InfraID)
+		if installConfig.Config.GCP.ComputeSubnet != "" {
+			subnet = installConfig.Config.GCP.ComputeSubnet
+		}
+		gcpConfig, err := gcpmanifests.CloudProviderConfig(clusterID.InfraID, installConfig.Config.GCP.ProjectID, subnet)
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")
 		}

--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -25,7 +25,7 @@ type global struct {
 }
 
 // CloudProviderConfig generates the cloud provider config for the GCP platform.
-func CloudProviderConfig(infraID, projectID string) (string, error) {
+func CloudProviderConfig(infraID, projectID, subnet string) (string, error) {
 	file := ini.Empty()
 	config := &config{
 		Global: global{
@@ -39,7 +39,7 @@ func CloudProviderConfig(infraID, projectID string) (string, error) {
 			NodeTags: []string{fmt.Sprintf("%s-worker", infraID)},
 
 			// Used for internal load balancers
-			SubnetworkName: fmt.Sprintf("%s-worker-subnet", infraID),
+			SubnetworkName: subnet,
 		},
 	}
 	if err := file.ReflectFrom(config); err != nil {

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -15,7 +15,7 @@ node-tags       = uid-worker
 subnetwork-name = uid-worker-subnet
 
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id")
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -14,4 +14,19 @@ type Platform struct {
 	// platform configuration.
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// Network specifies an existing VPC where the cluster should be created
+	// rather than provisioning a new one.
+	// +optional
+	Network string `json:"network,omitempty"`
+
+	// ControlPlaneSubnet is an existing subnet where the control plane will be deployed.
+	// The value should be the name of the subnet.
+	// +optional
+	ControlPlaneSubnet string `json:"controlPlaneSubnet,omitempty"`
+
+	// ComputeSubnet is an existing subnet where the compute nodes will be deployed.
+	// The value should be the name of the subnet.
+	// +optional
+	ComputeSubnet string `json:"computeSubnet,omitempty"`
 }


### PR DESCRIPTION
JIRA: [CORS-1213](https://jira.coreos.com/browse/CORS-1213)

This is the basic setup for installing to an existing VPC on GCP: users can specify their own VPC and subnets in install config and terraform will perform the installation. There is currently no validation. This is tested and installs the cluster successfully. 

The easiest way to create your own VPC, router, etc is to follow step [Create the VPC from the UPI docs](https://github.com/openshift/installer/blob/master/docs/user/gcp/install_upi.md#create-the-vpc).

This differs from the design doc in that I did add `VPC.name` to the install config (rather than just the subnets). I believe it is necessary to have the cluster network in order to create the firewall rules and to make sure the network is using the private DNS zone. 

I handled conditional creation of resources in Terraform through `count` and ternary operators e.g. `  count = var.preexisting_cluster_network == "" ? 1: 0`. The result is not as bad as I would have thought but let me know if there is a better way of handling all of this. 