### PR TITLE
bootstrap: replace Ignition files if they already exist instead of appending them

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/installer/pkg/asset/ignition/bootstrap/baremetal"
 	"io"
 	"io/ioutil"
 	"os"
@@ -23,6 +22,7 @@ import (
 	"github.com/openshift/installer/data"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition"
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap/baremetal"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/machines"
@@ -305,7 +305,9 @@ func (a *Bootstrap) addStorageFiles(base string, uri string, templateData *boots
 	}
 	ign := ignition.FileFromBytes(strings.TrimSuffix(base, ".template"), "root", mode, data)
 	ign.Append = appendToFile
-	a.Config.Storage.Files = append(a.Config.Storage.Files, ign)
+
+	// Replace files that already exist in the slice with ones added later, otherwise append them
+	a.Config.Storage.Files = replaceOrAppend(a.Config.Storage.Files, ign)
 
 	return nil
 }
@@ -442,7 +444,11 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 		&machines.Worker{},
 	} {
 		dependencies.Get(asset)
-		a.Config.Storage.Files = append(a.Config.Storage.Files, ignition.FilesFromAsset(rootDir, "root", 0644, asset)...)
+
+		// Replace files that already exist in the slice with ones added later, otherwise append them
+		for _, file := range ignition.FilesFromAsset(rootDir, "root", 0644, asset) {
+			a.Config.Storage.Files = replaceOrAppend(a.Config.Storage.Files, file)
+		}
 	}
 
 	// These files are all added with mode 0600; use for secret keys and the like.
@@ -491,12 +497,27 @@ func (a *Bootstrap) addParentFiles(dependencies asset.Parents) {
 		&tls.JournalCertKey{},
 	} {
 		dependencies.Get(asset)
-		a.Config.Storage.Files = append(a.Config.Storage.Files, ignition.FilesFromAsset(rootDir, "root", 0600, asset)...)
+
+		// Replace files that already exist in the slice with ones added later, otherwise append them
+		for _, file := range ignition.FilesFromAsset(rootDir, "root", 0600, asset) {
+			a.Config.Storage.Files = replaceOrAppend(a.Config.Storage.Files, file)
+		}
 	}
 
 	rootCA := &tls.RootCA{}
 	dependencies.Get(rootCA)
-	a.Config.Storage.Files = append(a.Config.Storage.Files, ignition.FileFromBytes(filepath.Join(rootDir, rootCA.CertFile().Filename), "root", 0644, rootCA.Cert()))
+	a.Config.Storage.Files = replaceOrAppend(a.Config.Storage.Files, ignition.FileFromBytes(filepath.Join(rootDir, rootCA.CertFile().Filename), "root", 0644, rootCA.Cert()))
+}
+
+func replaceOrAppend(files []igntypes.File, file igntypes.File) []igntypes.File {
+	for i, f := range files {
+		if f.Node.Path == file.Node.Path {
+			files[i] = file
+			return files
+		}
+	}
+	files = append(files, file)
+	return files
 }
 
 func applyTemplateData(template *template.Template, templateData interface{}) string {


### PR DESCRIPTION
This fixes an issue in Ignition Spec v3 where contradictory and/or duplicate entries
in the Storage.Files array are not allowed.

Specifically, in order to solve openshift/okd#37,
`data/data/bootstrap/gcp/files/usr/local/bin/report-progress.sh` will
now replace `data/data/bootstrap/files/usr/local/bin/report-progress.sh`
instead of being appended.

It also solves openshift/okd#63 by ensuring
`99_openshift-machineconfig_99-{master,worker]-ssh.yaml` aren't added
to the generated Ignition config twice.

I'm sure there is a more elegant way to do this - feedback is welcome!

Fixes: openshift/okd#37
Fixes: openshift/okd#63