### PR TITLE
aws: update the IAM role policy to remove hard coded partition ID

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -2,6 +2,8 @@ locals {
   public_endpoints = var.publish_strategy == "External" ? true : false
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_s3_bucket" "ignition" {
   acl = "private"
 
@@ -60,7 +62,7 @@ resource "aws_iam_role" "bootstrap" {
         {
             "Action": "sts:AssumeRole",
             "Principal": {
-                "Service": "ec2.amazonaws.com"
+                "Service": "ec2.${data.aws_partition.current.dns_suffix}"
             },
             "Effect": "Allow",
             "Sid": ""
@@ -104,7 +106,7 @@ resource "aws_iam_role_policy" "bootstrap" {
       "Action" : [
         "s3:GetObject"
       ],
-      "Resource": "arn:aws:s3:::*",
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::*",
       "Effect": "Allow"
     }
   ]

--- a/data/data/aws/iam/main.tf
+++ b/data/data/aws/iam/main.tf
@@ -2,6 +2,8 @@ locals {
   arn = "aws"
 }
 
+data "aws_partition" "current" {}
+
 resource "aws_iam_instance_profile" "worker" {
   name = "${var.cluster_id}-worker-profile"
 
@@ -19,7 +21,7 @@ resource "aws_iam_role" "worker_role" {
         {
             "Action": "sts:AssumeRole",
             "Principal": {
-                "Service": "ec2.amazonaws.com"
+                "Service": "ec2.${data.aws_partition.current.dns_suffix}"
             },
             "Effect": "Allow",
             "Sid": ""

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -1,10 +1,10 @@
 locals {
-  arn = "aws"
-
   // Because of the issue https://github.com/hashicorp/terraform/issues/12570, the consumers cannot use a dynamic list for count
   // and therefore are force to implicitly assume that the list is of aws_lb_target_group_arns_length - 1, in case there is no api_external
   target_group_arns_length = var.publish_strategy == "External" ? var.target_group_arns_length : var.target_group_arns_length - 1
 }
+
+data "aws_partition" "current" {}
 
 resource "aws_iam_instance_profile" "master" {
   name = "${var.cluster_id}-master-profile"
@@ -23,7 +23,7 @@ resource "aws_iam_role" "master_role" {
         {
             "Action": "sts:AssumeRole",
             "Principal": {
-                "Service": "ec2.amazonaws.com"
+                "Service": "ec2.${data.aws_partition.current.dns_suffix}"
             },
             "Effect": "Allow",
             "Sid": ""
@@ -62,7 +62,7 @@ resource "aws_iam_role_policy" "master_policy" {
       "Action" : [
         "s3:GetObject"
       ],
-      "Resource": "arn:${local.arn}:s3:::*",
+      "Resource": "arn:${data.aws_partition.current.partition}:s3:::*",
       "Effect": "Allow"
     },
     {


### PR DESCRIPTION
This change queries the default partition from aws and uses it when
deploying IAM role policies. This will enable provisioning of clusters
in partitions other than aws, which was previously hard coded.