### PR TITLE
baremetal: Disable network interfaces and BMH validations when needed

### DIFF
--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -106,4 +106,10 @@ type Platform struct {
 	//
 	// +optional
 	ClusterOSImage string `json:"clusterOSImage,omitempty" validate:"omitempty,osimageuri,urlexist"`
+
+	// SkipValidations is list of validations to skip during loading/fetching of install-config.yaml for baremetal platform
+	// currently to validations skipping is supported
+	// "interfaces" - skip validation of hosts networking interfaces via libvirt
+	// "hosts" - skips validation of hosts existannce it they values
+	SkipValidations string `json:"skipValidations,omitemtpy"`
 }

--- a/pkg/types/baremetal/validation/libvirt.go
+++ b/pkg/types/baremetal/validation/libvirt.go
@@ -19,6 +19,10 @@ func init() {
 func validateInterfaces(p *baremetal.Platform, fldPath *field.Path) field.ErrorList {
 	errorList := field.ErrorList{}
 
+	if strings.Contains(p.SkipValidations, "interfaces") {
+		return errorList
+	}
+
 	findInterface, err := interfaceValidator(p.LibvirtURI)
 	if err != nil {
 		errorList = append(errorList, field.InternalError(fldPath.Child("libvirtURI"), err))

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -194,8 +194,11 @@ func validateOSImages(p *baremetal.Platform, fldPath *field.Path) field.ErrorLis
 	return platformErrs
 }
 
-func validateHostsCount(hosts []*baremetal.Host, installConfig *types.InstallConfig) error {
-
+func validateHostsCount(p *baremetal.Platform, installConfig *types.InstallConfig) error {
+	if strings.Contains(p.SkipValidations, "hosts") {
+		return nil
+	}
+	hosts := p.Hosts
 	hostsNum := int64(len(hosts))
 	counter := int64(0)
 
@@ -270,7 +273,7 @@ func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("provisioningNetworkInterface"), p.ProvisioningNetworkInterface, "no provisioning network interface is configured, please set this value to be the interface on the provisioning network on your cluster's baremetal hosts"))
 	}
 
-	if p.Hosts == nil {
+	if p.Hosts == nil && !strings.Contains(p.SkipValidations, "hosts") {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("hosts"), p.Hosts, "bare metal hosts are missing"))
 	}
 
@@ -301,7 +304,7 @@ func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("bootstrapHostIP"), p.BootstrapProvisioningIP, err.Error()))
 	}
 
-	if err := validateHostsCount(p.Hosts, c); err != nil {
+	if err := validateHostsCount(p, c); err != nil {
 		allErrs = append(allErrs, field.Required(fldPath.Child("Hosts"), err.Error()))
 	}
 


### PR DESCRIPTION
Currently openshift-installer.baremetal compiles with TAG="baremetal libvirt".Therefore it tries to validate baremetal network interfaces using libvirt. In addition it requires the presence of BMH definitions in the install-config.yaml.
In Assisted-Installer product we use openshift-installer to produce ignitions while running a job on a openshift cluster, so we need to disable libvirt validation. Also, we don't use BMH during 1st day installation, and would like to not configure it with dummy values in install-config.yaml

Proposed change:
Add a field called "skipValidations" to the baremetal platform configuration in the install-config.yaml. If this field is NOT present, openshift-installer will execute as usual. In case this field is present, it will skip the validations defined by it.
Currently 2 validations are defined:
1) interfaces - skips network interfaces validations
2) hosts - skips BMH validation 