### PR TITLE
Bug 1774465: aws: pick instance types based on selected availability zones

### DIFF
--- a/pkg/asset/machines/aws/instance_types.go
+++ b/pkg/asset/machines/aws/instance_types.go
@@ -1,0 +1,54 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
+)
+
+// PreferredInstanceType returns a preferred instance type from the list of instance types provided in descending order of preference
+// based on filters like the list of required availability zones.
+func PreferredInstanceType(ctx context.Context, meta *awsconfig.Metadata, types []string, zones []string) (string, error) {
+	if len(types) == 0 {
+		return "", errors.New("at least one instance type required, empty instance types given")
+	}
+
+	sess, err := meta.Session(ctx)
+	if err != nil {
+		return types[0], err
+	}
+
+	client := ec2.New(sess, aws.NewConfig().WithRegion(meta.Region))
+	resp, err := client.DescribeInstanceTypeOfferingsWithContext(ctx, &ec2.DescribeInstanceTypeOfferingsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("location"),
+				Values: aws.StringSlice(zones),
+			},
+			{
+				Name:   aws.String("instance-type"),
+				Values: aws.StringSlice(types),
+			},
+		},
+		LocationType: aws.String("availability-zone"),
+	})
+	if err != nil {
+		return types[0], err
+	}
+	reqZones := sets.NewString(zones...)
+	found := map[string][]string{}
+	for _, offering := range resp.InstanceTypeOfferings {
+		found[aws.StringValue(offering.InstanceType)] = append(found[aws.StringValue(offering.InstanceType)], aws.StringValue(offering.Location))
+	}
+	for _, t := range types {
+		if reqZones.Difference(sets.NewString(found[t]...)).Len() == 0 {
+			return t, nil
+		}
+	}
+	return types[0], errors.New("no instance type found for the zone constraint")
+}

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -183,7 +183,8 @@ spec:
 							Replicas:       pointer.Int64Ptr(1),
 							Platform: types.MachinePoolPlatform{
 								AWS: &awstypes.MachinePool{
-									Zones: []string{"us-east-1a"},
+									Zones:        []string{"us-east-1a"},
+									InstanceType: "m4.xlarge",
 								},
 							},
 						},

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -184,7 +184,8 @@ spec:
 								Hyperthreading: tc.hyperthreading,
 								Platform: types.MachinePoolPlatform{
 									AWS: &awstypes.MachinePool{
-										Zones: []string{"us-east-1a"},
+										Zones:        []string{"us-east-1a"},
+										InstanceType: "m4.large",
 									},
 								},
 							},

--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -5,14 +5,14 @@ import (
 )
 
 var (
-	defaultMachineClass = map[string]string{
-		"ap-east-1":      "m5",
-		"ap-northeast-2": "m5",
-		"eu-north-1":     "m5",
-		"eu-west-3":      "m5",
-		"me-south-1":     "m5",
-		"us-gov-east-1":  "m5",
-		"us-west-2":      "m5",
+	defaultMachineClass = map[string][]string{
+		"ap-east-1":      {"m5", "m4"},
+		"ap-northeast-2": {"m5", "m4"},
+		"eu-north-1":     {"m5", "m4"},
+		"eu-west-3":      {"m5", "m4"},
+		"me-south-1":     {"m5", "m4"},
+		"us-gov-east-1":  {"m5", "m4"},
+		"us-west-2":      {"m5", "m4"},
 	}
 )
 
@@ -24,8 +24,18 @@ func SetPlatformDefaults(p *aws.Platform) {
 // region. We prefer m4 if available (more EBS volumes per node) but will use
 // m5 in regions that don't have m4.
 func InstanceClass(region string) string {
-	if class, ok := defaultMachineClass[region]; ok {
-		return class
+	if classes, ok := defaultMachineClass[region]; ok {
+		return classes[0]
 	}
 	return "m4"
+}
+
+// InstanceClasses returns a list of instance "class", in decreasing priority order, which we should use for a given
+// region. We prefer m4 if available (more EBS volumes per node) but will use
+// m5 in regions that don't have m4.
+func InstanceClasses(region string) []string {
+	if classes, ok := defaultMachineClass[region]; ok {
+		return classes
+	}
+	return []string{"m4", "m5"}
 }


### PR DESCRIPTION
Using new AWS API DescribeInstanceTypeOfferings [1] we can now check what instance types are available for specific region/AZs, which allows us to check which instance types are available in the selected AZs.
Since we default to m4 for most regions and only override to m5 for certain, in cases where new AZs are added to older regions like sa-east-1, see BZ 1774465 [2], we end up picking m4 when m5 is present in all the chosen AZs.

Now we can define a list in descreasing priority order for instance classes for a region and the installer can try to pick default based on what works for all the selected AZs. We still do not support heterogenous setup which different instance types in different regions, but this
solves the case when newer m5 needs to be used in certain regions based on the AZ selection.

The default order for instance classes stays m4 > m5.

[1]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypeOfferings.html
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1774465

/cc @wking @cuppett @sdodson 