### PR TITLE
Bug 1846296: openstack UPI: prune containers

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -895,6 +895,7 @@ $ ansible-playbook -i inventory.yaml  \
 	down-control-plane.yaml  \
 	down-compute-nodes.yaml  \
 	down-load-balancers.yaml \
+	down-containers.yaml     \
 	down-network.yaml        \
 	down-security-groups.yaml
 ```

--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -8,6 +8,7 @@
   - name: 'Compute resource names'
     set_fact:
       cluster_id_tag: "openshiftClusterID={{ infraID }}"
+      os_infra_id: "{{ infraID }}"
       os_network: "{{ infraID }}-network"
       os_subnet: "{{ infraID }}-nodes"
       os_router: "{{ infraID }}-external-router"

--- a/upi/openstack/down-containers.yaml
+++ b/upi/openstack/down-containers.yaml
@@ -1,0 +1,20 @@
+# Required Python packages:
+#
+# ansible
+# openstackclient
+# openstacksdk
+
+- import_playbook: common.yaml
+
+- hosts: all
+  gather_facts: no
+
+  tasks:
+  - name: 'List the containers associated with the cluster'
+    command:
+      cmd: "openstack container list --prefix {{ os_infra_id }} -f value -c Name"
+    register: container_list
+
+  - name: 'Delete the containers associated with the cluster'
+    command:
+      cmd: "openstack container delete -r {{ container_list.stdout }}"


### PR DESCRIPTION
Add a `down-` playbook to the OpenStack UPI documentation to delete any
remaining Swift container named after the cluster.

/label platform/openstack