### PR TITLE
[fcos] vSphere UPI: use IPs as node names

### DIFF
--- a/upi/vsphere/machine/ignition.tf
+++ b/upi/vsphere/machine/ignition.tf
@@ -16,7 +16,7 @@ data "ignition_file" "hostname" {
   mode       = "420"
 
   content {
-    content = "${var.name}-${count.index}"
+    content = "${local.ip_addresses[count.index]}"
   }
 }
 


### PR DESCRIPTION
Internal connectivity tests expect nodes to be resolvable. On our CI
these are not, so we have to use IP addresses instead of generated
node names to make tests pass.

See test results in https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_installer/3367/pull-ci-openshift-installer-fcos-e2e-vsphere/600

/cc @LorbusChris 