### PR TITLE
Remove the need for externally built libvirt CI images.

### DIFF
--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -11,6 +11,8 @@ RUN TAGS="libvirt" hack/build.sh
 FROM centos:7
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/mock-nss.sh /bin/mock-nss.sh
+COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/provision-host.sh /bin/provision-host.sh
+COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/create-cluster /bin/create-cluster
 COPY --from=builder /go/src/github.com/openshift/installer/images/libvirt/google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
 
 RUN yum update -y && \

--- a/images/libvirt/README.md
+++ b/images/libvirt/README.md
@@ -2,7 +2,7 @@
 
 This image enables launching a libvirt cluster for CI testing through two primary mechanisms:
   1. Targeting a libvirt service running on a remote host
-  2. Launching a libvirt VM nested in a GCE instance
+  2. Launching libvirt VMs nested in a GCE instance
 
 This image contains [`nss_wrapper`](https://cwrap.org/nss_wrapper.html) to execute `ssh` commands as
 a mock user to interact with the remote libvirt API or GCE instance from an OpenShift container.
@@ -51,3 +51,14 @@ containers:
     #!/bin/sh
     mock-nss.sh openshift-install <args>
 ```
+
+### Provision script
+
+The `provision-host.sh` script is copied to the libvirt-installer CI image.  This script contains all steps necessary
+to run a nested libvirt install.  You can look at the [libvirt developer docs](https://github.com/openshift/installer/tree/master/docs/dev/libvirt)
+for more context.  For CI testing, the `provision-host.sh` script is run inside a rhel8 GCP instance.  This is necessary to run before the install.
+
+### Create-Cluster script
+
+The `create-cluster` script is copied to the libvirt-installer CI image.  This script is what will run the installer within the rhel8 GCP instance.
+A 3 control-plane node and 2 compute node cluster is created.  The installer image is extracted from a provided release image.

--- a/images/libvirt/create-cluster
+++ b/images/libvirt/create-cluster
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+NAME="$1"
+if [ -z "$NAME" ]; then
+  echo "usage: create-cluster <name>"
+  exit 1
+fi
+
+# TODO: only need RELEASE_IMAGE, but temporarily need both while we transition in CI
+if [[ -z "$RELEASE_IMAGE" ]] && [[ -z "$OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE" ]]; then
+    echo "either \$RELEASE_IMAGE or \$OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE must be provided"
+    exit 1
+fi
+
+if [[ ! -z "$OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE" ]]; then
+    export RELEASE_IMAGE="${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}"
+    unset OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
+fi
+
+# extract libvirt installer from release image
+oc adm release extract -a ~/pull-secret --command openshift-baremetal-install "${RELEASE_IMAGE}"
+sudo mv openshift-baremetal-install /usr/local/bin/openshift-install
+
+CLUSTER_DIR="${HOME}/clusters/${NAME}"
+if [ -d "${CLUSTER_DIR}" ]; then
+  echo "WARNING: cluster ${NAME} already exists at ${CLUSTER_DIR}"
+else
+  mkdir -p ${CLUSTER_DIR}
+fi
+# Generate a default SSH key if one doesn't exist
+SSH_KEY="${HOME}/.ssh/id_rsa"
+if [ ! -f $SSH_KEY ]; then
+  ssh-keygen -t rsa -N "" -f $SSH_KEY
+fi
+export BASE_DOMAIN=openshift.testing
+export CLUSTER_NAME="${NAME}"
+export PUB_SSH_KEY="${SSH_KEY}.pub"
+PULL_SECRET=$(cat "${HOME}/pull-secret")
+
+cat > "${CLUSTER_DIR}/install-config.yaml" << EOF
+apiVersion: v1
+baseDomain: "${BASE_DOMAIN}"
+compute:
+- hyperthreading: Enabled
+  architecture: amd64
+  name: worker
+  platform: {}
+  replicas: 2
+controlPlane:
+  hyperthreading: Enabled
+  architecture: amd64
+  name: master
+  platform: {}
+  replicas: 3
+metadata:
+  creationTimestamp: null
+  name: "${CLUSTER_NAME}"
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 192.168.126.0/24
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  libvirt:
+    network:
+      if: tt0
+publish: External
+pullSecret: $(echo \'"${PULL_SECRET}"\')
+sshKey: |
+  $(cat "${PUB_SSH_KEY}")
+EOF
+
+# Create manifests and modify route domain
+openshift-install --dir="$CLUSTER_DIR" create manifests
+# Workaround for https://github.com/openshift/installer/issues/1007
+# Add custom domain to cluster-ingress
+yq write --inplace $CLUSTER_DIR/manifests/cluster-ingress-02-config.yml spec[domain] apps.$BASE_DOMAIN
+
+# Add master memory to 12 GB
+# This is only valid for openshift 4.3 onwards
+yq write --inplace ${CLUSTER_DIR}/openshift/99_openshift-cluster-api_master-machines-0.yaml spec.providerSpec.value[domainMemory] 14336
+
+openshift-install create cluster --log-level=debug --dir="$CLUSTER_DIR" || true
+openshift-install wait-for install-complete --log-level=debug --dir="$CLUSTER_DIR"

--- a/images/libvirt/provision-host.sh
+++ b/images/libvirt/provision-host.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+set -x
+
+sudo dnf install -y libvirt libvirt-devel libvirt-client git libvirt-daemon-kvm bind-utils jq gcc-c++
+# https://github.com/ironcladlou/openshift4-libvirt-gcp/issues/29
+sudo dnf install -y qemu-kvm-2.12.0-88.module+el8.1.0+5708+85d8e057.3
+
+# Install golang
+curl -L https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -o go1.13.8.linux-amd64.tar.gz
+tar -xvf go1.13.8.linux-amd64.tar.gz
+sudo mv go /usr/local
+export PATH=$PATH:/usr/local/go/bin
+
+# Install yq to manipulate manifest file created by installer.
+if [[ ! -e /usr/local/bin/yq ]]; then
+    curl -L https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64 -o yq
+    chmod +x yq
+    sudo mv yq /usr/local/bin/yq
+fi
+
+# Enable IP forwarding
+# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#enable-ip-forwarding
+sudo sysctl net.ipv4.ip_forward=1
+echo "net.ipv4.ip_forward = 1" | sudo tee /etc/sysctl.d/99-ipforward.conf
+sudo sysctl -p /etc/sysctl.d/99-ipforward.conf
+
+# Enable non-root access to libvirt stuff
+# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#make-sure-you-have-permissions-for-qemusystem
+sudo bash -c 'cat > /etc/polkit-1/rules.d/80-libvirt.rules' << EOF
+polkit.addRule(function(action, subject) {
+  if (action.id == "org.libvirt.unix.manage" subject.isInGroup("google-sudoers")) {
+      return polkit.Result.YES;
+  }
+});
+EOF
+
+# Configure libvirt to accept TCP connections
+# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#configure-libvirt-to-accept-tcp-connections
+sudo bash -c 'cat >> /etc/libvirt/libvirtd.conf' << EOF
+listen_tls = 0
+listen_tcp = 1
+auth_tcp="none"
+tcp_port = "16509"
+EOF
+sudo bash -c 'cat >> /etc/sysconfig/libvirtd' << EOF
+LIBVIRTD_ARGS="--listen"
+EOF
+sudo bash -c 'cat >> /etc/modprobe.d/kvm.conf' << EOF
+options kvm_intel nested=1
+EOF
+# Ensure nesting is enabled in the kernel
+# TODO: verify this is still necessary
+sudo modprobe -r kvm_intel
+sudo modprobe kvm_intel nested=1
+sudo systemctl restart libvirtd
+# Set up iptables and firewalld
+# TODO: discover the ports
+sudo firewall-cmd --add-rich-rule='rule family=ipv4 source address=192.168.126.0/24 destination address=192.168.122.1 port port=16509 protocol=tcp accept' --permanent --zone=libvirt
+sudo firewall-cmd --zone=libvirt --add-service=libvirt --permanent
+
+# Enable NetworkManager DNS overlay
+# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#set-up-networkmanager-dns-overlay
+echo -e "[main]\\ndns=dnsmasq" | sudo tee /etc/NetworkManager/conf.d/openshift.conf
+echo server=/openshift.testing/192.168.126.1 | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
+# Create new domain for ingress to make sure it able to resolve auth route URL
+echo address=/.apps.openshift.testing/192.168.126.51 | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
+sudo systemctl restart NetworkManager
+
+# Configure the default libvirt storage pool
+# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#configure-default-libvirt-storage-pool
+sudo virsh pool-define /dev/stdin <<EOF
+<pool type='dir'>
+  <name>default</name>
+  <target>
+    <path>/var/lib/libvirt/images</path>
+  </target>
+</pool>
+EOF
+sudo virsh pool-start default
+sudo virsh pool-autostart default
+
+echo "Installing oc client"
+curl -OL https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz
+tar -zxf oc.tar.gz
+rm -fr oc.tar.gz
+sudo mv oc /usr/local/bin
+sudo ln -s /usr/local/bin/oc /usr/local/bin/kubectl
+
+sudo bash -c 'cat >> /etc/bashrc' << EOF
+export PATH=$PATH:/usr/local/go/bin
+EOF


### PR DESCRIPTION
Currently, libvirt testing requires images built outside of CI, and not maintained by the installer team.
These images are built manually with packer out of https://github.com/ironcladlou/openshift4-libvirt-gcp/blob/rhel8/IMAGES.md
Instead, the provision script that is run when creating these external images should be maintained here,
and kept in line with any changes or updates in the installer repository.

Also baked into the libvirt CI images is a script that runs the install.  This also should live here and
be maintained by the installer team.

There will be a transition period in the libvirt test environment while these scripts are moved from external
images to the libvirt-installer image.  Once the transition is complete, the libvirt-installer image
no longer has to build the installer (saving time in the CI tests).  Instead, the installer will be
extracted from the provided release image (in CI, it's `${RELEASE_IMAGE_LATEST}`).

* CI template changes here: https://github.com/openshift/release/pull/9969  
    * I have an extra commit that tests this PR by curling provision.sh and create-cluster rather than moving from the libvirt-installer-image.  Once this merges, I'll remove that commit to test the new libvirt-installer-image. 
* Adding the libvirt workflow here (that will be updated as this & the above merge): https://github.com/openshift/release/pull/9885