### PR TITLE
baremetal: set the boot mode for hosts based on the input

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1010,6 +1010,13 @@ spec:
                           type: object
                         bootMACAddress:
                           type: string
+                        bootMode:
+                          description: BootMode puts the server in legacy (BIOS) or
+                            UEFI mode for booting. The default is UEFI.
+                          enum:
+                          - UEFI
+                          - legacy
+                          type: string
                         hardwareProfile:
                           type: string
                         name:

--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -148,6 +148,9 @@ include:
   be found here
   https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md
 
+* *bootMode* -- Put the server in legacy (BIOS) or UEFI mode for
+  booting. The default is UEFI.
+
 ```yaml
 apiVersion: v1
 baseDomain: test.metalkube.org
@@ -179,6 +182,7 @@ platform:
         bootMACAddress: 00:11:07:4e:f6:68
         rootDeviceHints:
           minSizeGigabytes: 20
+        bootMode: legacy
       - name: openshift-master-1
         role: master
         bmc:
@@ -188,6 +192,7 @@ platform:
         bootMACAddress: 00:11:07:4e:f6:6c
         rootDeviceHints:
           minSizeGigabytes: 20
+        bootMode: UEFI
       - name: openshift-master-2
         role: master
         bmc:

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ replace (
 	github.com/go-log/log => github.com/go-log/log v0.1.1-0.20181211034820-a514cf01a3eb // Pinned by MCO
 	github.com/hashicorp/terraform => github.com/openshift/terraform v0.12.20-openshift-4 // Pin to fork with deduplicated rpc types v0.12.20-openshift-4
 	github.com/hashicorp/terraform-plugin-sdk => github.com/openshift/hashicorp-terraform-plugin-sdk v1.14.0-openshift // Pin to fork with public rpc types
-	github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861 // Use OpenShift fork
+	github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe // Use OpenShift fork
 	github.com/metal3-io/cluster-api-provider-baremetal => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d // Pin OpenShift fork
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422 // Pin API
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 // Pin client-go

--- a/go.sum
+++ b/go.sum
@@ -842,17 +842,12 @@ github.com/gophercloud/gophercloud v0.6.0/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbG
 github.com/gophercloud/gophercloud v0.6.1-0.20191025185032-6ad562af8c1f/go.mod h1:GICNByuaEBibcjmjvI7QvYJSZEbGkcYwAR7EZK2WMqM=
 github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
 github.com/gophercloud/gophercloud v0.7.1-0.20191210042042-7aa2e52d21f9/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
-github.com/gophercloud/gophercloud v0.7.1-0.20191211202411-f940f50ff1f7/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
-github.com/gophercloud/gophercloud v0.8.0 h1:1ylFFLRx7otpfRPSuOm77q8HLSlSOwYCGDeXmXJhX7A=
-github.com/gophercloud/gophercloud v0.8.0/go.mod h1:Kc/QKr9thLKruO/dG0szY8kRIYS+iENz0ziI0hJf76A=
 github.com/gophercloud/gophercloud v0.10.1-0.20200424014253-c3bfe50899e5/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/gophercloud v0.11.0 h1:pYMP9UZBdQa3lsfIZ1tZor4EbtxiuB6BHhocenkiH/E=
 github.com/gophercloud/gophercloud v0.11.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/utils v0.0.0-20190124231947-9c3b9f2457ef/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
 github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
-github.com/gophercloud/utils v0.0.0-20191212191830-4533a07bd492 h1:NAwq2GgRiqbNLw1cA7KUdt7lDR/NzJtk4EXGxO3gqas=
-github.com/gophercloud/utils v0.0.0-20191212191830-4533a07bd492/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gophercloud/utils v0.0.0-20200508015959-b0167b94122c h1:iawx2ojEQA7c+GmkaVO5sN+k8YONibXyDO8RlsC+1bs=
 github.com/gophercloud/utils v0.0.0-20200508015959-b0167b94122c/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
@@ -872,7 +867,6 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
@@ -1426,8 +1420,8 @@ github.com/openshift-metal3/terraform-provider-ironic v0.2.1 h1:K/tPSylailvH70zC
 github.com/openshift-metal3/terraform-provider-ironic v0.2.1/go.mod h1:G79T6t60oBpYfZK/x960DRzYsNHdz5YVCHINx6QlmtU=
 github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422 h1:tgKcQVgHscJFBji1uLH5KjA81fGxNQkom5lETA5VURs=
 github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422/go.mod h1:l6TGeqJ92DrZBuWMNKcot1iZUHfbYSJyBWHGgg6Dn6s=
-github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861 h1:6bDJzmU92kE82UPjVKiO7WM5L4rhbaeuwd0P6GRfEuM=
-github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
+github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe h1:bu99IMkaN6o/JcxpWEb1eT8gDdL9hLcwOmfiVIbXWj8=
+github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240 h1:XYfJWv2Ch+qInGLDEedHRtDsJwnxyU1L8U7SY56NcA8=
@@ -1786,8 +1780,6 @@ github.com/terraform-providers/terraform-provider-local v1.4.0 h1:n0CNTMjBfCC5R6
 github.com/terraform-providers/terraform-provider-local v1.4.0/go.mod h1:nbnWkAjiiG0FHlsfYYMRfBwvDbo6eLjorQs/mmRGi14=
 github.com/terraform-providers/terraform-provider-null v1.0.1-0.20191204185112-e5c592237f62 h1:vi12lh3hnvMclOqFwEf73s8JCUTPTchOhEmf/7uMPn0=
 github.com/terraform-providers/terraform-provider-null v1.0.1-0.20191204185112-e5c592237f62/go.mod h1:RaAgicYv+oKLyZpaQB5BOkwL/t5WKYHQ+Q0kgMgXgR4=
-github.com/terraform-providers/terraform-provider-openstack v1.25.0 h1:cUGi9qbg/6B7lv4+HyrarINEtVMSIouEuEuVpOE/0zY=
-github.com/terraform-providers/terraform-provider-openstack v1.25.0/go.mod h1:cTefkvjGdhORynFvVsB2beWN+XmGhjAm3RBrnEJLvfs=
 github.com/terraform-providers/terraform-provider-openstack v1.28.0 h1:yiT3Z5fDkJt0YX5BDkX/+0uwGpX/uNjVsuYqFIJ/kL0=
 github.com/terraform-providers/terraform-provider-openstack v1.28.0/go.mod h1:MxR5egxGj9OfPTj0VorSjpIVAi3OT24jOMiCBH/d7hU=
 github.com/terraform-providers/terraform-provider-random v0.0.0-20190925200408-30dac3233094/go.mod h1:F4KE9YftuJyMiBth4W1kCrsyOHndtTjAmZ+ZzjqWY+4=

--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -2,6 +2,7 @@ package baremetal
 
 import (
 	"fmt"
+
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
 
 	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
@@ -78,6 +79,7 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 				BMC:             bmc,
 				BootMACAddress:  host.BootMACAddress,
 				HardwareProfile: host.HardwareProfile,
+				BootMode:        baremetalhost.BootMode(host.BootMode),
 			},
 		}
 		if i < len(machines) {

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -79,9 +79,8 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 
 		// Properties
 		propertiesMap := map[string]interface{}{
-			"local_gb":     profile.LocalGB,
-			"cpu_arch":     profile.CPUArch,
-			"capabilities": "boot_mode:uefi",
+			"local_gb": profile.LocalGB,
+			"cpu_arch": profile.CPUArch,
 		}
 
 		// Root device hints
@@ -97,6 +96,13 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 			rootDevice["hctl"] = profile.RootDeviceHints.HCTL
 		} else {
 			rootDevice["name"] = profile.RootDeviceHints.DeviceName
+		}
+
+		// explicitly set the boot mode to the default "uefi" in case
+		// it is not set
+		bootMode := "uefi"
+		if host.BootMode == baremetal.Legacy {
+			bootMode = "bios"
 		}
 
 		// Instance Info
@@ -117,9 +123,10 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(bootstrapProvisioningIP, "80"), imageFilename, compressedImageFilename)
 		cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)
 		instanceInfo := map[string]interface{}{
-			"root_gb":        25, // FIXME(stbenjam): Needed until https://storyboard.openstack.org/#!/story/2005165
-			"image_source":   cacheImageURL,
-			"image_checksum": cacheChecksumURL,
+			"root_gb":          25, // FIXME(stbenjam): Needed until https://storyboard.openstack.org/#!/story/2005165
+			"image_source":     cacheImageURL,
+			"image_checksum":   cacheChecksumURL,
+			"deploy_boot_mode": bootMode,
 		}
 
 		hosts = append(hosts, hostMap)

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -13,6 +13,17 @@ type BMC struct {
 	DisableCertificateVerification bool   `json:"disableCertificateVerification"`
 }
 
+// BootMode puts the server in legacy (BIOS) or UEFI mode for
+// booting. The default is UEFI.
+// +kubebuilder:validation:Enum=UEFI;legacy
+type BootMode string
+
+// Allowed boot mode from metal3
+const (
+	UEFI   BootMode = "UEFI"
+	Legacy BootMode = "legacy"
+)
+
 // Host stores all the configuration data for a baremetal host.
 type Host struct {
 	Name            string                    `json:"name,omitempty" validate:"required,uniqueField"`
@@ -21,6 +32,7 @@ type Host struct {
 	BootMACAddress  string                    `json:"bootMACAddress" validate:"required,uniqueField"`
 	HardwareProfile string                    `json:"hardwareProfile"`
 	RootDeviceHints *v1alpha1.RootDeviceHints `json:"rootDeviceHints,omitempty"`
+	BootMode        BootMode                  `json:"bootMode,omitempty"`
 }
 
 // Platform stores all the global configuration that all machinesets use.

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -274,6 +274,18 @@ func validateHostsCount(hosts []*baremetal.Host, installConfig *types.InstallCon
 	return nil
 }
 
+// ensure that the bootMode field contains a valid value
+func validateBootMode(hosts []*baremetal.Host, fldPath *field.Path) (errors field.ErrorList) {
+	for idx, host := range hosts {
+		switch host.BootMode {
+		case "", baremetal.UEFI, baremetal.Legacy:
+		default:
+			errors = append(errors, field.Invalid(fldPath.Index(idx).Child("bootMode"), host.BootMode, "bootMode must be one of \"UEFI\" or \"legacy\""))
+		}
+	}
+	return
+}
+
 // ValidatePlatform checks that the specified platform is valid.
 func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field.Path, c *types.InstallConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -310,6 +322,8 @@ func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field
 	}
 
 	allErrs = append(allErrs, validateHostsWithoutBMC(p.Hosts, fldPath)...)
+
+	allErrs = append(allErrs, validateBootMode(p.Hosts, fldPath.Child("Hosts"))...)
 
 	return allErrs
 }

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -110,6 +110,24 @@ func TestValidatePlatform(t *testing.T) {
 					host2().BootMACAddress("CA:FE:CA:FE:CA:FE")).build(),
 			expected: "baremetal.hosts\\[1\\].BootMACAddress: Duplicate value: \"CA:FE:CA:FE:CA:FE\"",
 		},
+		{
+			name: "invalid_boot_mode",
+			platform: platform().
+				Hosts(host1().BootMode("not-a-valid-value")).build(),
+			expected: "baremetal.Hosts\\[0\\].bootMode: Invalid value: \"not-a-valid-value\": bootMode must be one of \"UEFI\" or \"legacy\"",
+		},
+		{
+			name: "uefi_boot_mode",
+			platform: platform().
+				Hosts(host1().BootMode("UEFI")).build(),
+			expected: "",
+		},
+		{
+			name: "legacy_boot_mode",
+			platform: platform().
+				Hosts(host1().BootMode("legacy")).build(),
+			expected: "",
+		},
 	}
 
 	for _, tc := range cases {
@@ -397,6 +415,11 @@ func (hb *hostBuilder) Name(value string) *hostBuilder {
 
 func (hb *hostBuilder) BootMACAddress(value string) *hostBuilder {
 	hb.Host.BootMACAddress = value
+	return hb
+}
+
+func (hb *hostBuilder) BootMode(value string) *hostBuilder {
+	hb.Host.BootMode = baremetal.BootMode(value)
 	return hb
 }
 

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/redfish.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/redfish.go
@@ -9,6 +9,7 @@ func init() {
 	schemes := []string{"http", "https"}
 	registerFactory("redfish", newRedfishAccessDetails, schemes)
 	registerFactory("redfish-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
+	registerFactory("ilo5-redfish", newRedfishAccessDetails, schemes)
 	registerFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
 	registerFactory("idrac-virtualmedia", newRedfishiDracVirtualMediaAccessDetails, schemes)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -956,7 +956,7 @@ github.com/mattn/go-colorable
 github.com/mattn/go-isatty
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
-# github.com/metal3-io/baremetal-operator v0.0.0 => github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861
+# github.com/metal3-io/baremetal-operator v0.0.0 => github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe
 ## explicit
 github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1
 github.com/metal3-io/baremetal-operator/pkg/bmc
@@ -2059,7 +2059,7 @@ sigs.k8s.io/yaml
 # github.com/go-log/log => github.com/go-log/log v0.1.1-0.20181211034820-a514cf01a3eb
 # github.com/hashicorp/terraform => github.com/openshift/terraform v0.12.20-openshift-4
 # github.com/hashicorp/terraform-plugin-sdk => github.com/openshift/hashicorp-terraform-plugin-sdk v1.14.0-openshift
-# github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200702005656-4ce920a36861
+# github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe
 # github.com/metal3-io/cluster-api-provider-baremetal => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d
 # github.com/openshift/api => github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422
 # github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200116152001-92a2713fa240


### PR DESCRIPTION
* Use the instance_info/deploy_boot_mode instead of the capabilities based on feedback from the Ironic team.
* Use the host setting from the install-config, if there is any.
* Copy the boot mode from the install-config to the new host resource, if it is set.
* update baremetal-operator to include the boot mode field