### PR TITLE
Bug 1794839: data/azure: Use a single network security group for Azure clusters

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -37,7 +37,7 @@ module "bootstrap" {
   ilb_backend_pool_v6_id = module.vnet.internal_lb_backend_pool_v6_id
   tags                   = local.tags
   storage_account        = azurerm_storage_account.cluster
-  nsg_name               = module.vnet.master_nsg_name
+  nsg_name               = module.vnet.cluster_nsg_name
   private                = module.vnet.private
 
   use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6

--- a/data/data/azure/vnet/nsg.tf
+++ b/data/data/azure/vnet/nsg.tf
@@ -1,5 +1,5 @@
-resource "azurerm_network_security_group" "master" {
-  name                = "${var.cluster_id}-controlplane-nsg"
+resource "azurerm_network_security_group" "cluster" {
+  name                = "${var.cluster_id}-nsg"
   location            = var.region
   resource_group_name = var.resource_group_name
 }
@@ -8,20 +8,14 @@ resource "azurerm_subnet_network_security_group_association" "master" {
   count = var.preexisting_network ? 0 : 1
 
   subnet_id                 = azurerm_subnet.master_subnet[0].id
-  network_security_group_id = azurerm_network_security_group.master.id
-}
-
-resource "azurerm_network_security_group" "worker" {
-  name                = "${var.cluster_id}-node-nsg"
-  location            = var.region
-  resource_group_name = var.resource_group_name
+  network_security_group_id = azurerm_network_security_group.cluster.id
 }
 
 resource "azurerm_subnet_network_security_group_association" "worker" {
   count = var.preexisting_network ? 0 : 1
 
   subnet_id                 = azurerm_subnet.worker_subnet[0].id
-  network_security_group_id = azurerm_network_security_group.worker.id
+  network_security_group_id = azurerm_network_security_group.cluster.id
 }
 
 resource "azurerm_network_security_rule" "apiserver_in" {
@@ -35,5 +29,5 @@ resource "azurerm_network_security_rule" "apiserver_in" {
   source_address_prefix       = "*"
   destination_address_prefix  = "*"
   resource_group_name         = var.resource_group_name
-  network_security_group_name = azurerm_network_security_group.master.name
+  network_security_group_name = azurerm_network_security_group.cluster.name
 }

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -36,8 +36,8 @@ output "internal_lb_ip_v6_address" {
   value = var.use_ipv6 ? azurerm_lb.internal.private_ip_addresses[1] : null
 }
 
-output "master_nsg_name" {
-  value = azurerm_network_security_group.master.name
+output "cluster_nsg_name" {
+  value = azurerm_network_security_group.cluster.name
 }
 
 output "virtual_network_id" {

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -109,7 +109,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			return errors.Wrap(err, "could not get azure session")
 		}
 
-		nsg := fmt.Sprintf("%s-node-nsg", clusterID.InfraID)
+		nsg := fmt.Sprintf("%s-nsg", clusterID.InfraID)
 		nrg := fmt.Sprintf("%s-rg", clusterID.InfraID)
 		if installConfig.Config.Azure.NetworkResourceGroupName != "" {
 			nrg = installConfig.Config.Azure.NetworkResourceGroupName


### PR DESCRIPTION
The Kubernetes service load balancer programs a cluster specific
Azure NSG automatically to expose service load balancers. OpenShift
requires all nodes to be able to host service load balancer workloads
and so the simplest configuration is to have a single network security
group for the whole cluster. This does require exposing port 6443 on
all nodes, but in practice this does not reduce security because we
cannot rely on network security within the cluster to protect
workloads.

As a result of this change, a 3 node compact Azure cluster can be
grown to have a worker pool at runtime with no disruption to the
router or other components that depend on service load balancer.