### PR TITLE
pkg/destroy/aws: Stop skipping direct network-interface deletion

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -178,11 +178,6 @@ func (o *ClusterUninstaller) Run() error {
 										continue
 									}
 
-									if parsed.Service == "ec2" && strings.HasPrefix(parsed.Resource, "network-interface/") {
-										arnLogger.Debug("skip direct tag deletion, deleting the VPC should catch this")
-										continue
-									}
-
 									err = deleteARN(awsSession, parsed, filter, arnLogger)
 									if err != nil {
 										arnLogger.Debug(err)


### PR DESCRIPTION
I'd added this to save on AWS API-call volume in fc70eb221c (#1704).  But now that we support user-provided VPCs with installer-provided network interfaces, it's no longer feasible.  Happily, the tagged network interfaces are just for installer-created control-plane machines, see 4fcdc1cbb4 (#1361).  And since cf69c1e52a (#2169) we are terminating instances first and waiting for their termination to complete before proceeding to other resources.  So we should no longer have the long runs of failed network-interface deletion attempts while we wait for the instances to terminate, and this commit should make our removal more robust without increasing our API-call volume.