### PR TITLE
aws: Explicitly flag on ena_support

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -105,7 +105,11 @@ resource "aws_ami_copy" "main" {
   name              = "${var.cluster_id}-master"
   source_ami_id     = var.aws_ami
   source_ami_region = var.aws_region
-  encrypted         = true
+  # RHCOS includes the ena driver.
+  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html#enhanced-networking-ena-linux
+  ena_support = true
+  # We want a per-customer encrypted disk.
+  encrypted = true
 
   tags = merge(
     {


### PR DESCRIPTION
We want enhanced networking in AWS.  Now, it turns out that today
we have this in fact because `ore` in the latest
https://github.com/coreos/coreos-assembler turns this on
explicitly.  And when Terraform goes to copy AMI with encryption,
it preserves the value of that variable.

But, in the future we want to drop the AMIs from the RHCOS
pipeline and just upload a blob (like Azure/GCP), so let's add
this reminder to ourselves that we need to enable ENA when we
do that.

xref https://github.com/openshift/installer/issues/2906