### PR TITLE
Baremetal: Bug 1801238: Pull data from ironic inspector and annotate BareMetalHost

### DIFF
--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -3,6 +3,7 @@ resource "ironic_node_v1" "openshift-master-host" {
   name           = var.hosts[count.index]["name"]
   resource_class = "baremetal"
 
+  inspect   = true
   clean     = true
   available = true
 

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091
+. /usr/local/bin/release-image.sh
+
+export KUBECONFIG=/etc/kubernetes/kubeconfig
+
+# Wait till the baremetalhosts are populated
+until oc get baremetalhosts -n openshift-machine-api; do
+   echo Waiting for BareMetalHosts to appear...
+   sleep 20
+done
+
+# Wait for a master to appear.
+while [ "$(curl -s http://localhost:6385/v1/nodes | jq '.nodes[] | .uuid' | wc -l)" -lt 1 ]; do
+    echo waiting for a master node to show up
+    sleep 20
+done
+
+# Wait for the nodes to become active after introspection.
+# Probably don't need this but I want to be 100% sure.
+while curl -s http://localhost:6385/v1/nodes | jq '.nodes[] | .provision_state' | grep -v active; do
+    echo Waiting for nodes to become active
+    sleep 20
+done
+
+echo Nodes are all active
+
+BAREMETAL_OPERATOR_IMAGE=$(image_for baremetal-operator)
+
+for node in $(curl -s http://localhost:6385/v1/nodes | jq -r '.nodes[] | .uuid'); do
+    name=$(curl -H "X-OpenStack-Ironic-API-Version: 1.9" -s "http://localhost:6385/v1/nodes/$node" | jq -r .name)
+    echo "Host $name, UUID: $node"
+    # And use the baremetal operator tool to load the introspection data into
+    # the BareMetalHost CRs as annotations, which BMO then picks up.
+    HARDWARE_DETAILS=$(podman run --quiet --net=host \
+        --rm \
+        --name baremetal-operator \
+        --entrypoint /get-hardware-details \
+        "${BAREMETAL_OPERATOR_IMAGE}" \
+        http://localhost:5050/v1 "$node" | jq '{hardware: .}')
+
+     oc annotate --overwrite -n openshift-machine-api baremetalhosts "$name" 'baremetalhost.metal3.io/status'="$HARDWARE_DETAILS"
+done

--- a/data/data/bootstrap/baremetal/systemd/units/master-bmh-update.service
+++ b/data/data/bootstrap/baremetal/systemd/units/master-bmh-update.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Update master BareMetalHosts with introspection data
+Wants=bootkube.service
+After=release-image.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/master-bmh-update.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -331,9 +331,10 @@ func (a *Bootstrap) addSystemdUnits(uri string, templateData *bootstrapTemplateD
 		"systemd-journal-gatewayd.socket": {},
 		"approve-csr.service":             {},
 		// baremetal & openstack platform services
-		"keepalived.service": {},
-		"coredns.service":    {},
-		"ironic.service":     {},
+		"keepalived.service":        {},
+		"coredns.service":           {},
+		"ironic.service":            {},
+		"master-bmh-update.service": {},
 	}
 
 	directory, err := data.Assets.Open(uri)


### PR DESCRIPTION
Right now we don't get any introspection data about the masters
because they are provisioned by the bootstrap node and the information
is lost.  This patch adds a script to pull the introspection data
from ironic running on the bootstrap and places it in the BareMetalHost CRs
for the masters.  This is done via an annotation as we cannot directly
update the Status in BMH.  The annotation is picked up by the BMO
and added to the BMH CRs.

There are several bugs filed about this:

https://github.com/openshift-metal3/dev-scripts/issues/917
https://bugzilla.redhat.com/show_bug.cgi?id=1801238
