### PR TITLE
tls: add etcd kube-apiserver client to drive the etcd static pods

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -74,6 +74,7 @@ func (a *Bootstrap) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.InstallConfig{},
 		&kubeconfig.AdminInternalClient{},
+		&kubeconfig.Etcd{},
 		&kubeconfig.Kubelet{},
 		&kubeconfig.LoopbackClient{},
 		&machines.Master{},
@@ -88,6 +89,7 @@ func (a *Bootstrap) Dependencies() []asset.Asset {
 		&tls.AggregatorSignerCertKey{},
 		&tls.APIServerProxyCertKey{},
 		&tls.EtcdCABundle{},
+		&tls.EtcdKubeAPIServerClientCertCABundle{},
 		&tls.EtcdMetricCABundle{},
 		&tls.EtcdMetricSignerCertKey{},
 		&tls.EtcdMetricSignerClientCertKey{},
@@ -448,6 +450,7 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 	// These files are all added with mode 0600; use for secret keys and the like.
 	for _, asset := range []asset.WritableAsset{
 		&kubeconfig.AdminInternalClient{},
+		&kubeconfig.Etcd{},
 		&kubeconfig.Kubelet{},
 		&kubeconfig.LoopbackClient{},
 		&tls.AdminKubeConfigCABundle{},
@@ -457,6 +460,7 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 		&tls.AggregatorSignerCertKey{},
 		&tls.APIServerProxyCertKey{},
 		&tls.EtcdCABundle{},
+		&tls.EtcdKubeAPIServerClientCertCABundle{},
 		&tls.EtcdMetricCABundle{},
 		&tls.EtcdMetricSignerCertKey{},
 		&tls.EtcdMetricSignerClientCertKey{},

--- a/pkg/asset/kubeconfig/etcd.go
+++ b/pkg/asset/kubeconfig/etcd.go
@@ -1,0 +1,56 @@
+package kubeconfig
+
+import (
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/tls"
+)
+
+var (
+	kubeconfigEtcdPath = filepath.Join("auth", "kubeconfig-etcd")
+)
+
+// Etcd is the asset for the etcd kubeconfig.
+type Etcd struct {
+	kubeconfig
+}
+
+var _ asset.WritableAsset = (*Etcd)(nil)
+
+// Dependencies returns the dependency of the kubeconfig.
+func (k *Etcd) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&tls.KubeAPIServerCompleteCABundle{},
+		&tls.EtcdKubeAPIServerClientCert{},
+		&installconfig.InstallConfig{},
+	}
+}
+
+// Generate generates the kubeconfig.
+func (k *Etcd) Generate(parents asset.Parents) error {
+	ca := &tls.KubeAPIServerCompleteCABundle{}
+	clientcertkey := &tls.EtcdKubeAPIServerClientCert{}
+	installConfig := &installconfig.InstallConfig{}
+	parents.Get(ca, clientcertkey, installConfig)
+
+	return k.kubeconfig.generate(
+		ca,
+		clientcertkey,
+		getIntAPIServerURL(installConfig.Config),
+		installConfig.Config.GetName(),
+		"etcd-sa",
+		kubeconfigEtcdPath,
+	)
+}
+
+// Name returns the human-friendly name of the asset.
+func (k *Etcd) Name() string {
+	return "Kubeconfig Etcd"
+}
+
+// Load is a no-op because kubelet kubeconfig is not written to disk.
+func (k *Etcd) Load(asset.FileFetcher) (bool, error) {
+	return false, nil
+}

