### PR TITLE
WIP Azure IPI - Remove need for Subscription Admin Consent permission

### DIFF
--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -51,6 +51,24 @@ variable "azure_base_domain_resource_group_name" {
   description = "The resource group that contains the dns zone used as base domain for the cluster."
 }
 
+variable "azure_preexisting_resource_group" {
+  type        = bool
+  default     = false
+  description = "Specifies whether an existing resource group should be used for cluster resources or a new created."
+}
+
+variable "azure_resource_group_name" {
+  type        = string
+  default     = ""
+  description = "The name of the existing resource group to be used for cluster resources."
+}
+
+variable "azure_user_assigned_identity_id" {
+  type        = string
+  default     = ""
+  description = "ID of precreated user assigned identity if using existing resource group"
+}
+
 variable "azure_image_url" {
   type        = string
   description = "The URL of the vm image used for all nodes."

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -216,6 +216,9 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*azureprovider.AzureMachineProviderSpec)
 		}
 		preexistingnetwork := installConfig.Config.Azure.VirtualNetwork != ""
+		preexistingresourcegroup := installConfig.Config.Azure.ResourceGroupName != ""
+		
+		
 		data, err := azuretfvars.TFVars(
 			azuretfvars.TFVarsSources{
 				Auth:                        auth,
@@ -224,6 +227,9 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				WorkerConfigs:               workerConfigs,
 				ImageURL:                    string(*rhcosImage),
 				PreexistingNetwork:          preexistingnetwork,
+				PreexistingResourceGroup:    preexistingresourcegroup,
+				ResourceGroupName:           installConfig.Config.Azure.ResourceGroupName,
+				UserAssignedIdentity:        installConfig.Config.Azure.UserAssignedIdentity,
 				Publish:                     installConfig.Config.Publish,
 			},
 		)

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -88,7 +88,13 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 	case azure.Name:
 		config.Status.PlatformStatus.Type = configv1.AzurePlatformType
 
-		rg := fmt.Sprintf("%s-rg", clusterID.InfraID)
+		var rg string
+		
+		if installConfig.Config.Platform.Azure.ResourceGroupName != "" {
+			rg = installConfig.Config.Platform.Azure.ResourceGroupName
+		} else {
+			rg = fmt.Sprintf("%s-rg", clusterID.InfraID)
+		}
 		config.Status.PlatformStatus.Azure = &configv1.AzurePlatformStatus{
 			ResourceGroupName:        rg,
 			NetworkResourceGroupName: rg,

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -35,6 +35,10 @@ type config struct {
 	ComputeSubnet               string            `json:"azure_compute_subnet"`
 	PreexistingNetwork          bool              `json:"azure_preexisting_network"`
 	Private                     bool              `json:"azure_private"`
+	PreexistingResourceGroup    bool              `json:"azure_preexisting_resource_group",omitempty`
+	ResourceGroupName           string            `json:"azure_resource_group_name",omitempty`
+	UserAssignedIdentity        string            `json:"azure_user_assigned_identity_id",omitempty`
+	
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -46,6 +50,9 @@ type TFVarsSources struct {
 	ImageURL                    string
 	PreexistingNetwork          bool
 	Publish                     types.PublishingStrategy
+	PreexistingResourceGroup    bool 
+	ResourceGroupName           string
+	UserAssignedIdentity        string
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
@@ -76,6 +83,9 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ControlPlaneSubnet:          masterConfig.Subnet,
 		ComputeSubnet:               workerConfig.Subnet,
 		PreexistingNetwork:          sources.PreexistingNetwork,
+		PreexistingResourceGroup:		 sources.PreexistingResourceGroup,
+		ResourceGroupName:					 sources.ResourceGroupName,
+		UserAssignedIdentity: 			 sources.UserAssignedIdentity,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -28,6 +28,12 @@ type Platform struct {
 
 	// ComputeSubnet specifies an existing subnet for use by compute nodes
 	ComputeSubnet string `json:"computeSubnet,omitempty"`
+	
+	// ResourceGroupName specifies an existing resource group to deploy to
+	ResourceGroupName string `json:"resourceGroupName,omitempty"`
+	
+	// UserAssignedIdentity specifies an existing identity that has appropriate access to existing resource group
+	UserAssignedIdentity string `json:"userAssignedIdentity,omitempty"`
 }
 
 //SetBaseDomain parses the baseDomainID and sets the related fields on azure.Platform

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -39,5 +39,11 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 			allErrs = append(allErrs, field.Required(fldPath.Child("networkResourceGroupName"), "must provide a network resource group when supplying subnets"))
 		}
 	}
+	if (p.ResourceGroupName != "" && p.UserAssignedIdentity == "") {
+		allErrs = append(allErrs, field.Required(fldPath.Child("userAssignedIdentity"), "must provide user assigned identity when supplying resource group"))
+	}
+	if (p.ResourceGroupName == "" && p.UserAssignedIdentity != "") {
+		allErrs = append(allErrs, field.Required(fldPath.Child("resourceGroupName"), "must provide resource group name when supplying user assigned identity"))
+	}
 	return allErrs
 }


### PR DESCRIPTION
@fabianofranz  @jhixson74 I will probably need some help to get this one over the line.

### Background 
Initial proposal to allow deployments to Azure using IPI method without the need for Admin Consent, which is going to be an issue for a substantial portion of Azure accounts (including myself).
This is the subject of several issues, most specifically #2357 

Essentially the only thing in the original Azure IPI approach that drove the need for Admin Consent was the terraform code to create the User Assigned Identity. However, in my experience it's very very difficult to obtain service principals with excessive access, not to mention unfeathered access -- particularly in a production environment.


