### PR TITLE
openstack UPI: soft-anti-affinity policy for CP

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -595,6 +595,8 @@ $ ansible-playbook -i inventory.yaml 04_control-plane.yaml
 
 Our control plane will consist of three nodes. The servers will be passed the `master-?-ignition.json` files prepared earlier.
 
+The playbook places the Control Plane in a Server Group with "soft anti-affinity" policy.
+
 The master nodes should load the initial Ignition and then keep waiting until the bootstrap node stands up the Machine Config Server which will provide the rest of the configuration.
 
 ### Control Plane Trunks (Kuryr SDN)

--- a/upi/openstack/04_control-plane.yaml
+++ b/upi/openstack/04_control-plane.yaml
@@ -37,6 +37,13 @@
     with_indexed_items: "{{ ports.results }}"
     when: os_networking_type == "Kuryr"
 
+  - name: 'Create the Control Plane server group'
+    os_server_group:
+      name: "{{ os_cp_server_group_name }}"
+      policies:
+      - "soft-anti-affinity"
+    register: "cp_group"
+
   - name: 'Create the Control Plane servers'
     os_server:
       name: "{{ item.1 }}-{{ item.0 }}"
@@ -50,4 +57,6 @@
       userdata: "{{ lookup('file', [item.1, item.0, 'ignition.json'] | join('-')) | string }}"
       nics:
       - port-name: "{{ os_port_master }}-{{ item.0 }}"
+      scheduler_hints:
+        group: "{{ cp_group.id }}"
     with_indexed_items: "{{ [os_cp_server_name] * os_cp_nodes_number }}"

--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -23,6 +23,7 @@
       # Server names
       os_bootstrap_server_name: "{{ infraID }}-bootstrap"
       os_cp_server_name: "{{ infraID }}-master"
+      os_cp_server_group_name: "{{ infraID }}-master-group"
       os_compute_server_name: "{{ infraID }}-worker"
       # Trunk names
       os_cp_trunk_name: "{{ infraID }}-master-trunk"

--- a/upi/openstack/down-04_control-plane.yaml
+++ b/upi/openstack/down-04_control-plane.yaml
@@ -15,6 +15,11 @@
       state: absent
     with_indexed_items: "{{ [os_cp_server_name] * os_cp_nodes_number }}"
 
+  - name: 'Remove the Control Plane server group'
+    os_server_group:
+      name: "{{ os_cp_server_group_name }}"
+      state: absent
+
   - name: 'Remove the Control Plane trunks'
     os_trunk:
       name: "{{ item.1 }}-{{ item.0 }}"


### PR DESCRIPTION
This places the Control Plane servers in a Server Group that enforces
"soft anti-affinity" policy.

"Soft anti-affinity" will cause Nova to create VMs on separate hosts, if
that is possible.

Implements OSASINFRA-1015