### PR TITLE
[fcos] Enable openshift installer to decompress xz files and upload them as page blobs to Azure

### DIFF
--- a/cmd/openshift-install/internal-plugin.go
+++ b/cmd/openshift-install/internal-plugin.go
@@ -1,0 +1,45 @@
+package main
+
+// This command is necessary for Terraform's internal plugins (remote-exec, local-exec, ...) to work.
+// If they are used, Terraform will fork it's binary and call it with three parameters: 
+//     'internal-plugin' <TYPE: e.g. provisioner> <NAME: e.g. remote-exec>
+// As soon as the fork is running in the background, Terraform connects to it through RPC.
+
+// This command is hidden in the help menu.
+
+import (
+	"os"
+	"io/ioutil"
+	"github.com/pkg/errors"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/installer/pkg/terraform"	
+)
+
+func internalPluginCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "internal-plugin",
+		Short: "Run internal Terraform commands (local-exec, remote-exec, ...).",
+		Long:  "",
+		Args:  cobra.ExactArgs(2),
+		RunE:  runInternalPluginCmd,
+		Hidden: true,
+	}
+}
+
+func runInternalPluginCmd(cmd *cobra.Command, args []string) error {
+	// Copy the terraform.tfvars to a temp directory where the terraform will be invoked within.
+	tmpDir, err := ioutil.TempDir("", "openshift-install-")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temp dir for terraform internal-plugin execution")
+	}
+	defer os.RemoveAll(tmpDir)
+
+	err = terraform.InternalPlugin(tmpDir, args[0], args[1])
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -54,6 +54,7 @@ func installerMain() {
 		newVersionCmd(),
 		newGraphCmd(),
 		newCompletionCmd(),
+		internalPluginCmd(),
 	} {
 		rootCmd.AddCommand(subCmd)
 	}

--- a/data/data/azure/vhd-converter/convert.sh.tpl
+++ b/data/data/azure/vhd-converter/convert.sh.tpl
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+sudo apt-get update -qq
+sudo apt-get install qemu-utils -y
+
+wget https://aka.ms/downloadazcopy-v10-linux -O azcopy.tar
+tar xvf azcopy.tar --strip-components 1
+chmod +x azcopy
+
+wget ${vhd_url} -O fcos.vhd.xz
+xz -d fcos.vhd.xz
+
+echo "Convert vhd file to raw image..."
+qemu-img convert -f vpc -O raw fcos.vhd fcos.raw
+
+# Calculcate new size which is a multiple of 1MByte (rounded up).
+rawdisk="fcos.raw"
+vhddisk="fcos.vhd"
+MB=$((1024*1024))
+size=$(qemu-img info -f raw --output json "$rawdisk" | gawk 'match($0, /"virtual-size": ([0-9]+),/, val) {print val[1]}')
+rounded_size=$((($size/$MB + 1) * $MB))
+
+echo "Resize raw image..."
+qemu-img resize fcos.raw $rounded_size
+qemu-img convert -f raw -o subformat=fixed,force_size -O vpc fcos.raw fcos-fixed.vhd
+
+# Upload fixed size VHD file to Azure blob storage.
+echo "Upload fixed size VHD image to Azure blob storage..."
+./azcopy copy ./fcos-fixed.vhd '${primary_blob_endpoint}${container_name}/fcos.vhd${sas_token}'
+

