### PR TITLE
Azure: document custom VNets & cluster isolation

### DIFF
--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -9,6 +9,10 @@ The following options are available when using Azure:
 * `region` (required string): The Azure region where the cluster will be created.
 * `baseDomainResourceGroupName` (required string): The resource group where the Azure DNS zone for the base domain is found.
 * `defaultMachinePlatform` (optional object): Default [Azure-specific machine pool properties](#machine-pools) which applies to [machine pools](../customization.md#machine-pools) that do not define their own Azure-specific properties.
+* `networkResourceGroupName` (optional string): The resource group where the Azure VNet is found.
+* `virtualNetwork` (optional string): The name of an existing VNet where the cluster infrastructure should be provisioned.
+* `controlPlaneSubnet` (optional string): An existing subnet which should be used for the cluster control plane.
+* `computeSubnet` (optional string): An existing subnet which should be used by cluster nodes. 
 
 ## Machine pools
 
@@ -16,6 +20,15 @@ The following options are available when using Azure:
     * `diskSizeGB` (optional integer): The size of the disk in gigabytes (GB).
 * `type` (optional string): The Azure instance type.
 * `zones` (optional string slice): List of Azure availability zones that can be used (for example, `["1", "2", "3"]`).
+
+## Installing to Existing Networks & Subnetworks
+
+The installer can use an existing VNet and subnets when provisioning an OpenShift cluster. If one of `networkResourceGroupName`, `virtualNetwork`, `controlPlaneSubnet`, or `computeSubnet`is specified, all must be specified [(see example below)](#existing-vnet). The installer will use these existing networks when creating infrastructure such as virtual machines, load balancers, and DNS zones.
+
+### Cluster Isolation
+
+When pre-existing subnets are provided, the installer will not create a network security group (NSG) or alter an existing one attached to the subnet. This restriction means that no security rules are created. If multiple clusters are installed to the same VNet and isolation is desired, it must be enforced through an administrative task after the cluster is installed.
+
 
 ## Examples
 
@@ -72,6 +85,26 @@ platform:
   azure:
     region: centralus
     baseDomainResourceGroupName: os4-common
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+### Existing VNet
+
+An example Azure install config to use a pre-existing VNet and subnets:
+
+```yaml
+apiVersion: v1
+baseDomain: example.com
+metadata:
+  name: test-cluster
+platform:
+  azure:
+    region: centralus
+    baseDomainResourceGroupName: os4-common
+    networkResourceGroupName: example_vnet_rg
+    virtualNetwork: example_vnet
+    controlPlaneSubnet: example_master_subnet
+    computeSubnet: example_worker_subnet
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ```


### PR DESCRIPTION
Add documents for new install-config fields for BYO vnets. Document cluster isolation.

JIRA: [CORS-1209](https://jira.coreos.com/browse/CORS-1209)

Regarding cluster isolation, I assume this level of documentation is sufficient. If we were to document how cluster isolation should be performed manually that would be through official docs channels.

I left out details about what is required when supplying subnets because Azure validation is pending. I assume all of these resources need to be in the specified resourceGroup, but that is also probably somewhat self-evident, beyond that I'm not certain, but could definitely dig in if that should be added to this PR. 