### PR TITLE
Enabling Citrix ADC as an External LB

### DIFF
--- a/upi/vsphere/citrix_adc/main.tf
+++ b/upi/vsphere/citrix_adc/main.tf
@@ -1,0 +1,69 @@
+provider "citrixadc" {
+    username = "${var.citrix_adc_username}"
+    password = "${var.citrix_adc_password}"
+    endpoint = format("http://%s/", var.citrix_adc_ip)
+    insecure_skip_verify = true
+}
+
+locals {
+  api_server_sg_members = formatlist("%s:6443", var.api_backend_addresses)
+  machine_config_sg_members = formatlist("%s:22623", var.api_backend_addresses)
+  ingress_http_sg_members = formatlist("%s:80", var.ingress_backend_addresses)
+  ingress_https_sg_members = formatlist("%s:443", var.ingress_backend_addresses)
+}
+
+// API Server Load-Balancing
+resource "citrixadc_lbvserver" "openshift_api_server" {
+  name = "openshift_lb_api_server"
+  ipv46 = "${var.lb_ip_address}"
+  port = "${var.api_server["lb_port"]}"
+  servicetype = "${var.api_server["lb_protocol"]}"
+}
+resource "citrixadc_servicegroup" "openshift_api_server" {
+  servicegroupname = "openshift_sg_api_server"
+  servicetype = "${var.api_server["lb_protocol"]}"
+  lbvservers = ["${citrixadc_lbvserver.openshift_api_server.name}"]
+  servicegroupmembers = local.api_server_sg_members
+}
+
+// Machine Config Server Load-Balancing
+resource "citrixadc_lbvserver" "openshift_machine_config_server" {
+  name = "openshift_lb_machine_config_server"
+  ipv46 = "${var.lb_ip_address}"
+  port = "${var.machine_config_server["lb_port"]}"
+  servicetype = "${var.machine_config_server["lb_protocol"]}"
+}
+resource "citrixadc_servicegroup" "openshift_machine_config_server" {
+  servicegroupname = "openshift_sg_machine_config_server"
+  servicetype = "${var.machine_config_server["lb_protocol"]}"
+  lbvservers = ["${citrixadc_lbvserver.openshift_machine_config_server.name}"]
+  servicegroupmembers = local.machine_config_sg_members
+}
+
+// HTTP Ingress Load-Balancing
+resource "citrixadc_lbvserver" "openshift_ingress_http" {
+  name = "openshift_lb_ingress_http"
+  ipv46 = "${var.lb_ip_address}"
+  port = "${var.ingress_http["lb_port"]}"
+  servicetype = "${var.ingress_http["lb_protocol"]}"
+}
+resource "citrixadc_servicegroup" "openshift_ingress_http" {
+  servicegroupname = "openshift_sg_ingress_http"
+  servicetype = "${var.ingress_http["lb_protocol"]}"
+  lbvservers = ["${citrixadc_lbvserver.openshift_ingress_http.name}"]
+  servicegroupmembers = local.ingress_http_sg_members
+}
+
+// HTTPS Ingress Load-Balancing
+resource "citrixadc_lbvserver" "openshift_ingress_https" {
+  name = "openshift_lb_ingress_https"
+  ipv46 = "${var.lb_ip_address}"
+  port = "${var.ingress_https["lb_port"]}"
+  servicetype = "${var.ingress_https["lb_protocol"]}"
+}
+resource "citrixadc_servicegroup" "openshift_ingress_https" {
+  servicegroupname = "openshift_sg_ingress_https"
+  servicetype = "${var.ingress_https["lb_protocol"]}"
+  lbvservers = ["${citrixadc_lbvserver.openshift_ingress_https.name}"]
+  servicegroupmembers = local.ingress_https_sg_members
+}

--- a/upi/vsphere/citrix_adc/outputs.tf
+++ b/upi/vsphere/citrix_adc/outputs.tf
@@ -1,0 +1,4 @@
+output "ignition" {
+  value = data.ignition_config.citrix_adc.rendered
+}
+

--- a/upi/vsphere/citrix_adc/variables.tf
+++ b/upi/vsphere/citrix_adc/variables.tf
@@ -1,0 +1,55 @@
+variable "api_server" {
+  type = map
+  default = {
+    "lb_port" = "6443"
+    "lb_protocol" = "TCP"
+  }
+}
+
+variable "machine_config_server" {
+  type = map
+  default = { 
+    "lb_port" = "22623"
+    "lb_protocol" = "TCP"
+  }
+}
+
+variable "ingress_http" {
+  type = map
+  default = {
+    "lb_port" = "80"
+    "lb_protocol" = "TCP"
+  }
+}
+
+variable "ingress_https" {
+  type = map
+  default = {
+    "lb_port" = "443"
+    "lb_protocol" = "TCP"
+  }
+}
+
+variable "lb_ip_address" {
+  type = string
+}
+
+variable "api_backend_addresses" {
+  type = list(string)
+}
+
+variable "ingress_backend_addresses" {
+  type = list(string)
+}
+
+variable "citrix_adc_username" {
+  type = string
+}
+
+variable "citrix_adc_password" {
+  type = string
+}
+
+variable "citrix_adc_ip" {
+  type = string
+}

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -111,6 +111,26 @@ module "lb" {
   ssh_public_key_path       = var.ssh_public_key_path
 }
 
+// Configure Citrix ADC as an External LB
+module "citrix_adc" {
+
+  source        = "./citrix_adc"
+
+  citrix_adc_ip = var.citrix_adc_ip
+  citrix_adc_username = var.citrix_adc_username
+  citrix_adc_password = var.citrix_adc_password
+
+  lb_ip_address = module.ipam_lb.ip_addresses[0]
+
+  api_backend_addresses = flatten([
+    module.ipam_bootstrap.ip_addresses[0],
+    module.ipam_control_plane.ip_addresses]
+  )
+
+  ingress_backend_addresses = module.ipam_compute.ip_addresses
+
+}
+
 module "dns_cluster_domain" {
   source         = "./cluster_domain"
   cluster_domain = var.cluster_domain

--- a/upi/vsphere/variables.tf
+++ b/upi/vsphere/variables.tf
@@ -170,3 +170,19 @@ variable "ssh_public_key_path" {
   type    = string
   default = "~/.ssh/id_rsa.pub"
 }
+
+//////////
+// Citrix ADC Variables
+//////////
+
+variable "citrix_adc_ip" {
+  type = string
+}
+
+variable "citrix_adc_username" {
+  type = string
+}
+
+variable "citrix_adc_password" {
+  type = string
+}


### PR DESCRIPTION
Citrix ADC can be used as as External LB for Load-balancing the Control plane and worker plane nodes. Support for the same is added.
User can choose to use his existing (or create) Citrix ADC to act as an External LB on vSphere deployments.