### PR TITLE
Bug 1838631: Set validations for GCP disk sizes.

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -165,7 +165,8 @@ spec:
                               description: DiskSizeGB defines the size of disk in
                                 GB.
                               format: int64
-                              minimum: 0
+                              maximum: 65536
+                              minimum: 16
                               type: integer
                             DiskType:
                               description: DiskType defines the type of disk. The
@@ -451,7 +452,8 @@ spec:
                           DiskSizeGB:
                             description: DiskSizeGB defines the size of disk in GB.
                             format: int64
-                            minimum: 0
+                            maximum: 65536
+                            minimum: 16
                             type: integer
                           DiskType:
                             description: DiskType defines the type of disk. The valid
@@ -1055,7 +1057,8 @@ spec:
                           DiskSizeGB:
                             description: DiskSizeGB defines the size of disk in GB.
                             format: int64
-                            minimum: 0
+                            maximum: 65536
+                            minimum: 16
                             type: integer
                           DiskType:
                             description: DiskType defines the type of disk. The valid

--- a/docs/user/gcp/customization.md
+++ b/docs/user/gcp/customization.md
@@ -14,7 +14,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `type` (optional string): The [GCP machine type][machine-type].
 * `zones` (optional array of strings): The availability zones used for machines in the pool.
 * `osDisk` (optional object):
-    * `diskSizeGB` (optional integer): The size of the disk in gigabytes (GB).
+    * `diskSizeGB` (optional integer): The size of the disk in gigabytes (GB) (Minimum: 16GB, Maximum: 65536GB).
     * `diskType` (optional string): The type of disk (allowed values are: `pd-ssd`, and `pd-standard`. Default: `pd-ssd`).
 
 ## Installing to Existing Networks & Subnetworks

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -30,7 +30,8 @@ type OSDisk struct {
 
 	// DiskSizeGB defines the size of disk in GB.
 	//
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=16
+	// +kubebuilder:validation:Maximum=65536
 	DiskSizeGB int64 `json:"DiskSizeGB"`
 }
 

--- a/pkg/types/gcp/validation/machinepool.go
+++ b/pkg/types/gcp/validation/machinepool.go
@@ -18,9 +18,12 @@ func ValidateMachinePool(platform *gcp.Platform, p *gcp.MachinePool, fldPath *fi
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("zones").Index(i), zone, fmt.Sprintf("Zone not in configured region (%s)", platform.Region)))
 		}
 	}
-
-	if p.OSDisk.DiskSizeGB < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), p.OSDisk.DiskSizeGB, "must be a positive value"))
+	if p.OSDisk.DiskSizeGB != 0 {
+		if p.OSDisk.DiskSizeGB < 16 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), p.OSDisk.DiskSizeGB, "must be at least 16GB in size"))
+		} else if p.OSDisk.DiskSizeGB > 65536 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGB"), p.OSDisk.DiskSizeGB, "exceeding maximum GCP disk size limit, must be below 65536"))
+		}
 	}
 
 	if p.OSDisk.DiskType != "" {

--- a/pkg/types/gcp/validation/machinepool_test.go
+++ b/pkg/types/gcp/validation/machinepool_test.go
@@ -59,13 +59,31 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid disk type",
+			name: "invalid disk size",
 			pool: &gcp.MachinePool{
 				OSDisk: gcp.OSDisk{
 					DiskSizeGB: -120,
 				},
 			},
-			expected: `^test-path\.diskSizeGB: Invalid value: -120: must be a positive value$`,
+			expected: `^test-path\.diskSizeGB: Invalid value: -120: must be at least 16GB in size$`,
+		},
+		{
+			name: "insufficient disk size",
+			pool: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskSizeGB: 11,
+				},
+			},
+			expected: `^test-path\.diskSizeGB: Invalid value: 11: must be at least 16GB in size$`,
+		},
+		{
+			name: "exceeded disk size",
+			pool: &gcp.MachinePool{
+				OSDisk: gcp.OSDisk{
+					DiskSizeGB: 66000,
+				},
+			},
+			expected: `^test-path\.diskSizeGB: Invalid value: 66000: exceeding maximum GCP disk size limit, must be below 65536$`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Current disk size restrictions for GCP is set to be above 0.
The current size of the image is 16GB and hence the disk sizes
must at least be 16GB. Also, the maximum disk size limit on GCP
is 65536GB so users must not be allowed to create disks above that
limit. Added the validations to the install config input for GCP.