### PR TITLE
pkg/asset/installconfig/azure: create reusable session

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -25,7 +25,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
-	azureconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	openstackconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	ovirtconfig "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
@@ -247,15 +246,16 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Data:     data,
 		})
 	case azure.Name:
-		sess, err := azureconfig.GetSession(installConfig.Config.Platform.Azure.CloudName)
+		session, err := installConfig.Azure.Session()
 		if err != nil {
 			return err
 		}
+
 		auth := azuretfvars.Auth{
-			SubscriptionID: sess.Credentials.SubscriptionID,
-			ClientID:       sess.Credentials.ClientID,
-			ClientSecret:   sess.Credentials.ClientSecret,
-			TenantID:       sess.Credentials.TenantID,
+			SubscriptionID: session.Credentials.SubscriptionID,
+			ClientID:       session.Credentials.ClientID,
+			ClientSecret:   session.Credentials.ClientSecret,
+			TenantID:       session.Credentials.TenantID,
 		}
 		masters, err := mastersAsset.Machines()
 		if err != nil {

--- a/pkg/asset/installconfig/azure/azure.go
+++ b/pkg/asset/installconfig/azure/azure.go
@@ -20,12 +20,14 @@ const (
 
 // Platform collects azure-specific configuration.
 func Platform() (*azure.Platform, error) {
+	// Create client using public cloud because install config has not been generated yet.
 	const cloudName = azure.PublicCloud
-
-	client, err := NewClient(context.TODO(), cloudName)
+	ssn, err := GetSession(cloudName)
 	if err != nil {
 		return nil, err
 	}
+
+	client := NewClient(ssn)
 
 	regions, err := getRegions(context.TODO(), client)
 	if err != nil {

--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -5,15 +5,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	azsku "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	azres "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	azsubs "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-06-01/subscriptions"
 	"github.com/Azure/go-autorest/autorest/to"
-
-	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/pkg/errors"
 )
 
 //go:generate mockgen -source=./client.go -destination=mock/azureclient_generated.go -package=mock
@@ -34,19 +31,11 @@ type Client struct {
 }
 
 // NewClient initializes a client with a session.
-func NewClient(ctx context.Context, cloudName azure.CloudEnvironment) (*Client, error) {
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
-	defer cancel()
-
-	ssn, err := GetSession(cloudName)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get session")
-	}
-
+func NewClient(ssn *Session) *Client {
 	client := &Client{
 		ssn: ssn,
 	}
-	return client, nil
+	return client
 }
 
 // GetVirtualNetwork gets an Azure virtual network by name

--- a/pkg/asset/installconfig/azure/metadata.go
+++ b/pkg/asset/installconfig/azure/metadata.go
@@ -1,0 +1,73 @@
+package azure
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+
+	typesazure "github.com/openshift/installer/pkg/types/azure"
+)
+
+// Metadata holds additional metadata for InstallConfig resources that
+// does not need to be user-supplied (e.g. because it can be retrieved
+// from external APIs).
+type Metadata struct {
+	session *Session
+	client  *Client
+	dnsCfg  *DNSConfig
+
+	// CloudName indicates the Azure cloud environment (e.g. public, gov't).
+	CloudName typesazure.CloudEnvironment `json:"cloudName,omitempty"`
+
+	mutex sync.Mutex
+}
+
+// NewMetadata initializes a new Metadata object.
+func NewMetadata(cloudName typesazure.CloudEnvironment) *Metadata {
+	return &Metadata{CloudName: cloudName}
+}
+
+// Session holds an Azure session which can be used for Azure API calls
+// during asset generation.
+func (m *Metadata) Session() (*Session, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.unlockedSession()
+}
+
+func (m *Metadata) unlockedSession() (*Session, error) {
+	if m.session == nil {
+		var err error
+		m.session, err = GetSession(m.CloudName)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating Azure session")
+		}
+	}
+
+	return m.session, nil
+}
+
+// Client holds an Azure Client that implements calls to the Azure API.
+func (m *Metadata) Client() (*Client, error) {
+	if m.client == nil {
+		ssn, err := m.Session()
+		if err != nil {
+			return nil, err
+		}
+		m.client = NewClient(ssn)
+	}
+	return m.client, nil
+}
+
+// DNSConfig holds an Azure DNSConfig Client that implements calls to the Azure API.
+func (m *Metadata) DNSConfig() (*DNSConfig, error) {
+	if m.dnsCfg == nil {
+		ssn, err := m.Session()
+		if err != nil {
+			return nil, err
+		}
+		m.dnsCfg = NewDNSConfig(ssn)
+	}
+	return m.dnsCfg, nil
+}

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -31,6 +31,7 @@ type InstallConfig struct {
 	Config *types.InstallConfig `json:"config"`
 	File   *asset.File          `json:"file"`
 	AWS    *aws.Metadata        `json:"aws,omitempty"`
+	Azure  *icazure.Metadata    `json:"azure,omitempty"`
 }
 
 var _ asset.WritableAsset = (*InstallConfig)(nil)
@@ -134,7 +135,9 @@ func (a *InstallConfig) finish(filename string) error {
 	if a.Config.AWS != nil {
 		a.AWS = aws.NewMetadata(a.Config.Platform.AWS.Region, a.Config.Platform.AWS.Subnets, a.Config.AWS.ServiceEndpoints)
 	}
-
+	if a.Config.Azure != nil {
+		a.Azure = icazure.NewMetadata(a.Config.Azure.CloudName)
+	}
 	if err := validation.ValidateInstallConfig(a.Config, icopenstack.NewValidValuesFetcher()).ToAggregate(); err != nil {
 		if filename == "" {
 			return errors.Wrap(err, "invalid install config")
@@ -159,7 +162,7 @@ func (a *InstallConfig) finish(filename string) error {
 
 func (a *InstallConfig) platformValidation() error {
 	if a.Config.Platform.Azure != nil {
-		client, err := icazure.NewClient(context.TODO(), a.Config.Platform.Azure.CloudName)
+		client, err := a.Azure.Client()
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/asset"
-	azureconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	openstackconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	ovirtconfig "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
@@ -60,7 +59,7 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 	case baremetal.Name, libvirt.Name, none.Name, vsphere.Name:
 		// no creds to check
 	case azure.Name:
-		_, err = azureconfig.GetSession(ic.Config.Azure.CloudName)
+		_, err = ic.Azure.Session()
 		if err != nil {
 			return errors.Wrap(err, "creating Azure session")
 		}

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -47,7 +47,11 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 	case azure.Name:
-		err = azconfig.ValidatePublicDNS(ic.Config)
+		dnsConfig, err := ic.Azure.DNSConfig()
+		if err != nil {
+			return err
+		}
+		err = azconfig.ValidatePublicDNS(ic.Config, dnsConfig)
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/machines/azure/zones.go
+++ b/pkg/asset/machines/azure/zones.go
@@ -6,16 +6,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
-	azureutil "github.com/openshift/installer/pkg/asset/installconfig/azure"
-	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/asset/installconfig/azure"
 )
 
 // AvailabilityZones retrieves a list of availability zones for the given cloud, region, and instance type.
-func AvailabilityZones(cloud azure.CloudEnvironment, region string, instanceType string) ([]string, error) {
-	skusClient, err := skusClient(cloud)
+func AvailabilityZones(session *azure.Session, region string, instanceType string) ([]string, error) {
+	skusClient, err := skusClient(session)
 	if err != nil {
 		return nil, err
 	}
@@ -26,14 +25,9 @@ func AvailabilityZones(cloud azure.CloudEnvironment, region string, instanceType
 	return zones, nil
 }
 
-func skusClient(cloudName azure.CloudEnvironment) (client *compute.ResourceSkusClient, err error) {
-	ssn, err := azureutil.GetSession(cloudName)
-	if err != nil {
-		return nil, err
-	}
-
-	skusClient := compute.NewResourceSkusClient(ssn.Credentials.SubscriptionID)
-	skusClient.Authorizer = ssn.Authorizer
+func skusClient(session *azure.Session) (client *compute.ResourceSkusClient, err error) {
+	skusClient := compute.NewResourceSkusClient(session.Credentials.SubscriptionID)
+	skusClient.Authorizer = session.Authorizer
 	return &skusClient, nil
 }
 

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -250,7 +250,11 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Azure)
 		if len(mpool.Zones) == 0 {
-			azs, err := azure.AvailabilityZones(ic.Platform.Azure.CloudName, ic.Platform.Azure.Region, mpool.InstanceType)
+			session, err := installConfig.Azure.Session()
+			if err != nil {
+				return errors.Wrap(err, "failed to fetch session for availability zones")
+			}
+			azs, err := azure.AvailabilityZones(session, ic.Platform.Azure.Region, mpool.InstanceType)
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch availability zones")
 			}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -262,7 +262,11 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.Azure)
 			if len(mpool.Zones) == 0 {
-				azs, err := azure.AvailabilityZones(ic.Platform.Azure.CloudName, ic.Platform.Azure.Region, mpool.InstanceType)
+				session, err := installConfig.Azure.Session()
+				if err != nil {
+					return errors.Wrap(err, "failed to fetch session for availability zones")
+				}
+				azs, err := azure.AvailabilityZones(session, ic.Platform.Azure.Region, mpool.InstanceType)
 				if err != nil {
 					return errors.Wrap(err, "failed to fetch availability zones")
 				}

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	icopenstack "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	"github.com/openshift/installer/pkg/asset/manifests/azure"
 	gcpmanifests "github.com/openshift/installer/pkg/asset/manifests/gcp"
@@ -103,7 +102,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			cm.Data["ca-bundle.pem"] = string(caFile)
 		}
 	case azuretypes.Name:
-		session, err := icazure.GetSession(installConfig.Config.Platform.Azure.CloudName)
+		session, err := installConfig.Azure.Session()
 		if err != nil {
 			return errors.Wrap(err, "could not get azure session")
 		}

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	icaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
-	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
@@ -96,7 +95,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 			"Name": fmt.Sprintf("%s-int", clusterID.InfraID),
 		}}
 	case azuretypes.Name:
-		dnsConfig, err := icazure.NewDNSConfig(installConfig.Config.Azure.CloudName)
+		dnsConfig, err := installConfig.Azure.DNSConfig()
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	"github.com/openshift/installer/pkg/asset/installconfig/azure"
 	"github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	"github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	"github.com/openshift/installer/pkg/asset/machines"
@@ -97,7 +96,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 
 	case azuretypes.Name:
 		resourceGroupName := clusterID.InfraID + "-rg"
-		session, err := azure.GetSession(installConfig.Config.Platform.Azure.CloudName)
+		session, err := installConfig.Azure.Session()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit creates an Azure metadata struct in the installconfig asset
(similar to AWS) and stores an Azure session and clients for interacting
with the Azure API. This commit also refactors existing code to use
this functionality rather than plumbing the install config values repeatedly.