### PR TITLE
[FCOS] Azure fixes (correct FCOS version, decompress fcos image for Azure, page blob)

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -171,8 +171,8 @@ resource "azurerm_storage_blob" "rhcos_image" {
   resource_group_name    = azurerm_resource_group.main.name
   storage_account_name   = azurerm_storage_account.cluster.name
   storage_container_name = azurerm_storage_container.vhd.name
-  type                   = "block"
-  source_uri             = var.azure_image_url
+  type                   = "page"
+  source                 = var.azure_image_url
   metadata               = map("source_uri", var.azure_image_url)
 }
 

--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -57,7 +57,7 @@
     },
     "azure": {
         "image": "fedora-coreos-31.20200407.3.0-azure.x86_64.vhd",
-        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200407.3.0-azure.x86_64.vhd.xz"
+        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200407.3.0/x86_64/fedora-coreos-31.20200407.3.0-azure.x86_64.vhd.xz"
     },
     "baseURI": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200407.3.0/x86_64/",
     "buildid": "31.20200407.3.0",

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -57,7 +57,7 @@
     },
     "azure": {
         "image": "fedora-coreos-31.20200407.3.0-azure.x86_64.vhd",
-        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200323.3.2/x86_64/fedora-coreos-31.20200407.3.0-azure.x86_64.vhd.xz"
+        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200407.3.0/x86_64/fedora-coreos-31.20200407.3.0-azure.x86_64.vhd.xz"
     },
     "baseURI": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200407.3.0/x86_64/",
     "buildid": "31.20200407.3.0",

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -6,7 +6,9 @@ import (
 	"os"
 
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/pkg/errors"
 
+	"github.com/openshift/installer/pkg/tfvars/internal/cache"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure/defaults"
 	azureprovider "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
@@ -81,6 +83,11 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		emulateSingleStackIPv6 = true
 	}
 
+	cachedImage, err := cache.DownloadImageFile(sources.ImageURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to use cached Azure image")
+	}
+
 	cfg := &config{
 		Auth:                        sources.Auth,
 		Region:                      region,
@@ -89,7 +96,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		MasterAvailabilityZones:     masterAvailabilityZones,
 		VolumeType:                  masterConfig.OSDisk.ManagedDisk.StorageAccountType,
 		VolumeSize:                  masterConfig.OSDisk.DiskSizeGB,
-		ImageURL:                    sources.ImageURL,
+		ImageURL:                    cachedImage,
 		Private:                     sources.Publish == types.InternalPublishingStrategy,
 		BaseDomainResourceGroupName: sources.BaseDomainResourceGroupName,
 		NetworkResourceGroupName:    masterConfig.NetworkResourceGroup,


### PR DESCRIPTION
Hi,

these commits fix a few issues:

- FCOS version typo
- FCOS image for Azure will be decompressed
- blob type now is 'page'

The installer built with this commits still uploads the decompressed (8GByte big) FCOS image to Azure. For that to work you should run the openshift-install tool in an Azure cloud shell.

Greetings,

Josef

