### PR TITLE
[wip] vSphere UPI: before reboot release DHCP lease

### DIFF
--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -51,6 +51,7 @@ data "ignition_systemd_unit" "restart" {
 ConditionFirstBoot=yes
 [Service]
 Type=idle
+ExecStartPre=/usr/sbin/dhclient -r ens192
 ExecStart=/sbin/reboot
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The interface is configure after the reboot.
Before rebooting the instance send DHCPRELEASE