### PR TITLE
Bug 1771564: pkg/asset/manifests/proxy: Link trustedCA for transparent proxies

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -67,11 +67,11 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 			HTTPSProxy: installConfig.Config.Proxy.HTTPSProxy,
 			NoProxy:    installConfig.Config.Proxy.NoProxy,
 		}
+	}
 
-		if installConfig.Config.AdditionalTrustBundle != "" {
-			p.Config.Spec.TrustedCA = configv1.ConfigMapNameReference{
-				Name: additionalTrustBundleConfigMapName,
-			}
+	if installConfig.Config.AdditionalTrustBundle != "" {
+		p.Config.Spec.TrustedCA = configv1.ConfigMapNameReference{
+			Name: additionalTrustBundleConfigMapName,
 		}
 	}
 


### PR DESCRIPTION
Folks may want to configure additional CAs even in the absence of an explicitly-configured proxy (e.g. because they are using a transparent man-in-the-middle proxy).  With this commit, we set the proxy config to point at the trusted CA bundle regardless of whether the httpProxy or httpsProxy properties were set.

This also opens us up to folks who want to set additional CAs for other purposes (e.g. connecting to a local registry) by leaning on the network-operator's injection tooling and the proxy config's cluster-scoped `trustedCA` property.  That's cheating a bit, and for things like registry access there may be more appropriate operator-level configs that we could be setting.  But the installer-level `additionalTrustBundle` isn't documented as proxy-specific, so I think we want to adjust the installer as we go to put the configured trust bundle in the appropriate place to get the cluster components to pick it up, and at the moment the proxy config is that place.