### PR TITLE
Bug 1767066: Vendor terraform update to fix symlink bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ replace (
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.0.0 // Pin non-versioned import to v22.0.0
 	github.com/go-log/log => github.com/go-log/log v0.1.1-0.20181211034820-a514cf01a3eb // Pinned by MCO
 	github.com/hashicorp/consul => github.com/hashicorp/consul v1.6.2 // Pin to version required by terraform fork
-	github.com/hashicorp/terraform => github.com/openshift/hashicorp-terraform v0.12.20-openshift // Pin to fork with deduplicated rpc types
+	github.com/hashicorp/terraform => github.com/openshift/hashicorp-terraform v0.12.20-openshift-2 // Pin to fork with deduplicated rpc types
 	github.com/hashicorp/terraform-plugin-sdk => github.com/openshift/hashicorp-terraform-plugin-sdk v1.6.0-openshift // Pin to fork with public rpc types
 	github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200206190020-71b826cc0f0a // Use OpenShift fork
 	github.com/metal3-io/cluster-api-provider-baremetal => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d // Pin OpenShift fork

--- a/go.sum
+++ b/go.sum
@@ -1783,8 +1783,8 @@ github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200128081049-840376ca
 github.com/openshift/cluster-autoscaler-operator v0.0.0-20190521201101-62768a6ba480/go.mod h1:/XmV44Fh28Vo3Ye93qFrxAbcFJ/Uy+7LPD+jGjmfJYc=
 github.com/openshift/cluster-etcd-operator v0.0.0-alpha.0.0.20191025163650-5854b5c48ce4/go.mod h1:vcBAUefK8pQmTPQ3jlCemORXhnRnq3aTsfOSVeaWliY=
 github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible/go.mod h1:0BbpR1mrN0F2ZRae5N1XHcytmkvVPaeKgSQwRRBWugc=
-github.com/openshift/hashicorp-terraform v0.12.20-openshift h1:7Ljl6sDrRtmp2jHpPz7pow4lRtzd/nxHuZqaNfq81Ts=
-github.com/openshift/hashicorp-terraform v0.12.20-openshift/go.mod h1:R/dUWEZVB5itR8fNzx3g8QZMIwwWuI8rcwF8SbL1sq4=
+github.com/openshift/hashicorp-terraform v0.12.20-openshift-2 h1:lFBL2fP3PUiO99f2PfaauBUQMwxQBjCDTk7Z7+fsARk=
+github.com/openshift/hashicorp-terraform v0.12.20-openshift-2/go.mod h1:R/dUWEZVB5itR8fNzx3g8QZMIwwWuI8rcwF8SbL1sq4=
 github.com/openshift/hashicorp-terraform-plugin-sdk v1.6.0-openshift h1:lfMsjeRYTWs2FmLo9ak0fqV7ekzpKUtV2JkLKdlx3Zk=
 github.com/openshift/hashicorp-terraform-plugin-sdk v1.6.0-openshift/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
 github.com/openshift/imagebuilder v1.1.0/go.mod h1:9aJRczxCH0mvT6XQ+5STAQaPWz7OsWcU5/mRkt8IWeo=

--- a/vendor/github.com/hashicorp/terraform/command/meta_config.go
+++ b/vendor/github.com/hashicorp/terraform/command/meta_config.go
@@ -42,6 +42,11 @@ func (m *Meta) normalizePath(path string) string {
 		return path
 	}
 
+	cwd, err = filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return path
+	}
+
 	ret, err := filepath.Rel(cwd, path)
 	if err != nil {
 		return path

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -717,7 +717,7 @@ github.com/hashicorp/hil/scanner
 github.com/hashicorp/logutils
 # github.com/hashicorp/serf v0.8.5
 github.com/hashicorp/serf/coordinate
-# github.com/hashicorp/terraform v0.0.0 => github.com/openshift/hashicorp-terraform v0.12.20-openshift
+# github.com/hashicorp/terraform v0.0.0 => github.com/openshift/hashicorp-terraform v0.12.20-openshift-2
 github.com/hashicorp/terraform/addrs
 github.com/hashicorp/terraform/backend
 github.com/hashicorp/terraform/backend/atlas


### PR DESCRIPTION
Steps to create this commit:
1. update go.mod with new version of openshift/hashicorp-terraform
2. go mod tidy
3. go mod vendor

Fixes: #1839