### PR TITLE
uninstall: allow for azure uninstall to succeed for missing rg

### DIFF
--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -260,6 +260,10 @@ func deleteResourceGroup(ctx context.Context, client resources.GroupsGroupClient
 
 	delFuture, err := client.Delete(ctx, name)
 	if err != nil {
+		if wasNotFound(delFuture.Response()) {
+			logger.Debug("already deleted")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
When running an Azure uninstall for a cluster that has already been deleted, the uninstall fails due to an error deleting the resource group. This change accepts an already-deleted resource group as a successful uninstall of the resource group.

https://issues.redhat.com/browse/CO-863