### PR TITLE
OpenStack: fix runtime error with machine pool validation

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/validation.go
+++ b/pkg/asset/installconfig/openstack/validation/validation.go
@@ -16,7 +16,9 @@ func Validate(ic *types.InstallConfig) error {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, validatePlatform(ic, ci)...)
-	allErrs = append(allErrs, validateMachinePool(ic.ControlPlane.Platform.OpenStack, field.NewPath("controlPlane", "platform", "openstack"))...)
+	if ic.ControlPlane.Platform.OpenStack != nil {
+		allErrs = append(allErrs, validateMachinePool(ic.ControlPlane.Platform.OpenStack, field.NewPath("controlPlane", "platform", "openstack"))...)
+	}
 	for idx, compute := range ic.Compute {
 		fldPath := field.NewPath("compute").Index(idx)
 		if compute.Platform.OpenStack != nil {


### PR DESCRIPTION
The recent validations refactoring [1] caused the installer to panic with
nil pointer deference when running with an install-config.yaml where the
`controlPlane.platform.openstack` struct was unset.

This wasn't caught in CI since we do set the struct.

[1] https://github.com/openshift/installer/pull/3864