### PR TITLE
gcp: Flag RHCOS with SECURE_BOOT and UEFI_COMPATIBLE

### DIFF
--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -93,6 +93,14 @@ module "dns" {
 resource "google_compute_image" "cluster" {
   name = "${var.cluster_id}-rhcos-image"
 
+  # See https://github.com/openshift/installer/issues/2546
+  guest_os_features {
+    type = "SECURE_BOOT"
+  }
+  guest_os_features {
+    type = "UEFI_COMPATIBLE"
+  }
+
   raw_disk {
     source = var.gcp_image_uri
   }


### PR DESCRIPTION

This opts us in to some of the features from
https://cloud.google.com/security/shielded-cloud/shielded-vm
Specifically with this, we get a vTPM device.

And what's nice about having a TPM device is that we can start
to optionally make use of TPM devices in OpenShift which
will then work on both bare metal *and* in GCP.

Closes: #2546