### PR TITLE
OpenStack: clean-up cloud provider config

### DIFF
--- a/pkg/asset/manifests/openstack/cloudproviderconfig.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig.go
@@ -31,7 +31,6 @@ func CloudProviderConfig(cloud *clientconfig.Cloud) string {
 	res := `[Global]
 secret-name = openstack-credentials
 secret-namespace = kube-system
-kubeconfig-path = /var/lib/kubelet/kubeconfig
 `
 	if cloud.RegionName != "" {
 		res += "region = " + cloud.RegionName + "\n"

--- a/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
@@ -107,7 +107,6 @@ func TestCloudProviderConfig(t *testing.T) {
 	expectedConfig := `[Global]
 secret-name = openstack-credentials
 secret-namespace = kube-system
-kubeconfig-path = /var/lib/kubelet/kubeconfig
 region = my_region
 `
 	actualConfig := CloudProviderConfig(&cloud)


### PR DESCRIPTION
kubeconfig-path parameter was deprecated and not used anymore, so we can remove it from the config.
https://github.com/openshift/origin/blob/master/vendor/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go#L177-L178