### PR TITLE
Bug 1850714: adjust Azure UPI disk size to the same used in IPI

### DIFF
--- a/upi/azure/05_masters.json
+++ b/upi/azure/05_masters.json
@@ -110,6 +110,13 @@
       "metadata" : {
         "description" : "The size of the Master Virtual Machines"
       }
+    },
+    "diskSizeGB" : {
+      "type" : "int",
+      "defaultValue" : 1024,
+      "metadata" : {
+        "description" : "Size of the Master VM OS disk, in GB"
+      }
     }
   },
   "variables" : {
@@ -256,7 +263,7 @@
             "managedDisk": {
               "storageAccountType": "Premium_LRS"
             },
-            "diskSizeGB" : 128
+            "diskSizeGB" : "[parameters('diskSizeGB')]"
           }
         },
         "networkProfile" : {


### PR DESCRIPTION
Adjust Azure UPI to use a 1024 GB disk size by default, which is currently the default in IPI and the recommended size for better IOPS performance.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1850714