### PR TITLE
[FCOS] Use OVNKubernetes network config by default

### DIFF
--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -66,7 +66,7 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 		BaseDomain: "test-domain",
 		Networking: &types.Networking{
 			MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
-			NetworkType:    "OpenShiftSDN",
+			NetworkType:    "OVNKubernetes",
 			ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 			ClusterNetwork: []types.ClusterNetworkEntry{
 				{
@@ -128,7 +128,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				BaseDomain: "test-domain",
 				Networking: &types.Networking{
 					MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
-					NetworkType:    "OpenShiftSDN",
+					NetworkType:    "OVNKubernetes",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
 						{
@@ -197,7 +197,7 @@ platform:
     region: us-east-1
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 network:
-  type: OpenShiftSDN
+  type: OVNKubernetes
 `,
 			expectedFound: true,
 			expectedConfig: &types.InstallConfig{
@@ -210,7 +210,7 @@ network:
 				BaseDomain: "test-domain",
 				Networking: &types.Networking{
 					MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
-					NetworkType:    "OpenShiftSDN",
+					NetworkType:    "OVNKubernetes",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
 						{

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -17,7 +17,7 @@ var (
 	defaultServiceNetwork = ipnet.MustParseCIDR("172.30.0.0/16")
 	defaultClusterNetwork = ipnet.MustParseCIDR("10.128.0.0/14")
 	defaultHostPrefix     = 23
-	defaultNetworkType    = "OpenShiftSDN"
+	defaultNetworkType    = "OVNKubernetes"
 )
 
 // SetInstallConfigDefaults sets the defaults for the install config.

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -178,7 +178,7 @@ type Networking struct {
 
 	// NetworkType is the type of network to install.
 	// +optional
-	// Default is OpenShiftSDN.
+	// Default is OVNKubernetes.
 	NetworkType string `json:"networkType,omitempty"`
 
 	// ClusterNetwork is the IP address pool for pods.

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -32,7 +32,7 @@ func validInstallConfig() *types.InstallConfig {
 		},
 		BaseDomain: "test-domain",
 		Networking: &types.Networking{
-			NetworkType:    "OpenShiftSDN",
+			NetworkType:    "OVNKubernetes",
 			MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
 			ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 			ClusterNetwork: []types.ClusterNetworkEntry{


### PR DESCRIPTION
Switch default SDN plugin to OVN. It has more features, upstream community and OCP would eventually switch to it. 

Short-term goal is to work around https://bugzilla.redhat.com/show_bug.cgi?id=1781575