### PR TITLE
gcp upi: split templates to simplify shared vpc workflow.

### DIFF
--- a/upi/gcp/02_dns.py
+++ b/upi/gcp/02_dns.py
@@ -1,0 +1,18 @@
+def GenerateConfig(context):
+
+    resources = [{
+        'name': context.properties['infra_id'] + '-private-zone',
+        'type': 'dns.v1.managedZone',
+        'properties': {
+            'description': '',
+            'dnsName': context.properties['cluster_domain'] + '.',
+            'visibility': 'private',
+            'privateVisibilityConfig': {
+                'networks': [{
+                    'networkUrl': context.properties['cluster_network']
+                }]
+            }
+        }
+    }]
+
+    return {'resources': resources}

--- a/upi/gcp/02_lb_ext.py
+++ b/upi/gcp/02_lb_ext.py
@@ -54,19 +54,6 @@ def GenerateConfig(context):
             'target': '$(ref.' + context.properties['infra_id'] + '-ign-target-pool.selfLink)',
             'portRange': '22623'
         }
-    }, {
-        'name': context.properties['infra_id'] + '-private-zone',
-        'type': 'dns.v1.managedZone',
-        'properties': {
-            'description': '',
-            'dnsName': context.properties['cluster_domain'] + '.',
-            'visibility': 'private',
-            'privateVisibilityConfig': {
-                'networks': [{
-                    'networkUrl': context.properties['cluster_network']
-                }]
-            }
-        }
     }]
 
     return {'resources': resources}

--- a/upi/gcp/03_firewall.py
+++ b/upi/gcp/03_firewall.py
@@ -1,6 +1,18 @@
 def GenerateConfig(context):
 
     resources = [{
+        'name': context.properties['infra_id'] + '-bootstrap-in-ssh',
+        'type': 'compute.v1.firewall',
+        'properties': {
+            'network': context.properties['cluster_network'],
+            'allowed': [{
+                'IPProtocol': 'tcp',
+                'ports': ['22']
+            }],
+            'sourceRanges':  ['0.0.0.0/0'],
+            'targetTags': [context.properties['infra_id'] + '-bootstrap']
+        }
+    }, {
         'name': context.properties['infra_id'] + '-api',
         'type': 'compute.v1.firewall',
         'properties': {
@@ -119,20 +131,6 @@ def GenerateConfig(context):
                 context.properties['infra_id'] + '-master',
                 context.properties['infra_id'] + '-worker'
             ]
-        }
-    }, {
-        'name': context.properties['infra_id'] + '-master-node-sa',
-        'type': 'iam.v1.serviceAccount',
-        'properties': {
-            'accountId': context.properties['infra_id'] + '-m',
-            'displayName': context.properties['infra_id'] + '-master-node'
-        }
-    }, {
-        'name': context.properties['infra_id'] + '-worker-node-sa',
-        'type': 'iam.v1.serviceAccount',
-        'properties': {
-            'accountId': context.properties['infra_id'] + '-w',
-            'displayName': context.properties['infra_id'] + '-worker-node'
         }
     }]
 

--- a/upi/gcp/03_iam.py
+++ b/upi/gcp/03_iam.py
@@ -1,0 +1,19 @@
+def GenerateConfig(context):
+
+    resources = [{
+        'name': context.properties['infra_id'] + '-master-node-sa',
+        'type': 'iam.v1.serviceAccount',
+        'properties': {
+            'accountId': context.properties['infra_id'] + '-m',
+            'displayName': context.properties['infra_id'] + '-master-node'
+        }
+    }, {
+        'name': context.properties['infra_id'] + '-worker-node-sa',
+        'type': 'iam.v1.serviceAccount',
+        'properties': {
+            'accountId': context.properties['infra_id'] + '-w',
+            'displayName': context.properties['infra_id'] + '-worker-node'
+        }
+    }]
+
+    return {'resources': resources}

--- a/upi/gcp/04_bootstrap.py
+++ b/upi/gcp/04_bootstrap.py
@@ -7,18 +7,6 @@ def GenerateConfig(context):
             'region': context.properties['region']
         }
     }, {
-        'name': context.properties['infra_id'] + '-bootstrap-in-ssh',
-        'type': 'compute.v1.firewall',
-        'properties': {
-            'network': context.properties['cluster_network'],
-            'allowed': [{
-                'IPProtocol': 'tcp',
-                'ports': ['22']
-            }],
-            'sourceRanges':  ['0.0.0.0/0'],
-            'targetTags': [context.properties['infra_id'] + '-bootstrap']
-        }
-    }, {
         'name': context.properties['infra_id'] + '-bootstrap',
         'type': 'compute.v1.instance',
         'properties': {


### PR DESCRIPTION
Prior to this change, users needed to edit the gcp upi python templates
in order to provision an cluster using a shared VPC. This was prone to
user error.

This change breaks up the templates so that only the yaml files need to
be modified, thus greatly simplifying the process. All of the resources
that would be provisioned in the host project are now in their own
python templates (01_vpc.py, 02_dns.py, and 03_firewall.py). These
resources can be removed from the yaml files to be run against the
service project and placed into yaml files to be run against the host
project instead.

requires openshift/release#7540, openshift/release#7571