### PR TITLE
baremetal: append information about ironic.service to bootstrap motd

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -3,6 +3,14 @@ set -ex
 
 . /usr/local/bin/release-image.sh
 
+grep -q "ironic.service" /etc/motd || cat <<EOF>> /etc/motd
+
+For monitoring baremetal provisioning services, you can look at ironic.service logs:
+
+  journalctl -b -f -u ironic.service
+
+EOF
+
 IRONIC_IMAGE=$(image_for ironic)
 IRONIC_INSPECTOR_IMAGE=$(image_for ironic-inspector)
 IPA_DOWNLOADER_IMAGE=$(image_for ironic-ipa-downloader)


### PR DESCRIPTION
On baremetal, there's an additional service someone logging in to the
bootstrap may wish to review the logs for. This appends information
about ironic.service to /etc/motd.