### PR TITLE
Fix AWS storage size validation error message

### DIFF
--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -22,7 +22,7 @@ func ValidateMachinePool(platform *aws.Platform, p *aws.MachinePool, fldPath *fi
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("iops"), p.IOPS, "Storage IOPS must be positive"))
 	}
 	if p.Size < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("size"), p.IOPS, "Storage size must be positive"))
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("size"), p.Size, "Storage size must be positive"))
 	}
 	return allErrs
 }

--- a/pkg/types/aws/validation/machinepool_test.go
+++ b/pkg/types/aws/validation/machinepool_test.go
@@ -65,7 +65,7 @@ func TestValidateMachinePool(t *testing.T) {
 					Size: -10,
 				},
 			},
-			expected: `^test-path\.size: Invalid value: 0: Storage size must be positive$`,
+			expected: `^test-path\.size: Invalid value: -10: Storage size must be positive$`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
The value printed in the error message was the one for storage IOPS
instead of storage size.