### PR TITLE
Bug 1763927: asset/installconfig/aws: configure region when listing subnets

### DIFF
--- a/pkg/asset/installconfig/aws/metadata.go
+++ b/pkg/asset/installconfig/aws/metadata.go
@@ -112,7 +112,7 @@ func (m *Metadata) populateSubnets(ctx context.Context) error {
 		return err
 	}
 
-	m.vpc, m.privateSubnets, m.publicSubnets, err = subnets(ctx, session, m.subnets)
+	m.vpc, m.privateSubnets, m.publicSubnets, err = subnets(ctx, session, m.region, m.subnets)
 	return err
 }
 

--- a/pkg/asset/installconfig/aws/subnet.go
+++ b/pkg/asset/installconfig/aws/subnet.go
@@ -22,12 +22,12 @@ type Subnet struct {
 }
 
 // subnets retrieves metadata for the given subnet(s).
-func subnets(ctx context.Context, session *session.Session, ids []string) (vpc string, private map[string]Subnet, public map[string]Subnet, err error) {
+func subnets(ctx context.Context, session *session.Session, region string, ids []string) (vpc string, private map[string]Subnet, public map[string]Subnet, err error) {
 	metas := make(map[string]Subnet, len(ids))
 	private = map[string]Subnet{}
 	public = map[string]Subnet{}
 	var vpcFromSubnet string
-	client := ec2.New(session)
+	client := ec2.New(session, aws.NewConfig().WithRegion(region))
 
 	idPointers := make([]*string, len(ids))
 	for _, id := range ids {


### PR DESCRIPTION
If no default region is setup in aws credentials, or the default region is different from the picked region, list subnets call fails with `could not find region configuration`.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1763927

/assign @wking 
/cc @wking 