### PR TITLE
data/manifests/bootkube/cvo-overrides: Bump default to stable-4.5

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -5,5 +5,5 @@ metadata:
   name: version
 spec:
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph
-  channel: stable-4.4
+  channel: stable-4.5
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
Like d7fb12c07a (#2940), but for 4.5 (no that release-4.4 is no longer being fast-forwarded to track master).