### PR TITLE
Change ignition version to one compatible with 4.3

### DIFF
--- a/docs/user/azure/install_upi.md
+++ b/docs/user/azure/install_upi.md
@@ -344,7 +344,7 @@ Create the deployment using the `az` client:
 
 ```sh
 export BOOTSTRAP_URL=`az storage blob url --account-name ${CLUSTER_NAME}sa --account-key $ACCOUNT_KEY -c "files" -n "bootstrap.ign" -o tsv`
-export BOOTSTRAP_IGNITION=`jq -rcnM --arg v "3.1.0" --arg url $BOOTSTRAP_URL '{ignition:{version:$v,config:{replace:{source:$url}}}}' | base64 -w0`
+export BOOTSTRAP_IGNITION=`jq -rcnM --arg v "2.2.0" --arg url $BOOTSTRAP_URL '{ignition:{version:$v,config:{replace:{source:$url}}}}' | base64 -w0`
 
 az group deployment create -g $RESOURCE_GROUP \
   --template-file "04_bootstrap.json" \


### PR DESCRIPTION
At the top of the document- you've specified that this install was compatible with 4.3.

When we attempt to use this document to perform a 4.3 install- ignition fails to complete due to incorrect version. We can see that this bootstrap ignition version number was updated 7 days ago, it appears that this wasn't tested on 4.3.

There are a couple of ways to solve this- either change the listed version at the top of the document and test for new version, or change the ignition configs version number back to one which is compatible with 4.3