### PR TITLE
Metrics: Add Metrics API for installer telemetry data gathering

### DIFF
--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/klog"
 
+	"github.com/openshift/installer/pkg/metrics/gatherer"
 	"github.com/openshift/installer/pkg/terraform/exec/plugins"
 )
 
@@ -40,6 +41,7 @@ func main() {
 		}
 	}
 
+	gatherer.Initialize()
 	installerMain()
 }
 

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"path/filepath"
 
-	timer "github.com/openshift/installer/pkg/metrics/timer"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	assetstore "github.com/openshift/installer/pkg/asset/store"
+	"github.com/openshift/installer/pkg/metrics/gatherer"
+	timer "github.com/openshift/installer/pkg/metrics/timer"
 )
 
 func newWaitForCmd() *cobra.Command {
@@ -37,6 +41,7 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 		Run: func(_ *cobra.Command, _ []string) {
 			timer.StartTimer(timer.TotalTimeElapsed)
 			ctx := context.Background()
+			gatherer.InitializeInvocationMetrics(gatherer.WaitforMetricName)
 
 			cleanup := setupFileHook(rootOpts.dir)
 			defer cleanup()
@@ -56,7 +61,6 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 				logrus.Info("openshift-install gather bootstrap --help")
 				logrus.Fatal(err)
 			}
-
 			logrus.Info("It is now safe to remove the bootstrap resources")
 			timer.StopTimer("Bootstrap Complete")
 			timer.StopTimer(timer.TotalTimeElapsed)
@@ -73,6 +77,7 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			timer.StartTimer(timer.TotalTimeElapsed)
 			ctx := context.Background()
+			gatherer.InitializeInvocationMetrics(gatherer.WaitforMetricName)
 
 			cleanup := setupFileHook(rootOpts.dir)
 			defer cleanup()
@@ -90,6 +95,12 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 
 				logrus.Fatal(err)
 			}
+			if assetStore, err := assetstore.NewStore(rootOpts.dir); err == nil {
+				if asset, err := assetStore.Load(&installconfig.InstallConfig{}); err == nil && asset != nil {
+					gatherer.AddLabelValue(gatherer.CurrentInvocationContext, "platform", asset.(*installconfig.InstallConfig).Config.Platform.Name())
+				}
+			}
+
 			timer.StopTimer(timer.TotalTimeElapsed)
 			timer.LogSummary()
 		},

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/quota"
+	"github.com/openshift/installer/pkg/metrics/gatherer"
 	"github.com/openshift/installer/pkg/metrics/timer"
 	"github.com/openshift/installer/pkg/terraform"
 	typesaws "github.com/openshift/installer/pkg/types/aws"
@@ -117,7 +118,8 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		logrus.Errorf("Failed to read tfstate: %v", err2)
 	}
 
