### PR TITLE
bootkube.sh.template: stop gcp-routes.service after cvo-bootstrap

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -375,12 +375,16 @@ rm --force /etc/kubernetes/manifests/machineconfigoperator-bootstrap-pod.yaml
 
 echo "Starting cluster-bootstrap..."
 
-bootkube_podman_run \
-	--rm \
-	--volume "$PWD:/assets:z" \
-	--volume /etc/kubernetes:/etc/kubernetes:z \
-	"${CLUSTER_BOOTSTRAP_IMAGE}" \
-	start --tear-down-early=false --asset-dir=/assets --required-pods="openshift-kube-apiserver/kube-apiserver,openshift-kube-scheduler/openshift-kube-scheduler,openshift-kube-controller-manager/kube-controller-manager,openshift-cluster-version/cluster-version-operator"
+if [ ! -f cb-bootstrap.done ]
+then
+    bootkube_podman_run \
+        --rm \
+        --volume "$PWD:/assets:z" \
+        --volume /etc/kubernetes:/etc/kubernetes:z \
+        "${CLUSTER_BOOTSTRAP_IMAGE}" \
+        start --tear-down-early=false --asset-dir=/assets --required-pods="openshift-kube-apiserver/kube-apiserver,openshift-kube-scheduler/openshift-kube-scheduler,openshift-kube-controller-manager/kube-controller-manager,openshift-cluster-version/cluster-version-operator"
+    touch cb-bootstrap.done
+fi
 
 if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
 then

--- a/data/data/bootstrap/gcp/files/usr/local/bin/report-progress.sh
+++ b/data/data/bootstrap/gcp/files/usr/local/bin/report-progress.sh
@@ -9,11 +9,14 @@ wait_for_existance() {
 	done
 }
 
-echo "Waiting for bootstrap to complete..."
-wait_for_existance /opt/openshift/.bootkube.done
+echo "Waiting for cb-bootstrap to complete..."
+wait_for_existance /opt/openshift/cb-bootstrap.done
 
 ## remove the routes setup so that we can open up the blackhole
 systemctl stop gcp-routes.service
+
+echo "Waiting for bootstrap to complete..."
+wait_for_existance /opt/openshift/.bootkube.done
 
 echo "Reporting install progress..."
 while ! oc --config="$KUBECONFIG" create -f - <<-EOF


### PR DESCRIPTION
In order for the [call](https://github.com/openshift/installer/blob/b385f165cea0c7340742423df0c9b433ff76dca6/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L396) to the controle plane api work on gcp,
the gcp-routes.service needs to be stopped.