### PR TITLE
OpenStack: allow to specify additional networks and security groups for masters and workers

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -53,9 +53,10 @@ module "masters" {
     var.openstack_master_extra_sg_ids,
     [module.topology.master_sg_id],
   )
-  root_volume_size = var.openstack_master_root_volume_size
-  root_volume_type = var.openstack_master_root_volume_type
-  server_group_id  = var.openstack_master_server_group_id
+  root_volume_size       = var.openstack_master_root_volume_size
+  root_volume_type       = var.openstack_master_root_volume_type
+  server_group_id        = var.openstack_master_server_group_id
+  additional_network_ids = var.openstack_additional_network_ids
 }
 
 module "topology" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -67,6 +67,14 @@ resource "openstack_compute_instance_v2" "master_conf" {
     group = var.server_group_id
   }
 
+  dynamic network {
+    for_each = var.additional_network_ids
+
+    content {
+      uuid = network.value
+    }
+  }
+
   metadata = {
     # FIXME(mandre) shouldn't it be "${var.cluster_id}-master-${count.index}" ?
     Name = "${var.cluster_id}-master"

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -45,3 +45,8 @@ variable "server_group_id" {
   type        = string
   description = "ID of the server group to assign the servers to."
 }
+
+variable "additional_network_ids" {
+  type        = list(string)
+  description = "IDs of additional networks for master nodes."
+}

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -307,6 +307,12 @@ variable "openstack_external_dns" {
   default     = []
 }
 
+variable "openstack_additional_network_ids" {
+  type        = list(string)
+  description = "IDs of additional networks for master nodes."
+  default     = []
+}
+
 variable "openstack_master_flavor_name" {
   type        = string
   description = "Instance size for the master node(s). Example: `m1.medium`."

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -10,6 +10,8 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
   * [Minimal](#minimal)
   * [Custom-machine-pools](#custom-machine-pools)
 * [Image Overrides](#image-overrides)
+* [Additional Networks](#additional-networks)
+* [Additional Security Groups](#additional-security-groups)
 * [Further customization](#further-customization)
 
 ## Cluster-scoped properties
@@ -27,6 +29,8 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 ## Machine pools
 
+* `additionalNetworkIDs` (optional list of strings): IDs of additional networks for machines.
+* `additionalSecurityGroupIDs` (optional list of strings): IDs of additional security groups for machines.
 * `type` (optional string): The OpenStack flavor name for machines in the pool.
 * `rootVolume` (optional object): Defines the root volume for instances in the machine pool. The instances use ephemeral disks if not set.
   * `size` (required integer): Size of the root volume in GB.
@@ -126,6 +130,66 @@ Example:
 platform:
   openstack:
       clusterOSImage: my-rhcos
+```
+
+## Additional Networks
+
+You can set additional networks for your machines by defining `additionalNetworkIDs` parameter in the machine configuration. The parameter is a list of strings with additional network IDs:
+
+```yaml
+additionalNetworkIDs:
+- <network1_uuid>
+- <network2_uuid>
+```
+
+You can attach this parameter for both `controlPlane` and `compute` machines:
+
+Example:
+
+```yaml
+compute:
+- name: worker
+  platform:
+    openstack:
+      additionalNetworkIDs:
+      - fa806b2f-ac49-4bce-b9db-124bc64209bf
+controlPlane:
+  name: master
+  platform:
+    openstack:
+      additionalNetworkIDs:
+      - fa806b2f-ac49-4bce-b9db-124bc64209bf
+```
+
+**NOTE:** Allowed address pairs won't be created for the additional networks.
+
+## Additional Security Groups
+
+You can set additional security groups for your machines by defining `additionalSecurityGroupIDs` parameter in the machine configuration. The parameter is a list of strings with additional security group IDs:
+
+```yaml
+additionalSecurityGroupIDs:
+- <security_group1_id>
+- <security_group2_id>
+```
+
+You can attach this parameter for both `controlPlane` and `compute` machines:
+
+Example:
+
+```yaml
+compute:
+- name: worker
+  platform:
+    openstack:
+      additionalSecurityGroupIDs:
+      - 7ee219f3-d2e9-48a1-96c2-e7429f1b0da7
+controlPlane:
+  name: master
+  platform:
+    openstack:
+      additionalSecurityGroupIDs:
+      - 7ee219f3-d2e9-48a1-96c2-e7429f1b0da7
 ```
 
 ## Further customization

--- a/go.mod
+++ b/go.mod
@@ -162,5 +162,5 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.1 // Replaced by MCO/CRI-O
 	sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200316201703-923caeb1d0d8 // Pin OpenShift fork
 	sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b // Pin OpenShift fork
-	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200221124403-d699c3611b0c // Pin OpenShift fork
+	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200323110431-3311de91e078 // Pin OpenShift fork
 )

--- a/go.sum
+++ b/go.sum
@@ -1792,6 +1792,8 @@ github.com/openshift/cluster-api-provider-openstack v0.0.0-20200130125124-ef82ce
 github.com/openshift/cluster-api-provider-openstack v0.0.0-20200130125124-ef82ce374112/go.mod h1:ntMRKZlv++TExGO4g2jgsVIaHKJt8kKe72BAvMPV5vA=
 github.com/openshift/cluster-api-provider-openstack v0.0.0-20200221124403-d699c3611b0c h1:Rn/Ip2nbWUhvOF9/EZaorxKVcQnm427cSOJQJIFXuHQ=
 github.com/openshift/cluster-api-provider-openstack v0.0.0-20200221124403-d699c3611b0c/go.mod h1:ntMRKZlv++TExGO4g2jgsVIaHKJt8kKe72BAvMPV5vA=
+github.com/openshift/cluster-api-provider-openstack v0.0.0-20200323110431-3311de91e078 h1:Irj9ROcWhbeH6t2DEUDIpdIJgSLBaXww6AP/FMCmGmw=
+github.com/openshift/cluster-api-provider-openstack v0.0.0-20200323110431-3311de91e078/go.mod h1:ntMRKZlv++TExGO4g2jgsVIaHKJt8kKe72BAvMPV5vA=
 github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200128081049-840376ca5c09 h1:QJxGgIB7f5BqNPEZOCgV29NsDf1P439Bs3q0B5O3fP8=
 github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200128081049-840376ca5c09/go.mod h1:NcvJT99IauPosghKCineBG8yswe9JjuddiWuvsqge64=
 github.com/openshift/cluster-autoscaler-operator v0.0.0-20190521201101-62768a6ba480/go.mod h1:/XmV44Fh28Vo3Ye93qFrxAbcFJ/Uy+7LPD+jGjmfJYc=

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -390,6 +390,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			clusterID.InfraID,
 			caCert,
 			bootstrapIgn,
+			installConfig.Config.ControlPlane.Platform.OpenStack,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -14,31 +14,34 @@ import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
+	types_openstack "github.com/openshift/installer/pkg/types/openstack"
 	"github.com/pkg/errors"
 
 	"sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 )
 
 type config struct {
-	BaseImageName       string   `json:"openstack_base_image_name,omitempty"`
-	ExternalNetwork     string   `json:"openstack_external_network,omitempty"`
-	Cloud               string   `json:"openstack_credentials_cloud,omitempty"`
-	FlavorName          string   `json:"openstack_master_flavor_name,omitempty"`
-	LbFloatingIP        string   `json:"openstack_lb_floating_ip,omitempty"`
-	APIVIP              string   `json:"openstack_api_int_ip,omitempty"`
-	DNSVIP              string   `json:"openstack_node_dns_ip,omitempty"`
-	IngressVIP          string   `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport        string   `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport      string   `json:"openstack_octavia_support,omitempty"`
-	RootVolumeSize      int      `json:"openstack_master_root_volume_size,omitempty"`
-	RootVolumeType      string   `json:"openstack_master_root_volume_type,omitempty"`
-	BootstrapShim       string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
-	ExternalDNS         []string `json:"openstack_external_dns,omitempty"`
-	MasterServerGroupID string   `json:"openstack_master_server_group_id,omitempty"`
+	BaseImageName              string   `json:"openstack_base_image_name,omitempty"`
+	ExternalNetwork            string   `json:"openstack_external_network,omitempty"`
+	Cloud                      string   `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName                 string   `json:"openstack_master_flavor_name,omitempty"`
+	LbFloatingIP               string   `json:"openstack_lb_floating_ip,omitempty"`
+	APIVIP                     string   `json:"openstack_api_int_ip,omitempty"`
+	DNSVIP                     string   `json:"openstack_node_dns_ip,omitempty"`
+	IngressVIP                 string   `json:"openstack_ingress_ip,omitempty"`
+	TrunkSupport               string   `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport             string   `json:"openstack_octavia_support,omitempty"`
+	RootVolumeSize             int      `json:"openstack_master_root_volume_size,omitempty"`
+	RootVolumeType             string   `json:"openstack_master_root_volume_type,omitempty"`
+	BootstrapShim              string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
+	ExternalDNS                []string `json:"openstack_external_dns,omitempty"`
+	MasterServerGroupID        string   `json:"openstack_master_server_group_id,omitempty"`
+	AdditionalNetworkIDs       []string `json:"openstack_additional_network_ids,omitempty"`
+	AdditionalSecurityGroupIDs []string `json:"openstack_master_extra_sg_ids,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string, userCA string, bootstrapIgn string) ([]byte, error) {
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool) ([]byte, error) {
 
 	cfg := &config{
 		ExternalNetwork: externalNetwork,
@@ -125,6 +128,20 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 	}
 
 	cfg.MasterServerGroupID = masterConfig.ServerGroupID
+
+	cfg.AdditionalNetworkIDs = []string{}
+	if mpool.AdditionalNetworkIDs != nil {
+		for _, networkID := range mpool.AdditionalNetworkIDs {
+			cfg.AdditionalNetworkIDs = append(cfg.AdditionalNetworkIDs, networkID)
+		}
+	}
+
+	cfg.AdditionalSecurityGroupIDs = []string{}
+	if mpool.AdditionalSecurityGroupIDs != nil {
+		for _, sgID := range mpool.AdditionalSecurityGroupIDs {
+			cfg.AdditionalSecurityGroupIDs = append(cfg.AdditionalSecurityGroupIDs, sgID)
+		}
+	}
 
 	return json.MarshalIndent(cfg, "", "  ")
 }

--- a/pkg/types/openstack/machinepool.go
+++ b/pkg/types/openstack/machinepool.go
@@ -11,6 +11,17 @@ type MachinePool struct {
 	// The instances use ephemeral disks if not set.
 	// +optional
 	RootVolume *RootVolume `json:"rootVolume,omitempty"`
+
+	// AdditionalNetworkIDs contains IDs of additional networks for machines,
+	// where each ID is presented in UUID v4 format.
+	// Allowed address pairs won't be created for the additional networks.
+	// +optional
+	AdditionalNetworkIDs []string `json:"additionalNetworkIDs,omitempty"`
+
+	// AdditionalSecurityGroupIDs contains IDs of additional security groups for machines,
+	// where each ID is presented in UUID v4 format.
+	// +optional
+	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
 }
 
 // Set sets the values from `required` to `a`.
@@ -29,6 +40,14 @@ func (o *MachinePool) Set(required *MachinePool) {
 		}
 		o.RootVolume.Size = required.RootVolume.Size
 		o.RootVolume.Type = required.RootVolume.Type
+	}
+
+	if required.AdditionalNetworkIDs != nil {
+		o.AdditionalNetworkIDs = append(required.AdditionalNetworkIDs[:0:0], required.AdditionalNetworkIDs...)
+	}
+
+	if required.AdditionalSecurityGroupIDs != nil {
+		o.AdditionalSecurityGroupIDs = append(required.AdditionalSecurityGroupIDs[:0:0], required.AdditionalSecurityGroupIDs...)
 	}
 }
 

--- a/pkg/types/openstack/validation/machinepool.go
+++ b/pkg/types/openstack/validation/machinepool.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	guuid "github.com/google/uuid"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
@@ -20,5 +21,35 @@ func ValidateMachinePool(p *openstack.MachinePool, fldPath *field.Path) field.Er
 		}
 	}
 
+	allErrs = append(allErrs, validateUUIDV4s(p.AdditionalNetworkIDs, fldPath.Child("additionalNetworkIDs"))...)
+	allErrs = append(allErrs, validateUUIDV4s(p.AdditionalSecurityGroupIDs, fldPath.Child("additionalSecurityGroupIDs"))...)
+
 	return allErrs
+}
+
+func validateUUIDV4s(input []string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for idx, uuid := range input {
+		if !validUUIDv4(uuid) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(idx), uuid, "valid UUID v4 must be specified"))
+		}
+	}
+
+	return allErrs
+}
+
+// validUUIDv4 checks if string is in UUID v4 format
+// For more information: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
+func validUUIDv4(s string) bool {
+	uuid, err := guuid.Parse(s)
+	if err != nil {
+		return false
+	}
+
+	// check that version of the uuid
+	if uuid.Version().String() != "VERSION_4" {
+		return false
+	}
+
+	return true
 }

