### PR TITLE
Ovirt UPI: Start vms with async

### DIFF
--- a/upi/ovirt/masters.yml
+++ b/upi/ovirt/masters.yml
@@ -18,3 +18,5 @@
     with_items:
     - "{{ vms }}"
     when: item.ocp_type == 'master'
+    async: 60
+    poll: 0

--- a/upi/ovirt/workers.yml
+++ b/upi/ovirt/workers.yml
@@ -18,3 +18,5 @@
     with_items:
     - "{{ vms }}"
     when: item.ocp_type == 'worker'
+    async: 60
+    poll: 0


### PR DESCRIPTION
Add the async to the ansible tasks starting vms,
to have all vms starting in parallel

Signed-off-by: Roberto Ciatti <rciatti@redhat.com>