### PR TITLE
Bug 1857945: ovirt: if TLS verify is disable raise a question to users

### DIFF
--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -141,6 +141,23 @@ func askUsername(c *Config) error {
 	return nil
 }
 
+// askQuestionTrueOrFalse generic function to ask question to users which
+// requires true (Yes) or false (No) as answer
+func askQuestionTrueOrFalse(question string, helpMessage string) (bool, error) {
+	value := false
+	err := survey.AskOne(
+		&survey.Confirm{
+			Message: question,
+			Help:    helpMessage,
+		},
+		&value, survey.Required)
+	if err != nil {
+		return value, err
+	}
+
+	return value, nil
+}
+
 // askCredentials will handle username and password for connecting with Engine
 func askCredentials(c Config) (Config, error) {
 	loginAttempts := 3
@@ -220,6 +237,10 @@ func engineSetup() (Config, error) {
 	err = httpResource.downloadFile()
 	if err != nil {
 		logrus.Warning("cannot download PEM file from Engine!", err)
+		answer, err := askQuestionTrueOrFalse("Would you like to continue?", "By not using a trusted CA, insecure connections can cause man-in-the-middle attacks among many others.")
+		if !answer {
+			return engineConfig, err
+		}
 		engineConfig.Insecure = true
 	} else {
 		err = httpResource.addTrustBundle(httpResource.saveFilePath, &engineConfig)


### PR DESCRIPTION
Today if the installer cannot download the CA from Engine
it will continue without enabling TLS verify (connection Insecure).
Instead of warning only, let's make sure users agree with that.

Bug-URL: https://bugzilla.redhat.com/show_bug.cgi?id=1857945
Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>