### PR TITLE
add a more complete example of using libvirturi in metal docs

### DIFF
--- a/docs/user/metal/customization_ipi.md
+++ b/docs/user/metal/customization_ipi.md
@@ -124,6 +124,14 @@ permission to communicate with the libvirt services.
 The hypervisor must meet the network requirements described in
 the [Prerequisites](install_ipi.md#prerequisites) section.
 
+Example:
+
+```yaml
+platform:
+  baremetal:
+    libvirtURI: qemu+ssh://hyperuser@hypervisor.example.com/system
+```
+
 ## Disabling Certificate Verification for BMCs
 
 By default TLS clients communicating with BMCs will require valid


### PR DESCRIPTION
The other sections show an example that places the configuration
parameter in the right part of the structure in the YAML document. Add
a similar example for the libvirtURI.