### PR TITLE
docs/user/gcp/install_upi: Drop unused 'region' from compute

### DIFF
--- a/docs/user/gcp/install_upi.md
+++ b/docs/user/gcp/install_upi.md
@@ -703,7 +703,6 @@ EOF
 ```
 - `name`: the name of the compute node (for example worker-0)
 - `infra_id`: the infrastructure name (INFRA_ID above)
-- `region`: the region to deploy the cluster into (for example us-east1)
 - `zone`: the zone to deploy the worker node into (for example us-east1-b)
 - `compute_subnet`: the URI to the compute subnet
 - `image`: the URI to the RHCOS image


### PR DESCRIPTION
The consuming script has not been changed since it landed in cbe6f1549d (#2117).

The associated Markdown landed with a 'region' in the docs and YAML in cbe6f1549d.  It was removed from the YAML in 998a518a17 (#2574), but not the surrounding Markdown (until this commit).

Parallel openshift-docs fix in flight with openshift/openshift-docs#23500.