### PR TITLE
Bug 1815133: osp UPI machineset OS image name

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -350,7 +350,9 @@ Remove the control-plane Machines and compute MachineSets, because we'll be prov
 ```sh
 $ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 ```
-You are free to leave the compute MachineSets in if you want to create compute machines via the machine API, but if you do you may need to update the various references (`subnet`, etc.) to match your environment.
+Leave the compute MachineSets in if you want to create compute machines via the machine API. However, some references must be updated in the machineset spec (`openshift/99_openshift-cluster-api_worker-machineset-0.yaml`) to match your environment:
+
+* The OS image: `spec.template.spec.providerSpec.value.image`
 
 [mao]: https://github.com/openshift/machine-api-operator
 


### PR DESCRIPTION
The UPI documentation recommends keeping the worker Machineset in case
the user wants to create compute machines via the machine API. However,
the Machineset won't work unless the `image` property is updated to the
user-defined value.

This change adds a recommendation to update the OS image in case the
user wants to use the installer-provisioned Machineset.