### PR TITLE
baremetal: Only set BMC secret reference in Hosts when BMC details are specified

### DIFF
--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -34,24 +34,30 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 	}
 
 	for i, host := range config.Platform.BareMetal.Hosts {
-		// Each host needs a secret to hold the credentials for
-		// communicating with the management controller that drives
-		// that host.
-		secret := corev1.Secret{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Secret",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-bmc-secret", host.Name),
-				Namespace: "openshift-machine-api",
-			},
-			Data: map[string][]byte{
-				"username": []byte(host.BMC.Username),
-				"password": []byte(host.BMC.Password),
-			},
+		bmc := baremetalhost.BMCDetails{}
+		if host.BMC.Username != "" && host.BMC.Password != "" {
+			// Each host needs a secret to hold the credentials for
+			// communicating with the management controller that drives
+			// that host.
+			secret := corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-bmc-secret", host.Name),
+					Namespace: "openshift-machine-api",
+				},
+				Data: map[string][]byte{
+					"username": []byte(host.BMC.Username),
+					"password": []byte(host.BMC.Password),
+				},
+			}
+			bmc.Address = host.BMC.Address
+			bmc.CredentialsName = secret.Name
+			bmc.DisableCertificateVerification = host.BMC.DisableCertificateVerification
+			settings.Secrets = append(settings.Secrets, secret)
 		}
-		settings.Secrets = append(settings.Secrets, secret)
 
 		// Map string 'default' to hardware.DefaultProfileName
 		if host.HardwareProfile == "default" {
@@ -68,12 +74,8 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 				Namespace: "openshift-machine-api",
 			},
 			Spec: baremetalhost.BareMetalHostSpec{
-				Online: true,
-				BMC: baremetalhost.BMCDetails{
-					Address:                        host.BMC.Address,
-					CredentialsName:                secret.Name,
-					DisableCertificateVerification: host.BMC.DisableCertificateVerification,
-				},
+				Online:          true,
+				BMC:             bmc,
 				BootMACAddress:  host.BootMACAddress,
 				HardwareProfile: host.HardwareProfile,
 			},


### PR DESCRIPTION
This PR ensures that BMC secret is referenced in the hosts asset only when BMC credentials are specified. If not, the secret is not referenced.