### PR TITLE
bug 1774388: Stop setting non existent public target pool when InternalPublishingStrategy on GCP master machines

### DIFF
--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -105,12 +105,15 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 }
 
 // ConfigMasters assigns a set of load balancers to the given machines
-func ConfigMasters(machines []machineapi.Machine, clusterID string) {
+func ConfigMasters(machines []machineapi.Machine, clusterID string, publish types.PublishingStrategy) {
+	var targetPools []string
+	if publish == types.ExternalPublishingStrategy {
+		targetPools = append(targetPools, fmt.Sprintf("%s-api", clusterID))
+	}
+
 	for _, machine := range machines {
 		providerSpec := machine.Spec.ProviderSpec.Value.Object.(*gcpprovider.GCPMachineProviderSpec)
-		providerSpec.TargetPools = []string{
-			fmt.Sprintf("%s-api", clusterID),
-		}
+		providerSpec.TargetPools = targetPools
 	}
 }
 func getNetworks(platform *gcp.Platform, clusterID, role string) (string, string, error) {

--- a/pkg/asset/machines/gcp/machines_test.go
+++ b/pkg/asset/machines/gcp/machines_test.go
@@ -1,0 +1,61 @@
+// Package gcp generates Machine objects for gcp.
+package gcp
+
+import (
+	"fmt"
+	"testing"
+
+	gcpprovider "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
+	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	"github.com/openshift/installer/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestConfigMasters(t *testing.T) {
+	clusterID := "test"
+	testCases := []struct {
+		testCase            string
+		publishingStrategy  types.PublishingStrategy
+		expectedTargetPools []string
+	}{
+		{
+			testCase:           "External",
+			publishingStrategy: types.ExternalPublishingStrategy,
+			expectedTargetPools: []string{
+				fmt.Sprintf("%s-api", clusterID),
+			},
+		},
+		{
+			testCase:            "Internal",
+			publishingStrategy:  types.InternalPublishingStrategy,
+			expectedTargetPools: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		machines := []machineapi.Machine{
+			{
+				Spec: machineapi.MachineSpec{
+					ProviderSpec: machineapi.ProviderSpec{
+						Value: &runtime.RawExtension{Object: &gcpprovider.GCPMachineProviderSpec{}},
+					},
+				},
+			},
+			{
+				Spec: machineapi.MachineSpec{
+					ProviderSpec: machineapi.ProviderSpec{
+						Value: &runtime.RawExtension{Object: &gcpprovider.GCPMachineProviderSpec{}},
+					},
+				},
+			},
+		}
+		t.Run(tc.testCase, func(t *testing.T) {
+			ConfigMasters(machines, clusterID, tc.publishingStrategy)
+			for _, machine := range machines {
+				providerSpec := machine.Spec.ProviderSpec.Value.Object.(*gcpprovider.GCPMachineProviderSpec)
+				assert.Equal(t, providerSpec.TargetPools, tc.expectedTargetPools)
+			}
+		})
+	}
+}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -195,7 +195,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
-		gcp.ConfigMasters(machines, clusterID.InfraID)
+		gcp.ConfigMasters(machines, clusterID.InfraID, ic.Publish)
 	case libvirttypes.Name:
 		mpool := defaultLibvirtMachinePoolPlatform()
 		mpool.Set(ic.Platform.Libvirt.DefaultMachinePlatform)


### PR DESCRIPTION
Stop setting non existent public target pool when InternalPublishingStrategy on GCP master machines