### PR TITLE
[WIP] Bug 1824426: tag primary openstack network

### DIFF
--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -11,7 +11,7 @@ data "openstack_networking_network_v2" "external_network" {
 resource "openstack_networking_network_v2" "openshift-private" {
   name           = "${var.cluster_id}-openshift"
   admin_state_up = "true"
-  tags           = ["openshiftClusterID=${var.cluster_id}"]
+  tags           = ["openshiftClusterID=${var.cluster_id}", "${var.cluster_id}-primaryClusterNetwork"]
 }
 
 resource "openstack_networking_subnet_v2" "nodes" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -380,6 +380,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			clusterID.InfraID,
 			caCert,
 			bootstrapIgn,
+			installConfig.Config.Platform.OpenStack.MachinesSubnet,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -4,9 +4,10 @@ package openstack
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/attributestags"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
@@ -31,10 +32,11 @@ type config struct {
 	RootVolumeType         string   `json:"openstack_master_root_volume_type,omitempty"`
 	BootstrapShim          string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
 	ExternalDNS            []string `json:"openstack_external_dns,omitempty"`
+	MachinesNetwork            string   `json:"openstack_machines_network_id,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string, userCA string, bootstrapIgn string) ([]byte, error) {
+func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, lbFloatingIP string, apiVIP string, dnsVIP string, ingressVIP string, trunkSupport string, octaviaSupport string, baseImage string, infraID string, userCA string, bootstrapIgn string, machinesSubnet string) ([]byte, error) {
 
 	cfg := &config{
 		ExternalNetwork: externalNetwork,
@@ -98,6 +100,22 @@ func TFVars(masterConfig *v1alpha1.OpenstackProviderSpec, cloud string, external
 	if masterConfig.RootVolume != nil {
 		cfg.RootVolumeSize = masterConfig.RootVolume.Size
 		cfg.RootVolumeType = masterConfig.RootVolume.VolumeType
+	}
+
+	if machinesSubnet != "" {
+		cfg.MachinesNetwork, err = getNetworkFromSubnet(cloud, machinesSubnet)
+		if err != nil {
+			return nil, err
+		}
+
+		// Make sure that the network has the primary cluster network tag.
+		// In the case of multiple networks this tag is required for
+		// cluster-api-provider-openstack to define which ip address to set as
+		// the primary one.
+		err = setNetworkTag(cloud, cfg.MachinesNetwork, infraID+"-primaryClusterNetwork")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")
@@ -200,4 +218,42 @@ func getServiceCatalog(cloud string) (*tokens.ServiceCatalog, error) {
 	}
 
 	return serviceCatalog, nil
+}
+
+// getNetworkFromSubnet looks up a subnet in openstack and returns the ID of the network it's a part of
+func getNetworkFromSubnet(cloud string, subnetID string) (string, error) {
+	opts := &clientconfig.ClientOpts{
+		Cloud: cloud,
+	}
+
+	networkClient, err := clientconfig.NewServiceClient("network", opts)
+	if err != nil {
+		return "", err
+	}
+
+	subnet, err := subnets.Get(networkClient, subnetID).Extract()
+	if err != nil {
+		return "", err
+	}
+
+	return subnet.NetworkID, nil
+}
+
+// setNetworkTag sets a tag for the network
+func setNetworkTag(cloud string, networkID string, networkTag string) error {
+	opts := &clientconfig.ClientOpts{
+		Cloud: cloud,
+	}
+
+	networkClient, err := clientconfig.NewServiceClient("network", opts)
+	if err != nil {
+		return err
+	}
+
+	err = attributestags.Add(networkClient, "networks", networkID, networkTag).ExtractErr()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -43,4 +43,10 @@ type Platform struct {
 	// for cluster nodes or an existing Glance image name.
 	// +optional
 	ClusterOSImage string `json:"clusterOSImage,omitempty"`
+
+	// MachinesSubnet is the UUIDv4 of an openstack subnet. This subnet will be used by all nodes created by the installer.
+	// By setting this, the installer will no longer create a network and subnet.
+	// The subnet and network specified in MachinesSubnet will not be deleted or modified by the installer.
+	// +optional
+	MachinesSubnet string `json:"machinesSubnet,omitempty"`
 }


### PR DESCRIPTION
In the case of multiple added networks the tag
<infraID>-primaryClusterNetwork should allow
cluster-api-provider-openstack to define which
IP address to set as the primary one for machines.

Now CAPO can't do this, because Neutron returns the
list of networks in alphabetical order.