### PR TITLE
AWS: replace aws copy for encryption with encrypted EBS volumes

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -4,6 +4,8 @@ locals {
 
 data "aws_partition" "current" {}
 
+data "aws_ebs_default_kms_key" "current" {}
+
 resource "aws_s3_bucket" "ignition" {
   acl = "private"
 
@@ -142,6 +144,8 @@ resource "aws_instance" "bootstrap" {
     volume_type = var.volume_type
     volume_size = var.volume_size
     iops        = var.volume_type == "io1" ? var.volume_iops : 0
+    encrypted   = true
+    kms_key_id  = var.volume_kms_key_id == "" ? data.aws_ebs_default_kms_key.current.key_arn : var.volume_kms_key_id
   }
 
   volume_tags = merge(

--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -57,6 +57,11 @@ variable "volume_type" {
   description = "The volume type for the bootstrap node's root volume."
 }
 
+variable "volume_kms_key_id" {
+  type        = string
+  description = "The KMS key id that should be used to encrypt the bootstrap node's root block device."
+}
+
 variable "vpc_id" {
   type        = string
   description = "VPC ID is used to create resources like security group rules for bootstrap machine."

--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  ami                      = aws_ami_copy.main.id
+  ami                      = var.aws_ami
   instance_type            = var.aws_bootstrap_instance_type
   cluster_id               = var.cluster_id
   ignition                 = var.ignition_bootstrap
@@ -28,6 +28,7 @@ module "bootstrap" {
   vpc_id                   = module.vpc.vpc_id
   vpc_cidrs                = module.vpc.vpc_cidrs
   vpc_security_group_ids   = [module.vpc.master_sg_id]
+  volume_kms_key_id        = var.aws_master_root_volume_kms_key_id
   publish_strategy         = var.aws_publish_strategy
 
   tags = local.tags
@@ -48,9 +49,11 @@ module "masters" {
   root_volume_iops         = var.aws_master_root_volume_iops
   root_volume_size         = var.aws_master_root_volume_size
   root_volume_type         = var.aws_master_root_volume_type
+  root_volume_encrypted    = var.aws_master_root_volume_encrypted
+  root_volume_kms_key_id   = var.aws_master_root_volume_kms_key_id
   target_group_arns        = module.vpc.aws_lb_target_group_arns
   target_group_arns_length = module.vpc.aws_lb_target_group_arns_length
-  ec2_ami                  = aws_ami_copy.main.id
+  ec2_ami                  = var.aws_ami
   user_data_ign            = var.ignition_master
   publish_strategy         = var.aws_publish_strategy
 }
@@ -97,21 +100,5 @@ module "vpc" {
   )
 
   tags = local.tags
-}
-
-resource "aws_ami_copy" "main" {
-  name              = "${var.cluster_id}-master"
-  source_ami_id     = var.aws_ami
-  source_ami_region = var.aws_region
-  encrypted         = true
-
-  tags = merge(
-    {
-      "Name"         = "${var.cluster_id}-master"
-      "sourceAMI"    = var.aws_ami
-      "sourceRegion" = var.aws_region
-    },
-    local.tags,
-  )
 }
 

--- a/data/data/aws/master/main.tf
+++ b/data/data/aws/master/main.tf
@@ -6,6 +6,8 @@ locals {
 
 data "aws_partition" "current" {}
 
+data "aws_ebs_default_kms_key" "current" {}
+
 resource "aws_iam_instance_profile" "master" {
   name = "${var.cluster_id}-master-profile"
 
@@ -121,6 +123,8 @@ resource "aws_instance" "master" {
     volume_type = var.root_volume_type
     volume_size = var.root_volume_size
     iops        = var.root_volume_type == "io1" ? var.root_volume_iops : 0
+    encrypted   = var.root_volume_encrypted
+    kms_key_id  = var.root_volume_kms_key_id == "" ? data.aws_ebs_default_kms_key.current.key_arn : var.root_volume_kms_key_id
   }
 
   volume_tags = merge(

--- a/data/data/aws/master/variables.tf
+++ b/data/data/aws/master/variables.tf
@@ -50,6 +50,16 @@ variable "root_volume_type" {
   description = "The type of volume for the root block device."
 }
 
+variable "root_volume_encrypted" {
+  type        = bool
+  description = "Whether the root block device should be encrypted."
+}
+
+variable "root_volume_kms_key_id" {
+  type        = string
+  description = "The KMS key id that should be used tpo encrypt the root block device."
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -54,6 +54,27 @@ EOF
 
 }
 
+variable "aws_master_root_volume_encrypted" {
+  type = bool
+
+  description = <<EOF
+Indicates whether the root EBS volume for master is encrypted. Encrypted Amazon EBS volumes
+may only be attached to machines that support Amazon EBS encryption.
+EOF
+
+}
+
+variable "aws_master_root_volume_kms_key_id" {
+  type = string
+
+  description = <<EOF
+(optional) Indicates the KMS key that should be used to encrypt the Amazon EBS volume.
+If not set and root volume has to be encrypted, the default KMS key for the account will be used.
+EOF
+
+  default = ""
+}
+
 variable "aws_region" {
   type = string
   description = "The target AWS region for the cluster."

--- a/docs/user/aws/customization.md
+++ b/docs/user/aws/customization.md
@@ -20,6 +20,9 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
         This is only valid for `type` `io1`.
     * `size` (optional integer): Size of the root volume in gibibytes (GiB).
     * `type` (optional string):  The [type of volume][volume-type].
+    * `kmsKeyARN` (optional string): The [ARN of KMS key][ebs-kms-key] that should be used to encrypt the EBS volume.
+        When no key is specified by user, the account's [default KMS Key][kms-key-default] for the region will be used.
+        Example ARN values are: `arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab` or `arn:aws:kms:us-east-1:111122223333:alias/my-key`
 * `type` (optional string): The [EC2 instance type][instance-type].
 * `zones` (optional array of strings): The availability zones used for machines in the pool.
 
@@ -68,6 +71,7 @@ compute:
         iops: 4000
         size: 500
         type: io1
+        kmsKeyARN: arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab
       type: c5.9xlarge
       zones:
       - us-west-2c
@@ -83,5 +87,7 @@ sshKey: ssh-ed25519 AAAA...
 
 [availablity-zones]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
 [instance-type]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html
+[kms-key-default]: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+[kms-key]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
 [volume-iops]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html
 [volume-type]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603
 	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200128081049-840376ca5c09
 	github.com/openshift/library-go v0.0.0-20200210105614-4bf528465627
-	github.com/openshift/machine-api-operator v0.2.1-0.20200211164549-65f366001347
+	github.com/openshift/machine-api-operator v0.2.1-0.20200310180732-c63fa2b143f0
 	github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible
 	github.com/ovirt/go-ovirt v4.3.4+incompatible
 	github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200122105935-65b89ad00553
@@ -159,7 +159,7 @@ replace (
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.1 // Replaced by MCO/CRI-O
 	k8s.io/metrics => k8s.io/metrics v0.17.1 // Replaced by MCO/CRI-O
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.1 // Replaced by MCO/CRI-O
-	sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200204144622-0df2d100309c // Pin OpenShift fork
+	sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200316201703-923caeb1d0d8 // Pin OpenShift fork
 	sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b // Pin OpenShift fork
 	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200130125124-ef82ce374112 // Pin OpenShift fork
 )

--- a/go.sum
+++ b/go.sum
@@ -1766,8 +1766,8 @@ github.com/openshift/cluster-api v0.0.0-20191030113141-9a3a7bbe9258/go.mod h1:T1
 github.com/openshift/cluster-api v0.0.0-20191129101638-b09907ac6668 h1:IDZyg/Kye98ptqpc9j9rzPjZJlijjEDe8g7TZ67CmLU=
 github.com/openshift/cluster-api v0.0.0-20191129101638-b09907ac6668/go.mod h1:T18COkr6nLh9RyZKPMP7YjnwBME7RX8P2ar1SQbBltM=
 github.com/openshift/cluster-api-actuator-pkg v0.0.0-20190614215203-42228d06a2ca/go.mod h1:KNPaA64x3Ok7z538kvS2acwC5fEwvPfF0RdTx2geQEE=
-github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200204144622-0df2d100309c h1:Xy9oQu/23dWIfb16kuSwev++aCwszRPBdqwdMGYw0Zk=
-github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200204144622-0df2d100309c/go.mod h1:ZoUVLK6Sz9wmeVsD0Vc2AmHY3rJeAWQyQW2uRW7vwh4=
+github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200316201703-923caeb1d0d8 h1:PN6SLAJ3rhTxOORCOYCjUCeko6uisulOTGOcJ34oPDU=
+github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200316201703-923caeb1d0d8/go.mod h1:Tap/FtbogcRCV6aSVYY/FRhT+IBBQCRgE38fue32nqU=
 github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b h1:xVFJ2MCv6QBBk49FEzMmdQF/21qr8x5UhW1NFqZ13oM=
 github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b/go.mod h1:LPNjFna6F+ePHaXM/7QIyCF0sLsEtfuN16yY9sFZJ40=
 github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d h1:6+XwaVvSMPHm3nFdZW3g+iXiOHpf0Y2ajY5/Zr66Dt0=
@@ -1794,8 +1794,8 @@ github.com/openshift/library-go v0.0.0-20200210105614-4bf528465627 h1:Rs1RtB123V
 github.com/openshift/library-go v0.0.0-20200210105614-4bf528465627/go.mod h1:T+sDdW3J/cgxUSqPdAwmhFrJhfFRv1ZtCSTVY59phN4=
 github.com/openshift/machine-api-operator v0.0.0-20190312153711-9650e16c9880/go.mod h1:7HeAh0v04zQn1L+4ItUjvpBQYsm2Nf81WaZLiXTcnkc=
 github.com/openshift/machine-api-operator v0.2.1-0.20191128180243-986b771e661d/go.mod h1:9qQPF00anuIsc6RiHYfHE0+cZZImbvFNLln0NRBVVMg=
-github.com/openshift/machine-api-operator v0.2.1-0.20200211164549-65f366001347 h1:ATq+gLgVMVsYI62bckQymIMVTmS45fLm8ZqxJl4Da/Y=
-github.com/openshift/machine-api-operator v0.2.1-0.20200211164549-65f366001347/go.mod h1:b3huCV+DbroXP1sHtsU5xBwx97zqc6GKB5owyl2zsNM=
+github.com/openshift/machine-api-operator v0.2.1-0.20200310180732-c63fa2b143f0 h1:Na0422T5qq9e4AtBqH4hyqujESg29Akrf2asy/kc02U=
+github.com/openshift/machine-api-operator v0.2.1-0.20200310180732-c63fa2b143f0/go.mod h1:b3huCV+DbroXP1sHtsU5xBwx97zqc6GKB5owyl2zsNM=
 github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530 h1:r9eSp963LcaLw3YUyJHMHwZYXoaGXOc2MOKVQQrdRmw=
 github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530/go.mod h1:z3udws7UDLBp233iGbayvpZEwhWn74K9xzjDtCGJlok=
 github.com/openshift/runtime-utils v0.0.0-20191011150825-9169de69ebf6/go.mod h1:5gDRVvQwesU7cfwlpuMivdv3Dz/oslvv2qTBHCy4wqQ=

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -199,7 +199,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		for i, m := range workers {
 			workerConfigs[i] = m.Spec.Template.Spec.ProviderSpec.Value.Object.(*awsprovider.AWSMachineProviderConfig)
 		}
-		data, err := awstfvars.TFVars(vpc, privateSubnets, publicSubnets, installConfig.Config.Publish, masterConfigs, workerConfigs)
+		data, err := awstfvars.TFVars(awstfvars.TFVarsSources{
+			VPC:            vpc,
+			PrivateSubnets: privateSubnets,
+			PublicSubnets:  publicSubnets,
+			Publish:        installConfig.Config.Publish,
+			MasterConfigs:  masterConfigs,
+			WorkerConfigs:  workerConfigs,
+		})
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -97,6 +97,8 @@ func provider(clusterID string, region string, subnet string, instanceType strin
 					VolumeType: pointer.StringPtr(root.Type),
 					VolumeSize: pointer.Int64Ptr(int64(root.Size)),
 					Iops:       pointer.Int64Ptr(int64(root.IOPS)),
+					Encrypted:  pointer.BoolPtr(true),
+					KMSKey:     awsprovider.AWSResourceReference{ARN: pointer.StringPtr(root.KMSKeyARN)},
 				},
 			},
 		},

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -22,6 +22,8 @@ type config struct {
 	IOPS                    int64             `json:"aws_master_root_volume_iops"`
 	Size                    int64             `json:"aws_master_root_volume_size,omitempty"`
 	Type                    string            `json:"aws_master_root_volume_type,omitempty"`
+	Encrypted               bool              `json:"aws_master_root_volume_encrypted"`
+	KMSKeyID                string            `json:"aws_master_root_volume_kms_key_id,omitempty"`
 	Region                  string            `json:"aws_region,omitempty"`
 	VPC                     string            `json:"aws_vpc,omitempty"`
 	PrivateSubnets          []string          `json:"aws_private_subnets,omitempty"`
@@ -29,23 +31,33 @@ type config struct {
 	PublishStrategy         string            `json:"aws_publish_strategy,omitempty"`
 }
 
+// TFVarsSources contains the parameters to be converted into Terraform variables
+type TFVarsSources struct {
+	VPC                           string
+	PrivateSubnets, PublicSubnets []string
+
+	Publish types.PublishingStrategy
+
+	MasterConfigs, WorkerConfigs []*v1beta1.AWSMachineProviderConfig
+}
+
 // TFVars generates AWS-specific Terraform variables launching the cluster.
-func TFVars(vpc string, privateSubnets []string, publicSubnets []string, publish types.PublishingStrategy, masterConfigs []*v1beta1.AWSMachineProviderConfig, workerConfigs []*v1beta1.AWSMachineProviderConfig) ([]byte, error) {
-	masterConfig := masterConfigs[0]
+func TFVars(sources TFVarsSources) ([]byte, error) {
+	masterConfig := sources.MasterConfigs[0]
 
 	tags := make(map[string]string, len(masterConfig.Tags))
 	for _, tag := range masterConfig.Tags {
 		tags[tag.Name] = tag.Value
 	}
 
-	masterAvailabilityZones := make([]string, len(masterConfigs))
-	for i, c := range masterConfigs {
+	masterAvailabilityZones := make([]string, len(sources.MasterConfigs))
+	for i, c := range sources.MasterConfigs {
 		masterAvailabilityZones[i] = c.Placement.AvailabilityZone
 	}
 
 	exists := struct{}{}
 	availabilityZoneMap := map[string]struct{}{}
-	for _, c := range workerConfigs {
+	for _, c := range sources.WorkerConfigs {
 		availabilityZoneMap[c.Placement.AvailabilityZone] = exists
 	}
 	workerAvailabilityZones := make([]string, 0, len(availabilityZoneMap))
@@ -86,21 +98,31 @@ func TFVars(vpc string, privateSubnets []string, publicSubnets []string, publish
 		MasterInstanceType:      masterConfig.InstanceType,
 		Size:                    *rootVolume.EBS.VolumeSize,
 		Type:                    *rootVolume.EBS.VolumeType,
-		VPC:                     vpc,
-		PrivateSubnets:          privateSubnets,
-		PublishStrategy:         string(publish),
+		VPC:                     sources.VPC,
+		PrivateSubnets:          sources.PrivateSubnets,
+		PublishStrategy:         string(sources.Publish),
 	}
 
-	if len(publicSubnets) == 0 {
+	if len(sources.PublicSubnets) == 0 {
 		if cfg.VPC != "" {
 			cfg.PublicSubnets = &[]string{}
 		}
 	} else {
-		cfg.PublicSubnets = &publicSubnets
+		cfg.PublicSubnets = &sources.PublicSubnets
 	}
 
 	if rootVolume.EBS.Iops != nil {
 		cfg.IOPS = *rootVolume.EBS.Iops
+	}
+
+	cfg.Encrypted = true
+	if rootVolume.EBS.Encrypted != nil {
+		cfg.Encrypted = *rootVolume.EBS.Encrypted
+	}
+	if rootVolume.EBS.KMSKey.ID != nil && *rootVolume.EBS.KMSKey.ID != "" {
+		cfg.KMSKeyID = *rootVolume.EBS.KMSKey.ID
+	} else if rootVolume.EBS.KMSKey.ARN != nil && *rootVolume.EBS.KMSKey.ARN != "" {
+		cfg.KMSKeyID = *rootVolume.EBS.KMSKey.ARN
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/aws/machinepool.go
+++ b/pkg/types/aws/machinepool.go
@@ -37,6 +37,9 @@ func (a *MachinePool) Set(required *MachinePool) {
 	if required.EC2RootVolume.Type != "" {
 		a.EC2RootVolume.Type = required.EC2RootVolume.Type
 	}
+	if required.EC2RootVolume.KMSKeyARN != "" {
+		a.EC2RootVolume.KMSKeyARN = required.EC2RootVolume.KMSKeyARN
+	}
 }
 
 // EC2RootVolume defines the storage for an ec2 instance.
@@ -48,4 +51,10 @@ type EC2RootVolume struct {
 	Size int `json:"size"`
 	// Type defines the type of the volume.
 	Type string `json:"type"`
+
+	// The KMS key that will be used to encrypt the EBS volume.
+	// If no key is provided the default KMS key for the account will be used.
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+	// +optional
+	KMSKeyARN string `json:"kmsKeyARN,omitempty"`
 }

--- a/vendor/github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
@@ -55,6 +55,18 @@ type MachineHealthCheckSpec struct {
 	// "selector" are not healthy.
 	// +optional
 	MaxUnhealthy *intstr.IntOrString `json:"maxUnhealthy,omitempty"`
+
+	// It would be preferable for nodeStartupTimeout to be a metav1.Duration, but
+	// there's no good way to validate the format here.  Invalid input would cause
+	// problems with marshaling, so it's better to just make it a string and
+	// handle the conversion in the controller.
+	//
+	// Intentional blank line to keep this out of the OpenAPI description...
+
+	// Machines older than this duration without a node will be considered to have
+	// failed and will be remediated.
+	// +optional
+	NodeStartupTimeout string `json:"nodeStartupTimeout,omitempty"`
 }
 
 // UnhealthyCondition represents a Node condition type and value with a timeout

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1022,7 +1022,7 @@ github.com/openshift/cluster-api-provider-ovirt/pkg/apis
 github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1
 # github.com/openshift/library-go v0.0.0-20200210105614-4bf528465627
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
-# github.com/openshift/machine-api-operator v0.2.1-0.20200211164549-65f366001347
+# github.com/openshift/machine-api-operator v0.2.1-0.20200310180732-c63fa2b143f0
 github.com/openshift/machine-api-operator/pkg/apis/machine
 github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1
 github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider
@@ -1773,7 +1773,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# sigs.k8s.io/cluster-api-provider-aws v0.0.0 => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200204144622-0df2d100309c
+# sigs.k8s.io/cluster-api-provider-aws v0.0.0 => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200316201703-923caeb1d0d8
 sigs.k8s.io/cluster-api-provider-aws/pkg/apis
 sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1
 # sigs.k8s.io/cluster-api-provider-azure v0.0.0 => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b

--- a/vendor/sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1/awsmachineproviderconfig_types.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1/awsmachineproviderconfig_types.go
@@ -180,6 +180,9 @@ type EBSBlockDeviceSpec struct {
 	// may only be attached to machines that support Amazon EBS encryption.
 	Encrypted *bool `json:"encrypted,omitempty"`
 
+	// Indicates the KMS key that should be used to encrypt the Amazon EBS volume.
+	KMSKey AWSResourceReference `json:"kmsKey,omitempty"`
+
 	// The number of I/O operations per second (IOPS) that the volume supports.
 	// For io1, this represents the number of IOPS that are provisioned for the
 	// volume. For gp2, this represents the baseline performance of the volume and

--- a/vendor/sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1/zz_generated.deepcopy.go
@@ -272,6 +272,7 @@ func (in *EBSBlockDeviceSpec) DeepCopyInto(out *EBSBlockDeviceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	in.KMSKey.DeepCopyInto(&out.KMSKey)
 	if in.Iops != nil {
 		in, out := &in.Iops, &out.Iops
 		*out = new(int64)


### PR DESCRIPTION
xref: https://issues.redhat.com/browse/CORS-1352
depends on https://github.com/openshift/cluster-api-provider-aws/pull/303

Amazon supports using [encrypted root EBS volumes][1]. So instead of copying the AMI and encrypting in the process we can use the encypted EBS volumes instead which saves us making the AMI copy during install.

The change also allows the user to provide KMS key to the terraform instead of the default KMS key.

Using this change the instance boots with public RHCOS AMI, and the EBS volume is encrypted with default KMS key for the account and region.
```console
[4:42:15] ➜  installer git:(ami_no_copy) ✗ AWS_PROFILE=openshift-dev aws ec2 describe-volumes --region ca-central-1 --volume-ids vol-09ceb58bc9ac93602
{
    "Volumes": [
        {
            "Attachments": [
                {
                    "AttachTime": "2020-03-13T23:30:09.000Z",
                    "Device": "/dev/xvda",
                    "InstanceId": "i-0bdec7b64f2b9a607",
                    "State": "attached",
                    "VolumeId": "vol-09ceb58bc9ac93602",
                    "DeleteOnTermination": true
                }
            ],
            "AvailabilityZone": "ca-central-1b",
            "CreateTime": "2020-03-13T23:30:09.789Z",
            "Encrypted": true,
            "KmsKeyId": "arn:aws:kms:ca-central-1:<REDACTED>:key/1ffbfa61-7250-42de-9a75-cac64a8f0e4d",
            "Size": 120,
            "SnapshotId": "snap-0c8421bbe06f5f69d",
            "State": "in-use",
            "VolumeId": "vol-09ceb58bc9ac93602",
            "Iops": 360,
            "Tags": [
                {
                    "Key": "kubernetes.io/cluster/adahiya-1-djk4q",
                    "Value": "owned"
                },
                {
                    "Key": "Name",
                    "Value": "adahiya-1-djk4q-master-1-vol"
                }
            ],
            "VolumeType": "gp2"
        }
    ]
}
[4:42:28] ➜  installer git:(ami_no_copy) ✗ AWS_PROFILE=openshift-dev aws ec2 describe-instances --region ca-central-1 --instance-ids i-0bdec7b64f2b9a607
{
    "Reservations": [
        {
            "Groups": [],
            "Instances": [
                {
                    "AmiLaunchIndex": 0,
                    "ImageId": "ami-0d235b4920e9def96",
                    "InstanceId": "i-0bdec7b64f2b9a607",
                    "InstanceType": "m4.xlarge",
                    "LaunchTime": "2020-03-13T23:30:09.000Z",
...
                    "BlockDeviceMappings": [
                        {
                            "DeviceName": "/dev/xvda",
                            "Ebs": {
                                "AttachTime": "2020-03-13T23:30:09.000Z",
                                "DeleteOnTermination": true,
                                "Status": "attached",
                                "VolumeId": "vol-09ceb58bc9ac93602"
                            }
                        }
                    ],
...
                    "Tags": [
                        {
                            "Key": "Name",
                            "Value": "adahiya-1-djk4q-master-1"
                        },
                        {
                            "Key": "kubernetes.io/cluster/adahiya-1-djk4q",
                            "Value": "owned"
                        }
                    ],
...
        }
    ]
}
[4:44:31] ➜  installer git:(ami_no_copy) ✗
```

Users can provide the KMS Key ARN which should be used to encrypt the EBS volumes otherwise the default KMS key for the region will be used.

[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html