### PR TITLE
[FCOS] Download Azure image in the installer

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -170,8 +170,8 @@ resource "azurerm_storage_blob" "rhcos_image" {
   resource_group_name    = azurerm_resource_group.main.name
   storage_account_name   = azurerm_storage_account.cluster.name
   storage_container_name = azurerm_storage_container.vhd.name
-  type                   = "block"
-  source_uri             = var.azure_image_url
+  type                   = "page"
+  source                 = var.azure_image_url
   metadata               = map("source_uri", var.azure_image_url)
 }
 

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -170,8 +170,8 @@ resource "azurerm_storage_blob" "rhcos_image" {
   resource_group_name    = azurerm_resource_group.main.name
   storage_account_name   = azurerm_storage_account.cluster.name
   storage_container_name = azurerm_storage_container.vhd.name
-  type                   = "page"
-  source                 = var.azure_image_url
+  type                   = "Page"
+  source_uri             = var.azure_image_url
   metadata               = map("source_uri", var.azure_image_url)
 }
 

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -5,7 +5,9 @@ import (
 	"os"
 
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/pkg/errors"
 
+	"github.com/openshift/installer/pkg/tfvars/internal/cache"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure/defaults"
 	azureprovider "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
@@ -67,6 +69,11 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		emulateSingleStackIPv6 = true
 	}
 
+	cachedImage, err := cache.DownloadImageFile(sources.ImageURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to use cached Azure image")
+	}
+
 	cfg := &config{
 		Auth:                        sources.Auth,
 		Region:                      region,
@@ -75,7 +82,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		MasterAvailabilityZones:     masterAvailabilityZones,
 		VolumeType:                  masterConfig.OSDisk.ManagedDisk.StorageAccountType,
 		VolumeSize:                  masterConfig.OSDisk.DiskSizeGB,
-		ImageURL:                    sources.ImageURL,
+		ImageURL:                    cachedImage,
 		Private:                     sources.Publish == types.InternalPublishingStrategy,
 		BaseDomainResourceGroupName: sources.BaseDomainResourceGroupName,
 		NetworkResourceGroupName:    masterConfig.NetworkResourceGroup,


### PR DESCRIPTION
FCOS image is not yet available in the marketplace, so it needs to be downloaded by the installer

Cherry-pick of #3563 on `fcos` branch after it was wiped by the rebase.

/cc @LorbusChris 
@jomeier once you got a minute could you check that is the only change we need to restore Azure support?