### PR TITLE
azure: add OutboundType for controlling egress

### DIFF
--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -93,3 +93,16 @@ variable "emulate_single_stack_ipv6" {
   type        = bool
   description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
 }
+
+variable "outbound_udr" {
+  type    = bool
+  default = false
+
+  description = <<EOF
+This determined whether User defined routing will be used for egress to Internet.
+When false, Standard LB will be used for egress to the Internet.
+
+This is required because terraform cannot calculate counts during plan phase completely and therefore the `vnet/public-lb.tf`
+conditional need to be recreated. See https://github.com/hashicorp/terraform/issues/12570
+EOF
+}

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -41,6 +41,7 @@ module "bootstrap" {
   storage_account        = azurerm_storage_account.cluster
   nsg_name               = module.vnet.cluster_nsg_name
   private                = module.vnet.private
+  outbound_udr           = var.azure_outbound_user_defined_routing
 
   use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
   use_ipv6                  = var.use_ipv6
@@ -62,6 +63,7 @@ module "vnet" {
   master_subnet               = var.azure_control_plane_subnet
   worker_subnet               = var.azure_compute_subnet
   private                     = var.azure_private
+  outbound_udr                = var.azure_outbound_user_defined_routing
 
   use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
   use_ipv6                  = var.use_ipv6
@@ -88,6 +90,7 @@ module "master" {
   os_volume_type         = var.azure_master_root_volume_type
   os_volume_size         = var.azure_master_root_volume_size
   private                = module.vnet.private
+  outbound_udr           = var.azure_outbound_user_defined_routing
 
   use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
   use_ipv6                  = var.use_ipv6

--- a/data/data/azure/master/variables.tf
+++ b/data/data/azure/master/variables.tf
@@ -110,3 +110,16 @@ variable "emulate_single_stack_ipv6" {
   type        = bool
   description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
 }
+
+variable "outbound_udr" {
+  type    = bool
+  default = false
+
+  description = <<EOF
+This determined whether User defined routing will be used for egress to Internet.
+When false, Standard LB will be used for egress to the Internet.
+
+This is required because terraform cannot calculate counts during plan phase completely and therefore the `vnet/public-lb.tf`
+conditional need to be recreated. See https://github.com/hashicorp/terraform/issues/12570
+EOF
+}

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -121,3 +121,13 @@ variable "azure_emulate_single_stack_ipv6" {
   type        = bool
   description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
 }
+
+variable "azure_outbound_user_defined_routing" {
+  type    = bool
+  default = false
+
+  description = <<EOF
+This determined whether User defined routing will be used for egress to Internet.
+When false, Standard LB will be used for egress to the Internet.
+EOF
+}

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -1,9 +1,9 @@
 output "public_lb_backend_pool_v4_id" {
-  value = var.use_ipv4 ? azurerm_lb_backend_address_pool.public_lb_pool_v4[0].id : null
+  value = local.need_public_ipv4 ? azurerm_lb_backend_address_pool.public_lb_pool_v4[0].id : null
 }
 
 output "public_lb_backend_pool_v6_id" {
-  value = var.use_ipv6 ? azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id : null
+  value = local.need_public_ipv6 ? azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id : null
 }
 
 output "internal_lb_backend_pool_v4_id" {
@@ -19,11 +19,11 @@ output "public_lb_id" {
 }
 
 output "public_lb_pip_v4_fqdn" {
-  value = var.private || ! var.use_ipv4 ? null : data.azurerm_public_ip.cluster_public_ip_v4[0].fqdn
+  value = local.need_public_ipv4 ? data.azurerm_public_ip.cluster_public_ip_v4[0].fqdn : null
 }
 
 output "public_lb_pip_v6_fqdn" {
-  value = var.private || ! var.use_ipv6 ? null : data.azurerm_public_ip.cluster_public_ip_v6[0].fqdn
+  value = local.need_public_ipv6 ? data.azurerm_public_ip.cluster_public_ip_v6[0].fqdn : null
 }
 
 output "internal_lb_ip_v4_address" {

--- a/data/data/azure/vnet/variables.tf
+++ b/data/data/azure/vnet/variables.tf
@@ -76,3 +76,13 @@ variable "emulate_single_stack_ipv6" {
   type        = bool
   description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
 }
+
+variable "outbound_udr" {
+  type    = bool
+  default = false
+
+  description = <<EOF
+This determined whether User defined routing will be used for egress to Internet.
+When false, Standard LB will be used for egress to the Internet.
+EOF
+}

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -909,6 +909,15 @@ spec:
                     description: NetworkResourceGroupName specifies the network resource
                       group that contains an existing VNet
                     type: string
+                  outboundType:
+                    default: Loadbalancer
+                    description: OutboundType is a strategy for how egress from cluster
+                      is achieved. When not specified default is "Loadbalancer".
+                    enum:
+                    - ""
+                    - Loadbalancer
+                    - UserDefinedRouting
+                    type: string
                   region:
                     description: Region specifies the Azure region where the cluster
                       will be created.

--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -12,7 +12,10 @@ The following options are available when using Azure:
 * `networkResourceGroupName` (optional string): The resource group where the Azure VNet is found.
 * `virtualNetwork` (optional string): The name of an existing VNet where the cluster infrastructure should be provisioned.
 * `controlPlaneSubnet` (optional string): An existing subnet which should be used for the cluster control plane.
-* `computeSubnet` (optional string): An existing subnet which should be used by cluster nodes. 
+* `computeSubnet` (optional string): An existing subnet which should be used by cluster nodes.
+* `outboundType` (optional string):  OutboundType is a strategy for how egress from cluster is achieved. Valid values are `Loadbalancer` or `UserDefinedRouting`
+    * `Loadbalancer` (default): LoadbalancerOutboundType uses Standard loadbalancer for egress from the cluster, see [docs][azure-lb-outbound]
+    * `UserDefinedRouting`: UserDefinedRoutingOutboundType uses user defined routing for egress from the cluster, see [docs][azure-udr-outbound]. User defined routing for egress can only be used when deploying clusters to pre-existing virtual networks.
 
 ## Machine pools
 
@@ -93,6 +96,7 @@ platform:
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ```
+
 ### Existing VNet
 
 An example Azure install config to use a pre-existing VNet and subnets:
@@ -116,3 +120,6 @@ platform:
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ```
+
+[azure-lb-outbound]: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections#lb
+[azure-udr-outbound]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -285,6 +285,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				ImageURL:                    string(*rhcosImage),
 				PreexistingNetwork:          preexistingnetwork,
 				Publish:                     installConfig.Config.Publish,
+				OutboundType:                installConfig.Config.Azure.OutboundType,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -94,6 +94,11 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		mpool.OSDisk.DiskType = "Premium_LRS"
 	}
 
+	publicLB := clusterID
+	if platform.OutboundType == azure.UserDefinedRoutingOutboundType {
+		publicLB = ""
+	}
+
 	return &azureprovider.AzureMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "azureproviderconfig.openshift.io/v1beta1",
@@ -119,6 +124,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		Vnet:                 virtualNetwork,
 		ResourceGroup:        fmt.Sprintf("%s-rg", clusterID),
 		NetworkResourceGroup: networkResourceGroup,
+		PublicLoadBalancer:   publicLB,
 	}, nil
 }
 

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -214,7 +214,9 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		assetData["99_baremetal-provisioning-config.yaml"] = applyTemplateData(baremetalConfig.Files()[0].Data, bmTemplateData)
 	}
 
-	if platform == azuretypes.Name && installConfig.Config.Publish == types.InternalPublishingStrategy {
+	if platform == azuretypes.Name &&
+		installConfig.Config.Publish == types.InternalPublishingStrategy &&
+		installConfig.Config.Azure.OutboundType == azuretypes.LoadbalancerOutboundType {
 		privateClusterOutbound := &openshift.PrivateClusterOutbound{}
 		dependencies.Get(privateClusterOutbound)
 		assetData["99_private-cluster-outbound-service.yaml"] = applyTemplateData(privateClusterOutbound.Files()[0].Data, templateData)

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -143,6 +143,11 @@ func Test_PrintFields(t *testing.T) {
     networkResourceGroupName <string>
       NetworkResourceGroupName specifies the network resource group that contains an existing VNet
 
+    outboundType <string>
+      Default: "Loadbalancer"
+      Valid Values: "","Loadbalancer","UserDefinedRouting"
+      OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
+
     region <string> -required-
       Region specifies the Azure region where the cluster will be created.
 

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -40,6 +40,7 @@ type config struct {
 	ComputeSubnet               string            `json:"azure_compute_subnet"`
 	PreexistingNetwork          bool              `json:"azure_preexisting_network"`
 	Private                     bool              `json:"azure_private"`
+	OutboundUDR                 bool              `json:"azure_outbound_user_defined_routing"`
 	EmulateSingleStackIPv6      bool              `json:"azure_emulate_single_stack_ipv6"`
 }
 
@@ -53,6 +54,7 @@ type TFVarsSources struct {
 	ImageURL                    string
 	PreexistingNetwork          bool
 	Publish                     types.PublishingStrategy
+	OutboundType                azure.OutboundType
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
@@ -88,6 +90,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		VolumeSize:                  masterConfig.OSDisk.DiskSizeGB,
 		ImageURL:                    sources.ImageURL,
 		Private:                     sources.Publish == types.InternalPublishingStrategy,
+		OutboundUDR:                 sources.OutboundType == azure.UserDefinedRoutingOutboundType,
 		BaseDomainResourceGroupName: sources.BaseDomainResourceGroupName,
 		NetworkResourceGroupName:    masterConfig.NetworkResourceGroup,
 		VirtualNetwork:              masterConfig.Vnet,

--- a/pkg/types/azure/defaults/platform.go
+++ b/pkg/types/azure/defaults/platform.go
@@ -14,6 +14,9 @@ func SetPlatformDefaults(p *azure.Platform) {
 	if p.CloudName == "" {
 		p.CloudName = azure.PublicCloud
 	}
+	if p.OutboundType == "" {
+		p.OutboundType = azure.LoadbalancerOutboundType
+	}
 }
 
 // getInstanceClass returns the instance "class" we should use for a given region.

--- a/pkg/types/azure/defaults/platform_test.go
+++ b/pkg/types/azure/defaults/platform_test.go
@@ -18,16 +18,18 @@ func TestSetPlatformDefaults(t *testing.T) {
 			name:     "empty",
 			platform: &azure.Platform{},
 			expected: &azure.Platform{
-				CloudName: azure.PublicCloud,
+				CloudName:    azure.PublicCloud,
+				OutboundType: azure.LoadbalancerOutboundType,
 			},
 		},
 		{
-			name: "default",
+			name: "default cloud",
 			platform: &azure.Platform{
 				CloudName: azure.PublicCloud,
 			},
 			expected: &azure.Platform{
-				CloudName: azure.PublicCloud,
+				CloudName:    azure.PublicCloud,
+				OutboundType: azure.LoadbalancerOutboundType,
 			},
 		},
 		{
@@ -36,7 +38,30 @@ func TestSetPlatformDefaults(t *testing.T) {
 				CloudName: azure.USGovernmentCloud,
 			},
 			expected: &azure.Platform{
-				CloudName: azure.USGovernmentCloud,
+				CloudName:    azure.USGovernmentCloud,
+				OutboundType: azure.LoadbalancerOutboundType,
+			},
+		},
+		{
+			name: "default outbound",
+			platform: &azure.Platform{
+				CloudName:    azure.PublicCloud,
+				OutboundType: azure.LoadbalancerOutboundType,
+			},
+			expected: &azure.Platform{
+				CloudName:    azure.PublicCloud,
+				OutboundType: azure.LoadbalancerOutboundType,
+			},
+		},
+		{
+			name: "non-default cloud name",
+			platform: &azure.Platform{
+				CloudName:    azure.USGovernmentCloud,
+				OutboundType: azure.UserDefinedRoutingOutboundType,
+			},
+			expected: &azure.Platform{
+				CloudName:    azure.USGovernmentCloud,
+				OutboundType: azure.UserDefinedRoutingOutboundType,
 			},
 		},
 	}

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -2,6 +2,20 @@ package azure
 
 import "strings"
 
+// OutboundType is a strategy for how egress from cluster is achieved.
+// +kubebuilder:validation:Enum="";Loadbalancer;UserDefinedRouting
+type OutboundType string
+
+const (
+	// LoadbalancerOutboundType uses Standard loadbalancer for egress from the cluster.
+	// see https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections#lb
+	LoadbalancerOutboundType OutboundType = "Loadbalancer"
+
+	// UserDefinedRoutingOutboundType uses user defined routing for egress from the cluster.
+	// see https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview
+	UserDefinedRoutingOutboundType OutboundType = "UserDefinedRouting"
+)
+
 // Platform stores all the global configuration that all machinesets
 // use.
 type Platform struct {
@@ -42,6 +56,12 @@ type Platform struct {
 	// If empty, the value is equal to "AzurePublicCloud".
 	// +optional
 	CloudName CloudEnvironment `json:"cloudName,omitempty"`
+
+	// OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
+	//
+	// +kubebuilder:default=Loadbalancer
+	// +optional
+	OutboundType OutboundType `json:"outboundType"`
 }
 
 // CloudEnvironment is the name of the Azure cloud environment

--- a/pkg/types/azure/validation/platform_test.go
+++ b/pkg/types/azure/validation/platform_test.go
@@ -10,118 +10,136 @@ import (
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
+func validPlatform() *azure.Platform {
+	return &azure.Platform{
+		Region:                      "eastus",
+		BaseDomainResourceGroupName: "group",
+		OutboundType:                azure.LoadbalancerOutboundType,
+		CloudName:                   azure.PublicCloud,
+	}
+}
+
+func validNetworkPlatform() *azure.Platform {
+	p := validPlatform()
+	p.NetworkResourceGroupName = "networkresourcegroup"
+	p.VirtualNetwork = "virtualnetwork"
+	p.ComputeSubnet = "computesubnet"
+	p.ControlPlaneSubnet = "controlplanesubnet"
+	return p
+}
+
 func TestValidatePlatform(t *testing.T) {
 	cases := []struct {
 		name     string
 		platform *azure.Platform
-		valid    bool
+		expected string
 	}{
 		{
 			name: "invalid region",
-			platform: &azure.Platform{
-				Region:                      "",
-				BaseDomainResourceGroupName: "group",
-				CloudName:                   azure.PublicCloud,
-			},
-			valid: false,
+			platform: func() *azure.Platform {
+				p := validPlatform()
+				p.Region = ""
+				return p
+			}(),
+			expected: `^test-path\.region: Required value: region should be set to one of the supported Azure regions$`,
 		},
 		{
 			name: "invalid baseDomainResourceGroupName",
-			platform: &azure.Platform{
-				Region:                      "eastus",
-				BaseDomainResourceGroupName: "",
-				CloudName:                   azure.PublicCloud,
-			},
-			valid: false,
+			platform: func() *azure.Platform {
+				p := validPlatform()
+				p.BaseDomainResourceGroupName = ""
+				return p
+			}(),
+			expected: `^test-path\.baseDomainResourceGroupName: Required value: baseDomainResourceGroupName is the resource group name where the azure dns zone is deployed$`,
 		},
 		{
-			name: "minimal",
-			platform: &azure.Platform{
-				Region:                      "eastus",
-				BaseDomainResourceGroupName: "group",
-				CloudName:                   azure.PublicCloud,
-			},
-			valid: true,
+			name:     "minimal",
+			platform: validPlatform(),
 		},
 		{
 			name: "valid machine pool",
-			platform: &azure.Platform{
-				Region:                      "eastus",
-				BaseDomainResourceGroupName: "group",
-				DefaultMachinePlatform:      &azure.MachinePool{},
-				CloudName:                   azure.PublicCloud,
-			},
-			valid: true,
+			platform: func() *azure.Platform {
+				p := validPlatform()
+				p.DefaultMachinePlatform = &azure.MachinePool{}
+				return p
+			}(),
 		},
 		{
-			name: "valid subnets & virtual network",
-			platform: &azure.Platform{
-				Region:                      "eastus",
-				BaseDomainResourceGroupName: "group",
-				NetworkResourceGroupName:    "networkresourcegroup",
-				VirtualNetwork:              "virtualnetwork",
-				ComputeSubnet:               "computesubnet",
-				ControlPlaneSubnet:          "controlplanesubnet",
-				CloudName:                   azure.PublicCloud,
-			},
-			valid: true,
+			name:     "valid subnets & virtual network",
+			platform: validNetworkPlatform(),
 		},
 		{
 			name: "missing subnets",
-			platform: &azure.Platform{
-				Region:                   "eastus",
-				NetworkResourceGroupName: "networkresourcegroup",
-				VirtualNetwork:           "virtualnetwork",
-				CloudName:                azure.PublicCloud,
-			},
-			valid: false,
+			platform: func() *azure.Platform {
+				p := validNetworkPlatform()
+				p.ControlPlaneSubnet = ""
+				return p
+			}(),
+			expected: `^test-path\.controlPlaneSubnet: Required value: must provide a control plane subnet when a virtual network is specified$`,
 		},
 		{
 			name: "subnets missing virtual network",
-			platform: &azure.Platform{
-				Region:                   "eastus",
-				NetworkResourceGroupName: "networkresourcegroup",
-				ComputeSubnet:            "computesubnet",
-				CloudName:                azure.PublicCloud,
-			},
-			valid: false,
+			platform: func() *azure.Platform {
+				p := validNetworkPlatform()
+				p.ControlPlaneSubnet = ""
+				p.VirtualNetwork = ""
+				return p
+			}(),
+			expected: `^test-path\.virtualNetwork: Required value: must provide a virtual network when supplying subnets$`,
 		},
 		{
 			name: "missing network resource group",
-			platform: &azure.Platform{
-				Region:             "eastus",
-				VirtualNetwork:     "virtualnetwork",
-				ComputeSubnet:      "computesubnet",
-				ControlPlaneSubnet: "controlplanesubnet",
-				CloudName:          azure.PublicCloud,
-			},
-			valid: false,
+			platform: func() *azure.Platform {
+				p := validNetworkPlatform()
+				p.NetworkResourceGroupName = ""
+				return p
+			}(),
+			expected: `^\[test-path\.networkResourceGroupName: Required value: must provide a network resource group when a virtual network is specified, test-path\.networkResourceGroupName: Required value: must provide a network resource group when supplying subnets\]$`,
 		},
 		{
 			name: "missing cloud name",
-			platform: &azure.Platform{
-				Region:                      "eastus",
-				BaseDomainResourceGroupName: "group",
-			},
-			valid: false,
+			platform: func() *azure.Platform {
+				p := validPlatform()
+				p.CloudName = ""
+				return p
+			}(),
+			expected: `^test-path\.cloudName: Unsupported value: "": supported values:`,
 		},
 		{
 			name: "invalid cloud name",
-			platform: &azure.Platform{
-				Region:                      "eastus",
-				BaseDomainResourceGroupName: "group",
-				CloudName:                   azure.CloudEnvironment("AzureOtherCloud"),
-			},
-			valid: false,
+			platform: func() *azure.Platform {
+				p := validPlatform()
+				p.CloudName = azure.CloudEnvironment("AzureOtherCloud")
+				return p
+			}(),
+			expected: `^test-path\.cloudName: Unsupported value: "AzureOtherCloud": supported values:`,
+		},
+		{
+			name: "invalid outbound type",
+			platform: func() *azure.Platform {
+				p := validNetworkPlatform()
+				p.OutboundType = "random-egress"
+				return p
+			}(),
+			expected: `^test-path\.outboundType: Unsupported value: "random-egress": supported values: "Loadbalancer", "UserDefinedRouting"$`,
+		},
+		{
+			name: "invalid user defined type",
+			platform: func() *azure.Platform {
+				p := validPlatform()
+				p.OutboundType = azure.UserDefinedRoutingOutboundType
+				return p
+			}(),
+			expected: `^test-path\.outboundType: Invalid value: "UserDefinedRouting": UserDefinedRouting is only allowed when installing to pre-existing network$`,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidatePlatform(tc.platform, types.ExternalPublishingStrategy, field.NewPath("test-path")).ToAggregate()
-			if tc.valid {
+			if tc.expected == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				assert.Regexp(t, tc.expected, err)
 			}
 		})
 	}


### PR DESCRIPTION
enhancement: https://github.com/openshift/enhancements/pull/338
xref: https://issues.redhat.com/browse/CORS-1365
Similar to [AKS outbound type][3]

# pkg/types/azure: add OutboundType for controlling egress 
OutboundType is a strategy for how egress from cluster is achieved

Currently 2 strategies are:

- loadbalancer (default)
this uses the standard load balancer pointing to the control plane and compute nodes to provide egress based on [Azure Outbound for private machines behind standard LB][1]
for internal cluster, this means an public lb will be used to provide egress, i.e. even though all the endpoints of the cluster are internal and only accessible to the virtual network, there exists a public lb with public ip that provides the egress for the cluster

- user defined routing
this allows the user to configure the routing of the virtual network on their choosing. the installer is not expected to setup any egress, rather the installer should turn off egress from the standard lb. users have an option to setup the egress using [Azure network user defined routing][2]. An example is how AKS docuements using UDR for egress [AKS outbound type UDR][3].
This can also be used if the user is using all egress to internet using a proxy, or when the user expects no egress to the internet at all.
Since the routing for the virtual network needs to setup by the user up-front before installing a cluster, using this strategy would require a pre-existing network

# manifests/azure: no outbound k8s service type LB for UDR

For internal clusters, a dummy k8s service type LB is created for cluster. This service creates a public standard LB which is then used by compute nodes as an egress pathway to internet. Without this compute nodes in internal cluster would have no way to reach out to the internet.

But when the user is not using LB outbound type, i.e UDR, this service is no longer required because the user already has setup the network.

#  data/azure: implement outbound type LB and UDR

* when is public ipv4 LB required
- it's required for external clusters
- it's required for internal clusters when outbound is required using LB
- it's required for IPv6 clusters because Azure RM LB's can't be just ipv6.. :/

* when is public ipv6 LB required
- it's required for external ipv6 clusters
- it's required for internal clusters when outbound is required using LB

* azure_lb_rules
- the k8s API rules are required for external clusters
- the k8s API rules provide SNAT only when outbound is done using LB
- the k8s API rules are not required for internal clusters
- the outbound rules (dummy rules) are required for internal clusters when outboubd is done using LB

* azure_lb_backends
- the backends are only created when the frontend configurations are created because of the failure from Azure
```
Load Balancer /subscriptions/xx/resourceGroups/xx/providers/Microsoft.Network/loadBalancers/xx-public-lb does not have Frontend IP Configuration, but it has other child resources. This setup is not supported.
```
- since the backends are not created for certain cases, the master and bootstrap modules need to skip adding the virtual machines to the azure lb backends. Although it should be simple to switch on whether the backend was created i.e null/vs not null, the [terraform issue][4] doesn't allow such conditional in count.
```
ERROR Error: Invalid count argument
ERROR
ERROR   on ../../../../../../../tmp/openshift-install-941276375/bootstrap/main.tf line 142, in resource "azurerm_netwo
ERROR  142:   count = var.elb_backend_pool_v4_id == null ? 0 : 1
ERROR
ERROR The "count" value depends on resource attributes that cannot be determined
ERROR until apply, so Terraform cannot predict how many instances will be created.
ERROR To work around this, use the -target argument to first apply only the
ERROR resources that the count depends on.
```
So the master and bootstrap modules need to recreate the conditions of `need_public_ipv{4,6}` using the inputs `use_ipv{4,6}`, `private`, `outbound_udr`

[1]: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections#lb
[2]: https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-udr-overview
[3]: https://docs.microsoft.com/en-us/azure/aks/egress-outboundtype
[4]: https://github.com/hashicorp/terraform/issues/12570


/assign @fabianofranz @jhixson74 