### PR TITLE
asset/manifests/gcp: update the config to inlude master and worker node-tags

### DIFF
--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -3,30 +3,27 @@ package gcp
 import (
 	"bytes"
 	"fmt"
-
-	"github.com/pkg/errors"
-	ini "gopkg.in/ini.v1"
+	"text/template"
 )
 
 // https://github.com/kubernetes/kubernetes/blob/368ee4bb8ee7a0c18431cd87ee49f0c890aa53e5/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go#L188
 type config struct {
-	Global global `ini:"global"`
+	Global global `gcfg:"global"`
 }
 
 type global struct {
-	ProjectID string `ini:"project-id"`
+	ProjectID string `gcfg:"project-id"`
 
-	Regional  bool `ini:"regional"`
-	Multizone bool `ini:"multizone"`
+	Regional  bool `gcfg:"regional"`
+	Multizone bool `gcfg:"multizone"`
 
-	NodeTags []string `ini:"node-tags"`
+	NodeTags []string `gcfg:"node-tags"`
 
-	SubnetworkName string `ini:"subnetwork-name"`
+	SubnetworkName string `gcfg:"subnetwork-name"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the GCP platform.
 func CloudProviderConfig(infraID, projectID, subnet string) (string, error) {
-	file := ini.Empty()
 	config := &config{
 		Global: global{
 			ProjectID: projectID,
@@ -36,18 +33,27 @@ func CloudProviderConfig(infraID, projectID, subnet string) (string, error) {
 			Multizone: true,
 
 			// To make sure k8s cloud provide has tags for firewal for load balancer.
-			NodeTags: []string{fmt.Sprintf("%s-worker", infraID)},
+			NodeTags: []string{fmt.Sprintf("%s-master", infraID), fmt.Sprintf("%s-worker", infraID)},
 
 			// Used for internal load balancers
 			SubnetworkName: subnet,
 		},
 	}
-	if err := file.ReflectFrom(config); err != nil {
-		return "", errors.Wrap(err, "failed to reflect from config")
-	}
 	buf := &bytes.Buffer{}
-	if _, err := file.WriteTo(buf); err != nil {
-		return "", errors.Wrap(err, "failed to write out cloud provider config")
+	template := template.Must(template.New("gce cloudproviderconfig").Parse(configTmpl))
+	if err := template.Execute(buf, config); err != nil {
+		return "", err
 	}
 	return buf.String(), nil
 }
+
+var configTmpl = `[global]
+project-id      = {{.Global.ProjectID}}
+regional        = {{.Global.Regional}}
+multizone       = {{.Global.Multizone}}
+{{range $idx, $tag := .Global.NodeTags -}}
+node-tags       = {{$tag}}
+{{end -}}
+subnetwork-name = {{.Global.SubnetworkName}}
+
+`

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -11,6 +11,7 @@ func TestCloudProviderConfig(t *testing.T) {
 project-id      = test-project-id
 regional        = true
 multizone       = true
+node-tags       = uid-master
 node-tags       = uid-worker
 subnetwork-name = uid-worker-subnet
 


### PR DESCRIPTION
Tags for both master and worker need to be set, because in 4.3 both master and control-plane can be backends for k8s service type Load balancer and these are used
to create the correct firewal rules.

The cuurrent impl uses `gopkg.in/ini.v1` for writing the configuration, but the gce k8s code uses `gopkg.in/gcfg.v1` to read the configuration.
Although both are similar, gcfg handles multi-valued differently [1] which is esp problamatic for node-tags.

gcfg multi-value
```
node-tags = a
node-tags = b
```

ini multi-value
```
node-tags = [a, b]
```

Also gcfg only implements a reader and no Marshaller [2], therefore for the purpose of installer which is onl supposed to control few thing using go-templates to perform
the operation of marshalling seems acceptable.

[1]: https://github.com/go-gcfg/gcfg/blob/61b2c08bc8f6068f7c5ca684372f9a6cb1c45ebe/doc.go#L93-L96
[2]: https://github.com/go-gcfg/gcfg/blob/61b2c08bc8f6068f7c5ca684372f9a6cb1c45ebe/doc.go#L140

/cc @smarterclayton @jstuever 