### PR TITLE
Bug:1842871, oVirt - template temporary VM is created with no tag

### DIFF
--- a/data/data/ovirt/bootstrap/main.tf
+++ b/data/data/ovirt/bootstrap/main.tf
@@ -9,3 +9,8 @@ resource "ovirt_vm" "bootstrap" {
     custom_script = var.ignition_bootstrap
   }
 }
+
+resource "ovirt_tag" "cluster_tag" {
+  name   = "${var.cluster_id}-bootstrap"
+  vm_ids = [concat(ovirt_vm.bootstrap.id, var.ovirt_tmp_template_vm_id)]
+}

--- a/data/data/ovirt/bootstrap/variables.tf
+++ b/data/data/ovirt/bootstrap/variables.tf
@@ -12,6 +12,11 @@ variable "ovirt_template_id" {
   description = "The ID of VM template"
 }
 
+variable "ovirt_tmp_template_vm_id" {
+  type        = string
+  description = "The ID of tmp VM which was created for creating the templated"
+}
+
 variable "ignition_bootstrap" {
   type        = string
   description = "bootstrap ignition config"

--- a/data/data/ovirt/main.tf
+++ b/data/data/ovirt/main.tf
@@ -20,6 +20,7 @@ module "bootstrap" {
   source                               = "./bootstrap"
   ovirt_cluster_id                     = var.ovirt_cluster_id
   ovirt_template_id                    = module.template.releaseimage_template_id
+  ovirt_tmp_template_vm_id             = module.template.tmp_import_vm
   ignition_bootstrap                   = var.ignition_bootstrap
   cluster_id                           = var.cluster_id
   openstack_base_image_name            = var.openstack_base_image_name

--- a/data/data/ovirt/template/outputs.tf
+++ b/data/data/ovirt/template/outputs.tf
@@ -1,3 +1,7 @@
 output "releaseimage_template_id" {
   value = data.ovirt_templates.finalTemplate.templates.0.id
 }
+
+output "tmp_import_vm" {
+  value = data.tmp_import_vm.id
+}

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/openstack"
+	"github.com/openshift/installer/pkg/types/ovirt"
 	"github.com/pkg/errors"
 )
 
@@ -79,6 +80,8 @@ func Destroy(dir string) (err error) {
 		if err != nil {
 			return errors.Wrapf(err, "Failed to delete glance image %s", imageName)
 		}
+	case ovirt.Name:
+		extraArgs = append(extraArgs, "-target=module.template.ovirt_vm.tmp_import_vm")
 	}
 
 	extraArgs = append(extraArgs, "-target=module.bootstrap")


### PR DESCRIPTION
At the beginning of the installation the installer creates a temporary VM which it uses to create a template.
The temporary VM is created with no ovirt tag on it, and therefor it will not be removed on cluster destroy.
This will add a tag to the temporary VM.

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>