### PR TITLE
[FCOS] pkg: always overwrite files created

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -295,7 +295,6 @@ func (a *Bootstrap) addStorageFiles(base string, uri string, templateData *boots
 
 	var mode int
 	appendToFile := false
-	overwrite := true
 	if path.Base(path.Dir(uri)) == "bin" {
 		mode = 0555
 	} else if filename == "motd" {
@@ -308,7 +307,6 @@ func (a *Bootstrap) addStorageFiles(base string, uri string, templateData *boots
 	if appendToFile {
 		ign.Append = append(ign.Append, ign.Contents)
 	}
-	ign.Overwrite = &overwrite
 	a.Config.Storage.Files = append(a.Config.Storage.Files, ign)
 
 	// Replace files that already exist in the slice with ones added later, otherwise append them

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -294,19 +294,14 @@ func (a *Bootstrap) addStorageFiles(base string, uri string, templateData *boots
 	filename := path.Base(uri)
 
 	var mode int
-	appendToFile := false
 	if path.Base(path.Dir(uri)) == "bin" {
 		mode = 0555
 	} else if filename == "motd" {
 		mode = 0644
-		appendToFile = true
 	} else {
 		mode = 0600
 	}
 	ign := ignition.FileFromBytes(strings.TrimSuffix(base, ".template"), "root", mode, data)
-	if appendToFile {
-		ign.Append = append(ign.Append, ign.Contents)
-	}
 	a.Config.Storage.Files = append(a.Config.Storage.Files, ign)
 
 	// Replace files that already exist in the slice with ones added later, otherwise append them

--- a/pkg/asset/ignition/node.go
+++ b/pkg/asset/ignition/node.go
@@ -27,9 +27,11 @@ func FileFromString(path string, username string, mode int, contents string) ign
 // FileFromBytes creates an ignition-config file with the given contents.
 func FileFromBytes(path string, username string, mode int, contents []byte) ignition.File {
 	contentsString := dataurl.EncodeBytes(contents)
+	overwrite := true
 	return ignition.File{
 		Node: ignition.Node{
-			Path: path,
+			Path:      path,
+			Overwrite: &overwrite,
 			User: ignition.NodeUser{
 				Name: &username,
 			},

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -51,6 +51,7 @@ spec:
           verification: {}
         group: {}
         mode: 384
+        overwrite: true
         path: /etc/pivot/kernel-args
         user:
           name: root
@@ -90,6 +91,7 @@ spec:
           verification: {}
         group: {}
         mode: 384
+        overwrite: true
         path: /etc/pivot/kernel-args
         user:
           name: root

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -51,6 +51,7 @@ spec:
           verification: {}
         group: {}
         mode: 384
+        overwrite: true
         path: /etc/pivot/kernel-args
         user:
           name: root

--- a/pkg/tfvars/openstack/bootstrap_ignition.go
+++ b/pkg/tfvars/openstack/bootstrap_ignition.go
@@ -72,6 +72,7 @@ func createBootstrapSwiftObject(cloud string, bootstrapIgn string, clusterID str
 // in its Security section.
 func generateIgnitionShim(userCA string, clusterID string, swiftObject string) (string, error) {
 	fileMode := 420
+	overwrite := true
 
 	// Hostname Config
 	contents := fmt.Sprintf("data:text/plain;base64,%s", b64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s-bootstrap", clusterID))))
@@ -79,7 +80,8 @@ func generateIgnitionShim(userCA string, clusterID string, swiftObject string) (
 	// TODO
 	hostnameConfigFile := ignition.File{
 		Node: ignition.Node{
-			Path: "/etc/hostname",
+			Path:      "/etc/hostname",
+			Overwrite: &overwrite,
 		},
 		FileEmbedded1: ignition.FileEmbedded1{
 			Mode: &fileMode,


### PR DESCRIPTION
Ignition v3 would merge file contents by default. Installer should
ensure "overwrite: true" is set in generated Ignition config to avoid
that.

This also reset appending information to motd, as on FCOS bootstrap node this makes motd being duplicated