### PR TITLE
pkg/asset/machines/machineconfig/hyperthreading: Use KernelArguments

### DIFF
--- a/pkg/asset/machines/machineconfig/hyperthreading.go
+++ b/pkg/asset/machines/machineconfig/hyperthreading.go
@@ -3,15 +3,11 @@ package machineconfig
 import (
 	"fmt"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/openshift/installer/pkg/asset/ignition"
 )
 
 // ForHyperthreadingDisabled creates the MachineConfig to disable hyperthreading.
-// RHCOS ships with pivot.service that uses the `/etc/pivot/kernel-args` to override the kernel arguments for hosts.
 func ForHyperthreadingDisabled(role string) *mcfgv1.MachineConfig {
 	return &mcfgv1.MachineConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -25,15 +21,8 @@ func ForHyperthreadingDisabled(role string) *mcfgv1.MachineConfig {
 			},
 		},
 		Spec: mcfgv1.MachineConfigSpec{
-			Config: igntypes.Config{
-				Ignition: igntypes.Ignition{
-					Version: igntypes.MaxVersion.String(),
-				},
-				Storage: igntypes.Storage{
-					Files: []igntypes.File{
-						ignition.FileFromString("/etc/pivot/kernel-args", "root", 0600, "ADD nosmt"),
-					},
-				},
+			KernelArguments: []string{
+				"nosmt",
 			},
 		},
 	}

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -75,22 +75,13 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
     networkd: {}
     passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-          verification: {}
-        filesystem: root
-        mode: 384
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
+    storage: {}
     systemd: {}
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   osImageURL: ""
 `},
 		},
@@ -112,22 +103,13 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
     networkd: {}
     passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-          verification: {}
-        filesystem: root
-        mode: 384
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
+    storage: {}
     systemd: {}
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   osImageURL: ""
 `, `apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -75,22 +75,13 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
     networkd: {}
     passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-          verification: {}
-        filesystem: root
-        mode: 384
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
+    storage: {}
     systemd: {}
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   osImageURL: ""
 `},
 		},
@@ -112,22 +103,13 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
     networkd: {}
     passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-          verification: {}
-        filesystem: root
-        mode: 384
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
+    storage: {}
     systemd: {}
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   osImageURL: ""
 `, `apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig


### PR DESCRIPTION
The more-convenient property got vendored in with 5366d283fb (#2594) as part of FIPS support.

Docs [here][1].

[1]: https://github.com/openshift/machine-config-operator/blob/8fa45661c50047de097db3ed7592e48910bfe401/docs/MachineConfiguration.md#kernelarguments