### PR TITLE
OpenStack: add config_drive support

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -78,6 +78,8 @@ resource "openstack_compute_instance_v2" "bootstrap" {
     Name               = "${var.cluster_id}-bootstrap"
     openshiftClusterID = var.cluster_id
   }
+
+  config_drive = true
 }
 
 resource "openstack_networking_floatingip_v2" "bootstrap_fip" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -108,6 +108,8 @@ resource "openstack_compute_instance_v2" "master_conf_0" {
     Name = "${var.cluster_id}-master"
     openshiftClusterID = var.cluster_id
   }
+
+  config_drive = true
 }
 
 resource "openstack_compute_instance_v2" "master_conf_1" {
@@ -158,6 +160,8 @@ resource "openstack_compute_instance_v2" "master_conf_1" {
   }
 
   depends_on = [openstack_compute_instance_v2.master_conf_0]
+
+  config_drive = true
 }
 
 resource "openstack_compute_instance_v2" "master_conf_2" {
@@ -208,4 +212,6 @@ resource "openstack_compute_instance_v2" "master_conf_2" {
   }
 
   depends_on = [openstack_compute_instance_v2.master_conf_1]
+
+  config_drive = true
 }

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -162,6 +162,8 @@ func generateProvider(clusterID string, platform *openstack.Platform, mpool *ope
 			"Name":               fmt.Sprintf("%s-%s", clusterID, role),
 			"openshiftClusterID": clusterID,
 		},
+		// ConfigDrive type is *bool, so we can't use "true" directly and have to provide a pointer
+		ConfigDrive: &[]bool{true}[0],
 	}
 	if mpool.RootVolume != nil {
 		spec.RootVolume = &openstackprovider.RootVolume{


### PR DESCRIPTION
This patch allows instances to read metadata from the config-drive