### PR TITLE
Azure UPI: no need to manually associate workers with LB

### DIFF
--- a/upi/azure/06_workers.json
+++ b/upi/azure/06_workers.json
@@ -152,12 +152,7 @@
                       "privateIPAllocationMethod" : "Dynamic",
                       "subnet" : {
                         "id" : "[variables('nodeSubnetRef')]"
-                      },
-                      "loadBalancerBackendAddressPools" : [
-                        {
-                          "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('infraLoadBalancerName'), '/backendAddressPools/', parameters('baseName'))]"
-                        }
-                      ]
+                      }
                     }
                   }
                 ]


### PR DESCRIPTION
Minor fix: we don't need to manually associate workers to the ingress load balancer since they register themselves automatically. This change also allows us to create workers before the bootstrap process finishes.