### PR TITLE
Bug 1821638: oVirt, add os_type to ovirt templates

### DIFF
--- a/data/data/ovirt/template/main.tf
+++ b/data/data/ovirt/template/main.tf
@@ -49,6 +49,9 @@ resource "ovirt_vm" "tmp_import_vm" {
     disk_id   = ovirt_image_transfer.releaseimage.0.disk_id
     interface = "virtio_scsi"
   }
+  os {
+    type = "rhcos_x64"
+  }
   nics {
     name            = "nic1"
     vnic_profile_id = var.ovirt_vnic_profile_id

--- a/pkg/asset/installconfig/ovirt/validaton_test.go
+++ b/pkg/asset/installconfig/ovirt/validaton_test.go
@@ -26,6 +26,11 @@ func setup() {
 			writer.Write([]byte("{}"))
 			return
 		}
+		if request.Method == http.MethodOptions {
+			writer.WriteHeader(http.StatusOK)
+			writer.Write([]byte("{}"))
+			return
+		}
 	})
 }
 
@@ -48,7 +53,7 @@ func Test_validateAuth(t *testing.T) {
 		expectSuccess: true,
 	},
 		{
-			url:           "https://nonexisting",
+			url:           "https://nonexisting.com",
 			username:      "foo",
 			password:      "bar",
 			insecure:      false,


### PR DESCRIPTION
On RHV 4.3.9 we have change the ignition handling and API, to recognize an ignition is passed to the VM we need to specify the os_type as RHCOS.
During the installation the installer creates a ovirt templates to be used by the nodes, so we need to create the template with os_type = "rchos_x64".

Signed-off-by: Gal Zaidman <gzaidman@redhat.com>