### PR TITLE
[FCOS] bootstrap: reboot manually after pivot

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
@@ -42,5 +42,7 @@ if [ ! -f .pivot-done ]; then
 
   touch .pivot-done
   /usr/local/bin/machine-config-daemon pivot
+
+  systemctl reboot
 fi
 {{end -}}


### PR DESCRIPTION
MCD since release-4.6 doesn't reboot automatically, so during bootstrap
pivot it needs to happen manually.

See https://github.com/openshift/machine-config-operator/pull/1809