### PR TITLE
vshpere: download ova into cache

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/cluster/aws"
+	"github.com/openshift/installer/pkg/asset/cluster/vsphere"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/terraform"
@@ -74,6 +75,11 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	logrus.Infof("Creating infrastructure resources...")
 	if installConfig.Config.Platform.AWS != nil {
 		if err := aws.PreTerraform(context.TODO(), clusterID.InfraID, installConfig); err != nil {
+			return err
+		}
+	}
+	if installConfig.Config.Platform.VSphere != nil {
+		if err := vsphere.PreTerraform(context.TODO(), clusterID.InfraID, installConfig); err != nil {
 			return err
 		}
 	}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -425,17 +425,20 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		for i, c := range controlPlanes {
 			controlPlaneConfigs[i] = c.Spec.ProviderSpec.Value.Object.(*vsphereprovider.VSphereMachineProviderSpec)
 		}
-		data, err = vspheretfvars.TFVars(
+		data, cachedImage, err := vspheretfvars.TFVars(
 			vspheretfvars.TFVarsSources{
 				ControlPlaneConfigs: controlPlaneConfigs,
 				Username:            installConfig.Config.VSphere.Username,
 				Password:            installConfig.Config.VSphere.Password,
 				Cluster:             installConfig.Config.VSphere.Cluster,
+				ImageURI:            string(*rhcosImage),
 			},
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
+		installConfig.Config.VSphere.ClusterOSImage = cachedImage
+
 		t.FileList = append(t.FileList, &asset.File{
 			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
 			Data:     data,

--- a/pkg/asset/cluster/vsphere/vsphere.go
+++ b/pkg/asset/cluster/vsphere/vsphere.go
@@ -1,6 +1,9 @@
 package vsphere
 
 import (
+	"context"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
@@ -12,4 +15,11 @@ func Metadata(config *types.InstallConfig) *vsphere.Metadata {
 		Username: config.VSphere.Username,
 		Password: config.VSphere.Password,
 	}
+}
+
+// PreTerraform performs any infrastructure initialization which must
+// happen before Terraform creates the remaining infrastructure.
+func PreTerraform(ctx context.Context, infraID string, installConfig *installconfig.InstallConfig) error {
+	// TODO: create VM Template using cachedImage
+	return nil
 }

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -95,8 +95,15 @@ func osImage(config *types.InstallConfig) (string, error) {
 		// because this contains the necessary ironic config drive
 		// ignition support, which isn't enabled in the UPI BM images
 		osimage, err = rhcos.OpenStack(ctx, arch)
-	case none.Name, vsphere.Name:
+	case vsphere.Name:
+		// Check for RHCOS image URL override
+		if config.Platform.VSphere.ClusterOSImage != "" {
+			osimage = config.Platform.VSphere.ClusterOSImage
+			break
+		}
 
+		osimage, err = rhcos.VMware(ctx, arch)
+	case none.Name:
 	default:
 		return "", errors.New("invalid Platform")
 	}

--- a/pkg/rhcos/builds.go
+++ b/pkg/rhcos/builds.go
@@ -41,6 +41,10 @@ type metadata struct {
 			SHA256             string `json:"sha256"`
 			UncompressedSHA256 string `json:"uncompressed-sha256"`
 		} `json:"openstack"`
+		VMware struct {
+			Path   string `json:"path"`
+			SHA256 string `json:"sha256"`
+		} `json:"vmware"`
 	} `json:"images"`
 	OSTreeVersion string `json:"ostree-version"`
 }

--- a/pkg/rhcos/vmware.go
+++ b/pkg/rhcos/vmware.go
@@ -1,0 +1,44 @@
+package rhcos
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/pkg/errors"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+// VMware fetches the URL of the Red Hat Enterprise Linux CoreOS release.
+func VMware(ctx context.Context, arch types.Architecture) (string, error) {
+	meta, err := fetchRHCOSBuild(ctx, arch)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to fetch RHCOS metadata")
+	}
+
+	base, err := url.Parse(meta.BaseURI)
+	if err != nil {
+		return "", err
+	}
+
+	image, err := url.Parse(meta.Images.VMware.Path)
+	if err != nil {
+		return "", err
+	}
+
+	baseURL := base.ResolveReference(image).String()
+
+	// TODO: Get Uncompressed SHA256 into rhcos.json
+	// Attach sha256 checksum to the URL.  Always provide the
+	// uncompressed SHA256; the cache will take care of
+	// uncompressing before checksumming.
+	//baseURL += "?sha256=" + meta.Images.VMware.UncompressedSHA256
+
+	// Check that we have generated a valid URL
+	_, err = url.ParseRequestURI(baseURL)
+	if err != nil {
+		return "", err
+	}
+
+	return baseURL, nil
+}


### PR DESCRIPTION
This change caches a copy of the vmware ova specified in rhcos.json in
preperation to upload the OVA into a Template.

- [X] Determine ova uri from rhcos.json
- [x] Download and cache ova
- [x] Enable override of ova uri in install-config.yaml

Depends on: #2889 #2893