### PR TITLE
WIP: Verify that RHCOS major version matches expected

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
@@ -10,6 +10,20 @@
 
 RELEASE_IMAGE={{.ReleaseImage}}
 
+# Verify the OS here
+. /etc/os-release
+case "${ID}" in
+    rhcos) ;;
+    *) echo "ERROR: Unsupported OS ID=${ID}" 1>&2
+       exit 1 ;;
+esac
+openshift=$(echo ${VERSION} | cut -f 1 -d '.')
+case "${openshift}" in
+    43) ;;
+    *) echo "ERROR: Unsupported RHCOS OpenShift version ${openshift}"
+       exit 1;;
+esac
+
 echo "Pulling $RELEASE_IMAGE..."
 while ! podman pull --quiet "$RELEASE_IMAGE"
 do


### PR DESCRIPTION
This is just a draft, proposal untested WIP.

I've seen people in the past trying to use the wrong RHCOS
bootimages.  I'd like to make that a clean, clear error.
Various weird things can go wrong if e.g. one tries to use
a RHCOS 4.2 bootimage for 4.1 installer.

I'd also like to change this code at least *warn* if
the bootimage doesn't *exactly* match what's pinned in the
installer.

Cleaning this up will need to plumb through the pinned
install data into this script.

Also we'll need to add an environment variable like
`OPENSHIFT_INSTALL_ALLOW_OS_IMAGE_OVERRIDE` which
makes this script not error, so that one can easily
test new RHCOS versions without rebuilding/hacking the
installer.