### PR TITLE
OpenStack: Automate UPI with Kuryr

### DIFF
--- a/upi/openstack/01_security-groups.yaml
+++ b/upi/openstack/01_security-groups.yaml
@@ -13,9 +13,21 @@
     os_security_group:
       name: "{{ os_sg_master }}"
 
+  - name: 'Set master security group tag'
+    os_tag:
+      resource: "security_group"
+      name: "{{ os_sg_master }}"
+      tags: "{{ [cluster_id_tag] }}"
+
   - name: 'Create the worker security group'
     os_security_group:
       name: "{{ os_sg_worker }}"
+
+  - name: 'Set worker security group tag'
+    os_tag:
+      resource: "security_group"
+      name: "{{ os_sg_worker }}"
+      tags: "{{ [cluster_id_tag] }}"
 
   - name: 'Create master-sg rule "ICMP"'
     os_security_group_rule:

--- a/upi/openstack/02_network.yaml
+++ b/upi/openstack/02_network.yaml
@@ -15,6 +15,12 @@
     os_network:
       name: "{{ os_network }}"
 
+  - name: 'Set the cluster network tag'
+    os_tag:
+      resource: "network"
+      name: "{{ os_network }}"
+      tags: "{{ [cluster_id_tag] }}"
+
   - name: 'Create a subnet'
     os_subnet:
       name: "{{ os_subnet }}"
@@ -23,12 +29,24 @@
       allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
       allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
 
+  - name: 'Set the cluster subnet tag'
+    os_tag:
+      resource: "subnet"
+      name: "{{ os_subnet }}"
+      tags: "{{ [cluster_id_tag] }}"
+
   - name: 'Create external router'
     os_router:
       name: "{{ os_router }}"
       network: "{{ os_external_network }}"
       interfaces:
       - "{{ os_subnet }}"
+
+  - name: 'Set external router tag'
+    os_tag:
+      resource: "router"
+      name: "{{ os_router }}"
+      tags: "{{ [cluster_id_tag] }}"
 
   - name: 'Create the API port'
     os_port:
@@ -40,6 +58,12 @@
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_subnet_range | next_nth_usable(5) }}"
 
+  - name: 'Set API port tag'
+    os_tag:
+      resource: "port"
+      name: "{{ os_port_api }}"
+      tags: "{{ [cluster_id_tag] }}"
+
   - name: 'Create the Ingress port'
     os_port:
       name: "{{ os_port_ingress }}"
@@ -49,6 +73,12 @@
       fixed_ips:
       - subnet: "{{ os_subnet }}"
         ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
+
+  - name: 'Set the Ingress port tag'
+    os_tag:
+      resource: "port"
+      name: "{{ os_port_ingress }}"
+      tags: "{{ [cluster_id_tag] }}"
 
   # NOTE: openstack ansible module doesn't allow attaching Floating IPs to
   # ports, let's use the CLI instead

--- a/upi/openstack/03_bootstrap.yaml
+++ b/upi/openstack/03_bootstrap.yaml
@@ -20,6 +20,12 @@
       - ip_address: "{{ os_subnet_range | next_nth_usable(5) }}"
       - ip_address: "{{ os_subnet_range | next_nth_usable(6) }}"
 
+  - name: 'Set bootstrap port tag'
+    os_tag:
+      resource: "port"
+      name: "{{ os_port_bootstrap }}"
+      tags: "{{ [cluster_id_tag] }}"
+
   - name: 'Create the bootstrap server'
     os_server:
       name: "{{ os_bootstrap_server_name }}"

--- a/upi/openstack/04_control-plane.yaml
+++ b/upi/openstack/04_control-plane.yaml
@@ -23,6 +23,13 @@
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
     register: ports
 
+  - name: 'Set Control Plane ports tag'
+    os_tag:
+      resource: "port"
+      name: "{{ item.1 }}-{{ item.0 }}"
+      tags: "{{ [cluster_id_tag] }}"
+    with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
+
   - name: 'Create the Control Plane trunks'
     os_trunk:
       name: "{{ os_cp_trunk_name }}-{{ item.0 }}"

--- a/upi/openstack/04_control-plane.yaml
+++ b/upi/openstack/04_control-plane.yaml
@@ -21,6 +21,14 @@
       - ip_address: "{{ os_subnet_range | next_nth_usable(6) }}"
       - ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
+    register: ports
+
+  - name: 'Create the Control Plane trunks'
+    os_trunk:
+      name: "{{ os_cp_trunk_name }}-{{ item.0 }}"
+      port_id: "{{ item.1.id }}"
+    with_indexed_items: "{{ ports.results }}"
+    when: os_networking_type == "Kuryr"
 
   - name: 'Create the Control Plane servers'
     os_server:

