### PR TITLE
VSphere: add dhclient.conf & require cluster in install config

### DIFF
--- a/data/data/bootstrap/vsphere/files/etc/dhcp/dhclient.conf
+++ b/data/data/bootstrap/vsphere/files/etc/dhcp/dhclient.conf
@@ -1,0 +1,7 @@
+# Specifies that the bootstrap node should use its own local DNS server for
+# name resolution.
+#
+# For more information, see installer/data/data/bootstrap/baremetal/README.md
+#
+
+prepend domain-name-servers 127.0.0.1;

--- a/pkg/asset/manifests/operators_test.go
+++ b/pkg/asset/manifests/operators_test.go
@@ -48,6 +48,7 @@ func TestRedactedInstallConfig(t *testing.T) {
 			},
 			Platform: types.Platform{
 				VSphere: &vspheretypes.Platform{
+					Cluster:          "test-cluster",
 					VCenter:          "test-server-1",
 					Username:         "test-user-1",
 					Password:         "test-pass-1",
@@ -84,6 +85,7 @@ networking:
   - 1.2.3.4/5
 platform:
   vsphere:
+    cluster: test-cluster
     datacenter: test-datacenter
     defaultDatastore: test-datastore
     password: ""

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -86,6 +86,7 @@ func validVSpherePlatform() *vsphere.Platform {
 		Password:         "test-password",
 		Datacenter:       "test-datacenter",
 		DefaultDatastore: "test-datastore",
+		Cluster:          "test-cluster",
 	}
 }
 

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -22,7 +22,7 @@ type Platform struct {
 	Folder string `json:"folder,omitempty"`
 
 	// Cluster is the name of the cluster virtual machines will be cloned into.
-	Cluster string `json:"cluster,omitempty"`
+	Cluster string `json:"cluster"`
 
 	// ClusterOSImage overrides the url provided in rhcos.json to download the RHCOS OVA
 	ClusterOSImage string `json:"clusterOSImage,omitempty"`

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -41,5 +41,8 @@ func ValidatePlatform(p *vsphere.Platform, fldPath *field.Path) field.ErrorList 
 		}
 	}
 
+	if len(p.Cluster) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("cluster"), "must specify the cluster"))
+	}
 	return allErrs
 }

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -16,6 +16,7 @@ func validPlatform() *vsphere.Platform {
 		Password:         "test-password",
 		Datacenter:       "test-datacenter",
 		DefaultDatastore: "test-datastore",
+		Cluster:          "test-cluster",
 	}
 }
 
@@ -73,6 +74,15 @@ func TestValidatePlatform(t *testing.T) {
 				return p
 			}(),
 			expectedError: `^test-path\.defaultDatastore: Required value: must specify the default datastore$`,
+		},
+		{
+			name: "missing cluster",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.Cluster = ""
+				return p
+			}(),
+			expectedError: `^test-path\.cluster: Required value: must specify the cluster$`,
 		},
 		{
 			name: "valid VIPs",

--- a/upi/vsphere/README.md
+++ b/upi/vsphere/README.md
@@ -23,6 +23,7 @@ platform:
     password: YOUR_VSPHERE_PASSWORD
     datacenter: dc1
     defaultDatastore: nvme-ds1
+    cluster: devel
 pullSecret: YOUR_PULL_SECRET
 sshKey: YOUR_SSH_KEY
 ```


### PR DESCRIPTION
This pull request ties up a couple of loose threads with VSphere IPI.

Adds the missing dhclient.conf file for bootstrap to use its own dns server. This was originally @jcpowermac's work. 

A bit more substantial is requiring the `cluster` field in the `install-config.yaml`. As part of the TF config we are reading in a cluster resource, so if the name of a cluster is not supplied, TF will crash. 

There is a related PR to update the VSphere UPI job to supply the newly required field: openshift/release#6836.

/cc jcpowermac
/cc mtnbikenc