### PR TITLE
openstack UPI: Pin dependencies

### DIFF
--- a/upi/openstack/02_network.yaml
+++ b/upi/openstack/02_network.yaml
@@ -3,6 +3,7 @@
 # ansible
 # openstacksdk
 # netaddr
+# openstackclient
 
 - import_playbook: common.yaml
 

--- a/upi/openstack/README.md
+++ b/upi/openstack/README.md
@@ -16,17 +16,13 @@ These Ansible playbooks in this directory automate some of those steps. They are
 
 * Python
 * Ansible
-* Python dependencies listed in the playbooks. Namely:
+* Python modules required in the playbooks. Namely:
   * openstacksdk
   * netaddr
+  * openstackclient
 
-This command installs all required rependencies on a Fedora-derived Linux distribution:
 
-```shell
-yum install python-openstackclient ansible python-openstacksdk python-netaddr
-```
-
-Alternatively, the included `requirements.txt` helps using `pip` for gathering the required dependencies in a Python virtual environment:
+The included `requirements.txt` helps using `pip` for gathering the required dependencies in a Python virtual environment:
 
 ```shell
 python3 -m venv venv

--- a/upi/openstack/requirements.txt
+++ b/upi/openstack/requirements.txt
@@ -1,3 +1,4 @@
-ansible>=2.9
-netaddr>=0.7
-openstacksdk>=0.37.0
+ansible~=2.9.2
+netaddr~=0.7.19
+openstacksdk~=0.39.0
+openstackclient~=4.0.0


### PR DESCRIPTION
Ensure reproducibility by pinning specific versions for all Ansible
dependencies.

Additionally, this patch removes the instructions for installing with
YUM, as YUM-provided versions are not fully compatible with the
playbooks.

Implements OSASINFRA-1085