### PR TITLE
pkg/types/validation: Drop internal ClusterDomain

### DIFF
--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -4,7 +4,7 @@ import (
 	survey "gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/types/validation"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/validate"
 )
 
@@ -36,7 +36,9 @@ func (a *clusterName) Generate(parents asset.Parents) error {
 		})
 	}
 	validator = survey.ComposeValidators(validator, func(ans interface{}) error {
-		return validate.DomainName(validation.ClusterDomain(bd.BaseDomain, ans.(string)), false)
+		installConfig := &types.InstallConfig{BaseDomain: bd.BaseDomain}
+		installConfig.ObjectMeta.Name = ans.(string)
+		return validate.DomainName(installConfig.ClusterDomain(), false)
 	})
 
 	return survey.Ask([]*survey.Question{

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -34,12 +34,6 @@ const (
 	masterPoolName = "master"
 )
 
-// ClusterDomain returns the cluster domain for a cluster with the specified
-// base domain and cluster name.
-func ClusterDomain(baseDomain, clusterName string) string {
-	return fmt.Sprintf("%s.%s", clusterName, baseDomain)
-}
-
 // ValidateInstallConfig checks that the specified install config is valid.
 func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher openstackvalidation.ValidValuesFetcher) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -74,7 +68,7 @@ func ValidateInstallConfig(c *types.InstallConfig, openStackValidValuesFetcher o
 		allErrs = append(allErrs, field.Invalid(field.NewPath("baseDomain"), c.BaseDomain, baseDomainErr.Error()))
 	}
 	if nameErr == nil && baseDomainErr == nil {
-		clusterDomain := ClusterDomain(c.BaseDomain, c.ObjectMeta.Name)
+		clusterDomain := c.ClusterDomain()
 		if err := validate.DomainName(clusterDomain, true); err != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("baseDomain"), clusterDomain, err.Error()))
 		}


### PR DESCRIPTION
This logic became a method in 1ab1cd3fb0 (#1169); so we can drop the validation-specific helper which was from bf3ee0353a (#1255).  Or maybe we never needed the validation-specific helper ;).