### PR TITLE
Fix re-generation of install config on wait-for install-complete command

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -347,9 +347,8 @@ func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
 
 	// Wait longer for baremetal, due to length of time it takes to boot
 	if assetStore, err := assetstore.NewStore(rootOpts.dir); err == nil {
-		installConfig := &installconfig.InstallConfig{}
-		if err := assetStore.Fetch(installConfig); err == nil {
-			if installConfig.Config.Platform.Name() == baremetal.Name {
+		if installConfig, err := assetStore.Load(&installconfig.InstallConfig{}); err == nil && installConfig != nil {
+			if installConfig.(*installconfig.InstallConfig).Config.Platform.Name() == baremetal.Name {
 				timeout = 60 * time.Minute
 			}
 		}

--- a/pkg/asset/store.go
+++ b/pkg/asset/store.go
@@ -14,4 +14,8 @@ type Store interface {
 	// DestroyState removes everything from the internal state and the internal
 	// state file
 	DestroyState() error
+
+	// Load retrieves the state of the given asset but does not generate it if it
+	// does not exist and instead will return nil if not found.
+	Load(Asset) (Asset, error)
 }

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -357,3 +357,18 @@ func (s *storeImpl) purge(excluded []asset.WritableAsset) error {
 func increaseIndent(indent string) string {
 	return indent + "  "
 }
+
+// Load retrieves the given asset if it is present in the store and does not generate the asset
+// if it does not exist and will return nil.
+func (s *storeImpl) Load(a asset.Asset) (asset.Asset, error) {
+	foundOnDisk, err := s.load(a, "")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load asset")
+	}
+
+	if foundOnDisk.source == unfetched {
+		return nil, nil
+	}
+
+	return s.assets[reflect.TypeOf(a)].asset, nil
+}


### PR DESCRIPTION
If the cluster is created and the wait-for install-complete command
is called to check the status, the installer checks if the install
config exists to get the platform information to set the timeout for
baremetal clusters a little higher. Since the install config is
consumed during the cluster creation, the installer will then start
to re-generate the install config and ask the user to provide the
information again.

Modified the platform information gathering to only pick the information
up only if the information is available and if it does not exist, set the
timeout value to the maximum value required as default (60 seconds 
as the baremetal machines take long time to boot). This will now 
avoid re-generation of the install config.