### PR TITLE
openstack: Detail the clouds.yaml cacert option

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -217,13 +217,13 @@ sudo cp ca.crt.pem /etc/pki/ca-trust/source/anchors/
 sudo update-ca-trust extract
 ```
 
-Next, you should add the `cacert` key to your `clouds.yaml`. Its value should be a valid path to your CA cert that does not require root privilege to read.
+Next, you should add the `cacert` key to your `clouds.yaml`. Its value should be a valid path to your CA cert that does not require root privilege to read. The path can be either absolute, or relative to the current working directory while running the installer.
 
 ```yaml
 clouds:
   shiftstack:
     auth: ...
-    cacert: "ca.crt.pem"
+    cacert: "/etc/pki/ca-trust/source/anchors/ca.crt.pem"
 ```
 
 ## Standalone Single-Node Development Environment


### PR DESCRIPTION
The documentation was not clear as to where the path for "cacert" was
relative to.