### PR TITLE
data/aws/vpc: Restrict ICMP ingress to our security groups

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -33,14 +33,14 @@ resource "aws_security_group_rule" "master_egress" {
   cidr_blocks = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "master_ingress_icmp" {
-  type              = "ingress"
-  security_group_id = aws_security_group.master.id
+resource "aws_security_group_rule" "master_ingress_icmp_from_worker" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
 
-  protocol    = "icmp"
-  cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
-  from_port   = -1
-  to_port     = -1
+  protocol  = "icmp"
+  from_port = -1
+  to_port   = -1
 }
 
 resource "aws_security_group_rule" "master_ingress_ssh" {

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -23,14 +23,14 @@ resource "aws_security_group_rule" "worker_egress" {
   cidr_blocks = ["0.0.0.0/0"]
 }
 
-resource "aws_security_group_rule" "worker_ingress_icmp" {
-  type              = "ingress"
-  security_group_id = aws_security_group.worker.id
+resource "aws_security_group_rule" "worker_ingress_icmp_from_master" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.worker.id
+  source_security_group_id = aws_security_group.master.id
 
-  protocol    = "icmp"
-  cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
-  from_port   = -1
-  to_port     = -1
+  protocol  = "icmp"
+  from_port = -1
+  to_port   = -1
 }
 
 resource "aws_security_group_rule" "worker_ingress_ssh" {

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -51,10 +51,6 @@ Resources:
     Properties:
       GroupDescription: Cluster Master Security Group
       SecurityGroupIngress:
-      - IpProtocol: icmp
-        FromPort: 0
-        ToPort: 0
-        CidrIp: !Ref VpcCidr
       - IpProtocol: tcp
         FromPort: 22
         ToPort: 22
@@ -83,6 +79,16 @@ Resources:
         ToPort: 22
         CidrIp: !Ref VpcCidr
       VpcId: !Ref VpcId
+
+  MasterIngressICMP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: ICMP from workers
+      FromPort: -1
+      ToPort: -1
+      IpProtocol: icmp
 
   MasterIngressEtcd:
     Type: AWS::EC2::SecurityGroupIngress
@@ -193,6 +199,16 @@ Resources:
       FromPort: 30000
       ToPort: 32767
       IpProtocol: tcp
+
+  WorkerIngressICMP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: ICMP from masters
+      FromPort: -1
+      ToPort: -1
+      IpProtocol: icmp
 
   WorkerIngressVxlan:
     Type: AWS::EC2::SecurityGroupIngress


### PR DESCRIPTION
And in the UPI CloudFormation templates too.

We've allowed ICMP ingress for OpenStack since 6f76298e3c (coreos/tectonic-installer#1), which did not motivate the ICMP ingress.  Allowing ICMP ingress for AWS dates back to b620c16f0a (coreos/tectonic-installer#264).  The master rule was restricted to the VPC in e7bd29a849 (coreos/tectonic-installer#2147).  And the worker rules was restricted to the VPC in e131a74829 (#1550) in-cluster ICMP ingress.

There are [reasons][1] to allow in-cluster ICMP, including [Path MTU][2] [Discovery][3] (PMTUD).  Folks also use ping to [troubleshoot connectivity][4].  Restricting this to in-cluster security groups will avoid exposing ICMP ports to siblings living in shared VPCs, as we move towards allowing the installer to launch clusters in a pre-existing VPC.  It might also block ICMP ingress from our load balancers, where we probably want PMTUD and possibly other ICMP calls.  I'm not sure if there's a convenient way to allow access from the load-balancers while excluding it from sibling clusters that share the same VPC, but this commit is my attempt to get that.

CC @cuppett, @squeed

[1]: http://shouldiblockicmp.com/
[2]: https://tools.ietf.org/html/rfc1191
[3]: https://tools.ietf.org/html/rfc8201
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1689857#c2