### PR TITLE
pkg/validate: '%s' -> %q for IP quoting

### DIFF
--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -485,7 +485,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.BareMetal.APIVIP = ""
 				return c
 			}(),
-			expectedError: `^\[platform\.baremetal\.apiVIP: Invalid value: "": '' is not a valid IP, platform\.baremetal\.apiVIP: Invalid value: "": the virtual IP is expected to be in 10\.0\.0\.0/16 subnet]$`,
+			expectedError: `^\[platform\.baremetal\.apiVIP: Invalid value: "": "" is not a valid IP, platform\.baremetal\.apiVIP: Invalid value: "": the virtual IP is expected to be in 10\.0\.0\.0/16 subnet]$`,
 		},
 		{
 			name: "baremetal API VIP not an IP",
@@ -497,7 +497,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.BareMetal.APIVIP = "test"
 				return c
 			}(),
-			expectedError: `^\[platform\.baremetal\.apiVIP: Invalid value: "test": 'test' is not a valid IP, platform\.baremetal\.apiVIP: Invalid value: "test": the virtual IP is expected to be in 10\.0\.0\.0/16 subnet]$`,
+			expectedError: `^\[platform\.baremetal\.apiVIP: Invalid value: "test": "test" is not a valid IP, platform\.baremetal\.apiVIP: Invalid value: "test": the virtual IP is expected to be in 10\.0\.0\.0/16 subnet]$`,
 		},
 		{
 			name: "baremetal API VIP set to an incorrect value",
@@ -521,7 +521,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.BareMetal.DNSVIP = "test"
 				return c
 			}(),
-			expectedError: `^\[platform\.baremetal\.dnsVIP: Invalid value: "test": 'test' is not a valid IP, platform\.baremetal\.dnsVIP: Invalid value: "test": the virtual IP is expected to be in 10\.0\.0\.0/16 subnet]$`,
+			expectedError: `^\[platform\.baremetal\.dnsVIP: Invalid value: "test": "test" is not a valid IP, platform\.baremetal\.dnsVIP: Invalid value: "test": the virtual IP is expected to be in 10\.0\.0\.0/16 subnet]$`,
 		},
 		{
 			name: "baremetal DNS VIP set to an incorrect value",
@@ -545,7 +545,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.BareMetal.IngressVIP = "test"
 				return c
 			}(),
-			expectedError: `^\[platform\.baremetal\.ingressVIP: Invalid value: "test": 'test' is not a valid IP, platform\.baremetal\.ingressVIP: Invalid value: "test": the virtual IP is expected to be in 10\.0\.0\.0/16 subnet]$`,
+			expectedError: `^\[platform\.baremetal\.ingressVIP: Invalid value: "test": "test" is not a valid IP, platform\.baremetal\.ingressVIP: Invalid value: "test": the virtual IP is expected to be in 10\.0\.0\.0/16 subnet]$`,
 		},
 		{
 			name: "baremetal Ingress VIP set to an incorrect value",

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -166,7 +166,7 @@ func URIWithProtocol(uri string, protocol string) error {
 func IP(ip string) error {
 	addr := net.ParseIP(ip)
 	if addr == nil {
-		return fmt.Errorf("'%s' is not a valid IP", ip)
+		return fmt.Errorf("%q is not a valid IP", ip)
 	}
 	return nil
 }


### PR DESCRIPTION
Save a few characters and get safer quoting if the user gives us a candidate IP address that contains a single quote or some such.