### PR TITLE
Pass down release-image to the MCO on bootstrap

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -295,6 +295,7 @@ then
 			--baremetal-runtimecfg-image="${BAREMETAL_RUNTIMECFG_IMAGE}" \
 			--cloud-config-file=/assets/manifests/cloud-provider-config.yaml \
 			--cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}" \
+			--release-image="${RELEASE_IMAGE_DIGEST}" \
 			${ADDITIONAL_FLAGS}
 
 	# Bootstrap MachineConfigController uses /etc/mcc/bootstrap/manifests/ dir to


### PR DESCRIPTION
There is a new --release-image flag in MCO bootstrap
which is used to get the release-image being used from
the installer. This will help in validating the list of
blocked registries with day 1 support for Image CR and
registries.conf.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>