### PR TITLE
Bug 1823359: baremetal: update provisioning CR to quote strings

### DIFF
--- a/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
+++ b/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
@@ -3,9 +3,9 @@ kind: Provisioning
 metadata:
   name: provisioning-configuration
 spec:
-  provisioningInterface: {{.Baremetal.ProvisioningNetworkInterface}}
-  provisioningIP: {{.Baremetal.ClusterProvisioningIP}}
-  provisioningNetworkCIDR: {{.Baremetal.ProvisioningNetworkCIDR}}
+  provisioningInterface: "{{.Baremetal.ProvisioningNetworkInterface}}"
+  provisioningIP: "{{.Baremetal.ClusterProvisioningIP}}"
+  provisioningNetworkCIDR: "{{.Baremetal.ProvisioningNetworkCIDR}}"
   provisioningDHCPExternal: {{.Baremetal.ProvisioningDHCPExternal}}
-  provisioningDHCPRange: {{.Baremetal.ProvisioningDHCPRange}}
-  provisioningOSDownloadURL: {{.ProvisioningOSDownloadURL}}
+  provisioningDHCPRange: "{{.Baremetal.ProvisioningDHCPRange}}"
+  provisioningOSDownloadURL: "{{.ProvisioningOSDownloadURL}}"


### PR DESCRIPTION
For the provisioning config, it's allowable for provisioningDHCPRange to
be empty. If it is, the current template produces this YAML:

```yaml
spec:
   provisioningDHCPRange:
```

Unfortunately, in YAML-land the above is null not empty string, so when
you apply it, you get complaints:

```
Provisioning.metal3.io "provisioning-configuration" is invalid:
spec.provisioningDHCPRange: Invalid value: "null":
spec.provisioningDHCPRange in body must be of type string: "null"
```

This change ensures all string values are quoted, which will result in a
correct value for provisioningDHCPRange when empty.