### PR TITLE
OpenStack: Deprecate TrunkSupport and OctaviaSupport in the config 

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1295,8 +1295,9 @@ spec:
                       will not be deleted or modified by the installer.
                     type: string
                   octaviaSupport:
-                    description: OctaviaSupport holds a `0` or `1` value that indicates
+                    description: 'OctaviaSupport holds a `0` or `1` value that indicates
                       whether your OpenStack cluster supports Octavia Loadbalancing.
+                      Deprecated: this value is set by the installer automatically.'
                     type: string
                   region:
                     description: 'Region specifies the OpenStack region where the
@@ -1304,8 +1305,9 @@ spec:
                       by the installer.'
                     type: string
                   trunkSupport:
-                    description: TrunkSupport holds a `0` or `1` value that indicates
+                    description: 'TrunkSupport holds a `0` or `1` value that indicates
                       whether or not to use trunk ports in your OpenShift cluster.
+                      Deprecated: this value is set by the installer automatically.'
                     type: string
                 required:
                 - cloud

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -46,11 +46,11 @@ variable "external_dns" {
 }
 
 variable "trunk_support" {
-  type = string
+  type = bool
 }
 
 variable "octavia_support" {
-  type = string
+  type = bool
 }
 
 variable "machines_subnet_id" {

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -314,19 +314,19 @@ variable "openstack_master_flavor_name" {
 }
 
 variable "openstack_trunk_support" {
-  type = string
+  type = bool
 
   description = <<EOF
-Contains 0 if the OpenStack Neutron trunk extension is disabled and 1 if it is enabled.
+False if the OpenStack Neutron trunk extension is disabled and True if it is enabled.
 EOF
 
 }
 
 variable "openstack_octavia_support" {
-  type = string
+  type = bool
 
   description = <<EOF
-Contains 0 if the OpenStack Octavia endpoint is missing and 1 if it exists.
+False if the OpenStack Octavia endpoint is missing and True if it exists.
 EOF
 
 }

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -23,9 +23,9 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `externalDNS` (optional list of strings): The IP addresses of DNS servers to be used for the DNS resolution of all instances in the cluster
 * `externalNetwork` (required string): The OpenStack external network name to be used for installation.
 * `lbFloatingIP` (required string): Existing Floating IP to associate with the API load balancer.
-* `octaviaSupport` (optional string): Whether OpenStack supports Octavia (`1` for true or `0` for false)
+* `octaviaSupport` (deprecated string): Whether OpenStack supports Octavia (`1` for true or `0` for false)
 * `region` (deprecated string): The OpenStack region where the cluster will be created. Currently this value is not used by the installer.
-* `trunkSupport` (optional string): Whether OpenStack ports can be trunked (`1` for true or `0` for false)
+* `trunkSupport` (deprecated string): Whether OpenStack ports can be trunked (`1` for true or `0` for false)
 * `clusterOSImage` (optional string): Either a URL with `http(s)` or `file` scheme to override the default OS image for cluster nodes or an existing Glance image name.
 * `apiVIP` (optional string): An IP addresss on the machineNetwork that will be assigned to the API VIP. Be aware that the `10` and `11` of the machineNetwork will be taken by neutron dhcp by default, and wont be available.
 * `ingressVIP` (optional string): An IP address on the machineNetwork that will be assigned to the ingress VIP. Be aware that the `10` and `11` of the machineNetwork will be taken by neutron dhcp by default, and wont be available.

--- a/docs/user/openstack/kuryr.md
+++ b/docs/user/openstack/kuryr.md
@@ -108,15 +108,9 @@ apiVersion: v1
 networking:
   networkType: Kuryr
   ...
-platform:
-  openstack:
-    ...
-    trunkSupport: true
-    octaviaSupport: true
-    ...
 ```
 
-**NOTE:** both `trunkSupport` and `octaviaSupport` are automatically discovered by the installer, so there is no need to set them. But if your environment doesn't meet both requirements Kuryr SDN will not properly work, as trunks are needed to connect the pods to the OpenStack network and Octavia to create the OpenShift services.
+**NOTE:** If your environment doesn't support trunks or OpenStack Octavia service isn't available, Kuryr SDN will not properly work, as trunks are needed to connect the pods to the OpenStack network and Octavia to create the OpenShift services.
 
 ### Known limitations of installing with Kuryr SDN
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -393,8 +393,6 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			installConfig.Config.Platform.OpenStack.LbFloatingIP,
 			installConfig.Config.Platform.OpenStack.APIVIP,
 			installConfig.Config.Platform.OpenStack.IngressVIP,
-			installConfig.Config.Platform.OpenStack.TrunkSupport,
-			installConfig.Config.Platform.OpenStack.OctaviaSupport,
 			string(*rhcosImage),
 			clusterID.InfraID,
 			caCert,

--- a/pkg/asset/installconfig/openstack/openstack.go
+++ b/pkg/asset/installconfig/openstack/openstack.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/types/openstack"
@@ -125,37 +124,10 @@ func Platform() (*openstack.Platform, error) {
 		return nil, err
 	}
 
-	trunkSupport := "0"
-	var i int
-	netExts, err := validValuesFetcher.GetNetworkExtensionsAliases(cloud)
-	if err != nil {
-		logrus.Warning("Could not retrieve networking extension aliases. Assuming trunk ports are not supported.")
-	} else {
-		sort.Strings(netExts)
-		i = sort.SearchStrings(netExts, "trunk")
-		if i != len(netExts) && netExts[i] == "trunk" {
-			trunkSupport = "1"
-		}
-	}
-
-	octaviaSupport := "0"
-	serviceCatalog, err := validValuesFetcher.GetServiceCatalog(cloud)
-	if err != nil {
-		logrus.Warning("Could not retrieve service catalog. Assuming there is no Octavia load balancer service available.")
-	} else {
-		sort.Strings(serviceCatalog)
-		i = sort.SearchStrings(serviceCatalog, "octavia")
-		if i != len(serviceCatalog) && serviceCatalog[i] == "octavia" {
-			octaviaSupport = "1"
-		}
-	}
-
 	return &openstack.Platform{
 		Cloud:           cloud,
 		ExternalNetwork: extNet,
 		FlavorName:      flavor,
 		LbFloatingIP:    lbFloatingIP,
-		TrunkSupport:    trunkSupport,
-		OctaviaSupport:  octaviaSupport,
 	}, nil
 }

--- a/pkg/asset/installconfig/openstack/realvalidvaluesfetcher.go
+++ b/pkg/asset/installconfig/openstack/realvalidvaluesfetcher.go
@@ -3,10 +3,7 @@ package openstack
 import (
 	"github.com/pkg/errors"
 
-	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
-	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
-	netext "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
@@ -96,59 +93,6 @@ func (f realValidValuesFetcher) GetFlavorNames(cloud string) ([]string, error) {
 	}
 
 	return flavorNames, nil
-}
-
-func (f realValidValuesFetcher) GetNetworkExtensionsAliases(cloud string) ([]string, error) {
-	opts := defaultClientOpts(cloud)
-
-	conn, err := clientconfig.NewServiceClient("network", opts)
-	if err != nil {
-		return nil, err
-	}
-
-	allPages, err := netext.List(conn).AllPages()
-	if err != nil {
-		return nil, err
-	}
-
-	allExts, err := extensions.ExtractExtensions(allPages)
-	if err != nil {
-		return nil, err
-	}
-
-	extAliases := make([]string, len(allExts))
-	for i, ext := range allExts {
-		extAliases[i] = ext.Alias
-	}
-
-	return extAliases, nil
-}
-
-func (f realValidValuesFetcher) GetServiceCatalog(cloud string) ([]string, error) {
-	opts := defaultClientOpts(cloud)
-
-	conn, err := clientconfig.NewServiceClient("identity", opts)
-	if err != nil {
-		return nil, err
-	}
-
-	authResult := conn.GetAuthResult()
-	auth, ok := authResult.(tokens.CreateResult)
-	if !ok {
-		return nil, errors.New("unable to extract service catalog")
-	}
-
-	allServices, err := auth.ExtractServiceCatalog()
-	if err != nil {
-		return nil, err
-	}
-
-	serviceCatalogNames := make([]string, len(allServices.Entries))
-	for i, service := range allServices.Entries {
-		serviceCatalogNames[i] = service.Name
-	}
-
-	return serviceCatalogNames, nil
 }
 
 func (f realValidValuesFetcher) GetFloatingIPNames(cloud string, floatingNetworkName string) ([]string, error) {

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -31,9 +31,11 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	// TODO(flaper87): Add support for availability zones
 	machinesets := make([]*clusterapi.MachineSet, 0, 1)
 	az := ""
-	trunk := config.Platform.OpenStack.TrunkSupport
+	provider, err := generateProvider(clusterID, platform, mpool, osImage, az, role, userDataSecret)
+	if err != nil {
+		return nil, err
+	}
 
-	provider := generateProvider(clusterID, platform, mpool, osImage, az, role, userDataSecret, trunk)
 	// TODO(flaper87): Implement AZ support sometime soon
 	//name := fmt.Sprintf("%s-%s-%s", clustername, pool.Name, az)
 	name := fmt.Sprintf("%s-%s", clusterID, pool.Name)

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -30,8 +30,8 @@ type config struct {
 	LbFloatingIP               string   `json:"openstack_lb_floating_ip,omitempty"`
 	APIVIP                     string   `json:"openstack_api_int_ip,omitempty"`
 	IngressVIP                 string   `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport               string   `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport             string   `json:"openstack_octavia_support,omitempty"`
+	TrunkSupport               bool     `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport             bool     `json:"openstack_octavia_support,omitempty"`
 	RootVolumeSize             int      `json:"openstack_master_root_volume_size,omitempty"`
 	RootVolumeType             string   `json:"openstack_master_root_volume_type,omitempty"`
 	BootstrapShim              string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
@@ -44,7 +44,7 @@ type config struct {
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, apiVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, apiVIP string, ingressVIP string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
 
 	cfg := &config{
 		ExternalNetwork: externalNetwork,
@@ -54,9 +54,12 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 		APIVIP:          apiVIP,
 		IngressVIP:      ingressVIP,
 		ExternalDNS:     externalDNS,
-		TrunkSupport:    trunkSupport,
-		OctaviaSupport:  octaviaSupport,
 		MachinesSubnet:  machinesSubnet,
+	}
+
+	serviceCatalog, err := getServiceCatalog(cloud)
+	if err != nil {
+		return nil, errors.Errorf("Could not retrieve service catalog: %v", err)
 	}
 
 	// Normally baseImage contains a URL that we will use to create a new Glance image, but for testing
@@ -102,7 +105,7 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 		}
 	}
 
