### PR TITLE
Bug 1844103: allow OpaqueNetwork type in vSphere wizard

### DIFF
--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25"
 	"gopkg.in/AlecAivazis/survey.v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/installer/pkg/types/vsphere"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
@@ -20,8 +21,6 @@ import (
 )
 
 const root = "/..."
-const distributedVirtualPortGroupType = "DistributedVirtualPortgroup"
-const networkType = "Network"
 
 // vCenterClient contains the login info/creds and client for the vCenter.
 // They are contained in a single struct to facilitate client creation
@@ -305,9 +304,15 @@ func getNetwork(ctx context.Context, path string, finder *find.Finder, client *v
 		return n.Name(), nil
 	}
 
+	validNetworkTypes := sets.NewString(
+		"DistributedVirtualPortgroup",
+		"Network",
+		"OpaqueNetwork",
+	)
+
 	var networkChoices []string
 	for _, network := range networks {
-		if network.Reference().Type == distributedVirtualPortGroupType || network.Reference().Type == networkType {
+		if validNetworkTypes.Has(network.Reference().Type) {
 			n := network.(networkNamer)
 			networkChoices = append(networkChoices, n.Name())
 		}


### PR DESCRIPTION
The vSphere wizard only allows users to select networks of certain types. This commit adds the ability to select OpaqueNetworks.

OpaqueNetwork is what is used in VMC.

So now we allow:

- DistributedVirtualPortgroup
- Network
- OpaqueNetwork

@jcpowermac do you think there might be any other network types we are missing? Also should we continue this process of filtering networks by type?