### PR TITLE
Log credentials loading for AWS, Azure, GCP, OpenStack

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -437,11 +437,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4a14c92687d36a3875744de509bae52334a00ba487eb285b8a57645ec46acc7e"
+  digest = "1:d9bfa087ee01f521f964b82fdf179eeb2a52234455bd94068811ae2f6de7e677"
   name = "github.com/gophercloud/utils"
-  packages = ["openstack/clientconfig"]
+  packages = [
+    "env",
+    "openstack/clientconfig",
+  ]
   pruneopts = "NUT"
-  revision = "25f1b77b8c0367b43939dbb20f5dd12e3c9b0053"
+  revision = "6e51b8944d05c5799af3037f5a5c59124bc67797"
 
 [[projects]]
   digest = "1:c9898be5ce1ec9e8c04a85d9b83c18835c9571e36e39b989c9d3c110ad7d1817"

--- a/pkg/asset/installconfig/aws/session.go
+++ b/pkg/asset/installconfig/aws/session.go
@@ -21,17 +21,29 @@ func GetSession() (*session.Session, error) {
 	ssn := session.Must(session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	}))
+
+	sharedCredentialsProvider := &credentials.SharedCredentialsProvider{}
 	ssn.Config.Credentials = credentials.NewChainCredentials([]credentials.Provider{
 		&credentials.EnvProvider{},
-		&credentials.SharedCredentialsProvider{},
+		sharedCredentialsProvider,
 	})
-	_, err := ssn.Config.Credentials.Get()
+
+	creds, err := ssn.Config.Credentials.Get()
+	if err == nil {
+		switch creds.ProviderName {
+		case "SharedCredentialsProvider":
+			logrus.Infof("Credentials loaded from the %q profile in file %q", sharedCredentialsProvider.Profile, sharedCredentialsProvider.Filename)
+		case "EnvProvider":
+			logrus.Info("Credentials loaded from default AWS environment variables")
+		}
+	}
 	if err == credentials.ErrNoValidProvidersFoundInChain {
 		err = getCredentials()
 		if err != nil {
 			return nil, err
 		}
 	}
