### PR TITLE
openstack IPI: soft-anti-affinity policy for CP

### DIFF
--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -36,6 +36,11 @@ resource "openstack_blockstorage_volume_v3" "master_volume" {
   image_id = var.base_image_id
 }
 
+resource "openstack_compute_servergroup_v2" "master_group" {
+  name = "${var.cluster_id}-master-group"
+  policies = ["soft-anti-affinity"]
+}
+
 resource "openstack_compute_instance_v2" "master_conf" {
   name = "${var.cluster_id}-master-${count.index}"
   count = var.instance_count
@@ -61,6 +66,10 @@ resource "openstack_compute_instance_v2" "master_conf" {
 
   network {
     port = var.master_port_ids[count.index]
+  }
+
+  scheduler_hints {
+    group = "${openstack_compute_servergroup_v2.master_group.id}"
   }
 
   metadata = {

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -71,6 +71,8 @@ openstack quota set --secgroups 8 --secgroup-rules 100 <project>`
 
 The default deployment stands up 3 master nodes, which is the minimum amount required for a cluster. For each master node you stand up, you will need 1 instance, and 1 port available in your quota. They should be assigned a flavor with at least 16 GB RAM, 4 vCPUs, and 25 GB Disk. It is theoretically possible to run with a smaller flavor, but be aware that if it takes too long to stand up services, or certain essential services crash, the installer could time out, leading to a failed install.
 
+The Master Nodes are placed in a single Server Group with "soft anti-affinity" policy; the machines will therefore be creted on separate hosts when possible.
+
 ### Worker Nodes
 
 The default deployment stands up 3 worker nodes. In our testing we determined that 2 was the minimum number of workers you could have to get a successful install, but we don't recommend running with that few. Worker nodes host the applications you run on OpenShift, so it is in your best interest to have more of them. See [here](https://docs.openshift.com/enterprise/3.0/architecture/infrastructure_components/kubernetes_infrastructure.html#node) for more information. The flavor assigned to the worker nodes should have at least 2 vCPUs, 8 GB RAM and 25 GB Disk. However, if you are experiencing `Out Of Memory` issues, or your installs are timing out, you should increase the size of your flavor to match the masters: 4 vCPUs and 16 GB RAM.


### PR DESCRIPTION
This places the Control Plane servers in a Server Group that enforces
"soft anti-affinity" policy.

"Soft anti-affinity" will cause Nova to create VMs on separate hosts, if
that is possible.

Implements OSASINFRA-1300