### PR TITLE
AWS: Enable clusters with no public endpoints

### DIFF
--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -62,9 +62,19 @@ variable "vpc_id" {
   description = "VPC ID is used to create resources like security group rules for bootstrap machine."
 }
 
+variable "vpc_cidrs" {
+  type        = list(string)
+  default     = []
+  description = "VPC CIDR blocks."
+}
+
 variable "vpc_security_group_ids" {
   type        = list(string)
   default     = []
   description = "VPC security group IDs for the bootstrap node."
 }
 
+variable "publish_strategy" {
+  type        = string
+  description = "The publishing strategy for endpoints like load balancers"
+}

--- a/data/data/aws/master/variables.tf
+++ b/data/data/aws/master/variables.tf
@@ -70,3 +70,13 @@ variable "user_data_ign" {
   type = string
 }
 
+variable "publish_strategy" {
+  type        = string
+  description = <<EOF
+The publishing strategy for endpoints like load balancers.
+
+Because of the issue https://github.com/hashicorp/terraform/issues/12570, the consumers cannot use a dynamic list for count
+and therefore are force to implicitly assume that the list is of aws_lb_target_group_arns_length - 1, in case there is no api_external. And that's where this variable
+helps to decide if the target_group_arns is of length (target_group_arns_length) or (target_group_arns_length - 1)
+EOF
+}

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -54,3 +54,13 @@ variable "api_internal_lb_zone_id" {
   type        = string
 }
 
+variable "publish_strategy" {
+  type        = string
+  description = <<EOF
+The publishing strategy for endpoints like load balancers
+
+Because of the issue https://github.com/hashicorp/terraform/issues/12570, the consumers cannot count 0/1
+based on if api_external_lb_dns_name for example, which will be null when there is no external lb for API.
+So publish_strategy serves an coordinated proxy for that decision.
+EOF
+}

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -86,3 +86,8 @@ variable "aws_private_subnets" {
   default = null
   description = "(optional) Existing private subnets into which the cluster should be installed."
 }
+
+variable "aws_publish_strategy" {
+  type = string
+  description = "The cluster publishing strategy, either Internal or External"
+}

--- a/data/data/aws/vpc/common.tf
+++ b/data/data/aws/vpc/common.tf
@@ -1,6 +1,10 @@
 # Canonical internal state definitions for this module.
 # read only: only locals and data source definitions allowed. No resources or module blocks in this file
 
+locals {
+  public_endpoints = var.publish_strategy == "External" ? true : false
+}
+
 # all data sources should be input variable-agnostic and used as canonical source for querying "state of resources" and building outputs
 # (ie: we don't want "aws.new_vpc" and "data.aws_vpc.cluster_vpc", just "data.aws_vpc.cluster_vpc" used everwhere).
 

