### PR TITLE
[libvirt] Add default router for worker

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -73,6 +73,13 @@ resource "libvirt_network" "net" {
         data.libvirt_network_dns_host_template.masters.*.rendered,
         data.libvirt_network_dns_host_template.masters_int.*.rendered,
         data.libvirt_network_dns_host_template.etcds.*.rendered,
+        
+        data.libvirt_network_dns_host_template.worker-oauth-openshift.*.rendered,
+        data.libvirt_network_dns_host_template.worker-console-openshift-console.*.rendered,
+        data.libvirt_network_dns_host_template.worker-downloads-openshift-console.*.rendered,
+        data.libvirt_network_dns_host_template.worker-alertmanager-main-openshift-monitoring.*.rendered,
+        data.libvirt_network_dns_host_template.worker-grafana-openshift-monitoring.*.rendered,
+        data.libvirt_network_dns_host_template.worker-prometheus-k8s-openshift-monitoring.*.rendered,
       )
       content {
         hostname = hosts.value.hostname
@@ -142,6 +149,42 @@ data "libvirt_network_dns_host_template" "etcds" {
   count    = var.master_count
   ip       = var.libvirt_master_ips[count.index]
   hostname = "etcd-${count.index}.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_host_template" "worker-oauth-openshift" {
+  count    = 1
+  ip       = "192.168.126.51"
+  hostname = "oauth-openshift.apps.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_host_template" "worker-console-openshift-console" {
+  count    = 1
+  ip       = "192.168.126.51"
+  hostname = "console-openshift-console.apps.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_host_template" "worker-downloads-openshift-console" {
+  count    = 1
+  ip       = "192.168.126.51"
+  hostname = "downloads-openshift-console.apps.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_host_template" "worker-alertmanager-main-openshift-monitoring" {
+  count    = 1
+  ip       = "192.168.126.51"
+  hostname = "alertmanager-main-openshift-monitoring.apps.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_host_template" "worker-grafana-openshift-monitoring" {
+  count    = 1
+  ip       = "192.168.126.51"
+  hostname = "grafana-openshift-monitoring.apps.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_host_template" "worker-prometheus-k8s-openshift-monitoring" {
+  count    = 1
+  ip       = "192.168.126.51"
+  hostname = "prometheus-k8s-openshift-monitoring.apps.${var.cluster_domain}"
 }
 
 data "libvirt_network_dns_srv_template" "etcd_cluster" {


### PR DESCRIPTION
as console pod can't parse DNS something like
oauth-openshift.apps.test1.aa.testing so it failed to start
this PR added the definition directly into libvirt dnsmasq file

Related to #1007 

so the `virsh dumpxml` will have following output
```
 <host ip='192.168.126.51'>
      <hostname>oauth-openshift.apps.test1.aa.testing</hostname>
      <hostname>console-openshift-console.apps.test1.aa.testing</hostname>
      <hostname>downloads-openshift-console.apps.test1.aa.testing</hostname>
      <hostname>alertmanager-main-openshift-monitoring.apps.test1.aa.testing</hostname>
      <hostname>grafana-openshift-monitoring.apps.test1.aa.testing</hostname>
      <hostname>prometheus-k8s-openshift-monitoring.apps.test1.aa.testing</hostname>
 </host>
```

The `oc get co` shows the console op is running after cluster startup
```
[core@test1-6dpnj-master-0 ~]$ oc get co
NAME                                       VERSION                         AVAILABLE   PROGRESSING   DEGRADED   SINCE
authentication                             4.3.0-0.okd-2019-10-29-180250   True        False         False      3m4s
cloud-credential                           4.3.0-0.okd-2019-10-29-180250   True        False         False      17m
cluster-autoscaler                         4.3.0-0.okd-2019-10-29-180250   True        False         False      8m48s
console                                    4.3.0-0.okd-2019-10-29-180250   True        False         False      2m18s
dns                                        4.3.0-0.okd-2019-10-29-180250   True        False         False      15m
image-registry                             4.3.0-0.okd-2019-10-29-180250   True        False         False      4m52s
ingress                                    4.3.0-0.okd-2019-10-29-180250   True        False         False      4m57s
insights                                   4.3.0-0.okd-2019-10-29-180250   True        False         False      16m
kube-apiserver                             4.3.0-0.okd-2019-10-29-180250   True        False         False      12m
kube-controller-manager                    4.3.0-0.okd-2019-10-29-180250   True        False         False      12m
kube-scheduler                             4.3.0-0.okd-2019-10-29-180250   True        False         False      13m
machine-api                                4.3.0-0.okd-2019-10-29-180250   True        False         False      15m
machine-config                             4.3.0-0.okd-2019-10-29-180250   True        False         False      14m
marketplace                                4.3.0-0.okd-2019-10-29-180250   True        False         False      9m14s
monitoring                                 4.3.0-0.okd-2019-10-29-180250   True        False         False      112s
network                                    4.3.0-0.okd-2019-10-29-180250   True        False         False      15m
node-tuning                                4.3.0-0.okd-2019-10-29-180250   True        False         False      9m17s
openshift-apiserver                        4.3.0-0.okd-2019-10-29-180250   True        False         False      7m3s
openshift-controller-manager               4.3.0-0.okd-2019-10-29-180250   True        False         False      7m2s
openshift-samples                          4.3.0-0.okd-2019-10-29-180250   True        False         False      5m44s
operator-lifecycle-manager                 4.3.0-0.okd-2019-10-29-180250   True        False         False      15m
operator-lifecycle-manager-catalog         4.3.0-0.okd-2019-10-29-180250   True        False         False      15m
operator-lifecycle-manager-packageserver   4.3.0-0.okd-2019-10-29-180250   True        False         False      10m
service-ca                                 4.3.0-0.okd-2019-10-29-180250   True        False         False      16m
service-catalog-apiserver                  4.3.0-0.okd-2019-10-29-180250   True        False         False      10m
service-catalog-controller-manager         4.3.0-0.okd-2019-10-29-180250   True        False         False      10m
storage                                    4.3.0-0.okd-2019-10-29-180250   True        False         False      10m

```