### PR TITLE
data/baremetal/bootstrap: increase disk size to 16GiB

### DIFF
--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -1,6 +1,12 @@
-resource "libvirt_volume" "bootstrap" {
-  name   = "${var.cluster_id}-bootstrap"
+resource "libvirt_volume" "coreos_orig" {
+  name   = "${var.cluster_id}-orig"
   source = var.image
+}
+
+resource "libvirt_volume" "bootstrap" {
+  name           = "${var.cluster_id}-bootstrap"
+  base_volume_id = libvirt_volume.coreos_orig.id
+  size           = 17179869184
 }
 
 resource "libvirt_ignition" "bootstrap" {


### PR DESCRIPTION
Otherwise the default sysroot comes up as 2.5G which is too small, and
baremetal IPI gets errors like:

  startironic.sh[25249]:   write /var/tmp/storage989090957/3: no space left on device