### PR TITLE
GCP UPI: document how to install into a Shared VPC

### DIFF
--- a/docs/user/gcp/install_upi.md
+++ b/docs/user/gcp/install_upi.md
@@ -24,6 +24,10 @@ Use a [staged install](../overview.md#multiple-invocations) to enable desired cu
 ### Create an install config
 Create an install configuration as for [the usual approach](install.md#create-configuration).
 
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+skip this step and create the `install-config.yaml` manually using the documentation references/examples.
+The installer will not be able to access the public DNS zone in the host project for the base domain prompt.
+
 ```console
 $ openshift-install create install-config
 ? SSH Public Key /home/user_id/.ssh/id_rsa.pub
@@ -47,6 +51,36 @@ data["compute"][0]["replicas"] = 0;
 open(path, "w").write(yaml.dump(data, default_flow_style=False))'
 ```
 
+```console
+compute:
+- architecture: amd64
+  hyperthreading: Enabled
+  name: worker
+  platform: {}
+  replicas: 0
+```
+
+### Enable private cluster setting (optional)
+If you want to provision a private cluster, edit the resulting `install-config.yaml` to set `publish` to `Internal`.
+
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+`publish` must be set to `Internal`.
+The installer will not be able to access the public DNS zone for the the base domain in the host project, which is required for External clusters.
+This can be reversed in a step [below](enable-external-ingress-optional).
+
+```sh
+python -c '
+import yaml;
+path = "install-config.yaml";
+data = yaml.full_load(open(path));
+data["publish"] = "Internal";
+open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+```
+
+```console
+publish: Internal
+```
+
 ### Create manifests
 Create manifest to enable customizations which are not exposed via the install configuration.
 
@@ -63,7 +97,7 @@ We'll be providing those ourselves and don't want to involve [the machine-API op
 rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml
 ```
 
-### Remove compute machinesets (Optional)
+### Remove compute machinesets (optional)
 If you do not want the cluster to provision compute machines, remove the compute machinesets from the manifests as well.
 
 ```sh
@@ -84,9 +118,19 @@ data["spec"]["mastersSchedulable"] = False;
 open(path, "w").write(yaml.dump(data, default_flow_style=False))'
 ```
 
-### Remove DNS Zones (Optional)
+```console
+spec:
+  mastersSchedulable: false
+```
+
+### Remove DNS Zones (optional)
 If you don't want [the ingress operator][ingress-operator] to create DNS records on your behalf, remove the `privateZone` and `publicZone` sections from the DNS configuration.
 If you do so, you'll need to [add ingress DNS records manually](#add-the-ingress-dns-records) later on.
+
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+remove the `privateZone` section from the DNS configuration.
+The `publicZone` will not exist because of `publish: Internal` in `install-config.yaml`.
+Remove the `publicZone` line from the command to avoid an error.
 
 ```sh
 python -c '
@@ -96,6 +140,60 @@ data = yaml.full_load(open(path));
 del data["spec"]["publicZone"];
 del data["spec"]["privateZone"];
 open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+```
+
+```console
+spec:
+  baseDomain: example.com
+```
+
+### Update the cloud-provider manifest ([Shared VPC (XPN)][sharedvpc] only)
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+update the cloud provider configuration so it understands the network and subnetworks are in a different project (host project).
+Otherwise skip this step.
+
+```sh
+export HOST_PROJECT="example-shared-vpc"
+export HOST_PROJECT_NETWORK_NAME="example-network"
+export HOST_PROJECT_COMPUTE_SUBNET_NAME="example-worker-subnet"
+
+sed -i "s/    subnetwork-name.*/    network-project-id = ${HOST_PROJECT}\\n    network-name    = ${HOST_PROJECT_NETWORK_NAME}\\n    subnetwork-name = ${HOST_PROJECT_COMPUTE_SUBNET_NAME}/" manifests/cloud-provider-config.yaml
+```
+
+```console
+  config: |+
+    [global]
+    project-id      = example-project
+    regional        = true
+    multizone       = true
+    node-tags       = opensh-ptzzx-master
+    node-tags       = opensh-ptzzx-worker
+    node-instance-prefix = opensh-ptzzx
+    external-instance-groups-prefix = opensh-ptzzx
+    network-project-id = example-shared-vpc
+    network-name    = example-network
+    subnetwork-name = example-worker-subnet
+```
+
+### Enable external ingress (optional)
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+and you set `publish: Internal` in the `install-config.yaml` but really wanted `publish: External`
+then edit the `cluster-ingress-default-ingresscontroller.yaml` manifest to enable external ingress.
+
+```sh
+python -c '
+import yaml;
+path = "manifests/cluster-ingress-default-ingresscontroller.yaml";
+data = yaml.full_load(open(path));
+data["spec"]["endpointPublishingStrategy"]["loadBalancer"]["scope"] = "External";
+open(path, "w").write(yaml.dump(data, default_flow_style=False))'
+```
+
+```console
+ spec:
+  endpointPublishingStrategy:
+    loadBalancer:
+      scope: External
 ```
 
 ### Create Ignition configs
@@ -156,6 +254,8 @@ export WORKER_IGNITION=$(cat worker.ign)
 ```
 
 ## Create the VPC
+Create the VPC, network, and subnets for the cluster.
+This step can be skipped if installing into a pre-existing VPC, such as a [Shared VPC (XPN)][sharedvpc].
 
 Copy [`01_vpc.py`](../../../upi/gcp/01_vpc.py) locally.
 
@@ -187,6 +287,8 @@ gcloud deployment-manager deployments create ${INFRA_ID}-vpc --config 01_vpc.yam
 ```
 
 ## Configure VPC variables
+Configure the variables based on the VPC created with `01_vpc.yaml`.
+If you are using a pre-existing VPC, such as a [Shared VPC (XPN)][sharedvpc], set these to the `.selfLink` of the targeted resources.
 
 ```sh
 export CLUSTER_NETWORK=$(gcloud compute networks describe ${INFRA_ID}-network --format json | jq -r .selfLink)
@@ -195,6 +297,12 @@ export COMPUTE_SUBNET=$(gcloud compute networks subnets describe ${INFRA_ID}-wor
 ```
 
 ## Create DNS entries and load balancers
+Create the DNS zone and load balancers for the cluster.
+You can exclude the DNS zone or external load balancer by removing their associated section(s) from the `02_infra.yaml`.
+If you choose to exclude the DNS zone, you will need to create it some other way and ensure it is populated with the necessary records as documented below.
+
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+exclude the DNS section as it must be created in the host project.
 
 Copy [`02_dns.py`](../../../upi/gcp/02_dns.py) locally.
 Copy [`02_lb_ext.py`](../../../upi/gcp/02_lb_ext.py) locally.
@@ -240,8 +348,6 @@ EOF
 - `control_subnet`: the URI to the control subnet
 - `zones`: the zones to deploy the control plane instances into (for example us-east1-b, us-east1-c, us-east1-d)
 
-If you do not want external load balancers for the api, remove the `cluster-lb-ext` section from the file.
-
 Create the deployment using gcloud.
 
 ```sh
@@ -257,8 +363,10 @@ export CLUSTER_PUBLIC_IP=$(gcloud compute addresses describe ${INFRA_ID}-cluster
 ```
 
 ## Add DNS entries
-The templates do not create DNS entries due to limitations of Deployment
-Manager, so we must create them manually.
+The templates do not create DNS entries due to limitations of Deployment Manager, so we must create them manually.
+
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+use the `--account` and `--project` parameters to perform these actions in the host project.
 
 ### Add internal DNS entries
 
@@ -281,6 +389,13 @@ gcloud dns record-sets transaction execute --zone ${BASE_DOMAIN_ZONE_NAME}
 ```
 
 ## Create firewall rules and IAM roles
+Create the firewall rules and IAM roles for the cluster.
+You can exclude either of these by removing their associated section(s) from the `02_infra.yaml`.
+If you choose to do so, you will need to create the required resources some other way.
+Details about these resources can be found in the imported python templates.
+
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+exclude the firewall section as they must be created in the host project.
 
 Copy [`03_firewall.py`](../../../upi/gcp/03_firewall.py) locally.
 Copy [`03_iam.py`](../../../upi/gcp/03_iam.py) locally.
@@ -306,7 +421,7 @@ resources:
     infra_id: '${INFRA_ID}'
 EOF
 ```
-- `allowed_external_cidr`: limits access to the cluster API and ssh to the bootstrap host. (for example External: 0.0.0.0/0, Internal: 10.0.0.0/16)
+- `allowed_external_cidr`: limits access to the cluster API and ssh to the bootstrap host. (for example External: 0.0.0.0/0, Internal: ${NETWORK_CIDR})
 - `infra_id`: the infrastructure name (INFRA_ID above)
 - `region`: the region to deploy the cluster into (for example us-east1)
 - `cluster_network`: the URI to the cluster network
@@ -319,6 +434,8 @@ gcloud deployment-manager deployments create ${INFRA_ID}-security --config 03_se
 ```
 
 ## Configure security variables
+Configure the variables based on the `03_security.yaml` deployment.
+If you excluded the IAM section, ensure these are set to the `.email` of their associated resources.
 
 ```sh
 export MASTER_SERVICE_ACCOUNT=$(gcloud iam service-accounts list --filter "email~^${INFRA_ID}-m@${PROJECT_NAME}." --format json | jq -r '.[0].email')
@@ -326,8 +443,11 @@ export WORKER_SERVICE_ACCOUNT=$(gcloud iam service-accounts list --filter "email
 ```
 
 ## Add required roles to IAM service accounts
-The templates do not create the policy bindings due to limitations of Deployment
-Manager, so we must create them manually.
+The templates do not create the policy bindings due to limitations of Deployment Manager, so we must create them manually.
+
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+ensure these service accounts have `roles/compute.networkUser` access to each of the host project subnets used by the cluster so the instances can use the networks.
+Also ensure the master service account has `roles/compute.networkViewer` access to the host project itself so the gcp-cloud-provider can look for firewall settings as part of ingress controller operations.
 
 ```sh
 gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SERVICE_ACCOUNT}" --role "roles/compute.instanceAdmin"
@@ -477,8 +597,10 @@ export MASTER2_IP=$(gcloud compute instances describe ${INFRA_ID}-m-2 --zone ${Z
 ```
 
 ## Add DNS entries for control plane etcd
-The templates do not manage DNS entries due to limitations of Deployment
-Manager, so we must add the etcd entries manually.
+The templates do not manage DNS entries due to limitations of Deployment Manager, so we must add the etcd entries manually.
+
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+use the `--account` and `--project` parameters to perform these actions in the host project.
 
 ```sh
 if [ -f transaction.yaml ]; then rm transaction.yaml; fi
@@ -584,6 +706,9 @@ INFO Waiting up to 30m0s for the bootstrap-complete event...
 ## Destroy bootstrap resources
 At this point, you should delete the bootstrap resources.
 
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+it is safe to remove any bootstrap-specific firewall rules at this time.
+
 ```sh
 gcloud compute backend-services remove-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-instance-group --instance-group-zone=${ZONE_0}
 gsutil rm gs://${INFRA_ID}-bootstrap-ignition/bootstrap.ign
@@ -618,6 +743,9 @@ oc adm certificate approve csr-bfd72
 If you removed the DNS Zone configuration [earlier](#remove-dns-zones), you'll need to manually create some DNS records pointing at the ingress load balancer.
 You can create either a wildcard `*.apps.{baseDomain}.` or specific records (more on the specific records below).
 You can use A, CNAME, etc. records, as you see fit.
+
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+use the `--account` and `--project` parameters to perform these actions in the host project.
 
 ### Wait for the ingress-router to create a load balancer and populate the `EXTERNAL-IP`
 
@@ -657,6 +785,41 @@ downloads-openshift-console.apps.your.cluster.domain.example.com
 alertmanager-main-openshift-monitoring.apps.your.cluster.domain.example.com
 grafana-openshift-monitoring.apps.your.cluster.domain.example.com
 prometheus-k8s-openshift-monitoring.apps.your.cluster.domain.example.com
+```
+
+## Add the Ingress firewall rules (optional)
+If you are installing into a [Shared VPC (XPN)][sharedvpc],
+you'll need to manually create some firewall rules for the ingress services.
+These rules would normally be created by the ingress controller via the gcp cloud provider.
+When the cloud provider detects Shared VPC (XPN), it will instead emit cluster events informing which firewall rules need to be created.
+Either create each rule as requested by the events (option A), or create cluster-wide firewall rules for all services (option B).
+
+Use the `--account` and `--project` parameters to perform these actions in the host project.
+
+### Add firewall rules based on cluster events (option A)
+When the cluster is first provisioned, and as services are later created and modified, the gcp cloud provider may generate events informing of firewall rules required to be manually created in order to allow access to these services.
+
+```console
+Firewall change required by security admin: `gcloud compute firewall-rules create k8s-fw-a26e631036a3f46cba28f8df67266d55 --network example-network --description "{\"kubernetes.io/service-name\":\"openshift-ingress/router-default\", \"kubernetes.io/service-ip\":\"35.237.236.234\"}\" --allow tcp:443,tcp:80 --source-ranges 0.0.0.0/0 --target-tags exampl-fqzq7-master,exampl-fqzq7-worker --project example-project`
+```
+
+Create the firewall rules as instructed.
+
+### Add a cluster-wide health check firewall rule. (option B)
+Add a single firewall rule to allow the gce health checks to access all of the services.
+This enables the ingress load balancers to determine the health status of their instances.
+
+```sh
+gcloud compute firewall-rules create --allow='tcp:30000-32767,udp:30000-32767' --network="${CLUSTER_NETWORK}" --source-ranges='130.211.0.0/22,35.191.0.0/16,209.85.152.0/22,209.85.204.0/22' --target-tags="${INFRA_ID}-master,${INFRA_ID}-worker" ${INFRA_ID}-ingress-hc
+```
+
+### Add a cluster-wide service firewall rule. (option B)
+Add a single firewall rule to allow access to all cluster services.
+If you want your cluster to be private, you can use `--source-ranges=${NETWORK_CIDR}`.
+This rule may need to be updated accordingly when adding services on ports other than `tcp:80,tcp:443`.
+
+```sh
+gcloud compute firewall-rules create --allow='tcp:80,tcp:443' --network="${CLUSTER_NETWORK}" --source-ranges="0.0.0.0/0" --target-tags="${INFRA_ID}-master,${INFRA_ID}-worker" ${INFRA_ID}-ingress
 ```
 
 ## Monitor for cluster completion
@@ -725,3 +888,4 @@ openshift-service-catalog-controller-manager-operator   openshift-service-catalo
 [ingress-operator]: https://github.com/openshift/cluster-ingress-operator
 [kubernetes-service-load-balancers-exclude-masters]: https://github.com/kubernetes/kubernetes/issues/65618
 [machine-api-operator]: https://github.com/openshift/machine-api-operator
+[sharedvpc]: https://cloud.google.com/vpc/docs/shared-vpc


### PR DESCRIPTION
This change adds direction in the GCP UPI install document about how to
install a cluster using a Shared VPC. Because the VPC, networks,
subnets, and dns zones are in a different project (the host project),
the installer has problems finding them while creating the Ignition
files. Furthermore, some changes are required to the cloud-provider in
order for the cluster to properly provision resources in the subnets. In
addition, it is assumed the service account in the service project will
likely not have sufficient permissions in the host project to perform
all of the required tasks.

Depends on: #2574, #3270, #3309