### PR TITLE
Bug 1840710: libvirt: Bump machine memory from 7G to 8G

### DIFF
--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -63,7 +63,7 @@ func provider(clusterID string, networkInterfaceAddress string, platform *libvir
 			APIVersion: "libvirtproviderconfig.openshift.io/v1beta1",
 			Kind:       "LibvirtMachineProviderConfig",
 		},
-		DomainMemory: 7168,
+		DomainMemory: 8192,
 		DomainVcpu:   4,
 		Ignition: &libvirtprovider.Ignition{
 			UserDataSecret: userDataSecret,


### PR DESCRIPTION
From 4.4 onward, on libvirt installations, it is seen that with 7G of memory
as the default for the worker machines, the kube-storage-version-migrator pod does
not get provisioned successfully because the node does not meet its memory requirements.

Bumping to 8G fixes the issue.