### PR TITLE
Bug 1772002: manually prepare cloud provider's config

### DIFF
--- a/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
@@ -21,14 +21,13 @@ func TestCloudProviderConfigSecret(t *testing.T) {
 	}
 
 	expectedConfig := `[Global]
-auth-url    = https://my_auth_url.com/v3/
-username    = my_user
-password    = "my_secret_password"
-tenant-id   = f12f928576ae4d21bdb984da5dd1d3bf
-domain-id   = default
-domain-name = Default
-region      = my_region
-
+auth-url = "https://my_auth_url.com/v3/"
+username = "my_user"
+password = "my_secret_password"
+tenant-id = "f12f928576ae4d21bdb984da5dd1d3bf"
+domain-id = "default"
+domain-name = "Default"
+region = "my_region"
 `
 	actualConfig, err := CloudProviderConfigSecret(&cloud)
 	assert.NoError(t, err, "failed to create cloud provider config")
@@ -49,14 +48,13 @@ func TestCloudProviderConfigSecretUserDomain(t *testing.T) {
 	}
 
 	expectedConfig := `[Global]
-auth-url    = https://my_auth_url.com/v3/
-username    = my_user
-password    = "my_secret_password"
-tenant-id   = f12f928576ae4d21bdb984da5dd1d3bf
-domain-id   = default
-domain-name = Default
-region      = my_region
-
+auth-url = "https://my_auth_url.com/v3/"
+username = "my_user"
+password = "my_secret_password"
+tenant-id = "f12f928576ae4d21bdb984da5dd1d3bf"
+domain-id = "default"
+domain-name = "Default"
+region = "my_region"
 `
 	actualConfig, err := CloudProviderConfigSecret(&cloud)
 	assert.NoError(t, err, "failed to create cloud provider config")
@@ -64,31 +62,32 @@ region      = my_region
 }
 
 func TestCloudProviderConfigSecretQuoting(t *testing.T) {
-	cloud := clientconfig.Cloud{
-		AuthInfo: &clientconfig.AuthInfo{
-			Username:   "my_user",
-			Password:   "special \\r \\n \" \\ ",
-			AuthURL:    "https://my_auth_url.com/v3/",
-			ProjectID:  "f12f928576ae4d21bdb984da5dd1d3bf",
-			DomainID:   "default",
-			DomainName: "Default",
-		},
-		RegionName: "my_region",
+	passwords := map[string]string{
+		"regular":        "regular",
+		"with\\n":        "with\\\\n",
+		"with#":          "with#",
+		"with$":          "with$",
+		"with;":          "with;",
+		"with \n \" \\ ": "with \\n \\\" \\\\ ",
+		"with!":          "with!",
+		"with?":          "with?",
+		"with`":          "with`",
 	}
 
-	expectedConfig := `[Global]
-auth-url    = https://my_auth_url.com/v3/
-username    = my_user
-password    = "special \\r \\n \" \\ "
-tenant-id   = f12f928576ae4d21bdb984da5dd1d3bf
-domain-id   = default
-domain-name = Default
-region      = my_region
+	for k, v := range passwords {
+		cloud := clientconfig.Cloud{
+			AuthInfo: &clientconfig.AuthInfo{
+				Password: k,
+			},
+		}
 
+		expectedConfig := `[Global]
+password = "` + v + `"
 `
-	actualConfig, err := CloudProviderConfigSecret(&cloud)
-	assert.NoError(t, err, "failed to create cloud provider config")
-	assert.Equal(t, expectedConfig, string(actualConfig), "unexpected cloud provider config")
+		actualConfig, err := CloudProviderConfigSecret(&cloud)
+		assert.NoError(t, err, "failed to create cloud provider config")
+		assert.Equal(t, expectedConfig, string(actualConfig), "unexpected cloud provider config")
+	}
 }
 
 func TestCloudProviderConfig(t *testing.T) {


### PR DESCRIPTION
We can't use "go-ini" library to generate the config, because it's incompatible with "gcfg" library that we use to read the data.

For instance, if there is a string with a # character, then "go-ini" wraps it in bacticks, like \`aaa#bbb\`, but gcfg doesn't recognize it and  parses the data as \`aaa, skipping everything after the #.

So, we have to generate the config manually, avoiding possible issues with "go-ini".