### PR TITLE
Bug 1862065: aws: use default resolver for signing_region of global APIs

### DIFF
--- a/pkg/asset/installconfig/aws/session.go
+++ b/pkg/asset/installconfig/aws/session.go
@@ -199,9 +199,14 @@ func newAWSResolver(region string, services []typesaws.ServiceEndpoint) *awsReso
 func (ar *awsResolver) EndpointFor(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
 	if s, ok := ar.services[resolverKey(service)]; ok {
 		logrus.Debugf("resolved AWS service %s (%s) to %q", service, region, s.URL)
+		signingRegion := ar.region
+		def, _ := endpoints.DefaultResolver().EndpointFor(service, region)
+		if len(def.SigningRegion) > 0 {
+			signingRegion = def.SigningRegion
+		}
 		return endpoints.ResolvedEndpoint{
 			URL:           s.URL,
-			SigningRegion: ar.region,
+			SigningRegion: signingRegion,
 		}, nil
 	}
 	if rv, ok := ar.defaultEndpoints[region]; ok {


### PR DESCRIPTION
For global APIs the signing region is different from the cluster region, therefore when the
service overrides are set use the default resolver to get the signing region and use that when it's
non empty.

Since we only using the result when the output is non-empty we do not care about the error as we default to cluster region already.

Example:

```
apiVersion: v1
baseDomain: devcluster.openshift.com
controlPlane:
  name: master
  replicas: 3
compute:
- name: worker
  replicas: 3
metadata:
  name: adahiya-1
platform:
  aws:
    region: af-south-1
    serviceEndpoints:
    - name: ec2
      url: https://ec2.af-south-1.amazonaws.com
    - name: elasticloadbalancing
      url: https://elasticloadbalancing.af-south-1.amazonaws.com
    - name: s3
      url: https://s3.af-south-1.amazonaws.com
    - name: iam
      url: https://iam.af-south-1.amazonaws.com
    - name: tagging
      url: https://tagging.af-south-1.amazonaws.com
    - name: route53
      url: https://route53.amazonaws.com
pullSecret: ""
sshKey: ""
```

```
$ ./bin/openshift-install --dir dev create manifests
INFO Credentials loaded from the "default" profile in file "/home/adahiya/.aws/credentials"
INFO Consuming Install Config from target directory
INFO Manifests created in: dev/manifests and dev/openshift
```
s Please enter the commit message for your changes. Lines starting