### PR TITLE
Bug 1838559: Bump go-ovirt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/openshift/library-go v0.0.0-20200324092245-db2a8546af81
 	github.com/openshift/machine-api-operator v0.2.1-0.20200429102619-d36974451290
 	github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible
-	github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0
+	github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27
 	github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200406133650-74a154c1d861
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db // indirect
 	github.com/pborman/uuid v1.2.0
@@ -121,7 +121,6 @@ replace (
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422 // Pin API
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 // Pin client-go
 	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530 // Pin MCO so it doesn't get downgraded
-	github.com/ovirt/go-ovirt => github.com/ovirt/go-ovirt v0.0.0-20200320082526-4e97a11ff083
 	github.com/terraform-providers/terraform-provider-aws => github.com/openshift/terraform-provider-aws v1.60.1-0.20200526184553-1a716dcc0fa8 // Pin to openshift fork with tag v2.60.0-openshift-1
 	github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.40.1-0.20200508151851-2bfa0b7d4a9d // release-2.8.0 branch
 	github.com/terraform-providers/terraform-provider-vsphere => github.com/openshift/terraform-provider-vsphere v1.18.1-openshift-1

--- a/go.sum
+++ b/go.sum
@@ -2015,8 +2015,11 @@ github.com/otiai10/curr v0.0.0-20190513014714-f5a3d24e5776/go.mod h1:3HNVkVOU7vZ
 github.com/otiai10/mint v1.2.3/go.mod h1:YnfyPNhBvnY8bW4SGQHCs/aAFhkgySlMZbrF5U0bOVw=
 github.com/otiai10/mint v1.2.4/go.mod h1:d+b7n/0R3tdyUYYylALXpWQ/kTN+QobSq/4SRGBkR3M=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
-github.com/ovirt/go-ovirt v0.0.0-20200320082526-4e97a11ff083 h1:nW3qTnZ+ytoEZ1JL0EW3+mwjVcfjZ9WB3tSfOHQREgM=
-github.com/ovirt/go-ovirt v0.0.0-20200320082526-4e97a11ff083/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
+github.com/ovirt/go-ovirt v0.0.0-20200313072907-d30f754823a6/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
+github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0 h1:9dTL3/s4HXoLerbZL/N6EVHX62JWXNMIxJ+ephNTTYI=
+github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
+github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27 h1:jHcZg49imi3zydtFqly5vniMnFX7HxW27L9M095eLhI=
+github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
 github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200406133650-74a154c1d861 h1:vhOqmT4WRzfUys+NBhTzkRD08waA3dNDB7G5Pty2Rns=
 github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200406133650-74a154c1d861/go.mod h1:XFDLN/srNA1s2Dq+gp4zBvql6nRnfNJzDGzI5vtK85g=
 github.com/oxtoacart/bpool v0.0.0-20150712133111-4e1c5567d7c2/go.mod h1:L3UMQOThbttwfYRNFOWLLVXMhk5Lkio4GGOtw5UrxS0=

--- a/vendor/github.com/ovirt/go-ovirt/connection.go
+++ b/vendor/github.com/ovirt/go-ovirt/connection.go
@@ -94,6 +94,9 @@ func (c *Connection) testToken() (int, error) {
 		return 0, err
 	}
 	res, err := c.client.Do(options)
+	if err != nil {
+		return 0, err
+	}
 	defer res.Body.Close()
 
 	return res.StatusCode, err

--- a/vendor/github.com/ovirt/go-ovirt/reader.go
+++ b/vendor/github.com/ovirt/go-ovirt/reader.go
@@ -144,7 +144,6 @@ func (reader *XMLReader) ReadStrings(start *xml.StartElement) ([]string, error) 
 				return nil, err
 			}
 			strings = append(strings, str)
-			depth++
 		case xml.EndElement:
 			depth--
 		}
@@ -234,7 +233,7 @@ func (reader *XMLReader) ReadTime(start *xml.StartElement) (time.Time, error) {
 		var t time.Time
 		return t, err
 	}
-	
+
 	return time.Parse(time.RFC3339Nano, str)
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1056,7 +1056,7 @@ github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider
 github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1
 # github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible => github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530
 github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1
-# github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0 => github.com/ovirt/go-ovirt v0.0.0-20200320082526-4e97a11ff083
+# github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27
 github.com/ovirt/go-ovirt
 # github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200406133650-74a154c1d861
 github.com/ovirt/terraform-provider-ovirt/ovirt


### PR DESCRIPTION
Solve an issue related to RHV network parsing

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1838559

Signed-off-by: Roberto Ciatti <rciatti@redhat.com>