### PR TITLE
Bug 1836017: Configure haproxy to check /readyz

### DIFF
--- a/upi/vsphere/lb/haproxy.tmpl
+++ b/upi/vsphere/lb/haproxy.tmpl
@@ -28,9 +28,11 @@ frontend router-https
     default_backend router-https
 
 backend api-server
+    option  httpchk GET /readyz HTTP/1.0
+    option  log-health-checks
     balance roundrobin
     %{ for addr in api ~}
-    server ${addr} ${addr}:6443 check
+    server ${addr} ${addr}:6443 weight 1 verify none check check-ssl inter 1s fall 2 rise 3
     %{ endfor ~}
 
 backend machine-config-server


### PR DESCRIPTION
Current hapropy setting for the vsphere upi is to check the
6443 port to see if the api server is up in tcp mode. TCP breaks
graceful termination and /readyz provides error information before
the api server crashes which would give some time for the load
balancer to react.

Adding a check in the HAProxy server to check for the /readyz
port for 200 status.