### PR TITLE
types: add field to InstallConfig to force credentials mode

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -349,13 +349,13 @@ then
 		render \
 			--dest-dir=/assets/cco-bootstrap \
 			--manifests-dir=/assets/manifests \
-			--cloud-credential-operator-image=${CLOUD_CREDENTIAL_OPERATOR_IMAGE}
+			--cloud-credential-operator-image=${CLOUD_CREDENTIAL_OPERATOR_IMAGE} \
+			--force-mode={{.CloudCredentialsMode}}
 
 	cp cco-bootstrap/manifests/* manifests/
 	# skip copy if static pod manifest does not exist (ie CCO has been disabled)
-	if [ -f cco-bootstrap/bootstrap-manifests/cloud-credential-operator-pod.yaml ]; then
-		cp cco-bootstrap/bootstrap-manifests/* bootstrap-manifests/
-	fi
+	[ -d cco-bootstrap/bootstrap-manifests ] && [ "$(ls -A cco-bootstrap/bootstrap-manifests)" ] && \
+	  cp cco-bootstrap/bootstrap-manifests/* bootstrap-manifests/
 
 	touch cco-bootstrap.done
 fi

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -613,6 +613,17 @@ spec:
             default: false
             description: FIPS configures https://www.nist.gov/itl/fips-general-information
             type: boolean
+          forceCloudCredentialsMode:
+            description: ForceCredentialsMode instructs the installer to not attempt
+              to query the cloud permissions before attempting installation. It also
+              passes down the desired credentials mode to the cloud-credential-operator
+              so that it too does not attempt to query permissions.
+            enum:
+            - ""
+            - mint
+            - passthrough
+            - manual
+            type: string
           imageContentSources:
             description: ImageContentSources lists sources/repositories for the release-image
               content.

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -40,6 +40,10 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 	ic := &InstallConfig{}
 	dependencies.Get(ic)
 
+	if ic.Config.ForceCloudCredentialsMode != "" {
+		return nil
+	}
+
 	var err error
 	platform := ic.Config.Platform.Name()
 	switch platform {

--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -173,6 +173,7 @@ func (m *Manifests) generateBootKubeManifests(dependencies asset.Parents) []*ass
 	etcdEndpointHostnames[0] = "etcd-bootstrap"
 
 	templateData := &bootkubeTemplateData{
+		CloudCredentialsMode:       string(installConfig.Config.ForceCloudCredentialsMode),
 		CVOClusterID:               clusterID.UUID,
 		EtcdCaBundle:               string(etcdCABundle.Cert()),
 		EtcdEndpointDNSSuffix:      installConfig.Config.ClusterDomain(),

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -57,6 +57,7 @@ type cloudCredsSecretData struct {
 }
 
 type bootkubeTemplateData struct {
+	CloudCredentialsMode       string
 	CVOClusterID               string
 	EtcdCaBundle               string
 	EtcdEndpointDNSSuffix      string

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -119,6 +119,12 @@ type InstallConfig struct {
 	// +kubebuilder:default=false
 	// +optional
 	FIPS bool `json:"fips,omitempty"`
+
+	// ForceCredentialsMode instructs the installer to not attempt to query the cloud permissions before attempting
+	// installation. It also passes down the desired credentials mode to the cloud-credential-operator so that it too
+	// does not attempt to query permissions.
+	// +optional
+	ForceCloudCredentialsMode CloudCredentialsMode `json:"forceCloudCredentialsMode,omitempty"`
 }
 
 // ClusterDomain returns the DNS domain that all records for a cluster must belong to.
@@ -294,3 +300,20 @@ type ImageContentSource struct {
 	// +optional
 	Mirrors []string `json:"mirrors,omitempty"`
 }
+
+// CloudCredentialsMode is the mode in which the cloud-credential-operator operates.
+// +kubebuilder:validation:Enum="";mint;passthrough;manual
+type CloudCredentialsMode string
+
+const (
+	// ManualCloudCredentialsMode indicates that cloud-credential-operator should not process any CredentialsRequests.
+	ManualCloudCredentialsMode CloudCredentialsMode = "manual"
+
+	// MintCloudCredentialsMode indicates that cloud-credential-operator should be creating users for each
+	// CredentialsRequest.
+	MintCloudCredentialsMode CloudCredentialsMode = "mint"
+
+	// PassthroughCloudCredentialsMode indicates that cloud-credential-operator should just copy over the cluster's
+	// cloud credentials for each CredentialsRequest.
+	PassthroughCloudCredentialsMode CloudCredentialsMode = "passthrough"
+)


### PR DESCRIPTION
Add the forceCloudCredentialsMode field to InstallConfig. When set, the installer will not perform any permissions checks on the cloud credentials. The credentials mode set will be passed along to the cloud-credential-operator via a command-line argument added to the cco render command.

See https://github.com/openshift/enhancements/blob/master/enhancements/installer/aws-permissions-check-bypass.md

https://issues.redhat.com/browse/CO-1057