### PR TITLE
OpenStack: Add support to user provided subnet pool

### DIFF
--- a/upi/openstack/02_network.yaml
+++ b/upi/openstack/02_network.yaml
@@ -62,6 +62,20 @@
       tags: "{{ [cluster_id_tag] }}"
     when: os_networking_type == "Kuryr"
 
+  - name: 'Create pods subnet pool'
+    os_create_subnet_pool:
+      name: "{{ subnet_pool }}"
+      prefix_lenght: "{{ host_prefix }}"
+      prefixes: "{{ cluster_network_cidrs }}"
+    when: os_networking_type == "Kuryr"
+
+  - name: 'Set subnet pool tag'
+    os_tag:
+      resource: "subnet_pool"
+      name: "{{ subnet_pool }}"
+      tags: "{{ [cluster_id_tag] }}"
+    when: os_networking_type == "Kuryr"
+
   - name: 'Create external router'
     os_router:
       name: "{{ os_router }}"

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -17,6 +17,10 @@ all:
       # Service subnet cidr
       svc_subnet_range: '172.30.0.0/16'
       os_svc_network_range: '172.30.0.0/15'
+      # Subnet pool prefixes
+      cluster_network_cidrs: ['10.128.0.0/14']
+      # Subnet pool prefix length
+      host_prefix: '23'
 
       os_region_name: ''
       # Name of the SDN.

--- a/upi/openstack/library/os_create_subnet_pool.py
+++ b/upi/openstack/library/os_create_subnet_pool.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2019 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+DOCUMENTATION = '''
+---
+module: os_create_subnet_pool
+short_description: Create a subnet pool
+description:
+    - Create a subnet pool
+options:
+   name:
+     description:
+       - name of the new subnet pool
+     required: true
+   prefix_len:
+     description:
+        - subnet pool default prefix length
+   prefixes:
+     description:
+        - subnet pool prefixes
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
+
+
+def main():
+    ''' Main module function '''
+    argument_spec = openstack_full_argument_spec(
+        name=dict(type='str', required=True),
+        prefix_lenght=dict(type='str'),
+        prefixes=dict(type=list))
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    name = module.params['name']
+    prefix_lenght = module.params['prefix_lenght']
+    prefixes = module.params['prefixes']
+
+    sdk, cloud = openstack_cloud_from_module(module)
+    try:
+        subnet_pool = cloud.network.find_subnet_pool(name_or_id=name)
+        if not subnet_pool:
+            cloud.network.create_subnet_pool(
+                name=name, default_prefixlen=prefix_lenght, prefixes=prefixes)
+            module.exit_json(changed=True)
+    except sdk.exceptions.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+    module.exit_json(
+        changed=False)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Update UPI playbook to account for user provided subnet pool
for pods when Kuryr SDN is used.

Depends on: #2746 