--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -20,6 +20,8 @@ resource "aws_lb" "api_internal" {
 }
 
 resource "aws_lb" "api_external" {
+  count = local.public_endpoints ? 1 : 0
+
   name                             = "${var.cluster_id}-ext"
   load_balancer_type               = "network"
   subnets                          = data.aws_subnet.public.*.id
@@ -66,6 +68,8 @@ resource "aws_lb_target_group" "api_internal" {
 }
 
 resource "aws_lb_target_group" "api_external" {
+  count = local.public_endpoints ? 1 : 0
+
   name     = "${var.cluster_id}-aext"
   protocol = "TCP"
   port     = 6443
@@ -138,14 +142,14 @@ resource "aws_lb_listener" "api_internal_services" {
 }
 
 resource "aws_lb_listener" "api_external_api" {
-  count = var.public_master_endpoints ? 1 : 0
+  count = local.public_endpoints ? 1 : 0
 
-  load_balancer_arn = aws_lb.api_external.arn
+  load_balancer_arn = aws_lb.api_external[0].arn
   protocol          = "TCP"
   port              = "6443"
 
   default_action {
-    target_group_arn = aws_lb_target_group.api_external.arn
+    target_group_arn = aws_lb_target_group.api_external[0].arn
     type             = "forward"
   }
 }

--- a/data/data/aws/vpc/outputs.tf
+++ b/data/data/aws/vpc/outputs.tf
@@ -2,6 +2,10 @@ output "vpc_id" {
   value = data.aws_vpc.cluster_vpc.id
 }
 
+output "vpc_cidrs" {
+  value = [data.aws_vpc.cluster_vpc.cidr_block]
+}
+
 output "az_to_private_subnet_id" {
   value = zipmap(data.aws_subnet.private.*.availability_zone, data.aws_subnet.private.*.id)
 }
@@ -27,6 +31,9 @@ output "worker_sg_id" {
 }
 
 output "aws_lb_target_group_arns" {
+  // The order of the list is very important because the consumers assume the 3rd item is the external aws_lb_target_group
+  // Because of the issue https://github.com/hashicorp/terraform/issues/12570, the consumers cannot use a dynamic list for count
+  // and therefore are force to implicitly assume that the list is of aws_lb_target_group_arns_length - 1, in case there is no api_external
   value = compact(
     concat(
       aws_lb_target_group.api_internal.*.arn,
@@ -42,11 +49,11 @@ output "aws_lb_target_group_arns_length" {
 }
 
 output "aws_lb_api_external_dns_name" {
-  value = aws_lb.api_external.dns_name
+  value = local.public_endpoints ? aws_lb.api_external[0].dns_name : null
 }
 
 output "aws_lb_api_external_zone_id" {
-  value = aws_lb.api_external.zone_id
+  value = local.public_endpoints ? aws_lb.api_external[0].zone_id : null
 }
 
 output "aws_lb_api_internal_dns_name" {

--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -11,14 +11,9 @@ variable "cluster_id" {
   type = string
 }
 
-variable "private_master_endpoints" {
-  description = "If set to true, private-facing ingress resources are created."
-  default     = true
-}
-
-variable "public_master_endpoints" {
-  description = "If set to true, public-facing ingress resources are created."
-  default     = true
+variable "publish_strategy" {
+  type        = string
+  description = "The publishing strategy for endpoints like load balancers"
 }
 
 variable "region" {

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -21,6 +21,8 @@ The following `install-config.yaml` properties are available:
     The installer may also support older API versions.
 * `additionalTrustBundle` (optional string): a PEM-encoded X.509 certificate bundle that will be added to the nodes' trusted certificate store.
 * `baseDomain` (required string): The base domain to which the cluster should belong.
+* `publish` (optional string): This controls how the user facing endpoints of the cluster like the Kubernetes API, OpenShift routes etc. are exposed.
+    Valid values are `External` (the default) and `Internal`.
 * `controlPlane` (optional [machine-pool](#machine-pools)): The configuration for the machines that comprise the control plane.
 * `compute` (optional array of [machine-pools](#machine-pools)): The configuration for the machines that comprise the compute nodes.
 * `imageContentSources` (optional array of objects): Sources and repositories for the release-image content.

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -179,7 +179,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		for i, m := range workers {
 			workerConfigs[i] = m.Spec.Template.Spec.ProviderSpec.Value.Object.(*awsprovider.AWSMachineProviderConfig)
 		}
-		data, err := awstfvars.TFVars(vpc, privateSubnets, publicSubnets, masterConfigs, workerConfigs)
+		data, err := awstfvars.TFVars(vpc, privateSubnets, publicSubnets, installConfig.Config.Publish, masterConfigs, workerConfigs)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -91,6 +91,7 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 			None: &none.Platform{},
 		},
 		PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+		Publish:    types.ExternalPublishingStrategy,
 	}
 	assert.Equal(t, expected, installConfig.Config, "unexpected config generated")
 }
@@ -154,6 +155,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 					},
 				},
 				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				Publish:    types.ExternalPublishingStrategy,
 			},
 		},
 		{
@@ -235,6 +237,7 @@ network:
 					},
 				},
 				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				Publish:    types.ExternalPublishingStrategy,
 			},
 		},
 	}

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -144,18 +144,21 @@ func tagsFromUserTags(clusterID string, usertags map[string]string) ([]awsprovid
 }
 
 // ConfigMasters sets the PublicIP flag and assigns a set of load balancers to the given machines
-func ConfigMasters(machines []machineapi.Machine, clusterID string) {
+func ConfigMasters(machines []machineapi.Machine, clusterID string, publish types.PublishingStrategy) {
+	lbrefs := []awsprovider.LoadBalancerReference{{
+		Name: fmt.Sprintf("%s-int", clusterID),
+		Type: awsprovider.NetworkLoadBalancerType,
+	}}
+
+	if publish == types.ExternalPublishingStrategy {
+		lbrefs = append(lbrefs, awsprovider.LoadBalancerReference{
+			Name: fmt.Sprintf("%s-ext", clusterID),
+			Type: awsprovider.NetworkLoadBalancerType,
+		})
+	}
+
 	for _, machine := range machines {
 		providerSpec := machine.Spec.ProviderSpec.Value.Object.(*awsprovider.AWSMachineProviderConfig)
-		providerSpec.LoadBalancers = []awsprovider.LoadBalancerReference{
-			{
-				Name: fmt.Sprintf("%s-ext", clusterID),
-				Type: awsprovider.NetworkLoadBalancerType,
-			},
-			{
-				Name: fmt.Sprintf("%s-int", clusterID),
-				Type: awsprovider.NetworkLoadBalancerType,
-			},
-		}
+		providerSpec.LoadBalancers = lbrefs
 	}
 }

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -178,7 +178,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
-		aws.ConfigMasters(machines, clusterID.InfraID)
+		aws.ConfigMasters(machines, clusterID.InfraID, ic.Publish)
 	case gcptypes.Name:
 		mpool := defaultGCPMachinePoolPlatform()
 		mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -17,6 +17,7 @@ import (
 	icaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
+	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
@@ -78,11 +79,13 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 
 	switch installConfig.Config.Platform.Name() {
 	case awstypes.Name:
-		zone, err := icaws.GetPublicZone(installConfig.Config.BaseDomain)
-		if err != nil {
-			return errors.Wrapf(err, "getting public zone for %q", installConfig.Config.BaseDomain)
+		if installConfig.Config.Publish == types.ExternalPublishingStrategy {
+			zone, err := icaws.GetPublicZone(installConfig.Config.BaseDomain)
+			if err != nil {
+				return errors.Wrapf(err, "getting public zone for %q", installConfig.Config.BaseDomain)
+			}
+			config.Spec.PublicZone = &configv1.DNSZone{ID: strings.TrimPrefix(*zone.Id, "/hostedzone/")}
 		}
-		config.Spec.PublicZone = &configv1.DNSZone{ID: strings.TrimPrefix(*zone.Id, "/hostedzone/")}
 		config.Spec.PrivateZone = &configv1.DNSZone{Tags: map[string]string{
 			fmt.Sprintf("kubernetes.io/cluster/%s", clusterID.InfraID): "owned",
 			"Name": fmt.Sprintf("%s-int", clusterID.InfraID),

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -46,6 +46,11 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 			},
 		}
 	}
+
+	if c.Publish == "" {
+		c.Publish = types.ExternalPublishingStrategy
+	}
+
 	if c.ControlPlane == nil {
 		c.ControlPlane = &types.MachinePool{}
 	}

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -35,6 +35,7 @@ func defaultInstallConfig() *types.InstallConfig {
 		},
 		ControlPlane: defaultMachinePool("master"),
 		Compute:      []types.MachinePool{*defaultMachinePool("worker")},
+		Publish:      types.ExternalPublishingStrategy,
 	}
 }
 

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -42,6 +42,16 @@ var (
 	}
 )
 
+// PublishingStrategy is a strategy for how various endpoints for the cluster are exposed.
+type PublishingStrategy string
+
+const (
+	// ExternalPublishingStrategy exposes endpoints for the cluster to the Internet.
+	ExternalPublishingStrategy PublishingStrategy = "External"
+	// InternalPublishingStrategy exposes the endpoints for the cluster to the private network only.
+	InternalPublishingStrategy PublishingStrategy = "Internal"
+)
+
 // InstallConfig is the configuration for an OpenShift install.
 type InstallConfig struct {
 	// +optional
@@ -90,6 +100,11 @@ type InstallConfig struct {
 	// ImageContentSources lists sources/repositories for the release-image content.
 	// +optional
 	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
+
+	// Publish controls how the user facing endpoints of the cluster like the Kubernetes API, OpenShift routes etc. are exposed.
+	// When no strategy is specified, the strategy is `External`.
+	// +optional
+	Publish PublishingStrategy `json:"publish,omitempty"`
 }
 
 // ClusterDomain returns the DNS domain that all records for a cluster must belong to.

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -93,6 +93,9 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 		allErrs = append(allErrs, validateProxy(c.Proxy, field.NewPath("proxy"))...)
 	}
 	allErrs = append(allErrs, validateImageContentSources(c.ImageContentSources, field.NewPath("imageContentSources"))...)
+	if _, ok := validPublishingStrategies[c.Publish]; !ok {
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("publish"), c.Publish, validPublishingStrategyValues))
+	}
 	return allErrs
 }
 
