### PR TITLE
Do Not Merge openstack: Fail bootkube intentionally

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "Intentional error test observe bootkube failure"
+exit 1
+
 . /usr/local/bin/release-image.sh
 
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}


### PR DESCRIPTION
I want to validate that the CI now gathers bootstrap nova logs
correctly. This can only happen if the bootstrap server still exists
so we need to make sure bootstrapping doesn't complete.