### PR TITLE
Simplify bootstrap ignition config generation

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -2,11 +2,9 @@ package cluster
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	gcpprovider "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
 	libvirtprovider "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1"
 	"github.com/pkg/errors"
@@ -16,7 +14,6 @@ import (
 	openstackprovider "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
@@ -41,7 +38,6 @@ import (
 	"github.com/openshift/installer/pkg/types/openstack"
 	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
 	"github.com/openshift/installer/pkg/types/vsphere"
-	"github.com/openshift/installer/pkg/version"
 )
 
 const (
@@ -104,10 +100,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 	}
 
 	masterIgn := string(masterIgnAsset.Files()[0].Data)
-	bootstrapIgn, err := injectInstallInfo(bootstrapIgnAsset.Files()[0].Data)
-	if err != nil {
-		return errors.Wrap(err, "unable to inject installation info")
-	}
+	bootstrapIgn := string(bootstrapIgnAsset.Files()[0].Data)
 
 	masterCount := len(mastersAsset.MachineFiles)
 	data, err := tfvars.TFVars(
@@ -390,36 +383,4 @@ func (t *TerraformVariables) Load(f asset.FileFetcher) (found bool, err error) {
 	t.FileList = append(t.FileList, fileList...)
 
 	return true, nil
-}
-
-// injectInstallInfo adds information about the installer and its invoker as a
-// ConfigMap to the provided bootstrap Ignition config.
-func injectInstallInfo(bootstrap []byte) (string, error) {
-	config := &igntypes.Config{}
-	if err := json.Unmarshal(bootstrap, &config); err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal bootstrap Ignition config")
-	}
-
-	invoker := "user"
-	if env := os.Getenv("OPENSHIFT_INSTALL_INVOKER"); env != "" {
-		invoker = env
-	}
-
-	config.Storage.Files = append(config.Storage.Files, ignition.FileFromString("/opt/openshift/manifests/openshift-install.yml", "root", 0644, fmt.Sprintf(`---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: openshift-install
-  namespace: openshift-config
-data:
-  version: "%s"
-  invoker: "%s"
-`, version.Raw, invoker)))
-
-	ign, err := json.Marshal(config)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to marshal bootstrap Ignition config")
-	}
-
-	return string(ign), nil
 }


### PR DESCRIPTION
Now, when we have a generated ignition config, additionally we inject invoker information into it during TF vars generation.
This approach has downsides. First, we inject this data into the marshalled json file and not in the config structure itself, which means they are not the same after the change. Second, modification of
the asset in several places in the code leads to fuzzy architecture and potential errors.

This commit moves the data injection from the tfvars module to the bootstrap ignition module, where the asset is origionally generated.