### PR TITLE
Bug 1859874: Add basic engine URL validation

### DIFF
--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -16,7 +16,7 @@ func askCredentials() (Config, error) {
 				Message: "oVirt API endpoint URL",
 				Help:    "The URL of the oVirt engine API. For example, https://ovirt-engine-fqdn/ovirt-engine/api.",
 			},
-			Validate: survey.ComposeValidators(survey.Required),
+			Validate: survey.ComposeValidators(survey.Required, validURL),
 		},
 	}, &c.URL)
 	if err != nil {

--- a/pkg/asset/installconfig/ovirt/validaton.go
+++ b/pkg/asset/installconfig/ovirt/validaton.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/ovirt"
 	"github.com/openshift/installer/pkg/types/ovirt/validation"
+	"github.com/openshift/installer/pkg/validate"
 )
 
 // Validate executes ovirt specific validation
@@ -124,4 +125,13 @@ func validateVNICProfile(platform ovirt.Platform, con *ovirtsdk.Connection) erro
 			platform.NetworkName)
 	}
 	return nil
+}
+
+func validURL(val interface{}) error {
+	uri, ok := val.(string)
+	if !ok {
+		return fmt.Errorf("cannot check url validity on type %T", val)
+	}
+
+	return validate.URIWithProtocol(uri, "https")
 }

--- a/pkg/asset/installconfig/ovirt/validaton_test.go
+++ b/pkg/asset/installconfig/ovirt/validaton_test.go
@@ -83,3 +83,39 @@ func Test_validateAuth(t *testing.T) {
 func CreateMockOvirtServer(handler http.HandlerFunc) *httptest.Server {
 	return httptest.NewServer(handler)
 }
+
+func Test_validateURL(t *testing.T) {
+	httpsErrorRegExp := "must use https.*"
+	tests := []struct {
+		url           string
+		expectedError string
+	}{
+		{
+			url:           "engine.example.com",
+			expectedError: httpsErrorRegExp,
+		},
+		{
+			url:           "ftp://engine.example.com",
+			expectedError: httpsErrorRegExp,
+		},
+		{
+			url:           "http://engine.example.com",
+			expectedError: httpsErrorRegExp,
+		},
+		{
+			url: "https://engine.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			err := validURL(tt.url)
+
+			if tt.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, tt.expectedError, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a basic URL validator to avoid adding urls with no
scheme or scheme different from https.

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1859874

Signed-off-by: Roberto Ciatti <rciatti@redhat.com>