### PR TITLE
gitignore: add .openshift_install.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bin/
+.openshift_install.log


### PR DESCRIPTION
If the project is build without the --dir no need to show
.openshift_install.log in the git status command.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>