### PR TITLE
Bug 1791332: rhcos: Bump to 43.81.202001142154.0 for signed packages

### DIFF
--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,135 +1,135 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-09fb22ddd0a4d86f2"
+            "hvm": "ami-023d0452866845125"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0bd75e87c8a0229ef"
+            "hvm": "ami-0ba4f9a0358bcb44a"
         },
         "ap-south-1": {
-            "hvm": "ami-04a55167c7065a0a6"
+            "hvm": "ami-0bf62e963a473068e"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0979dcb0b79be432d"
+            "hvm": "ami-086b93722336bd1d9"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0cf719e1822121ccd"
+            "hvm": "ami-08929f33bfab49b83"
         },
         "ca-central-1": {
-            "hvm": "ami-06b2751401d0229ef"
+            "hvm": "ami-0f6d943a1fa9172fd"
         },
         "eu-central-1": {
-            "hvm": "ami-00ce664ca5dd298d4"
+            "hvm": "ami-0ceea534b63224411"
         },
         "eu-north-1": {
-            "hvm": "ami-01baea7a52221ca2b"
+            "hvm": "ami-06b7087b2768f644a"
         },
         "eu-west-1": {
-            "hvm": "ami-02418a8f4534a08a9"
+            "hvm": "ami-0e95125b57fa63b0d"
         },
         "eu-west-2": {
-            "hvm": "ami-00fe5bf7f0d02c08e"
+            "hvm": "ami-0eef98c447b85ffcd"
         },
         "eu-west-3": {
-            "hvm": "ami-04fd6a21a13ffd73d"
+            "hvm": "ami-0049e16104f360df6"
         },
         "me-south-1": {
-            "hvm": "ami-0fd3f43a89802c558"
+            "hvm": "ami-0b03ea038629fd02e"
         },
         "sa-east-1": {
-            "hvm": "ami-0b415086648b5d98c"
+            "hvm": "ami-0c80d785b30eef121"
         },
         "us-east-1": {
-            "hvm": "ami-0a58856038f0167b4"
+            "hvm": "ami-06f85a7940faa3217"
         },
         "us-east-2": {
-            "hvm": "ami-0f19a46f50c57e5f5"
+            "hvm": "ami-04a79d8d7cfa540cc"
         },
         "us-west-1": {
-            "hvm": "ami-02ac88fd3e5a38506"
+            "hvm": "ami-0633b392e8eff25e7"
         },
         "us-west-2": {
-            "hvm": "ami-0f695539ddb4c2d71"
+            "hvm": "ami-0d231993dddc5cd2e"
         }
     },
     "azure": {
-        "image": "rhcos-43.81.202001141554.0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-43.81.202001141554.0-azure.x86_64.vhd"
+        "image": "rhcos-43.81.202001142154.0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-43.81.202001142154.0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.202001141554.0/x86_64/",
-    "buildid": "43.81.202001141554.0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.202001142154.0/x86_64/",
+    "buildid": "43.81.202001142154.0",
     "gcp": {
-        "image": "rhcos-43-81-202001141554-0",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/43.81.202001141554.0.tar.gz"
+        "image": "rhcos-43-81-202001142154-0",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/43.81.202001142154.0.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-43.81.202001141554.0-aws.x86_64.vmdk.gz",
-            "sha256": "45d3d7acc8efcc2554835330b3b5f4e09c6315dba6338a3e75a7b30c37cdacf1",
-            "size": 813088211,
-            "uncompressed-sha256": "ad69a444f9ebaef63ecdc99b3820b84b7f32797bcbf2fb53561819b1f9505f27",
-            "uncompressed-size": 829384192
+            "path": "rhcos-43.81.202001142154.0-aws.x86_64.vmdk.gz",
+            "sha256": "d1436d2fb0bf19ea13e90b2e3a459441f0145a914fdd32c2ef09836372667035",
+            "size": 813199011,
+            "uncompressed-sha256": "1549d5dceacddf7b0955d372a19e7d49747aed77c06a3a8daa16a3fb401847cf",
+            "uncompressed-size": 829533184
         },
         "azure": {
-            "path": "rhcos-43.81.202001141554.0-azure.x86_64.vhd.gz",
-            "sha256": "8437c035dcf2bc20408f37aa26365f3f1d2d7c9fc3c488a56bcaa891fa8c0f0e",
-            "size": 800068631,
-            "uncompressed-sha256": "46e8b1c80c5cc427efb7b539a94623ed96214a3389296dd7642f35630234ff8e",
+            "path": "rhcos-43.81.202001142154.0-azure.x86_64.vhd.gz",
+            "sha256": "5011e20132838daabb218c9722700fffac6a25b744132e93d2dc6b0091a7c04c",
+            "size": 800063766,
+            "uncompressed-sha256": "fe82be89aa8eae7434ea4c8af9a5b5c85d10148a1dc3301b96d72704562b9208",
             "uncompressed-size": 2179508224
         },
         "gcp": {
-            "path": "rhcos-43.81.202001141554.0-gcp.x86_64.tar.gz",
-            "sha256": "42e81e6dc1b7e1d799dff1163384c8a56a0ccc1de0782136ba63a13f96ddb244",
-            "size": 799676766
+            "path": "rhcos-43.81.202001142154.0-gcp.x86_64.tar.gz",
+            "sha256": "5173ba725ad867a743f423eafbd8fc476f833d69163edef6fa08d5b63d6de505",
+            "size": 799655869
         },
         "initramfs": {
-            "path": "rhcos-43.81.202001141554.0-installer-initramfs.x86_64.img",
-            "sha256": "c5904a50404529db6ed830deacae0c1a5a87dbd6ef800af09aca0449ca5735f8"
+            "path": "rhcos-43.81.202001142154.0-installer-initramfs.x86_64.img",
+            "sha256": "3389babec8afc37023d122efba7785c3aea7797c9b4a038e98a9b90aacef1483"
         },
         "iso": {
-            "path": "rhcos-43.81.202001141554.0-installer.x86_64.iso",
-            "sha256": "eb3e59922bb33bdecb7659d6531b432ac5ec8827ea210b46e1603fe27c45fce6"
+            "path": "rhcos-43.81.202001142154.0-installer.x86_64.iso",
+            "sha256": "302081da24277ed752fee8d69839227f4f24ec71261f9dfe2752ea8c0f20a0ed"
         },
         "kernel": {
-            "path": "rhcos-43.81.202001141554.0-installer-kernel-x86_64",
+            "path": "rhcos-43.81.202001142154.0-installer-kernel-x86_64",
             "sha256": "7ace7ebdb828e1dc4d242b2fb8a360e7b97da7748d2fde4ffa3bd30232c04865"
         },
         "metal": {
-            "path": "rhcos-43.81.202001141554.0-metal.x86_64.raw.gz",
-            "sha256": "601bf58fc39c6acfd30b3ab51104fe07166b9aa62f3940b5eff405dc45f5c7b2",
-            "size": 801439317,
-            "uncompressed-sha256": "556335387398d35b1a37df91445d53970ecd06f30e06451a82e76fcdad26ee07",
+            "path": "rhcos-43.81.202001142154.0-metal.x86_64.raw.gz",
+            "sha256": "a22248455ad8adc95ae208ffebe4bc4afa1d50048807df884cae02bc794d7ea4",
+            "size": 801591981,
+            "uncompressed-sha256": "3643016762b248b079f4239e6f72948ebdb8d73e1fb1601bc666cbb46c0e238f",
             "uncompressed-size": 3340763136
         },
         "openstack": {
-            "path": "rhcos-43.81.202001141554.0-openstack.x86_64.qcow2.gz",
-            "sha256": "ba496b4f3593a77e3a69f31485088037b79951b8ab286bc45e30d64d7d033591",
-            "size": 801551789,
-            "uncompressed-sha256": "5a19241b7de78c4e450e9be23a4fe93a5107be8419ca19068a2d822c0db55972",
-            "uncompressed-size": 2131558400
-        },
-        "ostree": {
-            "path": "rhcos-43.81.202001141554.0-ostree.x86_64.tar",
-            "sha256": "b25d5ebf9198d6fe32ee459ebcea69dea0264f497b38abee94d3b8dd4874d9c7",
-            "size": 720885760
-        },
-        "qemu": {
-            "path": "rhcos-43.81.202001141554.0-qemu.x86_64.qcow2.gz",
-            "sha256": "40792f8d7c84cc62a278f2add00a7cf0071a03b8175b9324da34290aa2ec453e",
-            "size": 801926141,
-            "uncompressed-sha256": "dd392cb52908f25abe16abdbf9c9a03d572029b4c8c7c0970afff398ff6a3075",
+            "path": "rhcos-43.81.202001142154.0-openstack.x86_64.qcow2.gz",
+            "sha256": "a1bda656fa0892f7b936fdc6b6a6086bddaed5dafacedcd7a1e811abb78fe3b0",
+            "size": 801466080,
+            "uncompressed-sha256": "504b9008adf89bb3d05b75d393e057c6d66ba6c92cf631ca4445d99bbf7e2a57",
             "uncompressed-size": 2131492864
         },
+        "ostree": {
+            "path": "rhcos-43.81.202001142154.0-ostree.x86_64.tar",
+            "sha256": "bc9460975c9a3db1f39428129dab87796dc1d2739c38289c5156ceb710ae1e10",
+            "size": 720916480
+        },
+        "qemu": {
+            "path": "rhcos-43.81.202001142154.0-qemu.x86_64.qcow2.gz",
+            "sha256": "2da72a1eaee005458014cfbab93f77c459b8c63ff110f0d4cbf4c13e7001de68",
+            "size": 801832578,
+            "uncompressed-sha256": "6dbd3513a824cfe6de157e5d86972c2005b23d71bd8b3a61548f7a1f0a516b68",
+            "uncompressed-size": 2131427328
+        },
         "vmware": {
-            "path": "rhcos-43.81.202001141554.0-vmware.x86_64.ova",
-            "sha256": "fe1b5cfad5f66f1ba6a260da526c636f2488f5a6373bc05af9f1c82a230341e3",
-            "size": 829399040
+            "path": "rhcos-43.81.202001142154.0-vmware.x86_64.ova",
+            "sha256": "29b98763bc538ec0b7ad39774b643ef69dc0c0fdad25bd0da3078e54ab86253b",
+            "size": 829542400
         }
     },
     "oscontainer": {
-        "digest": "sha256:a5bfb67fc847e949a018a89c038532f04c992e53f0989c8ac7c8d062c3d3d286",
+        "digest": "sha256:8c4059f184596157f64d69c4edbea9c9ef600560b7804a482779f513c3e0f40e",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "0d52b1c71dce9d69dcea3854af8cc2dfa4ffc31c1681eebcf54114f8160f05e2",
-    "ostree-version": "43.81.202001141554.0"
+    "ostree-commit": "23527ffc123c6e2bedf3479ff7e96f38d92cec88d5a7951fa56e9d0ec75ddd77",
+    "ostree-version": "43.81.202001142154.0"
 }


### PR DESCRIPTION
Signed version of https://github.com/openshift/installer/pull/2914.

/cc @sdodson @jtligon @cuppett @miabbott @crawford 