### PR TITLE
platformtests: Drop no-longer-used directory

### DIFF
--- a/platformtests/README.md
+++ b/platformtests/README.md
@@ -1,9 +1,0 @@
-# Platform Tests
-
-This directory contains test suites checking per-platform assumptions.
-These tests require platform access that is not appropriate for platform-agnostic unit tests.
-The `t` directory name (unlike `tests`) allows us to share [the project `vendor` directory managed by `dep`](../docs/dev/dependencies.md#go).
-
-Platforms:
-
-* [aws](aws)


### PR DESCRIPTION
The guts were removed by 805a108ba7 (#3277), citing d45e881abe (#3051).  No need to keep the useless directory around now that it holds no code.