### PR TITLE
[Release 4.3] Bug 1811154: validation: Allow periods in gcp and azure cluster names.

### DIFF
--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -4,7 +4,6 @@ import (
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/asset"
-	gcpvalidation "github.com/openshift/installer/pkg/types/gcp/validation"
 	"github.com/openshift/installer/pkg/types/validation"
 	"github.com/openshift/installer/pkg/validate"
 )
@@ -32,8 +31,11 @@ func (a *clusterName) Generate(parents asset.Parents) error {
 	validator := survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 		return validate.DomainName(validation.ClusterDomain(bd.BaseDomain, ans.(string)), false)
 	})
+
 	if platform.GCP != nil {
-		validator = survey.ComposeValidators(validator, func(ans interface{}) error { return gcpvalidation.ValidateClusterName(ans.(string)) })
+		validator = survey.ComposeValidators(validator, func(ans interface{}) error {
+			return validate.ClusterName1035(ans.(string))
+		})
 	}
 
 	return survey.Ask([]*survey.Question{

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -1,10 +1,8 @@
 package validation
 
 import (
-	"regexp"
 	"sort"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/gcp"
@@ -71,15 +69,4 @@ func ValidatePlatform(p *gcp.Platform, fldPath *field.Path) field.ErrorList {
 	}
 
 	return allErrs
-}
-
-// ValidateClusterName confirms that the provided cluster name matches GCP naming requirements.
-func ValidateClusterName(clusterName string) error {
-	gcpResourceFmt := `(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)`
-
-	re := regexp.MustCompile("^" + gcpResourceFmt + "$")
-	if !re.MatchString(clusterName) {
-		return errors.Errorf("GCP requires cluster name to match regular expression %s", gcpResourceFmt)
-	}
-	return nil
 }

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -63,11 +63,11 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 		}
 	}
 	nameErr := validate.ClusterName(c.ObjectMeta.Name)
+	if c.Platform.GCP != nil {
+		nameErr = validate.ClusterName1035(c.ObjectMeta.Name)
+	}
 	if nameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, nameErr.Error()))
-	}
-	if gcpNameErr := gcpvalidation.ValidateClusterName(c.ObjectMeta.Name); c.Platform.GCP != nil && gcpNameErr != nil {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, gcpNameErr.Error()))
 	}
 	baseDomainErr := validate.DomainName(c.BaseDomain, true)
 	if baseDomainErr != nil {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -736,7 +736,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.ObjectMeta.Name = "1-invalid-cluster"
 				return c
 			}(),
-			expectedError: `^metadata\.name: Invalid value: "1-invalid-cluster": GCP requires cluster name to match regular expression \(\?:\[a-z\]\(\?:\[-a-z0-9\]\{0,61\}\[a-z0-9\]\)\?\)$`,
+			expectedError: `^metadata\.name: Invalid value: "1-invalid-cluster": cluster name must begin with a lower-case letter$`,
 		},
 		{
 			name: "release image source is not canonical",


### PR DESCRIPTION
This is a manual cherry-pick of #3239