### PR TITLE
[fcos] images: use 4.5 as a base

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -9,7 +9,7 @@ COPY . .
 RUN TAGS="libvirt baremetal" hack/build.sh
 
 
-FROM registry.svc.ci.openshift.org/origin/4.1:base
+FROM registry.svc.ci.openshift.org/origin/4.5:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json /var/cache/
 

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -7,7 +7,7 @@ COPY . .
 RUN hack/build.sh
 
 
-FROM registry.svc.ci.openshift.org/origin/4.1:base
+FROM registry.svc.ci.openshift.org/origin/4.5:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -5,9 +5,9 @@ WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 
-FROM registry.svc.ci.openshift.org/origin/4.2:cli AS cli
+FROM registry.svc.ci.openshift.org/origin/4.5:cli AS cli
 
-FROM registry.svc.ci.openshift.org/origin/4.2:base
+FROM registry.svc.ci.openshift.org/origin/4.5:base
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi


### PR DESCRIPTION
This enables us to simplify CI configuration, so that it would import less images