### PR TITLE
Add Azure CLI as a dependency in UPI CI image

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -16,9 +16,13 @@ COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
 COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json /var/lib/openshift-install/rhcos.json
 
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
+RUN sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" >/etc/yum.repos.d/azure-cli.repo'
+
 RUN yum install --setopt=tsflags=nodocs -y \
     gettext \
     openssh-clients \
+    azure-cli \
     openssl && \
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \


### PR DESCRIPTION
Adds the `az` (Azure CLI) dependency to the Dockerfile used by CI in UPI tests.

Based of the suggested installation method for yum-based distros here: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-yum?view=azure-cli-latest