### PR TITLE
bug 1729362: aws/permissions.go: add AttachNetworkInterface to required list

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -39,6 +39,7 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:AuthorizeSecurityGroupIngress",
 		"ec2:CopyImage",
 		"ec2:CreateNetworkInterface",
+		"ec2:AttachNetworkInterface",
 		"ec2:CreateSecurityGroup",
 		"ec2:CreateTags",
 		"ec2:CreateVolume",


### PR DESCRIPTION
If the user doesn't have this permission, it creates error like

```
ERROR 	* module.masters.aws_network_interface.master[1]: 1 error occurred:
ERROR 	* aws_network_interface.master.1: Error creating ENI: UnauthorizedOperation: You are not authorized to perform this operation.
ERROR 	status code: 403, request id: 9b772002-65ad-4642-86f3-4d314dcfa2e5
```

/cc @sdodson @wking 