### PR TITLE
baremetal: Use accessDetails.Driver() in terraform config

### DIFF
--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -66,7 +66,7 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		hostMap := map[string]interface{}{
 			"name":         host.Name,
 			"port_address": host.BootMACAddress,
-			"driver":       accessDetails.Type(),
+			"driver":       accessDetails.Driver(),
 		}
 
 		// Properties


### PR DESCRIPTION
When using redfish accessDetails.Type() differs from
accessDetails.Driver(), we simply need "redfish"(without
the http/https)

Closes: metal3-io/baremetal-operator#352 