### PR TITLE
[FCOS] pkg/asset: Drop requirement for CLI specified pull secret

### DIFF
--- a/pkg/asset/installconfig/pullsecret.go
+++ b/pkg/asset/installconfig/pullsecret.go
@@ -26,7 +26,7 @@ func (a *pullSecret) Generate(asset.Parents) error {
 				Message: "Pull Secret",
 				Help:    "The container registry pull secret for this cluster, as a single line of JSON (e.g. {\"auths\": {...}}).\n\nYou can get this secret from https://cloud.openshift.com/clusters/install#pull-secret",
 			},
-			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+			Validate: survey.ComposeValidators(func(ans interface{}) error {
 				return validate.ImagePullSecret(ans.(string))
 			}),
 		},

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -77,6 +77,10 @@ type imagePullSecret struct {
 
 // ImagePullSecret checks if the given string is a valid image pull secret and returns an error if not.
 func ImagePullSecret(secret string) error {
+	if secret == "" {
+		// Empty pull secrets are allowed, so return blank error
+		return *new(error)
+	}
 	var s imagePullSecret
 	err := json.Unmarshal([]byte(secret), &s)
 	if err != nil {


### PR DESCRIPTION
This PR lets the installer CLI accept empty pull secrets without throwing an error, since OKD does not require a valid pull secret. 