### PR TITLE
WIP: New cri-o and hyperkube, everything else is old

### DIFF
--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -37,7 +37,7 @@
             "hvm": "ami-08c7dc43c89946086"
         },
         "us-east-1": {
-            "hvm": "ami-04357755de991a68e"
+            "hvm": "ami-0c9811f7cdfe694cb"
         },
         "us-east-2": {
             "hvm": "ami-0a4a6bfc3acd09106"


### PR DESCRIPTION
Hyperkube:  4.3.0-201912131246.git.0.09a9468.el8
cri-o:      1.16.0-0.6.dev.rhaos4.3.git9ad059b.el8

Old _everything_ else from 2019-11-08 build.

/hold