### PR TITLE
Bug 1760197: Change GCP UPI firewall rules for network LB health check.

### DIFF
--- a/upi/gcp/03_security.py
+++ b/upi/gcp/03_security.py
@@ -44,7 +44,7 @@ def GenerateConfig(context):
                 'IPProtocol': 'tcp',
                 'ports': ['6080', '22624']
             }],
-            'sourceRanges':  ['35.191.0.0/16', '130.211.0.0/22'],
+            'sourceRanges': ['35.191.0.0/16', '209.85.152.0/22', '209.85.204.0/22'],
             'targetTags': [context.properties['infra_id'] + '-master']
         }
     }, {


### PR DESCRIPTION
This is an equivalent change to f0e25273cf9512b4aa99c26acdd153007d046e2d for UPI. The firewall rules did not allow for the complete range of network load balancer health checks.