### PR TITLE
Docs: stop using deprecated parameters

### DIFF
--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -139,7 +139,7 @@ baseDomain: example.com
 metadata:
   name: test-cluster
 networking:
-  clusterNetworks:
+  clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:


### PR DESCRIPTION
Since f09413d1f9f, `clusterNetworks` is deprecated in favor of
`clusterNetwork`.