### PR TITLE
pkg/asset/manifests/azure/cloudproviderconfig_test: node-subnet -> worker-subnet

### DIFF
--- a/pkg/asset/manifests/azure/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig_test.go
@@ -16,7 +16,7 @@ func TestCloudProviderConfig(t *testing.T) {
 		NetworkResourceGroupName: "clusterid-rg",
 		NetworkSecurityGroupName: "clusterid-node-nsg",
 		VirtualNetworkName:       "clusterid-vnet",
-		SubnetName:               "clusterid-node-subnet",
+		SubnetName:               "clusterid-worker-subnet",
 	}
 	expected := `{
 	"cloud": "AzurePublicCloud",
@@ -32,7 +32,7 @@ func TestCloudProviderConfig(t *testing.T) {
 	"location": "westeurope",
 	"vnetName": "clusterid-vnet",
 	"vnetResourceGroup": "clusterid-rg",
-	"subnetName": "clusterid-node-subnet",
+	"subnetName": "clusterid-worker-subnet",
 	"securityGroupName": "clusterid-node-nsg",
 	"routeTableName": "clusterid-node-routetable",
 	"primaryAvailabilitySetName": "",


### PR DESCRIPTION
Catch this example up with cfa5d59c6c (#2556).  This is just a dummy value for the unit tests, but it's nice to be internally consistent anyway ;).