### PR TITLE
BZ 1770101: bootstrap: Ensure we've configured crio before it's started

### DIFF
--- a/data/data/bootstrap/systemd/units/crio-configure.service.template
+++ b/data/data/bootstrap/systemd/units/crio-configure.service.template
@@ -2,6 +2,7 @@
 Description=Configure CRI-O to use the pause image
 After=release-image.service
 Requires=release-image.service
+Before=crio.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Systemd will run as much as possible in parallel, and run dependencies
of units even before units are started.  Hence we need to ensure
that we've configured crio before it's started.

https://bugzilla.redhat.com/show_bug.cgi?id=1770101