### PR TITLE
WIP: cmd/openshift-install/gather: Whitelist gathered operator conditions

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -95,7 +95,7 @@ var (
 				}
 
 				err = waitForBootstrapComplete(ctx, config, rootOpts.dir)
-				if err != nil {
+				if err != nil || true {
 					if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
 						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
 					}


### PR DESCRIPTION
In de5a26aa42 (#2450), I'd defaulted to logging unrecognized condition types, because:

* There shouldn't be many of them, and
* When they exist, it's not clear to the installer whether they are important or not, because the installer has no way to know what they mean.

But that leads to logged messages [like][1]:

    Cluster operator insights Disabled is False with :

which users can tell is expected (because we expect enabled operators), but which the installer cannot blacklist because `Disabled` is insights-specific and has no semantics declared in openshift/api.

With this PR, we:

* Skip conditions that we know are healthy (e.g. `Available=True`).  This was the previous behavior as well.
* Log at an error level conditions we know are unhealthy (e.g. `Degraded!=False`).  This was the previous behavior as well.
* Log at an info level conditions which we know could impact install success, but which are not necessarily errors (e.g. `Available=False`), because these could indicate an error, or they could be due to a slow install.  This was the previous behavior as well.
* Log at a debug level conditions with types we don't recognize (e.g. `Disabled`).  This is new in this commit; previously they were also at info level.  They'll still be in .openshift_install.log, but will no longer be in the installers standard error by default.

I [don't like][2] demoting potentially-useful debugging information, but @deads2k [here][3], @jstuever [here][4], and @smarterclayton [here][5] all seem to prefer excluding unrecognized types from the default standard error, so I'm caving in to popular demand ;).

[1]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-4.3/544
[2]: https://github.com/openshift/installer/pull/2450#discussion_r335022814
[3]: https://github.com/openshift/installer/pull/2450#discussion_r332247959
[4]: https://github.com/openshift/installer/pull/2450#discussion_r334685375
[5]: https://github.com/openshift/insights-operator/pull/39#issuecomment-548881225