### PR TITLE
Use "default-ingress-cert", not "router-ca"

### DIFF
--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -293,12 +293,12 @@ The installer fetches the URL for OpenShift console using the [route][route-obje
   console-openshift-console.apps.adahiya-1.devcluster.openshift.com
   ```
 
-### Installer Fails to Add Route CA to Kubeconfig
+### Installer Fails to Add Default Ingress Certificate to Kubeconfig
 
-The installer adds the CA certificate for the router to the list of trusted client certificate authorities in `${INSTALL_DIR}/auth/kubeconfig`. If the installer fails to add the router CA to `kubeconfig`, you can fetch the router CA from the cluster using:
+The installer adds the default ingress certificate to the list of trusted client certificate authorities in `${INSTALL_DIR}/auth/kubeconfig`. If the installer fails to add the ingress certificate to `kubeconfig`, you can fetch the certificate from the cluster using the following command:
 
 ```console
-$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get configmaps router-ca -n openshift-config-managed -o=jsonpath='{.data.ca-bundle\.crt}'
+$ oc --kubeconfig=${INSTALL_DIR}/auth/kubeconfig get configmaps default-ingress-cert -n openshift-config-managed -o=jsonpath='{.data.ca-bundle\.crt}'
 -----BEGIN CERTIFICATE-----
 MIIC/TCCAeWgAwIBAgIBATANBgkqhkiG9w0BAQsFADAuMSwwKgYDVQQDDCNjbHVz
 dGVyLWluZ3Jlc3Mtb3BlcmF0b3JAMTU1MTMwNzU4OTAeFw0xOTAyMjcyMjQ2Mjha


### PR DESCRIPTION
As of OpenShift 4.4.0, the `router-ca` configmap is deprecated, and the `default-ingress-cert` configmap should be used instead.

* `cmd/openshift-install/create.go` (`addRouterCAToClusterCA`): Replace use of `router-ca` with use of `default-ingress-cert`.  Return not-found errors to caller.
* `docs/user/troubleshooting.md`: Update references to "router-ca".

Thanks @stlaz for finding the issue!  https://github.com/openshift/cluster-ingress-operator/pull/377#issuecomment-606007260