### PR TITLE
data/aws: Shift etcd DNS records from route53 into bootstrap

### DIFF
--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -8,6 +8,17 @@ variable "cluster_id" {
   description = "The identifier for the cluster."
 }
 
+variable "etcd_count" {
+  description = "The number of etcd members."
+  type        = string
+}
+
+variable "etcd_ip_addresses" {
+  description = "List of string IPs for machines running etcd members."
+  type        = list(string)
+  default     = []
+}
+
 variable "ignition" {
   type        = string
   description = "The content of the bootstrap ignition file."
@@ -16,6 +27,11 @@ variable "ignition" {
 variable "instance_type" {
   type        = string
   description = "The instance type of the bootstrap node."
+}
+
+variable "internal_hosted_zone" {
+  type        = string
+  description = "The ID of the internal Route 53 hosted zone."
 }
 
 variable "subnet_id" {

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -17,7 +17,10 @@ module "bootstrap" {
   ami                      = aws_ami_copy.main.id
   instance_type            = var.aws_bootstrap_instance_type
   cluster_id               = var.cluster_id
+  etcd_count               = var.master_count
+  etcd_ip_addresses        = flatten(module.masters.ip_addresses)
   ignition                 = var.ignition_bootstrap
+	internal_hosted_zone     = module.route53.internal_hosted_zone
   subnet_id                = var.aws_publish_strategy == "External" ? module.vpc.az_to_public_subnet_id[var.aws_master_availability_zones[0]] : module.vpc.az_to_private_subnet_id[var.aws_master_availability_zones[0]]
   target_group_arns        = module.vpc.aws_lb_target_group_arns
   target_group_arns_length = module.vpc.aws_lb_target_group_arns_length
@@ -59,7 +62,7 @@ module "iam" {
   tags = local.tags
 }
 
-module "dns" {
+module "route53" {
   source = "./route53"
 
   api_external_lb_dns_name = module.vpc.aws_lb_api_external_dns_name
@@ -69,8 +72,6 @@ module "dns" {
   base_domain              = var.base_domain
   cluster_domain           = var.cluster_domain
   cluster_id               = var.cluster_id
-  etcd_count               = var.master_count
-  etcd_ip_addresses        = flatten(module.masters.ip_addresses)
   tags                     = local.tags
   vpc_id                   = module.vpc.vpc_id
   publish_strategy         = var.aws_publish_strategy

--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -67,29 +67,3 @@ resource "aws_route53_record" "api_external_internal_zone" {
     evaluate_target_health = false
   }
 }
-
-resource "aws_route53_record" "etcd_a_nodes" {
-  count   = var.etcd_count
-  type    = "A"
-  ttl     = "60"
-  zone_id = aws_route53_zone.int.zone_id
-  name    = "etcd-${count.index}.${var.cluster_domain}"
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibilty in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
-  records = [var.etcd_ip_addresses[count.index]]
-}
-
-resource "aws_route53_record" "etcd_cluster" {
-  type    = "SRV"
-  ttl     = "60"
-  zone_id = aws_route53_zone.int.zone_id
-  name    = "_etcd-server-ssl._tcp"
-  records = formatlist("0 10 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)
-}
-

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -3,17 +3,6 @@ variable "cluster_domain" {
   type        = string
 }
 
-variable "etcd_count" {
-  description = "The number of etcd members."
-  type        = string
-}
-
-variable "etcd_ip_addresses" {
-  description = "List of string IPs for machines running etcd members."
-  type        = list(string)
-  default     = []
-}
-
 variable "base_domain" {
   description = "The base domain used for public records."
   type        = string


### PR DESCRIPTION
These should be just for [etcd cluster formation][1].  Moving them to the bootstrap module means they'll be deleted after bootstrapping completes (by which point we have successfully formed the etcd cluster).  And the removal simplifies the post-install cluster environment and makes it clear that there are no in-cluster components which are leaning on these DNS records.

/hold

We may not actually want to bother removing these, but I wanted to file a pull request to get CI to show whether removing them at bootstrap-completion broke anything or not.

[1]: https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/clustering.md#dns-discovery