### PR TITLE
bootkube.sh.template: Changed command for BOOTSTRAP_IP

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -113,7 +113,10 @@ bootkube_podman_run \
 if [ ! -z "$CLUSTER_ETCD_OPERATOR_MANAGED" ]
 then
 	# TODO: host-etcd endpoint rendered by cluster-etcd-operator
-	BOOTSTRAP_IP=$(hostname -I | awk '{ print $1 }')
+	# "ip route get" can return a slightly different format on different linux releases
+	# but on every one of them it will have "src IP". That's why sed is used here.
+	# It will return IP of default gateway
+	BOOTSTRAP_IP=$(ip route get 1 | sed 's/^.*src \([^ ]*\).*$/\1/;q')
 	ETCD_ENDPOINTS=https://"${BOOTSTRAP_IP}":2379
 	if [ ! -f etcd-bootstrap.done ]
 	then


### PR DESCRIPTION
bootkube.sh.template: Changed command for BOOTSTRAP_IP
    
    new command uses "ip route get" to get ip address of default gateway of the node.
    
    Fixes #3041
    Till now "hostname -I | awk {'print 1'}" was used.
    The method that gets the first address produced by the hostname -I is unreliable,
    because (according to the documentation) one cannot make any assumptions about the order of the addresses.
    On baremetal we have more than one nic and sometimes wrong ip was used.