### PR TITLE
BUG 1839896: ovirt: General Improvements

### DIFF
--- a/data/data/ovirt/bootstrap/variables.tf
+++ b/data/data/ovirt/bootstrap/variables.tf
@@ -4,12 +4,12 @@ variable "cluster_id" {
 
 variable "ovirt_cluster_id" {
   type        = string
-  description = "The ID of oVirt's cluster"
+  description = "The ID of Cluster"
 }
 
 variable "ovirt_template_id" {
   type        = string
-  description = "The ID of oVirt's VM template"
+  description = "The ID of VM template"
 }
 
 variable "ignition_bootstrap" {

--- a/data/data/ovirt/masters/variables.tf
+++ b/data/data/ovirt/masters/variables.tf
@@ -14,12 +14,12 @@ variable "master_count" {
 
 variable "ovirt_cluster_id" {
   type        = string
-  description = "The ID of oVirt's cluster"
+  description = "The ID of Cluster"
 }
 
 variable "ovirt_template_id" {
   type        = string
-  description = "The ID of oVirt's VM template"
+  description = "The ID of VM template"
 }
 
 variable "ignition_master" {

--- a/data/data/ovirt/template/variables.tf
+++ b/data/data/ovirt/template/variables.tf
@@ -4,12 +4,12 @@ variable "cluster_id" {
 
 variable "ovirt_cluster_id" {
   type        = string
-  description = "The ID of oVirt's cluster"
+  description = "The ID of Cluster"
 }
 
 variable "ovirt_storage_domain_id" {
   type        = string
-  description = "The ID of oVirt's storage domain"
+  description = "The ID of Storage Domain"
 }
 
 variable "ignition_bootstrap" {
@@ -30,10 +30,10 @@ variable "openstack_base_image_local_file_path" {
 
 variable "ovirt_network_name" {
   type        = string
-  description = "The name of ovirt's logical network for the selected ovirt cluster."
+  description = "The name of Logical Network for the selected Cluster."
 }
 
 variable "ovirt_vnic_profile_id" {
   type        = string
-  description = "The ID of the vnic profile of ovirt's logical network."
+  description = "The ID of the vNIC profile of Logical Network."
 }

--- a/data/data/ovirt/variables-ovirt.tf
+++ b/data/data/ovirt/variables-ovirt.tf
@@ -6,27 +6,27 @@ variable "bootstrap_dns" {
 
 variable "ovirt_url" {
   type        = string
-  description = "The oVirt engine URL"
+  description = "The Engine URL"
 }
 
 variable "ovirt_username" {
   type        = string
-  description = "The name of user to access oVirt engine API"
+  description = "The name of user to access Engine API"
 }
 
 variable "ovirt_password" {
   type        = string
-  description = "The plain password of user to access oVirt engine API"
+  description = "The plain password of user to access Engine API"
 }
 
 variable "ovirt_cluster_id" {
   type        = string
-  description = "The ID of oVirt's cluster"
+  description = "The ID of Cluster"
 }
 
 variable "ovirt_storage_domain_id" {
   type        = string
-  description = "The ID of oVirt's stoage domain for the template"
+  description = "The ID of Storage Domain for the template"
 }
 
 variable "openstack_base_image_name" {
@@ -43,12 +43,12 @@ variable "openstack_base_image_local_file_path" {
 variable "ovirt_network_name" {
   type        = string
   default     = "ovirtmgmt"
-  description = "The name of ovirt's logical network for the selected ovirt cluster."
+  description = "The name of Logical Network for the selected Engine cluster."
 }
 
 variable "ovirt_vnic_profile_id" {
   type        = string
-  description = "The ID of the vnic profile of ovirt's logical network."
+  description = "The ID of the vNIC profile of Logical Network."
 }
 
 variable "ovirt_master_memory" {

--- a/docs/user/ovirt/customization.md
+++ b/docs/user/ovirt/customization.md
@@ -4,8 +4,8 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 ## Cluster-scoped properties
 
-* `ovirt_cluster_id` (required string): The oVirt cluster where the VMs will be created.
-* `ovirt_storage_domain_id` (required string): The storage domain ID where the VM disks will be created.
+* `ovirt_cluster_id` (required string): The Cluster where the VMs will be created.
+* `ovirt_storage_domain_id` (required string): The Storage Domain ID where the VM disks will be created.
 * `ovirt_network_name` (required string): The network name where the VM nics will be created.
 * `vnicProfileID` (required string): The ID of the [vNic profile][vnic-profile] used for the VM network interfaces.
     This can be inferred if the cluster network has a single profile.
@@ -36,7 +36,7 @@ For examples of platform-agnostic configuration fragments, see [here](../customi
 
 ### Minimal
 
-An example minimal oVirt install config is:
+An example minimal install config is:
 
 ```yaml
 apiVersion: v1
@@ -58,7 +58,7 @@ sshKey: ssh-ed25519 AAAA...
 
 ### Custom machine pools
 
-An example oVirt install config with custom machine pools:
+An example install config with custom machine pools:
 
 ```yaml
 apiVersion: v1

--- a/docs/user/ovirt/install_ipi.md
+++ b/docs/user/ovirt/install_ipi.md
@@ -48,7 +48,7 @@ The default master/worker:
 - 16 RAM
 - 120 GB disk
 
-For 3 masters/3 workers, the target oVirt cluster must have at least:
+For 3 masters/3 workers, the target Cluster **must have at least**:
 - 96RAM
 - 24vCPUs
 - 720GiB storage
@@ -117,10 +117,10 @@ Continue the installation using the install-config in the new folder `install_di
 $ openshift-install create cluster --dir=install_dir
 ``` 
 
-When the all prompts are done the installer will create 3 VMs under the oVirt
-cluster supplied, and another VM as the bootstrap node. 
+When the all prompts are done the installer will create 3 VMs under the
+Cluster supplied, and another VM as the bootstrap node.
 The bootstrap will perform ignition fully and will advertise the IP in the
-pre-login msg. Go to oVirt webadmin UI, and open the console of the bootstrap
+pre-login msg. Go to Engine webadmin UI, and open the console of the bootstrap
 VM to get it. 
 In the end the installer finishes and the cluster should be up.
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -433,10 +433,10 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				installConfig.Config.Platform.Ovirt.ClusterID,
 				installConfig.Config.Platform.Ovirt.NetworkName)
 			if err != nil {
-				return errors.Wrapf(err, "failed to compute values for oVirt platform")
+				return errors.Wrapf(err, "failed to compute values for Engine platform")
 			}
 			if len(profiles) != 1 {
-				return errors.Wrapf(err, "failed to compute values for oVirt platform, there are multiple vNic profiles.")
+				return errors.Wrapf(err, "failed to compute values for Engine platform, there are multiple vNIC profiles.")
 			}
 			installConfig.Config.Platform.Ovirt.VNICProfileID = profiles[0].MustId()
 		}

--- a/pkg/asset/installconfig/ovirt/client.go
+++ b/pkg/asset/installconfig/ovirt/client.go
@@ -28,11 +28,11 @@ func getConnection(ovirtConfig Config) (*ovirtsdk.Connection, error) {
 func NewConnection() (*ovirtsdk.Connection, error) {
 	ovirtConfig, err := NewConfig()
 	if err != nil {
-		return nil, errors.Wrap(err, "getting ovirt configuration")
+		return nil, errors.Wrap(err, "getting Engine configuration")
 	}
 	con, err := getConnection(ovirtConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "establishing ovirt connection")
+		return nil, errors.Wrap(err, "establishing Engine connection")
 	}
 	return con, nil
 }

--- a/pkg/asset/installconfig/ovirt/cluster.go
+++ b/pkg/asset/installconfig/ovirt/cluster.go
@@ -32,7 +32,7 @@ func askCluster(c *ovirtsdk4.Connection, p *ovirt.Platform) (string, error) {
 		}
 		clusterSlice := clusters.MustClusters()
 		for _, cluster := range clusterSlice.Slice() {
-			fmt.Println("\tCluster:", cluster.MustName())
+			logrus.Debug("\tCluster:", cluster.MustName())
 			clusterByNames[cluster.MustName()] = cluster
 			clusterNames = append(clusterNames, cluster.MustName())
 		}

--- a/pkg/asset/installconfig/ovirt/cluster.go
+++ b/pkg/asset/installconfig/ovirt/cluster.go
@@ -29,8 +29,8 @@ func askCluster(c *ovirtsdk4.Connection, p *ovirt.Platform) (string, error) {
 		clusterNames = append(clusterNames, cluster.MustName())
 	}
 	err = survey.AskOne(&survey.Select{
-		Message: "oVirt cluster",
-		Help:    "The oVirt cluster where the VMs will be created.",
+		Message: "Cluster",
+		Help:    "The Cluster where the VMs will be created.",
 		Options: clusterNames,
 	},
 		&clusterName,

--- a/pkg/asset/installconfig/ovirt/cluster.go
+++ b/pkg/asset/installconfig/ovirt/cluster.go
@@ -17,7 +17,12 @@ func askCluster(c *ovirtsdk4.Connection, p *ovirt.Platform) (string, error) {
 	var clusterNames []string
 	systemService := c.SystemService()
 
-	dcResp, err := datacentersAvailable(c, "status=up")
+	dcOptions := dataCenterConfig{
+		conn:         c,
+		searchFilter: "",
+	}
+
+	dcResp, err := datacentersAvailable(dcOptions)
 	if err != nil {
 		return "Failed to search Cluster available in the DataCenters!", err
 	}

--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -14,6 +14,7 @@ var defaultOvirtConfigPath = filepath.Join(os.Getenv("HOME"), ".ovirt", "ovirt-c
 // Config holds oVirt api access details
 type Config struct {
 	URL      string `yaml:"ovirt_url"`
+	FQDN     string `yaml:"ovirt_fqdn"`
 	PemURL   string `yaml:"ovirt_pem_url"`
 	Username string `yaml:"ovirt_username"`
 	Password string `yaml:"ovirt_password"`

--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -14,6 +14,7 @@ var defaultOvirtConfigPath = filepath.Join(os.Getenv("HOME"), ".ovirt", "ovirt-c
 // Config holds oVirt api access details
 type Config struct {
 	URL      string `yaml:"ovirt_url"`
+	PemURL   string `yaml:"ovirt_pem_url"`
 	Username string `yaml:"ovirt_username"`
 	Password string `yaml:"ovirt_password"`
 	CAFile   string `yaml:"ovirt_cafile,omitempty"`

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -173,18 +173,21 @@ func askUsername() error {
 }
 
 // askCredentials will handle username and password for connecting with Engine
-// In case of error during password, users will be prompted username again.
 func askCredentials() error {
-	err := askUsername()
-	if err != nil {
-		return err
-	}
 
-	err = askPassword()
-	if err != nil {
-		return askUsername()
-	}
+	loginAttempts := 3
+	for loginAttempts > 0 {
+		logrus.Debugf("Login attempts %d...", loginAttempts)
+		err := askUsername()
+		if err != nil {
+			return err
+		}
 
+		err = askPassword()
+		if err != nil {
+			loginAttempts = loginAttempts - 1
+		}
+	}
 	return nil
 }
 

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -1,67 +1,212 @@
 package ovirt
 
 import (
+	"crypto/tls"
 	"fmt"
-	"net/url"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/AlecAivazis/survey.v1"
 )
 
+// commands definitions
+const (
+	SudoCommand  = "/usr/bin/sudo"
+	CpCommand    = "/usr/bin/cp"
+	TrustCommand = "/usr/bin/trust"
+	CurlCommand  = "/usr/bin/curl"
+	ChmodCommand = "/usr/bin/chmod"
+)
+
+// checkURLResponse performs a GET on the provided urlAddr to ensure that
+// the url actually exists. Users can set skipVerify as true or false to
+// avoid cert validation. In case of failure, returns error.
+func checkURLResponse(urlAddr string, skipVerify bool) error {
+
+	logrus.Debugf("Checking URL Response... urlAddr: %s skipVerify: %s", urlAddr, strconv.FormatBool(skipVerify))
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+	}
+
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(urlAddr)
+	if err != nil {
+		return errors.Wrapf(err, "Error checking URL response")
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+// execCommand executes a command from cmdName with args
+// provided from cmdArgs. Returns the stdout in []byte and error or nil
+func execCommand(cmdName string, cmdArgs ...string) ([]byte, error) {
+	logrus.Debugf("Executing: %s %s ", cmdName, cmdArgs)
+	cmd := exec.Command(cmdName, cmdArgs...)
+	stdout, err := cmd.Output()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error executing the command")
+	}
+
+	return stdout, nil
+}
+
+// checkCATrust executes trust list command to validate if fqdn
+// provided is trusted locally. Returns true/false and error in case of
+// failure
+func checkCATrust(fqdn string) (bool, error) {
+	logrus.Infof("Checking if %s CA is trusted locally...", fqdn)
+
+	stdout, err := execCommand(TrustCommand, "list")
+	if err != nil {
+		return false, errors.Wrapf(err, "Cannot execute command: %s", TrustCommand)
+	}
+
+	if strings.Contains(string(stdout), fqdn) {
+		logrus.Info("Detected: Engine CA as trusted locally...")
+		return true, nil
+	}
+
+	logrus.Warningf("Engine: %s CA is NOT trusted locally...", fqdn)
+
+	return false, nil
+}
+
+// fileContent receives filename as argument and return the content as []byte
+func fileContent(filename string) ([]byte, error) {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error reading file: %s", filename)
+	}
+
+	return content, nil
+}
+
 func askCredentials() (Config, error) {
-	c := Config{}
+	EngineConfig := Config{}
 	err := survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Input{
-				Message: "oVirt API endpoint URL",
-				Help:    "The URL of the oVirt engine API. For example, https://ovirt-engine-fqdn/ovirt-engine/api.",
+				Message: "Engine FQDN[:PORT]",
+				Help:    "The Engine FQDN[:PORT] (engine.example.com:443)",
 			},
 			Validate: survey.ComposeValidators(survey.Required),
 		},
-	}, &c.URL)
+	}, &EngineConfig.FQDN)
 	if err != nil {
-		return c, err
+		return EngineConfig, err
 	}
 
-	var ovirtCertTrusted bool
-	err = survey.AskOne(
-		&survey.Confirm{
-			Message: "Is the oVirt CA trusted locally?",
-			Default: true,
-			Help:    "In order to securly communicate with the oVirt engine, the certificate authority must be trusted by the local system.",
-		},
-		&ovirtCertTrusted,
-		nil)
+	// Set c.URL with the API endpoint
+	EngineConfig.URL = fmt.Sprintf(
+		"https://%s/ovirt-engine/api",
+		EngineConfig.FQDN)
+
+	// Set PEM URL for Download
+	EngineConfig.PemURL = fmt.Sprintf(
+		"https://%s/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA",
+		EngineConfig.FQDN)
+	logrus.Debug("PEM URL: ", EngineConfig.PemURL)
+
+	// Simple http get to check if FQDN/URL are valid
+	err = checkURLResponse(EngineConfig.URL, true)
 	if err != nil {
-		return c, err
+		return EngineConfig, err
 	}
-	c.Insecure = !ovirtCertTrusted
 
-	if ovirtCertTrusted {
-		ovirtURL, err := url.Parse(c.URL)
-		if err != nil {
-			// should have passed validation, this is unexpected
-			return c, err
-		}
-		c.PemURL = fmt.Sprintf(
-			"%s://%s/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA",
-			ovirtURL.Scheme,
-			ovirtURL.Host)
-		logrus.Debug("PEM URL: ", c.PemURL)
+	// Check if CA is trusted locally
+	var importCACert bool = false
 
-		err = survey.AskOne(&survey.Multiline{
-			Message: "oVirt certificate bundle",
-			Help:    fmt.Sprintf("The oVirt certificate bundle can be downloaded from %s", c.PemURL),
-		},
-			&c.CABundle,
-			survey.ComposeValidators(survey.Required))
-		if err != nil {
-			return c, err
-		}
+	// Store if connection with Engine is secure
+	var ConnectionSecure bool = false
+
+	ConnectionSecure, err = checkCATrust(EngineConfig.FQDN)
+	if err != nil {
+		return EngineConfig, err
+	}
+
+	if ConnectionSecure {
+		EngineConfig.Insecure = false
 	} else {
-		logrus.Warning("Communication with the oVirt engine will be insecure.")
+		EngineConfig.Insecure = true
+		message := fmt.Sprintf("Would you like to import Engine CA cert locally from: %s ?", EngineConfig.PemURL)
+		err = survey.AskOne(
+			&survey.Confirm{
+				Message: message,
+				Default: false,
+				Help:    "In order to securly communicate with the oVirt engine, the certificate authority must be trusted by the local system.",
+			},
+			&importCACert,
+			nil)
+		if err != nil {
+			return EngineConfig, err
+		}
 	}
 
+	// If users request, let's work to import Engine CA locally
+	if importCACert == true {
+		logrus.Info("Downloading Engine CA cert from Engine...")
+		tmpFile, err := ioutil.TempFile(os.TempDir(), "engine-")
+		if err != nil {
+			fmt.Println("Cannot create temporary file", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		logrus.Debugf("CA cert temporary stored: %s", tmpFile.Name())
+
+		/* curl command */
+		_, err = execCommand(CurlCommand, "-k", EngineConfig.PemURL, "-o", tmpFile.Name())
+		if err != nil {
+			return EngineConfig, err
+		}
+		logrus.Debugf("PEM file: %s", tmpFile.Name())
+
+		var content []byte
+		content, err = fileContent(tmpFile.Name())
+		if err != nil {
+			return EngineConfig, err
+		}
+		logrus.Debug(string(content))
+
+		/* Check if CA file already exists */
+		CaPath := fmt.Sprintf("/etc/pki/ca-trust/source/anchors/%s.pem", strings.ReplaceAll(EngineConfig.FQDN, ".", "-"))
+		if _, err := os.Stat(CaPath); err == nil {
+			return EngineConfig, err
+		}
+
+		/* Copy the CA to anchors */
+		_, err = execCommand(SudoCommand, CpCommand, tmpFile.Name(), CaPath)
+		if err != nil {
+			return EngineConfig, err
+		}
+
+		/* chmod to allow non root users to read the cert */
+		_, err = execCommand(SudoCommand, ChmodCommand, "0644", CaPath)
+		if err != nil {
+			return EngineConfig, err
+		}
+
+		/* Update CA database */
+		_, err = execCommand(SudoCommand, "/usr/bin/update-ca-trust")
+		if err != nil {
+			return EngineConfig, err
+		}
+		EngineConfig.Insecure = false
+		logrus.Infof("%s imported with success!", CaPath)
+	}
+
+	if EngineConfig.Insecure == true {
+		logrus.Warning("Communication with the Engine will be insecure.")
+	}
+
+	// Ask Engine credentials
 	err = survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Input{
@@ -71,9 +216,9 @@ func askCredentials() (Config, error) {
 			},
 			Validate: survey.ComposeValidators(survey.Required),
 		},
-	}, &c.Username)
+	}, &EngineConfig.Username)
 	if err != nil {
-		return c, err
+		return EngineConfig, err
 	}
 
 	err = survey.Ask([]*survey.Question{
@@ -82,12 +227,12 @@ func askCredentials() (Config, error) {
 				Message: "oVirt engine password",
 				Help:    "",
 			},
-			Validate: survey.ComposeValidators(survey.Required, authenticated(&c)),
+			Validate: survey.ComposeValidators(survey.Required, authenticated(&EngineConfig)),
 		},
-	}, &c.Password)
+	}, &EngineConfig.Password)
 	if err != nil {
-		return c, err
+		return EngineConfig, err
 	}
 
-	return c, nil
+	return EngineConfig, nil
 }

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -229,7 +229,8 @@ func engineSetup() (Config, error) {
 	// Create tmpFile to store the Engine PEM file
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "engine-")
 	if err != nil {
-		fmt.Println("Cannot create temporary file", err)
+		logrus.Debug("Cannot create temporary file: ", err)
+		return EngineConfig, err
 	}
 	defer os.Remove(tmpFile.Name())
 
@@ -238,12 +239,14 @@ func engineSetup() (Config, error) {
 	HTTPResource.skipVerify = true
 	HTTPResource.urlAddr = EngineConfig.PemURL
 	err = HTTPResource.downloadFile()
-	if err == nil {
-		if HTTPResource.importCertIntoSystemPool(HTTPResource.saveFilePath) {
-			EngineConfig.Insecure = false
-		} else {
-			EngineConfig.Insecure = true
-		}
+	if err != nil {
+		logrus.Warning("Cannot download PEM file from Engine!", err)
+	}
+
+	if HTTPResource.importCertIntoSystemPool(HTTPResource.saveFilePath) {
+		EngineConfig.Insecure = false
+	} else {
+		EngineConfig.Insecure = true
 	}
 	logrus.Debugf("Engine PEM temporary stored: %s", HTTPResource.saveFilePath)
 

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -43,14 +43,15 @@ func askCredentials() (Config, error) {
 			// should have passed validation, this is unexpected
 			return c, err
 		}
-		pemURL := fmt.Sprintf(
+		c.PemURL = fmt.Sprintf(
 			"%s://%s/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA",
 			ovirtURL.Scheme,
 			ovirtURL.Host)
+		logrus.Debug("PEM URL: ", c.PemURL)
 
 		err = survey.AskOne(&survey.Multiline{
 			Message: "oVirt certificate bundle",
-			Help:    fmt.Sprintf("The oVirt certificate bundle can be downloaded from %s.", pemURL),
+			Help:    fmt.Sprintf("The oVirt certificate bundle can be downloaded from %s", c.PemURL),
 		},
 			&c.CABundle,
 			survey.ComposeValidators(survey.Required))

--- a/pkg/asset/installconfig/ovirt/datacenter.go
+++ b/pkg/asset/installconfig/ovirt/datacenter.go
@@ -1,0 +1,25 @@
+package ovirt
+
+import (
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// datacentersAvailable look for all datacenters available in the system.
+// Users can provide the criteria for the search. Example: status=up
+// with the status criteria as UP. Returns type: *ovirtsdk.DataCentersServiceListResponse
+func datacentersAvailable(c *ovirtsdk4.Connection, criteria string) (*ovirtsdk4.DataCentersServiceListResponse, error) {
+
+	searchCriteria := criteria
+	dcService := c.SystemService().DataCentersService()
+
+	logrus.Debugf("Searching for DataCenters with search criteria: %s", criteria)
+	dcResp, err := dcService.List().Search(searchCriteria).Send()
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to search available DataCenters!")
+	}
+
+	return dcResp, nil
+}

--- a/pkg/asset/installconfig/ovirt/datacenter.go
+++ b/pkg/asset/installconfig/ovirt/datacenter.go
@@ -7,16 +7,24 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type dataCenterConfig struct {
+	conn         *ovirtsdk4.Connection // ovirtsdk4 connection data
+	searchFilter string                // A search filter for datacenters
+}
+
 // datacentersAvailable look for all datacenters available in the system.
-// Users can provide the criteria for the search. Example: status=up
-// with the status criteria as UP. Returns type: *ovirtsdk.DataCentersServiceListResponse
-func datacentersAvailable(c *ovirtsdk4.Connection, criteria string) (*ovirtsdk4.DataCentersServiceListResponse, error) {
+// Users can provide the filter for the search. Example: status=down
+// If search filter not provided, the default filter will be "status=up"
+// Returns type: *ovirtsdk.DataCentersServiceListResponse
+func datacentersAvailable(d dataCenterConfig) (*ovirtsdk4.DataCentersServiceListResponse, error) {
 
-	searchCriteria := criteria
-	dcService := c.SystemService().DataCentersService()
+	if d.searchFilter == "" {
+		d.searchFilter = "status=up"
+	}
+	dcService := d.conn.SystemService().DataCentersService()
 
-	logrus.Debugf("Searching for DataCenters with search criteria: %s", criteria)
-	dcResp, err := dcService.List().Search(searchCriteria).Send()
+	logrus.Debugf("Searching for DataCenters with search filter: %s", d.searchFilter)
+	dcResp, err := dcService.List().Search(d.searchFilter).Send()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to search available DataCenters!")
 	}

--- a/pkg/asset/installconfig/ovirt/network.go
+++ b/pkg/asset/installconfig/ovirt/network.go
@@ -29,8 +29,8 @@ func askNetwork(c *ovirtsdk4.Connection, p *ovirt.Platform) error {
 		networkNames = append(networkNames, network.MustName())
 	}
 	err = survey.AskOne(&survey.Select{
-		Message: "oVirt network",
-		Help:    "The oVirt network of the deployed VMs. 'ovirtmgmt' is the default network. It is recommended to use a dedicated network for each OpenShift cluster.",
+		Message: "Network",
+		Help:    "The Engine network of the deployed VMs. 'ovirtmgmt' is the default network. It is recommended to use a dedicated network for each OpenShift cluster.",
 		Options: networkNames,
 	},
 		&networkName,
@@ -73,7 +73,7 @@ func askVNICProfileID(c *ovirtsdk4.Connection, p *ovirt.Platform) error {
 	// we have multiple vnic profile for the selected network
 	err = survey.AskOne(&survey.Select{
 		Message: "VNIC Profile",
-		Help:    "The oVirt VNIC profile of the VMs.",
+		Help:    "The Engine VNIC profile of the VMs.",
 		Options: profileNames,
 	},
 		&profileID,

--- a/pkg/asset/installconfig/ovirt/ovirt.go
+++ b/pkg/asset/installconfig/ovirt/ovirt.go
@@ -13,7 +13,7 @@ func Platform() (*ovirt.Platform, error) {
 
 	ovirtConfig, err := NewConfig()
 	if err != nil {
-		ovirtConfig, err = askCredentials()
+		ovirtConfig, err = engineSetup()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/asset/installconfig/ovirt/storage.go
+++ b/pkg/asset/installconfig/ovirt/storage.go
@@ -29,7 +29,7 @@ func askStorage(c *ovirtsdk4.Connection, p *ovirt.Platform, clusterName string) 
 		domainNames = append(domainNames, domain.MustName())
 	}
 	err = survey.AskOne(&survey.Select{
-		Message: "oVirt storage domain",
+		Message: "Storage domain",
 		Help:    "The storage domain will be used to create the disks of all the cluster nodes.",
 		Options: domainNames,
 	},

--- a/pkg/asset/installconfig/ovirt/validaton.go
+++ b/pkg/asset/installconfig/ovirt/validaton.go
@@ -21,7 +21,7 @@ func Validate(ic *types.InstallConfig) error {
 	if ic.Platform.Ovirt == nil {
 		return errors.New(field.Required(
 			ovirtPlatformPath,
-			"oVirt validation requires a oVirt platform configuration").Error())
+			"Validation requires a Engine platform configuration").Error())
 	}
 
 	allErrs = append(
@@ -90,14 +90,14 @@ func authenticated(c *Config) survey.Validator {
 			Build()
 
 		if err != nil {
-			return errors.Errorf("failed to construct connection to oVirt platform %s", err)
+			return errors.Errorf("failed to construct connection to Engine platform %s", err)
 		}
 
 		defer connection.Close()
 
 		err = connection.Test()
 		if err != nil {
-			return errors.Errorf("failed to connect to oVirt platform %s", err)
+			return errors.Errorf("failed to connect to Engine platform %s", err)
 		}
 		return nil
 	}

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -67,11 +67,11 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 	case ovirt.Name:
 		con, err := ovirtconfig.NewConnection()
 		if err != nil {
-			return errors.Wrap(err, "creating oVirt connection")
+			return errors.Wrap(err, "creating Engine connection")
 		}
 		err = con.Test()
 		if err != nil {
-			return errors.Wrap(err, "testing ovirt connection")
+			return errors.Wrap(err, "testing Engine connection")
 		}
 	default:
 		err = fmt.Errorf("unknown platform type %q", platform)


### PR DESCRIPTION
- ovirt: add PEM URL to config struct
- ovirt: IPI Improvements
- ovirt: User cannot fix wrong oVirt user once provided to the installer
- ovirt: remove the need of binaries in the credentials.go
- ovirt: replace static strings in the code from oVirt to Engine
- ovirt: do not allow users to select uninitialized DC
- ovirt: support communication with engine without ca cert
- ovirt: credentials - simplify logic
- ovirt: add datacenter config struct 
- ovirt: credentials - set max login attempts 

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>