### PR TITLE
validate: Allow IPv6 for bare metal IPI

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -108,8 +108,8 @@ func ClusterName(v string) error {
 }
 
 // SubnetCIDR checks if the given IP net is a valid CIDR.
-func SubnetCIDR(cidr *net.IPNet) error {
-	if cidr.IP.To4() == nil {
+func SubnetCIDR(cidr *net.IPNet, allowIPv6 bool) error {
+	if allowIPv6 == false && cidr.IP.To4() == nil {
 		return errors.New("must use IPv4")
 	}
 	if cidr.IP.IsUnspecified() {


### PR DESCRIPTION
This is an alternative to #3029 to consider for the 4.3 branch.

#3029 is required if we also want to backport azure support.  If we want to only backport the bare minimum to allow bare metal IPI IPv6 clusters, this validations change is enough.  Since azure doesn't fully work yet anyway, I propose just going with this for now.