### PR TITLE
Bug 1848106: data/azure: use outbound_rule instead of dummy inbound lb_rule

### DIFF
--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -120,36 +120,32 @@ resource "azurerm_lb_rule" "public_lb_rule_api_internal_v6" {
   probe_id                       = azurerm_lb_probe.public_lb_probe_api_internal[0].id
 }
 
-resource "azurerm_lb_rule" "internal_outbound_rule_v4" {
+resource "azurerm_lb_outbound_rule" "public_lb_outbound_rule_v4" {
   count = var.private && var.use_ipv4 ? 1 : 0
 
-  name                           = "internal_outbound_rule_v4"
-  resource_group_name            = var.resource_group_name
-  protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.public_lb_pool_v4[0].id
-  loadbalancer_id                = azurerm_lb.public.id
-  frontend_port                  = 27627
-  backend_port                   = 27627
-  frontend_ip_configuration_name = local.public_lb_frontend_ip_v4_configuration_name
-  enable_floating_ip             = false
-  idle_timeout_in_minutes        = 30
-  load_distribution              = "Default"
+  name                    = "outbound-rule-v4"
+  resource_group_name     = var.resource_group_name
+  loadbalancer_id         = azurerm_lb.public.id
+  backend_address_pool_id = azurerm_lb_backend_address_pool.public_lb_pool_v4[0].id
+  protocol                = "All"
+
+  frontend_ip_configuration {
+    name = local.public_lb_frontend_ip_v4_configuration_name
+  }
 }
 
-resource "azurerm_lb_rule" "internal_outbound_rule_v6" {
+resource "azurerm_lb_outbound_rule" "public_lb_outbound_rule_v6" {
   count = var.private && var.use_ipv6 ? 1 : 0
 
-  name                           = "internal_outbound_rule_v6"
-  resource_group_name            = var.resource_group_name
-  protocol                       = "Tcp"
-  backend_address_pool_id        = azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id
-  loadbalancer_id                = azurerm_lb.public.id
-  frontend_port                  = 27627
-  backend_port                   = 27627
-  frontend_ip_configuration_name = local.public_lb_frontend_ip_v6_configuration_name
-  enable_floating_ip             = false
-  idle_timeout_in_minutes        = 30
-  load_distribution              = "Default"
+  name                    = "outbound-rule-v6"
+  resource_group_name     = var.resource_group_name
+  loadbalancer_id         = azurerm_lb.public.id
+  backend_address_pool_id = azurerm_lb_backend_address_pool.public_lb_pool_v6[0].id
+  protocol                = "All"
+
+  frontend_ip_configuration {
+    name = local.public_lb_frontend_ip_v6_configuration_name
+  }
 }
 
 resource "azurerm_lb_probe" "public_lb_probe_api_internal" {


### PR DESCRIPTION
Using a dummy inbound rule can easily be replaced with an outbound rule that serves the exact purpose of egress traffic.

this also solves the issue where the installer and k8s are trying to create lb_rule for the same port.
```
2020-06-17T01:48:36.741071573Z E0617 01:48:36.741045       1 azure_loadbalancer.go:159] reconcileLoadBalancer(openshift-config-managed/outbound-provider) failed: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
2020-06-17T01:48:36.741071573Z   "error": {
2020-06-17T01:48:36.741071573Z     "code": "RulesUseSameBackendPortProtocolAndPool",
2020-06-17T01:48:36.741071573Z     "message": "Load balancing rules /subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/esstest03-2hn2f-rg/providers/Microsoft.Network/loadBalancers/esstest03-2hn2f/loadBalancingRules/internal_outbound_rule_v4 and /subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/esstest03-2hn2f-rg/providers/Microsoft.Network/loadBalancers/esstest03-2hn2f/loadBalancingRules/a180c6ccc20b4415cacb9eb31376fffb-TCP-27627 with floating IP disabled use the same protocol Tcp and backend port 27627, and must not be used with the same backend address pool /subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/esstest03-2hn2f-rg/providers/Microsoft.Network/loadBalancers/esstest03-2hn2f/backendAddressPools/esstest03-2hn2f.",
2020-06-17T01:48:36.741071573Z     "details": []
2020-06-17T01:48:36.741071573Z   }
2020-06-17T01:48:36.741071573Z }
2020-06-17T01:48:36.741152075Z E0617 01:48:36.741096       1 controller.go:244] error processing service openshift-config-managed/outbound-provider (will retry): failed to ensure load balancer: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
2020-06-17T01:48:36.741152075Z   "error": {
2020-06-17T01:48:36.741152075Z     "code": "RulesUseSameBackendPortProtocolAndPool",
2020-06-17T01:48:36.741152075Z     "message": "Load balancing rules /subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/esstest03-2hn2f-rg/providers/Microsoft.Network/loadBalancers/esstest03-2hn2f/loadBalancingRules/internal_outbound_rule_v4 and /subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/esstest03-2hn2f-rg/providers/Microsoft.Network/loadBalancers/esstest03-2hn2f/loadBalancingRules/a180c6ccc20b4415cacb9eb31376fffb-TCP-27627 with floating IP disabled use the same protocol Tcp and backend port 27627, and must not be used with the same backend address pool /subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/esstest03-2hn2f-rg/providers/Microsoft.Network/loadBalancers/esstest03-2hn2f/backendAddressPools/esstest03-2hn2f.",
2020-06-17T01:48:36.741152075Z     "details": []
2020-06-17T01:48:36.741152075Z   }
2020-06-17T01:48:36.741152075Z }
2020-06-17T01:48:36.741305781Z I0617 01:48:36.741241       1 event.go:278] Event(v1.ObjectReference{Kind:"Service", Namespace:"openshift-config-managed", Name:"outbound-provider", UID:"180c6ccc-20b4-415c-acb9-eb31376fffbf", APIVersion:"v1", ResourceVersion:"9340", FieldPath:""}): type: 'Warning' reason: 'SyncLoadBalancerFailed' Error syncing load balancer: failed to ensure load balancer: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: Retriable: false, RetryAfter: 0s, HTTPStatusCode: 400, RawError: {
2020-06-17T01:48:36.741305781Z   "error": {
2020-06-17T01:48:36.741305781Z     "code": "RulesUseSameBackendPortProtocolAndPool",
2020-06-17T01:48:36.741305781Z     "message": "Load balancing rules /subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/esstest03-2hn2f-rg/providers/Microsoft.Network/loadBalancers/esstest03-2hn2f/loadBalancingRules/internal_outbound_rule_v4 and /subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/esstest03-2hn2f-rg/providers/Microsoft.Network/loadBalancers/esstest03-2hn2f/loadBalancingRules/a180c6ccc20b4415cacb9eb31376fffb-TCP-27627 with floating IP disabled use the same protocol Tcp and backend port 27627, and must not be used with the same backend address pool /subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/esstest03-2hn2f-rg/providers/Microsoft.Network/loadBalancers/esstest03-2hn2f/backendAddressPools/esstest03-2hn2f.",
2020-06-17T01:48:36.741305781Z     "details": []
2020-06-17T01:48:36.741305781Z   }
2020-06-17T01:48:36.741305781Z }
```