### PR TITLE
Azure: Allow customer provisioned virtual networks & subnets

### DIFF
--- a/data/data/azure/dns/dns.tf
+++ b/data/data/azure/dns/dns.tf
@@ -12,7 +12,7 @@ resource "azureprivatedns_zone_virtual_network_link" "network" {
   name                  = "${var.cluster_id}-network-link"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azureprivatedns_zone.private.name
-  virtual_network_id    = var.virtual_network
+  virtual_network_id    = var.virtual_network_id
 }
 
 resource "azureprivatedns_a_record" "apiint_internal" {

--- a/data/data/azure/dns/variables.tf
+++ b/data/data/azure/dns/variables.tf
@@ -34,7 +34,7 @@ variable "internal_lb_ipaddress" {
   type        = string
 }
 
-variable "virtual_network" {
+variable "virtual_network_id" {
   description = "The ID for Virtual Network that will be linked to the Private DNS zone."
   type        = string
 }
@@ -54,4 +54,3 @@ variable "resource_group_name" {
   type        = string
   description = "Resource group for the deployment"
 }
-

--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -5,7 +5,8 @@ locals {
 }
 
 resource "azurerm_network_interface" "master" {
-  count               = var.instance_count
+  count = var.instance_count
+
   name                = "${var.cluster_id}-master${count.index}-nic"
   location            = var.region
   resource_group_name = var.resource_group_name

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -76,8 +76,33 @@ variable "azure_tenant_id" {
   description = "The tenant ID that should be used to interact with Azure API"
 }
 
-
 variable "azure_master_availability_zones" {
   type        = list(string)
   description = "The availability zones in which to create the masters. The length of this list must match master_count."
+}
+
+variable "azure_preexisting_network" {
+  type        = bool
+  default     = false
+  description = "Specifies whether an existing network should be used or a new one created for installation."
+}
+
+variable "azure_network_resource_group_name" {
+  type        = string
+  description = "The name of the network resource group, either existing or to be created."
+}
+
+variable "azure_virtual_network" {
+  type        = string
+  description = "The name of the virtual network, either existing or to be created."
+}
+
+variable "azure_control_plane_subnet" {
+  type        = string
+  description = "The name of the subnet for the control plane, either existing or to be created."
+}
+
+variable "azure_compute_subnet" {
+  type        = string
+  description = "The name of the subnet for worker nodes, either existing or to be created"
 }

--- a/data/data/azure/vnet/common.tf
+++ b/data/data/azure/vnet/common.tf
@@ -1,13 +1,37 @@
 # Canonical internal state definitions for this module.
 # read only: only locals and data source definitions allowed. No resources or module blocks in this file
 
+data "azurerm_subnet" "preexisting_master_subnet" {
+  count = var.preexisting_network ? 1 : 0
+
+  resource_group_name  = var.network_resource_group_name
+  virtual_network_name = var.virtual_network_name
+  name                 = var.master_subnet
+}
+
+data "azurerm_subnet" "preexisting_worker_subnet" {
+  count = var.preexisting_network ? 1 : 0
+
+  resource_group_name  = var.network_resource_group_name
+  virtual_network_name = var.virtual_network_name
+  name                 = var.worker_subnet
+}
+
+data "azurerm_virtual_network" "preexisting_virtual_network" {
+  count = var.preexisting_network ? 1 : 0
+
+  resource_group_name = var.network_resource_group_name
+  name                = var.virtual_network_name
+}
+
 // Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
 locals {
   master_subnet_cidr = cidrsubnet(var.vnet_cidr, 3, 0) #master subnet is a smaller subnet within the vnet. i.e from /21 to /24
-  node_subnet_cidr   = cidrsubnet(var.vnet_cidr, 3, 1) #node subnet is a smaller subnet within the vnet. i.e from /21 to /24
-}
+  worker_subnet_cidr = cidrsubnet(var.vnet_cidr, 3, 1) #node subnet is a smaller subnet within the vnet. i.e from /21 to /24
 
-data "azurerm_virtual_network" "cluster_vnet" {
-  name                = azurerm_virtual_network.cluster_vnet.name
-  resource_group_name = var.resource_group_name
+  master_subnet_id = var.preexisting_network ? data.azurerm_subnet.preexisting_master_subnet[0].id : azurerm_subnet.master_subnet[0].id
+  worker_subnet_id = var.preexisting_network ? data.azurerm_subnet.preexisting_worker_subnet[0].id : azurerm_subnet.worker_subnet[0].id
+
+  virtual_network    = var.preexisting_network ? data.azurerm_virtual_network.preexisting_virtual_network[0].name : azurerm_virtual_network.cluster_vnet[0].name
+  virtual_network_id = var.preexisting_network ? data.azurerm_virtual_network.preexisting_virtual_network[0].id : azurerm_virtual_network.cluster_vnet[0].id
 }

--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -10,7 +10,7 @@ resource "azurerm_lb" "internal" {
 
   frontend_ip_configuration {
     name                          = local.internal_lb_frontend_ip_configuration_name
-    subnet_id                     = azurerm_subnet.master_subnet.id
+    subnet_id                     = local.master_subnet_id
     private_ip_address_allocation = "Dynamic"
   }
 }

--- a/data/data/azure/vnet/nsg.tf
+++ b/data/data/azure/vnet/nsg.tf
@@ -5,7 +5,9 @@ resource "azurerm_network_security_group" "master" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "master" {
-  subnet_id                 = azurerm_subnet.master_subnet.id
+  count = var.preexisting_network ? 0 : 1
+
+  subnet_id                 = azurerm_subnet.master_subnet[0].id
   network_security_group_id = azurerm_network_security_group.master.id
 }
 
@@ -16,7 +18,9 @@ resource "azurerm_network_security_group" "worker" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "worker" {
-  subnet_id                 = azurerm_subnet.node_subnet.id
+  count = var.preexisting_network ? 0 : 1
+
+  subnet_id                 = azurerm_subnet.worker_subnet[0].id
   network_security_group_id = azurerm_network_security_group.worker.id
 }
 

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -2,14 +2,6 @@ output "cluster-pip" {
   value = azurerm_public_ip.cluster_public_ip.ip_address
 }
 
-output "network_id" {
-  value = data.azurerm_virtual_network.cluster_vnet.id
-}
-
-output "public_subnet_id" {
-  value = azurerm_subnet.master_subnet.id
-}
-
 output "public_lb_backend_pool_id" {
   value = azurerm_lb_backend_address_pool.master_public_lb_pool.id
 }
@@ -32,4 +24,16 @@ output "internal_lb_ip_address" {
 
 output "master_nsg_name" {
   value = azurerm_network_security_group.master.name
+}
+
+output "virtual_network_id" {
+  value = local.virtual_network_id
+}
+
+output "master_subnet_id" {
+  value = local.master_subnet_id
+}
+
+output "worker_subnet_id" {
+  value = local.worker_subnet_id
 }

--- a/data/data/azure/vnet/variables.tf
+++ b/data/data/azure/vnet/variables.tf
@@ -36,3 +36,29 @@ variable "dns_label" {
   type        = string
   description = "The label used to build the dns name. i.e. <label>.<region>.cloudapp.azure.com"
 }
+
+variable "preexisting_network" {
+  type        = bool
+  description = "This value determines if a vnet already exists or not. If true, then will not create a new vnet, subnet, or nsg's"
+  default     = false
+}
+
+variable "network_resource_group_name" {
+  type        = string
+  description = "This is the name of the network resource group for new or existing network resources"
+}
+
+variable "virtual_network_name" {
+  type        = string
+  description = "This is the name of the virtual network, new or existing"
+}
+
+variable "master_subnet" {
+  type        = string
+  description = "This is the name of the subnet used for the control plane, new or existing"
+}
+
+variable "worker_subnet" {
+  type        = string
+  description = "This is the name of the subnet used for the compute nodes, new or existing"
+}

--- a/data/data/azure/vnet/vnet.tf
+++ b/data/data/azure/vnet/vnet.tf
@@ -1,5 +1,7 @@
 resource "azurerm_virtual_network" "cluster_vnet" {
-  name                = "${var.cluster_id}-vnet"
+  count = var.preexisting_network ? 0 : 1
+
+  name                = var.virtual_network_name
   resource_group_name = var.resource_group_name
   location            = var.region
   address_space       = [var.vnet_cidr]
@@ -12,16 +14,19 @@ resource "azurerm_route_table" "route_table" {
 }
 
 resource "azurerm_subnet" "master_subnet" {
+  count = var.preexisting_network ? 0 : 1
+
   resource_group_name  = var.resource_group_name
   address_prefix       = local.master_subnet_cidr
-  virtual_network_name = data.azurerm_virtual_network.cluster_vnet.name
-  name                 = "${var.cluster_id}-master-subnet"
+  virtual_network_name = local.virtual_network
+  name                 = var.master_subnet
 }
 
-resource "azurerm_subnet" "node_subnet" {
+resource "azurerm_subnet" "worker_subnet" {
+  count = var.preexisting_network ? 0 : 1
+
   resource_group_name  = var.resource_group_name
-  address_prefix       = local.node_subnet_cidr
-  virtual_network_name = data.azurerm_virtual_network.cluster_vnet.name
-  name                 = "${var.cluster_id}-worker-subnet"
+  address_prefix       = local.worker_subnet_cidr
+  virtual_network_name = local.virtual_network
+  name                 = var.worker_subnet
 }
-

--- a/pkg/asset/manifests/azure/cloudproviderconfig.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig.go
@@ -7,10 +7,14 @@ import (
 
 //CloudProviderConfig is the azure cloud provider config
 type CloudProviderConfig struct {
-	TenantID       string
-	SubscriptionID string
-	GroupLocation  string
-	ResourcePrefix string
+	TenantID                 string
+	SubscriptionID           string
+	GroupLocation            string
+	ResourcePrefix           string
+	NetworkResourceGroupName string
+	NetworkSecurityGroupName string
+	VirtualNetworkName       string
+	SubnetName               string
 }
 
 // JSON generates the cloud provider json config for the azure platform.
@@ -32,10 +36,10 @@ func (params CloudProviderConfig) JSON() (string, error) {
 		},
 		ResourceGroup:          resourceGroupName,
 		Location:               params.GroupLocation,
-		SubnetName:             params.ResourcePrefix + "-node-subnet",
-		SecurityGroupName:      params.ResourcePrefix + "-node-nsg",
-		VnetName:               params.ResourcePrefix + "-vnet",
-		VnetResourceGroup:      resourceGroupName,
+		SubnetName:             params.SubnetName,
+		SecurityGroupName:      params.NetworkSecurityGroupName,
+		VnetName:               params.VirtualNetworkName,
+		VnetResourceGroup:      params.NetworkResourceGroupName,
 		RouteTableName:         params.ResourcePrefix + "-node-routetable",
 		CloudProviderBackoff:   true,
 		CloudProviderRateLimit: true,

--- a/pkg/asset/manifests/azure/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig_test.go
@@ -9,10 +9,14 @@ import (
 func TestCloudProviderConfig(t *testing.T) {
 
 	config := CloudProviderConfig{
-		GroupLocation:  "westeurope",
-		ResourcePrefix: "clusterid",
-		SubscriptionID: "subID",
-		TenantID:       "tenantID",
+		GroupLocation:            "westeurope",
+		ResourcePrefix:           "clusterid",
+		SubscriptionID:           "subID",
+		TenantID:                 "tenantID",
+		NetworkResourceGroupName: "clusterid-rg",
+		NetworkSecurityGroupName: "clusterid-node-nsg",
+		VirtualNetworkName:       "clusterid-vnet",
+		SubnetName:               "clusterid-node-subnet",
 	}
 	expected := `{
 	"cloud": "AzurePublicCloud",

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -98,11 +98,30 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "could not get azure session")
 		}
+
+		nsg := fmt.Sprintf("%s-node-nsg", clusterID.InfraID)
+		nrg := fmt.Sprintf("%s-rg", clusterID.InfraID)
+		if installConfig.Config.Azure.NetworkResourceGroupName != "" {
+			nrg = installConfig.Config.Azure.NetworkResourceGroupName
+		}
+		vnet := fmt.Sprintf("%s-vnet", clusterID.InfraID)
+		if installConfig.Config.Azure.VirtualNetwork != "" {
+			vnet = installConfig.Config.Azure.VirtualNetwork
+		}
+		subnet := fmt.Sprintf("%s-node-subnet", clusterID.InfraID)
+		if installConfig.Config.Azure.ComputeSubnet != "" {
+			subnet = installConfig.Config.Azure.ComputeSubnet
+		}
+
 		azureConfig, err := azure.CloudProviderConfig{
-			GroupLocation:  installConfig.Config.Azure.Region,
-			ResourcePrefix: clusterID.InfraID,
-			SubscriptionID: session.Credentials.SubscriptionID,
-			TenantID:       session.Credentials.TenantID,
+			GroupLocation:            installConfig.Config.Azure.Region,
+			ResourcePrefix:           clusterID.InfraID,
+			SubscriptionID:           session.Credentials.SubscriptionID,
+			TenantID:                 session.Credentials.TenantID,
+			NetworkResourceGroupName: nrg,
+			NetworkSecurityGroupName: nsg,
+			VirtualNetworkName:       vnet,
+			SubnetName:               subnet,
 		}.JSON()
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -10,11 +10,24 @@ type Platform struct {
 
 	// BaseDomainResourceGroupName specifies the resource group where the Azure DNS zone for the base domain is found.
 	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
+
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on Azure for machine pools which do not define their own
 	// platform configuration.
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// NetworkResourceGroupName specifies the network resource group that contains an existing VNet
+	NetworkResourceGroupName string `json:"networkResourceGroupName,omitempty"`
+
+	// VirtualNetwork specifies the name of an existing VNet for the installer to use
+	VirtualNetwork string `json:"virtualNetwork,omitempty"`
+
+	// ControlPlaneSubnet specifies an existing subnet for use by the control plane nodes
+	ControlPlaneSubnet string `json:"controlPlaneSubnet,omitempty"`
+
+	// ComputeSubnet specifies an existing subnet for use by compute nodes
+	ComputeSubnet string `json:"computeSubnet,omitempty"`
 }
 
 //SetBaseDomain parses the baseDomainID and sets the related fields on azure.Platform


### PR DESCRIPTION
Add NetworkResourceGroupName, VirtualNetwork, ControlPlaneSubnet, and
ComputeSubnet to the Azure platform struct and pass them to terraform. This is
the initial implementation, therefore, there is no error checking, isolation,
destroying, or terminal prompts. This is for install-config only.

For existing virtual networks, the installer will no longer create route tables, subnets,
virtual networks or network security groups. 

https://jira.coreos.com/browse/CORS-1206