### PR TITLE
etcd: remove etcd DNS entries because etcd no longer uses DNS

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -73,8 +73,6 @@ module "dns" {
   base_domain              = var.base_domain
   cluster_domain           = var.cluster_domain
   cluster_id               = var.cluster_id
-  etcd_count               = var.master_count
-  etcd_ip_addresses        = flatten(module.masters.ip_addresses)
   tags                     = local.tags
   vpc_id                   = module.vpc.vpc_id
   publish_strategy         = var.aws_publish_strategy

--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -68,28 +68,4 @@ resource "aws_route53_record" "api_external_internal_zone" {
   }
 }
 
-resource "aws_route53_record" "etcd_a_nodes" {
-  count   = var.etcd_count
-  type    = "A"
-  ttl     = "60"
-  zone_id = aws_route53_zone.int.zone_id
-  name    = "etcd-${count.index}.${var.cluster_domain}"
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibilty in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
-  records = [var.etcd_ip_addresses[count.index]]
-}
-
-resource "aws_route53_record" "etcd_cluster" {
-  type    = "SRV"
-  ttl     = "60"
-  zone_id = aws_route53_zone.int.zone_id
-  name    = "_etcd-server-ssl._tcp"
-  records = formatlist("0 10 2380 %s", aws_route53_record.etcd_a_nodes.*.fqdn)
-}
 

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -3,17 +3,6 @@ variable "cluster_domain" {
   type        = string
 }
 
