### PR TITLE
docs/user/customization: Fix 'clusterNetworks' -> 'clusterNetwork'

### DIFF
--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -137,7 +137,7 @@ baseDomain: example.com
 metadata:
   name: test-cluster
 networking:
-  clusterNetworks:
+  clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:


### PR DESCRIPTION
The plural form was deprecated in 2e7ecd3ab3 (#1356).