### PR TITLE
WIP bootstrap: change bootstrap host to replace itself with machine-os-content too

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -37,6 +37,21 @@ MDNS_PUBLISHER_IMAGE=$(image_for mdns-publisher)
 HAPROXY_IMAGE=$(image_for haproxy-router)
 BAREMETAL_RUNTIMECFG_IMAGE=$(image_for baremetal-runtimecfg)
 
+# Copy machine-config-daemon binary from payload and run pivot
+if [ ! -f .pivot-done ]; then
+  mkdir /run/pivot /etc/pivot
+  touch /run/pivot/reboot-needed
+  echo "${MACHINE_CONFIG_OSCONTENT}" > /etc/pivot/image-pullspec
+
+  hostmcd=/usr/local/bin/machine-config-daemon
+  bootkube_podman_run --entrypoint=sh "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
+    cat /usr/bin/machine-config-daemon > ${hostmcd}
+  chmod a+x ${hostmcd}
+  restorecon ${hostmcd}
+  touch .pivot-done
+  ${hostmcd} pivot
+fi
+
 mkdir --parents ./{bootstrap-manifests,manifests}
 
 if [ ! -f openshift-manifests.done ]


### PR DESCRIPTION
…pivot before proceeding

This ensures bootstrap node uses latest crio/kubelet from oscontainer. Bootimages may not be bumped frequent enough to reflect oscontainer updates

TODO:
* [ ] Needs enhancement filed?
* [ ] Find out why it fails

Fixes #2542 