### PR TITLE
Azure: Allow use to provide an empty resource group for cluster

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -26,7 +26,7 @@ provider "azureprivatedns" {
 
 module "bootstrap" {
   source                 = "./bootstrap"
-  resource_group_name    = azurerm_resource_group.main.name
+  resource_group_name    = data.azurerm_resource_group.main.name
   region                 = var.azure_region
   vm_size                = var.azure_bootstrap_vm_type
   vm_image               = azurerm_image.cluster.id
@@ -51,7 +51,7 @@ module "bootstrap" {
 
 module "vnet" {
   source              = "./vnet"
-  resource_group_name = azurerm_resource_group.main.name
+  resource_group_name = data.azurerm_resource_group.main.name
   vnet_v4_cidrs       = var.machine_v4_cidrs
   vnet_v6_cidrs       = var.machine_v6_cidrs
   cluster_id          = var.cluster_id
@@ -73,7 +73,7 @@ module "vnet" {
 
 module "master" {
   source                 = "./master"
-  resource_group_name    = azurerm_resource_group.main.name
+  resource_group_name    = data.azurerm_resource_group.main.name
   cluster_id             = var.cluster_id
   region                 = var.azure_region
   availability_zones     = var.azure_master_availability_zones
@@ -108,7 +108,7 @@ module "dns" {
   external_lb_fqdn_v6             = module.vnet.public_lb_pip_v6_fqdn
   internal_lb_ipaddress_v4        = module.vnet.internal_lb_ip_v4_address
   internal_lb_ipaddress_v6        = module.vnet.internal_lb_ip_v6_address
-  resource_group_name             = azurerm_resource_group.main.name
+  resource_group_name             = data.azurerm_resource_group.main.name
   base_domain_resource_group_name = var.azure_base_domain_resource_group_name
   private                         = module.vnet.private
 
@@ -124,9 +124,17 @@ resource "random_string" "storage_suffix" {
 }
 
 resource "azurerm_resource_group" "main" {
+  count = var.azure_resource_group_name == "" ? 1 : 0
+
   name     = "${var.cluster_id}-rg"
   location = var.azure_region
   tags     = local.tags
+}
+
+data "azurerm_resource_group" "main" {
+  name = var.azure_resource_group_name == "" ? "${var.cluster_id}-rg" : var.azure_resource_group_name
+
+  depends_on = [azurerm_resource_group.main]
 }
 
 data "azurerm_resource_group" "network" {
@@ -137,21 +145,21 @@ data "azurerm_resource_group" "network" {
 
 resource "azurerm_storage_account" "cluster" {
   name                     = "cluster${random_string.storage_suffix.result}"
-  resource_group_name      = azurerm_resource_group.main.name
+  resource_group_name      = data.azurerm_resource_group.main.name
   location                 = var.azure_region
   account_tier             = "Standard"
   account_replication_type = "LRS"
 }
 
 resource "azurerm_user_assigned_identity" "main" {
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = data.azurerm_resource_group.main.location
 
   name = "${var.cluster_id}-identity"
 }
 
 resource "azurerm_role_assignment" "main" {
-  scope                = azurerm_resource_group.main.id
+  scope                = data.azurerm_resource_group.main.id
   role_definition_name = "Contributor"
   principal_id         = azurerm_user_assigned_identity.main.principal_id
 }
@@ -181,7 +189,7 @@ resource "azurerm_storage_blob" "rhcos_image" {
 
 resource "azurerm_image" "cluster" {
   name                = var.cluster_id
-  resource_group_name = azurerm_resource_group.main.name
+  resource_group_name = data.azurerm_resource_group.main.name
   location            = var.azure_region
 
   os_disk {

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -38,7 +38,7 @@ Example: `{ "key" = "value", "foo" = "bar" }`
 EOF
 
 
-default = {}
+  default = {}
 }
 
 variable "azure_master_root_volume_type" {
@@ -92,38 +92,46 @@ variable "azure_preexisting_network" {
   description = "Specifies whether an existing network should be used or a new one created for installation."
 }
 
-variable "azure_network_resource_group_name" {
+variable "azure_resource_group_name" {
   type        = string
+  description = <<EOF
+The name of the resource group for the cluster. If this is set, the cluster is installed to that existing resource group
+otherwise a new resource group will be created using cluster id.
+EOF
+}
+
+variable "azure_network_resource_group_name" {
+  type = string
   description = "The name of the network resource group, either existing or to be created."
 }
 
 variable "azure_virtual_network" {
-  type        = string
+  type = string
   description = "The name of the virtual network, either existing or to be created."
 }
 
 variable "azure_control_plane_subnet" {
-  type        = string
+  type = string
   description = "The name of the subnet for the control plane, either existing or to be created."
 }
 
 variable "azure_compute_subnet" {
-  type        = string
+  type = string
   description = "The name of the subnet for worker nodes, either existing or to be created"
 }
 
 variable "azure_private" {
-  type        = bool
+  type = bool
   description = "This determines if this is a private cluster or not."
 }
 
 variable "azure_emulate_single_stack_ipv6" {
-  type        = bool
+  type = bool
   description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
 }
 
 variable "azure_outbound_user_defined_routing" {
-  type    = bool
+  type = bool
   default = false
 
   description = <<EOF

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -944,6 +944,17 @@ spec:
                     description: Region specifies the Azure region where the cluster
                       will be created.
                     type: string
+                  resourceGroupName:
+                    description: ResourceGroupName is the name of an already existing
+                      resource group where the cluster should be installed. This resource
+                      group should only be used for this specific cluster and the
+                      cluster components will assume assume ownership of all resources
+                      in the resource group. Destroying the cluster using installer
+                      will delete this resource group. This resource group must be
+                      empty with no other resources when trying to use it for creating
+                      a cluster. If empty, a new resource group will created for the
+                      cluster.
+                    type: string
                   virtualNetwork:
                     description: VirtualNetwork specifies the name of an existing
                       VNet for the installer to use

--- a/pkg/asset/cluster/azure/azure.go
+++ b/pkg/asset/cluster/azure/azure.go
@@ -9,7 +9,8 @@ import (
 // Metadata converts an install configuration to Azure metadata.
 func Metadata(config *types.InstallConfig) *azure.Metadata {
 	return &azure.Metadata{
-		CloudName: config.Platform.Azure.CloudName,
-		Region:    config.Platform.Azure.Region,
+		CloudName:         config.Platform.Azure.CloudName,
+		Region:            config.Platform.Azure.Region,
+		ResourceGroupName: config.Azure.ResourceGroupName,
 	}
 }

--- a/pkg/asset/cluster/azure/azure.go
+++ b/pkg/asset/cluster/azure/azure.go
@@ -37,7 +37,7 @@ func PreTerraform(ctx context.Context, clusterID string, installConfig *installc
 		return errors.Wrap(err, "failed to get session")
 	}
 
-	client := resources.NewGroupsClient(session.Credentials.SubscriptionID)
+	client := resources.NewGroupsClientWithBaseURI(session.Environment.ResourceManagerEndpoint, session.Credentials.SubscriptionID)
 	client.Authorizer = session.Authorizer
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/pkg/asset/cluster/azure/azure.go
+++ b/pkg/asset/cluster/azure/azure.go
@@ -2,6 +2,16 @@
 package azure
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 )
@@ -13,4 +23,40 @@ func Metadata(config *types.InstallConfig) *azure.Metadata {
 		Region:            config.Platform.Azure.Region,
 		ResourceGroupName: config.Azure.ResourceGroupName,
 	}
+}
+
+// PreTerraform performs any infrastructure initialization which must
+// happen before Terraform creates the remaining infrastructure.
+func PreTerraform(ctx context.Context, clusterID string, installConfig *installconfig.InstallConfig) error {
+	if len(installConfig.Config.Azure.ResourceGroupName) == 0 {
+		return nil
+	}
+
+	session, err := installConfig.Azure.Session()
+	if err != nil {
+		return errors.Wrap(err, "failed to get session")
+	}
+
+	client := resources.NewGroupsClient(session.Credentials.SubscriptionID)
+	client.Authorizer = session.Authorizer
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	group, err := client.Get(ctx, installConfig.Config.Azure.ResourceGroupName)
+	if err != nil {
+		return errors.Wrap(err, "failed to get the resource group")
+	}
+
+	if group.Tags == nil {
+		group.Tags = map[string]*string{}
+	}
+	group.Tags[fmt.Sprintf("kubernetes.io_cluster.%s", clusterID)] = to.StringPtr("owned")
+	logrus.Debugf("Tagging %s with kubernetes.io/cluster/%s: shared", installConfig.Config.Azure.ResourceGroupName, clusterID)
+	_, err = client.Update(ctx, installConfig.Config.Azure.ResourceGroupName, resources.GroupPatchable{
+		Tags: group.Tags,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to tag the resource group %s", installConfig.Config.Azure.ResourceGroupName)
+	}
+	return nil
 }

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -12,11 +12,14 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/cluster/aws"
+	"github.com/openshift/installer/pkg/asset/cluster/azure"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/quota"
 	"github.com/openshift/installer/pkg/metrics/timer"
 	"github.com/openshift/installer/pkg/terraform"
+	typesaws "github.com/openshift/installer/pkg/types/aws"
+	typesazure "github.com/openshift/installer/pkg/types/azure"
 )
 
 // Cluster uses the terraform executable to launch a cluster
@@ -78,8 +81,13 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	}
 
 	logrus.Infof("Creating infrastructure resources...")
-	if installConfig.Config.Platform.AWS != nil {
+	switch installConfig.Config.Platform.Name() {
+	case typesaws.Name:
 		if err := aws.PreTerraform(context.TODO(), clusterID.InfraID, installConfig); err != nil {
+			return err
+		}
+	case typesazure.Name:
+		if err := azure.PreTerraform(context.TODO(), clusterID.InfraID, installConfig); err != nil {
 			return err
 		}
 	}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -279,6 +279,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			azuretfvars.TFVarsSources{
 				Auth:                        auth,
 				CloudName:                   installConfig.Config.Azure.CloudName,
+				ResourceGroupName:           installConfig.Config.Azure.ResourceGroupName,
 				BaseDomainResourceGroupName: installConfig.Config.Azure.BaseDomainResourceGroupName,
 				MasterConfigs:               masterConfigs,
 				WorkerConfigs:               workerConfigs,

--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -23,6 +23,8 @@ type API interface {
 	ListLocations(ctx context.Context) (*[]azsubs.Location, error)
 	GetResourcesProvider(ctx context.Context, resourceProviderNamespace string) (*azres.Provider, error)
 	GetDiskSkus(ctx context.Context, region string) ([]azsku.ResourceSku, error)
+	GetGroup(ctx context.Context, groupName string) (*azres.Group, error)
+	ListResourceIDsByGroup(ctx context.Context, groupName string) ([]string, error)
 }
 
 // Client makes calls to the Azure API.
@@ -175,4 +177,37 @@ func (c *Client) GetDiskSkus(ctx context.Context, region string) ([]azsku.Resour
 	}
 
 	return nil, errors.Errorf("no disks for specified subscription in region %s", region)
+}
+
+// GetGroup returns resource group for the groupName.
+func (c *Client) GetGroup(ctx context.Context, groupName string) (*azres.Group, error) {
+	client := azres.NewGroupsClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
+	client.Authorizer = c.ssn.Authorizer
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	res, err := client.Get(ctx, groupName)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get resource group")
+	}
+	return &res, nil
+}
+
+// ListResourceIDsByGroup returns a list of resource IDs for resource group groupName.
+func (c *Client) ListResourceIDsByGroup(ctx context.Context, groupName string) ([]string, error) {
+	client := azres.NewClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
+	client.Authorizer = c.ssn.Authorizer
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	var res []string
+	for resPage, err := client.ListByResourceGroup(ctx, groupName, "", "", nil); resPage.NotDone(); err = resPage.NextWithContext(ctx) {
+		if err != nil {
+			return nil, errors.Wrap(err, "error fetching resource pages")
+		}
+		for _, page := range resPage.Values() {
+			res = append(res, to.String(page.ID))
+		}
+	}
+	return res, nil
 }

--- a/pkg/asset/installconfig/azure/mock/azureclient_generated.go
+++ b/pkg/asset/installconfig/azure/mock/azureclient_generated.go
@@ -126,3 +126,33 @@ func (mr *MockAPIMockRecorder) GetDiskSkus(ctx, region interface{}) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskSkus", reflect.TypeOf((*MockAPI)(nil).GetDiskSkus), ctx, region)
 }
+
+// GetGroup mocks base method.
+func (m *MockAPI) GetGroup(ctx context.Context, groupName string) (*resources.Group, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGroup", ctx, groupName)
+	ret0, _ := ret[0].(*resources.Group)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGroup indicates an expected call of GetGroup.
+func (mr *MockAPIMockRecorder) GetGroup(ctx, groupName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroup", reflect.TypeOf((*MockAPI)(nil).GetGroup), ctx, groupName)
+}
+
+// ListResourceIDsByGroup mocks base method.
+func (m *MockAPI) ListResourceIDsByGroup(ctx context.Context, groupName string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListResourceIDsByGroup", ctx, groupName)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListResourceIDsByGroup indicates an expected call of ListResourceIDsByGroup.
+func (mr *MockAPIMockRecorder) ListResourceIDsByGroup(ctx, groupName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceIDsByGroup", reflect.TypeOf((*MockAPI)(nil).ListResourceIDsByGroup), ctx, groupName)
+}

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -51,6 +51,11 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+		client, err := ic.Azure.Client()
+		if err != nil {
+			return err
+		}
+		return azconfig.ValidateForProvisioning(client, ic.Config)
 	case baremetal.Name:
 		err = bmconfig.ValidateProvisioning(ic.Config)
 		if err != nil {

--- a/pkg/asset/manifests/azure/cloudproviderconfig.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig.go
@@ -12,6 +12,7 @@ type CloudProviderConfig struct {
 	CloudName                azure.CloudEnvironment
 	TenantID                 string
 	SubscriptionID           string
+	ResourceGroupName        string
 	GroupLocation            string
 	ResourcePrefix           string
 	NetworkResourceGroupName string
@@ -23,7 +24,6 @@ type CloudProviderConfig struct {
 // JSON generates the cloud provider json config for the azure platform.
 // managed resource names are matching the convention defined by capz
 func (params CloudProviderConfig) JSON() (string, error) {
-	resourceGroupName := params.ResourcePrefix + "-rg"
 	config := config{
 		authConfig: authConfig{
 			Cloud:                       params.CloudName.Name(),
@@ -37,7 +37,7 @@ func (params CloudProviderConfig) JSON() (string, error) {
 			// ref: https://github.com/kubernetes/kubernetes/blob/4b7c607ba47928a7be77fadef1550d6498397a4c/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go#L69
 			UserAssignedIdentityID: "",
 		},
-		ResourceGroup:     resourceGroupName,
+		ResourceGroup:     params.ResourceGroupName,
 		Location:          params.GroupLocation,
 		SubnetName:        params.SubnetName,
 		SecurityGroupName: params.NetworkSecurityGroupName,

--- a/pkg/asset/manifests/azure/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig_test.go
@@ -12,6 +12,7 @@ func TestCloudProviderConfig(t *testing.T) {
 
 	config := CloudProviderConfig{
 		CloudName:                azure.PublicCloud,
+		ResourceGroupName:        "clusterid-rg",
 		GroupLocation:            "westeurope",
 		ResourcePrefix:           "clusterid",
 		SubscriptionID:           "subID",

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -108,7 +108,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 		}
 
 		nsg := fmt.Sprintf("%s-nsg", clusterID.InfraID)
-		nrg := fmt.Sprintf("%s-rg", clusterID.InfraID)
+		nrg := installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID)
 		if installConfig.Config.Azure.NetworkResourceGroupName != "" {
 			nrg = installConfig.Config.Azure.NetworkResourceGroupName
 		}
@@ -122,6 +122,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 		}
 		azureConfig, err := azure.CloudProviderConfig{
 			CloudName:                installConfig.Config.Azure.CloudName,
+			ResourceGroupName:        installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID),
 			GroupLocation:            installConfig.Config.Azure.Region,
 			ResourcePrefix:           clusterID.InfraID,
 			SubscriptionID:           session.Credentials.SubscriptionID,

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -107,7 +107,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 			}
 		}
 		config.Spec.PrivateZone = &configv1.DNSZone{
-			ID: dnsConfig.GetPrivateDNSZoneID(clusterID.InfraID+"-rg", installConfig.Config.ClusterDomain()),
+			ID: dnsConfig.GetPrivateDNSZoneID(installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID), installConfig.Config.ClusterDomain()),
 		}
 	case gcptypes.Name:
 		if installConfig.Config.Publish == types.ExternalPublishingStrategy {

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -1,7 +1,6 @@
 package manifests
 
 import (
-	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -107,7 +106,7 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 	case azure.Name:
 		config.Spec.PlatformSpec.Type = configv1.AzurePlatformType
 
-		rg := fmt.Sprintf("%s-rg", clusterID.InfraID)
+		rg := installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID)
 		config.Status.PlatformStatus.Azure = &configv1.AzurePlatformStatus{
 			ResourceGroupName:        rg,
 			NetworkResourceGroupName: rg,

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -95,7 +95,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		}
 
 	case azuretypes.Name:
-		resourceGroupName := clusterID.InfraID + "-rg"
+		resourceGroupName := installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID)
 		session, err := installConfig.Azure.Session()
 		if err != nil {
 			return err

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -158,6 +158,9 @@ func Test_PrintFields(t *testing.T) {
     region <string> -required-
       Region specifies the Azure region where the cluster will be created.
 
+    resourceGroupName <string>
+      ResourceGroupName is the name of an already existing resource group where the cluster should be installed. This resource group should only be used for this specific cluster and the cluster components will assume assume ownership of all resources in the resource group. Destroying the cluster using installer will delete this resource group. This resource group must be empty with no other resources when trying to use it for creating a cluster. If empty, a new resource group will created for the cluster.
+
     virtualNetwork <string>
       VirtualNetwork specifies the name of an existing VNet for the installer to use`,
 	}, {

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -34,6 +34,7 @@ type config struct {
 	ImageURL                    string            `json:"azure_image_url,omitempty"`
 	Region                      string            `json:"azure_region,omitempty"`
 	BaseDomainResourceGroupName string            `json:"azure_base_domain_resource_group_name,omitempty"`
+	ResourceGroupName           string            `json:"azure_resource_group_name"`
 	NetworkResourceGroupName    string            `json:"azure_network_resource_group_name"`
 	VirtualNetwork              string            `json:"azure_virtual_network"`
 	ControlPlaneSubnet          string            `json:"azure_control_plane_subnet"`
@@ -48,6 +49,7 @@ type config struct {
 type TFVarsSources struct {
 	Auth                        Auth
 	CloudName                   azure.CloudEnvironment
+	ResourceGroupName           string
 	BaseDomainResourceGroupName string
 	MasterConfigs               []*azureprovider.AzureMachineProviderSpec
 	WorkerConfigs               []*azureprovider.AzureMachineProviderSpec
@@ -91,6 +93,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ImageURL:                    sources.ImageURL,
 		Private:                     sources.Publish == types.InternalPublishingStrategy,
 		OutboundUDR:                 sources.OutboundType == azure.UserDefinedRoutingOutboundType,
+		ResourceGroupName:           sources.ResourceGroupName,
 		BaseDomainResourceGroupName: sources.BaseDomainResourceGroupName,
 		NetworkResourceGroupName:    masterConfig.NetworkResourceGroup,
 		VirtualNetwork:              masterConfig.Vnet,

--- a/pkg/types/azure/metadata.go
+++ b/pkg/types/azure/metadata.go
@@ -2,6 +2,7 @@ package azure
 
 // Metadata contains Azure metadata (e.g. for uninstalling the cluster).
 type Metadata struct {
-	CloudName CloudEnvironment `json:"cloudName"`
-	Region    string           `json:"region"`
+	CloudName         CloudEnvironment `json:"cloudName"`
+	Region            string           `json:"region"`
+	ResourceGroupName string           `json:"resourceGroupName"`
 }


### PR DESCRIPTION
### types/azure: add resourceGroupName

Add a field to azure platform to specific the name for an existing resource group
where the cluster should be installed.

- This resource group should only be used for this specific cluster and the cluster components will assume assume
ownership of all resources in the resource group.
- Destroying the cluster using installer will delete this resource group.
- This resource group must be empty with no other resources when trying to use it for creating a cluster.

If not set the installer will continue to create a new resource group using the Infra identifier.

### asset: update rg name to include user provided

Update the machines, cloudproviderconfig and infrastructure objects to use the
user provided resource group name when provided and fall back to generated name `<infraID>-rg` when
not set.

### terraform: update to use already existing group

Update the TF templates to accept a name for the cluster's resource group. When set the templates
use that existing resource group, otherwise a new resource group will be created.

### destroy: use user provided group name and fallback else to infraID

Store the user provided resource group in the metadata.json so that when destroying the cluster,
the destroy code path knows the resource group to be deleted.

If the resource group name is not set, we fallback to the generated resource group `<infraID>-rg`

### asset/cluster: tag the user provided rg with owned tag

The cluster resource group when created by the installer is tagged with `kubernetes.io_cluster_<infraID>=owned` tag.
This tag is used to clean up the service principles generated by cred-minter and also to mark that the resource group is owned by
this specific cluster.

Since user provided resource group still is owned by the cluster, we must tag this resource group similarly. Since terraform cannot
update the tags for an existing resource group, we have to fall back the pattern of `PreTerraform` previously used by AWS for pre-existing subnets.

We read existing tags from the resource group and add `kubernetes.io_cluster_<infraID>=owned` to it when sending an update for the resource group.

### asset/installconfig: add validations for user provided resource group

There are various validations that need to be added for a user provided resource group.

1. make sure that the resource group actually exists.
2. make sure that the location of the provided resource group matches the location of the cluster.
3. make sure the cluster is not in use by other OpenShift clusters by making sure there are no `kubernetes.io_cluster_<infraID>` style tags
4. make sure there are no resources that already exist in the resource group.
   user provided resource group is assumed to be completely owned by the cluster and to enforce that there is no sharing of the resource group
   we must enforce that there no resource already in that resource group. This forces the user to create a resource specific for the cluster preventing
   future ownership problems where the cluster tries to modify resource assuming it owns the resource group.
   Also since destroying the cluster using installer will destroy the resource group with all resources inside it, we need to make sure there were no
   pre existing resource that would be deleted in that case.