### PR TITLE
OpenStack: Create SG rules in parallel

### DIFF
--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -5,16 +5,6 @@ resource "openstack_networking_secgroup_v2" "worker" {
 
 # TODO(mandre) Explicitely enable egress
 
-// We can't create all security group rules at once because it may lead to
-// conflicts in Neutron. Therefore we have to create rules sequentially by
-// setting explicit dependencies between them.
-// For more information: https://github.com/hashicorp/terraform/issues/7519
-
-// FIXME(mfedosin): ideally we need to resolve this in the OpenStack Terraform
-// provider.
-// Remove the dependencies when https://github.com/terraform-providers/terraform-provider-openstack/issues/952
-// is fixed.
-
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
   direction      = "ingress"
   ethertype      = "IPv4"
@@ -24,8 +14,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
   # FIXME(mandre) AWS only allows ICMP from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.master_ingress_vrrp]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
@@ -37,8 +25,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
   # FIXME(mandre) AWS only allows SSH from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_icmp]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_mdns_udp" {
@@ -49,8 +35,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_mdns_udp" {
   port_range_max    = 5353
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_ssh]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_http" {
@@ -61,8 +45,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_http" {
   port_range_max    = 80
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_mdns_udp]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_https" {
@@ -73,8 +55,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_https" {
   port_range_max    = 443
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_http]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_router" {
@@ -85,8 +65,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_router" {
   port_range_max    = 1936
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_https]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan" {
@@ -97,8 +75,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan" {
   port_range_max    = 4789
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_router]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_geneve" {
@@ -109,8 +85,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_geneve" {
   port_range_max    = 6081
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_vxlan]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal" {
@@ -121,8 +95,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal" {
   port_range_max    = 9999
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_geneve]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_udp" {
@@ -133,8 +105,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_udp" {
   port_range_max    = 9999
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_internal]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecure" {
@@ -145,8 +115,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecur
   port_range_max    = 10250
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_internal_udp]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp" {
@@ -157,8 +125,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp" {
   port_range_max    = 32767
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_kubelet_insecure]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
@@ -169,8 +135,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
   port_range_max    = 32767
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_services_tcp]
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp" {
@@ -181,6 +145,4 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp" {
   protocol          = "112"
   remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
-
-  depends_on = [openstack_networking_secgroup_rule_v2.worker_ingress_services_udp]
 }


### PR DESCRIPTION
Terraform-provider-openstack suffered from a race condition that would
lead to conflicts in neutron and forced us to create security group
sequentially (via an explicit dependency on the previous rule) to
prevent failures. This is no longer the case in
terraform-provider-openstack v1.28.0 where this issue was fixed with
[1].

With the recent bump of terraform-provider-openstack to v1.28.0, we can
now remove the workaround.

This reverts commit 228aadf9ebde1b60490bff19511de49d6350008f.

[1] https://github.com/terraform-providers/terraform-provider-openstack/pull/994