### PR TITLE
[release-4.3] Bug 1757244: use region info when simulating permissions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -674,8 +674,8 @@
   revision = "3b0e988f8cb09a07f375dfc304b86c1a81cbc82b"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cd242e9cb5a2a75c6e6527828a698746225b397c8600f0d3f51d1f149fbeb28d"
+  branch = "release-4.3"
+  digest = "1:454f3ebed85be06f8ed32549474df4fb75624319314f222983d4bae6d4daa1cd"
   name = "github.com/openshift/cloud-credential-operator"
   packages = [
     "pkg/apis/cloudcredential/v1",
@@ -683,7 +683,7 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "44ed18ef8496f9417af89f92539b8385b1cc9d51"
+  revision = "16ebd83fd5269c41983406dd11758a2601751188"
 
 [[projects]]
   branch = "openshift-4.2-cluster-api-0.1.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -95,6 +95,10 @@ required = [
   name = "github.com/gophercloud/gophercloud"
 
 [[constraint]]
+  branch = "release-4.3"
+  name = "github.com/openshift/cloud-credential-operator"
+
+[[constraint]]
   branch = "master"
   name = "sigs.k8s.io/cluster-api-provider-openstack"
   source = "https://github.com/openshift/cluster-api-provider-openstack.git"

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -55,7 +55,8 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
-		err = awsconfig.ValidateCreds(ssn, permissionGroups)
+
+		err = awsconfig.ValidateCreds(ssn, permissionGroups, ic.Config.Platform.AWS.Region)
 		if err != nil {
 			return errors.Wrap(err, "validate AWS credentials")
 		}

--- a/vendor/github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1/credentialsrequest_types.go
+++ b/vendor/github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1/credentialsrequest_types.go
@@ -39,6 +39,9 @@ const (
 
 	// CloudCredOperatorNamespace is the namespace where the credentials operator runs.
 	CloudCredOperatorNamespace = "openshift-cloud-credential-operator"
+
+	// CloudCredOperatorConfigMap is an optional ConfigMap that can be used to alter behavior of the operator.
+	CloudCredOperatorConfigMap = "cloud-credential-operator-config"
 )
 
 // NOTE: Run "make" to regenerate code after modifying this file


### PR DESCRIPTION
manually revendor github.com/openshift/cloud-credential-oeprator with the branch constraint of 'release-4.3' then:
`dep ensure -update github.com/openshift/cloud-credential-operator`

cherry pick b78bc858e98dad87429257414ddac5355bca1e77 from master