### PR TITLE
[FCOS] pkg/asset: Force phony pull secret in place of no pull secret

### DIFF
--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -60,6 +60,11 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 		platform,
 	)
 
+	// Override empty pull secrets with valid json fake pull secret
+	if pullSecret.PullSecret == "" {
+		pullSecret.PullSecret = "{\"auths\":{\"fake\":{\"auth\": \"bar\"}}}"
+	}
+
 	a.Config = &types.InstallConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: types.InstallConfigVersion,


### PR DESCRIPTION
Right now, using a blank pull secret does not work as the kubelet expects valid auth json in `/root/.docker/config.json` on the bootstrap node. This PR just forces a phony pull secret instead of the empty string at install-config creation time to avoid any parsing issues with a completely empty pull secret. Can come up with a long term fix for no pull-secrets at all later.