### PR TITLE
Bug 1853859: Add validations for IP inputs

### DIFF
--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -363,6 +363,9 @@ func getVIPs() (string, string, error) {
 				Help:    "The VIP to be used for ingress to the cluster.",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				if apiVIP == (ans.(string)) {
+					return fmt.Errorf("%q should not be equal to the Virtual IP address for the API", ans.(string))
+				}
 				return validate.IP((ans).(string))
 			}),
 		},

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -74,6 +74,10 @@ func validateVIPs(p *vsphere.Platform, fldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressVIP"), p.IngressVIP, err.Error()))
 	}
 
+	if len(p.APIVIP) != 0 && len(p.IngressVIP) != 0 && p.APIVIP == p.IngressVIP {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("apiVIP"), p.APIVIP, "IPs for both API and Ingress should not be the same."))
+	}
+
 	return allErrs
 }
 

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -124,6 +124,16 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 			expectedError: `^test-path.ingressVIP: Invalid value: "192.168.111": "192.168.111" is not a valid IP`,
 		},
+		{
+			name: "Same API and Ingress VIP",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.APIVIP = "192.168.111.1"
+				p.IngressVIP = "192.168.111.1"
+				return p
+			}(),
+			expectedError: `^test-path.apiVIP: Invalid value: "192.168.111.1": IPs for both API and Ingress should not be the same`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
With the current setup, it is possible for the user to enter the
same IP address for the ingress and the API for vsphere. Creating
a cluster with these settings results in Bootstrap and one of the
 masters being assigned the same IP address during installation.

Added a validation to check if the given input for the Ingress is
not the same as API whose input would have been specified first
and throw an error if they are the same, prompting the user to
re-enter the IP address again.