### PR TITLE
Bump golang version to 1.12

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -5,7 +5,7 @@ set -ex
 # shellcheck disable=SC2068
 version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}
 
-minimum_go_version=1.10
+minimum_go_version=1.12
 current_go_version=$(go version | cut -d " " -f 3)
 
 if [ "$(version "${current_go_version#go}")" -lt "$(version "$minimum_go_version")" ]; then

--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -9,6 +9,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.10 \
+    docker.io/openshift/origin-release:golang-1.12 \
     ./hack/go-fmt.sh "${@}"
 fi

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -8,6 +8,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.10 \
+    docker.io/openshift/origin-release:golang-1.12 \
     ./hack/go-lint.sh "${@}"
 fi

--- a/hack/go-test.sh
+++ b/hack/go-test.sh
@@ -8,6 +8,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.10 \
+    docker.io/openshift/origin-release:golang-1.12 \
     ./hack/go-test.sh "${@}"
 fi

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -6,6 +6,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.10 \
+    docker.io/openshift/origin-release:golang-1.12 \
     ./hack/go-vet.sh "${@}"
 fi;

--- a/hack/run-bdd-suite.sh
+++ b/hack/run-bdd-suite.sh
@@ -16,6 +16,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.10 \
+    docker.io/openshift/origin-release:golang-1.12 \
     ./hack/run-bdd-suite.sh "${@}"
 fi;

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -13,6 +13,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.10 \
+    docker.io/openshift/origin-release:golang-1.12 \
     ./hack/verify-vendor.sh "${@}"
 fi

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -1,7 +1,7 @@
 # This Dockerfile is a used by CI to publish an installer image
 # It builds an image containing only the openshift-install.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 RUN yum install -y libvirt-devel && \
     yum clean all && rm -rf /var/cache/yum/*
 WORKDIR /go/src/github.com/openshift/installer

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -1,7 +1,7 @@
 # This Dockerfile builds an image containing the Mac version of the installer layered
 # on top of the Linux installer image.
 
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN go generate ./data && \

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -1,7 +1,7 @@
 # This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh

--- a/images/installer/Dockerfile.ci.rhel7
+++ b/images/installer/Dockerfile.ci.rhel7
@@ -1,7 +1,7 @@
 # This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -3,7 +3,7 @@
 # It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
 
 
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh

--- a/images/mock/Dockerfile
+++ b/images/mock/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 
 RUN go get github.com/golang/mock/gomock github.com/golang/mock/mockgen

--- a/images/nested-libvirt/Dockerfile
+++ b/images/nested-libvirt/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is a used by CI to test a libvirt cluster launched in a gce instance
 # It builds an image containing google-cloud-sdk, ns_wrapper and scripts to launch a VM for a libvirt install.
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN TAGS=libvirt hack/build.sh

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,6 +1,6 @@
 # This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -217,7 +217,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		preexistingnetwork := installConfig.Config.Azure.VirtualNetwork != ""
 		data, err := azuretfvars.TFVars(
 			azuretfvars.TFVarsSources{
-				Auth: auth,
+				Auth:                        auth,
 				BaseDomainResourceGroupName: installConfig.Config.Azure.BaseDomainResourceGroupName,
 				MasterConfigs:               masterConfigs,
 				WorkerConfigs:               workerConfigs,

--- a/pkg/asset/kubeconfig/kubeconfig.go
+++ b/pkg/asset/kubeconfig/kubeconfig.go
@@ -32,7 +32,7 @@ func (k *kubeconfig) generate(
 			{
 				Name: cluster,
 				Cluster: clientcmd.Cluster{
-					Server: apiURL,
+					Server:                   apiURL,
 					CertificateAuthorityData: ca.Cert(),
 				},
 			},

--- a/pkg/asset/tls/tls.go
+++ b/pkg/asset/tls/tls.go
@@ -66,12 +66,12 @@ func SelfSignedCertificate(cfg *CertCfg, key *rsa.PrivateKey) (*x509.Certificate
 	}
 	cert := x509.Certificate{
 		BasicConstraintsValid: true,
-		IsCA:         cfg.IsCA,
-		KeyUsage:     cfg.KeyUsages,
-		NotAfter:     time.Now().Add(cfg.Validity),
-		NotBefore:    time.Now(),
-		SerialNumber: serial,
-		Subject:      cfg.Subject,
+		IsCA:                  cfg.IsCA,
+		KeyUsage:              cfg.KeyUsages,
+		NotAfter:              time.Now().Add(cfg.Validity),
+		NotBefore:             time.Now(),
+		SerialNumber:          serial,
+		Subject:               cfg.Subject,
 	}
 	// verifies that the CN and/or OU for the cert is set
 	if len(cfg.Subject.CommonName) == 0 || len(cfg.Subject.OrganizationalUnit) == 0 {

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -77,9 +77,9 @@ func TFVars(vpc string, privateSubnets []string, publicSubnets []string, publish
 	instanceClass := defaults.InstanceClass(masterConfig.Placement.Region)
 
 	cfg := &config{
-		Region:    masterConfig.Placement.Region,
-		ExtraTags: tags,
-		AMI:       *masterConfig.AMI.ID,
+		Region:                  masterConfig.Placement.Region,
+		ExtraTags:               tags,
+		AMI:                     *masterConfig.AMI.ID,
 		MasterAvailabilityZones: masterAvailabilityZones,
 		WorkerAvailabilityZones: workerAvailabilityZones,
 		BootstrapInstanceType:   fmt.Sprintf("%s.large", instanceClass),

--- a/pkg/types/azure/validation/platform_test.go
+++ b/pkg/types/azure/validation/platform_test.go
@@ -17,7 +17,7 @@ func TestValidatePlatform(t *testing.T) {
 		{
 			name: "invalid region",
 			platform: &azure.Platform{
-				Region: "",
+				Region:                      "",
 				BaseDomainResourceGroupName: "group",
 			},
 			valid: false,
@@ -25,7 +25,7 @@ func TestValidatePlatform(t *testing.T) {
 		{
 			name: "invalid baseDomainResourceGroupName",
 			platform: &azure.Platform{
-				Region: "eastus",
+				Region:                      "eastus",
 				BaseDomainResourceGroupName: "",
 			},
 			valid: false,
@@ -33,7 +33,7 @@ func TestValidatePlatform(t *testing.T) {
 		{
 			name: "minimal",
 			platform: &azure.Platform{
-				Region: "eastus",
+				Region:                      "eastus",
 				BaseDomainResourceGroupName: "group",
 			},
 			valid: true,
@@ -41,7 +41,7 @@ func TestValidatePlatform(t *testing.T) {
 		{
 			name: "valid machine pool",
 			platform: &azure.Platform{
-				Region: "eastus",
+				Region:                      "eastus",
 				BaseDomainResourceGroupName: "group",
 				DefaultMachinePlatform:      &azure.MachinePool{},
 			},

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -95,13 +95,13 @@ func validBareMetalPlatform() *baremetal.Platform {
 		LibvirtURI:              "qemu+tcp://192.168.122.1/system",
 		BootstrapProvisioningIP: "127.0.0.1",
 		ClusterProvisioningIP:   "192.168.111.1",
-		Hosts:                  []*baremetal.Host{},
-		ExternalBridge:         iface[0].Name,
-		ProvisioningBridge:     iface[0].Name,
-		DefaultMachinePlatform: &baremetal.MachinePool{},
-		APIVIP:                 "10.0.0.5",
-		IngressVIP:             "10.0.0.4",
-		DNSVIP:                 "10.0.0.2",
+		Hosts:                   []*baremetal.Host{},
+		ExternalBridge:          iface[0].Name,
+		ProvisioningBridge:      iface[0].Name,
+		DefaultMachinePlatform:  &baremetal.MachinePool{},
+		APIVIP:                  "10.0.0.5",
+		IngressVIP:              "10.0.0.4",
+		DNSVIP:                  "10.0.0.2",
 	}
 }
 


### PR DESCRIPTION
This PR updated the current building system and ci images from golang 1.10 to 1.12.