### PR TITLE
gcp: use GCP Image published by RHCOS instead of creating per cluster

### DIFF
--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -48,7 +48,18 @@ variable "gcp_master_instance_type" {
 
 variable "gcp_image_uri" {
   type = string
-  description = "Image for all nodes."
+  description = "URL to Raw Image for all nodes. This is used in case a new image needs to be generated for the nodes."
+}
+
+variable "gcp_image" {
+  type = string
+  description = "URL to the Image for all nodes."
+}
+
+variable "gcp_preexisting_image" {
+  type = bool
+  default = true
+  description = "Specifies whether an existing GCP Image should be used or a new one created for installation"
 }
 
 variable "gcp_master_root_volume_type" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/openshiftinstall"
 	"github.com/openshift/installer/pkg/asset/rhcos"
+	rhcospkg "github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/tfvars"
 	awstfvars "github.com/openshift/installer/pkg/tfvars/aws"
 	azuretfvars "github.com/openshift/installer/pkg/tfvars/azure"
@@ -327,12 +328,17 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			publicZoneName = publicZone.Name
 		}
 		preexistingnetwork := installConfig.Config.GCP.Network != ""
+
+		imageRaw, err := rhcospkg.GCPRaw(ctx, installConfig.Config.ControlPlane.Architecture)
+		if err != nil {
+			return errors.Wrap(err, "failed to find Raw GCP image URL")
+		}
 		data, err := gcptfvars.TFVars(
 			gcptfvars.TFVarsSources{
 				Auth:               auth,
 				MasterConfigs:      masterConfigs,
 				WorkerConfigs:      workerConfigs,
-				ImageURI:           string(*rhcosImage),
+				ImageURI:           imageRaw,
 				ImageLicenses:      installConfig.Config.GCP.Licenses,
 				PublicZoneName:     publicZoneName,
 				PublishStrategy:    installConfig.Config.Publish,

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -69,7 +69,9 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 
 func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, osImage string, azIdx int, role, userDataSecret string) (*gcpprovider.GCPMachineProviderSpec, error) {
 	az := mpool.Zones[azIdx]
-
+	if len(platform.Licenses) > 0 {
+		osImage = fmt.Sprintf("%s-rhcos-image", clusterID)
+	}
 	network, subnetwork, err := getNetworks(platform, clusterID, role)
 	if err != nil {
 		return nil, err
@@ -87,7 +89,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 			Boot:       true,
 			SizeGb:     mpool.OSDisk.DiskSizeGB,
 			Type:       mpool.OSDisk.DiskType,
-			Image:      fmt.Sprintf("%s-rhcos-image", clusterID),
+			Image:      osImage,
 		}},
 		NetworkInterfaces: []*gcpprovider.GCPNetworkInterface{{
 			Network:    network,

--- a/pkg/rhcos/builds.go
+++ b/pkg/rhcos/builds.go
@@ -26,8 +26,9 @@ type metadata struct {
 		URL   string `json:"url"`
 	}
 	GCP struct {
-		Image string `json:"image"`
-		URL   string `json:"url"`
+		Image   string `json:"image"`
+		Project string `json:"project"`
+		URL     string `json:"url"`
 	}
 	BaseURI string `json:"baseURI"`
 	Images  struct {

--- a/pkg/rhcos/gcp.go
+++ b/pkg/rhcos/gcp.go
@@ -2,23 +2,29 @@ package rhcos
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/types"
 )
 
-// GCP fetches the URL of the public GCP storage bucket containing the RHCOS image
+// GCP fetches the URL of the public RHCOS image
 func GCP(ctx context.Context, arch types.Architecture) (string, error) {
 	meta, err := fetchRHCOSBuild(ctx, arch)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to fetch RHCOS metadata")
 	}
 
-	url := meta.GCP.URL
-	if url == "" {
-		return "", errors.New("no RHCOS GCP URL found")
+	return fmt.Sprintf("projects/%s/global/images/%s", meta.GCP.Project, meta.GCP.Image), nil
+}
+
+// GCPRaw fetches the URL of the public GCP storage bucket containing the RHCOS image
+func GCPRaw(ctx context.Context, arch types.Architecture) (string, error) {
+	meta, err := fetchRHCOSBuild(ctx, arch)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to fetch RHCOS metadata")
 	}
 
-	return url, nil
+	return meta.GCP.URL, nil
 }

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -21,6 +21,8 @@ type config struct {
 	MasterInstanceType      string   `json:"gcp_master_instance_type,omitempty"`
 	MasterAvailabilityZones []string `json:"gcp_master_availability_zones"`
 	ImageURI                string   `json:"gcp_image_uri,omitempty"`
+	Image                   string   `json:"gcp_image,omitempty"`
+	PreexistingImage        bool     `json:"gcp_preexisting_image"`
 	ImageLicenses           []string `json:"gcp_image_licenses,omitempty"`
 	VolumeType              string   `json:"gcp_master_root_volume_type"`
 	VolumeSize              int64    `json:"gcp_master_root_volume_size"`
@@ -36,7 +38,7 @@ type config struct {
 type TFVarsSources struct {
 	Auth               Auth
 	ImageURI           string
-	ImageLicenses      []string `json:"gcp_image_licenses,omitempty"`
+	ImageLicenses      []string
 	MasterConfigs      []*gcpprovider.GCPMachineProviderSpec
 	WorkerConfigs      []*gcpprovider.GCPMachineProviderSpec
 	PublicZoneName     string
@@ -52,6 +54,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	for i, c := range sources.MasterConfigs {
 		masterAvailabilityZones[i] = c.Zone
 	}
+
 	cfg := &config{
 		Auth:                    sources.Auth,
 		Region:                  masterConfig.Region,
@@ -61,6 +64,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		VolumeType:              masterConfig.Disks[0].Type,
 		VolumeSize:              masterConfig.Disks[0].SizeGb,
 		ImageURI:                sources.ImageURI,
+		Image:                   masterConfig.Disks[0].Image,
 		ImageLicenses:           sources.ImageLicenses,
 		PublicZoneName:          sources.PublicZoneName,
 		PublishStrategy:         string(sources.PublishStrategy),
@@ -68,6 +72,10 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ControlPlaneSubnet:      masterConfig.NetworkInterfaces[0].Subnetwork,
 		ComputeSubnet:           workerConfig.NetworkInterfaces[0].Subnetwork,
 		PreexistingNetwork:      sources.PreexistingNetwork,
+	}
+	cfg.PreexistingImage = true
+	if len(sources.ImageLicenses) > 0 {
+		cfg.PreexistingImage = false
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
### pkg/rhcos: allow fetching GCP image and url from metadata
The rhcos.json contains the GCP image project name and resource name.

Based on instance.insert api https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert the source image
for instance can use of the form `projects/debian-cloud/global/images/debian-9-stretch-vYYYYMMDD` where the image is in `debian-cloud`
project.

So this updates the rhcos.GCP to return the sourceImage in the form of `projects/<project name>/global/images/<image name>`

Since we still need to create GCP images in cases like where licenses are provided, we still need to link to GCS bucket with raw image.
So this adds a rhcos.GCPRaw function to return that URL.

### machines/gcp: use GCP image when licenses are not required

The machines will use the osImage as is for re-using the RHCOS published images. But for
cases where the licenses are set for platform, the installer will have to create a new GCP image
using the raw image. Therefore set the image for machines when platform.Licenses is provided to `<cluster-id>-rhcos-image`
to match the name of the image that will be created later on.

### gcp: only create new image when licenses are specified

Tf templates are provided with `gcp_image_uri` which is the location of the raw image, and
`gcp_image` which is the gcp image sources from one of the master machine objects.

Tf templates always use the `gcp_image` which is a pre-existing image published by RHCOS, but
in cases like where the Licenses are set for the GCP platform we will create a new image using the uri.