### PR TITLE
Bug 1778972: Default new file and directory permissions to not be world readable

### DIFF
--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -49,10 +49,10 @@ type File struct {
 func PersistToFile(asset WritableAsset, directory string) error {
 	for _, f := range asset.Files() {
 		path := filepath.Join(directory, f.Filename)
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 			return errors.Wrap(err, "failed to create dir")
 		}
-		if err := ioutil.WriteFile(path, f.Data, 0644); err != nil {
+		if err := ioutil.WriteFile(path, f.Data, 0640); err != nil {
 			return errors.Wrap(err, "failed to write file")
 		}
 	}

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -181,10 +181,10 @@ func (s *storeImpl) saveStateFile() error {
 	}
 
 	path := filepath.Join(s.directory, stateFileName)
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(path, data, 0644); err != nil {
+	if err := ioutil.WriteFile(path, data, 0640); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
By default, kubeconfig and kubeadmin-password are installed with world readable
permissions. This fix addresses that.

See CVE-2019-19335

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1778972