### PR TITLE
Bug 1795436: update error message when deleting default GCP routes

### DIFF
--- a/pkg/destroy/gcp/network.go
+++ b/pkg/destroy/gcp/network.go
@@ -84,7 +84,7 @@ func (o *ClusterUninstaller) destroyNetworks() error {
 		for _, route := range routes {
 			err := o.deleteRoute(route)
 			if err != nil {
-				o.Logger.Debugf("Failed to delete route %s: %v", route, err)
+				o.Logger.Debugf("Failed to delete route %s: %v", route.name, err)
 			}
 		}
 		err = o.deleteNetwork(item)

--- a/pkg/destroy/gcp/route.go
+++ b/pkg/destroy/gcp/route.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -56,6 +57,9 @@ func (o *ClusterUninstaller) deleteRoute(item cloudResource) error {
 	op, err := o.computeSvc.Routes.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
 	if err != nil && !isNoOp(err) {
 		o.resetRequestID(item.typeName, item.name)
+		if strings.HasPrefix(item.name, "default-route") {
+			return errors.New("this looks like a default route, which cannot be deleted manually but will be deleted with the corresponding network")
+		}
 		return errors.Wrapf(err, "failed to delete route %s", item.name)
 	}
 	if op != nil && op.Status == "DONE" && isErrorStatus(op.HttpErrorStatusCode) {


### PR DESCRIPTION
Default routes cannot be manually deleted in GCP, but that doesn't stop us from trying. These attempts result in error messages that look like this:

> Failed to delete route {default-route-013b0a83601b2182 default-route-013b0a83601b2182  route  }: failed to delete route default-route-013b0a83601b2182: googleapi: Error 400: The local route cannot be deleted., badRequest

These error messages have led some users, especially in CI to mistake these as significant errors. This commit attempts to make the error message look like something a l
ittle more expected:

> Failed to delete route default-route-bb10ec00c23c0493: this looks like a default route, which cannot be deleted manually but will be deleted with the corresponding network