### PR TITLE
OpenStack: Fail early when boostrap ignition shim is to big

### DIFF
--- a/pkg/tfvars/openstack/bootstrap_ignition.go
+++ b/pkg/tfvars/openstack/bootstrap_ignition.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -136,6 +137,12 @@ func generateIgnitionShim(userCA string, clusterID string, bootstrapConfigURL st
 	data, err := json.Marshal(ign)
 	if err != nil {
 		return "", err
+	}
+
+	// Check the size of the base64-rendered ignition shim isn't to big for nova
+	// https://docs.openstack.org/nova/latest/user/metadata.html#user-data
+	if len(base64.StdEncoding.EncodeToString(data)) > 65535 {
+		return "", fmt.Errorf("rendered bootstrap ignition shim exceeds the 64KB limit for nova user data -- try reducing the size of your CA cert bundle")
 	}
 
 	return string(data), nil


### PR DESCRIPTION
Nova has a hard limit of 64KB [1] for user data when booting VMs. This
was not a problem previously when everything that went into the user
data was under our control and small enough. With the recent addition
of self-signed certificate feature, the ignition size now depends on
the size of the CA cert file the user passes, and it may cause it to
exceed nova limit if the file is too large.

This commit checks the size of the rendered file as it would be passed
to nova user data and fails early with an appropriate message if it
exceeds the 64KB limit.

[1] https://docs.openstack.org/nova/latest/user/metadata.html#user-data

Fixes #3177