### PR TITLE
Give a proper error when misusing OPENSHIFT_INSTALL_AZURE_EMULATE_SINGLESTACK_IPV6

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -211,7 +211,12 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 		switch {
 		case p.BareMetal != nil:
 		case p.None != nil:
+
 		case p.Azure != nil && os.Getenv("OPENSHIFT_INSTALL_AZURE_EMULATE_SINGLESTACK_IPV6") == "true":
+			if !presence["machineNetwork"].IPv4 || !presence["machineNetwork"].IPv6 {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "IPv6", "OPENSHIFT_INSTALL_AZURE_EMULATE_SINGLESTACK_IPV6 requires both IPv4 and IPv6 machineNetwork values"))
+			}
+
 		default:
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "IPv6", "single-stack IPv6 is not supported for this platform"))
 		}


### PR DESCRIPTION
If you set `OPENSHIFT_INSTALL_AZURE_EMULATE_SINGLESTACK_IPV6=true` but accidentally pass an IPv4 config, the install will fail with:

```
ERROR                                              
ERROR Error: Insufficient record blocks            
ERROR                                              
ERROR   on  line 0:                                
ERROR   (source code not available)                
ERROR                                              
ERROR At least 1 "record" blocks are required.     
ERROR                                              
ERROR Failed to read tfstate: open /tmp/openshift-install-151306092/terraform.tfstate:
no such file or directory 
FATAL failed to fetch Cluster: failed to generate asset "Cluster": failed to create
cluster: failed to apply using Terraform 
```

If you pass an IPv6-only install-config it will fail with an even uglier error.

This PR fixes it to instead fail in both cases with:
```
FATAL failed to fetch Terraform Variables: failed to generate asset "Terraform
Variables": failed to get azure Terraform variables:
OPENSHIFT_INSTALL_AZURE_EMULATE_SINGLESTACK_IPV6 requires a dual-stack install-config 
```
