### PR TITLE
Bug 1812950: generate metadata before tfvars

### DIFF
--- a/pkg/asset/targets/targets.go
+++ b/pkg/asset/targets/targets.go
@@ -63,11 +63,11 @@ var (
 
 	// Cluster are the cluster targeted assets.
 	Cluster = []asset.WritableAsset{
+		&cluster.Metadata{},
 		&cluster.TerraformVariables{},
 		&kubeconfig.AdminClient{},
 		&password.KubeadminPassword{},
 		&tls.JournalCertKey{},
-		&cluster.Metadata{},
 		&cluster.Cluster{},
 	}
 )


### PR DESCRIPTION
Now we generate terraform config and create resources for OpenStack first, and only then we create the metadata.json file.
In case the resources were not created because of an error, we get garbage in the system. And the installer cannot remove it because the metadata file has not been generated yet.

This commit creates the file before the generation of terraform config.