### PR TITLE
Bug 1823659: os: Mention the bootstrap FIP

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -50,7 +50,7 @@ In order to run the latest version of the installer in OpenStack, at a bare mini
 
 For a successful installation it is required:
 
-- Floating IPs: 2
+- Floating IPs: 2 (plus one that will be created and destroyed by the Installer during the installation process)
 - Security Groups: 3
 - Security Group Rules: 60
 - Routers: 1


### PR DESCRIPTION
In order for the user to account for the needed resources, the
documentation should mention that while 2 floating IPs are needed for
running an OpenShift cluster, a third one will be used during
installation.