### PR TITLE
[fcos] libvirt fixes

### DIFF
--- a/data/data/libvirt/volume/main.tf
+++ b/data/data/libvirt/volume/main.tf
@@ -1,5 +1,12 @@
-resource "libvirt_volume" "coreos_base" {
-  name   = "${var.cluster_id}-base"
+resource "libvirt_volume" "coreos_base_initial" {
+  name   = "${var.cluster_id}-base-initial"
   source = var.image
   pool   = var.pool
+}
+
+resource "libvirt_volume" "coreos_base" {
+  name   = "${var.cluster_id}-base"
+  base_volume_id = "${libvirt_volume.coreos_base_initial.id}"
+  pool   = var.pool
+  size   = 17179869184
 }

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -29,3 +29,4 @@ USER 1000:1000
 ENV PATH /bin
 ENV HOME /output
 WORKDIR /output
+ENTRYPOINT ["/bin/openshift-install"]


### PR DESCRIPTION
2 fixes for OKD:

* set entrypoint in images/libvirt/Dockerfile. Not sure why it is unset (so that nested GCP can be tested)?
* resize FCOS image to 16GB when machines are created.

RHCOS image is 16GB, while FCOS is 8GB and single master installation needs a lot of space. This commit would resize bootstrap / master machines to 16GB

/cc @LorbusChris @praveenkumar

https://github.com/openshift/installer/pull/3587 was closed due to release repo misconfiguration