### PR TITLE
Fix Azure cloud provider subnet reference

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -108,7 +108,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 		if installConfig.Config.Azure.VirtualNetwork != "" {
 			vnet = installConfig.Config.Azure.VirtualNetwork
 		}
-		subnet := fmt.Sprintf("%s-node-subnet", clusterID.InfraID)
+		subnet := fmt.Sprintf("%s-worker-subnet", clusterID.InfraID)
 		if installConfig.Config.Azure.ComputeSubnet != "" {
 			subnet = installConfig.Config.Azure.ComputeSubnet
 		}


### PR DESCRIPTION
On Azure, the installer is configuring the cloud provider with a subnet using a
`-node-subnet` suffix. This is incorrect, as the actual subnet created for Azure
has a `-worker-subnet` suffix. The cloud provider refers to this subnet when
creating internal load balancers. Because of the invalid subnet reference,
kube-controller-manager fails to find the subnet, and thus fails to provision
internal load balancers. This commit fixes the reference and thus fixes internal
ingresscontrollers on Azure for new installations.

This commit does not fix existing invalid cloudprovider configmaps.

This is a fix of https://bugzilla.redhat.com/show_bug.cgi?id=1763727 only for
new installations.