### PR TITLE
Bug 1794640: OpenStack: Use dataurl library

### DIFF
--- a/pkg/tfvars/openstack/bootstrap_ignition.go
+++ b/pkg/tfvars/openstack/bootstrap_ignition.go
@@ -1,7 +1,6 @@
 package openstack
 
 import (
-	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -76,7 +75,7 @@ func generateIgnitionShim(userCA string, clusterID string, bootstrapConfigURL st
 		FileEmbedded1: ignition.FileEmbedded1{
 			Mode: &fileMode,
 			Contents: ignition.FileContents{
-				Source: fmt.Sprintf("data:text/plain;base64,%s", b64.StdEncoding.EncodeToString([]byte(contents))),
+				Source: dataurl.EncodeBytes([]byte(contents)),
 			},
 		},
 	}
@@ -90,7 +89,7 @@ func generateIgnitionShim(userCA string, clusterID string, bootstrapConfigURL st
 		FileEmbedded1: ignition.FileEmbedded1{
 			Mode: &fileMode,
 			Contents: ignition.FileContents{
-				Source: fmt.Sprintf("data:text/plain;base64,%s", b64.StdEncoding.EncodeToString([]byte(userCA))),
+				Source: dataurl.EncodeBytes([]byte(userCA)),
 			},
 		},
 	}


### PR DESCRIPTION
The original pull request for OpenStack self-signed certificates
support [1] formatted the dataurl for the bootstrap ignition file
rather than using the dataurl library used everywhere in the installer.

Let's be consistent with the other parts of the installer creating
dataurls and use the dataurl library.

[1] https://github.com/openshift/installer/pull/2932