### PR TITLE
Bug 1866328: use correct cloud name for tfvars

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -400,6 +400,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		data, err = openstacktfvars.TFVars(
 			masterSpecs,
+			installConfig.Config.Platform.OpenStack.Cloud,
 			installConfig.Config.Platform.OpenStack.ExternalNetwork,
 			installConfig.Config.Platform.OpenStack.ExternalDNS,
 			installConfig.Config.Platform.OpenStack.LbFloatingIP,

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -46,9 +46,7 @@ type config struct {
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, externalNetwork string, externalDNS []string, lbFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
-	cloud := masterConfigs[0].CloudName
-
+func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
 	zones := []string{}
 	seen := map[string]bool{}
 	for _, config := range masterConfigs {
@@ -60,7 +58,7 @@ func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, externalNetwork str
 
 	cfg := &config{
 		ExternalNetwork:         externalNetwork,
-		Cloud:                   masterConfigs[0].CloudName,
+		Cloud:                   cloud,
 		FlavorName:              masterConfigs[0].Flavor,
 		LbFloatingIP:            lbFloatingIP,
 		IngressFloatingIP:       ingressFloatingIP,


### PR DESCRIPTION
Now we use cloud name not from the install config, which is set by the user, but from master specs, where it is hardcoded to 'openstack'.

This patch starts using the value from the install config.