### PR TITLE
types: add field to InstallConfig to force credentials mode

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -609,6 +609,28 @@ spec:
             - name
             - platform
             type: object
+          credentialsMode:
+            description: "CredentialsMode is used to explicitly set the mode with
+              which CredentialRequests are satisfied. \n If this field is set, then
+              the installer will not attempt to query the cloud permissions before
+              attempting installation. If the field is not set or empty, then the
+              installer will perform its normal verification that the credentials
+              provided are sufficient to perform an installation. \n There are three
+              possible values for this field, but the valid values are dependent upon
+              the platform being used. \"mint\": create new credentials with a subset
+              of the overall permissions for each CredentialsRequest \"passthrough\":
+              copy the credentials with all of the overall permsissions for each CredentialsRequest
+              \"manual\": CredentialsRequests must be handled manually by the user
+              \n For each of the following platforms, the field can set to the specified
+              values. For all other platforms, the field must not be set. AWS: \"mint\",
+              \"passthrough\", \"manual\" Azure: \"mint\", \"passthrough\" GCP: \"mint\",
+              \"passthrough\""
+            enum:
+            - ""
+            - mint
+            - passthrough
+            - manual
+            type: string
           fips:
             default: false
             description: FIPS configures https://www.nist.gov/itl/fips-general-information

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -40,6 +40,10 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 	ic := &InstallConfig{}
 	dependencies.Get(ic)
 
