### PR TITLE
WIP: cmd/openshift-install/gather: Gather bootstrap console logs

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -95,7 +95,7 @@ var (
 				}
 
 				err = waitForBootstrapComplete(ctx, config, rootOpts.dir)
-				if err != nil {
+				if err != nil || true {
 					if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
 						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
 					}

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -116,12 +116,12 @@ func runGatherBootstrapCmd(directory string) error {
 
 	err = logGatherBootstrap(bootstrap, port, masters, directory)
 	if err != nil || true {
-		if errno, ok := errors.Cause(err).(syscall.Errno); ok && errno == syscall.ECONNREFUSED {
+	//	if errno, ok := errors.Cause(err).(syscall.Errno); ok && errno == syscall.ECONNREFUSED {
 			err2 := gatherConsoleLogs(context.TODO(), config, bootstrap, directory)
 			if err2 != nil {
 				logrus.Error(err2)
 			}
-		}
+	//	}
 	}
 
 	return err

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -115,7 +115,7 @@ func runGatherBootstrapCmd(directory string) error {
 	}
 
 	err = logGatherBootstrap(bootstrap, port, masters, directory)
-	if err != nil {
+	if err != nil || true {
 		if errno, ok := errors.Cause(err).(syscall.Errno); ok && errno == syscall.ECONNREFUSED {
 			err2 := gatherConsoleLogs(context.TODO(), config, bootstrap, directory)
 			if err2 != nil {

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -117,11 +118,15 @@ func runGatherBootstrapCmd(directory string) error {
 func logGatherBootstrap(bootstrap string, port int, masters []string, directory string) error {
 	logrus.Info("Pulling debug logs from the bootstrap machine")
 	client, err := ssh.NewClient("core", fmt.Sprintf("%s:%d", bootstrap, port), gatherBootstrapOpts.sshKeys)
-	if err != nil && len(gatherBootstrapOpts.sshKeys) == 0 {
-		return errors.Wrap(err, "failed to create SSH client, ensure the proper ssh key is in your keyring or specify with --key")
-	} else if err != nil {
+	if err != nil {
+		if errno, ok := err.(syscall.Errno); ok && errno == syscall.ECONNREFUSED {
+			return errors.Wrap(err, "failed to connect to the bootstrap machine")
+		} else if len(gatherBootstrapOpts.sshKeys) == 0 {
+			return errors.Wrap(err, "failed to create SSH client, ensure the proper ssh key is in your keyring or specify with --key")
+		}
 		return errors.Wrap(err, "failed to create SSH client")
 	}
+
 	gatherID := time.Now().Format("20060102150405")
 	if err := ssh.Run(client, fmt.Sprintf("/usr/local/bin/installer-gather.sh --id %s %s", gatherID, strings.Join(masters, " "))); err != nil {
 		return errors.Wrap(err, "failed to run remote command")

--- a/pkg/gather/aws/OWNERS
+++ b/pkg/gather/aws/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - aws-approvers
+reviewers:
+  - aws-reviewers

--- a/pkg/gather/aws/console.go
+++ b/pkg/gather/aws/console.go
@@ -1,0 +1,68 @@
+// Package AWS provides AWS-specific tools for gathering debugging information.
+package aws
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/pkg/errors"
+)
+
+// ConsoleLogs retrieves console logs from the AWS instance with the
+// given IP address.
+func ConsoleLogs(ctx context.Context, session *session.Session, ip string) ([]byte, error) {
+	client := ec2.New(session)
+	var instanceID string
+	err := client.DescribeInstancesPagesWithContext(
+		ctx,
+		&ec2.DescribeInstancesInput{
+			Filters: []*ec2.Filter{{
+				Name:   aws.String("ip-address"),
+				Values: []*string{&ip},
+			}},
+		},
+		func(results *ec2.DescribeInstancesOutput, lastPage bool) bool {
+			for _, reservation := range results.Reservations {
+				for _, instance := range reservation.Instances {
+					if instance.InstanceId != nil {
+						instanceID = *instance.InstanceId
+						return false
+					}
+				}
+			}
+
+			return !lastPage
+		},
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "describe instances")
+	}
+
+	if instanceID == "" {
+		return nil, errors.Errorf("unable to find an AWS instance ID for %q", ip)
+	}
+
+	consoleOutput, err := client.GetConsoleOutputWithContext(
+		ctx,
+		&ec2.GetConsoleOutputInput{
+			InstanceId: &instanceID,
+			Latest:     aws.Bool(true),
+		},
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "get console output for %s", instanceID)
+	}
+	if consoleOutput.Output == nil {
+		return nil, errors.Errorf("nil console output for %s", instanceID)
+	}
+
+	data, err := base64.StdEncoding.DecodeString(*consoleOutput.Output)
+	if err != nil {
+		return nil, errors.Wrapf(err, "decoding console output for %s", instanceID)
+	}
+
+	return data, nil
+}


### PR DESCRIPTION
Builds on #2810; review that first.  This PR adds AWS console-log retrieval to those connection-refused cases.  It should be especially useful in continuous integration when bumping RHCOS boot images (e.g. [this job][2]), when such boot-time failures are more likely.

[2]: https://github.com/openshift/installer/pull/2777#issuecomment-565237752