### PR TITLE
docs/user/aws/install_upi: Fix "machinesets" -> "machineset" typo

### DIFF
--- a/docs/user/aws/install_upi.md
+++ b/docs/user/aws/install_upi.md
@@ -45,7 +45,7 @@ INFO Consuming "Install Config" from target directory
 Remove the control-plane Machines and compute MachineSets, because we'll be providing those ourselves and don't want to involve [the machine-API operator][machine-api-operator]:
 
 ```console
-$ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machinesets-*.yaml
+$ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 ```
 
 You are free to leave the compute MachineSets in if you want to create compute machines via the machine API, but if you do you may need to update the various references (`subnet`, etc.) to match your environment.
@@ -128,13 +128,13 @@ $ tree
 Many of the operators and functions within OpenShift rely on tagging AWS resources. By default, Ignition
 generates a unique cluster identifier comprised of the cluster name specified during the invocation of the installer
 and a short string known internally as the infrastructure name. These values are seeded in the initial manifests within
-the Ignition configuration. To use the output of the default, generated 
+the Ignition configuration. To use the output of the default, generated
 `ignition-configs` extracting the internal infrastructure name is necessary.
 
-An example of a way to get this is below: 
+An example of a way to get this is below:
 
 ```
-$ jq -r .infraID metadata.json 
+$ jq -r .infraID metadata.json
 openshift-vw9j6
 ```
 
@@ -153,9 +153,9 @@ A created VPC via the template or manually should approximate a setup similar to
 
 The DNS and load balancer configuration within a CloudFormation template is provided
 [here](../../../upi/aws/cloudformation/02_cluster_infra.yaml). It uses a public hosted zone and creates a private hosted
-zone similar to the IPI installation method. 
+zone similar to the IPI installation method.
 It also creates load balancers, listeners, as well as hosted zone and subnet tags the same way as the IPI
-installation method. 
+installation method.
 This template can be run multiple times within a single VPC and in combination with the VPC
 template provided above.
 


### PR DESCRIPTION
Creating manifests:

```
$ openshift-install create manifests
WARNING There are no compute nodes specified. The cluster will not fully initialize without compute nodes. 
INFO Consuming "Install Config" from target directory 
```

Produces the following yaml files:

```
$ ls -lah openshift/
total 68K
drwxr-xr-x. 2 jdoss jdoss 4.0K Oct 10 14:39 .
drwxrwxr-x. 4 jdoss jdoss 4.0K Oct 10 14:39 ..
-rw-r--r--. 1 jdoss jdoss  293 Oct 10 14:39 99_binding-discovery.yaml
-rw-r--r--. 1 jdoss jdoss  219 Oct 10 14:39 99_cloud-creds-secret.yaml
-rw-r--r--. 1 jdoss jdoss  181 Oct 10 14:39 99_kubeadmin-password-secret.yaml
-rw-r--r--. 1 jdoss jdoss 1.5K Oct 10 14:39 99_openshift-cluster-api_master-machines-0.yaml
-rw-r--r--. 1 jdoss jdoss 1.5K Oct 10 14:39 99_openshift-cluster-api_master-machines-1.yaml
-rw-r--r--. 1 jdoss jdoss 1.5K Oct 10 14:39 99_openshift-cluster-api_master-machines-2.yaml
-rw-r--r--. 1 jdoss jdoss 2.7K Oct 10 14:39 99_openshift-cluster-api_master-user-data-secret.yaml
-rw-r--r--. 1 jdoss jdoss 2.1K Oct 10 14:39 99_openshift-cluster-api_worker-machineset-0.yaml
-rw-r--r--. 1 jdoss jdoss 2.1K Oct 10 14:39 99_openshift-cluster-api_worker-machineset-1.yaml
-rw-r--r--. 1 jdoss jdoss 2.1K Oct 10 14:39 99_openshift-cluster-api_worker-machineset-2.yaml
-rw-r--r--. 1 jdoss jdoss 2.1K Oct 10 14:39 99_openshift-cluster-api_worker-machineset-3.yaml
-rw-r--r--. 1 jdoss jdoss 2.7K Oct 10 14:39 99_openshift-cluster-api_worker-user-data-secret.yaml
-rw-r--r--. 1 jdoss jdoss 1.2K Oct 10 14:39 99_openshift-machineconfig_master.yaml
-rw-r--r--. 1 jdoss jdoss 1.2K Oct 10 14:39 99_openshift-machineconfig_worker.yaml
-rw-r--r--. 1 jdoss jdoss  222 Oct 10 14:39 99_role-cloud-creds-secret-reader.yaml
```

