### PR TITLE
Bug 1828342: bootstrap: add chrony config on Azure for host time synchronization

### DIFF
--- a/data/data/bootstrap/azure/README.md
+++ b/data/data/bootstrap/azure/README.md
@@ -1,0 +1,1 @@
+We are shipping custom chrony.conf file on bootstrap node to keep host time in sync on Azure platform. More detail in  https://github.com/openshift/machine-config-operator/pull/1682

--- a/data/data/bootstrap/azure/files/etc/chrony.conf
+++ b/data/data/bootstrap/azure/files/etc/chrony.conf
@@ -1,0 +1,44 @@
+# Make sure that chrony.conf content in machine-config-operator (/templates/common/azure/files) and
+# installer (data/data/bootstrap/azure/files/etc) repo are in sync.
+#
+# see https://bugzilla.redhat.com/show_bug.cgi?id=1765609 and https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync
+refclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+pool 2.rhel.pool.ntp.org iburst
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+keyfile /etc/chrony.keys
+
+# Get TAI-UTC offset and leap seconds from the system tz database.
+leapsectz right/UTC
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking


### PR DESCRIPTION
With default config, host time synchronization fails on bootstrap node
launched on Azure and can result in time drift from master nodes.
As per Azure best practices we are updating chrony.conf to use
PTP source clock https://docs.microsoft.com/en-us/azure/virtual-machines/linux/time-sync

Related fix for master/worker nodes - https://github.com/openshift/machine-config-operator/pull/1682