### PR TITLE
Do not error if iptables rule already exist

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -101,16 +101,18 @@ done
 # plane.  We are using iptables instead of dnsmasq's dhcp-host because
 # DHCPv6 wants to use DUID's instead of mac addresses.
 {{if .PlatformData.BareMetal.ProvisioningDHCPAllowList}}
-$IPTABLES -t raw -N DHCP
-$IPTABLES -t raw -A PREROUTING -p udp --dport 67 -j DHCP
-$IPTABLES -t raw -A PREROUTING -p udp --dport 547 -j DHCP
+if ! $IPTABLES -n --list DHCP > /dev/null 2>&1; then
+  $IPTABLES -t raw -N DHCP
+  $IPTABLES -t raw -A PREROUTING -p udp --dport 67 -j DHCP
+  $IPTABLES -t raw -A PREROUTING -p udp --dport 547 -j DHCP
 
-for mac in {{.PlatformData.BareMetal.ProvisioningDHCPAllowList}}
-do
-  $IPTABLES -t raw -A DHCP -m mac --mac-source "$mac" -j ACCEPT
-done
+  for mac in {{.PlatformData.BareMetal.ProvisioningDHCPAllowList}}
+  do
+    $IPTABLES -t raw -A DHCP -m mac --mac-source "$mac" -j ACCEPT
+  done
 
-$IPTABLES -t raw -A DHCP -j DROP
+  $IPTABLES -t raw -A DHCP -j DROP
+fi
 {{end}}
 
 # Wait for images to be downloaded/ready


### PR DESCRIPTION
When startironic loops several times, it hits this
iptables rules and errors with:
 + ip6tables -t raw -N DHCP
iptables: Chain already exists.

Ignore the error if that exists, so process is able to
continue.

Signed-off-by: Yolanda Robla <yroblamo@redhat.com>