### PR TITLE
Bug 1793618: Bump RHCOS to 43.81.202002131553.0

### DIFF
--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,135 +1,135 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-023d0452866845125"
+            "hvm": "ami-0b8f9be2bc4e599a1"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0ba4f9a0358bcb44a"
+            "hvm": "ami-015dbbe2367f9cfdd"
         },
         "ap-south-1": {
-            "hvm": "ami-0bf62e963a473068e"
+            "hvm": "ami-02104009268953063"
         },
         "ap-southeast-1": {
-            "hvm": "ami-086b93722336bd1d9"
+            "hvm": "ami-0bdf1ea1c4407363a"
         },
         "ap-southeast-2": {
-            "hvm": "ami-08929f33bfab49b83"
+            "hvm": "ami-02b0f88a766fb2be1"
         },
         "ca-central-1": {
-            "hvm": "ami-0f6d943a1fa9172fd"
+            "hvm": "ami-0f899a7c2d76474e8"
         },
         "eu-central-1": {
-            "hvm": "ami-0ceea534b63224411"
+            "hvm": "ami-0c58ff816ccb2a7b7"
         },
         "eu-north-1": {
-            "hvm": "ami-06b7087b2768f644a"
+            "hvm": "ami-0f687709ab537b435"
         },
         "eu-west-1": {
-            "hvm": "ami-0e95125b57fa63b0d"
+            "hvm": "ami-0daed47038c966b4e"
         },
         "eu-west-2": {
-            "hvm": "ami-0eef98c447b85ffcd"
+            "hvm": "ami-09194eb78d217b74c"
         },
         "eu-west-3": {
-            "hvm": "ami-0049e16104f360df6"
+            "hvm": "ami-0e77760568f630f26"
         },
         "me-south-1": {
-            "hvm": "ami-0b03ea038629fd02e"
+            "hvm": "ami-03a1ab2d60f647254"
         },
         "sa-east-1": {
-            "hvm": "ami-0c80d785b30eef121"
+            "hvm": "ami-0ab298a5fb75e91b6"
         },
         "us-east-1": {
-            "hvm": "ami-06f85a7940faa3217"
+            "hvm": "ami-0042a776dcdb3217c"
         },
         "us-east-2": {
-            "hvm": "ami-04a79d8d7cfa540cc"
+            "hvm": "ami-05df2e82f530d499d"
         },
         "us-west-1": {
-            "hvm": "ami-0633b392e8eff25e7"
+            "hvm": "ami-0cefee1a610c3e384"
         },
         "us-west-2": {
-            "hvm": "ami-0d231993dddc5cd2e"
+            "hvm": "ami-0eb178e7f9b6bc894"
         }
     },
     "azure": {
-        "image": "rhcos-43.81.202001142154.0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-43.81.202001142154.0-azure.x86_64.vhd"
+        "image": "rhcos-43.81.202002131553.0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-43.81.202002131553.0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.202001142154.0/x86_64/",
-    "buildid": "43.81.202001142154.0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.202002131553.0/x86_64/",
+    "buildid": "43.81.202002131553.0",
     "gcp": {
-        "image": "rhcos-43-81-202001142154-0",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/43.81.202001142154.0.tar.gz"
+        "image": "rhcos-43-81-202002131553-0",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/43.81.202002131553.0.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-43.81.202001142154.0-aws.x86_64.vmdk.gz",
-            "sha256": "d1436d2fb0bf19ea13e90b2e3a459441f0145a914fdd32c2ef09836372667035",
-            "size": 813199011,
-            "uncompressed-sha256": "1549d5dceacddf7b0955d372a19e7d49747aed77c06a3a8daa16a3fb401847cf",
-            "uncompressed-size": 829533184
+            "path": "rhcos-43.81.202002131553.0-aws.x86_64.vmdk.gz",
+            "sha256": "dd88b8e998787843c7c17a78ba320d242d676547b80da85c4393cc28ef8dc28a",
+            "size": 814560304,
+            "uncompressed-sha256": "6a107295e1d74fda19bf29fae5ab469388a06506f6e9c673c53337f463e1154f",
+            "uncompressed-size": 830874624
         },
         "azure": {
-            "path": "rhcos-43.81.202001142154.0-azure.x86_64.vhd.gz",
-            "sha256": "5011e20132838daabb218c9722700fffac6a25b744132e93d2dc6b0091a7c04c",
-            "size": 800063766,
-            "uncompressed-sha256": "fe82be89aa8eae7434ea4c8af9a5b5c85d10148a1dc3301b96d72704562b9208",
-            "uncompressed-size": 2179508224
+            "path": "rhcos-43.81.202002131553.0-azure.x86_64.vhd.gz",
+            "sha256": "8b92d65f8dfb8783a9cf9e3714f3541dc9c6f6c8598a599566f201768d5484a1",
+            "size": 801432763,
+            "uncompressed-sha256": "15ef5d6d4308ee1ae05558a3bf2bac53495310d7d5448f928c156ffa6214cd09",
+            "uncompressed-size": 2181605888
         },
         "gcp": {
-            "path": "rhcos-43.81.202001142154.0-gcp.x86_64.tar.gz",
-            "sha256": "5173ba725ad867a743f423eafbd8fc476f833d69163edef6fa08d5b63d6de505",
-            "size": 799655869
+            "path": "rhcos-43.81.202002131553.0-gcp.x86_64.tar.gz",
+            "sha256": "331f0075dfea60253b5341a196db6a77f49ae84ccf44c0d6ed878ed3840fff9c",
+            "size": 801069991
         },
         "initramfs": {
-            "path": "rhcos-43.81.202001142154.0-installer-initramfs.x86_64.img",
-            "sha256": "3389babec8afc37023d122efba7785c3aea7797c9b4a038e98a9b90aacef1483"
+            "path": "rhcos-43.81.202002131553.0-installer-initramfs.x86_64.img",
+            "sha256": "c4652ab087680eaa546173c840cee771aeeba1b437328ce665ea0d7173deeccd"
         },
         "iso": {
-            "path": "rhcos-43.81.202001142154.0-installer.x86_64.iso",
-            "sha256": "302081da24277ed752fee8d69839227f4f24ec71261f9dfe2752ea8c0f20a0ed"
+            "path": "rhcos-43.81.202002131553.0-installer.x86_64.iso",
+            "sha256": "ee344cce626bce3e3dabe13c74cdd232f2f3a97644bbf1d4b398676d39d7b740"
         },
         "kernel": {
-            "path": "rhcos-43.81.202001142154.0-installer-kernel-x86_64",
-            "sha256": "7ace7ebdb828e1dc4d242b2fb8a360e7b97da7748d2fde4ffa3bd30232c04865"
+            "path": "rhcos-43.81.202002131553.0-installer-kernel-x86_64",
+            "sha256": "4d7f7b0a631a8f3fd34c9d39e7a037655871f05d503af240e7647a5f4e6490c9"
         },
         "metal": {
-            "path": "rhcos-43.81.202001142154.0-metal.x86_64.raw.gz",
-            "sha256": "a22248455ad8adc95ae208ffebe4bc4afa1d50048807df884cae02bc794d7ea4",
-            "size": 801591981,
-            "uncompressed-sha256": "3643016762b248b079f4239e6f72948ebdb8d73e1fb1601bc666cbb46c0e238f",
-            "uncompressed-size": 3340763136
+            "path": "rhcos-43.81.202002131553.0-metal.x86_64.raw.gz",
+            "sha256": "8f1a95c5ecb635b8c6ee1d6c8d7b510d21789e490cb4f641e3307828089d0836",
+            "size": 802854578,
+            "uncompressed-sha256": "86a888d2bca315ffaa17905f415d56a1b42485eea57d9c36b336019641e5cabb",
+            "uncompressed-size": 3347054592
         },
         "openstack": {
-            "path": "rhcos-43.81.202001142154.0-openstack.x86_64.qcow2.gz",
-            "sha256": "a1bda656fa0892f7b936fdc6b6a6086bddaed5dafacedcd7a1e811abb78fe3b0",
-            "size": 801466080,
-            "uncompressed-sha256": "504b9008adf89bb3d05b75d393e057c6d66ba6c92cf631ca4445d99bbf7e2a57",
-            "uncompressed-size": 2131492864
+            "path": "rhcos-43.81.202002131553.0-openstack.x86_64.qcow2.gz",
+            "sha256": "a22fb361eb23309d6e83aa2c11e2508522bc4d129cfc207ed80a317305a57563",
+            "size": 802760496,
+            "uncompressed-sha256": "91495289522de0e5cc5348c53bec52e473a603861cf286244ede3f3961e55b5e",
+            "uncompressed-size": 2135425024
         },
         "ostree": {
-            "path": "rhcos-43.81.202001142154.0-ostree.x86_64.tar",
-            "sha256": "bc9460975c9a3db1f39428129dab87796dc1d2739c38289c5156ceb710ae1e10",
-            "size": 720916480
+            "path": "rhcos-43.81.202002131553.0-ostree.x86_64.tar",
+            "sha256": "6eac128bfe43c88e207be24a48ae20c77b9b62887791a2cdc471222e69e89876",
+            "size": 722309120
         },
         "qemu": {
-            "path": "rhcos-43.81.202001142154.0-qemu.x86_64.qcow2.gz",
-            "sha256": "2da72a1eaee005458014cfbab93f77c459b8c63ff110f0d4cbf4c13e7001de68",
-            "size": 801832578,
-            "uncompressed-sha256": "6dbd3513a824cfe6de157e5d86972c2005b23d71bd8b3a61548f7a1f0a516b68",
-            "uncompressed-size": 2131427328
+            "path": "rhcos-43.81.202002131553.0-qemu.x86_64.qcow2.gz",
+            "sha256": "ff621d70257b6a984f6803db667fe79ce62e6af14902c47791bad8708f318873",
+            "size": 803146768,
+            "uncompressed-sha256": "2ecfd7ba735f00fabb836f666f5e1039511710e904eddbde1e2d35abe9105df8",
+            "uncompressed-size": 2135359488
         },
         "vmware": {
-            "path": "rhcos-43.81.202001142154.0-vmware.x86_64.ova",
-            "sha256": "29b98763bc538ec0b7ad39774b643ef69dc0c0fdad25bd0da3078e54ab86253b",
-            "size": 829542400
+            "path": "rhcos-43.81.202002131553.0-vmware.x86_64.ova",
+            "sha256": "1ae49b99c312eb1d34d4a82ac7eb7c1d664f5b2e49db8805be62375c83b1caae",
+            "size": 830883840
         }
     },
     "oscontainer": {
-        "digest": "sha256:8c4059f184596157f64d69c4edbea9c9ef600560b7804a482779f513c3e0f40e",
+        "digest": "sha256:4674fd2c69e4436dd174f0d3a0a3de8de83a7d05d59f7d4f97d88917cfc42686",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "23527ffc123c6e2bedf3479ff7e96f38d92cec88d5a7951fa56e9d0ec75ddd77",
-    "ostree-version": "43.81.202001142154.0"
+    "ostree-commit": "b876033ae2864c6097a37e1abf74797a876974a3236bd485cf13c76833fd0822",
+    "ostree-version": "43.81.202002131553.0"
 }


