### PR TITLE
asset/releaseimage/default.go: bump to 4.3 release image

### DIFF
--- a/pkg/asset/releaseimage/default.go
+++ b/pkg/asset/releaseimage/default.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:4.2"
+	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:4.3"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
since master now tracks 4.3, bumping the master release-image to use 4.3

/cc @wking @smarterclayton 