### PR TITLE
Replace --config with --kubeconfig for `oc` command

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
+++ b/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
@@ -5,8 +5,8 @@ KUBECONFIG="${1}"
 echo "Approving all CSR requests until bootstrapping is complete..."
 while [ ! -f /opt/openshift/.bootkube.done ]
 do
-    oc --config="$KUBECONFIG" get csr --no-headers | grep Pending | \
+    oc --kubeconfig="$KUBECONFIG" get csr --no-headers | grep Pending | \
         awk '{print $1}' | \
-        xargs --no-run-if-empty oc --config="$KUBECONFIG" adm certificate approve
+        xargs --no-run-if-empty oc --kubeconfig="$KUBECONFIG" adm certificate approve
 	sleep 20
 done

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -77,37 +77,37 @@ function queue() {
 mkdir -p "${ARTIFACTS}/control-plane" "${ARTIFACTS}/resources"
 
 echo "Gathering cluster resources ..."
-queue resources/nodes.list oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get nodes -o jsonpath --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
-queue resources/masters.list oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get nodes -o jsonpath -l 'node-role.kubernetes.io/master' --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
+queue resources/nodes.list oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get nodes -o jsonpath --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
+queue resources/masters.list oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get nodes -o jsonpath -l 'node-role.kubernetes.io/master' --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
 # ShellCheck doesn't realize that $ns is for the Go template, not something we're trying to expand in the shell
 # shellcheck disable=2016
-queue resources/containers oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get pods --all-namespaces --template '{{ range .items }}{{ $name := .metadata.name }}{{ $ns := .metadata.namespace }}{{ range .spec.containers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ range .spec.initContainers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ end }}'
-queue resources/api-pods oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get pods -l apiserver=true --all-namespaces --template '{{ range .items }}-n {{ .metadata.namespace }} {{ .metadata.name }}{{ "\n" }}{{ end }}'
+queue resources/containers oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get pods --all-namespaces --template '{{ range .items }}{{ $name := .metadata.name }}{{ $ns := .metadata.namespace }}{{ range .spec.containers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ range .spec.initContainers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ end }}'
+queue resources/api-pods oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get pods -l apiserver=true --all-namespaces --template '{{ range .items }}-n {{ .metadata.namespace }} {{ .metadata.name }}{{ "\n" }}{{ end }}'
 
-queue resources/apiservices.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get apiservices -o json
-queue resources/clusteroperators.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get clusteroperators -o json
-queue resources/clusterversion.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get clusterversion -o json
-queue resources/configmaps.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get configmaps --all-namespaces -o json
-queue resources/csr.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get csr -o json
-queue resources/endpoints.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get endpoints --all-namespaces -o json
-queue resources/events.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get events --all-namespaces -o json
-queue resources/kubeapiserver.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get kubeapiserver -o json
-queue resources/kubecontrollermanager.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get kubecontrollermanager -o json
-queue resources/machineconfigpools.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get machineconfigpools -o json
-queue resources/machineconfigs.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get machineconfigs -o json
-queue resources/namespaces.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get namespaces -o json
-queue resources/nodes.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get nodes -o json
-queue resources/openshiftapiserver.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get openshiftapiserver -o json
-queue resources/pods.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get pods --all-namespaces -o json
-queue resources/rolebindings.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get rolebindings --all-namespaces -o json
-queue resources/roles.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get roles --all-namespaces -o json
+queue resources/apiservices.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get apiservices -o json
+queue resources/clusteroperators.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get clusteroperators -o json
+queue resources/clusterversion.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get clusterversion -o json
+queue resources/configmaps.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get configmaps --all-namespaces -o json
+queue resources/csr.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get csr -o json
+queue resources/endpoints.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get endpoints --all-namespaces -o json
+queue resources/events.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get events --all-namespaces -o json
+queue resources/kubeapiserver.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get kubeapiserver -o json
+queue resources/kubecontrollermanager.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get kubecontrollermanager -o json
+queue resources/machineconfigpools.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get machineconfigpools -o json
+queue resources/machineconfigs.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get machineconfigs -o json
+queue resources/namespaces.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get namespaces -o json
+queue resources/nodes.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get nodes -o json
+queue resources/openshiftapiserver.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get openshiftapiserver -o json
+queue resources/pods.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get pods --all-namespaces -o json
+queue resources/rolebindings.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get rolebindings --all-namespaces -o json
+queue resources/roles.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get roles --all-namespaces -o json
 # this just lists names and number of keys
-queue resources/secrets-names.txt oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get secrets --all-namespaces
+queue resources/secrets-names.txt oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get secrets --all-namespaces
 # this adds annotations, but strips out the SA tokens and dockercfg secrets which are noisy and may contain secrets in the annotations
-queue resources/secrets-names-with-annotations.txt oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get secrets --all-namespaces -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,TYPE:.type,ANNOTATIONS:.metadata.annotations | grep -v -- '-token-' | grep -v -- '-dockercfg-'
-queue resources/services.json oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get services --all-namespaces -o json
+queue resources/secrets-names-with-annotations.txt oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get secrets --all-namespaces -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,TYPE:.type,ANNOTATIONS:.metadata.annotations | grep -v -- '-token-' | grep -v -- '-dockercfg-'
+queue resources/services.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get services --all-namespaces -o json
 
-FILTER=gzip queue resources/openapi.json.gz oc --config=/opt/openshift/auth/kubeconfig --request-timeout=5s get --raw /openapi/v2
+FILTER=gzip queue resources/openapi.json.gz oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get --raw /openapi/v2
 
 echo "Waiting for logs ..."
 wait
@@ -120,7 +120,7 @@ elif test -s "${ARTIFACTS}/resources/masters.list"; then
     mapfile -t MASTERS < "${ARTIFACTS}/resources/masters.list"
 else
     # Find out master IPs from etcd discovery record
-    DOMAIN=$(sudo oc --config=/opt/openshift/auth/kubeconfig whoami --show-server | grep -oP "api.\\K([a-z\\.]*)")
+    DOMAIN=$(sudo oc --kubeconfig=/opt/openshift/auth/kubeconfig whoami --show-server | grep -oP "api.\\K([a-z\\.]*)")
     dig -t SRV "_etcd-server-ssl._tcp.${DOMAIN}" +short | cut -f 4 -d ' ' | sed 's/.$//' >"${ARTIFACTS}/resources/masters.list"
     mapfile -t MASTERS < "${ARTIFACTS}/resources/masters.list"
 fi

--- a/data/data/bootstrap/files/usr/local/bin/report-progress.sh
+++ b/data/data/bootstrap/files/usr/local/bin/report-progress.sh
@@ -13,7 +13,7 @@ echo "Waiting for bootstrap to complete..."
 wait_for_existance /opt/openshift/.bootkube.done
 
 echo "Reporting install progress..."
-while ! oc --config="$KUBECONFIG" create -f - <<-EOF
+while ! oc --kubeconfig="$KUBECONFIG" create -f - <<-EOF
 	apiVersion: v1
 	kind: ConfigMap
 	metadata:

--- a/data/data/bootstrap/gcp/files/usr/local/bin/report-progress.sh
+++ b/data/data/bootstrap/gcp/files/usr/local/bin/report-progress.sh
@@ -19,7 +19,7 @@ echo "Waiting for bootstrap to complete..."
 wait_for_existance /opt/openshift/.bootkube.done
 
 echo "Reporting install progress..."
-while ! oc --config="$KUBECONFIG" create -f - <<-EOF
+while ! oc --kubeconfig="$KUBECONFIG" create -f - <<-EOF
 	apiVersion: v1
 	kind: ConfigMap
 	metadata:

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -13,7 +13,7 @@ The installer doesn't provision worker nodes directly, like it does with master 
 The status of the Machine API Operator can be checked by running the following command from the machine used to install the cluster:
 
 ```sh
-oc --config=${INSTALL_DIR}/auth/kubeconfig --namespace=openshift-machine-api get deployments
+oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig --namespace=openshift-machine-api get deployments
 ```
 
 If the API is unavailable, that will need to be [investigated first](#kubernetes-api-is-unavailable).
@@ -30,7 +30,7 @@ machine-api-operator          1/1     1            1           86m
 Check the machine controller logs with the following command.
 
 ```sh
-oc --config=${INSTALL_DIR}/auth/kubeconfig --namespace=openshift-machine-api logs deployments/machine-api-controllers --container=machine-controller
+oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig --namespace=openshift-machine-api logs deployments/machine-api-controllers --container=machine-controller
 ```
 
 ### Kubernetes API is Unavailable
@@ -98,7 +98,7 @@ The installer uses the [cluster-version-operator] to create all the components o
 1. Inspecting the `ClusterVersion` object.
 
     ```console
-    $ oc --config=${INSTALL_DIR}/auth/kubeconfig get clusterversion -oyaml
+    $ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusterversion -oyaml
     apiVersion: config.openshift.io/v1
     kind: ClusterVersion
     metadata:
@@ -147,7 +147,7 @@ The installer uses the [cluster-version-operator] to create all the components o
     Some of most important [conditions][cluster-operator-conditions] to take note are `Failing`, `Available` and `Progressing`. You can look at the conditions using:
 
     ```console
-    $ oc --config=${INSTALL_DIR}/auth/kubeconfig get clusterversion version -o=jsonpath='{range .status.conditions[*]}{.type}{" "}{.status}{" "}{.message}{"\n"}{end}'
+    $ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusterversion version -o=jsonpath='{range .status.conditions[*]}{.type}{" "}{.status}{" "}{.message}{"\n"}{end}'
     Available True Done applying 4.1.1
     Failing False
     Progressing False Cluster version is 4.0.0-0.alpha-2019-02-26-194020
@@ -159,7 +159,7 @@ The installer uses the [cluster-version-operator] to create all the components o
     You can get the status of all the cluster operators:
 
     ```console
-    $ oc --config=${INSTALL_DIR}/auth/kubeconfig get clusteroperator
+    $ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator
     NAME                                  VERSION   AVAILABLE   PROGRESSING   FAILING   SINCE
     cluster-autoscaler                              True        False         False     17m
     cluster-storage-operator                        True        False         False     10m
@@ -188,7 +188,7 @@ The installer uses the [cluster-version-operator] to create all the components o
     To get detailed information on why an individual cluster operator is `Failing` or not yet `Available`, you can check the status of that individual operator, for example `monitoring`:
 
     ```console
-    $ oc --config=${INSTALL_DIR}/auth/kubeconfig get clusteroperator monitoring -oyaml
+    $ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator monitoring -oyaml
     apiVersion: config.openshift.io/v1
     kind: ClusterOperator
     metadata:
@@ -219,7 +219,7 @@ The installer uses the [cluster-version-operator] to create all the components o
     Again, the cluster operators also publish [conditions][cluster-operator-conditions] like `Failing`, `Available` and `Progressing` that can help user provide information on the current state of the operator:
 
     ```console
-    $ oc --config=${INSTALL_DIR}/auth/kubeconfig get clusteroperator monitoring -o=jsonpath='{range .status.conditions[*]}{.type}{" "}{.status}{" "}{.message}{"\n"}{end}'
+    $ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator monitoring -o=jsonpath='{range .status.conditions[*]}{.type}{" "}{.status}{" "}{.message}{"\n"}{end}'
     Available True Successfully rolled out the stack
     Progressing False
     Failing False
@@ -228,7 +228,7 @@ The installer uses the [cluster-version-operator] to create all the components o
     Each clusteroperator also publishes the list of objects owned by the cluster operator. To get that information:
 
     ```console
-    $ oc --config=${INSTALL_DIR}/auth/kubeconfig get clusteroperator kube-apiserver -o=jsonpath='{.status.relatedObjects}'
+    $ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator kube-apiserver -o=jsonpath='{.status.relatedObjects}'
     [map[resource:kubeapiservers group:operator.openshift.io name:cluster] map[group: name:openshift-config resource:namespaces] map[group: name:openshift-config-managed resource:namespaces] map[group: name:openshift-kube-apiserver-operator resource:namespaces] map[group: name:openshift-kube-apiserver resource:namespaces]]
     ```
 
@@ -241,7 +241,7 @@ The installer fetches the URL for OpenShift console using the [route][route-obje
 1. Check if the console router is `Available` or `Failing`
 
     ```console
-    $ oc --config=${INSTALL_DIR}/auth/kubeconfig get clusteroperator console -oyaml
+    $ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get clusteroperator console -oyaml
     apiVersion: config.openshift.io/v1
     kind: ClusterOperator
     metadata:
@@ -289,7 +289,7 @@ The installer fetches the URL for OpenShift console using the [route][route-obje
 2. Manually get the URL for `console`
 
   ```console
-  $ oc --config=${INSTALL_DIR}/auth/kubeconfig get route console -n openshift-console -o=jsonpath='{.spec.host}'
+  $ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get route console -n openshift-console -o=jsonpath='{.spec.host}'
   console-openshift-console.apps.adahiya-1.devcluster.openshift.com
   ```
 
@@ -298,7 +298,7 @@ The installer fetches the URL for OpenShift console using the [route][route-obje
 The installer adds the CA certificate for the router to the list of trusted client certificate authorities in `${INSTALL_DIR}/auth/kubeconfig`. If the installer fails to add the router CA to `kubeconfig`, you can fetch the router CA from the cluster using:
 
 ```console
-$ oc --config=${INSTALL_DIR}/auth/kubeconfig get configmaps router-ca -n openshift-config-managed -o=jsonpath='{.data.ca-bundle\.crt}'
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get configmaps router-ca -n openshift-config-managed -o=jsonpath='{.data.ca-bundle\.crt}'
 -----BEGIN CERTIFICATE-----
 MIIC/TCCAeWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDDCNjbHVz
 dGVyLWluZ3Jlc3Mtb3BlcmF0b3JAMTU1MTMwNzU4OTAeFw0xOTAyMjcyMjQ2Mjha
@@ -332,7 +332,7 @@ For other generic troubleshooting, see [the Kubernetes documentation][kubernetes
 This is the generic version of the [*No Worker Nodes Created*](#no-worker-nodes-created) troubleshooting procedure.
 
 ```console
-$ oc --config=${INSTALL_DIR}/auth/kubeconfig get pods --all-namespaces
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get pods --all-namespaces
 NAMESPACE                              NAME                                                              READY     STATUS              RESTARTS   AGE
 kube-system                            etcd-member-wking-master-0                                        1/1       Running             0          46s
 openshift-machine-api                  machine-api-operator-586bd5b6b9-bxq9s                             0/1       Pending             0          1m
@@ -343,7 +343,7 @@ openshift-cluster-dns-operator         cluster-dns-operator-7f4f6866b9-kzth5    
 You can investigate any pods listed as `Pending` with:
 
 ```sh
-oc --config=${INSTALL_DIR}/auth/kubeconfig describe -n openshift-machine-api pod/machine-api-operator-586bd5b6b9-bxq9s
+oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig describe -n openshift-machine-api pod/machine-api-operator-586bd5b6b9-bxq9s
 ```
 
 which may show events with warnings like:
@@ -355,7 +355,7 @@ Warning  FailedScheduling  1m (x10 over 1m)  default-scheduler  0/1 nodes are av
 You can get the image used for a crashing pod with:
 
 ```console
-$ oc --config=${INSTALL_DIR}/auth/kubeconfig get pod -o "jsonpath={range .status.containerStatuses[*]}{.name}{'\t'}{.state}{'\t'}{.image}{'\n'}{end}" -n openshift-machine-api machine-api-operator-586bd5b6b9-bxq9s
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get pod -o "jsonpath={range .status.containerStatuses[*]}{.name}{'\t'}{.state}{'\t'}{.image}{'\n'}{end}" -n openshift-machine-api machine-api-operator-586bd5b6b9-bxq9s
 machine-api-operator	map[running:map[startedAt:2018-11-13T19:04:50Z]]	registry.svc.ci.openshift.org/openshift/origin-v4.0-20181113175638@sha256:c97d0b53b98d07053090f3c9563cfd8277587ce94f8c2400b33e246aa08332c7
 ```
 


### PR DESCRIPTION
--config has been deprecated

Resolves warning message in log files:
Flag --config has been deprecated, use --kubeconfig instead