### PR TITLE
Bug 1693951: tls: extended lifetime of master kubelet bootstrap credentials

### DIFF
--- a/pkg/asset/tls/kubelet.go
+++ b/pkg/asset/tls/kubelet.go
@@ -157,6 +157,7 @@ func (a *KubeletBootstrapCABundle) Name() string {
 }
 
 // KubeletClientCertKey is the asset that generates the key/cert pair for kubelet client to apiserver.
+// This credential can be revoked by deleting the configmap containing its signer.
 type KubeletClientCertKey struct {
 	SignedCertKey
 }
@@ -181,7 +182,7 @@ func (a *KubeletClientCertKey) Generate(dependencies asset.Parents) error {
 		Subject:      pkix.Name{CommonName: "system:serviceaccount:openshift-machine-config-operator:node-bootstrapper", Organization: []string{"system:serviceaccounts:openshift-machine-config-operator"}},
 		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-		Validity:     ValidityOneDay,
+		Validity:     ValidityTenYears,
 	}
 
 	return a.SignedCertKey.Generate(cfg, ca, "kubelet-client", DoNotAppendParent)


### PR DESCRIPTION
The revocation can be managed by deleting the configmap where we store
the kubelet trust from openshift-config-managed.

implements https://github.com/openshift/enhancements/pull/196

/assign @rphillips 