### PR TITLE
WIP: Never disable hyperthreading and add tsx=on to kernel params

### DIFF
--- a/pkg/asset/machines/machineconfig/hyperthreading.go
+++ b/pkg/asset/machines/machineconfig/hyperthreading.go
@@ -3,11 +3,8 @@ package machineconfig
 import (
 	"fmt"
 
-	igntypes "github.com/coreos/ignition/config/v2_2/types"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/openshift/installer/pkg/asset/ignition"
 )
 
 // ForHyperthreadingDisabled creates the MachineConfig to disable hyperthreading.
@@ -25,15 +22,8 @@ func ForHyperthreadingDisabled(role string) *mcfgv1.MachineConfig {
 			},
 		},
 		Spec: mcfgv1.MachineConfigSpec{
-			Config: igntypes.Config{
-				Ignition: igntypes.Ignition{
-					Version: igntypes.MaxVersion.String(),
-				},
-				Storage: igntypes.Storage{
-					Files: []igntypes.File{
-						ignition.FileFromString("/etc/pivot/kernel-args", "root", 0600, "ADD nosmt"),
-					},
-				},
+			KernelArguments: []string{
+				"nosmt",
 			},
 		},
 	}

--- a/pkg/asset/machines/machineconfig/hyperthreading.go
+++ b/pkg/asset/machines/machineconfig/hyperthreading.go
@@ -23,6 +23,7 @@ func ForTSXEnabled(role string) *mcfgv1.MachineConfig {
 		Spec: mcfgv1.MachineConfigSpec{
 			KernelArguments: []string{
 				"tsx=on",
+				"tsx_async_abort=off",
 			},
 		},
 	}

--- a/pkg/asset/machines/machineconfig/hyperthreading.go
+++ b/pkg/asset/machines/machineconfig/hyperthreading.go
@@ -7,9 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// ForHyperthreadingDisabled creates the MachineConfig to disable hyperthreading.
-// RHCOS ships with pivot.service that uses the `/etc/pivot/kernel-args` to override the kernel arguments for hosts.
-func ForHyperthreadingDisabled(role string) *mcfgv1.MachineConfig {
+// ForTSXEnabled is an ugly hack.
+func ForTSXEnabled(role string) *mcfgv1.MachineConfig {
 	return &mcfgv1.MachineConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machineconfiguration.openshift.io/v1",
@@ -23,7 +22,7 @@ func ForHyperthreadingDisabled(role string) *mcfgv1.MachineConfig {
 		},
 		Spec: mcfgv1.MachineConfigSpec{
 			KernelArguments: []string{
-				"nosmt",
+				"tsx=on",
 			},
 		},
 	}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -37,7 +37,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines/openstack"
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	rhcosutils "github.com/openshift/installer/pkg/rhcos"
-	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
@@ -309,9 +308,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	}
 
 	machineConfigs := []*mcfgv1.MachineConfig{}
-	if pool.Hyperthreading == types.HyperthreadingDisabled {
-		machineConfigs = append(machineConfigs, machineconfig.ForHyperthreadingDisabled("master"))
-	}
+	machineConfigs = append(machineConfigs, machineconfig.ForTSXEnabled("master"))
 	if ic.SSHKey != "" {
 		machineConfigs = append(machineConfigs, machineconfig.ForAuthorizedKeys(ic.SSHKey, "master"))
 	}

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -75,22 +75,13 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
     networkd: {}
     passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-          verification: {}
-        filesystem: root
-        mode: 384
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
+    storage: {}
     systemd: {}
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   osImageURL: ""
 `},
 		},
@@ -112,22 +103,13 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
     networkd: {}
     passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-          verification: {}
-        filesystem: root
-        mode: 384
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
+    storage: {}
     systemd: {}
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   osImageURL: ""
 `, `apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -37,7 +37,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines/openstack"
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	rhcosutils "github.com/openshift/installer/pkg/rhcos"
-	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
@@ -148,9 +147,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 	var err error
 	ic := installConfig.Config
 	for _, pool := range ic.Compute {
-		if pool.Hyperthreading == types.HyperthreadingDisabled {
-			machineConfigs = append(machineConfigs, machineconfig.ForHyperthreadingDisabled("worker"))
-		}
+		machineConfigs = append(machineConfigs, machineconfig.ForTSXEnabled("worker"))
 		if ic.SSHKey != "" {
 			machineConfigs = append(machineConfigs, machineconfig.ForAuthorizedKeys(ic.SSHKey, "worker"))
 		}

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -75,22 +75,13 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
     networkd: {}
     passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-          verification: {}
-        filesystem: root
-        mode: 384
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
+    storage: {}
     systemd: {}
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   osImageURL: ""
 `},
 		},
@@ -112,22 +103,13 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 2.2.0
     networkd: {}
     passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-          verification: {}
-        filesystem: root
-        mode: 384
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
+    storage: {}
     systemd: {}
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   osImageURL: ""
 `, `apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig


### PR DESCRIPTION
Enable [Transactional Synchronization Extensions][1].  These were disabled by default for [CVE-2019-11135][2] ([article][3]), but we think the change is causing a perfomance impact.  Re-enable it to see if we recover.

While testing this, I'm stealing some scaffolding which was previously used for disabling hyperthreading.  We want both TSX and hyperthreading for this test.  If it turns out to be useful, we can work out if/how we want an install-config TSX knob to work.

[1]: https://en.wikipedia.org/wiki/Transactional_Synchronization_Extensions
[2]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11135
[3]: https://access.redhat.com/articles/tsx-asynchronousabort