### PR TITLE
[fcos] pkg/asset/releaseimage/default: set default release image to 4.4

### DIFF
--- a/pkg/asset/releaseimage/default.go
+++ b/pkg/asset/releaseimage/default.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:4.3"
+	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:4.4"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
This would be helpful for those who have to rebuild the installer from source