### PR TITLE
[fcos] add a new upstream community operator source

### DIFF
--- a/data/data/manifests/openshift/community-operators.yaml
+++ b/data/data/manifests/openshift/community-operators.yaml
@@ -8,5 +8,9 @@ spec:
     {
       name: "community-operators",
       disabled: false,
+    },
+    {
+      name: "upstream-community-operators",
+      disabled: false,
     }
   ]

--- a/data/data/manifests/openshift/upstream-community-operators.yaml
+++ b/data/data/manifests/openshift/upstream-community-operators.yaml
@@ -1,0 +1,16 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: upstream-community-operators
+  namespace: openshift-marketplace
+  finalizers:
+  - finalizer.operatorsources.operators.coreos.com
+  labels:
+    opsrc-provider: upstream-community
+spec:
+  authorizationToken: {}
+  displayName: Upstream Community Operators
+  endpoint: 'https://quay.io/cnr'
+  publisher: Red Hat
+  registryNamespace: upstream-community-operators
+  type: appregistry

--- a/pkg/asset/templates/content/openshift/community-operators.go
+++ b/pkg/asset/templates/content/openshift/community-operators.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	communityOperatorsFilename = "community-operators.yaml"
+	communityOperatorsFilename               = "community-operators.yaml"
+	upstreamCommunityOperatorsSourceFilename = "upstream-community-operators.yaml"
 )
 
 var _ asset.WritableAsset = (*CommunityOperators)(nil)
@@ -39,6 +40,14 @@ func (t *CommunityOperators) Generate(parents asset.Parents) error {
 		Filename: filepath.Join(content.TemplateDir, communityOperatorsFilename),
 		Data:     []byte(data),
 	})
+	data, err = content.GetOpenshiftTemplate(upstreamCommunityOperatorsSourceFilename)
+	if err != nil {
+		return err
+	}
+	t.FileList = append(t.FileList, &asset.File{
+		Filename: filepath.Join(content.TemplateDir, upstreamCommunityOperatorsSourceFilename),
+		Data:     []byte(data),
+	})
 	return nil
 }
 
@@ -50,6 +59,15 @@ func (t *CommunityOperators) Files() []*asset.File {
 // Load returns the asset from disk.
 func (t *CommunityOperators) Load(f asset.FileFetcher) (bool, error) {
 	file, err := f.FetchByName(filepath.Join(content.TemplateDir, communityOperatorsFilename))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	t.FileList = append(t.FileList, file)
+
+	file, err = f.FetchByName(filepath.Join(content.TemplateDir, upstreamCommunityOperatorsSourceFilename))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil


### PR DESCRIPTION
This adds a new "upstream-community-operators" operator source for OKD clusters, alongside with curated "community-operators"

Ref: https://github.com/openshift/okd/issues/99