### Proposal
This PR allows a 2 phase deployment flow where a subscription admin (or anyone with the lesser User Administrator role) can create a Resource Group and a User Assigned Identity with Contributor role assigned to that Resource Group. 
In Terraform terms this translates to
```
resource "azurerm_resource_group" "rg" {
  name     = var.resource_group_name
  location = var.location
}

resource "azurerm_user_assigned_identity" "main" {
  resource_group_name = azurerm_resource_group.rg.name
  location            = azurerm_resource_group.rg.location

  name = var.identity_name
}

resource "azurerm_role_assignment" "main" {
  scope                = azurerm_resource_group.rg.id
  role_definition_name = "Contributor"
  principal_id         = azurerm_user_assigned_identity.main.principal_id
}
```
If utilising the feature added in #2441 the `Contributor` or `Network Contributor` role should also be added to the resource group where the Vnet/Subnets are located.

For the second, installation, face the resource group and identity is then handed to the openshift installer via these two entries in `install-config.yaml`
```
platform:
  azure:
    resourceGroupName: my_precreated_resource_group
    userAssignedIdentity: ocpdeployer
```


### Current state of this commit

The terraform builds the network, boot and master nodes successfully with the identity specified in `install-config.yaml`, but the installer eventually fails with this message:
```
23:09 $ ../bin/openshift-install create cluster
INFO Credentials loaded from file "/Users/hans/.azure/osServicePrincipal.json" 
INFO Consuming Install Config from target directory 
INFO Creating infrastructure resources...         

ERROR                                              
ERROR Error: Code="OSProvisioningTimedOut" Message="OS Provisioning for VM 'hkdevtest-p6zp4-master-2' did not finish in the allotted time. The VM may still finish provisioning successfully. Please check provisioning state later. Also, make sure the image has been properly prepared (generalized).\r\n * Instructions for Windows: https://azure.microsoft.com/documentation/articles/virtual-machines-windows-upload-image/ \r\n * Instructions for Linux: https://azure.microsoft.com/documentation/articles/virtual-machines-linux-capture-image/ " 
ERROR                                              
ERROR   on ../../../../../../../../private/var/folders/51/_07vdgj96pj1hc2lyhf7l8640000gn/T/openshift-install-335924962/master/master.tf line 37, in resource "azurerm_virtual_machine" "master": 
ERROR   37: resource "azurerm_virtual_machine" "master" { 
ERROR                                              
ERROR                                              
ERROR                                              
ERROR Error: Code="OSProvisioningTimedOut" Message="OS Provisioning for VM 'hkdevtest-p6zp4-master-1' did not finish in the allotted time. The VM may still finish provisioning successfully. Please check provisioning state later. Also, make sure the image has been properly prepared (generalized).\r\n * Instructions for Windows: https://azure.microsoft.com/documentation/articles/virtual-machines-windows-upload-image/ \r\n * Instructions for Linux: https://azure.microsoft.com/documentation/articles/virtual-machines-linux-capture-image/ " 
ERROR                                              
ERROR   on ../../../../../../../../private/var/folders/51/_07vdgj96pj1hc2lyhf7l8640000gn/T/openshift-install-335924962/master/master.tf line 37, in resource "azurerm_virtual_machine" "master": 
ERROR   37: resource "azurerm_virtual_machine" "master" { 
ERROR                                              
ERROR                                              
ERROR                                              
ERROR Error: Code="OSProvisioningTimedOut" Message="OS Provisioning for VM 'hkdevtest-p6zp4-master-0' did not finish in the allotted time. The VM may still finish provisioning successfully. Please check provisioning state later. Also, make sure the image has been properly prepared (generalized).\r\n * Instructions for Windows: https://azure.microsoft.com/documentation/articles/virtual-machines-windows-upload-image/ \r\n * Instructions for Linux: https://azure.microsoft.com/documentation/articles/virtual-machines-linux-capture-image/ " 
ERROR                                              
ERROR   on ../../../../../../../../private/var/folders/51/_07vdgj96pj1hc2lyhf7l8640000gn/T/openshift-install-335924962/master/master.tf line 37, in resource "azurerm_virtual_machine" "master": 
ERROR   37: resource "azurerm_virtual_machine" "master" { 
ERROR                                              
ERROR                                              
FATAL failed to fetch Cluster: failed to generate asset "Cluster": failed to create cluster: failed to apply using Terraform 
```

I am not able to troubleshoot why. From the boot node I can see the process stopping on this step in bootkube.sh
```
until bootkube_podman_run \
		--rm \
		--name etcdctl \
		--env ETCDCTL_API=3 \
		--volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
		--entrypoint etcdctl \
		"${MACHINE_CONFIG_ETCD_IMAGE}" \
		--dial-timeout=10m \
		--cacert=/opt/openshift/tls/etcd-ca-bundle.crt \
		--cert=/opt/openshift/tls/etcd-client.crt \
		--key=/opt/openshift/tls/etcd-client.key \
		--endpoints="${ETCD_ENDPOINTS}" \
		endpoint health
do
	echo "etcdctl failed. Retrying in 5 seconds..."
	sleep 5
done
```

and I notice when I try ping the master nodes I get a lot of timeouts, so it seems the master nodes are rebooting a lot
```
--- 10.0.0.5 ping statistics ---
317 packets transmitted, 7 received, 97.7918% packet loss, time 782ms
```

Since I cannot create an environment without this code added, I'm not able to tell if this is because of this code, or a problem elsewhere in the codebase.

```
 ../bin/openshift-install version
../bin/openshift-install unreleased-master-2286-g24eebc9b2507d8d14e7cf1ce26ed556e1c484a1a-dirty
built from commit 24eebc9b2507d8d14e7cf1ce26ed556e1c484a1a
release image registry.svc.ci.openshift.org/origin/release:4.3
```

