### PR TITLE
Bug 1786268: Set GCP validation to precede domain validation.

### DIFF
--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -29,12 +29,14 @@ func (a *clusterName) Generate(parents asset.Parents) error {
 	platform := &platform{}
 	parents.Get(bd, platform)
 
-	validator := survey.ComposeValidators(survey.Required, func(ans interface{}) error {
-		return validate.DomainName(validation.ClusterDomain(bd.BaseDomain, ans.(string)), false)
-	})
+	validator := survey.Required
+
 	if platform.GCP != nil {
 		validator = survey.ComposeValidators(validator, func(ans interface{}) error { return gcpvalidation.ValidateClusterName(ans.(string)) })
 	}
+	validator = survey.ComposeValidators(validator, func(ans interface{}) error {
+		return validate.DomainName(validation.ClusterDomain(bd.BaseDomain, ans.(string)), false)
+	})
 
 	return survey.Ask([]*survey.Question{
 		{

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -62,11 +62,10 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 		}
 	}
 	nameErr := validate.ClusterName(c.ObjectMeta.Name)
-	if nameErr != nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, nameErr.Error()))
-	}
 	if gcpNameErr := gcpvalidation.ValidateClusterName(c.ObjectMeta.Name); c.Platform.GCP != nil && gcpNameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, gcpNameErr.Error()))
+	} else if nameErr != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, nameErr.Error()))
 	}
 	baseDomainErr := validate.DomainName(c.BaseDomain, true)
 	if baseDomainErr != nil {


### PR DESCRIPTION
When the user chooses to create an install config using the installer console, picks the GCP environment and gives an improper cluster name, the error message that is being displayed now is that the name fails to match the norms of openshift but a better error message is to show that GCP needs the name in a specific format.

Another bug was found when the user loads the install configs with an improper cluster name, both the GCP error message and the openshift error messages were being displayed. Fixed the UI errors.