### PR TITLE
Bug 1789746: Ensure enough number of retries for cluster with Kuryr SDN

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -101,7 +101,7 @@ func deleteRunner(deleteFuncName string, dFunction deleteFunc, opts *clientconfi
 	backoffSettings := wait.Backoff{
 		Duration: time.Second * 15,
 		Factor:   1.3,
-		Steps:    10,
+		Steps:    25,
 	}
 
 	err := wait.ExponentialBackoff(backoffSettings, func() (bool, error) {


### PR DESCRIPTION
When using Kuryr SDN the number of resources created on the
OpenStack side is way larger than for the OpenShift SDN case.
For this reason, as there is no specific order for the resources
to be deleted, the chances of the deletion of one resource (e.g.,
a network) being blocked by the deletion of another (e.g. a port
on that network) are higher, thus needed more retries.