### PR TITLE
Ability to select bootstrap floating ip in openstack installer

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -60,12 +60,10 @@ resource "openstack_compute_instance_v2" "bootstrap" {
   tags = ["openshiftClusterID=${var.cluster_id}"]
 }
 
-resource "openstack_networking_floatingip_v2" "bootstrap_fip" {
+resource "openstack_networking_floatingip_associate_v2" "bootstrap_fip" {
   count       = var.external_network != "" ? 1 : 0
-  description = "${var.cluster_id}-bootstrap-fip"
-  pool        = var.external_network
   port_id     = openstack_networking_port_v2.bootstrap_port.id
-  tags        = ["openshiftClusterID=${var.cluster_id}"]
-
+  floating_ip = var.bootstrap_floating_ip
   depends_on = [openstack_compute_instance_v2.bootstrap]
 }
+

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -78,3 +78,8 @@ variable "zone" {
   type = string
   description = "Availability Zone to schedule the bootstrap node onto"
 }
+
+variable "bootstrap_floating_ip" {
+  type = string
+  description = "Defines the floating ip for the bootstrap machine"
+}

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -41,6 +41,7 @@ module "bootstrap" {
   root_volume_size        = var.openstack_master_root_volume_size
   root_volume_type        = var.openstack_master_root_volume_type
   zone                    = var.openstack_master_availability_zones[0]
+  bootstrap_floating_ip   = var.openstack_bootstrap_floating_ip
 }
 
 module "masters" {

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -296,6 +296,11 @@ EOF
 
 }
 
+variable "openstack_bootstrap_floating_ip" {
+  type 	      = string
+  description = "Existing Floating IP to attach to the bootstrap node"
+}
+
 variable "openstack_api_int_ip" {
   type = string
   description = "IP on the node subnet reserved for api-int VIP."

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -412,6 +412,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			bootstrapIgn,
 			installConfig.Config.ControlPlane.Platform.OpenStack,
 			installConfig.Config.Platform.OpenStack.MachinesSubnet,
+			installConfig.Config.Platform.OpenStack.BootstrapFloatingIP,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -43,10 +43,11 @@ type config struct {
 	MachinesSubnet             string   `json:"openstack_machines_subnet_id,omitempty"`
 	MachinesNetwork            string   `json:"openstack_machines_network_id,omitempty"`
 	MasterAvailabilityZones    []string `json:"openstack_master_availability_zones,omitempty"`
+	BootstrapFloatingIP	   string   `json:"openstack_bootstrap_floating_ip,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, externalNetwork string, externalDNS []string, lbFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
+func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, externalNetwork string, externalDNS []string, lbFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string, bootstrapFloatingIP string) ([]byte, error) {
 	cloud := masterConfigs[0].CloudName
 
 	zones := []string{}
@@ -69,6 +70,7 @@ func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, externalNetwork str
 		ExternalDNS:             externalDNS,
 		MachinesSubnet:          machinesSubnet,
 		MasterAvailabilityZones: zones,
+		BootstrapFloatingIP: bootstrapFloatingIP,
 	}
 
 	serviceCatalog, err := getServiceCatalog(cloud)

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -26,6 +26,10 @@ type Platform struct {
 	// to associate with the OpenShift load balancer.
 	LbFloatingIP string `json:"lbFloatingIP,omitempty"`
 
+	// BootstrapFloatingIP is the IP address of an available floating IP in your OpenStack cluster
+        // to associate with the Bootstrap node
+        BootstrapFloatingIP string `json:"bootstrapFloatingIP"`
+
 	// IngressFloatingIP is the ID of an available floating IP in your OpenStack cluster
 	// that will be associated with the OpenShift ingress port
 	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`


### PR DESCRIPTION
The bootstrap machine needs the ability to talk to glance api via firewall rules / network connectivity. 

Currently the bootstrap machine is given a random IP from the floating ip pool. This is problematic when teams do not want to grant the entire floating ip CIDR access to the glance api. 

Giving the user the ability to select the floating ip the same way they do for the api floating ip solves this problem. Now users can select the ip the bootstrap will use which can then be targeted specifically for firewall rules. 