### PR TITLE
Bug 1847705: rhcos: Bump to 46.82.202006162207-0

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,135 +1,155 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-03debc82c86cb9fc1"
+            "hvm": "ami-0cc89ff7fae212eb7"
         },
         "ap-northeast-2": {
-            "hvm": "ami-032bfaf023d1d344a"
+            "hvm": "ami-0607290fa1a49d17a"
         },
         "ap-south-1": {
-            "hvm": "ami-04a2271e011bf7e97"
+            "hvm": "ami-0a2ac2eac6ec2c593"
         },
         "ap-southeast-1": {
-            "hvm": "ami-00b64116043693c93"
+            "hvm": "ami-0c2078712075ecff0"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0ae368af58a298763"
+            "hvm": "ami-0540365548f3a92f2"
         },
         "ca-central-1": {
-            "hvm": "ami-08c89ccb53798be30"
+            "hvm": "ami-0873a1643d5381d4c"
         },
         "eu-central-1": {
-            "hvm": "ami-09020a80c8f3b1b07"
+            "hvm": "ami-0cf97891967a50072"
         },
         "eu-north-1": {
-            "hvm": "ami-0665ded25a7f786d8"
+            "hvm": "ami-0f87a2273a38379bd"
         },
         "eu-west-1": {
-            "hvm": "ami-0d8964d864a2b651d"
+            "hvm": "ami-01906c0140bae9047"
         },
         "eu-west-2": {
-            "hvm": "ami-0186141e3c79bb69a"
+            "hvm": "ami-04f5dfb40c936d5f0"
         },
         "eu-west-3": {
-            "hvm": "ami-00631c9e97e086ad1"
+            "hvm": "ami-064df639fd24b7240"
         },
         "me-south-1": {
-            "hvm": "ami-0d4544874f9ec20bb"
+            "hvm": "ami-007b5c9ade829d426"
         },
         "sa-east-1": {
-            "hvm": "ami-0bd6d945b5fb94f15"
+            "hvm": "ami-07e8bc1b7a6ba82f0"
         },
         "us-east-1": {
-            "hvm": "ami-0097bded932c126bc"
+            "hvm": "ami-0139896443a30a831"
         },
         "us-east-2": {
-            "hvm": "ami-0254f6b4eaa3b9d0f"
+            "hvm": "ami-086e898760b1e1223"
         },
         "us-west-1": {
-            "hvm": "ami-058d97ab18b0e860a"
+            "hvm": "ami-02499ba142bf0c20c"
         },
         "us-west-2": {
-            "hvm": "ami-0bd693f82f222c33d"
+            "hvm": "ami-0c289820682ea9574"
         }
     },
     "azure": {
-        "image": "rhcos-45.81.202005200134-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.81.202005200134-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202006190240-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202006190240-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.81.202005200134-0/x86_64/",
-    "buildid": "45.81.202005200134-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202006190240-0/x86_64/",
+    "buildid": "46.82.202006190240-0",
     "gcp": {
-        "image": "rhcos-45-81-202005200134-0-gcp-x86-64",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-81-202005200134-0-gcp-x86-64.tar.gz"
+        "image": "rhcos-46-82-202006190240-0-gcp-x86-64",
+        "project": "rhcos-cloud",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202006190240-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-45.81.202005200134-0-aws.x86_64.vmdk.gz",
-            "sha256": "d234f42746197bca52fe13af50414e11388b7dcdee67f443f7443b0d413384b6",
-            "size": 892691141,
-            "uncompressed-sha256": "6449f179293e0be22f8e94458ac79e287de21dc03753a08e16dd99095c8fe042",
-            "uncompressed-size": 911347200
+            "path": "rhcos-46.82.202006190240-0-aws.x86_64.vmdk.gz",
+            "sha256": "afb7234b1a7c3756a90810b04348aec6cf28514117600e28be3c677947a560a9",
+            "size": 938437583,
+            "uncompressed-sha256": "8c1ec393d35542da4ed239c04c9c0ed35c884413b7904ffd8221b8755d8e1bd1",
+            "uncompressed-size": 958680064
         },
         "azure": {
-            "path": "rhcos-45.81.202005200134-0-azure.x86_64.vhd.gz",
-            "sha256": "04afa148f9c9c43018b7e1c518d076fe7900d66c499ad2ad9aed1c4191f8d396",
-            "size": 892027711,
-            "uncompressed-sha256": "1b672b2dfd27c633db729c34fa72083df370c140f06eb59833c006ee55edee10",
+            "path": "rhcos-46.82.202006190240-0-azure.x86_64.vhd.gz",
+            "sha256": "47c3df19992cb8ff3ff373a0e26e2d9df5a42fbb85cc49d42afd8ae67afbe476",
+            "size": 938872549,
+            "uncompressed-sha256": "152fe377f8b1ad2ba7819e9b86f8102e2180c7659050a14fe97ab0db8a54c6d2",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-45.81.202005200134-0-gcp.x86_64.tar.gz",
-            "sha256": "09d553434d6f9c2934602ab274f9bbdfeb9c3c698f42769519b5c1e7d8f32226",
-            "size": 877406720
+            "path": "rhcos-46.82.202006190240-0-gcp.x86_64.tar.gz",
+            "sha256": "e579e8482ec9762b69e316d1c7fa76d20c7a9b042b01043645772d7a72f479ff",
+            "size": 924220105
         },
         "initramfs": {
-            "path": "rhcos-45.81.202005200134-0-installer-initramfs.x86_64.img",
-            "sha256": "75c6e6d10a6744b68920e25fe13da19860f13ed0eb7a7744ae4ff38891e49af5"
+            "path": "rhcos-46.82.202006190240-0-installer-initramfs.x86_64.img",
+            "sha256": "a5ccb3e10ecbc1dc9cfc8c05475db8b452797889b72444558b05cc47717e9341"
         },
         "iso": {
-            "path": "rhcos-45.81.202005200134-0-installer.x86_64.iso",
-            "sha256": "d2aa854c5fab79e78c2cdf462c67b1fe04441b9c042d40c95b98e0d95ca6f86d"
+            "path": "rhcos-46.82.202006190240-0-installer.x86_64.iso",
+            "sha256": "978e9b1db8696657cd8d6a481f747a7ba5d7a554c47b3274f1b3edbe76e95bf3"
         },
         "kernel": {
-            "path": "rhcos-45.81.202005200134-0-installer-kernel-x86_64",
-            "sha256": "82333190f8b87da47e605608508650cb860b3d2bb48e8887c31a76323855fb18"
+            "path": "rhcos-46.82.202006190240-0-installer-kernel-x86_64",
+            "sha256": "57b1e7d0205dac1c6d0478ca045d35160d89d96c0cb746d5973fe68a2b36f498"
+        },
+        "live-initramfs": {
+            "path": "rhcos-46.82.202006190240-0-live-initramfs.x86_64.img",
+            "sha256": "c1d8cf026fdc4fc6d7fc025d422ebfd091d71125f98b5681be9530e080b3bf7a"
+        },
+        "live-iso": {
+            "path": "rhcos-46.82.202006190240-0-live.x86_64.iso",
+            "sha256": "c639872909db363a8e5350ac6f822f7d5669197a0ecca81d22cf7cc2ab83b621"
+        },
+        "live-kernel": {
+            "path": "rhcos-46.82.202006190240-0-live-kernel-x86_64",
+            "sha256": "57b1e7d0205dac1c6d0478ca045d35160d89d96c0cb746d5973fe68a2b36f498"
         },
         "metal": {
-            "path": "rhcos-45.81.202005200134-0-metal.x86_64.raw.gz",
-            "sha256": "fbbe3f1a6cd60ec0344ca88925efc812c1556654680d8663bffd0663ae55843a",
-            "size": 878855135,
-            "uncompressed-sha256": "4a211425bf1af046ffbd91c9c63b0d179db67f9dc4165a4a106a2f0a1c74df7e",
-            "uncompressed-size": 3807379456
+            "path": "rhcos-46.82.202006190240-0-metal.x86_64.raw.gz",
+            "sha256": "822a978c40329e9046c242f559a5e105ed2ddb8a940ab023081b3b692a2c5512",
+            "size": 926066447,
+            "uncompressed-sha256": "237060c2aced6b1b363b4662ce684a76c124a73739c73d3e910e0bd6176b09c3",
+            "uncompressed-size": 3851419648
+        },
+        "metal4k": {
+            "path": "rhcos-46.82.202006190240-0-metal4k.x86_64.raw.gz",
+            "sha256": "08cdc74800ac5f605941f0a04cdf6fc36a39b3b4315e7d933f02c53413e04aad",
+            "size": 923726908,
+            "uncompressed-sha256": "7fc76bc56544cf75db0931804b097ee9197e8afeb274e324fe9d99deeb48de3b",
+            "uncompressed-size": 3851419648
         },
         "openstack": {
-            "path": "rhcos-45.81.202005200134-0-openstack.x86_64.qcow2.gz",
-            "sha256": "62345f8eb00e3a2075aff9bb87a634ced1fbb95f66d56d5abfa462d0555ec1cb",
-            "size": 877680541,
-            "uncompressed-sha256": "cbbef9efff0a90d8b4b42b64d38b6a8083d2aad1496fac8bbb12a9a601eb0ba5",
-            "uncompressed-size": 2427125760
+            "path": "rhcos-46.82.202006190240-0-openstack.x86_64.qcow2.gz",
+            "sha256": "ba15fa4ab700f74e7fbaab6b0b8c3ed976c4b046b4e361b77a4ca297c3e02aef",
+            "size": 924566882,
+            "uncompressed-sha256": "a741f17e98adb15dda79aa7a8714b55be7e8ea792cd4a88d79190e305b11d3c1",
+            "uncompressed-size": 2465333248
         },
         "ostree": {
-            "path": "rhcos-45.81.202005200134-0-ostree.x86_64.tar",
-            "sha256": "1362fd7a1273fa5895f6f328e8d03e79033f52d72375f53099cb860a156d1535",
-            "size": 811059200
+            "path": "rhcos-46.82.202006190240-0-ostree.x86_64.tar",
+            "sha256": "09650ab75be3de59e9fcec5e3c02fcc16cbcfd44f554b78145726fb34ec23635",
+            "size": 852725760
         },
         "qemu": {
-            "path": "rhcos-45.81.202005200134-0-qemu.x86_64.qcow2.gz",
-            "sha256": "8d7190126d6a4edcf7d291084b8decf8beffd8bcb0ebc5f2cb83a3078a6be434",
-            "size": 879587420,
-            "uncompressed-sha256": "d3dae00f0d9ca9593249f1ac9e6f9ef6176a307721b5f4ab30b03eada8a1e44a",
-            "uncompressed-size": 2473328640
+            "path": "rhcos-46.82.202006190240-0-qemu.x86_64.qcow2.gz",
+            "sha256": "4b288a37c8b36551ae6e292b4adb81ec3599139449de400cef4168f2c7096ee6",
+            "size": 925555234,
+            "uncompressed-sha256": "f0ace7804a2f8bbed087643f854cf91b602d4d393f3472487e35311c44bcb255",
+            "uncompressed-size": 2514092032
         },
         "vmware": {
-            "path": "rhcos-45.81.202005200134-0-vmware.x86_64.ova",
-            "sha256": "2166966efba40c32ed845498cc7d8692ce2efd7c1fb307635df4b04633c27df0",
-            "size": 911360000
+            "path": "rhcos-46.82.202006190240-0-vmware.x86_64.ova",
+            "sha256": "743520706f349fd98fea17e610c34bf2ef4c803bc98883648e968a91136bb8af",
+            "size": 958689280
         }
     },
     "oscontainer": {
-        "digest": "sha256:55b59136f8f03b9f0cff1b5095c07b0ee03f95d734048ed004cdb74050bbb51f",
+        "digest": "sha256:54ade75ec742bdb709edeb976e64137da408ab98b6fb31839445ac3714900869",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "1e46236673938a570029e54117fff0c1a1eedb4a5e0ad12373d1a27407cfed3a",
-    "ostree-version": "45.81.202005200134-0"
+    "ostree-commit": "7858a6e67a225e03ff54e301010c69d5ffb2ab22ecb42c99adef747b92c38016",
+    "ostree-version": "46.82.202006190240-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,135 +1,155 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-03debc82c86cb9fc1"
+            "hvm": "ami-0cc89ff7fae212eb7"
         },
         "ap-northeast-2": {
-            "hvm": "ami-032bfaf023d1d344a"
+            "hvm": "ami-0607290fa1a49d17a"
         },
         "ap-south-1": {
-            "hvm": "ami-04a2271e011bf7e97"
+            "hvm": "ami-0a2ac2eac6ec2c593"
         },
         "ap-southeast-1": {
-            "hvm": "ami-00b64116043693c93"
+            "hvm": "ami-0c2078712075ecff0"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0ae368af58a298763"
+            "hvm": "ami-0540365548f3a92f2"
         },
         "ca-central-1": {
-            "hvm": "ami-08c89ccb53798be30"
+            "hvm": "ami-0873a1643d5381d4c"
         },
         "eu-central-1": {
-            "hvm": "ami-09020a80c8f3b1b07"
+            "hvm": "ami-0cf97891967a50072"
         },
         "eu-north-1": {
-            "hvm": "ami-0665ded25a7f786d8"
+            "hvm": "ami-0f87a2273a38379bd"
         },
         "eu-west-1": {
-            "hvm": "ami-0d8964d864a2b651d"
+            "hvm": "ami-01906c0140bae9047"
         },
         "eu-west-2": {
-            "hvm": "ami-0186141e3c79bb69a"
+            "hvm": "ami-04f5dfb40c936d5f0"
         },
         "eu-west-3": {
-            "hvm": "ami-00631c9e97e086ad1"
+            "hvm": "ami-064df639fd24b7240"
         },
         "me-south-1": {
-            "hvm": "ami-0d4544874f9ec20bb"
+            "hvm": "ami-007b5c9ade829d426"
         },
         "sa-east-1": {
-            "hvm": "ami-0bd6d945b5fb94f15"
+            "hvm": "ami-07e8bc1b7a6ba82f0"
         },
         "us-east-1": {
-            "hvm": "ami-0097bded932c126bc"
+            "hvm": "ami-0139896443a30a831"
         },
         "us-east-2": {
-            "hvm": "ami-0254f6b4eaa3b9d0f"
+            "hvm": "ami-086e898760b1e1223"
         },
         "us-west-1": {
-            "hvm": "ami-058d97ab18b0e860a"
+            "hvm": "ami-02499ba142bf0c20c"
         },
         "us-west-2": {
-            "hvm": "ami-0bd693f82f222c33d"
+            "hvm": "ami-0c289820682ea9574"
         }
     },
     "azure": {
-        "image": "rhcos-45.81.202005200134-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.81.202005200134-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202006190240-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202006190240-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.81.202005200134-0/x86_64/",
-    "buildid": "45.81.202005200134-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202006190240-0/x86_64/",
+    "buildid": "46.82.202006190240-0",
     "gcp": {
-        "image": "rhcos-45-81-202005200134-0-gcp-x86-64",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-81-202005200134-0-gcp-x86-64.tar.gz"
+        "image": "rhcos-46-82-202006190240-0-gcp-x86-64",
+        "project": "rhcos-cloud",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202006190240-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-45.81.202005200134-0-aws.x86_64.vmdk.gz",
-            "sha256": "d234f42746197bca52fe13af50414e11388b7dcdee67f443f7443b0d413384b6",
-            "size": 892691141,
-            "uncompressed-sha256": "6449f179293e0be22f8e94458ac79e287de21dc03753a08e16dd99095c8fe042",
-            "uncompressed-size": 911347200
+            "path": "rhcos-46.82.202006190240-0-aws.x86_64.vmdk.gz",
+            "sha256": "afb7234b1a7c3756a90810b04348aec6cf28514117600e28be3c677947a560a9",
+            "size": 938437583,
+            "uncompressed-sha256": "8c1ec393d35542da4ed239c04c9c0ed35c884413b7904ffd8221b8755d8e1bd1",
+            "uncompressed-size": 958680064
         },
         "azure": {
-            "path": "rhcos-45.81.202005200134-0-azure.x86_64.vhd.gz",
-            "sha256": "04afa148f9c9c43018b7e1c518d076fe7900d66c499ad2ad9aed1c4191f8d396",
-            "size": 892027711,
-            "uncompressed-sha256": "1b672b2dfd27c633db729c34fa72083df370c140f06eb59833c006ee55edee10",
+            "path": "rhcos-46.82.202006190240-0-azure.x86_64.vhd.gz",
+            "sha256": "47c3df19992cb8ff3ff373a0e26e2d9df5a42fbb85cc49d42afd8ae67afbe476",
+            "size": 938872549,
+            "uncompressed-sha256": "152fe377f8b1ad2ba7819e9b86f8102e2180c7659050a14fe97ab0db8a54c6d2",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-45.81.202005200134-0-gcp.x86_64.tar.gz",
-            "sha256": "09d553434d6f9c2934602ab274f9bbdfeb9c3c698f42769519b5c1e7d8f32226",
-            "size": 877406720
+            "path": "rhcos-46.82.202006190240-0-gcp.x86_64.tar.gz",
+            "sha256": "e579e8482ec9762b69e316d1c7fa76d20c7a9b042b01043645772d7a72f479ff",
+            "size": 924220105
         },
         "initramfs": {
-            "path": "rhcos-45.81.202005200134-0-installer-initramfs.x86_64.img",
-            "sha256": "75c6e6d10a6744b68920e25fe13da19860f13ed0eb7a7744ae4ff38891e49af5"
+            "path": "rhcos-46.82.202006190240-0-installer-initramfs.x86_64.img",
+            "sha256": "a5ccb3e10ecbc1dc9cfc8c05475db8b452797889b72444558b05cc47717e9341"
         },
         "iso": {
-            "path": "rhcos-45.81.202005200134-0-installer.x86_64.iso",
-            "sha256": "d2aa854c5fab79e78c2cdf462c67b1fe04441b9c042d40c95b98e0d95ca6f86d"
+            "path": "rhcos-46.82.202006190240-0-installer.x86_64.iso",
+            "sha256": "978e9b1db8696657cd8d6a481f747a7ba5d7a554c47b3274f1b3edbe76e95bf3"
         },
         "kernel": {
-            "path": "rhcos-45.81.202005200134-0-installer-kernel-x86_64",
-            "sha256": "82333190f8b87da47e605608508650cb860b3d2bb48e8887c31a76323855fb18"
+            "path": "rhcos-46.82.202006190240-0-installer-kernel-x86_64",
+            "sha256": "57b1e7d0205dac1c6d0478ca045d35160d89d96c0cb746d5973fe68a2b36f498"
+        },
+        "live-initramfs": {
+            "path": "rhcos-46.82.202006190240-0-live-initramfs.x86_64.img",
+            "sha256": "c1d8cf026fdc4fc6d7fc025d422ebfd091d71125f98b5681be9530e080b3bf7a"
+        },
+        "live-iso": {
+            "path": "rhcos-46.82.202006190240-0-live.x86_64.iso",
+            "sha256": "c639872909db363a8e5350ac6f822f7d5669197a0ecca81d22cf7cc2ab83b621"
+        },
+        "live-kernel": {
+            "path": "rhcos-46.82.202006190240-0-live-kernel-x86_64",
+            "sha256": "57b1e7d0205dac1c6d0478ca045d35160d89d96c0cb746d5973fe68a2b36f498"
         },
         "metal": {
-            "path": "rhcos-45.81.202005200134-0-metal.x86_64.raw.gz",
-            "sha256": "fbbe3f1a6cd60ec0344ca88925efc812c1556654680d8663bffd0663ae55843a",
-            "size": 878855135,
-            "uncompressed-sha256": "4a211425bf1af046ffbd91c9c63b0d179db67f9dc4165a4a106a2f0a1c74df7e",
-            "uncompressed-size": 3807379456
+            "path": "rhcos-46.82.202006190240-0-metal.x86_64.raw.gz",
+            "sha256": "822a978c40329e9046c242f559a5e105ed2ddb8a940ab023081b3b692a2c5512",
+            "size": 926066447,
+            "uncompressed-sha256": "237060c2aced6b1b363b4662ce684a76c124a73739c73d3e910e0bd6176b09c3",
+            "uncompressed-size": 3851419648
+        },
+        "metal4k": {
+            "path": "rhcos-46.82.202006190240-0-metal4k.x86_64.raw.gz",
+            "sha256": "08cdc74800ac5f605941f0a04cdf6fc36a39b3b4315e7d933f02c53413e04aad",
+            "size": 923726908,
+            "uncompressed-sha256": "7fc76bc56544cf75db0931804b097ee9197e8afeb274e324fe9d99deeb48de3b",
+            "uncompressed-size": 3851419648
         },
         "openstack": {
-            "path": "rhcos-45.81.202005200134-0-openstack.x86_64.qcow2.gz",
-            "sha256": "62345f8eb00e3a2075aff9bb87a634ced1fbb95f66d56d5abfa462d0555ec1cb",
-            "size": 877680541,
-            "uncompressed-sha256": "cbbef9efff0a90d8b4b42b64d38b6a8083d2aad1496fac8bbb12a9a601eb0ba5",
-            "uncompressed-size": 2427125760
+            "path": "rhcos-46.82.202006190240-0-openstack.x86_64.qcow2.gz",
+            "sha256": "ba15fa4ab700f74e7fbaab6b0b8c3ed976c4b046b4e361b77a4ca297c3e02aef",
+            "size": 924566882,
+            "uncompressed-sha256": "a741f17e98adb15dda79aa7a8714b55be7e8ea792cd4a88d79190e305b11d3c1",
+            "uncompressed-size": 2465333248
         },
         "ostree": {
-            "path": "rhcos-45.81.202005200134-0-ostree.x86_64.tar",
-            "sha256": "1362fd7a1273fa5895f6f328e8d03e79033f52d72375f53099cb860a156d1535",
-            "size": 811059200
+            "path": "rhcos-46.82.202006190240-0-ostree.x86_64.tar",
+            "sha256": "09650ab75be3de59e9fcec5e3c02fcc16cbcfd44f554b78145726fb34ec23635",
+            "size": 852725760
         },
         "qemu": {
-            "path": "rhcos-45.81.202005200134-0-qemu.x86_64.qcow2.gz",
-            "sha256": "8d7190126d6a4edcf7d291084b8decf8beffd8bcb0ebc5f2cb83a3078a6be434",
-            "size": 879587420,
-            "uncompressed-sha256": "d3dae00f0d9ca9593249f1ac9e6f9ef6176a307721b5f4ab30b03eada8a1e44a",
-            "uncompressed-size": 2473328640
+            "path": "rhcos-46.82.202006190240-0-qemu.x86_64.qcow2.gz",
+            "sha256": "4b288a37c8b36551ae6e292b4adb81ec3599139449de400cef4168f2c7096ee6",
+            "size": 925555234,
+            "uncompressed-sha256": "f0ace7804a2f8bbed087643f854cf91b602d4d393f3472487e35311c44bcb255",
+            "uncompressed-size": 2514092032
         },
         "vmware": {
-            "path": "rhcos-45.81.202005200134-0-vmware.x86_64.ova",
-            "sha256": "2166966efba40c32ed845498cc7d8692ce2efd7c1fb307635df4b04633c27df0",
-            "size": 911360000
+            "path": "rhcos-46.82.202006190240-0-vmware.x86_64.ova",
+            "sha256": "743520706f349fd98fea17e610c34bf2ef4c803bc98883648e968a91136bb8af",
+            "size": 958689280
         }
     },
     "oscontainer": {
-        "digest": "sha256:55b59136f8f03b9f0cff1b5095c07b0ee03f95d734048ed004cdb74050bbb51f",
+        "digest": "sha256:54ade75ec742bdb709edeb976e64137da408ab98b6fb31839445ac3714900869",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "1e46236673938a570029e54117fff0c1a1eedb4a5e0ad12373d1a27407cfed3a",
-    "ostree-version": "45.81.202005200134-0"
+    "ostree-commit": "7858a6e67a225e03ff54e301010c69d5ffb2ab22ecb42c99adef747b92c38016",
+    "ostree-version": "46.82.202006190240-0"
 }


### PR DESCRIPTION
There's a whole lot going on in 4.6, among the changes are the
Live ISO, RHEL 8.2 (so far), new static networking handling etc.

Among all that, also we are currently pivoting from 4.5 w/RHEL 8.1
which causes
https://bugzilla.redhat.com/show_bug.cgi?id=1847705