### PR TITLE
openstack UPI: Do not rely on auto_ip to create bootstrap FIP

### DIFF
--- a/upi/openstack/03_bootstrap.yaml
+++ b/upi/openstack/03_bootstrap.yaml
@@ -30,6 +30,12 @@
       image: "{{ os_image_rhcos }}"
       flavor: "{{ os_flavor_master }}"
       userdata: "{{ lookup('file', bootstrap_data) | string }}"
-      auto_ip: yes
+      auto_ip: no
       nics:
       - port-name: "{{ bootstrap_port }}"
+
+  - name: 'Create the bootstrap floating IP'
+    os_floating_ip:
+      state: present
+      network: "{{ os_external_network }}"
+      server: "{{ bootstrap_server }}"

--- a/upi/openstack/down-03_bootstrap.yaml
+++ b/upi/openstack/down-03_bootstrap.yaml
@@ -14,6 +14,7 @@
     os_server:
       name: "{{ bootstrap_server }}"
       state: absent
+      delete_fip: yes
 
   - name: 'Remove the bootstrap server port'
     os_port:


### PR DESCRIPTION
The `auto_ip` option to `os_server` is unreliable as it may not pick an
IP address from the floating IP pool we want in case the cloud has
multiple floating IP pools. Instead we create the FIP and assign it to
the node in a separate task.

We need to explicitely disable `auto_ip` as the default value is yes.