### PR TITLE
handle the posibility that CCO will have no pod definition

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -351,7 +351,10 @@ then
 			--cloud-credential-operator-image=${CLOUD_CREDENTIAL_OPERATOR_IMAGE}
 
 	cp cco-bootstrap/manifests/* manifests/
-	cp cco-bootstrap/bootstrap-manifests/* bootstrap-manifests/
+	# skip copy if static pod manifest does not exist (ie CCO has been disabled)
+	if [ -f cco-bootstrap/bootstrap-manifests/cloud-credential-operator-pod.yaml ]; then
+		cp cco-bootstrap/bootstrap-manifests/* bootstrap-manifests/
+	fi
 
 	touch cco-bootstrap.done
 fi


### PR DESCRIPTION
When disabling CCO, the bootstrap-manifests dir will be empty which will error bootkube.sh when trying to copy the contents of the empty dir.

Detect the empty dir and avoid trying to copy the contents the empty dir in that situation.