### PR TITLE
Bug 1836042: set folder absolute path in vSphere cloud provider

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -147,14 +146,13 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 		}
 		cm.Data[cloudProviderConfigDataKey] = gcpConfig
 	case vspheretypes.Name:
-		var folderRelPath string
-		if len(installConfig.Config.Platform.VSphere.Folder) != 0 {
-			folderRelPath = strings.SplitAfterN(installConfig.Config.Platform.VSphere.Folder, "vm/", 2)[1]
+		folderPath := installConfig.Config.Platform.VSphere.Folder
+		if len(folderPath) == 0 {
+			dataCenter := installConfig.Config.Platform.VSphere.Datacenter
+			folderPath = fmt.Sprintf("/%s/vm/%s", dataCenter, clusterID.InfraID)
 		}
-
 		vsphereConfig, err := vspheremanifests.CloudProviderConfig(
-			clusterID.InfraID,
-			folderRelPath,
+			folderPath,
 			installConfig.Config.Platform.VSphere,
 		)
 		if err != nil {

--- a/pkg/asset/manifests/vsphere/cloudproviderconfig.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig.go
@@ -14,7 +14,9 @@ func printIfNotEmpty(buf *bytes.Buffer, k, v string) {
 }
 
 // CloudProviderConfig generates the cloud provider config for the vSphere platform.
-func CloudProviderConfig(clusterID, folderRelPath string, p *vspheretypes.Platform) (string, error) {
+// folderPath is the absolute path to the VM folder that will be used for installation.
+// p is the vSphere platform struct.
+func CloudProviderConfig(folderPath string, p *vspheretypes.Platform) (string, error) {
 	buf := new(bytes.Buffer)
 
 	fmt.Fprintln(buf, "[Global]")
@@ -27,10 +29,7 @@ func CloudProviderConfig(clusterID, folderRelPath string, p *vspheretypes.Platfo
 	printIfNotEmpty(buf, "server", p.VCenter)
 	printIfNotEmpty(buf, "datacenter", p.Datacenter)
 	printIfNotEmpty(buf, "default-datastore", p.DefaultDatastore)
-	printIfNotEmpty(buf, "folder", folderRelPath)
-	if p.Folder == "" {
-		printIfNotEmpty(buf, "folder", clusterID)
-	}
+	printIfNotEmpty(buf, "folder", folderPath)
 	fmt.Fprintln(buf, "")
 
 	fmt.Fprintf(buf, "[VirtualCenter %q]\n", p.VCenter)

--- a/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig_test.go
@@ -1,6 +1,7 @@
 package vsphere
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,8 +10,6 @@ import (
 )
 
 func TestCloudProviderConfig(t *testing.T) {
-	clusterName := "test-cluster"
-	folderRelPath := ""
 	platform := &vspheretypes.Platform{
 		VCenter:          "test-name",
 		Username:         "test-username",
@@ -27,12 +26,13 @@ insecure-flag = "1"
 server = "test-name"
 datacenter = "test-datacenter"
 default-datastore = "test-datastore"
-folder = "test-cluster"
+folder = "/test-datacenter/vm/clusterID"
 
 [VirtualCenter "test-name"]
 datacenters = "test-datacenter"
 `
-	actualConfig, err := CloudProviderConfig(clusterName, folderRelPath, platform)
+	folderPath := fmt.Sprintf("/%s/vm/%s", "test-datacenter", "clusterID")
+	actualConfig, err := CloudProviderConfig(folderPath, platform)
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }


### PR DESCRIPTION
This is a partial revision of 814f64f4bce13a1c4472a104f72b7658b0e76abe,
where we update to use an absolute path rather than a relative path.
Using a relative path results in an error when trying to provision a PVC
and a subfolder was used for install.