### PR TITLE
baremetal: update terraform-provider-ironic and use newer API

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -4,7 +4,7 @@ provider "libvirt" {
 
 provider "ironic" {
   url          = "http://${var.bootstrap_provisioning_ip}:6385/v1"
-  microversion = "1.52"
+  microversion = "1.56"
   timeout      = 1500
 }
 

--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -791,12 +791,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:eba01da9d7286b80ecfb6b6ea6299b57f7a74ada8c94534e35eb9573816cfefc"
+  digest = "1:de93c160e5063276cb3e8ade27944446a759d0c8f7ae738b85e5ecde3999d71d"
   name = "github.com/openshift-metal3/terraform-provider-ironic"
   packages = ["ironic"]
   pruneopts = "NUT"
-  revision = "c68a8212f13053ab7b45f66f7c6deded348bcd23"
-  version = "v0.1.7"
+  revision = "2fa3321d8fd1d15d988fb9503392d7f071bb2454"
+  version = "v0.1.8"
 
 [[projects]]
   branch = "master"

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -70,4 +70,4 @@ ignored = [
 
 [[constraint]]
   name = "github.com/openshift-metal3/terraform-provider-ironic"
-  version = "v0.1.7"
+  version = "v0.1.8"

--- a/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/workflow.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/workflow.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
-	utils "github.com/gophercloud/utils/openstack/baremetal/v1/nodes"
 	"log"
 	"time"
 )
@@ -17,12 +16,12 @@ type provisionStateWorkflow struct {
 	target nodes.TargetProvisionState
 	wait   time.Duration
 
-	configDrive *utils.ConfigDrive
+	configDrive interface{}
 }
 
 // ChangeProvisionStateToTarget drives Ironic's state machine through the process to reach our desired end state. This requires multiple
 // possibly long-running steps.  If required, we'll build a config drive ISO for deployment.
-func ChangeProvisionStateToTarget(client *gophercloud.ServiceClient, uuid string, target nodes.TargetProvisionState, configDrive *utils.ConfigDrive) error {
+func ChangeProvisionStateToTarget(client *gophercloud.ServiceClient, uuid string, target nodes.TargetProvisionState, configDrive interface{}) error {
 
 	// Run the provisionStateWorkflow - this could take a while
 	wf := provisionStateWorkflow{
@@ -269,11 +268,7 @@ func (workflow *provisionStateWorkflow) buildProvisionStateOpts(target nodes.Tar
 
 	// If we're deploying, then build a config drive to send to Ironic
 	if target == "active" {
-		configDriveData, err := workflow.configDrive.ToConfigDrive()
-		if err != nil {
-			return nil, err
-		}
-		opts.ConfigDrive = configDriveData
+		opts.ConfigDrive = workflow.configDrive
 	}
 
 	return &opts, nil


### PR DESCRIPTION
With 1.56 of the Ironic API, we can send Ironic the JSON data for a config
drive, rather than a base64-encoded, gzipped ISO9660 image. This avoids
a dependency on the host running the installer to have mkisofs
available.