### PR TITLE
libvirt: Resize specifically to 16G

### DIFF
--- a/data/data/libvirt/bootstrap/main.tf
+++ b/data/data/libvirt/bootstrap/main.tf
@@ -2,6 +2,8 @@ resource "libvirt_volume" "bootstrap" {
   name           = "${var.cluster_id}-bootstrap"
   base_volume_id = var.base_volume_id
   pool           = var.pool
+  # If you change this, you probably want to change the control plane/workers too
+  size = 16000000000
 }
 
 resource "libvirt_ignition" "bootstrap" {

--- a/data/data/libvirt/volume/main.tf
+++ b/data/data/libvirt/volume/main.tf
@@ -1,5 +1,13 @@
-resource "libvirt_volume" "coreos_base" {
-  name   = "${var.cluster_id}-base"
+resource "libvirt_volume" "coreos_orig" {
+  name   = "${var.cluster_id}-orig"
   source = var.image
   pool   = var.pool
+}
+
+resource "libvirt_volume" "coreos_base" {
+  name           = "${var.cluster_id}-base"
+  base_volume_id = libvirt_volume.coreos_orig.id
+  pool           = var.pool
+  # If you change this, you probably want to change the bootstrap too
+  size = 16000000000
 }


### PR DESCRIPTION
Today for IaaS clouds, we default to an instance type, which
then in turn usually provides a default size.  RHCOS resizes on
boot to that size, distinct from its "default" 16G size.

However, libvirt installs were inheriting our default size.  We'd
like to shrink it because we plan to land encryption:
https://github.com/openshift/enhancements/pull/15
And the less data we need to encrypt, the better.

(In the future I'd like to make this configurable with a variable,
 but let's just prepare for the encryption work now)