### PR TITLE
OpenStack: add clusterOSImage validations

### DIFF
--- a/vendor/github.com/gophercloud/utils/openstack/imageservice/v2/images/utils.go
+++ b/vendor/github.com/gophercloud/utils/openstack/imageservice/v2/images/utils.go
@@ -1,0 +1,42 @@
+package images
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+)
+
+// IDFromName is a convienience function that returns an image's ID given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+
+	listOpts := images.ListOpts{
+		Name: name,
+	}
+
+	pages, err := images.List(client, listOpts).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := images.ExtractImages(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "image"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "image"}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -664,6 +664,7 @@ github.com/gophercloud/utils/openstack/baremetal/v1/nodes
 github.com/gophercloud/utils/openstack/clientconfig
 github.com/gophercloud/utils/openstack/compute/v2/flavors
 github.com/gophercloud/utils/openstack/compute/v2/images
+github.com/gophercloud/utils/openstack/imageservice/v2/images
 github.com/gophercloud/utils/openstack/networking/v2/networks
 github.com/gophercloud/utils/terraform/auth
 # github.com/h2non/filetype v1.0.12


### PR DESCRIPTION
This commit adds validations that custom Glance image specified by `clusterOSImage` config parameter exists and has Active status.