### PR TITLE
Bug 1857650: oVirt, fix incorrect template removal condition

### DIFF
--- a/pkg/asset/cluster/ovirt/ovirt.go
+++ b/pkg/asset/cluster/ovirt/ovirt.go
@@ -10,12 +10,12 @@ import (
 
 // Metadata converts an install configuration to ovirt metadata.
 func Metadata(config *types.InstallConfig) *ovirt.Metadata {
-	customImage, ok := os.LookupEnv("OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE")
+	_, ok := os.LookupEnv("OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE")
 	m := ovirt.Metadata{
 		ClusterID: config.Ovirt.ClusterID,
-		// if we have a custom image, don't remove the template, otherwise its
-		// a per deployment template, destroy it
-		RemoveTemplate: ok && customImage != "",
+		// if we have a custom image, don't remove the template,
+		// otherwise its a per deployment template, destroy it
+		RemoveTemplate: !ok,
 	}
 	return &m
 }


### PR DESCRIPTION
We want to remove the cluster template and the VM associated with it
when the overriding variable is not set, meaning when the installer
creates the cluster template.
If the override env variable is set then an existing template is used
on the installation and we don't want to remove it

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>