### PR TITLE
Bug 1857924: ovirt: remove defer ovirtConfig.Save()

### DIFF
--- a/pkg/asset/installconfig/ovirt/ovirt.go
+++ b/pkg/asset/installconfig/ovirt/ovirt.go
@@ -17,7 +17,6 @@ func Platform() (*ovirt.Platform, error) {
 		if err != nil {
 			return nil, err
 		}
-		defer ovirtConfig.Save()
 	}
 
 	c, err := ovirtsdk4.NewConnectionBuilder().
@@ -36,6 +35,7 @@ func Platform() (*ovirt.Platform, error) {
 	if err != nil {
 		return nil, err
 	}
+	ovirtConfig.Save()
 
 	clusterName, err := askCluster(c, &p)
 	if err != nil {


### PR DESCRIPTION
If users press ctrl c in the middle of questionary
process or an error happens it will save whatever users
have provided in the ovirt-config.yaml which can be incomplete and
prevent users to trigger a new installation asking a fresh
round of questions about their env.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1857924
Signed-off-by: Douglas Schilling Landgraf <dougsland@gmail.com>