### PR TITLE
Bug 1795776: data/bootstrap: delay the removal of bootstrap mcs

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -377,7 +377,6 @@ done
 echo "etcd cluster up. Killing etcd certificate signer..."
 
 podman rm --force etcd-signer
-rm --force /etc/kubernetes/manifests/machineconfigoperator-bootstrap-pod.yaml
 
 echo "Starting cluster-bootstrap..."
 
@@ -391,6 +390,8 @@ then
         start --tear-down-early=false --asset-dir=/assets --required-pods="openshift-kube-apiserver/kube-apiserver,openshift-kube-scheduler/openshift-kube-scheduler,openshift-kube-controller-manager/kube-controller-manager,openshift-cluster-version/cluster-version-operator"
     touch cb-bootstrap.done
 fi
+
+rm --force /etc/kubernetes/manifests/machineconfigoperator-bootstrap-pod.yaml
 
 if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
 then


### PR DESCRIPTION
The bootstrap MCS is responsible for serving Ignition configs to the
booting control plane machines while we wait for the full control plane
(which will host the in-cluster MCS). If we remove this too early, it
will prevent the control plane machines from booting and the control
plane from starting. The etcd health check, which is the gate before we
remove the MCS, reports healthly (since the one-node, bootstrap etcd
cluster is actually up) before the control plane machines had a chance
to boot. The result is that one or more of the control plane machines
get stuck during boot (because Ignition is still trying to fetch a
config) and the cluster fails to bootstrap.

This moves the bootstrap MCS removal after bootkube has finished, which
will ensure that all of the initial manifests have been loaded into the
cluster (including the MCO/MCS manifests).

Thank you, @abhinavdahiya, for identifying the culprit.