-variable "etcd_count" {
-  description = "The number of etcd members."
-  type        = string
-}
-
-variable "etcd_ip_addresses" {
-  description = "List of string IPs for machines running etcd members."
-  type        = list(string)
-  default     = []
-}
-
 variable "base_domain" {
   description = "The base domain used for public records."
   type        = string

--- a/data/data/azure/dns/variables.tf
+++ b/data/data/azure/dns/variables.tf
@@ -49,23 +49,6 @@ variable "virtual_network_id" {
   type        = string
 }
 
-variable "etcd_count" {
-  description = "The number of etcd members."
-  type        = string
-}
-
-variable "etcd_ip_v4_addresses" {
-  description = "List of string IPs in IPv4 for machines running etcd members."
-  type        = list(string)
-  default     = []
-}
-
-variable "etcd_ip_v6_addresses" {
-  description = "List of string IPs in IPv6 for machines running etcd members."
-  type        = list(string)
-  default     = []
-}
-
 variable "resource_group_name" {
   type        = string
   description = "Resource group for the deployment"

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -105,9 +105,6 @@ module "dns" {
   internal_lb_ipaddress_v6        = module.vnet.internal_lb_ip_v6_address
   resource_group_name             = azurerm_resource_group.main.name
   base_domain_resource_group_name = var.azure_base_domain_resource_group_name
-  etcd_count                      = var.master_count
-  etcd_ip_v4_addresses            = module.master.ip_v4_addresses
-  etcd_ip_v6_addresses            = module.master.ip_v6_addresses
   private                         = module.vnet.private
 
   use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6

--- a/data/data/bootstrap/baremetal/README.md
+++ b/data/data/bootstrap/baremetal/README.md
@@ -22,9 +22,7 @@ internal to the cluster as possible.
 There is a DNS VIP managed by `keepalived` in a manner similar to the API VIP
 discussed above.
 
-`coredns` runs with a custom `mdns` plugin (`coredns-mdns`) that can
-dynamically generate the DNS SRV record for `etcd`, as well as resolve the
-`etcd` hostnames.
+`coredns` runs with a custom `mdns` plugin (`coredns-mdns`).
 
 Relevant files:
 * **[files/etc/dhcp/dhclient.conf](files/etc/dhcp/dhclient.conf)** - Sepcify

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -119,10 +119,7 @@ if [ "$#" -ne 0 ]; then
 elif test -s "${ARTIFACTS}/resources/masters.list"; then
     mapfile -t MASTERS < "${ARTIFACTS}/resources/masters.list"
 else
-    # Find out master IPs from etcd discovery record
-    DOMAIN=$(sudo oc --kubeconfig=/opt/openshift/auth/kubeconfig whoami --show-server | grep -oP "api.\\K([a-z\\.]*)")
-    dig -t SRV "_etcd-server-ssl._tcp.${DOMAIN}" +short | cut -f 4 -d ' ' | sed 's/.$//' >"${ARTIFACTS}/resources/masters.list"
-    mapfile -t MASTERS < "${ARTIFACTS}/resources/masters.list"
+    echo "No masters found!"
 fi
 
 for master in "${MASTERS[@]}"

--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -37,20 +37,3 @@ resource "google_dns_record_set" "api_external_internal_zone" {
   managed_zone = google_dns_managed_zone.int.name
   rrdatas      = [var.api_internal_lb_ip]
 }
-
-resource "google_dns_record_set" "etcd_a_nodes" {
-  count        = var.etcd_count
-  type         = "A"
-  ttl          = "60"
-  managed_zone = google_dns_managed_zone.int.name
-  name         = "etcd-${count.index}.${var.cluster_domain}."
-  rrdatas      = [var.etcd_ip_addresses[count.index]]
-}
-
-resource "google_dns_record_set" "etcd_cluster" {
-  type         = "SRV"
-  ttl          = "60"
-  managed_zone = google_dns_managed_zone.int.name
-  name         = "_etcd-server-ssl._tcp.${var.cluster_domain}."
-  rrdatas      = formatlist("0 10 2380 %s", google_dns_record_set.etcd_a_nodes.*.name)
-}

--- a/data/data/gcp/dns/variables.tf
+++ b/data/data/gcp/dns/variables.tf
@@ -8,17 +8,6 @@ variable "network" {
   type        = string
 }
 
-variable "etcd_count" {
-  description = "The number of etcd members."
-  type        = string
-}
-
-variable "etcd_ip_addresses" {
-  description = "List of string IPs for machines running etcd members."
-  type        = list(string)
-  default     = []
-}
-
 variable "cluster_id" {
   type        = string
   description = "The identifier for the cluster."

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -84,8 +84,6 @@ module "dns" {
   cluster_id           = var.cluster_id
   public_dns_zone_name = var.gcp_public_dns_zone_name
   network              = module.network.network
-  etcd_ip_addresses    = flatten(module.master.ip_addresses)
-  etcd_count           = var.master_count
   cluster_domain       = var.cluster_domain
   api_external_lb_ip   = module.network.cluster_public_ip
   api_internal_lb_ip   = module.network.cluster_ip

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -54,25 +54,12 @@ resource "libvirt_network" "net" {
   dns {
     local_only = true
 
-    dynamic "srvs" {
-      for_each = data.libvirt_network_dns_srv_template.etcd_cluster.*.rendered
-      content {
-        domain   = srvs.value.domain
-        port     = srvs.value.port
-        protocol = srvs.value.protocol
-        service  = srvs.value.service
-        target   = srvs.value.target
-        weight   = srvs.value.weight
-      }
-    }
-
     dynamic "hosts" {
       for_each = concat(
         data.libvirt_network_dns_host_template.bootstrap.*.rendered,
         data.libvirt_network_dns_host_template.bootstrap_int.*.rendered,
         data.libvirt_network_dns_host_template.masters.*.rendered,
         data.libvirt_network_dns_host_template.masters_int.*.rendered,
-        data.libvirt_network_dns_host_template.etcds.*.rendered,
       )
       content {
         hostname = hosts.value.hostname
@@ -136,21 +123,5 @@ data "libvirt_network_dns_host_template" "masters_int" {
   count    = var.master_count
   ip       = var.libvirt_master_ips[count.index]
   hostname = "api-int.${var.cluster_domain}"
-}
-
-data "libvirt_network_dns_host_template" "etcds" {
-  count    = var.master_count
-  ip       = var.libvirt_master_ips[count.index]
-  hostname = "etcd-${count.index}.${var.cluster_domain}"
-}
-
-data "libvirt_network_dns_srv_template" "etcd_cluster" {
-  count    = var.master_count
-  service  = "etcd-server-ssl"
-  protocol = "tcp"
-  domain   = var.cluster_domain
-  port     = 2380
-  weight   = 10
-  target   = "etcd-${count.index}.${var.cluster_domain}"
 }
 


### PR DESCRIPTION
I'm not completely sure where all the DNS bits are, but this is my best starting guess.

Starting in 4.4, etcd does not rely on DNS entries.