### PR TITLE
Bug 1802035: openstack UPI: Document Ansible

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -38,6 +38,7 @@ In addition, it covers the installation with the default CNI (OpenShiftSDN), as 
 - [Using the OSP 4 installer with Kuryr](kuryr.md)
 - [Troubleshooting your cluster](troubleshooting.md)
 - [Customizing your install](customization.md)
+- [Installing OpenShift on OpenStack User-Provisioned Infrastructure](install_upi.md)
 - [Learn about the OpenShift on OpenStack networking infrastructure design](../../design/openstack/networking-infrastructure.md)
 
 ## OpenStack Requirements

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -2,6 +2,15 @@
 
 Beyond the [platform-agnostic `install-config.yaml` properties](../customization.md#platform-customization), the installer supports additional, OpenStack-specific properties.
 
+## Table of Contents
+
+* [Cluster-scoped properties](#cluster-scoped-properties)
+* [Machine pools](#machine-pools)
+* [Examples](#examples)
+  * [Minimal](#minimal)
+  * [Custom-machine-pools](#custom-machine-pools)
+* [Further customization](#further-customization)
+
 ## Cluster-scoped properties
 
 * `cloud` (required string): The name of the OpenStack cloud to use from `clouds.yaml`.
@@ -80,3 +89,7 @@ platform:
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ```
+
+## Further customization
+
+For customizing the installation beyond what is possible with `openshift-install`, refer to the [UPI (User Provided Infrastructure) documentation](./install_upi.md).

--- a/upi/openstack/README.md
+++ b/upi/openstack/README.md
@@ -1,25 +1,6 @@
-# Openstack User Provided Infrastructure installation
+# Ansible Playbooks for Openstack UPI
 
-This directory contains Ansible scripts that automate the command-line work in the [User-Provided-Infrastructure installation](../../docs/user/openstack/install_upi.md).
-
-## Requirements
-
-* Python
-* Ansible
-* Python modules required in the playbooks. Namely:
-  * openstacksdk
-  * netaddr
-  * openstackclient
-
-
-The included `requirements.txt` helps using `pip` for gathering the required dependencies in a Python virtual environment:
-
-```shell
-python3 -m venv venv
-source venv/bin/activate
-pip install -U pip
-pip install -r requirements.txt
-```
+This directory contains the Ansible scripts expected to automate most of the command-line work in the [User-Provided-Infrastructure installation](../../docs/user/openstack/install_upi.md).
 
 ## How to use
 
@@ -42,6 +23,5 @@ For every script, a symmetrical teardown playbook is provided:
 ```
 
 A full teardown can be achieved by running all the `down` scripts in reverse order.
-
 
 Please refer to the [UPI documentation](../../docs/user/openstack/install_upi.md) for step-by-step instructions.

--- a/upi/openstack/README.md
+++ b/upi/openstack/README.md
@@ -1,16 +1,6 @@
 # Openstack User Provided Infrastructure installation
 
-This directory contains the Ansible scripts that automate part of the work in the [UPI installation](../../docs/user/openstack/install_upi.md).
-
-## Rationale
-
-The tool for automated installation (IPI - Installer-Provided Infrastructure) cover the general case where all the OpenStack resources can be created ad-hoc.
-
-The UPI case (User-Provided Infrastructure) instead lets complete freedom to the end-user of customizing the cluster and its underpinning OpenStack resources.
-
-The installation process is detailed step by step in the relative [documentation](../../docs/user/openstack/install_upi.md).
-
-These Ansible playbooks in this directory automate some of those steps. They are provided as a template: edit them to match your needs.
+This directory contains Ansible scripts that automate the command-line work in the [User-Provided-Infrastructure installation](../../docs/user/openstack/install_upi.md).
 
 ## Requirements
 
@@ -37,7 +27,7 @@ Customize the cluster properties in the [Inventory](./inventory.yaml) file.
 
 **NOTE:** To deploy with Kuryr SDN, update the `os_networking_type` field to `Kuryr`.
 
-The playbooks are designed to reproduce an installation equivalent to IPI. Customize them as needed. It is advised to customize the teardown playbooks symmetrically.
+The playbooks in this directory are designed to reproduce an IPI installation, but are highly customizable. Please be aware of changes made to the install playbooks that may require changes to the teardown playbooks.
 
 Every step can be run like this:
 
@@ -52,3 +42,6 @@ For every script, a symmetrical teardown playbook is provided:
 ```
 
 A full teardown can be achieved by running all the `down` scripts in reverse order.
+
+
+Please refer to the [UPI documentation](../../docs/user/openstack/install_upi.md) for step-by-step instructions.


### PR DESCRIPTION
Detail a working Ansible UPI workflow in the Openshift Openstack user documentation.

I have changed the order of the steps in order to group all the preparation work at the beginning. That way, the user can then run all playbooks in sequence, without having to go back-and-forth between Ansible and local editing.

Implements OSASINFRA-1108