### PR TITLE
[FCOS] cvo-overrides.yaml: update default channel

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -5,5 +5,5 @@ metadata:
   name: version
 spec:
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph
-  channel: stable-4.5
+  channel: stable-4
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION

OKD doesn't use "stable-4.x" schema for channels, so it should be
`stable-4` on fresh installs