### PR TITLE
Bug 1771784: cmd/openshift-install: silence the logs from klog by setting sterrThreshold to highest

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
-	"k8s.io/klog"
 
 	"github.com/openshift/installer/pkg/terraform/exec/plugins"
 )
@@ -23,7 +23,10 @@ var (
 )
 
 func main() {
-	klog.SetOutput(ioutil.Discard)
+	// This attempts to configure glog (used by vendored Kubernetes code) not
+	// to log anything. Nobody likes you, glog. Go away.
+	flag.CommandLine.Parse([]string{})
+	flag.CommandLine.Set("stderrthreshold", "4")
 
 	if len(os.Args) > 0 {
 		base := filepath.Base(os.Args[0])

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
+	"k8s.io/klog"
 
 	"github.com/openshift/installer/pkg/terraform/exec/plugins"
 )
@@ -23,10 +24,12 @@ var (
 )
 
 func main() {
-	// This attempts to configure glog (used by vendored Kubernetes code) not
-	// to log anything. Nobody likes you, glog. Go away.
-	flag.CommandLine.Parse([]string{})
-	flag.CommandLine.Set("stderrthreshold", "4")
+	// This attempts to configure klog (used by vendored Kubernetes code) not
+	// to log anything.
+	var fs flag.FlagSet
+	klog.InitFlags(&fs)
+	fs.Set("stderrthreshold", "4")
+	klog.SetOutput(ioutil.Discard)
 
 	if len(os.Args) > 0 {
 		base := filepath.Base(os.Args[0])


### PR DESCRIPTION
The commit https://github.com/openshift/installer/commit/e3a504467d3e9be5f9a6b575b7d0005f27de0a9e changed
With switch to kubernetes-1.16.0, all the k8s libs are using klog [2], that doesn't add the flags and also allows to set the default Ouput writer
for all levels. Setting the klog output to ioutil.Discard keeps the current behavior

But the commit left some of the stderr outputs from klog still visible, turning on sterrThreshold to highest turns that off too.