### PR TITLE
Added a note about RHEL8.1 Go version

### DIFF
--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -10,6 +10,8 @@ The following dependencies must be installed on your system before you can build
 sudo yum install golang-bin gcc-c++
 ```
 
+NOTE: Currently RHEL8.1 provides Go version 1.12, so it cannot be used to build the installer.
+
 If you need support for [libvirt destroy](libvirt/README.md#cleanup), you should also install `libvirt-devel`.
 
 ### Go


### PR DESCRIPTION
RHEL8.1 doesn't include Go 1.13 in the official repositories so it cannot be used to build the installer.