### PR TITLE
VSphere: Rename keys in vsphere creds

### DIFF
--- a/data/data/manifests/openshift/cloud-creds-secret.yaml.template
+++ b/data/data/manifests/openshift/cloud-creds-secret.yaml.template
@@ -33,8 +33,8 @@ data:
   clouds.yaml: {{.CloudCreds.OpenStack.Base64encodeCloudCreds}}
   clouds.conf: {{.CloudCreds.OpenStack.Base64encodeCloudCredsINI}}
 {{- else if .CloudCreds.VSphere}}
-  {{.CloudCreds.VSphere.VCenter}}.username: {{.CloudCreds.VSphere.Base64encodeUsername}}
-  {{.CloudCreds.VSphere.VCenter}}.password: {{.CloudCreds.VSphere.Base64encodePassword}}
+  user: {{.CloudCreds.VSphere.Base64encodeUsername}}
+  password: {{.CloudCreds.VSphere.Base64encodePassword}}
 {{- else if .CloudCreds.Ovirt}}
   ovirt_url: {{.CloudCreds.Ovirt.Base64encodeURL}}
   ovirt_username: {{.CloudCreds.Ovirt.Base64encodeUsername}}


### PR DESCRIPTION
Currently we have a bug, because [the machine api expects the credentials to be in a different format](https://github.com/openshift/machine-api-operator/pull/447/files#diff-42dc9a958b3b7e91e9e10e4bb47ac66fR96-R109). 

This changes the vsphere-creds secret from having variable fields names to having static fields in the expected format.

Instead of, for example:
```
vcsa.vmware.devcluster.openshift.com.username: me
vcsa.vmware.devcluster.openshift.com.password: secret
```
We now have:
```
user: me
password: secret
```
I do not know whether VSphere has any dependencies on the format I am changing, or whether this is our desired format, so I decided to open this PR to discuss.
/cc @jcpowermac 
/cc @staebler 