### PR TITLE
Bug 1754939: cmd/openshift-install/gather: Gather ClusterOperator errors

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -96,6 +96,9 @@ var (
 
 				err = waitForBootstrapComplete(ctx, config, rootOpts.dir)
 				if err != nil {
+					if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
+						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
+					}
 					if err2 := runGatherBootstrapCmd(rootOpts.dir); err2 != nil {
 						logrus.Error("Attempted to gather debug logs after installation failure: ", err2)
 					}
@@ -110,6 +113,9 @@ var (
 
 				err = waitForInstallComplete(ctx, config, rootOpts.dir)
 				if err != nil {
+					if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
+						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
+					}
 					logrus.Fatal(err)
 				}
 			},

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -46,6 +46,10 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 
 			err = waitForBootstrapComplete(ctx, config, rootOpts.dir)
 			if err != nil {
+				if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
+					logrus.Error("Attempted to gather ClusterOperator status after wait failure: ", err2)
+				}
+
 				logrus.Info("Use the following commands to gather logs from the cluster")
 				logrus.Info("openshift-install gather bootstrap --help")
 				logrus.Fatal(err)
@@ -74,6 +78,10 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 
 			err = waitForInstallComplete(ctx, config, rootOpts.dir)
 			if err != nil {
+				if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
+					logrus.Error("Attempted to gather ClusterOperator status after wait failure: ", err2)
+				}
+
 				logrus.Fatal(err)
 			}
 		},


### PR DESCRIPTION
We currently show ClusterVersion messages when we time out, based on the expectation that the cluster-version operator (CVO) would bubble up and summarize any operator-level errors.  But while the CVO does expose the fact that there *was* an error, it sometimes simplifies to the point where [users can no longer determine the underlying condition][1], while [the ClusterOperator conditions are more useful][2].  With this pull-request, we'll gather and log surprising ClusterOperator conditions (`Available=false`, `Degraded=true`, etc.) to give the user a bit more information to dig into before they need to drop into `openshift-install gather bootstrap ...` or `oc adm must-gather ...`.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1754939#c10
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1754939#c16