### PR TITLE
gather: ensure gather data is all in one directory

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -134,5 +134,5 @@ do
   scp -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -r -q "core@[${master}]:/tmp/artifacts-${GATHER_ID}/*" "${ARTIFACTS}/control-plane/${master}/"
 done
 TAR_FILE="${TAR_FILE:-${HOME}/log-bundle-${GATHER_ID}.tar.gz}"
-tar cz -C "${ARTIFACTS}" . >"${TAR_FILE}"
+tar cz -C "${ARTIFACTS}" --transform "s?^\\.?log-bundle-${GATHER_ID}?" . > "${TAR_FILE}"
 echo "Log bundle written to ${TAR_FILE}"


### PR DESCRIPTION
Today if you extract a bootstrap gather tarball, you end up with all the
files dumped into the current working directory. Ideally these should
all be encapsulated in their own directory so as not to make a mess.

Before:

```
$ tar -xzvf ../log-bundle-20200305162726.tar.gz
./
./failed-units.txt
./unit-status/
./unit-status/NetworkManager-wait-online.service.txt
[...]
```

After:

```
$ tar -xzvf log-bundle-20200305162329.tar.gz
log-bundle-20200305162329/
log-bundle-20200305162329/failed-units.txt
log-bundle-20200305162329/unit-status/
log-bundle-20200305162329/unit-status/NetworkManager-wait-online.service.txt
[...]
```

I'm not sure if this breaks any automation anywhere that relies on this structure, but it's really bad form to pollute the cwd like this when extracting a tarball.
