### PR TITLE
Bug 1794313: Some cluster operators fail to come up because RHV CA is not trusted by a pod

### DIFF
--- a/data/data/manifests/openshift/cloud-creds-secret.yaml.template
+++ b/data/data/manifests/openshift/cloud-creds-secret.yaml.template
@@ -41,4 +41,5 @@ data:
   ovirt_password: {{.CloudCreds.Ovirt.Base64encodePassword}}
   ovirt_cafile: {{.CloudCreds.Ovirt.Base64encodeCAFile}}
   ovirt_insecure: {{.CloudCreds.Ovirt.Base64encodeInsecure}}
+  ovirt_ca_bundle: {{.CloudCreds.Ovirt.Base64encodeCABundle}}
 {{- end}}

--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Password string `yaml:"ovirt_password"`
 	CAFile   string `yaml:"ovirt_cafile,omitempty"`
 	Insecure bool   `yaml:"ovirt_insecure,omitempty"`
+	CABundle string `yaml:"ovirt_ca_bundle,omitempty"`
 }
 
 // LoadOvirtConfig from the following location (first wins):

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -175,6 +175,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 				Base64encodePassword: base64.StdEncoding.EncodeToString([]byte(conf.Password)),
 				Base64encodeCAFile:   base64.StdEncoding.EncodeToString([]byte(conf.CAFile)),
 				Base64encodeInsecure: base64.StdEncoding.EncodeToString([]byte(strconv.FormatBool(conf.Insecure))),
+				Base64encodeCABundle: base64.StdEncoding.EncodeToString([]byte(conf.CABundle)),
 			},
 		}
 	}

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -44,6 +44,7 @@ type OvirtCredsSecretData struct {
 	Base64encodePassword string
 	Base64encodeCAFile   string
 	Base64encodeInsecure string
+	Base64encodeCABundle string
 }
 
 type cloudCredsSecretData struct {


### PR DESCRIPTION
Some components of the cluster are interacting with oVirt API but don't
have way to verify it's certificate.

To support that the installer will ask for the CA bundle, and it
will be kept inside ovirt-credentials secret.

Once in ovirt-credentials secret it should be mounted into a container's
/etc/ssl/certs path. This way every https client will have the CA cert in
the trusted pool.

Related: https://github.com/openshift/cloud-credential-operator/pull/164