### PR TITLE
bootstrap: prepull all podman images

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -7,6 +7,10 @@ mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests
 
 ETCD_ENDPOINTS=
 
+bootkube_podman_pull() {
+    until podman pull "${@}"; do echo "Retrying pull ${@}"; sleep 5; done
+}
+
 bootkube_podman_run() {
     # we run all commands in the host-network to prevent IP conflicts with
     # end-user infrastructure.
@@ -21,6 +25,9 @@ MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 KUBE_ETCD_SIGNER_SERVER_IMAGE=$(image_for kube-etcd-signer-server)
 CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator || echo "no-ceo-image")
+
+bootkube_podman_pull "${CLUSTER_ETCD_OPERATOR_IMAGE}"
+
 CLUSTER_ETCD_OPERATOR_MANAGED=${CLUSTER_ETCD_OPERATOR_IMAGE:+$(bootkube_podman_run \
 	"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
 	/usr/bin/grep -oP Managed \
@@ -59,6 +66,7 @@ then
 
 	rm --recursive --force cvo-bootstrap
 
+	bootkube_podman_pull "${RELEASE_IMAGE_DIGEST}"
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
 		"${RELEASE_IMAGE_DIGEST}" \
@@ -84,6 +92,7 @@ echo "Starting etcd certificate signer..."
 
 trap "podman rm --force etcd-signer" ERR
 
+bootkube_podman_pull "${KUBE_ETCD_SIGNER_SERVER_IMAGE}"
 bootkube_podman_run \
 	--name etcd-signer \
 	--detach \
@@ -118,6 +127,7 @@ then
 	if [ ! -f etcd-bootstrap.done ]
 	then
 		echo "Rendering CEO Manifests..."
+		bootkube_podman_pull "${CLUSTER_ETCD_OPERATOR_IMAGE}"
 		bootkube_podman_run \
 			--volume "$PWD:/assets:z" \
 			"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
@@ -158,6 +168,7 @@ then
 
 	rm --recursive --force config-bootstrap
 
+	bootkube_podman_pull "${CONFIG_OPERATOR_IMAGE}"
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
 		"${CONFIG_OPERATOR_IMAGE}" \
@@ -177,6 +188,7 @@ then
 
 	rm --recursive --force kube-apiserver-bootstrap
 
+	bootkube_podman_pull "${KUBE_APISERVER_OPERATOR_IMAGE}"
 	bootkube_podman_run  \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_APISERVER_OPERATOR_IMAGE}" \
@@ -203,6 +215,7 @@ then
 
 	rm --recursive --force kube-controller-manager-bootstrap
 
+	bootkube_podman_pull "${KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE}"
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE}" \
@@ -226,6 +239,7 @@ then
 
 	rm --recursive --force kube-scheduler-bootstrap
 
+	bootkube_podman_pull "${KUBE_SCHEDULER_OPERATOR_IMAGE}"
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_SCHEDULER_OPERATOR_IMAGE}" \
@@ -248,6 +262,7 @@ then
 
 	rm --recursive --force ingress-operator-bootstrap
 
+	bootkube_podman_pull "${INGRESS_OPERATOR_IMAGE}"
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
 		"${INGRESS_OPERATOR_IMAGE}" \
@@ -271,6 +286,7 @@ then
 		ADDITIONAL_FLAGS="--cloud-provider-ca-file=/assets/tls/cloud-ca-cert.pem"
 	fi
 
+	bootkube_podman_pull "${MACHINE_CONFIG_OPERATOR_IMAGE}"
 	bootkube_podman_run \
 		--user 0 \
 		--volume "$PWD:/assets:z" \
@@ -340,6 +356,7 @@ then
 	rm --recursive --force cco-bootstrap
 
 	# shellcheck disable=SC2154
+	bootkube_podman_pull "${CLOUD_CREDENTIAL_OPERATOR_IMAGE}"
 	bootkube_podman_run \
 		--quiet \
 		--user 0 \
@@ -356,6 +373,7 @@ then
 fi
 
 # Wait for the etcd cluster to come up.
+bootkube_podman_pull "${MACHINE_CONFIG_ETCD_IMAGE}"
 until bootkube_podman_run \
 		--rm \
 		--name etcdctl \
@@ -382,6 +400,7 @@ echo "Starting cluster-bootstrap..."
 
 if [ ! -f cb-bootstrap.done ]
 then
+	bootkube_podman_pull "${CLUSTER_BOOTSTRAP_IMAGE}"
     bootkube_podman_run \
         --rm \
         --volume "$PWD:/assets:z" \
@@ -396,6 +415,7 @@ rm --force /etc/kubernetes/manifests/machineconfigoperator-bootstrap-pod.yaml
 if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
 then
 	echo "Waiting for CEO to finish..."
+	bootkube_podman_pull "${CLUSTER_ETCD_OPERATOR_IMAGE}"
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
 		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \


### PR DESCRIPTION
Make sure all images are pullable before running those. This ensures
detached podman containers won't hang is a weird state

/cc @vrutkovs