### PR TITLE
Openstack external dns doc

### DIFF
--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -7,6 +7,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `cloud` (required string): The name of the OpenStack cloud to use from `clouds.yaml`.
 * `computeFlavor` (required string): The OpenStack flavor to use for compute and control-plane machines.
     This is currently required, but has lower precedence than [the `type` property](#machine-pools) on [the `compute` and `controlPlane` machine-pools](../customization.md#platform-customization).
+* `externalDNS` (optional string slice): The IP addresses of DNS servers to be used for the DNS resolution of all instances in the cluster (for example, `["1.1.1.1", "8.8.8.8"]`).
 * `externalNetwork` (required string): The OpenStack external network name to be used for installation.
 * `lbFloatingIP` (required string): Existing Floating IP to associate with the API load balancer.
 * `octaviaSupport` (optional string): Whether OpenStack supports Octavia (`1` for true or `0` for false)

--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -420,7 +420,7 @@ $ openstack subnet create --subnet-range <192.0.2.0/24> --allocation-pool start=
 
 During deployment, the OpenShift nodes will need to be able to resolve public name records to download the OpenShift images and so on. They will also need to resolve the OpenStack API endpoint.
 
-The default resolvers are an often set up by the OpenStack administrator in Neutron. However, some deployments do not have default DNS servers set, meaning the servers are not able to resolve any records when they boot.
+The default resolvers are often set up by the OpenStack administrator in Neutron. However, some deployments do not have default DNS servers set, meaning the servers are not able to resolve any records when they boot.
 
 If you are in this situation, you can add resolvers to your Neutron subnet (`openshift-qlvwv-subnet`). These will be put into `/etc/resolv.conf` on your servers post-boot.
 

--- a/docs/user/openstack/known-issues.md
+++ b/docs/user/openstack/known-issues.md
@@ -24,3 +24,11 @@ machineCIDR:    10.0.0.0/16
 serviceNetwork: 172.30.0.0/16
 clusterNetwork: 10.128.0.0/14
 ```
+
+## Lack of default DNS servers on created subnets
+
+Some OpenStack clouds do not set default DNS servers for the newly created subnets. In this case, the bootstrap node may fail to resolve public name records to download the OpenShift images or resolve the OpenStack API endpoints.
+
+If you are in this situation, you can add resolvers to the provisioned subnet by setting the [`externalDNS` property in `install-config.yaml`](./customization.md#cluster-scoped-properties).
+
+Alternatively, for UPI, you will need to [set the subnet DNS resolvers](./install_upi.md#subnet-dns-optional).


### PR DESCRIPTION
Provide documentation for OpenStack `externalDNS` install-config.yaml's property, and explain how to overcome limitation of some OpenStack clouds caused by lack of default DNS resolvers on created subnets.