### PR TITLE
[FCOS] Use Ignition spec 3 in openstack terraform

### DIFF
--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -4,7 +4,6 @@ data "openstack_compute_flavor_v2" "masters_flavor" {
 
 data "ignition_file" "hostname" {
   count      = var.instance_count
-  filesystem = "root"
   mode       = "420" // 0644
   path       = "/etc/hostname"
 
@@ -18,7 +17,7 @@ EOF
 data "ignition_config" "master_ignition_config" {
   count = var.instance_count
 
-  append {
+  merge {
     source = "data:text/plain;charset=utf-8;base64,${base64encode(var.user_data_ign)}"
   }
 

--- a/upi/vsphere/lb/main.tf
+++ b/upi/vsphere/lb/main.tf
@@ -4,7 +4,6 @@ data "ignition_systemd_unit" "haproxy" {
 }
 
 data "ignition_file" "haproxy" {
-  filesystem = "root"
   path       = "/etc/haproxy/haproxy.conf"
   mode       = 0755
   content {
@@ -26,4 +25,3 @@ data "ignition_config" "lb" {
   files   = [data.ignition_file.haproxy.rendered]
   systemd = [data.ignition_systemd_unit.haproxy.rendered]
 }
-

--- a/upi/vsphere/vm/ignition.tf
+++ b/upi/vsphere/vm/ignition.tf
@@ -5,7 +5,6 @@ locals {
 data "ignition_file" "hostname" {
   for_each = var.hostnames_ip_addresses
 
-  filesystem = "root"
   path       = "/etc/hostname"
   mode       = "420"
 
@@ -17,7 +16,6 @@ data "ignition_file" "hostname" {
 data "ignition_file" "static_ip" {
   for_each = var.hostnames_ip_addresses
 
-  filesystem = "root"
   path       = "/etc/sysconfig/network-scripts/ifcfg-ens192"
   mode       = "420"
 
@@ -35,7 +33,7 @@ data "ignition_file" "static_ip" {
 data "ignition_config" "ign" {
   for_each = var.hostnames_ip_addresses
 
-  append {
+  merge {
     source = local.ignition_encoded
   }
 
@@ -44,4 +42,3 @@ data "ignition_config" "ign" {
     data.ignition_file.static_ip[each.key].rendered,
   ]
 }
-


### PR DESCRIPTION
openstack masters are using Ignition provider to generate Ignition file, so it needs to be ported to Ignition spec 3.

Fixes https://github.com/openshift/okd/issues/127