### PR TITLE
bootkube.sh: CEO: add cluster-config-file to parse sdn cidr

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -113,7 +113,6 @@ bootkube_podman_run \
 if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ] && [ ! -f etcd-bootstrap.done ]
 then
 	echo "Rendering CEO Manifests..."
-	mkdir -p /etc/etcd
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
 		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
@@ -127,15 +126,21 @@ then
 		--manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
 		--asset-input-dir /assets/tls \
 		--asset-output-dir /assets/etcd-bootstrap \
-		--config-output-file /assets/etcd-bootstrap/config
+		--config-output-file /assets/etcd-bootstrap/config \
+		--cluster-config-file=/assets/manifests/cluster-network-02-config.yml
 
 	# TODO: host-etcd endpoint rendered by cluster-etcd-operator
 	BOOTSTRAP_IP=$(hostname -I | awk '{ print $1 }')
 	ETCD_ENDPOINTS=https://"${BOOTSTRAP_IP}":2379
-	sed -i "/__BOOTSTRAP_IP__/${BOOTSTRAP_IP}/"  /opt/openshift/manifests/etcd-host-service-endpoints.yaml
+	sed -i "s/__BOOTSTRAP_IP__/${BOOTSTRAP_IP}/" /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 
 	cp etcd-bootstrap/manifests/* manifests/
 	cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+
+	# /etc/kubernetes/static-pod-resources/etcd-member is the location etcd-bootstrap tls assets.
+	mkdir --parents /etc/kubernetes/static-pod-resources/etcd-member
+	cp tls/etcd-ca-bundle.crt /etc/kubernetes/static-pod-resources/etcd-member/ca.crt
+	cp tls/etcd-metric-ca-bundle.crt /etc/kubernetes/static-pod-resources/etcd-member/metric-ca.crt
 
 	touch etcd-bootstrap.done
 else


### PR DESCRIPTION
This PR adds the cluster-config-file flag to render for CEO. This is important so that we can conclude if the cluster is singleStack IPv6.

We also internally changed render to not install CA certs on bootstrap node and instead manually move these assets for visibility as it is existing in current logic with other operators.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>