### PR TITLE
manifests/gcp: add infra-id as prefix for external IGs

### DIFF
--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -17,7 +17,9 @@ type global struct {
 	Regional  bool `gcfg:"regional"`
 	Multizone bool `gcfg:"multizone"`
 
-	NodeTags []string `gcfg:"node-tags"`
+	NodeTags                     []string `gcfg:"node-tags"`
+	NodeInstancePrefix           string   `gcfg:"node-instance-prefix"`
+	ExternalInstanceGroupsPrefix string   `gcfg:"external-instance-groups-prefix"`
 
 	SubnetworkName string `gcfg:"subnetwork-name"`
 }
@@ -33,7 +35,9 @@ func CloudProviderConfig(infraID, projectID, subnet string) (string, error) {
 			Multizone: true,
 
 			// To make sure k8s cloud provide has tags for firewal for load balancer.
-			NodeTags: []string{fmt.Sprintf("%s-master", infraID), fmt.Sprintf("%s-worker", infraID)},
+			NodeTags:                     []string{fmt.Sprintf("%s-master", infraID), fmt.Sprintf("%s-worker", infraID)},
+			NodeInstancePrefix:           infraID,
+			ExternalInstanceGroupsPrefix: infraID,
 
 			// Used for internal load balancers
 			SubnetworkName: subnet,
@@ -54,6 +58,8 @@ multizone       = {{.Global.Multizone}}
 {{range $idx, $tag := .Global.NodeTags -}}
 node-tags       = {{$tag}}
 {{end -}}
+node-instance-prefix = {{.Global.NodeInstancePrefix}}
+external-instance-groups-prefix = {{.Global.ExternalInstanceGroupsPrefix}}
 subnetwork-name = {{.Global.SubnetworkName}}
 
 `

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -13,6 +13,8 @@ regional        = true
 multizone       = true
 node-tags       = uid-master
 node-tags       = uid-worker
+node-instance-prefix = uid
+external-instance-groups-prefix = uid
 subnetwork-name = uid-worker-subnet
 
 `


### PR DESCRIPTION
To allow re-using the instance groups that control-plane machines already belong to for backend of internal LBs, the upstream PR [1]
requires we set the external-instance-groups-prefix to filter the instance groups for the clusters.

The upstream PR [1] is in flight, but origin backport [2] might actually be merged for now for the time we work with upstream to support the use-case.

[1]: https://github.com/kubernetes/kubernetes/pull/84466
[2]: https://github.com/openshift/origin/pull/24036

/cc @jstuever @sdodson @smarterclayton 