### PR TITLE
Baremetal: Support to send full ignition to masters

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -21,11 +21,13 @@ module "bootstrap" {
 module "masters" {
   source = "./masters"
 
-  master_count   = var.master_count
-  ignition       = var.ignition_master
-  hosts          = var.hosts
-  properties     = var.properties
-  root_devices   = var.root_devices
-  driver_infos   = var.driver_infos
-  instance_infos = var.instance_infos
+  master_count         = var.master_count
+  ignition             = var.ignition_master
+  hosts                = var.hosts
+  properties           = var.properties
+  root_devices         = var.root_devices
+  driver_infos         = var.driver_infos
+  instance_infos       = var.instance_infos
+  ignition_url         = var.ignition_url
+  ignition_url_ca_cert = var.ignition_url_ca_cert
 }

--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -41,7 +41,8 @@ resource "ironic_deployment" "openshift-master-deployment" {
     count.index,
   )
 
-  instance_info = var.instance_infos[count.index]
-  user_data     = var.ignition
+  instance_info         = var.instance_infos[count.index]
+  user_data_url         = var.ignition_url
+  user_data_url_ca_cert = var.ignition_url_ca_cert
 }
 

--- a/data/data/baremetal/masters/variables.tf
+++ b/data/data/baremetal/masters/variables.tf
@@ -33,3 +33,13 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
+
+variable "ignition_url" {
+  type        = string
+  description = "The URL of the full ignition"
+}
+
+variable "ignition_url_ca_cert" {
+  type        = string
+  description = "Root CA cert of the full ignition URL"
+}

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -47,3 +47,13 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
+
+variable "ignition_url" {
+  type        = string
+  description = "The URL of the full ignition"
+}
+
+variable "ignition_url_ca_cert" {
+  type        = string
+  description = "Root CA cert of the full ignition URL"
+}

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/h2non/filetype v1.0.12
 	github.com/hashicorp/go-azure-helpers v0.10.0
 	github.com/hashicorp/go-plugin v1.0.1
-	github.com/hashicorp/go-retryablehttp v0.6.4 // indirect
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.1.5 // indirect
 	github.com/hashicorp/serf v0.8.5 // indirect
