### PR TITLE
pass the manifests-dir param to CCO render

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -347,6 +347,7 @@ then
 		${CLOUD_CREDENTIAL_OPERATOR_IMAGE} \
 		render \
 			--dest-dir=/assets/cco-bootstrap \
+			--manifests-dir=/assets/manifests \
 			--cloud-credential-operator-image=${CLOUD_CREDENTIAL_OPERATOR_IMAGE}
 
 	cp cco-bootstrap/manifests/* manifests/


### PR DESCRIPTION
This allows someone installing OpenShift to slip in a ConfigMap that keeps cloud-credential-operator from ever starting up.

The process would look like:
openshift-install create manifests
create YAML for CCO Configmap for namespace/name: openshift-cloud-credential-operator/cloud-credential-operator-config
openshift-install create cluster

When the CCO render command sees the ConfigMap indicating that it should be disabled, it will not render the bootstrap Pod manifest, and the ConfigMap will make it into the cluster so the in-cluster CCO will also not attempt to run.