### PR TITLE
Bug 1815551: images/baremetal: make /etc/passwd writeable and add SSH client

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -15,7 +15,8 @@ COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     libvirt-libs openssl unzip jq openssh-clients && \
-    yum clean all && rm -rf /var/cache/yum/*
+    yum clean all && rm -rf /var/cache/yum/* && \
+    chmod g+w /etc/passwd
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -1,5 +1,5 @@
 # This Dockerfile is a used by CI to publish an installer image
-# It builds an image containing openshift-install, and nss mock.
+# It builds an image containing openshift-install.
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 RUN yum install -y libvirt-devel && \
@@ -11,11 +11,10 @@ RUN TAGS="libvirt baremetal" hack/build.sh
 
 FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
-COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-nss.sh /bin/mock-nss.sh
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    libvirt-libs nss_wrapper openssl unzip jq openssh-clients && \
+    libvirt-libs openssl unzip jq openssh-clients && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /output && chown 1000:1000 /output

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -1,5 +1,5 @@
 # This Dockerfile is a used by CI to publish an installer image
-# It builds an image containing only the openshift-install.
+# It builds an image containing openshift-install, and nss mock.
 
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 RUN yum install -y libvirt-devel && \
@@ -11,9 +11,11 @@ RUN TAGS="libvirt baremetal" hack/build.sh
 
 FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-nss.sh /bin/mock-nss.sh
 
 RUN yum update -y && \
-    yum install --setopt=tsflags=nodocs -y libvirt-libs && \
+    yum install --setopt=tsflags=nodocs -y \
+    libvirt-libs nss_wrapper openssl unzip jq openssh-clients && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /output && chown 1000:1000 /output


### PR DESCRIPTION
This a backport of PR #3301

We'll be using baremetal-installer as the container we setup packet
for metal IPI CI. We need to use SSH, but it's broken without having a
valid user in /etc/passwd.

This change is required for our CI infrastructure to use SSH correctly
until we have completely moved CI to 4.x infrastructure where
/etc/passwd becomes dynamic.

This was restored to the tests container[1], and is now also being added
to the baremetal/installer container.

[1] openshift/origin#24690