### PR TITLE
data/aws/vpc/common: Drop unused (private|public)_subnet_count variables

### DIFF
--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -9,11 +9,8 @@ locals {
   // The VPC ID to use to build the rest of the vpc data sources
   vpc_id = aws_vpc.new_vpc.id
 
-  // When referencing the _ids arrays or data source arrays via count = , always use the *_count variable rather than taking the length of the list
-  private_subnet_ids   = aws_subnet.private_subnet.*.id
-  public_subnet_ids    = aws_subnet.public_subnet.*.id
-  private_subnet_count = local.new_az_count
-  public_subnet_count  = local.new_az_count
+  private_subnet_ids = aws_subnet.private_subnet.*.id
+  public_subnet_ids  = aws_subnet.public_subnet.*.id
 }
 
 # all data sources should be input variable-agnostic and used as canonical source for querying "state of resources" and building outputs


### PR DESCRIPTION
The final consumers were removed in c80edadeb5 (#769).