### PR TITLE
Bug 1759146: data/rhcos: fix base url to use correct baseURI

### DIFF
--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -53,7 +53,7 @@
         "image": "rhcos-42.80.20191002.0.vhd",
         "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-42.80.20191002.0.vhd"
     },
-    "baseURI": "https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.2/42.80.20191002.0/",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.2/42.80.20191002.0/",
     "buildid": "42.80.20191002.0",
     "gcp": {
         "image": "rhcos-42-80-20191002-0",


### PR DESCRIPTION
The current baseURI is pointing at
releases-rhcos-art.cloud.privileged.psi.redhat.com, which is an internal
URL and signed by the corporate CA. This is breaking any 4.2 install that relies on downloading RHCOS (e.g. some UPI installs, baremetal IPI, etc), and the user is not on the VPN or is on the VPN and the particular server doesn't trust RH's corporate CA.