### PR TITLE
data/bootstrap/files/usr/local/bin/installer-gather: Make ${ARTIFACTS}

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -7,6 +7,7 @@ then
 fi
 
 ARTIFACTS="/tmp/artifacts-${GATHER_ID}"
+mkdir -p "${ARTIFACTS}"
 
 echo "Gathering bootstrap systemd summary ..."
 LANG=POSIX systemctl list-units --state=failed >& "${ARTIFACTS}/failed-units.txt"


### PR DESCRIPTION
[Fix][1]:

    time="2019-10-24T15:16:14Z" level=debug msg="/usr/local/bin/installer-gather.sh: line 12: /tmp/artifacts-20191024151613/failed-units.txt: No such file or directory"

from 8830652bbe (#2525).

[1]: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/5518/rehearse-5518-pull-ci-openshift-library-go-release-4.4-e2e-aws-encryption/4/artifacts/e2e-aws-encryption/installer/.openshift_install.log