### PR TITLE
Bug 1857651: oVirt, add condition for non existing tmp-vm

### DIFF
--- a/data/data/ovirt/template/outputs.tf
+++ b/data/data/ovirt/template/outputs.tf
@@ -3,5 +3,5 @@ output "releaseimage_template_id" {
 }
 
 output "tmp_import_vm" {
-  value = ovirt_vm.tmp_import_vm.0.id
+  value = length(ovirt_vm.tmp_import_vm) > 0 ? ovirt_vm.tmp_import_vm.0.id : ""
 }


### PR DESCRIPTION
PR https://github.com/openshift/installer/pull/3868 added the tmp vm as an output variable. This causes the installer to fail when that resource is not created i.e when we don't let the installer create the template, as we do on CI.
This caused all 4.6 and master PR to be red and fail before starting the installation.
We need to fix and add a condition to set the var only when the resource is created


Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>