### PR TITLE
destroy: provide a way to stop all uninstalls using context

### DIFF
--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -60,7 +61,7 @@ func runDestroyCmd(directory string) error {
 	if err != nil {
 		return errors.Wrap(err, "Failed while preparing to destroy cluster")
 	}
-	if err := destroyer.Run(); err != nil {
+	if err := destroyer.Run(context.Background()); err != nil {
 		return errors.Wrap(err, "Failed to destroy cluster")
 	}
 

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -100,7 +100,7 @@ func (o *ClusterUninstaller) validate() error {
 }
 
 // Run is the entrypoint to start the uninstall process
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run(context.Context) error {
 	return o.RunWithContext(context.Background())
 }
 

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -100,13 +100,7 @@ func (o *ClusterUninstaller) validate() error {
 }
 
 // Run is the entrypoint to start the uninstall process
-func (o *ClusterUninstaller) Run(context.Context) error {
-	return o.RunWithContext(context.Background())
-}
-
-// RunWithContext runs the uninstall process with a context.
-// The first return is the list of ARNs for resources that could not be destroyed.
-func (o *ClusterUninstaller) RunWithContext(ctx context.Context) error {
+func (o *ClusterUninstaller) Run(ctx context.Context) error {
 	err := o.validate()
 	if err != nil {
 		return err

--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -90,21 +90,21 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (o *ClusterUninstaller) Run(context.Context) error {
+func (o *ClusterUninstaller) Run(ctx context.Context) error {
 	o.configureClients()
 	group := o.InfraID + "-rg"
 	o.Logger.Debug("deleting public records")
-	if err := deletePublicRecords(context.TODO(), o.zonesClient, o.recordsClient, o.privateZonesClient, o.privateRecordSetsClient, o.Logger, group); err != nil {
+	if err := deletePublicRecords(ctx, o.zonesClient, o.recordsClient, o.privateZonesClient, o.privateRecordSetsClient, o.Logger, group); err != nil {
 		o.Logger.Debug(err)
 		return errors.Wrap(err, "failed to delete public DNS records")
 	}
 	o.Logger.Debug("deleting resource group")
-	if err := deleteResourceGroup(context.TODO(), o.resourceGroupsClient, o.Logger, group); err != nil {
+	if err := deleteResourceGroup(ctx, o.resourceGroupsClient, o.Logger, group); err != nil {
 		o.Logger.Debug(err)
 		return errors.Wrap(err, "failed to delete resource group")
 	}
 	o.Logger.Debug("deleting application registrations")
-	if err := deleteApplicationRegistrations(context.TODO(), o.applicationsClient, o.serviceprincipalsClient, o.Logger, o.InfraID); err != nil {
+	if err := deleteApplicationRegistrations(ctx, o.applicationsClient, o.serviceprincipalsClient, o.Logger, o.InfraID); err != nil {
 		o.Logger.Debug(err)
 		return errors.Wrap(err, "failed to delete application registrations and their service principals")
 	}

--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -90,7 +90,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run(context.Context) error {
 	o.configureClients()
 	group := o.InfraID + "-rg"
 	o.Logger.Debug("deleting public records")

--- a/pkg/destroy/baremetal/baremetal.go
+++ b/pkg/destroy/baremetal/baremetal.go
@@ -3,6 +3,8 @@
 package baremetal
 
 import (
+	"context"
+
 	"github.com/libvirt/libvirt-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -19,7 +21,7 @@ type ClusterUninstaller struct {
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run(context.Context) error {
 	o.Logger.Debug("Deleting bare metal resources")
 
 	// FIXME: close the connection

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -71,7 +71,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 }
 
 // Run is the entrypoint to start the uninstall process
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run(context.Context) error {
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
 

--- a/pkg/destroy/libvirt/libvirt.go
+++ b/pkg/destroy/libvirt/libvirt.go
@@ -3,6 +3,7 @@
 package libvirt
 
 import (
+	"context"
 	"strings"
 
 	libvirt "github.com/libvirt/libvirt-go"
@@ -57,7 +58,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run(ctx context.Context) error {
 	conn, err := libvirt.NewConnect(o.LibvirtURI)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to Libvirt daemon")

--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -79,7 +80,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run(context.Context) error {
 	// deleteFuncs contains the functions that will be launched as
 	// goroutines.
 	deleteFuncs := map[string]deleteFunc{

--- a/pkg/destroy/ovirt/destroyer.go
+++ b/pkg/destroy/ovirt/destroyer.go
@@ -1,6 +1,7 @@
 package ovirt
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -20,7 +21,7 @@ type ClusterUninstaller struct {
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (uninstaller *ClusterUninstaller) Run() error {
+func (uninstaller *ClusterUninstaller) Run(context.Context) error {
 	con, err := ovirt.NewConnection()
 	if err != nil {
 		return fmt.Errorf("failed to initialize connection to ovirt-engine's %s", err)

--- a/pkg/destroy/ovirt/destroyer_test.go
+++ b/pkg/destroy/ovirt/destroyer_test.go
@@ -1,0 +1,65 @@
+package ovirt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeoutWithContext(t *testing.T) {
+	cases := []struct {
+		name              string
+		timeout           time.Duration
+		contextTimeout    time.Duration
+		contextHasTimeout bool
+		expected          time.Duration
+		allowForDelta     bool
+	}{
+		{
+			name:     "no deadline",
+			timeout:  1 * time.Minute,
+			expected: 1 * time.Minute,
+		},
+		{
+			name:              "timeout sooner",
+			timeout:           1 * time.Minute,
+			contextTimeout:    2 * time.Minute,
+			contextHasTimeout: true,
+			expected:          1 * time.Minute,
+		},
+		{
+			name:              "timeout later",
+			timeout:           2 * time.Minute,
+			contextTimeout:    1 * time.Minute,
+			contextHasTimeout: true,
+			expected:          1 * time.Minute,
+			allowForDelta:     true,
+		},
+		{
+			name:              "context done",
+			timeout:           1 * time.Minute,
+			contextHasTimeout: true,
+			expected:          0,
+			allowForDelta:     true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			startTime := time.Now()
+			ctx := context.Background()
+			if tc.contextHasTimeout {
+				ctxWithTimeout, cancel := context.WithTimeout(ctx, tc.contextTimeout)
+				defer cancel()
+				ctx = ctxWithTimeout
+			}
+			actual := timeoutWithContext(ctx, tc.timeout)
+			endTime := time.Now()
+			if tc.allowForDelta {
+				delta := endTime.Sub(startTime)
+				assert.InDelta(t, tc.expected, actual, float64(delta))
+			}
+		})
+	}
+}

--- a/pkg/destroy/providers/types.go
+++ b/pkg/destroy/providers/types.go
@@ -1,6 +1,8 @@
 package providers
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/types"
@@ -9,7 +11,7 @@ import (
 // Destroyer allows multiple implementations of destroy
 // for different platforms.
 type Destroyer interface {
-	Run() error
+	Run(context.Context) error
 }
 
 // NewFunc is an interface for creating platform-specific destroyers.

--- a/pkg/destroy/vsphere/vsphere.go
+++ b/pkg/destroy/vsphere/vsphere.go
@@ -131,12 +131,12 @@ func getAttachedObjectsOnTag(ctx context.Context, client *rest.Client, tagName s
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run(ctx context.Context) error {
 	var folderList []types.ManagedObjectReference
 	var virtualMachineList []types.ManagedObjectReference
 
 	o.Logger.Debug("find attached objects on tag")
-	tagAttachedObjects, err := getAttachedObjectsOnTag(context.TODO(), o.RestClient, o.InfraID)
+	tagAttachedObjects, err := getAttachedObjectsOnTag(ctx, o.RestClient, o.InfraID)
 	if err != nil {
 		return err
 	}
@@ -162,12 +162,12 @@ func (o *ClusterUninstaller) Run() error {
 	}
 
 	o.Logger.Debug("find VirtualMachine objects")
-	virtualMachineMoList, err := getVirtualMachineManagedObjects(context.TODO(), o.Client, virtualMachineList)
+	virtualMachineMoList, err := getVirtualMachineManagedObjects(ctx, o.Client, virtualMachineList)
 	if err != nil {
 		return err
 	}
 	o.Logger.Debug("delete VirtualMachines")
-	err = deleteVirtualMachines(context.TODO(), o.Client, virtualMachineMoList, o.Logger)
+	err = deleteVirtualMachines(ctx, o.Client, virtualMachineMoList, o.Logger)
 	if err != nil {
 		return err
 	}
@@ -179,14 +179,14 @@ func (o *ClusterUninstaller) Run() error {
 	}
 
 	o.Logger.Debug("find Folder objects")
-	folderMoList, err := getFolderManagedObjects(context.TODO(), o.Client, folderList)
+	folderMoList, err := getFolderManagedObjects(ctx, o.Client, folderList)
 	if err != nil {
 		o.Logger.Errorln(err)
 		return err
 	}
 
 	o.Logger.Debug("delete Folder")
-	err = deleteFolder(context.TODO(), o.Client, folderMoList, o.Logger)
+	err = deleteFolder(ctx, o.Client, folderMoList, o.Logger)
 	if err != nil {
 		o.Logger.Errorln(err)
 		return err


### PR DESCRIPTION
The Run function in the Destroyer interface was modified to take a context as a parameter. This provides a way for the user stop the uninstall after a period of time by providing a context with a deadline.

The baremetal, libvirt, openstack, and ovirt providers do not provide a means by which most requests made to the provider can be stopped prematurely. In these cases, the context is checked prior to making the requests as a best effort. But the uninstall may continue for a period of time after the context is done.

The RunWithContext function introduced in https://github.com/openshift/installer/pull/3765 for AWS has been obsoleted since the Run function now accepts a context.

This will be used by Hive to backoff uninstall attempts.

https://issues.redhat.com/browse/CO-974