### PR TITLE
[fcos] openstack: remove "filesystem" from tf files

### DIFF
--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -3,10 +3,9 @@ data "openstack_compute_flavor_v2" "masters_flavor" {
 }
 
 data "ignition_file" "hostname" {
-  count      = var.instance_count
-  filesystem = "root"
-  mode       = "420" // 0644
-  path       = "/etc/hostname"
+  count = var.instance_count
+  mode  = "420" // 0644
+  path  = "/etc/hostname"
 
   content {
     content = <<EOF

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -17,7 +17,7 @@ EOF
 data "ignition_config" "master_ignition_config" {
   count = var.instance_count
 
-  append {
+  merge {
     source = "data:text/plain;charset=utf-8;base64,${base64encode(var.user_data_ign)}"
   }
 


### PR DESCRIPTION
This makes ignition files FCOS-compatible and should fix error during openstack install:

```
ERROR Error: Unsupported argument                  
ERROR                                              
ERROR   on ../../../../../tmp/openshift-install-117723343/masters/main.tf line 7, in data "ignition_file" "hostname": 
ERROR    7:   filesystem = "root"                  
ERROR                                              
ERROR An argument named "filesystem" is not expected here. 
```