### PR TITLE
Bug 1796996: baremetal: map hardware profile to baremetal-operator default

### DIFF
--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -2,6 +2,7 @@ package baremetal
 
 import (
 	"fmt"
+	"github.com/metal3-io/baremetal-operator/pkg/hardware"
 
 	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -51,6 +52,11 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 			},
 		}
 		settings.Secrets = append(settings.Secrets, secret)
+
+		// Map string 'default' to hardware.DefaultProfileName
+		if host.HardwareProfile == "default" {
+			host.HardwareProfile = hardware.DefaultProfileName
+		}
 
 		newHost := baremetalhost.BareMetalHost{
 			TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
We rely on vendored baremetal-operator code to handle various
information about baremetal servers including BMC credentials and
hardware profiles. The BMO uses the string 'unknown' as
`hardware.DefaultProfileName`.

As these string values are exposed to the user in the baremetal platform
as part of the install-config, it felt awkward if a user wanted to
explicitly use the default hardware profile to have to write the string
'unknown'. In golang, people are generally just writing the constant,
'hardware.DefaultProfileName`. So, in the terraform variables, we mapped
the string value 'default' to mean that, but it wasn't done for creating
the machines for workers.

Now that you can deploy workers during installation as a day-1
operation, if you specify the string  'default' for workers, they get
stuck in the 'match profile' state of the BMO. Keep in mind, these
baremetalhosts are all defined in the 'hosts' section of the install
config, but the profiles are now working differently depending on
whether it's part of the control plane (i.e. created by terraform) or
not.

This PR ensures the behavior is the same in both instances, so you can
use the string 'default' for workers and masters.

fixes #2705