### PR TITLE
Bug 1770223: bootstrap kubeconfig to use api-int

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -62,7 +62,7 @@ var _ asset.WritableAsset = (*Bootstrap)(nil)
 func (a *Bootstrap) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.InstallConfig{},
-		&kubeconfig.AdminClient{},
+		&kubeconfig.AdminInternalClient{},
 		&kubeconfig.Kubelet{},
 		&kubeconfig.LoopbackClient{},
 		&machines.Master{},
@@ -425,7 +425,7 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 
 	// These files are all added with mode 0600; use for secret keys and the like.
 	for _, asset := range []asset.WritableAsset{
-		&kubeconfig.AdminClient{},
+		&kubeconfig.AdminInternalClient{},
 		&kubeconfig.Kubelet{},
 		&kubeconfig.LoopbackClient{},
 		&tls.AdminKubeConfigCABundle{},

--- a/pkg/asset/kubeconfig/admin_internal.go
+++ b/pkg/asset/kubeconfig/admin_internal.go
@@ -1,0 +1,56 @@
+package kubeconfig
+
+import (
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/tls"
+)
+
+var (
+	kubeconfigAdminInternalPath = filepath.Join("auth", "kubeconfig")
+)
+
+// AdminInternalClient is the asset for the admin kubeconfig.
+type AdminInternalClient struct {
+	kubeconfig
+}
+
+var _ asset.WritableAsset = (*AdminInternalClient)(nil)
+
+// Dependencies returns the dependency of the kubeconfig.
+func (k *AdminInternalClient) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&tls.AdminKubeConfigClientCertKey{},
+		&tls.KubeAPIServerCompleteCABundle{},
+		&installconfig.InstallConfig{},
+	}
+}
+
+// Generate generates the kubeconfig.
+func (k *AdminInternalClient) Generate(parents asset.Parents) error {
+	ca := &tls.KubeAPIServerCompleteCABundle{}
+	clientCertKey := &tls.AdminKubeConfigClientCertKey{}
+	installConfig := &installconfig.InstallConfig{}
+	parents.Get(ca, clientCertKey, installConfig)
+
+	return k.kubeconfig.generate(
+		ca,
+		clientCertKey,
+		getIntAPIServerURL(installConfig.Config),
+		installConfig.Config.GetName(),
+		"admin",
+		kubeconfigAdminInternalPath,
+	)
+}
+
+// Name returns the human-friendly name of the asset.
+func (k *AdminInternalClient) Name() string {
+	return "Kubeconfig Admin Internal Client"
+}
+
+// Load returns the kubeconfig from disk.
+func (k *AdminInternalClient) Load(f asset.FileFetcher) (found bool, err error) {
+	return false, nil
+}

--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -114,10 +114,6 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
 // https://cloud.google.com/compute/docs/storing-retrieving-metadata
 func createNoProxy(installConfig *installconfig.InstallConfig, network *Networking) (string, error) {
-	apiServerURL, err := url.Parse(getAPIServerURL(installConfig.Config))
-	if err != nil {
-		return "", errors.New("failed parsing API server when creating Proxy manifest")
-	}
 	internalAPIServer, err := url.Parse(getInternalAPIServerURL(installConfig.Config))
 	if err != nil {
 		return "", errors.New("failed parsing internal API server when creating Proxy manifest")
@@ -129,7 +125,6 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 		".svc",
 		".cluster.local",
 		network.Config.Spec.ServiceNetwork[0],
-		apiServerURL.Hostname(),
 		internalAPIServer.Hostname(),
 		installConfig.Config.Networking.MachineCIDR.String(),
 	)


### PR DESCRIPTION
Prior to this change, the default kubeconfig on the bootstrap host used
the external api url. This caused issues when the external api was not
available such as when proxy is configured but the noProxy list does not
contain the external api. In such situation, the bootstrap host fails to
report bootstrap complete to the cluster. As a result, the installer
fails during the wait-for bootstrap-complete stage.

This change adds a new kubeconfig (adminInternal) which points to
api-int. The bootstrap host defaults to this new kubeconfig. Api-int
is already in the noProxy list. As a result, the bootstrap host can
report complete even when the external api is inaccessible.

This change also reinstates a previously reverted commit removing the
external api from the proxy list now that the issue has been resolved.

Backports https://github.com/openshift/installer/pull/2647