### PR TITLE
Bug 1808973: [WIP] azurerm terraform fixes for address_prefixes

### DIFF
--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_loadbalancer.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_loadbalancer.go
@@ -68,10 +68,9 @@ func resourceArmLoadBalancer() *schema.Resource {
 						},
 
 						"private_ip_address": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validate.IPv4AddressOrEmpty,
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
 						},
 
 						"private_ip_address_version": {


### PR DESCRIPTION
When a subnet uses address_prefixes, address_prefix is null in the virtual network resource. Add address_prefixes to virtual network resource and allow null for address_prefix. Don't assume IPv4 for private_ip_address on load balancer resource. 

https://bugzilla.redhat.com/show_bug.cgi?id=1808973