### PR TITLE
bump the minimum version for building installer to go 1.14

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.3.1-0.20200617211605-651903477185
   creationTimestamp: null
   name: installconfigs.install.openshift.io
 spec:
@@ -994,6 +994,53 @@ spec:
                           type: string
                         role:
                           type: string
+                        rootDeviceHints:
+                          description: RootDeviceHints holds the hints for specifying
+                            the storage location for the root filesystem for the image.
+                          properties:
+                            deviceName:
+                              description: A Linux device name like "/dev/vda". The
+                                hint must match the actual value exactly.
+                              type: string
+                            hctl:
+                              description: A SCSI bus address like 0:0:0:0. The hint
+                                must match the actual value exactly.
+                              type: string
+                            minSizeGigabytes:
+                              description: The minimum size of the device in Gigabytes.
+                              minimum: 0
+                              type: integer
+                            model:
+                              description: A vendor-specific device identifier. The
+                                hint can be a substring of the actual value.
+                              type: string
+                            rotational:
+                              description: True if the device should use spinning
+                                media, false otherwise.
+                              type: boolean
+                            serialNumber:
+                              description: Device serial number. The hint must match
+                                the actual value exactly.
+                              type: string
+                            vendor:
+                              description: The name of the vendor or manufacturer
+                                of the device. The hint can be a substring of the
+                                actual value.
+                              type: string
+                            wwn:
+                              description: Unique storage identifier. The hint must
+                                match the actual value exactly.
+                              type: string
+                            wwnVendorExtension:
+                              description: Unique vendor storage identifier. The hint
+                                must match the actual value exactly.
+                              type: string
+                            wwnWithExtension:
+                              description: Unique storage identifier with the vendor
+                                extension appended. The hint must match the actual
+                                value exactly.
+                              type: string
+                          type: object
                       required:
                       - bmc
                       - bootMACAddress
@@ -1097,6 +1144,16 @@ spec:
                           type: string
                         type: array
                     type: object
+                  licenses:
+                    description: Licenses is a list of licenses to apply to the compute
+                      images The value should a list of strings (https URLs only)
+                      representing the license keys. When set, this will cause the
+                      installer to copy the image into user's project. This option
+                      is incompatible with any mechanism that makes use of pre-built
+                      images such as the current env OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE
+                    items:
+                      type: string
+                    type: array
                   network:
                     description: Network specifies an existing VPC where the cluster
                       should be created rather than provisioning a new one.
