### PR TITLE
data/bootstrap/files/usr/local/bin/installer-masters-gather: Gather MCD logs

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -5,7 +5,7 @@ mkdir -p "${ARTIFACTS}"
 
 echo "Gathering master journals ..."
 mkdir -p "${ARTIFACTS}/journals"
-for service in kubelet crio
+for service in kubelet crio machine-config-daemon-host pivot
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
 done


### PR DESCRIPTION
The machine-config daemon usually runs in a Pod, and that's already being gathered.  But pivots happen via [the systemd service][1] I'm gathering with this commit.  Also attempt to gather `pivot.service`, which takes precedence as described [here][1].

[1]: https://github.com/openshift/machine-config-operator/blob/ead45a28a7df3bb89f4d18d34982b875df82aadd/templates/common/_base/units/machine-config-daemon-host.service