### PR TITLE
WIP DNM Put etcd storage in a ramdisk

### DIFF
--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -20,6 +20,25 @@ EOF
   }
 }
 
+data "ignition_systemd_unit" "etcd_ramdisk" {
+  name = "var-lib-etcd.mount"
+
+  content = <<EOF
+[Unit]
+Description=Mount etcd as a ramdisk
+Before=local-fs.target
+
+[Mount]
+What=none
+Where=/var/lib/etcd
+Type=tmpfs
+Options=size=2G
+
+[Install]
+WantedBy=local-fs.target
+EOF
+}
+
 data "ignition_config" "master_ignition_config" {
   count = var.instance_count
 
@@ -29,6 +48,10 @@ data "ignition_config" "master_ignition_config" {
 
   files = [
     element(data.ignition_file.hostname.*.id, count.index)
+  ]
+
+  systemd = [
+    data.ignition_systemd_unit.etcd_ramdisk.id,
   ]
 }
 


### PR DESCRIPTION
This mounts a 2GB ramdisk for `/var/lib/etcd`.

We want to observe the test behaviour when the etcd latency is really
low, sidestepping any disk performance issues in the OpenStack cloud.

This is not intended for use in production (none of the etcd data is
persisted on disk), but it should be helpful in identifying how many
issues are related to the cloud performance and separating ones that
are not.

It might also be an option for running the OpenStack CI on less
performant clouds.