### PR TITLE
upi/gcp: increase the NAT ports for control plane to 7168

### DIFF
--- a/upi/gcp/01_vpc.py
+++ b/upi/gcp/01_vpc.py
@@ -45,6 +45,7 @@ def GenerateConfig(context):
                 'name': context.properties['infra_id'] + '-nat-master',
                 'natIpAllocateOption': 'MANUAL_ONLY',
                 'natIps': ['$(ref.' + context.properties['infra_id'] + '-master-nat-ip.selfLink)'],
+                'minPortsPerVm': 7168,
                 'sourceSubnetworkIpRangesToNat': 'LIST_OF_SUBNETWORKS',
                 'subnetworks': [{
                     'name': '$(ref.' + context.properties['infra_id'] + '-master-subnet.selfLink)',
@@ -54,6 +55,7 @@ def GenerateConfig(context):
                 'name': context.properties['infra_id'] + '-nat-worker',
                 'natIpAllocateOption': 'MANUAL_ONLY',
                 'natIps': ['$(ref.' + context.properties['infra_id'] + '-worker-nat-ip.selfLink)'],
+                'minPortsPerVm': 128,
                 'sourceSubnetworkIpRangesToNat': 'LIST_OF_SUBNETWORKS',
                 'subnetworks': [{
                     'name': '$(ref.' + context.properties['infra_id'] + '-worker-subnet.selfLink)',


### PR DESCRIPTION
This change increases the minimum ports per control-plane instance to
allow much higher resiliency. It is based on #2376, which did the same
for GCP IPI.