### PR TITLE
baremetal: update docs to indicate stable IP's are required

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -24,10 +24,10 @@ purposes:
   * This network is the main network used by the cluster, including API traffic
     and application traffic.
   * ***DHCP***
-    * External DHCP is assumed on this network.  It is **strongly** recommended
-      to set up DHCP reservations for each of the hosts in the cluster to
-      ensure that they retain stable IP addresses. The addresses assigned by
-      DHCP need to be in the same subnet as the Virtual IPs discussed below.
+    * External DHCP is assumed on this network. Hosts *must* have stable
+      IP addresses, therefore you should set up DHCP reservations for
+      each of the hosts in the cluster. The addresses assigned by DHCP
+      need to be in the same subnet as the Virtual IPs discussed below.
     * A pool of dynamic addresses should also be available on this network, as
       the provisioning host and temporary bootstrap VM will also need addresses
       on this network.


### PR DESCRIPTION
The doc currently "strongly reccomends" static DHCP reservations in
machineCIDR. This updates the doc to be explicit that IP's must be
stable.