### PR TITLE
Bug 1798498: gather: enable bootstrap log gathering for baremetal

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/installer/pkg/terraform"
 	gatheraws "github.com/openshift/installer/pkg/terraform/gather/aws"
 	gatherazure "github.com/openshift/installer/pkg/terraform/gather/azure"
+	gatherbaremetal "github.com/openshift/installer/pkg/terraform/gather/baremetal"
 	gathergcp "github.com/openshift/installer/pkg/terraform/gather/gcp"
 	gatherlibvirt "github.com/openshift/installer/pkg/terraform/gather/libvirt"
 	gatheropenstack "github.com/openshift/installer/pkg/terraform/gather/openstack"
@@ -34,6 +35,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
+	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
 	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
@@ -183,6 +185,12 @@ func extractHostAddresses(config *types.InstallConfig, tfstate *terraform.State)
 		masters, err = gatherazure.ControlPlaneIPs(tfstate)
 		if err != nil {
 			logrus.Error(err)
+		}
+	case baremetaltypes.Name:
+		bootstrap = config.Platform.BareMetal.BootstrapProvisioningIP
+		masters, err = gatherbaremetal.ControlPlaneIPs(config, tfstate)
+		if err != nil {
+			return bootstrap, port, masters, err
 		}
 	case gcptypes.Name:
 		bootstrap, err = gathergcp.BootstrapIP(tfstate)

--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -4,6 +4,7 @@ provider "libvirt" {
 
 provider "ironic" {
   url          = "http://${var.bootstrap_provisioning_ip}:6385/v1"
+  inspector    = "http://${var.bootstrap_provisioning_ip}:5050/v1"
   microversion = "1.56"
   timeout      = 1500
 }

--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -46,3 +46,11 @@ resource "ironic_deployment" "openshift-master-deployment" {
   user_data     = var.ignition
 }
 
+data "ironic_introspection" "openshift-master-introspection" {
+  count = var.master_count
+
+  uuid = element(
+    ironic_node_v1.openshift-master-host.*.id,
+    count.index,
+  )
+}

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -21,7 +21,7 @@ done
 
 echo "Gathering bootstrap journals ..."
 mkdir -p "${ARTIFACTS}/bootstrap/journals"
-for service in release-image crio-configure bootkube kubelet crio approve-csr
+for service in release-image crio-configure bootkube kubelet crio approve-csr ironic master-update-bmh
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"
 done

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/metal3-io/cluster-api-provider-baremetal v0.0.0
 	github.com/mitchellh/cli v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6 // indirect
-	github.com/openshift-metal3/terraform-provider-ironic v0.2.0
+	github.com/openshift-metal3/terraform-provider-ironic v0.2.1
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/client-go v0.0.0-20200320150128-a906f3d8e723
 	github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e

--- a/go.sum
+++ b/go.sum
@@ -1768,8 +1768,8 @@ github.com/opencontainers/runtime-tools v0.9.0/go.mod h1:r3f7wjNzSs2extwzU3Y+6pK
 github.com/opencontainers/selinux v1.2.2/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.0/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openshift-metal3/terraform-provider-ironic v0.2.0 h1:MAImxv6UaTtvf2BkPG9YS+EvIqMsXQhNQNDfV7FE2D0=
-github.com/openshift-metal3/terraform-provider-ironic v0.2.0/go.mod h1:G79T6t60oBpYfZK/x960DRzYsNHdz5YVCHINx6QlmtU=
+github.com/openshift-metal3/terraform-provider-ironic v0.2.1 h1:K/tPSylailvH70zCR2zbugv+y/zs79a0Ri596sqS9nA=
+github.com/openshift-metal3/terraform-provider-ironic v0.2.1/go.mod h1:G79T6t60oBpYfZK/x960DRzYsNHdz5YVCHINx6QlmtU=
 github.com/openshift/api v0.0.0-20200413201024-c6e8c9b6eb9a h1:fIIKps4VKnxrXSp3lhgSatm5C1xb1qfMtJsmyr3iMXw=
 github.com/openshift/api v0.0.0-20200413201024-c6e8c9b6eb9a/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/baremetal-operator v0.0.0-20200206190020-71b826cc0f0a h1:65ZuRkPnQGh9uo0z93KosrPlwEWJNxUjxnuM9lyGBHc=

--- a/pkg/terraform/gather/baremetal/OWNERS
+++ b/pkg/terraform/gather/baremetal/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - baremetal-approvers
+reviewers:
+  - baremetal-reviewers

--- a/pkg/terraform/gather/baremetal/ip.go
+++ b/pkg/terraform/gather/baremetal/ip.go
@@ -1,0 +1,66 @@
+// Package baremetal contains utilities that help gather Baremetal specific
+// information from terraform state.
+package baremetal
+
+import (
+	"net"
+
+	"github.com/openshift/installer/pkg/terraform"
+	"github.com/openshift/installer/pkg/types"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// ControlPlaneIPs returns the ip addresses for control plane hosts, retrieved via Ironic introspection data. We prefer
+// to get an IP in a machine network, but will fallback to any valid IP returned by introspection data.
+func ControlPlaneIPs(config *types.InstallConfig, tfs *terraform.State) ([]string, error) {
+	mrs, err := terraform.LookupResource(tfs, "module.masters", "ironic_introspection", "openshift-master-introspection")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to lookup masters introspection data")
+	}
+
+	var errs []error
+	var masters []string
+
+	for idx, inst := range mrs.Instances {
+		interfaces, _, err := unstructured.NestedSlice(inst.Attributes, "interfaces")
+		if err != nil {
+			errs = append(errs, errors.Wrapf(err, "could not get interfaces for master-%d", idx))
+			continue
+		}
+
+		masterIP := ""
+		var ips []string
+
+		// Look at all interfaces -- if we find an IP in one of the machine networks, we've got the best IP. Otherwise,
+		// collect all the IP's and pick the first found.
+		for _, iface := range interfaces {
+			ipString, _, err := unstructured.NestedString(iface.(map[string]interface{}), "ip")
+			if err != nil {
+				continue
+			}
+
+			if ip := net.ParseIP(ipString); ip != nil {
+				for _, network := range config.MachineNetwork {
+					if network.CIDR.Contains(ip) {
+						masterIP = ipString
+						break
+					} else {
+						ips = append(ips, ipString)
+					}
+				}
+			}
+		}
+
+		if masterIP != "" {
+			masters = append(masters, masterIP)
+		} else if len(ips) > 0 {
+			masters = append(masters, ips[0])
+		} else {
+			errs = append(errs, errors.Wrapf(err, "could not get ip for master-%d", idx))
+		}
+	}
+
+	return masters, utilerrors.NewAggregate(errs)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1003,7 +1003,7 @@ github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/openshift-metal3/terraform-provider-ironic v0.2.0
+# github.com/openshift-metal3/terraform-provider-ironic v0.2.1
 github.com/openshift-metal3/terraform-provider-ironic/ironic
 # github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible => github.com/openshift/api v0.0.0-20200413201024-c6e8c9b6eb9a
 github.com/openshift/api/config/v1


### PR DESCRIPTION
This enables bootstrap log gathering for baremetal. We fetch the IP's
for the control plane hosts using ironic introspection data, and use
the provisioning IP for the bootstrap.

fixes #2009 