### PR TITLE
OpenStack UPI: add a router to cluster network

### DIFF
--- a/upi/openstack/01_network.yaml
+++ b/upi/openstack/01_network.yaml
@@ -21,3 +21,10 @@
       cidr: "{{ os_subnet_range }}"
       allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
       allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+
+  - name: 'Create external router'
+    os_router:
+      name: "{{ os_router }}"
+      network: "{{ os_external_network }}"
+      interfaces:
+      - "{{ cluster_subnet }}"

--- a/upi/openstack/down-01_network.yaml
+++ b/upi/openstack/down-01_network.yaml
@@ -6,6 +6,10 @@
 - hosts: all
 
   tasks:
+  - name: 'Remove the cluster router'
+    os_router:
+      name: "{{ os_router }}"
+      state: absent
   - name: 'Remove the cluster network'
     os_network:
       name: "{{ os_network }}"

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -9,6 +9,7 @@ all:
       os_cluster_name: 'openshift'
       os_flavor_master: 'm1.xlarge'
       os_image_rhcos: 'rhcos'
+      os_external_network: 'external'
 
       # Computed values
 
@@ -21,6 +22,10 @@ all:
       # os_network is the name of the OpenStack network that will contain the
       # OpenShift cluster.
       os_network: "{{ os_infra_id }}-network"
+
+      # os_router is the name of the router that connects the os_network to your
+      # cluster's external network (os_external_network)
+      os_router: "{{ os_infra_id }}-router"
 
       # os_sg_* are the names of the security groups that will be assigned to
       # the respective nodes.


### PR DESCRIPTION
Adds a router to the cluster network. This allows floating ips to be allocated and the cluster to be reached from outside the cluster.