### PR TITLE
[fcos] support xz-encoded images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/terraform-providers/terraform-provider-openstack v1.24.0
 	github.com/terraform-providers/terraform-provider-random v1.3.2-0.20191204175905-53436297444a
 	github.com/terraform-providers/terraform-provider-vsphere v1.14.0
+	github.com/ulikunitz/xz v0.5.6
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect

--- a/pkg/tfvars/internal/cache/cache.go
+++ b/pkg/tfvars/internal/cache/cache.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/ulikunitz/xz"
 
 	"golang.org/x/sys/unix"
 )
@@ -22,6 +23,7 @@ const (
 	applicationName = "openshift-installer"
 	imageDataType   = "image"
 	gzipFileType    = "application/x-gzip"
+	xzFileType      = "application/octet-stream"
 )
 
 // getCacheDir returns a local path of the cache, where the installer should put the data:
@@ -128,6 +130,12 @@ func cacheFile(reader io.Reader, filePath string, sha256Checksum string) (err er
 			return err
 		}
 		defer uncompressor.Close()
+		reader = uncompressor
+	case xzFileType:
+		uncompressor, err := xz.NewReader(reader)
+		if err != nil {
+			return err
+		}
 		reader = uncompressor
 	default:
 		// No need for an interposer otherwise


### PR DESCRIPTION
Some FCOS images are xz-compressed, however RHCOS is gzipped