### PR TITLE
Bug 1814651: os UPI known issues: stale resources

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -12,6 +12,9 @@ This provides a greater flexibility at the cost of a more explicit and interacti
 
 Below is a step-by-step guide to a UPI installation that mimics an automated IPI installation; prerequisites and steps described below should be adapted to the constraints of the target infrastructure.
 
+Please be aware of the [Known Issues](known-issues.md#known-issues-specific-to-user-provisioned-installations)
+of this method of installation.
+
 ## Table of Contents
 
 * [Prerequisites](#prerequisites)

--- a/docs/user/openstack/known-issues.md
+++ b/docs/user/openstack/known-issues.md
@@ -30,3 +30,13 @@ Some OpenStack clouds do not set default DNS servers for the newly created subne
 If you are having this problem in the IPI installer, you will need to set the [`externalDNS` property in `install-config.yaml`](./customization.md#cluster-scoped-properties).
 
 Alternatively, for UPI, you will need to [set the subnet DNS resolvers](./install_upi.md#subnet-dns-optional).
+
+# Known Issues specific to User-Provisioned Installations
+
+## Stale resources
+
+The teardown playbooks provided for UPI installation will not delete:
+ - Cinder volumes from PVs
+ - Swift container for image registry (bootstrap container is correctly deleted)
+
+These objects have to be manually removed after running the teardown playbooks.


### PR DESCRIPTION
Following objects are still present in the cluster, after deletion is
completed:
- Cinder volumes from PVs
- Swift container for image registry (bootstrap container is correctly
  deleted)

/label platform/openstack
/cc @mandre @MaysaMacedo