### PR TITLE
Bug 1849150: rhcos/amd64: Bump to 45.82.202006191325-0

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,135 +1,135 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-03debc82c86cb9fc1"
+            "hvm": "ami-0956316a96426025e"
         },
         "ap-northeast-2": {
-            "hvm": "ami-032bfaf023d1d344a"
+            "hvm": "ami-0a7124c2388526b52"
         },
         "ap-south-1": {
-            "hvm": "ami-04a2271e011bf7e97"
+            "hvm": "ami-05507a408130f4c0a"
         },
         "ap-southeast-1": {
-            "hvm": "ami-00b64116043693c93"
+            "hvm": "ami-0ce79be7586f62c6c"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0ae368af58a298763"
+            "hvm": "ami-02fe34f705a74e280"
         },
         "ca-central-1": {
-            "hvm": "ami-08c89ccb53798be30"
+            "hvm": "ami-023727141adabc2b5"
         },
         "eu-central-1": {
-            "hvm": "ami-09020a80c8f3b1b07"
+            "hvm": "ami-013a7f7d6cc80f0a4"
         },
         "eu-north-1": {
-            "hvm": "ami-0665ded25a7f786d8"
+            "hvm": "ami-0becdb814c48628f2"
         },
         "eu-west-1": {
-            "hvm": "ami-0d8964d864a2b651d"
+            "hvm": "ami-0609f8d0aab54657f"
         },
         "eu-west-2": {
-            "hvm": "ami-0186141e3c79bb69a"
+            "hvm": "ami-0a723b501eca69338"
         },
         "eu-west-3": {
-            "hvm": "ami-00631c9e97e086ad1"
+            "hvm": "ami-084ce5bbb8cb2473b"
         },
         "me-south-1": {
-            "hvm": "ami-0d4544874f9ec20bb"
+            "hvm": "ami-046bdd15c7b9a7861"
         },
         "sa-east-1": {
-            "hvm": "ami-0bd6d945b5fb94f15"
+            "hvm": "ami-085e14a775f7d2f6b"
         },
         "us-east-1": {
-            "hvm": "ami-0097bded932c126bc"
+            "hvm": "ami-010f813fb08c9ca79"
         },
         "us-east-2": {
-            "hvm": "ami-0254f6b4eaa3b9d0f"
+            "hvm": "ami-0ece32c2916738e00"
         },
         "us-west-1": {
-            "hvm": "ami-058d97ab18b0e860a"
+            "hvm": "ami-00a60bc4b66ea44ea"
         },
         "us-west-2": {
-            "hvm": "ami-0bd693f82f222c33d"
+            "hvm": "ami-03b4ee94fad636339"
         }
     },
     "azure": {
-        "image": "rhcos-45.81.202005200134-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.81.202005200134-0-azure.x86_64.vhd"
+        "image": "rhcos-45.82.202006191325-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.82.202006191325-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.81.202005200134-0/x86_64/",
-    "buildid": "45.81.202005200134-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.82.202006191325-0/x86_64/",
+    "buildid": "45.82.202006191325-0",
     "gcp": {
-        "image": "rhcos-45-81-202005200134-0-gcp-x86-64",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-81-202005200134-0-gcp-x86-64.tar.gz"
+        "image": "rhcos-45-82-202006191325-0-gcp-x86-64",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-82-202006191325-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-45.81.202005200134-0-aws.x86_64.vmdk.gz",
-            "sha256": "d234f42746197bca52fe13af50414e11388b7dcdee67f443f7443b0d413384b6",
-            "size": 892691141,
-            "uncompressed-sha256": "6449f179293e0be22f8e94458ac79e287de21dc03753a08e16dd99095c8fe042",
-            "uncompressed-size": 911347200
+            "path": "rhcos-45.82.202006191325-0-aws.x86_64.vmdk.gz",
+            "sha256": "c03d3c6a25295ce53de31c9d47d7c034e3719630591bb77713945dd76ed00e7c",
+            "size": 906391783,
+            "uncompressed-sha256": "8f89fd82e52914f34b960bb26afb773158a4f60bc4b1d0acc49b28221aa2b078",
+            "uncompressed-size": 926264320
         },
         "azure": {
-            "path": "rhcos-45.81.202005200134-0-azure.x86_64.vhd.gz",
-            "sha256": "04afa148f9c9c43018b7e1c518d076fe7900d66c499ad2ad9aed1c4191f8d396",
-            "size": 892027711,
-            "uncompressed-sha256": "1b672b2dfd27c633db729c34fa72083df370c140f06eb59833c006ee55edee10",
+            "path": "rhcos-45.82.202006191325-0-azure.x86_64.vhd.gz",
+            "sha256": "2d5fbdc34280d73e8622e31e7d82de07c39a6bf64ca417e4cf51f2417d5653f3",
+            "size": 907129692,
+            "uncompressed-sha256": "7d1b8a1849afe799d95535174365d71e5a97ca9bb40cefc43659e0335372b474",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-45.81.202005200134-0-gcp.x86_64.tar.gz",
-            "sha256": "09d553434d6f9c2934602ab274f9bbdfeb9c3c698f42769519b5c1e7d8f32226",
-            "size": 877406720
+            "path": "rhcos-45.82.202006191325-0-gcp.x86_64.tar.gz",
+            "sha256": "4778f1e04feb29094a7b8686b094d1b863f313b1d090c8038e3d20799971c962",
+            "size": 892418143
         },
         "initramfs": {
-            "path": "rhcos-45.81.202005200134-0-installer-initramfs.x86_64.img",
-            "sha256": "75c6e6d10a6744b68920e25fe13da19860f13ed0eb7a7744ae4ff38891e49af5"
+            "path": "rhcos-45.82.202006191325-0-installer-initramfs.x86_64.img",
+            "sha256": "2b295d9821128520d4b728d444d4684b48c8cc56e85d0402189a434d8e7c8579"
         },
         "iso": {
-            "path": "rhcos-45.81.202005200134-0-installer.x86_64.iso",
-            "sha256": "d2aa854c5fab79e78c2cdf462c67b1fe04441b9c042d40c95b98e0d95ca6f86d"
+            "path": "rhcos-45.82.202006191325-0-installer.x86_64.iso",
+            "sha256": "2fa67e47837cc58bd1cd5b69d941fc18046e091a962e340a61a5a050cd9656ad"
         },
         "kernel": {
-            "path": "rhcos-45.81.202005200134-0-installer-kernel-x86_64",
-            "sha256": "82333190f8b87da47e605608508650cb860b3d2bb48e8887c31a76323855fb18"
+            "path": "rhcos-45.82.202006191325-0-installer-kernel-x86_64",
+            "sha256": "998feda78468086fad450f2080f99281dcbca7c638fc0f4905fc3fb277d68459"
         },
         "metal": {
-            "path": "rhcos-45.81.202005200134-0-metal.x86_64.raw.gz",
-            "sha256": "fbbe3f1a6cd60ec0344ca88925efc812c1556654680d8663bffd0663ae55843a",
-            "size": 878855135,
-            "uncompressed-sha256": "4a211425bf1af046ffbd91c9c63b0d179db67f9dc4165a4a106a2f0a1c74df7e",
-            "uncompressed-size": 3807379456
+            "path": "rhcos-45.82.202006191325-0-metal.x86_64.raw.gz",
+            "sha256": "d96faa8946fc8472e4b0bcb3d26c02711852f72e21c591914e742a2bca951117",
+            "size": 894358331,
+            "uncompressed-sha256": "3645638ddb35b504c3ef5b7c5f6ac959458436eb5e56ecc519ce3eeb5135c24c",
+            "uncompressed-size": 3748659200
         },
         "openstack": {
-            "path": "rhcos-45.81.202005200134-0-openstack.x86_64.qcow2.gz",
-            "sha256": "62345f8eb00e3a2075aff9bb87a634ced1fbb95f66d56d5abfa462d0555ec1cb",
-            "size": 877680541,
-            "uncompressed-sha256": "cbbef9efff0a90d8b4b42b64d38b6a8083d2aad1496fac8bbb12a9a601eb0ba5",
-            "uncompressed-size": 2427125760
+            "path": "rhcos-45.82.202006191325-0-openstack.x86_64.qcow2.gz",
+            "sha256": "2a3866f4d5a709a59d456ef3fd88120c0667d4e47b1e5f18ebca1dce6614f40a",
+            "size": 892750339,
+            "uncompressed-sha256": "008dcd548581f98f93c30f4ce4c96549b3e5351d34a985134fd7dc38b9307b8e",
+            "uncompressed-size": 2388787200
         },
         "ostree": {
-            "path": "rhcos-45.81.202005200134-0-ostree.x86_64.tar",
-            "sha256": "1362fd7a1273fa5895f6f328e8d03e79033f52d72375f53099cb860a156d1535",
-            "size": 811059200
+            "path": "rhcos-45.82.202006191325-0-ostree.x86_64.tar",
+            "sha256": "24fecb20f83567ea1c4e7de2eab976309d319ddad54b49eb8c8772a164115ec8",
+            "size": 823951360
         },
         "qemu": {
-            "path": "rhcos-45.81.202005200134-0-qemu.x86_64.qcow2.gz",
-            "sha256": "8d7190126d6a4edcf7d291084b8decf8beffd8bcb0ebc5f2cb83a3078a6be434",
-            "size": 879587420,
-            "uncompressed-sha256": "d3dae00f0d9ca9593249f1ac9e6f9ef6176a307721b5f4ab30b03eada8a1e44a",
-            "uncompressed-size": 2473328640
+            "path": "rhcos-45.82.202006191325-0-qemu.x86_64.qcow2.gz",
+            "sha256": "f0a99295741a895bdf36ec70ddda753da7a61ab418ff017fe2b72aa14e6bff23",
+            "size": 894903251,
+            "uncompressed-sha256": "ce9e6adac25a6fdd7011a1dc5faa631c5406b2df600ee69c0c0a85044d46f6b3",
+            "uncompressed-size": 2436628480
         },
         "vmware": {
-            "path": "rhcos-45.81.202005200134-0-vmware.x86_64.ova",
-            "sha256": "2166966efba40c32ed845498cc7d8692ce2efd7c1fb307635df4b04633c27df0",
-            "size": 911360000
+            "path": "rhcos-45.82.202006191325-0-vmware.x86_64.ova",
+            "sha256": "aaed98ec888b5d6f9f72b2be1e4e51f9178a99b439b243967ff5b8bcd084042e",
+            "size": 926279680
         }
     },
     "oscontainer": {
-        "digest": "sha256:55b59136f8f03b9f0cff1b5095c07b0ee03f95d734048ed004cdb74050bbb51f",
+        "digest": "sha256:e262115259934def7fd0a5f15dc0dc9fe7a666f0982e7815ecd0a8b8b4ba4b89",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "1e46236673938a570029e54117fff0c1a1eedb4a5e0ad12373d1a27407cfed3a",
-    "ostree-version": "45.81.202005200134-0"
+    "ostree-commit": "3c1ded0e8180de2d9ef1c836ae2bd6f1f8215b28b55c96da1d13ec840ee58c7d",
+    "ostree-version": "45.82.202006191325-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,135 +1,135 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-03debc82c86cb9fc1"
+            "hvm": "ami-0956316a96426025e"
         },
         "ap-northeast-2": {
-            "hvm": "ami-032bfaf023d1d344a"
+            "hvm": "ami-0a7124c2388526b52"
         },
         "ap-south-1": {
-            "hvm": "ami-04a2271e011bf7e97"
+            "hvm": "ami-05507a408130f4c0a"
         },
         "ap-southeast-1": {
-            "hvm": "ami-00b64116043693c93"
+            "hvm": "ami-0ce79be7586f62c6c"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0ae368af58a298763"
+            "hvm": "ami-02fe34f705a74e280"
         },
         "ca-central-1": {
-            "hvm": "ami-08c89ccb53798be30"
+            "hvm": "ami-023727141adabc2b5"
         },
         "eu-central-1": {
-            "hvm": "ami-09020a80c8f3b1b07"
+            "hvm": "ami-013a7f7d6cc80f0a4"
         },
         "eu-north-1": {
-            "hvm": "ami-0665ded25a7f786d8"
+            "hvm": "ami-0becdb814c48628f2"
         },
         "eu-west-1": {
-            "hvm": "ami-0d8964d864a2b651d"
+            "hvm": "ami-0609f8d0aab54657f"
         },
         "eu-west-2": {
-            "hvm": "ami-0186141e3c79bb69a"
+            "hvm": "ami-0a723b501eca69338"
         },
         "eu-west-3": {
-            "hvm": "ami-00631c9e97e086ad1"
+            "hvm": "ami-084ce5bbb8cb2473b"
         },
         "me-south-1": {
-            "hvm": "ami-0d4544874f9ec20bb"
+            "hvm": "ami-046bdd15c7b9a7861"
         },
         "sa-east-1": {
-            "hvm": "ami-0bd6d945b5fb94f15"
+            "hvm": "ami-085e14a775f7d2f6b"
         },
         "us-east-1": {
-            "hvm": "ami-0097bded932c126bc"
+            "hvm": "ami-010f813fb08c9ca79"
         },
         "us-east-2": {
-            "hvm": "ami-0254f6b4eaa3b9d0f"
+            "hvm": "ami-0ece32c2916738e00"
         },
         "us-west-1": {
-            "hvm": "ami-058d97ab18b0e860a"
+            "hvm": "ami-00a60bc4b66ea44ea"
         },
         "us-west-2": {
-            "hvm": "ami-0bd693f82f222c33d"
+            "hvm": "ami-03b4ee94fad636339"
         }
     },
     "azure": {
-        "image": "rhcos-45.81.202005200134-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.81.202005200134-0-azure.x86_64.vhd"
+        "image": "rhcos-45.82.202006191325-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.82.202006191325-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.81.202005200134-0/x86_64/",
-    "buildid": "45.81.202005200134-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.82.202006191325-0/x86_64/",
+    "buildid": "45.82.202006191325-0",
     "gcp": {
-        "image": "rhcos-45-81-202005200134-0-gcp-x86-64",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-81-202005200134-0-gcp-x86-64.tar.gz"
+        "image": "rhcos-45-82-202006191325-0-gcp-x86-64",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-82-202006191325-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-45.81.202005200134-0-aws.x86_64.vmdk.gz",
-            "sha256": "d234f42746197bca52fe13af50414e11388b7dcdee67f443f7443b0d413384b6",
-            "size": 892691141,
-            "uncompressed-sha256": "6449f179293e0be22f8e94458ac79e287de21dc03753a08e16dd99095c8fe042",
-            "uncompressed-size": 911347200
+            "path": "rhcos-45.82.202006191325-0-aws.x86_64.vmdk.gz",
+            "sha256": "c03d3c6a25295ce53de31c9d47d7c034e3719630591bb77713945dd76ed00e7c",
+            "size": 906391783,
+            "uncompressed-sha256": "8f89fd82e52914f34b960bb26afb773158a4f60bc4b1d0acc49b28221aa2b078",
+            "uncompressed-size": 926264320
         },
         "azure": {
-            "path": "rhcos-45.81.202005200134-0-azure.x86_64.vhd.gz",
-            "sha256": "04afa148f9c9c43018b7e1c518d076fe7900d66c499ad2ad9aed1c4191f8d396",
-            "size": 892027711,
-            "uncompressed-sha256": "1b672b2dfd27c633db729c34fa72083df370c140f06eb59833c006ee55edee10",
+            "path": "rhcos-45.82.202006191325-0-azure.x86_64.vhd.gz",
+            "sha256": "2d5fbdc34280d73e8622e31e7d82de07c39a6bf64ca417e4cf51f2417d5653f3",
+            "size": 907129692,
+            "uncompressed-sha256": "7d1b8a1849afe799d95535174365d71e5a97ca9bb40cefc43659e0335372b474",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-45.81.202005200134-0-gcp.x86_64.tar.gz",
-            "sha256": "09d553434d6f9c2934602ab274f9bbdfeb9c3c698f42769519b5c1e7d8f32226",
-            "size": 877406720
+            "path": "rhcos-45.82.202006191325-0-gcp.x86_64.tar.gz",
+            "sha256": "4778f1e04feb29094a7b8686b094d1b863f313b1d090c8038e3d20799971c962",
+            "size": 892418143
         },
         "initramfs": {
-            "path": "rhcos-45.81.202005200134-0-installer-initramfs.x86_64.img",
-            "sha256": "75c6e6d10a6744b68920e25fe13da19860f13ed0eb7a7744ae4ff38891e49af5"
+            "path": "rhcos-45.82.202006191325-0-installer-initramfs.x86_64.img",
+            "sha256": "2b295d9821128520d4b728d444d4684b48c8cc56e85d0402189a434d8e7c8579"
         },
         "iso": {
-            "path": "rhcos-45.81.202005200134-0-installer.x86_64.iso",
-            "sha256": "d2aa854c5fab79e78c2cdf462c67b1fe04441b9c042d40c95b98e0d95ca6f86d"
+            "path": "rhcos-45.82.202006191325-0-installer.x86_64.iso",
+            "sha256": "2fa67e47837cc58bd1cd5b69d941fc18046e091a962e340a61a5a050cd9656ad"
         },
         "kernel": {
-            "path": "rhcos-45.81.202005200134-0-installer-kernel-x86_64",
-            "sha256": "82333190f8b87da47e605608508650cb860b3d2bb48e8887c31a76323855fb18"
+            "path": "rhcos-45.82.202006191325-0-installer-kernel-x86_64",
+            "sha256": "998feda78468086fad450f2080f99281dcbca7c638fc0f4905fc3fb277d68459"
         },
         "metal": {
-            "path": "rhcos-45.81.202005200134-0-metal.x86_64.raw.gz",
-            "sha256": "fbbe3f1a6cd60ec0344ca88925efc812c1556654680d8663bffd0663ae55843a",
-            "size": 878855135,
-            "uncompressed-sha256": "4a211425bf1af046ffbd91c9c63b0d179db67f9dc4165a4a106a2f0a1c74df7e",
-            "uncompressed-size": 3807379456
+            "path": "rhcos-45.82.202006191325-0-metal.x86_64.raw.gz",
+            "sha256": "d96faa8946fc8472e4b0bcb3d26c02711852f72e21c591914e742a2bca951117",
+            "size": 894358331,
+            "uncompressed-sha256": "3645638ddb35b504c3ef5b7c5f6ac959458436eb5e56ecc519ce3eeb5135c24c",
+            "uncompressed-size": 3748659200
         },
         "openstack": {
-            "path": "rhcos-45.81.202005200134-0-openstack.x86_64.qcow2.gz",
-            "sha256": "62345f8eb00e3a2075aff9bb87a634ced1fbb95f66d56d5abfa462d0555ec1cb",
-            "size": 877680541,
-            "uncompressed-sha256": "cbbef9efff0a90d8b4b42b64d38b6a8083d2aad1496fac8bbb12a9a601eb0ba5",
-            "uncompressed-size": 2427125760
+            "path": "rhcos-45.82.202006191325-0-openstack.x86_64.qcow2.gz",
+            "sha256": "2a3866f4d5a709a59d456ef3fd88120c0667d4e47b1e5f18ebca1dce6614f40a",
+            "size": 892750339,
+            "uncompressed-sha256": "008dcd548581f98f93c30f4ce4c96549b3e5351d34a985134fd7dc38b9307b8e",
+            "uncompressed-size": 2388787200
         },
         "ostree": {
-            "path": "rhcos-45.81.202005200134-0-ostree.x86_64.tar",
-            "sha256": "1362fd7a1273fa5895f6f328e8d03e79033f52d72375f53099cb860a156d1535",
-            "size": 811059200
+            "path": "rhcos-45.82.202006191325-0-ostree.x86_64.tar",
+            "sha256": "24fecb20f83567ea1c4e7de2eab976309d319ddad54b49eb8c8772a164115ec8",
+            "size": 823951360
         },
         "qemu": {
-            "path": "rhcos-45.81.202005200134-0-qemu.x86_64.qcow2.gz",
-            "sha256": "8d7190126d6a4edcf7d291084b8decf8beffd8bcb0ebc5f2cb83a3078a6be434",
-            "size": 879587420,
-            "uncompressed-sha256": "d3dae00f0d9ca9593249f1ac9e6f9ef6176a307721b5f4ab30b03eada8a1e44a",
-            "uncompressed-size": 2473328640
+            "path": "rhcos-45.82.202006191325-0-qemu.x86_64.qcow2.gz",
+            "sha256": "f0a99295741a895bdf36ec70ddda753da7a61ab418ff017fe2b72aa14e6bff23",
+            "size": 894903251,
+            "uncompressed-sha256": "ce9e6adac25a6fdd7011a1dc5faa631c5406b2df600ee69c0c0a85044d46f6b3",
+            "uncompressed-size": 2436628480
         },
         "vmware": {
-            "path": "rhcos-45.81.202005200134-0-vmware.x86_64.ova",
-            "sha256": "2166966efba40c32ed845498cc7d8692ce2efd7c1fb307635df4b04633c27df0",
-            "size": 911360000
+            "path": "rhcos-45.82.202006191325-0-vmware.x86_64.ova",
+            "sha256": "aaed98ec888b5d6f9f72b2be1e4e51f9178a99b439b243967ff5b8bcd084042e",
+            "size": 926279680
         }
     },
     "oscontainer": {
-        "digest": "sha256:55b59136f8f03b9f0cff1b5095c07b0ee03f95d734048ed004cdb74050bbb51f",
+        "digest": "sha256:e262115259934def7fd0a5f15dc0dc9fe7a666f0982e7815ecd0a8b8b4ba4b89",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "1e46236673938a570029e54117fff0c1a1eedb4a5e0ad12373d1a27407cfed3a",
-    "ostree-version": "45.81.202005200134-0"
+    "ostree-commit": "3c1ded0e8180de2d9ef1c836ae2bd6f1f8215b28b55c96da1d13ec840ee58c7d",
+    "ostree-version": "45.82.202006191325-0"
 }


### PR DESCRIPTION
Promoted here:
https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/logs/promote-release-openshift-machine-os-content-e2e-aws-4.5/1273982585365598208

This gets the bootimage to RHEL 8.2, among other things.