### PR TITLE
upi: update upi/vsphere/README.md

### DIFF
--- a/upi/vsphere/README.md
+++ b/upi/vsphere/README.md
@@ -35,11 +35,14 @@ There is an example terraform.tfvars file in this directory named terraform.tfva
 * cluster_domain
 * vsphere_user
 * vsphere_password
-* ipam_token
+* ipam_token OR bootstrap_ip, control_plane_ips, and compute_ips
 * bootstrap_ignition_url
 * control_plane_ignition
 * compute_ignition
+
 The bootstrap ignition config must be placed in a location that will be accessible by the bootstrap machine. For example, you could store the bootstrap ignition config in a gist.
+
+Even if declaring static IPs a DHCP server is still required early in the boot process to download the ignition files. 
 
 4. Run `terraform init`.
 


### PR DESCRIPTION
Clarify that a DHCP server is still required at the beginning of the installation to download the ignition files.

The current wording implies that a DHCP server is not required if you set the IPs in the tfvars. This is not the case, and the install will fail because the CoreOS nodes will never pull down the ignition file, because it never gets assigned an IP.

In response to #2552