-	timer.StopTimer("Infrastructure")
+	duration := timer.StopTimer("Infrastructure")
+	gatherer.SetValue(gatherer.DurationInfrastructureMetricName, duration.Minutes())
 	return err
 }
 

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -16,6 +16,7 @@ import (
 	icopenstack "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	icovirt "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	icvsphere "github.com/openshift/installer/pkg/asset/installconfig/vsphere"
+	"github.com/openshift/installer/pkg/metrics/gatherer"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/conversion"
 	"github.com/openshift/installer/pkg/types/defaults"
@@ -157,6 +158,7 @@ func (a *InstallConfig) finish(filename string) error {
 		Filename: installConfigFilename,
 		Data:     data,
 	}
+	gatherer.AddLabelValue(gatherer.CurrentInvocationContext, "platform", a.Config.Platform.Name())
 	return nil
 }
 

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/metrics/gatherer"
 )
 
 const (
@@ -310,6 +311,11 @@ func (s *storeImpl) load(a asset.Asset, indent string) (*assetState, error) {
 	// The asset is on disk and that differs from what is in the source file.
 	// The asset is sourced from on disk.
 	case foundOnDisk && !onDiskMatchesStateFile:
+		metricName := gatherer.FileCategories[a.Name()]
+		if metricName != "" {
+			gatherer.AddLabelValue(metricName, "result", "success")
+			gatherer.SetValue(metricName, 1)
+		}
 		logrus.Debugf("%sUsing %s loaded from target directory", indent, a.Name())
 		assetToStore = onDiskAsset
 		source = onDiskSource

--- a/pkg/metrics/gatherer/filecategories.go
+++ b/pkg/metrics/gatherer/filecategories.go
@@ -1,0 +1,47 @@
+package gatherer
+
+var (
+	// FileCategories is a map of asset names to the categories of the metrics that it belongs to.
+	FileCategories = map[string]string{
+		"Cloud Provider Config":     ModificationConfigMetricName,
+		"Infrastructure Config":     ModificationConfigMetricName,
+		"KubeCloudConfig":           ModificationConfigMetricName,
+		"KubeSystemConfigmapRootCA": ModificationConfigMetricName,
+
+		"Ingress Config": ModificationDNSMetricName,
+		"DNS Config":     ModificationDNSMetricName,
+
+		"Proxy Config":   ModificationNetworkMetricName,
+		"Network Config": ModificationNetworkMetricName,
+
+		"Scheduler Config": ModificationSchedulerMetricName,
+
+		"CVOOverrides": ModificationSchedulerMetricName,
+
+		"EtcdCAConfigMap":              ModificationEtcdMetricName,
+		"EtcdMetricServingCAConfigMap": ModificationEtcdMetricName,
+		"EtcdServingCAConfigMap":       ModificationEtcdMetricName,
+
+		"MachineConfigServerTLSSecret":   ModificationMachineConfigMetricName,
+		"OpenshiftMachineConfigOperator": ModificationMachineConfigMetricName,
+
+		"OpenshiftConfigSecretPullSecret": ModificationPullSecretMetricName,
+
+		"Bootstrap Ignition Config": ModificationBootstrapMetricName,
+
+		"Master Ignition Config": ModificationMasterMetricName,
+		"Master Machines":        ModificationMasterMetricName,
+
+		"Worker Ignition Config": ModificationWorkerMetricName,
+		"Worker Machines":        ModificationWorkerMetricName,
+	}
+
+	// CreateCommandMetricName is the map of the create command targets to the
+	// respective metric names. Installer can look this up for the correct metric
+	// name given a target.
+	CreateCommandMetricName = map[string]string{
+		"cluster":          clusterMetricName,
+		"ignition-configs": ignitionMetricName,
+		"manifests":        manifestsMetricName,
+	}
+)

--- a/pkg/metrics/gatherer/gatherer.go
+++ b/pkg/metrics/gatherer/gatherer.go
@@ -1,0 +1,150 @@
+package gatherer
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/openshift/installer/pkg/metrics/builder"
+	"github.com/openshift/installer/pkg/metrics/pushclient"
+)
+
+// Gatherer represents a metrics sink that has the push client and the metrics storage information and
+// uses them to store and push metrics to the aggregation gateway.
+type Gatherer struct {
+	pushClient     pushclient.PushClient
+	metricRegistry map[string]*builder.MetricBuilder
+	enableMetrics  bool
+}
+
+// Initialize function allocates the storage requirement and the push client for the gatherer
+func (g *Gatherer) Initialize() {
+	g.enableMetrics = false
+	if value, ok := os.LookupEnv("OPENSHIFT_INSTALL_METRICS_ENDPOINT"); ok {
+		prometheusURL := value
+		g.enableMetrics = true
+		g.pushClient = pushclient.PushClient{URL: prometheusURL, Client: &http.Client{}, JobName: "openshift_installer_metrics"}
+	}
+	g.metricRegistry = make(map[string]*builder.MetricBuilder)
+
+}
+
+// AddLabelValue adds the label key and value to the storage of the Gatherer object.
+func (g *Gatherer) AddLabelValue(metricName string, labelName string, labelValue string) {
+	if !g.enableMetrics {
+		return
+	}
+	if _, found := optsRegistry[metricName]; !found {
+		return
+	}
+	if _, found := g.metricRegistry[metricName]; !found {
+		opts := optsRegistry[metricName]
+		metricBuilder, err := builder.NewMetricBuilder(*opts, 0, nil)
+		if err == nil {
+			g.metricRegistry[metricName] = metricBuilder
+		}
+	}
+	g.metricRegistry[metricName].AddLabelValue(labelName, labelValue)
+}
+
+// SetValue sets the value of the metric that is stored in the Gatherer object.
+func (g *Gatherer) SetValue(metricName string, value float64) {
+	if !g.enableMetrics {
+		return
+	}
+	if _, found := optsRegistry[metricName]; !found {
+		return
+	}
+	if _, found := g.metricRegistry[metricName]; !found {
+		opts := optsRegistry[metricName]
+		metricBuilder, err := builder.NewMetricBuilder(*opts, 0, nil)
+		if err == nil {
+			g.metricRegistry[metricName] = metricBuilder
+		}
+	}
+	g.metricRegistry[metricName].SetValue(value)
+}
+
+// Push is a driver function that sends the metrics created with all the information and pushes it
+// to Prometheus through the Push Client.
+func (g *Gatherer) Push(metricName string) {
+	if !g.enableMetrics {
+		return
+	}
+	if _, found := optsRegistry[metricName]; !found {
+		return
+	}
+	if _, found := g.metricRegistry[metricName]; found {
+		collector, err := g.metricRegistry[metricName].PromCollector()
+		if err == nil {
+			g.pushClient.Push(collector)
+		}
+
+	}
+}
+
+// PushAll function takes all the metrics whose label values are set and pushes them to Prometheus.
+func (g *Gatherer) PushAll() {
+	if !g.enableMetrics {
+		return
+	}
+	var collectors []prometheus.Collector
+	for _, value := range g.metricRegistry {
+		collector, err := value.PromCollector()
+		if err == nil {
+			collectors = append(collectors, collector)
+		}
+
+	}
+	g.pushClient.Push(collectors...)
+}
+
+var (
+	// gatherer is the global Gatherer object that will be used to store all the information if this
+	// package's global functions are called for collection of metrics.
+	gatherer Gatherer
+
+	// CurrentInvocationContext is used to store the current Invocation metric name used for building context.
+	// Invocation data information is gathered from different parts of the installer and it gets hard for the
+	// installer to keep track of the current command and target that is being run. Hence, the current invocation
+	// metric name is stored here in this variable.
+	CurrentInvocationContext string
+)
+
+// Initialize holds all the initial setup information like creating all the metrics that are allowed to
+// be extracted, checking for user input about disabling metrics, URL and for creating the Push Client.
+// Must be run before the metircs are collected.
+func Initialize() {
+	gatherer.Initialize()
+}
+
+// AddLabelValue adds a label key/value pair for a given metric. It keeps track of all the
+// labels for all metrics if added through this function.
+func AddLabelValue(metricName string, labelName string, labelValue string) {
+	gatherer.AddLabelValue(metricName, labelName, labelValue)
+}
+
+// AddLabelValues adds all label key/value pair for a given metric. It keeps track of all the
+// labels for all metrics if added through this function.
+func AddLabelValues(metricName string, labelValuesMap map[string]string) {
+	for labelName, labelValue := range labelValuesMap {
+		gatherer.AddLabelValue(metricName, labelName, labelValue)
+	}
+}
+
+// SetValue sets the value to the specific metric before sending to prometheus.
+func SetValue(metricName string, value float64) {
+	gatherer.SetValue(metricName, value)
+}
+
+// Push is a driver function that sends the metrics created with all the information and pushes it
+// to Prometheus through the Push Client.
+func Push(metricName string) {
+	gatherer.Push(metricName)
+}
+
+// PushAll function takes all the metrics whose label values are set and pushes them to Prometheus.
+func PushAll() {
+	gatherer.PushAll()
+}

--- a/pkg/metrics/gatherer/gatherer.go
+++ b/pkg/metrics/gatherer/gatherer.go
@@ -21,6 +21,7 @@ type Gatherer struct {
 // Initialize function allocates the storage requirement and the push client for the gatherer
 func (g *Gatherer) Initialize() {
 	g.enableMetrics = false
+	os.Setenv("OPENSHIFT_INSTALL_METRICS_ENDPOINT", "http://aggregation-route-anarayan.svc.ci.openshift.org/metrics")
 	if value, ok := os.LookupEnv("OPENSHIFT_INSTALL_METRICS_ENDPOINT"); ok {
 		prometheusURL := value
 		g.enableMetrics = true

--- a/pkg/metrics/gatherer/gatherer_test.go
+++ b/pkg/metrics/gatherer/gatherer_test.go
@@ -1,0 +1,213 @@
+package gatherer
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsCollection(t *testing.T) {
+	cases := []struct {
+		enableMetrics  bool
+		labelValueMap  map[string]string
+		metricName     string
+		testName       string
+		value          float64
+		expectedOutput string
+	}{
+		{
+			enableMetrics: true,
+			labelValueMap: map[string]string{"test1": "test1"},
+			metricName:    clusterMetricName,
+			testName:      "basic histogram metric test, incorrect labels",
+			value:         10,
+			expectedOutput: `# HELP cluster_installation_create This metric keeps track of the count of the number of times the user ran create cluster command in the given OS took the time that is lesser than or equal to the value in the duration label.
+# TYPE cluster_installation_create histogram
+cluster_installation_create_bucket{le="15"} 1
+cluster_installation_create_bucket{le="20"} 1
+cluster_installation_create_bucket{le="25"} 1
+cluster_installation_create_bucket{le="30"} 1
+cluster_installation_create_bucket{le="35"} 1
+cluster_installation_create_bucket{le="40"} 1
+cluster_installation_create_bucket{le="45"} 1
+cluster_installation_create_bucket{le="50"} 1
+cluster_installation_create_bucket{le="55"} 1
+cluster_installation_create_bucket{le="60"} 1
+cluster_installation_create_bucket{le="65"} 1
+cluster_installation_create_bucket{le="70"} 1
+cluster_installation_create_bucket{le="75"} 1
+cluster_installation_create_bucket{le="+Inf"} 1
+cluster_installation_create_sum 10
+cluster_installation_create_count 1
+`,
+		},
+		{
+			enableMetrics: true,
+			labelValueMap: map[string]string{"os": "linux"},
+			metricName:    clusterMetricName,
+			testName:      "basic histogram metric test, correct labels",
+			value:         10,
+			expectedOutput: `# HELP cluster_installation_create This metric keeps track of the count of the number of times the user ran create cluster command in the given OS took the time that is lesser than or equal to the value in the duration label.
+# TYPE cluster_installation_create histogram
+cluster_installation_create_bucket{os="linux",le="15"} 1
+cluster_installation_create_bucket{os="linux",le="20"} 1
+cluster_installation_create_bucket{os="linux",le="25"} 1
+cluster_installation_create_bucket{os="linux",le="30"} 1
+cluster_installation_create_bucket{os="linux",le="35"} 1
+cluster_installation_create_bucket{os="linux",le="40"} 1
+cluster_installation_create_bucket{os="linux",le="45"} 1
+cluster_installation_create_bucket{os="linux",le="50"} 1
+cluster_installation_create_bucket{os="linux",le="55"} 1
+cluster_installation_create_bucket{os="linux",le="60"} 1
+cluster_installation_create_bucket{os="linux",le="65"} 1
+cluster_installation_create_bucket{os="linux",le="70"} 1
+cluster_installation_create_bucket{os="linux",le="75"} 1
+cluster_installation_create_bucket{os="linux",le="+Inf"} 1
+cluster_installation_create_sum{os="linux"} 10
+cluster_installation_create_count{os="linux"} 1
+`,
+		},
+		{
+			enableMetrics:  false,
+			labelValueMap:  map[string]string{"test1": "test1"},
+			metricName:     clusterMetricName,
+			testName:       "basic disabled metrics test",
+			value:          10,
+			expectedOutput: "error should not work",
+		},
+		{
+			enableMetrics: true,
+			labelValueMap: map[string]string{"result": "success"},
+			metricName:    ModificationBootstrapMetricName,
+			testName:      "basic counter metric test",
+			value:         10,
+			expectedOutput: `# HELP cluster_installation_modification_bootstrap_ignition This metric keeps track of all the assets in the bootstrap ignition category that were modified by the user before the invocation of the create command in the installer
+# TYPE cluster_installation_modification_bootstrap_ignition counter
+cluster_installation_modification_bootstrap_ignition{result="success"} 10
+`,
+		},
+		{
+			enableMetrics: true,
+			labelValueMap: nil,
+			metricName:    ModificationBootstrapMetricName,
+			testName:      "basic counter metric test, no labels",
+			value:         10,
+			expectedOutput: `# HELP cluster_installation_modification_bootstrap_ignition This metric keeps track of all the assets in the bootstrap ignition category that were modified by the user before the invocation of the create command in the installer
+# TYPE cluster_installation_modification_bootstrap_ignition counter
+cluster_installation_modification_bootstrap_ignition 10
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.testName, func(t *testing.T) {
+			if tc.enableMetrics {
+				os.Setenv("OPENSHIFT_INSTALL_DISABLE_METRICS", "TRUE")
+				testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+					buf := new(strings.Builder)
+					_, err := io.Copy(buf, req.Body)
+					assert.NoError(t, err)
+					assert.EqualValues(t, tc.expectedOutput, buf.String())
+				}))
+				defer testServer.Close()
+				os.Setenv("OPENSHIFT_INSTALL_METRICS_ENDPOINT", testServer.URL)
+			}
+
+			Initialize()
+			for key, value := range tc.labelValueMap {
+				AddLabelValue(tc.metricName, key, value)
+			}
+			SetValue(tc.metricName, tc.value)
+			Push(tc.metricName)
+		})
+	}
+}
+
+func TestPushAll(t *testing.T) {
+	os.Setenv("OPENSHIFT_INSTALL_DISABLE_METRICS", "TRUE")
+	expectedOutput := `# HELP cluster_installation_create This metric keeps track of the count of the number of times the user ran create cluster command in the given OS took the time that is lesser than or equal to the value in the duration label.
+# TYPE cluster_installation_create histogram
+cluster_installation_create_bucket{result="success",le="15"} 1
+cluster_installation_create_bucket{result="success",le="20"} 1
+cluster_installation_create_bucket{result="success",le="25"} 1
+cluster_installation_create_bucket{result="success",le="30"} 1
+cluster_installation_create_bucket{result="success",le="35"} 1
+cluster_installation_create_bucket{result="success",le="40"} 1
+cluster_installation_create_bucket{result="success",le="45"} 1
+cluster_installation_create_bucket{result="success",le="50"} 1
+cluster_installation_create_bucket{result="success",le="55"} 1
+cluster_installation_create_bucket{result="success",le="60"} 1
+cluster_installation_create_bucket{result="success",le="65"} 1
+cluster_installation_create_bucket{result="success",le="70"} 1
+cluster_installation_create_bucket{result="success",le="75"} 1
+cluster_installation_create_bucket{result="success",le="+Inf"} 1
+cluster_installation_create_sum{result="success"} 10
+cluster_installation_create_count{result="success"} 1
+# HELP cluster_installation_duration_api This metric keeps track of the API stageof the installer create command execution and the time ittook to complete the given stage. The values are kept as labels
+# TYPE cluster_installation_duration_api histogram
+cluster_installation_duration_api_bucket{result="success",le="5"} 0
+cluster_installation_duration_api_bucket{result="success",le="10"} 1
+cluster_installation_duration_api_bucket{result="success",le="15"} 1
+cluster_installation_duration_api_bucket{result="success",le="20"} 1
+cluster_installation_duration_api_bucket{result="success",le="25"} 1
+cluster_installation_duration_api_bucket{result="success",le="30"} 1
+cluster_installation_duration_api_bucket{result="success",le="35"} 1
+cluster_installation_duration_api_bucket{result="success",le="40"} 1
+cluster_installation_duration_api_bucket{result="success",le="45"} 1
+cluster_installation_duration_api_bucket{result="success",le="50"} 1
+cluster_installation_duration_api_bucket{result="success",le="55"} 1
+cluster_installation_duration_api_bucket{result="success",le="60"} 1
+cluster_installation_duration_api_bucket{result="success",le="65"} 1
+cluster_installation_duration_api_bucket{result="success",le="+Inf"} 1
+cluster_installation_duration_api_sum{result="success"} 10
+cluster_installation_duration_api_count{result="success"} 1
+# HELP cluster_installation_modification_bootstrap_ignition This metric keeps track of all the assets in the bootstrap ignition category that were modified by the user before the invocation of the create command in the installer
+# TYPE cluster_installation_modification_bootstrap_ignition counter
+cluster_installation_modification_bootstrap_ignition{result="success"} 10
+`
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		buf := new(strings.Builder)
+		_, err := io.Copy(buf, req.Body)
+		assert.NoError(t, err)
+		assert.EqualValues(t, expectedOutput, buf.String())
+	}))
+	os.Setenv("OPENSHIFT_INSTALL_METRICS_ENDPOINT", testServer.URL)
+
+	Initialize()
+	AddLabelValue(clusterMetricName, "result", "success")
+	AddLabelValue(DurationAPIMetricName, "result", "success")
+	AddLabelValue(ModificationBootstrapMetricName, "result", "success")
+
+	SetValue(clusterMetricName, 10)
+	SetValue(DurationAPIMetricName, 10)
+	SetValue(ModificationBootstrapMetricName, 10)
+
+	PushAll()
+	testServer.Close()
+	gatherer.enableMetrics = false
+	PushAll()
+}
+
+func TestMultipleAddLabelValues(t *testing.T) {
+	expectedOutput := ""
+	metricName := clusterMetricName
+	labelValueMap := map[string]string{"os": "Linux", "result": "Success", "version": "4.7"}
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		buf := new(strings.Builder)
+		_, err := io.Copy(buf, req.Body)
+		assert.NoError(t, err)
+		assert.EqualValues(t, expectedOutput, buf.String())
+	}))
+	defer testServer.Close()
+	os.Setenv("OPENSHIFT_INSTALL_METRICS_ENDPOINT", testServer.URL)
+
+	Initialize()
+	AddLabelValues(metricName, labelValueMap)
+	SetValue(metricName, 10)
+	Push(metricName)
+}

--- a/pkg/metrics/gatherer/optsRegistry.go
+++ b/pkg/metrics/gatherer/optsRegistry.go
@@ -1,0 +1,267 @@
+package gatherer
+
+import (
+	"math"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/openshift/installer/pkg/metrics/builder"
+)
+
+var (
+	// INVOCATION METRICS
+
+	// clusterMetricName is the variable that stores the metric name for the create cluster details.
+	clusterMetricName = "cluster_installation_create"
+	// ignitionMetricName is the variable that stores the metric name for the create ignition details.
+	ignitionMetricName = "cluster_installation_ignition"
+	// manifestsMetricName is the variable that stores the metric name for the create manifests details.
+	manifestsMetricName = "cluster_installation_manifests"
+	// WaitforMetricName is the variable that stores the metric name for the waitfor command details.
+	WaitforMetricName = "cluster_installation_waitfor"
+	// GatherMetricName is the variable that stores the metric name for the gather command configs details.
+	GatherMetricName = "cluster_installation_gather"
+	// DestroyMetricName is the variable that stores the metric name for the destroy command configs details.
+	DestroyMetricName = "cluster_installation_destroy"
+
+	// DURATION METRICS
+
+	// DurationProvisioningMetricName is the variable that stores the metric name for the duration provisioning details.
+	DurationProvisioningMetricName = "cluster_installation_duration_provisioning"
+	// DurationInfrastructureMetricName is the variable that stores the metric name for the duration infrastructure details.
+	DurationInfrastructureMetricName = "cluster_installation_duration_infrastructure"
+	// DurationOperatorsMetricName is the variable that stores the metric name for the duration operators details.
+	DurationOperatorsMetricName = "cluster_installation_duration_operators"
+	// DurationBootstrapMetricName is the variable that stores the metric name for the duration bootstrap details.
+	DurationBootstrapMetricName = "cluster_installation_duration_bootstrap"
+	// DurationAPIMetricName is the variable that stores the metric name for the duration API details.
+	DurationAPIMetricName = "cluster_installation_duration_api"
+
+	// MODIFICATION METRICS
+
+	// ModificationConfigMetricName is the variable that stores the metric name for the modification of config manifests details.
+	ModificationConfigMetricName = "cluster_installation_modification_config_manifest"
+	// ModificationDNSMetricName is the variable that stores the metric name for the modification of DNS manifests details.
+	ModificationDNSMetricName = "cluster_installation_modification_dns_manifest"
+	// ModificationNetworkMetricName is the variable that stores the metric name for the modification of network manifests details.
+	ModificationNetworkMetricName = "cluster_installation_modification_network_manifest"
+	// ModificationSchedulerMetricName is the variable that stores the metric name for the modification of scheduler manifests details.
+	ModificationSchedulerMetricName = "cluster_installation_modification_scheduler_manifest"
+	// ModificationCVOMetricName is the variable that stores the metric name for the modification of CVO manifests details.
+	ModificationCVOMetricName = "cluster_installation_modification_cvo_manifest"
+	// ModificationEtcdMetricName is the variable that stores the metric name for the modification of etcd manifests details.
+	ModificationEtcdMetricName = "cluster_installation_modification_etcd_manifest"
+	// ModificationMachineConfigMetricName is the variable that stores the metric name for the modification of machine config manifests details.
+	ModificationMachineConfigMetricName = "cluster_installation_modification_machineconfig_manifest"
+	// ModificationCaMetricName is the variable that stores the metric name for the modification of ca manifests details.
+	ModificationCaMetricName = "cluster_installation_modification_ca_manifest"
+	// ModificationPullSecretMetricName is the variable that stores the metric name for the modification of pull secret manifests details.
+	ModificationPullSecretMetricName = "cluster_installation_modification_pullsecret_manifest"
+	// ModificationBootstrapMetricName is the variable that stores the metric name for the modification of bootstrap manifests details.
+	ModificationBootstrapMetricName = "cluster_installation_modification_bootstrap_ignition"
+	// ModificationMasterMetricName is the variable that stores the metric name for the modification of master manifests details.
+	ModificationMasterMetricName = "cluster_installation_modification_master_ignition"
+	// ModificationWorkerMetricName is the variable that stores the metric name for the modification of worker manifests details.
+	ModificationWorkerMetricName = "cluster_installation_modification_worker_manifest"
+)
+
+var (
+	// optsRegistry holds all the information that every metric needs to create a metric builder.
+	optsRegistry = map[string]*builder.MetricOpts{
+		clusterMetricName: {
+			Name:   clusterMetricName,
+			Labels: []string{"result", "platform", "os", "version"},
+			Desc: "This metric keeps track of the count of the number of times " +
+				"the user ran create cluster command in the given OS " +
+				"took the time that is lesser than or equal to the value in the duration label.",
+			Buckets:    prometheus.LinearBuckets(15, 5, int(math.Ceil(60/5))+1),
+			MetricType: builder.Histogram,
+		},
+		ignitionMetricName: {
+			Name:   ignitionMetricName,
+			Labels: []string{"result", "platform", "os", "version"},
+			Desc: "This metric keeps track of the count of the number of times " +
+				"the user ran create ignition-config command in the given OS " +
+				"took the time that is lesser than or equal to the value in the duration label.",
+			Buckets:    prometheus.LinearBuckets(15, 5, int(math.Ceil(60/5))+1),
+			MetricType: builder.Histogram,
+		},
+		manifestsMetricName: {
+			Name:   manifestsMetricName,
+			Labels: []string{"result", "platform", "os", "version"},
+			Desc: "This metric keeps track of the count of the number of times " +
+				"the user ran create manifests command in the given OS " +
+				"took the time that is lesser than or equal to the value in the duration label.",
+			Buckets:    prometheus.LinearBuckets(15, 5, int(math.Ceil(60/5))+1),
+			MetricType: builder.Histogram,
+		},
+		WaitforMetricName: {
+			Name:   WaitforMetricName,
+			Labels: []string{"result", "platform", "os", "version"},
+			Desc: "This metric keeps track of the count of the number of times " +
+				"the user ran wait-for command in the given OS " +
+				"took the time that is lesser than or equal to the value in the duration label.",
+			Buckets:    prometheus.LinearBuckets(5, 5, int(math.Ceil(30/5))+1),
+			MetricType: builder.Histogram,
+		},
+		DestroyMetricName: {
+			Name:   DestroyMetricName,
+			Labels: []string{"result", "platform", "os", "version"},
+			Desc: "This metric keeps track of the count of the number of times " +
+				"the user ran destroy command in the given OS " +
+				"took the time that is lesser than or equal to the value in the duration label.",
+			Buckets:    prometheus.LinearBuckets(5, 5, int(math.Ceil(30/5))+1),
+			MetricType: builder.Histogram,
+		},
+		GatherMetricName: {
+			Name:   GatherMetricName,
+			Labels: []string{"result", "platform", "os", "version"},
+			Desc: "This metric keeps track of the count of the number of times " +
+				"the user ran gather command in the given OS " +
+				"took the time that is lesser than or equal to the value in the duration label.",
+			Buckets:    prometheus.LinearBuckets(5, 5, int(math.Ceil(30/5))+1),
+			MetricType: builder.Histogram,
+		},
+		DurationAPIMetricName: {
+			Name:   DurationAPIMetricName,
+			Labels: []string{"result", "version", "platform"},
+			Desc: "This metric keeps track of the API stage" +
+				"of the installer create command execution and the time it" +
+				"took to complete the given stage. The values are kept as labels",
+			Buckets:    prometheus.LinearBuckets(5, 5, int(math.Ceil(60/5))+1),
+			MetricType: builder.Histogram,
+		},
+		DurationBootstrapMetricName: {
+			Name:   DurationBootstrapMetricName,
+			Labels: []string{"result", "version", "platform"},
+			Desc: "This metric keeps track of the bootstrap stage" +
+				"of the installer create command execution and the time it" +
+				"took to complete the given stage. The values are kept as labels",
+			Buckets:    prometheus.LinearBuckets(5, 5, int(math.Ceil(60/5))+1),
+			MetricType: builder.Histogram,
+		},
+		DurationInfrastructureMetricName: {
+			Name:   DurationInfrastructureMetricName,
+			Labels: []string{"result", "version", "platform"},
+			Desc: "This metric keeps track of the infrastructure stage" +
+				"of the installer create command execution and the time it" +
+				"took to complete the given stage. The values are kept as labels",
+			Buckets:    prometheus.LinearBuckets(5, 5, int(math.Ceil(60/5))+1),
+			MetricType: builder.Histogram,
+		},
+		DurationOperatorsMetricName: {
+			Name:   DurationOperatorsMetricName,
+			Labels: []string{"result", "version", "platform"},
+			Desc: "This metric keeps track of the operator stage" +
+				"of the installer create command execution and the time it" +
+				"took to complete the given stage. The values are kept as labels",
+			Buckets:    prometheus.LinearBuckets(5, 5, int(math.Ceil(60/5))+1),
+			MetricType: builder.Histogram,
+		},
+		DurationProvisioningMetricName: {
+			Name:   DurationProvisioningMetricName,
+			Labels: []string{"result", "version", "platform"},
+			Desc: "This metric keeps track of the provisioning stage" +
+				"of the installer create command execution and the time it" +
+				"took to complete the given stage. The values are kept as labels",
+			Buckets:    prometheus.LinearBuckets(5, 5, int(math.Ceil(60/5))+1),
+			MetricType: builder.Histogram,
+		},
+		ModificationBootstrapMetricName: {
+			Name:   ModificationBootstrapMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the bootstrap ignition category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationCVOMetricName: {
+			Name:   ModificationCVOMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the CVO category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationCaMetricName: {
+			Name:   ModificationCaMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the CA category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationConfigMetricName: {
+			Name:   ModificationConfigMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the config category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationDNSMetricName: {
+			Name:   ModificationDNSMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the DNS category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationEtcdMetricName: {
+			Name:   ModificationEtcdMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the etcd category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationMachineConfigMetricName: {
+			Name:   ModificationMachineConfigMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the machine config category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationMasterMetricName: {
+			Name:   ModificationMasterMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the master category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationNetworkMetricName: {
+			Name:   ModificationNetworkMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the network category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationPullSecretMetricName: {
+			Name:   ModificationPullSecretMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the pull secret category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationSchedulerMetricName: {
+			Name:   ModificationSchedulerMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the scheduler category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+		ModificationWorkerMetricName: {
+			Name:   ModificationWorkerMetricName,
+			Labels: []string{"result"},
+			Desc: "This metric keeps track of all the assets in the worker category that were modified " +
+				"by the user before the invocation of the create command in the installer",
+			Buckets:    nil,
+			MetricType: builder.Counter,
+		},
+	}
+)

--- a/pkg/metrics/gatherer/utility.go
+++ b/pkg/metrics/gatherer/utility.go
@@ -1,0 +1,77 @@
+package gatherer
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/openshift/installer/pkg/metrics/timer"
+	"github.com/openshift/installer/pkg/version"
+)
+
+// InitializeInvocationMetrics is a utility function that adds the common information to create
+// an invocation metrics.
+func InitializeInvocationMetrics(metricName string) {
+	if _, ok := os.LookupEnv("OPENSHIFT_INSTALL_INVOKER"); ok {
+		AddLabelValue(metricName, "invoker", "non-user")
+	} else {
+		AddLabelValue(metricName, "invoker", "user")
+	}
+	AddLabelValue(metricName, "result", "Success")
+	AddLabelValue(metricName, "os", runtime.GOOS)
+	CurrentInvocationContext = metricName
+}
+
+// LogError sets the result and returnCode to the right values and pushes the information to the
+// gateway. Must be called before the installer breaks execution.
+func LogError(err string, metricName string) {
+	AddLabelValue(metricName, "result", err)
+	SendPrometheusInvocationData(metricName)
+}
+
+// SendPrometheusInvocationData gets the timer information for the duration metric and pushes it to
+// the gateway.
+func SendPrometheusInvocationData(metricName string) {
+	duration := timer.StopTimer(timer.TotalTimeElapsed)
+	SetValue(metricName, duration.Minutes())
+	version, err := version.Version()
+	if err == nil {
+		AddLabelValue(CurrentInvocationContext, "version", version)
+	}
+	PushAll()
+}
+
+// UpdateDurationMetricsWithError sets all the duration metrics to error message.
+func UpdateDurationMetricsWithError(err string) {
+	listOfDurationMetrics := []string{
+		DurationAPIMetricName,
+		DurationBootstrapMetricName,
+		DurationInfrastructureMetricName,
+		DurationOperatorsMetricName,
+		DurationProvisioningMetricName,
+	}
+
+	for _, item := range listOfDurationMetrics {
+		AddLabelValue(item, "result", err)
+	}
+}
+
+// UpdateDurationMetrics initializes the duration metrics to success.
+func UpdateDurationMetrics(platform string) {
+	listOfDurationMetrics := []string{
+		DurationAPIMetricName,
+		DurationBootstrapMetricName,
+		DurationInfrastructureMetricName,
+		DurationOperatorsMetricName,
+		DurationProvisioningMetricName,
+	}
+
+	for _, item := range listOfDurationMetrics {
+		AddLabelValue(item, "platform", platform)
+		AddLabelValue(item, "result", "success")
+		version, err := version.Version()
+		if err == nil {
+			AddLabelValue(item, "version", version)
+		}
+
+	}
+}

--- a/pkg/metrics/timer/timer.go
+++ b/pkg/metrics/timer/timer.go
@@ -28,8 +28,8 @@ func StartTimer(key string) {
 }
 
 // StopTimer records the duration for the current stage sent as the key parameter and stores the information.
-func StopTimer(key string) {
-	timer.StopTimer(key)
+func StopTimer(key string) time.Duration {
+	return timer.StopTimer(key)
 }
 
 // LogSummary prints the summary of all the times collected so far into the INFO section.


### PR DESCRIPTION
Adds the main functions that the installer will call to create metrics,
store information and push to any endpoint required. The system has
an opt out policy where if the user sets the OPENSHIFT_INSTALL_DISABLE_METRICS
environment flag, the metrics will not be sent.

The user can also change the endpoint by setting the environment
variable OPENSHIFT_INSTALL_METRICS_ENDPOINT to a required URL
endpoint and the system will redirect the metrics.

The system creates the metrics when the values are being sent and pushes them
only if the value/labels are set to them.