### PR TITLE
[release-4.3] bug 1808973: azure - vendor update to support multiple prefixes

### DIFF
--- a/pkg/terraform/exec/plugins/Gopkg.lock
+++ b/pkg/terraform/exec/plugins/Gopkg.lock
@@ -128,12 +128,12 @@
   version = "v2"
 
 [[projects]]
-  digest = "1:1929b21a34400d463a99336f8e2908d2a154dc525c52411a8d99bb519942dc4c"
+  digest = "1:aef9339f69dda1ca77fdb2fd83cf64c3f5087c1f00f69719eaa14679f5321512"
   name = "github.com/apparentlymart/go-cidr"
   packages = ["cidr"]
   pruneopts = "NUT"
-  revision = "b1115bf8e14a60131a196f908223e4506b0ddc35"
-  version = "v1.0.0"
+  revision = "c0fb5fbe0acb592411e2db59add389a43260ad44"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:b64410231651b7912fc7cbfed95cba05c5c61af1cc8c676e2accc79ea6c1d6ef"
@@ -847,7 +847,7 @@
   version = "v2.10.0"
 
 [[projects]]
-  digest = "1:78f3ea27f70c476e8c05f82dd96dcd662527d68e9967a6d5ac89aad44604b7a0"
+  digest = "1:d6be6c5b9c2fb05bd2dd5ada569c2fb9f8688d34abd711ce8c1973a5de023e1c"
   name = "github.com/terraform-providers/terraform-provider-azurerm"
   packages = [
     "azurerm",
@@ -862,9 +862,9 @@
     "version",
   ]
   pruneopts = "NUT"
-  revision = "7bc287e956632e40076a4deb227ec42108be9fb0"
+  revision = "7622916991c09e4d2f87f5be01b1bc882b396f1f"
   source = "https://github.com/openshift/terraform-provider-azurerm"
-  version = "v1.27.2-openshift"
+  version = "v1.27.2-openshift-2"
 
 [[projects]]
   digest = "1:2daa3bddc630ead813a47149cdc429816c43f9423a7d6e2aeff7ca794b072548"

