### PR TITLE
Bug 1855341: ovirt: Validate api and apps FQDN before cluster provisioning

### DIFF
--- a/pkg/asset/installconfig/ovirt/validation.go
+++ b/pkg/asset/installconfig/ovirt/validation.go
@@ -2,6 +2,7 @@ package ovirt
 
 import (
 	"fmt"
+	"net"
 
 	ovirtsdk "github.com/ovirt/go-ovirt"
 	"github.com/pkg/errors"
@@ -123,5 +124,26 @@ func validateVNICProfile(platform ovirt.Platform, con *ovirtsdk.Connection) erro
 			platform.VNICProfileID,
 			platform.NetworkName)
 	}
+	return nil
+}
+
+// ValidateProvisioning Performs Provisioning Validations for oVirt
+func ValidateProvisioning(ic *types.InstallConfig) error {
+	clusterName := ic.ObjectMeta.Name
+	zoneName := ic.BaseDomain
+	fmtStr := "DNS record  for %s was not found."
+
+	validFqdns := []string{
+		fmt.Sprintf("api.%s.%s", clusterName, zoneName),
+		fmt.Sprintf("test.apps.%s.%s", clusterName, zoneName),
+	}
+
+	for _, addr := range validFqdns {
+		_, err := net.LookupIP(addr)
+		if err != nil {
+			return fmt.Errorf(fmtStr, addr)
+		}
+	}
+
 	return nil
 }

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -8,6 +8,7 @@ import (
 	azconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	bmconfig "github.com/openshift/installer/pkg/asset/installconfig/baremetal"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
+	icovirt "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	vsconfig "github.com/openshift/installer/pkg/asset/installconfig/vsphere"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -75,8 +76,15 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
-	case aws.Name, libvirt.Name, none.Name, openstack.Name, ovirt.Name:
+	case ovirt.Name:
+		err = icovirt.ValidateProvisioning(ic.Config)
+		if err != nil {
+			return err
+		}
+
+	case aws.Name, libvirt.Name, none.Name, openstack.Name:
 		// no special provisioning requirements to check
+
 	default:
 		err = fmt.Errorf("unknown platform type %q", platform)
 	}


### PR DESCRIPTION
perform DNS resolution  validation to  both the API and the apps fqdn .

Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1855341

Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>