### PR TITLE
GCP: restrict MCS access to control plane & nodes

### DIFF
--- a/data/data/gcp/network/firewall.tf
+++ b/data/data/gcp/network/firewall.tf
@@ -12,20 +12,6 @@ resource "google_compute_firewall" "api" {
   target_tags   = ["${var.cluster_id}-master"]
 }
 
-resource "google_compute_firewall" "mcs" {
-  name    = "${var.cluster_id}-mcs"
-  network = local.cluster_network
-
-  # MCS
-  allow {
-    protocol = "tcp"
-    ports    = ["22623"]
-  }
-
-  source_ranges = [var.network_cidr]
-  target_tags   = ["${var.cluster_id}-master"]
-}
-
 resource "google_compute_firewall" "health_checks" {
   name    = "${var.cluster_id}-health-checks"
   network = local.cluster_network
@@ -68,6 +54,12 @@ resource "google_compute_firewall" "control_plane" {
   allow {
     protocol = "tcp"
     ports    = ["10259"]
+  }
+
+  # MCS
+  allow {
+    protocol = "tcp"
+    ports    = ["22623"]
   }
 
   source_tags = [


### PR DESCRIPTION
This PR is part of the effort to improve cluster isolation ([CORS-1217](https://jira.coreos.com/browse/CORS-1217)). Prior to this, the MCS firewall was open to any machine in the MachineCIDR. Only the control plane and compute nodes need access to the MCS, so this reduces the exposure.