### PR TITLE
Bug 1802768: Enable VM Accelerated Networking

### DIFF
--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -9,9 +9,10 @@ locals {
 resource "azurerm_network_interface" "master" {
   count = var.instance_count
 
-  name                = "${var.cluster_id}-master${count.index}-nic"
-  location            = var.region
-  resource_group_name = var.resource_group_name
+  name                          = "${var.cluster_id}-master${count.index}-nic"
+  location                      = var.region
+  resource_group_name           = var.resource_group_name
+  enable_accelerated_networking = true
 
   dynamic "ip_configuration" {
     for_each = [for ip in [


### PR DESCRIPTION
Enabling accelerated networking on master network interfaces
This is disabled by default, enabling this has a number of benefits at
no extra cost.

 - Lower Latency
 - Reduce jitter
 - Decrease CPU utilization

<https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli>