### PR TITLE
Add .vscode folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bin/
+/.vscode


### PR DESCRIPTION
Visual Studio Code users often generate a .vscode folder that contains a "workspace settings" file (settings.json) that overrides the "User settings".

This folder should obviously be ignored by git or any version control system.