### PR TITLE
VSphere: populate bootstrap dhclient.conf if user provides VIPs.

### DIFF
--- a/data/data/bootstrap/vsphere/OWNERS
+++ b/data/data/bootstrap/vsphere/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers

--- a/data/data/bootstrap/vsphere/files/etc/dhcp/dhclient.conf.template
+++ b/data/data/bootstrap/vsphere/files/etc/dhcp/dhclient.conf.template
@@ -1,0 +1,11 @@
+{{if .PlatformData.VSphere.UserProvidedVIPs}}
+
+
+# Specifies that the bootstrap node should use its own local DNS server for
+# name resolution.
+#
+# For more information, see installer/data/data/bootstrap/baremetal/README.md
+#
+
+prepend domain-name-servers 127.0.0.1;
+{{end}}

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap/baremetal"
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap/vsphere"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/machines"
@@ -32,6 +33,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/types"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 )
 
 const (
@@ -59,6 +61,7 @@ type bootstrapTemplateData struct {
 // template files that are specific to one platform.
 type platformTemplateData struct {
 	BareMetal *baremetal.TemplateData
+	VSphere   *vsphere.TemplateData
 }
 
 // Bootstrap is an asset that generates the ignition config for bootstrap nodes.
@@ -232,12 +235,14 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 		registries = append(registries, registry)
 	}
 
-	// Generate platform-specific baremetal data
+	// Generate platform-specific bootstrap data
 	var platformData platformTemplateData
 
 	switch installConfig.Platform.Name() {
 	case baremetaltypes.Name:
 		platformData.BareMetal = baremetal.GetTemplateData(installConfig.Platform.BareMetal)
+	case vspheretypes.Name:
+		platformData.VSphere = vsphere.GetTemplateData(installConfig.Platform.VSphere)
 	}
 
 	return &bootstrapTemplateData{

--- a/pkg/asset/ignition/bootstrap/vsphere/OWNERS
+++ b/pkg/asset/ignition/bootstrap/vsphere/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers

--- a/pkg/asset/ignition/bootstrap/vsphere/template.go
+++ b/pkg/asset/ignition/bootstrap/vsphere/template.go
@@ -1,0 +1,20 @@
+package vsphere
+
+import (
+	"github.com/openshift/installer/pkg/types/vsphere"
+)
+
+// TemplateData holds data specific to templates used for the vsphere platform.
+type TemplateData struct {
+	// UserProvidedIPs specifies whether users provided IP addresses in the install config.
+	UserProvidedVIPs bool
+}
+
+// GetTemplateData returns platform-specific data for bootstrap templates.
+func GetTemplateData(config *vsphere.Platform) *TemplateData {
+	var templateData TemplateData
+
+	templateData.UserProvidedVIPs = config.APIVIP != ""
+
+	return &templateData
+}


### PR DESCRIPTION
This change will set the bootstrap node to use local DNS servers when users provide VIPs in the VSphere install config. Self-hosted DNS is currently a requirement for installer-provisioned clusters, but is not a hard requirement for UPI.

I **assume** that having an empty dhclient.conf is fine in the case of UPI. I did not see a way of conditionally creating the file--only of conditionally changing the contents. I am curious if anyone can suggest an alternative approach.