### PR TITLE
baremetal: add owners to bootstrap subdirectories

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/OWNERS
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - baremetal-approvers
+reviewers:
+  - baremetal-reviewers


### PR DESCRIPTION
I didn't realize the OWNERS file in data/data/bootstrap/baremetal didn't
apply to subdirectories, so this adds it to usr/local/bin as well where
we host the ironic service scripts.