### PR TITLE
Bug 1776272: OpenStack: fix getting service catalog

### DIFF
--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -183,29 +183,13 @@ func getServiceCatalog(cloud string) (*tokens.ServiceCatalog, error) {
 		return nil, err
 	}
 
-	cloudConfig, err := clientconfig.GetCloudFromYAML(opts)
-	if err != nil {
-		return nil, err
+	authResult := conn.GetAuthResult()
+	auth, ok := authResult.(tokens.CreateResult)
+	if !ok {
+		return nil, errors.New("unable to extract service catalog")
 	}
 
-	domainName := cloudConfig.AuthInfo.DomainName
-	if domainName == "" {
-		domainName = cloudConfig.AuthInfo.UserDomainName
-	}
-
-	scope := tokens.Scope{
-		ProjectName: cloudConfig.AuthInfo.ProjectName,
-		DomainName:  domainName,
-	}
-
-	authOptions := tokens.AuthOptions{
-		Scope:      scope,
-		Username:   cloudConfig.AuthInfo.Username,
-		Password:   cloudConfig.AuthInfo.Password,
-		DomainName: domainName,
-	}
-
-	serviceCatalog, err := tokens.Create(conn, &authOptions).ExtractServiceCatalog()
+	serviceCatalog, err := auth.ExtractServiceCatalog()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/types/openstack/validation/realvalidvaluesfetcher.go
+++ b/pkg/types/openstack/validation/realvalidvaluesfetcher.go
@@ -136,29 +136,13 @@ func (f realValidValuesFetcher) GetServiceCatalog(cloud string) ([]string, error
 		return nil, err
 	}
 
-	cloudConfig, err := clientconfig.GetCloudFromYAML(opts)
-	if err != nil {
-		return nil, err
+	authResult := conn.GetAuthResult()
+	auth, ok := authResult.(tokens.CreateResult)
+	if !ok {
+		return nil, errors.New("unable to extract service catalog")
 	}
 
-	domainName := cloudConfig.AuthInfo.DomainName
-	if domainName == "" {
-		domainName = cloudConfig.AuthInfo.UserDomainName
-	}
-
-	scope := tokens.Scope{
-		ProjectName: cloudConfig.AuthInfo.ProjectName,
-		DomainName:  domainName,
-	}
-
-	authOptions := tokens.AuthOptions{
-		Scope:      scope,
-		Username:   cloudConfig.AuthInfo.Username,
-		Password:   cloudConfig.AuthInfo.Password,
-		DomainName: domainName,
-	}
-
-	allServices, err := tokens.Create(conn, &authOptions).ExtractServiceCatalog()
+	allServices, err := auth.ExtractServiceCatalog()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We obtain the service catalog in several places inside the code, but each time we expect that project_name is specified in the clouds.yaml, and if it's not there, installation fails.
In general it's not necessary and users can specify just project_id instead of the name.

This commit updates the service catalog downloading functions by removing this restriction.