### PR TITLE
ovirt: Create cloud provider config

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/manifests/azure"
 	gcpmanifests "github.com/openshift/installer/pkg/asset/manifests/gcp"
 	openstackmanifests "github.com/openshift/installer/pkg/asset/manifests/openstack"
+	ovirtmanifests "github.com/openshift/installer/pkg/asset/manifests/ovirt"
 	vspheremanifests "github.com/openshift/installer/pkg/asset/manifests/vsphere"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
@@ -83,7 +84,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 	}
 
 	switch installConfig.Config.Platform.Name() {
-	case awstypes.Name, libvirttypes.Name, nonetypes.Name, baremetaltypes.Name, ovirttypes.Name:
+	case awstypes.Name, libvirttypes.Name, nonetypes.Name, baremetaltypes.Name:
 		return nil
 	case openstacktypes.Name:
 		cloud, err := icopenstack.GetSession(installConfig.Config.Platform.OpenStack.Cloud)
@@ -159,6 +160,15 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			return errors.Wrap(err, "could not create cloud provider config")
 		}
 		cm.Data[cloudProviderConfigDataKey] = vsphereConfig
+	case ovirttypes.Name:
+		ovirtConfig, err := ovirtmanifests.CloudProviderConfig(
+			installConfig.Config.Platform.Ovirt.StorageDomainID,
+			installConfig.Config.Platform.Ovirt.ClusterID,
+			installConfig.Config.Platform.Ovirt.NetworkName)
+		if err != nil {
+			return err
+		}
+		cm.Data[cloudProviderConfigDataKey] = ovirtConfig
 	default:
 		return errors.New("invalid Platform")
 	}

--- a/pkg/asset/manifests/ovirt/OWNERS
+++ b/pkg/asset/manifests/ovirt/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - ovirt-approvers
+reviewers:
+  - ovirt-reviewers

--- a/pkg/asset/manifests/ovirt/cloudproviderconfig.go
+++ b/pkg/asset/manifests/ovirt/cloudproviderconfig.go
@@ -1,0 +1,23 @@
+package ovirt
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// CloudProviderConfig generates the cloud provider config for the oVirt platform.
+func CloudProviderConfig(storageDomainID string, clusterID string, networkName string) (string, error) {
+	c := config{
+		StorageDomainID: storageDomainID,
+		ClusterID:       clusterID,
+		NetworkName:     networkName,
+	}
+
+	buff := &bytes.Buffer{}
+	encoder := json.NewEncoder(buff)
+	encoder.SetIndent("", "\t")
+	if err := encoder.Encode(c); err != nil {
+		return "", err
+	}
+	return buff.String(), nil
+}

--- a/pkg/asset/manifests/ovirt/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/ovirt/cloudproviderconfig_test.go
@@ -1,0 +1,19 @@
+package ovirt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudProviderConfig(t *testing.T) {
+	expectedConfig := `{
+	"storageDomainId": "dd3ec3e5-e38b-4f02-9947-c669368cde56",
+	"clusterId": "dd3ec3e5-e38b-4f02-9947-c669368cde57",
+	"networkName": "production"
+}
+`
+	actualConfig, err := CloudProviderConfig("dd3ec3e5-e38b-4f02-9947-c669368cde56", "dd3ec3e5-e38b-4f02-9947-c669368cde57", "production")
+	assert.NoError(t, err, "failed to create cloud provider config")
+	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
+}

--- a/pkg/asset/manifests/ovirt/types.go
+++ b/pkg/asset/manifests/ovirt/types.go
@@ -1,0 +1,11 @@
+package ovirt
+
+//config is the oVirt's cloud provider config
+type config struct {
+	// StorageDomainID the id of the storage domain for the OS disks of VMs.
+	StorageDomainID string `json:"storageDomainId"`
+	// ClusterID the id of the cluster of the VMs.
+	ClusterID string `json:"clusterId"`
+	// NetworkName the name of the network used for the VMs network interfaces.
+	NetworkName string `json:"networkName"`
+}


### PR DESCRIPTION
Motivation
Some cluster components can use the platform details to create more
capabilities. One example is CSI driver, where the we want to initialize
a default storage class, with the `StorageDomainID` as one of its
parameters. The benefit would be the ability to generate a default
storage class with the details of the cloud provider config map.

Result
A config map with oVirt's cloud provider config
`oc get cm cloud-provider-config -n openshift-config`

Notes
oVirt does not have a supported external cloud provider or a cloud
provider config yet. What we have is this [1] and it may be used for future
reference.

[1] https://github.com/oVirt/ovirt-openshift-extensions/blob/master/cmd/ovirt-cloud-provider/ovirt-cloud-provider.go

Signed-off-by: Roy Golan <rgolan@redhat.com>
