### PR TITLE
data/bootstrap: allow for missing keepalived image

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -28,7 +28,7 @@ OPENSHIFT_HYPERKUBE_IMAGE=$(image_for hyperkube)
 
 CLUSTER_BOOTSTRAP_IMAGE=$(image_for cluster-bootstrap)
 
-KEEPALIVED_IMAGE=$(image_for keepalived-ipfailover)
+KEEPALIVED_IMAGE=$(image_for keepalived-ipfailover || echo "no-keepalived-image")
 COREDNS_IMAGE=$(image_for coredns)
 MDNS_PUBLISHER_IMAGE=$(image_for mdns-publisher)
 HAPROXY_IMAGE=$(image_for haproxy-router)


### PR DESCRIPTION
The keepalived container image is not available in RHEL 7 on s390x. As a
result, this container image cannot be built and included in the release
image. As a short term workaround, this allows the bootstrapping process
to proceed without having a valid container image for keepalived. This
is okay because the consumer of the pullspec, the Machine Config
Operator, only references this image when installing on "baremetal" and
"openstack". Installs on s390x will be okay because they will be using
"libvirt" (for CI) and "none" (for UPI installations).