### PR TITLE
installer-masters-gather: Grab the whole journal, not specific units

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -19,12 +19,8 @@ do
     systemctl status "${UNIT}" >& "${ARTIFACTS}/unit-status/${UNIT}.txt"
 done
 
-echo "Gathering master journals ..."
-mkdir -p "${ARTIFACTS}/journals"
-for service in kubelet crio machine-config-daemon-host pivot
-do
-    journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
-done
+echo "Gathering master journal ..."
+journalctl --no-hostname --no-pager --output=short > "${ARTIFACTS}/journal.txt"
 
 echo "Gathering master containers ..."
 mkdir -p "${ARTIFACTS}/containers"

--- a/docs/user/troubleshootingbootstrap.md
+++ b/docs/user/troubleshootingbootstrap.md
@@ -157,13 +157,9 @@ control-plane
 
 The containers directory contains the descriptions and logs from all the containers created by the kubelet using CRI-O on the control-plane host. The files are same as [containers directory](#directory-bootstrap-containers) on bootstrap host.
 
-#### directory: control-plane/name/journals
+#### directory: control-plane/name/journal.txt
 
-The journals directory contains the logs of **important** units on the control plane hosts. The list of such units is,
-
-* `crio.log`
-* `kubelet.log`
-* `machine-config-daemon-host.log` and `pivot.log`, these files have logs for RHCOS pivot related actions on the control plane host.
+The `journal.txt` file contains the full journal from the control plane host.
 
 ## Common Failures
 


### PR DESCRIPTION
I'm reworking this in https://github.com/openshift/machine-config-operator/pull/1766
and the new unit names aren't present here.  I am not aware of a reason
not to just grab the whole journal, so let's do that.