### PR TITLE
WIP: Bug 1810916: Hard anti-affinity in openstack UPI

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -704,7 +704,7 @@ $ ansible-playbook -i inventory.yaml 04_control-plane.yaml
 
 Our control plane will consist of three nodes. The servers will be passed the `master-?-ignition.json` files prepared earlier.
 
-The playbook places the Control Plane in a Server Group with "soft anti-affinity" policy.
+The playbook places the Control Plane in a Server Group with anti-affinity policy.
 
 The master nodes should load the initial Ignition and then keep waiting until the bootstrap node stands up the Machine Config Server which will provide the rest of the configuration.
 

--- a/upi/openstack/04_control-plane.yaml
+++ b/upi/openstack/04_control-plane.yaml
@@ -41,7 +41,7 @@
     os_server_group:
       name: "{{ os_cp_server_group_name }}"
       policies:
-      - "soft-anti-affinity"
+      - "anti-affinity"
     register: "cp_group"
 
   - name: 'Create the Control Plane servers'


### PR DESCRIPTION
soft-anti-affinity is not supported in the Ansible versions currently
supported by Red Hat.