### PR TITLE
pkg/terraform/exec/plugins: Switch to Azure 1.27.1 fork with Azure fixes

### DIFF
--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -28,7 +28,7 @@
   version = "v0.4.12"
 
 [[projects]]
-  digest = "1:8021e3abefedd67a86d9653d9d0c8a3233f3f8877557b893f0a7a78dbdc6f02a"
+  digest = "1:01b10cea3bf227c7617f26d9a080e47b27410a73ca01dffdcac0d36cfdf74af2"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "profiles/2017-03-09/resources/mgmt/resources",
@@ -97,8 +97,9 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "f0ff339f1297d3374fc36bcbfc7d1bbba045d992"
-  version = "v26.7.0"
+  revision = "07077554785f058c92843966f12d8b0cd3f8679d"
+  source = "https://github.com/openshift/azure-sdk-for-go"
+  version = "v26.7.1-openshift"
 
 [[projects]]
   digest = "1:90c9fd5fc13d2dc42520c321202481506f660e58ec9e2c546d2cc5304d7bba78"
@@ -885,7 +886,7 @@
   version = "v2.10.0"
 
 [[projects]]
-  digest = "1:95e2fb03b69a29c7f843830c392f684f110da8ca83649c821c20bad61d9116b5"
+  digest = "1:78f3ea27f70c476e8c05f82dd96dcd662527d68e9967a6d5ac89aad44604b7a0"
   name = "github.com/terraform-providers/terraform-provider-azurerm"
   packages = [
     "azurerm",
@@ -900,8 +901,9 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "05662fd82a299fff148a6a31cc9c2ba9b5841064"
-  version = "v1.27.1"
+  revision = "7bc287e956632e40076a4deb227ec42108be9fb0"
+  source = "https://github.com/openshift/terraform-provider-azurerm"
+  version = "v1.27.2-openshift"
 
 [[projects]]
   digest = "1:2daa3bddc630ead813a47149cdc429816c43f9423a7d6e2aeff7ca794b072548"

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -46,7 +46,13 @@ ignored = [
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-azurerm"
-  version = "=1.27.1"
+  source = "https://github.com/openshift/terraform-provider-azurerm"
+  version = "=v1.27.2-openshift"
+
+[[constraint]]
+  name = "github.com/Azure/azure-sdk-for-go"
+  source = "https://github.com/openshift/azure-sdk-for-go"
+  version = "=v26.7.1-openshift"
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-google"
@@ -63,10 +69,6 @@ ignored = [
 [[override]]
   name = "github.com/oVirt/terraform-provider-master"
   branch = "master"
-
-[[override]]
-  name = "github.com/Azure/azure-sdk-for-go"
-  version = "26.7.0"
 
 [[override]]
   name = "github.com/hashicorp/go-azure-helpers"

--- a/pkg/terraform/exec/plugins/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network/loadbalancers.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network/loadbalancers.go
@@ -79,7 +79,7 @@ func (client LoadBalancersClient) CreateOrUpdatePreparer(ctx context.Context, re
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-04-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -241,7 +241,7 @@ func (client LoadBalancersClient) GetPreparer(ctx context.Context, resourceGroup
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-04-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/pkg/terraform/exec/plugins/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network/models.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network/models.go
@@ -12772,6 +12772,8 @@ type FrontendIPConfigurationPropertiesFormat struct {
 	LoadBalancingRules *[]SubResource `json:"loadBalancingRules,omitempty"`
 	// PrivateIPAddress - The private IP address of the IP configuration.
 	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+	// PrivateIPAddressVersion - The private IP address version of the IP configuration.
+	PrivateIPAddressVersion *string `json:"privateIPAddressVersion,omitempty"`
 	// PrivateIPAllocationMethod - The Private IP allocation method. Possible values are: 'Static' and 'Dynamic'. Possible values include: 'Static', 'Dynamic'
 	PrivateIPAllocationMethod IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
 	// Subnet - The reference of the subnet resource.

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_subnet.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_subnet.go
@@ -31,6 +31,12 @@ func dataSourceArmSubnet() *schema.Resource {
 				Computed: true,
 			},
 
+			"address_prefixes": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+
 			"network_security_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -81,7 +87,18 @@ func dataSourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("virtual_network_name", virtualNetworkName)
 
 	if props := resp.SubnetPropertiesFormat; props != nil {
-		d.Set("address_prefix", props.AddressPrefix)
+		if props.AddressPrefix != nil {
+			d.Set("address_prefix", props.AddressPrefix)
+		}
+		if props.AddressPrefixes == nil {
+			if props.AddressPrefix != nil && len(*props.AddressPrefix) > 0 {
+				d.Set("address_prefixes", []string{*props.AddressPrefix})
+			} else {
+				d.Set("address_prefixes", []string{})
+			}
+		} else {
+			d.Set("address_prefixes", props.AddressPrefixes)
+		}
 
 		if props.NetworkSecurityGroup != nil {
 			d.Set("network_security_group_id", props.NetworkSecurityGroup.ID)

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_loadbalancer.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_loadbalancer.go
@@ -74,6 +74,17 @@ func resourceArmLoadBalancer() *schema.Resource {
 							ValidateFunc: validate.IPv4AddressOrEmpty,
 						},
 
+						"private_ip_address_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  string(network.IPv4),
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.IPv4),
+								string(network.IPv6),
+							}, false),
+						},
+
 						"public_ip_address_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -305,6 +316,10 @@ func expandAzureRmLoadBalancerFrontendIpConfigurations(d *schema.ResourceData) *
 			properties.PrivateIPAddress = &v
 		}
 
+		if v := data["private_ip_address_version"].(string); v != "" {
+			properties.PrivateIPAddressVersion = &v
+		}
+
 		if v := data["public_ip_address_id"].(string); v != "" {
 			properties.PublicIPAddress = &network.PublicIPAddress{
 				ID: &v,
@@ -359,6 +374,10 @@ func flattenLoadBalancerFrontendIpConfiguration(ipConfigs *[]network.FrontendIPC
 
 			if pip := props.PrivateIPAddress; pip != nil {
 				ipConfig["private_ip_address"] = *pip
+			}
+
+			if pip := props.PrivateIPAddressVersion; pip != nil {
+				ipConfig["private_ip_address_version"] = *pip
 			}
 
 			if pip := props.PublicIPAddress; pip != nil {

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_public_ip.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_public_ip.go
@@ -164,12 +164,6 @@ func resourceArmPublicIpCreateUpdate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Either `allocation_method` or `public_ip_address_allocation` must be specified.")
 	}
 
-	if strings.EqualFold(string(ipVersion), string(network.IPv6)) {
-		if strings.EqualFold(ipAllocationMethod, "static") {
-			return fmt.Errorf("Cannot specify publicIpAllocationMethod as Static for IPv6 PublicIp")
-		}
-	}
-
 	if strings.EqualFold(sku, "standard") {
 		if !strings.EqualFold(ipAllocationMethod, "static") {
 			return fmt.Errorf("Static IP allocation must be used when creating Standard SKU public IP addresses.")

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_subnet.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_subnet.go
@@ -39,8 +39,17 @@ func resourceArmSubnet() *schema.Resource {
 			},
 
 			"address_prefix": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Deprecated:    "Use the `address_prefixes` property instead.",
+				ConflictsWith: []string{"address_prefixes"},
+			},
+
+			"address_prefixes": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"address_prefix"},
 			},
 
 			"network_security_group_id": {
@@ -142,14 +151,31 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	addressPrefix := d.Get("address_prefix").(string)
+	var prefixSet bool
+	properties := network.SubnetPropertiesFormat{}
+	if value, ok := d.GetOk("address_prefixes"); ok {
+		var addressPrefixes []string
+		for _, item := range value.([]interface{}) {
+			addressPrefixes = append(addressPrefixes, item.(string))
+		}
+		properties.AddressPrefixes = &addressPrefixes
+		prefixSet = len(addressPrefixes) > 0
+	}
+	if value, ok := d.GetOk("address_prefix"); ok {
+		addressPrefix := value.(string)
+		properties.AddressPrefix = &addressPrefix
+		prefixSet = len(addressPrefix) > 0
+	}
+	if properties.AddressPrefixes != nil && len(*properties.AddressPrefixes) == 1 {
+		properties.AddressPrefix = &(*properties.AddressPrefixes)[0]
+		properties.AddressPrefixes = nil
+	}
+	if !prefixSet {
+		return fmt.Errorf("[ERROR] either address_prefix or address_prefixes is required")
+	}
 
 	azureRMLockByName(vnetName, virtualNetworkResourceName)
 	defer azureRMUnlockByName(vnetName, virtualNetworkResourceName)
-
-	properties := network.SubnetPropertiesFormat{
-		AddressPrefix: &addressPrefix,
-	}
 
 	if v, ok := d.GetOk("network_security_group_id"); ok {
 		nsgId := v.(string)
@@ -245,7 +271,18 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("virtual_network_name", vnetName)
 
 	if props := resp.SubnetPropertiesFormat; props != nil {
-		d.Set("address_prefix", props.AddressPrefix)
+		if props.AddressPrefix != nil {
+			d.Set("address_prefix", props.AddressPrefix)
+		}
+		if props.AddressPrefixes == nil {
+			if props.AddressPrefix != nil && len(*props.AddressPrefix) > 0 {
+				d.Set("address_prefixes", []string{*props.AddressPrefix})
+			} else {
+				d.Set("address_prefixes", []string{})
+			}
+		} else {
+			d.Set("address_prefixes", props.AddressPrefixes)
+		}
 
 		var securityGroupId *string
 		if props.NetworkSecurityGroup != nil {


### PR DESCRIPTION
The azurerm provider does not fully support IPv6. Until that time, switch
to a fork of the provider based on 1.27.1 plus three specific fixes that
allow dual stack configuration on Azure.

When we switch to newer azurerm/terraform, we can drop these. To do Azure
CI, we need these changes.