### PR TITLE
Bug 1840496: [baremetal] Remove DNS VIP

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -39,7 +39,6 @@ purposes:
     following purposes:
     * API - This IP will be used to reach the cluster API.
     * Ingress - This IP will be used by cluster ingress traffic
-    * DNS - This IP will be used internally by the cluster for automating
       internal DNS requirements.
   * ***External DNS*** - While the cluster automates the internal DNS
     requirements, two external DNS records must be created in whatever DNS
@@ -163,7 +162,6 @@ platform:
   baremetal:
     apiVIP: 192.168.111.5
     ingressVIP: 192.168.111.4
-    dnsVIP: 192.168.111.3
     provisioningNetworkInterface: enp1s0
     hosts:
       - name: openshift-master-0
@@ -211,15 +209,12 @@ sshKey: ...
 `defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration. |
 `apiVIP` | `api.<clusterdomain>` | The VIP to use for internal API communication. |
 `ingressVIP` | `test.apps.<clusterdomain>` | The VIP to use for ingress traffic. |
-`dnsVIP` | | The VIP to use for internal DNS communication. |
 
 ##### VIP Settings
 
 The `apiVIP` and `ingressVIP` settings must either be provided or
 pre-configured in DNS so that the default names resolve correctly (see
 the defaults in the table above).
-
-The `dnsVIP` setting has no default and must always be provided.
 
 ##### Describing Hosts
 

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -120,7 +120,6 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		config.Spec.PlatformSpec.Type = configv1.BareMetalPlatformType
 		config.Status.PlatformStatus.BareMetal = &configv1.BareMetalPlatformStatus{
 			APIServerInternalIP: installConfig.Config.Platform.BareMetal.APIVIP,
-			NodeDNSIP:           installConfig.Config.Platform.BareMetal.DNSVIP,
 			IngressIP:           installConfig.Config.Platform.BareMetal.IngressVIP,
 		}
 	case gcp.Name:

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -93,11 +93,6 @@ type Platform struct {
 	// +kubebuilder:validation:Format=ip
 	IngressVIP string `json:"ingressVIP"`
 
-	// DNSVIP is the VIP to use for internal DNS communication
-	//
-	// +kubebuilder:validation:Format=ip
-	DNSVIP string `json:"dnsVIP"`
-
 	// BootstrapOSImage is a URL to override the default OS image
 	// for the bootstrap node. The URL must contain a sha256 hash of the image
 	// e.g https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd...

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -294,13 +294,6 @@ func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressVIP"), p.IngressVIP, err.Error()))
 	}
 
-	if err := validate.IP(p.DNSVIP); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("dnsVIP"), p.DNSVIP, err.Error()))
-	}
-
-	if err := validateIPinMachineCIDR(p.DNSVIP, n); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("dnsVIP"), p.DNSVIP, err.Error()))
-	}
 	if err := validateIPNotinMachineCIDR(p.ClusterProvisioningIP, n); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("provisioningHostIP"), p.ClusterProvisioningIP, err.Error()))
 	}

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -102,12 +102,6 @@ func TestValidatePlatform(t *testing.T) {
 			expected: "Invalid value: \"192.168.222.2\": the virtual IP is expected to be in one of the machine networks",
 		},
 		{
-			name: "invalid_dnsvip",
-			platform: platform().
-				DNSVIP("192.168.222.3").build(),
-			expected: "Invalid value: \"192.168.222.3\": the virtual IP is expected to be in one of the machine networks",
-		},
-		{
 			name: "invalid_ingressvip",
 			platform: platform().
 				IngressVIP("192.168.222.4").build(),
@@ -389,7 +383,6 @@ func platform() *platformBuilder {
 	return &platformBuilder{
 		baremetal.Platform{
 			APIVIP:                       "192.168.111.2",
-			DNSVIP:                       "192.168.111.3",
 			IngressVIP:                   "192.168.111.4",
 			Hosts:                        []*baremetal.Host{},
 			LibvirtURI:                   "qemu://system",
@@ -438,11 +431,6 @@ func (pb *platformBuilder) ProvisioningDHCPRange(value string) *platformBuilder 
 
 func (pb *platformBuilder) APIVIP(value string) *platformBuilder {
 	pb.Platform.APIVIP = value
-	return pb
-}
-
-func (pb *platformBuilder) DNSVIP(value string) *platformBuilder {
-	pb.Platform.DNSVIP = value
 	return pb
 }
 

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -122,7 +122,6 @@ func validBareMetalPlatform() *baremetal.Platform {
 		DefaultMachinePlatform: &baremetal.MachinePool{},
 		APIVIP:                 "10.0.0.5",
 		IngressVIP:             "10.0.0.4",
-		DNSVIP:                 "10.0.0.2",
 	}
 }
 
@@ -620,30 +619,6 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: `^platform\.baremetal\.apiVIP: Invalid value: "10\.1\.0\.5": the virtual IP is expected to be in one of the machine networks$`,
-		},
-		{
-			name: "baremetal DNS VIP not an IP",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Platform = types.Platform{
-					BareMetal: validBareMetalPlatform(),
-				}
-				c.Platform.BareMetal.DNSVIP = "test"
-				return c
-			}(),
-			expectedError: `^\[platform\.baremetal\.dnsVIP: Invalid value: "test": "test" is not a valid IP, platform\.baremetal\.dnsVIP: Invalid value: "test": the virtual IP is expected to be in one of the machine networks]$`,
-		},
-		{
-			name: "baremetal DNS VIP set to an incorrect value",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Platform = types.Platform{
-					BareMetal: validBareMetalPlatform(),
-				}
-				c.Platform.BareMetal.DNSVIP = "10.1.0.6"
-				return c
-			}(),
-			expectedError: `^platform\.baremetal\.dnsVIP: Invalid value: "10\.1\.0\.6": the virtual IP is expected to be in one of the machine networks$`,
 		},
 		{
 			name: "baremetal Ingress VIP not an IP",


### PR DESCRIPTION
Use of this setting is being removed in [0]. Once that goes in we
can remove it from the installer as well.

0: https://github.com/openshift/machine-config-operator/pull/1569