### PR TITLE
Need to reset PasswordQuestionTemplate

### DIFF
--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -98,6 +98,7 @@ func (c *clientHTTP) checkURLResponse() error {
 // The password provided will be added in the Config struct.
 // If an error happens, it will ask again username for users.
 func askPassword(c *Config) error {
+	origPwdTpl := survey.PasswordQuestionTemplate
 	survey.PasswordQuestionTemplate = `
 {{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
 {{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
@@ -113,6 +114,9 @@ func askPassword(c *Config) error {
 			Validate: survey.ComposeValidators(survey.Required, authenticated(c)),
 		},
 	}, &c.Password)
+
+	survey.PasswordQuestionTemplate = origPwdTpl
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
After changing the template for the ovirt user password question,
we need to reset the template to avoid survey to use it for other
password questions like (Pull-secret)

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1857762