### PR TITLE
WIP [FCOS] vSphere: update UPI files to tf 1.12

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -34,7 +34,8 @@ RUN curl -L -O https://github.com/poseidon/terraform-provider-matchbox/releases/
     tar xzf terraform-provider-matchbox-${MATCHBOX_VERSION}-linux-amd64.tar.gz && \
     mv terraform-provider-matchbox-${MATCHBOX_VERSION}-linux-amd64/terraform-provider-matchbox /bin/terraform-provider-matchbox
 RUN curl -L -O https://github.com/LorbusChris/terraform-provider-ignition/raw/v2-bin-1/terraform-provider-ignition && \
-    mv terraform-provider-ignition /bin/terraform-provider-ignition
+    chmod +x terraform-provider-ignition && \
+    mv terraform-provider-ignition /bin/terraform-provider-ignition_v2.0.0
 RUN curl -L -O https://github.com/vmware/govmomi/releases/download/v0.21.0/govc_linux_amd64.gz && \
     gzip -d govc_linux_amd64.gz && \
     chmod +x govc_linux_amd64 && mv govc_linux_amd64 /bin/govc

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -26,7 +26,7 @@ RUN yum install --setopt=tsflags=nodocs -y \
     yum clean all && rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 
-ENV TERRAFORM_VERSION=0.12.19
+ENV TERRAFORM_VERSION=0.11.11
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin/
 ENV MATCHBOX_VERSION=v0.3.0

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -34,7 +34,7 @@ RUN curl -L -O https://github.com/poseidon/terraform-provider-matchbox/releases/
     tar xzf terraform-provider-matchbox-${MATCHBOX_VERSION}-linux-amd64.tar.gz && \
     mv terraform-provider-matchbox-${MATCHBOX_VERSION}-linux-amd64/terraform-provider-matchbox /bin/terraform-provider-matchbox
 RUN curl -L -O https://github.com/LorbusChris/terraform-provider-ignition/raw/v2-bin-1/terraform-provider-ignition && \
-    mv terraform-provider-ignition-2 /bin/terraform-provider-ignition
+    mv terraform-provider-ignition /bin/terraform-provider-ignition
 RUN curl -L -O https://github.com/vmware/govmomi/releases/download/v0.21.0/govc_linux_amd64.gz && \
     gzip -d govc_linux_amd64.gz && \
     chmod +x govc_linux_amd64 && mv govc_linux_amd64 /bin/govc

--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -1,5 +1,5 @@
 provider "ignition" {
-  version = "1.1.0"
+  version = "2.0.0"
 }
 
 locals {

--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -72,11 +72,11 @@ data "ignition_config" "ign" {
   }
 
   systemd = [
-    "${data.ignition_systemd_unit.restart.*.id[count.index]}",
+    "${data.ignition_systemd_unit.restart.*.rendered[count.index]}",
   ]
 
   files = [
-    "${data.ignition_file.hostname.*.id[count.index]}",
-    "${data.ignition_file.static_ip.*.id[count.index]}",
+    "${data.ignition_file.hostname.*.rendered[count.index]}",
+    "${data.ignition_file.static_ip.*.rendered[count.index]}",
   ]
 }


### PR DESCRIPTION
See https://github.com/openshift/installer/pull/2952#issuecomment-576450372

Current issues:
* ~~[x] Update code to tf 0.12~~
* ~~[ ] Fix `No instance found for the given address!` for `terraform state show 'module.bootstrap.external.ip_address'` call~~
* [x] Use terraform 0.11
* [ ] Find out why worker.ign and master.ign don't have external API endpoint set