### PR TITLE
[fcos] Add vrutkovs and LorbusChris to OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,12 +7,16 @@ aliases:
     - sdodson
     - smarterclayton
     - wking
+    - vrutkovs
+    - LorbusChris
   installer-reviewers:
     - jcpowermac
     - jhixson74
     - jstuever
     - mtnbikenc
     - patrickdillon
+    - vrutkovs
+    - LorbusChris
   libvirt-approvers:
     - abhinavdahiya
     - enxebre


### PR DESCRIPTION
This should help us to iterate faster and override e2e results until these are passing.

This only affects `fcos` branch and won't be transferred into `master` or `release-*`