### PR TITLE
Bug 1814593: OpenStack: Allow destroying cluster without trunk ports

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -648,6 +648,10 @@ func deleteTrunks(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fi
 	}
 	allPages, err := trunks.List(conn, listOpts).AllPages()
 	if err != nil {
+		if _, ok := err.(gophercloud.ErrDefault404); ok {
+			logger.Debug("Skip trunk deletion because the cloud doesn't support trunk ports")
+			return true, nil
+		}
 		logger.Error(err)
 		return false, nil
 	}


### PR DESCRIPTION
When the cloud doesn't have support for trunk ports, we should not try
to delete them.