### PR TITLE
pkg/destroy/aws: Dynamic partitions, fixing hard-coded 'aws'

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1299,6 +1299,7 @@
     "github.com/aws/aws-sdk-go/aws/awserr",
     "github.com/aws/aws-sdk-go/aws/credentials",
     "github.com/aws/aws-sdk-go/aws/defaults",
+    "github.com/aws/aws-sdk-go/aws/endpoints",
     "github.com/aws/aws-sdk-go/aws/request",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/ec2",


### PR DESCRIPTION
Partitions are more complicated than I thought when I wrote the hard-coded `arn:aws:ec2:...` prefix in 54cfed55a4 (#2169).  While most of our regions use `aws`, [China uses `aws-cn`][1], [GovCloud uses `aws-us-gov`][2], and there may be more.  Pull this ARN componet from the AWS SDK instead to track that sort of thing.

[1]: https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax
[2]: https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/#pkg-overview