@@ -304,3 +307,19 @@ func validateNamedRepository(r string) error {
 	}
 	return nil
 }
+
+var (
+	validPublishingStrategies = map[types.PublishingStrategy]struct{}{
+		types.ExternalPublishingStrategy: {},
+		types.InternalPublishingStrategy: {},
+	}
+
+	validPublishingStrategyValues = func() []string {
+		v := make([]string, 0, len(validPublishingStrategies))
+		for m := range validPublishingStrategies {
+			v = append(v, string(m))
+		}
+		sort.Strings(v)
+		return v
+	}()
+)

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -48,6 +48,7 @@ func validInstallConfig() *types.InstallConfig {
 			AWS: validAWSPlatform(),
 		},
 		PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+		Publish:    types.ExternalPublishingStrategy,
 		Proxy: &types.Proxy{
 			HTTPProxy:  "http://user:password@127.0.0.1:8080",
 			HTTPSProxy: "https://user:password@127.0.0.1:8080",
@@ -699,6 +700,15 @@ func TestValidateInstallConfig(t *testing.T) {
 				}}
 				return c
 			}(),
+		},
+		{
+			name: "invalid publishing strategy",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Publish = types.PublishingStrategy("ExternalInternalDoNotCare")
+				return c
+			}(),
+			expectedError: `^publish: Unsupported value: \"ExternalInternalDoNotCare\": supported values: \"External\", \"Internal\"`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
 pkg/types: add the publish strategy to install-config

