### PR TITLE
OpenStack: Make externalnetwork and lbfloating ip optional

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1317,9 +1317,6 @@ spec:
                 required:
                 - cloud
                 - computeFlavor
-                - externalNetwork
-                - ingressFloatingIP
-                - lbFloatingIP
                 - octaviaSupport
                 - region
                 - trunkSupport

--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -61,6 +61,7 @@ resource "openstack_compute_instance_v2" "bootstrap" {
 }
 
 resource "openstack_networking_floatingip_v2" "bootstrap_fip" {
+  count       = var.external_network != "" ? 1 : 0
   description = "${var.cluster_id}-bootstrap-fip"
   pool        = var.external_network
   port_id     = openstack_networking_port_v2.bootstrap_port.id

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -41,6 +41,7 @@ variable "api_int_ip" {
 
 variable "external_network" {
   type = string
+  default = ""
 }
 
 variable "private_network_id" {

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -21,15 +21,15 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `computeFlavor` (required string): The OpenStack flavor to use for compute and control-plane machines.
     This is currently required, but has lower precedence than [the `type` property](#machine-pools) on [the `compute` and `controlPlane` machine-pools](../customization.md#platform-customization).
 * `externalDNS` (optional list of strings): The IP addresses of DNS servers to be used for the DNS resolution of all instances in the cluster
-* `externalNetwork` (required string): The OpenStack external network name to be used for installation.
-* `lbFloatingIP` (required string): Existing Floating IP to associate with the API load balancer.
+* `externalNetwork` (optional string): Name of external network the installer will use to provide access to the cluster. If defined, a floating ip from this network will be created and associated with the bootstrap node to facilitate debugging and connection to the bootstrap node during installation. The lbFloatingIP property is a floating ip address selected from this network.
+* `lbFloatingIP` (optional string): Address of existing Floating IP from externalNetwork the installer will associate with the API load balancer. This property is only valid if externalNetwork is defined. If externalNetwork is not defined, this property is ignored.
 * `octaviaSupport` (deprecated string): Whether OpenStack supports Octavia (`1` for true or `0` for false)
 * `region` (deprecated string): The OpenStack region where the cluster will be created. Currently this value is not used by the installer.
 * `trunkSupport` (deprecated string): Whether OpenStack ports can be trunked (`1` for true or `0` for false)
 * `clusterOSImage` (optional string): Either a URL with `http(s)` or `file` scheme to override the default OS image for cluster nodes or an existing Glance image name.
-* `apiVIP` (optional string): An IP addresss on the machineNetwork that will be assigned to the API VIP. Be aware that the `10` and `11` of the machineNetwork will be taken by neutron dhcp by default, and wont be available.
+* `apiVIP` (optional string): An IP address on the machineNetwork that will be assigned to the API VIP. Be aware that the `10` and `11` of the machineNetwork will be taken by neutron dhcp by default, and wont be available.
 * `ingressVIP` (optional string): An IP address on the machineNetwork that will be assigned to the ingress VIP. Be aware that the `10` and `11` of the machineNetwork will be taken by neutron dhcp by default, and wont be available.
-* `machinesSubnet` (optional string): the UUID of an openstack subnet to install the nodes of the cluster onto. For more information on how to install with a custom subnet, see the [custom subnets](#custom-subnets) section of the docs.
+* `machinesSubnet` (optional string): the UUID of an OpenStack subnet to install the nodes of the cluster onto. For more information on how to install with a custom subnet, see the [custom subnets](#custom-subnets) section of the docs.
 
 ## Machine pools
 

--- a/pkg/asset/installconfig/openstack/openstack.go
+++ b/pkg/asset/installconfig/openstack/openstack.go
@@ -13,6 +13,10 @@ import (
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
+const (
+	noExtNet = "<none>"
+)
+
 // Validate validates the given installconfig for OpenStack platform
 func Validate(ic *types.InstallConfig) error {
 	return validation.Validate(ic)
@@ -52,6 +56,7 @@ func Platform() (*openstack.Platform, error) {
 	if err != nil {
 		return nil, err
 	}
+	networkNames = append(networkNames, noExtNet)
 	sort.Strings(networkNames)
 	var extNet string
 	err = survey.Ask([]*survey.Question{
@@ -60,6 +65,7 @@ func Platform() (*openstack.Platform, error) {
 				Message: "ExternalNetwork",
 				Help:    "The OpenStack external network name to be used for installation.",
 				Options: networkNames,
+				Default: noExtNet,
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 				value := ans.(string)
@@ -71,35 +77,41 @@ func Platform() (*openstack.Platform, error) {
 			}),
 		},
 	}, &extNet)
+	if extNet == noExtNet {
+		extNet = ""
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	floatingIPNames, err := getFloatingIPNames(cloud, extNet)
-	if err != nil {
-		return nil, err
-	}
-	sort.Strings(floatingIPNames)
-	var lbFloatingIP string
-	err = survey.Ask([]*survey.Question{
-		{
-			Prompt: &survey.Select{
-				Message: "APIFloatingIPAddress",
-				Help:    "The Floating IP address used for external access to the OpenShift API.",
-				Options: floatingIPNames,
+	lbFloatingIP := ""
+	if extNet != "" {
+		floatingIPNames, err := getFloatingIPNames(cloud, extNet)
+		if err != nil {
+			return nil, err
+		}
+		sort.Strings(floatingIPNames)
+		var lbFloatingIP string
+		err = survey.Ask([]*survey.Question{
+			{
+				Prompt: &survey.Select{
+					Message: "APIFloatingIPAddress",
+					Help:    "The Floating IP address used for external access to the OpenShift API.",
+					Options: floatingIPNames,
+				},
+				Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+					value := ans.(string)
+					i := sort.SearchStrings(floatingIPNames, value)
+					if i == len(floatingIPNames) || floatingIPNames[i] != value {
+						return errors.Errorf("invalid floating IP %q, should be one of %+v", value, strings.Join(floatingIPNames, ", "))
+					}
+					return nil
+				}),
 			},
-			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
-				value := ans.(string)
-				i := sort.SearchStrings(floatingIPNames, value)
-				if i == len(floatingIPNames) || floatingIPNames[i] != value {
-					return errors.Errorf("invalid floating IP %q, should be one of %+v", value, strings.Join(floatingIPNames, ", "))
-				}
-				return nil
-			}),
-		},
-	}, &lbFloatingIP)
-	if err != nil {
-		return nil, err
+		}, &lbFloatingIP)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	flavorNames, err := getFlavorNames(cloud)

--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -103,6 +103,9 @@ func (ci *cloudinfo) getFlavor(flavorName string) (*flavors.Flavor, error) {
 }
 
 func (ci *cloudinfo) getNetwork(networkName string) (*networks.Network, error) {
+	if networkName == "" {
+		return &networks.Network{}, nil
+	}
 	networkID, err := networkutils.IDFromName(ci.clients.networkClient, networkName)
 	if err != nil {
 		if errors.Is(err, gophercloud.ErrResourceNotFound{}) {

--- a/pkg/terraform/gather/openstack/ip.go
+++ b/pkg/terraform/gather/openstack/ip.go
@@ -16,7 +16,7 @@ func BootstrapIP(tfs *terraform.State) (string, error) {
 	// Floating IPs aren't required but we try them first. If one
 	// exists it would be the best means to access the bootstrap instance
 	fip, err := terraform.LookupResource(tfs, "module.bootstrap", "openstack_networking_floatingip_v2", "bootstrap_fip")
-	if err == nil && fip != nil {
+	if err == nil && fip != nil && len(fip.Instances) != 0 {
 		bootstrap, _, err := unstructured.NestedString(fip.Instances[0].Attributes, "address")
 		if err == nil {
 			return bootstrap, nil

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -17,18 +17,18 @@ type Platform struct {
 	Cloud string `json:"cloud"`
 
 	// ExternalNetwork is name of the external network in your OpenStack cluster.
-	ExternalNetwork string `json:"externalNetwork"`
+	ExternalNetwork string `json:"externalNetwork,omitempty"`
 
 	// FlavorName is the name of the compute flavor to use for instances in this cluster.
 	FlavorName string `json:"computeFlavor"`
 
 	// LbFloatingIP is the IP address of an available floating IP in your OpenStack cluster
 	// to associate with the OpenShift load balancer.
-	LbFloatingIP string `json:"lbFloatingIP"`
+	LbFloatingIP string `json:"lbFloatingIP,omitempty"`
 
 	// IngressFloatingIP is the ID of an available floating IP in your OpenStack cluster
 	// that will be associated with the OpenShift ingress port
-	IngressFloatingIP string `json:"ingressFloatingIP"`
+	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
 
 	// ExternalDNS holds the IP addresses of dns servers that will
 	// be added to the dns resolution of all instances in the cluster.


### PR DESCRIPTION

Removes floating ip binding from bootstrap server
if external network is not used