### PR TITLE
Bug 1794824: Remove empty string check from vsphere platformstatus create

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -143,12 +143,10 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		}
 	case vsphere.Name:
 		config.Status.PlatformStatus.Type = configv1.VSpherePlatformType
-		if installConfig.Config.VSphere.APIVIP != "" {
-			config.Status.PlatformStatus.VSphere = &configv1.VSpherePlatformStatus{
-				APIServerInternalIP: installConfig.Config.VSphere.APIVIP,
-				NodeDNSIP:           installConfig.Config.VSphere.DNSVIP,
-				IngressIP:           installConfig.Config.VSphere.IngressVIP,
-			}
+		config.Status.PlatformStatus.VSphere = &configv1.VSpherePlatformStatus{
+			APIServerInternalIP: installConfig.Config.VSphere.APIVIP,
+			NodeDNSIP:           installConfig.Config.VSphere.DNSVIP,
+			IngressIP:           installConfig.Config.VSphere.IngressVIP,
 		}
 	case ovirt.Name:
 		config.Status.PlatformStatus.Type = configv1.OvirtPlatformType


### PR DESCRIPTION
Removing the check for an empty string for APIVIP.  Always create PlatformStatus for vSphere.
Corresponding PR:
https://github.com/openshift/machine-config-operator/pull/1425