### PR TITLE
Bug 1713336: aws destroy: show warnings when things fail to delete after 5 minutes.

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -687,7 +687,7 @@ func terminateEC2InstanceByInstance(ec2Client *ec2.EC2, iamClient *iam.IAM, inst
 		return err
 	}
 
-	logger.Info("Terminating")
+	logger.Debug("Terminating")
 	return nil
 }
 
@@ -735,7 +735,7 @@ func terminateEC2InstancesByTags(ec2Client *ec2.EC2, iamClient *iam.IAM, filters
 								if *instance.State.Name == "terminated" {
 									arn := fmt.Sprintf("arn:%s:ec2:%s:%s:instance/%s", partition.ID(), *ec2Client.Config.Region, *reservation.OwnerId, *instance.InstanceId)
 									if _, ok := terminated[arn]; !ok {
-										instanceLogger.Debug("Terminated")
+										instanceLogger.Info("Terminated")
 										terminated[arn] = exists
 									}
 									continue

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -150,6 +150,7 @@ func (o *ClusterUninstaller) Run() error {
 		return err
 	}
 
+	tracker := new(errorTracker)
 	tagClientStack := append([]*resourcegroupstaggingapi.ResourceGroupsTaggingAPI(nil), tagClients...)
 	err = wait.PollImmediateInfinite(
 		time.Second*10,
@@ -183,7 +184,7 @@ func (o *ClusterUninstaller) Run() error {
 
 									err = deleteARN(awsSession, parsed, filter, arnLogger)
 									if err != nil {
-										arnLogger.Debug(err)
+										tracker.suppressWarning(arnString, err, arnLogger)
 										err = errors.Wrapf(err, "deleting %s", arnString)
 										continue
 									}
@@ -240,7 +241,7 @@ func (o *ClusterUninstaller) Run() error {
 
 					err = deleteARN(awsSession, parsed, nil, arnLogger)
 					if err != nil {
-						arnLogger.Debug(err)
+						tracker.suppressWarning(arnString, err, arnLogger)
 						err = errors.Wrapf(err, "deleting %s", arnString)
 						loopError = err
 						continue

--- a/pkg/destroy/aws/errortracker.go
+++ b/pkg/destroy/aws/errortracker.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	suppressDuration = time.Minute * 5
+)
+
+// errorTracker holds a history of errors
+type errorTracker struct {
+	history map[string]time.Time
+}
+
+// suppressWarning logs errors WARN once every duration and the rest to DEBUG
+func (o *errorTracker) suppressWarning(identifier string, err error, logger logrus.FieldLogger) {
+	if o.history == nil {
+		o.history = map[string]time.Time{}
+	}
+	if firstSeen, ok := o.history[identifier]; ok {
+		if time.Since(firstSeen) > suppressDuration {
+			logger.Warn(err)
+			o.history[identifier] = time.Now() // reset the clock
+		} else {
+			logger.Debug(err)
+		}
+	} else { // first error for this identifier
+		o.history[identifier] = time.Now()
+		logger.Debug(err)
+	}
+}


### PR DESCRIPTION
This change makes it so that errors encountered while attempting to
delete objects from AWS during destroy cluster will be logged as
WARNING level once every 5 minutes (per object). Otherwise they will
continue to be logged as DEBUG as encountered.

This change also modifies the logging of instances "Terminating" to DEBUG
while "Terminated" becomes INFO.