### PR TITLE
Bug 1858342: types: allow docker bridge network range except on libvirt

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -19,7 +19,8 @@ import (
 )
 
 var (
-	dockerBridgeCIDR = func() *net.IPNet {
+	// DockerBridgeCIDR is the network range that is used by default network for docker.
+	DockerBridgeCIDR = func() *net.IPNet {
 		_, cidr, _ := net.ParseCIDR("172.17.0.0/16")
 		return cidr
 	}()
@@ -133,9 +134,6 @@ func SubnetCIDR(cidr *net.IPNet) error {
 	nip := cidr.IP.Mask(cidr.Mask)
 	if nip.String() != cidr.IP.String() {
 		return fmt.Errorf("invalid network address. got %s, expecting %s", cidr.String(), (&net.IPNet{IP: nip, Mask: cidr.Mask}).String())
-	}
-	if DoCIDRsOverlap(cidr, dockerBridgeCIDR) {
-		return fmt.Errorf("overlaps with default Docker Bridge subnet (%v)", cidr.String())
 	}
 	return nil
 }

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -61,8 +61,6 @@ func TestSubnetCIDR(t *testing.T) {
 		{"1.2.3.4/32", ""},
 		{"0:0:0:0:0:1:102:304/116", "invalid network address. got ::1:102:304/116, expecting ::1:102:0/116"},
 		{"0:0:0:0:0:ffff:102:304/116", "invalid network address. got 1.2.3.4/20, expecting 1.2.0.0/20"},
-		{"172.17.0.0/20", "overlaps with default Docker Bridge subnet (172.17.0.0/20)"},
-		{"172.0.0.0/8", "overlaps with default Docker Bridge subnet (172.0.0.0/8)"},
 		{"255.255.255.255/1", "invalid network address. got 255.255.255.255/1, expecting 128.0.0.0/1"},
 		{"255.255.255.255/32", ""},
 	}


### PR DESCRIPTION
The networking team has made an argument that not allowing docker default network bridge for machine, service and cluster networks is
an invalid validation see https://bugzilla.redhat.com/show_bug.cgi?id=1858342#c2 . So we are dropping that validation.

But on libvirt platform overlap with docker bridge has known to cause problems therefore we are keeping the validation for this platform.

Also when this network range is in use, warning is shown to the user so that in case users keep weird errors we can quickly traige to networking team.

/cc @dcbw @sdodson 