### PR TITLE
vsphere: Close a possible race with Ignition firstboot completion

### DIFF
--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -49,6 +49,7 @@ data "ignition_systemd_unit" "restart" {
   content = <<EOF
 [Unit]
 ConditionFirstBoot=yes
+After=ignition-firstboot-complete.service
 [Service]
 Type=idle
 ExecStart=/sbin/reboot


### PR DESCRIPTION
I was looking at https://bugzilla.redhat.com/show_bug.cgi?id=1762509
and that linked to this code (I don't quite understand why
we're rebooting here...this code really needs like some comments)
but anyways one possible issue I see here is that we will
race with `ignition-firstboot-complete.service`.

I'm going to fix FCOS so that service runs much earlier too,
but let's add this ordering here.

And someone please explain in some comments what is going on
here.