### PR TITLE
Bug 1828238: OpenStack: Allow Booting bootstrap node from volume

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -28,12 +28,32 @@ data "openstack_compute_flavor_v2" "bootstrap_flavor" {
   name = var.flavor_name
 }
 
+resource "openstack_blockstorage_volume_v3" "bootstrap_volume" {
+  name  = "${var.cluster_id}-bootstrap"
+  count = var.root_volume_size == null ? 0 : 1
+
+  size        = var.root_volume_size
+  volume_type = var.root_volume_type
+  image_id    = var.base_image_id
+}
+
 resource "openstack_compute_instance_v2" "bootstrap" {
   name      = "${var.cluster_id}-bootstrap"
   flavor_id = data.openstack_compute_flavor_v2.bootstrap_flavor.id
-  image_id  = var.base_image_id
+  image_id  = var.root_volume_size == null ? var.base_image_id : null
 
   user_data = var.bootstrap_shim_ignition
+
+  dynamic block_device {
+    for_each = var.root_volume_size == null ? [] : [openstack_blockstorage_volume_v3.bootstrap_volume[0].id]
+    content {
+      uuid                  = block_device.value
+      source_type           = "volume"
+      boot_index            = 0
+      destination_type      = "volume"
+      delete_on_termination = true
+    }
+  }
 
   network {
     port = openstack_networking_port_v2.bootstrap_port.id

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -62,3 +62,13 @@ variable "nodes_subnet_id" {
 variable "cluster_domain" {
   type = string
 }
+
+variable "root_volume_size" {
+  type = number
+  description = "The size of the volume in gigabytes for the root block device."
+}
+
+variable "root_volume_type" {
+  type = string
+  description = "The type of volume for the root block device."
+}

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -38,6 +38,8 @@ module "bootstrap" {
   private_network_id      = module.topology.private_network_id
   master_sg_id            = module.topology.master_sg_id
   bootstrap_shim_ignition = var.openstack_bootstrap_shim_ignition
+  root_volume_size        = var.openstack_master_root_volume_size
+  root_volume_type        = var.openstack_master_root_volume_type
 }
 
 module "masters" {

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -31,6 +31,8 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
   * `size` (required integer): Size of the root volume in GB.
   * `type` (required string): The volume pool to create the volume from.
 
+**NOTE:** The bootstrap node follows the `type` and `rootVolume` parameters from the `controlPlane` machine pool.
+
 ## Examples
 
 Some example `install-config.yaml` are shown below.


### PR DESCRIPTION
Some OpenStack environments might enforce a policy where VMs can't boot
with ephemeral disks and need to boot from a cinder volume. In these
cases, it would be impossible to install OCP because even though we
configured the master and worker nodes to boot from volume using the
`rootVolume` setting, the bootstrap node would still boot from
ephemeral disk.

With this change, the bootstrap node follows the `rootVolume` settings
from controlPlane machine pool. This shouldn't be a surprising behavior
since the bootstrap node is already using the same flavor and security
groups as the control plane nodes.

This is a cherry-pick of https://github.com/openshift/installer/pull/3434