### PR TITLE
use correct base URI for other azure cloud environments

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -21,6 +21,7 @@ provider "azureprivatedns" {
   client_id       = var.azure_client_id
   client_secret   = var.azure_client_secret
   tenant_id       = var.azure_tenant_id
+  environment     = var.azure_environment
 }
 
 module "bootstrap" {

--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -86,14 +86,14 @@ func (c *Client) GetControlPlaneSubnet(ctx context.Context, resourceGroupName, v
 
 // getVnetsClient sets up a new client to retrieve vnets
 func (c *Client) getVirtualNetworksClient(ctx context.Context) (*aznetwork.VirtualNetworksClient, error) {
-	vnetsClient := aznetwork.NewVirtualNetworksClient(c.ssn.Credentials.SubscriptionID)
+	vnetsClient := aznetwork.NewVirtualNetworksClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
 	vnetsClient.Authorizer = c.ssn.Authorizer
 	return &vnetsClient, nil
 }
 
 // getSubnetsClient sets up a new client to retrieve a subnet
 func (c *Client) getSubnetsClient(ctx context.Context) (*aznetwork.SubnetsClient, error) {
-	subnetClient := aznetwork.NewSubnetsClient(c.ssn.Credentials.SubscriptionID)
+	subnetClient := aznetwork.NewSubnetsClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
 	subnetClient.Authorizer = c.ssn.Authorizer
 	return &subnetClient, nil
 }
@@ -118,7 +118,7 @@ func (c *Client) ListLocations(ctx context.Context) (*[]azsubs.Location, error) 
 
 // getSubscriptionsClient sets up a new client to retrieve subscription data
 func (c *Client) getSubscriptionsClient(ctx context.Context) (azsubs.Client, error) {
-	client := azsubs.NewClient()
+	client := azsubs.NewClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint)
 	client.Authorizer = c.ssn.Authorizer
 	return client, nil
 }
@@ -143,14 +143,14 @@ func (c *Client) GetResourcesProvider(ctx context.Context, resourceProviderNames
 
 // getProvidersClient sets up a new client to retrieve providers data
 func (c *Client) getProvidersClient(ctx context.Context) (azres.ProvidersClient, error) {
-	client := azres.NewProvidersClient(c.ssn.Credentials.SubscriptionID)
+	client := azres.NewProvidersClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
 	client.Authorizer = c.ssn.Authorizer
 	return client, nil
 }
 
 // GetDiskSkus returns all the disk SKU pages for a given region.
 func (c *Client) GetDiskSkus(ctx context.Context, region string) ([]azsku.ResourceSku, error) {
-	client := azsku.NewResourceSkusClient(c.ssn.Credentials.SubscriptionID)
+	client := azsku.NewResourceSkusClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
 	client.Authorizer = c.ssn.Authorizer
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/pkg/asset/installconfig/azure/dns.go
+++ b/pkg/asset/installconfig/azure/dns.go
@@ -125,13 +125,13 @@ func NewDNSConfig(ssn *Session) *DNSConfig {
 }
 
 func newZonesClient(session *Session) ZonesGetter {
-	azureClient := azdns.NewZonesClient(session.Credentials.SubscriptionID)
+	azureClient := azdns.NewZonesClientWithBaseURI(session.Environment.ResourceManagerEndpoint, session.Credentials.SubscriptionID)
 	azureClient.Authorizer = session.Authorizer
 	return &ZonesClient{azureClient: azureClient}
 }
 
 func newRecordSetsClient(session *Session) *RecordSetsClient {
-	azureClient := azdns.NewRecordSetsClient(session.Credentials.SubscriptionID)
+	azureClient := azdns.NewRecordSetsClientWithBaseURI(session.Environment.ResourceManagerEndpoint, session.Credentials.SubscriptionID)
 	azureClient.Authorizer = session.Authorizer
 	return &RecordSetsClient{azureClient: azureClient}
 }

--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -29,6 +29,7 @@ type Session struct {
 	GraphAuthorizer autorest.Authorizer
 	Authorizer      autorest.Authorizer
 	Credentials     Credentials
+	Environment     azureenv.Environment
 }
 
 //Credentials is the data type for credentials as understood by the azure sdk
@@ -76,6 +77,8 @@ func newSessionFromFile(authFilePath string, cloudName azure.CloudEnvironment) (
 		return nil, errors.Wrap(err, "failed to get settings from file")
 	}
 
+	authSettings.Values[auth.ActiveDirectoryEndpoint] = env.ActiveDirectoryEndpoint
+
 	credentials, err := getCredentials(authSettings)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to map authsettings to credentials")
@@ -102,6 +105,7 @@ func newSessionFromFile(authFilePath string, cloudName azure.CloudEnvironment) (
 		GraphAuthorizer: graphAuthorizer,
 		Authorizer:      authorizer,
 		Credentials:     *credentials,
+		Environment:     env,
 	}, nil
 }
 

--- a/pkg/asset/machines/azure/zones.go
+++ b/pkg/asset/machines/azure/zones.go
@@ -26,7 +26,7 @@ func AvailabilityZones(session *azure.Session, region string, instanceType strin
 }
 
 func skusClient(session *azure.Session) (client *compute.ResourceSkusClient, err error) {
-	skusClient := compute.NewResourceSkusClient(session.Credentials.SubscriptionID)
+	skusClient := compute.NewResourceSkusClientWithBaseURI(session.Environment.ResourceManagerEndpoint, session.Credentials.SubscriptionID)
 	skusClient.Authorizer = session.Authorizer
 	return &skusClient, nil
 }

--- a/pkg/migrate/azure/privatedns.go
+++ b/pkg/migrate/azure/privatedns.go
@@ -30,10 +30,10 @@ type legacyDNSClient struct {
 }
 
 func newLegacyDNSClient(session *azconfig.Session, resourceGroup string) *legacyDNSClient {
-	zonesClient := azdns.NewZonesClient(session.Credentials.SubscriptionID)
+	zonesClient := azdns.NewZonesClientWithBaseURI(dnsEndpoint(session), session.Credentials.SubscriptionID)
 	zonesClient.Authorizer = session.Authorizer
 
-	recordsetsClient := azdns.NewRecordSetsClient(session.Credentials.SubscriptionID)
+	recordsetsClient := azdns.NewRecordSetsClientWithBaseURI(dnsEndpoint(session), session.Credentials.SubscriptionID)
 	recordsetsClient.Authorizer = session.Authorizer
 
 	return &legacyDNSClient{resourceGroup, zonesClient, recordsetsClient}
@@ -125,16 +125,16 @@ type privateDNSClient struct {
 }
 
 func newPrivateDNSClient(session *azconfig.Session, resourceGroup string, virtualNetwork string, vnetResourceGroup string) *privateDNSClient {
-	zonesClient := azprivatedns.NewPrivateZonesClient(session.Credentials.SubscriptionID)
+	zonesClient := azprivatedns.NewPrivateZonesClientWithBaseURI(dnsEndpoint(session), session.Credentials.SubscriptionID)
 	zonesClient.Authorizer = session.Authorizer
 
-	recordsetsClient := azprivatedns.NewRecordSetsClient(session.Credentials.SubscriptionID)
+	recordsetsClient := azprivatedns.NewRecordSetsClientWithBaseURI(dnsEndpoint(session), session.Credentials.SubscriptionID)
 	recordsetsClient.Authorizer = session.Authorizer
 
-	virtualNetworkLinksClient := azprivatedns.NewVirtualNetworkLinksClient(session.Credentials.SubscriptionID)
+	virtualNetworkLinksClient := azprivatedns.NewVirtualNetworkLinksClientWithBaseURI(dnsEndpoint(session), session.Credentials.SubscriptionID)
 	virtualNetworkLinksClient.Authorizer = session.Authorizer
 
-	virtualNetworksClient := aznetwork.NewVirtualNetworksClient(session.Credentials.SubscriptionID)
+	virtualNetworksClient := aznetwork.NewVirtualNetworksClientWithBaseURI(dnsEndpoint(session), session.Credentials.SubscriptionID)
 	virtualNetworksClient.Authorizer = session.Authorizer
 
 	return &privateDNSClient{resourceGroup, vnetResourceGroup, virtualNetwork, zonesClient, recordsetsClient, virtualNetworkLinksClient, virtualNetworksClient}
@@ -527,4 +527,8 @@ func Eligible(cloudName azure.CloudEnvironment) error {
 	}
 
 	return nil
+}
+
+func dnsEndpoint(session *azconfig.Session) string {
+	return session.Environment.ResourceManagerEndpoint
 }


### PR DESCRIPTION
When support for other Azure cloud environments was added [1], there were some necessary changes that were omitted.

* Azure clients that are created need to use the base URI appropriate for the cloud environment.
* Azure authorizers need to use the ActiveDirectory endpoint appropriate for the cloud environment.
* The environment needs to be specified for the terraform azureprivatedns provider.

[1] https://github.com/openshift/installer/pull/3634