### PR TITLE
Remove storage of etcdctl when it fails

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -370,6 +370,7 @@ until bootkube_podman_run \
 		--endpoints="${ETCD_ENDPOINTS}" \
 		endpoint health
 do
+	podman rm --storage etcdctl || true
 	echo "etcdctl failed. Retrying in 5 seconds..."
 	sleep 5
 done


### PR DESCRIPTION
Some times the etcdctl pod is started and dies at the same
moment. A manual debug showed that the problem is that
the storage of the pod seems to be already in use:
Error: error creating container storage: the container
name "etcdctl" is already in use

Even if the pod does not exist. Adding a storage removal
command on every iteration is solving the problem.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>