### PR TITLE
ovirt: tag and remove tmp/bootstrap machines

### DIFF
--- a/data/data/ovirt/bootstrap/main.tf
+++ b/data/data/ovirt/bootstrap/main.tf
@@ -9,3 +9,8 @@ resource "ovirt_vm" "bootstrap" {
     custom_script = var.ignition_bootstrap
   }
 }
+
+resource "ovirt_tag" "cluster_bootstrap_tag" {
+  name   = "${var.cluster_id}-bootstrap"
+  vm_ids = concat([ovirt_vm.bootstrap.id], [var.ovirt_tmp_template_vm_id])
+}

--- a/data/data/ovirt/bootstrap/variables.tf
+++ b/data/data/ovirt/bootstrap/variables.tf
@@ -12,6 +12,11 @@ variable "ovirt_template_id" {
   description = "The ID of VM template"
 }
 
+variable "ovirt_tmp_template_vm_id" {
+  type        = string
+  description = "The ID of tmp VM which was created for creating the templated"
+}
+
 variable "ignition_bootstrap" {
   type        = string
   description = "bootstrap ignition config"

--- a/data/data/ovirt/main.tf
+++ b/data/data/ovirt/main.tf
@@ -20,6 +20,7 @@ module "bootstrap" {
   source                               = "./bootstrap"
   ovirt_cluster_id                     = var.ovirt_cluster_id
   ovirt_template_id                    = module.template.releaseimage_template_id
+  ovirt_tmp_template_vm_id             = module.template.tmp_import_vm
   ignition_bootstrap                   = var.ignition_bootstrap
   cluster_id                           = var.cluster_id
   openstack_base_image_name            = var.openstack_base_image_name

--- a/data/data/ovirt/template/outputs.tf
+++ b/data/data/ovirt/template/outputs.tf
@@ -1,3 +1,7 @@
 output "releaseimage_template_id" {
   value = data.ovirt_templates.finalTemplate.templates.0.id
 }
+
+output "tmp_import_vm" {
+  value = ovirt_vm.tmp_import_vm.0.id
+}

--- a/data/data/ovirt/template/variables.tf
+++ b/data/data/ovirt/template/variables.tf
@@ -12,6 +12,12 @@ variable "ovirt_storage_domain_id" {
   description = "The ID of Storage Domain"
 }
 
+variable "ovirt_tmp_template_vm_id" {
+  type        = string
+  default     = ""
+  description = "The ID of tmp VM which was created for creating the templated"
+}
+
 variable "ignition_bootstrap" {
   type        = string
   description = "bootstrap ignition config"

--- a/data/data/ovirt/variables-ovirt.tf
+++ b/data/data/ovirt/variables-ovirt.tf
@@ -19,6 +19,12 @@ variable "ovirt_password" {
   description = "The plain password of user to access Engine API"
 }
 
+variable "ovirt_tmp_template_vm_id" {
+  type        = string
+  default     = ""
+  description = "The ID of tmp VM which was created for creating the templated"
+}
+
 variable "ovirt_cluster_id" {
   type        = string
   description = "The ID of Cluster"


### PR DESCRIPTION
Currently, tmp/bootstrap VMs are not removed when destroy
command is called. This patch creates a ${tagname}-bootstrap
for tmp/bootstrap VMs.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1806471
Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>
Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>