Following the documentation it says to remove the following things:

`$ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machinesets-*.yaml`

Doing so left the `openshift/99_openshift-cluster-api_worker-machineset-*.yaml` files:

```
$ ls -lah openshift/
total 56K
drwxr-xr-x. 2 jdoss jdoss 4.0K Oct 10 14:44 .
drwxrwxr-x. 4 jdoss jdoss 4.0K Oct 10 14:39 ..
-rw-r--r--. 1 jdoss jdoss  293 Oct 10 14:39 99_binding-discovery.yaml
-rw-r--r--. 1 jdoss jdoss  219 Oct 10 14:39 99_cloud-creds-secret.yaml
-rw-r--r--. 1 jdoss jdoss  181 Oct 10 14:39 99_kubeadmin-password-secret.yaml
-rw-r--r--. 1 jdoss jdoss 2.7K Oct 10 14:39 99_openshift-cluster-api_master-user-data-secret.yaml
-rw-r--r--. 1 jdoss jdoss 2.1K Oct 10 14:39 99_openshift-cluster-api_worker-machineset-0.yaml
-rw-r--r--. 1 jdoss jdoss 2.1K Oct 10 14:39 99_openshift-cluster-api_worker-machineset-1.yaml
-rw-r--r--. 1 jdoss jdoss 2.1K Oct 10 14:39 99_openshift-cluster-api_worker-machineset-2.yaml
-rw-r--r--. 1 jdoss jdoss 2.1K Oct 10 14:39 99_openshift-cluster-api_worker-machineset-3.yaml
-rw-r--r--. 1 jdoss jdoss 2.7K Oct 10 14:39 99_openshift-cluster-api_worker-user-data-secret.yaml
-rw-r--r--. 1 jdoss jdoss 1.2K Oct 10 14:39 99_openshift-machineconfig_master.yaml
-rw-r--r--. 1 jdoss jdoss 1.2K Oct 10 14:39 99_openshift-machineconfig_worker.yaml
-rw-r--r--. 1 jdoss jdoss  222 Oct 10 14:39 99_role-cloud-creds-secret-reader.yaml
```

Removing the `s` from the `rm` command below:

`$ rm -rf openshift/99_openshift-cluster-api_worker-machineset-*.yaml`

Gives us the results we expect!

```
$ ls -lah openshift/
total 40K
drwxr-xr-x. 2 jdoss jdoss 4.0K Oct 10 14:45 .
drwxrwxr-x. 4 jdoss jdoss 4.0K Oct 10 14:39 ..
-rw-r--r--. 1 jdoss jdoss  293 Oct 10 14:39 99_binding-discovery.yaml
-rw-r--r--. 1 jdoss jdoss  219 Oct 10 14:39 99_cloud-creds-secret.yaml
-rw-r--r--. 1 jdoss jdoss  181 Oct 10 14:39 99_kubeadmin-password-secret.yaml
-rw-r--r--. 1 jdoss jdoss 2.7K Oct 10 14:39 99_openshift-cluster-api_master-user-data-secret.yaml
-rw-r--r--. 1 jdoss jdoss 2.7K Oct 10 14:39 99_openshift-cluster-api_worker-user-data-secret.yaml
-rw-r--r--. 1 jdoss jdoss 1.2K Oct 10 14:39 99_openshift-machineconfig_master.yaml
-rw-r--r--. 1 jdoss jdoss 1.2K Oct 10 14:39 99_openshift-machineconfig_worker.yaml
-rw-r--r--. 1 jdoss jdoss  222 Oct 10 14:39 99_role-cloud-creds-secret-reader.yaml
```

Here is the `openshift-install` version that I used.

```
$ openshift-install version
openshift-install v4.1.18-201909201915-dirty
built from commit 80c0ef5e57812daf721522db78972aa557730fc4
release image quay.io/openshift-release-dev/ocp-release@sha256:420633acf3fc7572372fe2df758152f6ab1f53a21c79a6c4b741fa0394c7df3a
```


