### PR TITLE
Bug 1781846: baremetal: configure ironic interfaces for other boot mechanisms

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -566,8 +566,8 @@
   version = "v0.0.4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:ba9e456b9fd41b6baf6c7800909fad13f3e5c45c796c89ac13d8724620c7fadf"
+  branch = "release-4.3"
+  digest = "1:b79e6a0ba1e0e21024ba285da0c16b72be2f154844fb16fb9ce0402e758003cf"
   name = "github.com/metal3-io/baremetal-operator"
   packages = [
     "pkg/apis/metal3/v1alpha1",
@@ -575,7 +575,7 @@
     "pkg/hardware",
   ]
   pruneopts = "NUT"
-  revision = "cd2cdd14084a1187ec7bff542ed5928602cf1ce9"
+  revision = "d981ea02fc551aeda75ccbf11da34ba9eed11f77"
   source = "https://github.com/openshift/baremetal-operator"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -116,7 +116,7 @@ required = [
   branch = "master"
   name = "golang.org/x/oauth2"
 
-[[constraint]]  
+[[constraint]]
   branch = "master"
   name = "github.com/openshift/cluster-api-provider-gcp"
 
@@ -124,7 +124,7 @@ required = [
   branch = "master"
   name = "github.com/openshift/machine-config-operator"
 
-[[constraint]]  
+[[constraint]]
   name = "github.com/containers/image"
   version = "2.0.0"
 
@@ -133,6 +133,6 @@ required = [
   source = "https://github.com/openshift/cluster-api-provider-baremetal/pkg/apis"
 
 [[constraint]]
-  branch = "master"
+  branch = "release-4.3"
   name = "github.com/metal3-io/baremetal-operator"
   source = "https://github.com/openshift/baremetal-operator"

--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -18,6 +18,12 @@ resource "ironic_node_v1" "openshift-master-host" {
 
   driver      = var.hosts[count.index]["driver"]
   driver_info = var.driver_infos[count.index]
+
+  boot_interface       = var.hosts[count.index]["boot_interface"]
+  management_interface = var.hosts[count.index]["management_interface"]
+  power_interface      = var.hosts[count.index]["power_interface"]
+  raid_interface       = var.hosts[count.index]["raid_interface"]
+  vendor_interface     = var.hosts[count.index]["vendor_interface"]
 }
 
 resource "ironic_allocation_v1" "openshift-master-allocation" {

--- a/data/data/baremetal/masters/variables.tf
+++ b/data/data/baremetal/masters/variables.tf
@@ -33,4 +33,3 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
-

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -47,4 +47,3 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
-

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -64,9 +64,14 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 
 		// Host Details
 		hostMap := map[string]interface{}{
-			"name":         host.Name,
-			"port_address": host.BootMACAddress,
-			"driver":       accessDetails.Type(),
+			"name":                 host.Name,
+			"port_address":         host.BootMACAddress,
+			"driver":               accessDetails.Driver(),
+			"boot_interface":       accessDetails.BootInterface(),
+			"management_interface": accessDetails.ManagementInterface(),
+			"power_interface":      accessDetails.PowerInterface(),
+			"raid_interface":       accessDetails.RAIDInterface(),
+			"vendor_interface":     accessDetails.VendorInterface(),
 		}
 
 		// Properties

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -327,6 +327,8 @@ func (cs CredentialsStatus) Match(secret corev1.Secret) bool {
 		return false
 	case cs.Reference.Name != secret.ObjectMeta.Name:
 		return false
+	case cs.Reference.Namespace != secret.ObjectMeta.Namespace:
+		return false
 	case cs.Version != secret.ObjectMeta.ResourceVersion:
 		return false
 	}
@@ -355,10 +357,10 @@ type BareMetalHostStatus struct {
 	Provisioning ProvisionStatus `json:"provisioning"`
 
 	// the last credentials we were able to validate as working
-	GoodCredentials CredentialsStatus `json:"goodCredentials"`
+	GoodCredentials CredentialsStatus `json:"goodCredentials,omitempty"`
 
 	// the last credentials we sent to the provisioning backend
-	TriedCredentials CredentialsStatus `json:"triedCredentials"`
+	TriedCredentials CredentialsStatus `json:"triedCredentials,omitempty"`
 
 	// the last error message reported by the provisioning subsystem
 	ErrorMessage string `json:"errorMessage"`

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/access.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/access.go
@@ -46,6 +46,11 @@ type AccessDetails interface {
 
 	// Boot interface to set
 	BootInterface() string
+
+	ManagementInterface() string
+	PowerInterface() string
+	RAIDInterface() string
+	VendorInterface() string
 }
 
 func getParsedURL(address string) (parsedURL *url.URL, err error) {
@@ -67,7 +72,7 @@ func getParsedURL(address string) (parsedURL *url.URL, err error) {
 		}
 		parsedURL = &url.URL{
 			Scheme: "ipmi",
-			Host: address,
+			Host:   address,
 		}
 	} else {
 		// Successfully parsed the URL

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac.go
@@ -1,8 +1,8 @@
 package bmc
 
 import (
-	"strings"
 	"net/url"
+	"strings"
 )
 
 func init() {
@@ -69,4 +69,20 @@ func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfa
 
 func (a *iDracAccessDetails) BootInterface() string {
 	return "ipxe"
+}
+
+func (a *iDracAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *iDracAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *iDracAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *iDracAccessDetails) VendorInterface() string {
+	return ""
 }

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ipmi.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ipmi.go
@@ -66,3 +66,19 @@ func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 func (a *ipmiAccessDetails) BootInterface() string {
 	return "ipxe"
 }
+
+func (a *ipmiAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *ipmiAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *ipmiAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *ipmiAccessDetails) VendorInterface() string {
+	return ""
+}

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/irmc.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/irmc.go
@@ -58,3 +58,19 @@ func (a *iRMCAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 func (a *iRMCAccessDetails) BootInterface() string {
 	return "pxe"
 }
+
+func (a *iRMCAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *iRMCAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *iRMCAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *iRMCAccessDetails) VendorInterface() string {
+	return ""
+}


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/installer/pull/2766 for 4.3. The vendoring isn't a strict cherry-pick as I've pointed Gopkg.toml to the release-4.3 branch of baremetal-operator to update it.

In order to support additional mechanisms for provisioning machines
beyond iPXE, such as Virtual Media, we need to be able to configure
various interfaces (boot_interface, power_interface, etc). This data comes from baremetal-operator, as baremetal-operator's BMC code now handles providers that use virtual media. Venoring was updated using the following command:

    dep ensure -update github.com/metal3-io/baremetal-operator
