### PR TITLE
Add newline to kubeadmin-password file

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -488,7 +488,7 @@ func logComplete(directory, consoleURL string) error {
 	logrus.Info("Install complete!")
 	logrus.Infof("To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=%s'", kubeconfig)
 	logrus.Infof("Access the OpenShift web-console here: %s", consoleURL)
-	logrus.Infof("Login to the console with user: %q, and password: %q", "kubeadmin", pw)
+	logrus.Infof("Login to the console with user: %q, and password: %q", "kubeadmin", strings.TrimRight(string(pw), "\n"))
 	return nil
 }
 

--- a/pkg/asset/password/password.go
+++ b/pkg/asset/password/password.go
@@ -80,7 +80,7 @@ func (a *KubeadminPassword) generateRandomPasswordHash(length int) error {
 
 	a.File = &asset.File{
 		Filename: kubeadminPasswordPath,
-		Data:     []byte(a.Password),
+		Data:     []byte(a.Password + "\n"),
 	}
 
 	return nil


### PR DESCRIPTION
This resolves a minor annoyance like this:

```
[jsmith@syrinx ~]$ cat auth/kubeadmin-password
12345-67890-abcde-fghij[jsmith@syrinx ~]$ 
```