### PR TITLE
Add new BootMode field

### DIFF
--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -2,6 +2,7 @@ package baremetal
 
 import (
 	"fmt"
+
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
 
 	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
@@ -11,6 +12,7 @@ import (
 	baremetalhost "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/baremetal"
 )
 
 // HostSettings hold the information needed to build the manifests to
@@ -78,6 +80,14 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 				HardwareProfile: host.HardwareProfile,
 			},
 		}
+
+		// we will always default to UEFI
+		if host.BootMode == baremetal.Legacy {
+			newHost.Spec.BootMode = baremetalhost.Legacy
+		} else {
+			newHost.Spec.BootMode = baremetalhost.UEFI
+		}
+
 		if i < len(machines) {
 			// Setting ExternallyProvisioned to true and adding a
 			// ConsumerRef without setting Image associates the host

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -77,10 +77,16 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		}
 
 		// Properties
+
+		// capabilities, default to uefi boot mode if no other value is present
+		capabilities := "boot_mode:uefi"
+		if host.BootMode == baremetal.Legacy {
+			capabilities = "boot_mode:bios"
+		}
 		propertiesMap := map[string]interface{}{
 			"local_gb":     profile.LocalGB,
 			"cpu_arch":     profile.CPUArch,
-			"capabilities": "boot_mode:uefi",
+			"capabilities": capabilities,
 		}
 
 		// Root device hints

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -12,13 +12,23 @@ type BMC struct {
 	DisableCertificateVerification bool   `json:"disableCertificateVerification"`
 }
 
+// BootMode is the boot mode of the system
+type BootMode string
+
+// Allowed boot mode from metal3
+const (
+	UEFI   BootMode = "UEFI"
+	Legacy BootMode = "legacy"
+)
+
 // Host stores all the configuration data for a baremetal host.
 type Host struct {
-	Name            string `json:"name,omitempty"`
-	BMC             BMC    `json:"bmc"`
-	Role            string `json:"role"`
-	BootMACAddress  string `json:"bootMACAddress"`
-	HardwareProfile string `json:"hardwareProfile"`
+	Name            string   `json:"name,omitempty"`
+	BMC             BMC      `json:"bmc"`
+	Role            string   `json:"role"`
+	BootMACAddress  string   `json:"bootMACAddress"`
+	BootMode        BootMode `json:"bootMode,omitempty"`
+	HardwareProfile string   `json:"hardwareProfile"`
 }
 
 // Platform stores all the global configuration that all machinesets use.

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1/baremetalhost_types.go
@@ -133,6 +133,14 @@ type BMCDetails struct {
 	DisableCertificateVerification bool `json:"disableCertificateVerification,omitempty"`
 }
 
+type BootMode string
+
+// Allowed boot mode from metal3
+const (
+	UEFI   BootMode = "UEFI"
+	Legacy BootMode = "legacy"
+)
+
 // BareMetalHostSpec defines the desired state of BareMetalHost
 type BareMetalHostSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code
@@ -156,6 +164,10 @@ type BareMetalHostSpec struct {
 	// types, but required for libvirt VMs driven by vbmc.
 	// +kubebuilder:validation:Pattern=`[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}`
 	BootMACAddress string `json:"bootMACAddress,omitempty"`
+
+	// Boot mode for baremetal server
+	// +kubebuilder:validation:Enum=UEFI;legacy
+	BootMode BootMode `json:"bootMode,omitempty"`
 
 	// Should the server be online?
 	Online bool `json:"online"`


### PR DESCRIPTION
Create a new field in BareMetalHost to indicate
boot mode. It can have UEFI and legacy values (defaulting
to UEFI). The boot_mode capability will be generated using
that field instead of hardcoding it. Also the right value
will be written in BareMetalHost definition, to pass the
right value to workers.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>