### PR TITLE
Bug 1862209: types/aws: validate Name and kubernetes.io/clustername/* keys are not allowed

### DIFF
--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -117,6 +117,35 @@ func TestValidatePlatform(t *testing.T) {
 			},
 			expected: `^test-path\.defaultMachinePlatform\.iops: Invalid value: -10: Storage IOPS must be positive$`,
 		},
+		{
+			name: "invalid userTags, Name key",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				UserTags: map[string]string{
+					"Name": "test-cluster",
+				},
+			},
+			expected: `^\Qtest-path.userTags[Name]: Invalid value: "test-cluster": Name key is not allowed for user defined tags\E$`,
+		},
+		{
+			name: "invalid userTags, key with kubernetes.io/clustername/",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				UserTags: map[string]string{
+					"kubernetes.io/clustername/test-cluster": "shared",
+				},
+			},
+			expected: `^\Qtest-path.userTags[kubernetes.io/clustername/test-cluster]: Invalid value: "shared": Keys with prefix 'kubernetes.io/clustername/' are not allowed for user defined tags\E$`,
+		},
+		{
+			name: "valid userTags",
+			platform: &aws.Platform{
+				Region: "us-east-1",
+				UserTags: map[string]string{
+					"app": "production",
+				},
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Allowing these values as user defined tags causes problems defined in https://bugzilla.redhat.com/show_bug.cgi?id=1862209