@@ -63,7 +62,7 @@ require (
 	github.com/metal3-io/cluster-api-provider-baremetal v0.0.0
 	github.com/mitchellh/cli v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 // indirect
-	github.com/openshift-metal3/terraform-provider-ironic v0.1.9
+	github.com/openshift-metal3/terraform-provider-ironic v0.2.0
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
 	github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e
@@ -107,7 +106,7 @@ require (
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0 // indirect
 	golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413
-	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1760,8 +1760,8 @@ github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pK
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.0/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openshift-metal3/terraform-provider-ironic v0.1.9 h1:8Ylp+ylSX/NtuGel90Ty9Fyg+mq523B2orH1FtC+fG0=
-github.com/openshift-metal3/terraform-provider-ironic v0.1.9/go.mod h1:gYfx1ioglruoE8BpF0h8MVbcAAFu6ruz+bD2X9VC0uU=
+github.com/openshift-metal3/terraform-provider-ironic v0.2.0 h1:MAImxv6UaTtvf2BkPG9YS+EvIqMsXQhNQNDfV7FE2D0=
+github.com/openshift-metal3/terraform-provider-ironic v0.2.0/go.mod h1:G79T6t60oBpYfZK/x960DRzYsNHdz5YVCHINx6QlmtU=
 github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b h1:BERD6sZj7w9Tt0RBpuw87AC0+SppyxEUgUG/Of5rI+E=
 github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/baremetal-operator v0.0.0-20200206190020-71b826cc0f0a h1:65ZuRkPnQGh9uo0z93KosrPlwEWJNxUjxnuM9lyGBHc=
@@ -2350,6 +2350,8 @@ golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f h1:J5lckAjkw6qYlOZNj90mLYNTEKDvWeuc1yieZ8qUzUE=
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190607214518-6fa95d984e88/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -2633,6 +2635,7 @@ golang.org/x/tools v0.0.0-20191204011308-9611592c72f6/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200102140908-9497f49d5709/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868 h1:6VZw2h4iwEB4GwgQU3Jvcsm8l9+yReTrErAEK1k6AC4=
 golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200204192400-7124308813f3 h1:Ms82wn6YK4ZycO6Bxyh0kxX3gFFVGo79CCuc52xgcys=
 golang.org/x/tools v0.0.0-20200204192400-7124308813f3/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200214201135-548b770e2dfa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -22,6 +22,8 @@ type config struct {
 	BootstrapOSImage        string `json:"bootstrap_os_image,omitempty"`
 	ExternalBridge          string `json:"external_bridge,omitempty"`
 	ProvisioningBridge      string `json:"provisioning_bridge,omitempty"`
+	IgnitionURL             string `json:"ignition_url,omitempty"`
+	IgnitionURLCACert       string `json:"ignition_url_ca_cert,omitempty"`
 
 	// Data required for control plane deployment - several maps per host, because of terraform's limitations
 	Hosts         []map[string]interface{} `json:"hosts"`
@@ -32,7 +34,7 @@ type config struct {
 }
 
 // TFVars generates bare metal specific Terraform variables.
-func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridge, provisioningBridge string, platformHosts []*baremetal.Host, image string) ([]byte, error) {
+func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridge, provisioningBridge string, platformHosts []*baremetal.Host, image string, ignitionURL string, ignitionURLCACert string) ([]byte, error) {
 	bootstrapOSImage, err := cache.DownloadImageFile(bootstrapOSImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to use cached bootstrap libvirt image")
@@ -132,6 +134,8 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		DriverInfos:             driverInfos,
 		RootDevices:             rootDevices,
 		InstanceInfos:           instanceInfos,
+		IgnitionURL:             ignitionURL,
+		IgnitionURLCACert:       ignitionURLCACert,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/vendor/golang.org/x/lint/go.mod
+++ b/vendor/golang.org/x/lint/go.mod
@@ -2,4 +2,4 @@ module golang.org/x/lint
 
 go 1.11
 
-require golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f
+require golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7

--- a/vendor/golang.org/x/lint/go.sum
+++ b/vendor/golang.org/x/lint/go.sum
@@ -1,8 +1,12 @@
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f h1:kDxGY2VmgABOe55qheT/TFqUMtcTHnomIPS1iv3G4Ms=
-golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 h1:EBZoQjiKKPaLbPrbpssUfuHtwM6KV/vb4U85g/cigFY=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/vendor/golang.org/x/lint/lint.go
+++ b/vendor/golang.org/x/lint/lint.go
@@ -839,6 +839,7 @@ var commonMethods = map[string]bool{
 	"ServeHTTP": true,
 	"String":    true,
 	"Write":     true,
+	"Unwrap":    true,
 }
 
 // lintFuncDoc examines doc comments on functions and methods.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1001,7 +1001,7 @@ github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/openshift-metal3/terraform-provider-ironic v0.1.9
+# github.com/openshift-metal3/terraform-provider-ironic v0.2.0
 github.com/openshift-metal3/terraform-provider-ironic/ironic
 # github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible => github.com/openshift/api v0.0.0-20200210091934-a0e53e94816b
 github.com/openshift/api/config/v1
@@ -1408,7 +1408,7 @@ golang.org/x/crypto/ssh/terminal
 # golang.org/x/exp v0.0.0-20191129062945-2f5052295587
 golang.org/x/exp/apidiff
 golang.org/x/exp/cmd/apidiff
-# golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+# golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 golang.org/x/lint
 golang.org/x/lint/golint
 # golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee


### PR DESCRIPTION
Today, the installer uses a stub ignition that simply points to the full rendered ignition hosted by the bootstrap. However, the full ignition may contain configuration to configure network interfaces with bonding, vlans, etc.

That means the full ignition would need to be sent to the masters instead of the stub, because the hosts may not have network connectivity until after ignition is run. This PR enables the baremetal platform to optionally send full ignition to masters.

Depends on:
https://github.com/openshift-metal3/terraform-provider-ironic/pull/38
~~https://github.com/metal3-io/baremetal-operator/pull/455~~
https://github.com/openshift/cluster-api-provider-baremetal/pull/65