### PR TITLE
Bug 1773686: GCP Gather: use bootstrap internal ip when missing external

### DIFF
--- a/pkg/terraform/gather/gcp/ip.go
+++ b/pkg/terraform/gather/gcp/ip.go
@@ -31,7 +31,17 @@ func BootstrapIP(tfs *terraform.State) (string, error) {
 		return "", errors.Wrap(err, "failed to lookup access config")
 	}
 	if !found {
-		return "", errors.New("bootstrap's network interface does not contain access_config")
+		return "", errors.New("could not find a usable IP address in accessConfigs")
+	}
+	if len(accessConfigs) == 0 {
+		networkIP, found, err := unstructured.NestedString(networkInterfaces[0].(map[string]interface{}), "network_ip")
+		if err != nil {
+			return "", errors.Wrap(err, "failed to lookup network_ip for bootstrap")
+		}
+		if !found {
+			return "", errors.New("could not find a usable network_ip address")
+		}
+		return networkIP, nil
 	}
 
 	bootstrap, found, err := unstructured.NestedString(accessConfigs[0].(map[string]interface{}), "nat_ip")


### PR DESCRIPTION
The BootstrapIP func is missing a length check for access configs, which causes a panic on private clusters because access configs is empty. This commit adds a length check and also looks up the private ip address of the bootstrap node to use instead.