### PR TITLE
[FCOS] bootstrap: disable zincati on bootstrap

### DIFF
--- a/data/data/bootstrap/files/etc/zincati/config.d/90-disable-feature.toml
+++ b/data/data/bootstrap/files/etc/zincati/config.d/90-disable-feature.toml
@@ -1,0 +1,2 @@
+[updates]
+enabled = false


### PR DESCRIPTION
FCOS update has been recently so bootstrap/masters get rebooted in the middle of pivot.

This would disable Zincati so that it would not hit FCOS update servers on bootstrap.

/cc @smarterclayton @LorbusChris 