### PR TITLE
[fcos] cvo-overrides.yaml: update upstream URL

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -4,6 +4,6 @@ metadata:
   namespace: openshift-cluster-version
   name: version
 spec:
-  upstream: https://api.openshift.com/api/upgrades_info/v1/graph
+  upstream: https://origin-release.svc.ci.openshift.org/graph
   channel: stable-4
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
Update CVO upstream setting from OCP Cincinnati to OKD's release-controller.

Fixes https://github.com/openshift/okd/issues/241