+
 	ssn.Handlers.Build.PushBackNamed(request.NamedHandler{
 		Name: "openshiftInstaller.OpenshiftInstallerUserAgentHandler",
 		Fn:   request.MakeAddToUserAgentHandler("OpenShift/4.x Installer", version.Raw),

--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -44,6 +44,8 @@ func GetSession() (*Session, error) {
 }
 
 func newSessionFromFile(authFilePath string) (*Session, error) {
+	logrus.Debugf("Trying to load credentials from file %q", authFilePath)
+
 	// NewAuthorizerFromFileWithResource uses `auth.GetSettingsFromFile`, which uses the `azureAuthEnv` to fetch the auth credentials.
 	// therefore setting the local env here to authFilePath allows NewAuthorizerFromFileWithResource to load credentials.
 	os.Setenv(azureAuthEnv, authFilePath)
@@ -70,6 +72,8 @@ func newSessionFromFile(authFilePath string) (*Session, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to map authsettings to credentials")
 	}
+
+	logrus.Infof("Credentials loaded from file %q", authFilePath)
 
 	authorizer, err := authSettings.ClientCredentialsAuthorizerWithResource(azureenv.PublicCloud.ResourceManagerEndpoint)
 	if err != nil {

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -13,10 +13,10 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig/aws"
 	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
+	icopenstack "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/conversion"
 	"github.com/openshift/installer/pkg/types/defaults"
-	openstackvalidation "github.com/openshift/installer/pkg/types/openstack/validation"
 	"github.com/openshift/installer/pkg/types/validation"
 )
 
@@ -132,7 +132,7 @@ func (a *InstallConfig) finish(filename string) error {
 		a.AWS = aws.NewMetadata(a.Config.Platform.AWS.Region, a.Config.Platform.AWS.Subnets)
 	}
 
-	if err := validation.ValidateInstallConfig(a.Config, openstackvalidation.NewValidValuesFetcher()).ToAggregate(); err != nil {
+	if err := validation.ValidateInstallConfig(a.Config, icopenstack.NewValidValuesFetcher()).ToAggregate(); err != nil {
 		if filename == "" {
 			return errors.Wrap(err, "invalid install config")
 		}

--- a/pkg/asset/installconfig/openstack/openstack.go
+++ b/pkg/asset/installconfig/openstack/openstack.go
@@ -9,12 +9,11 @@ import (
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/types/openstack"
-	openstackvalidation "github.com/openshift/installer/pkg/types/openstack/validation"
 )
 
 // Platform collects OpenStack-specific configuration.
 func Platform() (*openstack.Platform, error) {
-	validValuesFetcher := openstackvalidation.NewValidValuesFetcher()
+	validValuesFetcher := NewValidValuesFetcher()
 
 	cloudNames, err := validValuesFetcher.GetCloudNames()
 	if err != nil {

--- a/pkg/asset/installconfig/openstack/realvalidvaluesfetcher.go
+++ b/pkg/asset/installconfig/openstack/realvalidvaluesfetcher.go
@@ -1,4 +1,4 @@
-package validation
+package openstack
 
 import (
 	"github.com/pkg/errors"
@@ -10,21 +10,24 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+
+	"github.com/openshift/installer/pkg/types/openstack/validation"
 )
 
 type realValidValuesFetcher struct{}
 
 // NewValidValuesFetcher returns a new ValidValuesFetcher.
-func NewValidValuesFetcher() ValidValuesFetcher {
+func NewValidValuesFetcher() validation.ValidValuesFetcher {
 	return realValidValuesFetcher{}
 }
 
 // GetCloudNames gets the valid cloud names. These are read from clouds.yaml.
 func (f realValidValuesFetcher) GetCloudNames() ([]string, error) {
-	clouds, err := clientconfig.LoadCloudsYAML()
+	clouds, err := new(yamlLoadOpts).LoadCloudsYAML()
 	if err != nil {
 		return nil, err
 	}
+
 	i := 0
 	cloudNames := make([]string, len(clouds))
 	for k := range clouds {
@@ -36,9 +39,7 @@ func (f realValidValuesFetcher) GetCloudNames() ([]string, error) {
 
 // GetNetworkNames gets the valid network names.
 func (f realValidValuesFetcher) GetNetworkNames(cloud string) ([]string, error) {
-	opts := &clientconfig.ClientOpts{
-		Cloud: cloud,
-	}
+	opts := defaultClientOpts(cloud)
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
@@ -66,9 +67,7 @@ func (f realValidValuesFetcher) GetNetworkNames(cloud string) ([]string, error) 
 
 // GetFlavorNames gets a list of valid flavor names.
 func (f realValidValuesFetcher) GetFlavorNames(cloud string) ([]string, error) {
-	opts := &clientconfig.ClientOpts{
-		Cloud: cloud,
-	}
+	opts := defaultClientOpts(cloud)
 
 	conn, err := clientconfig.NewServiceClient("compute", opts)
 	if err != nil {
@@ -99,9 +98,7 @@ func (f realValidValuesFetcher) GetFlavorNames(cloud string) ([]string, error) {
 }
 
 func (f realValidValuesFetcher) GetNetworkExtensionsAliases(cloud string) ([]string, error) {
-	opts := &clientconfig.ClientOpts{
-		Cloud: cloud,
-	}
+	opts := defaultClientOpts(cloud)
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
@@ -127,9 +124,7 @@ func (f realValidValuesFetcher) GetNetworkExtensionsAliases(cloud string) ([]str
 }
 
 func (f realValidValuesFetcher) GetServiceCatalog(cloud string) ([]string, error) {
-	opts := &clientconfig.ClientOpts{
-		Cloud: cloud,
-	}
+	opts := defaultClientOpts(cloud)
 
 	conn, err := clientconfig.NewServiceClient("identity", opts)
 	if err != nil {
@@ -156,9 +151,7 @@ func (f realValidValuesFetcher) GetServiceCatalog(cloud string) ([]string, error
 }
 
 func (f realValidValuesFetcher) GetFloatingIPNames(cloud string, floatingNetworkName string) ([]string, error) {
-	opts := &clientconfig.ClientOpts{
-		Cloud: cloud,
-	}
+	opts := defaultClientOpts(cloud)
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {

--- a/pkg/asset/installconfig/openstack/session.go
+++ b/pkg/asset/installconfig/openstack/session.go
@@ -1,0 +1,79 @@
+// Package openstack collects OpenStack-specific configuration.
+package openstack
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/ghodss/yaml"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/sirupsen/logrus"
+)
+
+// Session is an object representing session for OpenStack.
+type Session struct {
+	CloudConfig *clientconfig.Cloud
+}
+
+// GetSession returns an OpenStack session for a given cloud name in clouds.yaml.
+func GetSession(cloudName string) (*Session, error) {
+	opts := defaultClientOpts(cloudName)
+	cloudConfig, err := clientconfig.GetCloudFromYAML(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &Session{
+		CloudConfig: cloudConfig,
+	}, nil
+}
+
+func defaultClientOpts(cloudName string) *clientconfig.ClientOpts {
+	opts := new(clientconfig.ClientOpts)
+	opts.Cloud = cloudName
+	opts.YAMLOpts = new(yamlLoadOpts)
+	return opts
+}
+
+type yamlLoadOpts struct{}
+
+func (opts yamlLoadOpts) LoadCloudsYAML() (map[string]clientconfig.Cloud, error) {
+	return loadAndLog(clientconfig.FindAndReadCloudsYAML)
+}
+
+func (opts yamlLoadOpts) LoadSecureCloudsYAML() (map[string]clientconfig.Cloud, error) {
+	clouds, err := loadAndLog(clientconfig.FindAndReadSecureCloudsYAML)
+	if err != nil {
+		if err.Error() == "no secure.yaml file found" {
+			// secure.yaml is optional so just ignore read error
+			return clouds, nil
+		}
+	}
+	return clouds, err
+}
+
+func (opts yamlLoadOpts) LoadPublicCloudsYAML() (map[string]clientconfig.Cloud, error) {
+	clouds, err := loadAndLog(clientconfig.FindAndReadPublicCloudsYAML)
+	if err != nil {
+		if err.Error() == "no clouds-public.yaml file found" {
+			// clouds-public.yaml is optional so just ignore read error
+			return clouds, nil
+		}
+	}
+	return clouds, err
+}
+
+func loadAndLog(fn func() (string, []byte, error)) (map[string]clientconfig.Cloud, error) {
+	filename, content, err := fn()
+	if err != nil {
+		return nil, err
+	}
+
+	var clouds clientconfig.Clouds
+	err = yaml.Unmarshal(content, &clouds)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal yaml")
+	}
+
+	logrus.Infof("Credentials loaded from file %q", filename)
+
+	return clouds.Clouds, nil
+}

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/asset"
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	azureconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
+	openstackconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
@@ -65,9 +65,7 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 			return errors.Wrap(err, "creating GCP session")
 		}
 	case openstack.Name:
-		opts := new(clientconfig.ClientOpts)
-		opts.Cloud = ic.Config.Platform.OpenStack.Cloud
-		_, err = clientconfig.GetCloudFromYAML(opts)
+		_, err = openstackconfig.GetSession(ic.Config.Platform.OpenStack.Cloud)
 	case baremetal.Name, libvirt.Name, none.Name, vsphere.Name:
 		// no creds to check
 	case azure.Name:

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
-	ospclientconfig "github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +13,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
+	icopenstack "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	"github.com/openshift/installer/pkg/asset/manifests/azure"
 	gcpmanifests "github.com/openshift/installer/pkg/asset/manifests/gcp"
 	openstackmanifests "github.com/openshift/installer/pkg/asset/manifests/openstack"
@@ -85,14 +85,12 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 	case awstypes.Name, libvirttypes.Name, nonetypes.Name, baremetaltypes.Name:
 		return nil
 	case openstacktypes.Name:
-		opts := &ospclientconfig.ClientOpts{}
-		opts.Cloud = installConfig.Config.Platform.OpenStack.Cloud
-		cloud, err := ospclientconfig.GetCloudFromYAML(opts)
+		cloud, err := icopenstack.GetSession(installConfig.Config.Platform.OpenStack.Cloud)
 		if err != nil {
 			return errors.Wrap(err, "failed to get cloud config for openstack")
 		}
 
-		cm.Data[cloudProviderConfigDataKey] = openstackmanifests.CloudProviderConfig(cloud)
+		cm.Data[cloudProviderConfigDataKey] = openstackmanifests.CloudProviderConfig(cloud.CloudConfig)
 	case azuretypes.Name:
 		session, err := icazure.GetSession()
 		if err != nil {

--- a/vendor/github.com/gophercloud/utils/env/env.go
+++ b/vendor/github.com/gophercloud/utils/env/env.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package env
+
+import (
+	"os"
+)
+
+func Getenv(s string) string {
+	return os.Getenv(s)
+}

--- a/vendor/github.com/gophercloud/utils/env/env_windows.go
+++ b/vendor/github.com/gophercloud/utils/env/env_windows.go
@@ -1,0 +1,106 @@
+package env
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/text/encoding/charmap"
+)
+
+func Getenv(s string) string {
+	var st uint32
+	env := os.Getenv(s)
+	if windows.GetConsoleMode(windows.Handle(syscall.Stdin), &st) == nil ||
+		windows.GetConsoleMode(windows.Handle(syscall.Stdout), &st) == nil ||
+		windows.GetConsoleMode(windows.Handle(syscall.Stderr), &st) == nil {
+		// detect windows console, should be skipped in cygwin environment
+		var cm charmap.Charmap
+		switch windows.GetACP() {
+		case 37:
+			cm = *charmap.CodePage037
+		case 1047:
+			cm = *charmap.CodePage1047
+		case 1140:
+			cm = *charmap.CodePage1140
+		case 437:
+			cm = *charmap.CodePage437
+		case 850:
+			cm = *charmap.CodePage850
+		case 852:
+			cm = *charmap.CodePage852
+		case 855:
+			cm = *charmap.CodePage855
+		case 858:
+			cm = *charmap.CodePage858
+		case 860:
+			cm = *charmap.CodePage860
+		case 862:
+			cm = *charmap.CodePage862
+		case 863:
+			cm = *charmap.CodePage863
+		case 865:
+			cm = *charmap.CodePage865
+		case 866:
+			cm = *charmap.CodePage866
+		case 28591:
+			cm = *charmap.ISO8859_1
+		case 28592:
+			cm = *charmap.ISO8859_2
+		case 28593:
+			cm = *charmap.ISO8859_3
+		case 28594:
+			cm = *charmap.ISO8859_4
+		case 28595:
+			cm = *charmap.ISO8859_5
+		case 28596:
+			cm = *charmap.ISO8859_6
+		case 28597:
+			cm = *charmap.ISO8859_7
+		case 28598:
+			cm = *charmap.ISO8859_8
+		case 28599:
+			cm = *charmap.ISO8859_9
+		case 28600:
+			cm = *charmap.ISO8859_10
+		case 28603:
+			cm = *charmap.ISO8859_13
+		case 28604:
+			cm = *charmap.ISO8859_14
+		case 28605:
+			cm = *charmap.ISO8859_15
+		case 28606:
+			cm = *charmap.ISO8859_16
+		case 20866:
+			cm = *charmap.KOI8R
+		case 21866:
+			cm = *charmap.KOI8U
+		case 1250:
+			cm = *charmap.Windows1250
+		case 1251:
+			cm = *charmap.Windows1251
+		case 1252:
+			cm = *charmap.Windows1252
+		case 1253:
+			cm = *charmap.Windows1253
+		case 1254:
+			cm = *charmap.Windows1254
+		case 1255:
+			cm = *charmap.Windows1255
+		case 1256:
+			cm = *charmap.Windows1256
+		case 1257:
+			cm = *charmap.Windows1257
+		case 1258:
+			cm = *charmap.Windows1258
+		case 874:
+			cm = *charmap.Windows874
+		default:
+			return env
+		}
+		if v, err := cm.NewEncoder().String(env); err == nil {
+			return v
+		}
+	}
+	return env
+}

--- a/vendor/github.com/gophercloud/utils/openstack/clientconfig/doc.go
+++ b/vendor/github.com/gophercloud/utils/openstack/clientconfig/doc.go
@@ -7,7 +7,7 @@ See https://docs.openstack.org/os-client-config/latest for details.
 Example to Create a Provider Client From clouds.yaml
 
 	opts := &clientconfig.ClientOpts{
-		Name: "hawaii",
+		Cloud: "hawaii",
 	}
 
 	pClient, err := clientconfig.AuthenticatedClient(opts)

--- a/vendor/github.com/gophercloud/utils/openstack/clientconfig/utils.go
+++ b/vendor/github.com/gophercloud/utils/openstack/clientconfig/utils.go
@@ -8,6 +8,8 @@ import (
 	"os/user"
 	"path/filepath"
 	"reflect"
+
+	"github.com/gophercloud/utils/env"
 )
 
 // defaultIfEmpty is a helper function to make it cleaner to set default value
@@ -87,7 +89,7 @@ func mergeInterfaces(overridingInterface, inferiorInterface interface{}) interfa
 	}
 }
 
-// findAndReadCloudsYAML attempts to locate a clouds.yaml file in the following
+// FindAndReadCloudsYAML attempts to locate a clouds.yaml file in the following
 // locations:
 //
 // 1. OS_CLIENT_CONFIG_FILE
@@ -96,35 +98,37 @@ func mergeInterfaces(overridingInterface, inferiorInterface interface{}) interfa
 // 4. unix-specific site_config_dir (/etc/openstack/clouds.yaml)
 //
 // If found, the contents of the file is returned.
-func findAndReadCloudsYAML() ([]byte, error) {
+func FindAndReadCloudsYAML() (string, []byte, error) {
 	// OS_CLIENT_CONFIG_FILE
-	if v := os.Getenv("OS_CLIENT_CONFIG_FILE"); v != "" {
+	if v := env.Getenv("OS_CLIENT_CONFIG_FILE"); v != "" {
 		if ok := fileExists(v); ok {
-			return ioutil.ReadFile(v)
+			content, err := ioutil.ReadFile(v)
+			return v, content, err
 		}
 	}
 
-	return findAndReadYAML("clouds.yaml")
+	return FindAndReadYAML("clouds.yaml")
 }
 
-func findAndReadPublicCloudsYAML() ([]byte, error) {
-	return findAndReadYAML("clouds-public.yaml")
+func FindAndReadPublicCloudsYAML() (string, []byte, error) {
+	return FindAndReadYAML("clouds-public.yaml")
 }
 
-func findAndReadSecureCloudsYAML() ([]byte, error) {
-	return findAndReadYAML("secure.yaml")
+func FindAndReadSecureCloudsYAML() (string, []byte, error) {
+	return FindAndReadYAML("secure.yaml")
 }
 
-func findAndReadYAML(yamlFile string) ([]byte, error) {
+func FindAndReadYAML(yamlFile string) (string, []byte, error) {
 	// current directory
 	cwd, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("unable to determine working directory: %s", err)
+		return "", nil, fmt.Errorf("unable to determine working directory: %s", err)
 	}
 
 	filename := filepath.Join(cwd, yamlFile)
 	if ok := fileExists(filename); ok {
-		return ioutil.ReadFile(filename)
+		content, err := ioutil.ReadFile(filename)
+		return filename, content, err
 	}
 
 	// unix user config directory: ~/.config/openstack.
@@ -133,17 +137,20 @@ func findAndReadYAML(yamlFile string) ([]byte, error) {
 		if homeDir != "" {
 			filename := filepath.Join(homeDir, ".config/openstack/"+yamlFile)
 			if ok := fileExists(filename); ok {
-				return ioutil.ReadFile(filename)
+				content, err := ioutil.ReadFile(filename)
+				return filename, content, err
 			}
 		}
 	}
 
 	// unix-specific site config directory: /etc/openstack.
-	if ok := fileExists("/etc/openstack/" + yamlFile); ok {
-		return ioutil.ReadFile("/etc/openstack/" + yamlFile)
+	filename = "/etc/openstack/" + yamlFile
+	if ok := fileExists(filename); ok {
+		content, err := ioutil.ReadFile(filename)
+		return filename, content, err
 	}
 
-	return nil, fmt.Errorf("no " + yamlFile + " file found")
+	return "", nil, fmt.Errorf("no " + yamlFile + " file found")
 }
 
 // fileExists checks for the existence of a file at a given location.


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CORS-1219

On AWS, Azure and GCP, provide `INFO` logs with the full path of the file where credentials were loaded from, and if possible `DEBUG` logs with all paths tried. OpenStack will be provided on a separate PR: https://github.com/openshift/installer/pull/2655.
