### PR TITLE
Bug 1750494: Use standard field validation in pkg/types/conversion/

### DIFF
--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -1,9 +1,12 @@
 package conversion
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
-	"github.com/pkg/errors"
 )
 
 // ConvertInstallConfig is modeled after the k8s conversion schemes, which is
@@ -16,9 +19,9 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 	case types.InstallConfigVersion, "v1beta3", "v1beta4":
 		// works
 	case "":
-		return errors.Errorf("no version was provided")
+		return field.Required(field.NewPath("apiVersion"), "no version was provided")
 	default:
-		return errors.Errorf("cannot upconvert from version %s", config.APIVersion)
+		return field.Invalid(field.NewPath("apiVersion"), config.APIVersion, fmt.Sprintf("cannot upconvert from version %s", config.APIVersion))
 	}
 	ConvertNetworking(config)
 


### PR DESCRIPTION
Install config validation uses k8s apimachinery validation. This commit updates pkg/types/conversion/ to use the same package in order to provide more context when field validation fails. 

Users were complaining about error messages that looked like this:
`FATAL failed to fetch Master Machines: failed to load asset "Install Config": failed to upconvert install config: cannot upconvert from version vi1`

The new error messages include the field that failed validation and the bad value:
`FATAL failed to fetch Master Machines: failed to load asset "Install Config": failed to upconvert install config: apiVersion: Invalid value: "vi1": cannot upconvert from version vi1`

