### PR TITLE
[OpenStack][UPI]: tweaks

### DIFF
--- a/upi/openstack/01_network.yaml
+++ b/upi/openstack/01_network.yaml
@@ -6,8 +6,12 @@
 
 - hosts: all
 
+  vars_files:
+  - metadata.json
   vars:
-    cluster_subnet: "{{ os_infra_id }}-nodes"
+    nodes_subnet: "{{ infraID }}-nodes"
+    os_network: "{{ infraID }}-network"
+    os_router: "{{ infraID }}-router"
 
   tasks:
   - name: 'Create the cluster network'
@@ -16,7 +20,7 @@
 
   - name: 'Create a subnet'
     os_subnet:
-      name: "{{ cluster_subnet }}"
+      name: "{{ nodes_subnet }}"
       network_name: "{{ os_network }}"
       cidr: "{{ os_subnet_range }}"
       allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
@@ -27,4 +31,4 @@
       name: "{{ os_router }}"
       network: "{{ os_external_network }}"
       interfaces:
-      - "{{ cluster_subnet }}"
+      - "{{ nodes_subnet }}"

--- a/upi/openstack/02_security-groups.yaml
+++ b/upi/openstack/02_security-groups.yaml
@@ -3,7 +3,14 @@
 # ansible
 # openstacksdk
 
+
 - hosts: all
+
+  vars_files:
+  - metadata.json
+  vars:
+    os_sg_master: "{{ infraID }}-master"
+    os_sg_worker: "{{ infraID }}-worker"
 
   tasks:
   - name: 'Create the master security group'

--- a/upi/openstack/03_bootstrap.yaml
+++ b/upi/openstack/03_bootstrap.yaml
@@ -6,11 +6,14 @@
 
 - hosts: all
 
+  vars_files:
+  - metadata.json
   vars:
-    bootstrap_data: "{{ os_infra_id }}-bootstrap-ignition.json"
-
-    bootstrap_server: "{{ os_infra_id }}-bootstrap"
-    bootstrap_port: "{{ os_infra_id }}-bootstrap-port"
+    bootstrap_data: "{{ infraID }}-bootstrap-ignition.json"
+    bootstrap_server: "{{ infraID }}-bootstrap"
+    bootstrap_port: "{{ infraID }}-bootstrap-port"
+    os_network: "{{ infraID }}-network"
+    os_sg_master: "{{ infraID }}-master"
 
   tasks:
   - name: 'Create the bootstrap server port'
@@ -22,7 +25,6 @@
       allowed_address_pairs:
       - ip_address: "{{ os_subnet_range | next_nth_usable(5) }}"
       - ip_address: "{{ os_subnet_range | next_nth_usable(6) }}"
-      - ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
 
   - name: 'Create the bootstrap server'
     os_server:

--- a/upi/openstack/04_control-plane.yaml
+++ b/upi/openstack/04_control-plane.yaml
@@ -6,21 +6,25 @@
 
 - hosts: all
 
+  vars_files:
+  - metadata.json
   vars:
     # The provided filename will be concatenated with the Control Plane node
     # name and its 0-indexed serial number.
     #
     # In this case, the first node will look for this filename:
-    #    "{{ os_infra_id }}-master-0-ignition.json"
+    #    "{{ infraID }}-master-0-ignition.json"
     cp_data: "ignition.json"
 
-    cp_server: "{{ os_infra_id }}-master"
-    cp_port: "{{ os_infra_id }}-master-port"
+    cp_server: "{{ infraID }}-master"
+    cp_port: "{{ infraID }}-master-port"
 
     # These computed lists are used to feed the Ansible loops with the number
     # of iterations specified in the Inventory.
     cp_servers: "{{ [cp_server] * os_cp_nodes_number }}"
     cp_ports: "{{ [cp_port] * os_cp_nodes_number }}"
+    os_network: "{{ infraID }}-network"
+    os_sg_master: "{{ infraID }}-master"
 
   tasks:
   - name: 'Create the Control Plane ports'
@@ -32,6 +36,7 @@
       allowed_address_pairs:
       - ip_address: "{{ os_subnet_range | next_nth_usable(5) }}"
       - ip_address: "{{ os_subnet_range | next_nth_usable(6) }}"
+      - ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
     with_indexed_items: "{{ cp_ports }}"
 
   - name: 'Create the Control Plane servers'

--- a/upi/openstack/05_compute-nodes.yaml
+++ b/upi/openstack/05_compute-nodes.yaml
@@ -6,11 +6,14 @@
 
 - hosts: all
 
+  vars_files:
+  - metadata.json
   vars:
     compute_data: "worker.ign"
