### PR TITLE
openstack: soft-anti-affinity policy for CP

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -55,6 +55,7 @@ module "masters" {
   )
   root_volume_size = var.openstack_master_root_volume_size
   root_volume_type = var.openstack_master_root_volume_type
+  server_group_id  = var.openstack_master_server_group_id
 }
 
 module "topology" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -63,6 +63,10 @@ resource "openstack_compute_instance_v2" "master_conf" {
     port = var.master_port_ids[count.index]
   }
 
+  scheduler_hints {
+    group = var.server_group_id
+  }
+
   metadata = {
     # FIXME(mandre) shouldn't it be "${var.cluster_id}-master-${count.index}" ?
     Name = "${var.cluster_id}-master"

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -40,3 +40,8 @@ variable "root_volume_type" {
   type        = string
   description = "The type of volume for the root block device."
 }
+
+variable "server_group_id" {
+  type        = string
+  description = "ID of the server group to assign the servers to."
+}

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -329,3 +329,8 @@ Contains 0 if the OpenStack Octavia endpoint is missing and 1 if it exists.
 EOF
 
 }
+
+variable "openstack_master_server_group_id" {
+  type        = string
+  description = "ID of the server group to assign the master servers to."
+}

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -71,6 +71,8 @@ openstack quota set --secgroups 8 --secgroup-rules 100 <project>`
 
 The default deployment stands up 3 master nodes, which is the minimum amount required for a cluster. For each master node you stand up, you will need 1 instance, and 1 port available in your quota. They should be assigned a flavor with at least 16 GB RAM, 4 vCPUs, and 25 GB Disk. It is theoretically possible to run with a smaller flavor, but be aware that if it takes too long to stand up services, or certain essential services crash, the installer could time out, leading to a failed install.
 
+The Master Nodes are placed in a single Server Group with "soft anti-affinity" policy; the machines will therefore be creted on separate hosts when possible.
+
 ### Worker Nodes
 
 The default deployment stands up 3 worker nodes. In our testing we determined that 2 was the minimum number of workers you could have to get a successful install, but we don't recommend running with that few. Worker nodes host the applications you run on OpenShift, so it is in your best interest to have more of them. See [here](https://docs.openshift.com/enterprise/3.0/architecture/infrastructure_components/kubernetes_infrastructure.html#node) for more information. The flavor assigned to the worker nodes should have at least 2 vCPUs, 8 GB RAM and 25 GB Disk. However, if you are experiencing `Out Of Memory` issues, or your installs are timing out, you should increase the size of your flavor to match the masters: 4 vCPUs and 16 GB RAM.

--- a/go.mod
+++ b/go.mod
@@ -161,5 +161,5 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.1 // Replaced by MCO/CRI-O
 	sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200204144622-0df2d100309c // Pin OpenShift fork
 	sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b // Pin OpenShift fork
-	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200130125124-ef82ce374112 // Pin OpenShift fork
+	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200221124403-d699c3611b0c // Pin OpenShift fork
 )

--- a/go.sum
+++ b/go.sum
@@ -1778,6 +1778,8 @@ github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-233678
 github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603/go.mod h1:7pQ9Bzha+ug/5zd+0ufbDEcnn2OnNlPwRwYrzhXk4NM=
 github.com/openshift/cluster-api-provider-openstack v0.0.0-20200130125124-ef82ce374112 h1:ny9quEJfUBkUyalPn4sRBX86Ci5Jx72pIO2Qjsxy0yA=
 github.com/openshift/cluster-api-provider-openstack v0.0.0-20200130125124-ef82ce374112/go.mod h1:ntMRKZlv++TExGO4g2jgsVIaHKJt8kKe72BAvMPV5vA=
+github.com/openshift/cluster-api-provider-openstack v0.0.0-20200221124403-d699c3611b0c h1:Rn/Ip2nbWUhvOF9/EZaorxKVcQnm427cSOJQJIFXuHQ=
+github.com/openshift/cluster-api-provider-openstack v0.0.0-20200221124403-d699c3611b0c/go.mod h1:ntMRKZlv++TExGO4g2jgsVIaHKJt8kKe72BAvMPV5vA=
 github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200128081049-840376ca5c09 h1:QJxGgIB7f5BqNPEZOCgV29NsDf1P439Bs3q0B5O3fP8=
 github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200128081049-840376ca5c09/go.mod h1:NcvJT99IauPosghKCineBG8yswe9JjuddiWuvsqge64=
 github.com/openshift/cluster-autoscaler-operator v0.0.0-20190521201101-62768a6ba480/go.mod h1:/XmV44Fh28Vo3Ye93qFrxAbcFJ/Uy+7LPD+jGjmfJYc=

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -32,6 +32,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	machinesets := make([]*clusterapi.MachineSet, 0, 1)
 	az := ""
 	trunk := config.Platform.OpenStack.TrunkSupport
+
 	provider := generateProvider(clusterID, platform, mpool, osImage, az, role, userDataSecret, trunk)
 	// TODO(flaper87): Implement AZ support sometime soon
 	//name := fmt.Sprintf("%s-%s-%s", clustername, pool.Name, az)

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/openstack"
-	"github.com/pkg/errors"
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
@@ -30,13 +29,10 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	}
 
 	// TODO(flaper87): Add support for availability zones
-	var machinesets []*clusterapi.MachineSet
+	machinesets := make([]*clusterapi.MachineSet, 0, 1)
 	az := ""
 	trunk := config.Platform.OpenStack.TrunkSupport
-	provider, err := provider(clusterID, platform, mpool, osImage, az, role, userDataSecret, trunk)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create provider")
-	}
+	provider := generateProvider(clusterID, platform, mpool, osImage, az, role, userDataSecret, trunk)
 	// TODO(flaper87): Implement AZ support sometime soon
 	//name := fmt.Sprintf("%s-%s-%s", clustername, pool.Name, az)
 	name := fmt.Sprintf("%s-%s", clusterID, pool.Name)

--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -1,4 +1,3 @@
-// Package openstack provides a cluster-destroyer for openstack clusters.
 package openstack
 
 import (
@@ -73,8 +72,23 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 
 // Run is the entrypoint to start the uninstall process.
 func (o *ClusterUninstaller) Run() error {
-	deleteFuncs := map[string]deleteFunc{}
-	populateDeleteFuncs(deleteFuncs)
+	// deleteFuncs contains the functions that will be launched as
+	// goroutines.
+	deleteFuncs := map[string]deleteFunc{
+		"deleteServers":        deleteServers,
+		"deleteTrunks":         deleteTrunks,
+		"deleteLoadBalancers":  deleteLoadBalancers,
+		"deletePorts":          deletePorts,
+		"deleteSecurityGroups": deleteSecurityGroups,
+		"deleteRouters":        deleteRouters,
+		"deleteSubnets":        deleteSubnets,
+		"deleteSubnetPools":    deleteSubnetPools,
+		"deleteNetworks":       deleteNetworks,
+		"deleteContainers":     deleteContainers,
+		"deleteVolumes":        deleteVolumes,
+		"deleteFloatingIPs":    deleteFloatingIPs,
+		"deleteImages":         deleteImages,
+	}
 	returnChannel := make(chan string)
 
 	opts := &clientconfig.ClientOpts{
@@ -115,24 +129,6 @@ func deleteRunner(deleteFuncName string, dFunction deleteFunc, opts *clientconfi
 	// record that the goroutine has run to completion
 	channel <- deleteFuncName
 	return
-}
-
-// populateDeleteFuncs is the list of functions that will be launched as
-// goroutines.
-func populateDeleteFuncs(funcs map[string]deleteFunc) {
-	funcs["deleteServers"] = deleteServers
-	funcs["deleteTrunks"] = deleteTrunks
-	funcs["deleteLoadBalancers"] = deleteLoadBalancers
-	funcs["deletePorts"] = deletePorts
-	funcs["deleteSecurityGroups"] = deleteSecurityGroups
-	funcs["deleteRouters"] = deleteRouters
-	funcs["deleteSubnets"] = deleteSubnets
-	funcs["deleteSubnetPools"] = deleteSubnetPools
-	funcs["deleteNetworks"] = deleteNetworks
-	funcs["deleteContainers"] = deleteContainers
-	funcs["deleteVolumes"] = deleteVolumes
-	funcs["deleteFloatingIPs"] = deleteFloatingIPs
-	funcs["deleteImages"] = deleteImages
 }
 
 // filterObjects will do client-side filtering given an appropriately filled out

--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/apiversions"
@@ -76,6 +77,7 @@ func (o *ClusterUninstaller) Run() error {
 	// goroutines.
 	deleteFuncs := map[string]deleteFunc{
 		"deleteServers":        deleteServers,
+		"deleteServerGroups":   deleteServerGroups,
 		"deleteTrunks":         deleteTrunks,
 		"deleteLoadBalancers":  deleteLoadBalancers,
 		"deletePorts":          deletePorts,
@@ -229,6 +231,61 @@ func deleteServers(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 		}
 	}
 	return len(filteredServers) == 0, nil
+}
+
+func deleteServerGroups(opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) (bool, error) {
+	logger.Debug("Deleting openstack server groups")
+	defer logger.Debugf("Exiting deleting openstack server groups")
+
+	// We need to delete all server groups that have names with the cluster
+	// ID as a prefix
+	var clusterID string
+	for k, v := range filter {
+		if strings.ToLower(k) == "openshiftclusterid" {
+			clusterID = v
+			break
+		}
+	}
+
+	conn, err := clientconfig.NewServiceClient("compute", opts)
+	if err != nil {
+		logger.Error(err)
+		return false, nil
+	}
+
+	allPages, err := servergroups.List(conn).AllPages()
+	if err != nil {
+		logger.Error(err)
+		return false, nil
+	}
+
+	allServerGroups, err := servergroups.ExtractServerGroups(allPages)
+	if err != nil {
+		logger.Error(err)
+		return false, nil
+	}
+
+	filteredGroups := make([]servergroups.ServerGroup, 0, len(allServerGroups))
+	for _, serverGroup := range allServerGroups {
+		if strings.HasPrefix(serverGroup.Name, clusterID) {
+			filteredGroups = append(filteredGroups, serverGroup)
+		}
+	}
+
+	for _, serverGroup := range filteredGroups {
+		logger.Debugf("Deleting Server Group %q", serverGroup.ID)
+		if err = servergroups.Delete(conn, serverGroup.ID).ExtractErr(); err != nil {
+			// Ignore the error if the server cannot be found and
+			// return with an appropriate message if it's another
+			// type of error
+			if _, ok := err.(gophercloud.ErrDefault404); !ok {
+				logger.Errorf("Deleting server group %q failed: %v", serverGroup.ID, err)
+				return false, nil
+			}
+			logger.Debugf("Cannot find server group %q. It's probably already been deleted.", serverGroup.ID)
+		}
+	}
+	return len(filteredGroups) == 0, nil
 }
 
 func deletePorts(opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) (bool, error) {

--- a/pkg/destroy/openstack/register.go
+++ b/pkg/destroy/openstack/register.go
@@ -1,4 +1,3 @@
-// Package openstack provides a cluster-destroyer for openstack clusters.
 package openstack
 
 import (

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -18,20 +18,21 @@ import (
 )
 
 type config struct {
-	BaseImageName   string   `json:"openstack_base_image_name,omitempty"`
-	ExternalNetwork string   `json:"openstack_external_network,omitempty"`
-	Cloud           string   `json:"openstack_credentials_cloud,omitempty"`
-	FlavorName      string   `json:"openstack_master_flavor_name,omitempty"`
-	LbFloatingIP    string   `json:"openstack_lb_floating_ip,omitempty"`
-	APIVIP          string   `json:"openstack_api_int_ip,omitempty"`
-	DNSVIP          string   `json:"openstack_node_dns_ip,omitempty"`
-	IngressVIP      string   `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport    string   `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport  string   `json:"openstack_octavia_support,omitempty"`
-	RootVolumeSize  int      `json:"openstack_master_root_volume_size,omitempty"`
-	RootVolumeType  string   `json:"openstack_master_root_volume_type,omitempty"`
-	BootstrapShim   string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
-	ExternalDNS     []string `json:"openstack_external_dns,omitempty"`
+	BaseImageName       string   `json:"openstack_base_image_name,omitempty"`
+	ExternalNetwork     string   `json:"openstack_external_network,omitempty"`
+	Cloud               string   `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName          string   `json:"openstack_master_flavor_name,omitempty"`
+	LbFloatingIP        string   `json:"openstack_lb_floating_ip,omitempty"`
+	APIVIP              string   `json:"openstack_api_int_ip,omitempty"`
+	DNSVIP              string   `json:"openstack_node_dns_ip,omitempty"`
+	IngressVIP          string   `json:"openstack_ingress_ip,omitempty"`
+	TrunkSupport        string   `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport      string   `json:"openstack_octavia_support,omitempty"`
+	RootVolumeSize      int      `json:"openstack_master_root_volume_size,omitempty"`
+	RootVolumeType      string   `json:"openstack_master_root_volume_type,omitempty"`
+	BootstrapShim       string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
+	ExternalDNS         []string `json:"openstack_external_dns,omitempty"`
+	MasterServerGroupID string   `json:"openstack_master_server_group_id,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
@@ -104,6 +105,8 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 		cfg.RootVolumeSize = masterConfig.RootVolume.Size
 		cfg.RootVolumeType = masterConfig.RootVolume.VolumeType
 	}