--- a/pkg/terraform/exec/plugins/Gopkg.toml
+++ b/pkg/terraform/exec/plugins/Gopkg.toml
@@ -47,7 +47,7 @@ ignored = [
 [[constraint]]
   name = "github.com/terraform-providers/terraform-provider-azurerm"
   source = "https://github.com/openshift/terraform-provider-azurerm"
-  version = "=v1.27.2-openshift"
+  version = "=v1.27.2-openshift-2"
 
 [[constraint]]
   name = "github.com/Azure/azure-sdk-for-go"

--- a/pkg/terraform/exec/plugins/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/apparentlymart/go-cidr/cidr/wrangling.go
@@ -29,9 +29,8 @@ func intToIP(ipInt *big.Int, bits int) net.IP {
 	return net.IP(ret)
 }
 
-func insertNumIntoIP(ip net.IP, num int, prefixLen int) net.IP {
+func insertNumIntoIP(ip net.IP, bigNum *big.Int, prefixLen int) net.IP {
 	ipInt, totalBits := ipToInt(ip)
-	bigNum := big.NewInt(int64(num))
 	bigNum.Lsh(bigNum, uint(totalBits-prefixLen))
 	ipInt.Or(ipInt, bigNum)
 	return intToIP(ipInt, totalBits)

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_loadbalancer.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_loadbalancer.go
@@ -68,10 +68,9 @@ func resourceArmLoadBalancer() *schema.Resource {
 						},
 
 						"private_ip_address": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ValidateFunc: validate.IPv4AddressOrEmpty,
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
 						},
 
 						"private_ip_address_version": {

--- a/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_virtual_network.go
+++ b/pkg/terraform/exec/plugins/vendor/github.com/terraform-providers/terraform-provider-azurerm/azurerm/resource_arm_virtual_network.go
@@ -91,10 +91,17 @@ func resourceArmVirtualNetwork() *schema.Resource {
 							ValidateFunc: validate.NoEmptyStrings,
 						},
 						"address_prefix": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validate.NoEmptyStrings,
+							Type:       schema.TypeString,
+							Optional:   true,
+							Deprecated: "Use the `address_prefixes` property instead.",
 						},
+
+						"address_prefixes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
 						"security_group": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -289,7 +296,36 @@ func expandVirtualNetworkProperties(ctx context.Context, d *schema.ResourceData,
 			}
 			log.Printf("[INFO] Completed GET of Subnet props ")
 
-			prefix := subnet["address_prefix"].(string)
+			var prefixSet int = 0
+			properties := network.SubnetPropertiesFormat{}
+			if value, ok := subnet["address_prefixes"]; ok {
+				var addressPrefixes []string
+				for _, item := range value.([]interface{}) {
+					addressPrefixes = append(addressPrefixes, item.(string))
+				}
+				properties.AddressPrefixes = &addressPrefixes
+				if len(addressPrefixes) > 0 {
+					prefixSet += 1
+				}
+			}
+			if value, ok := subnet["address_prefix"]; ok {
+				addressPrefix := value.(string)
+				properties.AddressPrefix = &addressPrefix
+				if len(addressPrefix) > 0 {
+					prefixSet += 1
+				}
+			}
+			if properties.AddressPrefixes != nil && len(*properties.AddressPrefixes) == 1 {
+				properties.AddressPrefix = &(*properties.AddressPrefixes)[0]
+				properties.AddressPrefixes = nil
+			}
+			if prefixSet == 0 {
+				return nil, fmt.Errorf("[ERROR] either address_prefix or address_prefixes is required")
+			}
+			if prefixSet == 2 {
+				return nil, fmt.Errorf("[ERROR] either address_prefix or address_prefixes must be set, not both")
+			}
+
 			secGroup := subnet["security_group"].(string)
 
 			//set the props from config and leave the rest intact
@@ -298,7 +334,8 @@ func expandVirtualNetworkProperties(ctx context.Context, d *schema.ResourceData,
 				subnetObj.SubnetPropertiesFormat = &network.SubnetPropertiesFormat{}
 			}
 
-			subnetObj.SubnetPropertiesFormat.AddressPrefix = &prefix
+			subnetObj.SubnetPropertiesFormat.AddressPrefixes = properties.AddressPrefixes
+			subnetObj.SubnetPropertiesFormat.AddressPrefix = properties.AddressPrefix
 
 			if secGroup != "" {
 				subnetObj.SubnetPropertiesFormat.NetworkSecurityGroup = &network.SecurityGroup{
@@ -381,6 +418,14 @@ func flattenVirtualNetworkSubnets(input *[]network.Subnet) *schema.Set {
 			}
 
 			if props := subnet.SubnetPropertiesFormat; props != nil {
+				if prefixes := props.AddressPrefixes; prefixes != nil {
+					var addressPrefixes []interface{}
+					for _, prefix := range *prefixes {
+						addressPrefixes = append(addressPrefixes, prefix)
+					}
+					output["address_prefixes"] = addressPrefixes
+				}
+
 				if prefix := props.AddressPrefix; prefix != nil {
 					output["address_prefix"] = *prefix
 				}
@@ -416,8 +461,14 @@ func resourceAzureSubnetHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		buf.WriteString(m["name"].(string))
-		buf.WriteString(m["address_prefix"].(string))
-
+		if v, ok := m["address_prefixes"]; ok {
+			for _, a := range v.([]interface{}) {
+				buf.WriteString(a.(string))
+			}
+		}
+		if v, ok := m["address_prefix"]; ok {
+			buf.WriteString(v.(string))
+		}
 		if v, ok := m["security_group"]; ok {
 			buf.WriteString(v.(string))
 		}


### PR DESCRIPTION
The azure subnet resource allows for multiple address prefixes using the
address_prefixes argument. The virtual network resource allows inline subnets,
but does not current support this argument. When the address_prefixes argument
is used, address_prefix will be null when terraform refreshes its state causing
terraform to panic. This code updates the virtual network resource to allow
address_prefixes to be used and for address_prefix to be null.

https://bugzilla.redhat.com/show_bug.cgi?id=1808973