### PR TITLE
Update GCP internal load balancers to use custom-provided networks.

### DIFF
--- a/data/data/gcp/network/common.tf
+++ b/data/data/gcp/network/common.tf
@@ -21,4 +21,5 @@ data "google_compute_subnetwork" "preexisting_worker_subnet" {
 
 locals {
   cluster_network = var.preexisting_network ? data.google_compute_network.preexisting_cluster_network[0].self_link : google_compute_network.cluster_network[0].self_link
+  master_subnet   = var.preexisting_network ? data.google_compute_subnetwork.preexisting_master_subnet[0].self_link : google_compute_subnetwork.master_subnet[0].self_link
 }

--- a/data/data/gcp/network/lb-private.tf
+++ b/data/data/gcp/network/lb-private.tf
@@ -1,7 +1,7 @@
 resource "google_compute_address" "cluster_ip" {
   name         = "${var.cluster_id}-cluster-ip"
   address_type = "INTERNAL"
-  subnetwork   = google_compute_subnetwork.master_subnet[0].self_link
+  subnetwork   = local.master_subnet
 }
 
 resource "google_compute_health_check" "api_internal" {
@@ -37,7 +37,8 @@ resource "google_compute_forwarding_rule" "api_internal" {
   ip_address      = google_compute_address.cluster_ip.address
   backend_service = google_compute_region_backend_service.api_internal.self_link
   ports           = ["6443", "22623"]
-  subnetwork      = google_compute_subnetwork.master_subnet[0].self_link
+  subnetwork      = local.master_subnet
+  network         = local.cluster_network
 
   load_balancing_scheme = "INTERNAL"
 }

--- a/data/data/gcp/network/outputs.tf
+++ b/data/data/gcp/network/outputs.tf
@@ -15,5 +15,5 @@ output "worker_subnet" {
 }
 
 output "master_subnet" {
-  value = var.preexisting_network ? data.google_compute_subnetwork.preexisting_master_subnet[0].self_link : google_compute_subnetwork.master_subnet[0].self_link
+  value = local.master_subnet
 }


### PR DESCRIPTION
The creation of internal load balancers was not taking into account custom-provided networks. This was causing failure on BYO VPC installs with the error:
```
ERROR                                              
ERROR Error: Error creating ForwardingRule: googleapi: Error 400: Invalid value for field 'resource.backendService': 'https://www.googleapis.com/compute/v1/projects/openshift-dev-installer/regions/us-east4/backendServices/pd-6bk9x-api-internal'. Forwarding rule network projects/openshift-dev-installer/global/networks/default must be the same as backend service network projects/openshift-dev-installer/global/networks/byovpc-network., invalid 
ERROR                                              
ERROR   on ../../../../../../../../tmp/openshift-install-913030725/network/lb-private.tf line 34, in resource "google_compute_forwarding_rule" "api_internal": 
ERROR   34: resource "google_compute_forwarding_rule" "api_internal" { 
ERROR                                              
ERROR                                              
FATAL failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: failed to apply using Terraform 
```

Updated references to master subnet as well.