### PR TITLE
pkg/asset/ignition/bootstrap: populate MachineCIDR from installConfig

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -6,6 +6,7 @@ set -euoE pipefail ## -E option will cause functions to inherit trap
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
 
 ETCD_ENDPOINTS=
+MACHINE_CIDR="{{ .MachineCIDR }}"
 
 bootkube_podman_run() {
     # we run all commands in the host-network to prevent IP conflicts with


### PR DESCRIPTION
The `MachineCIDR` is a very important value within the context of IPv4, IPv6 (single stack). This PR uses information populated in `installConfig` to conclude if we are single stack and which MachineCIDR should be used.