### PR TITLE
OWNER_ALIASES: ensure there are atleast 2 reviewers for each platform

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,33 +8,34 @@ aliases:
     - smarterclayton
     - wking
   installer-reviewers:
-    - fabianofranz
-    - jcpowermac
     - jhixson74
     - jstuever
     - mtnbikenc
     - patrickdillon
   libvirt-approvers:
-    - abhinavdahiya
-    - enxebre
+    - praveenkumar
+  libvirt-reviewers:
     - praveenkumar
     - zeenix
-  libvirt-reviewers:
   openstack-approvers:
     - Fedosin
     - adduarte
     - iamemilio
     - mandre
     - pierreprinetti
-    - tomassedovic
   openstack-reviewers:
+    - Fedosin
+    - iamemilio
+    - mandre
   vsphere-approvers:
-    - abhinavdahiya
     - dav1x
     - mtnbikenc
     - jcpowermac
-    - staebler
+    - patrickdillon
   vsphere-reviewers:
+    - mtnbikenc
+    - jcpowermac
+    - patrickdillon
   baremetal-approvers:
     - hardys
     - stbenjam
@@ -48,14 +49,20 @@ aliases:
     - jstuever
     - patrickdillon
   aws-reviewers:
+    - jstuever
+    - patrickdillon
   gcp-approvers:
     - jstuever
     - patrickdillon
   gcp-reviewers:
+    - jstuever
+    - patrickdillon
   azure-approvers:
     - fabianofranz
     - jhixson74
   azure-reviewers:
+    - fabianofranz
+    - jhixson74
   ovirt-approvers:
     - rgolangh
   ovirt-reviewers:


### PR DESCRIPTION
blunderbuss uses the nearest OWNERS file to calculate the reviewers for PR. Since there are only
platform approvers, all the PRs end up assigned to installer-reviewers.

From now on we should,
- ensure there are at least 2 revierwers when we define a OWNERS file
- duplicates in approvers and reviewers is acceptable, mimicing the approvers as reviewers should be the fine for now.

/cc @openshift/openshift-team-installer 