+
+	cfg.MasterServerGroupID = masterConfig.ServerGroupID
 
 	return json.MarshalIndent(cfg, "", "  ")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1780,7 +1780,7 @@ sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1
-# sigs.k8s.io/cluster-api-provider-openstack v0.0.0 => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200130125124-ef82ce374112
+# sigs.k8s.io/cluster-api-provider-openstack v0.0.0 => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200221124403-d699c3611b0c
 sigs.k8s.io/cluster-api-provider-openstack/pkg/apis
 sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1
 # sigs.k8s.io/controller-runtime v0.4.0

--- a/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/types.go
+++ b/vendor/sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1/types.go
@@ -82,6 +82,9 @@ type OpenstackProviderSpec struct {
 
 	// The volume metadata to boot from
 	RootVolume *RootVolume `json:"rootVolume,omitempty"`
+
+	// The server group to assign the machine to
+	ServerGroupID string `json:"serverGroupID,omitempty"`
 }
 
 type SecurityGroupParam struct {


### PR DESCRIPTION
This places the Control Plane servers in a Server Group that enforces "soft anti-affinity" policy.

"Soft anti-affinity" will cause Nova to create VMs on separate hosts, if that is possible.

Implements OSASINFRA-1300

/label platform/openstack
/cc pierreprinetti