### PR TITLE
update cloud provider to use folder from platform

### DIFF
--- a/pkg/asset/manifests/vsphere/cloudproviderconfig.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig.go
@@ -27,7 +27,10 @@ func CloudProviderConfig(clusterName string, p *vspheretypes.Platform) (string, 
 	printIfNotEmpty(buf, "server", p.VCenter)
 	printIfNotEmpty(buf, "datacenter", p.Datacenter)
 	printIfNotEmpty(buf, "default-datastore", p.DefaultDatastore)
-	printIfNotEmpty(buf, "folder", clusterName)
+	printIfNotEmpty(buf, "folder", p.Folder)
+	if p.Folder == "" {
+		printIfNotEmpty(buf, "folder", clusterName)
+	}
 	fmt.Fprintln(buf, "")
 
 	fmt.Fprintf(buf, "[VirtualCenter %q]\n", p.VCenter)


### PR DESCRIPTION
Cloud provider still uses cluster name for folder. Platform does include folder from install-config:

https://github.com/openshift/installer/blob/release-4.4/pkg/types/vsphere/platform.go#L22
But, the cloud provider still uses cluster name:
https://github.com/openshift/installer/blob/release-4.4/pkg/asset/manifests/vsphere/cloudproviderconfig.go#L30 (edited)

