### PR TITLE
maintenance: remove pools and volumes

### DIFF
--- a/scripts/maintenance/virsh-cleanup.sh
+++ b/scripts/maintenance/virsh-cleanup.sh
@@ -9,7 +9,6 @@ then
 fi
 
 CONNECT="${CONNECT:=qemu:///system}"
-POOL="${POOL:=default}"
 
 run()
 {
@@ -23,13 +22,18 @@ do
 	run virsh -c "${CONNECT}" undefine "${DOMAIN}"
 done
 
-virsh -c "${CONNECT}" vol-list "${POOL}" | tail -n +3 | while read -r VOLUME _
+for POOL in $(virsh -c "${CONNECT}" pool-list --all --name)
 do
-	if test -z "${VOLUME}"
-	then
-		continue
-	fi
-	run virsh -c "${CONNECT}" vol-delete --pool "${POOL}" "${VOLUME}"
+	virsh -c "${CONNECT}" vol-list "${POOL}" | tail -n +3 | while read -r VOLUME _
+	do
+		if test -z "${VOLUME}"
+		then
+			continue
+		fi
+		run virsh -c "${CONNECT}" vol-delete --pool "${POOL}" "${VOLUME}"
+	done
+	run virsh -c "${CONNECT}" pool-destroy "${POOL}"
+	run virsh -c "${CONNECT}" pool-undefine "${POOL}"
 done
 
 for NET in $(virsh -c "${CONNECT}" net-list --all --name)


### PR DESCRIPTION
This will clean up all volumes under all non-default pools. The
openshift CI creates a pool for each cluster.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>