### PR TITLE
openstack UPI: Ansible scripts

### DIFF
--- a/upi/openstack/OWNERS
+++ b/upi/openstack/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers

--- a/upi/openstack/README.md
+++ b/upi/openstack/README.md
@@ -1,0 +1,3 @@
+# Openstack User Provided Infrastructure installation
+
+This directory contains the Ansible scripts that automate part of the work in the [UPI installation](../../docs/user/openstack/install_upi.md).


### PR DESCRIPTION
This PR sets the ownership of the upi/openstack directory tree to the ShiftOnStack team.