### PR TITLE
Azure: remove unused resources

### DIFF
--- a/data/data/azure/vnet/vnet.tf
+++ b/data/data/azure/vnet/vnet.tf
@@ -7,12 +7,6 @@ resource "azurerm_virtual_network" "cluster_vnet" {
   address_space       = [var.vnet_cidr]
 }
 
-resource "azurerm_route_table" "route_table" {
-  name                = "${var.cluster_id}-node-routetable"
-  location            = var.region
-  resource_group_name = var.resource_group_name
-}
-
 resource "azurerm_subnet" "master_subnet" {
   count = var.preexisting_network ? 0 : 1
 


### PR DESCRIPTION
Remove Azure route table

Azure route table resource is not used anywhere and is not linked to any vnet. It is confusing to end-users and its additional cost in the long run. 