### PR TITLE
openstack: Use an invalid domain for testing

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -16,7 +16,7 @@ COPY --from=registry.svc.ci.openshift.org/origin/4.2:cli /usr/bin/oc /bin/oc
 RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all && rm -rf /var/cache/yum/* && \
     localedef -c -f UTF-8 -i en_US en_US.UTF-8 && \
     git config --system user.name test && \
-    git config --system user.email test@test.com && \
+    git config --system user.email test@example.com && \
     chmod g+w /etc/passwd
 
 RUN yum update -y && \


### PR DESCRIPTION
Replace a valid and registered domain with an IETF "invalid" domain for
testing purposes.

Ref: https://tools.ietf.org/html/rfc2606

/hold
until master branch is open.