### PR TITLE
Bug 1810840 : Quote user and password values for good UX and avoid co…

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -468,7 +468,7 @@ func logComplete(directory, consoleURL string) error {
 	logrus.Info("Install complete!")
 	logrus.Infof("To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=%s'", kubeconfig)
 	logrus.Infof("Access the OpenShift web-console here: %s", consoleURL)
-	logrus.Infof("Login to the console with user: kubeadmin, password: %s", pw)
+	logrus.Infof("Login to the console with user: %q, and password: %q", "kubeadmin", pw)
 	return nil
 }
 


### PR DESCRIPTION
Login details with the user value contains , (comma) char e.g "kubeadmin," which is sometimes misleading. For better UX, quote these values. 