### PR TITLE
Bug 1828638: set vSphere node diskSize based on machine pool

### DIFF
--- a/data/data/vsphere/master/main.tf
+++ b/data/data/vsphere/master/main.tf
@@ -20,7 +20,7 @@ resource "vsphere_virtual_machine" "vm" {
 
   disk {
     label            = "disk0"
-    size             = 120
+    size             = var.disk_size
     eagerly_scrub    = var.scrub_disk
     thin_provisioned = var.thin_disk
   }

--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -16,6 +16,8 @@ import (
 	libvirtvalidation "github.com/openshift/installer/pkg/types/libvirt/validation"
 	"github.com/openshift/installer/pkg/types/openstack"
 	openstackvalidation "github.com/openshift/installer/pkg/types/openstack/validation"
+	"github.com/openshift/installer/pkg/types/vsphere"
+	vspherevalidation "github.com/openshift/installer/pkg/types/vsphere/validation"
 )
 
 var (
@@ -92,6 +94,9 @@ func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolP
 	}
 	if p.BareMetal != nil {
 		validate(baremetal.Name, p.BareMetal, func(f *field.Path) field.ErrorList { return baremetalvalidation.ValidateMachinePool(p.BareMetal, f) })
+	}
+	if p.VSphere != nil {
+		validate(vsphere.Name, p.VSphere, func(f *field.Path) field.ErrorList { return vspherevalidation.ValidateMachinePool(p.VSphere, f) })
 	}
 	return allErrs
 }

--- a/pkg/types/vsphere/validation/machinepool.go
+++ b/pkg/types/vsphere/validation/machinepool.go
@@ -8,5 +8,18 @@ import (
 
 // ValidateMachinePool checks that the specified machine pool is valid.
 func ValidateMachinePool(p *vsphere.MachinePool, fldPath *field.Path) field.ErrorList {
-	return field.ErrorList{}
+	allErrs := field.ErrorList{}
+	if p.DiskSizeGB < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), p.DiskSizeGB, "storage disk size must be positive"))
+	}
+	if p.MemoryMiB < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("memoryMB"), p.MemoryMiB, "memory size must be positive"))
+	}
+	if p.NumCPUs < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("cpus"), p.NumCPUs, "number of CPUs must be positive"))
+	}
+	if p.NumCoresPerSocket < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("coresPerSocket"), p.NumCoresPerSocket, "cores per socket must be positive"))
+	}
+	return allErrs
 }

--- a/pkg/types/vsphere/validation/machinepool_test.go
+++ b/pkg/types/vsphere/validation/machinepool_test.go
@@ -11,23 +11,49 @@ import (
 
 func TestValidateMachinePool(t *testing.T) {
 	cases := []struct {
-		name  string
-		pool  *vsphere.MachinePool
-		valid bool
+		name           string
+		pool           *vsphere.MachinePool
+		expectedErrMsg string
 	}{
 		{
-			name:  "empty",
-			pool:  &vsphere.MachinePool{},
-			valid: true,
+			name:           "empty",
+			pool:           &vsphere.MachinePool{},
+			expectedErrMsg: "",
+		}, {
+			name: "negative disk size",
+			pool: &vsphere.MachinePool{
+				OSDisk: vsphere.OSDisk{
+					DiskSizeGB: -1,
+				},
+			},
+			expectedErrMsg: `^test-path\.diskSizeGB: Invalid value: -1: storage disk size must be positive$`,
+		}, {
+			name: "negative CPUs",
+			pool: &vsphere.MachinePool{
+				NumCPUs: -1,
+			},
+			expectedErrMsg: `^test-path\.cpus: Invalid value: -1: number of CPUs must be positive$`,
+		}, {
+			name: "negative cores",
+			pool: &vsphere.MachinePool{
+				NumCoresPerSocket: -1,
+			},
+			expectedErrMsg: `^test-path\.coresPerSocket: Invalid value: -1: cores per socket must be positive$`,
+		}, {
+			name: "negative memory",
+			pool: &vsphere.MachinePool{
+				MemoryMiB: -1,
+			},
+			expectedErrMsg: `^test-path\.memoryMB: Invalid value: -1: memory size must be positive$`,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidateMachinePool(tc.pool, field.NewPath("test-path")).ToAggregate()
-			if tc.valid {
+			if tc.expectedErrMsg == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				assert.Regexp(t, tc.expectedErrMsg, err)
 			}
 		})
 	}


### PR DESCRIPTION
The disk size for masters in terraform was hardcoded to 120 GB. This removes the hardcoded value and uses the value from the machinepool, whether it is the default or user-provided. Also adds validation and tests for the machine pools.

/cc @rna-afk 