### PR TITLE
Baremetal: Re-arrange validations for provisioning network at cluster creation time

### DIFF
--- a/pkg/asset/installconfig/baremetal/OWNERS
+++ b/pkg/asset/installconfig/baremetal/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - baremetal-approvers
+reviewers:
+  - baremetal-reviewers

--- a/pkg/asset/installconfig/baremetal/validation.go
+++ b/pkg/asset/installconfig/baremetal/validation.go
@@ -1,0 +1,22 @@
+package baremetal
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/baremetal/validation"
+)
+
+// ValidateProvisioning performs platform validation specifically for any optional requirement
+// to be called when the cluster creation takes place
+func ValidateProvisioning(ic *types.InstallConfig) error {
+	allErrs := field.ErrorList{}
+	if ic.Platform.BareMetal == nil {
+		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "Baremetal validation requires a baremetal platform configuration").Error())
+	}
+
+	allErrs = append(allErrs, validation.ValidateProvisioning(ic.Platform.BareMetal, ic.Networking, field.NewPath("platform").Child("baremetal"))...)
+
+	return allErrs.ToAggregate()
+}

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	azconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
+	bmconfig "github.com/openshift/installer/pkg/asset/installconfig/baremetal"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	vsconfig "github.com/openshift/installer/pkg/asset/installconfig/vsphere"
 	"github.com/openshift/installer/pkg/types/aws"
@@ -41,17 +42,17 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 	var err error
 	platform := ic.Config.Platform.Name()
 	switch platform {
-	case vsphere.Name:
-		err = vsconfig.ValidateForProvisioning(ic.Config)
-		if err != nil {
-			return err
-		}
 	case azure.Name:
 		dnsConfig, err := ic.Azure.DNSConfig()
 		if err != nil {
 			return err
 		}
 		err = azconfig.ValidatePublicDNS(ic.Config, dnsConfig)
+		if err != nil {
+			return err
+		}
+	case baremetal.Name:
+		err = bmconfig.ValidateProvisioning(ic.Config)
 		if err != nil {
 			return err
 		}
@@ -64,7 +65,12 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
-	case aws.Name, baremetal.Name, libvirt.Name, none.Name, openstack.Name, ovirt.Name:
+	case vsphere.Name:
+		err = vsconfig.ValidateForProvisioning(ic.Config)
+		if err != nil {
+			return err
+		}
+	case aws.Name, libvirt.Name, none.Name, openstack.Name, ovirt.Name:
 		// no special provisioning requirements to check
 	default:
 		err = fmt.Errorf("unknown platform type %q", platform)

--- a/pkg/types/baremetal/validation/libvirt.go
+++ b/pkg/types/baremetal/validation/libvirt.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	dynamicValidators = append(dynamicValidators, validateInterfaces)
+	dynamicProvisioningValidators = append(dynamicProvisioningValidators, validateInterfaces)
 }
 
 // validateInterfaces ensures that any interfaces required by the platform exist on the libvirt host.


### PR DESCRIPTION
This PR re-arranges all provisioning network validations until the `create` target. This enables end users to run other targets such as `ignition-configs`, `manifests` without specifying any config related to the provisioning network.

This is an implementation of [openshift/enhancements#388](https://github.com/openshift/enhancements/pull/388).

Co-Authored-By: @andfasano 