### PR TITLE
bootkube.sh: CEO: properly handle etcd endpoints on retry

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -5,7 +5,7 @@ set -euoE pipefail ## -E option will cause functions to inherit trap
 
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
 
-ETCD_ENDPOINTS={{.EtcdCluster}}
+ETCD_ENDPOINTS=
 
 bootkube_podman_run() {
     # we run all commands in the host-network to prevent IP conflicts with
@@ -110,40 +110,44 @@ bootkube_podman_run \
 # during initial operator rollout phase this logic allows us to deploy the operator via CVO
 # in an `Unmanaged` no-op state. after all of the pieces have merged and the operator is
 # deemed stable we can remove this logic and the operator will be `Managed` by default.
-if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ] && [ ! -f etcd-bootstrap.done ]
+if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ]
 then
-	echo "Rendering CEO Manifests..."
-	bootkube_podman_run \
-		--volume "$PWD:/assets:z" \
-		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-		/usr/bin/cluster-etcd-operator render \
-		--etcd-ca=/assets/tls/etcd-ca-bundle.crt \
-		--etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
-		--manifest-etcd-image "${MACHINE_CONFIG_ETCD_IMAGE}" \
-		--etcd-discovery-domain {{.ClusterDomain}} \
-		--manifest-cluster-etcd-operator-image "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
-		--manifest-setup-etcd-env-image "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
-		--manifest-kube-client-agent-image "${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
-		--asset-input-dir /assets/tls \
-		--asset-output-dir /assets/etcd-bootstrap \
-		--config-output-file /assets/etcd-bootstrap/config \
-		--cluster-config-file=/assets/manifests/cluster-network-02-config.yml
-
 	# TODO: host-etcd endpoint rendered by cluster-etcd-operator
 	BOOTSTRAP_IP=$(hostname -I | awk '{ print $1 }')
 	ETCD_ENDPOINTS=https://"${BOOTSTRAP_IP}":2379
-	sed -i "s/__BOOTSTRAP_IP__/${BOOTSTRAP_IP}/" /opt/openshift/manifests/etcd-host-service-endpoints.yaml
+	if [ ! -f etcd-bootstrap.done ]
+	then
+		echo "Rendering CEO Manifests..."
+		bootkube_podman_run \
+			--volume "$PWD:/assets:z" \
+			"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+			/usr/bin/cluster-etcd-operator render \
+			--etcd-ca=/assets/tls/etcd-ca-bundle.crt \
+			--etcd-metric-ca=/assets/tls/etcd-metric-ca-bundle.crt \
+			--manifest-etcd-image="${MACHINE_CONFIG_ETCD_IMAGE}" \
+			--etcd-discovery-domain={{.ClusterDomain}} \
+			--manifest-cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+			--manifest-setup-etcd-env-image="${MACHINE_CONFIG_OPERATOR_IMAGE}" \
+			--manifest-kube-client-agent-image="${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \
+			--asset-input-dir=/assets/tls \
+			--asset-output-dir=/assets/etcd-bootstrap \
+			--config-output-file=/assets/etcd-bootstrap/config \
+			--cluster-config-file=/assets/manifests/cluster-network-02-config.yml
 
-	cp etcd-bootstrap/manifests/* manifests/
-	cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+		sed -i "s/__BOOTSTRAP_IP__/${BOOTSTRAP_IP}/" /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 
-	# /etc/kubernetes/static-pod-resources/etcd-member is the location etcd-bootstrap tls assets.
-	mkdir --parents /etc/kubernetes/static-pod-resources/etcd-member
-	cp tls/etcd-ca-bundle.crt /etc/kubernetes/static-pod-resources/etcd-member/ca.crt
-	cp tls/etcd-metric-ca-bundle.crt /etc/kubernetes/static-pod-resources/etcd-member/metric-ca.crt
+		cp etcd-bootstrap/manifests/* manifests/
+		cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
 
-	touch etcd-bootstrap.done
+		# /etc/kubernetes/static-pod-resources/etcd-member is the location etcd-bootstrap tls assets.
+		mkdir --parents /etc/kubernetes/static-pod-resources/etcd-member
+		cp tls/etcd-ca-bundle.crt /etc/kubernetes/static-pod-resources/etcd-member/ca.crt
+		cp tls/etcd-metric-ca-bundle.crt /etc/kubernetes/static-pod-resources/etcd-member/metric-ca.crt
+
+		touch etcd-bootstrap.done
+	fi
 else
+	ETCD_ENDPOINTS={{.EtcdCluster}}
 	CLUSTER_ETCD_OPERATOR_IMAGE=
 	sed -i '/etcd-bootstrap/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 fi


### PR DESCRIPTION
This PR resolves an issue where on retry `ETCD_ENDPOINTS` was not properly handled. The result was an invalid list which could lead to installer timeouts.

This issue would not yet have affected any clusters as the issue would only be possible if CEO was in a Managed state which to date has not been true.