### PR TITLE
cmd/openshift-install/create: Mention 'wait-for' when install-complete fails

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -130,6 +130,8 @@ var (
 					if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
 						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
 					}
+					logrus.Info("Use the following command if you want to wait longer for install completion:")
+					logrus.Info("openshift-install wait-for install-complete --help")
 					logrus.Fatal(err)
 				}
 				timer.StopTimer(timer.TotalTimeElapsed)

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -52,7 +52,7 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 					logrus.Error("Attempted to gather ClusterOperator status after wait failure: ", err2)
 				}
 
-				logrus.Info("Use the following commands to gather logs from the cluster")
+				logrus.Info("Use the following command to gather logs from the cluster:")
 				logrus.Info("openshift-install gather bootstrap --help")
 				logrus.Fatal(err)
 			}


### PR DESCRIPTION
Folks might wish to wait longer, possibly after trying to manually recover some cluster component.  Personally I'd rather drop the `install-complete` timeout entirely and have callers supply their own timeout like:

```console
$ timeout 1h openshift-install create cluster
```

but @stbenjam feels that the current installer output is not sufficiently clear to allow users to make informed decisions about whether waiting longer or not makes sense.  Potentially product improvements like alerting on stuck-in-`Provisioned` compute machines and installer logging of firing alerts would help in this space.  But until we can drop the timeout, pointing folks at the wait-for command makes that safety valve more discoverable.

The `Use the following command...` language is originally from 07aa0e015e (#1627), so I'm just rolling forward with that approach instead of porting it to use `argv[0]` or something vs. it's current assumption that the installer command will be `openshift-install`.