### PR TITLE
[FCOS] bootstrap: replace CRIO's hooks dir on bootstrap

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -37,14 +37,14 @@ BAREMETAL_RUNTIMECFG_IMAGE=$(image_for baremetal-runtimecfg)
 
 # Copy machine-config-daemon binary from payload and run pivot
 if [ ! -f .pivot-done ]; then
-  mkdir /run/pivot /etc/pivot
+  mkdir --parents /run/pivot /etc/pivot
   touch /run/pivot/reboot-needed
   echo "${MACHINE_CONFIG_OSCONTENT}" > /etc/pivot/image-pullspec
 
   echo "ADD systemd.unified_cgroup_hierarchy=0" > /etc/pivot/kernel-args
   echo "DELETE mitigations=auto,nosmt" >> /etc/pivot/kernel-args
 
-  mkdir bin/
+  mkdir --parents bin/
   bootkube_podman_run --entrypoint=cat "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
     /usr/bin/machine-config-daemon > /usr/local/bin/machine-config-daemon
   chmod +x /usr/local/bin/machine-config-daemon

--- a/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
@@ -14,3 +14,4 @@ MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 sed --in-place --expression "s,pause_image *=.*,pause_image = \"${MACHINE_CONFIG_INFRA_IMAGE}\"," /etc/crio/crio.conf
 sed --in-place --expression 's,pause_command *=.*,pause_command = "/usr/bin/pod",' /etc/crio/crio.conf
+sed --in-place --expression 's,"/usr/share/containers/oci/hooks.d","/etc/containers/oci/hooks.d",' /etc/crio/crio.conf


### PR DESCRIPTION
This would ensure CRIO's bootstrap would use FCOS-compatible hooks dir.

PR https://github.com/openshift/machine-config-operator/pull/1311 would 
do the same for masters and workers.

This also ensures mkdir calls have `--parent` so that these would not fail if dirs already exist

/cc @LorbusChris @smarterclayton 