### PR TITLE
gcp upi: enable internal load balancers

### DIFF
--- a/upi/gcp/01_vpc.py
+++ b/upi/gcp/01_vpc.py
@@ -24,18 +24,6 @@ def GenerateConfig(context):
             'ipCidrRange': context.properties['worker_subnet_cidr']
         }
     }, {
-        'name': context.properties['infra_id'] + '-master-nat-ip',
-        'type': 'compute.v1.address',
-        'properties': {
-            'region': context.properties['region']
-        }
-    }, {
-        'name': context.properties['infra_id'] + '-worker-nat-ip',
-        'type': 'compute.v1.address',
-        'properties': {
-            'region': context.properties['region']
-        }
-    }, {
         'name': context.properties['infra_id'] + '-router',
         'type': 'compute.v1.router',
         'properties': {
@@ -43,8 +31,7 @@ def GenerateConfig(context):
             'network': '$(ref.' + context.properties['infra_id'] + '-network.selfLink)',
             'nats': [{
                 'name': context.properties['infra_id'] + '-nat-master',
-                'natIpAllocateOption': 'MANUAL_ONLY',
-                'natIps': ['$(ref.' + context.properties['infra_id'] + '-master-nat-ip.selfLink)'],
+                'natIpAllocateOption': 'AUTO_ONLY',
                 'minPortsPerVm': 7168,
                 'sourceSubnetworkIpRangesToNat': 'LIST_OF_SUBNETWORKS',
                 'subnetworks': [{
@@ -53,9 +40,8 @@ def GenerateConfig(context):
                 }]
             }, {
                 'name': context.properties['infra_id'] + '-nat-worker',
-                'natIpAllocateOption': 'MANUAL_ONLY',
-                'natIps': ['$(ref.' + context.properties['infra_id'] + '-worker-nat-ip.selfLink)'],
-                'minPortsPerVm': 128,
+                'natIpAllocateOption': 'AUTO_ONLY',
+                'minPortsPerVm': 512,
                 'sourceSubnetworkIpRangesToNat': 'LIST_OF_SUBNETWORKS',
                 'subnetworks': [{
                     'name': '$(ref.' + context.properties['infra_id'] + '-worker-subnet.selfLink)',

--- a/upi/gcp/02_lb_ext.py
+++ b/upi/gcp/02_lb_ext.py
@@ -30,30 +30,6 @@ def GenerateConfig(context):
             'target': '$(ref.' + context.properties['infra_id'] + '-api-target-pool.selfLink)',
             'portRange': '6443'
         }
-    }, {
-        'name': context.properties['infra_id'] + '-ign-http-health-check',
-        'type': 'compute.v1.httpHealthCheck',
-        'properties': {
-            'port': 22624,
-            'requestPath': '/healthz'
-        }
-    }, {
-        'name': context.properties['infra_id'] + '-ign-target-pool',
-        'type': 'compute.v1.targetPool',
-        'properties': {
-            'region': context.properties['region'],
-            'healthChecks': ['$(ref.' + context.properties['infra_id'] + '-ign-http-health-check.selfLink)'],
-            'instances': []
-        }
-    }, {
-        'name': context.properties['infra_id'] + '-ign-forwarding-rule',
-        'type': 'compute.v1.forwardingRule',
-        'properties': {
-            'region': context.properties['region'],
-            'IPAddress': '$(ref.' + context.properties['infra_id'] + '-cluster-public-ip.selfLink)',
-            'target': '$(ref.' + context.properties['infra_id'] + '-ign-target-pool.selfLink)',
-            'portRange': '22623'
-        }
     }]
 
     return {'resources': resources}

--- a/upi/gcp/02_lb_int.py
+++ b/upi/gcp/02_lb_int.py
@@ -1,0 +1,70 @@
+def GenerateConfig(context):
+
+    backends = []
+    for zone in context.properties['zones']:
+        backends.append({
+            'group': '$(ref.' + context.properties['infra_id'] + '-master-' + zone + '-instance-group' + '.selfLink)'
+        })
+
+    resources = [{
+        'name': context.properties['infra_id'] + '-cluster-ip',
+        'type': 'compute.v1.address',
+        'properties': {
+            'addressType': 'INTERNAL',
+            'region': context.properties['region'],
+            'subnetwork': context.properties['control_subnet']
+        }
+    }, {
+        'name': context.properties['infra_id'] + '-api-internal-health-check',
+        'type': 'compute.v1.healthCheck',
+        'properties': {
+            'httpsHealthCheck': {
+                'port': 6443,
+                'requestPath': '/readyz'
+            },
+            'type': "HTTPS"
+        }
+    }, {
+        'name': context.properties['infra_id'] + '-api-internal-backend-service',
+        'type': 'compute.v1.regionBackendService',
+        'properties': {
+            'backends': backends,
+            'healthChecks': ['$(ref.' + context.properties['infra_id'] + '-api-internal-health-check.selfLink)'],
+            'loadBalancingScheme': 'INTERNAL',
+            'region': context.properties['region'],
+            'protocol': 'TCP',
+            'timeoutSec': 120
+        }
+    }, {
+        'name': context.properties['infra_id'] + '-api-internal-forwarding-rule',
+        'type': 'compute.v1.forwardingRule',
+        'properties': {
+            'backendService': '$(ref.' + context.properties['infra_id'] + '-api-internal-backend-service.selfLink)',
+            'IPAddress': '$(ref.' + context.properties['infra_id'] + '-cluster-ip.selfLink)',
+            'loadBalancingScheme': 'INTERNAL',
+            'ports': ['6443','22623'],
+            'region': context.properties['region'],
+            'subnetwork': context.properties['control_subnet']
+        }
+    }]
+
+    for zone in context.properties['zones']:
+        resources.append({
+            'name': context.properties['infra_id'] + '-master-' + zone + '-instance-group',
+            'type': 'compute.v1.instanceGroup',
+            'properties': {
+                'namedPorts': [
+                    {
+                        'name': 'ignition',
+                        'port': 22623
+                    }, {
+                        'name': 'https',
+                        'port': 6443
+                    }
+                ],
+                'network': context.properties['cluster_network'],
+                'zone': zone
+            }
+        })
+
+    return {'resources': resources}

--- a/upi/gcp/03_firewall.py
+++ b/upi/gcp/03_firewall.py
@@ -9,7 +9,7 @@ def GenerateConfig(context):
                 'IPProtocol': 'tcp',
                 'ports': ['22']
             }],
-            'sourceRanges':  ['0.0.0.0/0'],
+            'sourceRanges': [context.properties['allowed_external_cidr']],
             'targetTags': [context.properties['infra_id'] + '-bootstrap']
         }
     }, {
@@ -21,23 +21,7 @@ def GenerateConfig(context):
                 'IPProtocol': 'tcp',
                 'ports': ['6443']
             }],
