### PR TITLE
Bug 1801863: Azure: fix must-gather in ipv6/dual-stack clusters

### DIFF
--- a/pkg/terraform/gather/azure/ip.go
+++ b/pkg/terraform/gather/azure/ip.go
@@ -15,6 +15,12 @@ func BootstrapIP(tfs *terraform.State) (string, error) {
 	var bootstrap string
 
 	publicIP, err := terraform.LookupResource(tfs, "module.bootstrap", "azurerm_public_ip", "bootstrap_public_ip")
+	if err != nil {
+		publicIP, err = terraform.LookupResource(tfs, "module.bootstrap", "azurerm_public_ip", "bootstrap_public_ip_v4")
+	}
+	if err != nil {
+		publicIP, err = terraform.LookupResource(tfs, "module.bootstrap", "azurerm_public_ip", "bootstrap_public_ip_v6")
+	}
 	if err == nil && len(publicIP.Instances) > 0 {
 		bootstrap, _, err = unstructured.NestedString(publicIP.Instances[0].Attributes, "ip_address")
 		if err != nil {


### PR DESCRIPTION
The terraform variables are named slightly differently in dual-stack/ipv6 clusters, but the code to run must-gather wasn't updated to match.

Fixes #3026