### PR TITLE
cmd/openshift-install/gather: Fix '{}' -> %s formatting

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -225,9 +225,9 @@ func logClusterOperatorConditions(ctx context.Context, config *rest.Config) erro
 				continue
 			}
 			if condition.Type == configv1.OperatorDegraded {
-				logrus.Errorf("Cluster operator {} {} is {} with {}: {}", operator.ObjectMeta.Name, condition.Type, condition.Status, condition.Reason, condition.Message)
+				logrus.Errorf("Cluster operator %s %s is %s with %s: %s", operator.ObjectMeta.Name, condition.Type, condition.Status, condition.Reason, condition.Message)
 			} else {
-				logrus.Infof("Cluster operator {} {} is {} with {}: {}", operator.ObjectMeta.Name, condition.Type, condition.Status, condition.Reason, condition.Message)
+				logrus.Infof("Cluster operator %s %s is %s with %s: %s", operator.ObjectMeta.Name, condition.Type, condition.Status, condition.Reason, condition.Message)
 			}
 		}
 	}


### PR DESCRIPTION
Fixing typos from de5a26aa42 (#2450).

WIP because I have an `|| True` in there for testing, which I'll pull once we see that the new formatting is working.