### PR TITLE
destroy/gcp: bubble up errors after 5 minutes

### DIFF
--- a/pkg/destroy/gcp/address.go
+++ b/pkg/destroy/gcp/address.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyAddresses() error {
 		return err
 	}
 	items := o.insertPendingItems("address", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteAddress(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("address")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("address"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/backendservice.go
+++ b/pkg/destroy/gcp/backendservice.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyBackendServices() error {
 		return err
 	}
 	items := o.insertPendingItems("backendservice", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteBackendService(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("backendservice")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("backendservice"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/disk.go
+++ b/pkg/destroy/gcp/disk.go
@@ -78,13 +78,14 @@ func (o *ClusterUninstaller) destroyDisks() error {
 		return err
 	}
 	items := o.insertPendingItems("disk", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteDisk(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("disk")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("disk"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/errortracker.go
+++ b/pkg/destroy/gcp/errortracker.go
@@ -1,0 +1,34 @@
+package gcp
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	suppressDuration = time.Minute * 5
+)
+
+// errorTracker holds a history of errors
+type errorTracker struct {
+	history map[string]time.Time
+}
+
+// suppressWarning logs errors WARN once every duration and the rest to DEBUG
+func (o *errorTracker) suppressWarning(identifier string, err error, logger logrus.FieldLogger) {
+	if o.history == nil {
+		o.history = map[string]time.Time{}
+	}
+	if firstSeen, ok := o.history[identifier]; ok {
+		if time.Since(firstSeen) > suppressDuration {
+			logger.Warn(err)
+			o.history[identifier] = time.Now() // reset the clock
+		} else {
+			logger.Debug(err)
+		}
+	} else { // first error for this identifier
+		o.history[identifier] = time.Now()
+		logger.Debug(err)
+	}
+}

--- a/pkg/destroy/gcp/firewall.go
+++ b/pkg/destroy/gcp/firewall.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyFirewalls() error {
 		return err
 	}
 	items := o.insertPendingItems("firewall", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteFirewall(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("firewall")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("firewall"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/forwardingrule.go
+++ b/pkg/destroy/gcp/forwardingrule.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyForwardingRules() error {
 		return err
 	}
 	items := o.insertPendingItems("forwardingrule", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteForwardingRule(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("forwardingrule")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("forwardingrule"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -51,6 +51,7 @@ type ClusterUninstaller struct {
 	// from metadata or by inferring it from existing cluster resources.
 	cloudControllerUID string
 
+	errorTracker
 	requestIDTracker
 	pendingItemTracker
 }

--- a/pkg/destroy/gcp/healthcheck.go
+++ b/pkg/destroy/gcp/healthcheck.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyHealthChecks() error {
 		return err
 	}
 	items := o.insertPendingItems("healthcheck", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteHealthCheck(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("healthcheck")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("healthcheck"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/httphealthcheck.go
+++ b/pkg/destroy/gcp/httphealthcheck.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyHTTPHealthChecks() error {
 		return err
 	}
 	items := o.insertPendingItems("httphealthcheck", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteHTTPHealthCheck(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("httphealthcheck")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("httphealthcheck"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/image.go
+++ b/pkg/destroy/gcp/image.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyImages() error {
 		return err
 	}
 	items := o.insertPendingItems("image", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteImage(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("image")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("image"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/instance.go
+++ b/pkg/destroy/gcp/instance.go
@@ -148,13 +148,14 @@ func (o *ClusterUninstaller) stopInstances() error {
 		}
 	}
 	items := o.getPendingItems("stopinstance")
-	errs := []error{}
 	for _, item := range items {
 		err := o.stopInstance(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("stopinstance")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("stopinstance"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/instancegroup.go
+++ b/pkg/destroy/gcp/instancegroup.go
@@ -105,13 +105,14 @@ func (o *ClusterUninstaller) destroyInstanceGroups() error {
 		return err
 	}
 	items := o.insertPendingItems("instancegroup", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteInstanceGroup(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("instancegroup")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("instancegroup"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/policybinding.go
+++ b/pkg/destroy/gcp/policybinding.go
@@ -76,5 +76,8 @@ func (o *ClusterUninstaller) destroyIAMPolicyBindings() error {
 	}
 	o.insertPendingItems("iampolicy", []cloudResource{{key: "policy", name: "policy", typeName: "iampolicy"}})
 	err = o.setProjectIAMPolicy(policy)
-	return aggregateError([]error{err}, 1)
+	if err != nil {
+		return err
+	}
+	return errors.Errorf("%d items pending", 1)
 }

--- a/pkg/destroy/gcp/router.go
+++ b/pkg/destroy/gcp/router.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyRouters() error {
 		return err
 	}
 	items := o.insertPendingItems("router", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteRouter(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("router")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("router"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/serviceaccount.go
+++ b/pkg/destroy/gcp/serviceaccount.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyServiceAccounts() error {
 	o.insertPendingItems("serviceaccount_binding", found) // store service accounts to remove project IAM binding
 
 	items := o.insertPendingItems("serviceaccount", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteServiceAccount(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("serviceaccount")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("serviceaccount"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/subnetwork.go
+++ b/pkg/destroy/gcp/subnetwork.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroySubnetworks() error {
 		return err
 	}
 	items := o.insertPendingItems("subnetwork", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteSubnetwork(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("subnetwork")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("subnetwork"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }

--- a/pkg/destroy/gcp/targetpool.go
+++ b/pkg/destroy/gcp/targetpool.go
@@ -72,13 +72,14 @@ func (o *ClusterUninstaller) destroyTargetPools() error {
 		return err
 	}
 	items := o.insertPendingItems("targetpool", found)
-	errs := []error{}
 	for _, item := range items {
 		err := o.deleteTargetPool(item)
 		if err != nil {
-			errs = append(errs, err)
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
 		}
 	}
-	items = o.getPendingItems("targetpool")
-	return aggregateError(errs, len(items))
+	if items = o.getPendingItems("targetpool"); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
 }


### PR DESCRIPTION
This change will allow errors to become visible to users using log-level
of warn or higher. It continues to log errors encountered while deleting
cloud resources as DEBUG while escalating the errors to WARN once every
5 minutes.