### PR TITLE
[fcos] Inject etcd and ingress tweaks when a single master is used

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -72,6 +72,9 @@ type Master struct {
 	// HostFiles is the list of baremetal hosts provided in the
 	// installer configuration.
 	HostFiles []*asset.File
+
+	//SingleMaster is a list of manifests to setup a single master cluster
+	SingleMasterFiles []*asset.File
 }
 
 const (
@@ -92,12 +95,15 @@ const (
 	// masterUserDataFileName is the filename used for the master
 	// user-data secret.
 	masterUserDataFileName = "99_openshift-cluster-api_master-user-data-secret.yaml"
+
+	singleMasterFileName = "99_openshift-single-master-%s.yaml"
 )
 
 var (
 	secretFileNamePattern        = fmt.Sprintf(secretFileName, "*")
 	hostFileNamePattern          = fmt.Sprintf(hostFileName, "*")
 	masterMachineFileNamePattern = fmt.Sprintf(masterMachineFileName, "*")
+	singleMasterFileNamePattern  = fmt.Sprintf(singleMasterFileName, "*")
 
 	_ asset.WritableAsset = (*Master)(nil)
 )
@@ -347,6 +353,18 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		Data:     data,
 	}
 
+	if pool.Replicas != nil && *pool.Replicas == 1 {
+		m.SingleMasterFiles = make([]*asset.File, 2)
+		m.SingleMasterFiles[0] = &asset.File{
+			Filename: filepath.Join(directory, fmt.Sprintf(singleMasterFileName, "etcd")),
+			Data:     etcdSingleMasterData,
+		}
+		m.SingleMasterFiles[1] = &asset.File{
+			Filename: filepath.Join(directory, fmt.Sprintf(singleMasterFileName, "ingress")),
+			Data:     ingressSingleMasterData,
+		}
+	}
+
 	machineConfigs := []*mcfgv1.MachineConfig{}
 	if pool.Hyperthreading == types.HyperthreadingDisabled {
 		HyperthreadingDisabledMC, err := machineconfig.ForHyperthreadingDisabled("master")
@@ -407,6 +425,7 @@ func (m *Master) Files() []*asset.File {
 	// reconcile a machine it can pick up the related host.
 	files = append(files, m.HostFiles...)
 	files = append(files, m.MachineFiles...)
+	files = append(files, m.SingleMasterFiles...)
 	return files
 }
 
@@ -445,6 +464,12 @@ func (m *Master) Load(f asset.FileFetcher) (found bool, err error) {
 		return true, err
 	}
 	m.MachineFiles = fileList
+
+	fileList, err = f.FetchByPattern(filepath.Join(directory, singleMasterFileNamePattern))
+	if err != nil {
+		return true, err
+	}
+	m.SingleMasterFiles = fileList
 
 	return true, nil
 }

--- a/pkg/asset/machines/singlemaster.go
+++ b/pkg/asset/machines/singlemaster.go
@@ -1,0 +1,20 @@
+package machines
+
+var etcdSingleMasterData = []byte(`apiVersion: operator.openshift.io/v1
+kind: Etcd
+metadata:
+  name: cluster
+spec:
+  managementState: Managed
+  unsupportedConfigOverrides:
+    useUnsupportedUnsafeNonHANonProductionUnstableEtcd: true
+`)
+
+var ingressSingleMasterData = []byte(`apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 1
+`)


### PR DESCRIPTION
Along with https://github.com/openshift/machine-config-operator/pull/1708 this enabled single master installations.

If master pool has a single replica unsupported etcd configuration is injected. Ingress replica is scaled to 1

/cc @LorbusChris 