### PR TITLE
Option to pass floating IP to ingress port

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1277,6 +1277,11 @@ spec:
                     description: ExternalNetwork is name of the external network in
                       your OpenStack cluster.
                     type: string
+                  ingressFloatingIP:
+                    description: IngressFloatingIP is the ID of an available floating
+                      IP in your OpenStack cluster that will be associated with the
+                      OpenShift ingress port
+                    type: string
                   ingressVIP:
                     description: 'IngressVIP is the static IP on the nodes subnet
                       that the apps port for openshift will be assigned Default: will
@@ -1313,6 +1318,7 @@ spec:
                 - cloud
                 - computeFlavor
                 - externalNetwork
+                - ingressFloatingIP
                 - lbFloatingIP
                 - octaviaSupport
                 - region

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -71,6 +71,7 @@ module "topology" {
   external_network_id = var.openstack_external_network_id
   masters_count       = var.master_count
   lb_floating_ip      = var.openstack_lb_floating_ip
+  ingress_floating_ip = var.openstack_ingress_floating_ip
   api_int_ip          = var.openstack_api_int_ip
   ingress_ip          = var.openstack_ingress_ip
   external_dns        = var.openstack_external_dns

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -127,6 +127,13 @@ resource "openstack_networking_floatingip_associate_v2" "api_fip" {
   depends_on  = [openstack_networking_router_interface_v2.nodes_router_interface]
 }
 
+resource "openstack_networking_floatingip_associate_v2" "ingress_fip" {
+  count       = length(var.ingress_floating_ip) == 0 ? 0 : 1
+  port_id     = openstack_networking_port_v2.ingress_port.id
+  floating_ip = var.ingress_floating_ip
+  depends_on  = [openstack_networking_router_interface_v2.nodes_router_interface]
+}
+
 resource "openstack_networking_router_v2" "openshift-external-router" {
   count               = local.create_router
   name                = "${var.cluster_id}-external-router"

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -29,6 +29,12 @@ variable "lb_floating_ip" {
   default     = ""
 }
 
+variable "ingress_floating_ip" {
+  description = "(optional) Existing floating IP address to attach to the ingress port created by the installer."
+  type        = string
+  default     = ""
+}
+
 variable "masters_count" {
   type = string
 }

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -286,35 +286,45 @@ EOF
 
 }
 
+variable "openstack_ingress_floating_ip" {
+  type    = string
+  default = ""
+
+  description = <<EOF
+(optional) Existing Floating IP to attach to the ingress port created by the installer.
+EOF
+
+}
+
 variable "openstack_api_int_ip" {
-  type        = string
+  type = string
   description = "IP on the node subnet reserved for api-int VIP."
 }
 
 variable "openstack_ingress_ip" {
-  type        = string
+  type = string
   description = "IP on the nodes subnet reserved for the ingress VIP."
 }
 
 variable "openstack_external_dns" {
-  type        = list(string)
+  type = list(string)
   description = "IP addresses of exernal dns servers to add to networks."
-  default     = []
+  default = []
 }
 
 variable "openstack_additional_network_ids" {
-  type        = list(string)
+  type = list(string)
   description = "IDs of additional networks for master nodes."
-  default     = []
+  default = []
 }
 
 variable "openstack_master_flavor_name" {
-  type        = string
+  type = string
   description = "Instance size for the master node(s). Example: `m1.medium`."
 }
 
 variable "openstack_trunk_support" {
-  type    = bool
+  type = bool
   default = false
 
   description = <<EOF
@@ -324,7 +334,7 @@ EOF
 }
 
 variable "openstack_octavia_support" {
-  type = bool
+  type    = bool
   default = false
 
   description = <<EOF
@@ -334,18 +344,18 @@ EOF
 }
 
 variable "openstack_master_server_group_name" {
-  type        = string
+  type = string
   description = "Name of the server group for the master nodes."
 }
 
 variable "openstack_machines_subnet_id" {
-  type        = string
-  default     = ""
+  type = string
+  default = ""
   description = "ID of the subnet to use for cluster machines. If empty, the installer will create a subnet to use as machinesSubnet."
 }
 
 variable "openstack_machines_network_id" {
-  type        = string
-  default     = ""
+  type = string
+  default = ""
   description = "ID of the network the machines subnet is on. If empty, the installer will create a network to use as machinesNetwork."
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -391,6 +391,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			installConfig.Config.Platform.OpenStack.ExternalNetwork,
 			installConfig.Config.Platform.OpenStack.ExternalDNS,
 			installConfig.Config.Platform.OpenStack.LbFloatingIP,
+			installConfig.Config.Platform.OpenStack.IngressFloatingIP,
 			installConfig.Config.Platform.OpenStack.APIVIP,
 			installConfig.Config.Platform.OpenStack.IngressVIP,
 			string(*rhcosImage),

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -28,6 +28,7 @@ type config struct {
 	Cloud                      string   `json:"openstack_credentials_cloud,omitempty"`
 	FlavorName                 string   `json:"openstack_master_flavor_name,omitempty"`
 	LbFloatingIP               string   `json:"openstack_lb_floating_ip,omitempty"`
+	IngressFloatingIP          string   `json:"openstack_ingress_floating_ip,omitempty"`
 	APIVIP                     string   `json:"openstack_api_int_ip,omitempty"`
 	IngressVIP                 string   `json:"openstack_ingress_ip,omitempty"`
 	TrunkSupport               bool     `json:"openstack_trunk_support,omitempty"`
@@ -44,17 +45,18 @@ type config struct {
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, apiVIP string, ingressVIP string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
 
 	cfg := &config{
-		ExternalNetwork: externalNetwork,
-		Cloud:           cloud,
-		FlavorName:      masterConfig.Flavor,
-		LbFloatingIP:    lbFloatingIP,
-		APIVIP:          apiVIP,
-		IngressVIP:      ingressVIP,
-		ExternalDNS:     externalDNS,
-		MachinesSubnet:  machinesSubnet,
+		ExternalNetwork:   externalNetwork,
+		Cloud:             cloud,
+		FlavorName:        masterConfig.Flavor,
+		LbFloatingIP:      lbFloatingIP,
+		IngressFloatingIP: ingressFloatingIP,
+		APIVIP:            apiVIP,
+		IngressVIP:        ingressVIP,
+		ExternalDNS:       externalDNS,
+		MachinesSubnet:    machinesSubnet,
 	}
 
 	serviceCatalog, err := getServiceCatalog(cloud)

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -26,6 +26,10 @@ type Platform struct {
 	// to associate with the OpenShift load balancer.
 	LbFloatingIP string `json:"lbFloatingIP"`
 
+	// IngressFloatingIP is the ID of an available floating IP in your OpenStack cluster
+	// that will be associated with the OpenShift ingress port
+	IngressFloatingIP string `json:"ingressFloatingIP"`
+
 	// ExternalDNS holds the IP addresses of dns servers that will
 	// be added to the dns resolution of all instances in the cluster.
 	// +optional


### PR DESCRIPTION
Customers have requested a more consistent experience for floating IPs in the installer, with a preference for how the loadbalancer FIP is implemented. To support this, we created an option for passing a floating ip for the ingress port that is identical in usage to the loadbalancer/api port implementation.