### PR TITLE
Bug 1806143: OpenStack: start using image import when possible

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -75,20 +75,6 @@ module "topology" {
   octavia_support     = var.openstack_octavia_support
 }
 
-resource "openstack_images_image_v2" "base_image" {
-  // we need to create a new image only if the base image local file path has been provided, plus base image name is <cluster_id>-rhcos
-  count = var.openstack_base_image_local_file_path != "" && var.openstack_base_image_name == "${var.cluster_id}-rhcos" ? 1 : 0
-
-  name             = var.openstack_base_image_name
-  local_file_path  = var.openstack_base_image_local_file_path
-  container_format = "bare"
-  disk_format      = "qcow2"
-
-  tags = ["openshiftClusterID=${var.cluster_id}"]
-}
-
 data "openstack_images_image_v2" "base_image" {
   name = var.openstack_base_image_name
-
-  depends_on = [openstack_images_image_v2.base_image]
 }

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -15,12 +15,6 @@ variable "openstack_base_image_name" {
   description = "Name of the base image to use for the nodes."
 }
 
-variable "openstack_base_image_local_file_path" {
-  type        = string
-  default     = ""
-  description = "Local file path of the base image file to use for the nodes."
-}
-
 variable "openstack_bootstrap_shim_ignition" {
   type        = string
   default     = ""

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/google/go-cmp v0.3.2-0.20191028172631-481baca67f93 // indirect
 	github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible // indirect
 	github.com/google/uuid v1.1.1
-	github.com/gophercloud/gophercloud v0.7.1-0.20191211202411-f940f50ff1f7
+	github.com/gophercloud/gophercloud v0.8.0
 	github.com/gophercloud/utils v0.0.0-20191212191830-4533a07bd492
 	github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de // indirect
 	github.com/gorilla/websocket v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1167,6 +1167,8 @@ github.com/gophercloud/gophercloud v0.2.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gophercloud/gophercloud v0.7.1-0.20191210042042-7aa2e52d21f9/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/gophercloud v0.7.1-0.20191211202411-f940f50ff1f7 h1:iYD//82P8YSpKrCUaYhLMoxnIXmT5qvNNKTy5iGgc30=
 github.com/gophercloud/gophercloud v0.7.1-0.20191211202411-f940f50ff1f7/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
+github.com/gophercloud/gophercloud v0.8.0 h1:1ylFFLRx7otpfRPSuOm77q8HLSlSOwYCGDeXmXJhX7A=
+github.com/gophercloud/gophercloud v0.8.0/go.mod h1:Kc/QKr9thLKruO/dG0szY8kRIYS+iENz0ziI0hJf76A=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
 github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
 github.com/gophercloud/utils v0.0.0-20191212191830-4533a07bd492 h1:NAwq2GgRiqbNLw1cA7KUdt7lDR/NzJtk4EXGxO3gqas=

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -16,21 +16,20 @@ import (
 )
 
 type config struct {
-	BaseImageName          string   `json:"openstack_base_image_name,omitempty"`
-	BaseImageLocalFilePath string   `json:"openstack_base_image_local_file_path,omitempty"`
-	ExternalNetwork        string   `json:"openstack_external_network,omitempty"`
-	Cloud                  string   `json:"openstack_credentials_cloud,omitempty"`
-	FlavorName             string   `json:"openstack_master_flavor_name,omitempty"`
-	LbFloatingIP           string   `json:"openstack_lb_floating_ip,omitempty"`
-	APIVIP                 string   `json:"openstack_api_int_ip,omitempty"`
-	DNSVIP                 string   `json:"openstack_node_dns_ip,omitempty"`
-	IngressVIP             string   `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport           string   `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport         string   `json:"openstack_octavia_support,omitempty"`
-	RootVolumeSize         int      `json:"openstack_master_root_volume_size,omitempty"`
-	RootVolumeType         string   `json:"openstack_master_root_volume_type,omitempty"`
-	BootstrapShim          string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
-	ExternalDNS            []string `json:"openstack_external_dns,omitempty"`
+	BaseImageName   string   `json:"openstack_base_image_name,omitempty"`
+	ExternalNetwork string   `json:"openstack_external_network,omitempty"`
+	Cloud           string   `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName      string   `json:"openstack_master_flavor_name,omitempty"`
+	LbFloatingIP    string   `json:"openstack_lb_floating_ip,omitempty"`
+	APIVIP          string   `json:"openstack_api_int_ip,omitempty"`
+	DNSVIP          string   `json:"openstack_node_dns_ip,omitempty"`
+	IngressVIP      string   `json:"openstack_ingress_ip,omitempty"`
+	TrunkSupport    string   `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport  string   `json:"openstack_octavia_support,omitempty"`
+	RootVolumeSize  int      `json:"openstack_master_root_volume_size,omitempty"`
+	RootVolumeType  string   `json:"openstack_master_root_volume_type,omitempty"`
+	BootstrapShim   string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
+	ExternalDNS     []string `json:"openstack_external_dns,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
@@ -62,7 +61,11 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 		if err != nil {
 			return nil, err
 		}
-		cfg.BaseImageLocalFilePath = localFilePath
+
+		err = uploadBaseImage(cloud, localFilePath, imageName, infraID)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// Not a URL -> use baseImage value as an overridden Glance image name.
 		// Need to check if this image exists and there are no other images with this name.

--- a/pkg/tfvars/openstack/rhcos_image.go
+++ b/pkg/tfvars/openstack/rhcos_image.go
@@ -1,0 +1,54 @@
+package openstack
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/sirupsen/logrus"
+)
+
+// uploadBaseImage creates a new image in Glance and uploads the RHCOS image there
+func uploadBaseImage(cloud string, localFilePath string, imageName string, clusterID string) error {
+	logrus.Debugln("Creating a Glance image for RHCOS...")
+
+	f, err := os.Open(localFilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	opts := clientconfig.ClientOpts{
+		Cloud: cloud,
+	}
+
+	conn, err := clientconfig.NewServiceClient("image", &opts)
+	if err != nil {
+		return err
+	}
+
+	imageCreateOpts := images.CreateOpts{
+		Name:            imageName,
+		ContainerFormat: "bare",
+		DiskFormat:      "qcow2",
+		Tags:            []string{fmt.Sprintf("openshiftClusterID=%s", clusterID)},
+		// TODO(mfedosin): add Description when gophercloud supports it.
+	}
+
+	img, err := images.Create(conn, imageCreateOpts).Extract()
+	if err != nil {
+		return err
+	}
+	logrus.Debugf("Image %s was created.", img.Name)
+
+	logrus.Debugf("Uploading RHCOS to the image %v with ID %v", img.Name, img.ID)
+	res := imagedata.Upload(conn, img.ID, f)
+	if res.Err != nil {
+		return err
+	}
+	logrus.Debugf("The data was uploaded.")
+
+	return nil
+}

--- a/pkg/tfvars/openstack/rhcos_image.go
+++ b/pkg/tfvars/openstack/rhcos_image.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/sirupsen/logrus"
@@ -51,4 +53,44 @@ func uploadBaseImage(cloud string, localFilePath string, imageName string, clust
 	logrus.Debugf("The data was uploaded.")
 
 	return nil
+}
+
+// isImageImportSupported checks if we can use Image Import mechanism for image uploading
+func isImageImportSupported(cloud string) (bool, error) {
+	// More information about the Discovery API:
+	// https://docs.openstack.org/api-ref/image/v2/?expanded=#image-service-info-discovery
+	logrus.Debugln("Checking if the image import mechanism is supported")
+
+	opts := clientconfig.ClientOpts{
+		Cloud: cloud,
+	}
+
+	conn, err := clientconfig.NewServiceClient("image", &opts)
+	if err != nil {
+		return false, err
+	}
+
+	s, err := imageimport.Get(conn).Extract()
+	if err != nil {
+		// ErrDefault404 means that image discovery API is not available for the cloud
+		if _, ok := err.(gophercloud.ErrDefault404); ok {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Next check is just to make sure the response data was not corrupted
+	if s.ImportMethods.Type != "array" {
+		return false, nil
+	}
+
+	for _, method := range s.ImportMethods.Value {
+		if method == string(imageimport.GlanceDirectMethod) {
+			logrus.Debugln("Glance Direct image import plugin was found")
+			return true, nil
+		}
+	}
+
+	logrus.Debugln("Glance Direct image import plugin was not found")
+	return false, nil
 }

--- a/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
+++ b/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
@@ -12,6 +12,7 @@
     description: |
       Run gophercloud acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test/run.yaml
+    nodeset: ubuntu-bionic
 
 - job:
     name: gophercloud-acceptance-test-ironic
@@ -19,6 +20,7 @@
     description: |
       Run gophercloud ironic acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test-ironic/run.yaml
+    nodeset: ubuntu-bionic
 
 - job:
     name: gophercloud-acceptance-test-stein
@@ -74,16 +76,6 @@
       global_env:
         OS_BRANCH: stable/newton
 
-- job:
-    name: gophercloud-acceptance-test-mitaka
-    parent: gophercloud-acceptance-test
-    description: |
-      Run gophercloud acceptance test on mitaka branch
-    vars:
-      global_env:
-        OS_BRANCH: stable/mitaka
-    nodeset: ubuntu-trusty
-
 - project:
     name: gophercloud/gophercloud
     check:
@@ -91,9 +83,6 @@
         - gophercloud-unittest
         - gophercloud-acceptance-test
         - gophercloud-acceptance-test-ironic
-    recheck-mitaka:
-      jobs:
-        - gophercloud-acceptance-test-mitaka
     recheck-newton:
       jobs:
         - gophercloud-acceptance-test-newton

--- a/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 0.8.0 (Unreleased)
+## 0.9.0 (Unreleased)
+
+## 0.8.0 (February 8, 2020)
+
+UPGRADE NOTES
+
+* The behavior of `keymanager/v1/acls.SetOpts` has changed. Instead of a struct, it is now `[]SetOpt`. See [GH-1816](https://github.com/gophercloud/gophercloud/pull/1816) for implementation details.
 
 IMPROVEMENTS
 
@@ -8,6 +14,32 @@ IMPROVEMENTS
 * Added `compute/v2/extensions/shelveunshelve.Unshelve` [GH-1799](https://github.com/gophercloud/gophercloud/pull/1799)
 * Added `containerinfra/v1/nodegroups.Get` [GH-1774](https://github.com/gophercloud/gophercloud/pull/1774)
 * Added `containerinfra/v1/nodegroups.List` [GH-1774](https://github.com/gophercloud/gophercloud/pull/1774)
+* Added `orchestration/v1/resourcetypes.List` [GH-1806](https://github.com/gophercloud/gophercloud/pull/1806)
+* Added `orchestration/v1/resourcetypes.GetSchema` [GH-1806](https://github.com/gophercloud/gophercloud/pull/1806)
+* Added `orchestration/v1/resourcetypes.GenerateTemplate` [GH-1806](https://github.com/gophercloud/gophercloud/pull/1806)
+* Added `keymanager/v1/acls.SetOpt` and changed `keymanager/v1/acls.SetOpts` to `[]SetOpt` [GH-1816](https://github.com/gophercloud/gophercloud/pull/1816)
+* Added `blockstorage/apiversions.List` [GH-458](https://github.com/gophercloud/gophercloud/pull/458)
+* Added `blockstorage/apiversions.Get` [GH-458](https://github.com/gophercloud/gophercloud/pull/458)
+* Added `StatusCodeError` interface and `GetStatusCode` convenience method [GH-1820](https://github.com/gophercloud/gophercloud/pull/1820)
+* Added pagination support to `compute/v2/extensions/usage.SingleTenant` [GH-1819](https://github.com/gophercloud/gophercloud/pull/1819)
+* Added pagination support to `compute/v2/extensions/usage.AllTenants` [GH-1819](https://github.com/gophercloud/gophercloud/pull/1819)
+* Added `placement/v1/resourceproviders.List` [GH-1815](https://github.com/gophercloud/gophercloud/pull/1815)
+* Allow `CreateMemberOptsBuilder` to be passed in `loadbalancer/v2/pools.Create` [GH-1822](https://github.com/gophercloud/gophercloud/pull/1822)
+* Added `Backup` to `loadbalancer/v2/pools.CreateMemberOpts` [GH-1824](https://github.com/gophercloud/gophercloud/pull/1824)
+* Added `MonitorAddress` to `loadbalancer/v2/pools.CreateMemberOpts` [GH-1824](https://github.com/gophercloud/gophercloud/pull/1824)
+* Added `MonitorPort` to `loadbalancer/v2/pools.CreateMemberOpts` [GH-1824](https://github.com/gophercloud/gophercloud/pull/1824)
+* Changed `Impersonation` to a non-required field in `identity/v3/extensions/trusts.CreateOpts` [GH-1818](https://github.com/gophercloud/gophercloud/pull/1818)
+* Added `InsertHeaders` to `loadbalancer/v2/listeners.UpdateOpts` [GH-1835]
+* Added `NUMATopology` to `baremetalintrospection/v1/introspection.Data` [GH-1842](https://github.com/gophercloud/gophercloud/pull/1842)
+* Added `placement/v1/resourceproviders.Create` [GH-1841](https://github.com/gophercloud/gophercloud/pull/1841)
+
+BUG FIXES
+
+* Changed `sort_key` to `sort_keys` in ` workflow/v2/crontriggers.ListOpts` [GH-1809](https://github.com/gophercloud/gophercloud/pull/1809)
+* Allow `blockstorage/extensions/schedulerstats.Capabilities.MaxOverSubscriptionRatio` to accept both string and int/float responses [GH-1817](https://github.com/gophercloud/gophercloud/pull/1817)
+* Fixed bug in `NewLoadBalancerV2` for situations when the LBaaS service was advertised without a `/v2.0` endpoint [GH-1829](https://github.com/gophercloud/gophercloud/pull/1829)
+* Fixed JSON tags in `baremetal/v1/ports.UpdateOperation` [GH-1840](https://github.com/gophercloud/gophercloud/pull/1840)
+* Fixed JSON tags in `networking/v2/extensions/lbaas/vips.commonResult.Extract()` [GH-1840](https://github.com/gophercloud/gophercloud/pull/1840)
 
 ## 0.7.0 (December 3, 2019)
 

--- a/vendor/github.com/gophercloud/gophercloud/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/errors.go
@@ -92,6 +92,23 @@ func (e ErrUnexpectedResponseCode) Error() string {
 	return e.choseErrString()
 }
 
+// GetStatusCode returns the actual status code of the error.
+func (e ErrUnexpectedResponseCode) GetStatusCode() int {
+	return e.Actual
+}
+
+// StatusCodeError is a convenience interface to easily allow access to the
+// status code field of the various ErrDefault* types.
+//
+// By using this interface, you only have to make a single type cast of
+// the returned error to err.(StatusCodeError) and then call GetStatusCode()
+// instead of having a large switch statement checking for each of the
+// ErrDefault* types.
+type StatusCodeError interface {
+	Error() string
+	GetStatusCode() int
+}
+
 // ErrDefault400 is the default error type returned on a 400 HTTP response code.
 type ErrDefault400 struct {
 	ErrUnexpectedResponseCode

--- a/vendor/github.com/gophercloud/gophercloud/go.mod
+++ b/vendor/github.com/gophercloud/gophercloud/go.mod
@@ -11,3 +11,4 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.7
 )
+

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/ports/requests.go
@@ -182,8 +182,8 @@ const (
 )
 
 type UpdateOperation struct {
-	Op    UpdateOp    `json:"op,required"`
-	Path  string      `json:"path,required"`
+	Op    UpdateOp    `json:"op" required:"true"`
+	Path  string      `json:"path" required:"true"`
 	Value interface{} `json:"value,omitempty"`
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetalintrospection/v1/introspection/results.go
@@ -171,6 +171,7 @@ type Data struct {
 	MemoryMB      int                          `json:"memory_mb"`
 	RootDisk      RootDiskType                 `json:"root_disk"`
 	Extra         ExtraHardwareDataType        `json:"extra"`
+	NUMATopology  NUMATopology                 `json:"numa_topology"`
 }
 
 // Sub Types defined under Data and deeper in the structure
@@ -262,6 +263,28 @@ type ExtraHardwareDataType struct {
 	Memory   ExtraHardwareDataSection `json:"memory"`
 	Network  ExtraHardwareDataSection `json:"network"`
 	System   ExtraHardwareDataSection `json:"system"`
+}
+
+type NUMATopology struct {
+	CPUs []NUMACPU `json:"cpus"`
+	NICs []NUMANIC `json:"nics"`
+	RAM  []NUMARAM `json:"ram"`
+}
+
+type NUMACPU struct {
+	CPU            int   `json:"cpu"`
+	NUMANode       int   `json:"numa_node"`
+	ThreadSiblings []int `json:"thread_siblings"`
+}
+
+type NUMANIC struct {
+	Name     string `json:"name"`
+	NUMANode int    `json:"numa_node"`
+}
+
+type NUMARAM struct {
+	NUMANode int `json:"numa_node"`
+	SizeKB   int `json:"size_kb"`
 }
 
 // UnmarshalJSON interprets an LLDP TLV [key, value] pair as an LLDPTLVType structure

--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
@@ -432,7 +433,11 @@ func NewImageServiceV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 // load balancer service.
 func NewLoadBalancerV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "load-balancer")
-	sc.ResourceBase = sc.Endpoint + "v2.0/"
+
+	// Fixes edge case having an OpenStack lb endpoint with trailing version number.
+	endpoint := strings.Replace(sc.Endpoint, "v2.0/", "", -1)
+
+	sc.ResourceBase = endpoint + "v2.0/"
 	return sc, err
 }
 
@@ -472,4 +477,9 @@ func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.Endp
 // NewWorkflowV2 creates a ServiceClient that may be used with the v2 workflow management package.
 func NewWorkflowV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOpts(client, eo, "workflowv2")
+}
+
+// NewPlacementV1 creates a ServiceClient that may be used with the placement package.
+func NewPlacementV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "placement")
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/doc.go
@@ -1,0 +1,27 @@
+/*
+Package imageimport enables management of images import and retrieval of the
+Imageservice Import API information.
+
+Example to Get an information about the Import API
+
+  importInfo, err := imageimport.Get(imagesClient).Extract()
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", importInfo)
+
+Example to Create a new image import
+
+  opts := imageimport.CreateOpts{
+    Name: imageimport.WebDownloadMethod,
+    URI:  "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
+  }
+  imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
+
+  err := imageimport.Create(imagesClient, imageID, opts).ExtractErr()
+  if err != nil {
+    panic(err)
+  }
+*/
+package imageimport

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/requests.go
@@ -1,0 +1,53 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+// ImportMethod represents valid Import API method.
+type ImportMethod string
+
+const (
+	// GlanceDirectMethod represents glance-direct Import API method.
+	GlanceDirectMethod ImportMethod = "glance-direct"
+
+	// WebDownloadMethod represents web-download Import API method.
+	WebDownloadMethod ImportMethod = "web-download"
+)
+
+// Get retrieves Import API information data.
+func Get(c *gophercloud.ServiceClient) (r GetResult) {
+	_, r.Err = c.Get(infoURL(c), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows to add additional parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToImportCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new image import.
+type CreateOpts struct {
+	Name ImportMethod `json:"name"`
+	URI  string       `json:"uri"`
+}
+
+// ToImportCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToImportCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"method": b}, nil
+}
+
+// Create requests the creation of a new image import on the server.
+func Create(client *gophercloud.ServiceClient, imageID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToImportCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(importURL(client, imageID), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/results.go
@@ -1,0 +1,38 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult represents the result of a get operation. Call its Extract method
+// to interpret it as ImportInfo.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult is the result of import Create operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type CreateResult struct {
+	gophercloud.ErrResult
+}
+
+// ImportInfo represents information data for the Import API.
+type ImportInfo struct {
+	ImportMethods ImportMethods `json:"import-methods"`
+}
+
+// ImportMethods contains information about available Import API methods.
+type ImportMethods struct {
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	Value       []string `json:"value"`
+}
+
+// Extract is a function that accepts a result and extracts ImportInfo.
+func (r commonResult) Extract() (*ImportInfo, error) {
+	var s *ImportInfo
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/urls.go
@@ -1,0 +1,17 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "images"
+	infoPath     = "info"
+	resourcePath = "import"
+)
+
+func infoURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(infoPath, resourcePath)
+}
+
+func importURL(c *gophercloud.ServiceClient, imageID string) string {
+	return c.ServiceURL(rootPath, imageID, resourcePath)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/requests.go
@@ -206,6 +206,9 @@ type UpdateOpts struct {
 	// Time, in milliseconds, to wait for additional TCP packets for content inspection
 	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
 
+	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
+	InsertHeaders *map[string]string `json:"insert_headers,omitempty"`
+
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
@@ -275,6 +275,15 @@ type CreateMemberOpts struct {
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Is the member a backup? Backup members only receive traffic when all non-backup members are down.
+	Backup *bool `json:"backup,omitempty"`
+
+	// An alternate IP address used for health monitoring a backend member.
+	MonitorAddress string `json:"monitor_address,omitempty"`
+
+	// An alternate protocol port used for health monitoring a backend member.
+	MonitorPort *int `json:"monitor_port,omitempty"`
 }
 
 // ToMemberCreateMap builds a request body from CreateMemberOpts.
@@ -283,7 +292,7 @@ func (opts CreateMemberOpts) ToMemberCreateMap() (map[string]interface{}, error)
 }
 
 // CreateMember will create and associate a Member with a particular Pool.
-func CreateMember(c *gophercloud.ServiceClient, poolID string, opts CreateMemberOpts) (r CreateMemberResult) {
+func CreateMember(c *gophercloud.ServiceClient, poolID string, opts CreateMemberOptsBuilder) (r CreateMemberResult) {
 	b, err := opts.ToMemberCreateMap()
 	if err != nil {
 		r.Err = err

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas/vips/results.go
@@ -125,7 +125,7 @@ type commonResult struct {
 // Extract is a function that accepts a result and extracts a VirtualIP.
 func (r commonResult) Extract() (*VirtualIP, error) {
 	var s struct {
-		VirtualIP *VirtualIP `json:"vip" json:"vip"`
+		VirtualIP *VirtualIP `json:"vip"`
 	}
 	err := r.ExtractInto(&s)
 	return s.VirtualIP, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -510,7 +510,7 @@ github.com/googleapis/gax-go/v2
 github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
-# github.com/gophercloud/gophercloud v0.7.1-0.20191211202411-f940f50ff1f7
+# github.com/gophercloud/gophercloud v0.8.0
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack
@@ -567,6 +567,7 @@ github.com/gophercloud/gophercloud/openstack/identity/v3/services
 github.com/gophercloud/gophercloud/openstack/identity/v3/tokens
 github.com/gophercloud/gophercloud/openstack/identity/v3/users
 github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata
+github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport
 github.com/gophercloud/gophercloud/openstack/imageservice/v2/images
 github.com/gophercloud/gophercloud/openstack/imageservice/v2/members
 github.com/gophercloud/gophercloud/openstack/keymanager/v1/containers


### PR DESCRIPTION
Now we use legacy image uploading that doesn't support image conversion. It leads to the fact that we upload qcow2 images to Ceph backend, which doesn't support this format:
https://access.redhat.com/solutions/2434691

By using the Image Import mechanism we make sure that all uploaded images will be automatically converted to Raw for Ceph (and only for Ceph) backends.

If the image import mechanism is not available we fallback to the legacy uploading.