### PR TITLE
OpenStack UPI: Set Default Compute Nodes to 3

### DIFF
--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -16,8 +16,8 @@ all:
       os_cp_nodes_number: 3
 
       # Number of provisioned Compute nodes.
-      # 2 is the minimum number for a fully-functional cluster.
-      os_compute_nodes_number: 2
+      # 3 is the minimum number for a fully-functional cluster.
+      os_compute_nodes_number: 3
 
       # Computed values
 


### PR DESCRIPTION
We don't support running clusters with less than 3 compute nodes, even if it is theoretically possible, because it is unreliable.