### PR TITLE
Bug 1841072: [UPI] Rely on security group ID when deleting it

### DIFF
--- a/upi/openstack/down-security-groups.yaml
+++ b/upi/openstack/down-security-groups.yaml
@@ -12,7 +12,7 @@
   tasks:
   - name: 'List security groups'
     command:
-      cmd: "openstack security group list --tags {{ cluster_id_tag }} -f value -c Name"
+      cmd: "openstack security group list --tags {{ cluster_id_tag }} -f value -c ID"
     register: security_groups
 
   - name: 'Remove the cluster security groups'


### PR DESCRIPTION
As OpenStack allows resources to have the same name, it's
possible that we end up with multiple security groups with
same name, and the deletion of those resources for UPI fails
as currently we're relying on sg Name. This commit fixes the
issue by ensuring the resoruce ID is used instead.