### PR TITLE
Enable user defined default ingresscontroller

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -23,6 +23,7 @@ CONFIG_OPERATOR_IMAGE=$(image_for cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
 KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(image_for cluster-kube-controller-manager-operator)
 KUBE_SCHEDULER_OPERATOR_IMAGE=$(image_for cluster-kube-scheduler-operator)
+INGRESS_OPERATOR_IMAGE=$(image_for cluster-ingress-operator)
 
 OPENSHIFT_HYPERKUBE_IMAGE=$(image_for hyperkube)
 
@@ -164,6 +165,24 @@ then
 	cp kube-scheduler-bootstrap/manifests/* manifests/
 
 	touch kube-scheduler-bootstrap.done
+fi
+
+if [ ! -f ingress-operator-bootstrap.done ]
+then
+	echo "Rendering Ingress Operator core manifests..."
+
+	rm --recursive --force ingress-operator-bootstrap
+
+	bootkube_podman_run \
+		--volume "$PWD:/assets:z" \
+		"${INGRESS_OPERATOR_IMAGE}" \
+		render \
+		--prefix=cluster-ingress- \
+		--output-dir=/assets/ingress-operator-manifests
+
+	cp ingress-operator-manifests/* manifests/
+
+	touch ingress-operator-bootstrap.done
 fi
 
 if [ ! -f mco-bootstrap.done ]


### PR DESCRIPTION
Render ingress operator manifests during bootstrap. This enables users to bring
their own default ingresscontroller resource by using `openshift-install create
manifests` and placing ingresscontroller YAML into the `manifests/` directory.

At the time of this commit, the rendered output on the bootstrap node will be
the ingressoperator CRD[1] and namespace[2].

This is the first part of the "User Defined Default Ingress Controller"
enhancement proposal[3].

[1] https://github.com/openshift/cluster-ingress-operator/blob/master/manifests/00-custom-resource-definition-internal.yaml
[2] https://github.com/openshift/cluster-ingress-operator/blob/master/manifests/00-namespace.yaml
[3] https://github.com/openshift/enhancements/blob/master/enhancements/user-defined-default-ingress-controller.md

TODO:
- [x] Merge https://github.com/openshift/cluster-ingress-operator/pull/309
- [x] Vet the filenames