### PR TITLE
Bug 1773910: Vendor survey to fix typo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1134,7 +1134,7 @@
   version = "v1.19.1"
 
 [[projects]]
-  digest = "1:de19d3688bad66ab5567a2e0a12951a6323a48afca7a7e6582a2b9d3a7456c1c"
+  digest = "1:c4e32536f0f5b5f6644337fcb58d53679e3d4720b0bd13699b60e4a9a9f93faa"
   name = "gopkg.in/AlecAivazis/survey.v1"
   packages = [
     ".",
@@ -1142,8 +1142,8 @@
     "terminal",
   ]
   pruneopts = "NUT"
-  revision = "e4af3b345125b0903edb492a33a99a23e9eb3487"
-  version = "v1.8.7"
+  revision = "da50ccef2fd74048e26b7846a731da4254035115"
+  version = "v1.8.8"
 
 [[projects]]
   digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -15,7 +15,7 @@ required = [
 
 [[constraint]]
   name = "gopkg.in/AlecAivazis/survey.v1"
-  version = "1.8.7"
+  version = "1.8.8"
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/multiselect.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/multiselect.go
@@ -52,7 +52,7 @@ var MultiSelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else }}
-	{{- "  "}}{{- color "cyan"}}[Use arrows to move, space to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
+	{{- "  "}}{{- color "cyan"}}[Use arrows to move, enter to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $option := .PageEntries}}
     {{- if eq $ix $.SelectedIndex}}{{color "cyan"}}{{ SelectFocusIcon }}{{color "reset"}}{{else}} {{end}}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/select.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/select.go
@@ -50,7 +50,7 @@ var SelectQuestionTemplate = `
 {{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
 {{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
 {{- else}}
-  {{- "  "}}{{- color "cyan"}}[Use arrows to move, space to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
+  {{- "  "}}{{- color "cyan"}}[Use arrows to move, enter to select, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
   {{- "\n"}}
   {{- range $ix, $choice := .PageEntries}}
     {{- if eq $ix $.SelectedIndex}}{{color "cyan+b"}}{{ SelectFocusIcon }} {{else}}{{color "default+hb"}}  {{end}}


### PR DESCRIPTION
The survey library incorrectly stated users should use "space" to make a selection rather than "enter." This vendors in a new patch to fix this. The commit was created by bumping the survey version in Gopkg.toml and running dep ensure.