### PR DESCRIPTION
```
./hack/update-rhcos-bootimage.py https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.3/43.81.202002131553.0/x86_64/meta.json
```

Notably, this includes a fix for IPv6 single-stack:
https://bugzilla.redhat.com/show_bug.cgi?id=1793618

```
$ ./differ.py --first-endpoint art --first-version 43.81.202001142154.0 --second-endpoint art --second-version 43.81.202002131553.0
{
    "sources": {
        "43.81.202001142154.0": "https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.3/43.81.202001142154.0/x86_64/commitmeta.json",
        "43.81.202002131553.0": "https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.3/43.81.202002131553.0/x86_64/commitmeta.json"
    },
    "diff": {
        "container-selinux": {
            "43.81.202001142154.0": "container-selinux-2.124.0-1.el8.noarch",
            "43.81.202002131553.0": "container-selinux-2.124.0-1.module+el8.1.1+5259+bcdd613a.noarch"
        },
        "containernetworking-plugins": {
            "43.81.202001142154.0": "containernetworking-plugins-0.8.3-1.el8.x86_64",
            "43.81.202002131553.0": "containernetworking-plugins-0.8.3-4.module+el8.1.1+5259+bcdd613a.x86_64"
        },
        "containers-common": {
            "43.81.202001142154.0": "containers-common-0.1.40-2.el8.x86_64",
            "43.81.202002131553.0": "containers-common-0.1.40-8.module+el8.1.1+5351+506397b0.x86_64"
        },
        "cri-o": {
            "43.81.202001142154.0": "cri-o-1.16.2-6.dev.rhaos4.3.git9e3db66.el8.x86_64",
            "43.81.202002131553.0": "cri-o-1.16.3-19.dev.rhaos4.3.git6c1f4bd.el8.x86_64"
        },
        "dracut": {
            "43.81.202001142154.0": "dracut-049-27.git20190906.el8_1.1.x86_64",
            "43.81.202002131553.0": "dracut-049-64.git20200123.el8.x86_64"
        },
        "dracut-network": {
            "43.81.202001142154.0": "dracut-network-049-27.git20190906.el8_1.1.x86_64",
            "43.81.202002131553.0": "dracut-network-049-64.git20200123.el8.x86_64"
        },
        "fuse-overlayfs": {
            "43.81.202001142154.0": "fuse-overlayfs-0.4.1-1.module+el8.1.0+4081+b29780af.x86_64",
            "43.81.202002131553.0": "fuse-overlayfs-0.7.2-1.module+el8.1.1+5259+bcdd613a.x86_64"
        },
        "glibc": {
            "43.81.202001142154.0": "glibc-2.28-72.el8.x86_64",
            "43.81.202002131553.0": "glibc-2.28-72.el8_1.1.x86_64"
        },
        "glibc-all-langpacks": {
            "43.81.202001142154.0": "glibc-all-langpacks-2.28-72.el8.x86_64",
            "43.81.202002131553.0": "glibc-all-langpacks-2.28-72.el8_1.1.x86_64"
        },
        "glibc-common": {
            "43.81.202001142154.0": "glibc-common-2.28-72.el8.x86_64",
            "43.81.202002131553.0": "glibc-common-2.28-72.el8_1.1.x86_64"
        },
        "grub2-common": {
            "43.81.202001142154.0": "grub2-common-2.02-78.el8.noarch",
            "43.81.202002131553.0": "grub2-common-2.02-78.el8_1.1.noarch"
        },
        "grub2-efi-x64": {
            "43.81.202001142154.0": "grub2-efi-x64-2.02-78.el8.x86_64",
            "43.81.202002131553.0": "grub2-efi-x64-2.02-78.el8_1.1.x86_64"
        },
        "grub2-pc": {
            "43.81.202001142154.0": "grub2-pc-2.02-78.el8.x86_64",
            "43.81.202002131553.0": "grub2-pc-2.02-78.el8_1.1.x86_64"
        },
        "grub2-pc-modules": {
            "43.81.202001142154.0": "grub2-pc-modules-2.02-78.el8.noarch",
            "43.81.202002131553.0": "grub2-pc-modules-2.02-78.el8_1.1.noarch"
        },
        "grub2-tools": {
            "43.81.202001142154.0": "grub2-tools-2.02-78.el8.x86_64",
            "43.81.202002131553.0": "grub2-tools-2.02-78.el8_1.1.x86_64"
        },
        "grub2-tools-extra": {
            "43.81.202001142154.0": "grub2-tools-extra-2.02-78.el8.x86_64",
            "43.81.202002131553.0": "grub2-tools-extra-2.02-78.el8_1.1.x86_64"
        },
        "grub2-tools-minimal": {
            "43.81.202001142154.0": "grub2-tools-minimal-2.02-78.el8.x86_64",
            "43.81.202002131553.0": "grub2-tools-minimal-2.02-78.el8_1.1.x86_64"
        },
        "ignition": {
            "43.81.202001142154.0": "ignition-0.34.0-1.rhaos4.3.git92f874c.el8.x86_64",
            "43.81.202002131553.0": "ignition-0.34.0-2.rhaos4.3.git92f874c.el8.x86_64"
        },
        "kernel": {
            "43.81.202001142154.0": "kernel-4.18.0-147.3.1.el8_1.x86_64",
            "43.81.202002131553.0": "kernel-4.18.0-147.5.1.el8_1.x86_64"
        },
        "kernel-core": {
            "43.81.202001142154.0": "kernel-core-4.18.0-147.3.1.el8_1.x86_64",
            "43.81.202002131553.0": "kernel-core-4.18.0-147.5.1.el8_1.x86_64"
        },
        "kernel-modules": {
            "43.81.202001142154.0": "kernel-modules-4.18.0-147.3.1.el8_1.x86_64",
            "43.81.202002131553.0": "kernel-modules-4.18.0-147.5.1.el8_1.x86_64"
        },
        "kernel-modules-extra": {
            "43.81.202001142154.0": "kernel-modules-extra-4.18.0-147.3.1.el8_1.x86_64",
            "43.81.202002131553.0": "kernel-modules-extra-4.18.0-147.5.1.el8_1.x86_64"
        },
        "libarchive": {
            "43.81.202001142154.0": "libarchive-3.3.2-7.el8.x86_64",
            "43.81.202002131553.0": "libarchive-3.3.2-8.el8_1.x86_64"
        },
        "machine-config-daemon": {
            "43.81.202001142154.0": "machine-config-daemon-4.3.0-202001131753.git.1.e2edc36.el8.x86_64",
            "43.81.202002131553.0": "machine-config-daemon-4.3.2-202002100501.git.1.c04d5aa.el8.x86_64"
        },
        "openldap": {
            "43.81.202001142154.0": "openldap-2.4.46-10.el8.x86_64",
            "43.81.202002131553.0": "openldap-2.4.46-11.el8_1.x86_64"
        },
        "openshift-clients": {
            "43.81.202001142154.0": "openshift-clients-4.3.0-202001030600.git.1.5e09fe6.el8.x86_64",
            "43.81.202002131553.0": "openshift-clients-4.3.2-202002070552.git.1.a322635.el8.x86_64"
        },
        "openshift-hyperkube": {
            "43.81.202001142154.0": "openshift-hyperkube-4.3.0-202001131753.git.0.0aee6a8.el8.x86_64",
            "43.81.202002131553.0": "openshift-hyperkube-4.3.2-202002091901.git.0.f9fe502.el8.x86_64"
        },
        "openssh": {
            "43.81.202001142154.0": "openssh-8.0p1-3.el8.x86_64",
            "43.81.202002131553.0": "openssh-8.0p1-4.el8_1.x86_64"
        },
        "openssh-clients": {
            "43.81.202001142154.0": "openssh-clients-8.0p1-3.el8.x86_64",
            "43.81.202002131553.0": "openssh-clients-8.0p1-4.el8_1.x86_64"
        },
        "openssh-server": {
            "43.81.202001142154.0": "openssh-server-8.0p1-3.el8.x86_64",
            "43.81.202002131553.0": "openssh-server-8.0p1-4.el8_1.x86_64"
        },
        "openvswitch2.11": {
            "43.81.202001142154.0": "openvswitch2.11-2.11.0-35.el8fdp.x86_64",
            "43.81.202002131553.0": "openvswitch2.11-2.11.0-47.el8fdp.x86_64"
        },
        "podman": {
            "43.81.202001142154.0": "podman-1.6.4-1.el8.x86_64",
            "43.81.202002131553.0": "podman-1.6.4-2.module+el8.1.1+5363+bf8ff1af.x86_64"
        },
        "podman-manpages": {
            "43.81.202001142154.0": "podman-manpages-1.6.4-1.el8.noarch",
            "43.81.202002131553.0": "podman-manpages-1.6.4-2.module+el8.1.1+5363+bf8ff1af.noarch"
        },
        "policycoreutils": {
            "43.81.202001142154.0": "policycoreutils-2.9-3.el8.x86_64",
            "43.81.202002131553.0": "policycoreutils-2.9-3.el8_1.1.x86_64"
        },
        "policycoreutils-python-utils": {
            "43.81.202001142154.0": "policycoreutils-python-utils-2.9-3.el8.noarch",
            "43.81.202002131553.0": "policycoreutils-python-utils-2.9-3.el8_1.1.noarch"
        },
        "python3-policycoreutils": {
            "43.81.202001142154.0": "python3-policycoreutils-2.9-3.el8.noarch",
            "43.81.202002131553.0": "python3-policycoreutils-2.9-3.el8_1.1.noarch"
        },
        "runc": {
            "43.81.202001142154.0": "runc-1.0.0-64.rc9.el8.x86_64",
            "43.81.202002131553.0": "runc-1.0.0-64.rc9.module+el8.1.1+5259+bcdd613a.x86_64"
        },
        "skopeo": {
            "43.81.202001142154.0": "skopeo-0.1.40-2.el8.x86_64",
            "43.81.202002131553.0": "skopeo-0.1.40-8.module+el8.1.1+5351+506397b0.x86_64"
        },
        "slirp4netns": {
            "43.81.202001142154.0": "slirp4netns-0.4.2-1.git21fdece.el8.x86_64",
            "43.81.202002131553.0": "slirp4netns-0.4.2-4.git21fdece.el8.x86_64"
        },
        "sqlite-libs": {
            "43.81.202001142154.0": "sqlite-libs-3.26.0-3.el8.x86_64",
            "43.81.202002131553.0": "sqlite-libs-3.26.0-4.el8_1.x86_64"
        },
        "sudo": {
            "43.81.202001142154.0": "sudo-1.8.25p1-8.el8_1.x86_64",
            "43.81.202002131553.0": "sudo-1.8.25p1-8.el8_1.1.x86_64"
        },
        "systemd": {
            "43.81.202001142154.0": "systemd-239-18.el8_1.1.x86_64",
            "43.81.202002131553.0": "systemd-239-18.el8_1.2.x86_64"
        },
        "systemd-journal-remote": {
            "43.81.202001142154.0": "systemd-journal-remote-239-18.el8_1.1.x86_64",
            "43.81.202002131553.0": "systemd-journal-remote-239-18.el8_1.2.x86_64"
        },
        "systemd-libs": {
            "43.81.202001142154.0": "systemd-libs-239-18.el8_1.1.x86_64",
            "43.81.202002131553.0": "systemd-libs-239-18.el8_1.2.x86_64"
        },
        "systemd-pam": {
            "43.81.202001142154.0": "systemd-pam-239-18.el8_1.1.x86_64",
            "43.81.202002131553.0": "systemd-pam-239-18.el8_1.2.x86_64"
        },
        "systemd-udev": {
            "43.81.202001142154.0": "systemd-udev-239-18.el8_1.1.x86_64",
            "43.81.202002131553.0": "systemd-udev-239-18.el8_1.2.x86_64"
        },
        "toolbox": {
            "43.81.202001142154.0": "toolbox-0.0.5-1.rhaos4.2.el8.noarch",
            "43.81.202002131553.0": "toolbox-0.0.6-1.rhaos4.3.el8.noarch"
        }
    }
}
```