--- a/pkg/asset/tls/etcd.go
+++ b/pkg/asset/tls/etcd.go
@@ -101,3 +101,100 @@ func (a *EtcdSignerClientCertKey) Generate(dependencies asset.Parents) error {
 func (a *EtcdSignerClientCertKey) Name() string {
 	return "Certificate (etcd-client)"
 }
+
+
+
+// EtcdKubeAPIServerClientCertSigner is a key/cert pair that signs the a client cert for the etcd static pods to use
+// to access the kube-apiserver to get the current list of endpoints in a happy path.
+type EtcdKubeAPIServerClientCertSigner struct {
+	SelfSignedCertKey
+}
+
+var _ asset.WritableAsset = (*EtcdKubeAPIServerClientCertSigner)(nil)
+
+// Dependencies returns the dependency of the EtcdKubeAPIServerClientCertSigner, which is empty.
+func (c *EtcdKubeAPIServerClientCertSigner) Dependencies() []asset.Asset {
+	return []asset.Asset{}
+}
+
+// Generate generates the root-ca key and cert pair.
+func (c *EtcdKubeAPIServerClientCertSigner) Generate(parents asset.Parents) error {
+	cfg := &CertCfg{
+		Subject:   pkix.Name{CommonName: "etcd-kube-apiserver-client-cert-signer", OrganizationalUnit: []string{"openshift"}},
+		KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		Validity:  ValidityTenYears,
+		IsCA:      true,
+	}
+
+	return c.SelfSignedCertKey.Generate(cfg, "etcd-kube-apiserver-client-cert-signer")
+}
+
+// Name returns the human-friendly name of the asset.
+func (c *EtcdKubeAPIServerClientCertSigner) Name() string {
+	return "Certificate (ketcd-kube-apiserver-client-cert-signer)"
+}
+
+// EtcdKubeAPIServerClientCertCABundle is the CA bundle for EtcdKubeAPIServerClientCertSigner
+type EtcdKubeAPIServerClientCertCABundle struct {
+	CertBundle
+}
+
+var _ asset.Asset = (*EtcdKubeAPIServerClientCertCABundle)(nil)
+
+// Dependencies returns the dependency of the cert bundle.
+func (a *EtcdKubeAPIServerClientCertCABundle) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&EtcdKubeAPIServerClientCertSigner{},
+	}
+}
+
+// Generate generates the cert bundle based on its dependencies.
+func (a *EtcdKubeAPIServerClientCertCABundle) Generate(deps asset.Parents) error {
+	var certs []CertInterface
+	for _, asset := range a.Dependencies() {
+		deps.Get(asset)
+		certs = append(certs, asset.(CertInterface))
+	}
+	return a.CertBundle.Generate("etcd-kube-apiserver-client-cert-ca-bundle", certs...)
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *EtcdKubeAPIServerClientCertCABundle) Name() string {
+	return "Certificate (etcd-kube-apiserver-client-cert-ca-bundle)"
+}
+
+// EtcdKubeAPIServerClientCert is the asset that generates the key/cert pair for etcd to communicate to the kube-apiserver.
+type EtcdKubeAPIServerClientCert struct {
+	SignedCertKey
+}
+
+var _ asset.Asset = (*EtcdKubeAPIServerClientCert)(nil)
+
+// Dependencies returns the dependency of the the cert/key pair, which includes
+// the parent CA, and install config if it depends on the install config for
+// DNS names, etc.
+func (a *EtcdKubeAPIServerClientCert) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&EtcdKubeAPIServerClientCertSigner{},
+	}
+}
+
+// Generate generates the cert/key pair based on its dependencies.
+func (a *EtcdKubeAPIServerClientCert) Generate(dependencies asset.Parents) error {
+	ca := &EtcdKubeAPIServerClientCertSigner{}
+	dependencies.Get(ca)
+
+	cfg := &CertCfg{
+		Subject:      pkix.Name{CommonName: "system:serviceaccount:openshift-etcd:default", Organization: []string{"system:serviceaccounts:openshift-etcd"}},
+		KeyUsages:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		Validity:     ValidityTenYears,
+	}
+
+	return a.SignedCertKey.Generate(cfg, ca, "etcd-kube-apiserver-client-cert", DoNotAppendParent)
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *EtcdKubeAPIServerClientCert) Name() string {
+	return "Certificate (etcd-kube-apiserver-client-cert)"
+}


### PR DESCRIPTION
etcd static pods use a loopback connection to the kube-apiserver to lookup their
endpoints in a happy-path mode.  This bootstraps faster as a client certificate
because there is no need to wait for service account tokens to be created.

/hold

@hexfusion I'd like to see links to where etcd consumes its credentials from and an POC PR showing how you will consume these values.