--- a/data/data/azure/vhd-converter/main.tf
+++ b/data/data/azure/vhd-converter/main.tf
@@ -1,0 +1,183 @@
+
+locals {
+  vhd-converter_nic_ip_configuration_name = "vhd-converter-nic-ip"
+}
+
+resource "random_string" "username" {
+  length  = 16
+  upper   = true
+  special = false
+  number  = true
+}
+
+resource "random_string" "password" {
+  length  = 32
+  upper   = true
+  special = true
+  override_special = "!_-"
+  number  = true
+}
+
+data "azurerm_storage_account_sas" "vhd-file" {
+  connection_string = var.storage_account.primary_connection_string
+  https_only        = true
+
+  resource_types {
+    service   = false
+    container = false
+    object    = true
+  }
+
+  services {
+    blob  = true
+    queue = false
+    table = false
+    file  = false
+  }
+
+  start  = timestamp()
+  expiry = timeadd(timestamp(), "3h")
+
+  permissions {
+    read    = true
+    list    = false
+    create  = true
+    add     = false
+    delete  = false
+    process = false
+    write   = true
+    update  = true
+  }
+}
+
+resource "azurerm_public_ip" "vhd-converter_public_ip" {
+  sku                 = "Standard"
+  location            = var.azure_region
+  name                = "${var.cluster_id}-vhd-converter-pip"
+  resource_group_name = var.resource_group_name
+  allocation_method   = "Static"
+}
+
+resource "azurerm_network_interface" "vhd-converter" {
+  name                = "${var.cluster_id}-vhd-converter-nic"
+  location            = var.azure_region
+  resource_group_name = var.resource_group_name
+
+  ip_configuration {
+    subnet_id                     = var.subnet_id
+    name                          = local.vhd-converter_nic_ip_configuration_name
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.vhd-converter_public_ip.id
+  }
+}
+
+# Rendere the bash script template with Terraform variables.
+data "template_file" "process-template" {
+  template = file("${path.module}/convert.sh.tpl")
+  vars = {
+    sas_token = data.azurerm_storage_account_sas.vhd-file.sas
+    primary_blob_endpoint = var.storage_account.primary_blob_endpoint
+    container_name = var.container_name
+    vhd_url = var.azure_image_url
+  }
+}
+
+resource "local_file" "bash-script" {
+  filename = "${path.module}/convert.sh"
+  content = data.template_file.process-template.rendered
+}
+
+resource "azurerm_virtual_machine" "vhd-converter" {
+  name                  = "${var.cluster_id}-vhd-converter"
+  location              = var.azure_region
+  resource_group_name   = var.resource_group_name
+  network_interface_ids = [azurerm_network_interface.vhd-converter.id]
+  vm_size               = var.vm_size
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [var.identity]
+  }
+
+  storage_os_disk {
+    name              = "${var.cluster_id}-vhd-converter_OSDisk" # os disk name needs to match cluster-api convention
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Premium_LRS"
+    disk_size_gb      = 100
+  }
+
+  # Some linux image from the Azure marketplace.
+  storage_image_reference {
+      publisher = "canonical"
+      offer     = "UbuntuServer"      
+      sku = "18.04-LTS"
+      version = "latest"
+  }
+
+  os_profile {
+    computer_name  = "${var.cluster_id}-vhd-converter-vm"
+    admin_username = random_string.username.result
+    admin_password = random_string.password.result
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  boot_diagnostics {
+    enabled     = false
+    storage_uri = var.storage_account.primary_blob_endpoint
+  }
+
+  # Copy VHD conversion script in VM.
+  provisioner "file" {
+    connection {
+      type = "ssh"
+      host = azurerm_public_ip.vhd-converter_public_ip.ip_address
+      agent = false
+      user = random_string.username.result
+      password = random_string.password.result
+      timeout = "180s"
+    }
+
+    source = "${path.module}/convert.sh"
+    destination = "/home/${random_string.username.result}/convert.sh"
+  }
+
+  # Start VHD conversion and wait until it finishes. After the script ran successfully, the VM is marked as completed
+  # and Terraform will start creating the VM image from the VHD file uploaded to the blob storage.
+  # Without 'remote-exec' Terraform wouldn't wait before trying to create the VM image. It would fail.
+  provisioner "remote-exec" {
+    connection {
+      type = "ssh"
+      host = azurerm_public_ip.vhd-converter_public_ip.ip_address
+      agent = false
+      user = random_string.username.result
+      password = random_string.password.result
+      timeout = "180s"
+    }
+
+    inline = [
+      "sudo chmod +x ./convert.sh",
+      "./convert.sh",
+    ]
+  }  
+}
+
+resource "azurerm_network_security_rule" "vhd-converter_ssh_in" {
+  name                        = "vhd-converter_ssh_in"
+  priority                    = 105
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = var.resource_group_name
+  network_security_group_name = var.nsg_name
+}

--- a/data/data/azure/vhd-converter/outputs.tf
+++ b/data/data/azure/vhd-converter/outputs.tf
@@ -1,0 +1,3 @@
+output "vhd-converter-vm" {
+  value = azurerm_virtual_machine.vhd-converter
+}

