### PR TITLE
gcp upi: allow nodePort between masters and workers 

### DIFF
--- a/upi/gcp/03_security.py
+++ b/upi/gcp/03_security.py
@@ -104,6 +104,12 @@ def GenerateConfig(context):
             },{
                 'IPProtocol': 'tcp',
                 'ports': ['10250']
+            },{
+                'IPProtocol': 'tcp',
+                'ports': ['30000-32767']
+            },{
+                'IPProtocol': 'udp',
+                'ports': ['30000-32767']
             }],
             'sourceTags': [
                 context.properties['infra_id'] + '-master',
@@ -113,36 +119,6 @@ def GenerateConfig(context):
                 context.properties['infra_id'] + '-master',
                 context.properties['infra_id'] + '-worker'
             ]
-        }
-    }, {
-        'name': context.properties['infra_id'] + '-internal-services-master',
-        'type': 'compute.v1.firewall',
-        'properties': {
-            'network': context.properties['cluster_network'],
-            'allowed': [{
-                'IPProtocol': 'tcp',
-                'ports': ['30000-32767']
-            },{
-                'IPProtocol': 'udp',
-                'ports': ['30000-32767']
-            }],
-            'sourceTags': [context.properties['infra_id'] + '-master'],
-            'targetTags': [context.properties['infra_id'] + '-master']
-        }
-    }, {
-        'name': context.properties['infra_id'] + '-internal-services-worker',
-        'type': 'compute.v1.firewall',
-        'properties': {
-            'network': context.properties['cluster_network'],
-            'allowed': [{
-                'IPProtocol': 'tcp',
-                'ports': ['30000-32767']
-            },{
-                'IPProtocol': 'udp',
-                'ports': ['30000-32767']
-            }],
-            'sourceTags': [context.properties['infra_id'] + '-worker'],
-            'targetTags': [context.properties['infra_id'] + '-worker']
         }
     }, {
         'name': context.properties['infra_id'] + '-master-node-sa',


### PR DESCRIPTION
Before this change, the gcp upi firewall rules limited access to the
nodePort ports from worker to worker and master to master. Access
between worker and master was denied. However, because gcp upi produces
masters that have the 'worker' role, the nodePort services could run on
masters and need to be accessed from pods on other workers. Or pods on
masters might need access to nodePort services on workers.

This change modifies the gcp upi firewall rules to allow the nodePort
services across the entire cluster.

Depends on #2419