### PR TITLE
images/baremetal: save rhcos.json in container image

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -11,6 +11,7 @@ RUN TAGS="libvirt baremetal" hack/build.sh
 
 FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json /var/cache/
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \


### PR DESCRIPTION
For the baremetal platform, we need to know where the images are in
order to mirror them.  Especially for IPv6 environments where we may not
have outbound internet access to download the images.

Typically, we download the rhcos.json from the sha reported by
`openshift-install version` but this doesn't work in CI, where PR's are
always rebased on master (or their target branch) and the sha reported doesn't exist on GitHub.

This is a temporary workaround until the machine OS content is part of
the release image itself.