### PR TITLE
Bug 1826739: openstack UPI: Fix step name

### DIFF
--- a/upi/openstack/down-load-balancers.yaml
+++ b/upi/openstack/down-load-balancers.yaml
@@ -10,7 +10,7 @@
   gather_facts: no
 
   tasks:
-  - name: 'Get a token for creating the server group'
+  - name: 'Get an auth token'
     os_auth:
     register: cloud
     when: os_networking_type == "Kuryr"


### PR DESCRIPTION
No functional changes.

An Ansible step mentions Server groups, while it gathers a token for
calls unrelated to server groups.

/cc @MaysaMacedo 
/label platform/openstack