### PR TITLE
Bug 1802526: AWS Terraform: use machine_cidr instead of VPC main cidr …

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -26,7 +26,7 @@ module "bootstrap" {
   target_group_arns        = module.vpc.aws_lb_target_group_arns
   target_group_arns_length = module.vpc.aws_lb_target_group_arns_length
   vpc_id                   = module.vpc.vpc_id
-  vpc_cidrs                = module.vpc.vpc_cidrs
+  vpc_cidrs                = var.machine_v4_cidrs
   vpc_security_group_ids   = [module.vpc.master_sg_id]
   volume_kms_key_id        = var.aws_master_root_volume_kms_key_id
   publish_strategy         = var.aws_publish_strategy
@@ -84,7 +84,7 @@ module "dns" {
 module "vpc" {
   source = "./vpc"
 
-  cidr_block       = var.machine_cidr
+  cidr_blocks      = var.machine_v4_cidrs
   cluster_id       = var.cluster_id
   region           = var.aws_region
   vpc              = var.aws_vpc

--- a/data/data/aws/vpc/outputs.tf
+++ b/data/data/aws/vpc/outputs.tf
@@ -2,10 +2,6 @@ output "vpc_id" {
   value = data.aws_vpc.cluster_vpc.id
 }
 
-output "vpc_cidrs" {
-  value = [data.aws_vpc.cluster_vpc.cidr_block]
-}
-
 output "az_to_private_subnet_id" {
   value = zipmap(data.aws_subnet.private.*.availability_zone, data.aws_subnet.private.*.id)
 }

--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -18,7 +18,7 @@ resource "aws_security_group_rule" "master_mcs" {
   security_group_id = aws_security_group.master.id
 
   protocol    = "tcp"
-  cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  cidr_blocks = var.cidr_blocks
   from_port   = 22623
   to_port     = 22623
 }
@@ -38,7 +38,7 @@ resource "aws_security_group_rule" "master_ingress_icmp" {
   security_group_id = aws_security_group.master.id
 
   protocol    = "icmp"
-  cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  cidr_blocks = var.cidr_blocks
   from_port   = -1
   to_port     = -1
 }
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "master_ingress_ssh" {
   security_group_id = aws_security_group.master.id
 
   protocol    = "tcp"
-  cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  cidr_blocks = var.cidr_blocks
   from_port   = 22
   to_port     = 22
 }
@@ -58,7 +58,7 @@ resource "aws_security_group_rule" "master_ingress_https" {
   security_group_id = aws_security_group.master.id
 
   protocol    = "tcp"
-  cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  cidr_blocks = var.cidr_blocks
   from_port   = 6443
   to_port     = 6443
 }

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -28,7 +28,7 @@ resource "aws_security_group_rule" "worker_ingress_icmp" {
   security_group_id = aws_security_group.worker.id
 
   protocol    = "icmp"
-  cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  cidr_blocks = var.cidr_blocks
   from_port   = -1
   to_port     = -1
 }
@@ -38,7 +38,7 @@ resource "aws_security_group_rule" "worker_ingress_ssh" {
   security_group_id = aws_security_group.worker.id
 
   protocol    = "tcp"
-  cidr_blocks = [data.aws_vpc.cluster_vpc.cidr_block]
+  cidr_blocks = var.cidr_blocks
   from_port   = 22
   to_port     = 22
 }

--- a/data/data/aws/vpc/variables.tf
+++ b/data/data/aws/vpc/variables.tf
@@ -3,8 +3,9 @@ variable "availability_zones" {
   description = "The availability zones in which to provision subnets."
 }
 
-variable "cidr_block" {
-  type = string
+variable "cidr_blocks" {
+  type        = list(string)
+  description = "A list of IPv4 CIDRs with 0 index being the main CIDR."
 }
 
 variable "cluster_id" {

--- a/data/data/aws/vpc/vpc.tf
+++ b/data/data/aws/vpc/vpc.tf
@@ -6,7 +6,7 @@ locals {
 resource "aws_vpc" "new_vpc" {
   count = var.vpc == null ? 1 : 0
 
-  cidr_block           = var.cidr_block
+  cidr_block           = var.cidr_blocks[0]
   enable_dns_hostnames = true
   enable_dns_support   = true
 

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -48,8 +48,8 @@ module "bootstrap" {
 module "vnet" {
   source              = "./vnet"
   resource_group_name = azurerm_resource_group.main.name
-  vnet_v4_cidrs       = var.azure_machine_v4_cidrs
-  vnet_v6_cidrs       = var.azure_machine_v6_cidrs
+  vnet_v4_cidrs       = var.machine_v4_cidrs
+  vnet_v6_cidrs       = var.machine_v6_cidrs
   cluster_id          = var.cluster_id
   region              = var.azure_region
   dns_label           = var.cluster_id

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -112,24 +112,6 @@ variable "azure_private" {
   description = "This determines if this is a private cluster or not."
 }
 
-variable "azure_machine_v4_cidrs" {
-  type = list(string)
-
-  description = <<EOF
-The list of IPv4 address spaces from which to assign machine IPs.
-EOF
-
-}
-
-variable "azure_machine_v6_cidrs" {
-  type = list(string)
-
-  description = <<EOF
-The list of IPv6 address spaces from which to assign machine IPs.
-EOF
-
-}
-
 variable "azure_emulate_single_stack_ipv6" {
   type        = bool
   description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."

--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -31,6 +31,7 @@ EOF
 
 variable "master_count" {
   type = string
+
   default = "1"
 
   description = <<EOF
@@ -70,7 +71,8 @@ EOF
 }
 
 variable "ignition_master" {
-  type    = string
+  type = string
+
   default = ""
 
   description = <<EOF
@@ -81,6 +83,7 @@ EOF
 
 variable "ignition_bootstrap" {
   type = string
+
   default = ""
 
   description = <<EOF

--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -11,6 +11,24 @@ EOF
 
 }
 
+variable "machine_v4_cidrs" {
+  type = list(string)
+
+  description = <<EOF
+The list of IPv4 address spaces from which to assign machine IPs.
+EOF
+
+}
+
+variable "machine_v6_cidrs" {
+  type = list(string)
+
+  description = <<EOF
+The list of IPv6 address spaces from which to assign machine IPs.
+EOF
+
+}
+
 variable "master_count" {
   type = string
   default = "1"

--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -2,15 +2,6 @@ terraform {
   required_version = ">= 0.12"
 }
 
-variable "machine_cidr" {
-  type = string
-
-  description = <<EOF
-The IP address space from which to assign machine IPs.
-EOF
-
-}
-
 variable "machine_v4_cidrs" {
   type = list(string)
 

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -1,8 +1,8 @@
 locals {
   labels = var.gcp_extra_labels
 
-  master_subnet_cidr = cidrsubnet(var.machine_cidr, 3, 0) #master subnet is a smaller subnet within the vnet. i.e from /21 to /24
-  worker_subnet_cidr = cidrsubnet(var.machine_cidr, 3, 1) #worker subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  master_subnet_cidr = cidrsubnet(var.machine_v4_cidrs[0], 3, 0) #master subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  worker_subnet_cidr = cidrsubnet(var.machine_v4_cidrs[0], 3, 1) #worker subnet is a smaller subnet within the vnet. i.e from /21 to /24
   public_endpoints   = var.gcp_publish_strategy == "External" ? true : false
 }
 
@@ -22,7 +22,7 @@ module "bootstrap" {
   cluster_id       = var.cluster_id
   ignition         = var.ignition_bootstrap
   network          = module.network.network
-  network_cidr     = var.machine_cidr
+  network_cidr     = var.machine_v4_cidrs[0]
   public_endpoints = local.public_endpoints
   subnet           = module.network.master_subnet
   zone             = var.gcp_master_availability_zones[0]
@@ -62,7 +62,7 @@ module "network" {
   cluster_id         = var.cluster_id
   master_subnet_cidr = local.master_subnet_cidr
   worker_subnet_cidr = local.worker_subnet_cidr
-  network_cidr       = var.machine_cidr
+  network_cidr       = var.machine_v4_cidrs[0]
   public_endpoints   = local.public_endpoints
 
   bootstrap_lb              = var.gcp_bootstrap_enabled && var.gcp_bootstrap_lb

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -50,7 +50,7 @@ resource "libvirt_network" "net" {
 
   domain = var.cluster_domain
 
-  addresses = [var.machine_cidr]
+  addresses = var.machine_v4_cidrs
 
   dns {
     local_only = true

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -63,7 +63,7 @@ module "masters" {
 module "topology" {
   source = "./topology"
 
-  cidr_block          = var.machine_cidr
+  cidr_block          = var.machine_v4_cidrs[0]
   cluster_id          = var.cluster_id
   cluster_domain      = var.cluster_domain
   external_network    = var.openstack_external_network

--- a/docs/user/aws/customization.md
+++ b/docs/user/aws/customization.md
@@ -28,6 +28,10 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `amiID` (optional string): The AMI that should be used to boot machines.
     If set, the AMI should belong to the same region as the cluster.
 
+## Installing to Existing VPC & Subnetworks
+
+The installer can use an existing VPC and subnets when provisioning an OpenShift cluster. A VPC will be inferred from the provided subnets. For a standard installation, a private and public subnet should be specified. ([see example below](#pre-existing-vpc--subnets)). Both of the subnets must be within the IP range specified in `networking.machineNetwork`. 
+
 ## Examples
 
 Some example `install-config.yaml` are shown below.
@@ -84,6 +88,28 @@ metadata:
 platform:
   aws:
     region: us-west-2
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+### Pre-existing VPC & Subnets
+
+An example install config for installing to an existing VPC and subnets is:
+
+```yaml
+apiVersion: v1
+baseDomain: example.com
+metadata:
+  name: test-cluster
+networking:
+  machineNetwork:
+  - cidr: 10.190.0.0/16
+platform:
+  aws:
+    region: us-west-2
+    subnets:
+    - subnet-0e953079d31ec4c74
+    - subnet-05e6864f66a954c27
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ```

--- a/docs/user/gcp/customization.md
+++ b/docs/user/gcp/customization.md
@@ -16,7 +16,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 ## Installing to Existing Networks & Subnetworks
 
-The installer can use an existing VPC and subnets when provisioning an OpenShift cluster. If one of `network`, `controlPlaneSubnet`, or `computeSubnet` is specified, all must be specified ([see example below](#pre-existing-networks-&-subnets)). Furthermore, each of the networks must belong to the project specified by `projectID`, and the subnets must belong to the specified cluster `region`. The installer will use these existing networks when creating infrastructure such as VM instances, load balancers, firewall rules, and DNS zones.
+The installer can use an existing VPC and subnets when provisioning an OpenShift cluster. If one of `network`, `controlPlaneSubnet`, or `computeSubnet` is specified, all must be specified ([see example below](#pre-existing-networks--subnets)). Furthermore, each of the networks must belong to the project specified by `projectID`, and the subnets must belong to the specified cluster `region`. The installer will use these existing networks when creating infrastructure such as VM instances, load balancers, firewall rules, and DNS zones.
 
 ### Cluster Isolation
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
@@ -126,12 +125,23 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 	}
 
+	machineV4CIDRs, machineV6CIDRs := []string{}, []string{}
+	for _, network := range installConfig.Config.Networking.MachineNetwork {
+		if network.CIDR.IPNet.IP.To4() != nil {
+			machineV4CIDRs = append(machineV4CIDRs, network.CIDR.IPNet.String())
+		} else {
+			machineV6CIDRs = append(machineV6CIDRs, network.CIDR.IPNet.String())
+		}
+	}
+
 	masterCount := len(mastersAsset.MachineFiles)
 	data, err := tfvars.TFVars(
 		clusterID.InfraID,
 		installConfig.Config.ClusterDomain(),
 		installConfig.Config.BaseDomain,
 		&installConfig.Config.Networking.MachineNetwork[0].CIDR.IPNet,
+		machineV4CIDRs,
+		machineV6CIDRs,
 		useIPv4,
 		useIPv6,
 		bootstrapIgn,
@@ -242,18 +252,6 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*azureprovider.AzureMachineProviderSpec)
 		}
 
-		var (
-			machineV4CIDRs []net.IPNet
-			machineV6CIDRs []net.IPNet
-		)
-		for _, network := range installConfig.Config.Networking.MachineNetwork {
-			if network.CIDR.IPNet.IP.To4() != nil {
-				machineV4CIDRs = append(machineV4CIDRs, network.CIDR.IPNet)
-			} else {
-				machineV6CIDRs = append(machineV6CIDRs, network.CIDR.IPNet)
-			}
-		}
-
 		preexistingnetwork := installConfig.Config.Azure.VirtualNetwork != ""
 		data, err := azuretfvars.TFVars(
 			azuretfvars.TFVarsSources{
@@ -264,8 +262,6 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				ImageURL:                    string(*rhcosImage),
 				PreexistingNetwork:          preexistingnetwork,
 				Publish:                     installConfig.Config.Publish,
-				MachineV4CIDRs:              machineV4CIDRs,
-				MachineV6CIDRs:              machineV6CIDRs,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -139,7 +139,6 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		clusterID.InfraID,
 		installConfig.Config.ClusterDomain(),
 		installConfig.Config.BaseDomain,
-		&installConfig.Config.Networking.MachineNetwork[0].CIDR.IPNet,
 		machineV4CIDRs,
 		machineV6CIDRs,
 		useIPv4,

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"encoding/json"
-	"net"
 	"os"
 
 	"github.com/Azure/go-autorest/autorest/to"
@@ -37,8 +36,6 @@ type config struct {
 	ComputeSubnet               string            `json:"azure_compute_subnet"`
 	PreexistingNetwork          bool              `json:"azure_preexisting_network"`
 	Private                     bool              `json:"azure_private"`
-	MachineV4CIDRs              []string          `json:"azure_machine_v4_cidrs"`
-	MachineV6CIDRs              []string          `json:"azure_machine_v6_cidrs"`
 	EmulateSingleStackIPv6      bool              `json:"azure_emulate_single_stack_ipv6"`
 }
 
@@ -51,9 +48,6 @@ type TFVarsSources struct {
 	ImageURL                    string
 	PreexistingNetwork          bool
 	Publish                     types.PublishingStrategy
-
-	MachineV4CIDRs []net.IPNet
-	MachineV6CIDRs []net.IPNet
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
@@ -66,14 +60,6 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	masterAvailabilityZones := make([]string, len(sources.MasterConfigs))
 	for i, c := range sources.MasterConfigs {
 		masterAvailabilityZones[i] = to.String(c.Zone)
-	}
-
-	machineV4CIDRStrings, machineV6CIDRStrings := []string{}, []string{}
-	for _, ipnet := range sources.MachineV4CIDRs {
-		machineV4CIDRStrings = append(machineV4CIDRStrings, ipnet.String())
-	}
-	for _, ipnet := range sources.MachineV6CIDRs {
-		machineV6CIDRStrings = append(machineV6CIDRStrings, ipnet.String())
 	}
 
 	var emulateSingleStackIPv6 bool
@@ -97,8 +83,6 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ControlPlaneSubnet:          masterConfig.Subnet,
 		ComputeSubnet:               workerConfig.Subnet,
 		PreexistingNetwork:          sources.PreexistingNetwork,
-		MachineV4CIDRs:              machineV4CIDRStrings,
-		MachineV6CIDRs:              machineV6CIDRStrings,
 		EmulateSingleStackIPv6:      emulateSingleStackIPv6,
 	}
 

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -3,20 +3,16 @@ package tfvars
 
 import (
 	"encoding/json"
-	"net"
 	"strings"
 )
 
 type config struct {
-	ClusterID     string `json:"cluster_id,omitempty"`
-	ClusterDomain string `json:"cluster_domain,omitempty"`
-	BaseDomain    string `json:"base_domain,omitempty"`
-	// DeprecatedMachineCIDR has been replaced with machine_v4_cidrs, use the first
-	// entry from there instead.
-	DeprecatedMachineCIDR string   `json:"machine_cidr"`
-	Masters               int      `json:"master_count,omitempty"`
-	MachineV4CIDRs        []string `json:"machine_v4_cidrs"`
-	MachineV6CIDRs        []string `json:"machine_v6_cidrs"`
+	ClusterID      string   `json:"cluster_id,omitempty"`
+	ClusterDomain  string   `json:"cluster_domain,omitempty"`
+	BaseDomain     string   `json:"base_domain,omitempty"`
+	Masters        int      `json:"master_count,omitempty"`
+	MachineV4CIDRs []string `json:"machine_v4_cidrs"`
+	MachineV6CIDRs []string `json:"machine_v6_cidrs"`
 
 	UseIPv4 bool `json:"use_ipv4"`
 	UseIPv6 bool `json:"use_ipv6"`
@@ -26,19 +22,18 @@ type config struct {
 }
 
 // TFVars generates terraform.tfvar JSON for launching the cluster.
-func TFVars(clusterID string, clusterDomain string, baseDomain string, deprecatedMachineCIDR *net.IPNet, machineV4CIDRs []string, machineV6CIDRs []string, useIPv4, useIPv6 bool, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
+func TFVars(clusterID string, clusterDomain string, baseDomain string, machineV4CIDRs []string, machineV6CIDRs []string, useIPv4, useIPv6 bool, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
 	config := &config{
-		ClusterID:             clusterID,
-		ClusterDomain:         strings.TrimSuffix(clusterDomain, "."),
-		BaseDomain:            strings.TrimSuffix(baseDomain, "."),
-		DeprecatedMachineCIDR: deprecatedMachineCIDR.String(),
-		MachineV4CIDRs:        machineV4CIDRs,
-		MachineV6CIDRs:        machineV6CIDRs,
-		UseIPv4:               useIPv4,
-		UseIPv6:               useIPv6,
-		Masters:               masterCount,
-		IgnitionBootstrap:     bootstrapIgn,
-		IgnitionMaster:        masterIgn,
+		ClusterID:         clusterID,
+		ClusterDomain:     strings.TrimSuffix(clusterDomain, "."),
+		BaseDomain:        strings.TrimSuffix(baseDomain, "."),
+		MachineV4CIDRs:    machineV4CIDRs,
+		MachineV6CIDRs:    machineV6CIDRs,
+		UseIPv4:           useIPv4,
+		UseIPv6:           useIPv6,
+		Masters:           masterCount,
+		IgnitionBootstrap: bootstrapIgn,
+		IgnitionMaster:    masterIgn,
 	}
 
 	return json.MarshalIndent(config, "", "  ")

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -13,8 +13,10 @@ type config struct {
 	BaseDomain    string `json:"base_domain,omitempty"`
 	// DeprecatedMachineCIDR has been replaced with machine_v4_cidrs, use the first
 	// entry from there instead.
-	DeprecatedMachineCIDR string `json:"machine_cidr"`
-	Masters               int    `json:"master_count,omitempty"`
+	DeprecatedMachineCIDR string   `json:"machine_cidr"`
+	Masters               int      `json:"master_count,omitempty"`
+	MachineV4CIDRs        []string `json:"machine_v4_cidrs"`
+	MachineV6CIDRs        []string `json:"machine_v6_cidrs"`
 
 	UseIPv4 bool `json:"use_ipv4"`
 	UseIPv6 bool `json:"use_ipv6"`
@@ -24,12 +26,14 @@ type config struct {
 }
 
 // TFVars generates terraform.tfvar JSON for launching the cluster.
-func TFVars(clusterID string, clusterDomain string, baseDomain string, deprecatedMachineCIDR *net.IPNet, useIPv4, useIPv6 bool, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
+func TFVars(clusterID string, clusterDomain string, baseDomain string, deprecatedMachineCIDR *net.IPNet, machineV4CIDRs []string, machineV6CIDRs []string, useIPv4, useIPv6 bool, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
 	config := &config{
 		ClusterID:             clusterID,
 		ClusterDomain:         strings.TrimSuffix(clusterDomain, "."),
 		BaseDomain:            strings.TrimSuffix(baseDomain, "."),
 		DeprecatedMachineCIDR: deprecatedMachineCIDR.String(),
+		MachineV4CIDRs:        machineV4CIDRs,
+		MachineV6CIDRs:        machineV6CIDRs,
 		UseIPv4:               useIPv4,
 		UseIPv6:               useIPv6,
 		Masters:               masterCount,


### PR DESCRIPTION
This PR:

1. Deprecates `machine_cidr` by creating (moving from Azure) two top-level TF vars for holding IPv4 & IPv6 machine CIDRs. All platforms are updated to use them.
2. Fixes BZ-1802526, where only the main CIDR from an AWS VPC was being added to the security group. This change adds all the IPv4 CIDRs to the SG.

Tested by slightly modifying the UPI 01_vpc.yaml cloudformation template: https://gist.github.com/patrickdillon/9c26636e7d5b500a511252ed7661f343