### PR TITLE
Return the correct error after uploading OpenStack image

### DIFF
--- a/pkg/tfvars/openstack/bootstrap_ignition.go
+++ b/pkg/tfvars/openstack/bootstrap_ignition.go
@@ -44,7 +44,7 @@ func uploadBootstrapConfig(cloud string, bootstrapIgn string, clusterID string) 
 	logrus.Debugf("Uploading bootstrap config to the image %v with ID %v", img.Name, img.ID)
 	res := imagedata.Upload(conn, img.ID, strings.NewReader(bootstrapIgn))
 	if res.Err != nil {
-		return "", err
+		return "", res.Err
 	}
 	logrus.Debugf("The config was uploaded.")
 


### PR DESCRIPTION
Now we return "err" from the previous call, but instead we should return "res.Err".