### PR TITLE
WIP: rhcos: new AMI for hack build of 43.81.201911081536.0

### DIFF
--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -37,7 +37,7 @@
             "hvm": "ami-0575a4791e03f4d25"
         },
         "us-east-1": {
-            "hvm": "ami-0aea6a5be0fc2b3fc"
+            "hvm": "ami-01a917dbb6126df4c"
         },
         "us-east-2": {
             "hvm": "ami-02b88883d49c41e94"


### PR DESCRIPTION
This is a rebuild of RHCOS `43.81.201911081536.0` with the latest
`kernel-4.18.0-147.0.3.el8_1` used, in order to see if a new kernel
broke `etcd` things.

See https://bugzilla.redhat.com/show_bug.cgi?id=1775878