### PR TITLE
Bug 1758306: data/rhcos: Bump to rhcos-4.3/43.80.20191002.1

### DIFF
--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,134 +1,132 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-03d80bc757baa3ea3"
+            "hvm": "ami-0a8324066353ef1d9"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0d38ddacba83423c9"
+            "hvm": "ami-07cb62f73a0fa6318"
         },
         "ap-south-1": {
-            "hvm": "ami-0167e201cc0375d94"
+            "hvm": "ami-0f79eb0d6ebb820aa"
         },
         "ap-southeast-1": {
-            "hvm": "ami-09e527c00c9470b5f"
+            "hvm": "ami-03b105b8c0b957e86"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0936f38cd6161ad80"
+            "hvm": "ami-0bc95c30ff7bec6d9"
         },
         "ca-central-1": {
-            "hvm": "ami-083a6c4d5fec9e7f7"
+            "hvm": "ami-0514f28f2707f566f"
         },
         "eu-central-1": {
-            "hvm": "ami-00731d73fad047d6a"
+            "hvm": "ami-0c778c8effd8c0d58"
         },
         "eu-north-1": {
-            "hvm": "ami-0359348d6d4ede973"
+            "hvm": "ami-07b48d5ffa0c25295"
         },
         "eu-west-1": {
-            "hvm": "ami-081ea939fd630c300"
+            "hvm": "ami-01effd1076c8cbb9f"
         },
         "eu-west-2": {
-            "hvm": "ami-09b7a1ccf7ecdb1a4"
+            "hvm": "ami-00801675c587fe451"
         },
         "eu-west-3": {
-            "hvm": "ami-06bfd7584bdd30674"
+            "hvm": "ami-026c1105fdc6f994a"
         },
         "sa-east-1": {
-            "hvm": "ami-00126ef34c2517237"
+            "hvm": "ami-05b9d1336268fed90"
         },
         "us-east-1": {
-            "hvm": "ami-0ae2df22579e00be5"
+            "hvm": "ami-0a8a5bd1afb530885"
         },
         "us-east-2": {
-            "hvm": "ami-01309f148f8cfae82"
+            "hvm": "ami-0bb333ebb5562bc77"
         },
         "us-west-1": {
-            "hvm": "ami-0b7932f135cd74eea"
+            "hvm": "ami-0addc017ba982b754"
         },
         "us-west-2": {
-            "hvm": "ami-07c648fffd195d6d9"
+            "hvm": "ami-0b0e1613f2ac28245"
         }
     },
     "azure": {
-        "image": "rhcos-42.80.20190827.1.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-42.80.20190827.1.vhd"
+        "image": "rhcos-43.80.20191002.1-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-43.80.20191002.1-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.2/42.80.20190827.1/",
-    "buildid": "42.80.20190827.1",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.80.20191002.1/x86_64/",
+    "buildid": "43.80.20191002.1",
     "gcp": {
-        "image": "rhcos-42-80-20190827-1",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/42.80.20190827.1.tar.gz"
+        "image": "rhcos-43-80-20191002-1",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/43.80.20191002.1.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-42.80.20190827.1-aws.vmdk",
-            "sha256": "578913174288148500529c0206ffdf2617024173eb275054c22dc15a086a0334",
-            "size": 697916205,
-            "uncompressed-sha256": "6af16e232a16f4c6566b150d2df5063b153371620bf0022425f9796dbc04963a",
-            "uncompressed-size": 712989696
+            "path": "rhcos-43.80.20191002.1-aws.x86_64.vmdk",
+            "sha256": "e10f776736e106e1f78c1cfb1137cae6b8f719e7d1c5b86f54c97f1a15903cc7",
+            "size": 711287734,
+            "uncompressed-sha256": "be289bb9ed539361ad5ab7d49f1798d33329246aed44af85c3f1d493a8cb5170",
+            "uncompressed-size": 726297600
         },
         "azure": {
-            "path": "rhcos-42.80.20190827.1.vhd",
-            "sha256": "46e896f70669b067bba8ccc765898ffabbb0a52a0e60eb92a85f6c1e404da86c",
-            "size": 686373862,
-            "uncompressed-sha256": "361e42de0566162909dcf6d01e50aac34402b5d7d97c470223c01ce38b03cf15",
-            "uncompressed-size": 1877444608
+            "path": "rhcos-43.80.20191002.1-azure.x86_64.vhd",
+            "sha256": "122b4684b77d98f62bf0587abfb40d8e18ff2e5e68eb60bacb912e49d51bcfff",
+            "size": 699466851,
+            "uncompressed-sha256": "6d859882178743535a83a3166fdd1a677a83365188fd9d972a4bd258e3372056",
+            "uncompressed-size": 1915202560
         },
         "gcp": {
-            "path": "rhcos-42.80.20190827.1-gcp.tar",
-            "sha256": "756ca630d02e2ee610d8a354cb506012548471b50624025e8e07bec933659e72",
-            "size": 686009425
+            "path": "rhcos-43.80.20191002.1-gcp.x86_64.tar",
+            "sha256": "74a36de776da5f8a61ac614ec82b92c22c7cea15cba09cf11a5da1c4fa30bc12",
+            "size": 699106634
         },
         "initramfs": {
-            "path": "rhcos-42.80.20190827.1-installer-initramfs.img",
-            "sha256": "65597c2a5fe318ac0b2327c91c0f1d7116fcd47a7cf9d651de998a002e2f507f"
+            "path": "rhcos-43.80.20191002.1-installer-initramfs.x86_64.img",
+            "sha256": "616bc8a305364369e8c241d4049b44d734e6853ad72ba33450d8e490e6cafb66"
         },
         "iso": {
-            "path": "rhcos-42.80.20190827.1-installer.iso",
-            "sha256": "e03bf2796b8191c9e503c17d3d6f825e8023b29c0226e4c6ee4bd76df5802c54"
+            "path": "rhcos-43.80.20191002.1-installer.x86_64.iso",
+            "sha256": "401b68928f8a54a60065b0fa64062fc0f2e1d3a97038e3d38f9b1adc26bc1c73"
         },
         "kernel": {
-            "path": "rhcos-42.80.20190827.1-installer-kernel",
-            "sha256": "f3cf1f2a5533fd172ad7dfab80926e1d1b633f2786d98b1abdeb4dce2e80f0ec"
+            "path": "rhcos-43.80.20191002.1-installer-kernel-x86_64",
+            "sha256": "a31a100ad4ad033240ad8547f55a803542f7a6212adb7df1d0fb4618383b9729"
         },
-        "metal-bios": {
-            "path": "rhcos-42.80.20190827.1-metal-bios.raw.gz",
-            "sha256": "a2fa9a32e509dddb585db03eb2649b44925c3509dd429d671c817d46bd369e31",
-            "size": 687679482,
-            "uncompressed-sha256": "a86c1b57880553f7724a42931877dda9781fe1c1bd398c122a66c1c1b344306f",
-            "uncompressed-size": 3155165184
-        },
-        "metal-uefi": {
-            "path": "rhcos-42.80.20190827.1-metal-uefi.raw.gz",
-            "sha256": "7a68de72aeb9a9d3a7c44d997f454bad7356e749c9c17f7a21883a967ff9d85a",
-            "size": 687078285,
-            "uncompressed-sha256": "b665987bff72af2440214aedec5d7552dcd6bebc73806ac5db7ff2eb2a773a21",
-            "uncompressed-size": 3155165184
+        "metal": {
+            "path": "rhcos-43.80.20191002.1-metal.x86_64.raw.gz",
+            "sha256": "57786ba28288ac2c913b8fc5517469434959a689a6fbdb172f1ae370adf8d5df",
+            "size": 700266884,
+            "uncompressed-sha256": "84dbd7969a2ff928f43e74295750557230ec43789ca63715e749cf03e9f38de7",
+            "uncompressed-size": 2756706304
         },
         "openstack": {
-            "path": "rhcos-42.80.20190827.1-openstack.qcow2",
-            "sha256": "688365b01b870400f34c5f5f38f3311396932f7389d36e18b27f79e74b49f843",
-            "size": 687517963,
-            "uncompressed-sha256": "9a99bdb826b9c6862eb827d114465af513dfcaffff687f69efacff8f49ff43fc",
-            "uncompressed-size": 1885536256
+            "path": "rhcos-43.80.20191002.1-openstack.x86_64.qcow2",
+            "sha256": "26646e2f87019b47e39b322b18f9b524d2a9c5d90410565ec5fd895d544c1d25",
+            "size": 700316680,
+            "uncompressed-sha256": "071dd9c430ba81e4353a2f1c49bc7462d3ff40f9d30dbc74881550ea7d8748a7",
+            "uncompressed-size": 1889402880
+        },
+        "ostree": {
+            "path": "rhcos-43.80.20191002.1-ostree.x86_64.tar",
+            "sha256": "e83efc12fa0edd857c600f5763a30f5bcd2fc00d80d1608fca662d8993fff543",
+            "size": 647639040
         },
         "qemu": {
-            "path": "rhcos-42.80.20190827.1-qemu.qcow2",
-            "sha256": "fb2139ad5f9495c78e083392538578b9958d638b1717ddbdb5dcfc7243a9e9b0",
-            "size": 687505016,
-            "uncompressed-sha256": "38fa48d1ff64ca63c9d4cc8d333dfe2e9d6b41d8b259cfd23a3ae06adc375bdd",
-            "uncompressed-size": 1885470720
+            "path": "rhcos-43.80.20191002.1-qemu.x86_64.qcow2",
+            "sha256": "29e867427e84b64970b8e0408b135b13f6e315b82882be5601e19529d4463773",
+            "size": 700315704,
+            "uncompressed-sha256": "b4cd810376dca356f987e2e7f8609f84d63720d5ad19d3101f84e82d1918c85e",
+            "uncompressed-size": 1889337344
         },
         "vmware": {
-            "path": "rhcos-42.80.20190827.1-vmware.ova",
-            "sha256": "032e8350e42d3044766e93b97dc5311cb2cb54be2c2b109ed1ca0a03c5404166",
-            "size": 713000960
+            "path": "rhcos-43.80.20191002.1-vmware.x86_64.ova",
+            "sha256": "01de390ceaba7696fde70b7a7d6cbe16e9c497427823c091e10616b368fedd02",
+            "size": 726312960
         }
     },
     "oscontainer": {
-        "digest": "sha256:5a2427869e1675f392cf1feb10ed62214801b74c9a0801ec986b3deb5b51a2d2",
+        "digest": "sha256:30857847ade065a57e02c9297cafdd6b2a95d086d0d99480980a3a6eaba2a95b",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "a5a7fc42669f4f0d10e6f6b25e0c8b8405a4f192d1ce0a2da8a32023dbcaa333",
-    "ostree-version": "42.80.20190827.1"
+    "ostree-commit": "da67d201b394913ffdd959141bb93ca3a0f31f7b19e4007a02bef6bc7d9392ef",
+    "ostree-version": "43.80.20191002.1"
 }


### PR DESCRIPTION
Generated with:

```console
$ hack/update-rhcos-bootimage.py https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.80.20191002.1/x86_64/meta.json
```

[Comparing][1] (currently private tool, sorry, but public RHCOS history [here][1b]) with our previous 42.80.20190827.1:

```console
$ ./differ.py --first-endpoint art --first-version 42.80.20190827.1 --second-endpoint art --second-version 43.80.20191002.1
{
    "sources": {
        "42.80.20190827.1": "https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.2/42.80.20190827.1/commitmeta.json",
        "43.80.20191002.1": "https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.3/43.80.20191002.1/x86_64/commitmeta.json"
    },
    "diff": {
        "kernel": {
            "42.80.20190827.1": "kernel.0.4.18.0.80.7.2.el8_0.x86_64",
            "43.80.20191002.1": "kernel.0.4.18.0.80.11.2.el8_0.x86_64"
        },
        "kbd-misc": {
            "42.80.20190827.1": "Not present",
            "43.80.20191002.1": "kbd-misc.0.2.0.4.8.el8.noarch"
        },
        "runc": {
            "42.80.20190827.1": "runc.0.1.0.0.60.rc8.rhaos4.2.git3cbe540.el8.x86_64",
            "43.80.20191002.1": "runc.0.1.0.0.56.rc8.dev.git425e105.module+el8.0.0+4017+bbba319f.x86_64"
        },
        "grub2-common": {
            "42.80.20190827.1": "grub2-common.1.2.02.66.el8.noarch",
            "43.80.20191002.1": "grub2-common.1.2.02.66.el8_0.1.noarch"
        },
        "sudo": {
            "42.80.20190827.1": "sudo.0.1.8.25p1.4.el8.x86_64",
            "43.80.20191002.1": "sudo.0.1.8.25p1.4.el8_0.1.x86_64"
        },
        "grub2-pc": {
            "42.80.20190827.1": "grub2-pc.1.2.02.66.el8.x86_64",
            "43.80.20191002.1": "grub2-pc.1.2.02.66.el8_0.1.x86_64"
        },
        "kbd": {
            "42.80.20190827.1": "Not present",
            "43.80.20191002.1": "kbd.0.2.0.4.8.el8.x86_64"
        },
        "openshift-hyperkube": {
            "42.80.20190827.1": "openshift-hyperkube.0.4.2.0.201908261819.git.0.b985ea3.el8.x86_64",
            "43.80.20191002.1": "openshift-hyperkube.0.4.3.0.201909302346.git.0.048606f.el8.x86_64"
        },
        "xkeyboard-config": {
            "42.80.20190827.1": "Not present",
            "43.80.20191002.1": "xkeyboard-config.0.2.24.3.el8.noarch"
        },
        "libnghttp2": {
            "42.80.20190827.1": "libnghttp2.0.1.33.0.1.el8.x86_64",
            "43.80.20191002.1": "libnghttp2.0.1.33.0.1.el8_0.1.x86_64"
        },
        "grub2-tools": {
            "42.80.20190827.1": "grub2-tools.1.2.02.66.el8.x86_64",
            "43.80.20191002.1": "grub2-tools.1.2.02.66.el8_0.1.x86_64"
        },
        "containers-common": {
            "42.80.20190827.1": "containers-common.1.0.1.32.4.git1715c90.el8.x86_64",
            "43.80.20191002.1": "containers-common.1.0.1.32.5.git1715c90.el8.x86_64"
        },
        "rpm": {
            "42.80.20190827.1": "rpm.0.4.14.2.10.el8_0.x86_64",
            "43.80.20191002.1": "rpm.0.4.14.2.11.el8_0.x86_64"
        },
        "rpm-plugin-selinux": {
            "42.80.20190827.1": "rpm-plugin-selinux.0.4.14.2.10.el8_0.x86_64",
            "43.80.20191002.1": "rpm-plugin-selinux.0.4.14.2.11.el8_0.x86_64"
        },
        "kbd-legacy": {
            "42.80.20190827.1": "Not present",
            "43.80.20191002.1": "kbd-legacy.0.2.0.4.8.el8.noarch"
        },
        "libnfsidmap": {
            "42.80.20190827.1": "libnfsidmap.1.2.3.3.14.el8_0.x86_64",
            "43.80.20191002.1": "libnfsidmap.1.2.3.3.14.el8_0.3.x86_64"
        },
        "kernel-modules": {
            "42.80.20190827.1": "kernel-modules.0.4.18.0.80.7.2.el8_0.x86_64",
            "43.80.20191002.1": "kernel-modules.0.4.18.0.80.11.2.el8_0.x86_64"
        },
        "tzdata": {
            "42.80.20190827.1": "tzdata.0.2019b.1.el8.noarch",
            "43.80.20191002.1": "tzdata.0.2019c.1.el8.noarch"
        },
        "grub2-pc-modules": {
            "42.80.20190827.1": "grub2-pc-modules.1.2.02.66.el8.noarch",
            "43.80.20191002.1": "grub2-pc-modules.1.2.02.66.el8_0.1.noarch"
        },
        "grub2-tools-minimal": {
            "42.80.20190827.1": "grub2-tools-minimal.1.2.02.66.el8.x86_64",
            "43.80.20191002.1": "grub2-tools-minimal.1.2.02.66.el8_0.1.x86_64"
        },
        "skopeo": {
            "42.80.20190827.1": "skopeo.1.0.1.32.4.git1715c90.el8.x86_64",
            "43.80.20191002.1": "skopeo.1.0.1.32.5.git1715c90.el8.x86_64"
        },
        "kernel-modules-extra": {
            "42.80.20190827.1": "kernel-modules-extra.0.4.18.0.80.7.2.el8_0.x86_64",
            "43.80.20191002.1": "kernel-modules-extra.0.4.18.0.80.11.2.el8_0.x86_64"
        },
        "grub2-tools-extra": {
            "42.80.20190827.1": "grub2-tools-extra.1.2.02.66.el8.x86_64",
            "43.80.20191002.1": "grub2-tools-extra.1.2.02.66.el8_0.1.x86_64"
        },
        "podman-manpages": {
            "42.80.20190827.1": "podman-manpages.0.1.4.2.1.module+el8.1.0+3423+f0eda5e0.noarch",
            "43.80.20191002.1": "podman-manpages.0.1.4.2.5.el8.noarch"
        },
        "nfs-utils": {
            "42.80.20190827.1": "nfs-utils.1.2.3.3.14.el8_0.x86_64",
            "43.80.20191002.1": "nfs-utils.1.2.3.3.14.el8_0.3.x86_64"
        },
        "podman": {
            "42.80.20190827.1": "podman.0.1.4.2.1.module+el8.1.0+3423+f0eda5e0.x86_64",
            "43.80.20191002.1": "podman.0.1.4.2.5.el8.x86_64"
        },
        "cifs-utils": {
            "42.80.20190827.1": "Not present",
            "43.80.20191002.1": "cifs-utils.0.6.8.2.el8.x86_64"
        },
        "selinux-policy": {
            "42.80.20190827.1": "selinux-policy.0.3.14.1.61.el8_0.1.noarch",
            "43.80.20191002.1": "selinux-policy.0.3.14.1.61.el8_0.2.noarch"
        },
        "grub2-efi-x64": {
            "42.80.20190827.1": "grub2-efi-x64.1.2.02.66.el8.x86_64",
            "43.80.20191002.1": "grub2-efi-x64.1.2.02.66.el8_0.1.x86_64"
        },
        "bash": {
            "42.80.20190827.1": "bash.0.4.4.19.7.el8.x86_64",
            "43.80.20191002.1": "bash.0.4.4.19.8.el8_0.x86_64"
        },
        "cri-tools": {
            "42.80.20190827.1": "cri-tools.0.1.14.0.1.rhaos4.2.el8.x86_64",
            "43.80.20191002.1": "cri-tools.0.1.14.0.2.rhaos4.2.el8.x86_64"
        },
        "rpm-libs": {
            "42.80.20190827.1": "rpm-libs.0.4.14.2.10.el8_0.x86_64",
            "43.80.20191002.1": "rpm-libs.0.4.14.2.11.el8_0.x86_64"
        },
        "cri-o": {
            "42.80.20190827.1": "cri-o.0.1.14.10.0.8.dev.rhaos4.2.gitaf00350.el8.x86_64",
            "43.80.20191002.1": "cri-o.0.1.14.10.0.21.dev.rhaos4.2.git0d4a906.el8.x86_64"
        },
        "kernel-core": {
            "42.80.20190827.1": "kernel-core.0.4.18.0.80.7.2.el8_0.x86_64",
            "43.80.20191002.1": "kernel-core.0.4.18.0.80.11.2.el8_0.x86_64"
        },
        "libxkbcommon": {
            "42.80.20190827.1": "Not present",
            "43.80.20191002.1": "libxkbcommon.0.0.8.2.1.el8.x86_64"
        },
        "setools-console": {
            "42.80.20190827.1": "setools-console.0.4.2.0.2.el8.x86_64",
            "43.80.20191002.1": "Not present"
        },
        "redhat-release-coreos": {
            "42.80.20190827.1": "redhat-release-coreos.0.420.8.3.el8.x86_64",
            "43.80.20191002.1": "redhat-release-coreos.0.43.80.3.el8.x86_64"
        },
        "ignition": {
            "42.80.20190827.1": "ignition.0.0.33.0.3.rhaos4.2.gitc65e95c.el8.x86_64",
            "43.80.20191002.1": "ignition.0.0.33.0.6.rhaos4.2.gitc65e95c.el8.x86_64"
        },
        "openshift-clients": {
            "42.80.20190827.1": "openshift-clients.0.4.2.0.201908261819.git.0.b985ea3.el8.x86_64",
            "43.80.20191002.1": "openshift-clients.0.4.3.0.201910021600.git.1.ad863c1.el8.x86_64"
        },
        "selinux-policy-targeted": {
            "42.80.20190827.1": "selinux-policy-targeted.0.3.14.1.61.el8_0.1.noarch",
            "43.80.20191002.1": "selinux-policy-targeted.0.3.14.1.61.el8_0.2.noarch"
        }
    }
}
```

It's not clear if there is any pre-pivot impact to these changes, But with cri-o, ignition, podman, and runc among the bumped packages, it seems like pre-pivot impact is at least possible.

This also picks up the signed-RPM change made to the internal pipeline [yesterday][2] (another internal link, sorry).

[1]: https://gitlab.cee.redhat.com/coretools/differ
[1b]: https://releases-rhcos-art.cloud.privileged.psi.redhat.com/?stream=releases/rhcos-4.3&release=43.80.20191002.1
[2]: https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/612#note_907837