### PR TITLE
WIP upi/openstack: Generate ignition and connectivity

### DIFF
--- a/upi/openstack/00_install_config.yaml
+++ b/upi/openstack/00_install_config.yaml
@@ -1,0 +1,109 @@
+# Required Python packages:
+#
+# ansible
+# openstacksdk
+# netaddr
+#
+# Required tools installed on the host:
+# python3
+# jq
+
+- hosts: all
+
+  tasks:
+  - name: "Backup the install-config.yaml file"
+    command:
+      chdir: "{{ install_config_directory }}"
+      cmd: "cp install-config.yaml install-config.yaml.backup"
+
+  - name: "Add the subnet range into install-config.yaml"
+    command:
+      chdir: "{{ install_config_directory }}"
+      cmd: >-
+        python3 -c 'import yaml;
+        path = "install-config.yaml";
+        data = yaml.safe_load(open(path));
+        data["networking"]["machineCIDR"] = "{{ os_subnet_range }}";
+        open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+
+  - name: "Empty out the Compute pools"
+    command:
+      chdir: "{{ install_config_directory }}"
+      cmd: >-
+        python3 -c 'import yaml;
+        path = "install-config.yaml";
+        data = yaml.safe_load(open(path));
+        data["compute"][0]["replicas"] = 0;
+        open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+
+  - name: "Create manifests"
+    command:
+      chdir: "{{ install_config_directory }}"
+      cmd: "openshift-install create manifests"
+
+  # NOTE: using the `shell` module because `command` doesn't handle globbing
+  - name: "Remove Machines and Machinesets manifests"
+    shell:
+      chdir: "{{ install_config_directory }}"
+      cmd: "rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml"
+
+  - name: "Make control plane nodes unchedulable"
+    command:
+      chdir: "{{ install_config_directory }}"
+      cmd: >-
+        python3 -c 'import yaml;
+        path = "manifests/cluster-scheduler-02-config.yml";
+        data = yaml.safe_load(open(path));
+        data["spec"]["mastersSchedulable"] = False;
+        open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+
+  - name: "Create ignition configs"
+    command:
+      chdir: "{{ install_config_directory }}"
+      cmd: "openshift-install create ignition-configs"
+
+  - name: "Save the Infra ID"
+    command:
+      chdir: "{{ install_config_directory }}"
+      cmd: "jq -r .infraID metadata.json"
+    register: "infraID"
+
+  - name: "Set hostname in bootstrap ignition"
+    command:
+      chdir: "{{ install_config_directory }}"
+      cmd: >-
+        python3 -c 'import base64;
+        import json;
+        import os;
+        path = "bootstrap.ign";
+        ignition = json.load(open(path, "r"));
+        hostname_b64 = base64.standard_b64encode(b"{{ infraID.stdout }}-bootstrap\n").decode().strip();
+        ignition["storage"]["files"].append({
+            "path": "/etc/hostname",
+            "mode": 420,
+            "contents": {
+                "source": "data:text/plain;charset=utf-8;base64," + hostname_b64,
+                "verification": {}
+            },
+            "filesystem": "root",
+        });
+        json.dump(ignition, open(path, "w"))'
+
+  - name: "Set hostname in master ignition"
+    shell:
+      chdir: "{{ install_config_directory }}"
+      cmd: >-
+        for index in $(seq 0 2); do
+          python3 -c "import base64, json, sys;
+        ignition = json.load(sys.stdin);
+        files = ignition['storage'].get('files', []);
+        files.append({'path': '/etc/hostname', 'mode': 420, 'contents': {'source': 'data:text/plain;charset=utf-8;base64,' + base64.standard_b64encode(b'{{ infraID.stdout }}-master-$index\n').decode().strip(), 'verification': {}}, 'filesystem': 'root'});
+        ignition['storage']['files'] = files;
+        json.dump(ignition, sys.stdout)" <master.ign >"{{ infraID.stdout }}-master-$index-ignition.json";
+        done
+
+  - debug: var=infraID.stdout
+
+  - debug: msg="Add the 'infraID.stdout' string into your Ansible inventory as 'os_cluster_name'"
+
+  - debug: msg="Publish the API and Ingress DNS records, resolving to the API and Ingress floating IP addresses"

--- a/upi/openstack/01_network.yaml
+++ b/upi/openstack/01_network.yaml
@@ -6,9 +6,6 @@
 
 - hosts: all
 
-  vars:
-    cluster_subnet: "{{ os_infra_id }}-nodes"
-
   tasks:
   - name: 'Create the cluster network'
     os_network:
