### PR TITLE
Bug 1817201: Fix intermittent deprovision loop on NoSuchHostedZone error

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -1716,6 +1716,11 @@ func deleteRoute53(session *session.Session, arn arn.ARN, logger logrus.FieldLog
 
 	sharedZoneID, err := getSharedHostedZone(client, id, logger)
 	if err != nil {
+		// In some cases AWS may return the zone in the list of tagged resources despite the fact
+		// it no longer exists.
+		if err.(awserr.Error).Code() == route53.ErrCodeNoSuchHostedZone {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
…ror.

It appears in some situations, AWS may return a route53 hosted zone when
querying for tagged resources, despite the fact that the zone no longer
exists.

Update deprovision code to catch this error and skip route53 cleanup
when present.