### PR TITLE
aws: update the bootstrap ignition fetching to use custom region endpoints

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -7,7 +7,8 @@ data "aws_partition" "current" {}
 data "aws_ebs_default_kms_key" "current" {}
 
 resource "aws_s3_bucket" "ignition" {
-  acl = "private"
+  bucket = var.ignition_bucket
+  acl    = "private"
 
   tags = merge(
     {
@@ -43,7 +44,7 @@ resource "aws_s3_bucket_object" "ignition" {
 
 data "ignition_config" "redirect" {
   replace {
-    source = "s3://${aws_s3_bucket.ignition.id}/bootstrap.ign"
+    source = var.ignition_presigned_url
   }
 }
 
@@ -103,13 +104,6 @@ resource "aws_iam_role_policy" "bootstrap" {
       "Effect": "Allow",
       "Action": "ec2:DetachVolume",
       "Resource": "*"
-    },
-    {
-      "Action" : [
-        "s3:GetObject"
-      ],
-      "Resource": "arn:${data.aws_partition.current.partition}:s3:::*",
-      "Effect": "Allow"
     }
   ]
 }

--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -13,6 +13,16 @@ variable "ignition" {
   description = "The content of the bootstrap ignition file."
 }
 
+variable "ignition_bucket" {
+  type        = string
+  description = "The S3 bucket where the ignition configuration is stored"
+}
+
+variable "ignition_presigned_url" {
+  type        = string
+  description = "The presigned URL for the S3 bucket where the ignition configuration is stored"
+}
+
 variable "instance_type" {
   type        = string
   description = "The instance type of the bootstrap node."

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -29,6 +29,8 @@ module "bootstrap" {
   instance_type            = var.aws_bootstrap_instance_type
   cluster_id               = var.cluster_id
   ignition                 = var.ignition_bootstrap
+  ignition_bucket          = var.aws_ignition_bucket
+  ignition_presigned_url   = var.aws_ignition_presigned_url
   subnet_id                = var.aws_publish_strategy == "External" ? module.vpc.az_to_public_subnet_id[var.aws_master_availability_zones[0]] : module.vpc.az_to_private_subnet_id[var.aws_master_availability_zones[0]]
   target_group_arns        = module.vpc.aws_lb_target_group_arns
   target_group_arns_length = module.vpc.aws_lb_target_group_arns_length

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -130,7 +130,18 @@ variable "aws_publish_strategy" {
   type        = string
   description = "The cluster publishing strategy, either Internal or External"
 }
+
 variable "aws_skip_region_validation" {
   type        = bool
   description = "This decides if the AWS provider should validate if the region is known."
+}
+
+variable "aws_ignition_bucket" {
+  type        = string
+  description = "The S3 bucket where the ignition configuration is stored"
+}
+
+variable "aws_ignition_presigned_url" {
+  type        = string
+  description = "The presigned URL for the S3 bucket where the ignition configuration is stored"
 }

--- a/pkg/asset/installconfig/aws/presign.go
+++ b/pkg/asset/installconfig/aws/presign.go
@@ -1,0 +1,24 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// PresignedS3URL returns a presigned S3 URL for a bucket/object pair
+func PresignedS3URL(session *session.Session, region string, bucket string, object string) (string, error) {
+	client := s3.New(session, aws.NewConfig().WithRegion(region))
+	req, _ := client.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(object),
+	})
+	presignedURL, err := req.Presign(60 * time.Minute)
+	if err != nil {
+		return "", err
+	}
+
+	return presignedURL, nil
+}

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -34,6 +34,8 @@ type config struct {
 	PublicSubnets           *[]string         `json:"aws_public_subnets,omitempty"`
 	PublishStrategy         string            `json:"aws_publish_strategy,omitempty"`
 	SkipRegionCheck         bool              `json:"aws_skip_region_validation"`
+	IgnitionBucket          string            `json:"aws_ignition_bucket"`
+	IgnitionPresignedURL    string            `json:"aws_ignition_presigned_url"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -47,6 +49,8 @@ type TFVarsSources struct {
 	AMIID, AMIRegion string
 
 	MasterConfigs, WorkerConfigs []*v1beta1.AWSMachineProviderConfig
+
+	IgnitionBucket, IgnitionPresignedURL string
 }
 
 // TFVars generates AWS-specific Terraform variables launching the cluster.
@@ -116,6 +120,8 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		PrivateSubnets:          sources.PrivateSubnets,
 		PublishStrategy:         string(sources.Publish),
 		SkipRegionCheck:         !configaws.IsKnownRegion(masterConfig.Placement.Region),
+		IgnitionBucket:          sources.IgnitionBucket,
+		IgnitionPresignedURL:    sources.IgnitionPresignedURL,
 	}
 
 	if len(sources.PublicSubnets) == 0 {


### PR DESCRIPTION
Update the S3 bucket that stores the ignition config to use a presigned URL.
This allows the S3 bucket to be accesseed via HTTP(s) similar to Azure and GCP
thus allowing the installer to pick the correct endpoint based on region/user
specification.

https://issues.redhat.com/browse/CORS-1322