### PR TITLE
Adding a few people to the ARO team to our list of reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -61,12 +61,16 @@ aliases:
     - fabianofranz
     - jhixson74
   azure-reviewers:
+    - asalkeld
+    - ehashman
     - fabianofranz
     - jhixson74
+    - jim-minter
+    - mjudeikis
   ovirt-approvers:
     - rgolangh
   ovirt-reviewers:
-    - rgolangh
-    - Gal-Zaidman
     - dougsland
+    - Gal-Zaidman
     - gekorob
+    - rgolangh


### PR DESCRIPTION
This is one way we'll help them stay in the loop with architectural changes.