### PR TITLE
baremetal: populate TypeMeta for baremetal provider config

### DIFF
--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -90,6 +90,10 @@ func provider(clusterName string, platform *baremetal.Platform, osImage string, 
 	cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(platform.ClusterProvisioningIP, "6180"), imageFilename, compressedImageFilename)
 	cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)
 	config := &baremetalprovider.BareMetalMachineProviderSpec{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "baremetal.cluster.k8s.io/v1alpha1",
+			Kind:       "BareMetalMachineProviderSpec",
+		},
 		Image: baremetalprovider.Image{
 			URL:      cacheImageURL,
 			Checksum: cacheChecksumURL,


### PR DESCRIPTION
Currently, we're not setting Kind or APIVersion in the baremetal
provider config, which is causing problems when recent code added to the
installer tries to unmarshal these resources.

Fixes https://github.com/openshift/installer/issues/3906