### PR TITLE
Bug 1794839: Azure masters should correctly support service load balancers

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -76,7 +76,6 @@ module "master" {
   vm_image               = azurerm_image.cluster.id
   identity               = azurerm_user_assigned_identity.main.id
   ignition               = var.ignition_master
-  external_lb_id         = module.vnet.public_lb_id
   elb_backend_pool_v4_id = module.vnet.public_lb_backend_pool_v4_id
   elb_backend_pool_v6_id = module.vnet.public_lb_backend_pool_v6_id
   ilb_backend_pool_v4_id = module.vnet.internal_lb_backend_pool_v4_id

--- a/data/data/azure/master/outputs.tf
+++ b/data/data/azure/master/outputs.tf
@@ -1,8 +1,0 @@
-output "ip_v4_addresses" {
-  value = var.use_ipv4 ? azurerm_network_interface.master.*.private_ip_address : []
-}
-
-output "ip_v6_addresses" {
-  value = var.use_ipv6 ? azurerm_network_interface.master.*.private_ip_addresses.1 : []
-}
-

--- a/data/data/azure/master/variables.tf
+++ b/data/data/azure/master/variables.tf
@@ -30,10 +30,6 @@ variable "instance_count" {
   type = string
 }
 
-variable "external_lb_id" {
-  type = string
-}
-
 variable "elb_backend_pool_v4_id" {
   type = string
 }

--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -5,7 +5,7 @@ locals {
 
 resource "azurerm_lb" "internal" {
   sku                 = "Standard"
-  name                = "${var.cluster_id}-internal-lb"
+  name                = "${var.cluster_id}-internal"
   resource_group_name = var.resource_group_name
   location            = var.region
 
@@ -39,7 +39,7 @@ resource "azurerm_lb_backend_address_pool" "internal_lb_controlplane_pool_v4" {
 
   resource_group_name = var.resource_group_name
   loadbalancer_id     = azurerm_lb.internal.id
-  name                = "${var.cluster_id}-internal-controlplane-v4"
+  name                = var.cluster_id
 }
 
 resource "azurerm_lb_backend_address_pool" "internal_lb_controlplane_pool_v6" {
@@ -47,7 +47,7 @@ resource "azurerm_lb_backend_address_pool" "internal_lb_controlplane_pool_v6" {
 
   resource_group_name = var.resource_group_name
   loadbalancer_id     = azurerm_lb.internal.id
-  name                = "${var.cluster_id}-internal-controlplane-v6"
+  name                = "${var.cluster_id}-IPv6"
 }
 
 resource "azurerm_lb_rule" "internal_lb_rule_api_internal_v4" {

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -1,9 +1,9 @@
 output "public_lb_backend_pool_v4_id" {
-  value = var.use_ipv4 ? azurerm_lb_backend_address_pool.master_public_lb_pool_v4[0].id : null
+  value = var.use_ipv4 ? azurerm_lb_backend_address_pool.public_lb_pool_v4[0].id : null
 }
 
 output "public_lb_backend_pool_v6_id" {
-  value = var.use_ipv6 ? azurerm_lb_backend_address_pool.master_public_lb_pool_v6[0].id : null
+  value = var.use_ipv6 ? azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id : null
 }
 
 output "internal_lb_backend_pool_v4_id" {

--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -44,7 +44,7 @@ data "azurerm_public_ip" "cluster_public_ip_v6" {
 
 resource "azurerm_lb" "public" {
   sku                 = "Standard"
-  name                = "${var.cluster_id}-public-lb"
+  name                = var.cluster_id
   resource_group_name = var.resource_group_name
   location            = var.region
 
@@ -70,20 +70,20 @@ resource "azurerm_lb" "public" {
   }
 }
 
-resource "azurerm_lb_backend_address_pool" "master_public_lb_pool_v4" {
+resource "azurerm_lb_backend_address_pool" "public_lb_pool_v4" {
   count = var.use_ipv4 ? 1 : 0
 
   resource_group_name = var.resource_group_name
   loadbalancer_id     = azurerm_lb.public.id
-  name                = "${var.cluster_id}-public-lb-control-plane-v4"
+  name                = var.cluster_id
 }
 
-resource "azurerm_lb_backend_address_pool" "master_public_lb_pool_v6" {
+resource "azurerm_lb_backend_address_pool" "public_lb_pool_v6" {
   count = var.use_ipv6 ? 1 : 0
 
   resource_group_name = var.resource_group_name
   loadbalancer_id     = azurerm_lb.public.id
-  name                = "${var.cluster_id}-public-lb-control-plane-v6"
+  name                = "${var.cluster_id}-IPv6"
 }
 
 resource "azurerm_lb_rule" "public_lb_rule_api_internal_v4" {
@@ -92,7 +92,7 @@ resource "azurerm_lb_rule" "public_lb_rule_api_internal_v4" {
   name                           = "api-internal-v4"
   resource_group_name            = var.resource_group_name
   protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool_v4[0].id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.public_lb_pool_v4[0].id
   loadbalancer_id                = azurerm_lb.public.id
   frontend_port                  = 6443
   backend_port                   = 6443
@@ -109,7 +109,7 @@ resource "azurerm_lb_rule" "public_lb_rule_api_internal_v6" {
   name                           = "api-internal-v6"
   resource_group_name            = var.resource_group_name
   protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool_v6[0].id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id
   loadbalancer_id                = azurerm_lb.public.id
   frontend_port                  = 6443
   backend_port                   = 6443
@@ -126,7 +126,7 @@ resource "azurerm_lb_rule" "internal_outbound_rule_v4" {
   name                           = "internal_outbound_rule_v4"
   resource_group_name            = var.resource_group_name
   protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool_v4[0].id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.public_lb_pool_v4[0].id
   loadbalancer_id                = azurerm_lb.public.id
   frontend_port                  = 27627
   backend_port                   = 27627
@@ -142,7 +142,7 @@ resource "azurerm_lb_rule" "internal_outbound_rule_v6" {
   name                           = "internal_outbound_rule_v6"
   resource_group_name            = var.resource_group_name
   protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.master_public_lb_pool_v6[0].id
+  backend_address_pool_id        = azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id
   loadbalancer_id                = azurerm_lb.public.id
   frontend_port                  = 27627
   backend_port                   = 27627


### PR DESCRIPTION
Azure only allows a NIC to be in one load balancer, which prevents
service load balancers from working on masters (the NIC is part of
the kube-apiserver LB). This prevents compact Azure clusters and
any future service that wishes to run on the master.

Instead, rename the Azure LB and backend pool so that it matches
the names the Azure cloud controller will add service load balancer
rules to. Azure LBs allow multiple frontends against a single
backend and so both kube-apiserver (selecting just masters) can
co-exist with service load balancers.

The only downside is a pod on a node on port 6443 would be included
in the balancer - but since we intend to move kube-apiserver behind
a service load balancer in the future and nothing stops the router
from being impacted the same way (someone getting root on any node
can add service load balancer frontends), it is no worse than current
behavior. Note that these injected endpoints would still require a
valid HTTPS certificate and so could not actually impersonate the
master.

Compact clusters and service load balancers spanning masters and
workers should now function.

There is an impact here that this changes our recommended deployment model (4.5+ clusters would be created correctly, older clusters would still be broke), so upgraded clusters will not be able to take advantage of this.  The failure mode for an unsupported cluster is silent - masters just don't get added to the service LB pool because they already are attached to the kube-apiserver LB.  We may have to flag an alert or condition at a future point before introduce services that depend on service LBs for admins to intervene.  An admin could migrate, although it could be annoying.