### PR TITLE
Bug 1762618: pkg/asset/ignition: bootstrap kubeconfig to use api-int

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -62,7 +62,7 @@ var _ asset.WritableAsset = (*Bootstrap)(nil)
 func (a *Bootstrap) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.InstallConfig{},
-		&kubeconfig.AdminClient{},
+		&kubeconfig.AdminInternalClient{},
 		&kubeconfig.Kubelet{},
 		&kubeconfig.LoopbackClient{},
 		&machines.Master{},
@@ -425,7 +425,7 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 
 	// These files are all added with mode 0600; use for secret keys and the like.
 	for _, asset := range []asset.WritableAsset{
-		&kubeconfig.AdminClient{},
+		&kubeconfig.AdminInternalClient{},
 		&kubeconfig.Kubelet{},
 		&kubeconfig.LoopbackClient{},
 		&tls.AdminKubeConfigCABundle{},

--- a/pkg/asset/kubeconfig/admin_internal.go
+++ b/pkg/asset/kubeconfig/admin_internal.go
@@ -1,0 +1,56 @@
+package kubeconfig
+
+import (
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/tls"
+)
+
+var (
+	kubeconfigAdminInternalPath = filepath.Join("auth", "kubeconfig")
+)
+
+// AdminInternalClient is the asset for the admin kubeconfig.
+type AdminInternalClient struct {
+	kubeconfig
+}
+
+var _ asset.WritableAsset = (*AdminInternalClient)(nil)
+
+// Dependencies returns the dependency of the kubeconfig.
+func (k *AdminInternalClient) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&tls.AdminKubeConfigClientCertKey{},
+		&tls.KubeAPIServerCompleteCABundle{},
+		&installconfig.InstallConfig{},
+	}
+}
+
+// Generate generates the kubeconfig.
+func (k *AdminInternalClient) Generate(parents asset.Parents) error {
+	ca := &tls.KubeAPIServerCompleteCABundle{}
+	clientCertKey := &tls.AdminKubeConfigClientCertKey{}
+	installConfig := &installconfig.InstallConfig{}
+	parents.Get(ca, clientCertKey, installConfig)
+
+	return k.kubeconfig.generate(
+		ca,
+		clientCertKey,
+		getIntAPIServerURL(installConfig.Config),
+		installConfig.Config.GetName(),
+		"admin",
+		kubeconfigAdminInternalPath,
+	)
+}
+
+// Name returns the human-friendly name of the asset.
+func (k *AdminInternalClient) Name() string {
+	return "Kubeconfig Admin Internal Client"
+}
+
+// Load returns the kubeconfig from disk.
+func (k *AdminInternalClient) Load(f asset.FileFetcher) (found bool, err error) {
+	return false, nil
+}


### PR DESCRIPTION
Prior to this change, the default kubeconfig on the bootstrap host used
the external api url. This caused issues when the external api was not
available such as when proxy is configured but the noProxy list does not
contain the external api. In such situation, the bootstrap host fails to
report bootstrap complete to the cluster. As a result, the installer
fails during the wait-for bootstrap-complete stage.

This change adds a new kubeconfig (adminInternal) which points to
api-int. The bootstrap host defaults to this new kubeconfig. Api-int
is already in the noProxy list. As a result, the bootstrap host can
report complete even when the external api is inaccessible.