### PR TITLE
docs/user/openstack: Replace try.openshift.com with www.openshift.com/try

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -242,7 +242,7 @@ OpenStack support has [known issues](known-issues.md). We will be documenting wo
 
 ### Initial Setup
 
-Please head to [try.openshift.com](https://try.openshift.com) to get the latest versions of the installer, and instructions to run it.
+Please head to [openshift.com/try](https://www.openshift.com/try) to get the latest versions of the installer, and instructions to run it.
 
 Before running the installer, we recommend you create a directory for each cluster you plan to deploy. See the documents on the [recommended workflow](../overview.md#multiple-invocations) for more information about why you should do it this way.
 


### PR DESCRIPTION
Respecting the 301 redirects currently in place:

```console
$ curl -sLi https://try.openshift.com | grep -i '^http\|^location'
HTTP/1.1 301 Moved Permanently
location: https://www.openshift.com/try/
HTTP/1.1 301 Moved Permanently
Location: https://www.openshift.com/try
HTTP/1.1 200 OK
```

From [the spec][1] for 301 redirects:

> The 301 (Moved Permanently) status code indicates that the target resource has been assigned a new permanent URI and any future references to this resource ought to use one of the enclosed URIs.

So we should no longer be using the outdated URI.

[1]: https://tools.ietf.org/html/rfc7231#section-6.4.2