### PR TITLE
Bug 1833425: pkg/explain/cmd.go: fix help text

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ "$IS_CONTAINER" != "" ]; then
+  set -x
+  go generate ./pkg/types/installconfig.go
+  go generate ./pkg/rhcos/ami.go
+  set +x
+  git diff --exit-code
+else
+  podman run --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
+    --workdir /go/src/github.com/openshift/installer \
+    docker.io/openshift/origin-release:golang-1.13 \
+    ./hack/verify-codegen.sh "${@}"
+fi

--- a/pkg/explain/cmd.go
+++ b/pkg/explain/cmd.go
@@ -22,10 +22,10 @@ installconfig.<fieldName>[.<fieldName>]
 `,
 		Example: `
 # Get the documentation of the resource and its fields
-kubectl explain installconfig
+openshift-install explain installconfig
 
 # Get the documentation of a AWS platform
-kubectl explain installconfig.platform.aws`,
+openshift-install explain installconfig.platform.aws`,
 		RunE: runCmd,
 	}
 

--- a/pkg/rhcos/ami_regions_generate.go
+++ b/pkg/rhcos/ami_regions_generate.go
@@ -77,7 +77,7 @@ package {{ .Pkg }}
 // AMIRegoins is a list of regions where the RHEL CoreOS is published.
 var AMIRegions = []string{
 {{- range $region := .Regions}}
-    "{{ $region }}",
+	"{{ $region }}",
 {{- end}}
 }
 `


### PR DESCRIPTION
6f929ae i missed that commit in #3515 so i have included it here.

/assign @patrickdillon 