### PR TITLE
Bug 1766066: Revert "Merge pull request #2471 from openshift-cherrypick-robot/cher…

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -114,6 +114,10 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
 // https://cloud.google.com/compute/docs/storing-retrieving-metadata
 func createNoProxy(installConfig *installconfig.InstallConfig, network *Networking) (string, error) {
+	apiServerURL, err := url.Parse(getAPIServerURL(installConfig.Config))
+	if err != nil {
+		return "", errors.New("failed parsing API server when creating Proxy manifest")
+	}
 	internalAPIServer, err := url.Parse(getInternalAPIServerURL(installConfig.Config))
 	if err != nil {
 		return "", errors.New("failed parsing internal API server when creating Proxy manifest")
@@ -125,6 +129,7 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 		".svc",
 		".cluster.local",
 		network.Config.Spec.ServiceNetwork[0],
+		apiServerURL.Hostname(),
 		internalAPIServer.Hostname(),
 		installConfig.Config.Networking.MachineCIDR.String(),
 	)


### PR DESCRIPTION
…ry-pick-2425-to-release-4.2"

This reverts commit 8a194c3c24c52d17455d525a69282400e5067cbe, reversing
changes made to e349157f325dba2d06666987603da39965be5319.

We found in BZ https://bugzilla.redhat.com/show_bug.cgi?id=1762618 that at least
some of our code, running on cluster, was accessing the external instead of internal
api.

While it is possible to make it work (by allowing your proxy to talk from internal
to the apiserver) this is a change/regression from GA. Since we hit this with at
least 1 part of our code we have decided to revert and try again with more testing.