### PR TITLE
validation/installconfig: fix the test to work with go 1.14

### DIFF
--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -698,7 +698,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.HTTPProxy = "http://bad%20uri"
 				return c
 			}(),
-			expectedError: `^\QHTTPProxy: Invalid value: "http://bad%20uri": parse http://bad%20uri: invalid URL escape "%20"\E$`,
+			expectedError: `^HTTPProxy: Invalid value: "http://bad%20uri": parse .*: invalid URL escape "%20"$`,
 		},
 		{
 			name: "invalid HTTPSProxy",
@@ -707,7 +707,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.HTTPSProxy = "https://bad%20uri"
 				return c
 			}(),
-			expectedError: `^\QHTTPSProxy: Invalid value: "https://bad%20uri": parse https://bad%20uri: invalid URL escape "%20"\E$`,
+			expectedError: `^HTTPSProxy: Invalid value: "https://bad%20uri": parse .*: invalid URL escape "%20"$`,
 		},
 		{
 			name: "invalid NoProxy domain",


### PR DESCRIPTION
on go 1.14, the error from url Parse seems to be now quoted compared to previous versions, and therefore the test fails to compare.
```
$ go version
go version go1.14.1 linux/amd64
$ go test ./pkg/types/validation/... -run "^TestValidateInstallConfig/invalid_HTTP"
--- FAIL: TestValidateInstallConfig (0.00s)
    --- FAIL: TestValidateInstallConfig/invalid_HTTPProxy (0.00s)
        installconfig_test.go:953:
                Error Trace:    installconfig_test.go:953
                Error:          Expect "HTTPProxy: Invalid value: "http://bad%20uri": parse "http://bad%20uri": invalid URL escape "%20"" to match "^\QHTTPProxy: Invalid value: "http://bad%20uri": parse http://bad%20uri: invalid URL escape "%20"\E$"
                Test:           TestValidateInstallConfig/invalid_HTTPProxy
    --- FAIL: TestValidateInstallConfig/invalid_HTTPSProxy (0.00s)
        installconfig_test.go:953:
                Error Trace:    installconfig_test.go:953
                Error:          Expect "HTTPSProxy: Invalid value: "https://bad%20uri": parse "https://bad%20uri": invalid URL escape "%20"" to match "^\QHTTPSProxy: Invalid value: "https://bad%20uri": parse https://bad%20uri: invalid URL escape "%20"\E$"
                Test:           TestValidateInstallConfig/invalid_HTTPSProxy
FAIL
FAIL    github.com/openshift/installer/pkg/types/validation     0.012s
FAIL
```

Modifying it to skip checking so strictly against the error helps remove that bug and also make the test check only the thing that matters to us the most, `invalid URL escape`