### PR TITLE
Bug 1793627: gcp destroy: handle nil when evaluating dns response

### DIFF
--- a/pkg/destroy/gcp/dns.go
+++ b/pkg/destroy/gcp/dns.go
@@ -87,10 +87,11 @@ func (o *ClusterUninstaller) deleteDNSZoneRecordSets(zoneName string, zoneDomain
 		o.resetRequestID("recordsets", zoneName)
 		return errors.Wrapf(err, "failed to delete DNS zone %s recordsets", zoneName)
 	}
-	if isErrorStatus(int64(change.ServerResponse.HTTPStatusCode)) {
+	if change != nil && isErrorStatus(int64(change.ServerResponse.HTTPStatusCode)) {
 		o.resetRequestID("recordsets", zoneName)
 		return errors.Errorf("failed to delete DNS zone %s recordsets with code: %d", zoneName, change.ServerResponse.HTTPStatusCode)
 	}
+	o.resetRequestID("recordsets", zoneName)
 	o.Logger.Infof("Deleted %d recordset(s) in zone %s", len(change.Deletions), zoneName)
 	return nil
 }


### PR DESCRIPTION
Previously, gcp destroy of dns records evaluated the response from
the dnsSvc.Changes.Create() call. However, sometimes this function
returns nil without returning an error. As a result, the installer
encountered 'panic: runtime error: invalid memory address or nil
pointer dereference'.

This change checks for a nil value before trying to evaluate the
returned object and returns an approperiate error.