### PR TITLE
[WIP] *: add logic for cluster-etcd-operator toggle

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -105,17 +105,17 @@ var (
 					logrus.Fatal("Bootstrap failed to complete: ", err)
 				}
 
-				logrus.Info("Destroying the bootstrap resources...")
-				err = destroybootstrap.Destroy(rootOpts.dir)
-				if err != nil {
-					logrus.Fatal(err)
-				}
-
 				err = waitForInstallComplete(ctx, config, rootOpts.dir)
 				if err != nil {
 					if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
 						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
 					}
+					logrus.Fatal(err)
+				}
+
+				logrus.Info("Destroying the bootstrap resources...")
+				err = destroybootstrap.Destroy(rootOpts.dir)
+				if err != nil {
 					logrus.Fatal(err)
 				}
 			},

--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -194,3 +194,7 @@ resource "aws_security_group_rule" "bootstrap_journald_gateway" {
   to_port     = 19531
 }
 
+output "ip_address" {
+  value = "${aws_instance.bootstrap.private_ip}"
+}
+

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -71,7 +71,7 @@ module "dns" {
   cluster_id               = var.cluster_id
   etcd_count               = var.master_count
   etcd_ip_addresses        = flatten(module.masters.ip_addresses)
-  bootstrap_ip_address     = module.bootstrap.ip_address 
+  bootstrap_ip_address     = module.bootstrap.ip_address
   tags                     = local.tags
   vpc_id                   = module.vpc.vpc_id
   publish_strategy         = var.aws_publish_strategy

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -71,6 +71,7 @@ module "dns" {
   cluster_id               = var.cluster_id
   etcd_count               = var.master_count
   etcd_ip_addresses        = flatten(module.masters.ip_addresses)
+  bootstrap_ip_address     = module.bootstrap.ip_address 
   tags                     = local.tags
   vpc_id                   = module.vpc.vpc_id
   publish_strategy         = var.aws_publish_strategy

--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -88,9 +88,9 @@ resource "aws_route53_record" "etcd_a_nodes" {
 resource "aws_route53_record" "bootstrap_a_node" {
   type    = "A"
   ttl     = "60"
-  zone_id = "${aws_route53_zone.int.zone_id}"
-  name    = "bootstrap.${var.cluster_domain}"
-  records = ["${var.bootstrap_ip_address}"]
+  zone_id = aws_route53_zone.int.zone_id
+  name    = "etcd-bootstrap.${var.cluster_domain}"
+  records = var.bootstrap_ip_address
 }
 
 resource "aws_route53_record" "etcd_cluster" {

--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -85,6 +85,14 @@ resource "aws_route53_record" "etcd_a_nodes" {
   records = [var.etcd_ip_addresses[count.index]]
 }
 
+resource "aws_route53_record" "bootstrap_a_node" {
+  type    = "A"
+  ttl     = "60"
+  zone_id = "${aws_route53_zone.int.zone_id}"
+  name    = "bootstrap.${var.cluster_domain}"
+  records = ["${var.bootstrap_ip_address}"]
+}
+
 resource "aws_route53_record" "etcd_cluster" {
   type    = "SRV"
   ttl     = "60"

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -14,6 +14,11 @@ variable "etcd_ip_addresses" {
   default     = []
 }
 
+variable "bootstrap_ip_address" {
+  description = "The IP address of the bootstrap node."
+  type        = "string"
+}
+
 variable "base_domain" {
   description = "The base domain used for public records."
   type        = string

--- a/data/data/azure/dns/dns.tf
+++ b/data/data/azure/dns/dns.tf
@@ -50,6 +50,15 @@ resource "azureprivatedns_a_record" "etcd_a_nodes" {
   records             = [var.etcd_ip_addresses[count.index]]
 }
 
+source "azurerm_dns_a_record" "etcd_a_bootstrap" {
+  count               = 1
+  name                = "bootstrap"
+  zone_name           = var.private_dns_zone_name
+  resource_group_name = var.resource_group_name
+  ttl                 = 60
+  records             = [azurerm_public_ip.bootstrap_public_ip.private_ip_address]
+}
+
 resource "azureprivatedns_srv_record" "etcd_cluster" {
   name                = "_etcd-server-ssl._tcp"
   zone_name           = azureprivatedns_zone.private.name

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -20,7 +20,11 @@ MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE=$(image_for kube-client-agent)
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 KUBE_ETCD_SIGNER_SERVER_IMAGE=$(image_for kube-etcd-signer-server)
-CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
+if image_for cluster-etcd-operator; then
+    CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
+else
+    CLUSTER_ETCD_OPERATOR_IMAGE=""
+fi
 CONFIG_OPERATOR_IMAGE=$(image_for cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
 KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(image_for cluster-kube-controller-manager-operator)
@@ -127,8 +131,11 @@ then
            --asset-output-dir /assets/etcd-bootstrap \
            --config-output-file /assets/etcd-bootstrap/config
 
-       cp etcd-bootstrap/manifests/* manifests/
-       cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+       if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
+       then
+              cp etcd-bootstrap/manifests/* manifests/
+              cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+       fi
        touch etcd-bootstrap.done
 fi
 

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -107,36 +107,37 @@ bootkube_podman_run \
         --metriccertdur=26280h
 
 
-if [ ! -f etcd-bootstrap.done ]
+if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
 then
-       echo "Rendering etcd Operator Manifests..."
-       rm -rf etcd-bootstrap
-       mkdir -p /etc/etcd
-       bootkube_podman_run \
-           --quiet \
-           --volume "$PWD:/assets:z" \
-           --volume /etc/kubernetes:/etc/kubernetes:z \
-           --volume /etc/etcd:/etc/etcd:z \
-           "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-           /usr/bin/cluster-etcd-operator render \
-           --etcd-ca=/assets/tls/etcd-ca-bundle.crt \
-           --etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
-           --manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
-           --etcd-discovery-domain {{.ClusterDomain}} \
-           --manifest-cluster-etcd-operator-image "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-           --manifest-setup-etcd-env-image "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
-           --manifest-image-pull-policy "TEST" \
-           --manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
-           --asset-input-dir /assets/tls \
-           --asset-output-dir /assets/etcd-bootstrap \
-           --config-output-file /assets/etcd-bootstrap/config
+    if [ ! -f etcd-bootstrap.done ]
+    then
+           echo "Rendering etcd Operator Manifests..."
+           rm -rf etcd-bootstrap
+           mkdir -p /etc/etcd
+           bootkube_podman_run \
+               --quiet \
+               --volume "$PWD:/assets:z" \
+               --volume /etc/kubernetes:/etc/kubernetes:z \
+               --volume /etc/etcd:/etc/etcd:z \
+               "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+               /usr/bin/cluster-etcd-operator render \
+               --etcd-ca=/assets/tls/etcd-ca-bundle.crt \
+               --etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
+               --manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
+               --etcd-discovery-domain {{.ClusterDomain}} \
+               --manifest-cluster-etcd-operator-image "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+               --manifest-setup-etcd-env-image "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
+               --manifest-image-pull-policy "TEST" \
+               --manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
+               --asset-input-dir /assets/tls \
+               --asset-output-dir /assets/etcd-bootstrap \
+               --config-output-file /assets/etcd-bootstrap/config
 
-       if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
-       then
-              cp etcd-bootstrap/manifests/* manifests/
-              cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
-       fi
-       touch etcd-bootstrap.done
+           cp etcd-bootstrap/manifests/* manifests/
+           cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+
+           touch etcd-bootstrap.done
+    fi
 fi
 
 if [ -f /etc/kubernetes/manifests/etcd-member-pod.yaml ]
@@ -161,6 +162,12 @@ then
 	cp config-bootstrap/manifests/* manifests/
 
 	touch config-bootstrap.done
+fi
+
+# TODO: host-etcd endpoint needs to be rendered by cluster-etcd-operator
+if [ -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
+then
+    sed -i '/192.0.2.1/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 fi
 
 if [ ! -f kube-apiserver-bootstrap.done ]

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -264,7 +264,7 @@ then
 			--dest-dir=/assets/mco-bootstrap \
 			--pull-secret=/assets/manifests/openshift-config-secret-pull-secret.yaml \
 			--etcd-image="${MACHINE_CONFIG_ETCD_IMAGE}" \
-			--kube-client-agent-image="${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
+			--kube-client-agent-image="${CLUSTER_ETCD_OPERATOR_IMAGE}" \
 			--machine-config-operator-image="${MACHINE_CONFIG_OPERATOR_IMAGE}" \
 			--machine-config-oscontent-image="${MACHINE_CONFIG_OSCONTENT}" \
 			--infra-image="${MACHINE_CONFIG_INFRA_IMAGE}" \

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -85,68 +85,76 @@ echo "Starting etcd certificate signer..."
 trap "podman rm --force etcd-signer" ERR
 
 bootkube_podman_run \
-        --name etcd-signer \
-        --detach \
-        --volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
-        "${KUBE_ETCD_SIGNER_SERVER_IMAGE}" \
-        serve \
-        --cacrt=/opt/openshift/tls/etcd-signer.crt \
-        --cakey=/opt/openshift/tls/etcd-signer.key \
-        --metric-cacrt=/opt/openshift/tls/etcd-metric-signer.crt \
-        --metric-cakey=/opt/openshift/tls/etcd-metric-signer.key \
-        --servcrt=/opt/openshift/tls/kube-apiserver-lb-server.crt \
-        --servkey=/opt/openshift/tls/kube-apiserver-lb-server.key \
-        --servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
-        --servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
-        --servcrt=/opt/openshift/tls/kube-apiserver-localhost-server.crt \
-        --servkey=/opt/openshift/tls/kube-apiserver-localhost-server.key \
-        --address=0.0.0.0:6443 \
-        --insecure-health-check-address=0.0.0.0:6080 \
-        --csrdir=/tmp \
-        --peercertdur=26280h \
-        --servercertdur=26280h \
-        --metriccertdur=26280h
-
+	--name etcd-signer \
+	--detach \
+	--volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
+	"${KUBE_ETCD_SIGNER_SERVER_IMAGE}" \
+	serve \
+	--cacrt=/opt/openshift/tls/etcd-signer.crt \
+	--cakey=/opt/openshift/tls/etcd-signer.key \
+	--metric-cacrt=/opt/openshift/tls/etcd-metric-signer.crt \
+	--metric-cakey=/opt/openshift/tls/etcd-metric-signer.key \
+	--servcrt=/opt/openshift/tls/kube-apiserver-lb-server.crt \
+	--servkey=/opt/openshift/tls/kube-apiserver-lb-server.key \
+	--servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
+	--servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
+	--servcrt=/opt/openshift/tls/kube-apiserver-localhost-server.crt \
+	--servkey=/opt/openshift/tls/kube-apiserver-localhost-server.key \
+	--address=0.0.0.0:6443 \
+	--insecure-health-check-address=0.0.0.0:6080 \
+	--csrdir=/tmp \
+	--peercertdur=26280h \
+	--servercertdur=26280h \
+	--metriccertdur=26280h
 
 if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
 then
-    if [ ! -f etcd-bootstrap.done ]
-    then
-           echo "Rendering etcd Operator Manifests..."
-           rm -rf etcd-bootstrap
-           mkdir -p /etc/etcd
-           bootkube_podman_run \
-               --quiet \
-               --volume "$PWD:/assets:z" \
-               --volume /etc/kubernetes:/etc/kubernetes:z \
-               --volume /etc/etcd:/etc/etcd:z \
-               "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-               /usr/bin/cluster-etcd-operator render \
-               --etcd-ca=/assets/tls/etcd-ca-bundle.crt \
-               --etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
-               --manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
-               --etcd-discovery-domain {{.ClusterDomain}} \
-               --manifest-cluster-etcd-operator-image "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-               --manifest-setup-etcd-env-image "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
-               --manifest-image-pull-policy "TEST" \
-               --manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
-               --asset-input-dir /assets/tls \
-               --asset-output-dir /assets/etcd-bootstrap \
-               --config-output-file /assets/etcd-bootstrap/config
+	if [ ! -f etcd-bootstrap.done ]
+	then
+		echo "Rendering etcd Operator Manifests..."
+		rm -rf etcd-bootstrap
+		mkdir -p /etc/etcd
+		bootkube_podman_run \
+			--quiet \
+			--volume "$PWD:/assets:z" \
+			--volume /etc/kubernetes:/etc/kubernetes:z \
+			--volume /etc/etcd:/etc/etcd:z \
+			"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+			/usr/bin/cluster-etcd-operator render \
+			--etcd-ca=/assets/tls/etcd-ca-bundle.crt \
+			--etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
+			--manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
+			--etcd-discovery-domain {{.ClusterDomain}} \
+			--manifest-cluster-etcd-operator-image "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+			--manifest-setup-etcd-env-image "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
+			--manifest-image-pull-policy "TEST" \
+			--manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
+			--asset-input-dir /assets/tls \
+			--asset-output-dir /assets/etcd-bootstrap \
+			--config-output-file /assets/etcd-bootstrap/config
 
-           if podman run --quiet "$CLUSTER_ETCD_OPERATOR_IMAGE" grep Managed /manifests/0000_12_etcd-operator_01_operator.cr.yaml > /dev/null
-           then
-                cp etcd-bootstrap/manifests/* manifests/
+		# during initial operator rollout phase this logic allows us to deploy the operator via CVO in an `Unmanaged` no-op state. after all of the pieces have
+		# merged and the operator is deemed stable we can remove this logic and the operator will be `Managed` by default.
+		CLUSTER_ETCD_OPERATOR_MANAGED=$(bootkube_podman_run \
+			--quiet \
+			"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+			/usr/bin/grep \
+			Managed /manifests/0000_12_etcd-operator_01_operator.cr.yaml > /dev/null)
 
-                cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+		if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ]
+		then
+			cp etcd-bootstrap/manifests/* manifests/
 
-                touch etcd-bootstrap.done
-           else
-                CLUSTER_ETCD_OPERATOR_IMAGE=""
-           fi
-    fi
+			cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+
+			touch etcd-bootstrap.done
+		else
+			CLUSTER_ETCD_OPERATOR_IMAGE=""
+		fi
+	fi
 fi
 
+#TODO: bootstrap endpoint will be IP based vs FQDN
 if [ -f /etc/kubernetes/manifests/etcd-member-pod.yaml ]
 then
 	ETCD_ENDPOINTS=$(printf "https://etcd-bootstrap.%s:2379" "{{.ClusterDomain}}")
@@ -174,7 +182,7 @@ fi
 # TODO: host-etcd endpoint needs to be rendered by cluster-etcd-operator
 if [ -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
 then
-    sed -i '/192.0.2.1/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
+    sed -i '/etcd-bootstrap/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 fi
 
 if [ ! -f kube-apiserver-bootstrap.done ]
@@ -308,10 +316,10 @@ then
 	cp manifests/* /etc/mcc/bootstrap/
 	cp auth/kubeconfig-kubelet /etc/mcs/kubeconfig
 	cp mco-bootstrap/bootstrap/machineconfigoperator-bootstrap-pod.yaml /etc/kubernetes/manifests/
-        if [ -d mco-bootstrap/baremetal/manifests ]; then
-            cp mco-bootstrap/baremetal/manifests/* /etc/kubernetes/manifests/
-            cp --recursive mco-bootstrap/baremetal/static-pod-resources/* /etc/kubernetes/static-pod-resources/
-        fi
+	if [ -d mco-bootstrap/baremetal/manifests ]; then
+		cp mco-bootstrap/baremetal/manifests/* /etc/kubernetes/manifests/
+		cp --recursive mco-bootstrap/baremetal/static-pod-resources/* /etc/kubernetes/static-pod-resources/
+	fi
 	if [ -d mco-bootstrap/openstack/manifests ]; then
 		cp mco-bootstrap/openstack/manifests/* /etc/kubernetes/manifests/
 		cp --recursive mco-bootstrap/openstack/static-pod-resources/* /etc/kubernetes/static-pod-resources/

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -264,7 +264,8 @@ then
 			--dest-dir=/assets/mco-bootstrap \
 			--pull-secret=/assets/manifests/openshift-config-secret-pull-secret.yaml \
 			--etcd-image="${MACHINE_CONFIG_ETCD_IMAGE}" \
-			--kube-client-agent-image="${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+			--kube-client-agent-image="${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
+			--cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}" \
 			--machine-config-operator-image="${MACHINE_CONFIG_OPERATOR_IMAGE}" \
 			--machine-config-oscontent-image="${MACHINE_CONFIG_OSCONTENT}" \
 			--infra-image="${MACHINE_CONFIG_INFRA_IMAGE}" \

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -5,6 +5,8 @@ set -euo pipefail
 
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
 
+ETCD_ENDPOINTS={{.EtcdCluster}}
+
 bootkube_podman_run() {
     # we run all commands in the host-network to prevent IP conflicts with
     # end-user infrastructure.
@@ -67,6 +69,74 @@ then
 	touch cvo-bootstrap.done
 fi
 
+# We originally wanted to run the etcd cert signer as
+# a static pod, but kubelet could't remove static pod
+# when API server is not up, so we have to run this as
+# podman container.
+# See https://github.com/kubernetes/kubernetes/issues/43292
+
+echo "Starting etcd certificate signer..."
+
+trap "podman rm --force etcd-signer" ERR
+
+bootkube_podman_run \
+        --name etcd-signer \
+        --detach \
+        --volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
+        "${KUBE_ETCD_SIGNER_SERVER_IMAGE}" \
+        serve \
+        --cacrt=/opt/openshift/tls/etcd-signer.crt \
+        --cakey=/opt/openshift/tls/etcd-signer.key \
+        --metric-cacrt=/opt/openshift/tls/etcd-metric-signer.crt \
+        --metric-cakey=/opt/openshift/tls/etcd-metric-signer.key \
+        --servcrt=/opt/openshift/tls/kube-apiserver-lb-server.crt \
+        --servkey=/opt/openshift/tls/kube-apiserver-lb-server.key \
+        --servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
+        --servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
+        --servcrt=/opt/openshift/tls/kube-apiserver-localhost-server.crt \
+        --servkey=/opt/openshift/tls/kube-apiserver-localhost-server.key \
+        --address=0.0.0.0:6443 \
+        --insecure-health-check-address=0.0.0.0:6080 \
+        --csrdir=/tmp \
+        --peercertdur=26280h \
+        --servercertdur=26280h \
+        --metriccertdur=26280h
+
+
+if [ ! -f etcd-bootstrap.done ]
+then
+       echo "Rendering etcd Operator Manifests..."
+       rm -rf etcd-bootstrap
+       mkdir -p /etc/etcd
+       bootkube_podman_run \
+           --quiet \
+           --volume "$PWD:/assets:z" \
+           --volume /etc/kubernetes:/etc/kubernetes:z \
+           --volume /etc/etcd:/etc/etcd:z \
+           "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+           /usr/bin/cluster-etcd-operator render \
+           --etcd-ca=/assets/tls/etcd-ca-bundle.crt \
+           --etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
+           --manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
+           --etcd-discovery-domain {{.ClusterDomain}} \
+           --manifest-cluster-etcd-operator-image "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+           --manifest-setup-etcd-env-image "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
+           --manifest-image-pull-policy "TEST" \
+           --manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
+           --asset-input-dir /assets/tls \
+           --asset-output-dir /assets/etcd-bootstrap \
+           --config-output-file /assets/etcd-bootstrap/config
+
+       cp etcd-bootstrap/manifests/* manifests/
+       cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+       touch etcd-bootstrap.done
+fi
+
+if [ -f /etc/kubernetes/manifests/etcd-member-pod.yaml ]
+then
+	ETCD_ENDPOINTS=$(printf "https://etcd-bootstrap.%s:2379" "{{.ClusterDomain}}")
+fi
+"z"
 if [ ! -f config-bootstrap.done ]
 then
 	echo "Rendering cluster config manifests..."
@@ -97,7 +167,7 @@ then
 		"${KUBE_APISERVER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-apiserver-operator render \
 		--manifest-etcd-serving-ca=etcd-ca-bundle.crt \
-		--manifest-etcd-server-urls={{.EtcdCluster}} \
+		--manifest-etcd-server-urls="${ETCD_ENDPOINTS}" \
 		--manifest-image="${OPENSHIFT_HYPERKUBE_IMAGE}" \
 		--manifest-operator-image="${KUBE_APISERVER_OPERATOR_IMAGE}" \
 		--asset-input-dir=/assets/tls \
@@ -234,35 +304,6 @@ then
 	touch mco-bootstrap.done
 fi
 
-
-if [ ! -f etcd-bootstrap.done ]
-then
-       echo "Rendering etcd Operator Manifests..."
-       rm -rf etcd-bootstrap
-       mkdir -p /etc/etcd
-       podman run \
-           --quiet \
-           --volume "$PWD:/assets:z" \
-           --volume /etc/kubernetes:/etc/kubernetes:z \
-           --volume /etc/etcd:/etc/etcd:z \
-           "${MACHINE_CONFIG_ETCD_OPERATOR_IMAGE}" \
-           /usr/bin/cluster-etcd-operator render \
-           --etcd-ca=/assets/tls/etcd-ca-bundle.crt \
-           --etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
-           --manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
-           --etcd-discovery-domain {{.ClusterDomain}} \
-           --manifest-setup-etcd-env-image "${MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE}" \
-           --manifest-image-pull-policy "TEST" \
-           --manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
-           --asset-input-dir /assets/tls \
-           --asset-output-dir /assets/etcd-bootstrap \
-           --config-output-file /assets/etcd-bootstrap/config
-
-       cp etcd-bootstrap/manifests/* manifests/
-       touch etcd-bootstrap.done
-fi
-
-
 if [ ! -f cco-bootstrap.done ]
 then
 	echo "Rendering CCO manifests..."
@@ -285,42 +326,6 @@ then
 	touch cco-bootstrap.done
 fi
 
-# We originally wanted to run the etcd cert signer as
-# a static pod, but kubelet could't remove static pod
-# when API server is not up, so we have to run this as
-# podman container.
-# See https://github.com/kubernetes/kubernetes/issues/43292
-
-echo "Starting etcd certificate signer..."
-
-trap "podman rm --force etcd-signer" ERR
-
-bootkube_podman_run \
-	--name etcd-signer \
-	--detach \
-	--volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
-	"${KUBE_ETCD_SIGNER_SERVER_IMAGE}" \
-	serve \
-	--cacrt=/opt/openshift/tls/etcd-signer.crt \
-	--cakey=/opt/openshift/tls/etcd-signer.key \
-	--metric-cacrt=/opt/openshift/tls/etcd-metric-signer.crt \
-	--metric-cakey=/opt/openshift/tls/etcd-metric-signer.key \
-	--servcrt=/opt/openshift/tls/kube-apiserver-lb-server.crt \
-	--servkey=/opt/openshift/tls/kube-apiserver-lb-server.key \
-	--servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
-	--servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
-	--servcrt=/opt/openshift/tls/kube-apiserver-localhost-server.crt \
-	--servkey=/opt/openshift/tls/kube-apiserver-localhost-server.key \
-	--address=0.0.0.0:6443 \
-	--insecure-health-check-address=0.0.0.0:6080 \
-	--csrdir=/tmp \
-	--peercertdur=26280h \
-	--servercertdur=26280h \
-	--metriccertdur=26280h
-
-echo "Waiting for bootstrap etcd..."
-cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
-
 # Wait for the etcd cluster to come up.
 until bootkube_podman_run \
 		--rm \
@@ -333,7 +338,7 @@ until bootkube_podman_run \
 		--cacert=/opt/openshift/tls/etcd-ca-bundle.crt \
 		--cert=/opt/openshift/tls/etcd-client.crt \
 		--key=/opt/openshift/tls/etcd-client.key \
-		--endpoints={{.EtcdCluster}} \
+		--endpoints="${ETCD_ENDPOINTS}" \
 		endpoint health
 do
 	echo "etcdctl failed. Retrying in 5 seconds..."

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -18,7 +18,7 @@ MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE=$(image_for kube-client-agent)
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 KUBE_ETCD_SIGNER_SERVER_IMAGE=$(image_for kube-etcd-signer-server)
-
+CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
 CONFIG_OPERATOR_IMAGE=$(image_for cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
 KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(image_for cluster-kube-controller-manager-operator)
@@ -234,6 +234,35 @@ then
 	touch mco-bootstrap.done
 fi
 
+
+if [ ! -f etcd-bootstrap.done ]
+then
+       echo "Rendering etcd Operator Manifests..."
+       rm -rf etcd-bootstrap
+       mkdir -p /etc/etcd
+       podman run \
+           --quiet \
+           --volume "$PWD:/assets:z" \
+           --volume /etc/kubernetes:/etc/kubernetes:z \
+           --volume /etc/etcd:/etc/etcd:z \
+           "${MACHINE_CONFIG_ETCD_OPERATOR_IMAGE}" \
+           /usr/bin/cluster-etcd-operator render \
+           --etcd-ca=/assets/tls/etcd-ca-bundle.crt \
+           --etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
+           --manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
+           --etcd-discovery-domain {{.ClusterDomain}} \
+           --manifest-setup-etcd-env-image "${MACHINE_CONFIG_SETUP_ETCD_ENV_IMAGE}" \
+           --manifest-image-pull-policy "TEST" \
+           --manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
+           --asset-input-dir /assets/tls \
+           --asset-output-dir /assets/etcd-bootstrap \
+           --config-output-file /assets/etcd-bootstrap/config
+
+       cp etcd-bootstrap/manifests/* manifests/
+       touch etcd-bootstrap.done
+fi
+
+
 if [ ! -f cco-bootstrap.done ]
 then
 	echo "Rendering CCO manifests..."
@@ -289,7 +318,8 @@ bootkube_podman_run \
 	--servercertdur=26280h \
 	--metriccertdur=26280h
 
-echo "Waiting for etcd cluster..."
+echo "Waiting for bootstrap etcd..."
+cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
 
 # Wait for the etcd cluster to come up.
 until bootkube_podman_run \

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -20,7 +20,8 @@ MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE=$(image_for kube-client-agent)
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 KUBE_ETCD_SIGNER_SERVER_IMAGE=$(image_for kube-etcd-signer-server)
-if image_for cluster-etcd-operator; then
+if image_for cluster-etcd-operator
+then
     CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
 else
     CLUSTER_ETCD_OPERATOR_IMAGE=""
@@ -133,10 +134,16 @@ then
                --asset-output-dir /assets/etcd-bootstrap \
                --config-output-file /assets/etcd-bootstrap/config
 
-           cp etcd-bootstrap/manifests/* manifests/
-           cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+           if podman run --quiet "$CLUSTER_ETCD_OPERATOR_IMAGE" grep Managed /manifests/0000_12_etcd-operator_01_operator.cr.yaml > /dev/null
+           then
+                cp etcd-bootstrap/manifests/* manifests/
 
-           touch etcd-bootstrap.done
+                cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+
+                touch etcd-bootstrap.done
+           else
+                CLUSTER_ETCD_OPERATOR_IMAGE=""
+           fi
     fi
 fi
 
@@ -287,8 +294,8 @@ then
 			--mdns-publisher-image="${MDNS_PUBLISHER_IMAGE}" \
 			--haproxy-image="${HAPROXY_IMAGE}" \
 			--baremetal-runtimecfg-image="${BAREMETAL_RUNTIMECFG_IMAGE}" \
-			--cloud-config-file=/assets/manifests/cloud-provider-config.yaml
-			#--cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}"
+			--cloud-config-file=/assets/manifests/cloud-provider-config.yaml \
+			--cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}"
 
 	# Bootstrap MachineConfigController uses /etc/mcc/bootstrap/manifests/ dir to
 	# 1. read the controller config rendered by MachineConfigOperator

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -20,11 +20,9 @@ MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE=$(image_for kube-client-agent)
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 KUBE_ETCD_SIGNER_SERVER_IMAGE=$(image_for kube-etcd-signer-server)
-if image_for cluster-etcd-operator
+if ! CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator 2> /dev/null)
 then
-    CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
-else
-    CLUSTER_ETCD_OPERATOR_IMAGE=""
+	CLUSTER_ETCD_OPERATOR_IMAGE=
 fi
 CONFIG_OPERATOR_IMAGE=$(image_for cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
@@ -138,26 +136,25 @@ then
 		CLUSTER_ETCD_OPERATOR_MANAGED=$(bootkube_podman_run \
 			--quiet \
 			"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-			/usr/bin/grep \
-			Managed /manifests/0000_12_etcd-operator_01_operator.cr.yaml > /dev/null)
+			/usr/bin/grep -oP \
+			Managed /manifests/0000_12_etcd-operator_01_operator.cr.yaml 2> /dev/null)
 
 		if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ]
 		then
 			cp etcd-bootstrap/manifests/* manifests/
 
 			cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
-
-			touch etcd-bootstrap.done
 		else
 			CLUSTER_ETCD_OPERATOR_IMAGE=""
 		fi
+		touch etcd-bootstrap.done
 	fi
 fi
 
 #TODO: bootstrap endpoint will be IP based vs FQDN
 if [ -f /etc/kubernetes/manifests/etcd-member-pod.yaml ]
 then
-	ETCD_ENDPOINTS=$(printf "https://etcd-bootstrap.%s:2379" "{{.ClusterDomain}}")
+	ETCD_ENDPOINTS="https://etcd-bootstrap.{{.ClusterDomain}}:2379"
 fi
 "z"
 if [ ! -f config-bootstrap.done ]
@@ -182,7 +179,7 @@ fi
 # TODO: host-etcd endpoint needs to be rendered by cluster-etcd-operator
 if [ -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
 then
-    sed -i '/etcd-bootstrap/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
+	sed -i '/etcd-bootstrap/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 fi
 
 if [ ! -f kube-apiserver-bootstrap.done ]

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -279,7 +279,6 @@ then
 			--pull-secret=/assets/manifests/openshift-config-secret-pull-secret.yaml \
 			--etcd-image="${MACHINE_CONFIG_ETCD_IMAGE}" \
 			--kube-client-agent-image="${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
-			--cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}" \
 			--machine-config-operator-image="${MACHINE_CONFIG_OPERATOR_IMAGE}" \
 			--machine-config-oscontent-image="${MACHINE_CONFIG_OSCONTENT}" \
 			--infra-image="${MACHINE_CONFIG_INFRA_IMAGE}" \
@@ -289,6 +288,7 @@ then
 			--haproxy-image="${HAPROXY_IMAGE}" \
 			--baremetal-runtimecfg-image="${BAREMETAL_RUNTIMECFG_IMAGE}" \
 			--cloud-config-file=/assets/manifests/cloud-provider-config.yaml
+			#--cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}"
 
 	# Bootstrap MachineConfigController uses /etc/mcc/bootstrap/manifests/ dir to
 	# 1. read the controller config rendered by MachineConfigOperator

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -105,50 +105,53 @@ bootkube_podman_run \
 	--servercertdur=26280h \
 	--metriccertdur=26280h
 
-if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
+if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ] && [ ! -f etcd-bootstrap.done ]
 then
-	if [ ! -f etcd-bootstrap.done ]
+	echo "Rendering etcd Operator Manifests..."
+	rm -rf etcd-bootstrap
+	mkdir -p /etc/etcd
+	bootkube_podman_run \
+		--quiet \
+		--volume "$PWD:/assets:z" \
+		--volume /etc/kubernetes:/etc/kubernetes:z \
+		--volume /etc/etcd:/etc/etcd:z \
+		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+		/usr/bin/cluster-etcd-operator render \
+		--etcd-ca=/assets/tls/etcd-ca-bundle.crt \
+		--etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
+		--manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
+		--etcd-discovery-domain {{.ClusterDomain}} \
+		--manifest-cluster-etcd-operator-image "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+		--manifest-setup-etcd-env-image "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
+		--manifest-image-pull-policy "TEST" \
+		--manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
+		--asset-input-dir /assets/tls \
+		--asset-output-dir /assets/etcd-bootstrap \
+		--config-output-file /assets/etcd-bootstrap/config
+
+	# during initial operator rollout phase this logic allows us to deploy the operator via CVO in an `Unmanaged` no-op state. after all of the pieces have
+	# merged and the operator is deemed stable we can remove this logic and the operator will be `Managed` by default.
+	CLUSTER_ETCD_OPERATOR_MANAGED=$(bootkube_podman_run \
+		--quiet \
+		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+		/usr/bin/grep -oP \
+		Managed /manifests/0000_12_etcd-operator_01_operator.cr.yaml 2> /dev/null)
+
+	if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ]
 	then
-		echo "Rendering etcd Operator Manifests..."
-		rm -rf etcd-bootstrap
-		mkdir -p /etc/etcd
-		bootkube_podman_run \
-			--quiet \
-			--volume "$PWD:/assets:z" \
-			--volume /etc/kubernetes:/etc/kubernetes:z \
-			--volume /etc/etcd:/etc/etcd:z \
-			"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-			/usr/bin/cluster-etcd-operator render \
-			--etcd-ca=/assets/tls/etcd-ca-bundle.crt \
-			--etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
-			--manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
-			--etcd-discovery-domain {{.ClusterDomain}} \
-			--manifest-cluster-etcd-operator-image "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-			--manifest-setup-etcd-env-image "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
-			--manifest-image-pull-policy "TEST" \
-			--manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
-			--asset-input-dir /assets/tls \
-			--asset-output-dir /assets/etcd-bootstrap \
-			--config-output-file /assets/etcd-bootstrap/config
+		cp etcd-bootstrap/manifests/* manifests/
 
-		# during initial operator rollout phase this logic allows us to deploy the operator via CVO in an `Unmanaged` no-op state. after all of the pieces have
-		# merged and the operator is deemed stable we can remove this logic and the operator will be `Managed` by default.
-		CLUSTER_ETCD_OPERATOR_MANAGED=$(bootkube_podman_run \
-			--quiet \
-			"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-			/usr/bin/grep -oP \
-			Managed /manifests/0000_12_etcd-operator_01_operator.cr.yaml 2> /dev/null)
-
-		if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ]
-		then
-			cp etcd-bootstrap/manifests/* manifests/
-
-			cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
-		else
-			CLUSTER_ETCD_OPERATOR_IMAGE=""
-		fi
-		touch etcd-bootstrap.done
+		cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+	else
+		CLUSTER_ETCD_OPERATOR_IMAGE=""
 	fi
+	touch etcd-bootstrap.done
+fi
+
+# TODO: host-etcd endpoint needs to be rendered by cluster-etcd-operator
+if [ -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
+then
+	sed -i '/etcd-bootstrap/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 fi
 
 #TODO: bootstrap endpoint will be IP based vs FQDN
@@ -156,7 +159,7 @@ if [ -f /etc/kubernetes/manifests/etcd-member-pod.yaml ]
 then
 	ETCD_ENDPOINTS="https://etcd-bootstrap.{{.ClusterDomain}}:2379"
 fi
-"z"
+
 if [ ! -f config-bootstrap.done ]
 then
 	echo "Rendering cluster config manifests..."
@@ -174,12 +177,6 @@ then
 	cp config-bootstrap/manifests/* manifests/
 
 	touch config-bootstrap.done
-fi
-
-# TODO: host-etcd endpoint needs to be rendered by cluster-etcd-operator
-if [ -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
-then
-	sed -i '/etcd-bootstrap/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 fi
 
 if [ ! -f kube-apiserver-bootstrap.done ]

--- a/data/data/gcp/bootstrap/output.tf
+++ b/data/data/gcp/bootstrap/output.tf
@@ -5,3 +5,8 @@ output "bootstrap_instances" {
 output "bootstrap_instance_groups" {
   value = google_compute_instance_group.bootstrap.*.self_link
 }
+
+output "ip_addresses" {
+  value = google_compute_instance.bootstrap[0].network_interface.0.network_ip
+}
+

--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -45,6 +45,14 @@ resource "google_dns_record_set" "etcd_a_nodes" {
   rrdatas      = [var.etcd_ip_addresses[count.index]]
 }
 
+resource "google_dns_record_set" "bootstrap_a_node" {
+  type         = "A"
+  ttl          = "60"
+  managed_zone = google_dns_managed_zone.int.name
+  name         = "etcd-bootstrap.${var.cluster_domain}."
+  rrdatas      = [var.bootstrap_ip_address]
+}
+
 resource "google_dns_record_set" "etcd_cluster" {
   type         = "SRV"
   ttl          = "60"

--- a/data/data/gcp/dns/variables.tf
+++ b/data/data/gcp/dns/variables.tf
@@ -19,6 +19,11 @@ variable "etcd_ip_addresses" {
   default     = []
 }
 
+variable "bootstrap_ip_address" {
+  description = "The IP address of the bootstrap node."
+  type        = string
+}
+
 variable "cluster_id" {
   type        = string
   description = "The identifier for the cluster."

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -85,6 +85,7 @@ module "dns" {
   public_dns_zone_name = var.gcp_public_dns_zone_name
   network              = module.network.network
   etcd_ip_addresses    = flatten(module.master.ip_addresses)
+  bootstrap_ip_address = module.bootstrap.ip_address
   etcd_count           = var.master_count
   cluster_domain       = var.cluster_domain
   api_external_lb_ip   = module.network.cluster_public_ip

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -55,7 +55,7 @@ resource "libvirt_network" "net" {
     local_only = true
 
     dynamic "srvs" {
-      for_each = data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered
+      for_each = concat(data.libvirt_network_dns_srv_template.etcd_masters.*.rendered, data.libvirt_network_dns_srv_template.etcd_bootstrap.*.rendered)
       content {
         domain   = srvs.value.domain
         port     = srvs.value.port
@@ -69,6 +69,7 @@ resource "libvirt_network" "net" {
     dynamic "hosts" {
       for_each = concat(
         data.libvirt_network_dns_host_template.bootstrap.*.rendered,
+        data.libvirt_network_dns_host_template.bootstrap_api.*.rendered,
         data.libvirt_network_dns_host_template.bootstrap_int.*.rendered,
         data.libvirt_network_dns_host_template.masters.*.rendered,
         data.libvirt_network_dns_host_template.masters_int.*.rendered,
@@ -117,6 +118,12 @@ resource "libvirt_domain" "master" {
 data "libvirt_network_dns_host_template" "bootstrap" {
   count    = var.bootstrap_dns ? 1 : 0
   ip       = var.libvirt_bootstrap_ip
+  hostname = "bootstrap.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_host_template" "bootstrap_api" {
+  count    = var.bootstrap_dns ? 1 : 0
+  ip       = var.libvirt_bootstrap_ip
   hostname = "api.${var.cluster_domain}"
 }
 
@@ -144,7 +151,7 @@ data "libvirt_network_dns_host_template" "etcds" {
   hostname = "etcd-${count.index}.${var.cluster_domain}"
 }
 
-data "libvirt_network_dns_srv_template" "etcd_cluster" {
+data "libvirt_network_dns_srv_template" "etcd_masters" {
   count    = var.master_count
   service  = "etcd-server-ssl"
   protocol = "tcp"
@@ -152,5 +159,15 @@ data "libvirt_network_dns_srv_template" "etcd_cluster" {
   port     = 2380
   weight   = 10
   target   = "etcd-${count.index}.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_srv_template" "etcd_bootstrap" {
+  count    = 1
+  service  = "etcd-server-ssl"
+  protocol = "tcp"
+  domain   = var.cluster_domain
+  port     = 2380
+  weight   = 10
+  target   = "bootstrap.${var.cluster_domain}"
 }
 

--- a/data/data/manifests/bootkube/etcd-host-service-endpoints.yaml.template
+++ b/data/data/manifests/bootkube/etcd-host-service-endpoints.yaml.template
@@ -8,8 +8,9 @@ metadata:
 subsets:
 - addresses:
 {{- range $idx, $member := .EtcdEndpointHostnames }}
-  - ip: 192.0.2.{{ add $idx 1 }}
-    hostname: {{ $member }}
+  - hostname: {{ $member }}
+    ip: 192.0.2.{{ add $idx 1 }}
+
 {{- end }}
   ports:
   - name: etcd

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -228,7 +228,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 		FIPS:                  installConfig.FIPS,
 		PullSecret:            installConfig.PullSecret,
 		ReleaseImage:          releaseImage,
-		EtcdCluster:           fmt.Sprintf("https://bootstrap.%s:2379", installConfig.ClusterDomain()),
+		EtcdCluster:           strings.Join(etcdEndpoints, ","),
 		Proxy:                 &proxy.Status,
 		Registries:            registries,
 		BootImage:             string(*rhcosImage),

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -49,6 +49,7 @@ type bootstrapTemplateData struct {
 	Proxy                 *configv1.ProxyStatus
 	Registries            []sysregistriesv2.Registry
 	BootImage             string
+	ClusterDomain         string
 }
 
 // Bootstrap is an asset that generates the ignition config for bootstrap nodes.
@@ -227,10 +228,11 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 		FIPS:                  installConfig.FIPS,
 		PullSecret:            installConfig.PullSecret,
 		ReleaseImage:          releaseImage,
-		EtcdCluster:           strings.Join(etcdEndpoints, ","),
+		EtcdCluster:           fmt.Sprintf("https://bootstrap.%s:2379", installConfig.ClusterDomain()),
 		Proxy:                 &proxy.Status,
 		Registries:            registries,
 		BootImage:             string(*rhcosImage),
+		ClusterDomain:         installConfig.ClusterDomain(),
 	}, nil
 }
 

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -166,10 +166,11 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		rootCA,
 	)
 
-	etcdEndpointHostnames := make([]string, *installConfig.Config.ControlPlane.Replicas)
+	etcdEndpointHostnames := make([]string, *installConfig.Config.ControlPlane.Replicas+1)
 	for i := range etcdEndpointHostnames {
-		etcdEndpointHostnames[i] = fmt.Sprintf("etcd-%d", i)
+		etcdEndpointHostnames[i] = fmt.Sprintf("etcd-%d", i-1)
 	}
+	etcdEndpointHostnames[0] = "etcd-bootstrap"
 
 	templateData := &bootkubeTemplateData{
 		CVOClusterID:               clusterID.UUID,

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -167,6 +167,7 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 	)
 
 	etcdEndpointHostnames := make([]string, *installConfig.Config.ControlPlane.Replicas+1)
+	etcdEndpointHostnames[0] = "etcd-bootstrap"
 	for i := range etcdEndpointHostnames {
 		etcdEndpointHostnames[i] = fmt.Sprintf("etcd-%d", i-1)
 	}


### PR DESCRIPTION
**NOTE cluster-etcd-operator is out for 4.3** 

In 4.3 cluster-etcd-operator will take over the process of bootstrapping the etcd cluster. To provide a clear path to disable/revert these changes we have setup the following conditional logic.

**MCO**: The MCO render command invoked in bootkube has a new optional flag to pass the value of the `cluster-etcd-operator` image[1]. The availability of this flags value[2] is used to conditionally adjust the `etcd-member` static pod spec allowing it to use the new bootstrapping method via the operator or fall back to the 4.2 SRV method.

**Installer**: The installer in 4.3 has a few notable changed introduced by this PR. First of all the `render` command populates a static pod manifest which creates a single member etcd cluster. After we have the single node cluster we can progress and cluster-operator can be deployed. This speeds up the time it takes for the operators to begin to reconcile as we are no longer waiting for all 3 etcds to bootstrap before we progress the operators.

**cluster-etcd-operator**: CEO is currently set as Unmanaged[3]. This allows us to include the CEO in CVO operator payload while setting the controllers to perform noop. This short term phase allows us to merge this PR proving that we can at the same time have CEO included in CVO but still use the old SRV bootstrap.

**Revert Plan**: If a case existed where we had a design error and the operator needed to be pulled from 4.3.
:
- Revert https://github.com/openshift/cluster-etcd-operator/pull/30/files
- Revert https://github.com/openshift/machine-config-operator/pull/1247

#####

[1] https://github.com/openshift/installer/pull/2608/files#diff-ce82c1d8a44f7dfc41dfc024085ccfeeR298
[2] https://github.com/openshift/machine-config-operator/blob/bd846958bc95d049547164046a962054fca093df/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml#L22
[3] https://github.com/openshift/cluster-etcd-operator/blob/master/manifests/0000_12_etcd-operator_01_operator.cr.yaml#L8

Depends on:
- [X]  https://github.com/openshift/machine-config-operator/pull/1224 (merged)
- [X] https://github.com/openshift/cluster-etcd-operator/pull/29 (merged)
- [X] https://github.com/openshift/machine-config-operator/pull/1221 (merged)
