### PR TITLE
images/baremetal: remove nss package as it's no longer needed 

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -1,5 +1,5 @@
 # This Dockerfile is a used by CI to publish an installer image
-# It builds an image containing openshift-install, and nss mock.
+# It builds an image containing openshift-install.
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 RUN yum install -y libvirt-devel && \
@@ -11,11 +11,10 @@ RUN TAGS="libvirt baremetal" hack/build.sh
 
 FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
-COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-nss.sh /bin/mock-nss.sh
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    libvirt-libs nss_wrapper openssl unzip jq openssh-clients && \
+    libvirt-libs openssl unzip jq openssh-clients && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /output && chown 1000:1000 /output


### PR DESCRIPTION
These images are failing to build internally for OSE due to missing the
nss wrapper package.

The underyling problem we are seeing when trying to use the
baremetal-installer image in CI to ssh to the packet server is that
user ID's are generated dynamically. This results in errors like this
when attempting to use SSH:

        No user exists for uid 102400000

The way most CI containers work around this is to echo a valid user to
/etc/passwd, as /etc/passwd is left writeable. The base images for
OpenShift now do this by default, so we can remove nss entirely.