### PR TITLE
data: Tune all cloud load balancers to have consistent intervals

### DIFF
--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -121,8 +121,8 @@ resource "azurerm_lb_rule" "internal_lb_rule_sint_v6" {
 resource "azurerm_lb_probe" "internal_lb_probe_sint" {
   name                = "sint-probe"
   resource_group_name = var.resource_group_name
-  interval_in_seconds = 10
-  number_of_probes    = 3
+  interval_in_seconds = 5
+  number_of_probes    = 2
   loadbalancer_id     = azurerm_lb.internal.id
   port                = 22623
   protocol            = "TCP"
@@ -131,8 +131,8 @@ resource "azurerm_lb_probe" "internal_lb_probe_sint" {
 resource "azurerm_lb_probe" "internal_lb_probe_api_internal" {
   name                = "api-internal-probe"
   resource_group_name = var.resource_group_name
-  interval_in_seconds = 10
-  number_of_probes    = 3
+  interval_in_seconds = 5
+  number_of_probes    = 2
   loadbalancer_id     = azurerm_lb.internal.id
   port                = 6443
   protocol            = "TCP"

--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -157,8 +157,8 @@ resource "azurerm_lb_probe" "public_lb_probe_api_internal" {
 
   name                = "api-internal-probe"
   resource_group_name = var.resource_group_name
-  interval_in_seconds = 10
-  number_of_probes    = 3
+  interval_in_seconds = 5
+  number_of_probes    = 2
   loadbalancer_id     = azurerm_lb.public.id
   port                = 6443
   protocol            = "TCP"

--- a/data/data/gcp/network/lb-private.tf
+++ b/data/data/gcp/network/lb-private.tf
@@ -7,6 +7,11 @@ resource "google_compute_address" "cluster_ip" {
 resource "google_compute_health_check" "api_internal" {
   name = "${var.cluster_id}-api-internal"
 
+  healthy_threshold   = 3
+  unhealthy_threshold = 3
+  check_interval_sec  = 2
+  timeout_sec         = 2
+
   https_health_check {
     port         = 6443
     request_path = "/readyz"

--- a/data/data/gcp/network/lb-public.tf
+++ b/data/data/gcp/network/lb-public.tf
@@ -9,6 +9,11 @@ resource "google_compute_http_health_check" "api" {
 
   name = "${var.cluster_id}-api"
 
+  healthy_threshold   = 3
+  unhealthy_threshold = 3
+  check_interval_sec  = 2
+  timeout_sec         = 2
+
   port         = 6080
   request_path = "/readyz"
 }


### PR DESCRIPTION
In general we want shorter health check intervals to detect apiserver
failures faster. The current defaults are on the long side, and we
have already standardized ingress to use the minimum intervals possible.

Azure and AWS can be tuned to 5s intervals, so make them consistent.
GCP is more efficient and can be tuned to 1s, but that may increase
idle load on the API servers, so set the default to 2s with 3 checks
to keep it closer to Azure and AWS.

This is consistent with the direction we are moving for general platform
recommendations.