### PR TITLE
Bug 1833483: Revert "baremetal: send full ignition to masters"

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -21,13 +21,11 @@ module "bootstrap" {
 module "masters" {
   source = "./masters"
 
-  master_count         = var.master_count
-  ignition             = var.ignition_master
-  hosts                = var.hosts
-  properties           = var.properties
-  root_devices         = var.root_devices
-  driver_infos         = var.driver_infos
-  instance_infos       = var.instance_infos
-  ignition_url         = var.ignition_url
-  ignition_url_ca_cert = var.ignition_url_ca_cert
+  master_count   = var.master_count
+  ignition       = var.ignition_master
+  hosts          = var.hosts
+  properties     = var.properties
+  root_devices   = var.root_devices
+  driver_infos   = var.driver_infos
+  instance_infos = var.instance_infos
 }

--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -41,8 +41,7 @@ resource "ironic_deployment" "openshift-master-deployment" {
     count.index,
   )
 
-  instance_info         = var.instance_infos[count.index]
-  user_data_url         = var.ignition_url
-  user_data_url_ca_cert = var.ignition_url_ca_cert
+  instance_info = var.instance_infos[count.index]
+  user_data     = var.ignition
 }
 

--- a/data/data/baremetal/masters/variables.tf
+++ b/data/data/baremetal/masters/variables.tf
@@ -33,13 +33,3 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
-
-variable "ignition_url" {
-  type        = string
-  description = "The URL of the full ignition"
-}
-
-variable "ignition_url_ca_cert" {
-  type        = string
-  description = "Root CA cert of the full ignition URL"
-}

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -47,13 +47,3 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
-
-variable "ignition_url" {
-  type        = string
-  description = "The URL of the full ignition"
-}
-
-variable "ignition_url_ca_cert" {
-  type        = string
-  description = "Root CA cert of the full ignition URL"
-}

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -22,8 +22,6 @@ type config struct {
 	BootstrapOSImage        string `json:"bootstrap_os_image,omitempty"`
 	ExternalBridge          string `json:"external_bridge,omitempty"`
 	ProvisioningBridge      string `json:"provisioning_bridge,omitempty"`
-	IgnitionURL             string `json:"ignition_url,omitempty"`
-	IgnitionURLCACert       string `json:"ignition_url_ca_cert,omitempty"`
 
 	// Data required for control plane deployment - several maps per host, because of terraform's limitations
 	Hosts         []map[string]interface{} `json:"hosts"`
@@ -34,7 +32,7 @@ type config struct {
 }
 
 // TFVars generates bare metal specific Terraform variables.
-func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridge, provisioningBridge string, platformHosts []*baremetal.Host, image string, ignitionURL string, ignitionURLCACert string) ([]byte, error) {
+func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridge, provisioningBridge string, platformHosts []*baremetal.Host, image string) ([]byte, error) {
 	bootstrapOSImage, err := cache.DownloadImageFile(bootstrapOSImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to use cached bootstrap libvirt image")
@@ -134,8 +132,6 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		DriverInfos:             driverInfos,
 		RootDevices:             rootDevices,
 		InstanceInfos:           instanceInfos,
-		IgnitionURL:             ignitionURL,
-		IgnitionURLCACert:       ignitionURLCACert,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
This was merged in https://github.com/openshift/installer/pull/3276
but had the side-effect of breaking an interface some users were
already reliant on, where additional config is added to the
pointer ignition output via `create ignition-configs`

Downstream bz https://bugzilla.redhat.com/show_bug.cgi?id=1833483
reported this issue, and we've taken the decision to revert this
to resolve that interface regression, and look at other ways to
satisfy the requirements that led to #3276

This reverts commit f67d61a7142a95063e096857a6c477bef376a3e7.