### PR TITLE
create cmd: Display command asset directories.

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -29,6 +29,7 @@ import (
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/logging"
 	assetstore "github.com/openshift/installer/pkg/asset/store"
 	targetassets "github.com/openshift/installer/pkg/asset/targets"
 	destroybootstrap "github.com/openshift/installer/pkg/destroy/bootstrap"
@@ -197,6 +198,10 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		if cmd.Name() != "cluster" {
+			logrus.Infof(logging.LogCreatedFiles(cmd.Name(), rootOpts.dir, targets))
+		}
+
 	}
 }
 

--- a/pkg/asset/logging/filelogging.go
+++ b/pkg/asset/logging/filelogging.go
@@ -1,0 +1,51 @@
+package logging
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/installer/pkg/asset"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// LogCreatedFiles checks all the asset files created and logs it for the user to see.
+func LogCreatedFiles(cmdName string, directory string, targets []asset.WritableAsset) string {
+	directory = filepath.Dir(fmt.Sprintf("%s//", directory))
+
+	assetDirs := sets.NewString()
+	for _, a := range targets {
+		for _, f := range a.Files() {
+			index := strings.Index(f.Filename, "/")
+			path := directory
+
+			if index != -1 {
+				path = filepath.Join(path, f.Filename[:index])
+			}
+			assetDirs.Insert(path)
+		}
+	}
+
+	if len(assetDirs) == 0 {
+		return ""
+	}
+
+	var directories string
+	keys := assetDirs.List()
+
+	if len(keys) == 1 {
+		directories = keys[0]
+	} else {
+		maxIndex := 3
+		if maxIndex >= len(keys) {
+			maxIndex = len(keys)
+			directories = strings.Join(keys[:maxIndex-1], ", ")
+			directories = fmt.Sprintf("%s and %s", strings.TrimRight(directories, ", "), keys[maxIndex-1])
+		} else {
+			directories = directory
+		}
+
+	}
+
+	return fmt.Sprintf("%s created in: %s", strings.Title(strings.ToLower(cmdName)), directories)
+}

--- a/pkg/asset/logging/filelogging_test.go
+++ b/pkg/asset/logging/filelogging_test.go
@@ -1,0 +1,161 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/machines"
+	"github.com/stretchr/testify/assert"
+)
+
+func getAsset(filename string) *asset.File {
+	return &asset.File{
+		Filename: filename,
+	}
+}
+
+func TestLogFilesChanged(t *testing.T) {
+	cases := []struct {
+		name                  string
+		assets                []asset.WritableAsset
+		cmdName               string
+		directory             string
+		expectedGenerationLog string
+	}{
+		{
+			name:                  "test empty assets list",
+			assets:                []asset.WritableAsset{},
+			cmdName:               "test",
+			directory:             "test",
+			expectedGenerationLog: "",
+		},
+		{
+			name: "test asset with one file",
+			assets: []asset.WritableAsset{
+				&installconfig.InstallConfig{
+					File: &asset.File{
+						Filename: "a.yaml",
+					},
+				},
+			},
+			cmdName:               "test install config",
+			directory:             "test/",
+			expectedGenerationLog: "Test Install Config created in: test",
+		},
+		{
+			name: "test asset with two files, same directory",
+			assets: []asset.WritableAsset{
+				&machines.Master{
+					MachineFiles: []*asset.File{
+						getAsset("a.yaml"),
+						getAsset("b.yaml"),
+					},
+				},
+			},
+			cmdName:               "machines",
+			directory:             "test",
+			expectedGenerationLog: "Machines created in: test",
+		},
+		{
+			name: "test asset with two files, two directories",
+			assets: []asset.WritableAsset{
+				&machines.Master{
+					MachineFiles: []*asset.File{
+						getAsset("a.yaml"),
+						getAsset("machines/b.yaml"),
+					},
+				},
+			},
+			cmdName:               "machines",
+			directory:             "test",
+			expectedGenerationLog: "Machines created in: test and test/machines",
+		},
+		{
+			name: "test asset with two files, two directories, but three entries (same file twice",
+			assets: []asset.WritableAsset{
+				&machines.Master{
+					MachineFiles: []*asset.File{
+						getAsset("a.yaml"),
+						getAsset("machines/b.yaml"),
+						getAsset("machines/b.yaml"),
+					},
+				},
+			},
+			cmdName:               "machines",
+			directory:             "test",
+			expectedGenerationLog: "Machines created in: test and test/machines",
+		},
+		{
+			name: "test asset with three files, two directories",
+			assets: []asset.WritableAsset{
+				&machines.Master{
+					MachineFiles: []*asset.File{
+						getAsset("a.yaml"),
+						getAsset("machines/b.yaml"),
+						getAsset("machines/c.yaml"),
+					},
+				},
+			},
+			cmdName:               "machine-config",
+			directory:             "test/",
+			expectedGenerationLog: "Machine-Config created in: test and test/machines",
+		},
+		{
+			name: "test asset with three files, three directories",
+			assets: []asset.WritableAsset{
+				&machines.Master{
+					MachineFiles: []*asset.File{
+						getAsset("a.yaml"),
+						getAsset("machines/b.yaml"),
+						getAsset("control-plane/c.yaml"),
+					},
+				},
+			},
+			cmdName:               "machines",
+			directory:             "test",
+			expectedGenerationLog: "Machines created in: test, test/control-plane and test/machines",
+		},
+		{
+			name: "test asset with five files, five directories",
+			assets: []asset.WritableAsset{
+				&machines.Master{
+					MachineFiles: []*asset.File{
+						getAsset("a.yaml"),
+						getAsset("machines/b.yaml"),
+						getAsset("control-plane/c.yaml"),
+						getAsset("master/c.yaml"),
+						getAsset("worker/c.yaml"),
+					},
+				},
+			},
+			cmdName:               "machines",
+			directory:             "test",
+			expectedGenerationLog: "Machines created in: test",
+		},
+		{
+			name: "test asset with five files, five nested directories",
+			assets: []asset.WritableAsset{
+				&machines.Master{
+					MachineFiles: []*asset.File{
+						getAsset("machines/workers/b.yaml"),
+						getAsset("control-plane/disks/c.yaml"),
+						getAsset("control-plane/VM/d.yaml"),
+						getAsset("machines/configurations/c.yaml"),
+					},
+				},
+			},
+			cmdName:               "machines",
+			directory:             "test",
+			expectedGenerationLog: "Machines created in: test/control-plane and test/machines",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			textOutput := LogCreatedFiles(tc.cmdName, tc.directory, tc.assets)
+			assert.EqualValues(t, tc.expectedGenerationLog, textOutput)
+		})
+
+	}
+}


### PR DESCRIPTION
Added a feature where the directories of the assets that were
used during any target of the create command is invoked, are
displayed on the screen. Examples of the display that will show
up are

'''
INFO install-config created in the test directory
INFO manifests created in the test/manifests and test/openshift directories
INFO ignition-configs created in the test and test/auth directories
'''