### PR TITLE
pkg/ipnet: add additional helper functions and ipv6 tests

### DIFF
--- a/pkg/ipnet/ipnet.go
+++ b/pkg/ipnet/ipnet.go
@@ -27,6 +27,22 @@ func (ipnet *IPNet) String() string {
 	return ipnet.IPNet.String()
 }
 
+// Version returns the IP version for an IPNet.
+func (ipnet *IPNet) Version() int {
+	// Per go documentation, To4() returns nil when using IPv6
+	if ipnet.IP.To4() == nil {
+		return 6
+	}
+
+	return 4
+}
+
+// CIDR returns the CIDR notation for a network, e.g. 255.255.255.0 would return 24.
+func (ipnet IPNet) CIDR() int {
+	cidr, _ := ipnet.IPNet.Mask.Size()
+	return cidr
+}
+
 // MarshalJSON interface for an IPNet
 func (ipnet IPNet) MarshalJSON() (data []byte, err error) {
 	if reflect.DeepEqual(ipnet.IPNet, emptyIPNet) {

--- a/pkg/ipnet/ipnet_test.go
+++ b/pkg/ipnet/ipnet_test.go
@@ -2,6 +2,7 @@ package ipnet
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"net"
 	"testing"
 )
@@ -23,6 +24,7 @@ func TestMarshal(t *testing.T) {
 		IP:   net.IP{192, 168, 0, 10},
 		Mask: net.IPv4Mask(255, 255, 255, 0),
 	}
+
 	assertJSON(t, stdlibIPNet, "{\"IP\":\"192.168.0.10\",\"Mask\":\"////AA==\"}")
 	wrappedIPNet := &IPNet{IPNet: *stdlibIPNet}
 	assertJSON(t, wrappedIPNet, "\"192.168.0.10/24\"")
@@ -30,13 +32,26 @@ func TestMarshal(t *testing.T) {
 	assertJSON(t, nil, "null")
 }
 
+func TestMarshalIPv6(t *testing.T) {
+	ipv6 := MustParseCIDR("fd2e:6f44:5dd8:b856::2/64")
+	assertJSON(t, ipv6, "\"fd2e:6f44:5dd8:b856::2/64\"")
+}
+
 func TestUnmarshal(t *testing.T) {
 	for _, ipNetIn := range []*IPNet{
 		nil,
-		{IPNet: net.IPNet{
-			IP:   net.IP{192, 168, 0, 10},
-			Mask: net.IPv4Mask(255, 255, 255, 0),
-		}},
+		{
+			IPNet: net.IPNet{
+				IP:   net.IP{192, 168, 0, 10},
+				Mask: net.IPv4Mask(255, 255, 255, 0),
+			},
+		},
+		{
+			IPNet: net.IPNet{
+				IP:   net.IP{253, 46, 111, 68, 93, 216, 184, 86, 0, 0, 0, 0, 0, 0, 0, 0},
+				Mask: net.IPMask{255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0},
+			},
+		},
 	} {
 		t.Run(ipNetIn.String(), func(t *testing.T) {
 			data, err := json.Marshal(ipNetIn)
@@ -55,4 +70,20 @@ func TestUnmarshal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVersion(t *testing.T) {
+	ipv6 := MustParseCIDR("fd2e:6f44:5dd8:b856::0/64")
+	assert.Equal(t, 6, ipv6.Version())
+
+	ipv4 := MustParseCIDR("172.22.0.0/24")
+	assert.Equal(t, 4, ipv4.Version())
+}
+
+func TestCIDR(t *testing.T) {
+	ipv6 := MustParseCIDR("fd2e:6f44:5dd8:b856::0/64")
+	assert.Equal(t, 64, ipv6.CIDR())
+
+	ipv4 := MustParseCIDR("172.22.0.0/24")
+	assert.Equal(t, 24, ipv4.CIDR())
 }


### PR DESCRIPTION
This updates IPnet package to include 2 new helper functions: Version()
and CIDR().  Version() returns the IP version, 4 or 6.  CIDR() returns
the CIDR notation for a network, e.g. when mask is 255.255.255.0, CIDR()
returns '24'.

This also extends ipnet_test to include handling of cases when using
IPv6 values.

@abhinavdahiya asked me to break these changes out from https://github.com/openshift/installer/pull/2895