### PR TITLE
Bug 1831760: Fix bootstrap certificate generation

### DIFF
--- a/pkg/asset/tls/tls.go
+++ b/pkg/asset/tls/tls.go
@@ -115,7 +115,7 @@ func SignedCertificate(
 		Version:               3,
 		BasicConstraintsValid: true,
 	}
-	pub := caCert.PublicKey.(*rsa.PublicKey)
+	pub := key.Public()
 	certTmpl.SubjectKeyId, err = generateSubjectKeyID(pub)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set subject key identifier")


### PR DESCRIPTION
Based on https://tools.ietf.org/html/rfc3280#section-4.2.1.1 and https://tools.ietf.org/html/rfc3280#section-4.2.1.2 
We should not set SubjectKeyId to signing certificate value. We should set it to the current certificate value.
 
