### PR TITLE
Remove quotes from installer log.

### DIFF
--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -194,7 +194,7 @@ func (s *storeImpl) saveStateFile() error {
 // necessary, and returns whether or not the asset had to be regenerated and
 // any errors.
 func (s *storeImpl) fetch(a asset.Asset, indent string) error {
-	logrus.Debugf("%sFetching %q...", indent, a.Name())
+	logrus.Debugf("%sFetching %s...", indent, a.Name())
 
 	assetState, ok := s.assets[reflect.TypeOf(a)]
 	if !ok {
@@ -209,7 +209,7 @@ func (s *storeImpl) fetch(a asset.Asset, indent string) error {
 	// that we always fetch the parent before children, so we don't need
 	// to worry about invalidating anything in the cache.
 	if assetState.source != unfetched {
-		logrus.Debugf("%sReusing previously-fetched %q", indent, a.Name())
+		logrus.Debugf("%sReusing previously-fetched %s", indent, a.Name())
 		reflect.ValueOf(a).Elem().Set(reflect.ValueOf(assetState.asset).Elem())
 		return nil
 	}
@@ -223,7 +223,7 @@ func (s *storeImpl) fetch(a asset.Asset, indent string) error {
 		}
 		parents.Add(d)
 	}
-	logrus.Debugf("%sGenerating %q...", indent, a.Name())
+	logrus.Debugf("%sGenerating %s...", indent, a.Name())
 	if err := a.Generate(parents); err != nil {
 		return errors.Wrapf(err, "failed to generate asset %q", a.Name())
 	}
@@ -234,7 +234,7 @@ func (s *storeImpl) fetch(a asset.Asset, indent string) error {
 
 // load loads the asset and all of its ancestors from on-disk and the state file.
 func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
-	logrus.Debugf("%sLoading %q...", indent, a.Name())
+	logrus.Debugf("%sLoading %s...", indent, a.Name())
 
 	// Stop descent if the asset has already been loaded.
 	if state, ok := s.assets[reflect.TypeOf(a)]; ok {
@@ -285,13 +285,13 @@ func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
 		}
 
 		if foundOnDisk && foundInStateFile {
-			logrus.Debugf("%sLoading %q from both state file and target directory", indent, a.Name())
+			logrus.Debugf("%sLoading %s from both state file and target directory", indent, a.Name())
 
 			// If the on-disk asset is the same as the one in the state file, there
 			// is no need to consider the one on disk and to mark the asset dirty.
 			onDiskMatchesStateFile = reflect.DeepEqual(onDiskAsset, stateFileAsset)
 			if onDiskMatchesStateFile {
-				logrus.Debugf("%sOn-disk %q matches asset in state file", indent, a.Name())
+				logrus.Debugf("%sOn-disk %s matches asset in state file", indent, a.Name())
 			}
 		}
 	}
@@ -304,18 +304,18 @@ func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
 	// A parent is dirty. The asset must be re-generated.
 	case anyParentsDirty:
 		if foundOnDisk {
-			logrus.Warningf("%sDiscarding the %q that was provided in the target directory because its dependencies are dirty and it needs to be regenerated", indent, a.Name())
+			logrus.Warningf("%sDiscarding the %s that was provided in the target directory because its dependencies are dirty and it needs to be regenerated", indent, a.Name())
 		}
 		source = unfetched
 	// The asset is on disk and that differs from what is in the source file.
 	// The asset is sourced from on disk.
 	case foundOnDisk && !onDiskMatchesStateFile:
-		logrus.Debugf("%sUsing %q loaded from target directory", indent, a.Name())
+		logrus.Debugf("%sUsing %s loaded from target directory", indent, a.Name())
 		assetToStore = onDiskAsset
 		source = onDiskSource
 	// The asset is in the state file. The asset is sourced from state file.
 	case foundInStateFile:
-		logrus.Debugf("%sUsing %q loaded from state file", indent, a.Name())
+		logrus.Debugf("%sUsing %s loaded from state file", indent, a.Name())
 		assetToStore = stateFileAsset
 		source = stateFileSource
 	// There is no existing source for the asset. The asset will be generated.
@@ -345,7 +345,7 @@ func (s *storeImpl) purge(excluded []asset.WritableAsset) error {
 		if !assetState.presentOnDisk || excl[reflect.TypeOf(assetState.asset)] {
 			continue
 		}
-		logrus.Infof("Consuming %q from target directory", assetState.asset.Name())
+		logrus.Infof("Consuming %s from target directory", assetState.asset.Name())
 		if err := asset.DeleteAssetFromDisk(assetState.asset.(asset.WritableAsset), s.directory); err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR changes asset fetching/generating logging to not output quotes. We currently use the %q string fmt verb when logging asset fetching/generating. I don't think this is a technical (or security) requirement. This results in extra " characters in log output, e.g.:

```
DEBUG   Using "Certificate (system:kube-apiserver-proxy)" loaded from state file 
DEBUG   Loading "Certificate (aggregator-signer)"... 
DEBUG   Loading "Certificate (system:kube-apiserver-proxy)"... 
DEBUG     Loading "Certificate (aggregator)"...    
DEBUG   Using "Certificate (system:kube-apiserver-proxy)" loaded from state file 
DEBUG   Loading "Certificate (etcd-ca-bundle)"...  
DEBUG   Loading "Certificate (etcd-metric-ca-bundle)"... 
DEBUG   Loading "Certificate (etcd-metric-signer)"... 
DEBUG   Loading "Certificate (etcd-metric-signer-client)"... 
DEBUG   Loading "Certificate (etcd-signer)"...     
DEBUG   Loading "Certificate (etcd-client)"...     
DEBUG   Loading "Certificate (journal-gatewayd)"... 
DEBUG     Loading "Root CA"...                     
DEBUG   Using "Certificate (journal-gatewayd)" loaded from state file 
DEBUG   Loading "Certificate (kube-apiserver-lb-ca-bundle)"... 
DEBUG   Loading "Certificate (kube-apiserver-external-lb-server)"... 
DEBUG     Loading "Certificate (kube-apiserver-lb-signer)"... 
DEBUG     Loading "Install Config"...              
DEBUG   Using "Certificate (kube-apiserver-external-lb-server)" loaded from state file 
DEBUG   Loading "Certificate (kube-apiserver-internal-lb-server)"... 
DEBUG     Loading "Certificate (kube-apiserver-lb-signer)"... 
DEBUG     Loading "Install Config"...              
```

vs without quotes: 

```
DEBUG   Using Certificate (system:kube-apiserver-proxy) loaded from state file 
DEBUG   Loading Certificate (etcd-ca-bundle)...    
DEBUG   Loading Certificate (etcd-metric-ca-bundle)... 
DEBUG   Loading Certificate (etcd-metric-signer)... 
DEBUG   Loading Certificate (etcd-metric-signer-client)... 
DEBUG   Loading Certificate (etcd-signer)...       
DEBUG   Loading Certificate (etcd-client)...       
DEBUG   Loading Certificate (journal-gatewayd)...  
DEBUG     Loading Root CA...                       
DEBUG   Using Certificate (journal-gatewayd) loaded from state file 
DEBUG   Loading Certificate (kube-apiserver-lb-ca-bundle)... 
DEBUG   Loading Certificate (kube-apiserver-external-lb-server)... 
DEBUG     Loading Certificate (kube-apiserver-lb-signer)... 
DEBUG     Loading Install Config...                
DEBUG   Using Certificate (kube-apiserver-external-lb-server) loaded from state file 
DEBUG   Loading Certificate (kube-apiserver-internal-lb-server)... 
DEBUG     Loading Certificate (kube-apiserver-lb-signer)... 
DEBUG     Loading Install Config...         
```

Even more noticeable is that CI logs escape the quotes, e.g.:

```
time="2019-09-30T19:57:22Z" level=debug msg="Reusing previously-fetched \"Certificate (journal-gatewayd)\""
time="2019-09-30T19:57:22Z" level=debug msg="Fetching \"Metadata\"..."
time="2019-09-30T19:57:22Z" level=debug msg="Loading \"Metadata\"..."
time="2019-09-30T19:57:22Z" level=debug msg="  Loading \"Cluster ID\"..."
time="2019-09-30T19:57:22Z" level=debug msg="  Loading \"Install Config\"..."
time="2019-09-30T19:57:22Z" level=debug msg="  Fetching \"Cluster ID\"..."
time="2019-09-30T19:57:22Z" level=debug msg="  Reusing previously-fetched \"Cluster ID\""
time="2019-09-30T19:57:22Z" level=debug msg="  Fetching \"Install Config\"..."
time="2019-09-30T19:57:22Z" level=debug msg="  Reusing previously-fetched \"Install Config\""
time="2019-09-30T19:57:22Z" level=debug msg="Generating \"Metadata\"..."
time="2019-09-30T19:57:23Z" level=debug msg="Fetching \"Cluster\"..."
```
vs without quotes from the logs of this PR's CI run:

```
time="2019-10-01T15:01:22Z" level=debug msg="Reusing previously-fetched Certificate (journal-gatewayd)"
time="2019-10-01T15:01:22Z" level=debug msg="Fetching Metadata..."
time="2019-10-01T15:01:22Z" level=debug msg="Loading Metadata..."
time="2019-10-01T15:01:22Z" level=debug msg="  Loading Cluster ID..."
time="2019-10-01T15:01:22Z" level=debug msg="  Loading Install Config..."
time="2019-10-01T15:01:22Z" level=debug msg="  Fetching Cluster ID..."
time="2019-10-01T15:01:22Z" level=debug msg="  Reusing previously-fetched Cluster ID"
time="2019-10-01T15:01:22Z" level=debug msg="  Fetching Install Config..."
time="2019-10-01T15:01:22Z" level=debug msg="  Reusing previously-fetched Install Config"
time="2019-10-01T15:01:22Z" level=debug msg="Generating Metadata..."
```