### PR TITLE
data/manifests/bootkube/cvo-overrides: Move to stable-4.3

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -5,5 +5,5 @@ metadata:
   name: version
 spec:
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph
-  channel: stable-4.2
+  channel: stable-4.3
   clusterID: {{.CVOClusterID}}

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -109,7 +109,7 @@ The installer uses the [cluster-version-operator] to create all the components o
       selfLink: /apis/config.openshift.io/v1/clusterversions/version
       uid: 6e0f4cf8-3ade-11e9-9034-0a923b47ded4
     spec:
-      channel: stable-4.2
+      channel: stable-4.3
       clusterID: 5ec312f9-f729-429d-a454-61d4906896ca
       upstream: https://api.openshift.com/api/upgrades_info/v1/graph
     status:


### PR DESCRIPTION
4.2 has branched off, so we can bump master to track stable-4.3.  This bump is like the previous 8eeb26840c (#1801).

Generated with:

```console
$ sed -i 's/stable-4.2/stable-4.3/' $(git grep -l stable-4.2)
```