### PR TITLE
Metrics: Add push client to push metrics to endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.10.1
 	github.com/prometheus/client_golang v1.5.1
+	github.com/prometheus/common v0.9.1
 	github.com/satori/uuid v1.2.0 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	github.com/sirupsen/logrus v1.5.0

--- a/pkg/metrics/pushclient/pushclient.go
+++ b/pkg/metrics/pushclient/pushclient.go
@@ -1,0 +1,36 @@
+package pushclient
+
+import (
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+	"github.com/prometheus/common/expfmt"
+)
+
+// PushClient is used to send Prometheus metrics objects to any Prometheus
+// Push Gateway. It stores the URL and the client that will be used to push
+// to the desired gateway.
+type PushClient struct {
+	URL     string
+	Client  *http.Client
+	JobName string
+}
+
+// Push uses all the configuration settings from the client and pushes to the prometheus
+// aggregation gateway. It takes in an additional list of collectors and pushes all of
+// them to the previously configured url.
+func (p *PushClient) Push(collectors ...prometheus.Collector) error {
+	pushClient := push.New(p.URL, p.JobName).Client(p.Client).Format(expfmt.FmtText)
+
+	for _, value := range collectors {
+		pushClient.Collector(value)
+	}
+
+	err := pushClient.Push()
+	if err != nil {
+		return errors.Wrap(err, "failed to push metrics")
+	}
+	return nil
+}

