### PR TITLE
data/data/bootstrap/files/usr/local/bin/release-image-download: Drop --quiet

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
@@ -12,7 +12,7 @@ set -euo pipefail
 RELEASE_IMAGE={{.ReleaseImage}}
 
 echo "Pulling $RELEASE_IMAGE..."
-while ! podman pull --quiet "$RELEASE_IMAGE"
+while ! podman pull "$RELEASE_IMAGE"
 do
     echo "Pull failed. Retrying $RELEASE_IMAGE..."
 done


### PR DESCRIPTION
We've had the option since 9dfdc3cac9 (#1293).  But since d1ec85a5cc404 (#2234) that image pull has happened in a separate unit, so output will be in `journals/release-image.log` and not cluttering up `journals/bootkube.log`.  So get noisy again, to get information like:

```console
$ podman pull quay.io/openshift-release-dev/ocp-release-nightly@sha256:542a73a1c3a7ce5e8fa89ea3cd8a9c346dec1f0d437cf7e40bcb773683770be1
Trying to pull quay.io/openshift-release-dev/ocp-release-nightly@sha256:542a73a1c3a7ce5e8fa89ea3cd8a9c346dec1f0d437cf7e40bcb773683770be1...Failed
error pulling image "quay.io/openshift-release-dev/ocp-release-nightly@sha256:542a73a1c3a7ce5e8fa89ea3cd8a9c346dec1f0d437cf7e40bcb773683770be1": unable to pull quay.io/openshift-release-dev/ocp-release-nightly@sha256:542a73a1c3a7ce5e8fa89ea3cd8a9c346dec1f0d437cf7e40bcb773683770be1: unable to pull image: Error determining manifest MIME type for docker://quay.io/openshift-release-dev/ocp-release-nightly@sha256:542a73a1c3a7ce5e8fa89ea3cd8a9c346dec1f0d437cf7e40bcb773683770be1: unexpected http code: 500 (Internal Server Error), URL: https://quay.io/v2/auth?scope=repository%3Aopenshift-release-dev%2Focp-release-nightly%3Apull&service=quay.io
```

instead of silence like:

```
-- Logs begin at Tue 2020-05-19 18:47:10 UTC, end at Tue 2020-05-19 19:12:00 UTC. --
May 19 18:47:40 ip-10-0-29-43 systemd[1]: Starting Download the OpenShift Release Image...
May 19 18:47:40 ip-10-0-29-43 release-image-download.sh[1747]: Pulling quay.io/openshift-release-dev/ocp-release-nightly@sha256:542a73a1c3a7ce5e8fa89ea3cd8a9c346dec1f0d437cf7e40bcb773683770be1...
May 19 18:47:41 ip-10-0-29-43 podman[1749]: 2020-05-19 18:47:41.135323376 +0000 UTC m=+0.318008863 system refresh
```