### PR TITLE
Update error message when gather bootstrap fails from create cluster.

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -103,7 +103,7 @@ var (
 						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
 					}
 					if err2 := runGatherBootstrapCmd(rootOpts.dir); err2 != nil {
-						logrus.Error("Attempted to gather debug logs after installation failure: ", err2)
+						logrus.Error("Attempted to gather debug logs after installation failure by running openshift-install gather bootstrap:", err2)
 					}
 					logrus.Fatal("Bootstrap failed to complete: ", err)
 				}

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -124,7 +124,7 @@ func logGatherBootstrap(bootstrap string, port int, masters []string, directory 
 	logrus.Info("Pulling debug logs from the bootstrap machine")
 	client, err := ssh.NewClient("core", net.JoinHostPort(bootstrap, strconv.Itoa(port)), gatherBootstrapOpts.sshKeys)
 	if err != nil && strings.Contains(err.Error(), "ssh: handshake failed: ssh: unable to authenticate") {
-		return errors.Wrap(err, "failed to create SSH client, ensure the private key is added to your authentication agent (ssh-agent) or specified with the --key parameter")
+		return errors.Wrap(err, "failed to create SSH session, ensure the private key is added to your authentication agent (ssh-agent) or specified with the --key parameter")
 	} else if err != nil {
 		return errors.Wrap(err, "failed to create SSH client")
 	}


### PR DESCRIPTION
The gather bootstrap error message specifies to use the --key command to specify a key. When that error message is shown after running create cluster, users may think the --key flag is available in the create cluster command.

Resolves: #3188

Error messages are hard... so suggestions are definitely encouraged.