### PR TITLE
aws: allow users to provide AMI for each machine pool

### DIFF
--- a/docs/user/aws/customization.md
+++ b/docs/user/aws/customization.md
@@ -25,6 +25,8 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
         Example ARN values are: `arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab` or `arn:aws:kms:us-east-1:111122223333:alias/my-key`
 * `type` (optional string): The [EC2 instance type][instance-type].
 * `zones` (optional array of strings): The availability zones used for machines in the pool.
+* `amiID` (optional string): The AMI that should be used to boot machines.
+    If set, the AMI should belong to the same region as the cluster.
 
 ## Examples
 
@@ -67,6 +69,7 @@ compute:
 - name: worker
   platform:
     aws:
+      amiID: ami-123456
       rootVolume:
         iops: 4000
         size: 500

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Machines returns a list of machines for a machinepool.
-func Machines(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, osImage, role, userDataSecret string, userTags map[string]string) ([]machineapi.Machine, error) {
+func Machines(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, role, userDataSecret string, userTags map[string]string) ([]machineapi.Machine, error) {
 	if poolPlatform := pool.Platform.Name(); poolPlatform != aws.Name {
 		return nil, fmt.Errorf("non-AWS machine-pool: %q", poolPlatform)
 	}
@@ -41,7 +41,7 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 			subnet,
 			mpool.InstanceType,
 			&mpool.EC2RootVolume,
-			osImage,
+			mpool.AMIID,
 			zone,
 			role,
 			userDataSecret,

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -14,7 +14,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, osImage, role, userDataSecret string, userTags map[string]string) ([]*machineapi.MachineSet, error) {
+func MachineSets(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, role, userDataSecret string, userTags map[string]string) ([]*machineapi.MachineSet, error) {
 	if poolPlatform := pool.Platform.Name(); poolPlatform != aws.Name {
 		return nil, fmt.Errorf("non-AWS machine-pool: %q", poolPlatform)
 	}
@@ -43,7 +43,7 @@ func MachineSets(clusterID string, region string, subnets map[string]string, poo
 			subnet,
 			mpool.InstanceType,
 			&mpool.EC2RootVolume,
-			osImage,
+			mpool.AMIID,
 			az,
 			role,
 			userDataSecret,

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -159,6 +159,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		}
 
 		mpool := defaultAWSMachinePoolPlatform()
+		mpool.AMIID = string(*rhcosImage)
 		mpool.Set(ic.Platform.AWS.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.AWS)
 		if len(mpool.Zones) == 0 {
@@ -187,7 +188,6 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			installConfig.Config.Platform.AWS.Region,
 			subnets,
 			pool,
-			string(*rhcosImage),
 			"master",
 			"master-user-data",
 			installConfig.Config.Platform.AWS.UserTags,

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -195,6 +195,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			}
 
 			mpool := defaultAWSMachinePoolPlatform()
+			mpool.AMIID = string(*rhcosImage)
 			mpool.Set(ic.Platform.AWS.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.AWS)
 			if len(mpool.Zones) == 0 {
@@ -222,7 +223,6 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				installConfig.Config.Platform.AWS.Region,
 				subnets,
 				&pool,
-				string(*rhcosImage),
 				"worker",
 				"worker-user-data",
 				installConfig.Config.Platform.AWS.UserTags,

--- a/pkg/types/aws/machinepool.go
+++ b/pkg/types/aws/machinepool.go
@@ -10,6 +10,10 @@ type MachinePool struct {
 	// eg. m4-large
 	InstanceType string `json:"type"`
 
+	// AMIID is the AMI that should be used to boot the ec2 instance.
+	// If set, the AMI should belong to the same region as the cluster.
+	AMIID string `json:"amiID,omitempty"`
+
 	// EC2RootVolume defines the root volume for EC2 instances in the machine pool.
 	EC2RootVolume `json:"rootVolume"`
 }
@@ -26,6 +30,10 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.InstanceType != "" {
 		a.InstanceType = required.InstanceType
+	}
+
+	if required.AMIID != "" {
+		a.AMIID = required.AMIID
 	}
 
 	if required.EC2RootVolume.IOPS != 0 {


### PR DESCRIPTION
users can set AMI for the platform or defaultMachinePool or individual machine pool, and the AMI used is based on increasing order of priority of the list mentioned before.

/assign @sdodson 
/cc @derekwaynecarr 