### PR TITLE
Bug 1763927: asset/cluster/aws: create resourcetaggingapi client with region

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -59,7 +59,7 @@ func PreTerraform(ctx context.Context, clusterID string, installConfig *installc
 		},
 	}
 
-	tagClient := resourcegroupstaggingapi.New(session)
+	tagClient := resourcegroupstaggingapi.New(session, aws.NewConfig().WithRegion(installConfig.Config.Platform.AWS.Region))
 	for i := 0; i < len(arns); i += 20 {
 		request.ResourceARNList = make([]*string, 0, 20)
 		for j := 0; i+j < len(arns) && j < 20; j++ {


### PR DESCRIPTION
fixes the error described in https://bugzilla.redhat.com/show_bug.cgi?id=1763927#c2

/assign @wking 
/test e2e-aws-shared-vpc