### PR TITLE
Bug 1822858: vsphere ipi: tag virtual machine created when importing ova

### DIFF
--- a/data/data/vsphere/main.tf
+++ b/data/data/vsphere/main.tf
@@ -44,6 +44,7 @@ resource "vsphereprivate_import_ova" "import" {
   datastore  = var.vsphere_datastore
   network    = var.vsphere_network
   folder     = vsphere_folder.folder.path
+  tag        = vsphere_tag.tag.id
 }
 
 resource "vsphere_tag_category" "category" {


### PR DESCRIPTION
- Add rest client
- Add function `attachTag`. This function creates a TagManager
that will attach a tag to virtual machine managedobject
- Modify terraform resource schema
- Use provided Folder to place virtual machine (template) in.
- Update terraform to use `tag` for imported virtual machine