### PR TITLE
Bug 1782546: rhcos: Bump to 43.81.201912091858.0

### DIFF
--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,132 +1,132 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-0e4526517ac524c64"
+            "hvm": "ami-0afb10d03bbb5c2d7"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0e616119366bf59c8"
+            "hvm": "ami-0626ca9496be1943e"
         },
         "ap-south-1": {
-            "hvm": "ami-0bb5479b43b5b9a6a"
+            "hvm": "ami-09f86e87cf87f0baa"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0733dbf3f7daa30f0"
+            "hvm": "ami-0c2f29b4bfd323414"
         },
         "ap-southeast-2": {
-            "hvm": "ami-01f88c7b2ffc45137"
+            "hvm": "ami-0884cbd9cdb58fc05"
         },
         "ca-central-1": {
-            "hvm": "ami-075cf25ace0174b41"
+            "hvm": "ami-099f45b9016d2381c"
         },
         "eu-central-1": {
-            "hvm": "ami-0d27c613cd5307caf"
+            "hvm": "ami-0cce1b0da1ada8687"
         },
         "eu-north-1": {
-            "hvm": "ami-0a7db400b3ccc5400"
+            "hvm": "ami-02a635301838351d9"
         },
         "eu-west-1": {
-            "hvm": "ami-0e173367c56629034"
+            "hvm": "ami-0f3219cc77034c608"
         },
         "eu-west-2": {
-            "hvm": "ami-08e7d384fb6f0be97"
+            "hvm": "ami-023549dc17b3e913b"
         },
         "eu-west-3": {
-            "hvm": "ami-0b765b4670474aaf2"
+            "hvm": "ami-03a57cd3ac282874a"
         },
         "sa-east-1": {
-            "hvm": "ami-05acc0e0f3fa4633c"
+            "hvm": "ami-0575a4791e03f4d25"
         },
         "us-east-1": {
-            "hvm": "ami-014ce8846db8b463d"
+            "hvm": "ami-0aea6a5be0fc2b3fc"
         },
         "us-east-2": {
-            "hvm": "ami-0c83319db4b3b3602"
+            "hvm": "ami-02b88883d49c41e94"
         },
         "us-west-1": {
-            "hvm": "ami-050658e468dd3db4b"
+            "hvm": "ami-0fd33deb765c27822"
         },
         "us-west-2": {
-            "hvm": "ami-04051ef4316373b52"
+            "hvm": "ami-0dd66dd9f4c0155b5"
         }
     },
     "azure": {
-        "image": "rhcos-43.81.201911221453.0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-43.81.201911221453.0-azure.x86_64.vhd"
+        "image": "rhcos-43.81.201912131630.0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-43.81.201912131630.0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.201911221453.0/x86_64/",
-    "buildid": "43.81.201911221453.0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.201912131630.0/x86_64/",
+    "buildid": "43.81.201912131630.0",
     "gcp": {
-        "image": "rhcos-43-81-201911221453-0",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/43.81.201911221453.0.tar.gz"
+        "image": "rhcos-43-81-201912131630-0",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/43.81.201912131630.0.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-43.81.201911221453.0-aws.x86_64.vmdk.gz",
-            "sha256": "bfa0dd7c3871a3253616276426b1889cedc8760fa21827d71b3d70be94325226",
-            "size": 811913882,
-            "uncompressed-sha256": "d591692b1a6d2b5f187114190a09ff263357a8e08037a8eba0ce5143407b5e28",
-            "uncompressed-size": 828133376
+            "path": "rhcos-43.81.201912131630.0-aws.x86_64.vmdk.gz",
+            "sha256": "4e04b2d591b8274ad097a95c94da02efc9c1f4880776e10fa216becb7055ede4",
+            "size": 803486246,
+            "uncompressed-sha256": "986c6d47ec9da8b68acb1d07fcfc26eb0d984790d089fdf212fabed5b95ee422",
+            "uncompressed-size": 819307008
         },
         "azure": {
-            "path": "rhcos-43.81.201911221453.0-azure.x86_64.vhd.gz",
-            "sha256": "c13f715c32a056660fd6cbdb1a783c9cee2617e08fb7d6e51d526b9368a81302",
-            "size": 798665441,
-            "uncompressed-sha256": "4668c06ebc66dfde1b526fbec3c98a0a046780df02d409bdaf5a026842cedb21",
-            "uncompressed-size": 2166922240
+            "path": "rhcos-43.81.201912131630.0-azure.x86_64.vhd.gz",
+            "sha256": "dd4bb6a987ce45b947421a7c8698ac6f4bd59628bbe001fa31c2b4180f0ad0c4",
+            "size": 790788319,
+            "uncompressed-sha256": "27869f76710dd8402e3affee5f1e10e439b150e3c4a05b6cd43512532ffe4ea5",
+            "uncompressed-size": 2095601664
         },
         "gcp": {
-            "path": "rhcos-43.81.201911221453.0-gcp.x86_64.tar.gz",
-            "sha256": "362a01a85ba888cabe45070cea625411cc56453241c0ccb5f9da13ccb238c483",
-            "size": 798260548
+            "path": "rhcos-43.81.201912131630.0-gcp.x86_64.tar.gz",
+            "sha256": "0896b990fe02dc6f98dec0d41915d91bd349cac74df51f9f95e612a28b0503b4",
+            "size": 790413253
         },
         "initramfs": {
-            "path": "rhcos-43.81.201911221453.0-installer-initramfs.x86_64.img",
-            "sha256": "67e78e3928a1c3f50319536ba132c53b9a00bb213ac542f8ae978dd0c9548832"
+            "path": "rhcos-43.81.201912131630.0-installer-initramfs.x86_64.img",
+            "sha256": "c6e37c143f19c0629e90d4a5bc1c9014eafe22510fb3f017235ff32f754fa9f9"
         },
         "iso": {
-            "path": "rhcos-43.81.201911221453.0-installer.x86_64.iso",
-            "sha256": "0a9f9e66cfc99f8b3c91d4c7a29e8378d6fa70587e290f6a90399e86a5dd2eb2"
+            "path": "rhcos-43.81.201912131630.0-installer.x86_64.iso",
+            "sha256": "75bd2d6a4b781e295d4efdaa7318186ec9aebfea78ddd9848813fe8d51df6e58"
         },
         "kernel": {
-            "path": "rhcos-43.81.201911221453.0-installer-kernel-x86_64",
+            "path": "rhcos-43.81.201912131630.0-installer-kernel-x86_64",
             "sha256": "46871de47e6a6cde7c1511a29b08c028024ca9f7d5d4cef0cad4cbf1ca0d6446"
         },
         "metal": {
-            "path": "rhcos-43.81.201911221453.0-metal.x86_64.raw.gz",
-            "sha256": "3b5a882c2af3e19d515b961855d144f293cab30190c2bdedd661af31a1fc4e2f",
-            "size": 800231490,
-            "uncompressed-sha256": "e957ededfcd0c9927cd19519fe54d855d238faed0c50fece0fbdfbc09e5ef7de",
-            "uncompressed-size": 3322937344
+            "path": "rhcos-43.81.201912131630.0-metal.x86_64.raw.gz",
+            "sha256": "9ac7f14f319f09ce24b8374317a184fa16b20a3e0b891c8ba8d0779c8a17153d",
+            "size": 792269647,
+            "uncompressed-sha256": "8943dbb9eed8ad8dceb9b3a4be4a2e31e2a20522be7e97660ebaa235f034debd",
+            "uncompressed-size": 3222274048
         },
         "openstack": {
-            "path": "rhcos-43.81.201911221453.0-openstack.x86_64.qcow2.gz",
-            "sha256": "7433e3ab54ed0c15892ed4db9d473c5a00973ed476fccf057aad746c6dbf52b5",
-            "size": 799979672,
-            "uncompressed-sha256": "f0e762efcef020e6eacf91234ca7cb5d3695b392d33cb91ddda5e0562b35538b",
-            "uncompressed-size": 2136342528
+            "path": "rhcos-43.81.201912131630.0-openstack.x86_64.qcow2.gz",
+            "sha256": "ffebbd68e8a1f2a245ca19522c16c86f67f9ac8e4e0c1f0a812b068b16f7265d",
+            "size": 792331469,
+            "uncompressed-sha256": "0a4a45718b5728b380aeda8bb12786afa0ce7facef8086ff49ac3e7b881e9211",
+            "uncompressed-size": 2046099456
         },
         "ostree": {
-            "path": "rhcos-43.81.201911221453.0-ostree.x86_64.tar",
-            "sha256": "5cf92e9a4aca7210680e54cd83418f9ead4a362c3ee2a9f2a6c86c46190a41f0",
-            "size": 720046080
+            "path": "rhcos-43.81.201912131630.0-ostree.x86_64.tar",
+            "sha256": "5d672afad3aec290cb8d9ad21fb16cefdd39d57707551ef4dcffb4312f5be8e7",
+            "size": 711987200
         },
         "qemu": {
-            "path": "rhcos-43.81.201911221453.0-qemu.x86_64.qcow2.gz",
-            "sha256": "340dfa4d92450f2eee852ed1e2d02e3138cc68d824827ef9cf0a40a7ea2f93da",
-            "size": 800366661,
-            "uncompressed-sha256": "073fb598762e56c7852e743f4e2f1187f7783f9bc741aa993e4cc36a70325ab2",
-            "uncompressed-size": 2136276992
+            "path": "rhcos-43.81.201912131630.0-qemu.x86_64.qcow2.gz",
+            "sha256": "34c0a6bb3c7efdc1abc8cd60c44c5263b7132d02e79646f75d739d3780767148",
+            "size": 792701343,
+            "uncompressed-sha256": "f40e826ac4a6c5c073416a7bc0039ec8726a338885d2031e7607cec8783e580e",
+            "uncompressed-size": 2046033920
         },
         "vmware": {
-            "path": "rhcos-43.81.201911221453.0-vmware.x86_64.ova",
-            "sha256": "fda1a8bee8545ed60908a9098a3abf8c9676e79394594ac5e073b5850b82b7c3",
-            "size": 828149760
+            "path": "rhcos-43.81.201912131630.0-vmware.x86_64.ova",
+            "sha256": "100e61a6b4d4d03625327ce5e65460965e9243dca5949f08dd16917924ba3d3a",
+            "size": 819322880
         }
     },
     "oscontainer": {
-        "digest": "sha256:c2c01ec413639f65ba7948c54f01237cf69fe8b56946d77ae75132080c111300",
+        "digest": "sha256:689b8e3c9138e6526c5b01a983868215c2d355847dc0ffef25da4dbce047bc26",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "e884477421640d1285c07a6dd9aaf01c9e125038ebbe6290a5e341eb3695a4d1",
-    "ostree-version": "43.81.201911221453.0"
+    "ostree-commit": "c1c60ec65d7b086d84c76905e70508febadd137367626f4723ffc5b3c9f8c8ed",
+    "ostree-version": "43.81.201912131630.0"
 }


### PR DESCRIPTION
This has encryption/FIPS fixes.  Among other things, TPM2 binding
by default on metal is disabled by default.  See also
https://github.com/openshift/enhancements/pull/140

Note this is not a direct cherry-pick because RHCOS has branched for 4.4.

https://bugzilla.redhat.com/show_bug.cgi?id=1775388