### PR TITLE
document bare metal ipi configuration parameters

### DIFF
--- a/docs/user/metal/customization_ipi.md
+++ b/docs/user/metal/customization_ipi.md
@@ -2,6 +2,22 @@
 
 ## Cluster-scoped properties
 
+### Advanced Configuration Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+`libvirtURI` | `qemu://localhost/system` | The location of the hypervisor for running the bootstrap VM. See [Using a Remote Hypervisor](using-a-remote-hypervisor) for more details. |
+`clusterProvisioningIP` | The third address on the provisioning network. `172.22.0.3` | The IP within the cluster where the provisioning services run. |
+`bootstrapProvisioningIP` | The second address on the provisioning network. `172.22.0.2` | The IP on the bootstrap VM where the provisioning services run while the control plane is being deployed. |
+`externalBridge` | `baremetal` | The name of the bridge of the hypervisor attached to the external network. |
+`provisioningBridge` | `provisioning` | The name of the bridge on the hypervisor attached to the provisioning network. |
+`provisioningNetworkCIDR` | `172.22.0.0/24` | The CIDR for the network to use for provisioning. |
+`provisioningDHCPExternal` | `false` | Flag indicating that DHCP for the provisioning network is managed outside of the cluster by existing infrastructure services. |
+`provisioningDHCPRange` | The tenth through the hundredth IP on the provisioning network. `172.22.0.10,172.22.0.100` | The IP range to use for hosts on the provisioning network. |
+`defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration. |
+`bootstrapOSImage` | *based on the release image* | A URL to override the default operating system image for the bootstrap node. The URL must contain a sha256 hash of the image. Example `https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd...` |
+`clusterOSImage` | *based on the release image* | A URL to override the default operating system for cluster nodes. The URL must include a sha256 hash of the image. Example `https://mirror.example.com/images/metal.qcow2.gz?sha256=3b5a8...` |
+
 ### Image Overrides
 
 When doing a disconnected installation, the baremetal platform has the
@@ -83,3 +99,35 @@ platform:
     provisioningDHCPExternal: true
 ```
 
+## Using a Remote Hypervisor
+
+The IPI installation process requires access to a libvirt-based
+hypervisor host on which to run a bootstrap VM. The VM is removed
+after the control plane is up and fully functional, so the hypervisor
+is not needed to operate the cluster. When running the installer by
+hand, it is most common to use the local host as the hypervisor. When
+network topology requires, it is possible to use a separate host.
+
+The `libvirtURI` can be used to specify the location of the remote
+hypervisor. For example
+`qemu+ssh://hyperuser@hypervisor.example.com/system` tells the
+installer to connect to `hypervisor.example.com` over ssh as the
+`hyperuser` user and create the bootstrap VM there.
+
+The user on the host running the installer must be able to connect via
+ssh to the hypervisor using the username given in the URI, without
+being prompted for a password.
+
+The user on the hypervisor must be in the `libvirt` group and have
+permission to communicate with the libvirt services.
+
+The hypervisor must meet the network requirements described in
+the [Prerequisites](install_ipi.md#prerequisites) section.
+
+## Disabling Certificate Verification for BMCs
+
+By default TLS clients communicating with BMCs will require valid
+certificates signed by a known certificate authority. In environments
+where certificates are signed by unknown authorities, this behavior
+can be disabled by setting `disableCertificateVerification` to `true`
+for each `bmc` entry.

--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -177,6 +177,66 @@ pullSecret: ...
 sshKey: ...
 ```
 
+#### Required Inputs
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+`provisioningNetworkInterface` | | The name of the network interface on control plane nodes connected to the provisioning network. |
+`hosts` | | Details about bare metal hosts to use to build the cluster. See below for more details. |
+`defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration. |
+`apiVIP` | `api.<clusterdomain>` | The VIP to use for internal API communication. |
+`ingressVIP` | `test.apps.<clusterdomain>` | The VIP to use for ingress traffic. |
+`dnsVIP` | | The VIP to use for internal DNS communication. |
+
+##### VIP Settings
+
+The `apiVIP` and `ingressVIP` settings must either be provided or
+pre-configured in DNS so that the default names resolve correctly (see
+the defaults in the table above).
+
+The `dnsVIP` setting has no default and must always be provided.
+
+##### Describing Hosts
+
+The `hosts` parameter is a list of separate bare metal assets that
+should be used to build the cluster.
+
+| Name | Default | Description |
+| --- | --- | --- |
+| `name` | | The name of the `BareMetalHost` resource to associate with the details. |
+| `role` | | Either `master` or `worker`. |
+| `bmc` | | Connection details for the baseboard management controller. See below for details. |
+| `bootMACAddress` | | The MAC address of the NIC the host will use to boot on the provisioning network. |
+
+The `bmc` parameter for each host is a set of values for accessing the
+baseboard management controller in the host.
+
+| Name | Default | Description |
+| --- | --- | --- |
+| `username` | | The username for authenticating to the BMC |
+| `password` | | The password associated with `username`. |
+| `address` | | The URL for communicating with the BMC controller, based on the provider being used. See [BMC Addressing](#bmc-addressing) for details. |
+
+##### BMC Addressing
+
+The `address` field for each `bmc` entry is a URL with details for
+connecting to the controller, including the type of controller in the
+URL scheme and its location on the network.
+
+IPMI hosts use `ipmi://<host>:<port>`. An unadorned `<host>:<port>` is
+also accepted. If the port is omitted, the default of 623 is used.
+
+Dell iDRAC hosts use `idrac://` (or `idrac+http://` to disable TLS).
+
+Fujitsu iRMC hosts use `irmc://<host>:<port>`, where `<port>` is
+optional if using the default.
+
+For Redfish, use `redfish://` (or `redfish+http://` to disable
+TLS). The hostname (or IP address) and the path to the system ID are
+both required.  For example
+`redfish://myhost.example/redfish/v1/Systems/System.Embedded.1` or
+`redfish://myhost.example/redfish/v1/Systems/1`
+
 ## Work in Progress
 
 Integration of the `baremetal` platform is still a work-in-progress across


### PR DESCRIPTION
Provide a table describing all of the configuration parameters for IPI
deployments on bare metal. Include a more verbose description of the
libvirtURI parameter and the context in which specifying it is
useful. Include examples of BMC address values.