### PR TITLE
baremetal: Clarify it's the matchbox instance that needs to be public reachable

### DIFF
--- a/upi/metal/README.md
+++ b/upi/metal/README.md
@@ -4,7 +4,7 @@
 
 ### Matchbox
 
-Setup an instance of matchbox using this [guide][coreos-matchbox-getting-started] which is accessible to everybody on the internet.
+Setup an instance of matchbox using this [guide][coreos-matchbox-getting-started]. The matchbox instance must be reachable from public internet.
 
 Store the tls assets that will be used for client authentication and the CA certificate that allows client to trust the matchbox server on the host that will run the example terraform scripts.
 


### PR DESCRIPTION
And it's not the guide we're talking about. I misunderstood and wasted a lot of time. :)