### PR TITLE
[OpenStack] Set default values for octavia and trunk support tf vars

### DIFF
--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -314,7 +314,8 @@ variable "openstack_master_flavor_name" {
 }
 
 variable "openstack_trunk_support" {
-  type = bool
+  type    = bool
+  default = false
 
   description = <<EOF
 False if the OpenStack Neutron trunk extension is disabled and True if it is enabled.
@@ -324,6 +325,7 @@ EOF
 
 variable "openstack_octavia_support" {
   type = bool
+  default = false
 
   description = <<EOF
 False if the OpenStack Octavia endpoint is missing and True if it exists.


### PR DESCRIPTION
Now if there is no support for octavia or trunks we don't pass `false` values to terraform. It leads to the fact that the terraform variables remain undefined.

To prevent this we should set default values to `false` for the variables.