### PR TITLE
WIP: BYO VPC validation

### DIFF
--- a/pkg/asset/installconfig/gcp/client.go
+++ b/pkg/asset/installconfig/gcp/client.go
@@ -1,0 +1,47 @@
+package gcp
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/api/option"
+	"github.com/pkg/errors"
+	compute "google.golang.org/api/compute/v1"
+)
+
+// API represents the calls made to the API.
+type API interface {
+	GetNetwork(ctx context.Context, network, project string) (*compute.Network, error)
+}
+
+// Client makes calls to the GCP API.
+type Client struct{}
+
+// GetNetwork wraps the GCP Compute Service call to get a network by name from a project
+func (c *Client) GetNetwork(ctx context.Context, network, project string) (*compute.Network, error) {
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	svc, err := getComputeService(ctx)
+	if err != nil {
+		return nil, err
+	}
+	res, err := svc.Networks.Get(project, network).Context(ctx).Do()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get network %s", network)
+	}
+	return res, nil
+}
+
+func getComputeService(ctx context.Context) (*compute.Service, error) {
+	ssn, err := GetSession(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get session")
+	}
+
+	svc, err := compute.NewService(ctx, option.WithCredentials(ssn.Credentials))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create compute service")
+	}
+	return svc, nil
+}

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -1,0 +1,67 @@
+package gcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+// Validator provides validation which requires access to the GCP API.
+type Validator struct {
+	Client        API
+	InstallConfig *types.InstallConfig
+}
+
+// Validate executes platform-specific validation.
+func (v *Validator) Validate() field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, v.validateVPC()...)
+
+	return allErrs
+}
+
+// validateVPC checks that the user-provided VPC is in the project and the provided subnets are valid.
+func (v *Validator) validateVPC() field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	network, err := v.Client.GetNetwork(context.TODO(), v.InstallConfig.GCP.Network, v.InstallConfig.GCP.ProjectID)
+	if err != nil {
+		return append(allErrs, field.Invalid(field.NewPath("network"), v.InstallConfig.GCP.Network, err.Error()))
+	}
+
+	if ok, errMsg := validateSubnet(network.Subnetworks, v.InstallConfig.GCP.ControlPlaneSubnet, v.InstallConfig.GCP.Region); !ok {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("controlPlaneSubnet"), v.InstallConfig.GCP.ControlPlaneSubnet, errMsg))
+	}
+
+	if ok, errMsg := validateSubnet(network.Subnetworks, v.InstallConfig.GCP.ComputeSubnet, v.InstallConfig.GCP.Region); !ok {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("computeSubnet"), v.InstallConfig.GCP.ComputeSubnet, errMsg))
+	}
+
+	return allErrs
+}
+
+// validateSubnets checks that the subnets are in the provided VPC and in the cluster region.
+func validateSubnet(subnets []string, userSubnet, region string) (bool, string) {
+	for _, vpcSubnet := range subnets {
+		if userSubnet == name(vpcSubnet) {
+			if !strings.Contains(vpcSubnet, region) {
+				return false, fmt.Sprintf("subnet %s not in region %s", vpcSubnet, region)
+			}
+			return true, ""
+		}
+	}
+	return false, fmt.Sprintf("could not find subnet %s", userSubnet)
+}
+
+// name takes the fully-qualified URL of the subnetwork, which is provided in the API call and returns the name.
+// Example url: https://www.googleapis.com/compute/v1/projects/openshift-dev-installer/regions/us-east4/subnetworks/byovpc-master-subnet
+// Returns: byovpc-master-subnet
+func name(url string) string {
+	splitSubnet := strings.Split(url, "/")
+	return splitSubnet[len(splitSubnet)-1]
+}


### PR DESCRIPTION
Initial take on BYO VPC validation. This provides (I believe) all validation where calls to GCP API are needed. I still need to do the basic validation that does not require calls to the API. I also need to write tests. The main reason for creating the GCP client and API interface (I am very open to renaming suggestions) is to mock out tests, so this might make more sense once I write the tests. I will also rewrite the existing DNS Public zones to use the client (and we can add some tests there). Posting now for early feedback. 