### PR TITLE
bootstrap: replace CRIO's hooks dir on bootstrap

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
@@ -14,3 +14,4 @@ MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 sed --in-place --expression "s,pause_image *=.*,pause_image = \"${MACHINE_CONFIG_INFRA_IMAGE}\"," /etc/crio/crio.conf
 sed --in-place --expression 's,pause_command *=.*,pause_command = "/usr/bin/pod",' /etc/crio/crio.conf
+sed --in-place --expression 's,"/usr/share/containers/oci/hooks.d","/etc/containers/oci/hooks.d",' /etc/crio/crio.conf


### PR DESCRIPTION
This would ensure CRIO's bootstrap would use *COS-compatible hooks dir, since eventually these systems won't have `oci-systemd-hooks` RPM installed.

Master/worker PR: https://github.com/openshift/machine-config-operator/pull/1314
FCOS PR: https://github.com/openshift/installer/pull/2795