### PR TITLE
Warn about security risks of the recommended libvirt install configuration

### DIFF
--- a/docs/dev/libvirt/README.md
+++ b/docs/dev/libvirt/README.md
@@ -129,8 +129,14 @@ errors. Double check that `security_driver = "none"` line is present in
 `/etc/libvirt/qemu.conf` and not commented out.
 
 #### Configure the service runner to pass `--listen` to libvirtd
-In addition to the config, you'll have to pass an additional command-line
-argument to libvirtd. On Fedora, modify `/etc/sysconfig/libvirtd` and set:
+
+**NOTE:** if the installation of libvirt included support for socket
+activation via the `libvirt-tcp.socket` systemd unit, the `--listen`
+argument should not be added and thus this step can be skipped.
+
+If socket activation is not available, you'll have to pass an additional
+command-line argument to libvirtd. On Red Hat based distros, modify
+`/etc/sysconfig/libvirtd` and set:
 
 ```
 LIBVIRTD_ARGS="--listen"

--- a/docs/dev/libvirt/README.md
+++ b/docs/dev/libvirt/README.md
@@ -100,8 +100,6 @@ auth_tcp="none"
 tcp_port = "16509"
 ```
 
-Note that authentication is not currently supported, but should be soon.
-
 On Fedora 31, you also need to enable and start the libvirtd TCP
 socket, which is managed by systemd:
 
@@ -111,6 +109,16 @@ sudo systemctl start libvirtd-tcp.socket
 ```
 
 after which you need to restart libvirtd.
+
+**NOTE:** that the above configuration disables all encryption and
+authentication options in libvirtd and causes it to listen on all
+network interfaces and IP addresses. **A connection to this privileged
+libvirtd gives the client privileges equivalent to those of a root
+shell.** This configuration has a security impact on a par with
+running a telnet server with no root password set. It is critical
+to follow the steps below to **configure the firewall to prevent
+access to libvirt from other hosts on the LAN/WAN**.
+
 
 #### Configure qemu.conf
 

--- a/docs/dev/libvirt/README.md
+++ b/docs/dev/libvirt/README.md
@@ -30,7 +30,7 @@ repository to ensure you get a new enough version of qemu-kvm.
 On Fedora, CentOS/RHEL:
 
 ```sh
-sudo yum install libvirt libvirt-devel libvirt-daemon-kvm qemu-kvm
+sudo yum install libvirt-devel libvirt-daemon-kvm libvirt-client
 ```
 
 Then start libvirtd:


### PR DESCRIPTION
The libvirt installer documentation is recommending a highly insecure configuration of libvirtd, with no auth or encryption, listening on all IP addresses, which gives clients prives equiv to a root shell. It does give some sense of this being an insecure config, but doesn't spell out the full implications to users following the doc. So this adds a much more explicit warning about the risks to fully inform users.

A few other minor improvements were made too.