### PR TITLE
pkg/asset/machines/baremetal: Drop unused networkInterfaceAddress from provider()

### DIFF
--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -32,7 +32,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	if pool.Replicas != nil {
 		total = *pool.Replicas
 	}
-	provider := provider(clustername, config.Networking.MachineCIDR.String(), platform, osImage, userDataSecret)
+	provider := provider(clustername, platform, osImage, userDataSecret)
 	var machines []machineapi.Machine
 	for idx := int64(0); idx < total; idx++ {
 		machine := machineapi.Machine{
@@ -62,7 +62,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	return machines, nil
 }
 
-func provider(clusterName string, networkInterfaceAddress string, platform *baremetal.Platform, osImage string, userDataSecret string) *baremetalprovider.BareMetalMachineProviderSpec {
+func provider(clusterName string, platform *baremetal.Platform, osImage string, userDataSecret string) *baremetalprovider.BareMetalMachineProviderSpec {
 	// The rhcos-downloader container launched by the baremetal-operator downloads the image,
 	// compresses it to speed up deployments and makes it available on platform.ClusterProvisioningIP, via http
 	// osImage looks like:

--- a/pkg/asset/machines/baremetal/machinesets.go
+++ b/pkg/asset/machines/baremetal/machinesets.go
@@ -32,7 +32,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		total = *pool.Replicas
 	}
 
-	provider := provider(clustername, config.Networking.MachineCIDR.String(), platform, osImage, userDataSecret)
+	provider := provider(clustername, platform, osImage, userDataSecret)
 	name := fmt.Sprintf("%s-%s-%d", clustername, pool.Name, 0)
 	mset := &machineapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
We've had the argument since the package landed in 0055065143 (#1873), but it has never been used.  Drop it to simplify the function calls, and to make it easier to use `grep` to answer questions like "does metal actually care about machineCIDR?" (apparently not).