### PR TITLE
libvirt: Inject Wildcard dns records in host's dnsmasq

### DIFF
--- a/hack/configure-dnsmasq.sh
+++ b/hack/configure-dnsmasq.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Configure the wildcard dns record in NetworkManager's dnsmasq configuration file.
+
+domain=$1
+
+echo -e "[main]\ndns=dnsmasq" | sudo tee /etc/NetworkManager/conf.d/openshift.conf
+echo -e "server=/$domain/192.168.126.1\naddress=/.apps.$domain/192.168.126.51" | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
+
+sudo systemctl restart NetworkManager

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -2,6 +2,7 @@ package installconfig
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/ghodss/yaml"
@@ -12,6 +13,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig/aws"
 	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
+	"github.com/openshift/installer/pkg/asset/installconfig/libvirt"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/conversion"
 	"github.com/openshift/installer/pkg/types/defaults"
@@ -129,6 +131,13 @@ func (a *InstallConfig) finish(filename string) error {
 
 	if a.Config.AWS != nil {
 		a.AWS = aws.NewMetadata(a.Config.Platform.AWS.Region, a.Config.Platform.AWS.Subnets)
+	}
+
+	if a.Config.Libvirt != nil {
+		err := libvirt.AddWildcardDNS(a.Config.BaseDomain)
+		if err != nil {
+			fmt.Print(err)
+		}
 	}
 
 	if err := validation.ValidateInstallConfig(a.Config, openstackvalidation.NewValidValuesFetcher()).ToAggregate(); err != nil {

--- a/pkg/asset/installconfig/libvirt/libvirt.go
+++ b/pkg/asset/installconfig/libvirt/libvirt.go
@@ -2,6 +2,8 @@
 package libvirt
 
 import (
+	"os/exec"
+
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/types/libvirt"
@@ -35,4 +37,15 @@ func Platform() (*libvirt.Platform, error) {
 // url and has non-empty scheme.
 func uriValidator(ans interface{}) error {
 	return validate.URI(ans.(string))
+}
+
+// AddWildcardDNS configures the host's dnsmasq, so that all apps can
+// found by Ingress Operator
+func AddWildcardDNS(domain string) error {
+	cmd := exec.Command("hack/configure-dnsmasq.sh", domain)
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
At this stage, we need a workaround to inject wildcard dns records in
host's dnsmasq, and domain entry in cluster-ingress-02-config.yml file should not contain cluster name, refer to
https://github.com/openshift/installer/blob/master/docs/dev/libvirt/README.md#console-doesnt-come-up.

We make it be done automatically at the installconfig-creating stage.

Fixes #1007