### PR TITLE
upi/metal various fixes

### DIFF
--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -12,6 +12,7 @@ locals {
     "coreos.inst.image_url=${var.pxe_os_image_url}",
     "coreos.inst.install_dev=sda",
     "coreos.inst.skip_media_check",
+    "ip=enp1s0f0:dhcp",
   ]
 
   pxe_kernel = "${var.pxe_kernel_url}"

--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -98,7 +98,7 @@ resource "packet_device" "masters" {
   count            = "${var.master_count}"
   hostname         = "master-${count.index}.${var.cluster_domain}"
   plan             = "c1.small.x86"
-  facilities       = ["any"]
+  facilities       = ["${local.packet_facility}"]
   operating_system = "custom_ipxe"
   ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=master"
   billing_cycle    = "hourly"
@@ -111,7 +111,7 @@ resource "packet_device" "workers" {
   count            = "${var.worker_count}"
   hostname         = "worker-${count.index}.${var.cluster_domain}"
   plan             = "c1.small.x86"
-  facilities       = ["any"]
+  facilities       = ["${local.packet_facility}"]
   operating_system = "custom_ipxe"
   ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=worker"
   billing_cycle    = "hourly"
@@ -133,7 +133,7 @@ module "bootstrap" {
 
   cluster_id = "${var.cluster_id}"
 
-  packet_facility   = "any"
+  packet_facility   = "${local.packet_facility}"
   packet_project_id = "${var.packet_project_id}"
 }
 


### PR DESCRIPTION
While attempting to reduce the number of times we fail to install during the e2e-metal job I've encounter a few different issues that contribute to the job's instability.

- [x] Only enable the first interface, the network topology that we've selected provides an LACP bond across available interfaces, however if the host hasn't been configured to use that properly it will attempt to bring up each interface using DHCP and that adds substantial delay to the boot process potentially leading to failure. I've removed this fix for now as I'm attempting to use a different instance type which may have different interface names than those on c1.small.x86
- [x] Specify the facility for all instances, without this I was seeing masters across SJC1 and EWR1 datacenters which is not compatible with etcd latency requirements
