### PR TITLE
docs: clarify enabling GCP service APIs

### DIFF
--- a/docs/user/gcp/README.md
+++ b/docs/user/gcp/README.md
@@ -1,9 +1,10 @@
 # GCP Project Setup
 
-This document is a guide for preparing a new GCP project for use with OpenShift. 
+This document is a guide for preparing a new GCP project for use with OpenShift.
 
 Follow along with the steps and links below to configure your GCP project and provision an OpenShift cluster:
 
+1. [Enable Service APIs](apis.md)
 1. [Setup DNS](dns.md)
 1. [Ensure sufficient quota](limits.md)
 1. [Create Installer Service Account](iam.md)

--- a/docs/user/gcp/apis.md
+++ b/docs/user/gcp/apis.md
@@ -1,0 +1,26 @@
+# GCP Service APIs
+To install OpenShift to your GCP project, the installer requires following [Service APIs][service-apis-summary] to be enabled for your project.
+
+## Enable API Services needed by your cluster
+
+You will need to enable the following API services in your project:
+
+- Compute Engine API (`compute.googleapis.com`)
+- Google Cloud APIs (`cloudapis.googleapis.com`)
+- Cloud Resource Manager API (`cloudresourcemanager.googleapis.com`)
+- Google DNS API (`dns.googleapis.com`)
+- Identity and Access Management (IAM) API (`iam.googleapis.com`)
+- IAM Service Account Credentials API (`iamcredentials.googleapis.com`)
+- Service Management API (`servicemanagement.googleapis.com`)
+- Service Usage API (`serviceusage.googleapis.com`)
+- Google Cloud Storage JSON API (`storage-api.googleapis.com`)
+- Cloud Storage (`storage-component.googleapis.com`)
+
+You can enable these services using the console or the CLI (console service names in parentheses)
+
+More information:
+- [GCP: Enable Services][enable-svc]
+
+
+[enable-svc]: https://cloud.google.com/service-usage/docs/enable-disable#enabling
+[service-apis-summary]: https://cloud.google.com/terms/services

--- a/docs/user/gcp/iam.md
+++ b/docs/user/gcp/iam.md
@@ -36,29 +36,7 @@ You will need to create and save a service account key for your service account 
 
 [GCP: Creating a service account key][sa-key]
 
-
-## Step 4: Enable API Services needed by your cluster
-
-You will need to enable the following API services in your project:
-
-- Compute Engine API (`compute.googleapis.com`)
-- Google Cloud APIs (`cloudapis.googleapis.com`)
-- Cloud Resource Manager API (`cloudresourcemanager.googleapis.com`)
-- Google DNS API (`dns.googleapis.com`)
-- Identity and Access Management (IAM) API (`iam.googleapis.com`)
-- IAM Service Account Credentials API (`iamcredentials.googleapis.com`)
-- Service Management API (`servicemanagement.googleapis.com`)
-- Service Usage API (`serviceusage.googleapis.com`)
-- Google Cloud Storage JSON API (`storage-api.googleapis.com`)
-- Cloud Storage (`storage-component.googleapis.com`)
-
-You can enable these services using the console or the CLI (console service names in parentheses)
-
-[GCP: Enable Services][enable-svc]
-
-
 [sa-create]: https://cloud.google.com/iam/docs/creating-managing-service-accounts#creating_a_service_account
 [gcp-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles
 [sa-assign]: https://cloud.google.com/iam/docs/granting-roles-to-service-accounts#granting_access_to_a_service_account_for_a_resource
 [sa-key]: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#creating_service_account_keys
-[enable-svc]: https://cloud.google.com/service-usage/docs/enable-disable#enabling


### PR DESCRIPTION
You need to enable to enable the APIs before you do things like set up DNS. Pulling this out into it's own step for clarity.