@@ -1475,5 +1532,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -18,7 +18,7 @@ We follow a hard flattening approach; i.e. direct and inherited dependencies are
 
 Dependencies are managed with [Go Modules](https://github.com/golang/go/wiki/Modules) but committed directly to the repository.
 
-We require at least Go 1.13.
+We require at least Go 1.14.
 
 - Add or update a dependency with `go get <dependency>@<version>`.
 - If you want to use a fork of a project or ensure that a dependency is not updated even when another dependency requires a newer version of it, manually add a [replace directive in the go.mod file](https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive). 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/installer
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Azure/azure-sdk-for-go v41.2.0+incompatible

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -5,7 +5,7 @@ set -ex
 # shellcheck disable=SC2068
 version() { IFS="."; printf "%03d%03d%03d\\n" $@; unset IFS;}
 
-minimum_go_version=1.13
+minimum_go_version=1.14
 current_go_version=$(go version | cut -d " " -f 3)
 
 if [ "$(version "${current_go_version#go}")" -lt "$(version "$minimum_go_version")" ]; then

--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -9,6 +9,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.13 \
+    docker.io/openshift/origin-release:golang-1.14 \
     ./hack/go-fmt.sh "${@}"
 fi

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -8,6 +8,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.13 \
+    docker.io/openshift/origin-release:golang-1.14 \
     ./hack/go-lint.sh "${@}"
 fi

--- a/hack/go-sec.sh
+++ b/hack/go-sec.sh
@@ -12,6 +12,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.13 \
+    docker.io/openshift/origin-release:golang-1.14 \
     ./hack/go-sec.sh "${@}"
 fi

--- a/hack/go-test.sh
+++ b/hack/go-test.sh
@@ -8,6 +8,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.13 \
+    docker.io/openshift/origin-release:golang-1.14 \
     ./hack/go-test.sh "${@}"
 fi

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -6,6 +6,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.13 \
+    docker.io/openshift/origin-release:golang-1.14 \
     ./hack/go-vet.sh "${@}"
 fi;

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -11,6 +11,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.13 \
+    docker.io/openshift/origin-release:golang-1.14 \
     ./hack/verify-codegen.sh "${@}"
 fi

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -9,6 +9,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.13 \
+    docker.io/openshift/origin-release:golang-1.14 \
     ./hack/verify-vendor.sh "${@}"
 fi

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -1,7 +1,7 @@
 # This Dockerfile is a used by CI to publish an installer image
 # It builds an image containing openshift-install.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 RUN yum install -y libvirt-devel && \
     yum clean all && rm -rf /var/cache/yum/*
 WORKDIR /go/src/github.com/openshift/installer

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -1,7 +1,7 @@
 # This Dockerfile builds an image containing the Mac version of the installer layered
 # on top of the Linux installer image.
 
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN go generate ./data && \

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -1,7 +1,7 @@
 # This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh

--- a/images/installer/Dockerfile.ci.rhel7
+++ b/images/installer/Dockerfile.ci.rhel7
@@ -1,7 +1,7 @@
 # This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -3,7 +3,7 @@
 # It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
 
 
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -1,7 +1,7 @@
 # This Dockerfile is a used by CI to publish an installer image for creating libvirt clusters
 # It builds an image containing openshift-install and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 RUN yum install -y libvirt-devel && \
     yum clean all && rm -rf /var/cache/yum/*
 WORKDIR /go/src/github.com/openshift/installer

--- a/images/mock/Dockerfile
+++ b/images/mock/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 
 RUN go get github.com/golang/mock/gomock github.com/golang/mock/mockgen

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,6 +1,6 @@
 # This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -14,6 +14,7 @@ cloud.google.com/go/bigtable/internal/option
 # cloud.google.com/go/storage v1.6.0
 cloud.google.com/go/storage
 # github.com/Azure/azure-sdk-for-go v41.2.0+incompatible
+## explicit
 github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources
 github.com/Azure/azure-sdk-for-go/profiles/latest/dns/mgmt/dns
 github.com/Azure/azure-sdk-for-go/services/analysisservices/mgmt/2017-08-01/analysisservices
@@ -110,17 +111,21 @@ github.com/Azure/azure-sdk-for-go/services/trafficmanager/mgmt/2018-04-01/traffi
 github.com/Azure/azure-sdk-for-go/services/web/mgmt/2019-08-01/web
 github.com/Azure/azure-sdk-for-go/version
 # github.com/Azure/go-autorest/autorest v0.10.0 => github.com/tombuildsstuff/go-autorest/autorest v0.10.1-0.20200416184303-d4e299a3c04a
+## explicit
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/azure
 # github.com/Azure/go-autorest/autorest/adal v0.8.2
+## explicit
 github.com/Azure/go-autorest/autorest/adal
 # github.com/Azure/go-autorest/autorest/azure/auth v0.4.1 => github.com/tombuildsstuff/go-autorest/autorest/azure/auth v0.4.3-0.20200416184303-d4e299a3c04a
+## explicit
 github.com/Azure/go-autorest/autorest/azure/auth
 # github.com/Azure/go-autorest/autorest/azure/cli v0.3.1
 github.com/Azure/go-autorest/autorest/azure/cli
 # github.com/Azure/go-autorest/autorest/date v0.2.0
 github.com/Azure/go-autorest/autorest/date
 # github.com/Azure/go-autorest/autorest/to v0.3.1-0.20191028180845-3492b2aff503
+## explicit
 github.com/Azure/go-autorest/autorest/to
 # github.com/Azure/go-autorest/autorest/validation v0.2.1-0.20191028180845-3492b2aff503
 github.com/Azure/go-autorest/autorest/validation
@@ -129,10 +134,12 @@ github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.5.0
 github.com/Azure/go-autorest/tracing
 # github.com/Azure/go-ntlmssp v0.0.0-20191115210519-2b2be6cc8ed4
+## explicit
 github.com/Azure/go-ntlmssp
 # github.com/BurntSushi/toml v0.3.1
 github.com/BurntSushi/toml
 # github.com/ChrisTrenkamp/goxpath v0.0.0-20190607011252-c5096ec8773d
+## explicit
 github.com/ChrisTrenkamp/goxpath
 github.com/ChrisTrenkamp/goxpath/internal/execxp
 github.com/ChrisTrenkamp/goxpath/internal/execxp/findutil
@@ -147,6 +154,8 @@ github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlbuilder
 github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlele
 github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlnode
 github.com/ChrisTrenkamp/goxpath/xconst
+# github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667
+## explicit
 # github.com/PuerkitoBio/purell v1.1.1
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
@@ -155,7 +164,10 @@ github.com/PuerkitoBio/urlesc
 github.com/agext/levenshtein
 # github.com/ajeddeloh/go-json v0.0.0-20170920214419-6a2fe990e083
 github.com/ajeddeloh/go-json
+# github.com/antchfx/xpath v1.1.2
+## explicit
 # github.com/apparentlymart/go-cidr v1.0.1
+## explicit
 github.com/apparentlymart/go-cidr/cidr
 # github.com/apparentlymart/go-textseg v1.0.0
 github.com/apparentlymart/go-textseg/textseg
@@ -164,6 +176,7 @@ github.com/armon/circbuf
 # github.com/armon/go-radix v1.0.0
 github.com/armon/go-radix
 # github.com/awalterschulze/gographviz v0.0.0-20190522210029-fa59802746ab
+## explicit
 github.com/awalterschulze/gographviz
 github.com/awalterschulze/gographviz/ast
 github.com/awalterschulze/gographviz/internal/errors
@@ -171,6 +184,7 @@ github.com/awalterschulze/gographviz/internal/lexer
 github.com/awalterschulze/gographviz/internal/parser
 github.com/awalterschulze/gographviz/internal/token
 # github.com/aws/aws-sdk-go v1.32.3
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -373,20 +387,25 @@ github.com/blang/semver
 # github.com/bmatcuk/doublestar v1.2.1
 github.com/bmatcuk/doublestar
 # github.com/btubbs/datetime v0.1.1
+## explicit
 github.com/btubbs/datetime
 # github.com/c4milo/gotoolkit v0.0.0-20190525173301-67483a18c17a
+## explicit
 github.com/c4milo/gotoolkit
 # github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 github.com/chzyer/readline
 # github.com/containers/image v3.0.2+incompatible
+## explicit
 github.com/containers/image/docker/reference
 github.com/containers/image/pkg/sysregistriesv2
 github.com/containers/image/types
 # github.com/coreos/go-semver v0.3.0
 github.com/coreos/go-semver/semver
 # github.com/coreos/go-systemd v0.0.0 => github.com/coreos/go-systemd/v22 v22.0.0
+## explicit
 github.com/coreos/go-systemd/unit
 # github.com/coreos/ignition v0.35.0
+## explicit
 github.com/coreos/ignition/config/shared/errors
 github.com/coreos/ignition/config/shared/validations
 github.com/coreos/ignition/config/util
@@ -411,6 +430,7 @@ github.com/dgrijalva/jwt-go
 # github.com/dimchansky/utfbom v1.1.0
 github.com/dimchansky/utfbom
 # github.com/dmacvicar/terraform-provider-libvirt v0.6.2
+## explicit
 github.com/dmacvicar/terraform-provider-libvirt/libvirt
 github.com/dmacvicar/terraform-provider-libvirt/libvirt/helper/suppress
 # github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
@@ -422,11 +442,14 @@ github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/fatih/color v1.7.0
 github.com/fatih/color
+# github.com/frankban/quicktest v1.7.2
+## explicit
 # github.com/gammazero/deque v0.0.0-20190130191400-2afb3858e9c7
 github.com/gammazero/deque
 # github.com/gammazero/workerpool v0.0.0-20190406235159-88d534f22b56
 github.com/gammazero/workerpool
 # github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
+## explicit
 github.com/ghodss/yaml
 # github.com/go-openapi/jsonpointer v0.19.3
 github.com/go-openapi/jsonpointer
@@ -442,6 +465,7 @@ github.com/go-playground/locales/currency
 # github.com/go-playground/universal-translator v0.17.0
 github.com/go-playground/universal-translator
 # github.com/go-playground/validator/v10 v10.2.0
+## explicit
 github.com/go-playground/validator/v10
 # github.com/gobuffalo/flect v0.2.0
 github.com/gobuffalo/flect
@@ -453,6 +477,7 @@ github.com/gogo/protobuf/sortkeys
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
 # github.com/golang/mock v1.4.3
+## explicit
 github.com/golang/mock/gomock
 # github.com/golang/protobuf v1.3.5
 github.com/golang/protobuf/proto
@@ -478,7 +503,10 @@ github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
+# github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible
+## explicit
 # github.com/google/uuid v1.1.1
+## explicit
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
@@ -487,6 +515,7 @@ github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/gophercloud/gophercloud v0.8.0
+## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/internal
 github.com/gophercloud/gophercloud/openstack
@@ -612,12 +641,14 @@ github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gophercloud/utils v0.0.0-20191212191830-4533a07bd492
+## explicit
 github.com/gophercloud/utils/client
 github.com/gophercloud/utils/env
 github.com/gophercloud/utils/openstack/baremetal/v1/nodes
 github.com/gophercloud/utils/openstack/clientconfig
 github.com/gophercloud/utils/terraform/auth
 # github.com/h2non/filetype v1.0.12
+## explicit
 github.com/h2non/filetype/matchers
 github.com/h2non/filetype/matchers/isobmff
 github.com/h2non/filetype/types
@@ -626,6 +657,7 @@ github.com/hashicorp/aws-sdk-go-base
 # github.com/hashicorp/errwrap v1.0.0
 github.com/hashicorp/errwrap
 # github.com/hashicorp/go-azure-helpers v0.10.0
+## explicit
 github.com/hashicorp/go-azure-helpers/authentication
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/response
@@ -641,6 +673,7 @@ github.com/hashicorp/go-hclog
 # github.com/hashicorp/go-multierror v1.1.0
 github.com/hashicorp/go-multierror
 # github.com/hashicorp/go-plugin v1.2.0
+## explicit
 github.com/hashicorp/go-plugin
 github.com/hashicorp/go-plugin/internal/plugin
 # github.com/hashicorp/go-retryablehttp v0.6.4
@@ -684,8 +717,10 @@ github.com/hashicorp/hil/ast
 github.com/hashicorp/hil/parser
 github.com/hashicorp/hil/scanner
 # github.com/hashicorp/logutils v1.0.0
+## explicit
 github.com/hashicorp/logutils
 # github.com/hashicorp/terraform v0.12.21 => github.com/openshift/terraform v0.12.20-openshift-3
+## explicit
 github.com/hashicorp/terraform/addrs
 github.com/hashicorp/terraform/backend
 github.com/hashicorp/terraform/backend/init
@@ -765,6 +800,7 @@ github.com/hashicorp/terraform-config-inspect/tfconfig
 # github.com/hashicorp/terraform-json v0.5.0
 github.com/hashicorp/terraform-json
 # github.com/hashicorp/terraform-plugin-sdk v1.14.0 => github.com/openshift/hashicorp-terraform-plugin-sdk v1.14.0-openshift
+## explicit
 github.com/hashicorp/terraform-plugin-sdk/acctest
 github.com/hashicorp/terraform-plugin-sdk/helper/acctest
 github.com/hashicorp/terraform-plugin-sdk/helper/customdiff
@@ -823,8 +859,12 @@ github.com/hashicorp/terraform-plugin-test
 github.com/hashicorp/terraform-svchost
 github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
+# github.com/hashicorp/vault v1.3.0
+## explicit
 # github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d
 github.com/hashicorp/yamux
+# github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c
+## explicit
 # github.com/hooklift/iso9660 v1.0.0
 github.com/hooklift/iso9660
 # github.com/imdario/mergo v0.3.8
@@ -846,6 +886,7 @@ github.com/kardianos/osext
 # github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 github.com/kballard/go-shellquote
 # github.com/keybase/go-crypto v0.0.0-20190828182435-a05457805304
+## explicit
 github.com/keybase/go-crypto/brainpool
 github.com/keybase/go-crypto/cast5
 github.com/keybase/go-crypto/curve25519
@@ -870,16 +911,20 @@ github.com/kr/text
 # github.com/leodido/go-urn v1.2.0
 github.com/leodido/go-urn
 # github.com/libvirt/libvirt-go v5.10.0+incompatible
+## explicit
 github.com/libvirt/libvirt-go
 # github.com/libvirt/libvirt-go-xml v5.10.0+incompatible
+## explicit
 github.com/libvirt/libvirt-go-xml
 # github.com/mailru/easyjson v0.7.0
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
 # github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786
+## explicit
 github.com/masterzen/simplexml/dom
 # github.com/masterzen/winrm v0.0.0-20190308153735-1d17eaf15943
+## explicit
 github.com/masterzen/winrm
 github.com/masterzen/winrm/soap
 # github.com/mattn/go-colorable v0.1.4
@@ -887,16 +932,19 @@ github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.12
 github.com/mattn/go-isatty
 # github.com/metal3-io/baremetal-operator v0.0.0 => github.com/openshift/baremetal-operator v0.0.0-20200611190251-d997d9c06ba8
+## explicit
 github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1
 github.com/metal3-io/baremetal-operator/pkg/bmc
 github.com/metal3-io/baremetal-operator/pkg/hardware
 github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/devicehints
 # github.com/metal3-io/cluster-api-provider-baremetal v0.0.0 => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d
+## explicit
 github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis
 github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1
 # github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 github.com/mgutz/ansi
 # github.com/mitchellh/cli v1.0.0
+## explicit
 github.com/mitchellh/cli
 # github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 github.com/mitchellh/colorstring
@@ -931,16 +979,20 @@ github.com/oklog/run
 # github.com/opencontainers/go-digest v1.0.0-rc1
 github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
+## explicit
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
 # github.com/openshift-metal3/terraform-provider-ironic v0.2.1
+## explicit
 github.com/openshift-metal3/terraform-provider-ironic/ironic
 # github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible => github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422
+## explicit
 github.com/openshift/api/config/v1
 github.com/openshift/api/operator/v1
 github.com/openshift/api/operator/v1alpha1
 github.com/openshift/api/route/v1
 # github.com/openshift/client-go v0.0.0-20200320150128-a906f3d8e723 => github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
+## explicit
 github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
@@ -948,46 +1000,61 @@ github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
 # github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e
+## explicit
 github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1
 github.com/openshift/cloud-credential-operator/pkg/aws
 github.com/openshift/cloud-credential-operator/version
 # github.com/openshift/cluster-api v0.0.0-20191129101638-b09907ac6668
+## explicit
 github.com/openshift/cluster-api/pkg/apis/machine/common
 github.com/openshift/cluster-api/pkg/apis/machine/v1beta1
 # github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200120152131-1b09fd9e7156
+## explicit
 github.com/openshift/cluster-api-provider-gcp/pkg/apis
 github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1
 # github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603
+## explicit
 github.com/openshift/cluster-api-provider-libvirt/pkg/apis
 github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1
 # github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200504092944-27473ea1ae43
+## explicit
 github.com/openshift/cluster-api-provider-ovirt/pkg/apis
 github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1
 # github.com/openshift/library-go v0.0.0-20200324092245-db2a8546af81
+## explicit
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 # github.com/openshift/machine-api-operator v0.2.1-0.20200429102619-d36974451290
+## explicit
 github.com/openshift/machine-api-operator/pkg/apis/machine
 github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1
 github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider
 github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1
 # github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible => github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530
+## explicit
 github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1
 # github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27
+## explicit
 github.com/ovirt/go-ovirt
 # github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200406133650-74a154c1d861
+## explicit
 github.com/ovirt/terraform-provider-ovirt/ovirt
 # github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db
+## explicit
 github.com/packer-community/winrmcp/winrmcp
 # github.com/pborman/uuid v1.2.0
+## explicit
 github.com/pborman/uuid
 # github.com/pierrec/lz4 v2.3.0+incompatible
+## explicit
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 github.com/pkg/browser
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pkg/sftp v1.10.1
+## explicit
 github.com/pkg/sftp
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
@@ -998,25 +1065,32 @@ github.com/posener/complete/cmd/install
 # github.com/satori/go.uuid v1.2.0
 github.com/satori/go.uuid
 # github.com/satori/uuid v1.2.0
+## explicit
 github.com/satori/uuid
 # github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 github.com/shurcooL/httpfs/vfsutil
 # github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
+## explicit
 github.com/shurcooL/vfsgen
 # github.com/sirupsen/logrus v1.5.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/afero v1.2.2
 github.com/spf13/afero
 github.com/spf13/afero/mem
 # github.com/spf13/cobra v0.0.6
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # github.com/stoewer/go-strcase v1.1.0
+## explicit
 github.com/stoewer/go-strcase
 # github.com/stretchr/testify v1.5.1
+## explicit
 github.com/stretchr/testify/assert
 # github.com/terraform-providers/terraform-provider-aws v0.0.0 => github.com/openshift/terraform-provider-aws v1.60.1-0.20200630224953-76d1fb4e5699
+## explicit
 github.com/terraform-providers/terraform-provider-aws/aws
 github.com/terraform-providers/terraform-provider-aws/aws/internal/flatmap
 github.com/terraform-providers/terraform-provider-aws/aws/internal/keyvaluetags
@@ -1036,6 +1110,7 @@ github.com/terraform-providers/terraform-provider-aws/aws/internal/service/works
 github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/tf
 github.com/terraform-providers/terraform-provider-azuread/azuread/helpers/validate
 # github.com/terraform-providers/terraform-provider-azurerm v0.0.0 => github.com/openshift/terraform-provider-azurerm v1.40.1-0.20200508151851-2bfa0b7d4a9d
+## explicit
 github.com/terraform-providers/terraform-provider-azurerm/azurerm
 github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/azure
 github.com/terraform-providers/terraform-provider-azurerm/azurerm/helpers/common
@@ -1263,17 +1338,23 @@ github.com/terraform-providers/terraform-provider-azurerm/azurerm/internal/timeo
 github.com/terraform-providers/terraform-provider-azurerm/azurerm/utils
 github.com/terraform-providers/terraform-provider-azurerm/version
 # github.com/terraform-providers/terraform-provider-google v1.20.1-0.20200623174414-27107f2ee160
+## explicit
 github.com/terraform-providers/terraform-provider-google/google
 github.com/terraform-providers/terraform-provider-google/version
 # github.com/terraform-providers/terraform-provider-ignition v1.2.1
+## explicit
 github.com/terraform-providers/terraform-provider-ignition/ignition
 # github.com/terraform-providers/terraform-provider-local v1.4.0
+## explicit
 github.com/terraform-providers/terraform-provider-local/local
 # github.com/terraform-providers/terraform-provider-openstack v1.25.0
+## explicit
 github.com/terraform-providers/terraform-provider-openstack/openstack
 # github.com/terraform-providers/terraform-provider-random v1.3.2-0.20190925210718-83518d96ae4f
+## explicit
 github.com/terraform-providers/terraform-provider-random/random
 # github.com/terraform-providers/terraform-provider-vsphere v1.16.2 => github.com/openshift/terraform-provider-vsphere v1.18.1-openshift-1
+## explicit
 github.com/terraform-providers/terraform-provider-vsphere/vsphere
 github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource
 github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/computeresource
@@ -1312,16 +1393,19 @@ github.com/tombuildsstuff/giovanni/storage/internal/endpoints
 github.com/tombuildsstuff/giovanni/storage/internal/metadata
 github.com/tombuildsstuff/giovanni/version
 # github.com/ulikunitz/xz v0.5.6
+## explicit
 github.com/ulikunitz/xz
 github.com/ulikunitz/xz/internal/hash
 github.com/ulikunitz/xz/internal/xlog
 github.com/ulikunitz/xz/lzma
 # github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
+## explicit
 github.com/vincent-petithory/dataurl
 # github.com/vmihailenco/msgpack v4.0.4+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
 # github.com/vmware/govmomi v0.22.2 => github.com/vmware/govmomi v0.22.2-0.20200420222347-5fceac570f29
+## explicit
 github.com/vmware/govmomi
 github.com/vmware/govmomi/event
 github.com/vmware/govmomi/find
@@ -1359,6 +1443,7 @@ github.com/vmware/govmomi/vmdk
 # github.com/xanzy/ssh-agent v0.2.1
 github.com/xanzy/ssh-agent
 # github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
+## explicit
 github.com/xlab/treeprint
 # github.com/zclconf/go-cty v1.2.1
 github.com/zclconf/go-cty/cty
@@ -1392,6 +1477,7 @@ go.opencensus.io/trace/tracestate
 # go4.org v0.0.0-20191010144846-132d2879e1e9
 go4.org/errorutil
 # golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
+## explicit
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blowfish
 golang.org/x/crypto/cast5
@@ -1416,6 +1502,7 @@ golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/lint v0.0.0-20200302205851-738671d3881b
+## explicit
 golang.org/x/lint
 golang.org/x/lint/golint
 # golang.org/x/mod v0.2.0
@@ -1434,12 +1521,14 @@ golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sys v0.0.0-20200331124033-c3d80250170d
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/unix
 golang.org/x/sys/windows
@@ -1497,6 +1586,7 @@ golang.org/x/tools/internal/typesinternal
 golang.org/x/xerrors
 golang.org/x/xerrors/internal
 # google.golang.org/api v0.25.0
+## explicit
 google.golang.org/api/appengine/v1
 google.golang.org/api/bigquery/v2
 google.golang.org/api/bigtableadmin/v2
@@ -1626,14 +1716,17 @@ google.golang.org/grpc/status
 google.golang.org/grpc/tap
 google.golang.org/grpc/test/bufconn
 # gopkg.in/AlecAivazis/survey.v1 v1.8.9-0.20200217094205-6773bdf39b7f
+## explicit
 gopkg.in/AlecAivazis/survey.v1
 gopkg.in/AlecAivazis/survey.v1/core
 gopkg.in/AlecAivazis/survey.v1/terminal
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/ini.v1 v1.51.0
+## explicit
 gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.2.8
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966
 gopkg.in/yaml.v3
@@ -1668,6 +1761,7 @@ honnef.co/go/tools/stylecheck
 honnef.co/go/tools/unused
 honnef.co/go/tools/version
 # k8s.io/api v0.18.3 => k8s.io/api v0.17.1
+## explicit
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/apps/v1
@@ -1709,10 +1803,12 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.18.2 => k8s.io/apiextensions-apiserver v0.17.1
+## explicit
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 # k8s.io/apimachinery v0.18.3 => k8s.io/apimachinery v0.17.1
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -1756,6 +1852,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.17.1
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme
@@ -1824,27 +1921,33 @@ k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 # k8s.io/klog v1.0.0
+## explicit
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 k8s.io/kube-openapi/pkg/common
 # k8s.io/utils v0.0.0-20200327001022-6496210b90e8
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # sigs.k8s.io/cluster-api-provider-aws v0.0.0 => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200506073438-9d49428ff837
+## explicit
 sigs.k8s.io/cluster-api-provider-aws/pkg/apis
 sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1
 # sigs.k8s.io/cluster-api-provider-azure v0.0.0 => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b
+## explicit
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1alpha1
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1
 # sigs.k8s.io/cluster-api-provider-openstack v0.0.0 => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200526112135-319a35b2e38e
+## explicit
 sigs.k8s.io/cluster-api-provider-openstack/pkg/apis
 sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1
 # sigs.k8s.io/controller-runtime v0.5.2
 sigs.k8s.io/controller-runtime/pkg/scheme
 # sigs.k8s.io/controller-tools v0.3.1-0.20200617211605-651903477185
+## explicit
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
 sigs.k8s.io/controller-tools/pkg/crd/markers
@@ -1861,3 +1964,44 @@ sigs.k8s.io/controller-tools/pkg/version
 sigs.k8s.io/controller-tools/pkg/webhook
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# github.com/Azure/go-autorest => github.com/tombuildsstuff/go-autorest v14.0.1-0.20200416184303-d4e299a3c04a+incompatible
+# github.com/Azure/go-autorest/autorest => github.com/tombuildsstuff/go-autorest/autorest v0.10.1-0.20200416184303-d4e299a3c04a
+# github.com/Azure/go-autorest/autorest/azure/auth => github.com/tombuildsstuff/go-autorest/autorest/azure/auth v0.4.3-0.20200416184303-d4e299a3c04a
+# github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.0.0
+# github.com/go-log/log => github.com/go-log/log v0.1.1-0.20181211034820-a514cf01a3eb
+# github.com/hashicorp/terraform => github.com/openshift/terraform v0.12.20-openshift-3
+# github.com/hashicorp/terraform-plugin-sdk => github.com/openshift/hashicorp-terraform-plugin-sdk v1.14.0-openshift
+# github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200611190251-d997d9c06ba8
+# github.com/metal3-io/cluster-api-provider-baremetal => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d
+# github.com/openshift/api => github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422
+# github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240
+# github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530
+# github.com/terraform-providers/terraform-provider-aws => github.com/openshift/terraform-provider-aws v1.60.1-0.20200630224953-76d1fb4e5699
+# github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.40.1-0.20200508151851-2bfa0b7d4a9d
+# github.com/terraform-providers/terraform-provider-vsphere => github.com/openshift/terraform-provider-vsphere v1.18.1-openshift-1
+# github.com/vmware/govmomi => github.com/vmware/govmomi v0.22.2-0.20200420222347-5fceac570f29
+# k8s.io/api => k8s.io/api v0.17.1
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.1
+# k8s.io/apimachinery => k8s.io/apimachinery v0.17.1
+# k8s.io/apiserver => k8s.io/apiserver v0.17.1
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.17.1
+# k8s.io/client-go => k8s.io/client-go v0.17.1
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.17.1
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.17.1
+# k8s.io/code-generator => k8s.io/code-generator v0.17.1
+# k8s.io/component-base => k8s.io/component-base v0.17.1
+# k8s.io/cri-api => k8s.io/cri-api v0.17.1
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.17.1
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.17.1
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.17.1
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.17.1
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.17.1
+# k8s.io/kubectl => k8s.io/kubectl v0.17.1
+# k8s.io/kubelet => k8s.io/kubelet v0.17.1
+# k8s.io/kubernetes => k8s.io/kubernetes v1.17.1
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.1
+# k8s.io/metrics => k8s.io/metrics v0.17.1
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.1
+# sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200506073438-9d49428ff837
+# sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b
+# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200526112135-319a35b2e38e


### PR DESCRIPTION
With Go 1.14 the handling of modules has improved in the sense that all the subcommands `go {test, generate}` now use the vendor when available by default. This makes it easier for us to run generate using the vendored tools like controller-tools etc. as it now uses the checked in vendor.
