### PR TITLE
Add vCenter CA to UPI CI image.

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -40,6 +40,10 @@ RUN curl -L -O https://github.com/poseidon/terraform-provider-matchbox/releases/
 RUN curl -L -O https://github.com/vmware/govmomi/releases/download/v0.20.0/govc_linux_amd64.gz && \
     gzip -d govc_linux_amd64.gz && \
     chmod +x govc_linux_amd64 && mv govc_linux_amd64 /bin/govc
+RUN curl -L -O -k https://vcsa-ci.vmware.devcluster.openshift.com/certs/download.zip && \
+    unzip download.zip && \
+    cp certs/lin/* /etc/pki/ca-trust/source/anchors && \
+    update-ca-trust extract
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000


### PR DESCRIPTION
A vSphere IPI install requires that the installer host have the vCenter's CA certificates. This commit adds the CA certs to the UPI image's system trust in order to enable CI for IPI installs.

The vSphere IPI install step would then use this upi image.

Blocks openshift/release#7586