-            'sourceRanges':  ['0.0.0.0/0'],
-            'targetTags': [context.properties['infra_id'] + '-master']
-        }
-    }, {
-        'name': context.properties['infra_id'] + '-mcs',
-        'type': 'compute.v1.firewall',
-        'properties': {
-            'network': context.properties['cluster_network'],
-            'allowed': [{
-                'IPProtocol': 'tcp',
-                'ports': ['22623']
-            }],
-            'sourceRanges':  [
-                context.properties['network_cidr'],
-                context.properties['master_nat_ip'],
-                context.properties['worker_nat_ip']
-            ],
+            'sourceRanges': [context.properties['allowed_external_cidr']],
             'targetTags': [context.properties['infra_id'] + '-master']
         }
     }, {
@@ -47,7 +31,7 @@ def GenerateConfig(context):
             'network': context.properties['cluster_network'],
             'allowed': [{
                 'IPProtocol': 'tcp',
-                'ports': ['6080', '22624']
+                'ports': ['6080', '6443', '22624']
             }],
             'sourceRanges': ['35.191.0.0/16', '130.211.0.0/22', '209.85.152.0/22', '209.85.204.0/22'],
             'targetTags': [context.properties['infra_id'] + '-master']
@@ -75,6 +59,9 @@ def GenerateConfig(context):
             },{
                 'IPProtocol': 'tcp',
                 'ports': ['10259']
+            },{
+                'IPProtocol': 'tcp',
+                'ports': ['22623']
             }],
             'sourceTags': [
                 context.properties['infra_id'] + '-master',
@@ -93,7 +80,7 @@ def GenerateConfig(context):
                 'IPProtocol': 'tcp',
                 'ports': ['22']
             }],
-            'sourceRanges':  [context.properties['network_cidr']],
+            'sourceRanges': [context.properties['network_cidr']],
             'targetTags': [
                 context.properties['infra_id'] + '-master',
                 context.properties['infra_id'] + '-worker'


### PR DESCRIPTION
This change adds 02_lb_int.py template to the workflow to enable
internal load balancers. The cluster will begin communicating to the api
and mcs through the internal load balancers. The external load balancer
can optionally be disabled for private clusters.

This change also updates the documentation to use the $(command) syntax
to be in line with the other platforms.

In addition, the variable definitions were all moved to immediately
after the associated resources were created. This will help make clear
where their origins are.

Depends on: #2574, openshift/release#7571