### PR TITLE
Add fips for bootstrap node; template ign machine config encap

### DIFF
--- a/data/data/bootstrap/files/etc/ignition-machine-config-encapsulated.json.template
+++ b/data/data/bootstrap/files/etc/ignition-machine-config-encapsulated.json.template
@@ -1,0 +1,14 @@
+{
+  "metadata": {
+    "name": "bootstrap-fips"
+  },
+  "spec": {
+    "config": {
+      "ignition": {
+        "version": "2.2.0"
+      }
+    },
+    "kernelArguments": [],
+    "fips": {{ .FIPS }}
+  }
+}

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -42,6 +42,7 @@ const (
 // template files.
 type bootstrapTemplateData struct {
 	AdditionalTrustBundle string
+	FIPS                  bool
 	EtcdCluster           string
 	PullSecret            string
 	ReleaseImage          string
@@ -223,6 +224,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 
 	return &bootstrapTemplateData{
 		AdditionalTrustBundle: installConfig.AdditionalTrustBundle,
+		FIPS:                  installConfig.FIPS,
 		PullSecret:            installConfig.PullSecret,
 		ReleaseImage:          releaseImage,
 		EtcdCluster:           strings.Join(etcdEndpoints, ","),


### PR DESCRIPTION
Adds `ignition-machine-config-encapsulated.json.template` to enable FIPS on bootstrap node if required.

Fixes #2634 