### PR TITLE
[fcos] Prevent crio from pulling the pause image. The crio-configure.service should test if crio already is installed before patching its config.

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
@@ -10,8 +10,11 @@ set -euo pipefail
 
 . /usr/local/bin/release-image.sh
 
-MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
+if [[ -d "/etc/crio" ]]; then
+  MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
-sed --in-place --expression "s,pause_image *=.*,pause_image = \"${MACHINE_CONFIG_INFRA_IMAGE}\"," /etc/crio/crio.conf
-sed --in-place --expression 's,pause_command *=.*,pause_command = "/usr/bin/pod",' /etc/crio/crio.conf
-sed --in-place --expression 's,"/usr/share/containers/oci/hooks.d","/etc/containers/oci/hooks.d",' /etc/crio/crio.conf
+  sed --in-place --expression "s,pause_image *=.*,pause_image = \"${MACHINE_CONFIG_INFRA_IMAGE}\"," /etc/crio/crio.conf
+  sed --in-place --expression 's,pause_command *=.*,pause_command = "/usr/bin/pod",' /etc/crio/crio.conf
+  sed --in-place --expression 's,"/usr/share/containers/oci/hooks.d","/etc/containers/oci/hooks.d",' /etc/crio/crio.conf
+fi
+

--- a/data/data/bootstrap/systemd/units/bootkube.service
+++ b/data/data/bootstrap/systemd/units/bootkube.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Bootstrap a Kubernetes cluster
-After=release-image.service
+Requires=crio-configure.service
+Wants=kubelet.service
+After=kubelet.service crio-configure.service
 ConditionPathExists=!/opt/openshift/.bootkube.done
 
 [Service]


### PR DESCRIPTION
Hi,

as default crio configures a pause image *k8s.gcr.io/pause:3.1* which is pulled from the internet at the first start of crio. This creates problems if OKD is installed in an offline scenario without access to the internet.

This was initially fixed by patching this image name last year but the fix was overwritten here:

https://github.com/openshift/installer/commit/112ac42637836367e829a3653e7470e68054aea6#diff-bf9773415bdef6d66a4de7fa216472c4

To make it work again I had to revert this change to bootkube.service and added a check for the directory */etc/crio* before the pause images name will be patched.

I tested that with a local vSphere installation. The pause image is not pulled from the internet, the cluster installation finished without problems (also in an offline environment from a mirror registry).

Greetings,

Josef