### PR TITLE
Bug 1827070: openstack: Explain why awscli in the CI image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -27,6 +27,7 @@ RUN yum update -y && \
     python-openstackclient ansible python-openstacksdk python-netaddr unzip && \
     yum clean all && rm -rf /var/cache/yum/*
 
+# The Continuous Integration machinery relies on Route53 for DNS while testing the cluster.
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install -b /bin && \


### PR DESCRIPTION
Documentation change.

Add a comment explaining why we are installing the AWS command-line
client in the CI image for OpenStack.

ref https://github.com/openshift/installer/pull/3478#issuecomment-617907257

/label platform/openstack
/assign @russellb 
/cc @mandre @iamemilio @adduarte