### PR TITLE
OpenStack: Security enhancement: RHCOS image checksum validations

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -76,11 +76,11 @@ module "topology" {
 }
 
 resource "openstack_images_image_v2" "base_image" {
-  // we need to create a new image only if the base image url has been provided, plus base image name is <cluster_id>-rhcos
-  count = var.openstack_base_image_url != "" && var.openstack_base_image_name == "${var.cluster_id}-rhcos" ? 1 : 0
+  // we need to create a new image only if the base image local file path has been provided, plus base image name is <cluster_id>-rhcos
+  count = var.openstack_base_image_local_file_path != "" && var.openstack_base_image_name == "${var.cluster_id}-rhcos" ? 1 : 0
 
   name             = var.openstack_base_image_name
-  image_source_url = var.openstack_base_image_url
+  local_file_path  = var.openstack_base_image_local_file_path
   container_format = "bare"
   disk_format      = "qcow2"
 

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -15,10 +15,10 @@ variable "openstack_base_image_name" {
   description = "Name of the base image to use for the nodes."
 }
 
-variable "openstack_base_image_url" {
+variable "openstack_base_image_local_file_path" {
   type        = string
   default     = ""
-  description = "URL of the base image to use for the nodes."
+  description = "Local file path of the base image file to use for the nodes."
 }
 
 variable "openstack_bootstrap_shim_ignition" {

--- a/pkg/rhcos/builds.go
+++ b/pkg/rhcos/builds.go
@@ -24,12 +24,14 @@ type metadata struct {
 	BaseURI string `json:"baseURI"`
 	Images  struct {
 		QEMU struct {
-			Path   string `json:"path"`
-			SHA256 string `json:"sha256"`
+			Path               string `json:"path"`
+			SHA256             string `json:"sha256"`
+			UncompressedSHA256 string `json:"uncompressed-sha256"`
 		} `json:"qemu"`
 		OpenStack struct {
-			Path   string `json:"path"`
-			SHA256 string `json:"sha256"`
+			Path               string `json:"path"`
+			SHA256             string `json:"sha256"`
+			UncompressedSHA256 string `json:"uncompressed-sha256"`
 		} `json:"openstack"`
 	} `json:"images"`
 	OSTreeVersion string `json:"ostree-version"`

--- a/pkg/rhcos/openstack.go
+++ b/pkg/rhcos/openstack.go
@@ -25,7 +25,17 @@ func OpenStack(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return base.ResolveReference(relOpenStack).String(), nil
+	// Attach uncompressed sha256 checksum to the URL
+	checkSuffix := "?sha256=" + meta.Images.OpenStack.UncompressedSHA256
+	baseURL := base.ResolveReference(relOpenStack).String() + checkSuffix
+
+	// Check that we have generated a valid URL
+	_, err = url.ParseRequestURI(baseURL)
+	if err != nil {
+		return "", err
+	}
+
+	return baseURL, nil
 }
 
 // GenerateOpenStackImageName returns Glance image name for instances.

--- a/pkg/tfvars/internal/cache/cache.go
+++ b/pkg/tfvars/internal/cache/cache.go
@@ -2,9 +2,11 @@ package cache
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -50,7 +52,7 @@ func getCacheDir(dataType string) (string, error) {
 }
 
 // cacheFile puts data in the cache
-func cacheFile(reader io.Reader, filePath string) (err error) {
+func cacheFile(reader io.Reader, filePath string, sha256Checksum string) (err error) {
 	logrus.Debugf("Unpacking file into %q...", filePath)
 
 	flockPath := fmt.Sprintf("%s.lock", filePath)
@@ -94,6 +96,12 @@ func cacheFile(reader io.Reader, filePath string) (err error) {
 		}
 	}()
 
+	// Wrap the reader in TeeReader to calculate sha256 checksum on the fly
+	hasher := sha256.New()
+	if sha256Checksum != "" {
+		reader = io.TeeReader(reader, hasher)
+	}
+
 	_, err = io.Copy(file, reader)
 	if err != nil {
 		return err
@@ -105,11 +113,24 @@ func cacheFile(reader io.Reader, filePath string) (err error) {
 	}
 	closed = true
 
+	// Validate sha256 checksum
+	if sha256Checksum != "" {
+		foundChecksum := fmt.Sprintf("%x", hasher.Sum(nil))
+		if sha256Checksum != foundChecksum {
+			logrus.Error("File sha256 checksum is invalid.")
+			return errors.Errorf("Checksum mismatch for %s; expected=%s found=%s", filePath, sha256Checksum, foundChecksum)
+		}
+
+		logrus.Debug("Checksum validation is complete...")
+	}
+
 	return os.Rename(tempPath, filePath)
 }
 
-// DownloadFile obtains a file from a given URL, puts it in the cache and returns
-// the local file path.
+// DownloadFile obtains a file from a given URL, puts it in the cache folder, defined by dataType parameter,
+// and returns the local file path.
+// If the query string contains sha256 parameter (i.e. https://example.com/data.bin?sha256=098a5a...),
+// then the downloaded data checksum will be compared with the provided value.
 func DownloadFile(baseURL string, dataType string) (string, error) {
 	// Convert the given URL into a file name using md5 algorithm
 	fileName := fmt.Sprintf("%x", md5.Sum([]byte(baseURL)))
@@ -124,27 +145,37 @@ func DownloadFile(baseURL string, dataType string) (string, error) {
 	_, err = os.Stat(filePath)
 	if err == nil {
 		logrus.Infof("The file was found in cache: %v. Reusing...", filePath)
-	} else {
-		if !os.IsNotExist(err) {
-			return "", err
-		}
+		return filePath, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
 
-		// Send a request
-		resp, err := http.Get(baseURL)
-		if err != nil {
-			return "", err
-		}
-		defer resp.Body.Close()
+	// Send a request
+	resp, err := http.Get(baseURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
 
-		// Check server response
-		if resp.StatusCode != http.StatusOK {
-			return "", errors.Errorf("bad status: %s", resp.Status)
-		}
+	// Check server response
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Errorf("bad status: %s", resp.Status)
+	}
 
-		err = cacheFile(resp.Body, filePath)
-		if err != nil {
-			return "", err
-		}
+	// Get sha256 checksum if it was provided as a part of the URL
+	var sha256Checksum string
+	parsedURL, err := url.ParseRequestURI(baseURL)
+	if err != nil {
+		return "", err
+	}
+	if sha256Checksums, ok := parsedURL.Query()["sha256"]; ok {
+		sha256Checksum = sha256Checksums[0]
+	}
+
+	err = cacheFile(resp.Body, filePath, sha256Checksum)
+	if err != nil {
+		return "", err
 	}
 
 	return filePath, nil

--- a/pkg/tfvars/internal/cache/cache.go
+++ b/pkg/tfvars/internal/cache/cache.go
@@ -1,0 +1,159 @@
+package cache
+
+import (
+	"crypto/md5"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	applicationName = "openshift-installer"
+	imageDataType   = "image"
+)
+
+// getCacheDir returns a local path of the cache, where the installer should put the data:
+// <user_cache_dir>/openshift-installer/<dataType>_cache
+// If the directory doesn't exist, it will be automatically created.
+func getCacheDir(dataType string) (string, error) {
+	if dataType == "" {
+		return "", errors.Errorf("data type can't be an empty string")
+	}
+
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	cacheDir := filepath.Join(userCacheDir, applicationName, dataType+"_cache")
+
+	_, err = os.Stat(cacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = os.MkdirAll(cacheDir, 0755)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			return "", err
+		}
+	}
+
+	return cacheDir, nil
+}
+
+// cacheFile puts data in the cache
+func cacheFile(reader io.Reader, filePath string) (err error) {
+	logrus.Debugf("Unpacking file into %q...", filePath)
+
+	flockPath := fmt.Sprintf("%s.lock", filePath)
+	flock, err := os.Create(flockPath)
+	if err != nil {
+		return err
+	}
+	defer flock.Close()
+	defer func() {
+		err2 := os.Remove(flockPath)
+		if err == nil {
+			err = err2
+		}
+	}()
+
+	err = unix.Flock(int(flock.Fd()), unix.LOCK_EX)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err2 := unix.Flock(int(flock.Fd()), unix.LOCK_UN)
+		if err == nil {
+			err = err2
+		}
+	}()
+
+	_, err = os.Stat(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil // another cacheFile beat us to it
+	}
+
+	tempPath := fmt.Sprintf("%s.tmp", filePath)
+	file, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0444)
+	if err != nil {
+		return err
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			file.Close()
+		}
+	}()
+
+	_, err = io.Copy(file, reader)
+	if err != nil {
+		return err
+	}
+
+	err = file.Close()
+	if err != nil {
+		return err
+	}
+	closed = true
+
+	return os.Rename(tempPath, filePath)
+}
+
+// DownloadFile obtains a file from a given URL, puts it in the cache and returns
+// the local file path.
+func DownloadFile(baseURL string, dataType string) (string, error) {
+	// Convert the given URL into a file name using md5 algorithm
+	fileName := fmt.Sprintf("%x", md5.Sum([]byte(baseURL)))
+
+	cacheDir, err := getCacheDir(dataType)
+	if err != nil {
+		return "", err
+	}
+	filePath := filepath.Join(cacheDir, fileName)
+
+	// If the file has already been cached, return its path
+	_, err = os.Stat(filePath)
+	if err == nil {
+		logrus.Infof("The file was found in cache: %v. Reusing...", filePath)
+	} else {
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+
+		// Send a request
+		resp, err := http.Get(baseURL)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+
+		// Check server response
+		if resp.StatusCode != http.StatusOK {
+			return "", errors.Errorf("bad status: %s", resp.Status)
+		}
+
+		err = cacheFile(resp.Body, filePath)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return filePath, nil
+}
+
+// DownloadImageFile is a helper function that obtains an image file from a given URL,
+// puts it in the cache and returns the local file path.
+func DownloadImageFile(baseURL string) (string, error) {
+	logrus.Infof("Obtaining RHCOS image file from '%v'", baseURL)
+
+	return DownloadFile(baseURL, imageDataType)
+}

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -9,27 +9,28 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openshift/installer/pkg/rhcos"
+	"github.com/openshift/installer/pkg/tfvars/internal/cache"
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 )
 
 type config struct {
-	BaseImageName   string   `json:"openstack_base_image_name,omitempty"`
-	BaseImageURL    string   `json:"openstack_base_image_url,omitempty"`
-	ExternalNetwork string   `json:"openstack_external_network,omitempty"`
-	Cloud           string   `json:"openstack_credentials_cloud,omitempty"`
-	FlavorName      string   `json:"openstack_master_flavor_name,omitempty"`
-	LbFloatingIP    string   `json:"openstack_lb_floating_ip,omitempty"`
-	APIVIP          string   `json:"openstack_api_int_ip,omitempty"`
-	DNSVIP          string   `json:"openstack_node_dns_ip,omitempty"`
-	IngressVIP      string   `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport    string   `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport  string   `json:"openstack_octavia_support,omitempty"`
-	RootVolumeSize  int      `json:"openstack_master_root_volume_size,omitempty"`
-	RootVolumeType  string   `json:"openstack_master_root_volume_type,omitempty"`
-	BootstrapShim   string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
-	ExternalDNS     []string `json:"openstack_external_dns,omitempty"`
+	BaseImageName          string   `json:"openstack_base_image_name,omitempty"`
+	BaseImageLocalFilePath string   `json:"openstack_base_image_local_file_path,omitempty"`
+	ExternalNetwork        string   `json:"openstack_external_network,omitempty"`
+	Cloud                  string   `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName             string   `json:"openstack_master_flavor_name,omitempty"`
+	LbFloatingIP           string   `json:"openstack_lb_floating_ip,omitempty"`
+	APIVIP                 string   `json:"openstack_api_int_ip,omitempty"`
+	DNSVIP                 string   `json:"openstack_node_dns_ip,omitempty"`
+	IngressVIP             string   `json:"openstack_ingress_ip,omitempty"`
+	TrunkSupport           string   `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport         string   `json:"openstack_octavia_support,omitempty"`
+	RootVolumeSize         int      `json:"openstack_master_root_volume_size,omitempty"`
+	RootVolumeType         string   `json:"openstack_master_root_volume_type,omitempty"`
+	BootstrapShim          string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
+	ExternalDNS            []string `json:"openstack_external_dns,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
@@ -73,7 +74,12 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 	cfg.BaseImageName = imageName
 	if isURL {
 		// Valid URL -> use baseImage as a URL that will be used to create new Glance image with name "<infraID>-rhcos".
-		cfg.BaseImageURL = baseImage
+		localFilePath, err := cache.DownloadImageFile(baseImage)
+		if err != nil {
+			return nil, err
+		}
+
+		cfg.BaseImageLocalFilePath = localFilePath
 	} else {
 		// Not a URL -> use baseImage value as an overridden Glance image name.
 		// Need to check if this image exists and there are no other images with this name.


### PR DESCRIPTION
This PR allows to validate RHCOS images sha256 checksums to prevent possible MITM attacks.

To do so we extract the uncompressed sha256 checksum from `rhcos.json` file and attach it to the URL like `?sha256=...`
Next step is to download the file from the given URL and put it in the cache folder. Previously it was done by Terraform, but it doesn't support checksum validation feature, so we have to do it ourselves.
Files in the cache are called based on their ETags.
Terraform default cache folder was located in `~/.terraform/image_cache`. Now we put images in `<user_cache_dir>/openshift-installer/image_cache`, for linux it is `~/.cache/openshift-installer/image_cache`. 

If sha256 checksum was provided we validate it.

The final step is to give Terraform local file path of the image file.