### PR TITLE
OpenStack: Temporary disable image import

### DIFF
--- a/pkg/tfvars/openstack/rhcos_image.go
+++ b/pkg/tfvars/openstack/rhcos_image.go
@@ -47,10 +47,14 @@ func uploadBaseImage(cloud string, localFilePath string, imageName string, clust
 	}
 	logrus.Debugf("Image %s was created.", img.Name)
 
-	useImageImport, err := isImageImportSupported(cloud)
-	if err != nil {
-		return err
-	}
+	// FIXME(mfedosin): We have to temporary disable image import, because it looks
+	// like there are problems on the server side.
+	// Revert this patch when the problems are fixed.
+	useImageImport := false
+	// useImageImport, err := isImageImportSupported(cloud)
+	// if err != nil {
+	// 	return err
+	// }
 
 	if useImageImport {
 		logrus.Debugf("Using Image Import API to upload RHCOS to the image %q with ID %q", img.Name, img.ID)


### PR DESCRIPTION
Looks like image import is not configured well on our testing cloud, which leads to the uploading error.

We have to temporary disable image import in the installer until the cloud is fixed.