### PR TITLE
cmd: gather logs on cluster asset creation failure

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -198,6 +198,12 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 
 		err := runner(rootOpts.dir)
 		if err != nil {
+			// Attempt to gather logs if cluster asset creation failed
+			if cmd.Name() == "cluster" {
+				if err2 := runGatherBootstrapCmd(rootOpts.dir); err2 != nil {
+					logrus.Error("Attempted to gather debug logs after installation failure: ", err2)
+				}
+			}
 			logrus.Fatal(err)
 		}
 		if cmd.Name() != "cluster" {


### PR DESCRIPTION
If we fail to create the cluster asset (i.e. run terraform), no logs get
gathered because we exit fatally. This changes the create cluster target
to try to gather logs before exiting. It does not run the entire PostRun
function.

This is useful on some platforms where terraform may fail but the
bootstrap host may be up enough to capture logs.

fixes #3927 