### PR TITLE
Bug 1801446: Move permissions check to cluster asset

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -36,10 +36,12 @@ func (c *Cluster) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.ClusterID{},
 		&installconfig.InstallConfig{},
-		// PlatformCredsCheck just checks the creds (and asks, if needed)
-		// We do not actually use it in this asset directly, hence
-		// it is put in the dependencies but not fetched in Generate
+		// PlatformCredsCheck checks the creds (and asks, if needed).
+		// PlatformPermsCheck checks for required account permissions.
+		// We do not actually use them in this asset directly, hence
+		// they are put in the dependencies but not fetched in Generate
 		&installconfig.PlatformCredsCheck{},
+		&installconfig.PlatformPermsCheck{},
 		&TerraformVariables{},
 		&password.KubeadminPassword{},
 	}

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/asset"
-	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	azureconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	"github.com/openshift/installer/pkg/types/aws"
@@ -45,20 +44,9 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 	platform := ic.Config.Platform.Name()
 	switch platform {
 	case aws.Name:
-		permissionGroups := []awsconfig.PermissionGroup{awsconfig.PermissionCreateBase, awsconfig.PermissionDeleteBase}
-		// If subnets are not provided in install-config.yaml, include network permissions
-		if len(ic.Config.AWS.Subnets) == 0 {
-			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateNetworking, awsconfig.PermissionDeleteNetworking)
-		}
-
-		ssn, err := ic.AWS.Session(ctx)
+		_, err := ic.AWS.Session(ctx)
 		if err != nil {
 			return err
-		}
-
-		err = awsconfig.ValidateCreds(ssn, permissionGroups, ic.Config.Platform.AWS.Region)
-		if err != nil {
-			return errors.Wrap(err, "validate AWS credentials")
 		}
 	case gcp.Name:
 		_, err = gcpconfig.GetSession(ctx)

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -1,0 +1,71 @@
+package installconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/openshift/installer/pkg/asset"
+	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/gcp"
+	"github.com/openshift/installer/pkg/types/libvirt"
+	"github.com/openshift/installer/pkg/types/none"
+	"github.com/openshift/installer/pkg/types/openstack"
+	"github.com/openshift/installer/pkg/types/vsphere"
+)
+
+// PlatformPermsCheck is an asset that checks platform credentials for the necessary permissions
+// to create a cluster.
+type PlatformPermsCheck struct {
+}
+
+var _ asset.Asset = (*PlatformPermsCheck)(nil)
+
+// Dependencies returns the dependencies for PlatformPermsCheck
+func (a *PlatformPermsCheck) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&InstallConfig{},
+	}
+}
+
+// Generate queries for input from the user.
+func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
+	ctx := context.TODO()
+	ic := &InstallConfig{}
+	dependencies.Get(ic)
+
+	var err error
+	platform := ic.Config.Platform.Name()
+	switch platform {
+	case aws.Name:
+		permissionGroups := []awsconfig.PermissionGroup{awsconfig.PermissionCreateBase, awsconfig.PermissionDeleteBase}
+		// If subnets are not provided in install-config.yaml, include network permissions
+		if len(ic.Config.AWS.Subnets) == 0 {
+			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateNetworking, awsconfig.PermissionDeleteNetworking)
+		}
+
+		ssn, err := ic.AWS.Session(ctx)
+		if err != nil {
+			return err
+		}
+
+		err = awsconfig.ValidateCreds(ssn, permissionGroups, ic.Config.Platform.AWS.Region)
+		if err != nil {
+			return errors.Wrap(err, "validate AWS credentials")
+		}
+	case azure.Name, baremetal.Name, gcp.Name, libvirt.Name, none.Name, openstack.Name, vsphere.Name:
+		// no permissions to check
+	default:
+		err = fmt.Errorf("unknown platform type %q", platform)
+	}
+	return err
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *PlatformPermsCheck) Name() string {
+	return "Platform Permissions Check"
+}


### PR DESCRIPTION
This is a manual cherry pick of 6eec6240298276d5788d74bf6bf394588fea012a. Major differences:

-  there is no ovirt type in the new `PlatformPermsCheck`
- ~~#3056 has not been backported so the signature for `ValidateCreds` does not have an arg for region~~

Separates the permissions check logic from PlatformCredsCheck and creates a similar PlatformPermsCheck. While PlatformCredsCheck checks whether credentials can authenticate to a platform, the new PlatformPermsCheck ensures that an account has the necessary permissions to create a cluster. PlatformPermsCheck is only needed when a cluster is being created and is currently only implemented for AWS.

This fixes BZ-1801446 where UPI calls to create manifest were failing due to insufficient permissions.