### PR TITLE
Baremetal: Add default storage pool at /var/lib/libvirt/openshift-images

### DIFF
--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -1,5 +1,12 @@
+resource "libvirt_pool" "bootstrap" {
+  name = "${var.cluster_id}-bootstrap"
+  type = "dir"
+  path = "/var/lib/libvirt/openshift-images/${var.cluster_id}-bootstrap"
+}
+
 resource "libvirt_volume" "bootstrap" {
   name   = "${var.cluster_id}-bootstrap"
+  pool   = libvirt_pool.bootstrap.name
   source = var.image
 }
 

--- a/data/data/baremetal/bootstrap/variables.tf
+++ b/data/data/baremetal/bootstrap/variables.tf
@@ -22,4 +22,3 @@ variable "provisioning_bridge" {
   type        = string
   description = "The name of the bridge used for provisioning"
 }
-

--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -99,7 +99,10 @@ use one of the hosts that is intended to later become a worker node in the same
 cluster.  That way it is already connected to the proper networks.
 
 It is recommended that the provisioning host be a bare metal host, as it must be
-able to use libvirt to launch the OpenShift bootstrap VM locally.
+able to use libvirt to launch the OpenShift bootstrap VM locally. Additionally,
+the installer creates a directory backed libvirt storage pool in the 
+`/var/lib/libvirt/openshift-images` directory. Sufficient disk space must be
+available in the directory to host the bootstrap VM volume.
 
 ### Supported Hardware
 

--- a/pkg/destroy/baremetal/baremetal.go
+++ b/pkg/destroy/baremetal/baremetal.go
@@ -13,6 +13,7 @@ import (
 
 // ClusterUninstaller holds the various options for the cluster we want to delete.
 type ClusterUninstaller struct {
+	InfraID                 string
 	LibvirtURI              string
 	BootstrapProvisioningIP string
 	Logger                  logrus.FieldLogger
@@ -23,9 +24,13 @@ func (o *ClusterUninstaller) Run() error {
 	o.Logger.Debug("Deleting bare metal resources")
 
 	// FIXME: close the connection
-	_, err := libvirt.NewConnect(o.LibvirtURI)
+	conn, err := libvirt.NewConnect(o.LibvirtURI)
 	if err != nil {
 		return errors.Wrap(err, "failed to connect to Libvirt daemon")
+	}
+	err = o.deleteStoragePool(conn)
+	if err != nil {
+		return errors.Wrap(err, "failed to clean baremetal bootstrap storage pool")
 	}
 
 	o.Logger.Debug("FIXME: delete resources!")
@@ -36,8 +41,55 @@ func (o *ClusterUninstaller) Run() error {
 // New returns bare metal Uninstaller from ClusterMetadata.
 func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.Destroyer, error) {
 	return &ClusterUninstaller{
+		InfraID:                 metadata.InfraID,
 		LibvirtURI:              metadata.ClusterPlatformMetadata.BareMetal.LibvirtURI,
 		BootstrapProvisioningIP: metadata.ClusterPlatformMetadata.BareMetal.BootstrapProvisioningIP,
 		Logger:                  logger,
 	}, nil
+}
+
+// deleteStoragePool destroys, deletes and undefines any storagePool left behind during the creation
+// of the bootstrap VM
+func (o *ClusterUninstaller) deleteStoragePool(conn *libvirt.Connect) error {
+	o.Logger.Debug("Deleting baremetal bootstrap volumes")
+
+	pname := o.InfraID + "-bootstrap"
+	pool, err := conn.LookupStoragePoolByName(pname)
+	if err != nil {
+		return errors.Wrapf(err, "get storage pool %q", pname)
+	}
+	defer pool.Free()
+
+	// delete vols
+	vols, err := pool.ListAllStorageVolumes(0)
+	if err != nil {
+		return errors.Wrapf(err, "list volumes in %q", pname)
+	}
+
+	for _, vol := range vols {
+		defer vol.Free()
+		vName, err := vol.GetName()
+		if err != nil {
+			return errors.Wrapf(err, "get volume names in %q", pname)
+		}
+		if err := vol.Delete(0); err != nil {
+			return errors.Wrapf(err, "delete volume %q from %q", vName, pname)
+		}
+		o.Logger.WithField("volume", vName).Info("Deleted volume")
+	}
+
+	if err := pool.Destroy(); err != nil {
+		return errors.Wrapf(err, "destroy pool %q", pname)
+	}
+
+	if err := pool.Delete(0); err != nil {
+		return errors.Wrapf(err, "delete pool %q", pname)
+	}
+
+	if err := pool.Undefine(); err != nil {
+		return errors.Wrapf(err, "undefine pool %q", pname)
+	}
+	o.Logger.WithField("pool", pname).Info("Deleted pool")
+
+	return nil
 }


### PR DESCRIPTION
This PR creates a default storage pool for Baremetal platform's bootstrap image instead of relying on the OS to create the default libvirt storage pool. The default storage location will be stored under /var/lib/libvirt/openshift-images.