### PR TITLE
baremetal: Allow rootDeviceHints to override Host profiles

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -134,13 +134,19 @@ platform should be considered experimental and still subject to change without
 backwards compatibility.  In particular, some items likely to change soon
 include:
 
-* The `hardwareProfile` is currently exposed as a way to allow specifying
+* **This field is deprecated. See rootDeviceHints instead.**
+  The `hardwareProfile` is currently exposed as a way to allow specifying
   different hardware parameters for deployment.  By default, we will deploy
   RHCOS to the first disk, but that may not be appropriate for all hardware.
   The `hardwareProfile` is the field we have available to change that.  This
   interface is subject to change.  In the meantime, hardware profiles can be
   found here:
   https://github.com/metal3-io/baremetal-operator/blob/master/pkg/hardware/profile.go#L48
+
+* *rootDeviceHints* -- Guidance for how to choose the device to
+  receive the image being provisioned. Documentation on using this field can
+  be found here
+  https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md
 
 ```yaml
 apiVersion: v1

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/metal3-io/baremetal-operator/pkg/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
+	"github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/devicehints"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/pkg/errors"
@@ -85,7 +86,14 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 
 		// Root device hints
 		rootDevice := make(map[string]interface{})
-		if profile.RootDeviceHints.HCTL != "" {
+
+		// host.RootDeviceHints overrides the root device hint in the profile
+		if host.RootDeviceHints != nil {
+			rootDeviceStringMap := devicehints.MakeHintMap(host.RootDeviceHints)
+			for key, value := range rootDeviceStringMap {
+				rootDevice[key] = value
+			}
+		} else if profile.RootDeviceHints.HCTL != "" {
 			rootDevice["hctl"] = profile.RootDeviceHints.HCTL
 		} else {
 			rootDevice["name"] = profile.RootDeviceHints.DeviceName

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -1,6 +1,7 @@
 package baremetal
 
 import (
+	"github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 	"github.com/openshift/installer/pkg/ipnet"
 )
 
@@ -14,11 +15,12 @@ type BMC struct {
 
 // Host stores all the configuration data for a baremetal host.
 type Host struct {
-	Name            string `json:"name,omitempty" validate:"required,uniqueField"`
-	BMC             BMC    `json:"bmc"`
-	Role            string `json:"role"`
-	BootMACAddress  string `json:"bootMACAddress" validate:"required,uniqueField"`
-	HardwareProfile string `json:"hardwareProfile"`
+	Name            string                    `json:"name,omitempty" validate:"required,uniqueField"`
+	BMC             BMC                       `json:"bmc"`
+	Role            string                    `json:"role"`
+	BootMACAddress  string                    `json:"bootMACAddress" validate:"required,uniqueField"`
+	HardwareProfile string                    `json:"hardwareProfile"`
+	RootDeviceHints *v1alpha1.RootDeviceHints `json:"rootDeviceHints,omitempty"`
 }
 
 // Platform stores all the global configuration that all machinesets use.

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/devicehints/devicehints.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/devicehints/devicehints.go
@@ -1,0 +1,54 @@
+package devicehints
+
+import (
+	"fmt"
+
+	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
+)
+
+// MakeHintMap converts a RootDeviceHints instance into a string map
+// suitable to pass to ironic.
+func MakeHintMap(source *metal3v1alpha1.RootDeviceHints) map[string]string {
+	hints := map[string]string{}
+
+	if source == nil {
+		return hints
+	}
+
+	if source.DeviceName != "" {
+		hints["name"] = fmt.Sprintf("s== %s", source.DeviceName)
+	}
+	if source.HCTL != "" {
+		hints["hctl"] = fmt.Sprintf("s== %s", source.HCTL)
+	}
+	if source.Model != "" {
+		hints["model"] = fmt.Sprintf("<in> %s", source.Model)
+	}
+	if source.Vendor != "" {
+		hints["vendor"] = fmt.Sprintf("<in> %s", source.Vendor)
+	}
+	if source.SerialNumber != "" {
+		hints["serial"] = fmt.Sprintf("s== %s", source.SerialNumber)
+	}
+	if source.MinSizeGigabytes != 0 {
+		hints["size"] = fmt.Sprintf(">= %d", source.MinSizeGigabytes)
+	}
+	if source.WWN != "" {
+		hints["wwn"] = fmt.Sprintf("s== %s", source.WWN)
+	}
+	if source.WWNWithExtension != "" {
+		hints["wwn_with_extension"] = fmt.Sprintf("s== %s", source.WWNWithExtension)
+	}
+	if source.WWNVendorExtension != "" {
+		hints["wwn_vendor_extension"] = fmt.Sprintf("s== %s", source.WWNVendorExtension)
+	}
+	switch {
+	case source.Rotational == nil:
+	case *source.Rotational == true:
+		hints["rotational"] = "true"
+	case *source.Rotational == false:
+		hints["rotational"] = "false"
+	}
+
+	return hints
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -975,6 +975,7 @@ github.com/mattn/go-isatty
 github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1
 github.com/metal3-io/baremetal-operator/pkg/bmc
 github.com/metal3-io/baremetal-operator/pkg/hardware
+github.com/metal3-io/baremetal-operator/pkg/provisioner/ironic/devicehints
 # github.com/metal3-io/cluster-api-provider-baremetal v0.0.0 => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d
 github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis
 github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1


### PR DESCRIPTION
Hardware profiles don't allow for all of the use cases
required in some baremetal environments, allow the
boot hints associated with them to be overridden.
    
e.g. to specifiy a device by serial number
```
      - name: openshift-master-0
        rootDeviceHints:
          serialNumber: 1111

```