+	if ic.Config.CredentialsMode != "" {
+		return nil
+	}
+
 	var err error
 	platform := ic.Config.Platform.Name()
 	switch platform {

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -35,6 +35,13 @@ func Test_PrintFields(t *testing.T) {
     controlPlane <object>
       ControlPlane is the configuration for the machines that comprise the control plane.
 
+    credentialsMode <string>
+      Valid Values: "","mint","passthrough","manual"
+      CredentialsMode is used to explicitly set the mode with which CredentialRequests are satisfied. 
+ If this field is set, then the installer will not attempt to query the cloud permissions before attempting installation. If the field is not set or empty, then the installer will perform its normal verification that the credentials provided are sufficient to perform an installation. 
+ There are three possible values for this field, but the valid values are dependent upon the platform being used. "mint": create new credentials with a subset of the overall permissions for each CredentialsRequest "passthrough": copy the credentials with all of the overall permsissions for each CredentialsRequest "manual": CredentialsRequests must be handled manually by the user 
+ For each of the following platforms, the field can set to the specified values. For all other platforms, the field must not be set. AWS: "mint", "passthrough", "manual" Azure: "mint", "passthrough" GCP: "mint", "passthrough"
+
     fips <boolean>
       Default: false
       FIPS configures https://www.nist.gov/itl/fips-general-information

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -119,6 +119,25 @@ type InstallConfig struct {
 	// +kubebuilder:default=false
 	// +optional
 	FIPS bool `json:"fips,omitempty"`
+
+	// CredentialsMode is used to explicitly set the mode with which CredentialRequests are satisfied.
+	//
+	// If this field is set, then the installer will not attempt to query the cloud permissions before attempting
+	// installation. If the field is not set or empty, then the installer will perform its normal verification that the
+	// credentials provided are sufficient to perform an installation.
+	//
+	// There are three possible values for this field, but the valid values are dependent upon the platform being used.
+	// "mint": create new credentials with a subset of the overall permissions for each CredentialsRequest
+	// "passthrough": copy the credentials with all of the overall permsissions for each CredentialsRequest
+	// "manual": CredentialsRequests must be handled manually by the user
+	//
+	// For each of the following platforms, the field can set to the specified values. For all other platforms, the
+	// field must not be set.
+	// AWS: "mint", "passthrough", "manual"
+	// Azure: "mint", "passthrough"
+	// GCP: "mint", "passthrough"
+	// +optional
+	CredentialsMode CredentialsMode `json:"credentialsMode,omitempty"`
 }
 
 // ClusterDomain returns the DNS domain that all records for a cluster must belong to.
@@ -294,3 +313,20 @@ type ImageContentSource struct {
 	// +optional
 	Mirrors []string `json:"mirrors,omitempty"`
 }
+
+// CredentialsMode is the mode by which CredentialsRequests will be satisfied.
+// +kubebuilder:validation:Enum="";mint;passthrough;manual
+type CredentialsMode string
+
+const (
+	// ManualCredentialsMode indicates that cloud-credential-operator should not process any CredentialsRequests.
+	ManualCredentialsMode CredentialsMode = "manual"
+
+	// MintCredentialsMode indicates that cloud-credential-operator should be creating users for each
+	// CredentialsRequest.
+	MintCredentialsMode CredentialsMode = "mint"
+
+	// PassthroughCredentialsMode indicates that cloud-credential-operator should just copy over the cluster's
+	// cloud credentials for each CredentialsRequest.
+	PassthroughCredentialsMode CredentialsMode = "passthrough"
+)

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -9,6 +9,7 @@ import (
 
 	dockerref "github.com/containers/image/docker/reference"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/ipnet"
@@ -98,6 +99,7 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 	if _, ok := validPublishingStrategies[c.Publish]; !ok {
 		allErrs = append(allErrs, field.NotSupported(field.NewPath("publish"), c.Publish, validPublishingStrategyValues))
 	}
+	allErrs = append(allErrs, validateCloudCredentialsMode(c.CredentialsMode, field.NewPath("credentialsMode"), c.Platform.Name())...)
 
 	return allErrs
 }
@@ -464,3 +466,29 @@ var (
 		return v
 	}()
 )
+
+func validateCloudCredentialsMode(mode types.CredentialsMode, fldPath *field.Path, platform string) field.ErrorList {
+	if mode == "" {
+		return nil
+	}
+	allErrs := field.ErrorList{}
+	// validPlatformCredentialsModes is a map from the platform name to a slice of credentials modes that are valid
+	// for the platform. If a platform name is not in the map, then the credentials mode cannot be set for that platform.
+	validPlatformCredentialsModes := map[string][]types.CredentialsMode{
+		aws.Name:   {types.MintCredentialsMode, types.PassthroughCredentialsMode, types.ManualCredentialsMode},
+		azure.Name: {types.MintCredentialsMode, types.PassthroughCredentialsMode},
+		gcp.Name:   {types.MintCredentialsMode, types.PassthroughCredentialsMode},
+	}
+	if validModes, ok := validPlatformCredentialsModes[platform]; ok {
+		validModesSet := sets.NewString()
+		for _, m := range validModes {
+			validModesSet.Insert(string(m))
+		}
+		if !validModesSet.Has(string(mode)) {
+			allErrs = append(allErrs, field.NotSupported(fldPath, mode, validModesSet.List()))
+		}
+	} else {
+		allErrs = append(allErrs, field.Invalid(fldPath, mode, fmt.Sprintf("cannot be set when using the %q platform", platform)))
+	}
+	return allErrs
+}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -913,6 +913,43 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 			expectedError: `^compute\[0\].architecture: Invalid value: "ppc64le": heteregeneous multi-arch is not supported; compute pool architecture must match control plane$`,
 		},
+		{
+			name: "valid cloud credentials mode",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.CredentialsMode = types.PassthroughCredentialsMode
+				return c
+			}(),
+		},
+		{
+			name: "unsupported manual cloud credentials mode",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.CredentialsMode = types.ManualCredentialsMode
+				return c
+			}(),
+			expectedError: `^credentialsMode: Unsupported value: "manual": supported values: "mint", "passthrough"$`,
+		},
+		{
+			name: "invalidly set cloud credentials mode",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{BareMetal: validBareMetalPlatform()}
+				c.CredentialsMode = types.PassthroughCredentialsMode
+				return c
+			}(),
+			expectedError: `^credentialsMode: Invalid value: "passthrough": cannot be set when using the "baremetal" platform$`,
+		},
+		{
+			name: "bad cloud credentials mode",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.CredentialsMode = "bad-mode"
+				return c
+			}(),
+			expectedError: `^credentialsMode: Unsupported value: "bad-mode": supported values: "manual", "mint", "passthrough"$`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Add the cloudCredentialsMode field to InstallConfig. When set, the installer will not perform any permissions checks on the cloud
credentials. The cloud-credential-operator render command will look at the installconfig to render the manifests appropriately.

See https://github.com/openshift/enhancements/blob/master/enhancements/installer/aws-permissions-check-bypass.md

https://issues.redhat.com/browse/CO-1057