### PR TITLE
Bug 1791400: cmd/openshift-install/destroy: Remove terraform.tfstate in 'destroy cluster'

### DIFF
--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -16,6 +19,7 @@ import (
 	_ "github.com/openshift/installer/pkg/destroy/openstack"
 	_ "github.com/openshift/installer/pkg/destroy/ovirt"
 	_ "github.com/openshift/installer/pkg/destroy/vsphere"
+	"github.com/openshift/installer/pkg/terraform"
 )
 
 func newDestroyCmd() *cobra.Command {
@@ -71,6 +75,12 @@ func runDestroyCmd(directory string) error {
 	err = store.DestroyState()
 	if err != nil {
 		return errors.Wrap(err, "failed to remove state file")
+	}
+
+	tfStateFilePath := filepath.Join(directory, terraform.StateFileName)
+	err = os.Remove(tfStateFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "failed to remove Terraform state")
 	}
 
 	return nil


### PR DESCRIPTION
So `destroy cluster` gets you all the way back to a clean slate, even if the cluster in question died during infrastructure provisioning (leaking mentioned [here][1] and [here][2]).

This will obviously not clean up the original asset directory in workflows where the user copies their `metadata.json` over into a new directory and runs `destroy cluster` in the new directory.  But since we have existing asset-state removal code that also behaves that way, I don't think it's a big deal.

`cmd/openshift-install/destroy.go` is a convenient place to put this now, when all of our providers are Terraform-based.  If, in the future, we move some providers off of Terraform (or add new, non-Terraform providers), we can push this down into the platform-specific destroyers.  We could also leave it here, because `terraform.tfstate` is unlikely to exist in the asset directory for non-Terraform providers and be something that the user wants to keep around, so the risk of false-positive removal is low.

[1]: https://github.com/openshift/installer/issues/2426#issue-499574040
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1662813