### PR TITLE
gcp: Enable clusters with no public endpoints

### DIFF
--- a/data/data/gcp/bootstrap/common.tf
+++ b/data/data/gcp/bootstrap/common.tf
@@ -1,0 +1,3 @@
+locals {
+  external_ip = var.public_endpoints ? [google_compute_address.bootstrap.address] : []
+}

--- a/data/data/gcp/bootstrap/variables.tf
+++ b/data/data/gcp/bootstrap/variables.tf
@@ -35,6 +35,15 @@ variable "network" {
   description = "The network the bootstrap node will be added to."
 }
 
+variable "network_cidr" {
+  type = string
+}
+
+variable "public_endpoints" {
+  type        = bool
+  description = "If the bootstrap instance should have externally accessible resources."
+}
+
 variable "subnet" {
   type        = string
   description = "The subnetwork the bootstrap node will be added to."

--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -11,6 +11,8 @@ resource "google_dns_managed_zone" "int" {
 }
 
 resource "google_dns_record_set" "api_external" {
+  count = var.public_endpoints ? 1 : 0
+
   name         = "api.${var.cluster_domain}."
   type         = "A"
   ttl          = "60"

--- a/data/data/gcp/dns/variables.tf
+++ b/data/data/gcp/dns/variables.tf
@@ -38,3 +38,8 @@ variable "cluster_domain" {
   description = "The domain for the cluster that all DNS records must belong"
   type        = string
 }
+
+variable "public_endpoints" {
+  type        = bool
+  description = "If the cluster should have externally accessible resources."
+}

--- a/data/data/gcp/network/firewall.tf
+++ b/data/data/gcp/network/firewall.tf
@@ -8,7 +8,7 @@ resource "google_compute_firewall" "api" {
     ports    = ["6443"]
   }
 
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = [var.public_endpoints ? "0.0.0.0/0" : var.network_cidr]
   target_tags   = ["${var.cluster_id}-master"]
 }
 
@@ -19,7 +19,7 @@ resource "google_compute_firewall" "health_checks" {
   # API, MCS (http)
   allow {
     protocol = "tcp"
-    ports    = ["6080", "22624"]
+    ports    = ["6080", "6443", "22624"]
   }
 
   source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22"]

--- a/data/data/gcp/network/lb-public.tf
+++ b/data/data/gcp/network/lb-public.tf
@@ -1,8 +1,12 @@
 resource "google_compute_address" "cluster_public_ip" {
+  count = var.public_endpoints ? 1 : 0
+
   name = "${var.cluster_id}-cluster-public-ip"
 }
 
 resource "google_compute_http_health_check" "api" {
+  count = var.public_endpoints ? 1 : 0
+
   name = "${var.cluster_id}-api"
 
   port         = 6080
@@ -10,16 +14,20 @@ resource "google_compute_http_health_check" "api" {
 }
 
 resource "google_compute_target_pool" "api" {
+  count = var.public_endpoints ? 1 : 0
+
   name = "${var.cluster_id}-api"
 
   instances     = var.master_instances
-  health_checks = [google_compute_http_health_check.api.self_link]
+  health_checks = [google_compute_http_health_check.api[0].self_link]
 }
 
 resource "google_compute_forwarding_rule" "api" {
+  count = var.public_endpoints ? 1 : 0
+
   name = "${var.cluster_id}-api"
 
-  ip_address = google_compute_address.cluster_public_ip.address
-  target     = google_compute_target_pool.api.self_link
+  ip_address = google_compute_address.cluster_public_ip[0].address
+  target     = google_compute_target_pool.api[0].self_link
   port_range = "6443"
 }

--- a/data/data/gcp/network/outputs.tf
+++ b/data/data/gcp/network/outputs.tf
@@ -3,7 +3,7 @@ output "cluster_ip" {
 }
 
 output "cluster_public_ip" {
-  value = google_compute_forwarding_rule.api.ip_address
+  value = var.public_endpoints ? google_compute_forwarding_rule.api[0].ip_address : null
 }
 
 output "network" {

--- a/data/data/gcp/network/variables.tf
+++ b/data/data/gcp/network/variables.tf
@@ -51,3 +51,8 @@ variable "preexisting_network" {
   type    = bool
   default = false
 }
+
+variable "public_endpoints" {
+  type        = bool
+  description = "If the bootstrap instance should have externally accessible resources."
+}

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -57,6 +57,7 @@ variable "gcp_master_root_volume_size" {
 
 variable "gcp_public_dns_zone_name" {
   type = string
+  default = null
   description = "The name of the public DNS zone to use for this cluster"
 }
 
@@ -86,4 +87,7 @@ variable "gcp_compute_subnet" {
   description = "The name of the subnet for worker nodes, either existing or to be created"
 }
 
-
+variable "gcp_publish_strategy" {
+  type = string
+  description = "The cluster publishing strategy, either Internal or External"
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -31,6 +31,7 @@ import (
 	gcptfvars "github.com/openshift/installer/pkg/tfvars/gcp"
 	libvirttfvars "github.com/openshift/installer/pkg/tfvars/libvirt"
 	openstacktfvars "github.com/openshift/installer/pkg/tfvars/openstack"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
@@ -233,6 +234,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Data:     data,
 		})
 	case gcp.Name:
+		var publicZoneName string
 		sess, err := gcpconfig.GetSession(ctx)
 		if err != nil {
 			return err
@@ -255,9 +257,12 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		for i, w := range workers {
 			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*gcpprovider.GCPMachineProviderSpec)
 		}
-		publicZone, err := gcpconfig.GetPublicZone(ctx, installConfig.Config.GCP.ProjectID, installConfig.Config.BaseDomain)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get GCP public zone")
+		if installConfig.Config.Publish == types.ExternalPublishingStrategy {
+			publicZone, err := gcpconfig.GetPublicZone(ctx, installConfig.Config.GCP.ProjectID, installConfig.Config.BaseDomain)
+			if err != nil {
+				return errors.Wrapf(err, "failed to get GCP public zone")
+			}
+			publicZoneName = publicZone.Name
 		}
 		preexistingnetwork := installConfig.Config.GCP.Network != ""
 		data, err := gcptfvars.TFVars(
@@ -266,7 +271,8 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				MasterConfigs:      masterConfigs,
 				WorkerConfigs:      workerConfigs,
 				ImageURI:           string(*rhcosImage),
-				PublicZoneName:     publicZone.Name,
+				PublicZoneName:     publicZoneName,
+				PublishStrategy:    installConfig.Config.Publish,
 				PreexistingNetwork: preexistingnetwork,
 			},
 		)

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -104,11 +104,13 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 			ID: dnsConfig.GetPrivateDNSZoneID(clusterID.InfraID+"-rg", installConfig.Config.ClusterDomain()),
 		}
 	case gcptypes.Name:
-		zone, err := icgcp.GetPublicZone(context.TODO(), installConfig.Config.Platform.GCP.ProjectID, installConfig.Config.BaseDomain)
-		if err != nil {
-			return errors.Wrapf(err, "failed to get public zone for %q", installConfig.Config.BaseDomain)
+		if installConfig.Config.Publish == types.ExternalPublishingStrategy {
+			zone, err := icgcp.GetPublicZone(context.TODO(), installConfig.Config.Platform.GCP.ProjectID, installConfig.Config.BaseDomain)
+			if err != nil {
+				return errors.Wrapf(err, "failed to get public zone for %q", installConfig.Config.BaseDomain)
+			}
+			config.Spec.PublicZone = &configv1.DNSZone{ID: zone.Name}
 		}
-		config.Spec.PublicZone = &configv1.DNSZone{ID: zone.Name}
 		config.Spec.PrivateZone = &configv1.DNSZone{ID: fmt.Sprintf("%s-private-zone", clusterID.InfraID)}
 	case libvirttypes.Name, openstacktypes.Name, baremetaltypes.Name, nonetypes.Name, vspheretypes.Name:
 	default:

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 
 	gcpprovider "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
+
+	"github.com/openshift/installer/pkg/types"
 )
 
 // Auth is the collection of credentials that will be used by terrform.
@@ -22,6 +24,7 @@ type config struct {
 	VolumeType              string   `json:"gcp_master_root_volume_type"`
 	VolumeSize              int64    `json:"gcp_master_root_volume_size"`
 	PublicZoneName          string   `json:"gcp_public_dns_zone_name,omitempty"`
+	PublishStrategy         string   `json:"gcp_publish_strategy,omitempty"`
 	PreexistingNetwork      bool     `json:"gcp_preexisting_network,omitempty"`
 	ClusterNetwork          string   `json:"gcp_cluster_network,omitempty"`
 	ControlPlaneSubnet      string   `json:"gcp_control_plane_subnet,omitempty"`
@@ -30,11 +33,13 @@ type config struct {
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
-	Auth                     Auth
-	MasterConfigs            []*gcpprovider.GCPMachineProviderSpec
-	WorkerConfigs            []*gcpprovider.GCPMachineProviderSpec
-	ImageURI, PublicZoneName string
-	PreexistingNetwork       bool
+	Auth               Auth
+	ImageURI           string
+	MasterConfigs      []*gcpprovider.GCPMachineProviderSpec
+	WorkerConfigs      []*gcpprovider.GCPMachineProviderSpec
+	PublicZoneName     string
+	PublishStrategy    types.PublishingStrategy
+	PreexistingNetwork bool
 }
 
 // TFVars generates gcp-specific Terraform variables launching the cluster.
@@ -55,6 +60,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		VolumeSize:              masterConfig.Disks[0].SizeGb,
 		ImageURI:                sources.ImageURI,
 		PublicZoneName:          sources.PublicZoneName,
+		PublishStrategy:         string(sources.PublishStrategy),
 		ClusterNetwork:          masterConfig.NetworkInterfaces[0].Network,
 		ControlPlaneSubnet:      masterConfig.NetworkInterfaces[0].Subnetwork,
 		ComputeSubnet:           workerConfig.NetworkInterfaces[0].Subnetwork,


### PR DESCRIPTION
This change allows the distinction between public and private clusters
in GCP based on installConfig.PublishingStrategy. It only creates the
public endpoints when installConfig.PublishingStrategy is "External".