### PR TITLE
cmd/openshift-install: shift timeouts from api to bootstrap

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -244,7 +244,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
 
 	discovery := client.Discovery()
 
-	apiTimeout := 30 * time.Minute
+	apiTimeout := 20 * time.Minute
 	logrus.Infof("Waiting up to %v for the Kubernetes API at %s...", apiTimeout, config.Host)
 	apiContext, cancel := context.WithTimeout(ctx, apiTimeout)
 	defer cancel()
@@ -285,7 +285,7 @@ func waitForBootstrapComplete(ctx context.Context, config *rest.Config, director
 // and waits for the bootstrap configmap to report that bootstrapping has
 // completed.
 func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset) error {
-	timeout := 30 * time.Minute
+	timeout := 40 * time.Minute
 	logrus.Infof("Waiting up to %v for bootstrapping to complete...", timeout)
 
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)


### PR DESCRIPTION
`cluster-etcd-operator` introduces a new workflow for the installer. By having am etcd instance on the bootstrap node we can quickly move to API up.

But currently, the scaling process of etcd is in some circumstances cresting the 30 min timeout. This PR addresses this short term issue by reducing the api timeout to 20 mins and adding that to the bootstrap timeout.

I had a conversation about this with Clayton this is not a permanent change. CEO must reduce install times not increase.

related to: https://github.com/openshift/cluster-etcd-operator/pull/58