### PR TITLE
Bug 1797806: asset/manifests: add new installation config map

### DIFF
--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -221,9 +221,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		})
 	}
 
-	if openshiftInstall.File != nil {
-		o.FileList = append(o.FileList, openshiftInstall.Files()...)
-	}
+	o.FileList = append(o.FileList, openshiftInstall.Files()...)
 
 	asset.SortFiles(o.FileList)
 


### PR DESCRIPTION
This is a follow-up for the logic introduced in 27de643e. The behavior
of the openshift-install ConfigMap is reverted, making it such that the
ConfigMap is always injected in an IPI installation, but never it a UPI
installation. A new ConfigMap, openshift-install-manifests, is
introduced, which is always injected at the manifests target. Both of
these ConfigMaps contain the same data: the invoker and the installer
version, at the time of their respective creation. This will allow us to
continue determining several things:

  1. Was the cluster installed via IPI or UPI?
  2. What invoked the installer to create the cluster?

It will also allow us to determine some new information:

  1. Regardless of installation strategy, what invoked the installer to
     create the manifests?
  2. Was the version of the installer used to create the manifests the
     same as the version that created the cluster (assuming IPI)?