### PR TITLE
images: Add ssh support to UPI container

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -15,6 +15,7 @@ COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
 COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json /var/lib/openshift-install/rhcos.json
+COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-nss.sh /bin/mock-nss.sh
 
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
 RUN sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" >/etc/yum.repos.d/azure-cli.repo'
@@ -23,6 +24,8 @@ RUN yum install --setopt=tsflags=nodocs -y \
     gettext \
     openssh-clients \
     azure-cli \
+    nss_wrapper \
+    openssh-clients \
     openssl && \
     yum update -y && \
     yum install --setopt=tsflags=nodocs -y \


### PR DESCRIPTION
This is to avoid nasty nss hacks in CI. cc @andfasano 