### PR TITLE
destroy: means to obtain gcp blocked resources

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -272,6 +272,17 @@ func newPendingItemTracker() pendingItemTracker {
 	}
 }
 
+// GetAllPendintItems returns a slice of all of the pending items across all types.
+func (t pendingItemTracker) GetAllPendingItems() []cloudResource {
+	var items []cloudResource
+	for _, is := range t.pendingItems {
+		for _, i := range is {
+			items = append(items, i)
+		}
+	}
+	return items
+}
+
 // getPendingItems returns the list of resources to be deleted.
 func (t pendingItemTracker) getPendingItems(itemType string) []cloudResource {
 	lastFound, exists := t.pendingItems[itemType]


### PR DESCRIPTION
Add a `GetAllPendingItems` function to the GCP destroyer that the user can use to get all of the resources that were not able to be destroyed.

This will be used by Hive to expose to the user the resources that cannot be deleted so that the user can take action on those resources.

https://issues.redhat.com/browse/CO-974