### PR TITLE
Bug 1821151: oVirt, fix rhcos os_type name

### DIFF
--- a/data/data/ovirt/template/main.tf
+++ b/data/data/ovirt/template/main.tf
@@ -50,7 +50,7 @@ resource "ovirt_vm" "tmp_import_vm" {
     interface = "virtio_scsi"
   }
   os {
-    type = "rhcos_x86"
+    type = "rhcos_x64"
   }
   nics {
     name            = "nic1"


### PR DESCRIPTION
On [1] we sent a patch to add the rchos os type,
the string we gave was wrong which caused the tepmplate to be created with the wrong OS type
This patch fixes the problem

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>