### PR TITLE
Bug 1803174: OpenStack CI Install awscli from zip

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -23,8 +23,13 @@ RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux && yum clean all 
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    python-openstackclient ansible python-openstacksdk python-netaddr awscli && \
+    python-openstackclient ansible python-openstacksdk python-netaddr unzip && \
     yum clean all && rm -rf /var/cache/yum/*
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install -b /bin && \
+    rm -rf ./aws awscliv2.zip
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000


### PR DESCRIPTION
Building OpenStack CI image started failing because it cannot install
awscli package from the repositories.

Let's follow the instruction from AWS rather than installing via yum:

https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html