### PR TITLE
openstack UPI: Skip gathering facts

### DIFF
--- a/upi/openstack/01_network.yaml
+++ b/upi/openstack/01_network.yaml
@@ -5,6 +5,7 @@
 # netaddr
 
 - hosts: all
+  gather_facts: no
 
   vars:
     cluster_subnet: "{{ os_infra_id }}-nodes"

--- a/upi/openstack/02_security-groups.yaml
+++ b/upi/openstack/02_security-groups.yaml
@@ -4,6 +4,7 @@
 # openstacksdk
 
 - hosts: all
+  gather_facts: no
 
   tasks:
   - name: 'Create the master security group'

--- a/upi/openstack/03_bootstrap.yaml
+++ b/upi/openstack/03_bootstrap.yaml
@@ -5,6 +5,7 @@
 # netaddr
 
 - hosts: all
+  gather_facts: no
 
   vars:
     bootstrap_data: "{{ os_infra_id }}-bootstrap-ignition.json"

--- a/upi/openstack/04_control-plane.yaml
+++ b/upi/openstack/04_control-plane.yaml
@@ -5,6 +5,7 @@
 # netaddr
 
 - hosts: all
+  gather_facts: no
 
   vars:
     # The provided filename will be concatenated with the Control Plane node

--- a/upi/openstack/05_compute-nodes.yaml
+++ b/upi/openstack/05_compute-nodes.yaml
@@ -5,6 +5,7 @@
 # netaddr
 
 - hosts: all
+  gather_facts: no
 
   vars:
     compute_data: "worker.ign"

--- a/upi/openstack/down-01_network.yaml
+++ b/upi/openstack/down-01_network.yaml
@@ -4,6 +4,7 @@
 # openstacksdk
 
 - hosts: all
+  gather_facts: no
 
   tasks:
   - name: 'Remove the cluster router'

--- a/upi/openstack/down-02_security-groups.yaml
+++ b/upi/openstack/down-02_security-groups.yaml
@@ -4,6 +4,7 @@
 # openstacksdk
 
 - hosts: all
+  gather_facts: no
 
   tasks:
   - name: 'Remove the master security group'

--- a/upi/openstack/down-03_bootstrap.yaml
+++ b/upi/openstack/down-03_bootstrap.yaml
@@ -4,6 +4,7 @@
 # openstacksdk
 
 - hosts: all
+  gather_facts: no
 
   vars:
     bootstrap_server: "{{ os_infra_id }}-bootstrap"

--- a/upi/openstack/down-04_control-plane.yaml
+++ b/upi/openstack/down-04_control-plane.yaml
@@ -4,6 +4,7 @@
 # openstacksdk
 
 - hosts: all
+  gather_facts: no
 
   vars:
     cp_server: "{{ os_infra_id }}-master"

--- a/upi/openstack/down-05_compute-nodes.yaml
+++ b/upi/openstack/down-05_compute-nodes.yaml
@@ -4,6 +4,7 @@
 # openstacksdk
 
 - hosts: all
+  gather_facts: no
 
   vars:
     compute_server: "{{ os_infra_id }}-worker"


### PR DESCRIPTION
As the target of Ansible is technically localhost, there is no need to
gather facts prior the playbook runs. This cuts on unnecessary waiting
time during execution.

/label platform/openstack