### PR TITLE
Add ovirt to machine pools

### DIFF
--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -81,6 +81,7 @@ The following machine-pool properties are available:
     * `azure` (optional object): [Azure-specific properties](azure/customization.md#machine-pools).
     * `gcp` (optional object): [GCP-specific properties](gcp/customization.md#machine-pools).
     * `openstack` (optional object): [OpenStack-specific properties](openstack/customization.md#machine-pools).
+    * `ovirt` (optional object): [oVirt-specific properties](openstack/customization.md#machine-pools).
     * `vsphere` (optional object): [vSphere-specific properties](vsphere/customization.md#machine-pools).
 * `replicas` (optional integer): The machine count for the machine pool.
 


### PR DESCRIPTION
Added a line for `platform` = `ovirt`. 
It's unclear why the target of the `<platform>-specific properties` links is also the section where the links are located, "Machine pools." We should update these targets and/or content to provide platform-specific properties.