### PR TITLE
Bug 1791318: Don't fail on unavailable features on OpenStack.

### DIFF
--- a/pkg/asset/installconfig/openstack/openstack.go
+++ b/pkg/asset/installconfig/openstack/openstack.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/types/openstack"
@@ -124,30 +125,29 @@ func Platform() (*openstack.Platform, error) {
 		return nil, err
 	}
 
+	trunkSupport := "0"
+	var i int
 	netExts, err := validValuesFetcher.GetNetworkExtensionsAliases(cloud)
 	if err != nil {
-		return nil, err
-	}
-	sort.Strings(netExts)
-	i := sort.SearchStrings(netExts, "trunk")
-	var trunkSupport string
-	if i == len(netExts) || netExts[i] != "trunk" {
-		trunkSupport = "0"
+		logrus.Warning("Could not retrieve networking extension aliases. Assuming trunk ports are not supported.")
 	} else {
-		trunkSupport = "1"
+		sort.Strings(netExts)
+		i = sort.SearchStrings(netExts, "trunk")
+		if i != len(netExts) && netExts[i] == "trunk" {
+			trunkSupport = "1"
+		}
 	}
 
+	octaviaSupport := "0"
 	serviceCatalog, err := validValuesFetcher.GetServiceCatalog(cloud)
 	if err != nil {
-		return nil, err
-	}
-	sort.Strings(serviceCatalog)
-	i = sort.SearchStrings(serviceCatalog, "octavia")
-	var octaviaSupport string
-	if i == len(serviceCatalog) || serviceCatalog[i] != "octavia" {
-		octaviaSupport = "0"
+		logrus.Warning("Could not retrieve service catalog. Assuming there is no Octavia load balancer service available.")
 	} else {
-		octaviaSupport = "1"
+		sort.Strings(serviceCatalog)
+		i = sort.SearchStrings(serviceCatalog, "octavia")
+		if i != len(serviceCatalog) && serviceCatalog[i] == "octavia" {
+			octaviaSupport = "1"
+		}
 	}
 
 	return &openstack.Platform{

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -108,13 +108,13 @@ func TestValidatePlatform(t *testing.T) {
 			name:      "network extensions fetch failure",
 			platform:  validPlatform(),
 			noNetExts: true,
-			valid:     false,
+			valid:     true,
 		},
 		{
 			name:             "service catalog fetch failure",
 			platform:         validPlatform(),
 			noServiceCatalog: true,
-			valid:            false,
+			valid:            true,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Currently if we are looking for extensions for Neutron or try to list
services, it might happen, that underlying OpenStack cloud doesn't
support listing either extension or services. This patch is fixing it,
and assumption is, that trunk support is disabled in a case of
inability of listing Neutron extensions, and/or octavia support is
disabled in case of inability of listing services, instead of aborting
installation.