### PR TITLE
gcp upi: add bootstrap to instance group

### DIFF
--- a/upi/gcp/04_bootstrap.py
+++ b/upi/gcp/04_bootstrap.py
@@ -39,6 +39,22 @@ def GenerateConfig(context):
             },
             'zone': context.properties['zone']
         }
+    }, {
+        'name': context.properties['infra_id'] + '-bootstrap-instance-group',
+        'type': 'compute.v1.instanceGroup',
+        'properties': {
+            'namedPorts': [
+                {
+                    'name': 'ignition',
+                    'port': 22623
+                }, {
+                    'name': 'https',
+                    'port': 6443
+                }
+            ],
+            'network': context.properties['cluster_network'],
+            'zone': context.properties['zone']
+        }
     }]
 
     return {'resources': resources}


### PR DESCRIPTION
Previously, the bootstrap host was being added to the first master
instance group. This causes an issue if the gcp cloud provider attempts
to create internal load balancers for the cluster because it ignores the
first master's instance groupd and tries to put it into a new instance
group. If there are workers that are in a different subnet, then the
cloud provider throws an error and never creates the ingress lbs.

This change creates an instance group for the bootstrap host, and
updates the doc to utilize it. It also removes the steps of adding and
removing the bootstrap host from the external target pools, as that is
not what we are doing with ipi.