### PR TITLE
crio: add conmon_cgroup option

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
@@ -14,3 +14,4 @@ MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 sed --in-place --expression "s,pause_image *=.*,pause_image = \"${MACHINE_CONFIG_INFRA_IMAGE}\"," /etc/crio/crio.conf
 sed --in-place --expression 's,pause_command *=.*,pause_command = "/usr/bin/pod",' /etc/crio/crio.conf
+sed --in-place --expression 's,^# conmon_cgroup.*,conmon_cgroup = "pod",' /etc/crio/crio.conf


### PR DESCRIPTION
workers and masters in 4.3+ use conmon_cgroup="pod"... for now.

ref: https://github.com/openshift/machine-config-operator/pull/1344
ref: https://bugzilla.redhat.com/show_bug.cgi?id=1783587