### PR TITLE
OpenStack: Deleting servers using tag-based filtering

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -57,11 +57,7 @@ resource "openstack_compute_instance_v2" "bootstrap" {
     port = openstack_networking_port_v2.bootstrap_port.id
   }
 
-  metadata = {
-    Name = "${var.cluster_id}-bootstrap"
-    # "kubernetes.io/cluster/${var.cluster_id}" = "owned"
-    openshiftClusterID = var.cluster_id
-  }
+  tags = ["openshiftClusterID=${var.cluster_id}"]
 }
 
 resource "openstack_networking_floatingip_v2" "bootstrap_fip" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -80,10 +80,5 @@ resource "openstack_compute_instance_v2" "master_conf" {
     }
   }
 
-  metadata = {
-    # FIXME(mandre) shouldn't it be "${var.cluster_id}-master-${count.index}" ?
-    Name = "${var.cluster_id}-master"
-    # "kubernetes.io/cluster/${var.cluster_id}" = "owned"
-    openshiftClusterID = var.cluster_id
-  }
+  tags = ["openshiftClusterID=${var.cluster_id}"]
 }

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -130,10 +130,6 @@ func generateProvider(clusterID string, platform *openstack.Platform, mpool *ope
 		Tags: []string{
 			fmt.Sprintf("openshiftClusterID=%s", clusterID),
 		},
-		ServerMetadata: map[string]string{
-			"Name":               fmt.Sprintf("%s-%s", clusterID, role),
-			"openshiftClusterID": clusterID,
-		},
 	}
 	if mpool.RootVolume != nil {
 		spec.RootVolume = &openstackprovider.RootVolume{

--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -198,14 +198,11 @@ func deleteServers(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 		logger.Error(err)
 		return false, nil
 	}
+	// Microversion "2.26" is the first that supports server tags
+	conn.Microversion = "2.26"
 
 	listOpts := servers.ListOpts{
-		// FIXME(shardy) when gophercloud supports tags we should
-		// filter by tag here
-		// https://github.com/gophercloud/gophercloud/pull/1115
-		// and Nova doesn't seem to support filter by Metadata, so for
-		// now we do client side filtering below based on the
-		// Metadata key (which matches the server properties).
+		TagsAny: strings.Join(filterTags(filter), ","),
 	}
 
 	allPages, err := servers.List(conn, listOpts).AllPages()
@@ -220,16 +217,7 @@ func deleteServers(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 		return false, nil
 	}
 
-	serverObjects := []ObjectWithTags{}
 	for _, server := range allServers {
-		serverObjects = append(
-			serverObjects, ObjectWithTags{
-				ID:   server.ID,
-				Tags: server.Metadata})
-	}
-
-	filteredServers := filterObjects(serverObjects, filter)
-	for _, server := range filteredServers {
 		logger.Debugf("Deleting Server %q", server.ID)
 		err = servers.Delete(conn, server.ID).ExtractErr()
 		if err != nil {
@@ -241,7 +229,7 @@ func deleteServers(opts *clientconfig.ClientOpts, filter Filter, logger logrus.F
 			logger.Debugf("Cannot find server %q. It's probably already been deleted.", server.ID)
 		}
 	}
-	return len(filteredServers) == 0, nil
+	return len(allServers) == 0, nil
 }
 
 func deleteServerGroups(opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) (bool, error) {


### PR DESCRIPTION
Now to delete servers we first get a list of all available servers from Nova, and then we iterate through them to find those with required metadata. In the case of a large number of servers, this can take a very long time.

Fortunately gophercloud introduced filtering by tags, so we can start using this feature to get only servers with the required tag.
https://github.com/gophercloud/gophercloud/pull/1759