### PR TITLE
Bug 1763936: OpenStack: enable node ports between control plane and compute

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -316,6 +316,18 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_tcp" {
   depends_on = ["openstack_networking_secgroup_rule_v2.master_ingress_etcd"]
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_tcp_from_worker" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.master.id
+
+  depends_on = ["openstack_networking_secgroup_rule_v2.master_ingress_services_tcp"]
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp" {
   direction         = "ingress"
   ethertype         = "IPv4"
@@ -325,7 +337,19 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp" {
   remote_group_id   = openstack_networking_secgroup_v2.master.id
   security_group_id = openstack_networking_secgroup_v2.master.id
 
-  depends_on = ["openstack_networking_secgroup_rule_v2.master_ingress_services_tcp"]
+  depends_on = ["openstack_networking_secgroup_rule_v2.master_ingress_services_tcp_from_worker"]
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp_from_worker" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_group_id   = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.master.id
+
+  depends_on = ["openstack_networking_secgroup_rule_v2.master_ingress_services_udp"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp" {
@@ -335,6 +359,6 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp" {
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
 
-  depends_on = ["openstack_networking_secgroup_rule_v2.master_ingress_services_udp"]
+  depends_on = ["openstack_networking_secgroup_rule_v2.master_ingress_services_udp_from_worker"]
 }
 

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -221,6 +221,18 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp" {
   depends_on = ["openstack_networking_secgroup_rule_v2.worker_ingress_kubelet_insecure_from_master"]
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp_from_master" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+
+  depends_on = ["openstack_networking_secgroup_rule_v2.worker_ingress_services_tcp"]
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
   direction         = "ingress"
   ethertype         = "IPv4"
@@ -230,7 +242,19 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
   remote_group_id   = openstack_networking_secgroup_v2.worker.id
   security_group_id = openstack_networking_secgroup_v2.worker.id
 
-  depends_on = ["openstack_networking_secgroup_rule_v2.worker_ingress_services_tcp"]
+  depends_on = ["openstack_networking_secgroup_rule_v2.worker_ingress_services_tcp_from_master"]
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp_from_master" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_group_id   = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+
+  depends_on = ["openstack_networking_secgroup_rule_v2.worker_ingress_services_udp"]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp" {
@@ -240,5 +264,5 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp" {
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
 
-  depends_on = ["openstack_networking_secgroup_rule_v2.worker_ingress_services_udp"]
+  depends_on = ["openstack_networking_secgroup_rule_v2.worker_ingress_services_udp_from_master"]
 }

--- a/upi/openstack/01_security-groups.yaml
+++ b/upi/openstack/01_security-groups.yaml
@@ -224,11 +224,27 @@
       port_range_min: 30000
       port_range_max: 32767
 
+  - name: 'Create master-sg rule "master ingress services (TCP) from worker"'
+    os_security_group_rule:
+      security_group: "{{ os_sg_master }}"
+      protocol: tcp
+      remote_group: "{{ os_sg_worker }}"
+      port_range_min: 30000
+      port_range_max: 32767
+
   - name: 'Create master-sg rule "master ingress services (UDP)"'
     os_security_group_rule:
       security_group: "{{ os_sg_master }}"
       protocol: udp
       remote_group: "{{ os_sg_master }}"
+      port_range_min: 30000
+      port_range_max: 32767
+
+  - name: 'Create master-sg rule "master ingress services (UDP) from worker"'
+    os_security_group_rule:
+      security_group: "{{ os_sg_master }}"
+      protocol: udp
+      remote_group: "{{ os_sg_worker }}"
       port_range_min: 30000
       port_range_max: 32767
 
@@ -369,11 +385,27 @@
       port_range_min: 30000
       port_range_max: 32767
 
+  - name: 'Create worker-sg rule "worker ingress services (TCP) from master"'
+    os_security_group_rule:
+      security_group: "{{ os_sg_worker }}"
+      protocol: tcp
+      remote_group: "{{ os_sg_master }}"
+      port_range_min: 30000
+      port_range_max: 32767
+
   - name: 'Create worker-sg rule "worker ingress services (UDP)"'
     os_security_group_rule:
       security_group: "{{ os_sg_worker }}"
       protocol: udp
       remote_group: "{{ os_sg_worker }}"
+      port_range_min: 30000
+      port_range_max: 32767
+
+  - name: 'Create worker-sg rule "worker ingress services (UDP) from master"'
+    os_security_group_rule:
+      security_group: "{{ os_sg_worker }}"
+      protocol: udp
+      remote_group: "{{ os_sg_master }}"
       port_range_min: 30000
       port_range_max: 32767
 


### PR DESCRIPTION
Explicitly allows access for ports 30000-32767 for both tcp and udp protocols between the control plane and compute instances for OpenStack platform.