### PR TITLE
Allow for mixed compute machine pools

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -321,10 +322,11 @@ func validateControlPlane(platform *types.Platform, pool *types.MachinePool, fld
 func validateCompute(platform *types.Platform, control *types.MachinePool, pools []types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	poolNames := map[string]bool{}
+	hostnameRE := regexp.MustCompile("^[a-z0-9][a-z0-9-]*$")
 	for i, p := range pools {
 		poolFldPath := fldPath.Index(i)
-		if p.Name != "worker" {
-			allErrs = append(allErrs, field.NotSupported(poolFldPath.Child("name"), p.Name, []string{"worker"}))
+		if !hostnameRE.MatchString(p.Name) {
+			allErrs = append(allErrs, field.Invalid(poolFldPath.Child("name"), p.Name, "must be a valid hostname"))
 		}
 		if poolNames[p.Name] {
 			allErrs = append(allErrs, field.Duplicate(poolFldPath.Child("name"), p.Name))

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -462,6 +462,28 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^compute\[1\]\.name: Duplicate value: "worker"$`,
 		},
 		{
+			name: "mixed compute",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Compute = []types.MachinePool{
+					*validMachinePool("worker"),
+					*validMachinePool("other-worker"),
+				}
+				return c
+			}(),
+		},
+		{
+			name: "invalid compute name",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Compute = []types.MachinePool{
+					*validMachinePool("invalid_worker"),
+				}
+				return c
+			}(),
+			expectedError: `^compute\[0\]\.name: Invalid value: "invalid_worker": must be a valid hostname$`,
+		},
+		{
 			name: "no compute replicas",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
The compute machine pool takes a list [1], however the installer only
allowed for one item named `worker`, effectively preventing from
deploying with mixed compute machine pools.
In certain cases, such as resource-constrained environments, it might
be needed to perform the initial deployment with mixed compute nodes.

This commit removes the restriction and checks that the pools names will
result in valid machine hostname.

[1] https://github.com/openshift/installer/blob/master/docs/user/customization.md#custom-machine-pools