### PR TITLE
Bug 1794755: cmd/openshift-install/create: wait 60 minutes for baremetal

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -28,9 +28,11 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
 	assetstore "github.com/openshift/installer/pkg/asset/store"
 	targetassets "github.com/openshift/installer/pkg/asset/targets"
 	destroybootstrap "github.com/openshift/installer/pkg/destroy/bootstrap"
+	"github.com/openshift/installer/pkg/types/baremetal"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 )
 
@@ -324,6 +326,17 @@ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset
 // that the cluster has been initialized.
 func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
 	timeout := 30 * time.Minute
+
+	// Wait longer for baremetal, due to length of time it takes to boot
+	if assetStore, err := assetstore.NewStore(rootOpts.dir); err == nil {
+		installConfig := &installconfig.InstallConfig{}
+		if err := assetStore.Fetch(installConfig); err == nil {
+			if installConfig.Config.Platform.Name() == baremetal.Name {
+				timeout = 60 * time.Minute
+			}
+		}
+	}
+
 	logrus.Infof("Waiting up to %v for the cluster at %s to initialize...", timeout, config.Host)
 	cc, err := configclient.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
Baremetal servers differ significantly from other platforms, especially
due to the length of time it can take to boot real hardware: servers go
through POST (power-on self checks) and hardware initializations that
can take many minutes to complete. When deploying the control plane as
well as workers in the installer, it reliably takes more than 30
minutes.

Recently, we added code to the installer and machine-api-operator that
now allows the installer to deploy workers on day 1. This change even on
virtualized baremetal is running up against the 30-minute time limit. On
real baremetal servers, it's guaranteed the install process is closer to
45 minutes.