### PR TITLE
Bug 1809691: baremetal: block 547/udp for DHCPv6 as well

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -103,7 +103,7 @@ done
 {{if .PlatformData.BareMetal.ProvisioningDHCPAllowList}}
 $IPTABLES -t raw -N DHCP
 $IPTABLES -t raw -A PREROUTING -p udp --dport 67 -j DHCP
-$IPTABLES -t raw -A PREROUTING -p udp --dport 546 -j DHCP
+$IPTABLES -t raw -A PREROUTING -p udp --dport 547 -j DHCP
 
 for mac in {{.PlatformData.BareMetal.ProvisioningDHCPAllowList}}
 do


### PR DESCRIPTION
When I was looking into which ports to block for DHCPv6, I misunderstood
the following:

        DHCPv6 uses UDP port number 546 for clients and port number 547 for servers.

RFC8415 says:

        Clients listen for DHCP messages on UDP port 546.  Servers and relay
        agents listen for DHCP messages on UDP port 547.

We need to add 547/udp to block any incoming requests.

4.4 BZ 1809695