### PR TITLE
oVirt: general improvements

### DIFF
--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -14,6 +14,7 @@ var defaultOvirtConfigPath = filepath.Join(os.Getenv("HOME"), ".config", "ovirt"
 // Config holds oVirt api access details
 type Config struct {
 	URL      string `yaml:"ovirt_url"`
+	FQDN     string `yaml:"ovirt_fqdn"`
 	PemURL   string `yaml:"ovirt_pem_url"`
 	Username string `yaml:"ovirt_username"`
 	Password string `yaml:"ovirt_password"`

--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -14,6 +14,7 @@ var defaultOvirtConfigPath = filepath.Join(os.Getenv("HOME"), ".ovirt", "ovirt-c
 // Config holds oVirt api access details
 type Config struct {
 	URL      string `yaml:"ovirt_url"`
+	PemURL   string `yaml:"ovirt_pem_url"`
 	Username string `yaml:"ovirt_username"`
 	Password string `yaml:"ovirt_password"`
 	CAFile   string `yaml:"ovirt_cafile,omitempty"`

--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 var defaultOvirtConfigEnvVar = "OVIRT_CONFIG"
-var defaultOvirtConfigPath = filepath.Join(os.Getenv("HOME"), ".ovirt", "ovirt-config.yaml")
+var defaultOvirtConfigPath = filepath.Join(os.Getenv("HOME"), ".config", "ovirt", "ovirt-config.yaml")
 
 // Config holds oVirt api access details
 type Config struct {

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/AlecAivazis/survey.v1"
 )
 
-// Check if URL can be reacheable before we proceed with the installation
+// Check if URL can be reached before we proceed with the installation
 // Parms:
 //	urlAddr - Full URL
 func checkUrlResponse(urlAddr string) {

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -12,7 +12,7 @@ import (
 // Check if URL can be reached before we proceed with the installation
 // Parms:
 //	urlAddr - Full URL
-func checkUrlResponse(urlAddr string) {
+func checkURLResponse(urlAddr string) {
 
 	logrus.Debug("Checking URL Response: ", urlAddr)
 	_, err := http.Get(urlAddr)
@@ -35,7 +35,7 @@ func askCredentials() (Config, error) {
 	if err != nil {
 		return c, err
 	}
-	checkUrlResponse(c.URL)
+	checkURLResponse(c.URL)
 
 	var ovirtCertTrusted bool
 	err = survey.AskOne(

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -2,11 +2,28 @@ package ovirt
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/AlecAivazis/survey.v1"
 )
+
+// Check if URL can be reacheable before we proceed with the installation
+// Parms:
+//	urlAddr - Full URL
+// Returns:
+//	err  - Error
+func checkUrlResponse(urlAddr string) (error) {
+
+	logrus.Debug("Checking URL Response: ", urlAddr)
+	_, err := http.Get(urlAddr)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	return err
+}
 
 func askCredentials() (Config, error) {
 	c := Config{}
@@ -22,6 +39,7 @@ func askCredentials() (Config, error) {
 	if err != nil {
 		return c, err
 	}
+	checkUrlResponse(c.URL)
 
 	var ovirtCertTrusted bool
 	err = survey.AskOne(

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -12,17 +12,13 @@ import (
 // Check if URL can be reacheable before we proceed with the installation
 // Parms:
 //	urlAddr - Full URL
-// Returns:
-//	err  - Error
-func checkUrlResponse(urlAddr string) (error) {
+func checkUrlResponse(urlAddr string) {
 
 	logrus.Debug("Checking URL Response: ", urlAddr)
 	_, err := http.Get(urlAddr)
 	if err != nil {
 		logrus.Fatal(err)
 	}
-
-	return err
 }
 
 func askCredentials() (Config, error) {

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -35,7 +35,6 @@ func askCredentials() (Config, error) {
 		return oVirtConfig, err
 	}
 
-
 	// Set c.URL with the API endpoint
 	oVirtConfig.URL = fmt.Sprintf(
 		"https://%s/ovirt-engine/api",

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -61,14 +61,15 @@ func askCredentials() (Config, error) {
 			// should have passed validation, this is unexpected
 			return c, err
 		}
-		pemURL := fmt.Sprintf(
+		c.PemURL = fmt.Sprintf(
 			"%s://%s/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA",
 			ovirtURL.Scheme,
 			ovirtURL.Host)
+		logrus.Debug("PEM URL: ", c.PemURL)
 
 		err = survey.AskOne(&survey.Multiline{
 			Message: "oVirt certificate bundle",
-			Help:    fmt.Sprintf("The oVirt certificate bundle can be downloaded from %s.", pemURL),
+			Help:    fmt.Sprintf("The oVirt certificate bundle can be downloaded from %s", c.PemURL),
 		},
 			&c.CABundle,
 			survey.ComposeValidators(survey.Required))

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -1,23 +1,100 @@
 package ovirt
 
 import (
+	"crypto/tls"
 	"fmt"
+	"io/ioutil"
+	"strings"
+	"strconv"
+	"os"
+	"os/exec"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/AlecAivazis/survey.v1"
 )
 
-// Check if URL can be reached before we proceed with the installation
-// Parms:
-//	urlAddr - Full URL
-func checkURLResponse(urlAddr string) {
+// Global vars for commands definitions
+const (
+	SUDO_BIN = "/usr/bin/sudo"
+	CP_BIN = "/usr/bin/cp"
+	TRUST_BIN = "/usr/bin/trust"
+	CURL_BIN = "/usr/bin/curl"
+	CHMOD_BIN = "/usr/bin/chmod"
+)
 
-	logrus.Debug("Checking URL Response: ", urlAddr)
-	_, err := http.Get(urlAddr)
-	if err != nil {
-		logrus.Fatal(err)
+// Check if URL can be reached before we proceed with the installation
+// Params:
+//	urlAddr - Full URL
+//	skipVerify - Do not try to validate cert
+func checkURLResponse(urlAddr string, skipVerify bool) {
+
+	logrus.Debugf("Checking URL Response... urlAddr: %s skipVerify: %s", urlAddr, strconv.FormatBool(skipVerify))
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify : skipVerify},
 	}
+
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(urlAddr)
+	if err != nil {
+		logrus.Fatalf("Error checking URL response: %s err: %s", urlAddr, err)
+	}
+	defer resp.Body.Close()
+}
+
+// Execute a command
+// Params:
+//	cmdName - Command name
+//	cmdArgs - Arguments for the command
+//
+// Return - stdout ([]byte)
+func execCommand(cmdName string, cmdArgs []string) ([]byte){
+	logrus.Debugf("Executing: %s %s ", cmdName, cmdArgs)
+	cmd := exec.Command(cmdName, cmdArgs...)
+	stdout, err := cmd.Output()
+	if err != nil {
+		logrus.Fatalf("Error executing the command: %s", err)
+	}
+
+	return stdout
+}
+
+// Check if CA is trusted locally
+// Params:
+//	fqdn - Fully qualified domain name
+//
+// Return:
+//	True  - CA is trusted
+//	False - CA is NOT trusted
+func checkCATrust(fqdn string) (bool){
+	logrus.Infof("Checking if %s CA is trusted locally...", fqdn)
+
+	LIST := []string {"list"}
+	stdout := execCommand(TRUST_BIN, LIST)
+
+	if strings.Contains(string(stdout), fqdn) {
+		logrus.Info("Detected: Engine CA as trusted locally...")
+		return true
+	}
+
+	logrus.Warningf("Engine: %s CA is NOT trusted locally...", fqdn)
+
+	return false
+}
+
+// Return file content
+// Params:
+//	filename - File name
+// Return:
+//	file content - []byte
+func fileContent(filename string) ([]byte){
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		logrus.Fatalf("Error reading file: %s Error: %s", filename, err)
+	}
+
+	return content
 }
 
 func askCredentials() (Config, error) {
@@ -25,8 +102,8 @@ func askCredentials() (Config, error) {
 	err := survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Input{
-				Message: "oVirt FQDN[:PORT]",
-				Help:    "The oVirt FQDN[:PORT] (ovirt.example.com:443)",
+				Message: "Engine FQDN[:PORT]",
+				Help:    "The Engine FQDN[:PORT] (engine.example.com:443)",
 			},
 			Validate: survey.ComposeValidators(survey.Required),
 		},
@@ -40,50 +117,82 @@ func askCredentials() (Config, error) {
 		"https://%s/ovirt-engine/api",
 		oVirtConfig.FQDN)
 
-	checkURLResponse(oVirtConfig.URL)
+	// Set PEM URL for Download
+	oVirtConfig.PemURL = fmt.Sprintf(
+		"https://%s/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA",
+		oVirtConfig.FQDN)
+	logrus.Debug("PEM URL: ", oVirtConfig.PemURL)
 
-	var ovirtCertTrusted bool
-	err = survey.AskOne(
+	// Simple http get to check if FQDN/URL are valid
+	checkURLResponse(oVirtConfig.URL, true)
+
+	// Check if CA is trusted locally
+	var importCACert bool = false
+	if checkCATrust(oVirtConfig.FQDN) {
+		oVirtConfig.Insecure = false
+	} else {
+		oVirtConfig.Insecure = true
+		message := fmt.Sprintf("Would you like to import Engine CA cert locally from: %s ?", oVirtConfig.PemURL)
+		err = survey.AskOne(
 		&survey.Confirm{
-			Message: "Is the oVirt CA trusted locally?",
-			Default: true,
-			Help:    "In order to securly communicate with the oVirt engine, the certificate authority must be trusted by the local system.",
+			Message: message,
+			Default: false,
+			Help:    "In order to securly communicate with the Engine, the certificate authority must be trusted by the local system.",
 		},
-		&ovirtCertTrusted,
+		&importCACert,
 		nil)
+	}
 	if err != nil {
 		return oVirtConfig, err
 	}
-	oVirtConfig.Insecure = !ovirtCertTrusted
 
-	if ovirtCertTrusted {
+	// If users request, let's work to import Engine CA locally
+	if importCACert == true {
+		logrus.Info("Downloading Engine CA cert from Engine...")
+		tmpFile, err := ioutil.TempFile(os.TempDir(), "engine-")
 		if err != nil {
-			// should have passed validation, this is unexpected
-			return oVirtConfig, err
+			fmt.Println("Cannot create temporary file", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		logrus.Debugf("CA cert temporary stored: %s", tmpFile.Name())
+
+		/* Build curl command */
+		OPTIONS_CURL := []string {"-k", oVirtConfig.PemURL, "-o", tmpFile.Name()}
+		execCommand(CURL_BIN, OPTIONS_CURL)
+		logrus.Debugf("PEM file: %s", tmpFile.Name())
+		logrus.Debug(string(fileContent(tmpFile.Name())))
+
+		/* Check if CA file already exists */
+		CA_FULL_PATH := fmt.Sprintf("/etc/pki/ca-trust/source/anchors/%s.pem", strings.ReplaceAll(oVirtConfig.FQDN, ".", "-"))
+		if _, err := os.Stat(CA_FULL_PATH); err == nil {
+			logrus.Fatalf("%s already exists, cannot import CA!", CA_FULL_PATH)
 		}
 
-		oVirtConfig.PemURL = fmt.Sprintf(
-			"https://%s/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA",
-			oVirtConfig.FQDN)
-		logrus.Debug("PEM URL: ", oVirtConfig.PemURL)
+		/* Copy the CA to anchors */
+		CA_TO_ANCHORS := []string {CP_BIN, tmpFile.Name(), CA_FULL_PATH}
+		execCommand(SUDO_BIN, CA_TO_ANCHORS)
 
-		err = survey.AskOne(&survey.Multiline{
-			Message: "oVirt certificate bundle",
-			Help:    fmt.Sprintf("The oVirt certificate bundle can be downloaded from %s", oVirtConfig.PemURL),
-		},
-			&oVirtConfig.CABundle,
-			survey.ComposeValidators(survey.Required))
-		if err != nil {
-			return oVirtConfig, err
-		}
-	} else {
-		logrus.Warning("Communication with the oVirt engine will be insecure.")
+		/* chmod to allow non root users to read the cert */
+		PERMS_PEMFILE := []string {CHMOD_BIN, "0644", CA_FULL_PATH}
+		execCommand(SUDO_BIN, PERMS_PEMFILE)
+
+		/* Update CA database */
+		UPDATE_CA_TRUST := []string {"/usr/bin/update-ca-trust"}
+		execCommand(SUDO_BIN, UPDATE_CA_TRUST)
+		oVirtConfig.Insecure = false
+		logrus.Infof("%s imported with success!", CA_FULL_PATH)
 	}
 
+	if oVirtConfig.Insecure == true {
+		logrus.Warning("Communication with the Engine will be insecure.")
+	}
+
+	// Ask Engine credentials
 	err = survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Input{
-				Message: "oVirt engine username",
+				Message: "Engine username",
 				Help:    "The user must have permissions to create VMs and disks on the Storage Domain with the same name as the OpenShift cluster.",
 				Default: "admin@internal",
 			},
@@ -97,7 +206,7 @@ func askCredentials() (Config, error) {
 	err = survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Password{
-				Message: "oVirt engine password",
+				Message: "Engine password",
 				Help:    "",
 			},
 			Validate: survey.ComposeValidators(survey.Required, authenticated(&oVirtConfig)),


### PR DESCRIPTION
- ovirt: add checkUrlResponse() for credentials
- ovirt: add PEM URL to config struct
- ovirt: yaml file stored in ${HOME}/.config/ovirt/
- ovirt: Ask users FQDN instead of API url
- ovirt: additional improvements
       - Auto-detect if users already have locally imported CA from engine
      - In case the CA Cert is not locally imported, offer to user to
        download and import automatically
      - Remove the need of copy/past certificate, auto download and install
        cert (if user allow)
      - Replace oVirt string to Engine as it is common name in upstream and
        downstream