### PR TITLE
gcp: Fix uninstaller for internal clusters on GCP.

### DIFF
--- a/pkg/destroy/gcp/cloudcontroller.go
+++ b/pkg/destroy/gcp/cloudcontroller.go
@@ -13,7 +13,7 @@ import (
 // https://github.com/openshift/kubernetes/blob/1e5983903742f64bca36a464582178c940353e9a/pkg/cloudprovider/providers/gce/gce_clusterid.go#L210-L238
 func (o *ClusterUninstaller) listCloudControllerInstanceGroups() ([]cloudResource, error) {
 	filter := fmt.Sprintf("name eq \"k8s-ig--%s\"", o.cloudControllerUID)
-	return o.listInstanceGroupsWithFilter("items/*/instanceGroups(name,zone),nextPageToken", filter, nil)
+	return o.listInstanceGroupsWithFilter("items/*/instanceGroups(name,selfLink,zone),nextPageToken", filter, nil)
 }
 
 // listCloudControllerBackendServices returns backend services created by the cloud controller.

--- a/pkg/destroy/gcp/instancegroup.go
+++ b/pkg/destroy/gcp/instancegroup.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (o *ClusterUninstaller) listInstanceGroups() ([]cloudResource, error) {
-	return o.listInstanceGroupsWithFilter("items/*/instanceGroups(name,zone),nextPageToken", o.clusterIDFilter(), nil)
+	return o.listInstanceGroupsWithFilter("items/*/instanceGroups(name,selfLink,zone),nextPageToken", o.clusterIDFilter(), nil)
 }
 
 // listInstanceGroupsWithFilter lists addresses in the project that satisfy the filter criteria.


### PR DESCRIPTION
Fixed the GCP uninstaller to get the instance group self links which
would be used to destroy them. Currently, the self links are used but
are not requested from GCP as a field when the instance groups are listed.
Therefore, the uninstaller does not get the appropriate link to target
for deletion. This fix is for the internal clusters uninstallation.