### PR TITLE
WIP Bug 1773108: upi/metal Only configure the first interface

### DIFF
--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -12,7 +12,7 @@ locals {
     "coreos.inst.image_url=${var.pxe_os_image_url}",
     "coreos.inst.install_dev=sda",
     "coreos.inst.skip_media_check",
-    "ip=enp1s0f0:dhcp,enp1s0f1:off",
+    "ip=enp1s0f0:dhcp",
   ]
 
   pxe_kernel = "${var.pxe_kernel_url}"

--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -12,6 +12,7 @@ locals {
     "coreos.inst.image_url=${var.pxe_os_image_url}",
     "coreos.inst.install_dev=sda",
     "coreos.inst.skip_media_check",
+    "ip=enp1s0f0:dhcp,enp1s0f1:off",
   ]
 
   pxe_kernel = "${var.pxe_kernel_url}"


### PR DESCRIPTION
Recent changes[1] mean that critical services wait for
NetworkManager-wait-online.service and the timeout has been increased[2] to
300 seconds which results in significant delays in booting instances
while we wait for the second interface.

1 - https://github.com/openshift/machine-config-operator/pull/1206
2 - https://bugzilla.redhat.com/show_bug.cgi?id=1741296