### PR TITLE
Bug 1835438: move vSphere folder validation to provisioning

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -21,7 +21,6 @@ func Validate(ic *types.InstallConfig) error {
 	}
 
 	allErrs = append(allErrs, validation.ValidatePlatform(ic.Platform.VSphere, field.NewPath("platform").Child("vsphere"))...)
-	allErrs = append(allErrs, folderExists(ic, field.NewPath("platform").Child("vsphere").Child("folder"))...)
 
 	return allErrs.ToAggregate()
 }
@@ -36,6 +35,7 @@ func ValidateForProvisioning(ic *types.InstallConfig) error {
 	}
 
 	allErrs = append(allErrs, validation.ValidateForProvisioning(ic.Platform.VSphere, field.NewPath("platform").Child("vsphere"))...)
+	allErrs = append(allErrs, folderExists(ic, field.NewPath("platform").Child("vsphere").Child("folder"))...)
 
 	return allErrs.ToAggregate()
 }


### PR DESCRIPTION
vSphere validation checks whether a folder exists when creating manifests or ignition configs. Creating the folder after the manifests or ignition configs is a valid UPI workflow so this check should only be run when provisioning infrastructure.

@abhinavdahiya we [discussed this before](https://github.com/openshift/installer/pull/3498#discussion_r418114851), but it seems I answered your question incorrectly.

cc @jcpowermac did you see UPI documentation that needs to be changed to work with the new folder requirements? I am not seeing it in the repo. perhaps you were looking at official docs?

