### PR TITLE
data/bootstrap/files/usr/local/bin/installer-*gather: Gather failed systemd units

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -8,6 +8,16 @@ fi
 
 ARTIFACTS="/tmp/artifacts-${GATHER_ID}"
 
+echo "Gathering bootstrap systemd summary ..."
+LANG=POSIX systemctl list-units --state=failed >& "${ARTIFACTS}/failed-units.txt"
+
+echo "Gathering bootstrap failed systemd unit status ..."
+mkdir -p "${ARTIFACTS}/unit-status"
+sed -n 's/^\* \([^ ]*\) .*/\1/p' < "${ARTIFACTS}/failed-units.txt" | while read -r UNIT
+do
+    systemctl status "${UNIT}" >& "${ARTIFACTS}/unit-status/${UNIT}.txt"
+done
+
 echo "Gathering bootstrap journals ..."
 mkdir -p "${ARTIFACTS}/bootstrap/journals"
 for service in release-image bootkube kubelet crio approve-csr

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -9,6 +9,16 @@ fi
 ARTIFACTS="/tmp/artifacts-${GATHER_ID}"
 mkdir -p "${ARTIFACTS}"
 
+echo "Gathering master systemd summary ..."
+LANG=POSIX systemctl list-units --state=failed >& "${ARTIFACTS}/failed-units.txt"
+
+echo "Gathering master failed systemd unit status ..."
+mkdir -p "${ARTIFACTS}/unit-status"
+sed -n 's/^\* \([^ ]*\) .*/\1/p' < "${ARTIFACTS}/failed-units.txt" | while read -r UNIT
+do
+    systemctl status "${UNIT}" >& "${ARTIFACTS}/unit-status/${UNIT}.txt"
+done
+
 echo "Gathering master journals ..."
 mkdir -p "${ARTIFACTS}/journals"
 for service in kubelet crio machine-config-daemon-host pivot


### PR DESCRIPTION
To help in cases where we die before getting far enough to launch a kubelet (or we have an issue with some other systemd-managed service).  In cases where there are no failing units, this will only add a small file and an empty directoy to the gathered tarball.

~To help in cases like [this][1], where one machine has no etcd running~

[The POSIX locale][2] gets us asterix prefixes in the `list-units` output, which are easier to match with sed than the default U+25CF (BLACK CIRCLE) it prints with `LANG=en_US.UTF-8`.  I'm not actually sure what locale we usually run on our control-plane machines, but it seems safest to not leave that up to the machines in this case.  Unfortunately I haven't found a way to have `list-units` spit out a more structured output format.

[1]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3/915
[2]: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_02