### PR TITLE
gcp: document gcp-routes service interdependency

### DIFF
--- a/data/data/gcp/network/lb-private.tf
+++ b/data/data/gcp/network/lb-private.tf
@@ -7,7 +7,18 @@ resource "google_compute_address" "cluster_ip" {
 resource "google_compute_health_check" "api_internal" {
   name = "${var.cluster_id}-api-internal"
 
+  // CAUTION: the gcp-routes mechanism must be _faster_ than this value:
+  //
+  //          Otherwise, local client traffic will go to the GCP LB until the
+  //          gcp-routes mechanism is done rerouting, and therefore back to the
+  //          local node in 1/3 of cases, which is blackholed (due to missing
+  //          hairpinning support).
   healthy_threshold   = 3
+  // CAUTION: the gcp-routes mechanism must be _slower_ than this value:
+  //
+  //          Otherwise, local client traffic  will go to the GCP LB until the LB
+  //          endpoint is deactived, and therefore back to the local node in 1/3
+  //          of cases, which is blackholed (due to missing hairpinning support).
   unhealthy_threshold = 3
   check_interval_sec  = 2
   timeout_sec         = 2


### PR DESCRIPTION
The readiness probes for the internal gcp LBs must match the gcp-routes timing values.

Today:
- gcp LB: 6-8s to notice health, 6-8s to notice failure (plus some unknown time to reconcile the LB)
- gcp-routes: 10-15s to notice health. 50-55s to notice failure (plus 1-2s to reconcile iptables), compare:

    https://github.com/openshift/machine-config-operator/blob/cecd8348f1d9da2ef5988dca4d6d3efbedebcd4b/cmd/gcp-routes-controller/run.go#L90

Note: the latter is wrong (too slow) for the health case. To be fixed in MCO in a follow-up.