### PR TITLE
Aws china support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/openshift-metal3/terraform-provider-ironic v0.1.9
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
-	github.com/openshift/cloud-credential-operator v0.0.0-20200206164830-e1ee12c64bec
+	github.com/openshift/cloud-credential-operator v0.0.0-20200302171258-9869473932ff
 	github.com/openshift/cluster-api v0.0.0-20191129101638-b09907ac6668
 	github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200120152131-1b09fd9e7156
 	github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603

--- a/go.sum
+++ b/go.sum
@@ -1760,8 +1760,8 @@ github.com/openshift/client-go v0.0.0-20191001081553-3b0e988f8cb0 h1:U0rtkdPj1lT
 github.com/openshift/client-go v0.0.0-20191001081553-3b0e988f8cb0/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240/go.mod h1:4riOwdj99Hd/q+iAcJZfNCsQQQMwURnZV6RL4WHYS5w=
-github.com/openshift/cloud-credential-operator v0.0.0-20200206164830-e1ee12c64bec h1:vG6PH8t/ZTNZmcBo+/M9ug1Ztt34pUHuaZn2wUsIQIs=
-github.com/openshift/cloud-credential-operator v0.0.0-20200206164830-e1ee12c64bec/go.mod h1:iPn+uhIe7nkP5BMHe2QnbLtg5m/AIQ1xvz9s3cig5ss=
+github.com/openshift/cloud-credential-operator v0.0.0-20200302171258-9869473932ff h1:GatcScjE3ikuFeGhnZGGB5tuQ25sH//FgcncZqDPSHU=
+github.com/openshift/cloud-credential-operator v0.0.0-20200302171258-9869473932ff/go.mod h1:iPn+uhIe7nkP5BMHe2QnbLtg5m/AIQ1xvz9s3cig5ss=
 github.com/openshift/cluster-api v0.0.0-20190805113604-f8de78af80fc/go.mod h1:mNsD1dsD4T57kV4/C6zTHke/Ro166xgnyyRZqkamiEU=
 github.com/openshift/cluster-api v0.0.0-20190923092624-4024de4fa64d/go.mod h1:mNsD1dsD4T57kV4/C6zTHke/Ro166xgnyyRZqkamiEU=
 github.com/openshift/cluster-api v0.0.0-20191030113141-9a3a7bbe9258/go.mod h1:T18COkr6nLh9RyZKPMP7YjnwBME7RX8P2ar1SQbBltM=
@@ -2681,8 +2681,6 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.1 h1:wdKvqQk7IttEw92GoRyKG2IDrUIpgpj6H6m81yfeMW0=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
-gopkg.in/AlecAivazis/survey.v1 v1.8.8 h1:5UtTowJZTz1j7NxVzDGKTz6Lm9IWm8DDF6b7a2wq9VY=
-gopkg.in/AlecAivazis/survey.v1 v1.8.8/go.mod h1:CaHjv79TCgAvXMSFJSVgonHXYWxnhzI3eoHtnX5UgUo=
 gopkg.in/AlecAivazis/survey.v1 v1.8.9-0.20200217094205-6773bdf39b7f h1:AQkMzsSzHWrgZWqGRpuRaRPDmyNibcXlpGcnQJ7HxZw=
 gopkg.in/AlecAivazis/survey.v1 v1.8.9-0.20200217094205-6773bdf39b7f/go.mod h1:CaHjv79TCgAvXMSFJSVgonHXYWxnhzI3eoHtnX5UgUo=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=

--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -236,7 +236,7 @@ func ValidateCreds(ssn *session.Session, groups []PermissionGroup, region string
 		return errors.Wrap(err, "getting creds from session")
 	}
 
-	client, err := ccaws.NewClient([]byte(creds.AccessKeyID), []byte(creds.SecretAccessKey), fmt.Sprintf("OpenShift/4.x Installer/%s", version.Raw))
+	client, err := ccaws.NewClient([]byte(creds.AccessKeyID), []byte(creds.SecretAccessKey), region, fmt.Sprintf("OpenShift/4.x Installer/%s", version.Raw))
 	if err != nil {
 		return errors.Wrap(err, "initialize cloud-credentials client")
 	}

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -81,7 +81,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 	switch installConfig.Config.Platform.Name() {
 	case awstypes.Name:
 		if installConfig.Config.Publish == types.ExternalPublishingStrategy {
-			zone, err := icaws.GetPublicZone(installConfig.Config.BaseDomain)
+			zone, err := icaws.GetPublicZone(installConfig.Config.BaseDomain, installConfig.AWS.Region)
 			if err != nil {
 				return errors.Wrapf(err, "getting public zone for %q", installConfig.Config.BaseDomain)
 			}

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -54,7 +54,10 @@ var (
 func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if _, ok := Regions[p.Region]; !ok {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("region"), p.Region, validRegionValues))
+		// TODO remove this when AWS China regions are officially supported
+		if p.Region != "cn-north-1" && p.Region != "cn-northwest-1" {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("region"), p.Region, validRegionValues))
+		}
 	}
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)

--- a/vendor/github.com/openshift/cloud-credential-operator/pkg/aws/client.go
+++ b/vendor/github.com/openshift/cloud-credential-operator/pkg/aws/client.go
@@ -102,8 +102,12 @@ func (c *awsClient) TagUser(input *iam.TagUserInput) (*iam.TagUserOutput, error)
 }
 
 // NewClient creates our client wrapper object for the actual AWS clients we use.
-func NewClient(accessKeyID, secretAccessKey []byte, infraName string) (Client, error) {
+func NewClient(accessKeyID, secretAccessKey []byte, region, infraName string) (Client, error) {
 	awsConfig := &awssdk.Config{}
+
+	if region != "" {
+		awsConfig.Region = &region
+	}
 
 	awsConfig.Credentials = credentials.NewStaticCredentials(
 		string(accessKeyID), string(secretAccessKey), "")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1002,7 +1002,7 @@ github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
 github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
-# github.com/openshift/cloud-credential-operator v0.0.0-20200206164830-e1ee12c64bec
+# github.com/openshift/cloud-credential-operator v0.0.0-20200302171258-9869473932ff
 github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1
 github.com/openshift/cloud-credential-operator/pkg/aws
 github.com/openshift/cloud-credential-operator/version


### PR DESCRIPTION
This add aws china region support, major changes are:
1. Rebased CCO
2. Hard coded route53 api endpoint and set tagging api "region" configuration to "cn-northwest-1"
