### PR TITLE
Bug 1864280: set AZs default for machine pool in the right place

### DIFF
--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -108,6 +108,7 @@ func defaultGCPMachinePoolPlatform() gcptypes.MachinePool {
 func defaultOpenStackMachinePoolPlatform(flavor string) openstacktypes.MachinePool {
 	return openstacktypes.MachinePool{
 		FlavorName: flavor,
+		Zones:      []string{""},
 	}
 }
 

--- a/pkg/types/openstack/machinepool.go
+++ b/pkg/types/openstack/machinepool.go
@@ -57,10 +57,7 @@ func (o *MachinePool) Set(required *MachinePool) {
 
 	if len(required.Zones) > 0 {
 		o.Zones = required.Zones
-	} else {
-		o.Zones = []string{""}
 	}
-
 }
 
 // RootVolume defines the storage for an instance.


### PR DESCRIPTION
Currently If mpool is empty, we don't set default AZs and the installer can't generate machinesets.
This commit moves setting the default to the right place.