### PR TITLE
[fcos] bootstrap: check files for duplicates before appending

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -302,7 +302,6 @@ func (a *Bootstrap) addStorageFiles(base string, uri string, templateData *boots
 		mode = 0600
 	}
 	ign := ignition.FileFromBytes(strings.TrimSuffix(base, ".template"), "root", mode, data)
-	a.Config.Storage.Files = append(a.Config.Storage.Files, ign)
 
 	// Replace files that already exist in the slice with ones added later, otherwise append them
 	if exists, i := sliceContainsFileAtIndex(a.Config.Storage.Files, ign); exists == true {


### PR DESCRIPTION
Generated files have been mistakenly appended due to overwrite refactoring of `ignition.FileFromBytes`. This breaks GCP install, it gets `report-progress.sh` included twice and bootstrap Ignition is rendered with duplicate files.

Verified that it fixes bootstrap startup on GCP