### PR TITLE
Bug 1805540: [WIP] pkg/asset/installconfig: Allow users to provide the Zone ID for the base domain

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -87,6 +87,7 @@ module "dns" {
   cluster_id               = var.cluster_id
   tags                     = local.tags
   vpc_id                   = module.vpc.vpc_id
+  public_zone_id           = var.aws_public_zone_id
   publish_strategy         = var.aws_publish_strategy
 }
 

--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -9,7 +9,7 @@ locals {
 data "aws_route53_zone" "public" {
   count = local.public_endpoints ? 1 : 0
 
-  name = var.base_domain
+  zone_id = var.public_zone_id
 }
 
 resource "aws_route53_zone" "int" {

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -43,6 +43,11 @@ variable "api_internal_lb_zone_id" {
   type        = string
 }
 
+variable "public_zone_id" {
+  description = "The ID of the public DNS zone"
+  type        = string
+}
+
 variable "publish_strategy" {
   type        = string
   description = <<EOF

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -126,6 +126,11 @@ variable "aws_private_subnets" {
   description = "(optional) Existing private subnets into which the cluster should be installed."
 }
 
+variable "aws_public_zone_id" {
+  type        = string
+  description = "The ID of the public DNS zone"
+}
+
 variable "aws_publish_strategy" {
   type        = string
   description = "The cluster publishing strategy, either Internal or External"

--- a/docs/user/aws/customization.md
+++ b/docs/user/aws/customization.md
@@ -7,6 +7,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `amiID` (optional string): The AMI that should be used to boot machines for the cluster.
     If set, the AMI should belong to the same region as the cluster.
 * `region` (required string): The AWS region where the cluster will be created.
+* `publicZoneID` (optional string): The public zone ID of the base domain DNS zone.
 * `subnets` (optional array of strings): Existing subnets (by ID) where cluster resources will be created.
     Leave unset to have the installer create subnets in a new VPC on your behalf.
 * `userTags` (optional object): Additional keys and values that the installer will add as tags to all resources that it creates.
@@ -110,6 +111,23 @@ platform:
     subnets:
     - subnet-0e953079d31ec4c74
     - subnet-05e6864f66a954c27
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+### Pre-existing route53 public hosted zone
+
+An example minimal AWS install config with a route53 hosted zone ID:
+
+```yaml
+apiVersion: v1
+baseDomain: example.com
+metadata:
+  name: test-cluster
+platform:
+  aws:
+    region: us-west-2
+    publicZoneID: Z3URY6TWQ91KVV
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ```

--- a/docs/user/gcp/customization.md
+++ b/docs/user/gcp/customization.md
@@ -4,6 +4,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 * `projectID` (required string): The project where the cluster should be created.
 * `region` (required string): The GCP region where the cluster should be created.
+* `publicZoneID` (optional string): The ID of the public DNS zone name (this is the GCP managed name).
 * `network` (optional string): The name of an existing GCP VPC where the cluster infrastructure should be provisioned.
 * `controlPlaneSubnet` (optional string): The name of an existing GCP subnet which should be used by the cluster control plane.
 * `computeSubnet` (optional string): The name of an existing GCP subnet which should be used by the cluster nodes.
@@ -135,3 +136,21 @@ platform:
 [compute-images]: https://cloud.google.com/compute/docs/reference/rest/v1/images
 [gcp-nested]: https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances
 [license-api]: https://cloud.google.com/compute/docs/reference/rest/v1/licenses/list
+
+### Pre-existing cloud DNS zone
+
+An example minimal GCP install config with a cloud DNS zone ID:
+
+```yaml
+apiVersion: v1
+baseDomain: example.com
+metadata:
+  name: example-cluster
+platform:
+  gcp:
+    project: example-project
+    region: us-east1
+    publicZoneID: installer-public-zone
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```

--- a/pkg/asset/installconfig/aws/basedomain.go
+++ b/pkg/asset/installconfig/aws/basedomain.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -14,6 +15,12 @@ import (
 	survey "gopkg.in/AlecAivazis/survey.v1"
 )
 
+// Zone represents an AWS route53 DNS Zone
+type Zone struct {
+	ID      string
+	DNSName string
+}
+
 // IsForbidden returns true if and only if the input error is an HTTP
 // 403 error from the AWS API.
 func IsForbidden(err error) bool {
@@ -21,47 +28,52 @@ func IsForbidden(err error) bool {
 	return ok && requestError.StatusCode() == http.StatusForbidden
 }
 
-// GetBaseDomain returns a base domain chosen from among the account's
-// public routes.
-func GetBaseDomain() (string, error) {
+// GetBaseDomain returns a base domain zone chosen from among the
+// account's public routes. The zone struct contains the zone ID
+// for the chosen base domain, to distinguish between multiple
+// public zones that share the same base domain.
+func GetBaseDomain() (zone *Zone, err error) {
 	session, err := GetSession()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	logrus.Debugf("listing AWS hosted zones")
 	client := route53.New(session)
-	publicZoneMap := map[string]struct{}{}
-	exists := struct{}{}
+	publicZoneMap := map[string][]string{}
 	if err := client.ListHostedZonesPages(
 		&route53.ListHostedZonesInput{},
 		func(resp *route53.ListHostedZonesOutput, lastPage bool) (shouldContinue bool) {
 			for _, zone := range resp.HostedZones {
 				if zone.Config != nil && !aws.BoolValue(zone.Config.PrivateZone) {
-					publicZoneMap[strings.TrimSuffix(*zone.Name, ".")] = exists
+					zoneName := strings.TrimSuffix(aws.StringValue(zone.Name), ".")
+					publicZoneID := strings.TrimPrefix(aws.StringValue(zone.Id), "/hostedzone/")
+					publicZoneMap[zoneName] = append(publicZoneMap[zoneName], publicZoneID)
 				}
 			}
 			return !lastPage
 		},
 	); err != nil {
-		return "", errors.Wrap(err, "list hosted zones")
+		return nil, errors.Wrap(err, "list hosted zones")
 	}
 
 	publicZones := make([]string, 0, len(publicZoneMap))
-	for name := range publicZoneMap {
-		publicZones = append(publicZones, name)
+	for name, ids := range publicZoneMap {
+		for _, id := range ids {
+			publicZones = append(publicZones, fmt.Sprintf("%s (%s)", name, id))
+		}
 	}
 	sort.Strings(publicZones)
 	if len(publicZones) == 0 {
-		return "", errors.New("no public Route 53 hosted zones found")
+		return nil, errors.New("no public Route 53 hosted zones found")
 	}
 
-	var domain string
+	var publicZoneNameChoice string
 	if err := survey.AskOne(&survey.Select{
 		Message: "Base Domain",
 		Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base and will also include the cluster name.\n\nIf you don't see you intended base-domain listed, create a new public Route53 hosted zone and rerun the installer.",
 		Options: publicZones,
-	}, &domain, func(ans interface{}) error {
+	}, &publicZoneNameChoice, func(ans interface{}) error {
 		choice := ans.(string)
 		i := sort.SearchStrings(publicZones, choice)
 		if i == len(publicZones) || publicZones[i] != choice {
@@ -69,10 +81,17 @@ func GetBaseDomain() (string, error) {
 		}
 		return nil
 	}); err != nil {
-		return "", errors.Wrap(err, "failed UserInput for base domain")
+		return nil, errors.Wrap(err, "failed UserInput for base domain")
 	}
 
-	return domain, nil
+	parts := strings.Split(publicZoneNameChoice, " ")
+	publicZoneName := parts[0]
+	publicZoneID := parts[1][1 : len(parts[1])-1]
+
+	return &Zone{
+		ID:      publicZoneID,
+		DNSName: publicZoneName,
+	}, nil
 }
 
 // GetPublicZone returns a public route53 zone that matches the name.
@@ -95,5 +114,17 @@ func GetPublicZone(sess *session.Session, name string) (*route53.HostedZone, err
 	if res == nil {
 		return nil, errors.Errorf("No public route53 zone found matching name %q", name)
 	}
+
 	return res, nil
+}
+
+// GetPublicZoneByID returns a public route53 zone from the zone ID
+func GetPublicZoneByID(sess *session.Session, zoneID string) (*route53.HostedZone, error) {
+	client := route53.New(sess)
+	zoneOutput, err := client.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(zoneID)})
+	if err != nil {
+		return nil, errors.Wrap(err, "getting hosted zone")
+	}
+
+	return zoneOutput.HostedZone, nil
 }

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -390,6 +390,27 @@ func TestValidate(t *testing.T) {
 		privateSubnets: validPrivateSubnets(),
 		publicSubnets:  validPublicSubnets(),
 		exptectErr:     `^platform\.aws\.amiID: Required value: AMI must be provided$`,
+	}, {
+		name: "valid public zone id",
+		installConfig: func() *types.InstallConfig {
+			c := validInstallConfig()
+			c.Platform.AWS.PublicZoneID = "valid-public-zone-id"
+			c.BaseDomain = "valid-public-zone"
+			return c
+		}(),
+		privateSubnets: validPrivateSubnets(),
+		publicSubnets:  validPublicSubnets(),
+	}, {
+		name: "invalid public zone",
+		installConfig: func() *types.InstallConfig {
+			c := validInstallConfig()
+			c.Platform.AWS.PublicZoneID = "valid-public-zone-id"
+			c.BaseDomain = "invalid-public-zone"
+			return c
+		}(),
+		privateSubnets: validPrivateSubnets(),
+		publicSubnets:  validPublicSubnets(),
+		exptectErr:     `^platform\.aws\.publicZoneID: Invalid value: \"valid-public-zone-id\": invalid zone id: valid-public-zone-id$`,
 	}}
 
 	for _, test := range tests {

--- a/pkg/asset/installconfig/basedomain.go
+++ b/pkg/asset/installconfig/basedomain.go
@@ -58,6 +58,8 @@ func (a *baseDomain) Generate(parents asset.Parents) error {
 			return err
 		}
 		a.BaseDomain = zone.Name
+		// XXX: It would be nice to check for forbidden/throttle error
+		// like aws and gcp here.
 		return platform.Azure.SetBaseDomain(zone.ID)
 	case gcp.Name:
 		a.BaseDomain, err = gcpconfig.GetBaseDomain(platform.GCP.ProjectID)

--- a/pkg/asset/installconfig/basedomain.go
+++ b/pkg/asset/installconfig/basedomain.go
@@ -62,8 +62,12 @@ func (a *baseDomain) Generate(parents asset.Parents) error {
 		// like aws and gcp here.
 		return platform.Azure.SetBaseDomain(zone.ID)
 	case gcp.Name:
-		a.BaseDomain, err = gcpconfig.GetBaseDomain(platform.GCP.ProjectID)
-
+		var err error
+		zone, err := gcpconfig.GetBaseDomain(platform.GCP.ProjectID)
+		if zone != nil {
+			a.BaseDomain = zone.DNSName
+			platform.GCP.PublicZoneID = zone.ID
+		}
 		// We are done if success (err == nil) or an err besides forbidden/throttling
 		if !(gcpconfig.IsForbidden(err) || gcpconfig.IsThrottled(err)) {
 			return err

--- a/pkg/asset/installconfig/basedomain.go
+++ b/pkg/asset/installconfig/basedomain.go
@@ -36,7 +36,12 @@ func (a *baseDomain) Generate(parents asset.Parents) error {
 	var err error
 	switch platform.CurrentName() {
 	case aws.Name:
-		a.BaseDomain, err = awsconfig.GetBaseDomain()
+		var err error
+		zone, err := awsconfig.GetBaseDomain()
+		if zone != nil {
+			a.BaseDomain = zone.DNSName
+			platform.AWS.PublicZoneID = zone.ID
+		}
 		cause := errors.Cause(err)
 		if !(awsconfig.IsForbidden(cause) || request.IsErrorThrottle(cause)) {
 			return err

--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -51,10 +51,10 @@ func (mr *MockAPIMockRecorder) GetNetwork(ctx, network, project interface{}) *go
 }
 
 // GetPublicDomains mocks base method.
-func (m *MockAPI) GetPublicDomains(ctx context.Context, project string) ([]string, error) {
+func (m *MockAPI) GetPublicDomains(ctx context.Context, project string) (map[string][]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPublicDomains", ctx, project)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].(map[string][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -66,18 +66,33 @@ func (mr *MockAPIMockRecorder) GetPublicDomains(ctx, project interface{}) *gomoc
 }
 
 // GetPublicDNSZone mocks base method.
-func (m *MockAPI) GetPublicDNSZone(ctx context.Context, baseDomain, project string) (*dns.ManagedZone, error) {
+func (m *MockAPI) GetPublicDNSZone(ctx context.Context, project, baseDomain string) (*dns.ManagedZone, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPublicDNSZone", ctx, baseDomain, project)
+	ret := m.ctrl.Call(m, "GetPublicDNSZone", ctx, project, baseDomain)
 	ret0, _ := ret[0].(*dns.ManagedZone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPublicDNSZone indicates an expected call of GetPublicDNSZone.
-func (mr *MockAPIMockRecorder) GetPublicDNSZone(ctx, baseDomain, project interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetPublicDNSZone(ctx, project, baseDomain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicDNSZone", reflect.TypeOf((*MockAPI)(nil).GetPublicDNSZone), ctx, baseDomain, project)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicDNSZone", reflect.TypeOf((*MockAPI)(nil).GetPublicDNSZone), ctx, project, baseDomain)
+}
+
+// GetPublicDNSZoneByID mocks base method
+func (m *MockAPI) GetPublicDNSZoneByID(ctx context.Context, project, publicZoneID string) (*dns.ManagedZone, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublicDNSZoneByID", ctx, project, publicZoneID)
+	ret0, _ := ret[0].(*dns.ManagedZone)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPublicDNSZoneByID indicates an expected call of GetPublicDNSZoneByID
+func (mr *MockAPIMockRecorder) GetPublicDNSZoneByID(ctx, project, publicZoneID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicDNSZoneByID", reflect.TypeOf((*MockAPI)(nil).GetPublicDNSZoneByID), ctx, project, publicZoneID)
 }
 
 // GetSubnetworks mocks base method.

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -112,11 +112,15 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 		}
 	case gcptypes.Name:
 		if installConfig.Config.Publish == types.ExternalPublishingStrategy {
-			zone, err := icgcp.GetPublicZone(context.TODO(), installConfig.Config.Platform.GCP.ProjectID, installConfig.Config.BaseDomain)
-			if err != nil {
-				return errors.Wrapf(err, "failed to get public zone for %q", installConfig.Config.BaseDomain)
+			publicZoneID := installConfig.Config.GCP.PublicZoneID
+			if publicZoneID == "" {
+				zone, err := icgcp.GetPublicZone(context.TODO(), installConfig.Config.Platform.GCP.ProjectID, installConfig.Config.BaseDomain)
+				if err != nil {
+					return errors.Wrapf(err, "failed to get public zone for %q", installConfig.Config.BaseDomain)
+				}
+				publicZoneID = zone.Name
 			}
-			config.Spec.PublicZone = &configv1.DNSZone{ID: zone.Name}
+			config.Spec.PublicZone = &configv1.DNSZone{ID: publicZoneID}
 		}
 		config.Spec.PrivateZone = &configv1.DNSZone{ID: fmt.Sprintf("%s-private-zone", clusterID.InfraID)}
 	case libvirttypes.Name, openstacktypes.Name, baremetaltypes.Name, nonetypes.Name, vspheretypes.Name, ovirttypes.Name:

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -102,9 +102,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
-
 		if installConfig.Config.Publish == types.ExternalPublishingStrategy {
-			//currently, this guesses the azure resource IDs from known parameter.
 			config.Spec.PublicZone = &configv1.DNSZone{
 				ID: dnsConfig.GetDNSZoneID(installConfig.Config.Azure.BaseDomainResourceGroupName, installConfig.Config.BaseDomain),
 			}

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -32,6 +32,7 @@ type config struct {
 	VPC                     string            `json:"aws_vpc,omitempty"`
 	PrivateSubnets          []string          `json:"aws_private_subnets,omitempty"`
 	PublicSubnets           *[]string         `json:"aws_public_subnets,omitempty"`
+	PublicZoneID            string            `json:"aws_public_zone_id"`
 	PublishStrategy         string            `json:"aws_publish_strategy,omitempty"`
 	SkipRegionCheck         bool              `json:"aws_skip_region_validation"`
 	IgnitionBucket          string            `json:"aws_ignition_bucket"`
@@ -51,6 +52,8 @@ type TFVarsSources struct {
 	MasterConfigs, WorkerConfigs []*v1beta1.AWSMachineProviderConfig
 
 	IgnitionBucket, IgnitionPresignedURL string
+
+	PublicZoneID string
 }
 
 // TFVars generates AWS-specific Terraform variables launching the cluster.
@@ -118,6 +121,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Type:                    *rootVolume.EBS.VolumeType,
 		VPC:                     sources.VPC,
 		PrivateSubnets:          sources.PrivateSubnets,
+		PublicZoneID:            sources.PublicZoneID,
 		PublishStrategy:         string(sources.Publish),
 		SkipRegionCheck:         !configaws.IsKnownRegion(masterConfig.Placement.Region),
 		IgnitionBucket:          sources.IgnitionBucket,

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -12,6 +12,9 @@ type Platform struct {
 	// Region specifies the AWS region where the cluster will be created.
 	Region string `json:"region"`
 
+	// PublicZoneID specifies the ID for the public DNS Zone
+	PublicZoneID string `json:"publicZoneID,omitempty"`
+
 	// Subnets specifies existing subnets (by ID) where cluster
 	// resources will be created.  Leave unset to have the installer
 	// create subnets in a new VPC on your behalf.

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -17,9 +17,10 @@ func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
 	if p.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "region must be specified"))
 	}
-
 	allErrs = append(allErrs, validateServiceEndpoints(p.ServiceEndpoints, fldPath.Child("serviceEndpoints"))...)
-
+	if len(p.PublicZoneID) == 1 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("publicZoneID"), p.PublicZoneID, "publicZoneID must have 2 or more characters"))
+	}
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -117,6 +117,21 @@ func TestValidatePlatform(t *testing.T) {
 			},
 			expected: `^test-path\.defaultMachinePlatform\.iops: Invalid value: -10: Storage IOPS must be positive$`,
 		},
+		{
+			name: "valid public zone id",
+			platform: &aws.Platform{
+				Region:       "us-east-1",
+				PublicZoneID: "valid-public-zone-id",
+			},
+		},
+		{
+			name: "invalid public zone id",
+			platform: &aws.Platform{
+				Region:       "us-east-1",
+				PublicZoneID: "v",
+			},
+			expected: `test-path.publicZoneID: Invalid value: \"v\": publicZoneID must have 2 or more characters`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -88,7 +88,7 @@ func (e CloudEnvironment) Name() string {
 	return string(e)
 }
 
-//SetBaseDomain parses the baseDomainID and sets the related fields on azure.Platform
+// SetBaseDomain parses the baseDomainID and sets the related fields on azure.Platform
 func (p *Platform) SetBaseDomain(baseDomainID string) error {
 	parts := strings.Split(baseDomainID, "/")
 	p.BaseDomainResourceGroupName = parts[4]

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -9,6 +9,11 @@ type Platform struct {
 	// Region specifies the GCP region where the cluster will be created.
 	Region string `json:"region"`
 
+	// PublicZoneID specifies the ID for the public DNS Zone
+	// This is the managed zone name and it is used as a tuple with the
+	// project ID to uniquely identify a DNS zone.
+	PublicZoneID string `json:"publicZoneID,omitempty"`
+
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on GCP for machine pools which do not define their own
 	// platform configuration.

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -75,7 +75,6 @@ func TestValidatePlatform(t *testing.T) {
 			},
 			valid: false,
 		},
-
 		{
 			name: "supported GCP disk type",
 			platform: &gcp.Platform{
@@ -87,6 +86,22 @@ func TestValidatePlatform(t *testing.T) {
 				},
 			},
 			valid: true,
+		},
+		{
+			name: "valid public zone id",
+			platform: &gcp.Platform{
+				Region:       "us-east1",
+				PublicZoneID: "valid-public-zone-id",
+			},
+			valid: true,
+		},
+		{
+			name: "invalid public zone id",
+			platform: &gcp.Platform{
+				Region:       "us-east1",
+				PublicZoneID: "1invalid-public-zone-id",
+			},
+			valid: false,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Updated PR since previous one got way out of date. My git-fu was not good enough. This is mostly complete but needs to push some variables into terraform. 

Cloud providers usually allow users to create multiple DNS zones for the
same name, and users can configure their domain with registrars to point
to a specific DNS Zone's nameservers.

So if there are multiple DNS zones with BaseDomain as their name, the
installer could end up picking the wrong DNS Zone. Such errors can be
difficult to debug.

This fix will allow users to pick the ZoneID when there are multiple
DNS Zones with the same name.

https://jira.coreos.com/browse/CORS-1070