### PR TITLE
ovirt: add pass_discard flag to the ovirt vm template

### DIFF
--- a/data/data/ovirt/template/main.tf
+++ b/data/data/ovirt/template/main.tf
@@ -54,8 +54,9 @@ resource "ovirt_vm" "tmp_import_vm" {
   cores      = var.ovirt_template_cpu
   memory     = var.ovirt_template_mem
   block_device {
-    disk_id   = ovirt_image_transfer.releaseimage.0.disk_id
-    interface = "virtio_scsi"
+    disk_id      = ovirt_image_transfer.releaseimage.0.disk_id
+    interface    = "virtio_scsi"
+    pass_discard = true
   }
   nics {
     name            = "nic1"


### PR DESCRIPTION
This flag causes the VirtIO-SCSI driver to pass the fstrm/discard
instructions to the underlying storage. Enabling this feature is
important for hyperconverged setups where storage is thinly provisoned.

Fixes #3021