### PR TITLE
[FCOS] install-masters-gather: gather logs for machine-config-daemon-pull

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -21,7 +21,7 @@ done
 
 echo "Gathering master journals ..."
 mkdir -p "${ARTIFACTS}/journals"
-for service in kubelet crio machine-config-daemon-host pivot
+for service in kubelet crio machine-config-daemon-host machine-config-daemon-pull pivot
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
 done


### PR DESCRIPTION
Save journal output of machine-config-daemon service. This simplifies debugging when MCD image is being pulled.

/cc @smarterclayton @LorbusChris 