### PR TITLE
Bug 1861088: aws: skip quota checking for not supported regions

### DIFF
--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -64,6 +64,10 @@ func (a *PlatformQuotaCheck) Generate(dependencies asset.Parents) error {
 	platform := ic.Config.Platform.Name()
 	switch platform {
 	case typesaws.Name:
+		if !quotaaws.SupportedRegions.Has(ic.AWS.Region) {
+			logrus.Debugf("%s does not support API for checking quotas, therefore skipping.", ic.AWS.Region)
+			return nil
+		}
 		services := []string{"ec2", "vpc"}
 		session, err := ic.AWS.Session(context.TODO())
 		if err != nil {

--- a/pkg/quota/aws/limits.go
+++ b/pkg/quota/aws/limits.go
@@ -7,6 +7,28 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicequotas"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// SupportedRegions is a list of AWS regions that support the servicequota APIs.
+// see https://docs.aws.amazon.com/general/latest/gr/servicequotas.html
+var SupportedRegions = sets.NewString(
+	"us-east-2",
+	"us-east-1",
+	"us-west-1",
+	"us-west-2",
+	"ap-south-1",
+	"ap-northeast-3",
+	"ap-northeast-2",
+	"ap-southeast-1",
+	"ap-southeast-2",
+	"ap-northeast-1",
+	"ca-central-1",
+	"eu-central-1",
+	"eu-west-1",
+	"eu-west-2",
+	"eu-west-3",
+	"sa-east-1",
 )
 
 // record stores the data from quota limits and usages.


### PR DESCRIPTION
The service quota APIs are only supported in certain regions [1] and therefore we must skip
checking quotas unless the region are from that list.

[1]: https://docs.aws.amazon.com/general/latest/gr/servicequotas.html

/cc @patrickdillon 