### PR TITLE
oVirt: remove tmp template VM on bootstrap destroy phase

### DIFF
--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/openstack"
+	"github.com/openshift/installer/pkg/types/ovirt"
 	"github.com/pkg/errors"
 )
 
@@ -79,6 +80,8 @@ func Destroy(dir string) (err error) {
 		if err != nil {
 			return errors.Wrapf(err, "Failed to delete glance image %s", imageName)
 		}
+	case ovirt.Name:
+		extraArgs = append(extraArgs, "-target=module.template.ovirt_vm.tmp_import_vm")
 	}
 
 	extraArgs = append(extraArgs, "-target=module.bootstrap")


### PR DESCRIPTION
This patch breaks the dependency between terraform resources:
releaseimage_template and tmp_import_vm

On ovirt before the bootstrap, masters and workers start they need to be created from a template.
The installer creates this template with the terraform template module.
As part of the process for creating the template, we create an oVirt tmp VM which should be sealed into a template for the bootstrap, masters and workers machines and then removed.
Until this PR the tmp VM will just stay in the oVirt cluster until cluster destroy is called, this is not good because it is just garbage in the oVirt cluster that the user will probably remove on its own once the installation is complete.
This PR makes bootstrap destroy command to destroy the tmp VM as well, which makes sense because it is created for bootstrapping the cluster.

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>