-
-    compute_server: "{{ os_infra_id }}-worker"
-    compute_port: "{{ os_infra_id }}-worker-port"
+    compute_server: "{{ infraID }}-worker"
+    compute_port: "{{ infraID }}-worker-port"
+    os_network: "{{ infraID }}-network"
+    os_sg_worker: "{{ infraID }}-worker"
 
     # These computed lists are used to feed the Ansible loops with the number
     # of iterations specified in the Inventory.

--- a/upi/openstack/down-01_network.yaml
+++ b/upi/openstack/down-01_network.yaml
@@ -5,6 +5,13 @@
 
 - hosts: all
 
+  vars_files:
+  - metadata.json
+  vars:
+    os_network: "{{ infraID }}-network"
+    os_router: "{{ infraID }}-router"
+
+
   tasks:
   - name: 'Remove the cluster router'
     os_router:

--- a/upi/openstack/down-02_security-groups.yaml
+++ b/upi/openstack/down-02_security-groups.yaml
@@ -5,6 +5,12 @@
 
 - hosts: all
 
+  vars_files:
+  - metadata.json
+  vars:
+    os_sg_master: "{{ infraID }}-master"
+    os_sg_worker: "{{ infraID }}-worker"
+
   tasks:
   - name: 'Remove the master security group'
     os_security_group:

--- a/upi/openstack/down-03_bootstrap.yaml
+++ b/upi/openstack/down-03_bootstrap.yaml
@@ -5,9 +5,11 @@
 
 - hosts: all
 
+  vars_files:
+  - metadata.json
   vars:
-    bootstrap_server: "{{ os_infra_id }}-bootstrap"
-    bootstrap_port: "{{ os_infra_id }}-bootstrap-port"
+    bootstrap_server: "{{ infraID }}-bootstrap"
+    bootstrap_port: "{{ infraID }}-bootstrap-port"
 
   tasks:
   - name: 'Remove the bootstrap server'

--- a/upi/openstack/down-04_control-plane.yaml
+++ b/upi/openstack/down-04_control-plane.yaml
@@ -5,9 +5,11 @@
 
 - hosts: all
 
+  vars_files:
+  - metadata.json
   vars:
-    cp_server: "{{ os_infra_id }}-master"
-    cp_port: "{{ os_infra_id }}-master-port"
+    cp_server: "{{ infraID }}-master"
+    cp_port: "{{ infraID }}-master-port"
 
     # These computed lists are used to feed the Ansible loops with the number
     # of iterations specified in the Inventory.

--- a/upi/openstack/down-05_compute-nodes.yaml
+++ b/upi/openstack/down-05_compute-nodes.yaml
@@ -5,9 +5,11 @@
 
 - hosts: all
 
+  vars_files:
+  - metadata.json
   vars:
-    compute_server: "{{ os_infra_id }}-worker"
-    compute_port: "{{ os_infra_id }}-worker-port"
+    compute_server: "{{ infraID }}-worker"
+    compute_port: "{{ infraID }}-worker-port"
 
     # These computed lists are used to feed the Ansible loops with the number
     # of iterations specified in the Inventory.

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -26,7 +26,7 @@ all:
       # OpenShift cluster resources. It is built in the form of:
       #
       #     "{{ os_cluster_name }}{{ installation-specific string }}"
-      os_infra_id: "{{ os_cluster_name }}-upi"
+      os_infra_id: "{{ os_cluster_name }}"
 
       # os_network is the name of the OpenStack network that will contain the
       # OpenShift cluster.

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -6,7 +6,6 @@ all:
 
       # User-provided values
       os_subnet_range: '10.0.0.0/16'
-      os_cluster_name: 'openshift'
       os_flavor_master: 'm1.xlarge'
       os_flavor_worker: 'm1.large'
       os_image_rhcos: 'rhcos'
@@ -19,24 +18,3 @@ all:
       # Number of provisioned Compute nodes.
       # 3 is the minimum number for a fully-functional cluster.
       os_compute_nodes_number: 3
-
-      # Computed values
-
-      # os_infra_id is the string we will use as a prefix for the names of the
-      # OpenShift cluster resources. It is built in the form of:
-      #
-      #     "{{ os_cluster_name }}{{ installation-specific string }}"
-      os_infra_id: "{{ os_cluster_name }}"
-
-      # os_network is the name of the OpenStack network that will contain the
-      # OpenShift cluster.
-      os_network: "{{ os_infra_id }}-network"
-
-      # os_router is the name of the router that connects the os_network to your
-      # cluster's external network (os_external_network)
-      os_router: "{{ os_infra_id }}-router"
-
-      # os_sg_* are the names of the security groups that will be assigned to
-      # the respective nodes.
-      os_sg_master: "{{ os_infra_id }}-master"
-      os_sg_worker: "{{ os_infra_id }}-worker"


### PR DESCRIPTION
- get cluster-name from infraID generated by the installer from the metadata.json now
- Make the naming scheme uniform with how we name resources in IPI