### PR TITLE
bug 1834177: upi/azure: Use a single network security group for Azure clusters

### DIFF
--- a/docs/user/azure/install_upi.md
+++ b/docs/user/azure/install_upi.md
@@ -391,7 +391,7 @@ INFO It is now safe to remove the bootstrap resources
 Once the bootstrapping process is complete you can deallocate and delete bootstrap resources:
 
 ```sh
-az network nsg rule delete -g $RESOURCE_GROUP --nsg-name ${INFRA_ID}-controlplane-nsg --name bootstrap_ssh_in
+az network nsg rule delete -g $RESOURCE_GROUP --nsg-name ${INFRA_ID}-nsg --name bootstrap_ssh_in
 az vm stop -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap
 az vm deallocate -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap
 az vm delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap --yes

--- a/upi/azure/01_vnet.json
+++ b/upi/azure/01_vnet.json
@@ -18,8 +18,7 @@
     "masterSubnetPrefix" : "10.0.0.0/24",
     "nodeSubnetName" : "[concat(parameters('baseName'), '-worker-subnet')]",
     "nodeSubnetPrefix" : "10.0.1.0/24",
-    "controlPlaneNsgName" : "[concat(parameters('baseName'), '-controlplane-nsg')]",
-    "nodeNsgName" : "[concat(parameters('baseName'), '-node-nsg')]"
+    "clusterNsgName" : "[concat(parameters('baseName'), '-nsg')]"
   },
   "resources" : [
     {
@@ -28,8 +27,7 @@
       "name" : "[variables('virtualNetworkName')]",
       "location" : "[variables('location')]",
       "dependsOn" : [
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('controlPlaneNsgName'))]",
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('nodeNsgName'))]"
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('clusterNsgName'))]"
       ],
       "properties" : {
         "addressSpace" : {
@@ -44,7 +42,7 @@
               "addressPrefix" : "[variables('masterSubnetPrefix')]",
               "serviceEndpoints": [],
               "networkSecurityGroup" : {
-                "id" : "[resourceId('Microsoft.Network/networkSecurityGroups', variables('controlPlaneNsgName'))]"
+                "id" : "[resourceId('Microsoft.Network/networkSecurityGroups', variables('clusterNsgName'))]"
               }
             }
           },
@@ -54,7 +52,7 @@
               "addressPrefix" : "[variables('nodeSubnetPrefix')]",
               "serviceEndpoints": [],
               "networkSecurityGroup" : {
-                "id" : "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nodeNsgName'))]"
+                "id" : "[resourceId('Microsoft.Network/networkSecurityGroups', variables('clusterNsgName'))]"
               }
             }
           }
@@ -63,30 +61,7 @@
     },
     {
       "type" : "Microsoft.Network/networkSecurityGroups",
-      "name" : "[variables('controlPlaneNsgName')]",
-      "apiVersion" : "2018-10-01",
-      "location" : "[variables('location')]",
-      "properties" : {
-        "securityRules" : [
-          {
-            "name" : "apiserver_in",
-            "properties" : {
-              "protocol" : "Tcp",
-              "sourcePortRange" : "*",
-              "destinationPortRange" : "6443",
-              "sourceAddressPrefix" : "*",
-              "destinationAddressPrefix" : "*",
-              "access" : "Allow",
-              "priority" : 101,
-              "direction" : "Inbound"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type" : "Microsoft.Network/networkSecurityGroups",
-      "name" : "[variables('nodeNsgName')]",
+      "name" : "[variables('clusterNsgName')]",
       "apiVersion" : "2018-10-01",
       "location" : "[variables('location')]",
       "properties" : {

--- a/upi/azure/04_bootstrap.json
+++ b/upi/azure/04_bootstrap.json
@@ -111,7 +111,7 @@
     "vmName" : "[concat(parameters('baseName'), '-bootstrap')]",
     "nicName" : "[concat(variables('vmName'), '-nic')]",
     "imageName" : "[concat(parameters('baseName'), '-image')]",
-    "controlPlaneNsgName" : "[concat(parameters('baseName'), '-controlplane-nsg')]",
+    "clusterNsgName" : "[concat(parameters('baseName'), '-nsg')]",
     "sshPublicIpAddressName" : "[concat(variables('vmName'), '-ssh-pip')]"
   },
   "resources" : [
@@ -223,7 +223,7 @@
     {
       "apiVersion" : "2018-06-01",
       "type": "Microsoft.Network/networkSecurityGroups/securityRules",
-      "name" : "[concat(variables('controlPlaneNsgName'), '/bootstrap_ssh_in')]",
+      "name" : "[concat(variables('clusterNsgName'), '/bootstrap_ssh_in')]",
       "location" : "[variables('location')]",
       "dependsOn" : [
         "[resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))]"

--- a/upi/azure/setup-manifests.py
+++ b/upi/azure/setup-manifests.py
@@ -31,7 +31,7 @@ with open('manifests/cloud-provider-config.yaml') as file:
     config.vnetName = infra_id + "-vnet"
     config.vnetResourceGroup = resource_group
     config.subnetName = infra_id + "-worker-subnet"
-    config.securityGroupName = infra_id + "-node-nsg"
+    config.securityGroupName = infra_id + "-nsg"
     config.routeTableName = ""
     config.cloudProviderRateLimit = False
     config.azure_resourcegroup = resource_group


### PR DESCRIPTION
This updates UPI to be in par with https://github.com/openshift/installer/pull/3561