### PR TITLE
Docs: update OpenStack documentation

### DIFF
--- a/docs/dev/openstack/OWNERS
+++ b/docs/dev/openstack/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers
+reviewers:
+  - openstack-reviewers

--- a/docs/dev/openstack/customization.md
+++ b/docs/dev/openstack/customization.md
@@ -1,0 +1,25 @@
+# RHCOS image customization
+
+By default the installer creates an image in Glance called `<clusterID>-rhcos`, and uploads the binary data from a predetermined in the installer location. The Glance image exists throughout the life of the cluster and is removed along with it.
+
+To change this behavior and upload binary data from a custom location the user may set `OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE` environment variable that points to that location, and then start the installation. In all other respects the process will be consistent with the default.
+
+Example:
+
+```sh
+export OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE="https://example.com/my-rhcos.qcow2"
+./openshift-install create cluster --dir ostest
+```
+
+**NOTE:** For this to work, the environment variable value must be a valid http(s) URL.
+
+If the user wants to reuse an existing Glance image without any uploading of binary data, then it is possible to set `OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE` environment variable that specifies the Glance image name. In this case no new Glance images will be created, and the image will stay when the cluster is destroyed.
+
+Example:
+
+```sh
+export OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE="my-rhcos"
+./openshift-install create cluster --dir ostest
+```
+
+**NOTE:** The only difference in behavior with the previous example is that the value here is not an http(s) URL.

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -16,6 +16,7 @@ In addition, it covers the installation with the default CNI (OpenShiftSDN), as 
     - [Disk Requirements](#disk-requirements)
     - [Neutron Public Network](#neutron-public-network)
     - [Nova Metadata Service](#nova-metadata-service)
+    - [Glance Service](#glance-service)
   - [OpenStack Credentials](#openstack-credentials)
   - [Standalone Single-Node Development Environment](#standalone-single-node-development-environment)
   - [Running The Installer](#running-the-installer)
@@ -158,6 +159,14 @@ openstack network list --long -c ID -c Name -c "Router Type"
 ### Nova Metadata Service
 
 Nova [metadata service](https://docs.openstack.org/nova/latest/user/metadata.html#metadata-service) must be enabled and available at `http://169.254.169.254`. Currently the service is used to deliver Ignition config files to Nova instances and provide information about the machine to `kubelet`.
+
+### Glance Service
+
+The creation of images in Glance should be available to the user. Now Glance is used for two things:
+
+- Right after the installation starts, the installer automatically uploads the actual `RHCOS` binary image to Glance with the name `<clusterID>-rhcos`. The image exists throughout the life of the cluster and is removed along with it.
+
+- The installer stores bootstrap ignition configs in a temporary image called `<clusterID>-ignition`. This is not a canonical use of the service, but this solution allows us to unify the installation process, since Glance is available on all OpenStack clouds, unlike Swift. The image exists for a limited period of time while the bootstrap process is running (normally 10-30 minutes), and then is automatically deleted.
 
 ## OpenStack Credentials
 

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -12,7 +12,7 @@ In addition, it covers the installation with the default CNI (OpenShiftSDN), as 
     - [Master Nodes](#master-nodes)
     - [Worker Nodes](#worker-nodes)
     - [Bootstrap Node](#bootstrap-node)
-    - [Swift](#swift)
+    - [Image Registry Requirements](#image-registry-requirements)
     - [Disk Requirements](#disk-requirements)
     - [Neutron Public Network](#neutron-public-network)
     - [Nova Metadata Service](#nova-metadata-service)
@@ -54,11 +54,7 @@ For a successful installation it is required:
 - vCPUs: 28
 - Volume Storage: 175 GB
 - Instances: 7
-- Swift containers: 2
-- Swift objects: 1
-- Available space in Swift: at least 10 MB
-
-**NOTE:** Size depends on the size of the bootstrap ignition file.
+- Depending on the type of [image registry backend](#image-registry-requirements) either 1 Swift container or an additional 100 GB volume.
 
 You may need to increase the security group related quotas from their default values. For example (as an OpenStack administrator):
 
@@ -78,17 +74,19 @@ The default deployment stands up 3 worker nodes. In our testing we determined th
 
 The bootstrap node is a temporary node that is responsible for standing up the control plane on the masters. Only one bootstrap node will be stood up and it will be deprovisioned once the production control plane is ready. To do so, you need 1 instance, and 1 port. We recommend a flavor with a minimum of 16 GB RAM, 4 vCPUs, and 25 GB Disk.
 
-### Swift
+### Image Registry Requirements
 
-Swift is required for installation as the user-data provided by OpenStack Metadata service is not big enough to store the ignition config files, so they are served by Swift instead.
+If Swift is available in the cloud where the installation is being performed, it is used as the default backend for the OpenShift image registry. At the time of installation only an empty container is created without loading any data. Later on, for the system to work properly, you need to have enough free space to store the container images.
 
-Swift is also used as a backend for the OpenShift image registry, but at the time of installation only an empty container is created without loading any data. Later on, for the system to work properly, you need to have enough free space to store the container images.
-
-The user must have `swiftoperator` permissions. As an OpenStack administrator:
+In this case the user must have `swiftoperator` permissions. As an OpenStack administrator:
 
 ```sh
 openstack role add --user <user> --project <project> swiftoperator
 ```
+
+If Swift is not available, the [PVC](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims) storage is used as the backend. For this purpose, a persistent volume of 100 GB will be created in Cinder and mounted to the image registry pod during the installation.
+
+**Note:** Since Cinder supports only [ReadWriteOnce](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) access mode, it's not possible to have more than one replica of the image registry pod.
 
 ### Disk Requirements
 

--- a/docs/user/openstack/known-issues.md
+++ b/docs/user/openstack/known-issues.md
@@ -34,32 +34,3 @@ Some OpenStack clouds do not set default DNS servers for the newly created subne
 If you are having this problem in the IPI installer, you will need to set the [`externalDNS` property in `install-config.yaml`](./customization.md#cluster-scoped-properties).
 
 Alternatively, for UPI, you will need to [set the subnet DNS resolvers](./install_upi.md#subnet-dns-optional).
-
-## Cluster destruction if its metadata has been lost
-
-When deploying a cluster, the installer generates metadata in the asset directory that is then used to destroy the cluster. If the metadata were accidentally deleted, the destruction of the cluster terminates with an error
-
-```txt
-FATAL Failed while preparing to destroy cluster: open clustername/metadata.json: no such file or directory
-```
-
-To avoid this error and successfully destroy the cluster, you need to restore the `metadata.json` file in a temporary asset directory. To do this, you only need to know ID of the cluster you want to destroy.
-
-First, you need to create a temporary directory where the `metadata.json` file will be located. The name and location can be anything, but to avoid possible conflicts, we recommend using `mktemp` command.
-
-```sh
-export TMP_DIR=$(mktemp -d -t shiftstack-XXXXXXXXXX)
-```
-
-The next step is to restore the `metadata.json` file.
-
-```sh
-export CLUSTER_ID=clustername-eiu38 # id of the cluster you want to destroy
-echo "{\"infraID\":\"$INFRA_ID\",\"openstack\":{\"identifier\":{\"openshiftClusterID\":\"$INFRA_ID\"}}}" > $TMP_DIR/metadata.json
-```
-
-Now you have a working directory and you can destroy the cluster by executing the following command:
-
-```sh
-openshift-install destroy cluster --dir $TMP_DIR
-```


### PR DESCRIPTION
This PR updates OpenStack documentation based on recent changes.

1. Updates Swift requirements. Now Swift is not a mandatory service but just an optional backend for image registry.
2. Adds Glance requirements. Glance is used for storing RHCOS images and bootstrap ignition configs.
3. Adds RHCOS image customization section for disconnected environments.
4. Moves "Cluster destruction if its metadata has been lost" section from "known-issues" to "troubleshooting".