### PR TITLE
Add AWS CLI to UPI image.

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -44,6 +44,10 @@ RUN curl -L -O -k https://vcsa-ci.vmware.devcluster.openshift.com/certs/download
     unzip download.zip && \
     cp certs/lin/* /etc/pki/ca-trust/source/anchors && \
     update-ca-trust extract
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install -b /bin && \
+    rm -rf ./aws awscliv2.zip
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000


### PR DESCRIPTION
Add the AWS CLI to the UPI image for use in the upi templates (which install the cli through pip) and the VSphere IPI template. These commands are the same as used by the OpenStack Dockerfile.

/test e2e-aws-upi 