### PR TITLE
OpenStack: support "file" scheme for custom os image urls

### DIFF
--- a/docs/dev/openstack/customization.md
+++ b/docs/dev/openstack/customization.md
@@ -13,6 +13,15 @@ export OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE="https://example.com/my-rhcos.qcow2"
 
 **NOTE:** For this to work, the environment variable value must be a valid http(s) URL.
 
+If the user wants to upload the image from the local file system, he can set the environment variable value as `file:///path/to/file`. In this case the installer will take this file and automatically create an image in Glance.
+
+Example:
+
+```sh
+export OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE="file:///home/user/rhcos.qcow2"
+./openshift-install create cluster --dir ostest
+```
+
 If the user wants to reuse an existing Glance image without any uploading of binary data, then it is possible to set `OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE` environment variable that specifies the Glance image name. In this case no new Glance images will be created, and the image will stay when the cluster is destroyed.
 
 Example:
@@ -22,4 +31,4 @@ export OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE="my-rhcos"
 ./openshift-install create cluster --dir ostest
 ```
 
-**NOTE:** The only difference in behavior with the previous example is that the value here is not an http(s) URL.
+**NOTE:** The only difference in behavior with the previous examples is that the value here is not an "http(s)" or "file" URL.

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -23,6 +23,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `octaviaSupport` (optional string): Whether OpenStack supports Octavia (`1` for true or `0` for false)
 * `region` (deprecated string): The OpenStack region where the cluster will be created. Currently this value is not used by the installer.
 * `trunkSupport` (optional string): Whether OpenStack ports can be trunked (`1` for true or `0` for false)
+* `clusterOSimage` (optional string): Either a URL with `http(s)` or `file` scheme to override the default OS image for cluster nodes or an existing Glance image name.
 
 ## Machine pools
 
@@ -107,7 +108,17 @@ platform:
       clusterOSImage: http://mirror.example.com/images/rhcos-43.81.201912131630.0-openstack.x86_64.qcow2.gz?sha256=ffebbd68e8a1f2a245ca19522c16c86f67f9ac8e4e0c1f0a812b068b16f7265d
 ```
 
-If the user wants to reuse an existing Glance image without any uploading of binary data, then it is possible to set `clusterOSImage` install config parameter that specifies the Glance image name. In this case no new Glance images will be created, and the image will stay when the cluster is destroyed. In other words, if `clusterOSImage` is not an http(s) URL, then the installer will look into Glance for an image with that name.
+If the user wants to upload the image from the local file system, he can set `clusterOSImage` as `file:///path/to/file`. In this case the installer will take this file and automatically create an image in Glance.
+
+Example:
+
+```yaml
+platform:
+  openstack:
+      clusterOSImage: file:///home/user/rhcos.qcow2
+```
+
+If the user wants to reuse an existing Glance image without any uploading of binary data, then it is possible to set `clusterOSImage` install config parameter that specifies the Glance image name. In this case no new Glance images will be created, and the image will stay when the cluster is destroyed. In other words, if `clusterOSImage` is not an "http(s)" or "file" URL, then the installer will look into Glance for an image with that name.
 
 Example:
 

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -4,6 +4,8 @@ package openstack
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"path/filepath"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -60,9 +62,25 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 	cfg.BaseImageName = imageName
 	if isURL {
 		// Valid URL -> use baseImage as a URL that will be used to create new Glance image with name "<infraID>-rhcos".
-		localFilePath, err := cache.DownloadImageFile(baseImage)
+		var localFilePath string
+
+		url, err := url.Parse(baseImage)
 		if err != nil {
 			return nil, err
+		}
+
+		// We support 'http(s)' and 'file' schemes. If the scheme is http(s), then we will upload a file from that
+		// location. Otherwise will take local file path from the URL.
+		switch url.Scheme {
+		case "http", "https":
+			localFilePath, err = cache.DownloadImageFile(baseImage)
+			if err != nil {
+				return nil, err
+			}
+		case "file":
+			localFilePath = filepath.FromSlash(url.Path)
+		default:
+			return nil, errors.Errorf("Unsupported URL scheme: '%v'", url.Scheme)
 		}
 
 		err = uploadBaseImage(cloud, localFilePath, imageName, infraID)

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -39,8 +39,8 @@ type Platform struct {
 	// cluster supports Octavia Loadbalancing.
 	OctaviaSupport string `json:"octaviaSupport"`
 
-	// ClusterOSImage is either a URL to override the default OS image
-	// for cluster nodes or an existing Glance image name.
+	// ClusterOSImage is either a URL with `http(s)` or `file` scheme to override
+	// the default OS image for cluster nodes, or an existing Glance image name.
 	// +optional
 	ClusterOSImage string `json:"clusterOSImage,omitempty"`
 }


### PR DESCRIPTION
Now we support http(s) schemes only, but for disconnected installs it's very convenient to specify the local file path to the image file.
    
This commit adds "file" scheme support, so users can set the location as  "file:///path/to/image".