### PR TITLE
vSphere: fix disk issues in TF, include default CPU & memory

### DIFF
--- a/data/data/vsphere/bootstrap/main.tf
+++ b/data/data/vsphere/bootstrap/main.tf
@@ -16,8 +16,10 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    label = "disk0"
-    size  = 120
+    label            = "disk0"
+    size             = 120
+    eagerly_scrub    = var.scrub_disk
+    thin_provisioned = var.thin_disk
   }
 
   clone {

--- a/data/data/vsphere/bootstrap/variables.tf
+++ b/data/data/vsphere/bootstrap/variables.tf
@@ -38,3 +38,11 @@ variable "tags" {
 variable "cluster_id" {
   type = string
 }
+
+variable "thin_disk" {
+  type = bool
+}
+
+variable "scrub_disk" {
+  type = bool
+}

--- a/data/data/vsphere/main.tf
+++ b/data/data/vsphere/main.tf
@@ -66,6 +66,8 @@ module "bootstrap" {
   datacenter    = data.vsphere_datacenter.datacenter.id
   template      = data.vsphere_virtual_machine.template.id
   guest_id      = data.vsphere_virtual_machine.template.guest_id
+  thin_disk     = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
+  scrub_disk    = data.vsphere_virtual_machine.template.disks.0.eagerly_scrub
 
   cluster_id = var.cluster_id
   tags       = [vsphere_tag.tag.id]
@@ -86,6 +88,8 @@ module "master" {
   datacenter    = data.vsphere_datacenter.datacenter.id
   template      = data.vsphere_virtual_machine.template.id
   guest_id      = data.vsphere_virtual_machine.template.guest_id
+  thin_disk     = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
+  scrub_disk    = data.vsphere_virtual_machine.template.disks.0.eagerly_scrub
   tags          = [vsphere_tag.tag.id]
 
   cluster_domain   = var.cluster_domain

--- a/data/data/vsphere/main.tf
+++ b/data/data/vsphere/main.tf
@@ -88,10 +88,11 @@ module "master" {
   guest_id      = data.vsphere_virtual_machine.template.guest_id
   tags          = [vsphere_tag.tag.id]
 
-  cluster_domain = var.cluster_domain
-  cluster_id     = var.cluster_id
-  memory         = var.control_plane_memory_mib
-  num_cpus       = var.control_plane_num_cpus
-  disk_size      = var.control_plane_disk_gib
+  cluster_domain   = var.cluster_domain
+  cluster_id       = var.cluster_id
+  memory           = var.vsphere_control_plane_memory_mib
+  num_cpus         = var.vsphere_control_plane_num_cpus
+  cores_per_socket = var.vsphere_control_plane_cores_per_socket
+  disk_size        = var.vsphere_control_plane_disk_gib
 }
 

--- a/data/data/vsphere/master/ignition.tf
+++ b/data/data/vsphere/master/ignition.tf
@@ -22,7 +22,7 @@ data "ignition_config" "ign" {
   }
 
   files = [
-    data.ignition_file.hostname[count.index].rendered
+    data.ignition_file.hostname[count.index].id
   ]
 }
 

--- a/data/data/vsphere/master/main.tf
+++ b/data/data/vsphere/master/main.tf
@@ -1,14 +1,15 @@
 resource "vsphere_virtual_machine" "vm" {
   count = var.instance_count
 
-  name             = "${var.cluster_id}-${var.name}-${count.index}"
-  resource_pool_id = var.resource_pool
-  datastore_id     = var.datastore
-  num_cpus         = var.num_cpus
-  memory           = var.memory
-  guest_id         = var.guest_id
-  folder           = var.folder
-  enable_disk_uuid = "true"
+  name                 = "${var.cluster_id}-${var.name}-${count.index}"
+  resource_pool_id     = var.resource_pool
+  datastore_id         = var.datastore
+  num_cpus             = var.num_cpus
+  num_cores_per_socket = var.cores_per_socket
+  memory               = var.memory
+  guest_id             = var.guest_id
+  folder               = var.folder
+  enable_disk_uuid     = "true"
 
   wait_for_guest_net_timeout  = "0"
   wait_for_guest_net_routable = "false"

--- a/data/data/vsphere/master/main.tf
+++ b/data/data/vsphere/master/main.tf
@@ -19,8 +19,10 @@ resource "vsphere_virtual_machine" "vm" {
   }
 
   disk {
-    label = "disk0"
-    size  = var.disk_size
+    label            = "disk0"
+    size             = 120
+    eagerly_scrub    = var.scrub_disk
+    thin_provisioned = var.thin_disk
   }
 
   clone {

--- a/data/data/vsphere/master/variables.tf
+++ b/data/data/vsphere/master/variables.tf
@@ -51,6 +51,10 @@ variable "num_cpus" {
   type = number
 }
 
+variable "cores_per_socket" {
+  type = number
+}
+
 variable "disk_size" {
   type = number
 }

--- a/data/data/vsphere/master/variables.tf
+++ b/data/data/vsphere/master/variables.tf
@@ -67,3 +67,10 @@ variable "cluster_id" {
   type = string
 }
 
+variable "thin_disk" {
+  type = bool
+}
+
+variable "scrub_disk" {
+  type = bool
+}

--- a/data/data/vsphere/variables-vsphere.tf
+++ b/data/data/vsphere/variables-vsphere.tf
@@ -50,14 +50,18 @@ variable "vsphere_folder" {
 // Control Plane machine variables
 ///////////
 
-variable "control_plane_memory_mib" {
+variable "vsphere_control_plane_memory_mib" {
   type = number
 }
 
-variable "control_plane_disk_gib" {
+variable "vsphere_control_plane_disk_gib" {
   type = number
 }
 
-variable "control_plane_num_cpus" {
+variable "vsphere_control_plane_num_cpus" {
+  type = number
+}
+
+variable "vsphere_control_plane_cores_per_socket" {
   type = number
 }

--- a/docs/user/vsphere/customization.md
+++ b/docs/user/vsphere/customization.md
@@ -12,7 +12,11 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 ## Machine pools
 
-There are currently no configurable vSphere-specific machine-pool properties.
+* `osDisk` (optional object):
+    * `diskSizeGB` (optional integer): The size of the disk in gigabytes (GB).
+* `cpus` (optional integer): The total number of virtual processor cores to assign a vm.
+* `coresPerSocket` (optional integer): The number of cores per socket in a vm. The number of vCPUs on the vm will be cpus/coresPerSocket (default is 1).
+* `memoryMB` (optional integer): The size of a VM's memory in megabytes.
 
 ## Examples
 
@@ -26,6 +30,45 @@ An example minimal vSphere install config is:
 ```yaml
 apiVersion: v1
 baseDomain: example.com
+metadata:
+  name: test-cluster
+platform:
+  vSphere:
+    vCenter: your.vcenter.example.com
+    username: username
+    password: password
+    datacenter: datacenter
+    defaultDatastore: datastore
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+### Custom Machine Pools
+
+An example vSphere install config with custom machine pools:
+```yaml
+apiVersion: v1
+baseDomain: example.com
+controlPlane:
+  name: master
+  platform:
+    vsphere:
+      cpus: 8
+      coresPerSocket: 2
+      memoryMB: 24576
+      osDisk:
+        diskSizeGB: 512
+  replicas: 3
+compute:
+- name: worker
+  platform:
+    vsphere:
+      cpus: 8
+      coresPerSocket: 2
+      memoryMB: 24576
+      osDisk:
+        diskSizeGB: 512
+  replicas: 5
 metadata:
   name: test-cluster
 platform:

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -309,6 +309,8 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		}
 	case vspheretypes.Name:
 		mpool := defaultVSphereMachinePoolPlatform()
+		mpool.NumCPUs = 4
+		mpool.MemoryMiB = 16384
 		mpool.Set(ic.Platform.VSphere.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.VSphere)
 		pool.Platform.VSphere = &mpool

--- a/pkg/asset/machines/vsphere/machines.go
+++ b/pkg/asset/machines/vsphere/machines.go
@@ -85,7 +85,10 @@ func provider(clusterID string, platform *vsphere.Platform, mpool *vsphere.Machi
 			Datastore:  platform.DefaultDatastore,
 			Folder:     clusterID,
 		},
-		DiskGiB: mpool.OSDisk.DiskSizeGB,
+		NumCPUs:           mpool.NumCPUs,
+		NumCoresPerSocket: mpool.NumCoresPerSocket,
+		MemoryMiB:         mpool.MemoryMiB,
+		DiskGiB:           mpool.OSDisk.DiskSizeGB,
 	}, nil
 }
 

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -111,6 +111,9 @@ func defaultOvirtMachinePoolPlatform() ovirttypes.MachinePool {
 
 func defaultVSphereMachinePoolPlatform() vspheretypes.MachinePool {
 	return vspheretypes.MachinePool{
+		NumCPUs:           2,
+		NumCoresPerSocket: 1,
+		MemoryMiB:         8192,
 		OSDisk: vspheretypes.OSDisk{
 			DiskSizeGB: 120,
 		},

--- a/pkg/tfvars/vsphere/vsphere.go
+++ b/pkg/tfvars/vsphere/vsphere.go
@@ -7,18 +7,19 @@ import (
 )
 
 type config struct {
-	VSphereURL      string `json:"vsphere_url"`
-	VSphereUsername string `json:"vsphere_username"`
-	VSpherePassword string `json:"vsphere_password"`
-	MemoryMiB       int64  `json:"control_plane_memory_mib"`
-	DiskGiB         int32  `json:"control_plane_disk_gib"`
-	NumCPUs         int32  `json:"control_plane_num_cpus"`
-	Cluster         string `json:"vsphere_cluster"`
-	Datacenter      string `json:"vsphere_datacenter"`
-	Datastore       string `json:"vsphere_datastore"`
-	Folder          string `json:"vsphere_folder"`
-	Network         string `json:"vsphere_network"`
-	Template        string `json:"vsphere_template"`
+	VSphereURL        string `json:"vsphere_url"`
+	VSphereUsername   string `json:"vsphere_username"`
+	VSpherePassword   string `json:"vsphere_password"`
+	MemoryMiB         int64  `json:"vsphere_control_plane_memory_mib"`
+	DiskGiB           int32  `json:"vsphere_control_plane_disk_gib"`
+	NumCPUs           int32  `json:"vsphere_control_plane_num_cpus"`
+	NumCoresPerSocket int32  `json:"vsphere_control_plane_cores_per_socket"`
+	Cluster           string `json:"vsphere_cluster"`
+	Datacenter        string `json:"vsphere_datacenter"`
+	Datastore         string `json:"vsphere_datastore"`
+	Folder            string `json:"vsphere_folder"`
+	Network           string `json:"vsphere_network"`
+	Template          string `json:"vsphere_template"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -34,18 +35,19 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	controlPlaneConfig := sources.ControlPlaneConfigs[0]
 
 	cfg := &config{
-		VSphereURL:      controlPlaneConfig.Workspace.Server,
-		VSphereUsername: sources.Username,
-		VSpherePassword: sources.Password,
-		MemoryMiB:       controlPlaneConfig.MemoryMiB,
-		DiskGiB:         controlPlaneConfig.DiskGiB,
-		NumCPUs:         controlPlaneConfig.NumCPUs,
-		Cluster:         sources.Cluster,
-		Datacenter:      controlPlaneConfig.Workspace.Datacenter,
-		Datastore:       controlPlaneConfig.Workspace.Datastore,
-		Folder:          controlPlaneConfig.Workspace.Folder,
-		Network:         controlPlaneConfig.Network.Devices[0].NetworkName,
-		Template:        controlPlaneConfig.Template,
+		VSphereURL:        controlPlaneConfig.Workspace.Server,
+		VSphereUsername:   sources.Username,
+		VSpherePassword:   sources.Password,
+		MemoryMiB:         controlPlaneConfig.MemoryMiB,
+		DiskGiB:           controlPlaneConfig.DiskGiB,
+		NumCPUs:           controlPlaneConfig.NumCPUs,
+		NumCoresPerSocket: controlPlaneConfig.NumCoresPerSocket,
+		Cluster:           sources.Cluster,
+		Datacenter:        controlPlaneConfig.Workspace.Datacenter,
+		Datastore:         controlPlaneConfig.Workspace.Datastore,
+		Folder:            controlPlaneConfig.Workspace.Folder,
+		Network:           controlPlaneConfig.Network.Devices[0].NetworkName,
+		Template:          controlPlaneConfig.Template,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/vsphere/machinepool.go
+++ b/pkg/types/vsphere/machinepool.go
@@ -3,6 +3,16 @@ package vsphere
 // MachinePool stores the configuration for a machine pool installed
 // on vSphere.
 type MachinePool struct {
+	// NumCPUs is the total number of virtual processor cores to assign a vm.
+	NumCPUs int32 `json:"cpus"`
+
+	// NumCoresPerSocket is the number of cores per socket in a vm. The number
+	// of vCPUs on the vm will be NumCPUs/NumCoresPerSocket.
+	NumCoresPerSocket int32 `json:"coresPerSocket"`
+
+	// Memory is the size of a VM's memory in MB.
+	MemoryMiB int64 `json:"memoryMB"`
+
 	// OSDisk defines the storage for instance.
 	OSDisk `json:"osDisk"`
 }
@@ -17,6 +27,18 @@ type OSDisk struct {
 func (p *MachinePool) Set(required *MachinePool) {
 	if required == nil || p == nil {
 		return
+	}
+
+	if required.NumCPUs != 0 {
+		p.NumCPUs = required.NumCPUs
+	}
+
+	if required.NumCoresPerSocket != 0 {
+		p.NumCoresPerSocket = required.NumCoresPerSocket
+	}
+
+	if required.MemoryMiB != 0 {
+		p.MemoryMiB = required.MemoryMiB
 	}
 
 	if required.OSDisk.DiskSizeGB != 0 {


### PR DESCRIPTION
- updates ignition in vSphere terraform code to use `id` instead of `rendered`, this prevents an error due to the version of the ignition provider used by the installer
- read and use `eagerly_scrub` and `thin_provision` from template to ensure that these settings are not changed after vm creation (causing failures)
- set default resources in tf amd machinesets based on [docs](https://docs.openshift.com/container-platform/4.2/installing/installing_vsphere/installing-vsphere.html#minimum-resource-requirements_installing-vsphere)
- require cluster in platform based on current terraform code, which must use a prexisting cluster

This can be tested in our vsphere dev cluster by hardcoding ` var.vsphere_template` to `rhcos-latest`. ~~and setting `allow_unverified_ssl` to true. I have not been able to get the installer to use the certs even when they are in the system trust.~~