--- a/upi/openstack/05_compute-nodes.yaml
+++ b/upi/openstack/05_compute-nodes.yaml
@@ -21,6 +21,13 @@
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
     register: ports
 
+  - name: 'Set Compute ports tag'
+    os_tag:
+      resource: "port"
+      name: "{{ item.1 }}-{{ item.0 }}"
+      tags: "{{ [cluster_id_tag] }}"
+    with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
+
   - name: 'Create the Compute trunks'
     os_trunk:
       name: "{{ os_compute_trunk_name }}-{{ item.0 }}"

--- a/upi/openstack/05_compute-nodes.yaml
+++ b/upi/openstack/05_compute-nodes.yaml
@@ -19,6 +19,14 @@
       allowed_address_pairs:
       - ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
+    register: ports
+
+  - name: 'Create the Compute trunks'
+    os_trunk:
+      name: "{{ os_compute_trunk_name }}-{{ item.0 }}"
+      port_id: "{{ item.1.id }}"
+    with_indexed_items: "{{ ports.results }}"
+    when: os_networking_type == "Kuryr"
 
   - name: 'Create the Compute servers'
     os_server:

--- a/upi/openstack/README.md
+++ b/upi/openstack/README.md
@@ -35,6 +35,8 @@ pip install -r requirements.txt
 
 Customize the cluster properties in the [Inventory](./inventory.yaml) file.
 
+**NOTE:** To deploy with Kuryr SDN, update the `os_networking_type` field to `Kuryr`.
+
 The playbooks are designed to reproduce an installation equivalent to IPI. Customize them as needed. It is advised to customize the teardown playbooks symmetrically.
 
 Every step can be run like this:

--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -7,9 +7,10 @@
   tasks:
   - name: 'Compute resource names'
     set_fact:
+      cluster_id_tag: "openshiftClusterID={{ infraID }}"
       os_network: "{{ infraID }}-network"
       os_subnet: "{{ infraID }}-nodes"
-      os_router: "{{ infraID }}-router"
+      os_router: "{{ infraID }}-external-router"
       # Port names
       os_port_api: "{{ infraID }}-api-port"
       os_port_ingress: "{{ infraID }}-ingress-port"
@@ -23,5 +24,10 @@
       os_bootstrap_server_name: "{{ infraID }}-bootstrap"
       os_cp_server_name: "{{ infraID }}-master"
       os_compute_server_name: "{{ infraID }}-worker"
+      # Trunk names
+      os_cp_trunk_name: "{{ infraID }}-master-trunk"
+      os_compute_trunk_name: "{{ infraID }}-worker-trunk"
+      # Subnet pool names
+      subnet_pool: "{{ infraID }}-kuryr-pod-subnetpool"
       # Ignition files
       os_bootstrap_ignition: "{{ infraID }}-bootstrap-ignition.json"

--- a/upi/openstack/down-01_security-groups.yaml
+++ b/upi/openstack/down-01_security-groups.yaml
@@ -9,12 +9,7 @@
   gather_facts: no
 
   tasks:
-  - name: 'Remove the master security group'
-    os_security_group:
-      name: "{{ os_sg_master }}"
-      state: absent
-
-  - name: 'Remove the worker security group'
-    os_security_group:
-      name: "{{ os_sg_worker }}"
-      state: absent
+  - name: 'Remove the cluster security groups'
+    os_delete_network_resources:
+      resource: "security_group"
+      tags: "{{ [cluster_id_tag] }}"

--- a/upi/openstack/down-02_network.yaml
+++ b/upi/openstack/down-02_network.yaml
@@ -9,22 +9,29 @@
   gather_facts: no
 
   tasks:
-  - name: 'Remove the API port'
-    os_port:
-      name: "{{ os_port_api }}"
-      state: absent
+  - name: 'Remove the ports from router'
+    os_delete_ports_on_router:
+      router: "{{ os_router }}"
+      tags: "{{ [cluster_id_tag] }}"
+    when: os_networking_type == "Kuryr"
 
-  - name: 'Remove the Ingress port'
-    os_port:
-      name: "{{ os_port_ingress }}"
-      state: absent
+  - name: 'Remove the cluster ports'
+    os_delete_network_resources:
+      resource: "port"
+      tags: "{{ [cluster_id_tag] }}"
 
   - name: 'Remove the cluster router'
     os_router:
       name: "{{ os_router }}"
       state: absent
 
-  - name: 'Remove the cluster network'
-    os_network:
-      name: "{{ os_network }}"
-      state: absent
+  - name: 'Remove the cluster networks'
+    os_delete_network_resources:
+      resource: "network"
+      tags: "{{ [cluster_id_tag] }}"
+
+  - name: 'Remove the cluster subnet pool'
+    os_delete_network_resources:
+      resource: "subnet_pool"
+      tags: "{{ [cluster_id_tag] }}"
+    when: os_networking_type == "Kuryr"

