### PR TITLE
Fix invocation of log.Errorf

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -186,7 +186,7 @@ func deleteServers(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 	conn, err := clientconfig.NewServiceClient("compute", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
@@ -201,13 +201,13 @@ func deleteServers(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 	allPages, err := servers.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allServers, err := servers.ExtractServers(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
@@ -241,7 +241,7 @@ func deletePorts(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fie
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	tags := filterTags(filter)
@@ -251,13 +251,13 @@ func deletePorts(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fie
 
 	allPages, err := ports.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allPorts, err := ports.ExtractPorts(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	for _, port := range allPorts {
@@ -266,12 +266,12 @@ func deletePorts(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fie
 		}
 		allPages, err := floatingips.List(conn, listOpts).AllPages()
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 			return false, nil
 		}
 		allFIPs, err := floatingips.ExtractFloatingIPs(allPages)
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 			return false, nil
 		}
 		// If a user provisioned floating ip was used, it needs to be dissociated.
@@ -306,7 +306,7 @@ func deleteSecurityGroups(opts *clientconfig.ClientOpts, filter Filter, logger l
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	tags := filterTags(filter)
@@ -316,13 +316,13 @@ func deleteSecurityGroups(opts *clientconfig.ClientOpts, filter Filter, logger l
 
 	allPages, err := sg.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allGroups, err := sg.ExtractGroups(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	for _, group := range allGroups {
@@ -347,7 +347,7 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	tags := filterTags(filter)
@@ -357,13 +357,13 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 	allPages, err := routers.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allRouters, err := routers.ExtractRouters(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	for _, router := range allRouters {
@@ -375,13 +375,13 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 		fipPages, err := floatingips.List(conn, fipOpts).AllPages()
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 			return false, nil
 		}
 
 		allFIPs, err := floatingips.ExtractFloatingIPs(fipPages)
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 			return false, nil
 		}
 
@@ -404,7 +404,7 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 		_, err = routers.Update(conn, router.ID, updateOpts).Extract()
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 		}
 
 		// Get router interface ports
@@ -413,12 +413,12 @@ func deleteRouters(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 		}
 		allPagesPort, err := ports.List(conn, portListOpts).AllPages()
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 			return false, nil
 		}
 		allPorts, err := ports.ExtractPorts(allPagesPort)
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 			return false, nil
 		}
 
@@ -464,7 +464,7 @@ func deleteSubnets(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	tags := filterTags(filter)
@@ -474,13 +474,13 @@ func deleteSubnets(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 	allPages, err := subnets.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allSubnets, err := subnets.ExtractSubnets(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	for _, subnet := range allSubnets {
@@ -505,7 +505,7 @@ func deleteNetworks(opts *clientconfig.ClientOpts, filter Filter, logger logrus.
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	tags := filterTags(filter)
@@ -515,13 +515,13 @@ func deleteNetworks(opts *clientconfig.ClientOpts, filter Filter, logger logrus.
 
 	allPages, err := networks.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allNetworks, err := networks.ExtractNetworks(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	for _, network := range allNetworks {
@@ -551,7 +551,7 @@ func deleteContainers(opts *clientconfig.ClientOpts, filter Filter, logger logru
 			logger.Debug("Skip container deletion because Swift endpoint is not found")
 			return true, nil
 		}
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	listOpts := containers.ListOpts{Full: false}
@@ -563,19 +563,19 @@ func deleteContainers(opts *clientconfig.ClientOpts, filter Filter, logger logru
 			logger.Debug("Skip container deletion because the user doesn't have the `swiftoperator` role")
 			return true, nil
 		}
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allContainers, err := containers.ExtractNames(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	for _, container := range allContainers {
 		metadata, err := containers.Get(conn, container, nil).ExtractMetadata()
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 			return false, nil
 		}
 		for key, val := range filter {
@@ -586,12 +586,12 @@ func deleteContainers(opts *clientconfig.ClientOpts, filter Filter, logger logru
 				listOpts := objects.ListOpts{Full: false}
 				allPages, err := objects.List(conn, container, listOpts).AllPages()
 				if err != nil {
-					logger.Errorf("%v", err)
+					logger.Error(err)
 					return false, nil
 				}
 				allObjects, err := objects.ExtractNames(allPages)
 				if err != nil {
-					logger.Errorf("%v", err)
+					logger.Error(err)
 					return false, nil
 				}
 				for _, object := range allObjects {
@@ -630,7 +630,7 @@ func deleteTrunks(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fi
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
@@ -640,13 +640,13 @@ func deleteTrunks(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fi
 	}
 	allPages, err := trunks.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allTrunks, err := trunks.ExtractTrunks(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	for _, trunk := range allTrunks {
@@ -676,7 +676,7 @@ func deleteLoadBalancers(opts *clientconfig.ClientOpts, filter Filter, logger lo
 			logger.Debug("Skip load balancer deletion because Octavia endpoint is not found")
 			return true, nil
 		}
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
@@ -708,13 +708,13 @@ func deleteLoadBalancers(opts *clientconfig.ClientOpts, filter Filter, logger lo
 		}
 		allPages, err := loadbalancers.List(conn, listOpts).AllPages()
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 			return false, nil
 		}
 
 		allLoadBalancers, err = loadbalancers.ExtractLoadBalancers(allPages)
 		if err != nil {
-			logger.Errorf("%v", err)
+			logger.Error(err)
 			return false, nil
 		}
 	}
@@ -725,13 +725,13 @@ func deleteLoadBalancers(opts *clientconfig.ClientOpts, filter Filter, logger lo
 
 	allPages, err := loadbalancers.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allLoadBalancersWithTaggedDescription, err := loadbalancers.ExtractLoadBalancers(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
@@ -762,7 +762,7 @@ func deleteSubnetPools(opts *clientconfig.ClientOpts, filter Filter, logger logr
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	tags := filterTags(filter)
@@ -772,13 +772,13 @@ func deleteSubnetPools(opts *clientconfig.ClientOpts, filter Filter, logger logr
 
 	allPages, err := subnetpools.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allSubnetPools, err := subnetpools.ExtractSubnetPools(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	for _, subnetPool := range allSubnetPools {
@@ -811,7 +811,7 @@ func deleteVolumes(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 	conn, err := clientconfig.NewServiceClient("volume", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
@@ -819,13 +819,13 @@ func deleteVolumes(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 
 	allPages, err := volumes.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allVolumes, err := volumes.ExtractVolumes(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
@@ -862,7 +862,7 @@ func deleteFloatingIPs(opts *clientconfig.ClientOpts, filter Filter, logger logr
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	tags := filterTags(filter)
@@ -872,13 +872,13 @@ func deleteFloatingIPs(opts *clientconfig.ClientOpts, filter Filter, logger logr
 
 	allPages, err := floatingips.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allFloatingIPs, err := floatingips.ExtractFloatingIPs(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 	for _, floatingIP := range allFloatingIPs {
@@ -902,7 +902,7 @@ func deleteImages(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fi
 
 	conn, err := clientconfig.NewServiceClient("image", opts)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
@@ -912,13 +912,13 @@ func deleteImages(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fi
 
 	allPages, err := images.List(conn, listOpts).AllPages()
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 
 	allImages, err := images.ExtractImages(allPages)
 	if err != nil {
-		logger.Errorf("%v", err)
+		logger.Error(err)
 		return false, nil
 	}
 


### PR DESCRIPTION
There's no need to use Errorf when there is nothing to format. In this
case, let's use logger.Error() instead.