### PR TITLE
[WIP] cmd/openshift-install: at install-complete failure summarize failing operators

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -95,7 +95,7 @@ var (
 				}
 
 				err = waitForBootstrapComplete(ctx, config, rootOpts.dir)
-				if err != nil {
+				if err != nil || true {
 					if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
 						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
 					}


### PR DESCRIPTION

This code builds priority queues for all operators and prioritizes based on
progressing, degrading, available and unknown operator states. If an error is
shown (progressing has highest priority), then all other entries logged for the
operator are debug. Based off of https://github.com/openshift/installer/pull/2610/. 

https://jira.coreos.com/browse/CORS-1245