### PR TITLE
data/bootstrap/files/usr/local/bin/approve-csr: Also approve v1beta1 CSRs

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
+++ b/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
@@ -5,7 +5,10 @@ KUBECONFIG="${1}"
 echo "Approving all CSR requests until bootstrapping is complete..."
 while [ ! -f /opt/openshift/.bootkube.done ]
 do
-    oc --kubeconfig="$KUBECONFIG" get csr --no-headers | grep Pending | \
+    oc --kubeconfig="$KUBECONFIG" get csrs --no-headers | grep Pending | \
+        awk '{print $1}' | \
+        xargs --no-run-if-empty oc --kubeconfig="$KUBECONFIG" adm certificate approve
+    oc --kubeconfig="$KUBECONFIG" get csrs.v1beta1.certificates.k8s.io --no-headers | grep Pending | \
         awk '{print $1}' | \
         xargs --no-run-if-empty oc --kubeconfig="$KUBECONFIG" adm certificate approve
 	sleep 20


### PR DESCRIPTION
The previous command assumes "latest version" CSRs, which is fine when that latest version is the only possible version (e.g. v0.18 [only defines `v1beta1`][1]).  But v0.19 will define [both `v1beta1` and `v1`][2], and for reasons I don't understand they aren't translated dynamically and we need to reach back and ask for the v1beta1 forms specifically.

[1]: https://github.com/kubernetes/api/tree/v0.18.0/certificates
[2]: https://github.com/kubernetes/api/tree/v0.19.0-rc.1/certificates