### PR TITLE
Remove the need for helper Python script in Azure UPI

### DIFF
--- a/docs/user/azure/install_upi.md
+++ b/docs/user/azure/install_upi.md
@@ -17,11 +17,10 @@ example.
   * python3
   * [jq][jqjson]
   * [yq][yqyaml]
-* python dotmap library: install it with `pip install dotmap`
 
 ## Create an install config
 
-Create an install configuration as for [the usual approach](install.md#create-configuration):
+Create an install configuration as for [the usual approach](install.md#create-configuration).
 
 ```console
 $ openshift-install create install-config
@@ -38,6 +37,10 @@ INFO Saving user credentials to "/home/user_id/.azure/osServicePrincipal.json"
 ? Pull Secret [? for help]
 ```
 
+Note that we're going to have a new Virtual Network and subnetworks created specifically for this deployment, but it is also possible to use a networking
+infrastructure already existing in your organization. Please refer to the [customization instructions](customization.md) for more details about setting
+up an install config for that scenario.
+
 ### Extract data from install config
 
 Some data from the install configuration file will be used on later steps. Export them as environment variables with:
@@ -48,7 +51,6 @@ export AZURE_REGION=`yq -r .platform.azure.region install-config.yaml`
 export SSH_KEY=`yq -r .sshKey install-config.yaml | xargs`
 export BASE_DOMAIN=`yq -r .baseDomain install-config.yaml`
 export BASE_DOMAIN_RESOURCE_GROUP=`yq -r .platform.azure.baseDomainResourceGroupName install-config.yaml`
-export RESOURCE_GROUP=$CLUSTER_NAME
 ```
 
 ### Empty the compute pool
@@ -75,32 +77,6 @@ INFO Consuming "Install Config" from target directory
 WARNING Making control-plane schedulable by setting MastersSchedulable to true for Scheduler cluster settings
 ```
 
-### Customize manifests
-
-The manifests need to reflect the resources to be created by the [Azure Resource Manager][azuretemplates] template, e.g. the
-resource group name. Also, we don't want [the ingress operator][ingress-operator] to create DNS records (we're going to
-do it manually) so we need to remove the `privateZone` and `publicZone` sections from the DNS configuration in manifests.
-
-A Python script named `setup-manifests.py` is provided to help with these and a few other changes required in manifests. This script
-works "as is" for a regular UPI deployment, but can be edited to reflect your own needs.
-
-For example, if you'd like to use a Virtual Network and subnets already existing in your organization (instead of a having new one
-created specifically for this deployment), you could either edit the `manifests/cluster-infrastructure-02-config.yml` file manually,
-or edit the script to provide their names and the resource group where they exist.
-
-```python3
-yamlx['status']['platformStatus']['azure']['networkResourceGroupName'] = "RESOURCE-GROUP-OF-MY-VNET"
-yamlx['status']['platformStatus']['azure']['virtualNetwork'] = "MY-VNET-NAME"
-yamlx['status']['platformStatus']['azure']['controlPlaneSubnet'] = resource_group + "MY-CONTROL-PLANE-SUBNET-NAME"
-yamlx['status']['platformStatus']['azure']['computeSubnet'] = resource_group + "MY-COMPUTE-NODES-SUBNET-NAME"
-```
-
-Finally, run the script to have the changes applies to your manifests:
-
-```sh
-python3 setup-manifests.py $RESOURCE_GROUP
-```
-
 ### Remove control plane machines and machinesets
 
 Remove the control plane machines and compute machinesets from the manifests.
