### PR TITLE
[release-4.4] Bug 1838885: installconfig: relax GCP cluster id restriction

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -43,7 +43,7 @@ resource "google_compute_firewall" "bootstrap_ingress_ssh" {
 resource "google_compute_instance" "bootstrap" {
   count = var.bootstrap_enabled ? 1 : 0
 
-  name         = "${var.cluster_id}-b"
+  name         = "${var.cluster_id}-bootstrap"
   machine_type = var.machine_type
   zone         = var.zone
 

--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -31,7 +31,7 @@ resource "google_project_iam_member" "master-service-account-user" {
 resource "google_compute_instance" "master" {
   count = var.instance_count
 
-  name         = "${var.cluster_id}-m-${count.index}"
+  name         = "${var.cluster_id}-master-${count.index}"
   machine_type = var.machine_type
   zone         = element(var.zones, count.index)
 

--- a/pkg/asset/installconfig/clusterid.go
+++ b/pkg/asset/installconfig/clusterid.go
@@ -9,7 +9,6 @@ import (
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/openshift/installer/pkg/asset"
-	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 )
 
 const (
@@ -43,11 +42,6 @@ func (a *ClusterID) Generate(dep asset.Parents) error {
 	// resource using InfraID usually have suffixes like `[-/_][a-z]{3,4}` eg. `_int`, `-ext` or `-ctlp`
 	// and the maximum length for most resources is approx 32.
 	maxLen := 27
-	switch ica.Config.Platform.Name() {
-	case gcptypes.Name:
-		// GCP has stricter limit on instance names which are prefixed with infra-id
-		maxLen = 12
-	}
 
 	// add random chars to the end to randomize
 	a.InfraID = generateInfraID(ica.Config.ObjectMeta.Name, maxLen)

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -45,7 +45,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "openshift-machine-api",
-				Name:      fmt.Sprintf("%s-%s-%d", clusterID, pool.Name[:1], idx),
+				Name:      fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, idx),
 				Labels: map[string]string{
 					"machine.openshift.io/cluster-api-cluster":      clusterID,
 					"machine.openshift.io/cluster-api-machine-role": role,

--- a/pkg/asset/machines/gcp/machinesets.go
+++ b/pkg/asset/machines/gcp/machinesets.go
@@ -42,7 +42,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
-		name := fmt.Sprintf("%s-%s-%s", clusterID, pool.Name[:1], strings.TrimPrefix(az, fmt.Sprintf("%s-", platform.Region)))
+		name := fmt.Sprintf("%s-%s-%s", clusterID, pool.Name, strings.TrimPrefix(az, fmt.Sprintf("%s-", platform.Region)))
 		mset := &machineapi.MachineSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.openshift.io/v1beta1",


### PR DESCRIPTION
#### installconfig: relax GCP cluster id restriction
(clean cherry-pick from https://github.com/openshift/installer/pull/3643)

The infra id of the clusters on GCP was reduced to 12 in #2088 because we couldn't handle the hostname seen by rhcos machine to be greater than 64.
More details on this are available in https://bugzilla.redhat.com/show_bug.cgi?id=1809345

now since BZ 1809345 is fixed by openshift/machine-config-operator#1711 and openshift/cluster-api-provider-gcp#88 the installer can relax the restriction on the infra-id to match the other platforms.

Why is it important?

On GCP all resources are prefixed with infra-id, which currently is 12 chars with 6 chars used by random bit, leaving only 6 chars from cluster name. This causes trouble associating the cluster to jobs in CI as most of the identifyable characters are dropped from the resource names in CI due to this restriction.

Also because of the previous restriction, only one char are used from pool's name, making is higly likely to collide in cases there are more.

#### pkg/destroy/gcp: ensure cluster service accounts and policy bindings are cleared
(clean cherry-pick from https://github.com/openshift/installer/pull/3646)
service account names or the name in it's email has max length of 30 and therefore using it for identifying makes it diffcult.
service account's displayName has 100 char limit and therefore using that ensure we can identity the service accounts much better.
The change checks both the email, and displayName to figure out if cluster id is prefixed.

secondly project iam policy only have service account email, and therefore to clean up members correctly, the change now lists the service accounts in the project for the cluster and
then uses that to check if a member of the policy maps to servce account of the cluster.

