### PR TITLE
images: add a new generic libvirt CI image

### DIFF
--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -1,0 +1,34 @@
+# This Dockerfile is a used by CI to publish an installer image for creating libvirt clusters
+# It builds an image containing openshift-install and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments.
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+RUN yum install -y libvirt-devel && \
+    yum clean all && rm -rf /var/cache/yum/*
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN TAGS="libvirt" hack/build.sh
+
+FROM centos:7
+COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-nss.sh /bin/mock-nss.sh
+COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
+
+RUN yum update -y && \
+    yum install --setopt=tsflags=nodocs -y epel-release && \
+    yum clean all && rm -rf /var/cache/yum/*
+RUN yum update -y && \
+    yum install --setopt=tsflags=nodocs -y \
+    genisoimage \
+    gettext \
+    google-cloud-sdk \
+    libvirt-client \
+    libvirt-libs \
+    nss_wrapper \
+    openssh-clients && \
+    yum clean all && rm -rf /var/cache/yum/*
+
+RUN mkdir /output && chown 1000:1000 /output
+USER 1000:1000
+ENV PATH /bin
+ENV HOME /output
+WORKDIR /output

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -14,9 +14,6 @@ COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-n
 COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
 
 RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y epel-release && \
-    yum clean all && rm -rf /var/cache/yum/*
-RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     genisoimage \
     gettext \

--- a/images/libvirt/README.md
+++ b/images/libvirt/README.md
@@ -1,0 +1,53 @@
+# Libvirt Installer for CI
+
+This image enables launching a libvirt cluster for CI testing through two primary mechanisms:
+  1. Targeting a libvirt service running on a remote host
+  2. Launching a libvirt VM nested in a GCE instance
+
+This image contains [`nss_wrapper`](https://cwrap.org/nss_wrapper.html) to execute `ssh` commands as
+a mock user to interact with the remote libvirt API or GCE instance from an OpenShift container.
+
+OpenShift containers run with an arbitrary uid, but SSH requires a valid user.  `nss_wrapper`
+allows for the container's user ID to be mapped to a username inside of a container.
+
+### Example Usage
+
+You can override the container's current user ID and group ID by providing `NSS_WRAPPER_GROUP`
+and `NSS_WRAPPER_PASSWD` for the mock files, as well as `NSS_USERNAME`, `NSS_UID`, `NSS_GROUPNAME`,
+and/or `NSS_GID`. In OpenShift CI, `NSS_USERNAME` and `NSS_GROUPNAME` are set.
+The random UID assigned to the container is the UID that the mock username is mapped to.
+
+```console
+$ podman run --rm \
+>   -e NSS_WRAPPER_GROUP=/tmp/group \
+>   -e NSS_WRAPPER_PASSWD=/tmp/passwd \
+>   -e NSS_UID=1000 \
+>   -e NSS_GID=1000 \
+>   -e NSS_USERNAME=testuser \
+>   -e NSS_GROUPNAME=testuser \
+>   nss_wrapper_img mock-nss.sh id testuser
+uid=1000(testuser) gid=1000(testuser) groups=1000(testuser)
+```
+
+Or, in an OpenShift container:
+
+```yaml
+containers:
+- name: setup
+  image: nss-wrapper-image
+  env:
+  - name: NSS_WRAPPER_PASSWD
+    value: /tmp/passwd
+  - name: NSS_WRAPPER_GROUP
+    value: /tmp/group
+  - name: NSS_USERNAME
+    value: mockuser
+  - name: NSS_GROUPNAME
+    value: mockuser
+  command:
+  - /bin/sh
+  - -c
+  - |
+    #!/bin/sh
+    mock-nss.sh openshift-install <args>
+```

--- a/images/libvirt/google-cloud-sdk.repo
+++ b/images/libvirt/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/images/libvirt/mock-nss.sh
+++ b/images/libvirt/mock-nss.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# mock passwd and group files
+(
+  exec 2>/dev/null
+  username="${NSS_USERNAME:-$(id -un)}"
+  uid="${NSS_UID:-$(id -u)}"
+
+  groupname="${NSS_GROUPNAME:-$(id -gn)}"
+  gid="${NSS_GID:-$(id -g)}"
+
+  echo "${username}:x:${uid}:${uid}:gecos:${HOME}:/bin/bash" > "${NSS_WRAPPER_PASSWD}"
+  echo "${groupname}:x:${gid}:" > "${NSS_WRAPPER_GROUP}"
+)
+
+# wrap command
+export LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+exec "$@"


### PR DESCRIPTION
The current nested-libvirt CI image is capable of provisioning libvirt clusters by creating a GCE VM instance that has all of the libvirt dependencies and using it as a hypervisor. This new image supports that workflow as well as providing the dependencies for running a libvirt installation against a remote libvirt service hosted on external hardware. This requires access to the libvirt client locally, which the nested libvirt image did not provide.