### PR TITLE
Bug 1764812: pkg/destroy/gcp/bucket.go: join multipe dashes when looking for cluster bucket prefix

### DIFF
--- a/pkg/asset/installconfig/clusterid.go
+++ b/pkg/asset/installconfig/clusterid.go
@@ -3,6 +3,7 @@ package installconfig
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/pborman/uuid"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
@@ -64,14 +65,20 @@ func (a *ClusterID) Name() string {
 // - only contains `alphanum` or `-`
 func generateInfraID(base string, maxLen int) string {
 	maxBaseLen := maxLen - (randomLen + 1)
-	// truncate to maxBaseLen
-	if len(base) > maxBaseLen {
-		base = base[:maxBaseLen]
-	}
 
 	// replace all characters that are not `alphanum` or `-` with `-`
 	re := regexp.MustCompile("[^A-Za-z0-9-]")
 	base = re.ReplaceAllString(base, "-")
+
+	// replace all multiple dashes in a sequence with single one.
+	re = regexp.MustCompile(`-{2,}`)
+	base = re.ReplaceAllString(base, "-")
+
+	// truncate to maxBaseLen
+	if len(base) > maxBaseLen {
+		base = base[:maxBaseLen]
+	}
+	base = strings.TrimRight(base, "-")
 
 	// add random chars to the end to randomize
 	return fmt.Sprintf("%s-%s", base, utilrand.String(randomLen))

--- a/pkg/asset/installconfig/clusterid_test.go
+++ b/pkg/asset/installconfig/clusterid_test.go
@@ -21,9 +21,13 @@ func Test_generateInfraID(t *testing.T) {
 		expLen:     27,
 		expNonRand: "qwertyuiopasdfghjklzx",
 	}, {
+		input:      "qwertyuiopasdfghjklz-cvbnm",
+		expLen:     26,
+		expNonRand: "qwertyuiopasdfghjklz",
+	}, {
 		input:      "qwe.rty.@iop!",
-		expLen:     13 + randomLen + 1,
-		expNonRand: "qwe-rty--iop-",
+		expLen:     11 + randomLen + 1,
+		expNonRand: "qwe-rty-iop",
 	}}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {

--- a/pkg/destroy/gcp/bucket.go
+++ b/pkg/destroy/gcp/bucket.go
@@ -1,10 +1,17 @@
 package gcp
 
 import (
+	"regexp"
+
 	"github.com/pkg/errors"
 
 	"google.golang.org/api/googleapi"
 	storage "google.golang.org/api/storage/v1"
+)
+
+var (
+	// multiDashes is a regexp matching multiple dashes in a sequence.
+	multiDashes = regexp.MustCompile(`-{2,}`)
 )
 
 func (o *ClusterUninstaller) listBuckets() ([]cloudResource, error) {
@@ -22,6 +29,7 @@ func (o *ClusterUninstaller) listBucketsWithFilter(fields string, prefix string,
 	result := []cloudResource{}
 	req := o.storageSvc.Buckets.List(o.ProjectID).Fields(googleapi.Field(fields))
 	if len(prefix) > 0 {
+		prefix = multiDashes.ReplaceAllString(prefix, "-")
 		req = req.Prefix(prefix)
 	}
 	err := req.Pages(ctx, func(list *storage.Buckets) error {


### PR DESCRIPTION
The registry-operator removes multiple dashes for the storage bucket name [1]. And since GCP does name based mathcing we leak the storage bucket.
And looks like the image-regsitry operator is removing the repeating dashes for all plaforms [2] even though looks like Azure is the only platform that has the restriction.

[1]: https://github.com/openshift/cluster-image-registry-operator/blob/a0efd48f8bc2c8d18d53fc5a9e5b8515b94bc2a4/pkg/storage/util/util.go#L140-L143
[2]: openshift/cluster-image-registry-operator#382