### PR TITLE
Bug 1836339: GCP: Enable disk type and size customization

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -148,6 +148,26 @@ spec:
                       description: GCP is the configuration used when installing on
                         GCP
                       properties:
+                        osDisk:
+                          description: OSDisk defines the storage for instance.
+                          properties:
+                            DiskSizeGB:
+                              description: DiskSizeGB defines the size of disk in
+                                GB.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            DiskType:
+                              description: DiskType defines the type of disk. The
+                                valid values are pd-standard and pd-ssd For control
+                                plane nodes, the valid value is pd-ssd.
+                              enum:
+                              - pd-ssd
+                              - pd-standard
+                              type: string
+                          required:
+                          - DiskSizeGB
+                          type: object
                         type:
                           description: InstanceType defines the GCP instance type.
                             eg. n1-standard-4
@@ -359,6 +379,25 @@ spec:
                     description: GCP is the configuration used when installing on
                       GCP
                     properties:
+                      osDisk:
+                        description: OSDisk defines the storage for instance.
+                        properties:
+                          DiskSizeGB:
+                            description: DiskSizeGB defines the size of disk in GB.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          DiskType:
+                            description: DiskType defines the type of disk. The valid
+                              values are pd-standard and pd-ssd For control plane
+                              nodes, the valid value is pd-ssd.
+                            enum:
+                            - pd-ssd
+                            - pd-standard
+                            type: string
+                        required:
+                        - DiskSizeGB
+                        type: object
                       type:
                         description: InstanceType defines the GCP instance type. eg.
                           n1-standard-4
@@ -888,6 +927,25 @@ spec:
                       used when installing on GCP for machine pools which do not define
                       their own platform configuration.
                     properties:
+                      osDisk:
+                        description: OSDisk defines the storage for instance.
+                        properties:
+                          DiskSizeGB:
+                            description: DiskSizeGB defines the size of disk in GB.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          DiskType:
+                            description: DiskType defines the type of disk. The valid
+                              values are pd-standard and pd-ssd For control plane
+                              nodes, the valid value is pd-ssd.
+                            enum:
+                            - pd-ssd
+                            - pd-standard
+                            type: string
+                        required:
+                        - DiskSizeGB
+                        type: object
                       type:
                         description: InstanceType defines the GCP instance type. eg.
                           n1-standard-4

--- a/docs/user/gcp/customization.md
+++ b/docs/user/gcp/customization.md
@@ -13,6 +13,9 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 * `type` (optional string): The [GCP machine type][machine-type].
 * `zones` (optional array of strings): The availability zones used for machines in the pool.
+* `osDisk` (optional object):
+    * `diskSizeGB` (optional integer): The size of the disk in gigabytes (GB).
+    * `diskType` (optional string): The type of disk (allowed values are: `pd-ssd`, and `pd-standard`. Default: `pd-ssd`).
 
 ## Installing to Existing Networks & Subnetworks
 
@@ -44,6 +47,9 @@ platform:
   gcp:
     project: example-project
     region: us-east1
