### PR TITLE
Bug 1852112: Ignore hostPrefix validation for non-(sdn/ovn) plugins

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -680,7 +680,8 @@ spec:
                     hostPrefix:
                       description: HostPrefix is the prefix size to allocate to each
                         node from the CIDR. For example, 24 would allocate 2^8=256
-                        adresses to each node.
+                        adresses to each node. If this field is not used by the plugin,
+                        it can be left unset.
                       format: int32
                       type: integer
                     hostSubnetLength:
@@ -691,7 +692,6 @@ spec:
                       type: integer
                   required:
                   - cidr
-                  - hostPrefix
                   type: object
                 type: array
               clusterNetworks:
@@ -706,7 +706,8 @@ spec:
                     hostPrefix:
                       description: HostPrefix is the prefix size to allocate to each
                         node from the CIDR. For example, 24 would allocate 2^8=256
-                        adresses to each node.
+                        adresses to each node. If this field is not used by the plugin,
+                        it can be left unset.
                       format: int32
                       type: integer
                     hostSubnetLength:
@@ -717,7 +718,6 @@ spec:
                       type: integer
                   required:
                   - cidr
-                  - hostPrefix
                   type: object
                 type: array
               machineCIDR:

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -39,7 +39,7 @@ The following `install-config.yaml` properties are available:
         The default is 10.128.0.0/14 with a host prefix of /23.
         * `cidr` (required [IP network](#ip-networks)): The IP block address pool.
         * `hostPrefix` (required integer): The prefix size to allocate to each node from the CIDR.
-        For example, 24 would allocate 2^8=256 adresses to each node.
+        For example, 24 would allocate 2^8=256 adresses to each node. If this field is not used by the plugin, it can be left unset.
     * `machineNetwork` (optional array of objects): The IP address pools for machines.
         * `cidr` (required [IP network](#ip-networks)): The IP block address pool.
             The default is 10.0.0.0/16 for all platforms other than libvirt.

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -279,8 +279,10 @@ type ClusterNetworkEntry struct {
 	CIDR ipnet.IPNet `json:"cidr"`
 
 	// HostPrefix is the prefix size to allocate to each node from the CIDR.
-	// For example, 24 would allocate 2^8=256 adresses to each node.
-	HostPrefix int32 `json:"hostPrefix"`
+	// For example, 24 would allocate 2^8=256 adresses to each node. If this
+	// field is not used by the plugin, it can be left unset.
+	// +optional
+	HostPrefix int32 `json:"hostPrefix,omitempty"`
 
 	// The size of blocks to allocate from the larger pool.
 	// This is the length in bits - so a 9 here will allocate a /23.

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -405,6 +405,27 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^networking\.clusterNetwork\[0]\.hostPrefix: Invalid value: 23: cluster network host subnetwork prefix must not be larger size than CIDR 192.168.1.0/24$`,
 		},
 		{
+			name: "cluster network host prefix unset",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.NetworkType = "OpenShiftSDN"
+				c.Networking.ClusterNetwork[0].CIDR = *ipnet.MustParseCIDR("192.168.1.0/24")
+				c.Networking.ClusterNetwork[0].HostPrefix = 0
+				return c
+			}(),
+			expectedError: `^networking\.clusterNetwork\[0]\.hostPrefix: Invalid value: 0: cluster network host subnetwork prefix must not be larger size than CIDR 192.168.1.0/24$`,
+		},
+		{
+			name: "cluster network host prefix unset ignored",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.NetworkType = "HostPrefixNotRequiredPlugin"
+				c.Networking.ClusterNetwork[0].CIDR = *ipnet.MustParseCIDR("192.168.1.0/24")
+				return c
+			}(),
+			expectedError: ``,
+		},
+		{
 			name: "missing control plane",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
For plugins like Calico which don't use the hostPrefix for anything,
it does not make sense to validate this field and force customers
to set specific values just to pass validation. These plugins should
be able to unset the hostPrefix completely and not have to worry about
it. This patch ensures that we perform the validation only for
OpenShiftSDN and OVNKubernetes. In the case of other plugins, we
check if the hostPrefix is unset(0) and if so, we skip the validation.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>