### PR TITLE
pkg/terraform/gather/aws: fallback to private_ip when public_ip is empty for bootstrap instance

### DIFF
--- a/pkg/terraform/gather/aws/ip.go
+++ b/pkg/terraform/gather/aws/ip.go
@@ -19,11 +19,14 @@ func BootstrapIP(tfs *terraform.State) (string, error) {
 	if len(br.Instances) == 0 {
 		return "", errors.New("no bootstrap instance found")
 	}
-	bootstrap, _, err := unstructured.NestedString(br.Instances[0].Attributes, "public_ip")
-	if err != nil {
-		return "", errors.New("no public_ip found for bootstrap")
+
+	for _, att := range []string{"public_ip", "private_ip"} {
+		ip, _, _ := unstructured.NestedString(br.Instances[0].Attributes, att)
+		if ip != "" {
+			return ip, nil
+		}
 	}
-	return bootstrap, nil
+	return "", errors.New("no usable IP found for bootstrap instance")
 }
 
 // ControlPlaneIPs returns the ip addresses for control plane hosts.


### PR DESCRIPTION
aws_instance has 2 attributes for IP: [public_ip][1] and [private_ip][2]. For bootstrap instance the [associate_public_ip_address][3] is set to true unless
the cluster needs to be private.

[1]: https://www.terraform.io/docs/providers/aws/r/instance.html#public_ip
[2]: https://www.terraform.io/docs/providers/aws/r/instance.html#private_ip-1
[3]: https://www.terraform.io/docs/providers/aws/r/instance.html#associate_public_ip_address

xref: https://jira.coreos.com/browse/CORS-1225

/cc @wking 