### PR TITLE
bug 1805251: Master azure terraform address prefixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ replace (
 	github.com/metal3-io/cluster-api-provider-baremetal => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d // Pin OpenShift fork
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b // Pin API
 	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530 // Pin MCO so it doesn't get downgraded
-	github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.41.1-openshift-2 // Pin to openshift fork with IPv6 fixes
+	github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.41.1-openshift-3 // Pin to openshift fork with IPv6 fixes
 	google.golang.org/api => google.golang.org/api v0.13.0 // Pin to version required by tf-provider-google
 	k8s.io/api => k8s.io/api v0.17.1 // Replaced by MCO/CRI-O
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.1 // Replaced by MCO/CRI-O

--- a/go.sum
+++ b/go.sum
@@ -1799,8 +1799,8 @@ github.com/openshift/machine-api-operator v0.2.1-0.20200211164549-65f366001347/g
 github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530 h1:r9eSp963LcaLw3YUyJHMHwZYXoaGXOc2MOKVQQrdRmw=
 github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530/go.mod h1:z3udws7UDLBp233iGbayvpZEwhWn74K9xzjDtCGJlok=
 github.com/openshift/runtime-utils v0.0.0-20191011150825-9169de69ebf6/go.mod h1:5gDRVvQwesU7cfwlpuMivdv3Dz/oslvv2qTBHCy4wqQ=
-github.com/openshift/terraform-provider-azurerm v1.41.1-openshift-2 h1:El3ZKTVtyGIxkXPzLNXhuiGb1iP9XEkYkyCmTRShi84=
-github.com/openshift/terraform-provider-azurerm v1.41.1-openshift-2/go.mod h1:O9UYVGp8E7aMa2dANw9oTQmaZZbbr8DMRpC56dyy00E=
+github.com/openshift/terraform-provider-azurerm v1.41.1-openshift-3 h1:aRnSZYFNqYXv8mc3/q6nP1WJP4VR8eugkdmJF6xnCs0=
+github.com/openshift/terraform-provider-azurerm v1.41.1-openshift-3/go.mod h1:O9UYVGp8E7aMa2dANw9oTQmaZZbbr8DMRpC56dyy00E=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/resource_arm_loadbalancer.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/resource_arm_loadbalancer.go
@@ -81,10 +81,9 @@ func resourceArmLoadBalancer() *schema.Resource {
 						},
 
 						"private_ip_address": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validate.IPv4AddressOrEmpty,
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
 						},
 
 						"private_ip_address_version": {

--- a/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/resource_arm_virtual_network.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/services/network/resource_arm_virtual_network.go
@@ -106,9 +106,15 @@ func resourceArmVirtualNetwork() *schema.Resource {
 						},
 
 						"address_prefix": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validate.NoEmptyStrings,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "Use the `address_prefixes` property instead.",
+						},
+
+						"address_prefixes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 
 						"security_group": {
@@ -307,7 +313,36 @@ func expandVirtualNetworkProperties(ctx context.Context, d *schema.ResourceData,
 			}
 			log.Printf("[INFO] Completed GET of Subnet props ")
 
-			prefix := subnet["address_prefix"].(string)
+			var prefixSet int = 0
+			properties := network.SubnetPropertiesFormat{}
+			if value, ok := subnet["address_prefixes"]; ok {
+				var addressPrefixes []string
+				for _, item := range value.([]interface{}) {
+					addressPrefixes = append(addressPrefixes, item.(string))
+				}
+				properties.AddressPrefixes = &addressPrefixes
+				if len(addressPrefixes) > 0 {
+					prefixSet += 1
+				}
+			}
+			if value, ok := subnet["address_prefix"]; ok {
+				addressPrefix := value.(string)
+				properties.AddressPrefix = &addressPrefix
+				if len(addressPrefix) > 0 {
+					prefixSet += 1
+				}
+			}
+			if properties.AddressPrefixes != nil && len(*properties.AddressPrefixes) == 1 {
+				properties.AddressPrefix = &(*properties.AddressPrefixes)[0]
+				properties.AddressPrefixes = nil
+			}
+			if prefixSet == 0 {
+				return nil, fmt.Errorf("[ERROR] either address_prefix or address_prefixes is required")
+			}
+			if prefixSet == 2 {
+				return nil, fmt.Errorf("[ERROR] either address_prefix or address_prefixes must be set, not both")
+			}
+
 			secGroup := subnet["security_group"].(string)
 
 			//set the props from config and leave the rest intact
@@ -316,7 +351,8 @@ func expandVirtualNetworkProperties(ctx context.Context, d *schema.ResourceData,
 				subnetObj.SubnetPropertiesFormat = &network.SubnetPropertiesFormat{}
 			}
 
-			subnetObj.SubnetPropertiesFormat.AddressPrefix = &prefix
+			subnetObj.SubnetPropertiesFormat.AddressPrefixes = properties.AddressPrefixes
+			subnetObj.SubnetPropertiesFormat.AddressPrefix = properties.AddressPrefix
 
 			if secGroup != "" {
 				subnetObj.SubnetPropertiesFormat.NetworkSecurityGroup = &network.SecurityGroup{
@@ -399,6 +435,14 @@ func flattenVirtualNetworkSubnets(input *[]network.Subnet) *schema.Set {
 			}
 
 			if props := subnet.SubnetPropertiesFormat; props != nil {
+				if prefixes := props.AddressPrefixes; prefixes != nil {
+					var addressPrefixes []interface{}
+					for _, prefix := range *prefixes {
+						addressPrefixes = append(addressPrefixes, prefix)
+					}
+					output["address_prefixes"] = addressPrefixes
+				}
+
 				if prefix := props.AddressPrefix; prefix != nil {
 					output["address_prefix"] = *prefix
 				}
@@ -434,8 +478,14 @@ func resourceAzureSubnetHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		buf.WriteString(m["name"].(string))
-		buf.WriteString(m["address_prefix"].(string))
-
+		if v, ok := m["address_prefixes"]; ok {
+			for _, a := range v.([]interface{}) {
+				buf.WriteString(a.(string))
+			}
+		}
+		if v, ok := m["address_prefix"]; ok {
+			buf.WriteString(v.(string))
+		}
 		if v, ok := m["security_group"]; ok {
 			buf.WriteString(v.(string))
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1083,7 +1083,7 @@ github.com/terraform-providers/terraform-provider-aws/aws/internal/service/batch
 github.com/terraform-providers/terraform-provider-aws/aws/internal/service/eks/token
 # github.com/terraform-providers/terraform-provider-azuread v0.7.0
 github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/tf
-# github.com/terraform-providers/terraform-provider-azurerm v0.0.0 => github.com/openshift/terraform-provider-azurerm v1.41.1-openshift-2
+# github.com/terraform-providers/terraform-provider-azurerm v0.0.0 => github.com/openshift/terraform-provider-azurerm v1.41.1-openshift-3
 github.com/terraform-providers/terraform-provider-azurerm/azurerm
 github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure
 github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/kubernetes


### PR DESCRIPTION
When a subnet uses address_prefixes, address_prefix is null in the virtual network resource. Add address_prefixes to virtual network resource and allow null for address_prefix. Don't assume IPv4 for private_ip_address on load balancer resource.

https://bugzilla.redhat.com/show_bug.cgi?id=1808973