### PR TITLE
GCP: Fix uninstaller to not use hardcoded base path.

### DIFF
--- a/pkg/destroy/gcp/cloudcontroller.go
+++ b/pkg/destroy/gcp/cloudcontroller.go
@@ -22,7 +22,7 @@ func (o *ClusterUninstaller) listCloudControllerInstanceGroups() ([]cloudResourc
 func (o *ClusterUninstaller) listCloudControllerBackendServices(instanceGroups []cloudResource) ([]cloudResource, error) {
 	urls := sets.NewString()
 	for _, instanceGroup := range instanceGroups {
-		urls.Insert(o.getInstanceGroupURL(instanceGroup))
+		urls.Insert(instanceGroup.url)
 	}
 	filter := "name eq \"a[0-9a-f]{30,50}\""
 	return o.listBackendServicesWithFilter("items(name,backends),nextPageToken", filter, func(item *compute.BackendService) bool {

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -163,13 +163,11 @@ func (o *ClusterUninstaller) destroyCluster() (bool, error) {
 
 // getZoneName extracts a zone name from a zone URL of the form:
 // https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a
-// Trimming the URL, leaves a string like: project-id/zones/us-central1-a
-// TODO: Find a better way to get the zone name to account for changes in base path
+// Splitting the URL with the delimiter `/projects`, leaves a string like: project-id/zones/us-central1-a
 func (o *ClusterUninstaller) getZoneName(zoneURL string) string {
-	path := strings.TrimLeft(zoneURL, "https://www.googleapis.com/compute/v1/projects/")
-	parts := strings.Split(path, "/")
-	if len(parts) >= 3 {
-		return parts[2]
+	parts := strings.Split(zoneURL, "/")
+	if len(parts) > 1 {
+		return parts[len(parts)-1]
 	}
 	return ""
 }
@@ -181,11 +179,6 @@ func (o *ClusterUninstaller) areAllClusterInstances(instances []cloudResource) b
 		}
 	}
 	return true
-}
-
-// TODO: Find a better way to get the instance group URL to account for changes in base path
-func (o *ClusterUninstaller) getInstanceGroupURL(ig cloudResource) string {
-	return fmt.Sprintf("%s%s/zones/%s/instanceGroups/%s", "https://www.googleapis.com/compute/v1/projects/", o.ProjectID, ig.zone, ig.name)
 }
 
 func (o *ClusterUninstaller) isClusterResource(name string) bool {

--- a/pkg/destroy/gcp/instance.go
+++ b/pkg/destroy/gcp/instance.go
@@ -12,11 +12,11 @@ import (
 
 // getInstanceNameAndZone extracts an instance and zone name from an instance URL in the form:
 // https://www.googleapis.com/compute/v1/projects/project-id/zones/us-central1-a/instances/instance-name
-// After trimming the service's base path, you get:
+// After splitting the service's base path with the work `/projects/`, you get:
 // project-id/zones/us-central1-a/instances/instance-name
 // TODO: Find a better way to get the instance name and zone to account for changes in base path
 func (o *ClusterUninstaller) getInstanceNameAndZone(instanceURL string) (string, string) {
-	path := strings.TrimLeft(instanceURL, "https://www.googleapis.com/compute/v1/projects/")
+	path := strings.Split(instanceURL, "/projects/")[1]
 	parts := strings.Split(path, "/")
 	if len(parts) >= 5 {
 		return parts[4], parts[2]

--- a/pkg/destroy/gcp/instancegroup.go
+++ b/pkg/destroy/gcp/instancegroup.go
@@ -37,6 +37,7 @@ func (o *ClusterUninstaller) listInstanceGroupsWithFilter(fields string, filter 
 						name:     item.Name,
 						typeName: "instancegroup",
 						zone:     zoneName,
+						url:      item.SelfLink,
 					})
 				}
 			}


### PR DESCRIPTION
The uninstaller currently hard codes the base path as the GCP
API base path has changed.

Change 1:
For the getZoneName function, the InstanceGroupAggregatedList,
InstanceAggregatedList and the disk list functions that calls
this to get the proper url all have a shortened URL as the key
in the list.Items map. Example of a shortened URL is
zones/us-central1-a.
Reusing the key value instead of hard coding the base path
and TrimLeft operation.

Change 2:
For the getInstanceGroupURL function, the call to the underlying
InstanceGroupAggregatedList to get the InstanceGroups already have
the URL to hit called the SelfLink which is now set to the returning
object and used for the URL, thus not requiring the call.

Change 3:
For the getInstanceNameAndZone, since the underlying object has only
the URL and no other relevant information, the base path is removed
and the TrimLeft operation is changed to Split based on the '/projects/'
URL query parameter instead of using the base path.

Previous commit information:
https://github.com/openshift/installer/pull/2745/commits/11c9773466bdcd034e8de3068f31bd140298515c#diff-4781d154886c4da10a007bb219f27d8aL170
TODO: Find a better solution for change 3.