### PR TITLE
Bug 1763936: aws: enable node ports between control plane and compute

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -243,6 +243,16 @@ resource "aws_security_group_rule" "master_ingress_services_tcp" {
   self      = true
 }
 
+resource "aws_security_group_rule" "master_ingress_services_tcp_from_worker" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
+
+  protocol  = "tcp"
+  from_port = 30000
+  to_port   = 32767
+}
+
 resource "aws_security_group_rule" "master_ingress_services_udp" {
   type              = "ingress"
   security_group_id = aws_security_group.master.id
@@ -253,3 +263,12 @@ resource "aws_security_group_rule" "master_ingress_services_udp" {
   self      = true
 }
 
+resource "aws_security_group_rule" "master_ingress_services_udp_from_worker" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
+
+  protocol  = "udp"
+  from_port = 30000
+  to_port   = 32767
+}

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -153,6 +153,16 @@ resource "aws_security_group_rule" "worker_ingress_services_tcp" {
   self      = true
 }
 
+resource "aws_security_group_rule" "worker_ingress_services_tcp_from_master" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.worker.id
+  source_security_group_id = aws_security_group.master.id
+
+  protocol  = "tcp"
+  from_port = 30000
+  to_port   = 32767
+}
+
 resource "aws_security_group_rule" "worker_ingress_services_udp" {
   type              = "ingress"
   security_group_id = aws_security_group.worker.id
@@ -163,3 +173,12 @@ resource "aws_security_group_rule" "worker_ingress_services_udp" {
   self      = true
 }
 
+resource "aws_security_group_rule" "worker_ingress_services_udp_from_master" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.worker.id
+  source_security_group_id = aws_security_group.master.id
+
+  protocol  = "udp"
+  from_port = 30000
+  to_port   = 32767
+}


### PR DESCRIPTION
This change explicitly allows access for ports 30000-32767 for both tcp
and udp protocols between the control plane and compute instances in
aws ipi at install time.