### PR TITLE
baremetal: add OWNERS to missing directories

### DIFF
--- a/images/baremetal/OWNERS
+++ b/images/baremetal/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - baremetal-approvers
+reviewers:
+  - baremetal-reviewers

--- a/pkg/asset/ignition/bootstrap/baremetal/OWNERS
+++ b/pkg/asset/ignition/bootstrap/baremetal/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - baremetal-approvers
+reviewers:
+  - baremetal-reviewers


### PR DESCRIPTION
images/baremetal and ignition/bootstrap/baremetal directories are
missing OWNERS files