### PR TITLE
rhcos/amd64: Bump to 45.82.202006230709-0

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,135 +1,135 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-0956316a96426025e"
+            "hvm": "ami-0530d04240177f118"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0a7124c2388526b52"
+            "hvm": "ami-09e4cd700276785d2"
         },
         "ap-south-1": {
-            "hvm": "ami-05507a408130f4c0a"
+            "hvm": "ami-0754b15d212830477"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0ce79be7586f62c6c"
+            "hvm": "ami-03b46cc4b1518c5a8"
         },
         "ap-southeast-2": {
-            "hvm": "ami-02fe34f705a74e280"
+            "hvm": "ami-0a5b99ab2234a4e6a"
         },
         "ca-central-1": {
-            "hvm": "ami-023727141adabc2b5"
+            "hvm": "ami-012bc4ee3b6c673bc"
         },
         "eu-central-1": {
-            "hvm": "ami-013a7f7d6cc80f0a4"
+            "hvm": "ami-02e08df1201f1c2f8"
         },
         "eu-north-1": {
-            "hvm": "ami-0becdb814c48628f2"
+            "hvm": "ami-0309c9d2fadcb2d5a"
         },
         "eu-west-1": {
-            "hvm": "ami-0609f8d0aab54657f"
+            "hvm": "ami-0bdd69d8e7cd18188"
         },
         "eu-west-2": {
-            "hvm": "ami-0a723b501eca69338"
+            "hvm": "ami-0e610e967a62dbdfa"
         },
         "eu-west-3": {
-            "hvm": "ami-084ce5bbb8cb2473b"
+            "hvm": "ami-0e817e26f638a71ac"
         },
         "me-south-1": {
-            "hvm": "ami-046bdd15c7b9a7861"
+            "hvm": "ami-024117d7c87b7ff08"
         },
         "sa-east-1": {
-            "hvm": "ami-085e14a775f7d2f6b"
+            "hvm": "ami-08e62f746b94950c1"
         },
         "us-east-1": {
-            "hvm": "ami-010f813fb08c9ca79"
+            "hvm": "ami-077ede5bed2e431ea"
         },
         "us-east-2": {
-            "hvm": "ami-0ece32c2916738e00"
+            "hvm": "ami-0f4ecf819275850dd"
         },
         "us-west-1": {
-            "hvm": "ami-00a60bc4b66ea44ea"
+            "hvm": "ami-0c4990e435bc6c5fe"
         },
         "us-west-2": {
-            "hvm": "ami-03b4ee94fad636339"
+            "hvm": "ami-000d6e92357ac605c"
         }
     },
     "azure": {
-        "image": "rhcos-45.82.202006191325-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.82.202006191325-0-azure.x86_64.vhd"
+        "image": "rhcos-45.82.202006230709-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.82.202006230709-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.82.202006191325-0/x86_64/",
-    "buildid": "45.82.202006191325-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.82.202006230709-0/x86_64/",
+    "buildid": "45.82.202006230709-0",
     "gcp": {
-        "image": "rhcos-45-82-202006191325-0-gcp-x86-64",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-82-202006191325-0-gcp-x86-64.tar.gz"
+        "image": "rhcos-45-82-202006230709-0-gcp-x86-64",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-82-202006230709-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-45.82.202006191325-0-aws.x86_64.vmdk.gz",
-            "sha256": "c03d3c6a25295ce53de31c9d47d7c034e3719630591bb77713945dd76ed00e7c",
-            "size": 906391783,
-            "uncompressed-sha256": "8f89fd82e52914f34b960bb26afb773158a4f60bc4b1d0acc49b28221aa2b078",
-            "uncompressed-size": 926264320
+            "path": "rhcos-45.82.202006230709-0-aws.x86_64.vmdk.gz",
+            "sha256": "6573a71c7750123be3434524253e2b1ae02533c5e364eb0f18c141cf39bfac92",
+            "size": 906465986,
+            "uncompressed-sha256": "4f26fadb61256131e33be6009272e6c49a04c8b68e70c48e5f29e17a9edf5f95",
+            "uncompressed-size": 926365696
         },
         "azure": {
-            "path": "rhcos-45.82.202006191325-0-azure.x86_64.vhd.gz",
-            "sha256": "2d5fbdc34280d73e8622e31e7d82de07c39a6bf64ca417e4cf51f2417d5653f3",
-            "size": 907129692,
-            "uncompressed-sha256": "7d1b8a1849afe799d95535174365d71e5a97ca9bb40cefc43659e0335372b474",
+            "path": "rhcos-45.82.202006230709-0-azure.x86_64.vhd.gz",
+            "sha256": "fa747236544b62e1202c5e8c09c867e5bd2172b704471420132fd0b7a73adb4a",
+            "size": 907173471,
+            "uncompressed-sha256": "5b2164c3acb83faabbcb5e2e7e411bfbb480dfeffbdc66dee9290e3eafdf2060",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-45.82.202006191325-0-gcp.x86_64.tar.gz",
-            "sha256": "4778f1e04feb29094a7b8686b094d1b863f313b1d090c8038e3d20799971c962",
-            "size": 892418143
+            "path": "rhcos-45.82.202006230709-0-gcp.x86_64.tar.gz",
+            "sha256": "0053d8de006deb4452e7ce1d104a994d71271a042bc214fcd7f44f2fe6bf52b9",
+            "size": 892473239
         },
         "initramfs": {
-            "path": "rhcos-45.82.202006191325-0-installer-initramfs.x86_64.img",
-            "sha256": "2b295d9821128520d4b728d444d4684b48c8cc56e85d0402189a434d8e7c8579"
+            "path": "rhcos-45.82.202006230709-0-installer-initramfs.x86_64.img",
+            "sha256": "9299123f6144a70838eb0138535d8bb3e0b06b5b57134c8d4e852bb94ca5c08b"
         },
         "iso": {
-            "path": "rhcos-45.82.202006191325-0-installer.x86_64.iso",
-            "sha256": "2fa67e47837cc58bd1cd5b69d941fc18046e091a962e340a61a5a050cd9656ad"
+            "path": "rhcos-45.82.202006230709-0-installer.x86_64.iso",
+            "sha256": "1bd1c2e330e3b90c40380887d640370b2ff57461f4ab71b6c85b9fffc9958551"
         },
         "kernel": {
-            "path": "rhcos-45.82.202006191325-0-installer-kernel-x86_64",
+            "path": "rhcos-45.82.202006230709-0-installer-kernel-x86_64",
             "sha256": "998feda78468086fad450f2080f99281dcbca7c638fc0f4905fc3fb277d68459"
         },
         "metal": {
-            "path": "rhcos-45.82.202006191325-0-metal.x86_64.raw.gz",
-            "sha256": "d96faa8946fc8472e4b0bcb3d26c02711852f72e21c591914e742a2bca951117",
-            "size": 894358331,
-            "uncompressed-sha256": "3645638ddb35b504c3ef5b7c5f6ac959458436eb5e56ecc519ce3eeb5135c24c",
-            "uncompressed-size": 3748659200
+            "path": "rhcos-45.82.202006230709-0-metal.x86_64.raw.gz",
+            "sha256": "ec6b64bb1ae19404f29cef614d1a1d50f3c95c1046ea5a25cfb92732cbef94f4",
+            "size": 894182620,
+            "uncompressed-sha256": "c466595abf7ce3ea0f365b93e4930ed01eabc725150780d908ba31fdbae6155c",
+            "uncompressed-size": 3750756352
         },
         "openstack": {
-            "path": "rhcos-45.82.202006191325-0-openstack.x86_64.qcow2.gz",
-            "sha256": "2a3866f4d5a709a59d456ef3fd88120c0667d4e47b1e5f18ebca1dce6614f40a",
-            "size": 892750339,
-            "uncompressed-sha256": "008dcd548581f98f93c30f4ce4c96549b3e5351d34a985134fd7dc38b9307b8e",
-            "uncompressed-size": 2388787200
+            "path": "rhcos-45.82.202006230709-0-openstack.x86_64.qcow2.gz",
+            "sha256": "c4fa79acbdf7b625083c3c8b9d76012f9457fd7abb5bca3e3b35724e2586c27c",
+            "size": 892797946,
+            "uncompressed-sha256": "d1982ac8cecc0490d3262320be311f6a73987d8afb8dc2297730039b0508f4f5",
+            "uncompressed-size": 2389508096
         },
         "ostree": {
-            "path": "rhcos-45.82.202006191325-0-ostree.x86_64.tar",
-            "sha256": "24fecb20f83567ea1c4e7de2eab976309d319ddad54b49eb8c8772a164115ec8",
-            "size": 823951360
+            "path": "rhcos-45.82.202006230709-0-ostree.x86_64.tar",
+            "sha256": "8b3ddb774a4a62723eadbbe86cd1d32fe3746a412122c7f295c9238cbd341104",
+            "size": 824053760
         },
         "qemu": {
-            "path": "rhcos-45.82.202006191325-0-qemu.x86_64.qcow2.gz",
-            "sha256": "f0a99295741a895bdf36ec70ddda753da7a61ab418ff017fe2b72aa14e6bff23",
-            "size": 894903251,
-            "uncompressed-sha256": "ce9e6adac25a6fdd7011a1dc5faa631c5406b2df600ee69c0c0a85044d46f6b3",
-            "uncompressed-size": 2436628480
+            "path": "rhcos-45.82.202006230709-0-qemu.x86_64.qcow2.gz",
+            "sha256": "6960b57466e46eb7f04bf86b81d2526fadf4bba8691d60e21823acde16e015f2",
+            "size": 895043504,
+            "uncompressed-sha256": "01f04133329d7297750df06069d1a9b73f44c99d3dd22591374db630ba96d775",
+            "uncompressed-size": 2436956160
         },
         "vmware": {
-            "path": "rhcos-45.82.202006191325-0-vmware.x86_64.ova",
-            "sha256": "aaed98ec888b5d6f9f72b2be1e4e51f9178a99b439b243967ff5b8bcd084042e",
-            "size": 926279680
+            "path": "rhcos-45.82.202006230709-0-vmware.x86_64.ova",
+            "sha256": "b6392b40b7d7857e2e9647a87b71fe3510c0b2dbd9ff675dac6f13bf43c16f2f",
+            "size": 926382080
         }
     },
     "oscontainer": {
-        "digest": "sha256:e262115259934def7fd0a5f15dc0dc9fe7a666f0982e7815ecd0a8b8b4ba4b89",
+        "digest": "sha256:3ce53cd86baeeb5012820f9872587618d3abab11a794d21fbad386a14cea6c07",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "3c1ded0e8180de2d9ef1c836ae2bd6f1f8215b28b55c96da1d13ec840ee58c7d",
-    "ostree-version": "45.82.202006191325-0"
+    "ostree-commit": "0b79771d2a6f1a091fdcfbf53814e3eff5b190f06e55384bed2e0337e4df0347",
+    "ostree-version": "45.82.202006230709-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,135 +1,135 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-0956316a96426025e"
+            "hvm": "ami-0530d04240177f118"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0a7124c2388526b52"
+            "hvm": "ami-09e4cd700276785d2"
         },
         "ap-south-1": {
-            "hvm": "ami-05507a408130f4c0a"
+            "hvm": "ami-0754b15d212830477"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0ce79be7586f62c6c"
+            "hvm": "ami-03b46cc4b1518c5a8"
         },
         "ap-southeast-2": {
-            "hvm": "ami-02fe34f705a74e280"
+            "hvm": "ami-0a5b99ab2234a4e6a"
         },
         "ca-central-1": {
-            "hvm": "ami-023727141adabc2b5"
+            "hvm": "ami-012bc4ee3b6c673bc"
         },
         "eu-central-1": {
-            "hvm": "ami-013a7f7d6cc80f0a4"
+            "hvm": "ami-02e08df1201f1c2f8"
         },
         "eu-north-1": {
-            "hvm": "ami-0becdb814c48628f2"
+            "hvm": "ami-0309c9d2fadcb2d5a"
         },
         "eu-west-1": {
-            "hvm": "ami-0609f8d0aab54657f"
+            "hvm": "ami-0bdd69d8e7cd18188"
         },
         "eu-west-2": {
-            "hvm": "ami-0a723b501eca69338"
+            "hvm": "ami-0e610e967a62dbdfa"
         },
         "eu-west-3": {
-            "hvm": "ami-084ce5bbb8cb2473b"
+            "hvm": "ami-0e817e26f638a71ac"
         },
         "me-south-1": {
-            "hvm": "ami-046bdd15c7b9a7861"
+            "hvm": "ami-024117d7c87b7ff08"
         },
         "sa-east-1": {
-            "hvm": "ami-085e14a775f7d2f6b"
+            "hvm": "ami-08e62f746b94950c1"
         },
         "us-east-1": {
-            "hvm": "ami-010f813fb08c9ca79"
+            "hvm": "ami-077ede5bed2e431ea"
         },
         "us-east-2": {
-            "hvm": "ami-0ece32c2916738e00"
+            "hvm": "ami-0f4ecf819275850dd"
         },
         "us-west-1": {
-            "hvm": "ami-00a60bc4b66ea44ea"
+            "hvm": "ami-0c4990e435bc6c5fe"
         },
         "us-west-2": {
-            "hvm": "ami-03b4ee94fad636339"
+            "hvm": "ami-000d6e92357ac605c"
         }
     },
     "azure": {
-        "image": "rhcos-45.82.202006191325-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.82.202006191325-0-azure.x86_64.vhd"
+        "image": "rhcos-45.82.202006230709-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-45.82.202006230709-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.82.202006191325-0/x86_64/",
-    "buildid": "45.82.202006191325-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.5/45.82.202006230709-0/x86_64/",
+    "buildid": "45.82.202006230709-0",
     "gcp": {
-        "image": "rhcos-45-82-202006191325-0-gcp-x86-64",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-82-202006191325-0-gcp-x86-64.tar.gz"
+        "image": "rhcos-45-82-202006230709-0-gcp-x86-64",
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-45-82-202006230709-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-45.82.202006191325-0-aws.x86_64.vmdk.gz",
-            "sha256": "c03d3c6a25295ce53de31c9d47d7c034e3719630591bb77713945dd76ed00e7c",
-            "size": 906391783,
-            "uncompressed-sha256": "8f89fd82e52914f34b960bb26afb773158a4f60bc4b1d0acc49b28221aa2b078",
-            "uncompressed-size": 926264320
+            "path": "rhcos-45.82.202006230709-0-aws.x86_64.vmdk.gz",
+            "sha256": "6573a71c7750123be3434524253e2b1ae02533c5e364eb0f18c141cf39bfac92",
+            "size": 906465986,
+            "uncompressed-sha256": "4f26fadb61256131e33be6009272e6c49a04c8b68e70c48e5f29e17a9edf5f95",
+            "uncompressed-size": 926365696
         },
         "azure": {
-            "path": "rhcos-45.82.202006191325-0-azure.x86_64.vhd.gz",
-            "sha256": "2d5fbdc34280d73e8622e31e7d82de07c39a6bf64ca417e4cf51f2417d5653f3",
-            "size": 907129692,
-            "uncompressed-sha256": "7d1b8a1849afe799d95535174365d71e5a97ca9bb40cefc43659e0335372b474",
+            "path": "rhcos-45.82.202006230709-0-azure.x86_64.vhd.gz",
+            "sha256": "fa747236544b62e1202c5e8c09c867e5bd2172b704471420132fd0b7a73adb4a",
+            "size": 907173471,
+            "uncompressed-sha256": "5b2164c3acb83faabbcb5e2e7e411bfbb480dfeffbdc66dee9290e3eafdf2060",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-45.82.202006191325-0-gcp.x86_64.tar.gz",
-            "sha256": "4778f1e04feb29094a7b8686b094d1b863f313b1d090c8038e3d20799971c962",
-            "size": 892418143
+            "path": "rhcos-45.82.202006230709-0-gcp.x86_64.tar.gz",
+            "sha256": "0053d8de006deb4452e7ce1d104a994d71271a042bc214fcd7f44f2fe6bf52b9",
+            "size": 892473239
         },
         "initramfs": {
-            "path": "rhcos-45.82.202006191325-0-installer-initramfs.x86_64.img",
-            "sha256": "2b295d9821128520d4b728d444d4684b48c8cc56e85d0402189a434d8e7c8579"
+            "path": "rhcos-45.82.202006230709-0-installer-initramfs.x86_64.img",
+            "sha256": "9299123f6144a70838eb0138535d8bb3e0b06b5b57134c8d4e852bb94ca5c08b"
         },
         "iso": {
-            "path": "rhcos-45.82.202006191325-0-installer.x86_64.iso",
-            "sha256": "2fa67e47837cc58bd1cd5b69d941fc18046e091a962e340a61a5a050cd9656ad"
+            "path": "rhcos-45.82.202006230709-0-installer.x86_64.iso",
+            "sha256": "1bd1c2e330e3b90c40380887d640370b2ff57461f4ab71b6c85b9fffc9958551"
         },
         "kernel": {
-            "path": "rhcos-45.82.202006191325-0-installer-kernel-x86_64",
+            "path": "rhcos-45.82.202006230709-0-installer-kernel-x86_64",
             "sha256": "998feda78468086fad450f2080f99281dcbca7c638fc0f4905fc3fb277d68459"
         },
         "metal": {
-            "path": "rhcos-45.82.202006191325-0-metal.x86_64.raw.gz",
-            "sha256": "d96faa8946fc8472e4b0bcb3d26c02711852f72e21c591914e742a2bca951117",
-            "size": 894358331,
-            "uncompressed-sha256": "3645638ddb35b504c3ef5b7c5f6ac959458436eb5e56ecc519ce3eeb5135c24c",
-            "uncompressed-size": 3748659200
+            "path": "rhcos-45.82.202006230709-0-metal.x86_64.raw.gz",
+            "sha256": "ec6b64bb1ae19404f29cef614d1a1d50f3c95c1046ea5a25cfb92732cbef94f4",
+            "size": 894182620,
+            "uncompressed-sha256": "c466595abf7ce3ea0f365b93e4930ed01eabc725150780d908ba31fdbae6155c",
+            "uncompressed-size": 3750756352
         },
         "openstack": {
-            "path": "rhcos-45.82.202006191325-0-openstack.x86_64.qcow2.gz",
-            "sha256": "2a3866f4d5a709a59d456ef3fd88120c0667d4e47b1e5f18ebca1dce6614f40a",
-            "size": 892750339,
-            "uncompressed-sha256": "008dcd548581f98f93c30f4ce4c96549b3e5351d34a985134fd7dc38b9307b8e",
-            "uncompressed-size": 2388787200
+            "path": "rhcos-45.82.202006230709-0-openstack.x86_64.qcow2.gz",
+            "sha256": "c4fa79acbdf7b625083c3c8b9d76012f9457fd7abb5bca3e3b35724e2586c27c",
+            "size": 892797946,
+            "uncompressed-sha256": "d1982ac8cecc0490d3262320be311f6a73987d8afb8dc2297730039b0508f4f5",
+            "uncompressed-size": 2389508096
         },
         "ostree": {
-            "path": "rhcos-45.82.202006191325-0-ostree.x86_64.tar",
-            "sha256": "24fecb20f83567ea1c4e7de2eab976309d319ddad54b49eb8c8772a164115ec8",
-            "size": 823951360
+            "path": "rhcos-45.82.202006230709-0-ostree.x86_64.tar",
+            "sha256": "8b3ddb774a4a62723eadbbe86cd1d32fe3746a412122c7f295c9238cbd341104",
+            "size": 824053760
         },
         "qemu": {
-            "path": "rhcos-45.82.202006191325-0-qemu.x86_64.qcow2.gz",
-            "sha256": "f0a99295741a895bdf36ec70ddda753da7a61ab418ff017fe2b72aa14e6bff23",
-            "size": 894903251,
-            "uncompressed-sha256": "ce9e6adac25a6fdd7011a1dc5faa631c5406b2df600ee69c0c0a85044d46f6b3",
-            "uncompressed-size": 2436628480
+            "path": "rhcos-45.82.202006230709-0-qemu.x86_64.qcow2.gz",
+            "sha256": "6960b57466e46eb7f04bf86b81d2526fadf4bba8691d60e21823acde16e015f2",
+            "size": 895043504,
+            "uncompressed-sha256": "01f04133329d7297750df06069d1a9b73f44c99d3dd22591374db630ba96d775",
+            "uncompressed-size": 2436956160
         },
         "vmware": {
-            "path": "rhcos-45.82.202006191325-0-vmware.x86_64.ova",
-            "sha256": "aaed98ec888b5d6f9f72b2be1e4e51f9178a99b439b243967ff5b8bcd084042e",
-            "size": 926279680
+            "path": "rhcos-45.82.202006230709-0-vmware.x86_64.ova",
+            "sha256": "b6392b40b7d7857e2e9647a87b71fe3510c0b2dbd9ff675dac6f13bf43c16f2f",
+            "size": 926382080
         }
     },
     "oscontainer": {
-        "digest": "sha256:e262115259934def7fd0a5f15dc0dc9fe7a666f0982e7815ecd0a8b8b4ba4b89",
+        "digest": "sha256:3ce53cd86baeeb5012820f9872587618d3abab11a794d21fbad386a14cea6c07",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "3c1ded0e8180de2d9ef1c836ae2bd6f1f8215b28b55c96da1d13ec840ee58c7d",
-    "ostree-version": "45.82.202006191325-0"
+    "ostree-commit": "0b79771d2a6f1a091fdcfbf53814e3eff5b190f06e55384bed2e0337e4df0347",
+    "ostree-version": "45.82.202006230709-0"
 }


