### PR TITLE
data/aws/vpc: Drop new_az_count and vpc_id locals

### DIFF
--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -3,12 +3,6 @@
 
 // Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
 locals {
-  // How many AZs to create subnets in
-  new_az_count = length(var.availability_zones)
-
-  // The VPC ID to use to build the rest of the vpc data sources
-  vpc_id = aws_vpc.new_vpc.id
-
   private_subnet_ids = aws_subnet.private_subnet.*.id
   public_subnet_ids  = aws_subnet.public_subnet.*.id
 }
@@ -17,6 +11,6 @@ locals {
 # (ie: we don't want "aws.new_vpc" and "data.aws_vpc.cluster_vpc", just "data.aws_vpc.cluster_vpc" used everwhere).
 
 data "aws_vpc" "cluster_vpc" {
-  id = local.vpc_id
+  id = aws_vpc.new_vpc.id
 }
 

--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -46,7 +46,7 @@ resource "aws_lb_target_group" "api_internal" {
   name     = "${var.cluster_id}-aint"
   protocol = "TCP"
   port     = 6443
-  vpc_id   = local.vpc_id
+  vpc_id   = data.aws_vpc.cluster_vpc.id
 
   target_type = "ip"
 
@@ -71,7 +71,7 @@ resource "aws_lb_target_group" "api_external" {
   name     = "${var.cluster_id}-aext"
   protocol = "TCP"
   port     = 6443
-  vpc_id   = local.vpc_id
+  vpc_id   = data.aws_vpc.cluster_vpc.id
 
   target_type = "ip"
 
@@ -96,7 +96,7 @@ resource "aws_lb_target_group" "services" {
   name     = "${var.cluster_id}-sint"
   protocol = "TCP"
   port     = 22623
-  vpc_id   = local.vpc_id
+  vpc_id   = data.aws_vpc.cluster_vpc.id
 
   target_type = "ip"
 

--- a/data/data/aws/vpc/vpc-private.tf
+++ b/data/data/aws/vpc/vpc-private.tf
@@ -1,5 +1,5 @@
 resource "aws_route_table" "private_routes" {
-  count  = local.new_az_count
+  count  = length(var.availability_zones)
   vpc_id = data.aws_vpc.cluster_vpc.id
 
   tags = merge(
@@ -11,7 +11,7 @@ resource "aws_route_table" "private_routes" {
 }
 
 resource "aws_route" "to_nat_gw" {
-  count                  = local.new_az_count
+  count                  = length(var.availability_zones)
   route_table_id         = aws_route_table.private_routes[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = element(aws_nat_gateway.nat_gw.*.id, count.index)
@@ -23,7 +23,7 @@ resource "aws_route" "to_nat_gw" {
 }
 
 resource "aws_subnet" "private_subnet" {
-  count = local.new_az_count
+  count = length(var.availability_zones)
 
   vpc_id = data.aws_vpc.cluster_vpc.id
 
@@ -41,7 +41,7 @@ resource "aws_subnet" "private_subnet" {
 }
 
 resource "aws_route_table_association" "private_routing" {
-  count          = local.new_az_count
+  count          = length(var.availability_zones)
   route_table_id = aws_route_table.private_routes[count.index].id
   subnet_id      = aws_subnet.private_subnet[count.index].id
 }

--- a/data/data/aws/vpc/vpc-public.tf
+++ b/data/data/aws/vpc/vpc-public.tf
@@ -36,7 +36,7 @@ resource "aws_route" "igw_route" {
 }
 
 resource "aws_subnet" "public_subnet" {
-  count  = local.new_az_count
+  count  = length(var.availability_zones)
   vpc_id = data.aws_vpc.cluster_vpc.id
 
   cidr_block = cidrsubnet(local.new_public_cidr_range, 3, count.index)
@@ -52,13 +52,13 @@ resource "aws_subnet" "public_subnet" {
 }
 
 resource "aws_route_table_association" "route_net" {
-  count          = local.new_az_count
+  count          = length(var.availability_zones)
   route_table_id = aws_route_table.default.id
   subnet_id      = aws_subnet.public_subnet[count.index].id
 }
 
 resource "aws_eip" "nat_eip" {
-  count = local.new_az_count
+  count = length(var.availability_zones)
   vpc   = true
 
   tags = merge(
@@ -75,7 +75,7 @@ resource "aws_eip" "nat_eip" {
 }
 
 resource "aws_nat_gateway" "nat_gw" {
-  count         = local.new_az_count
+  count         = length(var.availability_zones)
   allocation_id = aws_eip.nat_eip[count.index].id
   subnet_id     = aws_subnet.public_subnet[count.index].id
 


### PR DESCRIPTION
Builds on #2432; no need to review until that one lands.

The zone-count variables date back to f828666224 (coreos/tectonic-installer#3092).  But with Terraform 0.12, which we've used since 64c44cde21 (#1739), we have better array handling, and no longer need count
variables.

Similarly, there's no need for `vpc_id`, when we can extract that ID from `data.aws_vpc.cluster_vpc`.