### PR TITLE
WIP: asset/machines: add osEncryption option to machine definitions

### DIFF
--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -71,6 +71,9 @@ The following machine-pool properties are available:
 * `hyperthreading` (optional string): Determines the mode of hyperthreading that machines in the pool will utilize.
     Valid values are `Enabled` (the default) and `Disabled`.
 * `name` (required string): The name of the machine pool.
+* `osEncryption` (optional string): The OS Encryption policy to be used.
+    Valid values are `Disabled` (default), `TPM2`, or a custom string to be placed into `/etc/clevis.json`
+    For gcp, the default is TPM2.
 * `platform` (optional object): Platform-specific machine-pool configuration.
     * `aws` (optional object): [AWS-specific properties](aws/customization.md#machine-pools).
     * `azure` (optional object): [Azure-specific properties](azure/customization.md#machine-pools).

--- a/pkg/asset/machines/machineconfig/osencryption.go
+++ b/pkg/asset/machines/machineconfig/osencryption.go
@@ -1,0 +1,53 @@
+package machineconfig
+
+import (
+	"fmt"
+
+	igntypes "github.com/coreos/ignition/config/v2_2/types"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/installer/pkg/asset/ignition"
+	"github.com/openshift/installer/pkg/types"
+)
+
+// ForOSEncryptionPolicy creates the MachineConfig based on OSEncryptionPolicy
+func ForOSEncryptionPolicy(policy types.OSEncryptionPolicy, role string) *mcfgv1.MachineConfig {
+	machineConfig := mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("50-%s-osencryption", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: igntypes.Config{
+				Ignition: igntypes.Ignition{
+					Version: igntypes.MaxVersion.String(),
+				},
+			},
+		},
+	}
+	switch policy {
+	case "", types.OSEncryptionPolicyDisabled:
+		return nil
+	case types.OSEncryptionPolicyTPM2:
+		machineConfig.Spec.Config.Storage = igntypes.Storage{
+			Files: []igntypes.File{
+				ignition.FileFromString("/etc/clevis.json", "root", 0644, "{}\n"),
+			},
+		}
+		return &machineConfig
+	default:
+		machineConfig.Spec.Config.Storage = igntypes.Storage{
+			Files: []igntypes.File{
+				ignition.FileFromString("/etc/clevis.json", "root", 0644, string(policy)),
+			},
+		}
+		return &machineConfig
+	}
+}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -309,6 +309,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	}
 
 	machineConfigs := []*mcfgv1.MachineConfig{}
+	machineConfigs = append(machineConfigs, machineconfig.ForOSEncryptionPolicy(pool.OSEncryption, "master"))
 	if pool.Hyperthreading == types.HyperthreadingDisabled {
 		machineConfigs = append(machineConfigs, machineconfig.ForHyperthreadingDisabled("master"))
 	}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -148,6 +148,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 	var err error
 	ic := installConfig.Config
 	for _, pool := range ic.Compute {
+		machineConfigs = append(machineConfigs, machineconfig.ForOSEncryptionPolicy(pool.OSEncryption, "worker"))
 		if pool.Hyperthreading == types.HyperthreadingDisabled {
 			machineConfigs = append(machineConfigs, machineconfig.ForHyperthreadingDisabled("worker"))
 		}

--- a/pkg/types/defaults/machinepools.go
+++ b/pkg/types/defaults/machinepools.go
@@ -2,6 +2,8 @@ package defaults
 
 import (
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/gcp"
+	gcpdefaults "github.com/openshift/installer/pkg/types/gcp/defaults"
 	"github.com/openshift/installer/pkg/types/libvirt"
 )
 
@@ -16,5 +18,10 @@ func SetMachinePoolDefaults(p *types.MachinePool, platform string) {
 	}
 	if p.Hyperthreading == "" {
 		p.Hyperthreading = types.HyperthreadingEnabled
+	}
+	switch platform {
+	case gcp.Name:
+		gcpdefaults.SetMachinePoolDefaults(p)
+	default:
 	}
 }

--- a/pkg/types/gcp/defaults/machinepools.go
+++ b/pkg/types/gcp/defaults/machinepools.go
@@ -1,0 +1,12 @@
+package defaults
+
+import (
+	"github.com/openshift/installer/pkg/types"
+)
+
+// SetMachinePoolDefaults sets the defaults for the machine pool.
+func SetMachinePoolDefaults(p *types.MachinePool) {
+	if p.OSEncryption == "" {
+		p.OSEncryption = types.OSEncryptionPolicyTPM2
+	}
+}

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -10,6 +10,16 @@ import (
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
+// OSEncryptionPolicy is a policy for how the OS disks will be encrypted.
+type OSEncryptionPolicy string
+
+const (
+	// OSEncryptionPolicyDisabled explicitly disables encryption.
+	OSEncryptionPolicyDisabled = "Disabled"
+	// OSEncryptionPolicyTPM2 configures Clevis to use TPM2.
+	OSEncryptionPolicyTPM2 = "TPM2"
+)
+
 // HyperthreadingMode is the mode of hyperthreading for a machine.
 type HyperthreadingMode string
 
@@ -38,6 +48,11 @@ type MachinePool struct {
 	// +optional
 	// Default is for hyperthreading to be enabled.
 	Hyperthreading HyperthreadingMode `json:"hyperthreading,omitempty"`
+
+	// OSEncryption determins the method used to encrypt the os disks.
+	// +optional
+	// Default is platform specific.
+	OSEncryption OSEncryptionPolicy `json:"osEncryption,omitempty"`
 }
 
 // MachinePoolPlatform is the platform-specific configuration for a machine


### PR DESCRIPTION
This change adds an osEncryption option to the machine definitions in
the install-config.yaml to support encryption policies. It defaults to
Disabled on all platforms except GCP, which defaults to TPM2.

https://github.com/openshift/enhancements/blob/master/enhancements/automated-policy-based-disk-encryption.md