### PR TITLE
Bug 1823967: Add the --pod-infra-container-image flag to the kubelet service

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/kubelet-pause-image.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/kubelet-pause-image.sh.template
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Before kubelet.service and crio.service start, ensure
+# that we're using the pause image from our payload just like the primary cluster.
+# Need to set the --pod-infra-container-image flag for the kubelet to point to the pause image from the payload
+# So we add MACHINE_CONFIG_INFRA_IMAGE to an environment file and source that in the kubelet service
+
+. /usr/local/bin/release-image.sh
+
+echo "MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)" > /etc/kubernetes/kubelet-pause-image-override

--- a/data/data/bootstrap/systemd/units/kubelet.service.template
+++ b/data/data/bootstrap/systemd/units/kubelet.service.template
@@ -1,14 +1,16 @@
 [Unit]
 Description=Kubernetes Kubelet
-Wants=rpc-statd.service crio.service
-After=crio.service
+Wants=rpc-statd.service crio.service release-image.service
+After=crio.service release-image.service
 
 [Service]
 Type=notify
 ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
 ExecStartPre=/bin/mkdir --parents /etc/kubernetes/kubelet-plugins/volume/exec
+ExecStartPre=/usr/local/bin/kubelet-pause-image.sh
 Environment=KUBELET_RUNTIME_REQUEST_TIMEOUT=10m
 EnvironmentFile=-/etc/kubernetes/kubelet-env
+EnvironmentFile=-/etc/kubernetes/kubelet-pause-image-override
 
 ExecStart=/usr/bin/hyperkube \
   kubelet \
@@ -21,7 +23,8 @@ ExecStart=/usr/bin/hyperkube \
     --cgroup-driver=systemd \
     --serialize-image-pulls=false \
     --v=2 \
-    --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec
+    --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
+    --pod-infra-container-image=${MACHINE_CONFIG_INFRA_IMAGE}
 
 Restart=always
 RestartSec=10


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1823967

Override the --pod-infra-container-image flag to point to the pause
image from the release payload. By default, this flag is set to k8s.gcr.io/pause:3.1
and the kubelet asks the runtime for the image status of this image every few minutes,
which is why we were seeing the warning logs in cri-o saying that this image was not
found. This is avoided by making the pod-infra-container-image flag point to the actual
pause image being used from the release payload.

The MCO PR is https://github.com/openshift/machine-config-operator/pull/1776

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>