### PR TITLE
bootstrap: Make crio-configure.service RequiredBy=crio.service

### DIFF
--- a/data/data/bootstrap/systemd/units/crio-configure.service.template
+++ b/data/data/bootstrap/systemd/units/crio-configure.service.template
@@ -8,3 +8,6 @@ Before=crio.service
 Type=oneshot
 ExecStart=/usr/local/bin/crio-configure.sh
 RemainAfterExit=true
+
+[Install]
+RequiredBy=crio.service


### PR DESCRIPTION
If this service fails, we shouldn't go on and still try to
have crio start which might then use the upstream pause
image.

Came out of looking at https://github.com/openshift/installer/pull/3652