### PR TITLE
Bug 1773002: baremetal: validate interfaces through libvirt API 

### DIFF
--- a/pkg/types/baremetal/validation/libvirt.go
+++ b/pkg/types/baremetal/validation/libvirt.go
@@ -1,0 +1,77 @@
+// +build baremetal
+
+package validation
+
+import (
+	"fmt"
+	"github.com/libvirt/libvirt-go"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"strings"
+)
+
+func init() {
+	dynamicValidators = append(dynamicValidators, validateInterfaces)
+}
+
+// validateInterfaces ensures that any interfaces required by the platform exist on the libvirt host.
+func validateInterfaces(p *baremetal.Platform, fldPath *field.Path) field.ErrorList {
+	errorList := field.ErrorList{}
+
+	findInterface, err := interfaceValidator(p.LibvirtURI)
+	if err != nil {
+		errorList = append(errorList, field.InternalError(fldPath.Child("libvirtURI"), err))
+		return errorList
+	}
+
+	if err := findInterface(p.ExternalBridge); err != nil {
+		errorList = append(errorList, field.Invalid(fldPath.Child("externalBridge"), p.ExternalBridge, err.Error()))
+	}
+
+	if err := findInterface(p.ProvisioningBridge); err != nil {
+		errorList = append(errorList, field.Invalid(fldPath.Child("provisioningBridge"), p.ProvisioningBridge, err.Error()))
+	}
+
+	return errorList
+}
+
+// interfaceValidator fetches the valid interface names from a particular libvirt instance, and returns a closure
+// to validate if an interface is found among them
+func interfaceValidator(libvirtURI string) (func(string) error, error) {
+	// Connect to libvirt and obtain a list of interface names
+	conn, err := libvirt.NewConnect(libvirtURI)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not connect to libvirt")
+	}
+
+	interfaces, err := conn.ListAllInterfaces(libvirt.CONNECT_LIST_INTERFACES_ACTIVE)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not list libvirt interfaces")
+	}
+
+	interfaceNames := make([]string, len(interfaces))
+	for idx, iface := range interfaces {
+		iface, err := iface.GetName()
+		if err == nil {
+			interfaceNames[idx] = iface
+		} else {
+			return nil, errors.Wrap(err, "could not get interface name from libvirt")
+		}
+	}
+
+	// Return a closure to validate if any particular interface is found among interfaceNames
+	return func(interfaceName string) error {
+		if len(interfaceNames) == 0 {
+			return fmt.Errorf("no interfaces found")
+		} else {
+			for _, foundInterface := range interfaceNames {
+				if foundInterface == interfaceName {
+					return nil
+				}
+			}
+
+			return fmt.Errorf("could not find interface %q, valid interfaces are %s", interfaceName, strings.Join(interfaceNames, ", "))
+		}
+	}, nil
+}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -171,14 +171,6 @@ func IP(ip string) error {
 	return nil
 }
 
-// Interface validates if a string is a valid network interface
-func Interface(iface string) error {
-	if _, err := net.InterfaceByName(iface); err != nil {
-		return fmt.Errorf("%s is not a valid network interface: %s", iface, err)
-	}
-	return nil
-}
-
 // MAC validates that a value is a valid mac address
 func MAC(addr string) error {
 	_, err := net.ParseMAC(addr)


### PR DESCRIPTION
The current validation assumes that interfaces exist on the same host as
running the installer, although we expose the ability to change the
libvirtURI.  This means the bootstrap VM could theoretically be placed
on a remote host, so we should validate the interfaces through libvirt
to handle that case.

Because the platform validators always get compiled, we add a new
mechanism for registering dynamic validators that are only used when the
baremetal platform has been compiled into the openshift-install.