### PR TITLE
data/rhcos: Roll back to 43.81.201911081536.0

### DIFF
--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,132 +1,132 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-0e4526517ac524c64"
+            "hvm": "ami-052ddcff4599d0e78"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0e616119366bf59c8"
+            "hvm": "ami-0aa397cbf47c04d5d"
         },
         "ap-south-1": {
-            "hvm": "ami-0bb5479b43b5b9a6a"
+            "hvm": "ami-001a435063321c252"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0733dbf3f7daa30f0"
+            "hvm": "ami-06f607f08424d5c7e"
         },
         "ap-southeast-2": {
-            "hvm": "ami-01f88c7b2ffc45137"
+            "hvm": "ami-0865270db75af456d"
         },
         "ca-central-1": {
-            "hvm": "ami-075cf25ace0174b41"
+            "hvm": "ami-051d94af1b00b3aec"
         },
         "eu-central-1": {
-            "hvm": "ami-0d27c613cd5307caf"
+            "hvm": "ami-0f56a52f48e3c796b"
         },
         "eu-north-1": {
-            "hvm": "ami-0a7db400b3ccc5400"
+            "hvm": "ami-0996cb1fa6e59ffc9"
         },
         "eu-west-1": {
-            "hvm": "ami-0e173367c56629034"
+            "hvm": "ami-0b737234752276dc9"
         },
         "eu-west-2": {
-            "hvm": "ami-08e7d384fb6f0be97"
+            "hvm": "ami-089a72e876cd04480"
         },
         "eu-west-3": {
-            "hvm": "ami-0b765b4670474aaf2"
+            "hvm": "ami-06bdc681f5036f855"
         },
         "sa-east-1": {
-            "hvm": "ami-05acc0e0f3fa4633c"
+            "hvm": "ami-0f7da453d498f9fc1"
         },
         "us-east-1": {
-            "hvm": "ami-014ce8846db8b463d"
+            "hvm": "ami-067ba917d0b0b4b1c"
         },
         "us-east-2": {
-            "hvm": "ami-0c83319db4b3b3602"
+            "hvm": "ami-0e38af8f6ca02c451"
         },
         "us-west-1": {
-            "hvm": "ami-050658e468dd3db4b"
+            "hvm": "ami-0a9c47d8eb38fe7c6"
         },
         "us-west-2": {
-            "hvm": "ami-04051ef4316373b52"
+            "hvm": "ami-0647e51f4958543ab"
         }
     },
     "azure": {
-        "image": "rhcos-43.81.201911221453.0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-43.81.201911221453.0-azure.x86_64.vhd"
+        "image": "rhcos-43.81.201911081536.0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-43.81.201911081536.0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.201911221453.0/x86_64/",
-    "buildid": "43.81.201911221453.0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.201911081536.0/x86_64/",
+    "buildid": "43.81.201911081536.0",
     "gcp": {
-        "image": "rhcos-43-81-201911221453-0",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/43.81.201911221453.0.tar.gz"
+        "image": "rhcos-43-81-201911081536-0",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/43.81.201911081536.0.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-43.81.201911221453.0-aws.x86_64.vmdk.gz",
-            "sha256": "bfa0dd7c3871a3253616276426b1889cedc8760fa21827d71b3d70be94325226",
-            "size": 811913882,
-            "uncompressed-sha256": "d591692b1a6d2b5f187114190a09ff263357a8e08037a8eba0ce5143407b5e28",
-            "uncompressed-size": 828133376
+            "path": "rhcos-43.81.201911081536.0-aws.x86_64.vmdk.gz",
+            "sha256": "31882bdc6dcbe826e6df14ce6c20f14167e931aca93032a692c79bc6ce884d7c",
+            "size": 782421320,
+            "uncompressed-sha256": "b76e80c84ca2c6d888bf2d4032759c3f74a99517b2757ef9f3c8bee96a7cb507",
+            "uncompressed-size": 798500352
         },
         "azure": {
-            "path": "rhcos-43.81.201911221453.0-azure.x86_64.vhd.gz",
-            "sha256": "c13f715c32a056660fd6cbdb1a783c9cee2617e08fb7d6e51d526b9368a81302",
-            "size": 798665441,
-            "uncompressed-sha256": "4668c06ebc66dfde1b526fbec3c98a0a046780df02d409bdaf5a026842cedb21",
-            "uncompressed-size": 2166922240
+            "path": "rhcos-43.81.201911081536.0-azure.x86_64.vhd.gz",
+            "sha256": "10a4d72f6347b24166419c705fec28407584ad608ab596a5f33a29be3241fadb",
+            "size": 769226723,
+            "uncompressed-sha256": "4cb29f3f04fc5745dde082a3be4c97486f4ced6b1e30ce47f67af3dc69f71c5a",
+            "uncompressed-size": 2135457280
         },
         "gcp": {
-            "path": "rhcos-43.81.201911221453.0-gcp.x86_64.tar.gz",
-            "sha256": "362a01a85ba888cabe45070cea625411cc56453241c0ccb5f9da13ccb238c483",
-            "size": 798260548
+            "path": "rhcos-43.81.201911081536.0-gcp.x86_64.tar.gz",
+            "sha256": "e587ff3af225154ee35f9c38f31ff0c41463329d2bb07e8e3ff284e080d69d7c",
+            "size": 768846073
         },
         "initramfs": {
-            "path": "rhcos-43.81.201911221453.0-installer-initramfs.x86_64.img",
-            "sha256": "67e78e3928a1c3f50319536ba132c53b9a00bb213ac542f8ae978dd0c9548832"
+            "path": "rhcos-43.81.201911081536.0-installer-initramfs.x86_64.img",
+            "sha256": "3cbceaad7a1de42f65e973ecc676ac312151e65a3428c06c56f4b662b228c1e3"
         },
         "iso": {
-            "path": "rhcos-43.81.201911221453.0-installer.x86_64.iso",
-            "sha256": "0a9f9e66cfc99f8b3c91d4c7a29e8378d6fa70587e290f6a90399e86a5dd2eb2"
+            "path": "rhcos-43.81.201911081536.0-installer.x86_64.iso",
+            "sha256": "bd45101de9e6ded46b31a8b74e14ba974c26b3fb6d106390a2219af13aa883cc"
         },
         "kernel": {
-            "path": "rhcos-43.81.201911221453.0-installer-kernel-x86_64",
-            "sha256": "46871de47e6a6cde7c1511a29b08c028024ca9f7d5d4cef0cad4cbf1ca0d6446"
+            "path": "rhcos-43.81.201911081536.0-installer-kernel-x86_64",
+            "sha256": "789028335b64ddad343f61f2abfdc9819ed8e9dfad4df43a2694c0a0ba780d16"
         },
         "metal": {
-            "path": "rhcos-43.81.201911221453.0-metal.x86_64.raw.gz",
-            "sha256": "3b5a882c2af3e19d515b961855d144f293cab30190c2bdedd661af31a1fc4e2f",
-            "size": 800231490,
-            "uncompressed-sha256": "e957ededfcd0c9927cd19519fe54d855d238faed0c50fece0fbdfbc09e5ef7de",
-            "uncompressed-size": 3322937344
+            "path": "rhcos-43.81.201911081536.0-metal.x86_64.raw.gz",
+            "sha256": "8b806d70c5bdaef1c6fc2d45b49fbeab66252ec198c5acb3cf7315b5be79f0af",
+            "size": 770447460,
+            "uncompressed-sha256": "8219acc52f052c9701e459b0e59de0fb2860050906d21761eb309f0ad13f917a",
+            "uncompressed-size": 3014656000
         },
         "openstack": {
-            "path": "rhcos-43.81.201911221453.0-openstack.x86_64.qcow2.gz",
-            "sha256": "7433e3ab54ed0c15892ed4db9d473c5a00973ed476fccf057aad746c6dbf52b5",
-            "size": 799979672,
-            "uncompressed-sha256": "f0e762efcef020e6eacf91234ca7cb5d3695b392d33cb91ddda5e0562b35538b",
-            "uncompressed-size": 2136342528
+            "path": "rhcos-43.81.201911081536.0-openstack.x86_64.qcow2.gz",
+            "sha256": "e09d8300d3e209fad8d428c4c366b55a9a4b9e3a6d5ae0217073e9d3338b5a08",
+            "size": 770073664,
+            "uncompressed-sha256": "c8486e336d30edbc91b563edadacf4607a61920b01f4f53a9497e1d6fb95d10a",
+            "uncompressed-size": 2105278464
         },
         "ostree": {
-            "path": "rhcos-43.81.201911221453.0-ostree.x86_64.tar",
-            "sha256": "5cf92e9a4aca7210680e54cd83418f9ead4a362c3ee2a9f2a6c86c46190a41f0",
-            "size": 720046080
+            "path": "rhcos-43.81.201911081536.0-ostree.x86_64.tar",
+            "sha256": "fd81155ddce2325af5038b9b0a61c0cf19ca71ebaaa0f526ed04caa93090f673",
+            "size": 713287680
         },
         "qemu": {
-            "path": "rhcos-43.81.201911221453.0-qemu.x86_64.qcow2.gz",
-            "sha256": "340dfa4d92450f2eee852ed1e2d02e3138cc68d824827ef9cf0a40a7ea2f93da",
-            "size": 800366661,
-            "uncompressed-sha256": "073fb598762e56c7852e743f4e2f1187f7783f9bc741aa993e4cc36a70325ab2",
-            "uncompressed-size": 2136276992
+            "path": "rhcos-43.81.201911081536.0-qemu.x86_64.qcow2.gz",
+            "sha256": "884d49c6b5b21ee644ee8dc5117161b053800334de10a9e992cfb9d47c98828b",
+            "size": 770419381,
+            "uncompressed-sha256": "ff03581e9070a507a7ef96ebc81fe1d01b838a6c0bafb471214927cb6d2f60e5",
+            "uncompressed-size": 2105212928
         },
         "vmware": {
-            "path": "rhcos-43.81.201911221453.0-vmware.x86_64.ova",
-            "sha256": "fda1a8bee8545ed60908a9098a3abf8c9676e79394594ac5e073b5850b82b7c3",
-            "size": 828149760
+            "path": "rhcos-43.81.201911081536.0-vmware.x86_64.ova",
+            "sha256": "a7e7b2c2190e56f83287248d5feb9913d17b5d6fb8eb2245180b626573b30b71",
+            "size": 798515200
         }
     },
     "oscontainer": {
-        "digest": "sha256:c2c01ec413639f65ba7948c54f01237cf69fe8b56946d77ae75132080c111300",
+        "digest": "sha256:f6550beb2d95b4a0ced1d802ebc41770e2ce35a49fa519e8f50034d7315f099e",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "e884477421640d1285c07a6dd9aaf01c9e125038ebbe6290a5e341eb3695a4d1",
-    "ostree-version": "43.81.201911221453.0"
+    "ostree-commit": "025d77d2680e3a2ce60b3b832106319fefb81cfefbf1bf26fcf4bd1aeae0712d",
+    "ostree-version": "43.81.201911081536.0"
 }


### PR DESCRIPTION
We suspect 3c05621537 (#2666) made etcd sad, with a jump in leader elections and [`etcdserver: request timed out`][1].  Not clear on why yet, but here's trying the older RHCOS to see how it plays.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1775878