### PR TITLE
data/azure/main: Set metadata to URL, not the string "var.azure_image_url"

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -149,7 +149,7 @@ resource "azurerm_storage_blob" "rhcos_image" {
   storage_container_name = azurerm_storage_container.vhd.name
   type                   = "block"
   source_uri             = var.azure_image_url
-  metadata               = map("source_uri", "var.azure_image_url")
+  metadata               = map("source_uri", var.azure_image_url)
   attempts               = 2
 }
 


### PR DESCRIPTION
Fixing a typo from 5416b42b9d (#1976).  Carries #2468.