### PR TITLE
Bug 1777232: Add GCP-specific validation of cluster name.

### DIFF
--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -4,6 +4,7 @@ import (
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/asset"
+	gcpvalidation "github.com/openshift/installer/pkg/types/gcp/validation"
 	"github.com/openshift/installer/pkg/types/validation"
 	"github.com/openshift/installer/pkg/validate"
 )
@@ -18,13 +19,22 @@ var _ asset.Asset = (*clusterName)(nil)
 func (a *clusterName) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&baseDomain{},
+		&platform{},
 	}
 }
 
 // Generate queries for the cluster name from the user.
 func (a *clusterName) Generate(parents asset.Parents) error {
 	bd := &baseDomain{}
-	parents.Get(bd)
+	platform := &platform{}
+	parents.Get(bd, platform)
+
+	validator := survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+		return validate.DomainName(validation.ClusterDomain(bd.BaseDomain, ans.(string)), false)
+	})
+	if platform.GCP != nil {
+		validator = survey.ComposeValidators(validator, func(ans interface{}) error { return gcpvalidation.ValidateClusterName(ans.(string)) })
+	}
 
 	return survey.Ask([]*survey.Question{
 		{
@@ -32,9 +42,7 @@ func (a *clusterName) Generate(parents asset.Parents) error {
 				Message: "Cluster Name",
 				Help:    "The name of the cluster.  This will be used when generating sub-domains.\n\nFor libvirt, choose a name that is unique enough to be used as a prefix during cluster deletion.  For example, if you use 'demo' as your cluster name, `openshift-install destroy cluster` may destroy all domains, networks, pools, and volumes that begin with 'demo'.",
 			},
-			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
-				return validate.DomainName(validation.ClusterDomain(bd.BaseDomain, ans.(string)), false)
-			}),
+			Validate: validator,
 		},
 	}, &a.ClusterName)
 }

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -1,10 +1,13 @@
 package validation
 
 import (
+	"regexp"
 	"sort"
 
-	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types/gcp"
 )
 
 var (
@@ -68,4 +71,15 @@ func ValidatePlatform(p *gcp.Platform, fldPath *field.Path) field.ErrorList {
 	}
 
 	return allErrs
+}
+
+// ValidateClusterName confirms that the provided cluster name matches GCP naming requirements.
+func ValidateClusterName(clusterName string) error {
+	gcpResourceFmt := `(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)`
+
+	re := regexp.MustCompile("^" + gcpResourceFmt + "$")
+	if !re.MatchString(clusterName) {
+		return errors.Errorf("GCP requires cluster name to match regular expression %s", gcpResourceFmt)
+	}
+	return nil
 }

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -64,6 +64,9 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 	if nameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, nameErr.Error()))
 	}
+	if gcpNameErr := gcpvalidation.ValidateClusterName(c.ObjectMeta.Name); c.Platform.GCP != nil && gcpNameErr != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, gcpNameErr.Error()))
+	}
 	baseDomainErr := validate.DomainName(c.BaseDomain, true)
 	if baseDomainErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("baseDomain"), c.BaseDomain, baseDomainErr.Error()))

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -647,6 +647,18 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 		},
 		{
+			name: "invalid GCP cluster name",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{
+					GCP: validGCPPlatform(),
+				}
+				c.ObjectMeta.Name = "1-invalid-cluster"
+				return c
+			}(),
+			expectedError: `^metadata\.name: Invalid value: "1-invalid-cluster": GCP requires cluster name to match regular expression \(\?:\[a-z\]\(\?:\[-a-z0-9\]\{0,61\}\[a-z0-9\]\)\?\)$`,
+		},
+		{
 			name: "release image source is not canonical",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
Validation of the Cluster Name in the wizard or metadata.name in the install-config only ensures validity as a domain name. The cluster name is also used to name resources created by the installer, and this commit adds validation to ensure that the domain name meets the requirements for naming resources in GCP. This has caused failed installs in GCP when cluster names begin with numbers.