### PR TITLE
Bug 1796618: [release-4.3 IPv6] Replace MachineCIDR with MachineNetwork, add Azure IPv6

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -1,5 +1,6 @@
 locals {
-  bootstrap_nic_ip_configuration_name = "bootstrap-nic-ip"
+  bootstrap_nic_ip_v4_configuration_name = "bootstrap-nic-ip-v4"
+  bootstrap_nic_ip_v6_configuration_name = "bootstrap-nic-ip-v6"
 }
 
 data "azurerm_storage_account_sas" "ignition" {
@@ -61,20 +62,38 @@ data "ignition_config" "redirect" {
   }
 }
 
-resource "azurerm_public_ip" "bootstrap_public_ip" {
-  count = var.private ? 0 : 1
+resource "azurerm_public_ip" "bootstrap_public_ip_v4" {
+  count = var.private || ! var.use_ipv4 ? 0 : 1
 
   sku                 = "Standard"
   location            = var.region
-  name                = "${var.cluster_id}-bootstrap-pip"
+  name                = "${var.cluster_id}-bootstrap-pip-v4"
   resource_group_name = var.resource_group_name
   allocation_method   = "Static"
 }
 
-data "azurerm_public_ip" "bootstrap_public_ip" {
+data "azurerm_public_ip" "bootstrap_public_ip_v4" {
   count = var.private ? 0 : 1
 
-  name                = azurerm_public_ip.bootstrap_public_ip[0].name
+  name                = azurerm_public_ip.bootstrap_public_ip_v4[0].name
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_public_ip" "bootstrap_public_ip_v6" {
+  count = var.private || ! var.use_ipv6 ? 0 : 1
+
+  sku                 = "Standard"
+  location            = var.region
+  name                = "${var.cluster_id}-bootstrap-pip-v6"
+  resource_group_name = var.resource_group_name
+  allocation_method   = "Static"
+  ip_version          = "IPv6"
+}
+
+data "azurerm_public_ip" "bootstrap_public_ip_v6" {
+  count = var.private || ! var.use_ipv6 ? 0 : 1
+
+  name                = azurerm_public_ip.bootstrap_public_ip_v6[0].name
   resource_group_name = var.resource_group_name
 }
 
@@ -83,24 +102,73 @@ resource "azurerm_network_interface" "bootstrap" {
   location            = var.region
   resource_group_name = var.resource_group_name
 
-  ip_configuration {
-    subnet_id                     = var.subnet_id
-    name                          = local.bootstrap_nic_ip_configuration_name
-    private_ip_address_allocation = "Dynamic"
-    public_ip_address_id          = var.private ? null : azurerm_public_ip.bootstrap_public_ip[0].id
+  dynamic "ip_configuration" {
+    for_each = [for ip in [
+      {
+        // LIMITATION: azure does not allow an ipv6 address to be primary today
+        primary : var.use_ipv4,
+        name : local.bootstrap_nic_ip_v4_configuration_name,
+        ip_address_version : "IPv4",
+        public_ip_id : var.private ? null : azurerm_public_ip.bootstrap_public_ip_v4[0].id,
+        include : var.use_ipv4 || var.use_ipv6,
+      },
+      {
+        primary : ! var.use_ipv4,
+        name : local.bootstrap_nic_ip_v6_configuration_name,
+        ip_address_version : "IPv6",
+        public_ip_id : var.private ? null : azurerm_public_ip.bootstrap_public_ip_v6[0].id,
+        include : var.use_ipv6,
+      },
+      ] : {
+      primary : ip.primary
+      name : ip.name
+      ip_address_version : ip.ip_address_version
+      public_ip_id : ip.public_ip_id
+      include : ip.include
+      } if ip.include
+    ]
+    content {
+      primary                       = ip_configuration.value.primary
+      name                          = ip_configuration.value.name
+      subnet_id                     = var.subnet_id
+      private_ip_address_version    = ip_configuration.value.ip_address_version
+      private_ip_address_allocation = "Dynamic"
+      public_ip_address_id          = ip_configuration.value.public_ip_id
+    }
   }
 }
 
-resource "azurerm_network_interface_backend_address_pool_association" "public_lb_bootstrap" {
+resource "azurerm_network_interface_backend_address_pool_association" "public_lb_bootstrap_v4" {
+  // should be 'count = var.use_ipv4 && ! var.emulate_single_stack_ipv6 ? 1 : 0', but we need a V4 LB for egress for quay
+  count = var.use_ipv4 ? 1 : 0
+
   network_interface_id    = azurerm_network_interface.bootstrap.id
-  backend_address_pool_id = var.elb_backend_pool_id
-  ip_configuration_name   = local.bootstrap_nic_ip_configuration_name
+  backend_address_pool_id = var.elb_backend_pool_v4_id
+  ip_configuration_name   = local.bootstrap_nic_ip_v4_configuration_name
 }
 
-resource "azurerm_network_interface_backend_address_pool_association" "internal_lb_bootstrap" {
+resource "azurerm_network_interface_backend_address_pool_association" "public_lb_bootstrap_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
   network_interface_id    = azurerm_network_interface.bootstrap.id
-  backend_address_pool_id = var.ilb_backend_pool_id
-  ip_configuration_name   = local.bootstrap_nic_ip_configuration_name
+  backend_address_pool_id = var.elb_backend_pool_v6_id
+  ip_configuration_name   = local.bootstrap_nic_ip_v6_configuration_name
+}
+
+resource "azurerm_network_interface_backend_address_pool_association" "internal_lb_bootstrap_v4" {
+  count = var.use_ipv4 ? 1 : 0
+
+  network_interface_id    = azurerm_network_interface.bootstrap.id
+  backend_address_pool_id = var.ilb_backend_pool_v4_id
+  ip_configuration_name   = local.bootstrap_nic_ip_v4_configuration_name
+}
+
+resource "azurerm_network_interface_backend_address_pool_association" "internal_lb_bootstrap_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
+  network_interface_id    = azurerm_network_interface.bootstrap.id
+  backend_address_pool_id = var.ilb_backend_pool_v6_id
+  ip_configuration_name   = local.bootstrap_nic_ip_v6_configuration_name
 }
 
 resource "azurerm_virtual_machine" "bootstrap" {
@@ -150,8 +218,10 @@ resource "azurerm_virtual_machine" "bootstrap" {
   }
 
   depends_on = [
-    azurerm_network_interface_backend_address_pool_association.public_lb_bootstrap,
-    azurerm_network_interface_backend_address_pool_association.internal_lb_bootstrap
+    azurerm_network_interface_backend_address_pool_association.public_lb_bootstrap_v4,
+    azurerm_network_interface_backend_address_pool_association.public_lb_bootstrap_v6,
+    azurerm_network_interface_backend_address_pool_association.internal_lb_bootstrap_v4,
+    azurerm_network_interface_backend_address_pool_association.internal_lb_bootstrap_v6
   ]
 }
 

--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -38,14 +38,24 @@ variable "subnet_id" {
   description = "The subnet ID for the bootstrap node."
 }
 
-variable "elb_backend_pool_id" {
+variable "elb_backend_pool_v4_id" {
   type        = string
   description = "The external load balancer bakend pool id. used to attach the bootstrap NIC"
 }
 
-variable "ilb_backend_pool_id" {
+variable "elb_backend_pool_v6_id" {
+  type        = string
+  description = "The external load balancer bakend pool id for ipv6. used to attach the bootstrap NIC"
+}
+
+variable "ilb_backend_pool_v4_id" {
   type        = string
   description = "The internal load balancer bakend pool id. used to attach the bootstrap NIC"
+}
+
+variable "ilb_backend_pool_v6_id" {
+  type        = string
+  description = "The internal load balancer bakend pool id for ipv6. used to attach the bootstrap NIC"
 }
 
 variable "storage_account" {
@@ -67,4 +77,19 @@ variable "nsg_name" {
 variable "private" {
   type        = bool
   description = "This value determines if this is a private cluster or not."
+}
+
+variable "use_ipv4" {
+  type        = bool
+  description = "This value determines if this is cluster should use IPv4 networking."
+}
+
+variable "use_ipv6" {
+  type        = bool
+  description = "This value determines if this is cluster should use IPv6 networking."
+}
+
+variable "emulate_single_stack_ipv6" {
+  type        = bool
+  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
 }

--- a/data/data/azure/dns/variables.tf
+++ b/data/data/azure/dns/variables.tf
@@ -24,13 +24,23 @@ variable "base_domain_resource_group_name" {
   type        = string
 }
 
-variable "external_lb_fqdn" {
-  description = "External API's LB fqdn"
+variable "external_lb_fqdn_v4" {
+  description = "External API's LB fqdn for IPv4"
   type        = string
 }
 
-variable "internal_lb_ipaddress" {
-  description = "External API's LB Ip address"
+variable "external_lb_fqdn_v6" {
+  description = "External API's LB fqdn for IPv6"
+  type        = string
+}
+
+variable "internal_lb_ipaddress_v4" {
+  description = "External API's LB IP v4 address"
+  type        = string
+}
+
+variable "internal_lb_ipaddress_v6" {
+  description = "External API's LB IP v6 address"
   type        = string
 }
 
@@ -44,8 +54,14 @@ variable "etcd_count" {
   type        = string
 }
 
-variable "etcd_ip_addresses" {
-  description = "List of string IPs for machines running etcd members."
+variable "etcd_ip_v4_addresses" {
+  description = "List of string IPs in IPv4 for machines running etcd members."
+  type        = list(string)
+  default     = []
+}
+
+variable "etcd_ip_v6_addresses" {
+  description = "List of string IPs in IPv6 for machines running etcd members."
   type        = list(string)
   default     = []
 }
@@ -58,4 +74,19 @@ variable "resource_group_name" {
 variable "private" {
   type        = bool
   description = "This value determines if this is a private cluster or not."
+}
+
+variable "use_ipv4" {
+  type        = bool
+  description = "This value determines if this is cluster should use IPv4 networking."
+}
+
+variable "use_ipv6" {
+  type        = bool
+  description = "This value determines if this is cluster should use IPv6 networking."
+}
+
+variable "emulate_single_stack_ipv6" {
+  type        = bool
+  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
 }

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -22,27 +22,34 @@ provider "azureprivatedns" {
 }
 
 module "bootstrap" {
-  source              = "./bootstrap"
-  resource_group_name = azurerm_resource_group.main.name
-  region              = var.azure_region
-  vm_size             = var.azure_bootstrap_vm_type
-  vm_image            = azurerm_image.cluster.id
-  identity            = azurerm_user_assigned_identity.main.id
-  cluster_id          = var.cluster_id
-  ignition            = var.ignition_bootstrap
-  subnet_id           = module.vnet.master_subnet_id
-  elb_backend_pool_id = module.vnet.public_lb_backend_pool_id
-  ilb_backend_pool_id = module.vnet.internal_lb_backend_pool_id
-  tags                = local.tags
-  storage_account     = azurerm_storage_account.cluster
-  nsg_name            = module.vnet.master_nsg_name
-  private             = module.vnet.private
+  source                 = "./bootstrap"
+  resource_group_name    = azurerm_resource_group.main.name
+  region                 = var.azure_region
+  vm_size                = var.azure_bootstrap_vm_type
+  vm_image               = azurerm_image.cluster.id
+  identity               = azurerm_user_assigned_identity.main.id
+  cluster_id             = var.cluster_id
+  ignition               = var.ignition_bootstrap
+  subnet_id              = module.vnet.master_subnet_id
+  elb_backend_pool_v4_id = module.vnet.public_lb_backend_pool_v4_id
+  elb_backend_pool_v6_id = module.vnet.public_lb_backend_pool_v6_id
+  ilb_backend_pool_v4_id = module.vnet.internal_lb_backend_pool_v4_id
+  ilb_backend_pool_v6_id = module.vnet.internal_lb_backend_pool_v6_id
+  tags                   = local.tags
+  storage_account        = azurerm_storage_account.cluster
+  nsg_name               = module.vnet.master_nsg_name
+  private                = module.vnet.private
+
+  use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
+  use_ipv6                  = var.use_ipv6
+  emulate_single_stack_ipv6 = var.azure_emulate_single_stack_ipv6
 }
 
 module "vnet" {
   source              = "./vnet"
   resource_group_name = azurerm_resource_group.main.name
-  vnet_cidr           = var.machine_cidr
+  vnet_v4_cidrs       = var.azure_machine_v4_cidrs
+  vnet_v6_cidrs       = var.azure_machine_v6_cidrs
   cluster_id          = var.cluster_id
   region              = var.azure_region
   dns_label           = var.cluster_id
@@ -53,27 +60,37 @@ module "vnet" {
   master_subnet               = var.azure_control_plane_subnet
   worker_subnet               = var.azure_compute_subnet
   private                     = var.azure_private
+
+  use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
+  use_ipv6                  = var.use_ipv6
+  emulate_single_stack_ipv6 = var.azure_emulate_single_stack_ipv6
 }
 
 module "master" {
-  source              = "./master"
-  resource_group_name = azurerm_resource_group.main.name
-  cluster_id          = var.cluster_id
-  region              = var.azure_region
-  availability_zones  = var.azure_master_availability_zones
-  vm_size             = var.azure_master_vm_type
-  vm_image            = azurerm_image.cluster.id
-  identity            = azurerm_user_assigned_identity.main.id
-  ignition            = var.ignition_master
-  external_lb_id      = module.vnet.public_lb_id
-  elb_backend_pool_id = module.vnet.public_lb_backend_pool_id
-  ilb_backend_pool_id = module.vnet.internal_lb_backend_pool_id
-  subnet_id           = module.vnet.master_subnet_id
-  instance_count      = var.master_count
-  storage_account     = azurerm_storage_account.cluster
-  os_volume_type      = var.azure_master_root_volume_type
-  os_volume_size      = var.azure_master_root_volume_size
-  private             = module.vnet.private
+  source                 = "./master"
+  resource_group_name    = azurerm_resource_group.main.name
+  cluster_id             = var.cluster_id
+  region                 = var.azure_region
+  availability_zones     = var.azure_master_availability_zones
+  vm_size                = var.azure_master_vm_type
+  vm_image               = azurerm_image.cluster.id
+  identity               = azurerm_user_assigned_identity.main.id
+  ignition               = var.ignition_master
+  external_lb_id         = module.vnet.public_lb_id
+  elb_backend_pool_v4_id = module.vnet.public_lb_backend_pool_v4_id
+  elb_backend_pool_v6_id = module.vnet.public_lb_backend_pool_v6_id
+  ilb_backend_pool_v4_id = module.vnet.internal_lb_backend_pool_v4_id
+  ilb_backend_pool_v6_id = module.vnet.internal_lb_backend_pool_v6_id
+  subnet_id              = module.vnet.master_subnet_id
+  instance_count         = var.master_count
+  storage_account        = azurerm_storage_account.cluster
+  os_volume_type         = var.azure_master_root_volume_type
+  os_volume_size         = var.azure_master_root_volume_size
+  private                = module.vnet.private
+
+  use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
+  use_ipv6                  = var.use_ipv6
+  emulate_single_stack_ipv6 = var.azure_emulate_single_stack_ipv6
 }
 
 module "dns" {
@@ -82,13 +99,20 @@ module "dns" {
   cluster_id                      = var.cluster_id
   base_domain                     = var.base_domain
   virtual_network_id              = module.vnet.virtual_network_id
-  external_lb_fqdn                = module.vnet.public_lb_pip_fqdn
-  internal_lb_ipaddress           = module.vnet.internal_lb_ip_address
+  external_lb_fqdn_v4             = module.vnet.public_lb_pip_v4_fqdn
+  external_lb_fqdn_v6             = module.vnet.public_lb_pip_v6_fqdn
+  internal_lb_ipaddress_v4        = module.vnet.internal_lb_ip_v4_address
+  internal_lb_ipaddress_v6        = module.vnet.internal_lb_ip_v6_address
   resource_group_name             = azurerm_resource_group.main.name
   base_domain_resource_group_name = var.azure_base_domain_resource_group_name
   etcd_count                      = var.master_count
-  etcd_ip_addresses               = module.master.ip_addresses
+  etcd_ip_v4_addresses            = module.master.ip_v4_addresses
+  etcd_ip_v6_addresses            = module.master.ip_v6_addresses
   private                         = module.vnet.private
+
+  use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
+  use_ipv6                  = var.use_ipv6
+  emulate_single_stack_ipv6 = var.azure_emulate_single_stack_ipv6
 }
 
 resource "random_string" "storage_suffix" {

--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -1,7 +1,9 @@
 locals {
   // The name of the masters' ipconfiguration is hardcoded to "pipconfig". It needs to match cluster-api
   // https://github.com/openshift/cluster-api-provider-azure/blob/master/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go#L131
-  ip_configuration_name = "pipConfig"
+  ip_v4_configuration_name = "pipConfig"
+  // TODO: Azure machine provider probably needs to look for pipConfig-v6 as well (or a different name like pipConfig-secondary)
+  ip_v6_configuration_name = "pipConfig-v6"
 }
 
 resource "azurerm_network_interface" "master" {
@@ -11,27 +13,69 @@ resource "azurerm_network_interface" "master" {
   location            = var.region
   resource_group_name = var.resource_group_name
 
-  ip_configuration {
-    subnet_id                     = var.subnet_id
-    name                          = local.ip_configuration_name
-    private_ip_address_allocation = "Dynamic"
+  dynamic "ip_configuration" {
+    for_each = [for ip in [
+      {
+        // LIMITATION: azure does not allow an ipv6 address to be primary today
+        primary : var.use_ipv4,
+        name : local.ip_v4_configuration_name,
+        ip_address_version : "IPv4",
+        include : var.use_ipv4 || var.use_ipv6
+      },
+      {
+        primary : ! var.use_ipv4,
+        name : local.ip_v6_configuration_name,
+        ip_address_version : "IPv6",
+        include : var.use_ipv6
+      },
+      ] : {
+      primary : ip.primary
+      name : ip.name
+      ip_address_version : ip.ip_address_version
+      include : ip.include
+      } if ip.include
+    ]
+    content {
+      primary                       = ip_configuration.value.primary
+      name                          = ip_configuration.value.name
+      subnet_id                     = var.subnet_id
+      private_ip_address_version    = ip_configuration.value.ip_address_version
+      private_ip_address_allocation = "Dynamic"
+    }
   }
 }
 
-resource "azurerm_network_interface_backend_address_pool_association" "master" {
-  count = var.instance_count
+resource "azurerm_network_interface_backend_address_pool_association" "master_v4" {
+  // should be 'count = var.use_ipv4 && ! var.emulate_single_stack_ipv6 ? var.instance_count : 0', but we need a V4 LB for egress for quay
+  count = var.use_ipv4 ? var.instance_count : 0
 
   network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
-  backend_address_pool_id = var.elb_backend_pool_id
-  ip_configuration_name   = local.ip_configuration_name #must be the same as nic's ip configuration name.
+  backend_address_pool_id = var.elb_backend_pool_v4_id
+  ip_configuration_name   = local.ip_v4_configuration_name
 }
 
-resource "azurerm_network_interface_backend_address_pool_association" "master_internal" {
-  count = var.instance_count
+resource "azurerm_network_interface_backend_address_pool_association" "master_v6" {
+  count = var.use_ipv6 ? var.instance_count : 0
 
   network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
-  backend_address_pool_id = var.ilb_backend_pool_id
-  ip_configuration_name   = local.ip_configuration_name #must be the same as nic's ip configuration name.
+  backend_address_pool_id = var.elb_backend_pool_v6_id
+  ip_configuration_name   = local.ip_v6_configuration_name
+}
+
+resource "azurerm_network_interface_backend_address_pool_association" "master_internal_v4" {
+  count = var.use_ipv4 ? var.instance_count : 0
+
+  network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
+  backend_address_pool_id = var.ilb_backend_pool_v4_id
+  ip_configuration_name   = local.ip_v4_configuration_name
+}
+
+resource "azurerm_network_interface_backend_address_pool_association" "master_internal_v6" {
+  count = var.use_ipv6 ? var.instance_count : 0
+
+  network_interface_id    = element(azurerm_network_interface.master.*.id, count.index)
+  backend_address_pool_id = var.ilb_backend_pool_v6_id
+  ip_configuration_name   = local.ip_v6_configuration_name
 }
 
 resource "azurerm_virtual_machine" "master" {

--- a/data/data/azure/master/outputs.tf
+++ b/data/data/azure/master/outputs.tf
@@ -1,4 +1,8 @@
-output "ip_addresses" {
-  value = azurerm_network_interface.master.*.private_ip_address
+output "ip_v4_addresses" {
+  value = var.use_ipv4 ? azurerm_network_interface.master.*.private_ip_address : []
+}
+
+output "ip_v6_addresses" {
+  value = var.use_ipv6 ? azurerm_network_interface.master.*.private_ip_addresses.1 : []
 }
 

--- a/data/data/azure/master/variables.tf
+++ b/data/data/azure/master/variables.tf
@@ -34,11 +34,19 @@ variable "external_lb_id" {
   type = string
 }
 
-variable "elb_backend_pool_id" {
+variable "elb_backend_pool_v4_id" {
   type = string
 }
 
-variable "ilb_backend_pool_id" {
+variable "elb_backend_pool_v6_id" {
+  type = string
+}
+
+variable "ilb_backend_pool_v4_id" {
+  type = string
+}
+
+variable "ilb_backend_pool_v6_id" {
   type = string
 }
 
@@ -90,4 +98,19 @@ variable "availability_zones" {
 variable "private" {
   type        = bool
   description = "This value determines if this is a private cluster or not."
+}
+
+variable "use_ipv4" {
+  type        = bool
+  description = "This value determines if this is cluster should use IPv4 networking."
+}
+
+variable "use_ipv6" {
+  type        = bool
+  description = "This value determines if this is cluster should use IPv6 networking."
+}
+
+variable "emulate_single_stack_ipv6" {
+  type        = bool
+  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
 }

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -111,3 +111,26 @@ variable "azure_private" {
   type        = bool
   description = "This determines if this is a private cluster or not."
 }
+
+variable "azure_machine_v4_cidrs" {
+  type = list(string)
+
+  description = <<EOF
+The list of IPv4 address spaces from which to assign machine IPs.
+EOF
+
+}
+
+variable "azure_machine_v6_cidrs" {
+  type = list(string)
+
+  description = <<EOF
+The list of IPv6 address spaces from which to assign machine IPs.
+EOF
+
+}
+
+variable "azure_emulate_single_stack_ipv6" {
+  type        = bool
+  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
+}

--- a/data/data/azure/vnet/common.tf
+++ b/data/data/azure/vnet/common.tf
@@ -26,8 +26,11 @@ data "azurerm_virtual_network" "preexisting_virtual_network" {
 
 // Only reference data sources which are guaranteed to exist at any time (above) in this locals{} block
 locals {
-  master_subnet_cidr = cidrsubnet(var.vnet_cidr, 3, 0) #master subnet is a smaller subnet within the vnet. i.e from /21 to /24
-  worker_subnet_cidr = cidrsubnet(var.vnet_cidr, 3, 1) #node subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  master_subnet_cidr_v4 = var.use_ipv4 ? cidrsubnet(var.vnet_v4_cidrs[0], 3, 0) : null  #master subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  master_subnet_cidr_v6 = var.use_ipv6 ? cidrsubnet(var.vnet_v6_cidrs[0], 16, 0) : null #master subnet is a smaller subnet within the vnet. i.e from /48 to /64
+
+  worker_subnet_cidr_v4 = var.use_ipv4 ? cidrsubnet(var.vnet_v4_cidrs[0], 3, 1) : null  #node subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  worker_subnet_cidr_v6 = var.use_ipv6 ? cidrsubnet(var.vnet_v6_cidrs[0], 16, 1) : null #node subnet is a smaller subnet within the vnet. i.e from /48 to /64
 
   master_subnet_id = var.preexisting_network ? data.azurerm_subnet.preexisting_master_subnet[0].id : azurerm_subnet.master_subnet[0].id
   worker_subnet_id = var.preexisting_network ? data.azurerm_subnet.preexisting_worker_subnet[0].id : azurerm_subnet.worker_subnet[0].id

--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -1,5 +1,6 @@
 locals {
-  internal_lb_frontend_ip_configuration_name = "internal-lb-ip"
+  internal_lb_frontend_ip_v4_configuration_name = "internal-lb-ip-v4"
+  internal_lb_frontend_ip_v6_configuration_name = "internal-lb-ip-v6"
 }
 
 resource "azurerm_lb" "internal" {
@@ -8,43 +9,109 @@ resource "azurerm_lb" "internal" {
   resource_group_name = var.resource_group_name
   location            = var.region
 
-  frontend_ip_configuration {
-    name                          = local.internal_lb_frontend_ip_configuration_name
-    subnet_id                     = local.master_subnet_id
-    private_ip_address_allocation = "Dynamic"
+  dynamic "frontend_ip_configuration" {
+    for_each = [for ip in [
+      // TODO: internal LB should block v4 for better single stack emulation (&& ! var.emulate_single_stack_ipv6)
+      //   but RHCoS initramfs can't do v6 and so fails to ignite. https://issues.redhat.com/browse/GRPA-1343 
+      { name : local.internal_lb_frontend_ip_v4_configuration_name, ipv6 : false, include : var.use_ipv4 },
+      { name : local.internal_lb_frontend_ip_v6_configuration_name, ipv6 : true, include : var.use_ipv6 },
+      ] : {
+      name : ip.name
+      ipv6 : ip.ipv6
+      include : ip.include
+      } if ip.include
+    ]
+
+    content {
+      name                       = frontend_ip_configuration.value.name
+      subnet_id                  = local.master_subnet_id
+      private_ip_address_version = frontend_ip_configuration.value.ipv6 ? "IPv6" : "IPv4"
+      # WORKAROUND: Allocate a high ipv6 internal LB address to avoid the race with NIC allocation (a master and the LB
+      #   were being assigned the same IP dynamically). Issue is being tracked as a support ticket to Azure.
+      private_ip_address_allocation = frontend_ip_configuration.value.ipv6 ? "Static" : "Dynamic"
+      private_ip_address            = frontend_ip_configuration.value.ipv6 ? cidrhost(local.master_subnet_cidr_v6, -2) : null
+    }
   }
 }
 
-resource "azurerm_lb_backend_address_pool" "internal_lb_controlplane_pool" {
+resource "azurerm_lb_backend_address_pool" "internal_lb_controlplane_pool_v4" {
+  count = var.use_ipv4 ? 1 : 0
+
   resource_group_name = var.resource_group_name
   loadbalancer_id     = azurerm_lb.internal.id
-  name                = "${var.cluster_id}-internal-controlplane"
+  name                = "${var.cluster_id}-internal-controlplane-v4"
 }
 
-resource "azurerm_lb_rule" "internal_lb_rule_api_internal" {
-  name                           = "api-internal"
+resource "azurerm_lb_backend_address_pool" "internal_lb_controlplane_pool_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
+  resource_group_name = var.resource_group_name
+  loadbalancer_id     = azurerm_lb.internal.id
+  name                = "${var.cluster_id}-internal-controlplane-v6"
+}
+
+resource "azurerm_lb_rule" "internal_lb_rule_api_internal_v4" {
+  count = var.use_ipv4 ? 1 : 0
+
+  name                           = "api-internal-v4"
   resource_group_name            = var.resource_group_name
   protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_controlplane_pool.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[0].id
   loadbalancer_id                = azurerm_lb.internal.id
   frontend_port                  = 6443
   backend_port                   = 6443
-  frontend_ip_configuration_name = local.internal_lb_frontend_ip_configuration_name
+  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v4_configuration_name
   enable_floating_ip             = false
   idle_timeout_in_minutes        = 30
   load_distribution              = "Default"
   probe_id                       = azurerm_lb_probe.internal_lb_probe_api_internal.id
 }
 
-resource "azurerm_lb_rule" "internal_lb_rule_sint" {
-  name                           = "sint"
+resource "azurerm_lb_rule" "internal_lb_rule_api_internal_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
+  name                           = "api-internal-v6"
   resource_group_name            = var.resource_group_name
   protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_controlplane_pool.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v6[0].id
+  loadbalancer_id                = azurerm_lb.internal.id
+  frontend_port                  = 6443
+  backend_port                   = 6443
+  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v6_configuration_name
+  enable_floating_ip             = false
+  idle_timeout_in_minutes        = 30
+  load_distribution              = "Default"
+  probe_id                       = azurerm_lb_probe.internal_lb_probe_api_internal.id
+}
+
+resource "azurerm_lb_rule" "internal_lb_rule_sint_v4" {
+  count = var.use_ipv4 ? 1 : 0
+
+  name                           = "sint-v4"
+  resource_group_name            = var.resource_group_name
+  protocol                       = "Tcp"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[0].id
   loadbalancer_id                = azurerm_lb.internal.id
   frontend_port                  = 22623
   backend_port                   = 22623
-  frontend_ip_configuration_name = local.internal_lb_frontend_ip_configuration_name
+  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v4_configuration_name
+  enable_floating_ip             = false
+  idle_timeout_in_minutes        = 30
+  load_distribution              = "Default"
+  probe_id                       = azurerm_lb_probe.internal_lb_probe_sint.id
+}
+
+resource "azurerm_lb_rule" "internal_lb_rule_sint_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
+  name                           = "sint-v6"
+  resource_group_name            = var.resource_group_name
+  protocol                       = "Tcp"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v6[0].id
+  loadbalancer_id                = azurerm_lb.internal.id
+  frontend_port                  = 22623
+  backend_port                   = 22623
+  frontend_ip_configuration_name = local.internal_lb_frontend_ip_v6_configuration_name
   enable_floating_ip             = false
   idle_timeout_in_minutes        = 30
   load_distribution              = "Default"
@@ -70,4 +137,3 @@ resource "azurerm_lb_probe" "internal_lb_probe_api_internal" {
   port                = 6443
   protocol            = "TCP"
 }
-

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -1,25 +1,39 @@
-output "cluster-pip" {
-  value = var.private ? null : azurerm_public_ip.cluster_public_ip.ip_address
+output "public_lb_backend_pool_v4_id" {
+  value = var.use_ipv4 ? azurerm_lb_backend_address_pool.master_public_lb_pool_v4[0].id : null
 }
 
-output "public_lb_backend_pool_id" {
-  value = azurerm_lb_backend_address_pool.master_public_lb_pool.id
+output "public_lb_backend_pool_v6_id" {
+  value = var.use_ipv6 ? azurerm_lb_backend_address_pool.master_public_lb_pool_v6[0].id : null
 }
 
-output "internal_lb_backend_pool_id" {
-  value = azurerm_lb_backend_address_pool.internal_lb_controlplane_pool.id
+output "internal_lb_backend_pool_v4_id" {
+  value = var.use_ipv4 ? azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v4[0].id : null
+}
+
+output "internal_lb_backend_pool_v6_id" {
+  value = var.use_ipv6 ? azurerm_lb_backend_address_pool.internal_lb_controlplane_pool_v6[0].id : null
 }
 
 output "public_lb_id" {
   value = var.private ? null : azurerm_lb.public.id
 }
 
-output "public_lb_pip_fqdn" {
-  value = var.private ? null : data.azurerm_public_ip.cluster_public_ip.fqdn
+output "public_lb_pip_v4_fqdn" {
+  value = var.private || ! var.use_ipv4 ? null : data.azurerm_public_ip.cluster_public_ip_v4[0].fqdn
 }
 
-output "internal_lb_ip_address" {
-  value = azurerm_lb.internal.private_ip_address
+output "public_lb_pip_v6_fqdn" {
+  value = var.private || ! var.use_ipv6 ? null : data.azurerm_public_ip.cluster_public_ip_v6[0].fqdn
+}
+
+output "internal_lb_ip_v4_address" {
+  value = var.use_ipv4 ? azurerm_lb.internal.private_ip_addresses[0] : null
+}
+
+output "internal_lb_ip_v6_address" {
+  // TODO: internal LB should block v4 for better single stack emulation (&& ! var.emulate_single_stack_ipv6)
+  //   but RHCoS initramfs can't do v6 and so fails to ignite. https://issues.redhat.com/browse/GRPA-1343 
+  value = var.use_ipv6 ? azurerm_lb.internal.private_ip_addresses[1] : null
 }
 
 output "master_nsg_name" {

--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -1,18 +1,44 @@
 locals {
-  public_lb_frontend_ip_configuration_name = "public-lb-ip"
+  public_lb_frontend_ip_v4_configuration_name = "public-lb-ip-v4"
+  public_lb_frontend_ip_v6_configuration_name = "public-lb-ip-v6"
 }
 
-resource "azurerm_public_ip" "cluster_public_ip" {
+resource "azurerm_public_ip" "cluster_public_ip_v4" {
+  // DEBUG: Azure apparently requires dual stack LB for v6
+  count = var.use_ipv4 || true ? 1 : 0
+
   sku                 = "Standard"
   location            = var.region
-  name                = "${var.cluster_id}-pip"
+  name                = "${var.cluster_id}-pip-v4"
   resource_group_name = var.resource_group_name
   allocation_method   = "Static"
   domain_name_label   = var.dns_label
 }
 
-data "azurerm_public_ip" "cluster_public_ip" {
-  name                = azurerm_public_ip.cluster_public_ip.name
+data "azurerm_public_ip" "cluster_public_ip_v4" {
+  // DEBUG: Azure apparently requires dual stack LB for v6
+  count = var.use_ipv4 || true ? 1 : 0
+
+  name                = azurerm_public_ip.cluster_public_ip_v4[0].name
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_public_ip" "cluster_public_ip_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
+  ip_version          = "IPv6"
+  sku                 = "Standard"
+  location            = var.region
+  name                = "${var.cluster_id}-pip-v6"
+  resource_group_name = var.resource_group_name
+  allocation_method   = "Static"
+  domain_name_label   = var.dns_label
+}
+
+data "azurerm_public_ip" "cluster_public_ip_v6" {
+  count = var.use_ipv6 ? 1 : 0
+
+  name                = azurerm_public_ip.cluster_public_ip_v6[0].name
   resource_group_name = var.resource_group_name
 }
 
@@ -22,46 +48,105 @@ resource "azurerm_lb" "public" {
   resource_group_name = var.resource_group_name
   location            = var.region
 
-  frontend_ip_configuration {
-    name                 = local.public_lb_frontend_ip_configuration_name
-    public_ip_address_id = azurerm_public_ip.cluster_public_ip.id
+  dynamic "frontend_ip_configuration" {
+    for_each = [for ip in [
+      // DEBUG: Azure apparently requires dual stack LB for external load balancers v6
+      { name : local.public_lb_frontend_ip_v4_configuration_name, value : azurerm_public_ip.cluster_public_ip_v4[0].id, include : true, ipv6 : false },
+      { name : local.public_lb_frontend_ip_v6_configuration_name, value : azurerm_public_ip.cluster_public_ip_v6[0].id, include : var.use_ipv6, ipv6 : true },
+      ] : {
+      name : ip.name
+      value : ip.value
+      ipv6 : ip.ipv6
+      include : ip.include
+      } if ip.include
+    ]
+
+    content {
+      name                          = frontend_ip_configuration.value.name
+      public_ip_address_id          = frontend_ip_configuration.value.value
+      private_ip_address_version    = frontend_ip_configuration.value.ipv6 ? "IPv6" : "IPv4"
+      private_ip_address_allocation = "Dynamic"
+    }
   }
 }
 
-resource "azurerm_lb_backend_address_pool" "master_public_lb_pool" {
+resource "azurerm_lb_backend_address_pool" "master_public_lb_pool_v4" {
+  count = var.use_ipv4 ? 1 : 0
+
   resource_group_name = var.resource_group_name
   loadbalancer_id     = azurerm_lb.public.id
-  name                = "${var.cluster_id}-public-lb-control-plane"
+  name                = "${var.cluster_id}-public-lb-control-plane-v4"
 }
 
-resource "azurerm_lb_rule" "public_lb_rule_api_internal" {
-  count = var.private ? 0 : 1
+resource "azurerm_lb_backend_address_pool" "master_public_lb_pool_v6" {
+  count = var.use_ipv6 ? 1 : 0
 
-  name                           = "api-internal"
+  resource_group_name = var.resource_group_name
+  loadbalancer_id     = azurerm_lb.public.id
+  name                = "${var.cluster_id}-public-lb-control-plane-v6"
+}
+
+resource "azurerm_lb_rule" "public_lb_rule_api_internal_v4" {
+  count = var.private || ! var.use_ipv4 ? 0 : 1
+
+  name                           = "api-internal-v4"
   resource_group_name            = var.resource_group_name
   protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool_v4[0].id
   loadbalancer_id                = azurerm_lb.public.id
   frontend_port                  = 6443
   backend_port                   = 6443
-  frontend_ip_configuration_name = local.public_lb_frontend_ip_configuration_name
+  frontend_ip_configuration_name = local.public_lb_frontend_ip_v4_configuration_name
   enable_floating_ip             = false
   idle_timeout_in_minutes        = 30
   load_distribution              = "Default"
   probe_id                       = azurerm_lb_probe.public_lb_probe_api_internal[0].id
 }
 
-resource "azurerm_lb_rule" "internal_outbound_rule" {
-  count = var.private ? 1 : 0
+resource "azurerm_lb_rule" "public_lb_rule_api_internal_v6" {
+  count = var.private || ! var.use_ipv6 ? 0 : 1
 
-  name                           = "internal_outbound_rule"
+  name                           = "api-internal-v6"
   resource_group_name            = var.resource_group_name
   protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool.id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool_v6[0].id
+  loadbalancer_id                = azurerm_lb.public.id
+  frontend_port                  = 6443
+  backend_port                   = 6443
+  frontend_ip_configuration_name = local.public_lb_frontend_ip_v6_configuration_name
+  enable_floating_ip             = false
+  idle_timeout_in_minutes        = 30
+  load_distribution              = "Default"
+  probe_id                       = azurerm_lb_probe.public_lb_probe_api_internal[0].id
+}
+
+resource "azurerm_lb_rule" "internal_outbound_rule_v4" {
+  count = var.private && var.use_ipv4 ? 1 : 0
+
+  name                           = "internal_outbound_rule_v4"
+  resource_group_name            = var.resource_group_name
+  protocol                       = "Tcp"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool_v4[0].id
   loadbalancer_id                = azurerm_lb.public.id
   frontend_port                  = 27627
   backend_port                   = 27627
-  frontend_ip_configuration_name = local.public_lb_frontend_ip_configuration_name
+  frontend_ip_configuration_name = local.public_lb_frontend_ip_v4_configuration_name
+  enable_floating_ip             = false
+  idle_timeout_in_minutes        = 30
+  load_distribution              = "Default"
+}
+
+resource "azurerm_lb_rule" "internal_outbound_rule_v6" {
+  count = var.private && var.use_ipv6 ? 1 : 0
+
+  name                           = "internal_outbound_rule_v6"
+  resource_group_name            = var.resource_group_name
+  protocol                       = "Tcp"
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool_v6[0].id
+  loadbalancer_id                = azurerm_lb.public.id
+  frontend_port                  = 27627
+  backend_port                   = 27627
+  frontend_ip_configuration_name = local.public_lb_frontend_ip_v6_configuration_name
   enable_floating_ip             = false
   idle_timeout_in_minutes        = 30
   load_distribution              = "Default"

--- a/data/data/azure/vnet/variables.tf
+++ b/data/data/azure/vnet/variables.tf
@@ -1,5 +1,9 @@
-variable "vnet_cidr" {
-  type = string
+variable "vnet_v4_cidrs" {
+  type = list(string)
+}
+
+variable "vnet_v6_cidrs" {
+  type = list(string)
 }
 
 variable "resource_group_name" {
@@ -56,4 +60,19 @@ variable "worker_subnet" {
 variable "private" {
   type        = bool
   description = "The determines if this is a private/internal cluster or not."
+}
+
+variable "use_ipv4" {
+  type        = bool
+  description = "This value determines if this is cluster should use IPv4 networking."
+}
+
+variable "use_ipv6" {
+  type        = bool
+  description = "This value determines if this is cluster should use IPv6 networking."
+}
+
+variable "emulate_single_stack_ipv6" {
+  type        = bool
+  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
 }

--- a/data/data/azure/vnet/vnet.tf
+++ b/data/data/azure/vnet/vnet.tf
@@ -4,7 +4,7 @@ resource "azurerm_virtual_network" "cluster_vnet" {
   name                = var.virtual_network_name
   resource_group_name = var.resource_group_name
   location            = var.region
-  address_space       = [var.vnet_cidr]
+  address_space       = concat(var.vnet_v4_cidrs, var.vnet_v6_cidrs)
 }
 
 resource "azurerm_route_table" "route_table" {
@@ -16,8 +16,11 @@ resource "azurerm_route_table" "route_table" {
 resource "azurerm_subnet" "master_subnet" {
   count = var.preexisting_network ? 0 : 1
 
-  resource_group_name  = var.resource_group_name
-  address_prefix       = local.master_subnet_cidr
+  resource_group_name = var.resource_group_name
+  address_prefixes = [for cidr in [
+    { value : local.master_subnet_cidr_v4, include : var.use_ipv4 },
+    { value : local.master_subnet_cidr_v6, include : var.use_ipv6 }
+  ] : cidr.value if cidr.include]
   virtual_network_name = local.virtual_network
   name                 = var.master_subnet
 }
@@ -25,8 +28,11 @@ resource "azurerm_subnet" "master_subnet" {
 resource "azurerm_subnet" "worker_subnet" {
   count = var.preexisting_network ? 0 : 1
 
-  resource_group_name  = var.resource_group_name
-  address_prefix       = local.worker_subnet_cidr
+  resource_group_name = var.resource_group_name
+  address_prefixes = [for cidr in [
+    { value : local.worker_subnet_cidr_v4, include : var.use_ipv4 },
+    { value : local.worker_subnet_cidr_v6, include : var.use_ipv6 }
+  ] : cidr.value if cidr.include]
   virtual_network_name = local.virtual_network
   name                 = var.worker_subnet
 }

--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -83,3 +83,20 @@ EOF
 
 }
 
+variable "use_ipv4" {
+  type = bool
+
+  description = <<EOF
+Should the cluster be created with ipv4 networking.
+EOF
+
+}
+
+variable "use_ipv6" {
+  type = bool
+
+  description = <<EOF
+Should the cluster be created with ipv6 networking.
+EOF
+
+}

--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -29,7 +29,6 @@ The installer can use an existing VNet and subnets when provisioning an OpenShif
 
 When pre-existing subnets are provided, the installer will not create a network security group (NSG) or alter an existing one attached to the subnet. This restriction means that no security rules are created. If multiple clusters are installed to the same VNet and isolation is desired, it must be enforced through an administrative task after the cluster is installed.
 
-
 ## Examples
 
 Some example `install-config.yaml` are shown below.

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -34,17 +34,18 @@ The following `install-config.yaml` properties are available:
     * `name` (required string): The name of the cluster.
         DNS records for the cluster are all subdomains of `{{.metadata.name}}.{{.baseDomain}}`.
 * `networking` (optional object): The configuration for the pod network provider in the cluster.
-    * `clusterNetwork` (optional array of objects): The IP address pool for pods.
+    * `clusterNetwork` (optional array of objects): The IP address pools for pods.
         The default is 10.128.0.0/14 with a host prefix of /23.
         * `cidr` (required [IP network](#ip-networks)): The IP block address pool.
         * `hostPrefix` (required integer): The prefix size to allocate to each node from the CIDR.
         For example, 24 would allocate 2^8=256 adresses to each node.
-    * `machineCIDR` (optional [IP network](#ip-networks)): The IP address pool for machines.
-        The default is 10.0.0.0/16 for all platforms other than libvirt.
-        For libvirt, the default is 192.168.126.0/24.
+    * `machineNetwork` (optional array of objects): The IP address pools for machines.
+        * `cidr` (required [IP network](#ip-networks)): The IP block address pool.
+            The default is 10.0.0.0/16 for all platforms other than libvirt.
+            For libvirt, the default is 192.168.126.0/24.
     * `networkType` (optional string): The type of network to install.
         The default is [OpenShiftSDN][openshift-sdn].
-    * `serviceNetwork` (optional array of [IP networks](#ip-networks)): The IP address pool for services.
+    * `serviceNetwork` (optional array of [IP networks](#ip-networks)): The IP address pools for services.
         The default is 172.30.0.0/16.
 * `platform` (required object): The configuration for the specific platform upon which to perform the installation.
     * `aws` (optional object): [AWS-specific properties](aws/customization.md#cluster-scoped-properties).
@@ -137,7 +138,8 @@ networking:
   clusterNetworks:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - cidr: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16

--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -113,7 +113,8 @@ baseDomain: test.metalkube.org
 metadata:
   name: ostest
 networking:
-  machineCIDR: 192.168.111.0/24
+  machineNetwork:
+  - cidr: 192.168.111.0/24
 compute:
 - name: worker
   replicas: 1

--- a/docs/user/openstack/known-issues.md
+++ b/docs/user/openstack/known-issues.md
@@ -15,9 +15,12 @@ Since the installer requires the *Name* of your external network and Red Hat Cor
 If your external network's CIDR range is the same as one of the default network ranges, then you will need to change the matching network range by running the installer with a custom `install-config.yaml`. If users are experiencing unusual networking problems, please contact your cluster administrator and validate that none of your network CIDRs are overlapping with the external network. We were unfortunately unable to support validation for this due to a lack of support in gophercloud, and even if we were, it is likely that the CIDR range of the floating ip would only be accessible cluster administrators. The default network CIDR are as follows:
 
 ```txt
-machineCIDR:    10.0.0.0/16
-serviceNetwork: 172.30.0.0/16
-clusterNetwork: 10.128.0.0/14
+machineNetwork:
+- cidr: "10.0.0.0/16"
+serviceNetwork:
+- "172.30.0.0/16"
+clusterNetwork:
+- cidr: "10.128.0.0/14"
 ```
 
 ## Lack of default DNS servers on created subnets

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -116,7 +116,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		clusterID.InfraID,
 		installConfig.Config.ClusterDomain(),
 		installConfig.Config.BaseDomain,
-		&installConfig.Config.Networking.MachineCIDR.IPNet,
+		&installConfig.Config.Networking.MachineNetwork[0].CIDR.IPNet,
 		bootstrapIgn,
 		masterIgn,
 		masterCount,
@@ -294,7 +294,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		data, err = libvirttfvars.TFVars(
 			masters[0].Spec.ProviderSpec.Value.Object.(*libvirtprovider.LibvirtMachineProviderConfig),
 			string(*rhcosImage),
-			&installConfig.Config.Networking.MachineCIDR.IPNet,
+			&installConfig.Config.Networking.MachineNetwork[0].CIDR.IPNet,
 			installConfig.Config.Platform.Libvirt.Network.IfName,
 			masterCount,
 		)

--- a/pkg/asset/installconfig/aws/validation_test.go
+++ b/pkg/asset/installconfig/aws/validation_test.go
@@ -18,7 +18,9 @@ var (
 func validInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
-			MachineCIDR: ipnet.MustParseCIDR(validCIDR),
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR(validCIDR)},
+			},
 		},
 		Publish: types.ExternalPublishingStrategy,
 		Platform: types.Platform{
@@ -184,7 +186,7 @@ func TestValidate(t *testing.T) {
 			}
 			return s
 		}(),
-		exptectErr: `^platform\.aws\.subnets\[6\]: Invalid value: \"invalid-cidr-subnet\": CIDR range 192\.168\.126\.0/24 is outside of the MachineCIDR 10\.0\.0\.0/16$`,
+		exptectErr: `^platform\.aws\.subnets\[6\]: Invalid value: \"invalid-cidr-subnet\": subnet's CIDR range start 192.168.126.0 is outside of the specified machine networks$`,
 	}, {
 		name: "invalid cidr does not belong to machine CIDR",
 		installConfig: func() *types.InstallConfig {
@@ -207,7 +209,7 @@ func TestValidate(t *testing.T) {
 			}
 			return s
 		}(),
-		exptectErr: `^\[platform\.aws\.subnets\[6\]: Invalid value: \"invalid-private-cidr-subnet\": CIDR range 192\.168\.126\.0/24 is outside of the MachineCIDR 10\.0\.0\.0/16, platform\.aws\.subnets\[7\]: Invalid value: \"invalid-public-cidr-subnet\": CIDR range 192\.168\.127\.0/24 is outside of the MachineCIDR 10\.0\.0\.0/16\]$`,
+		exptectErr: `^\[platform\.aws\.subnets\[6\]: Invalid value: \"invalid-private-cidr-subnet\": subnet's CIDR range start 192.168.126.0 is outside of the specified machine networks, platform\.aws\.subnets\[7\]: Invalid value: \"invalid-public-cidr-subnet\": subnet's CIDR range start 192.168.127.0 is outside of the specified machine networks\]$`,
 	}, {
 		name: "invalid missing public subnet in a zone",
 		installConfig: func() *types.InstallConfig {

--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -6,7 +6,6 @@ import (
 	"net"
 
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
-	"github.com/openshift/installer/pkg/ipnet"
 	aztypes "github.com/openshift/installer/pkg/types/azure"
 
 	"github.com/openshift/installer/pkg/types"
@@ -16,12 +15,13 @@ import (
 // Validate executes platform-specific validation.
 func Validate(client API, ic *types.InstallConfig) error {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateNetworks(client, ic.Azure, ic.Networking.MachineCIDR, field.NewPath("platform").Child("azure"))...)
+
+	allErrs = append(allErrs, validateNetworks(client, ic.Azure, ic.Networking.MachineNetwork, field.NewPath("platform").Child("azure"))...)
 	return allErrs.ToAggregate()
 }
 
 // validateNetworks checks that the user-provided VNet and subnets are valid.
-func validateNetworks(client API, p *aztypes.Platform, machineCIDR *ipnet.IPNet, fieldPath *field.Path) field.ErrorList {
+func validateNetworks(client API, p *aztypes.Platform, machineNetworks []types.MachineNetworkEntry, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if p.VirtualNetwork != "" {
@@ -35,21 +35,21 @@ func validateNetworks(client API, p *aztypes.Platform, machineCIDR *ipnet.IPNet,
 			return append(allErrs, field.Invalid(fieldPath.Child("computeSubnet"), p.ComputeSubnet, "failed to retrieve compute subnet"))
 		}
 
-		allErrs = append(allErrs, validateSubnet(client, machineCIDR, fieldPath.Child("computeSubnet"), computeSubnet, p.ComputeSubnet)...)
+		allErrs = append(allErrs, validateSubnet(client, fieldPath.Child("computeSubnet"), computeSubnet, p.ComputeSubnet, machineNetworks)...)
 
 		controlPlaneSubnet, err := client.GetControlPlaneSubnet(context.TODO(), p.NetworkResourceGroupName, p.VirtualNetwork, p.ControlPlaneSubnet)
 		if err != nil {
 			return append(allErrs, field.Invalid(fieldPath.Child("controlPlaneSubnet"), p.ControlPlaneSubnet, "failed to retrieve control plane subnet"))
 		}
 
-		allErrs = append(allErrs, validateSubnet(client, machineCIDR, fieldPath.Child("controlPlaneSubnet"), controlPlaneSubnet, p.ControlPlaneSubnet)...)
+		allErrs = append(allErrs, validateSubnet(client, fieldPath.Child("controlPlaneSubnet"), controlPlaneSubnet, p.ControlPlaneSubnet, machineNetworks)...)
 	}
 
 	return allErrs
 }
 
 // validateSubnet checks that the subnet is in the same network as the machine CIDR
-func validateSubnet(client API, machineCIDR *ipnet.IPNet, fieldPath *field.Path, subnet *aznetwork.Subnet, subnetName string) field.ErrorList {
+func validateSubnet(client API, fieldPath *field.Path, subnet *aznetwork.Subnet, subnetName string, networks []types.MachineNetworkEntry) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	subnetIP, _, err := net.ParseCIDR(*subnet.AddressPrefix)
@@ -57,10 +57,15 @@ func validateSubnet(client API, machineCIDR *ipnet.IPNet, fieldPath *field.Path,
 		return append(allErrs, field.Invalid(fieldPath, subnetName, "unable to parse subnet CIDR"))
 	}
 
-	if !machineCIDR.Contains(subnetIP) {
-		errMsg := fmt.Sprintf("subnet %v has an IP address range %v outside of the MachineCIDR %v", subnetName, subnet.AddressPrefix, machineCIDR)
-		return append(allErrs, field.Invalid(fieldPath, subnetName, errMsg))
-	}
+	allErrs = append(allErrs, validateMachineNetworksContainIP(fieldPath, networks, *subnet.Name, subnetIP)...)
+	return allErrs
+}
 
-	return nil
+func validateMachineNetworksContainIP(fldPath *field.Path, networks []types.MachineNetworkEntry, subnetName string, ip net.IP) field.ErrorList {
+	for _, network := range networks {
+		if network.CIDR.Contains(ip) {
+			return nil
+		}
+	}
+	return field.ErrorList{field.Invalid(fldPath, subnetName, fmt.Sprintf("subnet %s address prefix is outside of the specified machine networks", ip))}
 }

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -28,7 +28,9 @@ var (
 
 	invalidateMachineCIDR = func(ic *types.InstallConfig) {
 		_, newCidr, _ := net.ParseCIDR("192.168.111.0/24")
-		ic.MachineCIDR = &ipnet.IPNet{IPNet: *newCidr}
+		ic.MachineNetwork = []types.MachineNetworkEntry{
+			{CIDR: ipnet.IPNet{IPNet: *newCidr}},
+		}
 	}
 
 	invalidateNetworkResourceGroup = func(ic *types.InstallConfig) {
@@ -61,7 +63,9 @@ var (
 func validInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
-			MachineCIDR: ipnet.MustParseCIDR(validCIDR),
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR(validCIDR)},
+			},
 		},
 		Platform: types.Platform{
 			Azure: &azure.Platform{
@@ -94,7 +98,7 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 		{
 			name:     "Invalid subnet range",
 			edits:    editFunctions{invalidateMachineCIDR},
-			errorMsg: "subnet .+ has an IP address range .+ outside of the MachineCIDR",
+			errorMsg: "subnet .+ address prefix is outside of the specified machine networks",
 		},
 		{
 			name:     "Invalid virtual network",

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -27,7 +27,9 @@ var (
 
 	invalidateMachineCIDR = func(ic *types.InstallConfig) {
 		_, newCidr, _ := net.ParseCIDR("192.168.111.0/24")
-		ic.MachineCIDR = &ipnet.IPNet{IPNet: *newCidr}
+		ic.MachineNetwork = []types.MachineNetworkEntry{
+			{CIDR: ipnet.IPNet{IPNet: *newCidr}},
+		}
 	}
 
 	invalidateNetwork       = func(ic *types.InstallConfig) { ic.GCP.Network = "invalid-vpc" }
@@ -53,7 +55,9 @@ var (
 func validInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
-			MachineCIDR: ipnet.MustParseCIDR(validCIDR),
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR(validCIDR)},
+			},
 		},
 		Platform: types.Platform{
 			GCP: &gcp.Platform{
@@ -90,7 +94,7 @@ func TestGCPInstallConfigValidation(t *testing.T) {
 			name:           "Invalid subnet range",
 			edits:          editFunctions{invalidateMachineCIDR},
 			expectedError:  true,
-			expectedErrMsg: "computeSubnet: Invalid value.*MachineCIDR",
+			expectedErrMsg: "computeSubnet: Invalid value.*subnet CIDR range start 10.0.0.0 is outside of the specified machine networks",
 		},
 		{
 			name:           "Invalid network",

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -65,7 +65,9 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 		},
 		BaseDomain: "test-domain",
 		Networking: &types.Networking{
-			MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+			},
 			NetworkType:    "OpenShiftSDN",
 			ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 			ClusterNetwork: []types.ClusterNetworkEntry{
@@ -127,7 +129,9 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				},
 				BaseDomain: "test-domain",
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+					},
 					NetworkType:    "OpenShiftSDN",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
@@ -209,7 +213,9 @@ network:
 				},
 				BaseDomain: "test-domain",
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("10.0.0.0/16"),
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+					},
 					NetworkType:    "OpenShiftSDN",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 					ClusterNetwork: []types.ClusterNetworkEntry{

--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -27,7 +27,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	if pool.Replicas != nil {
 		total = *pool.Replicas
 	}
-	provider := provider(clusterID, config.Networking.MachineCIDR.String(), platform, userDataSecret)
+	provider := provider(clusterID, config.Networking.MachineNetwork[0].CIDR.String(), platform, userDataSecret)
 	var machines []machineapi.Machine
 	for idx := int64(0); idx < total; idx++ {
 		machine := machineapi.Machine{

--- a/pkg/asset/machines/libvirt/machinesets.go
+++ b/pkg/asset/machines/libvirt/machinesets.go
@@ -31,7 +31,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		total = *pool.Replicas
 	}
 
-	provider := provider(clusterID, config.Networking.MachineCIDR.String(), platform, userDataSecret)
+	provider := provider(clusterID, config.Networking.MachineNetwork[0].CIDR.String(), platform, userDataSecret)
 	name := fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, 0)
 	mset := &machineapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/asset/manifests/operators_test.go
+++ b/pkg/asset/manifests/operators_test.go
@@ -22,7 +22,9 @@ func TestRedactedInstallConfig(t *testing.T) {
 			SSHKey:     "test-ssh-key",
 			BaseDomain: "test-domain",
 			Networking: &types.Networking{
-				MachineCIDR: ipnet.MustParseCIDR("1.2.3.4/5"),
+				MachineNetwork: []types.MachineNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("1.2.3.4/5")},
+				},
 				NetworkType: "test-network-type",
 				ClusterNetwork: []types.ClusterNetworkEntry{
 					{
@@ -71,7 +73,8 @@ networking:
   clusterNetwork:
   - cidr: 1.2.3.4/5
     hostPrefix: 6
-  machineCIDR: 1.2.3.4/5
+  machineNetwork:
+  - cidr: 1.2.3.4/5
   networkType: test-network-type
   serviceNetwork:
   - 1.2.3.4/5

--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -124,10 +124,9 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 		"localhost",
 		".svc",
 		".cluster.local",
-		network.Config.Spec.ServiceNetwork[0],
 		internalAPIServer.Hostname(),
-		installConfig.Config.Networking.MachineCIDR.String(),
 	)
+
 	platform := installConfig.Config.Platform.Name()
 
 	if platform != vsphere.Name && platform != none.Name {
@@ -153,6 +152,14 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 	for i := int64(0); i < *installConfig.Config.ControlPlane.Replicas; i++ {
 		etcdHost := fmt.Sprintf("etcd-%d.%s", i, installConfig.Config.ClusterDomain())
 		set.Insert(etcdHost)
+	}
+
+	for _, network := range installConfig.Config.Networking.ServiceNetwork {
+		set.Insert(network.String())
+	}
+
+	for _, network := range installConfig.Config.Networking.MachineNetwork {
+		set.Insert(network.CIDR.String())
 	}
 
 	for _, clusterNetwork := range network.Config.Spec.ClusterNetwork {

--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -28,7 +28,7 @@
   version = "v0.4.12"
 
 [[projects]]
-  digest = "1:8021e3abefedd67a86d9653d9d0c8a3233f3f8877557b893f0a7a78dbdc6f02a"
+  digest = "1:01b10cea3bf227c7617f26d9a080e47b27410a73ca01dffdcac0d36cfdf74af2"
   name = "github.com/Azure/azure-sdk-for-go"
   packages = [
     "profiles/2017-03-09/resources/mgmt/resources",
@@ -97,8 +97,9 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "f0ff339f1297d3374fc36bcbfc7d1bbba045d992"
-  version = "v26.7.0"
+  revision = "07077554785f058c92843966f12d8b0cd3f8679d"
+  source = "https://github.com/openshift/azure-sdk-for-go"
+  version = "v26.7.1-openshift"
 
 [[projects]]
   digest = "1:90c9fd5fc13d2dc42520c321202481506f660e58ec9e2c546d2cc5304d7bba78"
@@ -846,7 +847,7 @@
   version = "v2.10.0"
 
 [[projects]]
-  digest = "1:95e2fb03b69a29c7f843830c392f684f110da8ca83649c821c20bad61d9116b5"
+  digest = "1:78f3ea27f70c476e8c05f82dd96dcd662527d68e9967a6d5ac89aad44604b7a0"
   name = "github.com/terraform-providers/terraform-provider-azurerm"
   packages = [
     "azurerm",
@@ -861,8 +862,9 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "05662fd82a299fff148a6a31cc9c2ba9b5841064"
-  version = "v1.27.1"
+  revision = "7bc287e956632e40076a4deb227ec42108be9fb0"
+  source = "https://github.com/openshift/terraform-provider-azurerm"
+  version = "v1.27.2-openshift"
 
 [[projects]]
   digest = "1:2daa3bddc630ead813a47149cdc429816c43f9423a7d6e2aeff7ca794b072548"

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -46,7 +46,13 @@ ignored = [
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-azurerm"
-  version = "=1.27.1"
+  source = "https://github.com/openshift/terraform-provider-azurerm"
+  version = "=v1.27.2-openshift"
+
+[[constraint]]
+  name = "github.com/Azure/azure-sdk-for-go"
+  source = "https://github.com/openshift/azure-sdk-for-go"
+  version = "=v26.7.1-openshift"
 
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-google"

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -77,3 +77,7 @@ ignored = [
 [[constraint]]
   name = "github.com/openshift-metal3/terraform-provider-ironic"
   version = "v0.1.8"
+
+[[override]]
+  name = "github.com/apparentlymart/go-cidr"
+  version = "v1.0.1"

--- a/pkg/terraform/exec/plugins/azureprivatedns/provider.go
+++ b/pkg/terraform/exec/plugins/azureprivatedns/provider.go
@@ -55,6 +55,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"azureprivatedns_zone":                      resourceArmPrivateDNSZone(),
 			"azureprivatedns_a_record":                  resourceArmPrivateDNSARecord(),
+			"azureprivatedns_aaaa_record":               resourceArmPrivateDNSAAAARecord(),
 			"azureprivatedns_srv_record":                resourceArmPrivateDNSSrvRecord(),
 			"azureprivatedns_zone_virtual_network_link": resourceArmPrivateDNSZoneVirtualNetworkLink(),
 		},

--- a/pkg/terraform/exec/plugins/azureprivatedns/resource_private_dns_aaaa_record.go
+++ b/pkg/terraform/exec/plugins/azureprivatedns/resource_private_dns_aaaa_record.go
@@ -1,0 +1,179 @@
+package azureprivatedns
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure"
+	"github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils"
+)
+
+func resourceArmPrivateDNSAAAARecord() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmPrivateDNSAAAARecordCreateUpdate,
+		Read:   resourceArmPrivateDNSAAAARecordRead,
+		Update: resourceArmPrivateDNSAAAARecordCreateUpdate,
+		Delete: resourceArmPrivateDNSAAAARecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
+
+			"zone_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"records": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
+			"ttl": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceArmPrivateDNSAAAARecordCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient).recordSetsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	name := d.Get("name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	zoneName := d.Get("zone_name").(string)
+
+	ttl := int64(d.Get("ttl").(int))
+	t := d.Get("tags").(map[string]interface{})
+
+	parameters := privatedns.RecordSet{
+		Name: &name,
+		RecordSetProperties: &privatedns.RecordSetProperties{
+			Metadata:    expandTags(t),
+			TTL:         &ttl,
+			AaaaRecords: expandAzureRmPrivateDNSAAAARecords(d),
+		},
+	}
+
+	eTag := ""
+	ifNoneMatch := "" // set to empty to allow updates to records after creation
+	if _, err := client.CreateOrUpdate(ctx, resGroup, zoneName, privatedns.AAAA, name, parameters, eTag, ifNoneMatch); err != nil {
+		return fmt.Errorf("error creating/updating Private DNS AAAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	}
+
+	resp, err := client.Get(ctx, resGroup, zoneName, privatedns.AAAA, name)
+	if err != nil {
+		return fmt.Errorf("error retrieving Private DNS AAAA Record %q (Zone %q / Resource Group %q): %s", name, zoneName, resGroup, err)
+	}
+
+	if resp.ID == nil {
+		return fmt.Errorf("cannot read Private DNS AAAA Record %s (resource group %s) ID", name, resGroup)
+	}
+
+	d.SetId(*resp.ID)
+
+	return resourceArmPrivateDNSAAAARecordRead(d, meta)
+}
+
+func resourceArmPrivateDNSAAAARecordRead(d *schema.ResourceData, meta interface{}) error {
+	dnsClient := meta.(*ArmClient).recordSetsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resGroup := id.ResourceGroup
+	name := id.Path["AAAA"]
+	zoneName := id.Path["privateDnsZones"]
+
+	resp, err := dnsClient.Get(ctx, resGroup, zoneName, privatedns.AAAA, name)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading Private DNS A record %s: %+v", name, err)
+	}
+
+	d.Set("name", name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("zone_name", zoneName)
+	d.Set("ttl", resp.TTL)
+
+	if err := d.Set("records", flattenAzureRmPrivateDNSAAAARecords(resp.AaaaRecords)); err != nil {
+		return err
+	}
+	flattenAndSetTags(d, resp.Metadata)
+
+	return nil
+}
+
+func resourceArmPrivateDNSAAAARecordDelete(d *schema.ResourceData, meta interface{}) error {
+	dnsClient := meta.(*ArmClient).recordSetsClient
+	ctx := meta.(*ArmClient).StopContext
+
+	id, err := azure.ParseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resGroup := id.ResourceGroup
+	name := id.Path["AAAA"]
+	zoneName := id.Path["privateDnsZones"]
+
+	resp, err := dnsClient.Delete(ctx, resGroup, zoneName, privatedns.AAAA, name, "")
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("error deleting Private DNS AAAA Record %s: %+v", name, err)
+	}
+
+	return nil
+}
+
+func flattenAzureRmPrivateDNSAAAARecords(records *[]privatedns.AaaaRecord) []string {
+	results := make([]string, 0)
+	if records == nil {
+		return results
+	}
+
+	for _, record := range *records {
+		if record.Ipv6Address == nil {
+			continue
+		}
+
+		results = append(results, *record.Ipv6Address)
+	}
+
+	return results
+}
+
+func expandAzureRmPrivateDNSAAAARecords(d *schema.ResourceData) *[]privatedns.AaaaRecord {
+	recordStrings := d.Get("records").(*schema.Set).List()
+	records := make([]privatedns.AaaaRecord, len(recordStrings))
+
+	for i, v := range recordStrings {
+		ipv6 := v.(string)
+		records[i] = privatedns.AaaaRecord{
+			Ipv6Address: &ipv6,
+		}
+	}
+
+	return &records
+}

--- a/pkg/terraform/exec/plugins/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network/loadbalancers.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network/loadbalancers.go
@@ -79,7 +79,7 @@ func (client LoadBalancersClient) CreateOrUpdatePreparer(ctx context.Context, re
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-04-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}
@@ -241,7 +241,7 @@ func (client LoadBalancersClient) GetPreparer(ctx context.Context, resourceGroup
 		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
 	}
 
-	const APIVersion = "2018-12-01"
+	const APIVersion = "2019-04-01"
 	queryParameters := map[string]interface{}{
 		"api-version": APIVersion,
 	}

--- a/pkg/terraform/exec/plugins/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network/models.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network/models.go
@@ -12772,6 +12772,8 @@ type FrontendIPConfigurationPropertiesFormat struct {
 	LoadBalancingRules *[]SubResource `json:"loadBalancingRules,omitempty"`
 	// PrivateIPAddress - The private IP address of the IP configuration.
 	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+	// PrivateIPAddressVersion - The private IP address version of the IP configuration.
+	PrivateIPAddressVersion *string `json:"privateIPAddressVersion,omitempty"`
 	// PrivateIPAllocationMethod - The Private IP allocation method. Possible values are: 'Static' and 'Dynamic'. Possible values include: 'Static', 'Dynamic'
 	PrivateIPAllocationMethod IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
 	// Subnet - The reference of the subnet resource.

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_subnet.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/data_source_subnet.go
@@ -31,6 +31,12 @@ func dataSourceArmSubnet() *schema.Resource {
 				Computed: true,
 			},
 
+			"address_prefixes": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+
 			"network_security_group_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -81,7 +87,18 @@ func dataSourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("virtual_network_name", virtualNetworkName)
 
 	if props := resp.SubnetPropertiesFormat; props != nil {
-		d.Set("address_prefix", props.AddressPrefix)
+		if props.AddressPrefix != nil {
+			d.Set("address_prefix", props.AddressPrefix)
+		}
+		if props.AddressPrefixes == nil {
+			if props.AddressPrefix != nil && len(*props.AddressPrefix) > 0 {
+				d.Set("address_prefixes", []string{*props.AddressPrefix})
+			} else {
+				d.Set("address_prefixes", []string{})
+			}
+		} else {
+			d.Set("address_prefixes", props.AddressPrefixes)
+		}
 
 		if props.NetworkSecurityGroup != nil {
 			d.Set("network_security_group_id", props.NetworkSecurityGroup.ID)

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_loadbalancer.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_loadbalancer.go
@@ -74,6 +74,17 @@ func resourceArmLoadBalancer() *schema.Resource {
 							ValidateFunc: validate.IPv4AddressOrEmpty,
 						},
 
+						"private_ip_address_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  string(network.IPv4),
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(network.IPv4),
+								string(network.IPv6),
+							}, false),
+						},
+
 						"public_ip_address_id": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -305,6 +316,10 @@ func expandAzureRmLoadBalancerFrontendIpConfigurations(d *schema.ResourceData) *
 			properties.PrivateIPAddress = &v
 		}
 
+		if v := data["private_ip_address_version"].(string); v != "" {
+			properties.PrivateIPAddressVersion = &v
+		}
+
 		if v := data["public_ip_address_id"].(string); v != "" {
 			properties.PublicIPAddress = &network.PublicIPAddress{
 				ID: &v,
@@ -359,6 +374,10 @@ func flattenLoadBalancerFrontendIpConfiguration(ipConfigs *[]network.FrontendIPC
 
 			if pip := props.PrivateIPAddress; pip != nil {
 				ipConfig["private_ip_address"] = *pip
+			}
+
+			if pip := props.PrivateIPAddressVersion; pip != nil {
+				ipConfig["private_ip_address_version"] = *pip
 			}
 
 			if pip := props.PublicIPAddress; pip != nil {

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_public_ip.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_public_ip.go
@@ -164,12 +164,6 @@ func resourceArmPublicIpCreateUpdate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Either `allocation_method` or `public_ip_address_allocation` must be specified.")
 	}
 
-	if strings.EqualFold(string(ipVersion), string(network.IPv6)) {
-		if strings.EqualFold(ipAllocationMethod, "static") {
-			return fmt.Errorf("Cannot specify publicIpAllocationMethod as Static for IPv6 PublicIp")
-		}
-	}
-
 	if strings.EqualFold(sku, "standard") {
 		if !strings.EqualFold(ipAllocationMethod, "static") {
 			return fmt.Errorf("Static IP allocation must be used when creating Standard SKU public IP addresses.")

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_subnet.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_subnet.go
@@ -39,8 +39,17 @@ func resourceArmSubnet() *schema.Resource {
 			},
 
 			"address_prefix": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Deprecated:    "Use the `address_prefixes` property instead.",
+				ConflictsWith: []string{"address_prefixes"},
+			},
+
+			"address_prefixes": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"address_prefix"},
 			},
 
 			"network_security_group_id": {
@@ -142,14 +151,31 @@ func resourceArmSubnetCreateUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	addressPrefix := d.Get("address_prefix").(string)
+	var prefixSet bool
+	properties := network.SubnetPropertiesFormat{}
+	if value, ok := d.GetOk("address_prefixes"); ok {
+		var addressPrefixes []string
+		for _, item := range value.([]interface{}) {
+			addressPrefixes = append(addressPrefixes, item.(string))
+		}
+		properties.AddressPrefixes = &addressPrefixes
+		prefixSet = len(addressPrefixes) > 0
+	}
+	if value, ok := d.GetOk("address_prefix"); ok {
+		addressPrefix := value.(string)
+		properties.AddressPrefix = &addressPrefix
+		prefixSet = len(addressPrefix) > 0
+	}
+	if properties.AddressPrefixes != nil && len(*properties.AddressPrefixes) == 1 {
+		properties.AddressPrefix = &(*properties.AddressPrefixes)[0]
+		properties.AddressPrefixes = nil
+	}
+	if !prefixSet {
+		return fmt.Errorf("[ERROR] either address_prefix or address_prefixes is required")
+	}
 
 	azureRMLockByName(vnetName, virtualNetworkResourceName)
 	defer azureRMUnlockByName(vnetName, virtualNetworkResourceName)
-
-	properties := network.SubnetPropertiesFormat{
-		AddressPrefix: &addressPrefix,
-	}
 
 	if v, ok := d.GetOk("network_security_group_id"); ok {
 		nsgId := v.(string)
@@ -245,7 +271,18 @@ func resourceArmSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("virtual_network_name", vnetName)
 
 	if props := resp.SubnetPropertiesFormat; props != nil {
-		d.Set("address_prefix", props.AddressPrefix)
+		if props.AddressPrefix != nil {
+			d.Set("address_prefix", props.AddressPrefix)
+		}
+		if props.AddressPrefixes == nil {
+			if props.AddressPrefix != nil && len(*props.AddressPrefix) > 0 {
+				d.Set("address_prefixes", []string{*props.AddressPrefix})
+			} else {
+				d.Set("address_prefixes", []string{})
+			}
+		} else {
+			d.Set("address_prefixes", props.AddressPrefixes)
+		}
 
 		var securityGroupId *string
 		if props.NetworkSecurityGroup != nil {

--- a/pkg/terraform/exec/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
+++ b/pkg/terraform/exec/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
@@ -44,7 +44,7 @@ func Subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
 	}
 
 	return &net.IPNet{
-		IP:   insertNumIntoIP(ip, num, newPrefixLen),
+		IP:   insertNumIntoIP(ip, big.NewInt(int64(num)), newPrefixLen),
 		Mask: net.CIDRMask(newPrefixLen, addrLen),
 	}, nil
 }
@@ -56,28 +56,32 @@ func Subnet(base *net.IPNet, newBits int, num int) (*net.IPNet, error) {
 func Host(base *net.IPNet, num int) (net.IP, error) {
 	ip := base.IP
 	mask := base.Mask
+	bigNum := big.NewInt(int64(num))
 
 	parentLen, addrLen := mask.Size()
 	hostLen := addrLen - parentLen
 
-	maxHostNum := uint64(1<<uint64(hostLen)) - 1
+	maxHostNum := big.NewInt(int64(1))
+	maxHostNum.Lsh(maxHostNum, uint(hostLen))
+	maxHostNum.Sub(maxHostNum, big.NewInt(1))
 
-	numUint64 := uint64(num)
-	if num < 0 {
-		numUint64 = uint64(-num) - 1
-		num = int(maxHostNum - numUint64)
+	numUint64 := big.NewInt(int64(bigNum.Uint64()))
+	if bigNum.Cmp(big.NewInt(0)) == -1 {
+		numUint64.Neg(bigNum)
+		numUint64.Sub(numUint64, big.NewInt(int64(1)))
+		bigNum.Sub(maxHostNum, numUint64)
 	}
 
-	if numUint64 > maxHostNum {
+	if numUint64.Cmp(maxHostNum) == 1 {
 		return nil, fmt.Errorf("prefix of %d does not accommodate a host numbered %d", parentLen, num)
 	}
-        var bitlength int
-        if ip.To4() != nil {
-              bitlength = 32
-        } else {
-              bitlength = 128
-        }
-	return insertNumIntoIP(ip, num, bitlength), nil
+	var bitlength int
+	if ip.To4() != nil {
+		bitlength = 32
+	} else {
+		bitlength = 128
+	}
+	return insertNumIntoIP(ip, bigNum, bitlength), nil
 }
 
 // AddressRange returns the first and last addresses in the given CIDR range.
@@ -129,7 +133,11 @@ func VerifyNoOverlap(subnets []*net.IPNet, CIDRBlock *net.IPNet) error {
 		if !CIDRBlock.Contains(firstLastIP[i][0]) || !CIDRBlock.Contains(firstLastIP[i][1]) {
 			return fmt.Errorf("%s does not fully contain %s", CIDRBlock.String(), s.String())
 		}
-		for j := i + 1; j < len(subnets); j++ {
+		for j := 0; j < len(subnets); j++ {
+			if i == j {
+				continue
+			}
+
 			first := firstLastIP[j][0]
 			last := firstLastIP[j][1]
 			if s.Contains(first) || s.Contains(last) {

--- a/pkg/terraform/exec/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
+++ b/pkg/terraform/exec/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
@@ -29,9 +29,8 @@ func intToIP(ipInt *big.Int, bits int) net.IP {
 	return net.IP(ret)
 }
 
-func insertNumIntoIP(ip net.IP, num int, prefixLen int) net.IP {
+func insertNumIntoIP(ip net.IP, bigNum *big.Int, prefixLen int) net.IP {
 	ipInt, totalBits := ipToInt(ip)
-	bigNum := big.NewInt(int64(num))
 	bigNum.Lsh(bigNum, uint(totalBits-prefixLen))
 	ipInt.Or(ipInt, bigNum)
 	return intToIP(ipInt, totalBits)

--- a/pkg/terraform/gather/azure/ip.go
+++ b/pkg/terraform/gather/azure/ip.go
@@ -15,6 +15,12 @@ func BootstrapIP(tfs *terraform.State) (string, error) {
 	var bootstrap string
 
 	publicIP, err := terraform.LookupResource(tfs, "module.bootstrap", "azurerm_public_ip", "bootstrap_public_ip")
+	if err != nil {
+		publicIP, err = terraform.LookupResource(tfs, "module.bootstrap", "azurerm_public_ip", "bootstrap_public_ip_v4")
+	}
+	if err != nil {
+		publicIP, err = terraform.LookupResource(tfs, "module.bootstrap", "azurerm_public_ip", "bootstrap_public_ip_v6")
+	}
 	if err == nil && len(publicIP.Instances) > 0 {
 		bootstrap, _, err = unstructured.NestedString(publicIP.Instances[0].Attributes, "ip_address")
 		if err != nil {

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -2,6 +2,8 @@ package azure
 
 import (
 	"encoding/json"
+	"net"
+	"os"
 
 	"github.com/Azure/go-autorest/autorest/to"
 
@@ -35,6 +37,9 @@ type config struct {
 	ComputeSubnet               string            `json:"azure_compute_subnet"`
 	PreexistingNetwork          bool              `json:"azure_preexisting_network"`
 	Private                     bool              `json:"azure_private"`
+	MachineV4CIDRs              []string          `json:"azure_machine_v4_cidrs"`
+	MachineV6CIDRs              []string          `json:"azure_machine_v6_cidrs"`
+	EmulateSingleStackIPv6      bool              `json:"azure_emulate_single_stack_ipv6"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -46,6 +51,9 @@ type TFVarsSources struct {
 	ImageURL                    string
 	PreexistingNetwork          bool
 	Publish                     types.PublishingStrategy
+
+	MachineV4CIDRs []net.IPNet
+	MachineV6CIDRs []net.IPNet
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
@@ -58,6 +66,19 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	masterAvailabilityZones := make([]string, len(sources.MasterConfigs))
 	for i, c := range sources.MasterConfigs {
 		masterAvailabilityZones[i] = to.String(c.Zone)
+	}
+
+	machineV4CIDRStrings, machineV6CIDRStrings := []string{}, []string{}
+	for _, ipnet := range sources.MachineV4CIDRs {
+		machineV4CIDRStrings = append(machineV4CIDRStrings, ipnet.String())
+	}
+	for _, ipnet := range sources.MachineV6CIDRs {
+		machineV6CIDRStrings = append(machineV6CIDRStrings, ipnet.String())
+	}
+
+	var emulateSingleStackIPv6 bool
+	if os.Getenv("OPENSHIFT_INSTALL_AZURE_EMULATE_SINGLESTACK_IPV6") == "true" {
+		emulateSingleStackIPv6 = true
 	}
 
 	cfg := &config{
@@ -76,6 +97,9 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ControlPlaneSubnet:          masterConfig.Subnet,
 		ComputeSubnet:               workerConfig.Subnet,
 		PreexistingNetwork:          sources.PreexistingNetwork,
+		MachineV4CIDRs:              machineV4CIDRStrings,
+		MachineV6CIDRs:              machineV6CIDRStrings,
+		EmulateSingleStackIPv6:      emulateSingleStackIPv6,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -11,23 +11,30 @@ type config struct {
 	ClusterID     string `json:"cluster_id,omitempty"`
 	ClusterDomain string `json:"cluster_domain,omitempty"`
 	BaseDomain    string `json:"base_domain,omitempty"`
-	MachineCIDR   string `json:"machine_cidr"`
-	Masters       int    `json:"master_count,omitempty"`
+	// DeprecatedMachineCIDR has been replaced with machine_v4_cidrs, use the first
+	// entry from there instead.
+	DeprecatedMachineCIDR string `json:"machine_cidr"`
+	Masters               int    `json:"master_count,omitempty"`
+
+	UseIPv4 bool `json:"use_ipv4"`
+	UseIPv6 bool `json:"use_ipv6"`
 
 	IgnitionBootstrap string `json:"ignition_bootstrap,omitempty"`
 	IgnitionMaster    string `json:"ignition_master,omitempty"`
 }
 
 // TFVars generates terraform.tfvar JSON for launching the cluster.
-func TFVars(clusterID string, clusterDomain string, baseDomain string, machineCIDR *net.IPNet, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
+func TFVars(clusterID string, clusterDomain string, baseDomain string, deprecatedMachineCIDR *net.IPNet, useIPv4, useIPv6 bool, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
 	config := &config{
-		ClusterID:         clusterID,
-		ClusterDomain:     strings.TrimSuffix(clusterDomain, "."),
-		BaseDomain:        strings.TrimSuffix(baseDomain, "."),
-		MachineCIDR:       machineCIDR.String(),
-		Masters:           masterCount,
-		IgnitionBootstrap: bootstrapIgn,
-		IgnitionMaster:    masterIgn,
+		ClusterID:             clusterID,
+		ClusterDomain:         strings.TrimSuffix(clusterDomain, "."),
+		BaseDomain:            strings.TrimSuffix(baseDomain, "."),
+		DeprecatedMachineCIDR: deprecatedMachineCIDR.String(),
+		UseIPv4:               useIPv4,
+		UseIPv6:               useIPv6,
+		Masters:               masterCount,
+		IgnitionBootstrap:     bootstrapIgn,
+		IgnitionMaster:        masterIgn,
 	}
 
 	return json.MarshalIndent(config, "", "  ")

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -20,15 +20,19 @@ type dynamicValidator func(*baremetal.Platform, *field.Path) field.ErrorList
 var dynamicValidators []dynamicValidator
 
 func validateIPinMachineCIDR(vip string, n *types.Networking) error {
-	if !n.MachineCIDR.Contains(net.ParseIP(vip)) {
-		return fmt.Errorf("the virtual IP is expected to be in %s subnet", n.MachineCIDR.String())
+	for _, network := range n.MachineNetwork {
+		if network.CIDR.Contains(net.ParseIP(vip)) {
+			return nil
+		}
 	}
-	return nil
+	return fmt.Errorf("the virtual IP is expected to be in one of the machine networks")
 }
 
 func validateIPNotinMachineCIDR(ip string, n *types.Networking) error {
-	if n.MachineCIDR.Contains(net.ParseIP(ip)) {
-		return fmt.Errorf("the IP must not be in %s subnet", n.MachineCIDR.String())
+	for _, network := range n.MachineNetwork {
+		if network.CIDR.Contains(net.ParseIP(ip)) {
+			return fmt.Errorf("the IP must not be in one of the machine networks")
+		}
 	}
 	return nil
 }

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -28,7 +28,7 @@ func TestValidatePlatform(t *testing.T) {
 	}
 
 	dynamicValidators = append(dynamicValidators, interfaceValidator)
-	network := &types.Networking{MachineCIDR: ipnet.MustParseCIDR("192.168.111.0/24")}
+	network := &types.Networking{MachineNetwork: []types.MachineNetworkEntry{{CIDR: *ipnet.MustParseCIDR("192.168.111.0/24")}}}
 	cases := []struct {
 		name     string
 		platform *baremetal.Platform
@@ -81,7 +81,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.222.2\": the virtual IP is expected to be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.222.2\": the virtual IP is expected to be in one of the machine networks",
 		},
 		{
 			name: "invalid_dnsvip",
@@ -97,7 +97,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.222.3\": the virtual IP is expected to be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.222.3\": the virtual IP is expected to be in one of the machine networks",
 		},
 		{
 			name: "invalid_ingressvip",
@@ -113,7 +113,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.222.4\": the virtual IP is expected to be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.222.4\": the virtual IP is expected to be in one of the machine networks",
 		},
 		{
 			name: "invalid_hosts",
@@ -194,7 +194,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.111.5\": the IP must not be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.111.5\": the IP must not be in one of the machine networks",
 		},
 		{
 			name: "invalid_bootstrapprovip",
@@ -210,7 +210,7 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningBridge:      "br1",
 			},
 			network:  network,
-			expected: "Invalid value: \"192.168.111.5\": the IP must not be in 192.168.111.0/24 subnet",
+			expected: "Invalid value: \"192.168.111.5\": the IP must not be in one of the machine networks",
 		},
 		{
 			name: "invalid_bootstraposimage",

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -41,6 +41,12 @@ func ConvertNetworking(config *types.InstallConfig) {
 		netconf.ClusterNetwork = netconf.DeprecatedClusterNetworks
 	}
 
+	if len(netconf.MachineNetwork) == 0 && netconf.DeprecatedMachineCIDR != nil {
+		netconf.MachineNetwork = []types.MachineNetworkEntry{
+			{CIDR: *netconf.DeprecatedMachineCIDR},
+		}
+	}
+
 	if len(netconf.ServiceNetwork) == 0 && netconf.DeprecatedServiceCIDR != nil {
 		netconf.ServiceNetwork = []ipnet.IPNet{*netconf.DeprecatedServiceCIDR}
 	}

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -53,7 +53,7 @@ func TestConvertInstallConfig(t *testing.T) {
 					APIVersion: "v1beta3",
 				},
 				Networking: &types.Networking{
-					MachineCIDR:           ipnet.MustParseCIDR("1.1.1.1/24"),
+					DeprecatedMachineCIDR: ipnet.MustParseCIDR("1.1.1.1/24"),
 					DeprecatedType:        "foo",
 					DeprecatedServiceCIDR: ipnet.MustParseCIDR("1.2.3.4/32"),
 					DeprecatedClusterNetworks: []types.ClusterNetworkEntry{
@@ -70,8 +70,10 @@ func TestConvertInstallConfig(t *testing.T) {
 					APIVersion: types.InstallConfigVersion,
 				},
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
-					NetworkType:    "foo",
+					NetworkType: "foo",
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("1.1.1.1/24")},
+					},
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/32")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
 						{
@@ -84,6 +86,7 @@ func TestConvertInstallConfig(t *testing.T) {
 
 					// deprecated fields are preserved
 					DeprecatedType:        "foo",
+					DeprecatedMachineCIDR: ipnet.MustParseCIDR("1.1.1.1/24"),
 					DeprecatedServiceCIDR: ipnet.MustParseCIDR("1.2.3.4/32"),
 					DeprecatedClusterNetworks: []types.ClusterNetworkEntry{
 						{
@@ -103,7 +106,9 @@ func TestConvertInstallConfig(t *testing.T) {
 					APIVersion: types.InstallConfigVersion,
 				},
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("1.1.1.1/24")},
+					},
 					NetworkType:    "foo",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/32")},
 					ClusterNetwork: []types.ClusterNetworkEntry{
@@ -119,7 +124,9 @@ func TestConvertInstallConfig(t *testing.T) {
 					APIVersion: types.InstallConfigVersion,
 				},
 				Networking: &types.Networking{
-					MachineCIDR:    ipnet.MustParseCIDR("1.1.1.1/24"),
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("1.1.1.1/24")},
+					},
 					NetworkType:    "foo",
 					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("1.2.3.4/32")},
 					ClusterNetwork: []types.ClusterNetworkEntry{

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -26,10 +26,14 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 	if c.Networking == nil {
 		c.Networking = &types.Networking{}
 	}
-	if c.Networking.MachineCIDR == nil {
-		c.Networking.MachineCIDR = defaultMachineCIDR
+	if len(c.Networking.MachineNetwork) == 0 {
+		c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+			{CIDR: *defaultMachineCIDR},
+		}
 		if c.Platform.Libvirt != nil {
-			c.Networking.MachineCIDR = libvirtdefaults.DefaultMachineCIDR
+			c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+				{CIDR: *libvirtdefaults.DefaultMachineCIDR},
+			}
 		}
 	}
 	if c.Networking.NetworkType == "" {

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -23,7 +23,9 @@ import (
 func defaultInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
-			MachineCIDR:    defaultMachineCIDR,
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *defaultMachineCIDR},
+			},
 			NetworkType:    defaultNetworkType,
 			ServiceNetwork: []ipnet.IPNet{*defaultServiceNetwork},
 			ClusterNetwork: []types.ClusterNetworkEntry{
@@ -55,7 +57,7 @@ func defaultAzureInstallConfig() *types.InstallConfig {
 
 func defaultLibvirtInstallConfig() *types.InstallConfig {
 	c := defaultInstallConfig()
-	c.Networking.MachineCIDR = libvirtdefaults.DefaultMachineCIDR
+	c.Networking.MachineNetwork[0].CIDR = *libvirtdefaults.DefaultMachineCIDR
 	c.Platform.Libvirt = &libvirt.Platform{}
 	libvirtdefaults.SetPlatformDefaults(c.Platform.Libvirt)
 	c.ControlPlane.Replicas = pointer.Int64Ptr(1)

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -181,29 +181,36 @@ func (p *Platform) Name() string {
 
 // Networking defines the pod network provider in the cluster.
 type Networking struct {
-	// MachineCIDR is the IP address pool for machines.
-	// +optional
-	// Default is 10.0.0.0/16 for all platforms other than libvirt.
-	// For libvirt, the default is 192.168.126.0/24.
-	MachineCIDR *ipnet.IPNet `json:"machineCIDR,omitempty"`
-
 	// NetworkType is the type of network to install.
 	// +optional
 	// Default is OpenShiftSDN.
 	NetworkType string `json:"networkType,omitempty"`
 
-	// ClusterNetwork is the IP address pool for pods.
+	// MachineNetwork is the list of IP address pools for machines.
+	// This field replaces MachineCIDR, and if set MachineCIDR must
+	// be empty or match the first entry in the list.
+	// +optional
+	// Default is 10.0.0.0/16 for all platforms other than libvirt.
+	// For libvirt, the default is 192.168.126.0/24.
+	MachineNetwork []MachineNetworkEntry `json:"machineNetwork,omitempty"`
+
+	// ClusterNetwork is the list of IP address pools for pods.
 	// +optional
 	// Default is 10.128.0.0/14 and a host prefix of /23.
 	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork,omitempty"`
 
-	// ServiceNetwork is the IP address pool for services.
+	// ServiceNetwork is the list of IP address pools for services.
 	// +optional
 	// Default is 172.30.0.0/16.
 	// NOTE: currently only one entry is supported.
 	ServiceNetwork []ipnet.IPNet `json:"serviceNetwork,omitempty"`
 
 	// Deprected types, scheduled to be removed
+
+	// Deprecated name for MachineCIDRs. If set, MachineCIDRs must
+	// be empty or the first index must match.
+	// +optional
+	DeprecatedMachineCIDR *ipnet.IPNet `json:"machineCIDR,omitempty"`
 
 	// Deprecated name for NetworkType
 	// +optional
@@ -216,6 +223,12 @@ type Networking struct {
 	// Deprecated name for ClusterNetwork
 	// +optional
 	DeprecatedClusterNetworks []ClusterNetworkEntry `json:"clusterNetworks,omitempty"`
+}
+
+// MachineNetworkEntry is a single IP address block for node IP blocks.
+type MachineNetworkEntry struct {
+	// CIDR is the IP block address pool for machines within the cluster.
+	CIDR ipnet.IPNet `json:"cidr"`
 }
 
 // ClusterNetworkEntry is a single IP address block for pod IP blocks. IP blocks

--- a/pkg/types/openstack/defaults/platform.go
+++ b/pkg/types/openstack/defaults/platform.go
@@ -30,7 +30,7 @@ func SetPlatformDefaults(p *openstack.Platform) {
 // cluster. The DNS static pods running on the nodes resolve the
 // api-int record to APIVIP.
 func APIVIP(networking *types.Networking) (net.IP, error) {
-	return cidr.Host(&networking.MachineCIDR.IPNet, 5)
+	return cidr.Host(&networking.MachineNetwork[0].CIDR.IPNet, 5)
 }
 
 // DNSVIP returns the internal virtual IP address (VIP) put in front
@@ -38,7 +38,7 @@ func APIVIP(networking *types.Networking) (net.IP, error) {
 // operator these services provide name resolution for the nodes
 // themselves.
 func DNSVIP(networking *types.Networking) (net.IP, error) {
-	return cidr.Host(&networking.MachineCIDR.IPNet, 6)
+	return cidr.Host(&networking.MachineNetwork[0].CIDR.IPNet, 6)
 }
 
 // IngressVIP returns the internal virtual IP address (VIP) put in
@@ -47,5 +47,5 @@ func DNSVIP(networking *types.Networking) (net.IP, error) {
 // e.g. `console`. The DNS static pods running on the nodes resolve
 // the wildcard apps record to IngressVIP.
 func IngressVIP(networking *types.Networking) (net.IP, error) {
-	return cidr.Host(&networking.MachineCIDR.IPNet, 7)
+	return cidr.Host(&networking.MachineNetwork[0].CIDR.IPNet, 7)
 }

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -825,7 +825,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "invalid dual-stack configuration, bad platform",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.Platform = types.Platform{Azure: validAzurePlatform()}
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
 				c.Networking = validDualStackNetworkingConfig()
 				return c
 			}(),
@@ -835,11 +835,11 @@ func TestValidateInstallConfig(t *testing.T) {
 			name: "invalid single-stack IPv6 configuration, bad platform",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
-				c.Platform = types.Platform{Azure: validAzurePlatform()}
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
 				c.Networking = validIPv6NetworkingConfig()
 				return c
 			}(),
-			expectedError: `Invalid value: "IPv6": IPv6 is not supported for this platform`,
+			expectedError: `Invalid value: "IPv6": single-stack IPv6 is not supported for this platform`,
 		},
 		{
 			name: "invalid dual-stack configuration, bad plugin",

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -109,9 +109,6 @@ func ClusterName(v string) error {
 
 // SubnetCIDR checks if the given IP net is a valid CIDR.
 func SubnetCIDR(cidr *net.IPNet) error {
-	if cidr.IP.To4() == nil {
-		return errors.New("must use IPv4")
-	}
 	if cidr.IP.IsUnspecified() {
 		return errors.New("address must be specified")
 	}

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -59,7 +59,7 @@ func TestSubnetCIDR(t *testing.T) {
 		{"1.2.3.4/1", "invalid network address. got 1.2.3.4/1, expecting 0.0.0.0/1"},
 		{"1.2.3.4/31", ""},
 		{"1.2.3.4/32", ""},
-		{"0:0:0:0:0:1:102:304/116", "must use IPv4"},
+		{"0:0:0:0:0:1:102:304/116", "invalid network address. got ::1:102:304/116, expecting ::1:102:0/116"},
 		{"0:0:0:0:0:ffff:102:304/116", "invalid network address. got 1.2.3.4/20, expecting 1.2.0.0/20"},
 		{"172.17.0.0/20", "overlaps with default Docker Bridge subnet (172.17.0.0/20)"},
 		{"172.0.0.0/8", "overlaps with default Docker Bridge subnet (172.0.0.0/8)"},

--- a/upi/vsphere/README.md
+++ b/upi/vsphere/README.md
@@ -14,7 +14,8 @@ baseDomain: devcluster.openshift.com
 metadata:
   name: mstaeble
 networking:
-  machineCIDR: "139.178.89.192/26"
+  machineNetwork:
+  - cidr: "139.178.89.192/26"
 platform:
   vsphere:
     vCenter: vcsa.vmware.devcluster.openshift.com


### PR DESCRIPTION
This is a backport of PRs #2829, #2847, and #3094 

These changes are necessary to be able to test IPv6 on a platform other than `baremetal`.