### PR TITLE
baremetal: Prevent race condition when adding HardwareDetails

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
@@ -40,5 +40,5 @@ for node in $(curl -s http://localhost:6385/v1/nodes | jq -r '.nodes[] | .uuid')
         "${BAREMETAL_OPERATOR_IMAGE}" \
         http://localhost:5050/v1 "$node" | jq '{hardware: .}')
 
-     oc annotate --overwrite -n openshift-machine-api baremetalhosts "$name" 'baremetalhost.metal3.io/status'="$HARDWARE_DETAILS"
+     oc annotate --overwrite -n openshift-machine-api baremetalhosts "$name" 'baremetalhost.metal3.io/status'="$HARDWARE_DETAILS" 'baremetalhost.metal3.io/paused-'
 done

--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -87,6 +87,9 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 			// hosts are in the same order as the control plane
 			// machines.
 			newHost.Spec.ExternallyProvisioned = true
+			// Pause reconciliation until we can annotate with the initial
+			// status containing the HardwareDetails
+			newHost.ObjectMeta.Annotations = map[string]string{"baremetalhost.metal3.io/paused": ""}
 			machine := machines[i]
 			newHost.Spec.ConsumerRef = &corev1.ObjectReference{
 				APIVersion: machine.TypeMeta.APIVersion,


### PR DESCRIPTION
We add HardwareDetails to a BareMetalHost resource by including them in
initial Status data that is attached to the Host as an annotation. This
annotation must be present before the BareMetalHost is first reconciled
(thus creating the Status subresource), otherwise it will be ignored.

It is not possible to add the annotation at the time the BareMetalHost
is created. Therefore, we were previously relying on it being added
before the baremetal-operator is up and running. In practice this works
because the baremetal-operator takes a long time to start up, but in
fact this is a race.

Prevent the race by setting the baremetalhost.metal3.io/paused
annotation on the CR at the time it is created, and removing it again
when the status annotation is added. This annotation prevents the
operator from attempting to reconcile the resource.