### PR TITLE
[release-4.4] Bug 1813851: OpenStack: start using image import when possible

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -398,8 +398,7 @@
   version = "v0.2.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:0989b632c84399624334e9ed9b8157319cf01d211140c0a4f78f780564caeeb0"
+  digest = "1:28944402500e0013e987179c15016f1b151889f7c1337df136aeafa05a675003"
   name = "github.com/gophercloud/gophercloud"
   packages = [
     ".",
@@ -414,6 +413,7 @@
     "openstack/identity/v2/tokens",
     "openstack/identity/v3/tokens",
     "openstack/imageservice/v2/imagedata",
+    "openstack/imageservice/v2/imageimport",
     "openstack/imageservice/v2/images",
     "openstack/loadbalancer/v2/apiversions",
     "openstack/loadbalancer/v2/l7policies",
@@ -438,7 +438,8 @@
     "pagination",
   ]
   pruneopts = "NUT"
-  revision = "6ad562af8c1fd8a69397a13caf58fa184d115b56"
+  revision = "21353468abed58d85242df15e1be5339ba985662"
+  version = "v0.8.0"
 
 [[projects]]
   branch = "master"
@@ -1471,6 +1472,7 @@
     "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
     "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
     "github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata",
+    "github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport",
     "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions",
     "github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/loadbalancers",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,8 +91,8 @@ required = [
   branch = "master"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/gophercloud/gophercloud"
+  version = "0.8.0"
 
 [[constraint]]
   branch = "master"

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -75,20 +75,6 @@ module "topology" {
   octavia_support     = var.openstack_octavia_support
 }
 
-resource "openstack_images_image_v2" "base_image" {
-  // we need to create a new image only if the base image local file path has been provided, plus base image name is <cluster_id>-rhcos
-  count = var.openstack_base_image_local_file_path != "" && var.openstack_base_image_name == "${var.cluster_id}-rhcos" ? 1 : 0
-
-  name             = var.openstack_base_image_name
-  local_file_path  = var.openstack_base_image_local_file_path
-  container_format = "bare"
-  disk_format      = "qcow2"
-
-  tags = ["openshiftClusterID=${var.cluster_id}"]
-}
-
 data "openstack_images_image_v2" "base_image" {
   name = var.openstack_base_image_name
-
-  depends_on = ["openstack_images_image_v2.base_image"]
 }

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -15,12 +15,6 @@ variable "openstack_base_image_name" {
   description = "Name of the base image to use for the nodes."
 }
 
-variable "openstack_base_image_local_file_path" {
-  type        = string
-  default     = ""
-  description = "Local file path of the base image file to use for the nodes."
-}
-
 variable "openstack_bootstrap_shim_ignition" {
   type        = string
   default     = ""

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -16,21 +16,20 @@ import (
 )
 
 type config struct {
-	BaseImageName          string   `json:"openstack_base_image_name,omitempty"`
-	BaseImageLocalFilePath string   `json:"openstack_base_image_local_file_path,omitempty"`
-	ExternalNetwork        string   `json:"openstack_external_network,omitempty"`
-	Cloud                  string   `json:"openstack_credentials_cloud,omitempty"`
-	FlavorName             string   `json:"openstack_master_flavor_name,omitempty"`
-	LbFloatingIP           string   `json:"openstack_lb_floating_ip,omitempty"`
-	APIVIP                 string   `json:"openstack_api_int_ip,omitempty"`
-	DNSVIP                 string   `json:"openstack_node_dns_ip,omitempty"`
-	IngressVIP             string   `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport           string   `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport         string   `json:"openstack_octavia_support,omitempty"`
-	RootVolumeSize         int      `json:"openstack_master_root_volume_size,omitempty"`
-	RootVolumeType         string   `json:"openstack_master_root_volume_type,omitempty"`
-	BootstrapShim          string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
-	ExternalDNS            []string `json:"openstack_external_dns,omitempty"`
+	BaseImageName   string   `json:"openstack_base_image_name,omitempty"`
+	ExternalNetwork string   `json:"openstack_external_network,omitempty"`
+	Cloud           string   `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName      string   `json:"openstack_master_flavor_name,omitempty"`
+	LbFloatingIP    string   `json:"openstack_lb_floating_ip,omitempty"`
+	APIVIP          string   `json:"openstack_api_int_ip,omitempty"`
+	DNSVIP          string   `json:"openstack_node_dns_ip,omitempty"`
+	IngressVIP      string   `json:"openstack_ingress_ip,omitempty"`
+	TrunkSupport    string   `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport  string   `json:"openstack_octavia_support,omitempty"`
+	RootVolumeSize  int      `json:"openstack_master_root_volume_size,omitempty"`
+	RootVolumeType  string   `json:"openstack_master_root_volume_type,omitempty"`
+	BootstrapShim   string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
+	ExternalDNS     []string `json:"openstack_external_dns,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
@@ -62,7 +61,11 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 		if err != nil {
 			return nil, err
 		}
-		cfg.BaseImageLocalFilePath = localFilePath
+
+		err = uploadBaseImage(cloud, localFilePath, imageName, infraID)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// Not a URL -> use baseImage value as an overridden Glance image name.
 		// Need to check if this image exists and there are no other images with this name.

--- a/pkg/tfvars/openstack/rhcos_image.go
+++ b/pkg/tfvars/openstack/rhcos_image.go
@@ -1,0 +1,54 @@
+package openstack
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/sirupsen/logrus"
+)
+
+// uploadBaseImage creates a new image in Glance and uploads the RHCOS image there
+func uploadBaseImage(cloud string, localFilePath string, imageName string, clusterID string) error {
+	logrus.Debugln("Creating a Glance image for RHCOS...")
+
+	f, err := os.Open(localFilePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	opts := clientconfig.ClientOpts{
+		Cloud: cloud,
+	}
+
+	conn, err := clientconfig.NewServiceClient("image", &opts)
+	if err != nil {
+		return err
+	}
+
+	imageCreateOpts := images.CreateOpts{
+		Name:            imageName,
+		ContainerFormat: "bare",
+		DiskFormat:      "qcow2",
+		Tags:            []string{fmt.Sprintf("openshiftClusterID=%s", clusterID)},
+		// TODO(mfedosin): add Description when gophercloud supports it.
+	}
+
+	img, err := images.Create(conn, imageCreateOpts).Extract()
+	if err != nil {
+		return err
+	}
+	logrus.Debugf("Image %s was created.", img.Name)
+
+	logrus.Debugf("Uploading RHCOS to the image %v with ID %v", img.Name, img.ID)
+	res := imagedata.Upload(conn, img.ID, f)
+	if res.Err != nil {
+		return err
+	}
+	logrus.Debugf("The data was uploaded.")
+
+	return nil
+}

--- a/pkg/tfvars/openstack/rhcos_image.go
+++ b/pkg/tfvars/openstack/rhcos_image.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imagedata"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/sirupsen/logrus"
@@ -51,4 +53,44 @@ func uploadBaseImage(cloud string, localFilePath string, imageName string, clust
 	logrus.Debugf("The data was uploaded.")
 
 	return nil
+}
+
+// isImageImportSupported checks if we can use Image Import mechanism for image uploading
+func isImageImportSupported(cloud string) (bool, error) {
+	// More information about the Discovery API:
+	// https://docs.openstack.org/api-ref/image/v2/?expanded=#image-service-info-discovery
+	logrus.Debugln("Checking if the image import mechanism is supported")
+
+	opts := clientconfig.ClientOpts{
+		Cloud: cloud,
+	}
+
+	conn, err := clientconfig.NewServiceClient("image", &opts)
+	if err != nil {
+		return false, err
+	}
+
+	s, err := imageimport.Get(conn).Extract()
+	if err != nil {
+		// ErrDefault404 means that image discovery API is not available for the cloud
+		if _, ok := err.(gophercloud.ErrDefault404); ok {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Next check is just to make sure the response data was not corrupted
+	if s.ImportMethods.Type != "array" {
+		return false, nil
+	}
+
+	for _, method := range s.ImportMethods.Value {
+		if method == string(imageimport.GlanceDirectMethod) {
+			logrus.Debugln("Glance Direct image import plugin was found")
+			return true, nil
+		}
+	}
+
+	logrus.Debugln("Glance Direct image import plugin was not found")
+	return false, nil
 }

--- a/vendor/github.com/gophercloud/gophercloud/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/errors.go
@@ -92,6 +92,23 @@ func (e ErrUnexpectedResponseCode) Error() string {
 	return e.choseErrString()
 }
 
+// GetStatusCode returns the actual status code of the error.
+func (e ErrUnexpectedResponseCode) GetStatusCode() int {
+	return e.Actual
+}
+
+// StatusCodeError is a convenience interface to easily allow access to the
+// status code field of the various ErrDefault* types.
+//
+// By using this interface, you only have to make a single type cast of
+// the returned error to err.(StatusCodeError) and then call GetStatusCode()
+// instead of having a large switch statement checking for each of the
+// ErrDefault* types.
+type StatusCodeError interface {
+	Error() string
+	GetStatusCode() int
+}
+
 // ErrDefault400 is the default error type returned on a 400 HTTP response code.
 type ErrDefault400 struct {
 	ErrUnexpectedResponseCode

--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
@@ -432,7 +433,11 @@ func NewImageServiceV2(client *gophercloud.ProviderClient, eo gophercloud.Endpoi
 // load balancer service.
 func NewLoadBalancerV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "load-balancer")
-	sc.ResourceBase = sc.Endpoint + "v2.0/"
+
+	// Fixes edge case having an OpenStack lb endpoint with trailing version number.
+	endpoint := strings.Replace(sc.Endpoint, "v2.0/", "", -1)
+
+	sc.ResourceBase = endpoint + "v2.0/"
 	return sc, err
 }
 
@@ -472,4 +477,9 @@ func NewContainerInfraV1(client *gophercloud.ProviderClient, eo gophercloud.Endp
 // NewWorkflowV2 creates a ServiceClient that may be used with the v2 workflow management package.
 func NewWorkflowV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
 	return initClientOpts(client, eo, "workflowv2")
+}
+
+// NewPlacementV1 creates a ServiceClient that may be used with the placement package.
+func NewPlacementV1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
+	return initClientOpts(client, eo, "placement")
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/endpoint_location.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/endpoint_location.go
@@ -29,11 +29,12 @@ func V2EndpointURL(catalog *tokens2.ServiceCatalog, opts gophercloud.EndpointOpt
 		}
 	}
 
-	// Report an error if the options were ambiguous.
+	// If multiple endpoints were found, use the first result
+	// and disregard the other endpoints.
+	//
+	// This behavior matches the Python library. See GH-1764.
 	if len(endpoints) > 1 {
-		err := &ErrMultipleMatchingEndpointsV2{}
-		err.Endpoints = endpoints
-		return "", err
+		endpoints = endpoints[0:1]
 	}
 
 	// Extract the appropriate URL from the matching Endpoint.
@@ -91,9 +92,12 @@ func V3EndpointURL(catalog *tokens3.ServiceCatalog, opts gophercloud.EndpointOpt
 		}
 	}
 
-	// Report an error if the options were ambiguous.
+	// If multiple endpoints were found, use the first result
+	// and disregard the other endpoints.
+	//
+	// This behavior matches the Python library. See GH-1764.
 	if len(endpoints) > 1 {
-		return "", ErrMultipleMatchingEndpointsV3{Endpoints: endpoints}
+		endpoints = endpoints[0:1]
 	}
 
 	// Extract the URL from the matching Endpoint.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/errors.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/gophercloud/gophercloud"
-	tokens2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
-	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 )
 
 // ErrEndpointNotFound is the error when no suitable endpoint can be found
@@ -22,28 +20,6 @@ type ErrInvalidAvailabilityProvided struct{ gophercloud.ErrInvalidInput }
 
 func (e ErrInvalidAvailabilityProvided) Error() string {
 	return fmt.Sprintf("Unexpected availability in endpoint query: %s", e.Value)
-}
-
-// ErrMultipleMatchingEndpointsV2 is the error when more than one endpoint
-// for the given options is found in the v2 catalog
-type ErrMultipleMatchingEndpointsV2 struct {
-	gophercloud.BaseError
-	Endpoints []tokens2.Endpoint
-}
-
-func (e ErrMultipleMatchingEndpointsV2) Error() string {
-	return fmt.Sprintf("Discovered %d matching endpoints: %#v", len(e.Endpoints), e.Endpoints)
-}
-
-// ErrMultipleMatchingEndpointsV3 is the error when more than one endpoint
-// for the given options is found in the v3 catalog
-type ErrMultipleMatchingEndpointsV3 struct {
-	gophercloud.BaseError
-	Endpoints []tokens3.Endpoint
-}
-
-func (e ErrMultipleMatchingEndpointsV3) Error() string {
-	return fmt.Sprintf("Discovered %d matching endpoints: %#v", len(e.Endpoints), e.Endpoints)
 }
 
 // ErrNoAuthURL is the error when the OS_AUTH_URL environment variable is not

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/doc.go
@@ -1,0 +1,27 @@
+/*
+Package imageimport enables management of images import and retrieval of the
+Imageservice Import API information.
+
+Example to Get an information about the Import API
+
+  importInfo, err := imageimport.Get(imagesClient).Extract()
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("%+v\n", importInfo)
+
+Example to Create a new image import
+
+  opts := imageimport.CreateOpts{
+    Name: imageimport.WebDownloadMethod,
+    URI:  "http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img",
+  }
+  imageID := "da3b75d9-3f4a-40e7-8a2c-bfab23927dea"
+
+  err := imageimport.Create(imagesClient, imageID, opts).ExtractErr()
+  if err != nil {
+    panic(err)
+  }
+*/
+package imageimport

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/requests.go
@@ -1,0 +1,53 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+// ImportMethod represents valid Import API method.
+type ImportMethod string
+
+const (
+	// GlanceDirectMethod represents glance-direct Import API method.
+	GlanceDirectMethod ImportMethod = "glance-direct"
+
+	// WebDownloadMethod represents web-download Import API method.
+	WebDownloadMethod ImportMethod = "web-download"
+)
+
+// Get retrieves Import API information data.
+func Get(c *gophercloud.ServiceClient) (r GetResult) {
+	_, r.Err = c.Get(infoURL(c), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows to add additional parameters to the Create request.
+type CreateOptsBuilder interface {
+	ToImportCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies parameters of a new image import.
+type CreateOpts struct {
+	Name ImportMethod `json:"name"`
+	URI  string       `json:"uri"`
+}
+
+// ToImportCreateMap constructs a request body from CreateOpts.
+func (opts CreateOpts) ToImportCreateMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+	return map[string]interface{}{"method": b}, nil
+}
+
+// Create requests the creation of a new image import on the server.
+func Create(client *gophercloud.ServiceClient, imageID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToImportCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(importURL(client, imageID), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/results.go
@@ -1,0 +1,38 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult represents the result of a get operation. Call its Extract method
+// to interpret it as ImportInfo.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult is the result of import Create operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type CreateResult struct {
+	gophercloud.ErrResult
+}
+
+// ImportInfo represents information data for the Import API.
+type ImportInfo struct {
+	ImportMethods ImportMethods `json:"import-methods"`
+}
+
+// ImportMethods contains information about available Import API methods.
+type ImportMethods struct {
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	Value       []string `json:"value"`
+}
+
+// Extract is a function that accepts a result and extracts ImportInfo.
+func (r commonResult) Extract() (*ImportInfo, error) {
+	var s *ImportInfo
+	err := r.ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/imageservice/v2/imageimport/urls.go
@@ -1,0 +1,17 @@
+package imageimport
+
+import "github.com/gophercloud/gophercloud"
+
+const (
+	rootPath     = "images"
+	infoPath     = "info"
+	resourcePath = "import"
+)
+
+func infoURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(infoPath, resourcePath)
+}
+
+func importURL(c *gophercloud.ServiceClient, imageID string) string {
+	return c.ServiceURL(rootPath, imageID, resourcePath)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/requests.go
@@ -206,6 +206,9 @@ type UpdateOpts struct {
 	// Time, in milliseconds, to wait for additional TCP packets for content inspection
 	TimeoutTCPInspect *int `json:"timeout_tcp_inspect,omitempty"`
 
+	// A dictionary of optional headers to insert into the request before it is sent to the backend member.
+	InsertHeaders *map[string]string `json:"insert_headers,omitempty"`
+
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
 }

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/doc.go
@@ -25,14 +25,15 @@ Example to List Monitors
 Example to Create a Monitor
 
 	createOpts := monitors.CreateOpts{
-		Type:          "HTTP",
-		Name:          "db",
-		PoolID:        "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
-		Delay:         20,
-		Timeout:       10,
-		MaxRetries:    5,
-		URLPath:       "/check",
-		ExpectedCodes: "200-299",
+		Type:           "HTTP",
+		Name:           "db",
+		PoolID:         "84f1b61f-58c4-45bf-a8a9-2dafb9e5214d",
+		Delay:          20,
+		Timeout:        10,
+		MaxRetries:     5,
+		MaxRetriesDown: 4,
+		URLPath:        "/check",
+		ExpectedCodes:  "200-299",
 	}
 
 	monitor, err := monitors.Create(networkClient, createOpts).Extract()
@@ -45,12 +46,13 @@ Example to Update a Monitor
 	monitorID := "d67d56a6-4a86-4688-a282-f46444705c64"
 
 	updateOpts := monitors.UpdateOpts{
-		Name:          "NewHealthmonitorName",
-		Delay:         3,
-		Timeout:       20,
-		MaxRetries:    10,
-		URLPath:       "/another_check",
-		ExpectedCodes: "301",
+		Name:           "NewHealthmonitorName",
+		Delay:          3,
+		Timeout:        20,
+		MaxRetries:     10,
+		MaxRetriesDown: 8,
+		URLPath:        "/another_check",
+		ExpectedCodes:  "301",
 	}
 
 	monitor, err := monitors.Update(networkClient, monitorID, updateOpts).Extract()

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/requests.go
@@ -19,24 +19,25 @@ type ListOptsBuilder interface {
 // sort by a particular Monitor attribute. SortDir sets the direction, and is
 // either `asc' or `desc'. Marker and Limit are used for pagination.
 type ListOpts struct {
-	ID            string `q:"id"`
-	Name          string `q:"name"`
-	TenantID      string `q:"tenant_id"`
-	ProjectID     string `q:"project_id"`
-	PoolID        string `q:"pool_id"`
-	Type          string `q:"type"`
-	Delay         int    `q:"delay"`
-	Timeout       int    `q:"timeout"`
-	MaxRetries    int    `q:"max_retries"`
-	HTTPMethod    string `q:"http_method"`
-	URLPath       string `q:"url_path"`
-	ExpectedCodes string `q:"expected_codes"`
-	AdminStateUp  *bool  `q:"admin_state_up"`
-	Status        string `q:"status"`
-	Limit         int    `q:"limit"`
-	Marker        string `q:"marker"`
-	SortKey       string `q:"sort_key"`
-	SortDir       string `q:"sort_dir"`
+	ID             string `q:"id"`
+	Name           string `q:"name"`
+	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
+	PoolID         string `q:"pool_id"`
+	Type           string `q:"type"`
+	Delay          int    `q:"delay"`
+	Timeout        int    `q:"timeout"`
+	MaxRetries     int    `q:"max_retries"`
+	MaxRetriesDown int    `q:"max_retries_down"`
+	HTTPMethod     string `q:"http_method"`
+	URLPath        string `q:"url_path"`
+	ExpectedCodes  string `q:"expected_codes"`
+	AdminStateUp   *bool  `q:"admin_state_up"`
+	Status         string `q:"status"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
 }
 
 // ToMonitorListQuery formats a ListOpts into a query string.
@@ -106,6 +107,10 @@ type CreateOpts struct {
 	// Number of permissible ping failures before changing the member's
 	// status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries" required:"true"`
+
+	// Number of permissible ping failures befor changing the member's
+	// status to ERROR. Must be a number between 1 and 10.
+	MaxRetriesDown int `json:"max_retries_down,omitempty"`
 
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
 	URLPath string `json:"url_path,omitempty"`
@@ -190,6 +195,10 @@ type UpdateOpts struct {
 	// Number of permissible ping failures before changing the member's
 	// status to INACTIVE. Must be a number between 1 and 10.
 	MaxRetries int `json:"max_retries,omitempty"`
+
+	// Number of permissible ping failures befor changing the member's
+	// status to ERROR. Must be a number between 1 and 10.
+	MaxRetriesDown int `json:"max_retries_down,omitempty"`
 
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
 	// Required for HTTP(S) types.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/monitors/results.go
@@ -50,6 +50,10 @@ type Monitor struct {
 	// member to INACTIVE. A valid value is from 1 to 10.
 	MaxRetries int `json:"max_retries"`
 
+	// Number of allowed connection failures before changing the status of the
+	// member to Error. A valid value is from 1 to 10.
+	MaxRetriesDown int `json:"max_retries_down"`
+
 	// The HTTP method that the monitor uses for requests.
 	HTTPMethod string `json:"http_method"`
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
@@ -275,6 +275,15 @@ type CreateMemberOpts struct {
 	// The administrative state of the Pool. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// Is the member a backup? Backup members only receive traffic when all non-backup members are down.
+	Backup *bool `json:"backup,omitempty"`
+
+	// An alternate IP address used for health monitoring a backend member.
+	MonitorAddress string `json:"monitor_address,omitempty"`
+
+	// An alternate protocol port used for health monitoring a backend member.
+	MonitorPort *int `json:"monitor_port,omitempty"`
 }
 
 // ToMemberCreateMap builds a request body from CreateMemberOpts.
@@ -283,7 +292,7 @@ func (opts CreateMemberOpts) ToMemberCreateMap() (map[string]interface{}, error)
 }
 
 // CreateMember will create and associate a Member with a particular Pool.
-func CreateMember(c *gophercloud.ServiceClient, poolID string, opts CreateMemberOpts) (r CreateMemberResult) {
+func CreateMember(c *gophercloud.ServiceClient, poolID string, opts CreateMemberOptsBuilder) (r CreateMemberResult) {
 	b, err := opts.ToMemberCreateMap()
 	if err != nil {
 		r.Err = err


### PR DESCRIPTION
Now we use legacy image uploading that doesn't support image conversion. It leads to the fact that we upload qcow2 images to Ceph backend, which doesn't support this format:
https://access.redhat.com/solutions/2434691

By using the Image Import mechanism we make sure that all uploaded images will be automatically converted to Raw for Ceph (and only for Ceph) backends.

If the image import mechanism is not available we fallback to the legacy uploading.

cherry-picked from: https://github.com/openshift/installer/pull/3162