### PR TITLE
[release-4.2] Bug 1803221: use region info when simulating permissions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -600,8 +600,8 @@
   revision = "e9678e3b850da36470c5554609c6cd110aace47e"
 
 [[projects]]
-  branch = "master"
-  digest = "1:cd242e9cb5a2a75c6e6527828a698746225b397c8600f0d3f51d1f149fbeb28d"
+  branch = "release-4.2"
+  digest = "1:07bb9db889efd40b52622f6fd37e5f9a229400e555e3053fc52c88b0f18f9341"
   name = "github.com/openshift/cloud-credential-operator"
   packages = [
     "pkg/apis/cloudcredential/v1",
@@ -609,7 +609,7 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "44ed18ef8496f9417af89f92539b8385b1cc9d51"
+  revision = "5ed8e486d83ed48e4a34a598e3214257905e3a07"
 
 [[projects]]
   branch = "openshift-4.2-cluster-api-0.1.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -95,6 +95,10 @@ required = [
   name = "github.com/gophercloud/gophercloud"
 
 [[constraint]]
+  branch = "release-4.2"
+  name = "github.com/openshift/cloud-credential-operator"
+
+[[constraint]]
   branch = "master"
   name = "sigs.k8s.io/cluster-api-provider-openstack"
   source = "https://github.com/openshift/cluster-api-provider-openstack.git"

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -47,7 +47,7 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "creating AWS session")
 		}
-		err = awsconfig.ValidateCreds(ssn)
+		err = awsconfig.ValidateCreds(ssn, ic.Config.Platform.AWS.Region)
 		if err != nil {
 			return errors.Wrap(err, "validate AWS credentials")
 		}


### PR DESCRIPTION
manually revendor github.com/openshift/cloud-credential-oeprator with the branch constraint of 'release-4.2' then:
dep ensure -update github.com/openshift/cloud-credential-operator

cherry pick b78bc85 from master. not a clean backport, needed manual fixups.