### PR TITLE
openstack: Add ansible to the CI image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -21,7 +21,7 @@ RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all 
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    python-openstackclient && \
+    python-openstackclient ansible python-openstacksdk python-netaddr && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /output && chown 1000:1000 /output


### PR DESCRIPTION
This adds the necessary dependencies (see `upi/openstack/requirements.txt`) to run the OpenStack UPI playbooks in the CI.

This is a prerequisite for adding the OpenStack UPI CI job.