### PR TITLE
Bug 1777516: Quote values in vSphere INI config

### DIFF
--- a/pkg/asset/manifests/vsphere/cloudproviderconfig.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig.go
@@ -4,66 +4,34 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/pkg/errors"
-	ini "gopkg.in/ini.v1"
-
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 )
 
-type config struct {
-	Global    global
-	Workspace workspace
-}
-
-type global struct {
-	SecretName      string `ini:"secret-name"`
-	SecretNamespace string `ini:"secret-namespace"`
-	InsecureFlag    int    `ini:"insecure-flag"`
-}
-
-type workspace struct {
-	Server           string `ini:"server"`
-	Datacenter       string `ini:"datacenter"`
-	DefaultDatastore string `ini:"default-datastore"`
-	Folder           string `ini:"folder"`
-}
-
-type virtualCenter struct {
-	Datacenters string `ini:"datacenters"`
+func printIfNotEmpty(buf *bytes.Buffer, k, v string) {
+	if v != "" {
+		fmt.Fprintf(buf, "%s = %q\n", k, v)
+	}
 }
 
 // CloudProviderConfig generates the cloud provider config for the vSphere platform.
 func CloudProviderConfig(clusterName string, p *vspheretypes.Platform) (string, error) {
-	file := ini.Empty()
-	config := &config{
-		Global: global{
-			SecretName:      "vsphere-creds",
-			SecretNamespace: "kube-system",
-			InsecureFlag:    1,
-		},
-		Workspace: workspace{
-			Server:           p.VCenter,
-			Datacenter:       p.Datacenter,
-			DefaultDatastore: p.DefaultDatastore,
-			Folder:           clusterName,
-		},
-	}
-	if err := file.ReflectFrom(config); err != nil {
-		return "", errors.Wrap(err, "failed to reflect from config")
-	}
-	s, err := file.NewSection(fmt.Sprintf("VirtualCenter %q", p.VCenter))
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to create section for virtual center")
-	}
-	if err := s.ReflectFrom(
-		&virtualCenter{
-			Datacenters: p.Datacenter,
-		}); err != nil {
-		return "", errors.Wrapf(err, "failed to reflect from virtual center")
-	}
-	buf := &bytes.Buffer{}
-	if _, err := file.WriteTo(buf); err != nil {
-		return "", errors.Wrap(err, "failed to write out cloud provider config")
-	}
+	buf := new(bytes.Buffer)
+
+	fmt.Fprintln(buf, "[Global]")
+	printIfNotEmpty(buf, "secret-name", "vsphere-creds")
+	printIfNotEmpty(buf, "secret-namespace", "kube-system")
+	printIfNotEmpty(buf, "insecure-flag", "1")
+	fmt.Fprintln(buf, "")
+
+	fmt.Fprintln(buf, "[Workspace]")
+	printIfNotEmpty(buf, "server", p.VCenter)
+	printIfNotEmpty(buf, "datacenter", p.Datacenter)
+	printIfNotEmpty(buf, "default-datastore", p.DefaultDatastore)
+	printIfNotEmpty(buf, "folder", clusterName)
+	fmt.Fprintln(buf, "")
+
+	fmt.Fprintf(buf, "[VirtualCenter %q]\n", p.VCenter)
+	printIfNotEmpty(buf, "datacenters", p.Datacenter)
+
 	return buf.String(), nil
 }

--- a/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
@@ -18,19 +18,18 @@ func TestCloudProviderConfig(t *testing.T) {
 		DefaultDatastore: "test-datastore",
 	}
 	expectedConfig := `[Global]
-secret-name      = vsphere-creds
-secret-namespace = kube-system
-insecure-flag    = 1
+secret-name = "vsphere-creds"
+secret-namespace = "kube-system"
+insecure-flag = "1"
 
 [Workspace]
-server            = test-name
-datacenter        = test-datacenter
-default-datastore = test-datastore
-folder            = test-cluster
+server = "test-name"
+datacenter = "test-datacenter"
+default-datastore = "test-datastore"
+folder = "test-cluster"
 
 [VirtualCenter "test-name"]
-datacenters = test-datacenter
-
+datacenters = "test-datacenter"
 `
 	actualConfig, err := CloudProviderConfig(clusterName, platform)
 	assert.NoError(t, err, "failed to create cloud provider config")


### PR DESCRIPTION
Before this change, the dependency used for INI generation was
incorrectly escaping special characters.

With this change, every value is double-quoted and escaped with Go
syntax.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1747474
ref: https://github.com/openshift/installer/pull/2659

If values with quotes are OK for your use case, you may want to merge this change which builds the INI without the help of an external dependency. We found quoted values like these to be correctly parsed by `gopkg.in/gcfg.v1`.

/cc @wking 
/hold