### PR TITLE
types: capitalize CredentialsMode values

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -617,19 +617,19 @@ spec:
               installer will perform its normal verification that the credentials
               provided are sufficient to perform an installation. \n There are three
               possible values for this field, but the valid values are dependent upon
-              the platform being used. \"mint\": create new credentials with a subset
-              of the overall permissions for each CredentialsRequest \"passthrough\":
-              copy the credentials with all of the overall permsissions for each CredentialsRequest
-              \"manual\": CredentialsRequests must be handled manually by the user
+              the platform being used. \"Mint\": create new credentials with a subset
+              of the overall permissions for each CredentialsRequest \"Passthrough\":
+              copy the credentials with all of the overall permissions for each CredentialsRequest
+              \"Manual\": CredentialsRequests must be handled manually by the user
               \n For each of the following platforms, the field can set to the specified
-              values. For all other platforms, the field must not be set. AWS: \"mint\",
-              \"passthrough\", \"manual\" Azure: \"mint\", \"passthrough\" GCP: \"mint\",
-              \"passthrough\""
+              values. For all other platforms, the field must not be set. AWS: \"Mint\",
+              \"Passthrough\", \"Manual\" Azure: \"Mint\", \"Passthrough\" GCP: \"Mint\",
+              \"Passthrough\""
             enum:
             - ""
-            - mint
-            - passthrough
-            - manual
+            - Mint
+            - Passthrough
+            - Manual
             type: string
           fips:
             default: false

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -36,11 +36,11 @@ func Test_PrintFields(t *testing.T) {
       ControlPlane is the configuration for the machines that comprise the control plane.
 
     credentialsMode <string>
-      Valid Values: "","mint","passthrough","manual"
+      Valid Values: "","Mint","Passthrough","Manual"
       CredentialsMode is used to explicitly set the mode with which CredentialRequests are satisfied. 
  If this field is set, then the installer will not attempt to query the cloud permissions before attempting installation. If the field is not set or empty, then the installer will perform its normal verification that the credentials provided are sufficient to perform an installation. 
- There are three possible values for this field, but the valid values are dependent upon the platform being used. "mint": create new credentials with a subset of the overall permissions for each CredentialsRequest "passthrough": copy the credentials with all of the overall permsissions for each CredentialsRequest "manual": CredentialsRequests must be handled manually by the user 
- For each of the following platforms, the field can set to the specified values. For all other platforms, the field must not be set. AWS: "mint", "passthrough", "manual" Azure: "mint", "passthrough" GCP: "mint", "passthrough"
+ There are three possible values for this field, but the valid values are dependent upon the platform being used. "Mint": create new credentials with a subset of the overall permissions for each CredentialsRequest "Passthrough": copy the credentials with all of the overall permissions for each CredentialsRequest "Manual": CredentialsRequests must be handled manually by the user 
+ For each of the following platforms, the field can set to the specified values. For all other platforms, the field must not be set. AWS: "Mint", "Passthrough", "Manual" Azure: "Mint", "Passthrough" GCP: "Mint", "Passthrough"
 
     fips <boolean>
       Default: false

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -127,15 +127,15 @@ type InstallConfig struct {
 	// credentials provided are sufficient to perform an installation.
 	//
 	// There are three possible values for this field, but the valid values are dependent upon the platform being used.
-	// "mint": create new credentials with a subset of the overall permissions for each CredentialsRequest
-	// "passthrough": copy the credentials with all of the overall permsissions for each CredentialsRequest
-	// "manual": CredentialsRequests must be handled manually by the user
+	// "Mint": create new credentials with a subset of the overall permissions for each CredentialsRequest
+	// "Passthrough": copy the credentials with all of the overall permissions for each CredentialsRequest
+	// "Manual": CredentialsRequests must be handled manually by the user
 	//
 	// For each of the following platforms, the field can set to the specified values. For all other platforms, the
 	// field must not be set.
-	// AWS: "mint", "passthrough", "manual"
-	// Azure: "mint", "passthrough"
-	// GCP: "mint", "passthrough"
+	// AWS: "Mint", "Passthrough", "Manual"
+	// Azure: "Mint", "Passthrough"
+	// GCP: "Mint", "Passthrough"
 	// +optional
 	CredentialsMode CredentialsMode `json:"credentialsMode,omitempty"`
 }
@@ -315,18 +315,18 @@ type ImageContentSource struct {
 }
 
 // CredentialsMode is the mode by which CredentialsRequests will be satisfied.
-// +kubebuilder:validation:Enum="";mint;passthrough;manual
+// +kubebuilder:validation:Enum="";Mint;Passthrough;Manual
 type CredentialsMode string
 
 const (
 	// ManualCredentialsMode indicates that cloud-credential-operator should not process any CredentialsRequests.
-	ManualCredentialsMode CredentialsMode = "manual"
+	ManualCredentialsMode CredentialsMode = "Manual"
 
 	// MintCredentialsMode indicates that cloud-credential-operator should be creating users for each
 	// CredentialsRequest.
-	MintCredentialsMode CredentialsMode = "mint"
+	MintCredentialsMode CredentialsMode = "Mint"
 
 	// PassthroughCredentialsMode indicates that cloud-credential-operator should just copy over the cluster's
 	// cloud credentials for each CredentialsRequest.
-	PassthroughCredentialsMode CredentialsMode = "passthrough"
+	PassthroughCredentialsMode CredentialsMode = "Passthrough"
 )

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -940,7 +940,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.CredentialsMode = types.ManualCredentialsMode
 				return c
 			}(),
-			expectedError: `^credentialsMode: Unsupported value: "manual": supported values: "mint", "passthrough"$`,
+			expectedError: `^credentialsMode: Unsupported value: "Manual": supported values: "Mint", "Passthrough"$`,
 		},
 		{
 			name: "invalidly set cloud credentials mode",
@@ -950,7 +950,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.CredentialsMode = types.PassthroughCredentialsMode
 				return c
 			}(),
-			expectedError: `^credentialsMode: Invalid value: "passthrough": cannot be set when using the "baremetal" platform$`,
+			expectedError: `^credentialsMode: Invalid value: "Passthrough": cannot be set when using the "baremetal" platform$`,
 		},
 		{
 			name: "bad cloud credentials mode",
@@ -959,7 +959,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.CredentialsMode = "bad-mode"
 				return c
 			}(),
-			expectedError: `^credentialsMode: Unsupported value: "bad-mode": supported values: "manual", "mint", "passthrough"$`,
+			expectedError: `^credentialsMode: Unsupported value: "bad-mode": supported values: "Manual", "Mint", "Passthrough"$`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
By convention, API constants should be capitalized.