### PR TITLE
Bug 1802820: SSH to bootstrap node in Azure UPI

### DIFF
--- a/docs/user/azure/install_upi.md
+++ b/docs/user/azure/install_upi.md
@@ -344,7 +344,6 @@ az group deployment create -g $RESOURCE_GROUP \
   --template-file "04_bootstrap.json" \
   --parameters bootstrapIgnition="$BOOTSTRAP_IGNITION" \
   --parameters sshKeyData="$SSH_KEY" \
-  --parameters privateDNSZoneName="${CLUSTER_NAME}.${BASE_DOMAIN}" \
   --parameters baseName="$INFRA_ID"
 ```
 
@@ -382,12 +381,14 @@ INFO It is now safe to remove the bootstrap resources
 Once the bootstrapping process is complete you can deallocate and delete bootstrap resources:
 
 ```sh
+az network nsg rule delete -g $RESOURCE_GROUP --nsg-name ${INFRA_ID}-controlplane-nsg --name bootstrap_ssh_in
 az vm stop -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap
 az vm deallocate -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap
 az vm delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap --yes
 az disk delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap_OSDisk --no-wait --yes
 az network nic delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap-nic --no-wait
 az storage blob delete --account-key $ACCOUNT_KEY --account-name ${CLUSTER_NAME}sa --container-name files --name bootstrap.ign
+az network public-ip delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap-ssh-pip
 ```
 
 ## Access the OpenShift API

--- a/upi/azure/04_bootstrap.json
+++ b/upi/azure/04_bootstrap.json
@@ -22,12 +22,6 @@
         "description" : "SSH RSA public key file as a string."
       }
     },
-    "privateDNSZoneName" : {
-      "type" : "string",
-      "metadata" : {
-        "description" : "Name of the private DNS zone the bootstrap node is going to be attached to"
-      }
-    },
     "bootstrapVMSize" : {
       "type" : "string",
       "defaultValue" : "Standard_D4s_v3",
@@ -116,20 +110,43 @@
     "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "vmName" : "[concat(parameters('baseName'), '-bootstrap')]",
     "nicName" : "[concat(variables('vmName'), '-nic')]",
-    "imageName" : "[concat(parameters('baseName'), '-image')]"
+    "imageName" : "[concat(parameters('baseName'), '-image')]",
+    "controlPlaneNsgName" : "[concat(parameters('baseName'), '-controlplane-nsg')]",
+    "sshPublicIpAddressName" : "[concat(variables('vmName'), '-ssh-pip')]"
   },
   "resources" : [
+    {
+      "apiVersion" : "2018-12-01",
+      "type" : "Microsoft.Network/publicIPAddresses",
+      "name" : "[variables('sshPublicIpAddressName')]",
+      "location" : "[variables('location')]",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties" : {
+        "publicIPAllocationMethod" : "Static",
+        "dnsSettings" : {
+          "domainNameLabel" : "[variables('sshPublicIpAddressName')]"
+        }
+      }
+    },
     {
       "apiVersion" : "2018-06-01",
       "type" : "Microsoft.Network/networkInterfaces",
       "name" : "[variables('nicName')]",
       "location" : "[variables('location')]",
+      "dependsOn" : [
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('sshPublicIpAddressName'))]"
+      ],
       "properties" : {
         "ipConfigurations" : [
           {
             "name" : "pipConfig",
             "properties" : {
               "privateIPAllocationMethod" : "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('sshPublicIpAddressName'))]"
+              },
               "subnet" : {
                 "id" : "[variables('masterSubnetRef')]"
               },
@@ -201,6 +218,25 @@
             }
           ]
         }
+      }
+    },
+    {
+      "apiVersion" : "2018-06-01",
+      "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+      "name" : "[concat(variables('controlPlaneNsgName'), '/bootstrap_ssh_in')]",
+      "location" : "[variables('location')]",
+      "dependsOn" : [
+        "[resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))]"
+      ],
+      "properties": {
+        "protocol" : "Tcp",
+        "sourcePortRange" : "*",
+        "destinationPortRange" : "22",
+        "sourceAddressPrefix" : "*",
+        "destinationAddressPrefix" : "*",
+        "access" : "Allow",
+        "priority" : 100,
+        "direction" : "Inbound"
       }
     }
   ]


### PR DESCRIPTION
Adds support to accessing the bootstrap node through SSH in Azure UPI, and remove it at the bootstrap cleanup steps.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1802820