### PR TITLE
vsphere ipi: align with baremetal and remove DNSVIP

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation_test.go
+++ b/pkg/asset/installconfig/vsphere/validation_test.go
@@ -33,7 +33,6 @@ func validIPIInstallConfig() *types.InstallConfig {
 				VCenter:          "valid_vcenter",
 				APIVIP:           "192.168.111.0",
 				IngressVIP:       "192.168.111.1",
-				DNSVIP:           "192.168.111.2",
 			},
 		},
 	}

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -138,7 +138,6 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		if installConfig.Config.VSphere.APIVIP != "" {
 			config.Status.PlatformStatus.VSphere = &configv1.VSpherePlatformStatus{
 				APIServerInternalIP: installConfig.Config.VSphere.APIVIP,
-				NodeDNSIP:           installConfig.Config.VSphere.DNSVIP,
 				IngressIP:           installConfig.Config.VSphere.IngressVIP,
 			}
 		}

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -33,9 +33,6 @@ type Platform struct {
 	// IngressVIP is the virtual IP address for ingress
 	IngressVIP string `json:"ingressVIP,omitempty"`
 
-	// DNSVIP is the virtual IP address for DNS
-	DNSVIP string `json:"dnsVIP,omitempty"`
-
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on VSphere for machine pools which do not define their own
 	// platform configuration.

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -29,7 +29,7 @@ func ValidatePlatform(p *vsphere.Platform, fldPath *field.Path) field.ErrorList 
 	}
 
 	// If all VIPs are empty, skip IP validation.  All VIPs are required to be defined together.
-	if strings.Join([]string{p.APIVIP, p.IngressVIP, p.DNSVIP}, "") != "" {
+	if strings.Join([]string{p.APIVIP, p.IngressVIP}, "") != "" {
 		allErrs = append(allErrs, validateVIPs(p, fldPath)...)
 	}
 
@@ -67,12 +67,6 @@ func validateVIPs(p *vsphere.Platform, fldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, field.Required(fldPath.Child("ingressVIP"), "must specify a VIP for Ingress"))
 	} else if err := validate.IP(p.IngressVIP); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressVIP"), p.IngressVIP, err.Error()))
-	}
-
-	if len(p.DNSVIP) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("dnsVIP"), "must specify a VIP for DNS"))
-	} else if err := validate.IP(p.DNSVIP); err != nil {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("dnsVIP"), p.DNSVIP, err.Error()))
 	}
 
 	return allErrs

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -80,7 +80,6 @@ func TestValidatePlatform(t *testing.T) {
 				p := validPlatform()
 				p.APIVIP = "192.168.111.2"
 				p.IngressVIP = "192.168.111.3"
-				p.DNSVIP = "192.168.111.4"
 				return p
 			}(),
 			// expectedError: `^test-path\.apiVIP: Invalid value: "": "" is not a valid IP`,
@@ -91,7 +90,6 @@ func TestValidatePlatform(t *testing.T) {
 				p := validPlatform()
 				p.APIVIP = ""
 				p.IngressVIP = "192.168.111.3"
-				p.DNSVIP = "192.168.111.4"
 				return p
 			}(),
 			expectedError: `^test-path\.apiVIP: Required value: must specify a VIP for the API`,
@@ -102,21 +100,9 @@ func TestValidatePlatform(t *testing.T) {
 				p := validPlatform()
 				p.APIVIP = "192.168.111.2"
 				p.IngressVIP = ""
-				p.DNSVIP = "192.168.111.4"
 				return p
 			}(),
 			expectedError: `^test-path\.ingressVIP: Required value: must specify a VIP for Ingress`,
-		},
-		{
-			name: "missing DNS VIP",
-			platform: func() *vsphere.Platform {
-				p := validPlatform()
-				p.APIVIP = "192.168.111.2"
-				p.IngressVIP = "192.168.111.3"
-				p.DNSVIP = ""
-				return p
-			}(),
-			expectedError: `^test-path\.dnsVIP: Required value: must specify a VIP for DNS`,
 		},
 		{
 			name: "Invalid API VIP",
@@ -124,7 +110,6 @@ func TestValidatePlatform(t *testing.T) {
 				p := validPlatform()
 				p.APIVIP = "192.168.111"
 				p.IngressVIP = "192.168.111.2"
-				p.DNSVIP = "192.168.111.3"
 				return p
 			}(),
 			expectedError: `^test-path.apiVIP: Invalid value: "192.168.111": "192.168.111" is not a valid IP`,
@@ -135,21 +120,9 @@ func TestValidatePlatform(t *testing.T) {
 				p := validPlatform()
 				p.APIVIP = "192.168.111.1"
 				p.IngressVIP = "192.168.111"
-				p.DNSVIP = "192.168.111.3"
 				return p
 			}(),
 			expectedError: `^test-path.ingressVIP: Invalid value: "192.168.111": "192.168.111" is not a valid IP`,
-		},
-		{
-			name: "Invalid DNS VIP",
-			platform: func() *vsphere.Platform {
-				p := validPlatform()
-				p.APIVIP = "192.168.111.2"
-				p.IngressVIP = "192.168.111.3"
-				p.DNSVIP = "192.168.111"
-				return p
-			}(),
-			expectedError: `^test-path.dnsVIP: Invalid value: "192.168.111": "192.168.111" is not a valid IP`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
These changes remove the required field `NodeDNSIP` from openshift/api
and `DNSVIP` from the vsphere platform.