### PR TITLE
[release-4.3] Bug 1840230: data/azure/vnet: switch to HTTPS probes for lbs

### DIFF
--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -125,7 +125,8 @@ resource "azurerm_lb_probe" "internal_lb_probe_sint" {
   number_of_probes    = 3
   loadbalancer_id     = azurerm_lb.internal.id
   port                = 22623
-  protocol            = "TCP"
+  protocol            = "HTTPS"
+  request_path        = "/healthz"
 }
 
 resource "azurerm_lb_probe" "internal_lb_probe_api_internal" {
@@ -135,5 +136,6 @@ resource "azurerm_lb_probe" "internal_lb_probe_api_internal" {
   number_of_probes    = 3
   loadbalancer_id     = azurerm_lb.internal.id
   port                = 6443
-  protocol            = "TCP"
+  protocol            = "HTTPS"
+  request_path        = "/readyz"
 }

--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -161,5 +161,6 @@ resource "azurerm_lb_probe" "public_lb_probe_api_internal" {
   number_of_probes    = 3
   loadbalancer_id     = azurerm_lb.public.id
   port                = 6443
-  protocol            = "TCP"
+  protocol            = "HTTPS"
+  request_path        = "/readyz"
 }

--- a/pkg/asset/tls/tls.go
+++ b/pkg/asset/tls/tls.go
@@ -115,7 +115,7 @@ func SignedCertificate(
 		Version:               3,
 		BasicConstraintsValid: true,
 	}
-	pub := caCert.PublicKey.(*rsa.PublicKey)
+	pub := key.Public()
 	certTmpl.SubjectKeyId, err = generateSubjectKeyID(pub)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to set subject key identifier")


### PR DESCRIPTION
#### data/azure/vnet: switch to HTTPS probes for lbs
(clean cherry-pick from https://github.com/openshift/installer/pull/3600)

#### fix bootstrap certificates
(clean cherry-pick from https://github.com/openshift/installer/pull/3551)
Based on https://tools.ietf.org/html/rfc3280#section-4.2.1.1 and https://tools.ietf.org/html/rfc3280#section-4.2.1.2
We should not set SubjectKeyId to signing certificate value. We should set it to the current certificate value.

replaces https://github.com/openshift/installer/pull/3658 and https://github.com/openshift/installer/pull/3659

/assign e-tienne