### PR TITLE
OpenStack: automatically populate RHCOS image

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -336,10 +336,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1d318d726b1fe59a7719a571f28b899fd608bd8e7a7b09b88c7be6d96eea0852"
+  digest = "1:f57b7ddc21b0593c06ce50d1b32ec2fcb91617cb7ee4f94b7a04d86377b3d708"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
+    "internal",
     "openstack",
     "openstack/blockstorage/v3/volumes",
     "openstack/common/extensions",
@@ -349,6 +350,7 @@
     "openstack/identity/v2/tenants",
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/tokens",
+    "openstack/imageservice/v2/images",
     "openstack/loadbalancer/v2/apiversions",
     "openstack/loadbalancer/v2/l7policies",
     "openstack/loadbalancer/v2/listeners",
@@ -1323,6 +1325,7 @@
     "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
     "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
     "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
+    "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers",
     "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -336,7 +336,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:721fd76934b8bef9c9cb85ac5e4a1b8505347ce384f292eadaecfa1b33cb32e6"
+  digest = "1:1d318d726b1fe59a7719a571f28b899fd608bd8e7a7b09b88c7be6d96eea0852"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -372,7 +372,7 @@
     "pagination",
   ]
   pruneopts = "NUT"
-  revision = "157432124aab520975efedb5e54b95287785578d"
+  revision = "863d5406e68f374ee607452672b18a177134bbbc"
 
 [[projects]]
   branch = "master"

--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -109,11 +109,6 @@ EOF
   }
 }
 
-data "openstack_images_image_v2" "bootstrap_image" {
-  name = var.image_name
-  most_recent = true
-}
-
 data "openstack_compute_flavor_v2" "bootstrap_flavor" {
   name = var.flavor_name
 }
