### PR TITLE
Bug 1795625: ovirt's worker template is created with 1 CPU

### DIFF
--- a/data/data/ovirt/template/main.tf
+++ b/data/data/ovirt/template/main.tf
@@ -73,6 +73,7 @@ resource "ovirt_template" "releaseimage_template" {
   // create from vm
   vm_id      = ovirt_vm.tmp_import_vm.0.id
   depends_on = [ovirt_vm.tmp_import_vm]
+  cores      = var.ovirt_template_cpu
 }
 
 // finally get the template by name(should be unique), fail if it doesn't exist


### PR DESCRIPTION
Use the ovirt_template_cpu variable in the template resource creation.