### PR TITLE
Bug 1850417: data/manifests/bootkube/cvo-overrides: Bump default to stable-4.6

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -5,5 +5,5 @@ metadata:
   name: version
 spec:
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph
-  channel: stable-4.5
+  channel: stable-4.6
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
Like 9cd119dfa9 (#3287), but for 4.6 (now that release-4.5 is no longer being fast-forwarded to track master).