### PR TITLE
Baremetal: Be explicit that addresses must be in same subnet

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -26,7 +26,8 @@ purposes:
   * ***DHCP***
     * External DHCP is assumed on this network.  It is **strongly** recommended
       to set up DHCP reservations for each of the hosts in the cluster to
-      ensure that they retain stable IP addresses.
+      ensure that they retain stable IP addresses. The addresses assigned by
+      DHCP need to be in the same subnet as the Virtual IPs discussed below.
     * A pool of dynamic addresses should also be available on this network, as
       the provisioning host and temporary bootstrap VM will also need addresses
       on this network.


### PR DESCRIPTION
When starting the static pods on a host, we determine the correct
address to use by comparing its subnet with the VIP subnet. If the
external address assigned by DHCP is in a different subnet from the
VIPs then we can't determine which address to use and deployment
will fail. This change makes the requirement for addresses to be in
the same subnet explicit.