### PR TITLE
hack/update-rhcos-bootimage: Drop the f-string

### DIFF
--- a/hack/update-rhcos-bootimage.py
+++ b/hack/update-rhcos-bootimage.py
@@ -34,7 +34,7 @@ newmeta['amis'] = {
 }
 newmeta['baseURI'] = urllib.parse.urljoin(args.meta, '.')
 
-with open(os.path.join(metadata_dir, f"rhcos-{args.arch}.json"), 'w') as f:
+with open(os.path.join(metadata_dir, 'rhcos-{}.json'.format(args.arch)), 'w') as f:
     json.dump(newmeta, f, sort_keys=True, indent=4)
 
 # Continue to populate the legacy metadata file because there are still


### PR DESCRIPTION
F-strings are [new in 3.6][1], and my old RHEL 7.5 CSB has the old Python 3.4.9 by default.  I'm probably just way behind the times, but it doesn't cost much to use the older `.format()` to make this compatible with all of Python 3 ;).

[1]: https://www.python.org/dev/peps/pep-0498/