### PR TITLE
ipv6: Fix joining IP and port number

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -118,7 +120,7 @@ func runGatherBootstrapCmd(directory string) error {
 
 func logGatherBootstrap(bootstrap string, port int, masters []string, directory string) error {
 	logrus.Info("Pulling debug logs from the bootstrap machine")
-	client, err := ssh.NewClient("core", fmt.Sprintf("%s:%d", bootstrap, port), gatherBootstrapOpts.sshKeys)
+	client, err := ssh.NewClient("core", net.JoinHostPort(bootstrap, strconv.Itoa(port)), gatherBootstrapOpts.sshKeys)
 	if err != nil && len(gatherBootstrapOpts.sshKeys) == 0 {
 		return errors.Wrap(err, "failed to create SSH client, ensure the proper ssh key is in your keyring or specify with --key")
 	} else if err != nil {

--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -2,6 +2,7 @@ package machine
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 
 	ignition "github.com/coreos/ignition/config/v2_2/types"
@@ -23,18 +24,18 @@ func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, ro
 	case baremetaltypes.Name:
 		// Baremetal needs to point directly at the VIP because we don't have a
 		// way to configure DNS before Ignition runs.
-		ignitionHost = fmt.Sprintf("%s:22623", installConfig.BareMetal.APIVIP)
+		ignitionHost = net.JoinHostPort(installConfig.BareMetal.APIVIP, "22623")
 	case openstacktypes.Name:
 		apiVIP, err := openstackdefaults.APIVIP(installConfig.Networking)
 		if err == nil {
-			ignitionHost = fmt.Sprintf("%s:22623", apiVIP.String())
+			ignitionHost = net.JoinHostPort(apiVIP.String(), "22623")
 		} else {
 			ignitionHost = fmt.Sprintf("api-int.%s:22623", installConfig.ClusterDomain())
 		}
 	case ovirttypes.Name:
-		ignitionHost = fmt.Sprintf("%s:22623", installConfig.Ovirt.APIVIP)
+		ignitionHost = net.JoinHostPort(installConfig.Ovirt.APIVIP, "22623")
 	case vspheretypes.Name:
-		ignitionHost = fmt.Sprintf("%s:22623", installConfig.VSphere.APIVIP)
+		ignitionHost = net.JoinHostPort(installConfig.VSphere.APIVIP, "22623")
 	default:
 		ignitionHost = fmt.Sprintf("api-int.%s:22623", installConfig.ClusterDomain())
 	}

--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -3,6 +3,7 @@ package baremetal
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"path"
 	"strings"
@@ -86,7 +87,7 @@ func provider(clusterName string, platform *baremetal.Platform, osImage string, 
 	// ref https://github.com/openshift/ironic-rhcos-downloader/pull/12
 	imageFilename := path.Base(strings.TrimSuffix(imageURL.String(), ".gz"))
 	compressedImageFilename := strings.Replace(imageFilename, "openstack", "compressed", 1)
-	cacheImageURL := fmt.Sprintf("http://%s:6180/images/%s/%s", platform.ClusterProvisioningIP, imageFilename, compressedImageFilename)
+	cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(platform.ClusterProvisioningIP, "6180"), imageFilename, compressedImageFilename)
 	cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)
 	config := &baremetalprovider.BareMetalMachineProviderSpec{
 		Image: baremetalprovider.Image{

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -4,14 +4,16 @@ package baremetal
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
+	"path"
+	"strings"
+
 	"github.com/metal3-io/baremetal-operator/pkg/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/pkg/errors"
-	"net/url"
-	"path"
-	"strings"
 )
 
 type config struct {
@@ -59,8 +61,8 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 			Password: host.BMC.Password,
 		}
 		driverInfo := accessDetails.DriverInfo(credentials)
-		driverInfo["deploy_kernel"] = fmt.Sprintf("http://%s/images/ironic-python-agent.kernel", bootstrapProvisioningIP)
-		driverInfo["deploy_ramdisk"] = fmt.Sprintf("http://%s/images/ironic-python-agent.initramfs", bootstrapProvisioningIP)
+		driverInfo["deploy_kernel"] = fmt.Sprintf("http://%s/images/ironic-python-agent.kernel", net.JoinHostPort(bootstrapProvisioningIP, "80"))
+		driverInfo["deploy_ramdisk"] = fmt.Sprintf("http://%s/images/ironic-python-agent.initramfs", net.JoinHostPort(bootstrapProvisioningIP, "80"))
 
 		// Host Details
 		hostMap := map[string]interface{}{
@@ -103,7 +105,7 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		// ref https://github.com/openshift/ironic-rhcos-downloader/pull/12
 		imageFilename := path.Base(strings.TrimSuffix(imageURL.String(), ".gz"))
 		compressedImageFilename := strings.Replace(imageFilename, "openstack", "compressed", 1)
-		cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", bootstrapProvisioningIP, imageFilename, compressedImageFilename)
+		cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(bootstrapProvisioningIP, "80"), imageFilename, compressedImageFilename)
 		cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)
 		instanceInfo := map[string]interface{}{
 			"root_gb":        25, // FIXME(stbenjam): Needed until https://storyboard.openstack.org/#!/story/2005165


### PR DESCRIPTION
You can't just manually join an IP and port because that will break
with an IPv6 address.  net.JoinHostPort() will do the right thing and
add square brackets around an IPv6 address.

Reported-by: Steven Hardy <shardy@redhat.com>