### PR TITLE
[release-4.2] Bug 1771358: manually prepare cloud provider's config

### DIFF
--- a/pkg/asset/manifests/openstack/cloudproviderconfig.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig.go
@@ -1,12 +1,10 @@
 package openstack
 
 import (
-	"bytes"
 	"strconv"
+	"strings"
 
 	"github.com/gophercloud/utils/openstack/clientconfig"
-	"github.com/pkg/errors"
-	ini "gopkg.in/ini.v1"
 )
 
 type config struct {
@@ -43,8 +41,6 @@ kubeconfig-path = /var/lib/kubelet/kubeconfig
 // CloudProviderConfigSecret generates the cloud provider config for the OpenStack
 // platform, that will be stored in the system secret.
 func CloudProviderConfigSecret(cloud *clientconfig.Cloud) ([]byte, error) {
-	file := ini.Empty()
-
 	domainID := cloud.AuthInfo.DomainID
 	if domainID == "" {
 		domainID = cloud.AuthInfo.UserDomainID
@@ -55,27 +51,41 @@ func CloudProviderConfigSecret(cloud *clientconfig.Cloud) ([]byte, error) {
 		domainName = cloud.AuthInfo.UserDomainName
 	}
 
-	config := &config{
-		Global: global{
-			AuthURL:    cloud.AuthInfo.AuthURL,
-			Username:   cloud.AuthInfo.Username,
-			UserID:     cloud.AuthInfo.UserID,
-			Password:   strconv.Quote(cloud.AuthInfo.Password),
-			TenantID:   cloud.AuthInfo.ProjectID,
-			TenantName: cloud.AuthInfo.ProjectName,
-			DomainID:   domainID,
-			DomainName: domainName,
-			Region:     cloud.RegionName,
-			CAFile:     cloud.CACertFile,
-		},
+	// We have to generate this config manually without "go-ini" library, because its
+	// output data is incompatible with "gcfg".
+	// For instance, if there is a string with a # character, then "go-ini" wraps it in bacticks,
+	// like `aaa#bbb`, but gcfg doesn't recognize it and  parses the data as `aaa, skipping
+	// everything after the #.
+	// For more information: https://bugzilla.redhat.com/show_bug.cgi?id=1771358
+	var res strings.Builder
+	res.WriteString("[Global]\n")
+	if cloud.AuthInfo.AuthURL != "" {
+		res.WriteString("auth-url = " + strconv.Quote(cloud.AuthInfo.AuthURL) + "\n")
 	}
-	if err := file.ReflectFrom(config); err != nil {
-		return nil, errors.Wrap(err, "failed to reflect from config")
+	if cloud.AuthInfo.Username != "" {
+		res.WriteString("username = " + strconv.Quote(cloud.AuthInfo.Username) + "\n")
+	}
+	if cloud.AuthInfo.Password != "" {
+		res.WriteString("password = " + strconv.Quote(cloud.AuthInfo.Password) + "\n")
+	}
+	if cloud.AuthInfo.ProjectID != "" {
+		res.WriteString("tenant-id = " + strconv.Quote(cloud.AuthInfo.ProjectID) + "\n")
+	}
+	if cloud.AuthInfo.ProjectName != "" {
+		res.WriteString("tenant-name = " + strconv.Quote(cloud.AuthInfo.ProjectName) + "\n")
+	}
+	if domainID != "" {
+		res.WriteString("domain-id = " + strconv.Quote(domainID) + "\n")
+	}
+	if domainName != "" {
+		res.WriteString("domain-name = " + strconv.Quote(domainName) + "\n")
+	}
+	if cloud.RegionName != "" {
+		res.WriteString("region = " + strconv.Quote(cloud.RegionName) + "\n")
+	}
+	if cloud.CACertFile != "" {
+		res.WriteString("ca-file = " + strconv.Quote(cloud.CACertFile) + "\n")
 	}
 
-	buf := &bytes.Buffer{}
-	if _, err := file.WriteTo(buf); err != nil {
-		return nil, errors.Wrap(err, "failed to write out cloud provider config")
-	}
-	return buf.Bytes(), nil
+	return []byte(res.String()), nil
 }

--- a/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
@@ -21,14 +21,13 @@ func TestCloudProviderConfigSecret(t *testing.T) {
 	}
 
 	expectedConfig := `[Global]
-auth-url    = https://my_auth_url.com/v3/
-username    = my_user
-password    = "my_secret_password"
-tenant-id   = f12f928576ae4d21bdb984da5dd1d3bf
-domain-id   = default
-domain-name = Default
-region      = my_region
-
+auth-url = "https://my_auth_url.com/v3/"
+username = "my_user"
+password = "my_secret_password"
+tenant-id = "f12f928576ae4d21bdb984da5dd1d3bf"
+domain-id = "default"
+domain-name = "Default"
+region = "my_region"
 `
 	actualConfig, err := CloudProviderConfigSecret(&cloud)
 	assert.NoError(t, err, "failed to create cloud provider config")
@@ -49,14 +48,13 @@ func TestCloudProviderConfigSecretUserDomain(t *testing.T) {
 	}
 
 	expectedConfig := `[Global]
-auth-url    = https://my_auth_url.com/v3/
-username    = my_user
-password    = "my_secret_password"
-tenant-id   = f12f928576ae4d21bdb984da5dd1d3bf
-domain-id   = default
-domain-name = Default
-region      = my_region
-
+auth-url = "https://my_auth_url.com/v3/"
+username = "my_user"
+password = "my_secret_password"
+tenant-id = "f12f928576ae4d21bdb984da5dd1d3bf"
+domain-id = "default"
+domain-name = "Default"
+region = "my_region"
 `
 	actualConfig, err := CloudProviderConfigSecret(&cloud)
 	assert.NoError(t, err, "failed to create cloud provider config")
@@ -64,31 +62,32 @@ region      = my_region
 }
 
 func TestCloudProviderConfigSecretQuoting(t *testing.T) {
-	cloud := clientconfig.Cloud{
-		AuthInfo: &clientconfig.AuthInfo{
-			Username:   "my_user",
-			Password:   "special \\r \\n \" \\ ",
-			AuthURL:    "https://my_auth_url.com/v3/",
-			ProjectID:  "f12f928576ae4d21bdb984da5dd1d3bf",
-			DomainID:   "default",
-			DomainName: "Default",
-		},
-		RegionName: "my_region",
+	passwords := map[string]string{
+		"regular":        "regular",
+		"with\\n":        "with\\\\n",
+		"with#":          "with#",
+		"with$":          "with$",
+		"with;":          "with;",
+		"with \n \" \\ ": "with \\n \\\" \\\\ ",
+		"with!":          "with!",
+		"with?":          "with?",
+		"with`":          "with`",
 	}
 
-	expectedConfig := `[Global]
-auth-url    = https://my_auth_url.com/v3/
-username    = my_user
-password    = "special \\r \\n \" \\ "
-tenant-id   = f12f928576ae4d21bdb984da5dd1d3bf
-domain-id   = default
-domain-name = Default
-region      = my_region
+	for k, v := range passwords {
+		cloud := clientconfig.Cloud{
+			AuthInfo: &clientconfig.AuthInfo{
+				Password: k,
+			},
+		}
 
+		expectedConfig := `[Global]
+password = "` + v + `"
 `
-	actualConfig, err := CloudProviderConfigSecret(&cloud)
-	assert.NoError(t, err, "failed to create cloud provider config")
-	assert.Equal(t, expectedConfig, string(actualConfig), "unexpected cloud provider config")
+		actualConfig, err := CloudProviderConfigSecret(&cloud)
+		assert.NoError(t, err, "failed to create cloud provider config")
+		assert.Equal(t, expectedConfig, string(actualConfig), "unexpected cloud provider config")
+	}
 }
 
 func TestCloudProviderConfig(t *testing.T) {


### PR DESCRIPTION
We can't use "go-ini" library to generate the config, because it's incompatible with "gcfg" library that we use to read the data.

For instance, if there is a string with a # character, then "go-ini" wraps it in bacticks, like \`aaa#bbb\`, but gcfg doesn't recognize it and parses the data as \`aaa, skipping everything after the #.

So, we have to generate the config manually, avoiding possible issues with "go-ini".