### PR TITLE
Bug 1820222: libvirt: Bump bootstrap memory to 5G for ppc64le

### DIFF
--- a/data/data/libvirt/bootstrap/main.tf
+++ b/data/data/libvirt/bootstrap/main.tf
@@ -13,7 +13,7 @@ resource "libvirt_ignition" "bootstrap" {
 resource "libvirt_domain" "bootstrap" {
   name = "${var.cluster_id}-bootstrap"
 
-  memory = "2048"
+  memory = var.bootstrap_memory
 
   vcpu = "2"
 

--- a/data/data/libvirt/bootstrap/variables.tf
+++ b/data/data/libvirt/bootstrap/variables.tf
@@ -33,3 +33,8 @@ variable "pool" {
   type        = string
   description = "The name of the storage pool."
 }
+
+variable "bootstrap_memory" {
+  type        = number
+  description = "RAM in MiB allocated to the bootstrap node"
+}

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -19,13 +19,14 @@ module "volume" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  cluster_domain = var.cluster_domain
-  addresses      = [var.libvirt_bootstrap_ip]
-  base_volume_id = module.volume.coreos_base_volume_id
-  cluster_id     = var.cluster_id
-  ignition       = var.ignition_bootstrap
-  network_id     = libvirt_network.net.id
-  pool           = libvirt_pool.storage_pool.name
+  cluster_domain   = var.cluster_domain
+  addresses        = [var.libvirt_bootstrap_ip]
+  base_volume_id   = module.volume.coreos_base_volume_id
+  cluster_id       = var.cluster_id
+  ignition         = var.ignition_bootstrap
+  network_id       = libvirt_network.net.id
+  pool             = libvirt_pool.storage_pool.name
+  bootstrap_memory = var.libvirt_bootstrap_memory
 }
 
 resource "libvirt_volume" "master" {

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -44,3 +44,9 @@ variable "libvirt_master_vcpu" {
   default     = "4"
 }
 
+variable "libvirt_bootstrap_memory" {
+  type        = number
+  description = "RAM in MiB allocated to the bootstrap node"
+  default     = 2048
+}
+

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -324,6 +324,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			&installConfig.Config.Networking.MachineNetwork[0].CIDR.IPNet,
 			installConfig.Config.Platform.Libvirt.Network.IfName,
 			masterCount,
+			installConfig.Config.ControlPlane.Architecture,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -10,21 +10,23 @@ import (
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/pkg/errors"
 )
 
 type config struct {
-	URI          string   `json:"libvirt_uri,omitempty"`
-	Image        string   `json:"os_image,omitempty"`
-	IfName       string   `json:"libvirt_network_if"`
-	MasterIPs    []string `json:"libvirt_master_ips,omitempty"`
-	BootstrapIP  string   `json:"libvirt_bootstrap_ip,omitempty"`
-	MasterMemory string   `json:"libvirt_master_memory,omitempty"`
-	MasterVcpu   string   `json:"libvirt_master_vcpu,omitempty"`
+	URI             string   `json:"libvirt_uri,omitempty"`
+	Image           string   `json:"os_image,omitempty"`
+	IfName          string   `json:"libvirt_network_if"`
+	MasterIPs       []string `json:"libvirt_master_ips,omitempty"`
+	BootstrapIP     string   `json:"libvirt_bootstrap_ip,omitempty"`
+	MasterMemory    string   `json:"libvirt_master_memory,omitempty"`
+	MasterVcpu      string   `json:"libvirt_master_vcpu,omitempty"`
+	BootstrapMemory int      `json:"libvirt_bootstrap_memory,omitempty"`
 }
 
 // TFVars generates libvirt-specific Terraform variables.
-func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, machineCIDR *net.IPNet, bridge string, masterCount int) ([]byte, error) {
+func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, machineCIDR *net.IPNet, bridge string, masterCount int, architecture types.Architecture) ([]byte, error) {
 	bootstrapIP, err := cidr.Host(machineCIDR, 10)
 	if err != nil {
 		return nil, errors.Errorf("failed to generate bootstrap IP: %v", err)
@@ -48,6 +50,11 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, 
 		MasterIPs:    masterIPs,
 		MasterMemory: strconv.Itoa(masterConfig.DomainMemory),
 		MasterVcpu:   strconv.Itoa(masterConfig.DomainVcpu),
+	}
+
+	// Power PC systems typically require more memory because the page size is 64K and not the default 4K
+	if architecture == types.ArchitecturePPC64LE {
+		cfg.BootstrapMemory = 5120
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
On ppc64le there were OOM kills being observed during the bootstrap process
because of insufficient memory and bumping the memory seemed to solve the problem.
The libvirt defaults for the master and worker memory are 7G and 5G respectively,
so setting the boostrap default to 5G for ppc64le. ppc64le uses 64K pages rather than
the default 4K page size and thus requires more memory.

(cherry picked from commit c57c68097e2a8219267972c7c443eaf26e57bc6e)