### PR TITLE
Bug 1732124: Azure: don't allow installing with the same cluster name as an existing install

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -6,9 +6,11 @@ import (
 	"net"
 	"strings"
 
+	azdns "github.com/Azure/azure-sdk-for-go/profiles/latest/dns/mgmt/dns"
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	aztypes "github.com/openshift/installer/pkg/types/azure"
+	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -115,4 +117,45 @@ func validateRegion(client API, fieldPath *field.Path, p *aztypes.Platform) fiel
 	}
 
 	return field.ErrorList{field.Invalid(fieldPath, p.Region, fmt.Sprintf("region %q does not support resource creation", p.Region))}
+}
+
+// ValidatePublicDNS checks DNS for CNAME, A, and AAA records for
+// api.zoneName. If a record exists, it's likely a cluster already exists.
+func ValidatePublicDNS(ic *types.InstallConfig) error {
+	// If this is an internal cluster, this check is not necessary
+	if ic.Publish == types.InternalPublishingStrategy {
+		return nil
+	}
+
+	clusterName := ic.ObjectMeta.Name
+	record := fmt.Sprintf("api.%s", clusterName)
+
+	azureDNS, err := NewDNSConfig()
+	if err != nil {
+		return err
+	}
+
+	rgName := ic.Azure.BaseDomainResourceGroupName
+	zoneName := ic.BaseDomain
+	fmtStr := "api.%s %s record already exists in %s and might be in use by another cluster, please remove it to continue"
+
+	// Look for an existing CNAME first
+	rs, err := azureDNS.GetDNSRecordSet(rgName, zoneName, record, azdns.CNAME)
+	if err == nil && rs.CnameRecord != nil {
+		return errors.New(fmt.Sprintf(fmtStr, zoneName, azdns.CNAME, clusterName))
+	}
+
+	// Look for an A record
+	rs, err = azureDNS.GetDNSRecordSet(rgName, zoneName, record, azdns.A)
+	if err == nil && rs.ARecords != nil && len(*rs.ARecords) > 0 {
+		return errors.New(fmt.Sprintf(fmtStr, zoneName, azdns.A, clusterName))
+	}
+
+	// Look for an AAAA record
+	rs, err = azureDNS.GetDNSRecordSet(rgName, zoneName, record, azdns.AAAA)
+	if err == nil && rs.AaaaRecords != nil && len(*rs.AaaaRecords) > 0 {
+		return errors.New(fmt.Sprintf(fmtStr, zoneName, azdns.AAAA, clusterName))
+	}
+
+	return nil
 }

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/installer/pkg/asset"
+	azconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	vsconfig "github.com/openshift/installer/pkg/asset/installconfig/vsphere"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -43,7 +44,12 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
-	case azure.Name, aws.Name, baremetal.Name, gcp.Name, libvirt.Name, none.Name, openstack.Name, ovirt.Name:
+	case azure.Name:
+		err = azconfig.ValidatePublicDNS(ic.Config)
+		if err != nil {
+			return err
+		}
+	case aws.Name, baremetal.Name, gcp.Name, libvirt.Name, none.Name, openstack.Name, ovirt.Name:
 		// no special provisioning requirements to check
 	default:
 		err = fmt.Errorf("unknown platform type %q", platform)


### PR DESCRIPTION
This code checks to see if an existing DNS record exists for api.clusterName and fails if it exists. 

See https://bugzilla.redhat.com/show_bug.cgi?id=1732124