### PR TITLE
Bug 1822701: OpenStack: Set vrrp protocol number instead of name

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -353,9 +353,11 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp_fr
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "vrrp"
+  direction = "ingress"
+  ethertype = "IPv4"
+  # Explicitly set the vrrp protocol number to prevent cases when the Neutron Plugin
+  # is disabled and it cannot identify a number by name.
+  protocol          = "112"
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
 

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -258,9 +258,11 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp_fr
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "vrrp"
+  direction = "ingress"
+  ethertype = "IPv4"
+  # Explicitly set the vrrp protocol number to prevent cases when the Neutron Plugin
+  # is disabled and it cannot identify a number by name.
+  protocol          = "112"
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
 


### PR DESCRIPTION
If VRRP plugin is disabled in neutron, then Terraform fails to fetch the desired protocol number.

To prevent the issue this patch explicitly sets the protocol number to 112 for the sg rules.

For more information:
https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-security-group-rule-detail