### PR TITLE
WIP bootkube.sh populate complete list of etcd endpoints during bootstrap

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -244,7 +244,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
 
 	discovery := client.Discovery()
 
-	apiTimeout := 30 * time.Minute
+	apiTimeout := 20 * time.Minute
 	logrus.Infof("Waiting up to %v for the Kubernetes API at %s...", apiTimeout, config.Host)
 	apiContext, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
@@ -285,7 +285,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
 // and waits for the bootstrap configmap to report that bootstrapping has
 // completed.
 func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset) error {
-	timeout := 30 * time.Minute
+	timeout := 40 * time.Minute
 	logrus.Infof("Waiting up to %v for bootstrapping to complete...", timeout)
 
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -6,6 +6,7 @@ set -euoE pipefail ## -E option will cause functions to inherit trap
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
 
 ETCD_ENDPOINTS=
+ETCDCTL_ENDPOINTS=
 
 bootkube_podman_run() {
     # we run all commands in the host-network to prevent IP conflicts with
@@ -114,7 +115,8 @@ if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ]
 then
 	# TODO: host-etcd endpoint rendered by cluster-etcd-operator
 	BOOTSTRAP_IP=$(hostname -I | awk '{ print $1 }')
-	ETCD_ENDPOINTS=https://"${BOOTSTRAP_IP}":2379
+	ETCD_ENDPOINTS="{{.EtcdCluster}},https://${BOOTSTRAP_IP}:2379"
+	ETCDCTL_ENDPOINTS="https://${BOOTSTRAP_IP}:2379"
 	if [ ! -f etcd-bootstrap.done ]
 	then
 		echo "Rendering CEO Manifests..."
@@ -148,6 +150,7 @@ then
 	fi
 else
 	ETCD_ENDPOINTS={{.EtcdCluster}}
+	ETCDCTL_ENDPOINTS="$ETCD_ENDPOINTS"
 	CLUSTER_ETCD_OPERATOR_IMAGE=
 	sed -i '/etcd-bootstrap/I,+1 d' /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 fi
@@ -367,7 +370,7 @@ until bootkube_podman_run \
 		--cacert=/opt/openshift/tls/etcd-ca-bundle.crt \
 		--cert=/opt/openshift/tls/etcd-client.crt \
 		--key=/opt/openshift/tls/etcd-client.key \
-		--endpoints="${ETCD_ENDPOINTS}" \
+		--endpoints="${ETCDCTL_ENDPOINTS}" \
 		endpoint health
 do
 	echo "etcdctl failed. Retrying in 5 seconds..."


### PR DESCRIPTION
This PR attempts to reduce initial bootstrap complexity caused by only populating the bootstrap endpoint. By feeding apiserver the entire list during bootstrap we avoid the scenario where `cluster-etcd-operator` completes scaling up to 4 members. The result of this scaling is the host-etcd service is also adjusted to reflect all of the scaled etcd endpoints.  Meanwhile, the cluster-kube-apiserver-operator has not yet rolled out the new static pod assets in the correct revision. So when we reap the bootstrap node we leave apiserver with a single backend endpoint pointing at the bootstrap node that is no longer alive.

In the previous version of the etcd client balancer, this would have proven overly disruptive but the new balancer handles the sub connection round-robin failover very gracefully.

We consider this a short term solution while we improve the timings and complexity around this process.

Requires https://github.com/openshift/cluster-etcd-operator/pull/60