### PR TITLE
[fcos] don't include duplicate files in bootstrap.ign

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/openshift/installer/pkg/asset/ignition/bootstrap/baremetal"
-
 	"github.com/containers/image/pkg/sysregistriesv2"
 	"github.com/coreos/ignition/v2/config/util"
 	igntypes "github.com/coreos/ignition/v2/config/v3_0/types"

--- a/pkg/asset/machines/machineconfig/authorizedkeys.go
+++ b/pkg/asset/machines/machineconfig/authorizedkeys.go
@@ -1,0 +1,37 @@
+package machineconfig
+
+import (
+	"fmt"
+
+	ignv3_0types "github.com/coreos/ignition/v2/config/v3_0/types"
+	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ForAuthorizedKeys creates the MachineConfig to set the authorized key for `core` user.
+func ForAuthorizedKeys(key string, role string) *mcfgv1.MachineConfig {
+	return &mcfgv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: mcfgv1.SchemeGroupVersion.String(),
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("99-%s-ssh", role),
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/role": role,
+			},
+		},
+		Spec: mcfgv1.MachineConfigSpec{
+			Config: ignv3_0types.Config{
+				Ignition: ignv3_0types.Ignition{
+					Version: ignv3_0types.MaxVersion.String(),
+				},
+				Passwd: ignv3_0types.Passwd{
+					Users: []ignv3_0types.PasswdUser{{
+						Name: "core", SSHAuthorizedKeys: []ignv3_0types.SSHAuthorizedKey{ignv3_0types.SSHAuthorizedKey(key)},
+					}},
+				},
+			},
+		},
+	}
+}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -337,6 +337,9 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	if pool.Hyperthreading == types.HyperthreadingDisabled {
 		machineConfigs = append(machineConfigs, machineconfig.ForHyperthreadingDisabled("master"))
 	}
+	if ic.SSHKey != "" {
+		machineConfigs = append(machineConfigs, machineconfig.ForAuthorizedKeys(ic.SSHKey, "master"))
+	}
 	if ic.FIPS {
 		machineConfigs = append(machineConfigs, machineconfig.ForFIPSEnabled("master"))
 	}

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -60,6 +60,73 @@ spec:
   osImageURL: ""
 `},
 		},
+		{
+			name:           "key present hyperthreading disabled",
+			key:            "ssh-rsa: dummy-key",
+			hyperthreading: types.HyperthreadingDisabled,
+			expectedMachineConfig: []string{`apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-master-disable-hyperthreading
+spec:
+  config:
+    ignition:
+      config:
+        replace:
+          source: null
+          verification: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.0.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
+          verification: {}
+        group: {}
+        mode: 384
+        path: /etc/pivot/kernel-args
+        user:
+          name: root
+    systemd: {}
+  fips: false
+  kernelArguments: null
+  osImageURL: ""
+`, `apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-master-ssh
+spec:
+  config:
+    ignition:
+      config:
+        replace:
+          source: null
+          verification: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.0.0
+    passwd:
+      users:
+      - name: core
+        sshAuthorizedKeys:
+        - 'ssh-rsa: dummy-key'
+    storage: {}
+    systemd: {}
+  fips: false
+  kernelArguments: null
+  osImageURL: ""
+`},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -74,6 +141,7 @@ spec:
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test-cluster",
 						},
+						SSHKey:     tc.key,
 						BaseDomain: "test-domain",
 						Platform: types.Platform{
 							AWS: &awstypes.Platform{

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -167,6 +167,9 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		if pool.Hyperthreading == types.HyperthreadingDisabled {
 			machineConfigs = append(machineConfigs, machineconfig.ForHyperthreadingDisabled("worker"))
 		}
+		if ic.SSHKey != "" {
+			machineConfigs = append(machineConfigs, machineconfig.ForAuthorizedKeys(ic.SSHKey, "worker"))
+		}
 		if ic.FIPS {
 			machineConfigs = append(machineConfigs, machineconfig.ForFIPSEnabled("worker"))
 		}


### PR DESCRIPTION
PR to cherrypick #3078 from master to fcos to allow testing due to ssh keys missing from mc. 

Hopefully fixes openshift/okd#63

-------
Original Description:

bootstrap: replace Ignition files if they already exist instead of appending them instead of appending them.

This fixes an issue in Ignition Spec v3 where contradictory entries
in the Storage.Files array are not allowed.

Specifically, in order to solve https://github.com/openshift/okd/issues/37,
`data/data/bootstrap/gcp/files/usr/local/bin/report-progress.sh` will
now replace `data/data/bootstrap/files/usr/local/bin/report-progress.sh`
instead of being appended.

It also solves https://github.com/openshift/okd/issues/63 by ensuring
`99_openshift-machineconfig_99-{master,worker]-ssh.yaml` aren't added
to the generated Ignition config twice.