### PR TITLE
Add ability to debug terraform

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -63,7 +64,13 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "failed to create temp dir for terraform execution")
 	}
-	defer os.RemoveAll(tmpDir)
+
+	tf_log := strings.ToLower(os.Getenv("TF_LOG"))
+	if tf_log == "debug" || tf_log == "trace" {
+		defer os.Rename(tmpDir, fmt.Sprintf("%s-cluster", tmpDir))
+	} else {
+		defer os.RemoveAll(tmpDir)
+	}
 
 	extraArgs := []string{}
 	for _, file := range terraformVariables.Files() {

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -35,7 +35,13 @@ func Destroy(dir string) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "failed to create temporary directory for Terraform execution")
 	}
-	defer os.RemoveAll(tempDir)
+
+	tf_log := strings.ToLower(os.Getenv("TF_LOG"))
+	if tf_log == "debug" || tf_log == "trace" {
+		defer os.Rename(tempDir, fmt.Sprintf("%s-bootstrap", tempDir))
+	} else {
+		defer os.RemoveAll(tempDir)
+	}
 
 	extraArgs := []string{}
 	for _, filename := range []string{terraform.StateFileName, cluster.TfVarsFileName, tfPlatformVarsFileName} {


### PR DESCRIPTION
It is useful at times to be able to keep the terraform around that is used for
creating the bootstrap and cluster. This code renames the directories to
${ID}-bootstrap and ${ID}-cluster when the environmental variable TF_LOG is set
to "trace" or "debug".