### PR TITLE
Bug 1710981: Default AWS instance type to 'm5'

### DIFF
--- a/docs/user/aws/limits.md
+++ b/docs/user/aws/limits.md
@@ -72,8 +72,8 @@ to be created. The security groups which exist after the default install are:
 By default, a cluster will create:
 
 * One m4.large bootstrap machine (2 vCPUs but removed after install)
-* Three m4.xlarge master nodes (4 vCPUs each).
-* Three m4.large worker nodes (2 vCPUs each).
+* Three m5.xlarge master nodes (4 vCPUs each).
+* Three m5.large worker nodes (2 vCPUs each).
 
 Currently, these vCPU counts are not within a new account's default limit. The default limit is 1 but for all these instances you will need 20. To increase the limit you have to [contact the AWS support](https://console.aws.amazon.com/support/cases?#/create?issueType=service-limit-increase&limitType=ec2-instances).
 If you intend to start with a higher number of workers, enable autoscaling and large workloads

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -188,7 +188,7 @@ spec:
 							Platform: types.MachinePoolPlatform{
 								AWS: &awstypes.MachinePool{
 									Zones:        []string{"us-east-1a"},
-									InstanceType: "m4.xlarge",
+									InstanceType: "m5.xlarge",
 								},
 							},
 						},

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -189,7 +189,7 @@ spec:
 								Platform: types.MachinePoolPlatform{
 									AWS: &awstypes.MachinePool{
 										Zones:        []string{"us-east-1a"},
-										InstanceType: "m4.large",
+										InstanceType: "m5.large",
 									},
 								},
 							},

--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -6,13 +6,8 @@ import (
 
 var (
 	defaultMachineClass = map[string][]string{
-		"ap-east-1":      {"m5", "m4"},
-		"ap-northeast-2": {"m5", "m4"},
-		"eu-north-1":     {"m5", "m4"},
-		"eu-west-3":      {"m5", "m4"},
-		"me-south-1":     {"m5", "m4"},
-		"us-gov-east-1":  {"m5", "m4"},
-		"us-west-2":      {"m5", "m4"},
+		// Example region default machine class override:
+		// "ap-east-1":      {"m5", "m4"},
 	}
 )
 
@@ -21,21 +16,19 @@ func SetPlatformDefaults(p *aws.Platform) {
 }
 
 // InstanceClass returns the instance "class" we should use for a given
-// region. We prefer m4 if available (more EBS volumes per node) but will use
-// m5 in regions that don't have m4.
+// region. Default is m5 unless a region override is defined in defaultMachineClass.
 func InstanceClass(region string) string {
 	if classes, ok := defaultMachineClass[region]; ok {
 		return classes[0]
 	}
-	return "m4"
+	return "m5"
 }
 
 // InstanceClasses returns a list of instance "class", in decreasing priority order, which we should use for a given
-// region. We prefer m4 if available (more EBS volumes per node) but will use
-// m5 in regions that don't have m4.
+// region. Default is m5 then m4 unless a region override is defined in defaultMachineClass.
 func InstanceClasses(region string) []string {
 	if classes, ok := defaultMachineClass[region]; ok {
 		return classes
 	}
-	return []string{"m4", "m5"}
+	return []string{"m5", "m4"}
 }

--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -49,7 +49,7 @@ Parameters:
     Description: IAM profile to associate with master nodes.
     Type: String
   MasterInstanceType:
-    Default: m4.xlarge
+    Default: m5.xlarge
     Type: String
     AllowedValues:
     - "m4.xlarge"

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -30,7 +30,7 @@ Parameters:
     Description: IAM profile to associate with master nodes.
     Type: String
   WorkerInstanceType:
-    Default: m4.large
+    Default: m5.large
     Type: String
     AllowedValues:
     - "m4.large"


### PR DESCRIPTION
Changes default AWS instance type from m4 to m5.

Fixes #2919.