--- a/pkg/types/openstack/validation/machinepool_test.go
+++ b/pkg/types/openstack/validation/machinepool_test.go
@@ -56,6 +56,70 @@ func TestValidateMachinePool(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "valid additional network ids",
+			pool: &openstack.MachinePool{
+				AdditionalNetworkIDs: []string{
+					"51e5fe10-5325-4a32-bce8-7ebe9708c453",
+					"3ade1375-acfd-4eda-90be-3530af4f25ec",
+					"460e993b-e932-43c6-a7a2-e51ca58f4eae",
+				},
+			},
+		},
+		{
+			name: "invalid additional network ids",
+			pool: &openstack.MachinePool{
+				AdditionalNetworkIDs: []string{
+					"51e5fe10-5325-4a32-bce8-7ebe9708c453",
+					"INVALID",
+					"",
+				},
+			},
+			expected: `^\[test-path.additionalNetworkIDs\[1\]: Invalid value: \"INVALID\": valid UUID v4 must be specified, test-path.additionalNetworkIDs\[2\]: Invalid value: \"\": valid UUID v4 must be specified\]$`,
+		},
+		{
+			name: "wrong additional network ids version",
+			pool: &openstack.MachinePool{
+				AdditionalNetworkIDs: []string{
+					"25b91ff0-75c3-11ea-9aff-4fc68ed06d45", // VERSION_1
+					"bd15ec47-a3ec-329b-812b-9c617ca86881", // VERSION_3
+					"39499c61-11eb-5f02-a519-f2e38575cedd", // VERSION_5
+				},
+			},
+			expected: `^\[test-path.additionalNetworkIDs\[0\]: Invalid value: \"25b91ff0-75c3-11ea-9aff-4fc68ed06d45\": valid UUID v4 must be specified, test-path.additionalNetworkIDs\[1\]: Invalid value: \"bd15ec47-a3ec-329b-812b-9c617ca86881\": valid UUID v4 must be specified, test-path.additionalNetworkIDs\[2\]: Invalid value: \"39499c61-11eb-5f02-a519-f2e38575cedd\": valid UUID v4 must be specified\]$`,
+		},
+		{
+			name: "valid additional security group ids",
+			pool: &openstack.MachinePool{
+				AdditionalSecurityGroupIDs: []string{
+					"51e5fe10-5325-4a32-bce8-7ebe9708c453",
+					"3ade1375-acfd-4eda-90be-3530af4f25ec",
+					"460e993b-e932-43c6-a7a2-e51ca58f4eae",
+				},
+			},
+		},
+		{
+			name: "invalid additional security group ids",
+			pool: &openstack.MachinePool{
+				AdditionalSecurityGroupIDs: []string{
+					"51e5fe10-5325-4a32-bce8-7ebe9708c453",
+					"INVALID",
+					"",
+				},
+			},
+			expected: `^\[test-path.additionalSecurityGroupIDs\[1\]: Invalid value: \"INVALID\": valid UUID v4 must be specified, test-path.additionalSecurityGroupIDs\[2\]: Invalid value: \"\": valid UUID v4 must be specified\]$`,
+		},
+		{
+			name: "wrong additional security group ids version",
+			pool: &openstack.MachinePool{
+				AdditionalSecurityGroupIDs: []string{
+					"25b91ff0-75c3-11ea-9aff-4fc68ed06d45", // VERSION_1
+					"bd15ec47-a3ec-329b-812b-9c617ca86881", // VERSION_3
+					"39499c61-11eb-5f02-a519-f2e38575cedd", // VERSION_5
+				},
+			},
+			expected: `^\[test-path.additionalSecurityGroupIDs\[0\]: Invalid value: \"25b91ff0-75c3-11ea-9aff-4fc68ed06d45\": valid UUID v4 must be specified, test-path.additionalSecurityGroupIDs\[1\]: Invalid value: \"bd15ec47-a3ec-329b-812b-9c617ca86881\": valid UUID v4 must be specified, test-path.additionalSecurityGroupIDs\[2\]: Invalid value: \"39499c61-11eb-5f02-a519-f2e38575cedd\": valid UUID v4 must be specified\]$`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -470,7 +470,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: `^compute\[0\]\.platform\.openstack: Invalid value: openstack\.MachinePool{FlavorName:"", RootVolume:\(\*openstack\.RootVolume\)\(nil\)}: cannot specify "openstack" for machine pool when cluster is using "aws"$`,
+			expectedError: `^compute\[0\]\.platform\.openstack: Invalid value: openstack\.MachinePool{.*}: cannot specify "openstack" for machine pool when cluster is using "aws"$`,
 		},
 		{
 			name: "missing platform",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1810,7 +1810,7 @@ sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1
-# sigs.k8s.io/cluster-api-provider-openstack v0.0.0 => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200221124403-d699c3611b0c
+# sigs.k8s.io/cluster-api-provider-openstack v0.0.0 => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200323110431-3311de91e078
 sigs.k8s.io/cluster-api-provider-openstack/pkg/apis
 sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1
 # sigs.k8s.io/controller-runtime v0.4.0

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -121,6 +121,8 @@ type NetworkParam struct {
 	Filter Filter `json:"filter,omitempty"`
 	// Subnet within a network to use
 	Subnets []SubnetParam `json:"subnets,omitempty"`
+	// NoAllowedAddressPairs disables creation of allowed address pairs for the network ports
+	NoAllowedAddressPairs bool `json:"noAllowedAddressPairs,omitempty"`
 }
 
 type Filter struct {


### PR DESCRIPTION
In some cases we may need to provide access to additional networks and security groups. An example of this need would be to mount RWX volumes from OpenStack Manila, when shares are in another network (OSP default).
Since we plan to use Manila as the primary backend for the image registry, it is essential that we have this feature in IPI.

This PR adds two new parameters to OpenStack's MachinePool:
* `additionalNetworkIDs` (optional list of strings): IDs of additional networks for machines.
* `additionalSecurityGroupIDs` (optional list of strings): IDs of additional security groups for machines.