### PR TITLE
Fix indentation on a UPI Playbook task

### DIFF
--- a/upi/openstack/down-06_load-balancers.yaml
+++ b/upi/openstack/down-06_load-balancers.yaml
@@ -26,7 +26,7 @@
 
   - set_fact:
       versions: "{{ octavia_versions.json.versions | selectattr('id', 'match', 'v2.5') | map(attribute='id') | list }}"
-      when: os_networking_type == "Kuryr"
+    when: os_networking_type == "Kuryr"
 
   - name: 'List tagged loadbalancers'
     uri:


### PR DESCRIPTION
This commit fix an indentation on the UPI destroy playbook
for loadbalancers.