--- a/upi/openstack/down-04_control-plane.yaml
+++ b/upi/openstack/down-04_control-plane.yaml
@@ -15,6 +15,13 @@
       state: absent
     with_indexed_items: "{{ [os_cp_server_name] * os_cp_nodes_number }}"
 
+  - name: 'Remove the Control Plane trunks'
+    os_trunk:
+      name: "{{ item.1 }}-{{ item.0 }}"
+      state: absent
+    with_indexed_items: "{{ [os_cp_trunk_name] * os_cp_nodes_number }}"
+    when: os_networking_type == "Kuryr"
+
   - name: 'Remove the Control Plane ports'
     os_port:
       name: "{{ item.1 }}-{{ item.0 }}"

--- a/upi/openstack/down-05_compute-nodes.yaml
+++ b/upi/openstack/down-05_compute-nodes.yaml
@@ -15,6 +15,13 @@
       state: absent
     with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"
 
+  - name: 'Remove the Compute trunks'
+    os_trunk:
+      name: "{{ item.1 }}-{{ item.0 }}"
+      state: absent
+    with_indexed_items: "{{ [os_compute_trunk_name] * os_compute_nodes_number }}"
+    when: os_networking_type == "Kuryr"
+
   - name: 'Remove the Compute ports'
     os_port:
       name: "{{ item.1 }}-{{ item.0 }}"

--- a/upi/openstack/down-06_load-balancers.yaml
+++ b/upi/openstack/down-06_load-balancers.yaml
@@ -1,0 +1,19 @@
+# Required Python packages:
+#
+# ansible
+# openstacksdk
+
+- import_playbook: common.yaml
+
+- hosts: all
+  gather_facts: no
+
+  tasks:
+  # NOTE: Kuryr creates an Octavia load balancer
+  # for each service present on the cluster. Let's make
+  # sure to remove the resources generated.
+  - name: 'Remove the cluster load balancers'
+    os_delete_lb_resources:
+      tags: "{{ [cluster_id_tag] }}"
+      region_name: "{{ os_region_name }}"
+    when: os_networking_type == "Kuryr"

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -15,6 +15,11 @@ all:
       # OpenShift Ingress floating IP address
       os_ingress_fip: '203.0.113.19'
 
+      os_region_name: ''
+      # Name of the SDN.
+      # Possible values are OpenshiftSDN or Kuryr.
+      os_networking_type: 'OpenshiftSDN'
+
       # Number of provisioned Control Plane nodes
       # 3 is the minimum number for a fully-functional cluster.
       os_cp_nodes_number: 3

--- a/upi/openstack/library/os_delete_lb_resources.py
+++ b/upi/openstack/library/os_delete_lb_resources.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DOCUMENTATION = '''
+---
+module: os_delete_lb_resources
+short_description: Delete load balancer resources
+description:
+    - Delete load balancer resources filtered by tag
+options:
+   tags:
+     description:
+        - The tags to filter the load balancer
+     required: true
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
+
+_OCTAVIA_TAG_VERSION = 2, 5
+
+
+def main():
+    ''' Main module function '''
+    argument_spec = openstack_full_argument_spec(
+        tags=dict(type=list, required=True),
+        region_name=dict(type=str, required=True))
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    tags = module.params['tags']
+    region_name = module.params['region_name']
+
+    sdk, cloud = openstack_cloud_from_module(module)
+    try:
+        regions = cloud.load_balancer.get_all_version_data()
+        endpoints = regions.get(region_name, list(regions.values())[0])
+        services = list(endpoints.values())[0]
+        versions = services.get('load-balancer', list(services.values())[0])
+
+        tag_supported = any(
+            tuple(map(int, v['version'].split('.'))) >= _OCTAVIA_TAG_VERSION
+            for v in versions)
+
+        resources = list(cloud.load_balancer.load_balancers(
+            description=tags))
+        if tag_supported:
+            resources.extend(list(cloud.load_balancer.load_balancers(
+                tags=tags)))
+        for resource in resources:
+            cloud.load_balancer.delete_load_balancer(resource, cascade=True)
+    except sdk.exceptions.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+    module.exit_json(
+        changed=True)
+
+if __name__ == '__main__':
+    main()

--- a/upi/openstack/library/os_delete_network_resources.py
+++ b/upi/openstack/library/os_delete_network_resources.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DOCUMENTATION = '''
+---
+module: os_delete_network_resources
+short_description: Delete network resources
+description:
+    - Delete network resources filtered by tag
+options:
+   resource:
+     description:
+        - The name of a network resource
+     required: true
+   tags:
+     description:
+        - The tags to filter the network resources
+     required: true
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
+
+
+def main():
+    ''' Main module function '''
+    argument_spec = openstack_full_argument_spec(
+        resource=dict(type=str, required=True),
+        tags=dict(type=list, required=True))
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    resource = module.params['resource']
+    tags = module.params['tags']
+
+    sdk, cloud = openstack_cloud_from_module(module)
+    try:
+        get_resources = getattr(cloud.network, '{0}s'.format(resource), None)
+        if get_resources:
+            resources = get_resources(tags=tags)
+            network_attr = 'delete_{0}'.format(resource)
+            delete_resource = getattr(cloud.network, network_attr, None)
+            if delete_resource:
+                for resource in resources:
+                    delete_resource(resource)
+    except sdk.exceptions.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+    module.exit_json(
+        changed=True)
+
+if __name__ == '__main__':
+    main()

