### PR TITLE
Fix projectID typo in GCP customization docs

### DIFF
--- a/docs/user/gcp/customization.md
+++ b/docs/user/gcp/customization.md
@@ -94,7 +94,7 @@ metadata:
   name: example-cluster
 platform:
   gcp:
-    project: example-project
+    projectID: example-project
     region: us-east1
     computeSubnet: example-worker-subnet
     controlPlaneSubnet: example-controlplane-subnet


### PR DESCRIPTION
Correcting typo project -> projectID for GCP customization.

hat tip: @kalexand-rh 