### PR TITLE
Bug  1774813: Create a bootstrap instance group in GCP.

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -83,3 +83,22 @@ resource "google_compute_instance" "bootstrap" {
     ignore_changes = [min_cpu_platform]
   }
 }
+
+resource "google_compute_instance_group" "bootstrap" {
+  count = var.bootstrap_enabled ? 1 : 0
+
+  name = "${var.cluster_id}-bootstrap"
+  zone = var.zone
+
+  named_port {
+    name = "ignition"
+    port = "22623"
+  }
+
+  named_port {
+    name = "https"
+    port = "6443"
+  }
+
+  instances = google_compute_instance.bootstrap.*.self_link
+}

--- a/data/data/gcp/bootstrap/output.tf
+++ b/data/data/gcp/bootstrap/output.tf
@@ -1,3 +1,7 @@
 output "bootstrap_instances" {
-  value = google_compute_instance.bootstrap.*
+  value = google_compute_instance.bootstrap.*.self_link
+}
+
+output "bootstrap_instance_groups" {
+  value = google_compute_instance_group.bootstrap.*.self_link
 }

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -47,8 +47,6 @@ module "master" {
   root_volume_size = var.gcp_master_root_volume_size
   root_volume_type = var.gcp_master_root_volume_type
 
-  bootstrap_instances = module.bootstrap.bootstrap_instances
-
   labels = local.labels
 }
 
@@ -67,8 +65,9 @@ module "network" {
   network_cidr       = var.machine_cidr
   public_endpoints   = local.public_endpoints
 
-  bootstrap_lb        = var.gcp_bootstrap_enabled
-  bootstrap_instances = module.bootstrap.bootstrap_instances
+  bootstrap_lb              = var.gcp_bootstrap_enabled && var.gcp_bootstrap_lb
+  bootstrap_instances       = module.bootstrap.bootstrap_instances
+  bootstrap_instance_groups = module.bootstrap.bootstrap_instance_groups
 
   master_instances       = module.master.master_instances
   master_instance_groups = module.master.master_instance_groups

--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -85,5 +85,5 @@ resource "google_compute_instance_group" "master" {
     port = "6443"
   }
 
-  instances = [for instance in concat(google_compute_instance.master.*, var.bootstrap_instances) : instance.self_link if instance.zone == var.zones[count.index]]
+  instances = [for instance in google_compute_instance.master.* : instance.self_link if instance.zone == var.zones[count.index]]
 }

--- a/data/data/gcp/master/variables.tf
+++ b/data/data/gcp/master/variables.tf
@@ -47,8 +47,3 @@ variable "root_volume_type" {
 variable "zones" {
   type = list
 }
-
-variable "bootstrap_instances" {
-  type        = list
-  description = "A list containing the bootstrap node."
-}

--- a/data/data/gcp/network/lb-private.tf
+++ b/data/data/gcp/network/lb-private.tf
@@ -21,7 +21,7 @@ resource "google_compute_region_backend_service" "api_internal" {
   timeout_sec           = 120
 
   dynamic "backend" {
-    for_each = var.master_instance_groups
+    for_each = var.bootstrap_lb ? concat(var.bootstrap_instance_groups, var.master_instance_groups) : var.master_instance_groups
 
     content {
       group = backend.value

--- a/data/data/gcp/network/lb-public.tf
+++ b/data/data/gcp/network/lb-public.tf
@@ -18,7 +18,7 @@ resource "google_compute_target_pool" "api" {
 
   name = "${var.cluster_id}-api"
 
-  instances     = var.master_instances
+  instances     = var.bootstrap_lb ? concat(var.bootstrap_instances, var.master_instances) : var.master_instances
   health_checks = [google_compute_http_health_check.api[0].self_link]
 }
 

--- a/data/data/gcp/network/variables.tf
+++ b/data/data/gcp/network/variables.tf
@@ -1,16 +1,22 @@
+
+variable "cluster_id" {
+  type = string
+}
+
 variable "bootstrap_instances" {
   type        = list
   description = "The bootstrap instance."
+}
+
+variable "bootstrap_instance_groups" {
+  type        = list
+  description = "The bootstrap instance groups."
 }
 
 variable "bootstrap_lb" {
   type        = bool
   description = "If the bootstrap instance should be in the load balancers."
   default     = true
-}
-
-variable "cluster_id" {
-  type = string
 }
 
 variable "master_instances" {

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -30,6 +30,12 @@ variable "gcp_bootstrap_enabled" {
   default = true
 }
 
+variable "gcp_bootstrap_lb" {
+  type = bool
+  description = "Setting this to false allows the bootstrap resources to be removed from the cluster load balancers."
+  default = true
+}
+
 variable "gcp_bootstrap_instance_type" {
   type = string
   description = "Instance type for the bootstrap node. Example: `n1-standard-4`"

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -55,10 +55,17 @@ func Destroy(dir string) (err error) {
 
 	switch platform {
 	case gcp.Name:
+		// First remove the bootstrap node from the load balancers to avoid race condition.
+		_, err = terraform.Apply(tempDir, platform, append(extraArgs, "-var=gcp_bootstrap_lb=false")...)
+		if err != nil {
+			return errors.Wrap(err, "failed disabling bootstrap load balancing")
+		}
+
+		// Then destory the bootstrap instance and instance group so destroy runs cleanly.
 		// First remove the bootstrap from LB target and its instance so that bootstrap module is cleanly destroyed.
 		_, err = terraform.Apply(tempDir, platform, append(extraArgs, "-var=gcp_bootstrap_enabled=false")...)
 		if err != nil {
-			return errors.Wrap(err, "Terraform apply")
+			return errors.Wrap(err, "failed disabling bootstrap")
 		}
 	case libvirt.Name:
 		// First remove the bootstrap node from DNS


### PR DESCRIPTION
Previously the bootstrap node has been added to the first master instance group. This commit creates an independent instance group for the bootstrap node so that Kubernetes will not consider the master instance group to have a non-cluster node.