@@ -16,7 +13,7 @@
 
   - name: 'Create a subnet'
     os_subnet:
-      name: "{{ cluster_subnet }}"
+      name: "{{ os_subnet }}"
       network_name: "{{ os_network }}"
       cidr: "{{ os_subnet_range }}"
       allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"

--- a/upi/openstack/02.5_connectivity.yaml
+++ b/upi/openstack/02.5_connectivity.yaml
@@ -1,0 +1,42 @@
+# Required Python packages:
+#
+# ansible
+# openstacksdk
+# netaddr
+
+- hosts: all
+
+  vars:
+    external_router: "{{ os_infra_id }}-external-router"
+    api_port: "{{ os_infra_id }}-api-port"
+    ingress_port: "{{ os_infra_id }}-ingress-port"
+
+  tasks:
+  - name: 'Create the external router'
+    os_router:
+      name: "{{ external_router }}"
+      network: "{{ os_external_network_name }}"
+      interfaces:
+      - "{{ os_subnet }}"
+
+  - name: 'Create the API port'
+    os_port:
+      name: "{{ api_port }}"
+      network: "{{ os_network }}"
+      security_groups:
+      - "{{ os_sg_master }}"
+      allowed_address_pairs:
+      - ip_address: "{{ os_subnet_range | next_nth_usable(5) }}"
+
+  - name: 'Create the Ingress port'
+    os_port:
+      name: "{{ ingress_port }}"
+      network: "{{ os_network }}"
+      security_groups:
+      - "{{ os_sg_worker }}"
+      allowed_address_pairs:
+      - ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
+
+  - debug: msg="Attach the API Floating IP address to '{{ api_port }}'"
+
+  - debug: msg="Attach the Ingress Floating IP address to '{{ ingress_port }}'"

--- a/upi/openstack/down-00_install_config.yaml
+++ b/upi/openstack/down-00_install_config.yaml
@@ -1,0 +1,13 @@
+# Required Python packages:
+#
+# ansible
+# openstacksdk
+# netaddr
+
+- hosts: all
+
+  tasks:
+  - name: "Delete everything in the install config directory"
+    shell:
+      chdir: "{{ install_config_directory }}"
+      cmd: "rm -rf .openshift_install* *.ign *.json auth manifests openshift"

--- a/upi/openstack/down-02.5_connectivity.yaml
+++ b/upi/openstack/down-02.5_connectivity.yaml
@@ -1,0 +1,28 @@
+# Required Python packages:
+#
+# ansible
+# openstacksdk
+# netaddr
+
+- hosts: all
+
+  vars:
+    external_router: "{{ os_infra_id }}-external-router"
+    api_port: "{{ os_infra_id }}-api-port"
+    ingress_port: "{{ os_infra_id }}-ingress-port"
+
+  tasks:
+  - name: 'Remove the API port'
+    os_port:
+      name: "{{ api_port }}"
+      state: absent
+
+  - name: 'Remove the Ingress port'
+    os_port:
+      name: "{{ ingress_port }}"
+      state: absent
+
+  - name: 'Remove the external router'
+    os_router:
+      name: "{{ external_router }}"
+      state: absent

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -3,21 +3,22 @@ all:
     localhost:
       ansible_connection: local
       ansible_python_interpreter: "{{ansible_playbook_python}}"
+      # TODO: change this to the absolute path where your install-config.yaml is
+      # TODO(shadower): if we have the playbooks and install-config in the same
+      # directory, this and the `chdir` nonsense is not necessary. Test that!
+      install_config_directory: "."
 
       os_subnet_range: '10.0.0.0/16'
-      os_cluster_name: 'openshift'
+      # TODO: set this to your infraID (see `metadata.json`).
+      os_infra_id: 'openshift-2r74r'
+      os_external_network_name: 'external'
 
       # Computed values
-
-      # os_infra_id is the string we will use as a prefix for the names of the
-      # OpenShift cluster resources. It is built in the form of:
-      #
-      #     "{{ os_cluster_name }}{{ installation-specific string }}"
-      os_infra_id: "{{ os_cluster_name }}-upi"
 
       # os_network is the name of the OpenStack network that will contain the
       # OpenShift cluster.
       os_network: "{{ os_infra_id }}-network"
+      os_subnet: "{{ os_infra_id }}-nodes"
 
       # os_sg_* are the names of the security groups that will be assigned to
       # the respective nodes.


### PR DESCRIPTION
**WARNING: This is utterly gross right now, needs a major cleanup.**

This add a playbook that takes `install-config.yaml` and turns it
into the ignition files, applying all the modifications.

It also adds a second playbook that creates the router and api/ingress
ports.