### PR TITLE
Bug 1810916: openstack UPI: Adapt the script to older Ansible

### DIFF
--- a/upi/openstack/04_control-plane.yaml
+++ b/upi/openstack/04_control-plane.yaml
@@ -37,12 +37,36 @@
     with_indexed_items: "{{ ports.results }}"
     when: os_networking_type == "Kuryr"
 
+  - name: 'Get a token for creating the server group'
+    os_auth:
+    register: cloud
+
+  # If microversion 2.15 is not available, replace with:
+  # - name: 'Create the Control Plane server group'
+  #   uri:
+  #     method: POST
+  #     headers:
+  #       X-Auth-Token: "{{ cloud.ansible_facts.auth_token }}"
+  #       X-OpenStack-Nova-API-Version: '2.64'
+  #     url: "{{ cloud.ansible_facts.service_catalog | selectattr('name', 'match', 'nova') | first | json_query('endpoints') | selectattr('interface', 'match', 'public') | first | json_query('url') }}/os-server-groups"
+  #     body_format: json
+  #     body:
+  #       server_group:
+  #         name: "{{ os_cp_server_group_name }}"
+  #         policy: "soft-anti-affinity"
   - name: 'Create the Control Plane server group'
-    os_server_group:
-      name: "{{ os_cp_server_group_name }}"
-      policies:
-      - "soft-anti-affinity"
-    register: "cp_group"
+    uri:
+      method: POST
+      headers:
+        X-Auth-Token: "{{ cloud.ansible_facts.auth_token }}"
+        X-OpenStack-Nova-API-Version: '2.15'
+      url: "{{ cloud.ansible_facts.service_catalog | selectattr('name', 'match', 'nova') | first | json_query('endpoints') | selectattr('interface', 'match', 'public') | first | json_query('url') }}/os-server-groups"
+      body_format: json
+      body:
+        server_group:
+          name: "{{ os_cp_server_group_name }}"
+          policies:
+          - soft-anti-affinity
 
   - name: 'Create the Control Plane servers'
     os_server:


### PR DESCRIPTION
The Ansible version that ships with RHEL does not have knowledge of Nova
microversions from 2.15; they will block the 'soft-anti-affinity'
policy.

This change replaces the use of the os_server_group module with a raw
HTTP call to the Nova API, in order to specify microversion 2.15, the
first compatible with soft-anti-affinity.