### PR TITLE
bug 1807169: use localhost for bootstrap IP until bootkube is fixed

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -113,8 +113,7 @@ bootkube_podman_run \
 if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ]
 then
 	# TODO: host-etcd endpoint rendered by cluster-etcd-operator
-	BOOTSTRAP_IP=$(hostname -I | awk '{ print $1 }')
-	ETCD_ENDPOINTS=https://"${BOOTSTRAP_IP}":2379
+	ETCD_ENDPOINTS=https://localhost:2379
 	if [ ! -f etcd-bootstrap.done ]
 	then
 		echo "Rendering CEO Manifests..."
@@ -134,7 +133,8 @@ then
 			--config-output-file=/assets/etcd-bootstrap/config \
 			--cluster-config-file=/assets/manifests/cluster-network-02-config.yml
 
-		sed -i "s/__BOOTSTRAP_IP__/${BOOTSTRAP_IP}/" /opt/openshift/manifests/etcd-host-service-endpoints.yaml
+		# pass an IP in the sample range to pass validation, but be ignored.
+		sed -i "s/__BOOTSTRAP_IP__/192.0.2.200/" /opt/openshift/manifests/etcd-host-service-endpoints.yaml
 
 		cp etcd-bootstrap/manifests/* manifests/
 		cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/


### PR DESCRIPTION
It is possible to use localhost for the short term to get unstuck and correctly predict "correct" values in individual render commands. This is a temporary workaround to ship 4.4.

The bootkube script should be aware of the 'correct' ipv6 address to configuring rendering of multiple components.