### PR DESCRIPTION
The `machine-os-content` has been promoted. This pulls in a few packages which were not present in the plashets previously.

cc @dustymabe @sohankunkerkar @sdodson @miabbott @imcleod 

# Package Diff
```
    "diff": {
        "coreos-installer": {
            "rhcos-4.5/45.82.202006191325-0": "coreos-installer-0-2.rhaos4.4.gite5aa5dc.el8.noarch",
            "rhcos-4.5/45.82.202006230709-0": "coreos-installer-0-3.rhaos4.5.gite5aa5dc.el8.noarch"
        },
        "coreos-installer-dracut": {
            "rhcos-4.5/45.82.202006191325-0": "coreos-installer-dracut-0-2.rhaos4.4.gite5aa5dc.el8.noarch",
            "rhcos-4.5/45.82.202006230709-0": "coreos-installer-dracut-0-3.rhaos4.5.gite5aa5dc.el8.noarch"
        },
        "cri-o": {
            "rhcos-4.5/45.82.202006191325-0": "cri-o-1.18.1-13.dev.rhaos4.5.git6d00f64.el8.x86_64",
            "rhcos-4.5/45.82.202006230709-0": "cri-o-1.18.2-15.dev.rhaos4.5.git7c4494f.el8.x86_64"
        },
        "gnutls": {
            "rhcos-4.5/45.82.202006191325-0": "gnutls-3.6.8-10.el8_2.x86_64",
            "rhcos-4.5/45.82.202006230709-0": "gnutls-3.6.8-11.el8_2.x86_64"
        },
        "machine-config-daemon": {
            "rhcos-4.5/45.82.202006191325-0": "machine-config-daemon-4.5.0-202006180838.git.2517.dfdd0e6.el8.x86_64",
            "rhcos-4.5/45.82.202006230709-0": "machine-config-daemon-4.5.0-202006221333.p0.git.2523.97085bd.el8.x86_64"
        },
        "openshift-clients": {
            "rhcos-4.5/45.82.202006191325-0": "openshift-clients-4.5.0-202006161654.git.3591.1374c7e.el8.x86_64",
            "rhcos-4.5/45.82.202006230709-0": "openshift-clients-4.5.0-202006221333.p0.git.3591.fed89ff.el8.x86_64"
        },
        "openshift-hyperkube": {
            "rhcos-4.5/45.82.202006191325-0": "openshift-hyperkube-4.5.0-202006161654.git.0.1b27ce3.el8.x86_64",
            "rhcos-4.5/45.82.202006230709-0": "openshift-hyperkube-4.5.0-202006221333.p0.git.0.7d990e8.el8.x86_64"
        },
        "redhat-release-coreos": {
            "rhcos-4.5/45.82.202006191325-0": "redhat-release-coreos-45.82-5.el8.x86_64",
            "rhcos-4.5/45.82.202006230709-0": "redhat-release-coreos-45.82-6.el8.x86_64"
        }
    }
```
