### PR TITLE
*: add support for cluster-etcd-operator

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -20,7 +20,11 @@ MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE=$(image_for kube-client-agent)
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 KUBE_ETCD_SIGNER_SERVER_IMAGE=$(image_for kube-etcd-signer-server)
-CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
+CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator || echo "no-ceo-image")
+CLUSTER_ETCD_OPERATOR_MANAGED=${CLUSTER_ETCD_OPERATOR_IMAGE:+$(bootkube_podman_run \
+	"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+	/usr/bin/grep -oP Managed \
+	/manifests/0000_12_etcd-operator_01_operator.cr.yaml)} || echo "CEO is Unmanaged"
 
 CONFIG_OPERATOR_IMAGE=$(image_for cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
@@ -103,10 +107,12 @@ bootkube_podman_run \
 	--servercertdur=26280h \
 	--metriccertdur=26280h
 
-if [ ! -f etcd-bootstrap.done ]
+# during initial operator rollout phase this logic allows us to deploy the operator via CVO
+# in an `Unmanaged` no-op state. after all of the pieces have merged and the operator is
+# deemed stable we can remove this logic and the operator will be `Managed` by default.
+if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ] && [ ! -f etcd-bootstrap.done ]
 then
 	echo "Rendering CEO Manifests..."
-	rm -rf etcd-bootstrap
 	mkdir -p /etc/etcd
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
@@ -132,6 +138,9 @@ then
 	cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
 
 	touch etcd-bootstrap.done
+else
+	CLUSTER_ETCD_OPERATOR_IMAGE=
+	sed -i '/etcd-bootstrap/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 fi
 
 if [ ! -f config-bootstrap.done ]

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -5,6 +5,8 @@ set -euoE pipefail ## -E option will cause functions to inherit trap
 
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
 
+ETCD_ENDPOINTS={{.EtcdCluster}}
+
 bootkube_podman_run() {
     # we run all commands in the host-network to prevent IP conflicts with
     # end-user infrastructure.
@@ -18,6 +20,7 @@ MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE=$(image_for kube-client-agent)
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 KUBE_ETCD_SIGNER_SERVER_IMAGE=$(image_for kube-etcd-signer-server)
+CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
 
 CONFIG_OPERATOR_IMAGE=$(image_for cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
@@ -67,6 +70,70 @@ then
 	touch cvo-bootstrap.done
 fi
 
+# We originally wanted to run the etcd cert signer as
+# a static pod, but kubelet could't remove static pod
+# when API server is not up, so we have to run this as
+# podman container.
+# See https://github.com/kubernetes/kubernetes/issues/43292
+
+echo "Starting etcd certificate signer..."
+
+trap "podman rm --force etcd-signer" ERR
+
+bootkube_podman_run \
+	--name etcd-signer \
+	--detach \
+	--volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
+	"${KUBE_ETCD_SIGNER_SERVER_IMAGE}" \
+	serve \
+	--cacrt=/opt/openshift/tls/etcd-signer.crt \
+	--cakey=/opt/openshift/tls/etcd-signer.key \
+	--metric-cacrt=/opt/openshift/tls/etcd-metric-signer.crt \
+	--metric-cakey=/opt/openshift/tls/etcd-metric-signer.key \
+	--servcrt=/opt/openshift/tls/kube-apiserver-lb-server.crt \
+	--servkey=/opt/openshift/tls/kube-apiserver-lb-server.key \
+	--servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
+	--servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
+	--servcrt=/opt/openshift/tls/kube-apiserver-localhost-server.crt \
+	--servkey=/opt/openshift/tls/kube-apiserver-localhost-server.key \
+	--address=0.0.0.0:6443 \
+	--insecure-health-check-address=0.0.0.0:6080 \
+	--csrdir=/tmp \
+	--peercertdur=26280h \
+	--servercertdur=26280h \
+	--metriccertdur=26280h
+
+if [ ! -f etcd-bootstrap.done ]
+then
+	echo "Rendering CEO Manifests..."
+	rm -rf etcd-bootstrap
+	mkdir -p /etc/etcd
+	bootkube_podman_run \
+		--volume "$PWD:/assets:z" \
+		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+		/usr/bin/cluster-etcd-operator render \
+		--etcd-ca=/assets/tls/etcd-ca-bundle.crt \
+		--etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
+		--manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
+		--etcd-discovery-domain {{.ClusterDomain}} \
+		--manifest-cluster-etcd-operator-image "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+		--manifest-setup-etcd-env-image "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
+		--manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
+		--asset-input-dir /assets/tls \
+		--asset-output-dir /assets/etcd-bootstrap \
+		--config-output-file /assets/etcd-bootstrap/config
+
+	# TODO: host-etcd endpoint rendered by cluster-etcd-operator
+	BOOTSTRAP_IP=$(hostname -I | awk '{ print $1 }')
+	ETCD_ENDPOINTS=https://"${BOOTSTRAP_IP}":2379
+	sed -i "/__BOOTSTRAP_IP__/${BOOTSTRAP_IP}/"  /opt/openshift/manifests/etcd-host-service-endpoints.yaml
+
+	cp etcd-bootstrap/manifests/* manifests/
+	cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+
+	touch etcd-bootstrap.done
+fi
+
 if [ ! -f config-bootstrap.done ]
 then
 	echo "Rendering cluster config manifests..."
@@ -97,7 +164,7 @@ then
 		"${KUBE_APISERVER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-apiserver-operator render \
 		--manifest-etcd-serving-ca=etcd-ca-bundle.crt \
-		--manifest-etcd-server-urls={{.EtcdCluster}} \
+		--manifest-etcd-server-urls="${ETCD_ENDPOINTS}" \
 		--manifest-image="${OPENSHIFT_HYPERKUBE_IMAGE}" \
 		--manifest-operator-image="${KUBE_APISERVER_OPERATOR_IMAGE}" \
 		--asset-input-dir=/assets/tls \
@@ -203,7 +270,8 @@ then
 			--mdns-publisher-image="${MDNS_PUBLISHER_IMAGE}" \
 			--haproxy-image="${HAPROXY_IMAGE}" \
 			--baremetal-runtimecfg-image="${BAREMETAL_RUNTIMECFG_IMAGE}" \
-			--cloud-config-file=/assets/manifests/cloud-provider-config.yaml
+			--cloud-config-file=/assets/manifests/cloud-provider-config.yaml \
+			--cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}"
 
 	# Bootstrap MachineConfigController uses /etc/mcc/bootstrap/manifests/ dir to
 	# 1. read the controller config rendered by MachineConfigOperator
@@ -216,10 +284,10 @@ then
 	cp manifests/* /etc/mcc/bootstrap/
 	cp auth/kubeconfig-kubelet /etc/mcs/kubeconfig
 	cp mco-bootstrap/bootstrap/machineconfigoperator-bootstrap-pod.yaml /etc/kubernetes/manifests/
-        if [ -d mco-bootstrap/baremetal/manifests ]; then
-            cp mco-bootstrap/baremetal/manifests/* /etc/kubernetes/manifests/
-            cp --recursive mco-bootstrap/baremetal/static-pod-resources/* /etc/kubernetes/static-pod-resources/
-        fi
+	if [ -d mco-bootstrap/baremetal/manifests ]; then
+		cp mco-bootstrap/baremetal/manifests/* /etc/kubernetes/manifests/
+		cp --recursive mco-bootstrap/baremetal/static-pod-resources/* /etc/kubernetes/static-pod-resources/
+	fi
 	if [ -d mco-bootstrap/openstack/manifests ]; then
 		cp mco-bootstrap/openstack/manifests/* /etc/kubernetes/manifests/
 		cp --recursive mco-bootstrap/openstack/static-pod-resources/* /etc/kubernetes/static-pod-resources/
@@ -256,41 +324,6 @@ then
 	touch cco-bootstrap.done
 fi
 
-# We originally wanted to run the etcd cert signer as
-# a static pod, but kubelet could't remove static pod
-# when API server is not up, so we have to run this as
-# podman container.
-# See https://github.com/kubernetes/kubernetes/issues/43292
-
-echo "Starting etcd certificate signer..."
-
-trap "podman rm --force etcd-signer" ERR
-
-bootkube_podman_run \
-	--name etcd-signer \
-	--detach \
-	--volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
-	"${KUBE_ETCD_SIGNER_SERVER_IMAGE}" \
-	serve \
-	--cacrt=/opt/openshift/tls/etcd-signer.crt \
-	--cakey=/opt/openshift/tls/etcd-signer.key \
-	--metric-cacrt=/opt/openshift/tls/etcd-metric-signer.crt \
-	--metric-cakey=/opt/openshift/tls/etcd-metric-signer.key \
-	--servcrt=/opt/openshift/tls/kube-apiserver-lb-server.crt \
-	--servkey=/opt/openshift/tls/kube-apiserver-lb-server.key \
-	--servcrt=/opt/openshift/tls/kube-apiserver-internal-lb-server.crt \
-	--servkey=/opt/openshift/tls/kube-apiserver-internal-lb-server.key \
-	--servcrt=/opt/openshift/tls/kube-apiserver-localhost-server.crt \
-	--servkey=/opt/openshift/tls/kube-apiserver-localhost-server.key \
-	--address=0.0.0.0:6443 \
-	--insecure-health-check-address=0.0.0.0:6080 \
-	--csrdir=/tmp \
-	--peercertdur=26280h \
-	--servercertdur=26280h \
-	--metriccertdur=26280h
-
-echo "Waiting for etcd cluster..."
-
 # Wait for the etcd cluster to come up.
 until bootkube_podman_run \
 		--rm \
@@ -303,7 +336,7 @@ until bootkube_podman_run \
 		--cacert=/opt/openshift/tls/etcd-ca-bundle.crt \
 		--cert=/opt/openshift/tls/etcd-client.crt \
 		--key=/opt/openshift/tls/etcd-client.key \
-		--endpoints={{.EtcdCluster}} \
+		--endpoints="${ETCD_ENDPOINTS}" \
 		endpoint health
 do
 	echo "etcdctl failed. Retrying in 5 seconds..."

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -357,6 +357,17 @@ bootkube_podman_run \
 	"${CLUSTER_BOOTSTRAP_IMAGE}" \
 	start --tear-down-early=false --asset-dir=/assets --required-pods="openshift-kube-apiserver/kube-apiserver,openshift-kube-scheduler/openshift-kube-scheduler,openshift-kube-controller-manager/kube-controller-manager,openshift-cluster-version/cluster-version-operator"
 
+if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
+then
+	echo "Waiting for CEO to finish..."
+	bootkube_podman_run \
+		--volume "$PWD:/assets:z" \
+		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+		/usr/bin/cluster-etcd-operator \
+			wait-for-ceo \
+			--kubeconfig /assets/auth/kubeconfig
+fi
+
 # Workaround for https://github.com/opencontainers/runc/pull/1807
 touch /opt/openshift/.bootkube.done
 echo "bootkube.service complete"

--- a/data/data/manifests/bootkube/etcd-host-service-endpoints.yaml.template
+++ b/data/data/manifests/bootkube/etcd-host-service-endpoints.yaml.template
@@ -8,8 +8,8 @@ metadata:
 subsets:
 - addresses:
 {{- range $idx, $member := .EtcdEndpointHostnames }}
-  - ip: 192.0.2.{{ add $idx 1 }}
-    hostname: {{ $member }}
+  - hostname: {{ $member }}
+    ip: {{if eq $member "etcd-bootstrap"}}__BOOTSTRAP_IP__{{else}}192.0.2.{{ add $idx 1 }}{{end}}
 {{- end }}
   ports:
   - name: etcd

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -49,6 +49,7 @@ type bootstrapTemplateData struct {
 	Proxy                 *configv1.ProxyStatus
 	Registries            []sysregistriesv2.Registry
 	BootImage             string
+	ClusterDomain         string
 }
 
 // Bootstrap is an asset that generates the ignition config for bootstrap nodes.
@@ -231,6 +232,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 		Proxy:                 &proxy.Status,
 		Registries:            registries,
 		BootImage:             string(*rhcosImage),
+		ClusterDomain:         installConfig.ClusterDomain(),
 	}, nil
 }
 

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -166,10 +166,11 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 		rootCA,
 	)
 
-	etcdEndpointHostnames := make([]string, *installConfig.Config.ControlPlane.Replicas)
+	etcdEndpointHostnames := make([]string, *installConfig.Config.ControlPlane.Replicas+1)
 	for i := range etcdEndpointHostnames {
-		etcdEndpointHostnames[i] = fmt.Sprintf("etcd-%d", i)
+		etcdEndpointHostnames[i] = fmt.Sprintf("etcd-%d", i-1)
 	}
+	etcdEndpointHostnames[0] = "etcd-bootstrap"
 
 	templateData := &bootkubeTemplateData{
 		CVOClusterID:               clusterID.UUID,


### PR DESCRIPTION
In 4.4 cluster-etcd-operator will take over the process of bootstrapping the etcd cluster. To provide a clear path to disable/revert these changes we have setup the following conditional logic.

**MCO**: The MCO render command invoked in bootkube has a new optional flag to pass the value of the `cluster-etcd-operator` image[1]. The availability of this flags value[2] is used to conditionally adjust the `etcd-member` static pod spec allowing it to use the new bootstrapping method via the operator or fall back to the 4.3 SRV method.

**Installer**: The installer in 4.4 has a few notable changes introduced by this PR. First of all the `render` command populates a static pod manifest which creates a single member etcd cluster. After we have the single node cluster we can progress and cluster-operator can be deployed. This speeds up the time it takes for the operators to begin to reconcile as we are no longer waiting for all 3 etcds to bootstrap before we progress the operators.

**cluster-etcd-operator**: CEO is currently set as Unmanaged[3]. This allows us to include the CEO in CVO operator payload while setting the controllers to perform noop. This short term phase allows us to merge this PR proving that we can at the same time have CEO included in CVO but still use the old SRV bootstrap.

**Revert Plan**: If a case existed where we had a design error and the operator needed to be pulled from 4.4.
:
- Revert https://github.com/openshift/cluster-etcd-operator/pull/30/files
- Revert https://github.com/openshift/machine-config-operator/pull/1247

#####

[1] https://github.com/openshift/installer/pull/2608/files#diff-ce82c1d8a44f7dfc41dfc024085ccfeeR298
[2] https://github.com/openshift/machine-config-operator/blob/bd846958bc95d049547164046a962054fca093df/templates/master/00-master/_base/files/etc-kubernetes-manifests-etcd-member.yaml#L22
[3] https://github.com/openshift/cluster-etcd-operator/blob/master/manifests/0000_12_etcd-operator_01_operator.cr.yaml#L8

Depends on:
- [X]  https://github.com/openshift/machine-config-operator/pull/1224 (merged)
- [X] https://github.com/openshift/cluster-etcd-operator/pull/29 (merged)
- [X] https://github.com/openshift/machine-config-operator/pull/1221 (merged)