--- a/data/data/azure/vhd-converter/variables.tf
+++ b/data/data/azure/vhd-converter/variables.tf
@@ -1,0 +1,60 @@
+variable "vm_size" {
+  type        = string
+  description = "The SKU ID for the bootstrap node."
+}
+
+variable "azure_image_url" {
+  type        = string
+  description = "The resource id of the vm image used for bootstrap."
+}
+
+variable "azure_region" {
+  type        = string
+  description = "The region for the deployment."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The resource group name for the deployment."
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "The identifier for the cluster."
+}
+
+variable "identity" {
+  type        = string
+  description = "The user assigned identity id for the vm."
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "The subnet ID for the bootstrap node."
+}
+
+variable "storage_account" {
+  type        = any
+  description = "the storage account for the cluster. It can be used for boot diagnostics."
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "tags to be applied to created resources."
+}
+
+variable "nsg_name" {
+  type        = string
+  description = "The network security group for the subnet."
+}
+
+variable "container_name" {
+  type        = string
+  description = "The name of the container where we store the VHD file."
+}
+
+variable "private" {
+  type        = bool
+  description = "This value determines if this is a private cluster or not."
+}

--- a/pkg/terraform/exec/exec.go
+++ b/pkg/terraform/exec/exec.go
@@ -30,6 +30,9 @@ var commands = map[string]cmdFunc{
 	"init": func(meta command.Meta) cli.Command {
 		return &command.InitCommand{Meta: meta}
 	},
+	"internal-plugin": func(meta command.Meta) cli.Command {
+		return &command.InternalPluginCommand{Meta: meta}
+	},
 }
 
 func runner(cmd string, dir string, args []string, stdout, stderr io.Writer) int {
@@ -103,6 +106,11 @@ func Destroy(datadir string, args []string, stdout, stderr io.Writer) int {
 // Init is wrapper around `terraform init` subcommand.
 func Init(datadir string, args []string, stdout, stderr io.Writer) int {
 	return runner("init", datadir, args, stdout, stderr)
+}
+
+// InternalPlugin is wrapper around `terraform internal-plugin` subcommand.
+func InternalPlugin(datadir string, args []string, stdout, stderr io.Writer) int {
+	return runner("internal-plugin", datadir, args, stdout, stderr)
 }
 
 // makeShutdownCh creates an interrupt listener and returns a channel.

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -123,7 +123,7 @@ func unpackAndInit(dir string, platform string) (err error) {
 	defer lpError.Close()
 
 	args := []string{
-		"-get-plugins=false",
+		"-get-plugins=true",  // TODO: template plugin is required. Handle this the same as the other plugins.
 	}
 	args = append(args, dir)
 	if exitCode := texec.Init(dir, args, lpDebug, lpError); exitCode != 0 {

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -158,3 +158,21 @@ func setupEmbeddedPlugins(dir string) error {
 	}
 	return nil
 }
+
+// InternalPlugin handles internal Terraform plugins like the local-exec / remote-exec provisioners.
+func InternalPlugin(dir string, extraArgs ...string) (err error) {
+	defaultArgs := []string{}
+	args := append(defaultArgs, extraArgs...)
+
+	tDebug := &lineprinter.Trimmer{WrappedPrint: logrus.Debug}
+	tError := &lineprinter.Trimmer{WrappedPrint: logrus.Error}
+	lpDebug := &lineprinter.LinePrinter{Print: tDebug.Print}
+	lpError := &lineprinter.LinePrinter{Print: tError.Print}
+	defer lpDebug.Close()
+	defer lpError.Close()
+
+	if exitCode := texec.InternalPlugin(dir, args, lpDebug, lpError); exitCode != 0 {
+		return errors.New("failed to call internal-plugin using Terraform")
+	}
+	return nil
+}


### PR DESCRIPTION
Hi,

If the coreos team converts the fcos image to a fixed size VHD file (I think thats a good idea): How does this 8GByte big image come into the Azure storage account?

If the installer must upload it, this will last very long. Seems not to be very feasible, if it's necessary each time we run the installer.

Yes it would be great I we wouldn't have to deal with the fcos image at all. I hope it gets to the Azure market place very soon.

Greetings,

Josef