@@ -121,7 +116,7 @@ data "openstack_compute_flavor_v2" "bootstrap_flavor" {
 resource "openstack_compute_instance_v2" "bootstrap" {
   name = "${var.cluster_id}-bootstrap"
   flavor_id = data.openstack_compute_flavor_v2.bootstrap_flavor.id
-  image_id = data.openstack_images_image_v2.bootstrap_image.id
+  image_id = var.base_image_id
 
   user_data = data.ignition_config.redirect.rendered
 

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -1,6 +1,6 @@
-variable "image_name" {
+variable "base_image_id" {
   type        = string
-  description = "The name of the Glance image for the bootstrap node."
+  description = "The identifier of the Glance image for the bootstrap node."
 }
 
 variable "extra_tags" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -1,8 +1,3 @@
-data "openstack_images_image_v2" "masters_img" {
-  name        = var.base_image
-  most_recent = true
-}
-
 data "openstack_compute_flavor_v2" "masters_flavor" {
   name = var.flavor_name
 }
@@ -38,7 +33,7 @@ resource "openstack_blockstorage_volume_v3" "master_volume" {
 
   size = var.root_volume_size
   volume_type = var.root_volume_type
-  image_id = data.openstack_images_image_v2.masters_img.id
+  image_id = var.base_image_id
 }
 
 resource "openstack_compute_instance_v2" "master_conf" {
@@ -46,7 +41,7 @@ resource "openstack_compute_instance_v2" "master_conf" {
   count = var.instance_count
 
   flavor_id = data.openstack_compute_flavor_v2.masters_flavor.id
-  image_id = var.root_volume_size == null ? data.openstack_images_image_v2.masters_img.id : null
+  image_id = var.root_volume_size == null ? var.base_image_id : null
   security_groups = var.master_sg_ids
   user_data = element(
     data.ignition_config.master_ignition_config.*.rendered,

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -1,5 +1,6 @@
-variable "base_image" {
-  type = string
+variable "base_image_id" {
+  type        = string
+  description = "The identifier of the Glance image for master nodes."
 }
 
 variable "cluster_id" {

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -10,10 +10,15 @@ variable "openstack_master_root_volume_size" {
   description = "The size of the volume in gigabytes for the root block device of master nodes."
 }
 
-variable "openstack_base_image" {
+variable "openstack_base_image_name" {
   type        = string
-  default     = "rhcos"
   description = "Name of the base image to use for the nodes."
+}
+
+variable "openstack_base_image_url" {
+  type        = string
+  default     = ""
+  description = "URL of the base image to use for the nodes."
 }
 
 variable "openstack_credentials_auth_url" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -280,6 +280,8 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			ingressVIP.String(),
 			installConfig.Config.Platform.OpenStack.TrunkSupport,
 			installConfig.Config.Platform.OpenStack.OctaviaSupport,
+			string(*rhcosImage),
+			clusterID.InfraID,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines/machineconfig"
 	"github.com/openshift/installer/pkg/asset/machines/openstack"
 	"github.com/openshift/installer/pkg/asset/rhcos"
+	rhcosutils "github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
@@ -181,7 +182,10 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.Set(ic.Platform.OpenStack.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.OpenStack)
 		pool.Platform.OpenStack = &mpool
-		machines, err = openstack.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data")
+
+		imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
+
+		machines, err = openstack.Machines(clusterID.InfraID, ic, pool, imageName, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines/machineconfig"
 	"github.com/openshift/installer/pkg/asset/machines/openstack"
 	"github.com/openshift/installer/pkg/asset/rhcos"
+	rhcosutils "github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
@@ -247,7 +248,9 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			mpool.Set(pool.Platform.OpenStack)
 			pool.Platform.OpenStack = &mpool
 
-			sets, err := openstack.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data")
+			imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
+
+			sets, err := openstack.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", "worker-user-data")
 			if err != nil {
 				return errors.Wrap(err, "failed to create master machine objects")
 			}

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -78,7 +78,7 @@ func osImage(config *types.InstallConfig) (string, error) {
 	case libvirt.Name:
 		osimage, err = rhcos.QEMU(ctx)
 	case openstack.Name:
-		osimage = "rhcos"
+		osimage, err = rhcos.OpenStack(ctx)
 	case azure.Name:
 		osimage, err = rhcos.VHD(ctx)
 	case baremetal.Name:

--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
@@ -133,6 +134,7 @@ func populateDeleteFuncs(funcs map[string]deleteFunc) {
 	funcs["deleteContainers"] = deleteContainers
 	funcs["deleteVolumes"] = deleteVolumes
 	funcs["deleteFloatingIPs"] = deleteFloatingIPs
+	funcs["deleteImages"] = deleteImages
 }
 
 // filterObjects will do client-side filtering given an appropriately filled out
@@ -875,4 +877,42 @@ func deleteFloatingIPs(opts *clientconfig.ClientOpts, filter Filter, logger logr
 		}
 	}
 	return len(allFloatingIPs) == 0, nil
+}
+
+func deleteImages(opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) (bool, error) {
+	logger.Debug("Deleting openstack base image")
+	defer logger.Debugf("Exiting deleting openstack base image")
+
+	conn, err := clientconfig.NewServiceClient("image", opts)
+	if err != nil {
+		logger.Fatalf("%v", err)
+		os.Exit(1)
+	}
+
+	listOpts := images.ListOpts{
+		Tags: filterTags(filter),
+	}
+
+	allPages, err := images.List(conn, listOpts).AllPages()
+	if err != nil {
+		logger.Fatalf("%v", err)
+		os.Exit(1)
+	}
+
+	allImages, err := images.ExtractImages(allPages)
+	if err != nil {
+		logger.Fatalf("%v", err)
+		os.Exit(1)
+	}
+
+	for _, image := range allImages {
+		logger.Debugf("Deleting image: %+v", image.ID)
+		err := images.Delete(conn, image.ID).ExtractErr()
+		if err != nil {
+			// This can fail if the image is still in use by other VMs
+			logger.Debugf("Deleting Image failed: %v", err)
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/pkg/rhcos/openstack.go
+++ b/pkg/rhcos/openstack.go
@@ -27,3 +27,17 @@ func OpenStack(ctx context.Context) (string, error) {
 
 	return base.ResolveReference(relOpenStack).String(), nil
 }
+
+// GenerateOpenStackImageName returns Glance image name for instances.
+func GenerateOpenStackImageName(rhcosImage, infraID string) (imageName string, isURL bool) {
+	// Here we check whether rhcosImage is a URL or not. If this is the first case, it means that Glance image
+	// should be created by the installer with the universal name "<infraID>-rhcos". Otherwise, it means
+	// that we are given the name of the pre-created Glance image, which the installer should use for node
+	// provisioning.
+	_, err := url.ParseRequestURI(rhcosImage)
+	if err != nil {
+		return rhcosImage, false
+	}
+
+	return infraID + "-rhcos", true
+}

--- a/vendor/github.com/gophercloud/gophercloud/internal/pkg.go
+++ b/vendor/github.com/gophercloud/gophercloud/internal/pkg.go
@@ -1,0 +1,1 @@
+package internal

--- a/vendor/github.com/gophercloud/gophercloud/internal/util.go
+++ b/vendor/github.com/gophercloud/gophercloud/internal/util.go
@@ -1,0 +1,34 @@
+package internal
+
+import (
+	"reflect"
+	"strings"
+)
+
+// RemainingKeys will inspect a struct and compare it to a map. Any struct
+// field that does not have a JSON tag that matches a key in the map or
+// a matching lower-case field in the map will be returned as an extra.
+//
+// This is useful for determining the extra fields returned in response bodies
+// for resources that can contain an arbitrary or dynamic number of fields.
+func RemainingKeys(s interface{}, m map[string]interface{}) (extras map[string]interface{}) {
+	extras = make(map[string]interface{})
+	for k, v := range m {
+		extras[k] = v
+	}
+
+	valueOf := reflect.ValueOf(s)
+	typeOf := reflect.TypeOf(s)
+	for i := 0; i < valueOf.NumField(); i++ {
+		field := typeOf.Field(i)
+
+		lowerField := strings.ToLower(field.Name)
+		delete(extras, lowerField)
+
+		if tagValue := field.Tag.Get("json"); tagValue != "" && tagValue != "-" {
+			delete(extras, tagValue)
+		}
+	}
+
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/tokens/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/identity/v3/tokens/results.go
@@ -144,6 +144,15 @@ func (r commonResult) ExtractProject() (*Project, error) {
 	return s.Project, err
 }
 
+// ExtractDomain returns Domain to which User is authorized.
+func (r commonResult) ExtractDomain() (*Domain, error) {
+	var s struct {
+		Domain *Domain `json:"domain"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Domain, err
+}
+
 // CreateResult is the response from a Create request. Use ExtractToken()
 // to interpret it as a Token, or ExtractServiceCatalog() to interpret it
 // as a service catalog.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/doc.go
@@ -1,0 +1,60 @@
+/*
+Package images enables management and retrieval of images from the OpenStack
+Image Service.
+
+Example to List Images
+
+	images.ListOpts{
+		Owner: "a7509e1ae65945fda83f3e52c6296017",
+	}
+
+	allPages, err := images.List(imagesClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allImages, err := images.ExtractImages(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, image := range allImages {
+		fmt.Printf("%+v\n", image)
+	}
+
+Example to Create an Image
+
+	createOpts := images.CreateOpts{
+		Name:       "image_name",
+		Visibility: images.ImageVisibilityPrivate,
+	}
+
+	image, err := images.Create(imageClient, createOpts)
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update an Image
+
+	imageID := "1bea47ed-f6a9-463b-b423-14b9cca9ad27"
+
+	updateOpts := images.UpdateOpts{
+		images.ReplaceImageName{
+			NewName: "new_name",
+		},
+	}
+
+	image, err := images.Update(imageClient, imageID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete an Image
+
+	imageID := "1bea47ed-f6a9-463b-b423-14b9cca9ad27"
+	err := images.Delete(imageClient, imageID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package images

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/requests.go
@@ -1,0 +1,366 @@
+package images
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToImageListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the server attributes you want to see returned. Marker and Limit are used
+// for pagination.
+//
+// http://developer.openstack.org/api-ref-image-v2.html
+type ListOpts struct {
+	// ID is the ID of the image.
+	// Multiple IDs can be specified by constructing a string
+	// such as "in:uuid1,uuid2,uuid3".
+	ID string `q:"id"`
+
+	// Integer value for the limit of values to return.
+	Limit int `q:"limit"`
+
+	// UUID of the server at which you want to set a marker.
+	Marker string `q:"marker"`
+
+	// Name filters on the name of the image.
+	// Multiple names can be specified by constructing a string
+	// such as "in:name1,name2,name3".
+	Name string `q:"name"`
+
+	// Visibility filters on the visibility of the image.
+	Visibility ImageVisibility `q:"visibility"`
+
+	// MemberStatus filters on the member status of the image.
+	MemberStatus ImageMemberStatus `q:"member_status"`
+
+	// Owner filters on the project ID of the image.
+	Owner string `q:"owner"`
+
+	// Status filters on the status of the image.
+	// Multiple statuses can be specified by constructing a string
+	// such as "in:saving,queued".
+	Status ImageStatus `q:"status"`
+
+	// SizeMin filters on the size_min image property.
+	SizeMin int64 `q:"size_min"`
+
+	// SizeMax filters on the size_max image property.
+	SizeMax int64 `q:"size_max"`
+
+	// Sort sorts the results using the new style of sorting. See the OpenStack
+	// Image API reference for the exact syntax.
+	//
+	// Sort cannot be used with the classic sort options (sort_key and sort_dir).
+	Sort string `q:"sort"`
+
+	// SortKey will sort the results based on a specified image property.
+	SortKey string `q:"sort_key"`
+
+	// SortDir will sort the list results either ascending or decending.
+	SortDir string `q:"sort_dir"`
+
+	// Tags filters on specific image tags.
+	Tags []string `q:"tag"`
+
+	// CreatedAtQuery filters images based on their creation date.
+	CreatedAtQuery *ImageDateQuery
+
+	// UpdatedAtQuery filters images based on their updated date.
+	UpdatedAtQuery *ImageDateQuery
+
+	// ContainerFormat filters images based on the container_format.
+	// Multiple container formats can be specified by constructing a
+	// string such as "in:bare,ami".
+	ContainerFormat string `q:"container_format"`
+
+	// DiskFormat filters images based on the disk_format.
+	// Multiple disk formats can be specified by constructing a string
+	// such as "in:qcow2,iso".
+	DiskFormat string `q:"disk_format"`
+}
+
+// ToImageListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToImageListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	params := q.Query()
+
+	if opts.CreatedAtQuery != nil {
+		createdAt := opts.CreatedAtQuery.Date.Format(time.RFC3339)
+		if v := opts.CreatedAtQuery.Filter; v != "" {
+			createdAt = fmt.Sprintf("%s:%s", v, createdAt)
+		}
+
+		params.Add("created_at", createdAt)
+	}
+
+	if opts.UpdatedAtQuery != nil {
+		updatedAt := opts.UpdatedAtQuery.Date.Format(time.RFC3339)
+		if v := opts.UpdatedAtQuery.Filter; v != "" {
+			updatedAt = fmt.Sprintf("%s:%s", v, updatedAt)
+		}
+
+		params.Add("updated_at", updatedAt)
+	}
+
+	q = &url.URL{RawQuery: params.Encode()}
+
+	return q.String(), err
+}
+
+// List implements image list request.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToImageListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		imagePage := ImagePage{
+			serviceURL:     c.ServiceURL(),
+			LinkedPageBase: pagination.LinkedPageBase{PageResult: r},
+		}
+
+		return imagePage
+	})
+}
+
+// CreateOptsBuilder allows extensions to add parameters to the Create request.
+type CreateOptsBuilder interface {
+	// Returns value that can be passed to json.Marshal
+	ToImageCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents options used to create an image.
+type CreateOpts struct {
+	// Name is the name of the new image.
+	Name string `json:"name" required:"true"`
+
+	// Id is the the image ID.
+	ID string `json:"id,omitempty"`
+
+	// Visibility defines who can see/use the image.
+	Visibility *ImageVisibility `json:"visibility,omitempty"`
+
+	// Tags is a set of image tags.
+	Tags []string `json:"tags,omitempty"`
+
+	// ContainerFormat is the format of the
+	// container. Valid values are ami, ari, aki, bare, and ovf.
+	ContainerFormat string `json:"container_format,omitempty"`
+
+	// DiskFormat is the format of the disk. If set,
+	// valid values are ami, ari, aki, vhd, vmdk, raw, qcow2, vdi,
+	// and iso.
+	DiskFormat string `json:"disk_format,omitempty"`
+
+	// MinDisk is the amount of disk space in
+	// GB that is required to boot the image.
+	MinDisk int `json:"min_disk,omitempty"`
+
+	// MinRAM is the amount of RAM in MB that
+	// is required to boot the image.
+	MinRAM int `json:"min_ram,omitempty"`
+
+	// protected is whether the image is not deletable.
+	Protected *bool `json:"protected,omitempty"`
+
+	// properties is a set of properties, if any, that
+	// are associated with the image.
+	Properties map[string]string `json:"-"`
+}
+
+// ToImageCreateMap assembles a request body based on the contents of
+// a CreateOpts.
+func (opts CreateOpts) ToImageCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Properties != nil {
+		for k, v := range opts.Properties {
+			b[k] = v
+		}
+	}
+	return b, nil
+}
+
+// Create implements create image request.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToImageCreateMap()
+	if err != nil {
+		r.Err = err
+		return r
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{OkCodes: []int{201}})
+	return
+}
+
+// Delete implements image delete request.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), nil)
+	return
+}
+
+// Get implements image get request.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+// Update implements image updated request.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToImageUpdateMap()
+	if err != nil {
+		r.Err = err
+		return r
+	}
+	_, r.Err = client.Patch(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: map[string]string{"Content-Type": "application/openstack-images-v2.1-json-patch"},
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	// returns value implementing json.Marshaler which when marshaled matches
+	// the patch schema:
+	// http://specs.openstack.org/openstack/glance-specs/specs/api/v2/http-patch-image-api-v2.html
+	ToImageUpdateMap() ([]interface{}, error)
+}
+
+// UpdateOpts implements UpdateOpts
+type UpdateOpts []Patch
+
+// ToImageUpdateMap assembles a request body based on the contents of
+// UpdateOpts.
+func (opts UpdateOpts) ToImageUpdateMap() ([]interface{}, error) {
+	m := make([]interface{}, len(opts))
+	for i, patch := range opts {
+		patchJSON := patch.ToImagePatchMap()
+		m[i] = patchJSON
+	}
+	return m, nil
+}
+
+// Patch represents a single update to an existing image. Multiple updates
+// to an image can be submitted at the same time.
+type Patch interface {
+	ToImagePatchMap() map[string]interface{}
+}
+
+// UpdateVisibility represents an updated visibility property request.
+type UpdateVisibility struct {
+	Visibility ImageVisibility
+}
+
+// ToImagePatchMap assembles a request body based on UpdateVisibility.
+func (r UpdateVisibility) ToImagePatchMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "replace",
+		"path":  "/visibility",
+		"value": r.Visibility,
+	}
+}
+
+// ReplaceImageName represents an updated image_name property request.
+type ReplaceImageName struct {
+	NewName string
+}
+
+// ToImagePatchMap assembles a request body based on ReplaceImageName.
+func (r ReplaceImageName) ToImagePatchMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "replace",
+		"path":  "/name",
+		"value": r.NewName,
+	}
+}
+
+// ReplaceImageChecksum represents an updated checksum property request.
+type ReplaceImageChecksum struct {
+	Checksum string
+}
+
+// ReplaceImageChecksum assembles a request body based on ReplaceImageChecksum.
+func (r ReplaceImageChecksum) ToImagePatchMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "replace",
+		"path":  "/checksum",
+		"value": r.Checksum,
+	}
+}
+
+// ReplaceImageTags represents an updated tags property request.
+type ReplaceImageTags struct {
+	NewTags []string
+}
+
+// ToImagePatchMap assembles a request body based on ReplaceImageTags.
+func (r ReplaceImageTags) ToImagePatchMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "replace",
+		"path":  "/tags",
+		"value": r.NewTags,
+	}
+}
+
+// ReplaceImageMinDisk represents an updated min_disk property request.
+type ReplaceImageMinDisk struct {
+	NewMinDisk int
+}
+
+// ToImagePatchMap assembles a request body based on ReplaceImageTags.
+func (r ReplaceImageMinDisk) ToImagePatchMap() map[string]interface{} {
+	return map[string]interface{}{
+		"op":    "replace",
+		"path":  "/min_disk",
+		"value": r.NewMinDisk,
+	}
+}
+
+// UpdateOp represents a valid update operation.
+type UpdateOp string
+
+const (
+	AddOp     UpdateOp = "add"
+	ReplaceOp UpdateOp = "replace"
+	RemoveOp  UpdateOp = "remove"
+)
+
+// UpdateImageProperty represents an update property request.
+type UpdateImageProperty struct {
+	Op    UpdateOp
+	Name  string
+	Value string
+}
+
+// ToImagePatchMap assembles a request body based on UpdateImageProperty.
+func (r UpdateImageProperty) ToImagePatchMap() map[string]interface{} {
+	updateMap := map[string]interface{}{
+		"op":   r.Op,
+		"path": fmt.Sprintf("/%s", r.Name),
+	}
+
+	if r.Value != "" {
+		updateMap["value"] = r.Value
+	}
+
+	return updateMap
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/results.go
@@ -1,0 +1,202 @@
+package images
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/internal"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Image represents an image found in the OpenStack Image service.
+type Image struct {
+	// ID is the image UUID.
+	ID string `json:"id"`
+
+	// Name is the human-readable display name for the image.
+	Name string `json:"name"`
+
+	// Status is the image status. It can be "queued" or "active"
+	// See imageservice/v2/images/type.go
+	Status ImageStatus `json:"status"`
+
+	// Tags is a list of image tags. Tags are arbitrarily defined strings
+	// attached to an image.
+	Tags []string `json:"tags"`
+
+	// ContainerFormat is the format of the container.
+	// Valid values are ami, ari, aki, bare, and ovf.
+	ContainerFormat string `json:"container_format"`
+
+	// DiskFormat is the format of the disk.
+	// If set, valid values are ami, ari, aki, vhd, vmdk, raw, qcow2, vdi,
+	// and iso.
+	DiskFormat string `json:"disk_format"`
+
+	// MinDiskGigabytes is the amount of disk space in GB that is required to
+	// boot the image.
+	MinDiskGigabytes int `json:"min_disk"`
+
+	// MinRAMMegabytes [optional] is the amount of RAM in MB that is required to
+	// boot the image.
+	MinRAMMegabytes int `json:"min_ram"`
+
+	// Owner is the tenant ID the image belongs to.
+	Owner string `json:"owner"`
+
+	// Protected is whether the image is deletable or not.
+	Protected bool `json:"protected"`
+
+	// Visibility defines who can see/use the image.
+	Visibility ImageVisibility `json:"visibility"`
+
+	// Checksum is the checksum of the data that's associated with the image.
+	Checksum string `json:"checksum"`
+
+	// SizeBytes is the size of the data that's associated with the image.
+	SizeBytes int64 `json:"-"`
+
+	// Metadata is a set of metadata associated with the image.
+	// Image metadata allow for meaningfully define the image properties
+	// and tags.
+	// See http://docs.openstack.org/developer/glance/metadefs-concepts.html.
+	Metadata map[string]string `json:"metadata"`
+
+	// Properties is a set of key-value pairs, if any, that are associated with
+	// the image.
+	Properties map[string]interface{}
+
+	// CreatedAt is the date when the image has been created.
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is the date when the last change has been made to the image or
+	// it's properties.
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// File is the trailing path after the glance endpoint that represent the
+	// location of the image or the path to retrieve it.
+	File string `json:"file"`
+
+	// Schema is the path to the JSON-schema that represent the image or image
+	// entity.
+	Schema string `json:"schema"`
+
+	// VirtualSize is the virtual size of the image
+	VirtualSize int64 `json:"virtual_size"`
+}
+
+func (r *Image) UnmarshalJSON(b []byte) error {
+	type tmp Image
+	var s struct {
+		tmp
+		SizeBytes interface{} `json:"size"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Image(s.tmp)
+
+	switch t := s.SizeBytes.(type) {
+	case nil:
+		r.SizeBytes = 0
+	case float32:
+		r.SizeBytes = int64(t)
+	case float64:
+		r.SizeBytes = int64(t)
+	default:
+		return fmt.Errorf("Unknown type for SizeBytes: %v (value: %v)", reflect.TypeOf(t), t)
+	}
+
+	// Bundle all other fields into Properties
+	var result interface{}
+	err = json.Unmarshal(b, &result)
+	if err != nil {
+		return err
+	}
+	if resultMap, ok := result.(map[string]interface{}); ok {
+		delete(resultMap, "self")
+		delete(resultMap, "size")
+		r.Properties = internal.RemainingKeys(Image{}, resultMap)
+	}
+
+	return err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any commonResult as an Image.
+func (r commonResult) Extract() (*Image, error) {
+	var s *Image
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// CreateResult represents the result of a Create operation. Call its Extract
+// method to interpret it as an Image.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an Update operation. Call its Extract
+// method to interpret it as an Image.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a Get operation. Call its Extract
+// method to interpret it as an Image.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a Delete operation. Call its
+// ExtractErr method to interpret it as an Image.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// ImagePage represents the results of a List request.
+type ImagePage struct {
+	serviceURL string
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if an ImagePage contains no Images results.
+func (r ImagePage) IsEmpty() (bool, error) {
+	images, err := ExtractImages(r)
+	return len(images) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to
+// the next page of results.
+func (r ImagePage) NextPageURL() (string, error) {
+	var s struct {
+		Next string `json:"next"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	if s.Next == "" {
+		return "", nil
+	}
+
+	return nextPageURL(r.serviceURL, s.Next)
+}
+
+// ExtractImages interprets the results of a single page from a List() call,
+// producing a slice of Image entities.
+func ExtractImages(r pagination.Page) ([]Image, error) {
+	var s struct {
+		Images []Image `json:"images"`
+	}
+	err := (r.(ImagePage)).ExtractInto(&s)
+	return s.Images, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/types.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/types.go
@@ -1,0 +1,104 @@
+package images
+
+import (
+	"time"
+)
+
+// ImageStatus image statuses
+// http://docs.openstack.org/developer/glance/statuses.html
+type ImageStatus string
+
+const (
+	// ImageStatusQueued is a status for an image which identifier has
+	// been reserved for an image in the image registry.
+	ImageStatusQueued ImageStatus = "queued"
+
+	// ImageStatusSaving denotes that an image’s raw data is currently being
+	// uploaded to Glance
+	ImageStatusSaving ImageStatus = "saving"
+
+	// ImageStatusActive denotes an image that is fully available in Glance.
+	ImageStatusActive ImageStatus = "active"
+
+	// ImageStatusKilled denotes that an error occurred during the uploading
+	// of an image’s data, and that the image is not readable.
+	ImageStatusKilled ImageStatus = "killed"
+
+	// ImageStatusDeleted is used for an image that is no longer available to use.
+	// The image information is retained in the image registry.
+	ImageStatusDeleted ImageStatus = "deleted"
+
+	// ImageStatusPendingDelete is similar to Delete, but the image is not yet
+	// deleted.
+	ImageStatusPendingDelete ImageStatus = "pending_delete"
+
+	// ImageStatusDeactivated denotes that access to image data is not allowed to
+	// any non-admin user.
+	ImageStatusDeactivated ImageStatus = "deactivated"
+)
+
+// ImageVisibility denotes an image that is fully available in Glance.
+// This occurs when the image data is uploaded, or the image size is explicitly
+// set to zero on creation.
+// According to design
+// https://wiki.openstack.org/wiki/Glance-v2-community-image-visibility-design
+type ImageVisibility string
+
+const (
+	// ImageVisibilityPublic all users
+	ImageVisibilityPublic ImageVisibility = "public"
+
+	// ImageVisibilityPrivate users with tenantId == tenantId(owner)
+	ImageVisibilityPrivate ImageVisibility = "private"
+
+	// ImageVisibilityShared images are visible to:
+	// - users with tenantId == tenantId(owner)
+	// - users with tenantId in the member-list of the image
+	// - users with tenantId in the member-list with member_status == 'accepted'
+	ImageVisibilityShared ImageVisibility = "shared"
+
+	// ImageVisibilityCommunity images:
+	// - all users can see and boot it
+	// - users with tenantId in the member-list of the image with
+	//	 member_status == 'accepted' have this image in their default image-list.
+	ImageVisibilityCommunity ImageVisibility = "community"
+)
+
+// MemberStatus is a status for adding a new member (tenant) to an image
+// member list.
+type ImageMemberStatus string
+
+const (
+	// ImageMemberStatusAccepted is the status for an accepted image member.
+	ImageMemberStatusAccepted ImageMemberStatus = "accepted"
+
+	// ImageMemberStatusPending shows that the member addition is pending
+	ImageMemberStatusPending ImageMemberStatus = "pending"
+
+	// ImageMemberStatusAccepted is the status for a rejected image member
+	ImageMemberStatusRejected ImageMemberStatus = "rejected"
+
+	// ImageMemberStatusAll
+	ImageMemberStatusAll ImageMemberStatus = "all"
+)
+
+// ImageDateFilter represents a valid filter to use for filtering
+// images by their date during a List.
+type ImageDateFilter string
+
+const (
+	FilterGT  ImageDateFilter = "gt"
+	FilterGTE ImageDateFilter = "gte"
+	FilterLT  ImageDateFilter = "lt"
+	FilterLTE ImageDateFilter = "lte"
+	FilterNEQ ImageDateFilter = "neq"
+	FilterEQ  ImageDateFilter = "eq"
+)
+
+// ImageDateQuery represents a date field to be used for listing images.
+// If no filter is specified, the query will act as though FilterEQ was
+// set.
+type ImageDateQuery struct {
+	Date   time.Time
+	Filter ImageDateFilter
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/images/urls.go
@@ -1,0 +1,65 @@
+package images
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/utils"
+)
+
+// `listURL` is a pure function. `listURL(c)` is a URL for which a GET
+// request will respond with a list of images in the service `c`.
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("images")
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("images")
+}
+
+// `imageURL(c,i)` is the URL for the image identified by ID `i` in
+// the service `c`.
+func imageURL(c *gophercloud.ServiceClient, imageID string) string {
+	return c.ServiceURL("images", imageID)
+}
+
+// `getURL(c,i)` is a URL for which a GET request will respond with
+// information about the image identified by ID `i` in the service
+// `c`.
+func getURL(c *gophercloud.ServiceClient, imageID string) string {
+	return imageURL(c, imageID)
+}
+
+func updateURL(c *gophercloud.ServiceClient, imageID string) string {
+	return imageURL(c, imageID)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, imageID string) string {
+	return imageURL(c, imageID)
+}
+
+// builds next page full url based on current url
+func nextPageURL(serviceURL, requestedNext string) (string, error) {
+	base, err := utils.BaseEndpoint(serviceURL)
+	if err != nil {
+		return "", err
+	}
+
+	requestedNextURL, err := url.Parse(requestedNext)
+	if err != nil {
+		return "", err
+	}
+
+	base = gophercloud.NormalizeURL(base)
+	nextPath := base + strings.TrimPrefix(requestedNextURL.Path, "/")
+
+	nextURL, err := url.Parse(nextPath)
+	if err != nil {
+		return "", err
+	}
+
+	nextURL.RawQuery = requestedNextURL.RawQuery
+
+	return nextURL.String(), nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/requests.go
@@ -131,6 +131,9 @@ type CreateOpts struct {
 
 	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
 	InsertHeaders map[string]string `json:"insert_headers,omitempty"`
+
+	// A list of IPv4, IPv6 or mix of both CIDRs
+	AllowedCIDRs []string `json:"allowed_cidrs,omitempty"`
 }
 
 // ToListenerCreateMap builds a request body from CreateOpts.
@@ -202,6 +205,9 @@ type UpdateOpts struct {
 
 	// Time, in milliseconds, to wait for additional TCP packets for content inspection
 	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
+
+	// A list of IPv4, IPv6 or mix of both CIDRs
+	AllowedCIDRs []string `json:"allowed_cidrs,omitempty"`
 }
 
 // ToListenerUpdateMap builds a request body from UpdateOpts.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/results.go
@@ -77,6 +77,9 @@ type Listener struct {
 
 	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
 	InsertHeaders map[string]string `json:"insert_headers"`
+
+	// A list of IPv4, IPv6 or mix of both CIDRs
+	AllowedCIDRs []string `json:"allowed_cidrs"`
 }
 
 type Stats struct {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers/results.go
@@ -1,6 +1,9 @@
 package loadbalancers
 
 import (
+	"encoding/json"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools"
@@ -20,6 +23,11 @@ type LoadBalancer struct {
 
 	// Owner of the LoadBalancer.
 	ProjectID string `json:"project_id"`
+
+	// UpdatedAt and CreatedAt contain ISO-8601 timestamps of when the state of the
+	// loadbalancer last changed, and when it was created.
+	UpdatedAt time.Time `json:"-"`
+	CreatedAt time.Time `json:"-"`
 
 	// The provisioning status of the LoadBalancer.
 	// This value is ACTIVE, PENDING_CREATE or ERROR.
@@ -63,6 +71,44 @@ type LoadBalancer struct {
 	// Tags is a list of resource tags. Tags are arbitrarily defined strings
 	// attached to the resource.
 	Tags []string `json:"tags"`
+}
+
+func (r *LoadBalancer) UnmarshalJSON(b []byte) error {
+	type tmp LoadBalancer
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = LoadBalancer(s1.tmp)
+		r.CreatedAt = time.Time(s1.CreatedAt)
+		r.UpdatedAt = time.Time(s1.UpdatedAt)
+
+		return nil
+	}
+
+	// Support for newer neutron time format
+	var s2 struct {
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	err = json.Unmarshal(b, &s2)
+	if err != nil {
+		return err
+	}
+
+	*r = LoadBalancer(s2.tmp)
+	r.CreatedAt = time.Time(s2.CreatedAt)
+	r.UpdatedAt = time.Time(s2.UpdatedAt)
+
+	return nil
 }
 
 // StatusTree represents the status of a loadbalancer.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/requests.go
@@ -108,7 +108,6 @@ type CreateOpts struct {
 	MaxRetries int `json:"max_retries" required:"true"`
 
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
-	// Required for HTTP(S) types.
 	URLPath string `json:"url_path,omitempty"`
 
 	// The HTTP method used for requests by the Monitor. If this attribute
@@ -116,8 +115,8 @@ type CreateOpts struct {
 	HTTPMethod string `json:"http_method,omitempty"`
 
 	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
-	// a single status like "200", or a range like "200-202". Required for HTTP(S)
-	// types.
+	// a single status like "200", a range like "200-202", or a combination like
+	// "200-202, 401".
 	ExpectedCodes string `json:"expected_codes,omitempty"`
 
 	// TenantID is the UUID of the project who owns the Monitor.
@@ -138,24 +137,7 @@ type CreateOpts struct {
 
 // ToMonitorCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
-	b, err := gophercloud.BuildRequestBody(opts, "healthmonitor")
-	if err != nil {
-		return nil, err
-	}
-
-	switch opts.Type {
-	case TypeHTTP, TypeHTTPS:
-		switch opts.URLPath {
-		case "":
-			return nil, fmt.Errorf("URLPath must be provided for HTTP and HTTPS")
-		}
-		switch opts.ExpectedCodes {
-		case "":
-			return nil, fmt.Errorf("ExpectedCodes must be provided for HTTP and HTTPS")
-		}
-	}
-
-	return b, nil
+	return gophercloud.BuildRequestBody(opts, "healthmonitor")
 }
 
 /*

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
@@ -1,6 +1,9 @@
 package groups
 
 import (
+	"encoding/json"
+	"time"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/pagination"
@@ -25,11 +28,54 @@ type SecGroup struct {
 	// TenantID is the project owner of the security group.
 	TenantID string `json:"tenant_id"`
 
+	// UpdatedAt and CreatedAt contain ISO-8601 timestamps of when the state of the
+	// security group last changed, and when it was created.
+	UpdatedAt time.Time `json:"-"`
+	CreatedAt time.Time `json:"-"`
+
 	// ProjectID is the project owner of the security group.
 	ProjectID string `json:"project_id"`
 
 	// Tags optionally set via extensions/attributestags
 	Tags []string `json:"tags"`
+}
+
+func (r *SecGroup) UnmarshalJSON(b []byte) error {
+	type tmp SecGroup
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = SecGroup(s1.tmp)
+		r.CreatedAt = time.Time(s1.CreatedAt)
+		r.UpdatedAt = time.Time(s1.UpdatedAt)
+
+		return nil
+	}
+
+	// Support for newer neutron time format
+	var s2 struct {
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	err = json.Unmarshal(b, &s2)
+	if err != nil {
+		return err
+	}
+
+	*r = SecGroup(s2.tmp)
+	r.CreatedAt = time.Time(s2.CreatedAt)
+	r.UpdatedAt = time.Time(s2.UpdatedAt)
+
+	return nil
 }
 
 // SecGroupPage is the page returned by a pager when traversing over a


### PR DESCRIPTION
This PR allows to automatically populate a Glance image if it was not pre-created by the user.

Goals:
1. Automatically create a Glance image with the required version for the cluster.
2. The name of the created image must be unique. We have chosen names in format "\<InfraID\>-rhcos".
3. Delete the image together with the cluster.
4. If OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE variable is set and it is not a URL, do not create an image in Glance, but reuse the existing one and do not delete it when deleting the cluster.
5. If OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE variable is set and it is a URL - create a new Glance image from the URL ignoring rhcos.json file data, delete the Glance image along with the cluster.

Not included in goals of this work:
Generation of the URL from which we download the image file. It is obtained by the existing rhcos.OpenStack function based on the data from rhcos.json file.

Prerequisites:
In OpenShift 4.2, the name of the asset was hardcoded to "rhcos". Although it can be overridden with the env variable, users still have to create an image manually.
This is inconvenient for users and can lead to unpleasant consequences when OpenShift clusters of different versions can accidentally use the same RHCOS image.

Technical solution:
We consider 3 situations:
1. OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE is not set (default behavior)
RHCOS image file URL is generated from rhcos.json file by rhcos.OpenStack function. New Glance image called "\<InfraID\>-rhcos" is created by Terraform.
2. OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE is set and contains a URL.
RHCOS image file URL is provided by the variable, rhcos.json data is ignored. New Glance image called "\<InfraID\>-rhcos" is created by Terraform.
3. OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE is set and contains a string (not a URL).
Installer will reuse the existing Glance image defined by the variable, no new Glance images will be created.

Gotchas:
1. When creating a Glance image, Terraform first downloads the image file to the local hard disk in the ~/.terraform/image-cache folder and does not delete it after. Terrafom won't download the same data again afterwards, but anyway this may cause the hard disk to overflow if images with different versions are downloaded frequently.
2. When a file is loaded into Glance (has a status "saving"), the image cannot be deleted from OpenStack. You must either wait until the end of the download or explicitly interrupt it on the client side.

Future work:
1. Verify that the image defined by OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE variable exists.
2. Check that the image defined by the variable is the only one with such a name.
3. Checksum validations.