### PR TITLE
images/baremetal: make /etc/passwd writeable

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -15,7 +15,8 @@ COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     libvirt-libs openssl unzip jq openssh-clients && \
-    yum clean all && rm -rf /var/cache/yum/*
+    yum clean all && rm -rf /var/cache/yum/* && \
+    chmod g+w /etc/passwd
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000


### PR DESCRIPTION
We'll be using baremetal-installer as the container we setup packet
for metal IPI CI. We need to use SSH, but it's broken without having a
valid user in /etc/passwd.

This change is required for our CI infrastructure to use SSH correctly
until we have completely moved CI to 4.x infrastructure where
/etc/passwd becomes dynamic.

This was restored to the tests container[1], and is now also being added
to the baremetal/installer container.

[1] https://github.com/openshift/origin/pull/24690