### PR TITLE
Bug 1835867: data/data/aws/vpc: create subnet sizes based on az count

### DIFF
--- a/data/data/aws/vpc/vpc-private.tf
+++ b/data/data/aws/vpc/vpc-private.tf
@@ -29,7 +29,7 @@ resource "aws_subnet" "private_subnet" {
 
   vpc_id = data.aws_vpc.cluster_vpc.id
 
-  cidr_block = cidrsubnet(local.new_private_cidr_range, 3, count.index)
+  cidr_block = cidrsubnet(local.new_private_cidr_range, ceil(log(length(var.availability_zones), 2)), count.index)
 
   availability_zone = var.availability_zones[count.index]
 

--- a/data/data/aws/vpc/vpc-public.tf
+++ b/data/data/aws/vpc/vpc-public.tf
@@ -47,7 +47,7 @@ resource "aws_subnet" "public_subnet" {
   count = var.public_subnets == null ? length(var.availability_zones) : 0
 
   vpc_id            = data.aws_vpc.cluster_vpc.id
-  cidr_block        = cidrsubnet(local.new_public_cidr_range, 3, count.index)
+  cidr_block        = cidrsubnet(local.new_public_cidr_range, ceil(log(length(var.availability_zones), 2)), count.index)
   availability_zone = var.availability_zones[count.index]
 
   tags = merge(


### PR DESCRIPTION
For every availability zone, we need a subnet. `ceil(log2(num of AZs))` finds the smallest exponent of 2 that is greater than or equal to `num of AZs`

Using that to split the private/public machine_cidr range allows the installer to carve out network ranges for each AZ with minimum unused.
Previously the installer would create 8 ranges always even when only a few were required.

