### PR TITLE
Bug 1842607: update README with vSphere IPI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 * [OpenStack](docs/user/openstack/README.md)
 * [OpenStack (UPI) (Experimental)](docs/user/openstack/install_upi.md)
 * [oVirt](docs/user/ovirt/install_ipi.md)
-* [vSphere](docs/user/vsphere/install_upi.md)
+* [vSphere](docs/user/vsphere/README.md)
+* [vSphere (UPI)](docs/user/vsphere/install_upi.md)
 
 ## Quick Start
 


### PR DESCRIPTION
I missed this in #3672.

Updates vSphere link to point to IPI and adds link for UPI.
