### PR TITLE
Bug 1779793: vSphere UPI: set specific version of ignition provider

### DIFF
--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -1,3 +1,7 @@
+provider "ignition" {
+  version = "1.1.0"
+}
+
 locals {
   mask = "${element(split("/", var.machine_cidr), 1)}"
   gw   = "${cidrhost(var.machine_cidr,1)}"


### PR DESCRIPTION
v1.2.0 of the ignition provider breaks the vSphere UPI terraform with
invalid json

cherry-pick: #2749