### PR TITLE
GCP UPI: restrict MCS firewall access to control plane & workers

### DIFF
--- a/upi/gcp/03_security.py
+++ b/upi/gcp/03_security.py
@@ -13,22 +13,6 @@ def GenerateConfig(context):
             'targetTags': [context.properties['infra_id'] + '-master']
         }
     }, {
-        'name': context.properties['infra_id'] + '-mcs',
-        'type': 'compute.v1.firewall',
-        'properties': {
-            'network': context.properties['cluster_network'],
-            'allowed': [{
-                'IPProtocol': 'tcp',
-                'ports': ['22623']
-            }],
-            'sourceRanges':  [
-                context.properties['network_cidr'],
-                context.properties['master_nat_ip'],
-                context.properties['worker_nat_ip']
-            ],
-            'targetTags': [context.properties['infra_id'] + '-master']
-        }
-    }, {
         'name': context.properties['infra_id'] + '-health-checks',
         'type': 'compute.v1.firewall',
         'properties': {
@@ -63,6 +47,9 @@ def GenerateConfig(context):
             },{
                 'IPProtocol': 'tcp',
                 'ports': ['10259']
+            },{
+                'IPProtocol': 'tcp',
+                'ports': ['22623']
             }],
             'sourceTags': [
                 context.properties['infra_id'] + '-master',


### PR DESCRIPTION
UPI analog for IPI 7c0fa088902df00262dedbb8ca0e923419941e36 (#2550). Prior to this change, access to MCS was open to nework_cidr. This change restricts access to control plane & worker nodes.

/cc @jstuever 
/test e2e-gcp-upi