### PR TITLE
bootstrap: Remove --allow-privileged from kubelet flags

### DIFF
--- a/data/data/bootstrap/systemd/units/kubelet.service.template
+++ b/data/data/bootstrap/systemd/units/kubelet.service.template
@@ -15,7 +15,6 @@ ExecStart=/usr/bin/hyperkube \
     --container-runtime-endpoint=/var/run/crio/crio.sock \
     --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
     --pod-manifest-path=/etc/kubernetes/manifests \
-    --allow-privileged \
     --minimum-container-ttl-duration=6m0s \
     --cluster-domain=cluster.local \
     --cgroup-driver=systemd \


### PR DESCRIPTION
See https://github.com/openshift/machine-config-operator/commit/8f86081d651d7114bae767eee830960bf74c8995

I'm trying to update the RHCOS bootimage to 4.3 with Kube 1.16
and this is now a fatal error.