### PR TITLE
Remove temporary cached files

### DIFF
--- a/pkg/tfvars/internal/cache/cache.go
+++ b/pkg/tfvars/internal/cache/cache.go
@@ -85,6 +85,17 @@ func cacheFile(reader io.Reader, filePath string, sha256Checksum string) (err er
 	}
 
 	tempPath := fmt.Sprintf("%s.tmp", filePath)
+
+	// Delete the temporary file that may have been left over from previous launches.
+	err = os.Remove(tempPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return errors.Errorf("failed to clean up %s: %v", tempPath, err)
+		}
+	} else {
+		logrus.Debugf("Temporary file %v that remained after the previous launches was deleted", tempPath)
+	}
+
 	file, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0444)
 	if err != nil {
 		return err

--- a/pkg/tfvars/libvirt/cache.go
+++ b/pkg/tfvars/libvirt/cache.go
@@ -139,6 +139,17 @@ func cacheImage(reader io.Reader, imagePath string) (err error) {
 	}
 
 	tempPath := fmt.Sprintf("%s.tmp", imagePath)
+
+	// Delete the temporary file that may have been left over from previous launches.
+	err = os.Remove(tempPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to clean up %s: %v", tempPath, err)
+		}
+	} else {
+		logrus.Debugf("Temporary file %v that remained after the previous launches was deleted", tempPath)
+	}
+
 	file, err := os.OpenFile(tempPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0444)
 	if err != nil {
 		return err


### PR DESCRIPTION
If the installer crashes (OOM, checksum validations, etc.) while downloading an OS image, temporary files remain in the system, clogging it.

This commit makes sure that temporary files are deleted before starting a new download.

Fixes: https://github.com/openshift/installer/issues/1668