### PR TITLE
Bug 1794750: cmd/openshift-install: use binary name for usage

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -65,7 +65,7 @@ func installerMain() {
 
 func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:              "openshift-install",
+		Use:              filepath.Base(os.Args[0]),
 		Short:            "Creates OpenShift clusters",
 		Long:             "",
 		PersistentPreRun: runRootCmd,


### PR DESCRIPTION
When openshift-install prints a usage message, it always uses the
hardcoded value "openshift-install", but in the case of the baremetal
installer, `oc` extracts it as `openshift-baremetal-install`.

In case the installer is renamed, we should look at `os.Args[0]` for the
correct name instead of having this hardcoded.

Before:
```
$ openshift-baremetal-install 
Creates OpenShift clusters

Usage:
  openshift-install [command]

Available Commands:
  completion  Outputs shell completions for the openshift-install command
  create      Create part of an OpenShift cluster
  destroy     Destroy part of an OpenShift cluster
  gather      Gather debugging data for a given installation failure
  graph       Outputs the internal dependency graph for installer
  help        Help about any command
  version     Print version information
  wait-for    Wait for install-time events

Flags:
      --dir string         assets directory (default ".")
  -h, --help               help for openshift-install
      --log-level string   log level (e.g. "debug | info | warn | error") (default "info")

Use "openshift-install [command] --help" for more information about a command.
```

After:
```
$ openshift-baremetal-install 
Creates OpenShift clusters

Usage:
  openshift-baremetal-install [command]

Available Commands:
  completion  Outputs shell completions for the openshift-install command
  create      Create part of an OpenShift cluster
  destroy     Destroy part of an OpenShift cluster
  gather      Gather debugging data for a given installation failure
  graph       Outputs the internal dependency graph for installer
  help        Help about any command
  version     Print version information
  wait-for    Wait for install-time events

Flags:
      --dir string         assets directory (default ".")
  -h, --help               help for openshift-baremetal-install
      --log-level string   log level (e.g. "debug | info | warn | error") (default "info")

Use "openshift-baremetal-install [command] --help" for more information about a command.
```