### PR TITLE
OpenStack Availibility Zones

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -233,6 +233,12 @@ spec:
                           description: FlavorName defines the OpenStack Nova flavor.
                             eg. m1.large
                           type: string
+                        zones:
+                          description: Zones contains a list of availabilty zones
+                            that instances can be deployed on
+                          items:
+                            type: string
+                          type: array
                       required:
                       - type
                       type: object
@@ -520,6 +526,12 @@ spec:
                         description: FlavorName defines the OpenStack Nova flavor.
                           eg. m1.large
                         type: string
+                      zones:
+                        description: Zones contains a list of availabilty zones that
+                          instances can be deployed on
+                        items:
+                          type: string
+                        type: array
                     required:
                     - type
                     type: object
@@ -1303,6 +1315,12 @@ spec:
                         description: FlavorName defines the OpenStack Nova flavor.
                           eg. m1.large
                         type: string
+                      zones:
+                        description: Zones contains a list of availabilty zones that
+                          instances can be deployed on
+                        items:
+                          type: string
+                        type: array
                     required:
                     - type
                     type: object

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -73,3 +73,8 @@ variable "root_volume_type" {
   type = string
   description = "The type of volume for the root block device."
 }
+
+variable "zone" {
+  type = string
+  description = "Availability Zone to schedule the bootstrap node onto"
+}

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -40,6 +40,7 @@ module "bootstrap" {
   master_port_ids         = module.topology.master_port_ids
   root_volume_size        = var.openstack_master_root_volume_size
   root_volume_type        = var.openstack_master_root_volume_type
+  zone                    = var.openstack_master_availability_zones[0]
 }
 
 module "masters" {
@@ -59,6 +60,7 @@ module "masters" {
   root_volume_type       = var.openstack_master_root_volume_type
   server_group_name      = var.openstack_master_server_group_name
   additional_network_ids = var.openstack_additional_network_ids
+  zones                  = var.openstack_master_availability_zones
 }
 
 module "topology" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -47,6 +47,7 @@ resource "openstack_compute_instance_v2" "master_conf" {
   flavor_id = data.openstack_compute_flavor_v2.masters_flavor.id
   image_id = var.root_volume_size == null ? var.base_image_id : null
   security_groups = var.master_sg_ids
+  availability_zone = var.zones[count.index % length(var.zones)]
   user_data = element(
     data.ignition_config.master_ignition_config.*.rendered,
     count.index,

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -50,3 +50,8 @@ variable "additional_network_ids" {
   type        = list(string)
   description = "IDs of additional networks for master nodes."
 }
+
+variable "zones" {
+  type        = list(string)
+  description = "Availability Zones to schedule masters on."
+}

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -359,3 +359,9 @@ variable "openstack_machines_network_id" {
   default = ""
   description = "ID of the network the machines subnet is on. If empty, the installer will create a network to use as machinesNetwork."
 }
+
+variable "openstack_master_availability_zones" {
+  type = list(string)
+  default = [""]
+  description = "List of availability Zones to Schedule the masters on"
+}

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -4,16 +4,18 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 ## Table of Contents
 
-* [Cluster-scoped properties](#cluster-scoped-properties)
-* [Machine pools](#machine-pools)
-* [Examples](#examples)
-  * [Minimal](#minimal)
-  * [Custom-machine-pools](#custom-machine-pools)
-* [Image Overrides](#image-overrides)
-* [Custom Subnets](#custom-subnets)
-* [Additional Networks](#additional-networks)
-* [Additional Security Groups](#additional-security-groups)
-* [Further customization](#further-customization)
+- [OpenStack Platform Customization](#openstack-platform-customization)
+  - [Table of Contents](#table-of-contents)
+  - [Cluster-scoped properties](#cluster-scoped-properties)
+  - [Machine pools](#machine-pools)
+  - [Examples](#examples)
+    - [Minimal](#minimal)
+    - [Custom machine pools](#custom-machine-pools)
+  - [Image Overrides](#image-overrides)
+  - [Custom Subnets](#custom-subnets)
+  - [Additional Networks](#additional-networks)
+  - [Additional Security Groups](#additional-security-groups)
+  - [Further customization](#further-customization)
 
 ## Cluster-scoped properties
 
@@ -40,6 +42,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `rootVolume` (optional object): Defines the root volume for instances in the machine pool. The instances use ephemeral disks if not set.
   * `size` (required integer): Size of the root volume in GB.
   * `type` (required string): The volume pool to create the volume from.
+* `zones` (optional list of strings): The names of the availability zones you want to install your nodes on. If unset, the installer will use your default compute zone.
 
 **NOTE:** The bootstrap node follows the `type` and `rootVolume` parameters from the `controlPlane` machine pool.
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -393,9 +393,13 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		if err != nil {
 			return err
 		}
+
+		var masterSpecs []*openstackprovider.OpenstackProviderSpec
+		for _, master := range masters {
+			masterSpecs = append(masterSpecs, master.Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec))
+		}
 		data, err = openstacktfvars.TFVars(
-			masters[0].Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec),
-			installConfig.Config.Platform.OpenStack.Cloud,
+			masterSpecs,
 			installConfig.Config.Platform.OpenStack.ExternalNetwork,
 			installConfig.Config.Platform.OpenStack.ExternalDNS,
 			installConfig.Config.Platform.OpenStack.LbFloatingIP,

--- a/pkg/asset/installconfig/openstack/validation/machinepool_test.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 var (
+	validFlavor = "valid-flavor"
+	validZone   = "valid-zone"
+
 	validCtrlPlaneFlavor = "valid-control-plane-flavor"
 	validComputeFlavor   = "valid-compute-flavor"
 
@@ -54,6 +57,9 @@ func validMpoolCloudInfo() *CloudInfo {
 				VCPUs: 2,
 			},
 		},
+		Zones: []string{
+			validZone,
+		},
 	}
 }
 
@@ -73,6 +79,28 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  false,
 			expectedErrMsg: "",
+		},
+		{
+			name: "valid zone",
+			mpool: func() *openstack.MachinePool {
+				mp := validMachinePool()
+				mp.Zones = []string{validZone}
+				return mp
+			}(),
+			cloudInfo:      validMpoolCloudInfo(),
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name: "invalid zone",
+			mpool: func() *openstack.MachinePool {
+				mp := validMachinePool()
+				mp.Zones = []string{"invalid-zone"}
+				return mp
+			}(),
+			cloudInfo:      validMpoolCloudInfo(),
+			expectedError:  true,
+			expectedErrMsg: "Zone either does not exist in this cloud, or is not available",
 		},
 		{
 			name:           "valid compute",

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -22,64 +22,75 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	}
 	platform := config.Platform.OpenStack
 	mpool := pool.Platform.OpenStack
+	trunkSupport, err := checkNetworkExtensionAvailability(platform.Cloud, "trunk")
+	if err != nil {
+		return nil, err
+	}
 
 	total := int32(0)
 	if pool.Replicas != nil {
 		total = int32(*pool.Replicas)
 	}
 
+	numOfAZs := int32(len(mpool.Zones))
 	// TODO(flaper87): Add support for availability zones
-	machinesets := make([]*clusterapi.MachineSet, 0, 1)
-	az := ""
-	provider, err := generateProvider(clusterID, platform, mpool, osImage, az, role, userDataSecret)
-	if err != nil {
-		return nil, err
-	}
+	var machinesets []*clusterapi.MachineSet
 
-	// TODO(flaper87): Implement AZ support sometime soon
-	//name := fmt.Sprintf("%s-%s-%s", clustername, pool.Name, az)
-	name := fmt.Sprintf("%s-%s", clusterID, pool.Name)
-	mset := &clusterapi.MachineSet{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "machine.openshift.io/v1beta1",
-			Kind:       "MachineSet",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "openshift-machine-api",
-			Name:      name,
-			Labels: map[string]string{
-				"machine.openshift.io/cluster-api-cluster":      clusterID,
-				"machine.openshift.io/cluster-api-machine-role": role,
-				"machine.openshift.io/cluster-api-machine-type": role,
+	for idx, az := range mpool.Zones {
+		replicas := int32(total / numOfAZs)
+		if int32(idx) < total%numOfAZs {
+			replicas++
+		}
+		provider, err := generateProvider(clusterID, platform, mpool, osImage, az, role, userDataSecret, trunkSupport)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO(flaper87): Implement AZ support sometime soon
+		//name := fmt.Sprintf("%s-%s-%s", clustername, pool.Name, az)
+		name := fmt.Sprintf("%s-%s", clusterID, pool.Name)
+		mset := &clusterapi.MachineSet{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "machine.openshift.io/v1beta1",
+				Kind:       "MachineSet",
 			},
-		},
-		Spec: clusterapi.MachineSetSpec{
-			Replicas: &total,
-			Selector: metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"machine.openshift.io/cluster-api-machineset": name,
-					"machine.openshift.io/cluster-api-cluster":    clusterID,
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "openshift-machine-api",
+				Name:      name,
+				Labels: map[string]string{
+					"machine.openshift.io/cluster-api-cluster":      clusterID,
+					"machine.openshift.io/cluster-api-machine-role": role,
+					"machine.openshift.io/cluster-api-machine-type": role,
 				},
 			},
-			Template: clusterapi.MachineTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"machine.openshift.io/cluster-api-machineset":   name,
-						"machine.openshift.io/cluster-api-cluster":      clusterID,
-						"machine.openshift.io/cluster-api-machine-role": role,
-						"machine.openshift.io/cluster-api-machine-type": role,
+			Spec: clusterapi.MachineSetSpec{
+				Replicas: &total,
+				Selector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"machine.openshift.io/cluster-api-machineset": name,
+						"machine.openshift.io/cluster-api-cluster":    clusterID,
 					},
 				},
-				Spec: clusterapi.MachineSpec{
-					ProviderSpec: clusterapi.ProviderSpec{
-						Value: &runtime.RawExtension{Object: provider},
+				Template: clusterapi.MachineTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"machine.openshift.io/cluster-api-machineset":   name,
+							"machine.openshift.io/cluster-api-cluster":      clusterID,
+							"machine.openshift.io/cluster-api-machine-role": role,
+							"machine.openshift.io/cluster-api-machine-type": role,
+						},
 					},
-					// we don't need to set Versions, because we control those via cluster operators.
+					Spec: clusterapi.MachineSpec{
+						ProviderSpec: clusterapi.ProviderSpec{
+							Value: &runtime.RawExtension{Object: provider},
+						},
+						// we don't need to set Versions, because we control those via cluster operators.
+					},
 				},
 			},
-		},
+		}
+		machinesets = append(machinesets, mset)
 	}
-	machinesets = append(machinesets, mset)
 
 	return machinesets, nil
 }

--- a/pkg/types/openstack/machinepool.go
+++ b/pkg/types/openstack/machinepool.go
@@ -22,9 +22,14 @@ type MachinePool struct {
 	// where each ID is presented in UUID v4 format.
 	// +optional
 	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
+
+	// Zones contains a list of availabilty zones that instances can be deployed on
+	//
+	// +optional
+	Zones []string `json:"zones,omitempty"`
 }
 
-// Set sets the values from `required` to `a`.
+// Set sets the values from `required` to `o`.
 func (o *MachinePool) Set(required *MachinePool) {
 	if required == nil || o == nil {
 		return
@@ -49,6 +54,13 @@ func (o *MachinePool) Set(required *MachinePool) {
 	if required.AdditionalSecurityGroupIDs != nil {
 		o.AdditionalSecurityGroupIDs = append(required.AdditionalSecurityGroupIDs[:0:0], required.AdditionalSecurityGroupIDs...)
 	}
+
+	if len(required.Zones) > 0 {
+		o.Zones = required.Zones
+	} else {
+		o.Zones = []string{""}
+	}
+
 }
 
 // RootVolume defines the storage for an instance.


### PR DESCRIPTION
Following suit with AWS, OpenStack is adding support for custom AZs
for installer machine pools. Users can pass a list of zones to use
and the nodes in that machine pool will be spread across them. When
no custom zones are passed, the installer will discover and use all
zones.

Issue: #2391 