### PR TITLE
Bug 1763936: aws upi: enable udp ports 9000-9999 and 30000-32767

### DIFF
--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -154,6 +154,26 @@ Resources:
       ToPort: 9999
       IpProtocol: tcp
 
+  MasterIngressInternalUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: udp
+
+  MasterIngressWorkerInternalUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: udp
+
   MasterIngressKube:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -244,7 +264,7 @@ Resources:
       ToPort: 9999
       IpProtocol: tcp
 
-  WorkerIngressWorkerInternal:
+  WorkerIngressMasterInternal:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt WorkerSecurityGroup.GroupId
@@ -253,6 +273,26 @@ Resources:
       FromPort: 9000
       ToPort: 9999
       IpProtocol: tcp
+
+  WorkerIngressInternalUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: udp
+
+  WorkerIngressMasterInternalUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Internal cluster communication
+      FromPort: 9000
+      ToPort: 9999
+      IpProtocol: udp
 
   WorkerIngressKube:
     Type: AWS::EC2::SecurityGroupIngress

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -214,6 +214,26 @@ Resources:
       ToPort: 32767
       IpProtocol: tcp
 
+  MasterIngressIngressServicesUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: udp
+
+  MasterIngressWorkerIngressServicesUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: udp
+
   WorkerIngressVxlan:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
@@ -324,7 +344,7 @@ Resources:
       ToPort: 32767
       IpProtocol: tcp
 
-  WorkerIngressWorkerIngressServices:
+  WorkerIngressMasterIngressServices:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !GetAtt WorkerSecurityGroup.GroupId
@@ -333,6 +353,26 @@ Resources:
       FromPort: 30000
       ToPort: 32767
       IpProtocol: tcp
+
+  WorkerIngressIngressServicesUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: udp
+
+  WorkerIngressMasterIngressServicesUDP:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt WorkerSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Kubernetes ingress services
+      FromPort: 30000
+      ToPort: 32767
+      IpProtocol: udp
 
   MasterIamRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
This change allows access for udp ports 9000-9999 and 30000-32767 on aws upi clusters the same way we do on ipi clusters.
