### PR TITLE
Bug 1821653: Fix LB deletion for lbs with same or status pending

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -901,4 +901,7 @@ $ ansible-playbook -i inventory.yaml  \
 
 The playbook `down-load-balancers.yaml` idempotently deletes the load balancers created by the Kuryr installation, if any.
 
+**NOTE:** The deletion of load balancers with `provisioning_status` `PENDING-*` is skipped. Make sure to retry the
+`down-load-balancers.yaml` playbook once the load balancers have transitioned to `ACTIVE`.
+
 Then, remove the `api` and `*.apps` DNS records.

--- a/upi/openstack/down-load-balancers.yaml
+++ b/upi/openstack/down-load-balancers.yaml
@@ -1,6 +1,7 @@
 # Required Python packages:
 #
 # ansible
+# openstackcli
 # openstacksdk
 
 - import_playbook: common.yaml
@@ -43,14 +44,13 @@
   # for each service present on the cluster. Let's make
   # sure to remove the resources generated.
   - name: 'Remove the cluster load balancers'
-    os_loadbalancer:
-      name: "{{ item.name }}"
-      state: absent
-      wait: no
+    command:
+      cmd: "openstack loadbalancer delete --cascade {{ item.id }}"
     with_items: "{{ lbs_tagged.json.loadbalancers }}"
     when:
     - os_networking_type == "Kuryr"
     - versions | length > 0
+    - '"PENDING" not in item.provisioning_status'
 
   - name: 'List loadbalancers tagged on description'
     uri:
@@ -67,10 +67,10 @@
   # for each service present on the cluster. Let's make
   # sure to remove the resources generated.
   - name: 'Remove the cluster load balancers'
-    os_loadbalancer:
-      name: "{{ item.name }}"
-      state: absent
+    command:
+      cmd: "openstack loadbalancer delete --cascade {{ item.id }}"
     with_items: "{{ lbs_description.json.loadbalancers }}"
     when:
     - os_networking_type == "Kuryr"
     - versions | length == 0
+    - '"PENDING" not in item.provisioning_status'


### PR DESCRIPTION
This commit ensures the lb ID is used instead of the name
when deleting a lb, as openstack allows multiple load balancers
with same name to coexist. Also, it ensures the deletion of lb
with status different than ERROR or ACTIVE to be skipped.