### PR TITLE
Bug 1826100: - vSphere IPI - Platform and cloud provider read Folder but machine creation still using clusterID

### DIFF
--- a/pkg/asset/machines/vsphere/machines.go
+++ b/pkg/asset/machines/vsphere/machines.go
@@ -83,7 +83,7 @@ func provider(clusterID string, platform *vsphere.Platform, mpool *vsphere.Machi
 			Server:     platform.VCenter,
 			Datacenter: platform.Datacenter,
 			Datastore:  platform.DefaultDatastore,
-			Folder:     clusterID,
+			Folder:     platform.Folder,
 		},
 		NumCPUs:           mpool.NumCPUs,
 		NumCoresPerSocket: mpool.NumCoresPerSocket,


### PR DESCRIPTION
Platform and Cloudprovider now use Folder from install-config, however machine workspace is set to ClusterID

https://github.com/openshift/installer/blob/c904277e59dd947a8884265b2511034b05c38644/pkg/asset/machines/vsphere/machines.go#L86

How reproducible:

Steps to Reproduce:
1. Create install-config and deploy via "openshift create cluster"
2. VMs are created in foldernamed $CLUSTERID
3. VM cloud providers uses the correct path

Actual results:
VMs are created in foldernamed $CLUSTERID