### PR TITLE
add customizable num_cpu for vsphere UPI installation

### DIFF
--- a/upi/vsphere/machine/main.tf
+++ b/upi/vsphere/machine/main.tf
@@ -19,7 +19,7 @@ resource "vsphere_virtual_machine" "vm" {
   name             = "${var.name}-${count.index}"
   resource_pool_id = "${var.resource_pool_id}"
   datastore_id     = "${data.vsphere_datastore.datastore.id}"
-  num_cpus         = "4"
+  num_cpus         = "${var.num_cpu}"
   memory           = "${var.memory}"
   guest_id         = "${data.vsphere_virtual_machine.template.guest_id}"
   folder           = "${var.folder}"

--- a/upi/vsphere/machine/variables.tf
+++ b/upi/vsphere/machine/variables.tf
@@ -62,3 +62,7 @@ variable "ip_addresses" {
 variable "memory" {
   type = "string"
 }
+
+variable "num_cpu" {
+  type = "string"
+}

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -42,6 +42,7 @@ module "bootstrap" {
   ip_addresses     = ["${compact(list(var.bootstrap_ip))}"]
   machine_cidr     = "${var.machine_cidr}"
   memory           = "8192"
+  num_cpu          = "4"
 }
 
 module "control_plane" {
@@ -62,6 +63,7 @@ module "control_plane" {
   ip_addresses     = ["${var.control_plane_ips}"]
   machine_cidr     = "${var.machine_cidr}"
   memory           = "16384"
+  num_cpu          = "4"
 }
 
 module "compute" {
@@ -82,6 +84,7 @@ module "compute" {
   ip_addresses     = ["${var.compute_ips}"]
   machine_cidr     = "${var.machine_cidr}"
   memory           = "8192"
+  num_cpu          = "4"
 }
 
 module "dns" {


### PR DESCRIPTION
This allows for customizing the number of CPUs assigned to a VM for vSphere UPI using terraform. 