### PR TITLE
Bug 1858418: ovirt_template: Increase ovirt_templates search criteria

### DIFF
--- a/data/data/ovirt/template/main.tf
+++ b/data/data/ovirt/template/main.tf
@@ -10,7 +10,7 @@
 // the template.
 data "ovirt_templates" "osImage" {
   search = {
-    criteria       = "name=${var.openstack_base_image_name} or name=Blank"
+    criteria       = "name=${var.openstack_base_image_name} or name=Blank*"
     case_sensitive = true
   }
 }


### PR DESCRIPTION
Current search criteria will miss a template called Blank1 and fail the install.