+    osDisk:
+      diskType: pd-ssd
+      diskSizeGB: 120
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ```
@@ -63,6 +69,9 @@ compute:
       zones:
       - us-central1-a
       - us-central1-c
+      osDisk:
+        diskType: pd-standard
+        diskSizeGB: 128
   replicas: 3
 controlPlane:
   name: master
@@ -72,6 +81,9 @@ controlPlane:
       zones:
       - us-central1-a
       - us-central1-c
+      osDisk:
+        diskType: pd-ssd
+        diskSizeGB: 1024
   replicas: 3
 metadata:
   name: example-cluster

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -31,6 +31,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	if pool.Replicas != nil {
 		total = *pool.Replicas
 	}
+
 	var machines []machineapi.Machine
 	for idx := int64(0); idx < total; idx++ {
 		azIndex := int(idx) % len(azs)
@@ -84,8 +85,8 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 		Disks: []*gcpprovider.GCPDisk{{
 			AutoDelete: true,
 			Boot:       true,
-			SizeGb:     128,
-			Type:       "pd-ssd",
+			SizeGb:     mpool.OSDisk.DiskSizeGB,
+			Type:       mpool.OSDisk.DiskType,
 			Image:      fmt.Sprintf("%s-rhcos-image", clusterID),
 		}},
 		NetworkInterfaces: []*gcpprovider.GCPNetworkInterface{{

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -95,6 +95,10 @@ func defaultAzureMachinePoolPlatform() azuretypes.MachinePool {
 func defaultGCPMachinePoolPlatform() gcptypes.MachinePool {
 	return gcptypes.MachinePool{
 		InstanceType: "n1-standard-4",
+		OSDisk: gcptypes.OSDisk{
+			DiskSizeGB: 128,
+			DiskType:   "pd-ssd",
+		},
 	}
 }
 

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -12,6 +12,26 @@ type MachinePool struct {
 	//
 	// +optional
 	InstanceType string `json:"type"`
+
+	// OSDisk defines the storage for instance.
+	//
+	// +optional
+	OSDisk `json:"osDisk"`
+}
+
+// OSDisk defines the disk for machines on GCP.
+type OSDisk struct {
+	// DiskType defines the type of disk.
+	// The valid values are pd-standard and pd-ssd
+	// For control plane nodes, the valid value is pd-ssd.
+	// +optional
+	// +kubebuilder:validation:Enum=pd-ssd;pd-standard
+	DiskType string `json:"DiskType"`
+
+	// DiskSizeGB defines the size of disk in GB.
+	//
+	// +kubebuilder:validation:Minimum=0
+	DiskSizeGB int64 `json:"DiskSizeGB"`
 }
 
 // Set sets the values from `required` to `a`.
@@ -26,5 +46,13 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.InstanceType != "" {
 		a.InstanceType = required.InstanceType
+	}
+
+	if required.OSDisk.DiskSizeGB > 0 {
+		a.OSDisk.DiskSizeGB = required.OSDisk.DiskSizeGB
+	}
+
+	if required.OSDisk.DiskType != "" {
+		a.OSDisk.DiskType = required.OSDisk.DiskType
 	}
 }

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/gcp"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -14,6 +16,43 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 	for i, zone := range p.Zones {
 		if !strings.HasPrefix(zone, platform.Region) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("zones").Index(i), zone, fmt.Sprintf("Zone not in configured region (%s)", platform.Region)))
+		}
+	}
+
+	if p.OSDisk.DiskSizeGB < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), p.OSDisk.DiskSizeGB, "must be a positive value"))
+	}
+
+	if p.OSDisk.DiskType != "" {
+		diskTypes := sets.NewString("pd-standard", "pd-ssd")
+		if !diskTypes.Has(p.OSDisk.DiskType) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))
+		}
+	}
+
+	return allErrs
+}
+
+// ValidateMasterDiskType checks that the specified disk type is valid for control plane.
+func ValidateMasterDiskType(p *types.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if p.Name == "master" && p.Platform.GCP.OSDisk.DiskType == "pd-standard" {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskType"), p.Platform.GCP.OSDisk.DiskType, fmt.Sprintf("%s not compatible with control planes.", p.Platform.GCP.OSDisk.DiskType)))
+	}
+
+	return allErrs
+}
+
+// ValidateDefaultDiskType checks that the specified disk type is valid for default GCP Machine Platform.
+func ValidateDefaultDiskType(p *gcp.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if p != nil && p.OSDisk.DiskType != "" {
+		diskTypes := sets.NewString("pd-ssd")
+
+		if !diskTypes.Has(p.OSDisk.DiskType) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("diskType"), p.OSDisk.DiskType, diskTypes.List()))
 		}
 	}
 

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -33,6 +33,40 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 			expected: `^test-path\.zones\[1]: Invalid value: "us-central1-f": Zone not in configured region \(us-east1\)$`,
 		},
+		{
+			name: "valid disk type",
+			pool: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskType: "pd-standard",
+				},
+			},
+		},
+		{
+			name: "invalid disk type",
+			pool: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskType: "pd-",
+				},
+			},
+			expected: `^test-path\.diskType: Unsupported value: "pd-": supported values: "pd-ssd", "pd-standard"$`,
+		},
+		{
+			name: "valid disk size",
+			pool: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskSizeGB: 100,
+				},
+			},
+		},
+		{
+			name: "invalid disk type",
+			pool: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskSizeGB: -120,
+				},
+			},
+			expected: `^test-path\.diskSizeGB: Invalid value: -120: must be a positive value$`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -55,6 +55,7 @@ func ValidatePlatform(p *gcp.Platform, fldPath *field.Path) field.ErrorList {
 	}
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
+		allErrs = append(allErrs, ValidateDefaultDiskType(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}
 	if p.Network != "" {
 		if p.ComputeSubnet == "" {

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -63,6 +63,31 @@ func TestValidatePlatform(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			name: "unsupported GCP disk type",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				DefaultMachinePlatform: &gcp.MachinePool{
+					OSDisk: gcp.OSDisk{
+						DiskType: "pd-standard",
+					},
+				},
+			},
+			valid: false,
+		},
+
+		{
+			name: "supported GCP disk type",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				DefaultMachinePlatform: &gcp.MachinePool{
+					OSDisk: gcp.OSDisk{
+						DiskType: "pd-ssd",
+					},
+				},
+			},
+			valid: true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -12,6 +12,8 @@ import (
 	azurevalidation "github.com/openshift/installer/pkg/types/azure/validation"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	baremetalvalidation "github.com/openshift/installer/pkg/types/baremetal/validation"
+	"github.com/openshift/installer/pkg/types/gcp"
+	gcpvalidation "github.com/openshift/installer/pkg/types/gcp/validation"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	libvirtvalidation "github.com/openshift/installer/pkg/types/libvirt/validation"
 	"github.com/openshift/installer/pkg/types/openstack"
@@ -63,11 +65,11 @@ func ValidateMachinePool(platform *types.Platform, p *types.MachinePool, fldPath
 	if !validArchitectures[p.Architecture] {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("architecture"), p.Architecture, validArchitectureValues))
 	}
-	allErrs = append(allErrs, validateMachinePoolPlatform(platform, &p.Platform, fldPath.Child("platform"))...)
+	allErrs = append(allErrs, validateMachinePoolPlatform(platform, &p.Platform, p, fldPath.Child("platform"))...)
 	return allErrs
 }
 
-func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolPlatform, fldPath *field.Path) field.ErrorList {
+func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolPlatform, pool *types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	platformName := platform.Name()
 	validate := func(n string, value interface{}, validation func(*field.Path) field.ErrorList) {
@@ -84,6 +86,9 @@ func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolP
 	if p.Azure != nil {
 		validate(azure.Name, p.Azure, func(f *field.Path) field.ErrorList { return azurevalidation.ValidateMachinePool(p.Azure, f) })
 	}
+	if p.GCP != nil {
+		validate(gcp.Name, p.GCP, func(f *field.Path) field.ErrorList { return validateGCPMachinePool(platform, p, pool, f) })
+	}
 	if p.Libvirt != nil {
 		validate(libvirt.Name, p.Libvirt, func(f *field.Path) field.ErrorList { return libvirtvalidation.ValidateMachinePool(p.Libvirt, f) })
 	}
@@ -93,5 +98,14 @@ func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolP
 	if p.BareMetal != nil {
 		validate(baremetal.Name, p.BareMetal, func(f *field.Path) field.ErrorList { return baremetalvalidation.ValidateMachinePool(p.BareMetal, f) })
 	}
+	return allErrs
+}
+
+func validateGCPMachinePool(platform *types.Platform, p *types.MachinePoolPlatform, pool *types.MachinePool, f *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, gcpvalidation.ValidateMachinePool(platform.GCP, p.GCP, f)...)
+	allErrs = append(allErrs, gcpvalidation.ValidateMasterDiskType(pool, f)...)
+
 	return allErrs
 }

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
@@ -141,6 +142,48 @@ func TestValidateMachinePool(t *testing.T) {
 					AWS:     &aws.MachinePool{},
 					Libvirt: &libvirt.MachinePool{},
 				}
+				return p
+			}(),
+			valid: false,
+		},
+		{
+			name:     "valid GCP",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("test-name")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{},
+				}
+				p.Platform.GCP.OSDisk.DiskSizeGB = 100
+				p.Platform.GCP.OSDisk.DiskType = "pd-standard"
+				return p
+			}(),
+			valid: true,
+		},
+		{
+			name:     "invalid GCP disk size",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("test-name")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{},
+				}
+				p.Platform.GCP.OSDisk.DiskSizeGB = -100
+				p.Platform.GCP.OSDisk.DiskType = "pd-standard"
+				return p
+			}(),
+			valid: false,
+		},
+		{
+			name:     "invalid GCP disk type",
+			platform: &types.Platform{GCP: &gcp.Platform{Region: "us-east-1"}},
+			pool: func() *types.MachinePool {
+				p := validMachinePool("test-name")
+				p.Platform = types.MachinePoolPlatform{
+					GCP: &gcp.MachinePool{},
+				}
+				p.Platform.GCP.OSDisk.DiskSizeGB = 100
+				p.Platform.GCP.OSDisk.DiskType = "pd-"
 				return p
 			}(),
 			valid: false,


### PR DESCRIPTION
Currently, the installer does not allow the users to customize the
type and size of the disks for the workers and control plane.
Added the option for the user to specify the type and the size of
the disks for both machines in GCP.

The user can specify two types of disks, pd-standard and pd-ssd disks
which are the options that GCP/Terraform provides. pd-standard is not
recommended for control planes and will not be allowed as a value in
the DefaultMachinePlatform and the master compute section.