### PR TITLE
Update terraform-provider-libvirt version to v0.6.0.

### DIFF
--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -383,14 +383,15 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:1e1c7b87d9c9d66cc9bc11e96924ec0016a20f427f001106f1eed659f51704aa"
+  digest = "1:d24d68b5a2409dfd1436784c3f992ddc53c5afd0ac0bb700d4378aa56b26a0ed"
   name = "github.com/dmacvicar/terraform-provider-libvirt"
   packages = [
     "libvirt",
     "libvirt/helper/suppress",
   ]
   pruneopts = "NUT"
-  revision = "c0e46b59df8718cdd905b1a3fb9738b0d4905143"
+  revision = "1c8597df6630ceeca4765d08ab49c596768dd45c"
+  version = "v0.6.0"
 
 [[projects]]
   branch = "master"
@@ -1197,7 +1198,6 @@
     "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure",
     "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/response",
     "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/suppress",
-    "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/tf",
     "github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/validate",
     "github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils",
     "github.com/terraform-providers/terraform-provider-azurerm/version",

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -11,7 +11,7 @@ ignored = [
 
 [[constraint]]
   name = "github.com/dmacvicar/terraform-provider-libvirt"
-  revision = "c0e46b59df8718cdd905b1a3fb9738b0d4905143"
+  version = "=0.6.0"
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-aws"

--- a/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/domain.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/domain.go
@@ -1,11 +1,16 @@
 package libvirt
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -230,26 +235,182 @@ func newDiskForCloudInit(virConn *libvirt.Connect, volumeKey string) (libvirtxml
 	return disk, nil
 }
 
-func setCoreOSIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {
+func getFirstDiskPath(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *libvirt.Connect) (string, error) {
+	prefix := fmt.Sprintf("disk.%d", 0)
+
+	if volumeKey, ok := d.GetOk(prefix + ".volume_id"); ok {
+		diskVolume, err := virConn.LookupStorageVolByKey(volumeKey.(string))
+		if err != nil {
+			return "", fmt.Errorf("Error lookup storage disk volume: %s", err)
+		}
+		diskVolumeFile, err := diskVolume.GetPath()
+		if err != nil {
+			return "", fmt.Errorf("Error get path of disk volume: %s", err)
+		}
+		return diskVolumeFile, nil
+	}
+	return "", fmt.Errorf("failed to find disk 0")
+}
+
+func getStderr(stderr io.ReadCloser) string {
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(stderr)
+	return buf.String()
+}
+
+func inlineUpdateCoreOsIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *libvirt.Connect) error {
+	if ignition, ok := d.GetOk("coreos_ignition"); ok {
+
+		// Get the root disk (first disk) volume location
+		rootPath, err := getFirstDiskPath(d, domainDef, virConn)
+		if err != nil {
+			return err
+		}
+
+		// Get the ingition file to be uploaded
+		ignitionKey, err := getIgnitionVolumeKeyFromTerraformID(ignition.(string))
+		if err != nil {
+			return err
+		}
+		diskVolume, err := virConn.LookupStorageVolByKey(ignitionKey)
+		if err != nil {
+			return err
+		}
+		fileToUpload, err := diskVolume.GetPath()
+		if err != nil {
+			return err
+		}
+		err = guestfishExecution(rootPath, fileToUpload)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var execCommand = exec.Command
+
+func guestfishExecution(rootPath string, fileToUpload string) error {
+	// This is the file in coreos image going to be copied from local
+	fileRemoteLocation := "/ignition/config.ign"
+
+	// eval  $(guestfish --listen -a $1)
+	cmd := execCommand("guestfish", "--listen", "-a", rootPath)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("Get stdout failed: %v", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("Get stderr failed: %v", err)
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return fmt.Errorf("Start command failed: %v", err)
+	}
+
+	// if the command start successfully, the output will be following format
+	// GUESTFISH_PID=xxxx; export GUESTFISH_PID, so we need get the PID and set by using os.Setenv
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(stdout)
+	guestfishPidLabel := strings.Split(buf.String(), ";")
+	guestfishPidValue := strings.Split(guestfishPidLabel[0], "=")
+	os.Setenv(guestfishPidValue[0], guestfishPidValue[1])
+
+	// guestfish --remote -- run
+	cmd = execCommand("guestfish", "--remote", "--", "run")
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Launch failed: %v, %s", err, getStderr(stderr))
+	}
+
+	// guestfish --remote -- exit
+	defer func() {
+		cmd := execCommand("guestfish", "--remote", "--", "exit")
+		cmd.Run()
+	}()
+
+	// guestfish --remote -- findfs-label
+	cmd = execCommand("guestfish", "--remote", "--", "findfs-label", "boot")
+	output, err := cmd.Output()
+
+	if err != nil {
+		return fmt.Errorf("Failed to find fs label: %v", err)
+	}
+
+	bootDisk := strings.TrimSpace(string(output))
+	if len(bootDisk) == 0 {
+		return fmt.Errorf("failed to get the boot filesystem")
+	}
+
+	// guestfish --remote -- mount $2 /
+	cmd = execCommand("guestfish", "--remote", "--", "mount", bootDisk, "/")
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Mount failed: %v, %s", err, getStderr(stderr))
+	}
+
+	// guestfish --remote -- mkdir-p /ignition
+	cmd = execCommand("guestfish", "--remote", "--", "mkdir-p", "/ignition")
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Mkdir failed: %v, %s", err, getStderr(stderr))
+	}
+
+	// This is the real command that upload the file from current location (the local file system)
+	// to remote file location (the coreos file system)
+	// guestfish --remote -- upload $4 $3/$4
+	cmd = execCommand("guestfish", "--remote", "--", "upload", fileToUpload, fileRemoteLocation)
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Upload failed: %v, %s", err, getStderr(stderr))
+	}
+
+	// guestfish --remote -- umount-all
+	cmd = execCommand("guestfish", "--remote", "--", "umount-all")
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("Unmount failed: %v, %s", err, getStderr(stderr))
+	}
+
+	return nil
+}
+
+// Use fw_cfg device to update coresos
+func fwcfgUpdateCoreOSIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {
 	if ignition, ok := d.GetOk("coreos_ignition"); ok {
 		ignitionKey, err := getIgnitionVolumeKeyFromTerraformID(ignition.(string))
 		if err != nil {
 			return err
 		}
+		// `fw_cfg_name` stands for firmware config is defined by a key and a value
+		// credits for this cryptic name: https://github.com/qemu/qemu/commit/81b2b81062612ebeac4cd5333a3b15c7d79a5a3d
+		if fwCfg, ok := d.GetOk("fw_cfg_name"); ok {
 
-		domainDef.QEMUCommandline = &libvirtxml.DomainQEMUCommandline{
-			Args: []libvirtxml.DomainQEMUCommandlineArg{
-				{
-					Value: "-fw_cfg",
+			domainDef.QEMUCommandline = &libvirtxml.DomainQEMUCommandline{
+				Args: []libvirtxml.DomainQEMUCommandlineArg{
+					{
+						Value: "-fw_cfg",
+					},
+					{
+						Value: fmt.Sprintf("name=%s,file=%s", fwCfg, ignitionKey),
+					},
 				},
-				{
-					Value: fmt.Sprintf("name=opt/com.coreos/config,file=%s", ignitionKey),
-				},
-			},
+			}
 		}
 	}
 
 	return nil
+}
+
+func updateCoreOSIgnition(d *schema.ResourceData, domainDef *libvirtxml.Domain, virConn *libvirt.Connect) error {
+	if runtime.GOARCH == "s390x" || runtime.GOARCH == "s390" {
+		// There is no support for fw_cfg in s390x, so instead of doing fw_cfg
+		// we have to inline update the coreos ignition file
+		return inlineUpdateCoreOsIgnition(d, domainDef, virConn)
+	}
+	return fwcfgUpdateCoreOSIgnition(d, domainDef)
 }
 
 func setVideo(d *schema.ResourceData, domainDef *libvirtxml.Domain) error {

--- a/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/domain_def.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/domain_def.go
@@ -69,14 +69,6 @@ func newDomainDef() libvirtxml.Domain {
 					},
 				},
 			},
-			RNGs: []libvirtxml.DomainRNG{
-				{
-					Model: "virtio",
-					Backend: &libvirtxml.DomainRNGBackend{
-						Random: &libvirtxml.DomainRNGBackendRandom{Device: "/dev/urandom"},
-					},
-				},
-			},
 		},
 		Features: &libvirtxml.DomainFeatureList{
 			PAE:  &libvirtxml.DomainFeature{},
@@ -89,6 +81,21 @@ func newDomainDef() libvirtxml.Domain {
 		domainDef.Type = v
 	} else {
 		domainDef.Type = "kvm"
+	}
+
+	// FIXME: We should allow setting this from configuration as well.
+	rngDev := os.Getenv("TF_LIBVIRT_RNG_DEV")
+	if rngDev == "" {
+		rngDev = "/dev/urandom"
+	}
+
+	domainDef.Devices.RNGs = []libvirtxml.DomainRNG{
+		{
+			Model: "virtio",
+			Backend: &libvirtxml.DomainRNGBackend{
+				Random: &libvirtxml.DomainRNGBackendRandom{Device: rngDev},
+			},
+		},
 	}
 
 	return domainDef

--- a/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/resource_libvirt_domain.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/resource_libvirt_domain.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dmacvicar/terraform-provider-libvirt/libvirt/helper/suppress"
 	"github.com/hashicorp/terraform/helper/schema"
 	libvirt "github.com/libvirt/libvirt-go"
-	"github.com/libvirt/libvirt-go-xml"
+	libvirtxml "github.com/libvirt/libvirt-go-xml"
 )
 
 type pendingMapping struct {
@@ -104,6 +104,12 @@ func resourceLibvirtDomain() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Default:  "",
+			},
+			"fw_cfg_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "opt/com.coreos/config",
 			},
 			"filesystem": {
 				Type:     schema.TypeList,
@@ -469,7 +475,7 @@ func resourceLibvirtDomainCreate(d *schema.ResourceData, meta interface{}) error
 	setFirmware(d, &domainDef)
 	setBootDevices(d, &domainDef)
 
-	if err := setCoreOSIgnition(d, &domainDef); err != nil {
+	if err := updateCoreOSIgnition(d, &domainDef, virConn); err != nil {
 		return err
 	}
 

--- a/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/volume_def.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/dmacvicar/terraform-provider-libvirt/libvirt/volume_def.go
@@ -60,11 +60,15 @@ func newDefBackingStoreFromLibvirt(baseVolume *libvirt.StorageVol) (libvirtxml.S
 	if err != nil {
 		return libvirtxml.StorageVolumeBackingStore{}, fmt.Errorf("could not get base image path: %s", err)
 	}
-	backingStoreDef := libvirtxml.StorageVolumeBackingStore{
-		Path: baseVolPath,
-		Format: &libvirtxml.StorageVolumeTargetFormat{
+	var backingStoreVolFormat *libvirtxml.StorageVolumeTargetFormat
+	if baseVolumeDef.Target.Format != nil {
+		backingStoreVolFormat = &libvirtxml.StorageVolumeTargetFormat{
 			Type: baseVolumeDef.Target.Format.Type,
-		},
+		}
+	}
+	backingStoreDef := libvirtxml.StorageVolumeBackingStore{
+		Path:   baseVolPath,
+		Format: backingStoreVolFormat,
 	}
 	return backingStoreDef, nil
 }


### PR DESCRIPTION
Update terraform-provider-libvirt version to v0.6.0.

The terraform-provider-libvirt v0.6.0 contains the support of guestfs for s390 platform.
So this PR is to update erraform-provider-libvirt version.

Fixes #2499.