### PR TITLE
Bug 1827067: openstack UPI: Server group name to match IPI

### DIFF
--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -23,7 +23,7 @@
       # Server names
       os_bootstrap_server_name: "{{ infraID }}-bootstrap"
       os_cp_server_name: "{{ infraID }}-master"
-      os_cp_server_group_name: "{{ infraID }}-master-group"
+      os_cp_server_group_name: "{{ infraID }}-master"
       os_compute_server_name: "{{ infraID }}-worker"
       # Trunk names
       os_cp_trunk_name: "{{ infraID }}-master-trunk"


### PR DESCRIPTION
The installer creates a server group as a side effect of the manifest
generation.

Prior to this patch, the UPI playbooks created yet another server group
and left the installer-created one unused.

With this patch, the UPI playbooks reuse the server group created by the
installer, rather than creating an additional one.

/cc @adduarte @MaysaMacedo @mandre 
/label platform/openstack