### PR TITLE
[WIP] baremetal: Allow rootHints to override Host profiles

### DIFF
--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -85,7 +85,11 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 
 		// Root device hints
 		rootDevice := make(map[string]interface{})
-		if profile.RootDeviceHints.HCTL != "" {
+
+		// host.RootHint overrides the root device hint in the profile
+		if len(host.RootHint) != 0 {
+			rootDevice = host.RootHint
+		} else if profile.RootDeviceHints.HCTL != "" {
 			rootDevice["hctl"] = profile.RootDeviceHints.HCTL
 		} else {
 			rootDevice["name"] = profile.RootDeviceHints.DeviceName

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -19,6 +19,7 @@ type Host struct {
 	Role            string `json:"role"`
 	BootMACAddress  string `json:"bootMACAddress" validate:"required,uniqueField"`
 	HardwareProfile string `json:"hardwareProfile"`
+	RootHint        map[string]interface{} `json:"rootHint"`
 }
 
 // Platform stores all the global configuration that all machinesets use.


### PR DESCRIPTION
Hardware profiles don't allow for all of the use cases
required in some baremetal environments, allow the
root hints associated with them to be overridden.

e.g. to specifiy a device by serial number
      - name: openshift-master-0
        rootHint: '{"serial": "1111"}'