### PR TITLE
Bug 1813422: baremetal: validate no overlap between provisioning and machine nets

### DIFF
--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -143,6 +143,13 @@ func TestValidatePlatform(t *testing.T) {
 				ProvisioningNetworkInterface("").build(),
 			expected: "Invalid value: \"\": no provisioning network interface is configured, please set this value to be the interface on the provisioning network on your cluster's baremetal hosts",
 		},
+
+		{
+			name:     "invalid_provisioning_network_overlapping_CIDR",
+			platform: platform().ProvisioningNetworkCIDR("192.168.111.192/23").build(),
+			expected: "Invalid value: \"192.168.111.192/23\": cannot overlap with machine network: 192.168.111.0/24 overlaps with 192.168.111.192/23",
+		},
+
 		{
 			name: "invalid_clusterprovip_machineCIDR",
 			platform: platform().


### PR DESCRIPTION
Currently there's no explicit check for overlap between these two
networks, we only check if the default calculated VIPs exist in a
machine network. This is not reliable, and the error message is also not
very clear.

For example, if the machineCIDR is `192.168.111.192/26`, and the
provisioningNetworkCIDR is `192.168.111.0/24` the default VIP's will
not be in the machineCIDR range -- this will validate successfully, even
though it's not a valid configuration.

This adds explict checks and errors for this case.