### PR TITLE
libvirt: Provide alternate base pool dir capability

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -5,7 +5,7 @@ provider "libvirt" {
 resource "libvirt_pool" "storage_pool" {
   name = var.cluster_id
   type = "dir"
-  path = "/var/lib/libvirt/openshift-images/${var.cluster_id}"
+  path = "${var.libvirt_base_pooldir}/openshift-images/${var.cluster_id}"
 }
 
 module "volume" {

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -44,3 +44,9 @@ variable "libvirt_master_vcpu" {
   default     = "4"
 }
 
+# Base directory location for libvirt image storage
+variable "libvirt_base_pooldir" {
+  type        = string
+  description = "Base libvirt pool storage directory"
+  default     = "/var/lib/libvirt"
+}

--- a/docs/dev/libvirt/README.md
+++ b/docs/dev/libvirt/README.md
@@ -208,6 +208,12 @@ TAGS=libvirt hack/build.sh
 
 With [libvirt configured](#install-and-enable-libvirt), you can proceed with [the usual quick-start](../../../README.md#quick-start).
 
+Note that by default, the base image storage location is set to `/var/lib/libvirt`. If a different base image storage location is desired, for example, a directory on a separate filesystem mount utilizing the same or separate storage drive with additional capacity or providing increased performance, export the following variable defining the base storage directory location to utilize, _prior_ to executing any `openshift-install` commands:
+
+```sh
+export TF_VAR_libvirt_base_pooldir="/some/other/directory"
+```
+
 ## Cleanup
 
 To remove resources associated with your cluster, run:


### PR DESCRIPTION
This change provides the means to utilize a TF_VAR variable
'TF_VAR_libvirt_base_pooldir' to specify an alternate base pool
directory storage location during libvirt-based deployments.