### PR TITLE
Bug 1784322: Added Azure validation for cluster names

### DIFF
--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -4,6 +4,7 @@ import (
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/asset"
+	azurevalidation "github.com/openshift/installer/pkg/types/azure/validation"
 	gcpvalidation "github.com/openshift/installer/pkg/types/gcp/validation"
 	"github.com/openshift/installer/pkg/types/validation"
 	"github.com/openshift/installer/pkg/validate"
@@ -33,6 +34,8 @@ func (a *clusterName) Generate(parents asset.Parents) error {
 
 	if platform.GCP != nil {
 		validator = survey.ComposeValidators(validator, func(ans interface{}) error { return gcpvalidation.ValidateClusterName(ans.(string)) })
+	} else if platform.Azure != nil {
+		validator = survey.ComposeValidators(validator, func(ans interface{}) error { return azurevalidation.ValidateClusterName(ans.(string)) })
 	}
 	validator = survey.ComposeValidators(validator, func(ans interface{}) error {
 		return validate.DomainName(validation.ClusterDomain(bd.BaseDomain, ans.(string)), false)

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -1,9 +1,13 @@
 package validation
 
 import (
+	"regexp"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // ValidatePlatform checks that the specified platform is valid.
@@ -40,4 +44,15 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 		}
 	}
 	return allErrs
+}
+
+// ValidateClusterName confirms that the provided cluster name matches Azure naming requirements.
+func ValidateClusterName(clusterName string) error {
+	azureResourceFmt := `[a-z][a-z0-9-]{1,61}[a-z0-9]`
+
+	re := regexp.MustCompile("^" + azureResourceFmt + "$")
+	if !re.MatchString(clusterName) {
+		return errors.Errorf("Azure requires cluster name to match regular expression %s", azureResourceFmt)
+	}
+	return nil
 }

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -65,6 +65,8 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 	nameErr := validate.ClusterName(c.ObjectMeta.Name)
 	if gcpNameErr := gcpvalidation.ValidateClusterName(c.ObjectMeta.Name); c.Platform.GCP != nil && gcpNameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, gcpNameErr.Error()))
+	} else if azureNameErr := azurevalidation.ValidateClusterName(c.ObjectMeta.Name); c.Platform.Azure != nil && azureNameErr != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, azureNameErr.Error()))
 	} else if nameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, nameErr.Error()))
 	}


### PR DESCRIPTION
The Azure platform requires a specific format for the names of the clusters which was not present in the installer. Added the checks during both the creation and loading of the install config files to check for Azure validation specifically before trying to create the cluster on Azure if the user chooses said cloud platform.

@patrickdillon 