### PR TITLE
bug 1821932: cmd/openshift-install/gather: clarify location of log bundle

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -155,7 +155,11 @@ func logGatherBootstrap(bootstrap string, port int, masters []string, directory 
 	if err := ssh.PullFileTo(client, fmt.Sprintf("/home/core/log-bundle-%s.tar.gz", gatherID), file); err != nil {
 		return errors.Wrap(err, "failed to pull log file from remote")
 	}
-	logrus.Infof("Bootstrap gather logs captured here %q", file)
+	path, err := filepath.Abs(file)
+	if err != nil {
+		return errors.Wrap(err, "failed to stat log file")
+	}
+	logrus.Infof("Bootstrap gather logs captured here %q", path)
 	return nil
 }
 


### PR DESCRIPTION
When gathering bootstrap logs, it's not clear where the log bundle is written.
This prints out the absolute path to the log bundle.

Without fix:

DEBUG Log bundle written to /var/home/core/log-bundle-20200421144316.tar.gz 
INFO Bootstrap gather logs captured here "log-bundle-20200421144316.tar.gz" 

With fix:

DEBUG Log bundle written to /var/home/core/log-bundle-20200421144316.tar.gz 
INFO Bootstrap gather logs captured here "/home/jhixson/Test-AWS-Fail/log-bundle-20200421144316.tar.gz" 