### PR TITLE
baremetal: make provisioning network optional

### DIFF
--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -37,12 +37,11 @@ resource "libvirt_domain" "bootstrap" {
     mode = "host-passthrough"
   }
 
-  network_interface {
-    bridge = var.external_bridge
-  }
-
-  network_interface {
-    bridge = var.provisioning_bridge
+  dynamic "network_interface" {
+    for_each = var.bridges
+    content {
+      bridge = network_interface.value
+    }
   }
 }
 

--- a/data/data/baremetal/bootstrap/variables.tf
+++ b/data/data/baremetal/bootstrap/variables.tf
@@ -13,12 +13,7 @@ variable "ignition" {
   description = "The content of the bootstrap ignition file."
 }
 
-variable "external_bridge" {
-  type        = string
-  description = "The name of the bridge providing external access"
-}
-
-variable "provisioning_bridge" {
-  type        = string
-  description = "The name of the bridge used for provisioning"
+variable "bridges" {
+  type        = list(string)
+  description = "A list of network interfaces to attach to the bootstrap virtual machine"
 }

--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -12,11 +12,10 @@ provider "ironic" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  cluster_id          = var.cluster_id
-  image               = var.bootstrap_os_image
-  ignition            = var.ignition_bootstrap
-  external_bridge     = var.external_bridge
-  provisioning_bridge = var.provisioning_bridge
+  cluster_id = var.cluster_id
+  image      = var.bootstrap_os_image
+  ignition   = var.ignition_bootstrap
+  bridges    = compact([var.external_bridge, var.provisioning_bridge])
 }
 
 module "masters" {

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -23,10 +23,16 @@ for name in ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb i
 done
 
 # Start the provisioning nic if not already started
-PROVISIONING_NIC=ens4
-if ! nmcli -t device | grep "$PROVISIONING_NIC:ethernet:connected:provisioning"; then
+PROVISIONING_NIC={{.PlatformData.BareMetal.ProvisioningInterface}}
+
+if ! nmcli -t device | grep "$PROVISIONING_NIC:ethernet:connected"; then
     nmcli c add type ethernet ifname $PROVISIONING_NIC con-name provisioning {{ if .PlatformData.BareMetal.ProvisioningIPv6 }} ip6 {{ else }} ip4 {{ end }} {{.PlatformData.BareMetal.ProvisioningIP}}/{{.PlatformData.BareMetal.ProvisioningCIDR}}
     nmcli c up provisioning
+else
+  connection=$(nmcli -t device show $PROVISIONING_NIC | grep GENERAL.CONNECTION | cut -d: -f2)
+  nmcli con modify "$connection" ifname $PROVISIONING_NIC {{ if .PlatformData.BareMetal.ProvisioningIPv6 }} ip6 {{ else }} ip4 {{ end }} {{.PlatformData.BareMetal.ProvisioningIP}}/{{.PlatformData.BareMetal.ProvisioningCIDR}}
+  nmcli con reload "$connection"
+  nmcli con up "$connection"
 fi
 
 # Wait for the interface to come up
@@ -53,14 +59,19 @@ done
 # Start dnsmasq, http, mariadb, and ironic containers using same image
 # Currently we do this outside of a pod because we need to ensure the images
 # are downloaded before starting the API pods
-podman run -d --net host --privileged --name mariadb \
-     -v $IRONIC_SHARED_VOLUME:/shared:z --entrypoint /bin/runmariadb \
-     --env MARIADB_PASSWORD=$mariadb_password ${IRONIC_IMAGE}
-
-podman run -d --net host --privileged --name dnsmasq \
+{{ if .PlatformData.BareMetal.ProvisioningDNSMasq }}
+dnsmasq_container_name="dnsmasq"
+podman run -d --net host --privileged --name $dnsmasq_container_name \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env DHCP_RANGE=$DHCP_RANGE \
      -v $IRONIC_SHARED_VOLUME:/shared:z --entrypoint /bin/rundnsmasq ${IRONIC_IMAGE}
+{{ else }}
+dnsmasq_container_name=""
+{{ end }}
+
+podman run -d --net host --privileged --name mariadb \
+     -v $IRONIC_SHARED_VOLUME:/shared:z --entrypoint /bin/runmariadb \
+     --env MARIADB_PASSWORD=$mariadb_password ${IRONIC_IMAGE}
 
 podman run -d --net host --privileged --name httpd \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
@@ -146,7 +157,7 @@ sudo podman run -d --net host --privileged --name ironic-api \
 # Now loop so the service remains active and restart everything should one of the containers exit unexpectedly.
 # The alternative would be RemainAfterExit=yes but then we lose the ability to restart if something crashes.
 while true; do
-    for name in ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb; do
+    for name in ironic-api ironic-conductor ironic-inspector $dnsmasq_container_name httpd mariadb; do
         # Note there are two levels of go templating here, the outer braces
         # are for the templating done in openshift-install, to escape the
         # templating input to the --format option of podman inspect

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1119,11 +1119,9 @@ spec:
                       on the host that will run the bootstrap VM.
                     type: string
                   provisioningDHCPExternal:
-                    description: ProvisioningDHCPExternal indicates that DHCP is provided
-                      by an external service, appropriately configured with next-server
-                      set to BootstrapProvisioningIP for the control plane, and ClusterProvisioningIP
-                      for workers. The default for this field is false, which means
-                      we will start and manage a DHCP server on the provisioning network.
+                    description: DeprecatedProvisioningDHCPExternal indicates that
+                      DHCP is provided by an external service. This parameter is replaced
+                      by ProvisioningNetwork being set to "Unmanaged".
                     type: boolean
                   provisioningDHCPRange:
                     description: ProvisioningDHCPRange is used to provide DHCP services
@@ -1134,6 +1132,16 @@ spec:
                       provisioning network where the baremetal-operator pod runs provisioning
                       services, and an http server to cache some downloaded content
                       e.g RHCOS/IPA images
+                    type: string
+                  provisioningNetwork:
+                    default: Managed
+                    description: ProvisioningNetwork is used to indicate if we will
+                      have a provisioning network, and how it will be managed.
+                    enum:
+                    - ""
+                    - Managed
+                    - Unmanaged
+                    - Disabled
                     type: string
                   provisioningNetworkCIDR:
                     description: ProvisioningNetworkCIDR defines the network to use

--- a/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
+++ b/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
@@ -6,6 +6,6 @@ spec:
   provisioningInterface: "{{.Baremetal.ProvisioningNetworkInterface}}"
   provisioningIP: "{{.Baremetal.ClusterProvisioningIP}}"
   provisioningNetworkCIDR: "{{.Baremetal.ProvisioningNetworkCIDR}}"
-  provisioningDHCPExternal: {{.Baremetal.ProvisioningDHCPExternal}}
+  provisioningNetwork: "{{.Baremetal.ProvisioningNetwork}}"
   provisioningDHCPRange: "{{.Baremetal.ProvisioningDHCPRange}}"
   provisioningOSDownloadURL: "{{.ProvisioningOSDownloadURL}}"

--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -17,8 +17,10 @@ deployments, see [install_upi.md](install_upi.md).
 
 ### Network Requirements
 
-It is assumed that all hosts have at least 2 NICs, used for the following
-purposes:
+You have the choice of a single or dual NIC setup, depending on whether
+you would like to use PXE/DHCP-based provisioning or not. Please note
+that disabling the provisioning network means that host BMC's must be
+accessible over the external network which may not be desirable.
 
 * **NIC #1 - External Network**
   * This network is the main network used by the cluster, including API traffic
@@ -46,12 +48,15 @@ purposes:
     * `api.<cluster-name>.<base-domain>` - pointing to the API VIP
     * `*.apps.<cluster-name>.<base-domain>` - pointing to the Ingress VIP
 
-* **NIC #2 - Provisioning Network**
+* **NIC #2 - Provisioning Network (optional) **
   * A private network used for PXE based provisioning.
   * You must specify `provisioningNetworkInterface` to indicate which
-    interface is connected to this network.
-  * DHCP is automated for this network by default, to rely on external
-    DHCP, set the platform's `provisioningDHCPExternal` option to `true`
+    interface is connected to this network on the control plane nodes.
+  * The provisioning network may be "Managed" (default), "Unmanaged," or
+    "Disabled."
+  * In managed mode, DHCP and TFTP are configured to run in the cluster. In
+    unmanaged mode, TFTP is still available but you must configure DHCP
+    externally.
   * Addressing for this network defaults to `172.22.0.0/24`, but is
     configurable by setting the `provisioningNetworkCIDR` option.
   * Two IP's are required to be available for use, one for the bootstrap
@@ -277,6 +282,9 @@ both required.  For example
 
 To use virtual media instead of PXE for attaching the provisioning
 image to the host, use `redfish-virtualmedia://` or `idrac-virtualmedia://`
+
+Please note that when the provisioning network is disabled, the only
+supported BMC's are virtual media.
 
 ## Work in Progress
 

--- a/pkg/asset/ignition/bootstrap/baremetal/template_test.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestTemplatingIPv4(t *testing.T) {
 	bareMetalConfig := baremetal.Platform{
-		ProvisioningNetworkCIDR:  ipnet.MustParseCIDR("172.22.0.0/24"),
-		BootstrapProvisioningIP:  "172.22.0.2",
-		ProvisioningDHCPExternal: false,
-		ProvisioningDHCPRange:    "172.22.0.10,172.22.0.100",
+		ProvisioningNetworkCIDR: ipnet.MustParseCIDR("172.22.0.0/24"),
+		BootstrapProvisioningIP: "172.22.0.2",
+		ProvisioningNetwork:     baremetal.ManagedProvisioningNetwork,
+		ProvisioningDHCPRange:   "172.22.0.10,172.22.0.100",
 		Hosts: []*baremetal.Host{
 			{
 				Role:           "master",
@@ -33,7 +33,7 @@ func TestTemplatingIPv4(t *testing.T) {
 		},
 	}
 
-	result := GetTemplateData(&bareMetalConfig)
+	result := GetTemplateData(&bareMetalConfig, nil)
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "172.22.0.10,172.22.0.100")
 	assert.Equal(t, result.ProvisioningCIDR, 24)
@@ -44,12 +44,12 @@ func TestTemplatingIPv4(t *testing.T) {
 
 func TestTemplatingIPv6(t *testing.T) {
 	bareMetalConfig := baremetal.Platform{
-		ProvisioningNetworkCIDR:  ipnet.MustParseCIDR("fd2e:6f44:5dd8:b856::0/64"),
-		BootstrapProvisioningIP:  "fd2e:6f44:5dd8:b856::2",
-		ProvisioningDHCPExternal: true,
+		ProvisioningNetworkCIDR: ipnet.MustParseCIDR("fd2e:6f44:5dd8:b856::0/64"),
+		BootstrapProvisioningIP: "fd2e:6f44:5dd8:b856::2",
+		ProvisioningNetwork:     baremetal.UnmanagedProvisioningNetwork,
 	}
 
-	result := GetTemplateData(&bareMetalConfig)
+	result := GetTemplateData(&bareMetalConfig, nil)
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "")
 	assert.Equal(t, result.ProvisioningCIDR, 64)

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -245,7 +245,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 
 	switch installConfig.Platform.Name() {
 	case baremetaltypes.Name:
-		platformData.BareMetal = baremetal.GetTemplateData(installConfig.Platform.BareMetal)
+		platformData.BareMetal = baremetal.GetTemplateData(installConfig.Platform.BareMetal, installConfig.MachineNetwork)
 	case vspheretypes.Name:
 		platformData.VSphere = vsphere.GetTemplateData(installConfig.Platform.VSphere)
 	}

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -18,11 +18,11 @@ import (
 )
 
 type config struct {
-	LibvirtURI              string `json:"libvirt_uri,omitempty"`
-	BootstrapProvisioningIP string `json:"bootstrap_provisioning_ip,omitempty"`
-	BootstrapOSImage        string `json:"bootstrap_os_image,omitempty"`
-	ExternalBridge          string `json:"external_bridge,omitempty"`
-	ProvisioningBridge      string `json:"provisioning_bridge,omitempty"`
+	LibvirtURI              string `json:"libvirt_uri"`
+	BootstrapProvisioningIP string `json:"bootstrap_provisioning_ip"`
+	BootstrapOSImage        string `json:"bootstrap_os_image"`
+	ExternalBridge          string `json:"external_bridge"`
+	ProvisioningBridge      string `json:"provisioning_bridge"`
 
 	// Data required for control plane deployment - several maps per host, because of terraform's limitations
 	Hosts         []map[string]interface{} `json:"hosts"`

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -35,6 +35,27 @@ type Host struct {
 	BootMode        BootMode                  `json:"bootMode,omitempty"`
 }
 
+// ProvisioningNetwork determines how we will use the provisioning network.
+// +kubebuilder:validation:Enum="";Managed;Unmanaged;Disabled
+type ProvisioningNetwork string
+
+const (
+	// ManagedProvisioningNetwork indicates we should fully manage the provisioning network, including DHCP
+	// services required for PXE-based provisioning.
+	ManagedProvisioningNetwork ProvisioningNetwork = "Managed"
+
+	// UnmanagedProvisioningNetwork indicates responsibility for managing the provisioning network is left to the
+	// user. No DHCP server will be configured, however TFTP remains enabled if a user wants to use PXE-based provisioning.
+	// However, they will need to configure external DHCP correctly with next-server definitions set to the relevant
+	// provisioning IP's.
+	UnmanagedProvisioningNetwork ProvisioningNetwork = "Unmanaged"
+
+	// DisabledProvisioningNetwork indicates that no provisioning network will be used. Provisioning capabilities
+	// will be limited to virtual media-based deployments only, and neither DHCP nor TFTP will be operated by the
+	// cluster.
+	DisabledProvisioningNetwork ProvisioningNetwork = "Disabled"
+)
+
 // Platform stores all the global configuration that all machinesets use.
 type Platform struct {
 	// LibvirtURI is the identifier for the libvirtd connection.  It must be
@@ -63,6 +84,11 @@ type Platform struct {
 	// +optional
 	ExternalBridge string `json:"externalBridge,omitempty"`
 
+	// ProvisioningNetwork is used to indicate if we will have a provisioning network, and how it will be managed.
+	// +kubebuilder:default=Managed
+	// +optional
+	ProvisioningNetwork ProvisioningNetwork `json:"provisioningNetwork,omitempty"`
+
 	// Provisioning bridge is used for provisioning nodes, on the host that
 	// will run the bootstrap VM.
 	// +optional
@@ -76,12 +102,10 @@ type Platform struct {
 	// +optional
 	ProvisioningNetworkCIDR *ipnet.IPNet `json:"provisioningNetworkCIDR,omitempty"`
 
-	// ProvisioningDHCPExternal indicates that DHCP is provided by an external service, appropriately
-	// configured with next-server set to BootstrapProvisioningIP for the control plane, and
-	// ClusterProvisioningIP for workers. The default for this field is false, which means we will
-	// start and manage a DHCP server on the provisioning network.
+	// DeprecatedProvisioningDHCPExternal indicates that DHCP is provided by an external service. This parameter is
+	// replaced by ProvisioningNetwork being set to "Unmanaged".
 	// +optional
-	ProvisioningDHCPExternal bool `json:"provisioningDHCPExternal,omitempty"`
+	DeprecatedProvisioningDHCPExternal bool `json:"provisioningDHCPExternal,omitempty"`
 
 	// ProvisioningDHCPRange is used to provide DHCP services to hosts
 	// for provisioning.

--- a/pkg/types/baremetal/validation/libvirt.go
+++ b/pkg/types/baremetal/validation/libvirt.go
@@ -29,7 +29,7 @@ func validateInterfaces(p *baremetal.Platform, fldPath *field.Path) field.ErrorL
 		errorList = append(errorList, field.Invalid(fldPath.Child("externalBridge"), p.ExternalBridge, err.Error()))
 	}
 
-	if err := findInterface(p.ProvisioningBridge); err != nil {
+	if err := findInterface(p.ProvisioningBridge); p.ProvisioningNetwork != baremetal.DisabledProvisioningNetwork && err != nil {
 		errorList = append(errorList, field.Invalid(fldPath.Child("provisioningBridge"), p.ProvisioningBridge, err.Error()))
 	}
 

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/baremetal"
 )
 
 // ConvertInstallConfig is modeled after the k8s conversion schemes, which is
@@ -24,6 +25,11 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 		return field.Invalid(field.NewPath("apiVersion"), config.APIVersion, fmt.Sprintf("cannot upconvert from version %s", config.APIVersion))
 	}
 	ConvertNetworking(config)
+
+	switch config.Platform.Name() {
+	case baremetal.Name:
+		ConvertBaremetal(config)
+	}
 
 	config.APIVersion = types.InstallConfigVersion
 	return nil
@@ -62,5 +68,14 @@ func ConvertNetworking(config *types.InstallConfig) {
 			_, size := entry.CIDR.Mask.Size()
 			netconf.ClusterNetwork[i].HostPrefix = int32(size) - entry.DeprecatedHostSubnetLength
 		}
+	}
+}
+
+// ConvertBaremetal upconverts deprecated fields in the baremetal
+// platform. ProvisioningDHCPExternal has been replaced by setting
+// the ProvisioningNetwork field to "Unmanaged"
+func ConvertBaremetal(config *types.InstallConfig) {
+	if config.Platform.BareMetal.DeprecatedProvisioningDHCPExternal == true && config.Platform.BareMetal.ProvisioningNetwork == "" {
+		config.Platform.BareMetal.ProvisioningNetwork = baremetal.UnmanagedProvisioningNetwork
 	}
 }

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -95,6 +95,7 @@ func validBareMetalPlatform() *baremetal.Platform {
 		ProvisioningNetworkCIDR:      ipnet.MustParseCIDR("192.168.111.0/24"),
 		BootstrapProvisioningIP:      "192.168.111.1",
 		ClusterProvisioningIP:        "192.168.111.2",
+		ProvisioningNetwork:          baremetal.ManagedProvisioningNetwork,
 		Hosts: []*baremetal.Host{
 			{
 				Name:           "host1",
@@ -598,7 +599,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.BareMetal.APIVIP = ""
 				return c
 			}(),
-			expectedError: `^\[platform\.baremetal\.apiVIP: Invalid value: "": "" is not a valid IP, platform\.baremetal\.apiVIP: Invalid value: "": the virtual IP is expected to be in one of the machine networks]$`,
+			expectedError: `^\[platform\.baremetal\.apiVIP: Invalid value: "": "" is not a valid IP, platform\.baremetal\.apiVIP: Invalid value: "": IP expected to be in one of the machine networks: 10.0.0.0/16]$`,
 		},
 		{
 			name: "baremetal API VIP not an IP",
@@ -610,7 +611,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.BareMetal.APIVIP = "test"
 				return c
 			}(),
-			expectedError: `^\[platform\.baremetal\.apiVIP: Invalid value: "test": "test" is not a valid IP, platform\.baremetal\.apiVIP: Invalid value: "test": the virtual IP is expected to be in one of the machine networks]$`,
+			expectedError: `^\[platform\.baremetal\.apiVIP: Invalid value: "test": "test" is not a valid IP, platform\.baremetal\.apiVIP: Invalid value: "test": IP expected to be in one of the machine networks: 10.0.0.0/16]$`,
 		},
 		{
 			name: "baremetal API VIP set to an incorrect value",
@@ -622,7 +623,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.BareMetal.APIVIP = "10.1.0.5"
 				return c
 			}(),
-			expectedError: `^platform\.baremetal\.apiVIP: Invalid value: "10\.1\.0\.5": the virtual IP is expected to be in one of the machine networks$`,
+			expectedError: `^platform\.baremetal\.apiVIP: Invalid value: "10\.1\.0\.5": IP expected to be in one of the machine networks: 10.0.0.0/16$`,
 		},
 		{
 			name: "baremetal Ingress VIP not an IP",
@@ -634,7 +635,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.BareMetal.IngressVIP = "test"
 				return c
 			}(),
-			expectedError: `^\[platform\.baremetal\.ingressVIP: Invalid value: "test": "test" is not a valid IP, platform\.baremetal\.ingressVIP: Invalid value: "test": the virtual IP is expected to be in one of the machine networks]$`,
+			expectedError: `^\[platform\.baremetal\.ingressVIP: Invalid value: "test": "test" is not a valid IP, platform\.baremetal\.ingressVIP: Invalid value: "test": IP expected to be in one of the machine networks: 10.0.0.0/16]$`,
 		},
 		{
 			name: "baremetal Ingress VIP set to an incorrect value",
@@ -646,7 +647,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform.BareMetal.IngressVIP = "10.1.0.7"
 				return c
 			}(),
-			expectedError: `^platform\.baremetal\.ingressVIP: Invalid value: "10\.1\.0\.7": the virtual IP is expected to be in one of the machine networks$`,
+			expectedError: `^platform\.baremetal\.ingressVIP: Invalid value: "10\.1\.0\.7": IP expected to be in one of the machine networks: 10.0.0.0/16$`,
 		}, {
 			name: "valid vsphere platform",
 			installConfig: func() *types.InstallConfig {


### PR DESCRIPTION
This implements [the enhancement request that makes the provisioning
network optional](https://github.com/openshift/enhancements/pull/386). It introduces a new platform configuration called
"provisioningNetwork" that takes 3 possible values: managed, unmanaged,
and disabled. The "unmanaged" option replaces the external DHCP flag
that was previously used.

When the network is set to "disabled," it is expected that users use
virtualmedia configuration. We will deploy no DHCP/TFTP provisioning
services for a user to use.