### PR TITLE
baremetal: Start coreos-downloader before ipa-downloader

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -78,14 +78,13 @@ IPTABLES=iptables
 # from the internet location ( IP=n.n.n.n:nn or [x:x::x]:nn )
 IP=$(echo $RHCOS_BOOT_IMAGE_URL | sed -e 's/.*:\/\/\([^/]*\)\/.*/\1/g' )
 CACHEURL="http://$IP/images"
-podman run -d --net host --name ipa-downloader \
-     --env CACHEURL=${CACHEURL} \
-     -v $IRONIC_SHARED_VOLUME:/shared:z ${IPA_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh
-
 podman run -d --net host --name coreos-downloader \
      --env CACHEURL=${CACHEURL} \
      -v $IRONIC_SHARED_VOLUME:/shared:z ${COREOS_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh $RHCOS_BOOT_IMAGE_URL
 
+podman run -d --net host --name ipa-downloader \
+     --env CACHEURL=${CACHEURL} \
+     -v $IRONIC_SHARED_VOLUME:/shared:z ${IPA_DOWNLOADER_IMAGE} /usr/local/bin/get-resource.sh
 
 # Add firewall rules to ensure the IPA ramdisk can reach httpd, Ironic and the Inspector API on the host
 for port in 80 5050 6385 ; do


### PR DESCRIPTION
coreos-downloader usually takes longer, starting it sooner should
allow it to start doing its thing while the ipa-downloader image
is being retrieved.