### PR TITLE
[WIP] baremetal: Pass through of config variables to ironic

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -88,8 +88,8 @@ podman run -d --net host --name ipa-downloader \
 
 # Add firewall rules to ensure the IPA ramdisk can reach httpd, Ironic and the Inspector API on the host
 for port in 80 5050 6385 ; do
-    if ! sudo $IPTABLES -C INPUT -i $PROVISIONING_NIC -p tcp -m tcp --dport $port -j ACCEPT > /dev/null 2>&1; then
-        sudo $IPTABLES -I INPUT -i $PROVISIONING_NIC -p tcp -m tcp --dport $port -j ACCEPT
+    if ! $IPTABLES -C INPUT -i $PROVISIONING_NIC -p tcp -m tcp --dport $port -j ACCEPT > /dev/null 2>&1; then
+        $IPTABLES -I INPUT -i $PROVISIONING_NIC -p tcp -m tcp --dport $port -j ACCEPT
     fi
 done
 
@@ -119,7 +119,7 @@ while ! curl --fail http://localhost/images/rhcos-ootpa-latest.qcow2.md5sum ; do
 while ! curl --fail --head http://localhost/images/ironic-python-agent.initramfs ; do sleep 1; done
 while ! curl --fail --head http://localhost/images/ironic-python-agent.kernel ; do sleep 1; done
 
-sudo podman run -d --net host --privileged --name ironic-conductor \
+podman run -d --net host --privileged --name ironic-conductor \
      --env MARIADB_PASSWORD=$mariadb_password \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120 \
@@ -133,7 +133,7 @@ podman run -d --net host --privileged --name ironic-inspector \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_INSPECTOR_IMAGE}"
 
-sudo podman run -d --net host --privileged --name ironic-api \
+podman run -d --net host --privileged --name ironic-api \
      --env MARIADB_PASSWORD=$mariadb_password \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --entrypoint /bin/runironic-api \

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -22,6 +22,10 @@ for name in ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb i
     podman ps --all | grep -w "$name$" && podman rm $name -f
 done
 
+{{- range $n, $v := .PlatformData.BareMetal.IronicExtraConf }}
+export {{ $n }}='{{ $v }}'
+{{- end }}
+
 # Start the provisioning nic if not already started
 PROVISIONING_NIC=ens4
 if ! nmcli -t device | grep "$PROVISIONING_NIC:ethernet:connected:provisioning"; then
@@ -123,6 +127,7 @@ podman run -d --net host --privileged --name ironic-conductor \
      --env MARIADB_PASSWORD=$mariadb_password \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120 \
+     --env "OS_*" \
      --entrypoint /bin/runironic-conductor \
      -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
 
@@ -131,11 +136,13 @@ sleep 10
 
 podman run -d --net host --privileged --name ironic-inspector \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
+     --env "OS_*" \
      -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_INSPECTOR_IMAGE}"
 
 podman run -d --net host --privileged --name ironic-api \
      --env MARIADB_PASSWORD=$mariadb_password \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
+     --env "OS_*" \
      --entrypoint /bin/runironic-api \
      -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
 

--- a/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
+++ b/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
@@ -9,3 +9,7 @@ spec:
   provisioningDHCPExternal: {{.Baremetal.ProvisioningDHCPExternal}}
   provisioningDHCPRange: "{{.Baremetal.ProvisioningDHCPRange}}"
   provisioningOSDownloadURL: "{{.ProvisioningOSDownloadURL}}"
+  ironicExtraConf:
+{{- range $n, $v := .Baremetal.IronicExtraConf }}
+    {{ $n }}: '{{ $v }}'
+{{- end }}

--- a/docs/user/metal/customization_ipi.md
+++ b/docs/user/metal/customization_ipi.md
@@ -139,3 +139,19 @@ certificates signed by a known certificate authority. In environments
 where certificates are signed by unknown authorities, this behavior
 can be disabled by setting `disableCertificateVerification` to `true`
 for each `bmc` entry.
+
+## Customizing ironic for provisioning
+
+Should you need to adjust any of the config options in ironic you can
+set ironicExtraConf in the platform section of install-config.yaml. Each
+config option should be expressed as a key/value pair with the format
+
+OS_<section>_\_<name>=<value> - where `section` and `name` are the
+reprepresent the config option in ironic.conf e.g. to set a IPA ssh key and
+set the number of ironic API workers
+
+```yaml
+platform:
+  baremetal:
+    ironicExtraConf: {"OS_PXE__PXE_APPEND_PARAMS":'nofb nomodeset vga=normal sshkey="ssh-rsa AAAA..."', "OS_API__API_WORKERS":"8"}
+```

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -23,6 +23,8 @@ type TemplateData struct {
 	// ProvisioningDHCPAllowList contains a space-separated list of all of the control plane's boot
 	// MAC addresses. Requests to bootstrap DHCP from other hosts will be ignored.
 	ProvisioningDHCPAllowList string
+
+	IronicExtraConf map[string]interface{}
 }
 
 // GetTemplateData returns platform-specific data for bootstrap templates.
@@ -47,6 +49,8 @@ func GetTemplateData(config *baremetal.Platform) *TemplateData {
 		}
 		templateData.ProvisioningDHCPAllowList = strings.Join(dhcpAllowList, " ")
 	}
+
+	templateData.IronicExtraConf = config.IronicExtraConf
 
 	return &templateData
 }

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -108,4 +108,9 @@ type Platform struct {
 	//
 	// +optional
 	ClusterOSImage string `json:"clusterOSImage,omitempty" validate:"omitempty,osimageuri,urlexist"`
+
+	// IronicExtraConf is a map of config options to be passed to ironic,  each entry should take the
+	// format OS_<section>_\_<name>=<value> - where `section` and `name` reprepresent the
+	// config option in ironic.conf
+	IronicExtraConf map[string]interface{} `json:"ironicExtraConf,omitempty"`
 }


### PR DESCRIPTION
Makes use of oslo.config's ability to read config from env variables
see https://github.com/metal3-io/ironic-image/pull/165