### PR TITLE
Libvirt: Make master disk size configurable

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -34,6 +34,7 @@ resource "libvirt_volume" "master" {
   name           = "${var.cluster_id}-master-${count.index}"
   base_volume_id = module.volume.coreos_base_volume_id
   pool           = libvirt_pool.storage_pool.name
+  size           = var.libvirt_master_size
 }
 
 resource "libvirt_ignition" "master" {

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -50,3 +50,11 @@ variable "libvirt_bootstrap_memory" {
   default     = 2048
 }
 
+# Currently RHCOS maintain its default 16G size if that
+# changes we need to change it here also
+# https://github.com/coreos/coreos-assembler/pull/924
+variable "libvirt_master_size" {
+  type        = string
+  description = "Size of the volume in bytes"
+  default     = "17179869184"
+}

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -23,6 +23,7 @@ type config struct {
 	MasterMemory    string   `json:"libvirt_master_memory,omitempty"`
 	MasterVcpu      string   `json:"libvirt_master_vcpu,omitempty"`
 	BootstrapMemory int      `json:"libvirt_bootstrap_memory,omitempty"`
+	MasterDiskSize  string   `json:"libvirt_master_size,omitempty"`
 }
 
 // TFVars generates libvirt-specific Terraform variables.
@@ -50,6 +51,10 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, 
 		MasterIPs:    masterIPs,
 		MasterMemory: strconv.Itoa(masterConfig.DomainMemory),
 		MasterVcpu:   strconv.Itoa(masterConfig.DomainVcpu),
+	}
+
+	if masterConfig.Volume.VolumeSize != nil {
+		cfg.MasterDiskSize = masterConfig.Volume.VolumeSize.String()
 	}
 
 	if architecture == types.ArchitecturePPC64LE {


### PR DESCRIPTION
With this patch user can specify the volume size of master node using the machine config.

```
$ openshift-install create manifests --dir mydir
$ yq write --inplace mydir/openshift/99_openshift-cluster-api_master-machines-0.yaml spec.providerSpec.value.volume[volumeSize] 32212254720
$ openshift-install create cluster --dir mydir
```