### PR TITLE
Bug 1857188: OpenStack: skip container deletion if it was removed

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -649,6 +649,12 @@ func deleteContainers(opts *clientconfig.ClientOpts, filter Filter, logger logru
 	for _, container := range allContainers {
 		metadata, err := containers.Get(conn, container, nil).ExtractMetadata()
 		if err != nil {
+			// Some containers that we fetched previously can already be deleted in
+			// runtime. We should ignore these cases and continue to iterate through
+			// the remaining containers.
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				continue
+			}
 			logger.Error(err)
 			return false, nil
 		}


### PR DESCRIPTION
During deletion of containers we get a list of available containers first, and then we iterate through them to find the ones we need,
based on their metadata.
Since this is not an atomic operation, it may happen that the containers can be removed at runtime. We should ignore these cases and continue to iterate through the remaining ones.