### PR TITLE
[FCOS] Revert "upi/vsphere/machine/ignition: set hostname to IP address"

### DIFF
--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -16,7 +16,7 @@ data "ignition_file" "hostname" {
   mode       = "420"
 
   content {
-    content = "${local.ip_addresses[count.index]}"
+    content = "${var.name}-${count.index}"
   }
 }
 


### PR DESCRIPTION
This reverts commit 1e47b5c154dee9c2b10c080c8415d6559eb0ae0b.
OVN didn't support non-resolvable node names, so we had to put IP addresses
as a hostname. The fix for this has been merged, so we can go back to
human-readable names