--- a/upi/openstack/library/os_delete_ports_on_router.py
+++ b/upi/openstack/library/os_delete_ports_on_router.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DOCUMENTATION = '''
+---
+module: os_delete_ports_on_router
+short_description: Delete ports from a router
+description:
+    -  Delete ports from a router
+options:
+   router:
+     description:
+        - The name of the router
+     required: true
+   tags:
+     description:
+        - The tags to filter the network resources
+     required: true
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
+
+
+def main():
+    ''' Main module function '''
+    argument_spec = openstack_full_argument_spec(
+        router=dict(type=str, required=True),
+        tags=dict(type=list, required=True))
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    router = module.params['router']
+    tags = module.params['tags']
+
+    sdk, cloud = openstack_cloud_from_module(module)
+    try:
+        ports = list(
+            cloud.network.ports(device_owner='network:router_interface'))
+        ports.extend(list(
+            cloud.network.ports(
+                device_owner='network:ha_router_replicated_interface')))
+        router_obj = cloud.network.find_router(router)
+        for port in ports:
+            out = cloud.network.remove_interface_from_router(
+                router_obj, port_id=port.id)
+    except sdk.exceptions.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+    module.exit_json(
+        changed=True)
+
+if __name__ == '__main__':
+    main()

--- a/upi/openstack/library/os_tag.py
+++ b/upi/openstack/library/os_tag.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DOCUMENTATION = '''
+---
+module: os_tag
+short_description: Set a tag to a resource
+description:
+    - Set a tag to a Network resource
+options:
+   resource:
+     description:
+       - The type of the Network resource.
+     required: true
+   name:
+     description:
+        - The name of the resource to be tagged
+     required: true
+   tags:
+     description:
+        - Tags to be set on the resources
+     required: true
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
+
+
+def main():
+    ''' Main module function '''
+    argument_spec = openstack_full_argument_spec(
+        resource=dict(type=str, required=True),
+        name=dict(type=str, required=True),
+        tags=dict(type='list', required=True))
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    resource = module.params['resource']
+    name = module.params['name']
+    tags = module.params['tags']
+
+    sdk, cloud = openstack_cloud_from_module(module)
+    try:
+        network_attr = 'find_{0}'.format(resource)
+        get_resource = getattr(cloud.network, network_attr, None)
+        if get_resource:
+            resource = get_resource(name)
+            cloud.network.set_tags(resource, tags)
+    except sdk.exceptions.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+    module.exit_json(
+        changed=True)
+
+if __name__ == '__main__':
+    main()

--- a/upi/openstack/library/os_trunk.py
+++ b/upi/openstack/library/os_trunk.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DOCUMENTATION = '''
+---
+module: os_trunk
+short_description: Create or delete a Network trunk
+description:
+    - Create or delete a Network Trunk for a parent port
+options:
+   name:
+     description:
+       - The name of the trunk that should be created/deleted.
+     required: true
+   port_id:
+     description:
+        - ID of the parent port
+        - Required when I(state) is 'present'
+   state:
+     description:
+        - Indicate desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
+
+
+def main():
+    ''' Main module function '''
+    argument_spec = openstack_full_argument_spec(
+        name=dict(type='str', required=True),
+        port_id=dict(type='str'),
+        state=dict(default='present', choices=['absent', 'present']))
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    name = module.params['name']
+    port_id = module.params['port_id']
+    state = module.params['state']
+
+    sdk, cloud = openstack_cloud_from_module(module)
+    try:
+        trunk = cloud.network.find_trunk(name_or_id=name)
+        if state == 'present':
+            if not port_id:
+                module.fail_json(msg='port_id required with present state')
+            if not trunk:
+                cloud.network.create_trunk(name=name, port_id=port_id)
+        elif state == 'absent':
+            if trunk:
+                cloud.network.delete_trunk(trunk)
+    except sdk.exceptions.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+    module.exit_json(
+        changed=True)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Update ansile playbooks to support setting Kuryr as networking
type for a User Provided installation.