### PR TITLE
Readme.md: Remove experimental tag for OpenStack UPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 * [GCP (UPI)](docs/user/gcp/install_upi.md)
 * [Libvirt with KVM](docs/dev/libvirt/README.md) (development only)
 * [OpenStack](docs/user/openstack/README.md)
-* [OpenStack (UPI) (Experimental)](docs/user/openstack/install_upi.md)
+* [OpenStack (UPI)](docs/user/openstack/install_upi.md)
 * [oVirt](docs/user/ovirt/install_ipi.md)
 * [oVirt (UPI)](docs/user/ovirt/install_upi.md)
 * [vSphere](docs/user/vsphere/README.md)


### PR DESCRIPTION
As of OCP 4.5, OpenStack UPI is fully supported.