### PR TITLE
ovirt: update approvers list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -72,6 +72,9 @@ aliases:
     - mjudeikis
   ovirt-approvers:
     - rgolangh
+    - dougsland
+    - Gal-Zaidman
+    - gekorob
   ovirt-reviewers:
     - dougsland
     - Gal-Zaidman


### PR DESCRIPTION
We have more developers working day by day to make OCP on oVirt
a great product. This patch update the list of approvers with
people that have at least some contributions related to both
projects.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>