### PR TITLE
add cloud-cred-operator as static pod

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -24,6 +24,8 @@ KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
 KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(image_for cluster-kube-controller-manager-operator)
 KUBE_SCHEDULER_OPERATOR_IMAGE=$(image_for cluster-kube-scheduler-operator)
 
+CLOUD_CREDENTIAL_OPERATOR_IMAGE=$(image_for cloud-credential-operator)
+
 OPENSHIFT_HYPERKUBE_IMAGE=$(image_for hyperkube)
 
 CLUSTER_BOOTSTRAP_IMAGE=$(image_for cluster-bootstrap)
@@ -216,6 +218,28 @@ then
 	cp tls/machine-config-server.key /etc/ssl/mcs/tls.key
 
 	touch mco-bootstrap.done
+fi
+
+if [ ! -f cco-bootstrap.done ]
+then
+	echo "Rendering CCO manifests..."
+
+	rm --recursive --force cco-bootstrap
+
+	# shellcheck disable=SC2154
+	bootkube_podman_run \
+		--quiet \
+		--user 0 \
+		--volume "$PWD:/assets:z" \
+		${CLOUD_CREDENTIAL_OPERATOR_IMAGE} \
+		render \
+			--dest-dir=/assets/cco-bootstrap \
+			--cloud-credential-operator-image=${CLOUD_CREDENTIAL_OPERATOR_IMAGE}
+
+	cp cco-bootstrap/manifests/* manifests/
+	cp cco-bootstrap/bootstrap-manifests/* bootstrap-manifests/
+
+	touch cco-bootstrap.done
 fi
 
 # We originally wanted to run the etcd cert signer as


### PR DESCRIPTION
allow cloud-cred-operator to run on the bootstrap node to allow processing of CredentialsRequests for components that need early cloud credentials

details of the request for this comes from the network-operator team ( https://github.com/openshift/cluster-network-operator/pull/211#issuecomment-537984649 ):
    
  Kuryr is a CNI plugin that provides networking to Pods and Services through OpenStack Neutron and OpenStack Octavia. This is desirable when OpenShift is running on OpenStack as avoiding double encapsulation (OpenStack SDN + OpenShift SDN) is a performance improvement. To achieve that Kuryr needs access to APIs of the underlying OpenStack cloud in order to create networks, subnets, ports (ifaces) and loadbalancers for the OpenShift resources. That obviously requires clouds credentials to be part of Kuryr configuration that CNO prepares (CNO itself needs those as well as it creates some OpenStack resources to "bootstrap" Kuryr).

  Currently we're just reading the root secret, i.e. openstack-credentials from kube-system namespace, but I assume the point of CCO is to limit access to that one and only give access to credentials to the requesting entities.
