### PR TITLE
Bug 1841913: images: libvirt: add yq to libvirt CI image

### DIFF
--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -24,6 +24,8 @@ RUN yum update -y && \
     openssh-clients && \
     yum clean all && rm -rf /var/cache/yum/*
 
+RUN curl -L https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64 -o /usr/bin/yq && \
+    chmod +x /usr/bin/yq
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin


### PR DESCRIPTION
For s390x/ppc64le we do some amount of yaml manipulation, for example: https://github.com/openshift/release/pull/9362
and we plan to add a volume size which will have increased disk space for certain tests. yq will be especially useful and easier to use than sed for these manipulations.