### PR TITLE
docs/user/vsphere: Fix "vcenter" -> "vCenter"

### DIFF
--- a/docs/user/vsphere/customization.md
+++ b/docs/user/vsphere/customization.md
@@ -30,7 +30,7 @@ metadata:
   name: test-cluster
 platform:
   vSphere:
-    vcenter: your.vcenter.example.com
+    vCenter: your.vcenter.example.com
     username: username
     password: password
     datacenter: datacenter

--- a/docs/user/vsphere/install_upi.md
+++ b/docs/user/vsphere/install_upi.md
@@ -142,7 +142,7 @@ metadata:
 platform:
   vsphere:
     ## The hostname or IP address of the vCenter
-    vcenter: your.vcenter.server
+    vCenter: your.vcenter.server
     ## The name of the user for accessing the vCenter
     username: your_vsphere_username
     ## The password associated with the user


### PR DESCRIPTION
It's been `vCenter` since the property landed in 3e73413069 (#1591).  This commit fixes `vcenter` typos from 0ec07d0769 (#1545) and a947609d66 (#2162).