--- a/pkg/metrics/pushclient/pushclient_test.go
+++ b/pkg/metrics/pushclient/pushclient_test.go
@@ -1,0 +1,124 @@
+package pushclient
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPushMetricsToGateway(t *testing.T) {
+	promCollector := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name:        "test",
+			Help:        "test metrics",
+			ConstLabels: map[string]string{"test1": "test1"},
+		},
+	)
+
+	promCollector.Add(10)
+
+	expectedOutput := `# HELP test test metrics
+# TYPE test counter
+test{test1="test1"} 10
+`
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		buf := new(strings.Builder)
+		_, err := io.Copy(buf, req.Body)
+		assert.NoError(t, err)
+		assert.EqualValues(t, expectedOutput, buf.String())
+		fmt.Println("all done")
+	}))
+	defer testServer.Close()
+
+	pushClient := PushClient{URL: testServer.URL, Client: &http.Client{}, JobName: "installer_metrics"}
+	pushClient.Push(promCollector)
+
+}
+
+func TestPushMetricsToAllGateway(t *testing.T) {
+	counter := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name:        "test_counter",
+			Help:        "test metrics",
+			ConstLabels: map[string]string{"test1": "test1"},
+		},
+	)
+	counter.Add(10)
+
+	histogram := prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:        "test_histogram",
+			Help:        "test metrics",
+			ConstLabels: map[string]string{"test1": "test1"},
+		},
+	)
+	histogram.Observe(10)
+
+	promCollector := []prometheus.Collector{counter, histogram}
+
+	expectedOutput := `# HELP test_counter test metrics
+# TYPE test_counter counter
+test_counter{test1="test1"} 10
+# HELP test_histogram test metrics
+# TYPE test_histogram histogram
+test_histogram_bucket{test1="test1",le="0.005"} 0
+test_histogram_bucket{test1="test1",le="0.01"} 0
+test_histogram_bucket{test1="test1",le="0.025"} 0
+test_histogram_bucket{test1="test1",le="0.05"} 0
+test_histogram_bucket{test1="test1",le="0.1"} 0
+test_histogram_bucket{test1="test1",le="0.25"} 0
+test_histogram_bucket{test1="test1",le="0.5"} 0
+test_histogram_bucket{test1="test1",le="1"} 0
+test_histogram_bucket{test1="test1",le="2.5"} 0
+test_histogram_bucket{test1="test1",le="5"} 0
+test_histogram_bucket{test1="test1",le="10"} 1
+test_histogram_bucket{test1="test1",le="+Inf"} 1
+test_histogram_sum{test1="test1"} 10
+test_histogram_count{test1="test1"} 1
+`
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		buf := new(strings.Builder)
+		_, err := io.Copy(buf, req.Body)
+		assert.NoError(t, err)
+		assert.EqualValues(t, expectedOutput, buf.String())
+		fmt.Println("all done")
+	}))
+	defer testServer.Close()
+	pushClient := PushClient{URL: testServer.URL, Client: &http.Client{}, JobName: "installer_metrics"}
+	err := pushClient.Push(promCollector...)
+	assert.NoError(t, err)
+}
+
+func TestPushMetricsBadServer(t *testing.T) {
+	counter := prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name:        "test_counter",
+			Help:        "test metrics",
+			ConstLabels: map[string]string{"test1": "test1"},
+		},
+	)
+	counter.Add(10)
+
+	promCollector := []prometheus.Collector{counter}
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		http.Error(w, "test error message", http.StatusForbidden)
+	}))
+	defer testServer.Close()
+	pushClient := PushClient{URL: testServer.URL, Client: &http.Client{}, JobName: "installer_metrics"}
+	err := pushClient.Push(promCollector...)
+
+	errorMessage := fmt.Sprintf("failed to push metrics: unexpected status code 403 while pushing to %s/metrics/job/installer_metrics: test error message\n", testServer.URL)
+
+	if assert.Error(t, err) {
+		assert.EqualError(t, err, errorMessage)
+	}
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/push/push.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/push/push.go
@@ -1,0 +1,309 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package push provides functions to push metrics to a Pushgateway. It uses a
+// builder approach. Create a Pusher with New and then add the various options
+// by using its methods, finally calling Add or Push, like this:
+//
+//    // Easy case:
+//    push.New("http://example.org/metrics", "my_job").Gatherer(myRegistry).Push()
+//
+//    // Complex case:
+//    push.New("http://example.org/metrics", "my_job").
+//        Collector(myCollector1).
+//        Collector(myCollector2).
+//        Grouping("zone", "xy").
+//        Client(&myHTTPClient).
+//        BasicAuth("top", "secret").
+//        Add()
+//
+// See the examples section for more detailed examples.
+//
+// See the documentation of the Pushgateway to understand the meaning of
+// the grouping key and the differences between Push and Add:
+// https://github.com/prometheus/pushgateway
+package push
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	contentTypeHeader = "Content-Type"
+	// base64Suffix is appended to a label name in the request URL path to
+	// mark the following label value as base64 encoded.
+	base64Suffix = "@base64"
+)
+
+// HTTPDoer is an interface for the one method of http.Client that is used by Pusher
+type HTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Pusher manages a push to the Pushgateway. Use New to create one, configure it
+// with its methods, and finally use the Add or Push method to push.
+type Pusher struct {
+	error error
+
+	url, job string
+	grouping map[string]string
+
+	gatherers  prometheus.Gatherers
+	registerer prometheus.Registerer
+
+	client             HTTPDoer
+	useBasicAuth       bool
+	username, password string
+
+	expfmt expfmt.Format
+}
+
+// New creates a new Pusher to push to the provided URL with the provided job
+// name. You can use just host:port or ip:port as url, in which case “http://”
+// is added automatically. Alternatively, include the schema in the
+// URL. However, do not include the “/metrics/jobs/…” part.
+func New(url, job string) *Pusher {
+	var (
+		reg = prometheus.NewRegistry()
+		err error
+	)
+	if !strings.Contains(url, "://") {
+		url = "http://" + url
+	}
+	if strings.HasSuffix(url, "/") {
+		url = url[:len(url)-1]
+	}
+
+	return &Pusher{
+		error:      err,
+		url:        url,
+		job:        job,
+		grouping:   map[string]string{},
+		gatherers:  prometheus.Gatherers{reg},
+		registerer: reg,
+		client:     &http.Client{},
+		expfmt:     expfmt.FmtProtoDelim,
+	}
+}
+
+// Push collects/gathers all metrics from all Collectors and Gatherers added to
+// this Pusher. Then, it pushes them to the Pushgateway configured while
+// creating this Pusher, using the configured job name and any added grouping
+// labels as grouping key. All previously pushed metrics with the same job and
+// other grouping labels will be replaced with the metrics pushed by this
+// call. (It uses HTTP method “PUT” to push to the Pushgateway.)
+//
+// Push returns the first error encountered by any method call (including this
+// one) in the lifetime of the Pusher.
+func (p *Pusher) Push() error {
+	return p.push(http.MethodPut)
+}
+
+// Add works like push, but only previously pushed metrics with the same name
+// (and the same job and other grouping labels) will be replaced. (It uses HTTP
+// method “POST” to push to the Pushgateway.)
+func (p *Pusher) Add() error {
+	return p.push(http.MethodPost)
+}
+
+// Gatherer adds a Gatherer to the Pusher, from which metrics will be gathered
+// to push them to the Pushgateway. The gathered metrics must not contain a job
+// label of their own.
+//
+// For convenience, this method returns a pointer to the Pusher itself.
+func (p *Pusher) Gatherer(g prometheus.Gatherer) *Pusher {
+	p.gatherers = append(p.gatherers, g)
+	return p
+}
+
+// Collector adds a Collector to the Pusher, from which metrics will be
+// collected to push them to the Pushgateway. The collected metrics must not
+// contain a job label of their own.
+//
+// For convenience, this method returns a pointer to the Pusher itself.
+func (p *Pusher) Collector(c prometheus.Collector) *Pusher {
+	if p.error == nil {
+		p.error = p.registerer.Register(c)
+	}
+	return p
+}
+
+// Grouping adds a label pair to the grouping key of the Pusher, replacing any
+// previously added label pair with the same label name. Note that setting any
+// labels in the grouping key that are already contained in the metrics to push
+// will lead to an error.
+//
+// For convenience, this method returns a pointer to the Pusher itself.
+func (p *Pusher) Grouping(name, value string) *Pusher {
+	if p.error == nil {
+		if !model.LabelName(name).IsValid() {
+			p.error = fmt.Errorf("grouping label has invalid name: %s", name)
+			return p
+		}
+		p.grouping[name] = value
+	}
+	return p
+}
+
+// Client sets a custom HTTP client for the Pusher. For convenience, this method
+// returns a pointer to the Pusher itself.
+// Pusher only needs one method of the custom HTTP client: Do(*http.Request).
+// Thus, rather than requiring a fully fledged http.Client,
+// the provided client only needs to implement the HTTPDoer interface.
+// Since *http.Client naturally implements that interface, it can still be used normally.
+func (p *Pusher) Client(c HTTPDoer) *Pusher {
+	p.client = c
+	return p
+}
+
+// BasicAuth configures the Pusher to use HTTP Basic Authentication with the
+// provided username and password. For convenience, this method returns a
+// pointer to the Pusher itself.
+func (p *Pusher) BasicAuth(username, password string) *Pusher {
+	p.useBasicAuth = true
+	p.username = username
+	p.password = password
+	return p
+}
+
+// Format configures the Pusher to use an encoding format given by the
+// provided expfmt.Format. The default format is expfmt.FmtProtoDelim and
+// should be used with the standard Prometheus Pushgateway. Custom
+// implementations may require different formats. For convenience, this
+// method returns a pointer to the Pusher itself.
+func (p *Pusher) Format(format expfmt.Format) *Pusher {
+	p.expfmt = format
+	return p
+}
+
+// Delete sends a “DELETE” request to the Pushgateway configured while creating
+// this Pusher, using the configured job name and any added grouping labels as
+// grouping key. Any added Gatherers and Collectors added to this Pusher are
+// ignored by this method.
+//
+// Delete returns the first error encountered by any method call (including this
+// one) in the lifetime of the Pusher.
+func (p *Pusher) Delete() error {
+	if p.error != nil {
+		return p.error
+	}
+	req, err := http.NewRequest(http.MethodDelete, p.fullURL(), nil)
+	if err != nil {
+		return err
+	}
+	if p.useBasicAuth {
+		req.SetBasicAuth(p.username, p.password)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := ioutil.ReadAll(resp.Body) // Ignore any further error as this is for an error message only.
+		return fmt.Errorf("unexpected status code %d while deleting %s: %s", resp.StatusCode, p.fullURL(), body)
+	}
+	return nil
+}
+
+func (p *Pusher) push(method string) error {
+	if p.error != nil {
+		return p.error
+	}
+	mfs, err := p.gatherers.Gather()
+	if err != nil {
+		return err
+	}
+	buf := &bytes.Buffer{}
+	enc := expfmt.NewEncoder(buf, p.expfmt)
+	// Check for pre-existing grouping labels:
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "job" {
+					return fmt.Errorf("pushed metric %s (%s) already contains a job label", mf.GetName(), m)
+				}
+				if _, ok := p.grouping[l.GetName()]; ok {
+					return fmt.Errorf(
+						"pushed metric %s (%s) already contains grouping label %s",
+						mf.GetName(), m, l.GetName(),
+					)
+				}
+			}
+		}
+		enc.Encode(mf)
+	}
+	req, err := http.NewRequest(method, p.fullURL(), buf)
+	if err != nil {
+		return err
+	}
+	if p.useBasicAuth {
+		req.SetBasicAuth(p.username, p.password)
+	}
+	req.Header.Set(contentTypeHeader, string(p.expfmt))
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Pushgateway 0.10+ responds with StatusOK, earlier versions with StatusAccepted.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, _ := ioutil.ReadAll(resp.Body) // Ignore any further error as this is for an error message only.
+		return fmt.Errorf("unexpected status code %d while pushing to %s: %s", resp.StatusCode, p.fullURL(), body)
+	}
+	return nil
+}
+
+// fullURL assembles the URL used to push/delete metrics and returns it as a
+// string. The job name and any grouping label values containing a '/' will
+// trigger a base64 encoding of the affected component and proper suffixing of
+// the preceding component. If the component does not contain a '/' but other
+// special character, the usual url.QueryEscape is used for compatibility with
+// older versions of the Pushgateway and for better readability.
+func (p *Pusher) fullURL() string {
+	urlComponents := []string{}
+	if encodedJob, base64 := encodeComponent(p.job); base64 {
+		urlComponents = append(urlComponents, "job"+base64Suffix, encodedJob)
+	} else {
+		urlComponents = append(urlComponents, "job", encodedJob)
+	}
+	for ln, lv := range p.grouping {
+		if encodedLV, base64 := encodeComponent(lv); base64 {
+			urlComponents = append(urlComponents, ln+base64Suffix, encodedLV)
+		} else {
+			urlComponents = append(urlComponents, ln, encodedLV)
+		}
+	}
+	return fmt.Sprintf("%s/metrics/%s", p.url, strings.Join(urlComponents, "/"))
+}
+
+// encodeComponent encodes the provided string with base64.RawURLEncoding in
+// case it contains '/'. If not, it uses url.QueryEscape instead. It returns
+// true in the former case.
+func encodeComponent(s string) (string, bool) {
+	if strings.Contains(s, "/") {
+		return base64.RawURLEncoding.EncodeToString([]byte(s)), true
+	}
+	return url.QueryEscape(s), false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1091,9 +1091,11 @@ github.com/posener/complete/cmd/install
 ## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
+github.com/prometheus/client_golang/prometheus/push
 # github.com/prometheus/client_model v0.2.0
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.9.1
+## explicit
 github.com/prometheus/common/expfmt
 github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model


### PR DESCRIPTION
Creates a push client that will be used to push metrics to
Prometheus Aggregation Gateway. The client can be used for 
any type of Gateway and it takes in the URL and the HTTP Client
that would have all the necessary information(authentication) 
required to push to the gateway.

Configured to take in Prometheus Objects for pushing to gateway.
https://github.com/prometheus/client_golang/tree/master/prometheus