### PR TITLE
Bug 1850940: OpenStack: Wait for router to create FIP

### DIFF
--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -122,6 +122,7 @@ resource "openstack_networking_floatingip_associate_v2" "api_fip" {
   count       = length(var.lb_floating_ip) == 0 ? 0 : 1
   port_id     = openstack_networking_port_v2.api_port.id
   floating_ip = var.lb_floating_ip
+  depends_on  = [openstack_networking_router_interface_v2.nodes_router_interface]
 }
 
 resource "openstack_networking_router_v2" "openshift-external-router" {


### PR DESCRIPTION
This is a cherry-pick of https://github.com/openshift/installer/pull/3780

The api_fip should have an explicit dependency on the
nodes_router_interface otherwise it may fail with:

  Error: Error associating openstack_networking_floatingip_associate_v2
  floating_ip xxx with port xxx: Resource not found

/label platform/openstack
/assign mandre