### PR TITLE
[FCOS] cvo-overrides.yaml: point OKD releases to release-controller

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -4,6 +4,6 @@ metadata:
   namespace: openshift-cluster-version
   name: version
 spec:
-  upstream: https://api.openshift.com/api/upgrades_info/v1/graph
-  channel: stable-4.5
+  upstream: https://origin-release.svc.ci.openshift.org/graph
+  channel: stable-4
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
/cc @LorbusChris

New OKD clusters should point updates to stable versions at https://origin-release.svc.ci.openshift.org/#4-stable