### PR TITLE
vendor: update baremetal-operator for virtual media support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ replace (
 	github.com/go-log/log => github.com/go-log/log v0.1.1-0.20181211034820-a514cf01a3eb // Pinned by MCO
 	github.com/hashicorp/terraform => github.com/openshift/terraform v0.12.20-openshift-3 // Pin to fork with deduplicated rpc types
 	github.com/hashicorp/terraform-plugin-sdk => github.com/openshift/hashicorp-terraform-plugin-sdk v1.14.0-openshift // Pin to fork with public rpc types
-	github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200611190251-d997d9c06ba8 // Use OpenShift fork
+	github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861 // Use OpenShift fork
 	github.com/metal3-io/cluster-api-provider-baremetal => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d // Pin OpenShift fork
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422 // Pin API
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 // Pin client-go

--- a/go.sum
+++ b/go.sum
@@ -1418,8 +1418,8 @@ github.com/openshift-metal3/terraform-provider-ironic v0.2.1 h1:K/tPSylailvH70zC
 github.com/openshift-metal3/terraform-provider-ironic v0.2.1/go.mod h1:G79T6t60oBpYfZK/x960DRzYsNHdz5YVCHINx6QlmtU=
 github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422 h1:tgKcQVgHscJFBji1uLH5KjA81fGxNQkom5lETA5VURs=
 github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422/go.mod h1:l6TGeqJ92DrZBuWMNKcot1iZUHfbYSJyBWHGgg6Dn6s=
-github.com/openshift/baremetal-operator v0.0.0-20200611190251-d997d9c06ba8 h1:4+l1eA6G4QiEBFFRo3H5EpJWOpAsl7Yp6YmrTaGi+gU=
-github.com/openshift/baremetal-operator v0.0.0-20200611190251-d997d9c06ba8/go.mod h1:LA81KAnnVvs7+JfVpSOSBAQOO3dztUpa33S2kzU+RqU=
+github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861 h1:6bDJzmU92kE82UPjVKiO7WM5L4rhbaeuwd0P6GRfEuM=
+github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/access.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/access.go
@@ -1,6 +1,7 @@
 package bmc
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 	"strings"
@@ -16,8 +17,12 @@ var factories = map[string]AccessDetailsFactory{}
 
 // We could make this function public if we want to support
 // out-of-tree factories.
-func registerFactory(name string, factory AccessDetailsFactory) {
+func registerFactory(name string, factory AccessDetailsFactory, schemes []string) {
 	factories[name] = factory
+
+	for _, scheme := range schemes {
+		factories[fmt.Sprintf("%s+%s", name, scheme)] = factory
+	}
 }
 
 // AccessDetails contains the information about how to get to a BMC.

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ibmc.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ibmc.go
@@ -6,9 +6,7 @@ import (
 )
 
 func init() {
-	registerFactory("ibmc", newIbmcAccessDetails)
-	registerFactory("ibmc+http", newIbmcAccessDetails)
-	registerFactory("ibmc+https", newIbmcAccessDetails)
+	registerFactory("ibmc", newIbmcAccessDetails, []string{"http", "https"})
 }
 
 func newIbmcAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac.go
@@ -6,9 +6,7 @@ import (
 )
 
 func init() {
-	registerFactory("idrac", newIDRACAccessDetails)
-	registerFactory("idrac+http", newIDRACAccessDetails)
-	registerFactory("idrac+https", newIDRACAccessDetails)
+	registerFactory("idrac", newIDRACAccessDetails, []string{"http", "https"})
 }
 
 func newIDRACAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ipmi.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ipmi.go
@@ -5,8 +5,8 @@ import (
 )
 
 func init() {
-	registerFactory("ipmi", newIPMIAccessDetails)
-	registerFactory("libvirt", newIPMIAccessDetails)
+	registerFactory("ipmi", newIPMIAccessDetails, []string{})
+	registerFactory("libvirt", newIPMIAccessDetails, []string{})
 }
 
 func newIPMIAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/irmc.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/irmc.go
@@ -5,7 +5,7 @@ import (
 )
 
 func init() {
-	registerFactory("irmc", newIRMCAccessDetails)
+	registerFactory("irmc", newIRMCAccessDetails, []string{})
 }
 
 func newIRMCAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/redfish.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/redfish.go
@@ -6,12 +6,11 @@ import (
 )
 
 func init() {
-	registerFactory("redfish", newRedfishAccessDetails)
-	registerFactory("redfish+http", newRedfishAccessDetails)
-	registerFactory("redfish+https", newRedfishAccessDetails)
-	registerFactory("redfish-virtualmedia", newRedfishVirtualMediaAccessDetails)
-	registerFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails)
-	registerFactory("idrac-virtualmedia", newRedfishiDracVirtualMediaAccessDetails)
+	schemes := []string{"http", "https"}
+	registerFactory("redfish", newRedfishAccessDetails, schemes)
+	registerFactory("redfish-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
+	registerFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
+	registerFactory("idrac-virtualmedia", newRedfishiDracVirtualMediaAccessDetails, schemes)
 }
 
 func redfishDetails(parsedURL *url.URL, disableCertificateVerification bool) *redfishAccessDetails {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -931,7 +931,7 @@ github.com/masterzen/winrm/soap
 github.com/mattn/go-colorable
 # github.com/mattn/go-isatty v0.0.12
 github.com/mattn/go-isatty
-# github.com/metal3-io/baremetal-operator v0.0.0 => github.com/openshift/baremetal-operator v0.0.0-20200611190251-d997d9c06ba8
+# github.com/metal3-io/baremetal-operator v0.0.0 => github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861
 ## explicit
 github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1
 github.com/metal3-io/baremetal-operator/pkg/bmc
@@ -1971,7 +1971,7 @@ sigs.k8s.io/yaml
 # github.com/go-log/log => github.com/go-log/log v0.1.1-0.20181211034820-a514cf01a3eb
 # github.com/hashicorp/terraform => github.com/openshift/terraform v0.12.20-openshift-3
 # github.com/hashicorp/terraform-plugin-sdk => github.com/openshift/hashicorp-terraform-plugin-sdk v1.14.0-openshift
-# github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200611190251-d997d9c06ba8
+# github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861
 # github.com/metal3-io/cluster-api-provider-baremetal => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d
 # github.com/openshift/api => github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422
 # github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240


### PR DESCRIPTION
This commit updates baremetal-operator to include support for using
`redfish-virtualmedia+http` baseboard management controllers URI's.
Previously, baremetal operator didn't recognize that format of BMC
despite being a valid construction.