This commit adds a enum(string) type PublishingStrategy. It supports 2 options

* ExternalPublishingStrategy : the endpoints are exposed to the Internet
* InternalPublishingStrategy : the endpoints are exposed to the `Private Network` only

This enum type is added to the InstallConfig to control the strategy for the cluster endpoints. Cluster endpoints include the API server,
the default Ingress controller, public IPs etc.

Also adds the defaulting to make sure this strategy is `External` by default, keeping the backward-compatible behavior, and validation to make sure only valid enum options are set.

 pkg/asset: update machines and DNS for external-internal strategy

For aws, only when the strategy is External, do we set the public Route53 zone for the basedomain in DNSes.config.openshift.com cluster object.

 data/aws: add publish strategy External/Internal feature

Adds the `aws_publish_strategy` variable to the terraform root variables to allow skipping public resources.

The brief list of resources that are only created when strategy is External are:

- Public Load Balancers for API (6443) (aws_lb.api_external, aws_lb_target_group.api_external, aws_lb_listener.api_external_api)
- Public DNS record (aws_route53_record.api_external)
- No public IP address associated to bootstrap-host (associate_public_ip_address: false)
- No security group rule that allows SSH to bootstrap-host from Internet (aws_security_group_rule.ssh), rather switching to VPC only.

Due to terraform issue hashicorp/terraform#12570, where count cannot use variables that are dynamic as they are not computed during plan, certain implicit assumes/hacks need to be continued

An error below shows how the aws_lb_target list can't be used as sole source for allowing other modules like bootstrap and master attach isntances without caring about publish strategy.
Similarly the error also shows how route53 module cannot turn off the public records based on existence of the external LBs alone.

```
ERROR Error: Invalid count argument
ERROR
ERROR   on ../../../../../../../tmp/openshift-install-940637305/bootstrap/main.tf line 154, in resource "aws_lb_target_group_attachment" "bootstrap":
ERROR  154:   count = length(var.target_group_arns)
ERROR
ERROR The "count" value depends on resource attributes that cannot be determined
ERROR until apply, so Terraform cannot predict how many instances will be created.
ERROR To work around this, use the -target argument to first apply only the
ERROR resources that the count depends on.
ERROR
ERROR
ERROR Error: Invalid count argument
ERROR
ERROR   on ../../../../../../../tmp/openshift-install-940637305/master/main.tf line 131, in resource "aws_lb_target_group_attachment" "master":
ERROR  131:   count = var.instance_count * length(var.target_group_arns)
ERROR
ERROR The "count" value depends on resource attributes that cannot be determined
ERROR until apply, so Terraform cannot predict how many instances will be created.
ERROR To work around this, use the -target argument to first apply only the
ERROR resources that the count depends on.
ERROR
ERROR
ERROR Error: Invalid count argument
ERROR
ERROR   on ../../../../../../../tmp/openshift-install-940637305/route53/base.tf line 2, in data "aws_route53_zone" "public":
ERROR    2:   count = var.api_external_lb_dns_name != null ? 1 : 0
ERROR
ERROR The "count" value depends on resource attributes that cannot be determined
ERROR until apply, so Terraform cannot predict how many instances will be created.
ERROR To work around this, use the -target argument to first apply only the
ERROR resources that the count depends on.
```

For instances to communicate with internet, they need to
- either have public IP in a public subnet or,
- be launched in private subnet.

For more info see https://forums.aws.amazon.com/thread.jspa?threadID=96369

Therefore the bootstrap instance is created in public subnet for External strategy and private subnet for others

Also the bootstrap instance SSH rules are modified to target Internet (0.0.0.0) for External and allow only VPC CIDR ranges otherwise

xref: https://jira.coreos.com/browse/CORS-1221

/cc @wking