### PR TITLE
Bug 1816155: OpenStack: Add retries to DeleteGlanceImage

### DIFF
--- a/pkg/destroy/openstack/glance.go
+++ b/pkg/destroy/openstack/glance.go
@@ -1,19 +1,42 @@
 package openstack
 
 import (
+	"time"
+
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // DeleteGlanceImage deletes the image with the specified name
 func DeleteGlanceImage(name string, cloud string) error {
+	backoffSettings := wait.Backoff{
+		Duration: time.Second * 20,
+		Steps:    30,
+	}
+
+	err := wait.ExponentialBackoff(backoffSettings, func() (bool, error) {
+		return deleteGlanceImage(name, cloud)
+	})
+	if err != nil {
+		return errors.Errorf("Unrecoverable error/timed out: %v", err)
+	}
+
+	return nil
+}
+
+func deleteGlanceImage(name string, cloud string) (bool, error) {
 	opts := clientconfig.ClientOpts{
 		Cloud: cloud,
 	}
 
 	conn, err := clientconfig.NewServiceClient("image", &opts)
 	if err != nil {
-		return err
+		logrus.Warningf("There was an error during the image removal: %v", err)
+		return false, nil
 	}
 
 	listOpts := images.ListOpts{
@@ -22,19 +45,22 @@ func DeleteGlanceImage(name string, cloud string) error {
 
 	allPages, err := images.List(conn, listOpts).AllPages()
 	if err != nil {
-		return err
+		logrus.Warningf("There was an error during the image removal: %v", err)
+		return false, nil
 	}
 
 	allImages, err := images.ExtractImages(allPages)
 	if err != nil {
-		return err
+		logrus.Warningf("There was an error during the image removal: %v", err)
+		return false, nil
 	}
 
 	for _, image := range allImages {
 		err := images.Delete(conn, image.ID).ExtractErr()
 		if err != nil {
-			return err
+			logrus.Warningf("There was an error during the image removal: %v", err)
+			return false, nil
 		}
 	}
-	return nil
+	return true, nil
 }


### PR DESCRIPTION
Now if the function fails, we stop the installation immediately, but it's better to retry several times before finally stopping the installation.