### PR TITLE
WIP: DNM: use dm-linear for null-cipher

### DIFF
--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -37,7 +37,7 @@
             "hvm": "ami-08c7dc43c89946086"
         },
         "us-east-1": {
-            "hvm": "ami-04357755de991a68e"
+            "hvm": "ami-0dafd06b5d9f94302"
         },
         "us-east-2": {
             "hvm": "ami-0a4a6bfc3acd09106"

--- a/pkg/asset/releaseimage/pullspec.go
+++ b/pkg/asset/releaseimage/pullspec.go
@@ -37,7 +37,7 @@ func (a *Image) Generate(dependencies asset.Parents) error {
 		}
 		logrus.Debugf("Using internal constant for release image %s", pullSpec)
 	}
-	a.PullSpec = pullSpec
+	a.PullSpec = "quay.io/redhat/behoward-testing:43darkmuggle.81.201912172258.0"
 
 	ref, err := dockerref.ParseNamed(pullSpec)
 	if err != nil {


### PR DESCRIPTION
/hold

TEST PR to remove the LUKS overhead for the null-cipher.