### PR TITLE
images/libvirt: remove epel-release

### DIFF
--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -14,9 +14,6 @@ COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-n
 COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
 
 RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y epel-release && \
-    yum clean all && rm -rf /var/cache/yum/*
-RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     genisoimage \
     gettext \


### PR DESCRIPTION
When we built the installer for CI, we discovered that the dependency on epel-release, which was required to build locally, doesn't seem to be present when building from openshift/release.