### PR TITLE
Baremetal: Enable installer survey for baremetal platform

### DIFF
--- a/pkg/asset/installconfig/baremetal/baremetal.go
+++ b/pkg/asset/installconfig/baremetal/baremetal.go
@@ -1,0 +1,117 @@
+// Package baremetal collects bare metal specific configuration.
+package baremetal
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"gopkg.in/AlecAivazis/survey.v1"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+
+	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	baremetaldefaults "github.com/openshift/installer/pkg/types/baremetal/defaults"
+)
+
+// Platform collects bare metal specific configuration.
+func Platform() (*baremetal.Platform, error) {
+	var provisioningNetworkCIDR, externalBridge, provisioningBridge, provisioningNetworkInterface string
+	var hosts []*baremetal.Host
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Provisioning Network CIDR",
+				Help:    "The network used for provisioning.",
+				Default: "172.22.0.0/24",
+			},
+			Validate: survey.ComposeValidators(survey.Required, ipNetValidator),
+		},
+	}, &provisioningNetworkCIDR); err != nil {
+		return nil, err
+	}
+	provNetCIDR, err := ipnet.ParseCIDR(provisioningNetworkCIDR)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "External bridge",
+				Help:    "External bridge is used for external communication by the bootstrap virtual machine.",
+				Default: baremetaldefaults.ExternalBridge,
+			},
+		},
+	}, &externalBridge); err != nil {
+		return nil, err
+	}
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Provisioning bridge",
+				Help:    "Provisioning bridge is used to provision machines by the bootstrap virtual machine.",
+				Default: baremetaldefaults.ProvisioningBridge,
+			},
+		},
+	}, &provisioningBridge); err != nil {
+		return nil, err
+	}
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Provisioning Network Interface",
+				Help:    "The name of the network interface on a control plane host connected to the provisioning network.",
+			},
+			Validate: survey.Required,
+		},
+	}, &provisioningNetworkInterface); err != nil {
+		return nil, err
+	}
+
+	// Keep prompting for hosts
+	for {
+		var hostRole string
+		survey.AskOne(&survey.Select{
+			Message: "Add a Host:",
+			Options: []string{"control plane", "worker"},
+		}, &hostRole, nil)
+
+		var host *baremetal.Host
+		var err error
+		host, err = Host()
+		// Check for kebyoard interrupt or else we'll loop forever
+		if errors.Is(err, terminal.InterruptErr) {
+			fmt.Println("interrupted - hosts were not added")
+			break
+		} else if err != nil {
+			fmt.Printf("invalid host - please try again")
+			continue
+		}
+		hosts = append(hosts, host)
+
+		more := false
+		survey.AskOne(&survey.Confirm{
+			Message: "Add another host?",
+		}, &more, nil)
+		if !more {
+			break
+		}
+	}
+
+	return &baremetal.Platform{
+		ExternalBridge:               externalBridge,
+		ProvisioningBridge:           provisioningBridge,
+		ProvisioningNetworkCIDR:      provNetCIDR,
+		ProvisioningNetworkInterface: provisioningNetworkInterface,
+		Hosts:                        hosts,
+	}, nil
+}
+
+// ipNetValidator validates for a valid IP
+func ipNetValidator(ans interface{}) error {
+	_, err := ipnet.ParseCIDR(ans.(string))
+	return err
+}

--- a/pkg/asset/installconfig/baremetal/host.go
+++ b/pkg/asset/installconfig/baremetal/host.go
@@ -1,0 +1,82 @@
+package baremetal
+
+import (
+	"gopkg.in/AlecAivazis/survey.v1"
+
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/validate"
+)
+
+// Host prompts the user for hardware details about a baremetal host.
+func Host() (*baremetal.Host, error) {
+	var host baremetal.Host
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Name",
+			},
+			Validate: survey.ComposeValidators(survey.Required),
+		},
+	}, &host.Name); err != nil {
+		return nil, err
+	}
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "BMC Address",
+				Help:    "The address for the BMC, e.g. ipmi://192.168.0.1",
+			},
+			Validate: survey.ComposeValidators(survey.Required, uriValidator),
+		},
+	}, &host.BMC.Address); err != nil {
+		return nil, err
+	}
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "BMC Username",
+			},
+			Validate: survey.ComposeValidators(survey.Required),
+		},
+	}, &host.BMC.Username); err != nil {
+		return nil, err
+	}
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Password{
+				Message: "BMC Password",
+			},
+			Validate: survey.ComposeValidators(survey.Required),
+		},
+	}, &host.BMC.Password); err != nil {
+		return nil, err
+	}
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Boot MAC Address",
+			},
+			Validate: survey.ComposeValidators(survey.Required, macValidator),
+		},
+	}, &host.BootMACAddress); err != nil {
+		return nil, err
+	}
+
+	return &host, nil
+}
+
+// uriValidator validates if the answer provided in prompt is a valid
+// url and has non-empty scheme.
+func uriValidator(ans interface{}) error {
+	return validate.URI(ans.(string))
+}
+
+// macValidator validates if the answer provided is a valid mac address
+func macValidator(ans interface{}) error {
+	return validate.MAC(ans.(string))
+}

--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	azureconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
+	baremetalconfig "github.com/openshift/installer/pkg/asset/installconfig/baremetal"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	libvirtconfig "github.com/openshift/installer/pkg/asset/installconfig/libvirt"
 	openstackconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
@@ -18,6 +19,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/none"
@@ -52,18 +54,23 @@ func (a *platform) Generate(asset.Parents) error {
 		if err != nil {
 			return err
 		}
-	case libvirt.Name:
-		a.Libvirt, err = libvirtconfig.Platform()
-		if err != nil {
-			return err
-		}
 	case azure.Name:
 		a.Azure, err = azureconfig.Platform()
 		if err != nil {
 			return err
 		}
+	case baremetal.Name:
+		a.BareMetal, err = baremetalconfig.Platform()
+		if err != nil {
+			return err
+		}
 	case gcp.Name:
 		a.GCP, err = gcpconfig.Platform()
+		if err != nil {
+			return err
+		}
+	case libvirt.Name:
+		a.Libvirt, err = libvirtconfig.Platform()
 		if err != nil {
 			return err
 		}
@@ -74,13 +81,13 @@ func (a *platform) Generate(asset.Parents) error {
 		if err != nil {
 			return err
 		}
-	case vsphere.Name:
-		a.VSphere, err = vsphereconfig.Platform()
+	case ovirt.Name:
+		a.Ovirt, err = ovirtconfig.Platform()
 		if err != nil {
 			return err
 		}
-	case ovirt.Name:
-		a.Ovirt, err = ovirtconfig.Platform()
+	case vsphere.Name:
+		a.VSphere, err = vsphereconfig.Platform()
 		if err != nil {
 			return err
 		}

--- a/pkg/types/installconfig_baremetal.go
+++ b/pkg/types/installconfig_baremetal.go
@@ -1,0 +1,14 @@
+// +build baremetal
+
+package types
+
+import (
+	"sort"
+
+	"github.com/openshift/installer/pkg/types/baremetal"
+)
+
+func init() {
+	PlatformNames = append(PlatformNames, baremetal.Name)
+	sort.Strings(PlatformNames)
+}


### PR DESCRIPTION
baremetal: Enable installer survey for baremetal platform

This PR enables installer survey for the baremetal platform where the user is asked a minimal set of questions, which combined with sane defaults to construct an installer-config file. The config file can either directly used to create a cluster or can be customized by editing it manually before creating the cluster. 