@@ -109,6 +85,60 @@ We'll be providing those ourselves and don't want to involve the [machine-API op
 ```sh
 rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml
 rm -f openshift/99_openshift-cluster-api_worker-machineset-*.yaml
+```
+
+### Make control-plane nodes unschedulable
+
+Currently [emptying the compute pools](#empty-the-compute-pool) makes control-plane nodes schedulable.
+But due to a [Kubernetes limitation][kubernetes-service-load-balancers-exclude-masters], router pods running on control-plane nodes will not be reachable by the ingress load balancer.
+Update the scheduler configuration to keep router pods and other workloads off the control-plane nodes:
+
+```sh
+python3 -c '
+import yaml;
+path = "manifests/cluster-scheduler-02-config.yml";
+data = yaml.full_load(open(path));
+data["spec"]["mastersSchedulable"] = False;
+open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+```
+
+### Remove DNS Zones
+
+We don't want [the ingress operator][ingress-operator] to create DNS records (we're going to do it manually) so we need to remove
+the `privateZone` and `publicZone` sections from the DNS configuration in manifests.
+
+```sh
+python3 -c '
+import yaml;
+path = "manifests/cluster-dns-02-config.yml";
+data = yaml.full_load(open(path));
+del data["spec"]["publicZone"];
+del data["spec"]["privateZone"];
+open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+```
+
+### Resource Group Name and Infra ID
+
+The OpenShift cluster has been assigned an identifier in the form of `<cluster_name>-<random_string>`. This identifier, called "Infra ID", will be used as
+the base name of most resources that will be created in this example. Export the Infra ID as an environment variable that will be used later in this example:
+
+```sh
+export INFRA_ID=`yq -r '.status.infrastructureName' manifests/cluster-infrastructure-02-config.yml`
+```
+
+Also, all resources created in this Azure deployment will exist as part of a [resource group][azure-resource-group]. The resource group name is also
+based on the Infra ID, in the form of `<cluster_name>-<random_string>-rg`. Export the resource group name to an environment variable that will be user later:
+
+```sh
+export RESOURCE_GROUP=`yq -r '.status.platformStatus.azure.resourceGroupName' manifests/cluster-infrastructure-02-config.yml`
+```
+
+**Optional:** it's possible to choose any other name for the Infra ID and/or the resource group, but in that case some adjustments in manifests are needed.
+A Python script is provided to help with these adjustments. Export the `INFRA_ID` and the `RESOURCE_GROUP` environment variables with the desired names and invoke
+the script with:
+
+```sh
+python3 setup-manifests.py $RESOURCE_GROUP $INFRA_ID
 ```
 
 ## Create ignition configs
@@ -145,34 +175,18 @@ $ tree
 └── worker.ign
 ```
 
-## Infra ID
-
-The OpenShift cluster has been assigned an identifier in the form of `<cluster name>-<random string>`. You do not need this for anything in this example, but it is a good idea to keep it around.
-At this point you can see the various metadata about your future cluster in `metadata.json`.
-
-The Infra ID is under the `infraID` key:
-
-```console
-$ export INFRA_ID=$(jq -r .infraID metadata.json)
-$ echo $INFRA_ID
-openshift-vw4j5
-```
-
 ## Create The Resource Group and identity
 
-All resources created in this Azure deployment will exist as part of a [resource group][azure-resource-group]. Use the commands
-below to create it in the selected Azure region. In this example we're going to use the cluster name as the unique
-resource group name, but feel free to choose any other name and export it in the `RESOURCE_GROUP` environment variable,
-which will be used in the subsequent steps.
+Use the command below to create the resource group in the selected Azure region:
 
 ```sh
 az group create --name $RESOURCE_GROUP --location $AZURE_REGION
 ```
 
-Also, create an identity which will be used to grant the required access to cluster operators.
+Also, create an identity which will be used to grant the required access to cluster operators:
 
 ```sh
-az identity create -g $RESOURCE_GROUP -n ${RESOURCE_GROUP}-identity
+az identity create -g $RESOURCE_GROUP -n ${INFRA_ID}-identity
 ```
 
 ## Upload the files to a Storage Account
@@ -220,12 +234,6 @@ do
 done
 ```
 
-Save the blob URL of the copied image for later use:
-
-```sh
-export VHD_BLOB_URL=`az storage blob url --account-name ${CLUSTER_NAME}sa --account-key $ACCOUNT_KEY -c vhd -n "rhcos.vhd" -o tsv`
-```
-
 ### Upload the bootstrap ignition
 
 Create a blob storage container and upload the generated `bootstrap.ign` file:
@@ -233,12 +241,6 @@ Create a blob storage container and upload the generated `bootstrap.ign` file:
 ```sh
 az storage container create --name files --account-name ${CLUSTER_NAME}sa --public-access blob
 az storage blob upload --account-name ${CLUSTER_NAME}sa --account-key $ACCOUNT_KEY -c "files" -f "bootstrap.ign" -n "bootstrap.ign"
-```
-
-Save the blob URL of the copied file for later use:
-
-```sh
-export BOOTSTRAP_URL=`az storage blob url --account-name ${CLUSTER_NAME}sa --account-key $ACCOUNT_KEY -c "files" -n "bootstrap.ign" -o tsv`
 ```
 
 ## Create the DNS zones
@@ -268,7 +270,7 @@ az network private-dns zone create -g $RESOURCE_GROUP -n ${CLUSTER_NAME}.${BASE_
 Grant the *Contributor* role to the Azure identity so that the Ingress Operator can create a public IP and its load balancer. You can do that with:
 
 ```sh
-export PRINCIPAL_ID=`az identity show -g $RESOURCE_GROUP -n ${RESOURCE_GROUP}-identity --query principalId --out tsv`
+export PRINCIPAL_ID=`az identity show -g $RESOURCE_GROUP -n ${INFRA_ID}-identity --query principalId --out tsv`
 export RESOURCE_GROUP_ID=`az group show -g $RESOURCE_GROUP --query id --out tsv`
 az role assignment create --assignee "$PRINCIPAL_ID" --role 'Contributor' --scope "$RESOURCE_GROUP_ID"
 ```
@@ -287,21 +289,25 @@ own needs (e.g. change the subnets address prefixes in CIDR format).
 
 ```sh
 az group deployment create -g $RESOURCE_GROUP \
-  --template-file "01_vnet.json"
+  --template-file "01_vnet.json" \
+  --parameters baseName="$INFRA_ID"
 ```
 
 Link the VNet just created to the private DNS zone:
 
 ```sh
-az network private-dns link vnet create -g $RESOURCE_GROUP -z ${CLUSTER_NAME}.${BASE_DOMAIN} -n ${CLUSTER_NAME}-network-link -v "${RESOURCE_GROUP}-vnet" -e false
+az network private-dns link vnet create -g $RESOURCE_GROUP -z ${CLUSTER_NAME}.${BASE_DOMAIN} -n ${INFRA_ID}-network-link -v "${INFRA_ID}-vnet" -e false
 ```
 
 ## Deploy the image
 
 ```sh
+export VHD_BLOB_URL=`az storage blob url --account-name ${CLUSTER_NAME}sa --account-key $ACCOUNT_KEY -c vhd -n "rhcos.vhd" -o tsv`
+
 az group deployment create -g $RESOURCE_GROUP \
   --template-file "02_storage.json" \
-  --parameters vhdBlobURL="${VHD_BLOB_URL}"
+  --parameters vhdBlobURL="$VHD_BLOB_URL" \
+  --parameters baseName="$INFRA_ID"
 ```
 
 ## Deploy the load balancers
@@ -311,33 +317,36 @@ Deploy the load balancers and public IP addresses:
 ```sh
 az group deployment create -g $RESOURCE_GROUP \
   --template-file "03_infra.json" \
-  --parameters privateDNSZoneName="${CLUSTER_NAME}.${BASE_DOMAIN}"
+  --parameters privateDNSZoneName="${CLUSTER_NAME}.${BASE_DOMAIN}" \
+  --parameters baseName="$INFRA_ID"
 ```
 
 Create an `api` DNS record in the *public* zone for the API public load balancer. Note that the `BASE_DOMAIN_RESOURCE_GROUP` must point to the resource group where the public DNS zone exists.
 
 ```sh
-export PUBLIC_IP=`az network public-ip list -g $RESOURCE_GROUP --query "[?name=='${CLUSTER_NAME}-master-pip'] | [0].ipAddress" -o tsv`
+export PUBLIC_IP=`az network public-ip list -g $RESOURCE_GROUP --query "[?name=='${INFRA_ID}-master-pip'] | [0].ipAddress" -o tsv`
 az network dns record-set a add-record -g $BASE_DOMAIN_RESOURCE_GROUP -z ${CLUSTER_NAME}.${BASE_DOMAIN} -n api -a $PUBLIC_IP --ttl 60
 ```
 
 Or, in case of adding this cluster to an already existing public zone, use instead:
 
 ```sh
-export PUBLIC_IP=`az network public-ip list -g $RESOURCE_GROUP --query "[?name=='${CLUSTER_NAME}-master-pip'] | [0].ipAddress" -o tsv`
+export PUBLIC_IP=`az network public-ip list -g $RESOURCE_GROUP --query "[?name=='${INFRA_ID}-master-pip'] | [0].ipAddress" -o tsv`
 az network dns record-set a add-record -g $BASE_DOMAIN_RESOURCE_GROUP -z ${BASE_DOMAIN} -n api.${CLUSTER_NAME} -a $PUBLIC_IP --ttl 60
 ```
 
 ## Launch the temporary cluster bootstrap
 
 ```sh
+export BOOTSTRAP_URL=`az storage blob url --account-name ${CLUSTER_NAME}sa --account-key $ACCOUNT_KEY -c "files" -n "bootstrap.ign" -o tsv`
 export BOOTSTRAP_IGNITION=`python3 setup-bootstrap-ignition.py $BOOTSTRAP_URL`
 
 az group deployment create -g $RESOURCE_GROUP \
   --template-file "04_bootstrap.json" \
   --parameters bootstrapIgnition="$BOOTSTRAP_IGNITION" \
   --parameters sshKeyData="$SSH_KEY" \
-  --parameters privateDNSZoneName="${CLUSTER_NAME}.${BASE_DOMAIN}"
+  --parameters privateDNSZoneName="${CLUSTER_NAME}.${BASE_DOMAIN}" \
+  --parameters baseName="$INFRA_ID"
 ```
 
 ## Launch the permanent control plane
@@ -349,7 +358,8 @@ az group deployment create -g $RESOURCE_GROUP \
   --template-file "05_masters.json" \
   --parameters masterIgnition="$MASTER_IGNITION" \
   --parameters sshKeyData="$SSH_KEY" \
-  --parameters privateDNSZoneName="${CLUSTER_NAME}.${BASE_DOMAIN}"
+  --parameters privateDNSZoneName="${CLUSTER_NAME}.${BASE_DOMAIN}" \
+  --parameters baseName="$INFRA_ID"
 ```
 
 ## Wait for the bootstrap complete
@@ -373,11 +383,11 @@ INFO It is now safe to remove the bootstrap resources
 Once the bootstrapping process is complete you can deallocate and delete bootstrap resources:
 
 ```sh
-az vm stop -g $RESOURCE_GROUP --name ${RESOURCE_GROUP}-bootstrap
-az vm deallocate -g $RESOURCE_GROUP --name ${RESOURCE_GROUP}-bootstrap
-az vm delete -g $RESOURCE_GROUP --name ${RESOURCE_GROUP}-bootstrap --yes
-az disk delete -g $RESOURCE_GROUP --name ${RESOURCE_GROUP}-bootstrap_OSDisk --no-wait --yes
-az network nic delete -g $RESOURCE_GROUP --name ${RESOURCE_GROUP}-bootstrap-nic --no-wait
+az vm stop -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap
+az vm deallocate -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap
+az vm delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap --yes
+az disk delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap_OSDisk --no-wait --yes
+az network nic delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap-nic --no-wait
 az storage blob delete --account-key $ACCOUNT_KEY --account-name ${CLUSTER_NAME}sa --container-name files --name bootstrap.ign
 ```
 
@@ -406,7 +416,8 @@ export WORKER_IGNITION=`cat worker.ign | base64`
 az group deployment create -g $RESOURCE_GROUP \
   --template-file "06_workers.json" \
   --parameters workerIgnition="$WORKER_IGNITION" \
-  --parameters sshKeyData="$SSH_KEY"
+  --parameters sshKeyData="$SSH_KEY" \
+  --parameters baseName="$INFRA_ID"
 ```
 
 ### Approve the worker CSRs

--- a/upi/azure/01_vnet.json
+++ b/upi/azure/01_vnet.json
@@ -1,16 +1,25 @@
 {
   "$schema" : "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion" : "1.0.0.0",
+  "parameters" : {
+    "baseName" : {
+      "type" : "string",
+      "minLength" : 1,
+      "metadata" : {
+        "description" : "Base name to be used in resource names (usually the cluster's Infra ID)"
+      }
+    }
+  },
   "variables" : {
     "location" : "[resourceGroup().location]",
-    "virtualNetworkName" : "[concat(resourceGroup().name, '-vnet')]",
+    "virtualNetworkName" : "[concat(parameters('baseName'), '-vnet')]",
     "addressPrefix" : "10.0.0.0/16",
-    "masterSubnetName" : "[concat(resourceGroup().name, '-master-subnet')]",
+    "masterSubnetName" : "[concat(parameters('baseName'), '-master-subnet')]",
     "masterSubnetPrefix" : "10.0.0.0/24",
-    "nodeSubnetName" : "[concat(resourceGroup().name, '-node-subnet')]",
+    "nodeSubnetName" : "[concat(parameters('baseName'), '-worker-subnet')]",
     "nodeSubnetPrefix" : "10.0.1.0/24",
-    "controlPlaneNsgName" : "[concat(resourceGroup().name, '-controlplane-nsg')]",
-    "nodeNsgName" : "[concat(resourceGroup().name, '-node-nsg')]"
+    "controlPlaneNsgName" : "[concat(parameters('baseName'), '-controlplane-nsg')]",
+    "nodeNsgName" : "[concat(parameters('baseName'), '-node-nsg')]"
   },
   "resources" : [
     {

--- a/upi/azure/02_storage.json
+++ b/upi/azure/02_storage.json
@@ -2,6 +2,13 @@
   "$schema" : "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion" : "1.0.0.0",
   "parameters" : {
+    "baseName" : {
+      "type" : "string",
+      "minLength" : 1,
+      "metadata" : {
+        "description" : "Base name to be used in resource names (usually the cluster's Infra ID)"
+      }
+    },
     "vhdBlobURL" : {
       "type" : "string",
       "metadata" : {
@@ -11,7 +18,7 @@
   },
   "variables" : {
     "location" : "[resourceGroup().location]",
-    "imageName" : "[concat(resourceGroup().name, '-image')]"
+    "imageName" : "[concat(parameters('baseName'), '-image')]"
   },
   "resources" : [
     {

--- a/upi/azure/03_infra.json
+++ b/upi/azure/03_infra.json
@@ -2,6 +2,13 @@
   "$schema" : "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion" : "1.0.0.0",
   "parameters" : {
+    "baseName" : {
+      "type" : "string",
+      "minLength" : 1,
+      "metadata" : {
+        "description" : "Base name to be used in resource names (usually the cluster's Infra ID)"
+      }
+    },
     "privateDNSZoneName" : {
       "type" : "string",
       "metadata" : {
@@ -11,15 +18,15 @@
   },
   "variables" : {
     "location" : "[resourceGroup().location]",
-    "virtualNetworkName" : "[concat(resourceGroup().name, '-vnet')]",
+    "virtualNetworkName" : "[concat(parameters('baseName'), '-vnet')]",
     "virtualNetworkID" : "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "masterSubnetName" : "[concat(resourceGroup().name, '-master-subnet')]",
+    "masterSubnetName" : "[concat(parameters('baseName'), '-master-subnet')]",
     "masterSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
-    "masterPublicIpAddressName" : "[concat(resourceGroup().name, '-master-pip')]",
+    "masterPublicIpAddressName" : "[concat(parameters('baseName'), '-master-pip')]",
     "masterPublicIpAddressID" : "[resourceId('Microsoft.Network/publicIPAddresses', variables('masterPublicIpAddressName'))]",
-    "masterLoadBalancerName" : "[concat(resourceGroup().name, '-public-lb')]",
+    "masterLoadBalancerName" : "[concat(parameters('baseName'), '-public-lb')]",
     "masterLoadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('masterLoadBalancerName'))]",
-    "internalLoadBalancerName" : "[concat(resourceGroup().name, '-internal-lb')]",
+    "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "internalLoadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('internalLoadBalancerName'))]",
     "skuName": "Standard"
   },

--- a/upi/azure/04_bootstrap.json
+++ b/upi/azure/04_bootstrap.json
@@ -2,6 +2,13 @@
   "$schema" : "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion" : "1.0.0.0",
   "parameters" : {
+    "baseName" : {
+      "type" : "string",
+      "minLength" : 1,
+      "metadata" : {
+        "description" : "Base name to be used in resource names (usually the cluster's Infra ID)"
+      }
+    },
     "bootstrapIgnition" : {
       "type" : "string",
       "minLength" : 1,
@@ -99,17 +106,17 @@
   },
   "variables" : {
     "location" : "[resourceGroup().location]",
-    "virtualNetworkName" : "[concat(resourceGroup().name, '-vnet')]",
+    "virtualNetworkName" : "[concat(parameters('baseName'), '-vnet')]",
     "virtualNetworkID" : "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "masterSubnetName" : "[concat(resourceGroup().name, '-master-subnet')]",
+    "masterSubnetName" : "[concat(parameters('baseName'), '-master-subnet')]",
     "masterSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
-    "masterLoadBalancerName" : "[concat(resourceGroup().name, '-public-lb')]",
-    "internalLoadBalancerName" : "[concat(resourceGroup().name, '-internal-lb')]",
+    "masterLoadBalancerName" : "[concat(parameters('baseName'), '-public-lb')]",
+    "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
-    "identityName" : "[concat(resourceGroup().name, '-identity')]",
-    "vmName" : "[concat(resourceGroup().name, '-bootstrap')]",
+    "identityName" : "[concat(parameters('baseName'), '-identity')]",
+    "vmName" : "[concat(parameters('baseName'), '-bootstrap')]",
     "nicName" : "[concat(variables('vmName'), '-nic')]",
-    "imageName" : "[concat(resourceGroup().name, '-image')]"
+    "imageName" : "[concat(parameters('baseName'), '-image')]"
   },
   "resources" : [
     {

--- a/upi/azure/05_masters.json
+++ b/upi/azure/05_masters.json
@@ -2,6 +2,13 @@
   "$schema" : "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion" : "1.0.0.0",
   "parameters" : {
+    "baseName" : {
+      "type" : "string",
+      "minLength" : 1,
+      "metadata" : {
+        "description" : "Base name to be used in resource names (usually the cluster's Infra ID)"
+      }
+    },
     "masterIgnition" : {
       "type" : "string",
       "metadata" : {
@@ -107,19 +114,20 @@
   },
   "variables" : {
     "location" : "[resourceGroup().location]",
-    "virtualNetworkName" : "[concat(resourceGroup().name, '-vnet')]",
+    "virtualNetworkName" : "[concat(parameters('baseName'), '-vnet')]",
     "virtualNetworkID" : "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "masterSubnetName" : "[concat(resourceGroup().name, '-master-subnet')]",
+    "masterSubnetName" : "[concat(parameters('baseName'), '-master-subnet')]",
     "masterSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
-    "masterLoadBalancerName" : "[concat(resourceGroup().name, '-public-lb')]",
-    "internalLoadBalancerName" : "[concat(resourceGroup().name, '-internal-lb')]",
+    "masterLoadBalancerName" : "[concat(parameters('baseName'), '-public-lb')]",
+    "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
-    "identityName" : "[concat(resourceGroup().name, '-identity')]",
+    "identityName" : "[concat(parameters('baseName'), '-identity')]",
+    "imageName" : "[concat(parameters('baseName'), '-image')]",
     "copy" : [
       {
         "name" : "vmNames",
         "count" :  "[parameters('numberOfMasters')]",
-        "input" : "[concat(resourceGroup().name, '-master-', copyIndex('vmNames'))]"
+        "input" : "[concat(parameters('baseName'), '-master-', copyIndex('vmNames'))]"
       }
     ]
   },
@@ -217,7 +225,7 @@
         },
         "storageProfile" : {
           "imageReference": {
-            "id": "[resourceId('Microsoft.Compute/images', concat(resourceGroup().name, '-image'))]"
+            "id": "[resourceId('Microsoft.Compute/images', variables('imageName'))]"
           },
           "osDisk" : {
             "name": "[concat(variables('vmNames')[copyIndex()], '_OSDisk')]",

--- a/upi/azure/06_workers.json
+++ b/upi/azure/06_workers.json
@@ -2,6 +2,13 @@
   "$schema" : "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion" : "1.0.0.0",
   "parameters" : {
+    "baseName" : {
+      "type" : "string",
+      "minLength" : 1,
+      "metadata" : {
+        "description" : "Base name to be used in resource names (usually the cluster's Infra ID)"
+      }
+    },
     "workerIgnition" : {
       "type" : "string",
       "metadata" : {
@@ -101,18 +108,19 @@
   },
   "variables" : {
     "location" : "[resourceGroup().location]",
-    "virtualNetworkName" : "[concat(resourceGroup().name, '-vnet')]",
+    "virtualNetworkName" : "[concat(parameters('baseName'), '-vnet')]",
     "virtualNetworkID" : "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "nodeSubnetName" : "[concat(resourceGroup().name, '-node-subnet')]",
+    "nodeSubnetName" : "[concat(parameters('baseName'), '-worker-subnet')]",
     "nodeSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('nodeSubnetName'))]",
-    "infraLoadBalancerName" : "[resourceGroup().name]",
+    "infraLoadBalancerName" : "[parameters('baseName')]",
     "sshKeyPath" : "/home/capi/.ssh/authorized_keys",
-    "identityName" : "[concat(resourceGroup().name, '-identity')]",
+    "identityName" : "[concat(parameters('baseName'), '-identity')]",
+    "imageName" : "[concat(parameters('baseName'), '-image')]",
     "copy" : [
       {
         "name" : "vmNames",
         "count" :  "[parameters('numberOfNodes')]",
-        "input" : "[concat(resourceGroup().name, '-worker-', variables('location'), '-', copyIndex('vmNames', 1))]"
+        "input" : "[concat(parameters('baseName'), '-worker-', variables('location'), '-', copyIndex('vmNames', 1))]"
       }
     ]
   },
@@ -147,7 +155,7 @@
                       },
                       "loadBalancerBackendAddressPools" : [
                         {
-                          "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('infraLoadBalancerName'), '/backendAddressPools/', resourceGroup().name)]"
+                          "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('infraLoadBalancerName'), '/backendAddressPools/', parameters('baseName'))]"
                         }
                       ]
                     }
@@ -194,7 +202,7 @@
                 },
                 "storageProfile" : {
                   "imageReference": {
-                    "id": "[resourceId('Microsoft.Compute/images', concat(resourceGroup().name, '-image'))]"
+                    "id": "[resourceId('Microsoft.Compute/images', variables('imageName'))]"
                   },
                   "osDisk" : {
                     "name": "[concat(variables('vmNames')[copyIndex()],'_OSDisk')]",


### PR DESCRIPTION
The previous version of Azure UPI provided a script called `setup-manifests.py` which was mandatory for the deployment and required editing the generated manifest files.

This PR removes the need of that script, making the primary workflow rely on the generated Infra ID and resource group names, while still providing the script as an option in case of a different resource group name and/or base resource names are desired.

This was also desired by the docs team.