### PR TITLE
oVirt UPI: initial setup

### DIFF
--- a/upi/ovirt/OWNERS
+++ b/upi/ovirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - ovirt-approvers
+reviewers:
+  - ovirt-reviewers

--- a/upi/ovirt/README.md
+++ b/upi/ovirt/README.md
@@ -1,0 +1,3 @@
+# oVirt/RHV User Provided Infrastructure
+
+This folder contains the Ansible scripts to help automate as possible the UPI installation process.


### PR DESCRIPTION
This PR is setting the initial README file and the ownership of the oVirt upi folder