### PR TITLE
types: Deprecate MachineCIDR, replace with MachineNetwork: []

### DIFF
--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -29,7 +29,6 @@ The installer can use an existing VNet and subnets when provisioning an OpenShif
 
 When pre-existing subnets are provided, the installer will not create a network security group (NSG) or alter an existing one attached to the subnet. This restriction means that no security rules are created. If multiple clusters are installed to the same VNet and isolation is desired, it must be enforced through an administrative task after the cluster is installed.
 
-
 ## Examples
 
 Some example `install-config.yaml` are shown below.

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -34,17 +34,18 @@ The following `install-config.yaml` properties are available:
     * `name` (required string): The name of the cluster.
         DNS records for the cluster are all subdomains of `{{.metadata.name}}.{{.baseDomain}}`.
 * `networking` (optional object): The configuration for the pod network provider in the cluster.
-    * `clusterNetwork` (optional array of objects): The IP address pool for pods.
+    * `clusterNetwork` (optional array of objects): The IP address pools for pods.
         The default is 10.128.0.0/14 with a host prefix of /23.
         * `cidr` (required [IP network](#ip-networks)): The IP block address pool.
         * `hostPrefix` (required integer): The prefix size to allocate to each node from the CIDR.
         For example, 24 would allocate 2^8=256 adresses to each node.
-    * `machineCIDR` (optional [IP network](#ip-networks)): The IP address pool for machines.
-        The default is 10.0.0.0/16 for all platforms other than libvirt.
-        For libvirt, the default is 192.168.126.0/24.
+    * `machineNetwork` (optional array of objects): The IP address pools for machines.
+        * `cidr` (required [IP network](#ip-networks)): The IP block address pool.
+            The default is 10.0.0.0/16 for all platforms other than libvirt.
+            For libvirt, the default is 192.168.126.0/24.
     * `networkType` (optional string): The type of network to install.
         The default is [OpenShiftSDN][openshift-sdn].
-    * `serviceNetwork` (optional array of [IP networks](#ip-networks)): The IP address pool for services.
+    * `serviceNetwork` (optional array of [IP networks](#ip-networks)): The IP address pools for services.
         The default is 172.30.0.0/16.
 * `platform` (required object): The configuration for the specific platform upon which to perform the installation.
     * `aws` (optional object): [AWS-specific properties](aws/customization.md#cluster-scoped-properties).
@@ -137,7 +138,8 @@ networking:
   clusterNetworks:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - cidr: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16

--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -113,7 +113,8 @@ baseDomain: test.metalkube.org
 metadata:
   name: ostest
 networking:
-  machineCIDR: 192.168.111.0/24
+  machineNetwork:
+  - cidr: 192.168.111.0/24
 compute:
 - name: worker
   replicas: 1

--- a/docs/user/openstack/known-issues.md
+++ b/docs/user/openstack/known-issues.md
@@ -19,9 +19,12 @@ A partial fix for Self Signed Certificates has been merged, enabling the bootstr
 If your external network's CIDR range is the same as one of the default network ranges, then you will need to change the matching network range by running the installer with a custom `install-config.yaml`. If users are experiencing unusual networking problems, please contact your cluster administrator and validate that none of your network CIDRs are overlapping with the external network. We were unfortunately unable to support validation for this due to a lack of support in gophercloud, and even if we were, it is likely that the CIDR range of the floating ip would only be accessible cluster administrators. The default network CIDR are as follows:
 
 ```txt
-machineCIDR:    10.0.0.0/16
-serviceNetwork: 172.30.0.0/16
-clusterNetwork: 10.128.0.0/14
+machineNetwork:
+- cidr: "10.0.0.0/16"
+serviceNetwork:
+- "172.30.0.0/16"
+clusterNetwork:
+- cidr: "10.128.0.0/14"
 ```
 
 ## Lack of default DNS servers on created subnets

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -114,7 +114,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		clusterID.InfraID,
 		installConfig.Config.ClusterDomain(),
 		installConfig.Config.BaseDomain,
-		&installConfig.Config.Networking.MachineCIDR.IPNet,
+		&installConfig.Config.Networking.MachineNetwork[0].CIDR.IPNet,
 		bootstrapIgn,
 		masterIgn,
 		masterCount,
@@ -292,7 +292,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		data, err = libvirttfvars.TFVars(
 			masters[0].Spec.ProviderSpec.Value.Object.(*libvirtprovider.LibvirtMachineProviderConfig),
 			string(*rhcosImage),
-			&installConfig.Config.Networking.MachineCIDR.IPNet,
+			&installConfig.Config.Networking.MachineNetwork[0].CIDR.IPNet,
 			installConfig.Config.Platform.Libvirt.Network.IfName,
 			masterCount,
 		)

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -18,7 +18,9 @@ var (
 func validInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
-			MachineCIDR: ipnet.MustParseCIDR(validCIDR),
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR(validCIDR)},
+			},
 		},
 		Publish: types.ExternalPublishingStrategy,
 		Platform: types.Platform{
@@ -184,7 +186,7 @@ func TestValidate(t *testing.T) {
 			}
 			return s
 		}(),
-		exptectErr: `^platform\.aws\.subnets\[6\]: Invalid value: \"invalid-cidr-subnet\": CIDR range 192\.168\.126\.0/24 is outside of the MachineCIDR 10\.0\.0\.0/16$`,
+		exptectErr: `^platform\.aws\.subnets\[6\]: Invalid value: \"invalid-cidr-subnet\": subnet's CIDR range start 192.168.126.0 is outside of the specified machine networks$`,
 	}, {
 		name: "invalid cidr does not belong to machine CIDR",
 		installConfig: func() *types.InstallConfig {
@@ -207,7 +209,7 @@ func TestValidate(t *testing.T) {
 			}
 			return s
 		}(),
-		exptectErr: `^\[platform\.aws\.subnets\[6\]: Invalid value: \"invalid-private-cidr-subnet\": CIDR range 192\.168\.126\.0/24 is outside of the MachineCIDR 10\.0\.0\.0/16, platform\.aws\.subnets\[7\]: Invalid value: \"invalid-public-cidr-subnet\": CIDR range 192\.168\.127\.0/24 is outside of the MachineCIDR 10\.0\.0\.0/16\]$`,
+		exptectErr: `^\[platform\.aws\.subnets\[6\]: Invalid value: \"invalid-private-cidr-subnet\": subnet's CIDR range start 192.168.126.0 is outside of the specified machine networks, platform\.aws\.subnets\[7\]: Invalid value: \"invalid-public-cidr-subnet\": subnet's CIDR range start 192.168.127.0 is outside of the specified machine networks\]$`,
 	}, {
 		name: "invalid missing public subnet in a zone",
 		installConfig: func() *types.InstallConfig {

--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -6,7 +6,6 @@ import (
 	"net"
 
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
-	"github.com/openshift/installer/pkg/ipnet"
 	aztypes "github.com/openshift/installer/pkg/types/azure"
 
 	"github.com/openshift/installer/pkg/types"
@@ -16,12 +15,13 @@ import (
 // Validate executes platform-specific validation.
 func Validate(client API, ic *types.InstallConfig) error {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateNetworks(client, ic.Azure, ic.Networking.MachineCIDR, field.NewPath("platform").Child("azure"))...)
+
+	allErrs = append(allErrs, validateNetworks(client, ic.Azure, ic.Networking.MachineNetwork, field.NewPath("platform").Child("azure"))...)
 	return allErrs.ToAggregate()
 }
 
 // validateNetworks checks that the user-provided VNet and subnets are valid.
-func validateNetworks(client API, p *aztypes.Platform, machineCIDR *ipnet.IPNet, fieldPath *field.Path) field.ErrorList {
+func validateNetworks(client API, p *aztypes.Platform, machineNetworks []types.MachineNetworkEntry, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if p.VirtualNetwork != "" {
@@ -35,21 +35,21 @@ func validateNetworks(client API, p *aztypes.Platform, machineCIDR *ipnet.IPNet,
 			return append(allErrs, field.Invalid(fieldPath.Child("computeSubnet"), p.ComputeSubnet, "failed to retrieve compute subnet"))
 		}
 
-		allErrs = append(allErrs, validateSubnet(client, machineCIDR, fieldPath.Child("computeSubnet"), computeSubnet, p.ComputeSubnet)...)
+		allErrs = append(allErrs, validateSubnet(client, fieldPath.Child("computeSubnet"), computeSubnet, p.ComputeSubnet, machineNetworks)...)
 
 		controlPlaneSubnet, err := client.GetControlPlaneSubnet(context.TODO(), p.NetworkResourceGroupName, p.VirtualNetwork, p.ControlPlaneSubnet)
 		if err != nil {
 			return append(allErrs, field.Invalid(fieldPath.Child("controlPlaneSubnet"), p.ControlPlaneSubnet, "failed to retrieve control plane subnet"))
 		}
 
-		allErrs = append(allErrs, validateSubnet(client, machineCIDR, fieldPath.Child("controlPlaneSubnet"), controlPlaneSubnet, p.ControlPlaneSubnet)...)
+		allErrs = append(allErrs, validateSubnet(client, fieldPath.Child("controlPlaneSubnet"), controlPlaneSubnet, p.ControlPlaneSubnet, machineNetworks)...)
 	}
 
 	return allErrs
 }
 
 // validateSubnet checks that the subnet is in the same network as the machine CIDR
-func validateSubnet(client API, machineCIDR *ipnet.IPNet, fieldPath *field.Path, subnet *aznetwork.Subnet, subnetName string) field.ErrorList {
+func validateSubnet(client API, fieldPath *field.Path, subnet *aznetwork.Subnet, subnetName string, networks []types.MachineNetworkEntry) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	subnetIP, _, err := net.ParseCIDR(*subnet.AddressPrefix)
@@ -57,10 +57,15 @@ func validateSubnet(client API, machineCIDR *ipnet.IPNet, fieldPath *field.Path,
 		return append(allErrs, field.Invalid(fieldPath, subnetName, "unable to parse subnet CIDR"))
 	}
 
-	if !machineCIDR.Contains(subnetIP) {
-		errMsg := fmt.Sprintf("subnet %v has an IP address range %v outside of the MachineCIDR %v", subnetName, subnet.AddressPrefix, machineCIDR)
-		return append(allErrs, field.Invalid(fieldPath, subnetName, errMsg))
-	}
+	allErrs = append(allErrs, validateMachineNetworksContainIP(fieldPath, networks, *subnet.Name, subnetIP)...)
+	return allErrs
+}
 
-	return nil
+func validateMachineNetworksContainIP(fldPath *field.Path, networks []types.MachineNetworkEntry, subnetName string, ip net.IP) field.ErrorList {
+	for _, network := range networks {
+		if network.CIDR.Contains(ip) {
+			return nil
+		}
+	}
+	return field.ErrorList{field.Invalid(fldPath, subnetName, fmt.Sprintf("subnet %s address prefix is outside of the specified machine networks", ip))}
 }

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -28,7 +28,9 @@ var (
 
 	invalidateMachineCIDR = func(ic *types.InstallConfig) {
 		_, newCidr, _ := net.ParseCIDR("192.168.111.0/24")
-		ic.MachineCIDR = &ipnet.IPNet{IPNet: *newCidr}
+		ic.MachineNetwork = []types.MachineNetworkEntry{
+			{CIDR: ipnet.IPNet{IPNet: *newCidr}},
+		}
 	}
 
 	invalidateNetworkResourceGroup = func(ic *types.InstallConfig) {
@@ -61,7 +63,9 @@ var (
 func validInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
-			MachineCIDR: ipnet.MustParseCIDR(validCIDR),
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR(validCIDR)},
+			},
 		},
 		Platform: types.Platform{
 			Azure: &azure.Platform{
@@ -94,7 +98,7 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 		{
 			name:     "Invalid subnet range",
 			edits:    editFunctions{invalidateMachineCIDR},
-			errorMsg: "subnet .+ has an IP address range .+ outside of the MachineCIDR",
+			errorMsg: "subnet .+ address prefix is outside of the specified machine networks",
 		},
 		{
 			name:     "Invalid virtual network",

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -27,7 +27,9 @@ var (
 
 	invalidateMachineCIDR = func(ic *types.InstallConfig) {
 		_, newCidr, _ := net.ParseCIDR("192.168.111.0/24")
-		ic.MachineCIDR = &ipnet.IPNet{IPNet: *newCidr}
+		ic.MachineNetwork = []types.MachineNetworkEntry{
+			{CIDR: ipnet.IPNet{IPNet: *newCidr}},
+		}
 	}
 
 	invalidateNetwork       = func(ic *types.InstallConfig) { ic.GCP.Network = "invalid-vpc" }
@@ -53,7 +55,9 @@ var (
 func validInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
-			MachineCIDR: ipnet.MustParseCIDR(validCIDR),
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR(validCIDR)},
+			},
 		},
 		Platform: types.Platform{
 			GCP: &gcp.Platform{
@@ -90,7 +94,7 @@ func TestGCPInstallConfigValidation(t *testing.T) {
 			name:           "Invalid subnet range",
 			edits:          editFunctions{invalidateMachineCIDR},
 			expectedError:  true,
-			expectedErrMsg: "computeSubnet: Invalid value.*MachineCIDR",
+			expectedErrMsg: "computeSubnet: Invalid value.*subnet CIDR range start 10.0.0.0 is outside of the specified machine networks",
 		},
 		{
 			name:           "Invalid network",

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -65,7 +65,9 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 		},
 		BaseDomain: "test-domain",
 		Networking: &types.Networking{
-			MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+			},
 			NetworkType:    "OpenShiftSDN",
 			ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 			ClusterNetwork: []types.ClusterNetworkEntry{
@@ -127,7 +129,9 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				},
 				BaseDomain: "test-domain",
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+					},
 					NetworkType:    "OpenShiftSDN",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
@@ -209,7 +213,9 @@ network:
 				},
 				BaseDomain: "test-domain",
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+					},
 					NetworkType:    "OpenShiftSDN",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 					ClusterNetwork: []types.ClusterNetworkEntry{

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -27,7 +27,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	if pool.Replicas != nil {
 		total = *pool.Replicas
 	}
-	provider := provider(clusterID, config.Networking.MachineCIDR.String(), platform, userDataSecret)
+	provider := provider(clusterID, config.Networking.MachineNetwork[0].CIDR.String(), platform, userDataSecret)
 	var machines []machineapi.Machine
 	for idx := int64(0); idx < total; idx++ {
 		machine := machineapi.Machine{

--- a/pkg/asset/machines/libvirt/machinesets.go
+++ b/pkg/asset/machines/libvirt/machinesets.go
@@ -31,7 +31,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		total = *pool.Replicas
 	}
 
-	provider := provider(clusterID, config.Networking.MachineCIDR.String(), platform, userDataSecret)
+	provider := provider(clusterID, config.Networking.MachineNetwork[0].CIDR.String(), platform, userDataSecret)
 	name := fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, 0)
 	mset := &machineapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/asset/manifests/operators_test.go
+++ b/pkg/asset/manifests/operators_test.go
@@ -22,7 +22,9 @@ func TestRedactedInstallConfig(t *testing.T) {
 			SSHKey:     "test-ssh-key",
 			BaseDomain: "test-domain",
 			Networking: &types.Networking{
-				MachineCIDR: ipnet.MustParseCIDR("1.2.3.4/5"),
+				MachineNetwork: []types.MachineNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("1.2.3.4/5")},
+				},
 				NetworkType: "test-network-type",
 				ClusterNetwork: []types.ClusterNetworkEntry{
 					{
@@ -71,7 +73,8 @@ networking:
   clusterNetwork:
   - cidr: 1.2.3.4/5
     hostPrefix: 6
-  machineCIDR: 1.2.3.4/5
+  machineNetwork:
+  - cidr: 1.2.3.4/5
   networkType: test-network-type
   serviceNetwork:
   - 1.2.3.4/5

--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -124,10 +124,9 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 		"localhost",
 		".svc",
 		".cluster.local",
-		network.Config.Spec.ServiceNetwork[0],
 		internalAPIServer.Hostname(),
-		installConfig.Config.Networking.MachineCIDR.String(),
 	)
+
 	platform := installConfig.Config.Platform.Name()
 
 	if platform != vsphere.Name && platform != none.Name {
@@ -153,6 +152,14 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 	for i := int64(0); i < *installConfig.Config.ControlPlane.Replicas; i++ {
 		etcdHost := fmt.Sprintf("etcd-%d.%s", i, installConfig.Config.ClusterDomain())
 		set.Insert(etcdHost)
+	}
+
+	for _, network := range installConfig.Config.Networking.ServiceNetwork {
+		set.Insert(network.String())
+	}
+
+	for _, network := range installConfig.Config.Networking.MachineNetwork {
+		set.Insert(network.CIDR.String())
 	}
 
 	for _, clusterNetwork := range network.Config.Spec.ClusterNetwork {

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -20,15 +20,19 @@ type dynamicValidator func(*baremetal.Platform, *field.Path) field.ErrorList
 var dynamicValidators []dynamicValidator
 
 func validateIPinMachineCIDR(vip string, n *types.Networking) error {
-	if !n.MachineCIDR.Contains(net.ParseIP(vip)) {
-		return fmt.Errorf("the virtual IP is expected to be in %s subnet", n.MachineCIDR.String())
+	for _, network := range n.MachineNetwork {
+		if network.CIDR.Contains(net.ParseIP(vip)) {
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("the virtual IP is expected to be in one of the machine networks")
 }
 
 func validateIPNotinMachineCIDR(ip string, n *types.Networking) error {
-	if n.MachineCIDR.Contains(net.ParseIP(ip)) {
-		return fmt.Errorf("the IP must not be in %s subnet", n.MachineCIDR.String())
+	for _, network := range n.MachineNetwork {
+		if network.CIDR.Contains(net.ParseIP(ip)) {
+			return fmt.Errorf("the IP must not be in one of the machine networks")
+		}
 	}
 	return nil
 }

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -28,7 +28,7 @@ func TestValidatePlatform(t *testing.T) {
 	}
 
 	dynamicValidators = append(dynamicValidators, interfaceValidator)
-	network := &types.Networking{MachineCIDR: ipnet.MustParseCIDR("192.168.111.0/24")}
+	network := &types.Networking{MachineNetwork: []types.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.111.0/24")}}}
 	cases := []struct {
 		name     string
 		platform *baremetal.Platform
@@ -81,7 +81,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.222.2\": the virtual IP is expected to be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.222.2\": the virtual IP is expected to be in one of the machine networks",
 		},
 		{
 			name: "invalid_dnsvip",
@@ -97,7 +97,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.222.3\": the virtual IP is expected to be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.222.3\": the virtual IP is expected to be in one of the machine networks",
 		},
 		{
 			name: "invalid_ingressvip",
@@ -113,7 +113,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.222.4\": the virtual IP is expected to be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.222.4\": the virtual IP is expected to be in one of the machine networks",
 		},
 		{
 			name: "invalid_hosts",
@@ -194,7 +194,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.111.5\": the IP must not be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.111.5\": the IP must not be in one of the machine networks",
 		},
 		{
 			name: "invalid_bootstrapprovip",
@@ -210,7 +210,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.111.5\": the IP must not be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.111.5\": the IP must not be in one of the machine networks",
 		},
 		{
 			name: "invalid_bootstraposimage",

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -41,6 +41,12 @@ func ConvertNetworking(config *types.InstallConfig) {
 		netconf.ClusterNetwork = netconf.DeprecatedClusterNetworks
 	}
 
+	if len(netconf.MachineNetwork) == 0 && netconf.DeprecatedMachineCIDR != nil {
+		netconf.MachineNetwork = []types.MachineNetworkEntry{
+			{CIDR: *netconf.DeprecatedMachineCIDR},
+		}
+	}
+
 	if len(netconf.ServiceNetwork) == 0 && netconf.DeprecatedServiceCIDR != nil {
 		netconf.ServiceNetwork = []ipnet.IPNet{*netconf.DeprecatedServiceCIDR}
 	}

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -53,7 +53,7 @@ func TestConvertInstallConfig(t *testing.T) {
 					APIVersion: "v1beta3",
 				},
 				Networking: &types.Networking{
-					MachineCIDR:           ipnet.MustParseCIDR("1.1.1.1/24"),
+					DeprecatedMachineCIDR: ipnet.MustParseCIDR("1.1.1.1/24"),
 					DeprecatedType:        "foo",
 					DeprecatedServiceCIDR: ipnet.MustParseCIDR("1.2.3.4/32"),
 					DeprecatedClusterNetworks: []types.ClusterNetworkEntry{
@@ -70,8 +70,10 @@ func TestConvertInstallConfig(t *testing.T) {
 					APIVersion: types.InstallConfigVersion,
 				},
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
-					NetworkType:    "foo",
+					NetworkType: "foo",
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("1.1.1.1/24")},
+					},
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/32")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
 						{
@@ -84,6 +86,7 @@ func TestConvertInstallConfig(t *testing.T) {
 
 					// deprecated fields are preserved
 					DeprecatedType:        "foo",
+					DeprecatedMachineCIDR: ipnet.MustParseCIDR("1.1.1.1/24"),
 					DeprecatedServiceCIDR: ipnet.MustParseCIDR("1.2.3.4/32"),
 					DeprecatedClusterNetworks: []types.ClusterNetworkEntry{
 						{
@@ -103,7 +106,9 @@ func TestConvertInstallConfig(t *testing.T) {
 					APIVersion: types.InstallConfigVersion,
 				},
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("1.1.1.1/24")},
+					},
 					NetworkType:    "foo",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/32")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
@@ -119,7 +124,9 @@ func TestConvertInstallConfig(t *testing.T) {
 					APIVersion: types.InstallConfigVersion,
 				},
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("1.1.1.1/24")},
+					},
 					NetworkType:    "foo",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/32")},
 					ClusterNetwork: []types.ClusterNetworkEntry{

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -26,10 +26,14 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 	if c.Networking == nil {
 		c.Networking = &types.Networking{}
 	}
-	if c.Networking.MachineCIDR == nil {
-		c.Networking.MachineCIDR = defaultMachineCIDR
+	if len(c.Networking.MachineNetwork) == 0 {
+		c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+			{CIDR: *defaultMachineCIDR},
+		}
 		if c.Platform.Libvirt != nil {
-			c.Networking.MachineCIDR = libvirtdefaults.DefaultMachineCIDR
+			c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+				{CIDR: *libvirtdefaults.DefaultMachineCIDR},
+			}
 		}
 	}
 	if c.Networking.NetworkType == "" {

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -23,7 +23,9 @@ import (
 func defaultInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
-			MachineCIDR:    defaultMachineCIDR,
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *defaultMachineCIDR},
+			},
 			NetworkType:    defaultNetworkType,
 			ServiceNetwork: []ipnet.IPNet{*defaultServiceNetwork},
 			ClusterNetwork: []types.ClusterNetworkEntry{
@@ -55,7 +57,7 @@ func defaultAzureInstallConfig() *types.InstallConfig {
 
 func defaultLibvirtInstallConfig() *types.InstallConfig {
 	c := defaultInstallConfig()
-	c.Networking.MachineCIDR = libvirtdefaults.DefaultMachineCIDR
+	c.Networking.MachineNetwork[0].CIDR = *libvirtdefaults.DefaultMachineCIDR
 	c.Platform.Libvirt = &libvirt.Platform{}
 	libvirtdefaults.SetPlatformDefaults(c.Platform.Libvirt)
 	c.ControlPlane.Replicas = pointer.Int64Ptr(1)

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -181,29 +181,36 @@ func (p *Platform) Name() string {
 
 // Networking defines the pod network provider in the cluster.
 type Networking struct {
-	// MachineCIDR is the IP address pool for machines.
-	// +optional
-	// Default is 10.0.0.0/16 for all platforms other than libvirt.
-	// For libvirt, the default is 192.168.126.0/24.
-	MachineCIDR *ipnet.IPNet `json:"machineCIDR,omitempty"`
-
 	// NetworkType is the type of network to install.
 	// +optional
 	// Default is OpenShiftSDN.
 	NetworkType string `json:"networkType,omitempty"`
 
-	// ClusterNetwork is the IP address pool for pods.
+	// MachineNetwork is the list of IP address pools for machines.
+	// This field replaces MachineCIDR, and if set MachineCIDR must
+	// be empty or match the first entry in the list.
+	// +optional
+	// Default is 10.0.0.0/16 for all platforms other than libvirt.
+	// For libvirt, the default is 192.168.126.0/24.
+	MachineNetwork []MachineNetworkEntry `json:"machineNetwork,omitempty"`
+
+	// ClusterNetwork is the list of IP address pools for pods.
 	// +optional
 	// Default is 10.128.0.0/14 and a host prefix of /23.
 	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork,omitempty"`
 
-	// ServiceNetwork is the IP address pool for services.
+	// ServiceNetwork is the list of IP address pools for services.
 	// +optional
 	// Default is 172.30.0.0/16.
 	// NOTE: currently only one entry is supported.
 	ServiceNetwork []ipnet.IPNet `json:"serviceNetwork,omitempty"`
 
 	// Deprected types, scheduled to be removed
+
+	// Deprecated name for MachineCIDRs. If set, MachineCIDRs must
+	// be empty or the first index must match.
+	// +optional
+	DeprecatedMachineCIDR *ipnet.IPNet `json:"machineCIDR,omitempty"`
 
 	// Deprecated name for NetworkType
 	// +optional
@@ -216,6 +223,12 @@ type Networking struct {
 	// Deprecated name for ClusterNetwork
 	// +optional
 	DeprecatedClusterNetworks []ClusterNetworkEntry `json:"clusterNetworks,omitempty"`
+}
+
+// MachineNetworkEntry is a single IP address block for node IP blocks.
+type MachineNetworkEntry struct {
+	// CIDR is the IP block address pool for machines within the cluster.
+	CIDR ipnet.IPNet `json:"cidr"`
 }
 
 // ClusterNetworkEntry is a single IP address block for pod IP blocks. IP blocks

--- a/pkg/types/openstack/defaults/platform.go
+++ b/pkg/types/openstack/defaults/platform.go
@@ -30,7 +30,7 @@ func SetPlatformDefaults(p *openstack.Platform) {
 // cluster. The DNS static pods running on the nodes resolve the
 // api-int record to APIVIP.
 func APIVIP(networking *types.Networking) (net.IP, error) {
-	return cidr.Host(&networking.MachineCIDR.IPNet, 5)
+	return cidr.Host(&networking.MachineNetwork[0].CIDR.IPNet, 5)
 }
 
 // DNSVIP returns the internal virtual IP address (VIP) put in front
@@ -38,7 +38,7 @@ func APIVIP(networking *types.Networking) (net.IP, error) {
 // operator these services provide name resolution for the nodes
 // themselves.
 func DNSVIP(networking *types.Networking) (net.IP, error) {
-	return cidr.Host(&networking.MachineCIDR.IPNet, 6)
+	return cidr.Host(&networking.MachineNetwork[0].CIDR.IPNet, 6)
 }
 
 // IngressVIP returns the internal virtual IP address (VIP) put in
@@ -47,5 +47,5 @@ func DNSVIP(networking *types.Networking) (net.IP, error) {
 // e.g. `console`. The DNS static pods running on the nodes resolve
 // the wildcard apps record to IngressVIP.
 func IngressVIP(networking *types.Networking) (net.IP, error) {
-	return cidr.Host(&networking.MachineCIDR.IPNet, 7)
+	return cidr.Host(&networking.MachineNetwork[0].CIDR.IPNet, 7)
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -109,9 +109,6 @@ func ClusterName(v string) error {
 
 // SubnetCIDR checks if the given IP net is a valid CIDR.
 func SubnetCIDR(cidr *net.IPNet) error {
-	if cidr.IP.To4() == nil {
-		return errors.New("must use IPv4")
-	}
 	if cidr.IP.IsUnspecified() {
 		return errors.New("address must be specified")
 	}

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -59,7 +59,7 @@ func TestSubnetCIDR(t *testing.T) {
 		{"1.2.3.4/1", "invalid network address. got 1.2.3.4/1, expecting 0.0.0.0/1"},
 		{"1.2.3.4/31", ""},
 		{"1.2.3.4/32", ""},
-		{"0:0:0:0:0:1:102:304/116", "must use IPv4"},
+		{"0:0:0:0:0:1:102:304/116", "invalid network address. got ::1:102:304/116, expecting ::1:102:0/116"},
 		{"0:0:0:0:0:ffff:102:304/116", "invalid network address. got 1.2.3.4/20, expecting 1.2.0.0/20"},
 		{"172.17.0.0/20", "overlaps with default Docker Bridge subnet (172.17.0.0/20)"},
 		{"172.0.0.0/8", "overlaps with default Docker Bridge subnet (172.0.0.0/8)"},

--- a/upi/vsphere/README.md
+++ b/upi/vsphere/README.md
@@ -14,7 +14,8 @@ baseDomain: devcluster.openshift.com
 metadata:
   name: mstaeble
 networking:
-  machineCIDR: "139.178.89.192/26"
+  machineNetwork:
+  - cidr: "139.178.89.192/26"
 platform:
   vsphere:
     vCenter: vcsa.vmware.devcluster.openshift.com


### PR DESCRIPTION
Better support future IPv6 and dual stack by allowing some platforms
to accept multiple machine CIDRs. Add validation logic that checks
for some known IPv6 behaviors at the same time.