### PR TITLE
baremetal: Make master-bmh-update script more robust

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
@@ -37,7 +37,6 @@ for node in $(curl -s http://localhost:6385/v1/nodes | jq -r '.nodes[] | .uuid')
     # the BareMetalHost CRs as annotations, which BMO then picks up.
     HARDWARE_DETAILS=$(podman run --quiet --net=host \
         --rm \
-        --name baremetal-operator \
         --entrypoint /get-hardware-details \
         "${BAREMETAL_OPERATOR_IMAGE}" \
         http://localhost:5050/v1 "$node" | jq '{hardware: .}')

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -euo pipefail
+
 # shellcheck disable=SC1091
 . /usr/local/bin/release-image.sh
 

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/master-bmh-update.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC1091
 . /usr/local/bin/release-image.sh
 
-export KUBECONFIG=/etc/kubernetes/kubeconfig
+export KUBECONFIG=/opt/openshift/auth/kubeconfig-loopback
 
 # Wait till the baremetalhosts are populated
 until oc get baremetalhosts -n openshift-machine-api; do

--- a/data/data/bootstrap/baremetal/systemd/units/master-bmh-update.service
+++ b/data/data/bootstrap/baremetal/systemd/units/master-bmh-update.service
@@ -5,7 +5,10 @@ After=release-image.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/master-bmh-update.sh
+# FIXME https://github.com/systemd/systemd/pull/13754/
+# Doesn't yet exist in our systemd version, when it does
+# we can replace the loop with Restart=on-failure
+ExecStart=/usr/bin/sh -c 'while ! /usr/local/bin/master-bmh-update.sh; do echo "master-bmh-update.sh failed, retrying" && sleep 10; done'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We missed some review items in #3591 and also I noticed we're ignoring errors currently without any way to retry.

This led to some confusion when debugging issues on 4.4 because the script silently failed even though the baremetal-operator image was missing the necessary entrypoint - hopefully these changes make things a little more robust.