### PR TITLE
azure: set the os disk type based on machine objects

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -63,6 +63,7 @@ module "master" {
   subnet_id           = module.vnet.public_subnet_id
   instance_count      = var.master_count
   storage_account     = azurerm_storage_account.cluster
+  os_volume_type      = var.azure_master_root_volume_type
   os_volume_size      = var.azure_master_root_volume_size
 }
 

--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -51,7 +51,7 @@ resource "azurerm_virtual_machine" "master" {
     name              = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
     caching           = "ReadOnly"
     create_option     = "FromImage"
-    managed_disk_type = "Premium_LRS"
+    managed_disk_type = var.os_volume_type
     disk_size_gb      = var.os_volume_size
   }
 

--- a/data/data/azure/master/variables.tf
+++ b/data/data/azure/master/variables.tf
@@ -57,10 +57,14 @@ variable "subnet_id" {
   description = "The subnet to attach the masters to."
 }
 
+variable "os_volume_type" {
+  type        = string
+  description = "The type of the volume for the root block device."
+}
+
 variable "os_volume_size" {
   type        = string
   description = "The size of the volume in gigabytes for the root block device."
-  default     = "100"
 }
 
 variable "tags" {

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -36,19 +36,24 @@ EOF
 default = {}
 }
 
+variable "azure_master_root_volume_type" {
+  type        = string
+  description = "The type of the volume the root block device of master nodes."
+}
+
 variable "azure_master_root_volume_size" {
-type        = string
-description = "The size of the volume in gigabytes for the root block device of master nodes."
+  type        = string
+  description = "The size of the volume in gigabytes for the root block device of master nodes."
 }
 
 variable "azure_base_domain_resource_group_name" {
-type        = string
-description = "The resource group that contains the dns zone used as base domain for the cluster."
+  type        = string
+  description = "The resource group that contains the dns zone used as base domain for the cluster."
 }
 
 variable "azure_image_url" {
-type        = string
-description = "The URL of the vm image used for all nodes."
+  type        = string
+  description = "The URL of the vm image used for all nodes."
 }
 
 variable "azure_subscription_id" {

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -23,7 +23,8 @@ type config struct {
 	BootstrapInstanceType       string            `json:"azure_bootstrap_vm_type,omitempty"`
 	MasterInstanceType          string            `json:"azure_master_vm_type,omitempty"`
 	MasterAvailabilityZones     []string          `json:"azure_master_availability_zones"`
-	VolumeSize                  int32             `json:"azure_master_root_volume_size,omitempty"`
+	VolumeType                  string            `json:"azure_master_root_volume_type"`
+	VolumeSize                  int32             `json:"azure_master_root_volume_size"`
 	ImageURL                    string            `json:"azure_image_url,omitempty"`
 	Region                      string            `json:"azure_region,omitempty"`
 	BaseDomainResourceGroupName string            `json:"azure_base_domain_resource_group_name,omitempty"`
@@ -46,6 +47,7 @@ func TFVars(auth Auth, baseDomainResourceGroupName string, imageURL string, mast
 		BootstrapInstanceType:       defaults.BootstrapInstanceType(region),
 		MasterInstanceType:          masterConfig.VMSize,
 		MasterAvailabilityZones:     masterAvailabilityZones,
+		VolumeType:                  masterConfig.OSDisk.ManagedDisk.StorageAccountType,
 		VolumeSize:                  masterConfig.OSDisk.DiskSizeGB,
 		ImageURL:                    imageURL,
 	}


### PR DESCRIPTION
Like most of the other platforms, the disk type for master machines is present in the machine object, and the terraform should
use that to create control plane machines.

This allows users to use multi-stage installs to modify the control-plane root volume disk type.

This change explicitly skips the addition of making it easy for users to specify this setting in install-config for future work.

/assign @jhixson74 