### PR TITLE
Bug 1865707: [baremetal] Add host roles to hosts in baremetal survey

### DIFF
--- a/pkg/asset/installconfig/baremetal/baremetal.go
+++ b/pkg/asset/installconfig/baremetal/baremetal.go
@@ -100,6 +100,11 @@ func Platform() (*baremetal.Platform, error) {
 			fmt.Printf("invalid host - please try again")
 			continue
 		}
+		if hostRole == "control plane" {
+			host.Role = "master"
+		} else {
+			host.Role = hostRole
+		}
 		hosts = append(hosts, host)
 
 		more := false


### PR DESCRIPTION
This PR fixes a bug in the baremetal survey where the host role is not currently
set. We also change the phrase for control plane back to 'master' temporarily until
the whole ecosystem moves away from the 'master/slave' terminology.