### PR TITLE
[FCOS] Installer expects the Azure storage account to be a page blob but it isn't

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -150,7 +150,7 @@ resource "azurerm_storage_blob" "rhcos_image" {
   resource_group_name    = azurerm_resource_group.main.name
   storage_account_name   = azurerm_storage_account.cluster.name
   storage_container_name = azurerm_storage_container.vhd.name
-  type                   = "block"
+  type                   = "page"
   source_uri             = var.azure_image_url
   metadata               = map("source_uri", var.azure_image_url)
   attempts               = 2


### PR DESCRIPTION
Hi

```
fcos is downloaded from fedora coreos and uploaded to Azure because the Image is currently not in the Azure Marketplace because of legal issues.
And because without page blob mode the upload would take much longer it is enforced.
```

Greetings,

Josef