-	glancePublicURL, err := getGlancePublicURL(cloud)
+	glancePublicURL, err := getGlancePublicURL(serviceCatalog)
 	if err != nil {
 		return nil, err
 	}
@@ -124,6 +127,13 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 	}
 
 	cfg.BootstrapShim = userCAIgnition
+
+	cfg.TrunkSupport = masterConfig.Trunk
+
+	cfg.OctaviaSupport, err = isOctaviaSupported(serviceCatalog)
+	if err != nil {
+		return nil, err
+	}
 
 	if masterConfig.RootVolume != nil {
 		cfg.RootVolumeSize = masterConfig.RootVolume.Size
@@ -217,12 +227,7 @@ func validateOverriddenImageName(imageName, cloud string) error {
 // 2. In getGlancePublicURL we iterate through the catalog and find "public" endpoint for "image".
 
 // getGlancePublicURL obtains Glance public endpoint URL
-func getGlancePublicURL(cloud string) (string, error) {
-	serviceCatalog, err := getServiceCatalog(cloud)
-	if err != nil {
-		return "", err
-	}
-
+func getGlancePublicURL(serviceCatalog *tokens.ServiceCatalog) (string, error) {
 	glancePublicURL, err := openstack.V3EndpointURL(serviceCatalog, gophercloud.EndpointOpts{
 		Type:         "image",
 		Availability: gophercloud.AvailabilityPublic,
@@ -295,4 +300,20 @@ func setNetworkTag(cloud string, networkID string, networkTag string) error {
 	}
 
 	return nil
+}
+
+func isOctaviaSupported(serviceCatalog *tokens.ServiceCatalog) (bool, error) {
+	_, err := openstack.V3EndpointURL(serviceCatalog, gophercloud.EndpointOpts{
+		Type:         "load-balancer",
+		Name:         "octavia",
+		Availability: gophercloud.AvailabilityPublic,
+	})
+	if err != nil {
+		if _, ok := err.(*gophercloud.ErrEndpointNotFound); ok {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -33,10 +33,12 @@ type Platform struct {
 
 	// TrunkSupport holds a `0` or `1` value that indicates whether or not to use trunk ports
 	// in your OpenShift cluster.
+	// Deprecated: this value is set by the installer automatically.
 	TrunkSupport string `json:"trunkSupport"`
 
 	// OctaviaSupport holds a `0` or `1` value that indicates whether your OpenStack
 	// cluster supports Octavia Loadbalancing.
+	// Deprecated: this value is set by the installer automatically.
 	OctaviaSupport string `json:"octaviaSupport"`
 
 	// ClusterOSImage is either a URL with `http(s)` or `file` scheme to override

--- a/pkg/types/openstack/validation/mock/validvaluesfetcher_generated.go
+++ b/pkg/types/openstack/validation/mock/validvaluesfetcher_generated.go
@@ -77,36 +77,6 @@ func (mr *MockValidValuesFetcherMockRecorder) GetFlavorNames(cloud interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlavorNames", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetFlavorNames), cloud)
 }
 
-// GetNetworkExtensionsAliases mocks base method.
-func (m *MockValidValuesFetcher) GetNetworkExtensionsAliases(cloud string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNetworkExtensionsAliases", cloud)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNetworkExtensionsAliases indicates an expected call of GetNetworkExtensionsAliases.
-func (mr *MockValidValuesFetcherMockRecorder) GetNetworkExtensionsAliases(cloud interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkExtensionsAliases", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetNetworkExtensionsAliases), cloud)
-}
-
-// GetServiceCatalog mocks base method.
-func (m *MockValidValuesFetcher) GetServiceCatalog(cloud string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceCatalog", cloud)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetServiceCatalog indicates an expected call of GetServiceCatalog.
-func (mr *MockValidValuesFetcherMockRecorder) GetServiceCatalog(cloud interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceCatalog", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetServiceCatalog), cloud)
-}
-
 // GetFloatingIPNames mocks base method.
 func (m *MockValidValuesFetcher) GetFloatingIPNames(cloud, floatingNetwork string) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -49,24 +48,6 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("computeFlavor"), errors.New("could not retrieve valid flavors")))
 		} else if !isValidValue(p.FlavorName, validFlavors) {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("computeFlavor"), p.FlavorName, validFlavors))
-		}
-		p.TrunkSupport = "0"
-		netExts, err := fetcher.GetNetworkExtensionsAliases(p.Cloud)
-		if err != nil {
-			logrus.Warning("Could not retrieve networking extension aliases. Assuming trunk ports are not supported.")
-		} else {
-			if isValidValue("trunk", netExts) {
-				p.TrunkSupport = "1"
-			}
-		}
-		p.OctaviaSupport = "0"
-		serviceCatalog, err := fetcher.GetServiceCatalog(p.Cloud)
-		if err != nil {
-			logrus.Warning("Could not retrieve service catalog. Assuming there is no Octavia load balancer service available.")
-		} else {
-			if isValidValue("octavia", serviceCatalog) {
-				p.OctaviaSupport = "1"
-			}
 		}
 	}
 	if p.DefaultMachinePlatform != nil {

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -39,8 +39,6 @@ func TestValidatePlatform(t *testing.T) {
 		noClouds              bool
 		noNetworks            bool
 		noFlavors             bool
-		noNetExts             bool
-		noServiceCatalog      bool
 		validMachinesSubnet   bool
 		invalidMachinesSubnet bool
 		valid                 bool
@@ -125,20 +123,6 @@ func TestValidatePlatform(t *testing.T) {
 			networking: validNetworking(),
 			noFlavors:  true,
 			valid:      false,
-		},
-		{
-			name:       "network extensions fetch failure",
-			platform:   validPlatform(),
-			networking: validNetworking(),
-			noNetExts:  true,
-			valid:      true,
-		},
-		{
-			name:             "service catalog fetch failure",
-			platform:         validPlatform(),
-			networking:       validNetworking(),
-			noServiceCatalog: true,
-			valid:            true,
 		},
 		{
 			name: "valid custom API vip",
@@ -282,24 +266,6 @@ func TestValidatePlatform(t *testing.T) {
 			} else {
 				fetcher.EXPECT().GetFlavorNames(tc.platform.Cloud).
 					Return([]string{"test-flavor"}, nil).
-					MaxTimes(1)
-			}
-			if tc.noNetExts {
-				fetcher.EXPECT().GetNetworkExtensionsAliases(tc.platform.Cloud).
-					Return(nil, errors.New("no network extensions")).
-					MaxTimes(1)
-			} else {
-				fetcher.EXPECT().GetNetworkExtensionsAliases(tc.platform.Cloud).
-					Return([]string{"trunk"}, nil).
-					MaxTimes(1)
-			}
-			if tc.noServiceCatalog {
-				fetcher.EXPECT().GetServiceCatalog(tc.platform.Cloud).
-					Return(nil, errors.New("no service catalog")).
-					MaxTimes(1)
-			} else {
-				fetcher.EXPECT().GetServiceCatalog(tc.platform.Cloud).
-					Return([]string{"octavia"}, nil).
 					MaxTimes(1)
 			}
 			if tc.validMachinesSubnet {

--- a/pkg/types/openstack/validation/validvaluesfetcher.go
+++ b/pkg/types/openstack/validation/validvaluesfetcher.go
@@ -10,10 +10,6 @@ type ValidValuesFetcher interface {
 	GetNetworkNames(cloud string) ([]string, error)
 	// GetFlavorNames gets the valid flavor names.
 	GetFlavorNames(cloud string) ([]string, error)
-	// GetNetworkExtensionsAliases gets the aliases for all the networking enabled extensions
-	GetNetworkExtensionsAliases(cloud string) ([]string, error)
-	// GetServiceCatalog gets the catalog service names
-	GetServiceCatalog(cloud string) ([]string, error)
 	// GetFloatingIPNames gets the floating IPs
 	GetFloatingIPNames(cloud string, floatingNetwork string) ([]string, error)
 	// GetSubnetCIDR gets the CIDR of a subnet

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -942,8 +942,6 @@ func TestValidateInstallConfig(t *testing.T) {
 			fetcher.EXPECT().GetCloudNames().Return([]string{"test-cloud"}, nil).AnyTimes()
 			fetcher.EXPECT().GetNetworkNames(gomock.Any()).Return([]string{"test-network"}, nil).AnyTimes()
 			fetcher.EXPECT().GetFlavorNames(gomock.Any()).Return([]string{"test-flavor"}, nil).AnyTimes()
-			fetcher.EXPECT().GetNetworkExtensionsAliases(gomock.Any()).Return([]string{"trunk"}, nil).AnyTimes()
-			fetcher.EXPECT().GetServiceCatalog(gomock.Any()).Return([]string{"octavia"}, nil).AnyTimes()
 
 			err := ValidateInstallConfig(tc.installConfig, fetcher).ToAggregate()
 			if tc.expectedError == "" {


### PR DESCRIPTION
Despite the fact these two values can be set by the user, they are overwritten by the installer every time in two places.
First time during config validation:
https://github.com/openshift/installer/blob/release-4.4/pkg/types/openstack/validation/platform.go#L35-L52
And the second time in the installconfig asset:
https://github.com/openshift/installer/blob/release-4.4/pkg/asset/installconfig/openstack/openstack.go#L128-L151
Every time all possible errors are ignored, which leads to an unpredictable behavior, when depending on the quality of the network connection, we may get different results.
Then these values are passed to terraform.

This PR deprecates these parameters in the install config, since users can't define them anyway.
Also, from now the values will be fetched from `tvfars` module directly, and only once; all code from `validation` and `installconfig` will be removed.
And finally, we won't ignore possible errors anymore.