### PR TITLE
libvirt: Use OpenStack rhcos image instead of Qemu for s390x and ppc64le

### DIFF
--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -79,7 +79,15 @@ func osImage(config *types.InstallConfig) (string, error) {
 	case gcp.Name:
 		osimage, err = rhcos.GCP(ctx, arch)
 	case libvirt.Name:
-		osimage, err = rhcos.QEMU(ctx, arch)
+		// The qemu image for s390x and ppc64le are useless for now because both arches do not support fw_cfg
+		// Refer: https://github.com/coreos/ignition/issues/825 and https://github.com/coreos/ignition/issues/666
+		// Use the OpenStack image as there is support for config drive on libvirt for both s390x and ppc64le
+		switch arch {
+		case "s390x", "ppc64le":
+			osimage, err = rhcos.OpenStack(ctx, arch)
+		default:
+			osimage, err = rhcos.QEMU(ctx, arch)
+		}
 	case openstack.Name:
 		if oi := config.Platform.OpenStack.ClusterOSImage; oi != "" {
 			osimage = oi


### PR DESCRIPTION
The Qemu image on non x86 architectures (specifically s390x, ppc64le) suffers from a problem
that it does not support fw_cfg which is used to inject ignition config. As of today there is
no alternative to that in Qemu. A while ago config drive support was added to s390x and ppc64le
for the libvirt environment to get around that problem. But currently that fix is usable only with
the OpenStack image. So, with this fix , the OpenStack image is picked automatically for a libvirt
install until we have something similar to fw_cfg for s390x and ppc64le.