### PR TITLE
Bug 1742227: destroy/gcp: also remove instances with owned label.

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -196,6 +196,10 @@ func (o *ClusterUninstaller) clusterIDFilter() string {
 	return fmt.Sprintf("name eq \"%s-.*\"", o.ClusterID)
 }
 
+func (o *ClusterUninstaller) clusterLabelFilter() string {
+	return fmt.Sprintf("labels.kubernetes-io-cluster-%s eq \"owned\"", o.ClusterID)
+}
+
 func isNoOp(err error) bool {
 	if err == nil {
 		return false

--- a/pkg/destroy/gcp/instance.go
+++ b/pkg/destroy/gcp/instance.go
@@ -24,7 +24,16 @@ func (o *ClusterUninstaller) getInstanceNameAndZone(instanceURL string) (string,
 }
 
 func (o *ClusterUninstaller) listInstances() ([]cloudResource, error) {
-	return o.listInstancesWithFilter("items/*/instances(name,zone,status),nextPageToken", o.clusterIDFilter(), nil)
+	byName, err := o.listInstancesWithFilter("items/*/instances(name,zone,status),nextPageToken", o.clusterIDFilter(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	byLabel, err := o.listInstancesWithFilter("items/*/instances(name,zone,status),nextPageToken", o.clusterLabelFilter(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return append(byName, byLabel...), nil
 }
 
 // listInstancesWithFilter lists instances in the project that satisfy the filter criteria.


### PR DESCRIPTION
Prior to this change, the gcp destroy process would get stuck in an
infinite loop in the case where an instance has been provisioned in
a cluster subnetwork but the instance name does not contain the infra_id
identifier. As a result, the instance would be ignored and the google
api would complain that the subnetwork was still in use when attempting
to delete it. This can be experienced after adding new machine groups to
a cluster such that the new instance names do not contain the infra_id.

This change enables the destroy process to also delete instances that are
labeled with kubernetes-io-cluster-infraid:owned. This ensures all of
the instances created by the cluster are deleted. As a result, cluster
provisioned instances will no longer block on deletion of subnetworks.

https://github.com/openshift/cluster-api-provider-gcp/pull/57
https://cloud.google.com/compute/docs/reference/rest/v1/instances/list
https://cloud.google.com/compute/docs/labeling-resources#filter