### PR TITLE
upi/gcp: control plane to use pd-ssd

### DIFF
--- a/upi/gcp/05_control_plane.py
+++ b/upi/gcp/05_control_plane.py
@@ -9,6 +9,7 @@ def GenerateConfig(context):
                 'boot': True,
                 'initializeParams': {
                     'diskSizeGb': context.properties['root_volume_size'],
+                    'diskType': 'zones/' + context.properties['zones'][0] + '/diskTypes/pd-ssd',
                     'sourceImage': context.properties['image']
                 }
             }],
@@ -42,6 +43,7 @@ def GenerateConfig(context):
                 'boot': True,
                 'initializeParams': {
                     'diskSizeGb': context.properties['root_volume_size'],
+                    'diskType': 'zones/' + context.properties['zones'][1] + '/diskTypes/pd-ssd',
                     'sourceImage': context.properties['image']
                 }
             }],
@@ -75,6 +77,7 @@ def GenerateConfig(context):
                 'boot': True,
                 'initializeParams': {
                     'diskSizeGb': context.properties['root_volume_size'],
+                    'diskType': 'zones/' + context.properties['zones'][2] + '/diskTypes/pd-ssd',
                     'sourceImage': context.properties['image']
                 }
             }],


### PR DESCRIPTION
This change updates the gcp upi templates to use pd-ssd disk types on
the control plane instances just like we do in gcp ipi.