### PR TITLE
validation: OVN requires a HostPrefix of 64 for IPv6 networks

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -300,8 +300,10 @@ func validateClusterNetwork(n *types.Networking, cn *types.ClusterNetworkEntry, 
 	if cn.HostPrefix < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("hostPrefix"), cn.HostPrefix, "hostPrefix must be positive"))
 	}
-	if ones, _ := cn.CIDR.Mask.Size(); cn.HostPrefix < int32(ones) {
+	if ones, bits := cn.CIDR.Mask.Size(); cn.HostPrefix < int32(ones) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("hostPrefix"), cn.HostPrefix, "cluster network host subnetwork prefix must not be larger size than CIDR "+cn.CIDR.String()))
+	} else if bits == 128 && cn.HostPrefix != 64 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("hostPrefix"), cn.HostPrefix, "cluster network host subnetwork prefix must be 64 for IPv6 networks"))
 	}
 	return allErrs
 }

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -895,6 +895,17 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 			expectedError: `Invalid value: "DualStack": dual-stack IPv4/IPv6 is not supported for this platform, specify only one type of address`,
 		},
+		{
+			name: "invalid IPv6 hostprefix",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validIPv6NetworkingConfig()
+				c.Networking.ClusterNetwork[0].HostPrefix = 72
+				return c
+			}(),
+			expectedError: `Invalid value: 72: cluster network host subnetwork prefix must be 64 for IPv6 networks`,
+		},
 
 		{
 			name: "valid ovirt platform",


### PR DESCRIPTION
While tracking down a 4.4 IPv6 bug we realized that OVN only supports dynamic address assignment on /64 networks on IPv6. (Standard IPv6 automatic address assignment also requires this, and DHCPv6 mostly does as well, so it's not a strange requirement.)

We'll need to propagate this requirement to a few other places, and decide if it should be ovn-kubernetes-specific or apply to all IPv6-supporting network plugins. But for now, OCP only supports IPv6 with HostPrefix=64, so enforce that in the installer.

/cc @smarterclayton @russellb 