### PR TITLE
openstack:  add note about compressed image format

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -97,7 +97,19 @@ Etcd is run on your control plane nodes, and it has disk requirements that need 
 
 ### Red Hat Enterprise Linux CoreOS (RHCOS)
 
-Get the latest RHCOS image [here](https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/). The installer requires a proper RHCOS image in the OpenStack cluster or project:
+Get the latest RHCOS image [here](https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/latest/).
+
+**NOTE:** The OpenStack QCOW2 image is delivered in compressed format.  You will need to provide the necessary options to `curl` or `wget` when downloading the image, otherwise your image may appear corrupted.
+
+For example:
+
+```sh
+curl --compressed -J -L -O <url of OpenStack QCOW2>
+
+wget --compresion=auto <url of OpenStack QCOW2>
+```
+
+The installer requires a proper RHCOS image in the OpenStack cluster or project:
 
 ```sh
 openstack image create --container-format=bare --disk-format=qcow2 --file rhcos-${RHCOSVERSION}-openstack.qcow2 rhcos


### PR DESCRIPTION
The OpenStack QCOW2 is delivered in compressed format and needs to be
retrieved with the proper options for it to be usable.

See https://bugzilla.redhat.com/show_bug.cgi?id=1755506 for additional
info.