### PR TITLE
Bug 1772080: Strip ".gz" suffix from baremetal image vars 

### DIFF
--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -82,7 +82,9 @@ func provider(clusterName string, platform *baremetal.Platform, osImage string, 
 	}
 	imageURL.RawQuery = ""
 	imageURL.Fragment = ""
-	imageFilename := path.Base(imageURL.String())
+	// We strip any .gz suffix because ironic-rhcos-downloader unzips the image
+	// ref https://github.com/openshift/ironic-rhcos-downloader/pull/12
+	imageFilename := path.Base(strings.TrimSuffix(imageURL.String(), ".gz"))
 	compressedImageFilename := strings.Replace(imageFilename, "openstack", "compressed", 1)
 	cacheImageURL := fmt.Sprintf("http://%s:6180/images/%s/%s", platform.ClusterProvisioningIP, imageFilename, compressedImageFilename)
 	cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -94,7 +94,9 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		}
 		imageURL.RawQuery = ""
 		imageURL.Fragment = ""
-		imageFilename := path.Base(imageURL.String())
+		// We strip any .gz suffix because ironic-rhcos-downloader unzips the image
+		// ref https://github.com/openshift/ironic-rhcos-downloader/pull/12
+		imageFilename := path.Base(strings.TrimSuffix(imageURL.String(), ".gz"))
 		compressedImageFilename := strings.Replace(imageFilename, "openstack", "compressed", 1)
 		cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", bootstrapProvisioningIP, imageFilename, compressedImageFilename)
 		cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)


### PR DESCRIPTION
This was recently added to the rhcos.json data but we uncompress
the image in ironic-rhcos-downloader, so the appropriate path
to give to terraform and the machine does not contain this suffix.

Related-Bug: #2661