### PR TITLE
OpenStack: Custom subnets

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -76,6 +76,8 @@ module "topology" {
   external_dns        = var.openstack_external_dns
   trunk_support       = var.openstack_trunk_support
   octavia_support     = var.openstack_octavia_support
+  machines_subnet_id  = var.openstack_machines_subnet_id
+  machines_network_id = var.openstack_machines_network_id
 }
 
 data "openstack_images_image_v2" "base_image" {

--- a/data/data/openstack/topology/outputs.tf
+++ b/data/data/openstack/topology/outputs.tf
@@ -7,10 +7,10 @@ output "master_port_ids" {
 }
 
 output "private_network_id" {
-  value = openstack_networking_network_v2.openshift-private.id
+  value = local.nodes_network_id
 }
 
 output "nodes_subnet_id" {
-  value = openstack_networking_subnet_v2.nodes.id
+  value = local.nodes_subnet_id
 }
 

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -56,3 +56,13 @@ variable "trunk_support" {
 variable "octavia_support" {
   type = string
 }
+
+variable "machines_subnet_id" {
+  type    = string
+  default = ""
+}
+
+variable "machines_network_id" {
+  type    = string
+  default = ""
+}

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -340,3 +340,15 @@ variable "openstack_master_server_group_id" {
   type        = string
   description = "ID of the server group to assign the master servers to."
 }
+
+variable "openstack_machines_subnet_id" {
+  type        = string
+  default     = ""
+  description = "ID of the subnet to use for cluster machines. If empty, the installer will create a subnet to use as machinesSubnet."
+}
+
+variable "openstack_machines_network_id" {
+  type        = string
+  default     = ""
+  description = "ID of the network the machines subnet is on. If empty, the installer will create a network to use as machinesNetwork."
+}

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -28,6 +28,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `clusterOSImage` (optional string): Either a URL with `http(s)` or `file` scheme to override the default OS image for cluster nodes or an existing Glance image name.
 * `apiVIP` (optional string): An IP addresss on the machineNetwork that will be assigned to the API VIP. Be aware that the `10` and `11` of the machineNetwork will be taken by neutron dhcp by default, and wont be available.
 * `ingressVIP` (optional string): An IP address on the machineNetwork that will be assigned to the ingress VIP. Be aware that the `10` and `11` of the machineNetwork will be taken by neutron dhcp by default, and wont be available.
+* `machinesSubnet` (optional string): the UUID of an openstack subnet to install the nodes of the cluster onto. The first CIDR in `networks.machineNetwork` must match the cidr of the `machinesSubnet`. Also note that setting `externalDNS` while setting `machinesSubnet` is invalid usage. If you want to add a DNS to your cluster while using a custom subnet, add it to the subnet in openstack [like this](https://docs.openstack.org/neutron/rocky/admin/config-dns-res.html).
 
 ## Machine pools
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -385,6 +385,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			caCert,
 			bootstrapIgn,
 			installConfig.Config.ControlPlane.Platform.OpenStack,
+			installConfig.Config.Platform.OpenStack.MachinesSubnet,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/asset/installconfig/openstack/realvalidvaluesfetcher.go
+++ b/pkg/asset/installconfig/openstack/realvalidvaluesfetcher.go
@@ -9,6 +9,7 @@ import (
 	netext "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	"github.com/openshift/installer/pkg/types/openstack/validation"
@@ -190,4 +191,22 @@ func (f realValidValuesFetcher) GetFloatingIPNames(cloud string, floatingNetwork
 	}
 
 	return floatingIPNames, nil
+}
+
+func (f realValidValuesFetcher) GetSubnetCIDR(cloud string, subnetID string) (string, error) {
+	opts := &clientconfig.ClientOpts{
+		Cloud: cloud,
+	}
+
+	networkClient, err := clientconfig.NewServiceClient("network", opts)
+	if err != nil {
+		return "", err
+	}
+
+	subnet, err := subnets.Get(networkClient, subnetID).Extract()
+	if err != nil {
+		return "", err
+	}
+
+	return subnet.CIDR, nil
 }

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -86,17 +86,22 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 }
 
 func generateProvider(clusterID string, platform *openstack.Platform, mpool *openstack.MachinePool, osImage string, az string, role, userDataSecret string, trunk string) *openstackprovider.OpenstackProviderSpec {
-	networks := []openstackprovider.NetworkParam{
-		{
-			Subnets: []openstackprovider.SubnetParam{
-				{
-					Filter: openstackprovider.SubnetFilter{
-						Name: fmt.Sprintf("%s-nodes", clusterID),
-						Tags: fmt.Sprintf("%s=%s", "openshiftClusterID", clusterID),
-					},
-				},
-			},
-		},
+	var networks []openstackprovider.NetworkParam
+	if platform.MachinesSubnet != "" {
+		networks = []openstackprovider.NetworkParam{{
+			Subnets: []openstackprovider.SubnetParam{{
+				UUID: platform.MachinesSubnet,
+			}}},
+		}
+	} else {
+		networks = []openstackprovider.NetworkParam{{
+			Subnets: []openstackprovider.SubnetParam{{
+				Filter: openstackprovider.SubnetFilter{
+					Name: fmt.Sprintf("%s-nodes", clusterID),
+					Tags: fmt.Sprintf("%s=%s", "openshiftClusterID", clusterID),
+				}},
+			}},
+		}
 	}
 	for _, networkID := range mpool.AdditionalNetworkIDs {
 		networks = append(networks, openstackprovider.NetworkParam{

--- a/pkg/asset/mock/filefetcher_generated.go
+++ b/pkg/asset/mock/filefetcher_generated.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockFileFetcher is a mock of FileFetcher interface
+// MockFileFetcher is a mock of FileFetcher interface.
 type MockFileFetcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileFetcherMockRecorder
 }
 
-// MockFileFetcherMockRecorder is the mock recorder for MockFileFetcher
+// MockFileFetcherMockRecorder is the mock recorder for MockFileFetcher.
 type MockFileFetcherMockRecorder struct {
 	mock *MockFileFetcher
 }
 
-// NewMockFileFetcher creates a new mock instance
+// NewMockFileFetcher creates a new mock instance.
 func NewMockFileFetcher(ctrl *gomock.Controller) *MockFileFetcher {
 	mock := &MockFileFetcher{ctrl: ctrl}
 	mock.recorder = &MockFileFetcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFileFetcher) EXPECT() *MockFileFetcherMockRecorder {
 	return m.recorder
 }
 
-// FetchByName mocks base method
+// FetchByName mocks base method.
 func (m *MockFileFetcher) FetchByName(arg0 string) (*asset.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchByName", arg0)
@@ -42,13 +42,13 @@ func (m *MockFileFetcher) FetchByName(arg0 string) (*asset.File, error) {
 	return ret0, ret1
 }
 
-// FetchByName indicates an expected call of FetchByName
+// FetchByName indicates an expected call of FetchByName.
 func (mr *MockFileFetcherMockRecorder) FetchByName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchByName", reflect.TypeOf((*MockFileFetcher)(nil).FetchByName), arg0)
 }
 
-// FetchByPattern mocks base method
+// FetchByPattern mocks base method.
 func (m *MockFileFetcher) FetchByPattern(pattern string) ([]*asset.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FetchByPattern", pattern)
@@ -57,7 +57,7 @@ func (m *MockFileFetcher) FetchByPattern(pattern string) ([]*asset.File, error) 
 	return ret0, ret1
 }
 
-// FetchByPattern indicates an expected call of FetchByPattern
+// FetchByPattern indicates an expected call of FetchByPattern.
 func (mr *MockFileFetcherMockRecorder) FetchByPattern(pattern interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchByPattern", reflect.TypeOf((*MockFileFetcher)(nil).FetchByPattern), pattern)

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -53,4 +53,10 @@ type Platform struct {
 	// Default: will be set to the 7 on the first entry in the machineNewtwork CIDR
 	// +optional
 	IngressVIP string `json:"ingressVIP,omitempty"`
+
+	// MachinesSubnet is the UUIDv4 of an openstack subnet. This subnet will be used by all nodes created by the installer.
+	// By setting this, the installer will no longer create a network and subnet.
+	// The subnet and network specified in MachinesSubnet will not be deleted or modified by the installer.
+	// +optional
+	MachinesSubnet string `json:"machinesSubnet,omitempty"`
 }

--- a/pkg/types/openstack/validation/mock/validvaluesfetcher_generated.go
+++ b/pkg/types/openstack/validation/mock/validvaluesfetcher_generated.go
@@ -9,30 +9,30 @@ import (
 	reflect "reflect"
 )
 
-// MockValidValuesFetcher is a mock of ValidValuesFetcher interface
+// MockValidValuesFetcher is a mock of ValidValuesFetcher interface.
 type MockValidValuesFetcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockValidValuesFetcherMockRecorder
 }
 
-// MockValidValuesFetcherMockRecorder is the mock recorder for MockValidValuesFetcher
+// MockValidValuesFetcherMockRecorder is the mock recorder for MockValidValuesFetcher.
 type MockValidValuesFetcherMockRecorder struct {
 	mock *MockValidValuesFetcher
 }
 
-// NewMockValidValuesFetcher creates a new mock instance
+// NewMockValidValuesFetcher creates a new mock instance.
 func NewMockValidValuesFetcher(ctrl *gomock.Controller) *MockValidValuesFetcher {
 	mock := &MockValidValuesFetcher{ctrl: ctrl}
 	mock.recorder = &MockValidValuesFetcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockValidValuesFetcher) EXPECT() *MockValidValuesFetcherMockRecorder {
 	return m.recorder
 }
 
-// GetCloudNames mocks base method
+// GetCloudNames mocks base method.
 func (m *MockValidValuesFetcher) GetCloudNames() ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCloudNames")
@@ -41,13 +41,13 @@ func (m *MockValidValuesFetcher) GetCloudNames() ([]string, error) {
 	return ret0, ret1
 }
 
-// GetCloudNames indicates an expected call of GetCloudNames
+// GetCloudNames indicates an expected call of GetCloudNames.
 func (mr *MockValidValuesFetcherMockRecorder) GetCloudNames() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudNames", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetCloudNames))
 }
 
-// GetNetworkNames mocks base method
+// GetNetworkNames mocks base method.
 func (m *MockValidValuesFetcher) GetNetworkNames(cloud string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNetworkNames", cloud)
@@ -56,13 +56,13 @@ func (m *MockValidValuesFetcher) GetNetworkNames(cloud string) ([]string, error)
 	return ret0, ret1
 }
 
-// GetNetworkNames indicates an expected call of GetNetworkNames
+// GetNetworkNames indicates an expected call of GetNetworkNames.
 func (mr *MockValidValuesFetcherMockRecorder) GetNetworkNames(cloud interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkNames", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetNetworkNames), cloud)
 }
 
-// GetFlavorNames mocks base method
+// GetFlavorNames mocks base method.
 func (m *MockValidValuesFetcher) GetFlavorNames(cloud string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFlavorNames", cloud)
@@ -71,13 +71,13 @@ func (m *MockValidValuesFetcher) GetFlavorNames(cloud string) ([]string, error) 
 	return ret0, ret1
 }
 
-// GetFlavorNames indicates an expected call of GetFlavorNames
+// GetFlavorNames indicates an expected call of GetFlavorNames.
 func (mr *MockValidValuesFetcherMockRecorder) GetFlavorNames(cloud interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlavorNames", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetFlavorNames), cloud)
 }
 
-// GetNetworkExtensionsAliases mocks base method
+// GetNetworkExtensionsAliases mocks base method.
 func (m *MockValidValuesFetcher) GetNetworkExtensionsAliases(cloud string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNetworkExtensionsAliases", cloud)
@@ -86,13 +86,13 @@ func (m *MockValidValuesFetcher) GetNetworkExtensionsAliases(cloud string) ([]st
 	return ret0, ret1
 }
 
-// GetNetworkExtensionsAliases indicates an expected call of GetNetworkExtensionsAliases
+// GetNetworkExtensionsAliases indicates an expected call of GetNetworkExtensionsAliases.
 func (mr *MockValidValuesFetcherMockRecorder) GetNetworkExtensionsAliases(cloud interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkExtensionsAliases", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetNetworkExtensionsAliases), cloud)
 }
 
-// GetServiceCatalog mocks base method
+// GetServiceCatalog mocks base method.
 func (m *MockValidValuesFetcher) GetServiceCatalog(cloud string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceCatalog", cloud)
@@ -101,13 +101,13 @@ func (m *MockValidValuesFetcher) GetServiceCatalog(cloud string) ([]string, erro
 	return ret0, ret1
 }
 
-// GetServiceCatalog indicates an expected call of GetServiceCatalog
+// GetServiceCatalog indicates an expected call of GetServiceCatalog.
 func (mr *MockValidValuesFetcherMockRecorder) GetServiceCatalog(cloud interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceCatalog", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetServiceCatalog), cloud)
 }
 
-// GetFloatingIPNames mocks base method
+// GetFloatingIPNames mocks base method.
 func (m *MockValidValuesFetcher) GetFloatingIPNames(cloud, floatingNetwork string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFloatingIPNames", cloud, floatingNetwork)
@@ -116,8 +116,23 @@ func (m *MockValidValuesFetcher) GetFloatingIPNames(cloud, floatingNetwork strin
 	return ret0, ret1
 }
 
-// GetFloatingIPNames indicates an expected call of GetFloatingIPNames
+// GetFloatingIPNames indicates an expected call of GetFloatingIPNames.
 func (mr *MockValidValuesFetcherMockRecorder) GetFloatingIPNames(cloud, floatingNetwork interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFloatingIPNames", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetFloatingIPNames), cloud, floatingNetwork)
+}
+
+// GetSubnetCIDR mocks base method.
+func (m *MockValidValuesFetcher) GetSubnetCIDR(cloud, subnetID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubnetCIDR", cloud, subnetID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubnetCIDR indicates an expected call of GetSubnetCIDR.
+func (mr *MockValidValuesFetcherMockRecorder) GetSubnetCIDR(cloud, subnetID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetCIDR", reflect.TypeOf((*MockValidValuesFetcher)(nil).GetSubnetCIDR), cloud, subnetID)
 }

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -33,15 +33,17 @@ func validNetworking() *types.Networking {
 
 func TestValidatePlatform(t *testing.T) {
 	cases := []struct {
-		name             string
-		platform         *openstack.Platform
-		networking       *types.Networking
-		noClouds         bool
-		noNetworks       bool
-		noFlavors        bool
-		noNetExts        bool
-		noServiceCatalog bool
-		valid            bool
+		name                  string
+		platform              *openstack.Platform
+		networking            *types.Networking
+		noClouds              bool
+		noNetworks            bool
+		noFlavors             bool
+		noNetExts             bool
+		noServiceCatalog      bool
+		validMachinesSubnet   bool
+		invalidMachinesSubnet bool
+		valid                 bool
 	}{
 		{
 			name:       "minimal",
@@ -198,6 +200,58 @@ func TestValidatePlatform(t *testing.T) {
 			networking: validNetworking(),
 			valid:      false,
 		},
+		{
+			name: "valid MachinesSubnet",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.MachinesSubnet = "c664df47-4f7e-4852-819e-e66f9882b7b3"
+				return p
+			}(),
+			networking:          validNetworking(),
+			validMachinesSubnet: true,
+			valid:               true,
+		},
+		{
+			name: "valid MachinesSubnet invalid machineNetwork",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.MachinesSubnet = "c664df47-4f7e-4852-819e-e66f9882b7b3"
+				return p
+			}(),
+			networking: func() *types.Networking {
+				n := validNetworking()
+				n.MachineNetwork[0].CIDR = *ipnet.MustParseCIDR("105.90.0.0/16")
+				return n
+			}(),
+			validMachinesSubnet: true,
+			valid:               false,
+		},
+		{
+			name: "invalid MachinesSubnet",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.MachinesSubnet = "subnet-c17b"
+				return p
+			}(),
+			networking:            validNetworking(),
+			invalidMachinesSubnet: true,
+			valid:                 false,
+		},
+		{
+			name: "valid MachinesSubnet externalDNS set",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.MachinesSubnet = "c664df47-4f7e-4852-819e-e66f9882b7b3"
+				p.ExternalDNS = []string{
+					"192.168.1.12",
+					"10.0.5.16",
+				}
+				return p
+			}(),
+			networking:          validNetworking(),
+			validMachinesSubnet: true,
+			valid:               false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -246,6 +300,16 @@ func TestValidatePlatform(t *testing.T) {
 			} else {
 				fetcher.EXPECT().GetServiceCatalog(tc.platform.Cloud).
 					Return([]string{"octavia"}, nil).
+					MaxTimes(1)
+			}
+			if tc.validMachinesSubnet {
+				fetcher.EXPECT().GetSubnetCIDR(tc.platform.Cloud, tc.platform.MachinesSubnet).
+					Return("10.0.0.0/16", nil).
+					MaxTimes(1)
+			}
+			if tc.invalidMachinesSubnet {
+				fetcher.EXPECT().GetSubnetCIDR(tc.platform.Cloud, tc.platform.MachinesSubnet).
+					Return("", errors.New("invalid machinesSubnet")).
 					MaxTimes(1)
 			}
 

--- a/pkg/types/openstack/validation/validvaluesfetcher.go
+++ b/pkg/types/openstack/validation/validvaluesfetcher.go
@@ -16,4 +16,6 @@ type ValidValuesFetcher interface {
 	GetServiceCatalog(cloud string) ([]string, error)
 	// GetFloatingIPNames gets the floating IPs
 	GetFloatingIPNames(cloud string, floatingNetwork string) ([]string, error)
+	// GetSubnetCIDR gets the CIDR of a subnet
+	GetSubnetCIDR(cloud string, subnetID string) (string, error)
 }


### PR DESCRIPTION
Enable IPI support for users to pass the installer an already provisioned subnet in openstack to use as the nods subnet. The installer should take the subnet passed to the install config, if there is one, and should not create a network, or a subnet in openstack.

```yaml
apiVersion: v1
baseDomain: example.com
metadata: 
  name: test-cluster
platform: 
  openstack: 
    nodesSubnet: abcd-4321
pullSecret: '{"auths": ...}'
sshKey: ssh-ed25519 AAAA...
```
