### PR TITLE
gcp upi: document how to tag the masters and workers

### DIFF
--- a/docs/user/gcp/install_upi.md
+++ b/docs/user/gcp/install_upi.md
@@ -524,6 +524,18 @@ EOF
 - `machine_type`: the machine type of the instance (for example n1-standard-4)
 - `bootstrap_ign`: the URL output when creating a signed URL above.
 
+You can add custom tags to `04_bootstrap.py` as needed
+
+```console
+            'tags': {
+                'items': [
+                    context.properties['infra_id'] + '-master',
+                    context.properties['infra_id'] + '-bootstrap',
+                    'my-custom-tag-example'
+                ]
+            },
+```
+
 Create the deployment using gcloud.
 
 ```sh
@@ -581,6 +593,17 @@ EOF
 - `machine_type`: the machine type of the instance (for example n1-standard-4)
 - `service_account_email`: the email address for the master service account created above
 - `ignition`: the contents of the master.ign file
+
+You can add custom tags to `05_control_plane.py` as needed
+
+```console
+            'tags': {
+                'items': [
+                    context.properties['infra_id'] + '-master',
+                    'my-custom-tag-example'
+                ]
+            },
+```
 
 Create the deployment using gcloud.
 
@@ -687,6 +710,17 @@ EOF
 - `machine_type`: The machine type of the instance (for example n1-standard-4)
 - `service_account_email`: the email address for the worker service account created above
 - `ignition`: the contents of the worker.ign file
+
+You can add custom tags to `06_worker.py` as needed
+
+```console
+            'tags': {
+                'items': [
+                    context.properties['infra_id'] + '-worker',
+                    'my-custom-tag-example'
+                ]
+            },
+```
 
 Create the deployment using gcloud.
 


### PR DESCRIPTION
This change documents how to add custom tags to the bootstrap, master,
and worker nodes at install time. This will enable users with custom
firewall rules to use previously known tags to enable communications to
their cluster.

This PR depends on: #3309, #3278