### PR TITLE
ovirt: remove template from the deploy

### DIFF
--- a/pkg/destroy/ovirt/destroyer.go
+++ b/pkg/destroy/ovirt/destroyer.go
@@ -117,7 +117,7 @@ func (uninstaller *ClusterUninstaller) removeVM(vmsService *ovirtsdk.VmsService,
 func (uninstaller *ClusterUninstaller) removeTemplate(con *ovirtsdk.Connection) error {
 	if uninstaller.Metadata.Ovirt.RemoveTemplate {
 		search, err := con.SystemService().TemplatesService().
-			List().Search(fmt.Sprintf("name=%s", uninstaller.Metadata.InfraID)).Send()
+			List().Search(fmt.Sprintf("name=%s-rhcos", uninstaller.Metadata.InfraID)).Send()
 		if err != nil {
 			return fmt.Errorf("couldn't find a template with name %s", uninstaller.Metadata.InfraID)
 		}


### PR DESCRIPTION
The destroy cluster command do not remove the template created during the OCP 
deploy due incorrect search criteria. It keeps consuming resource from oVirt.
    
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1855501
Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>
