### PR TITLE
Bug 1843314: baremetal: bump ironic timeout to 3600 seconds

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -6,7 +6,7 @@ provider "ironic" {
   url          = "http://${var.bootstrap_provisioning_ip}:6385/v1"
   inspector    = "http://${var.bootstrap_provisioning_ip}:5050/v1"
   microversion = "1.56"
-  timeout      = 1500
+  timeout      = 3600
 }
 
 module "bootstrap" {


### PR DESCRIPTION
terraform-provider-ironic [recently changed the approach it uses for
timeouts](https://github.com/openshift-metal3/terraform-provider-ironic/pull/41) from an estimate based on number of attempts, to using a
go routine in a context. The logic it used to estimate was off by more
than a factor of two. That means the current 1500 second timeout was
actually more than 3000.

This commit restores the previously unintended behavior as now
explicitly set. The latest RHCOS images are around 800 MB in size. At
256kB/s, this would be 3,125 seconds to download. We also have to allow
time for the bootstrap VM itself to boot, which we could alot 5 minutes
for, totaling 3,425 seconds. I round it up to 3600 just for the even
number.

This timeout is unfortunate but I think is required for users who
download the images directly from the internet and not a local cache.
Ideally we would be able to monitor in real time what the
machine-os-downloader container is doing, and fail earlier if an error
it encountered was fatal. The problem is it happens while the
installer is running terraform, so I'm not sure the plans in
https://github.com/openshift/enhancements/pull/328 would even
be able to cover this case.