### PR TITLE
Bug 1763936: gcp: enable node ports between control plane and compute

### DIFF
--- a/data/data/gcp/network/firewall.tf
+++ b/data/data/gcp/network/firewall.tf
@@ -119,6 +119,18 @@ resource "google_compute_firewall" "internal_cluster" {
     ports    = ["10250"]
   }
 
+  # services tcp
+  allow {
+    protocol = "tcp"
+    ports    = ["30000-32767"]
+  }
+
+  # services udp
+  allow {
+    protocol = "udp"
+    ports    = ["30000-32767"]
+  }
+
   source_tags = [
     "${var.cluster_id}-master",
     "${var.cluster_id}-worker"
@@ -127,44 +139,4 @@ resource "google_compute_firewall" "internal_cluster" {
     "${var.cluster_id}-master",
     "${var.cluster_id}-worker"
   ]
-}
-
-resource "google_compute_firewall" "internal_services_master" {
-  name    = "${var.cluster_id}-internal-services-master"
-  network = local.cluster_network
-
-  # services tcp
-  allow {
-    protocol = "tcp"
-    ports    = ["30000-32767"]
-  }
-
-  # services udp
-  allow {
-    protocol = "udp"
-    ports    = ["30000-32767"]
-  }
-
-  source_tags = ["${var.cluster_id}-master"]
-  target_tags = ["${var.cluster_id}-master"]
-}
-
-resource "google_compute_firewall" "internal_services_worker" {
-  name    = "${var.cluster_id}-internal-services-worker"
-  network = local.cluster_network
-
-  # services tcp
-  allow {
-    protocol = "tcp"
-    ports    = ["30000-32767"]
-  }
-
-  # services udp
-  allow {
-    protocol = "udp"
-    ports    = ["30000-32767"]
-  }
-
-  source_tags = ["${var.cluster_id}-worker"]
-  target_tags = ["${var.cluster_id}-worker"]
 }


### PR DESCRIPTION
This change explicitly allows access for ports 30000-32767 for both tcp
and udp protocols between the control plane and compute instances in
gcp ipi at install time.