### PR TITLE
Bug 1793592: gcp: set connection drain timeout on private lb

### DIFF
--- a/data/data/gcp/network/lb-private.tf
+++ b/data/data/gcp/network/lb-private.tf
@@ -20,6 +20,9 @@ resource "google_compute_region_backend_service" "api_internal" {
   protocol              = "TCP"
   timeout_sec           = 120
 
+  // time for kube-apiserver to drain open connections: little more than 70s shutdown-delay-duration + 60s request timeout
+  connection_draining_timeout_sec = 135
+
   dynamic "backend" {
     for_each = var.bootstrap_lb ? concat(var.bootstrap_instance_groups, var.master_instance_groups) : var.master_instance_groups
 


### PR DESCRIPTION
The kube-apiserver waits 70 seconds before stopping the http server(shutdown-delay) and then keeps processing in-flight requests for up to 60 seconds. Hence, the connection drain timeout of the LB must be at least 130s in order to not interfere with kube-apiserver's graceful termination procedure.

The value was zero before (checked through GCP console).