### PR TITLE
approve-csr.sh: work around broken oc adm cert approve v1 support

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
+++ b/data/data/bootstrap/files/usr/local/bin/approve-csr.sh
@@ -6,7 +6,7 @@ echo "Approving all CSR requests until bootstrapping is complete..."
 while [ ! -f /opt/openshift/.bootkube.done ]
 do
     oc --kubeconfig="$KUBECONFIG" get csr --no-headers | grep Pending | \
-        awk '{print $1}' | \
+        awk '{print "certificatesigningrequests.v1beta1.certificates.k8s.io/"$1}' | \
         xargs --no-run-if-empty oc --kubeconfig="$KUBECONFIG" adm certificate approve
 	sleep 20
 done


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/91692 makes 1.18 oc support v1 CSRs. But for openshift/kubernetes#166 rebase we don't have that patch. This change here is a workaround replicating what https://github.com/kubernetes/kubernetes/pull/91692 does in code. It gets us over the hump.