### PR TITLE
VSphere: Strip :<port> from vCenter in cloud-creds-secret

### DIFF
--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/ghodss/yaml"
@@ -152,9 +153,12 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 			},
 		}
 	case vspheretypes.Name:
+		// Strip illegal colons which may apppear if VCenter has a port.
+		vCenter := strings.Split(installConfig.Config.VSphere.VCenter, ":")[0]
+
 		cloudCreds = cloudCredsSecretData{
 			VSphere: &VSphereCredsSecretData{
-				VCenter:              installConfig.Config.VSphere.VCenter,
+				VCenter:              vCenter,
 				Base64encodeUsername: base64.StdEncoding.EncodeToString([]byte(installConfig.Config.VSphere.Username)),
 				Base64encodePassword: base64.StdEncoding.EncodeToString([]byte(installConfig.Config.VSphere.Password)),
 			},


### PR DESCRIPTION
VCenter requires that the cloud-creds-secret contain the workstation in the key of the username and password. e,g:
```
data:
   10.0.1.200.username: QWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs
   10.0.1.200.password: cGFzc3dvcmQ=
```

This is for compatibility with upstream storage: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/k8s-secret.html

We need to strip any colons and ports that are included in the workstation, as they are illegal keys in secrets file.

Fixes #3024 