### PR TITLE
WIP [FCOS] bootstrap: replace Ignition files if they are already defined

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -294,18 +294,14 @@ func (a *Bootstrap) addStorageFiles(base string, uri string, templateData *boots
 	filename := path.Base(uri)
 
 	var mode int
-	appendToFile := false
-	overwrite := true
 	if path.Base(path.Dir(uri)) == "bin" {
 		mode = 0555
 	} else if filename == "motd" {
 		mode = 0644
-		appendToFile = true
 	} else {
 		mode = 0600
 	}
 	ign := ignition.FileFromBytes(strings.TrimSuffix(base, ".template"), "root", mode, data)
-	ign.Append = appendToFile
 
 	// Replace files that already exist in the slice with ones added later, otherwise append them
 	a.Config.Storage.Files = replaceOrAppend(a.Config.Storage.Files, ign)


### PR DESCRIPTION
instead of appending them.

This fixes an issue in Ignition Spec v3 where contradictory entries
in the Storage.Files array are not allowed.

Specifically, in order to solve openshift/okd#37,
`data/data/bootstrap/gcp/files/usr/local/bin/report-progress.sh` will
now replace `data/data/bootstrap/files/usr/local/bin/report-progress.sh`
instead of being appended.

It also solves openshift/okd#63 by ensuring
`99_openshift-machineconfig_99-{master,worker]-ssh.yaml` aren't added
to the generated Ignition config twice.

Cherry-pick of #3078 on fcos branch (automatic cherrypick has hit merge conflicts)

TODO:

* [ ] Fix motd append