### PR TITLE
cmd/openshift-install: Info logging for old installers

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -16,8 +16,9 @@ fi
 MODE="${MODE:-release}"
 GIT_COMMIT="${SOURCE_GIT_COMMIT:-$(git rev-parse --verify 'HEAD^{commit}')}"
 GIT_TAG="${BUILD_VERSION:-$(git describe --always --abbrev=40 --dirty)}"
+GIT_COMMIT_DATE="$(git log -1 --format='%cd' --date=short "${GIT_COMMIT}" || date -u '+%Y-%m-%d')"
 GOFLAGS="${GOFLAGS:--mod=vendor}"
-LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=${GIT_TAG} -X github.com/openshift/installer/pkg/version.Commit=${GIT_COMMIT}"
+LDFLAGS="${LDFLAGS} -X github.com/openshift/installer/pkg/version.Raw=${GIT_TAG} -X github.com/openshift/installer/pkg/version.Commit=${GIT_COMMIT} -X github.com/openshift/installer/pkg/version.CommitDate=${GIT_COMMIT_DATE}"
 TAGS="${TAGS:-}"
 OUTPUT="${OUTPUT:-bin/openshift-install}"
 export CGO_ENABLED=0

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -26,6 +26,10 @@ var (
 	// Set in hack/build.sh.
 	Commit = ""
 
+	// CommitDate is the commit date, in YYYY-MM-DD format, from which
+	// the installer was built.  Set in hack/build.sh.
+	CommitDate = ""
+
 	// defaultReleaseInfoPadded may be replaced in the binary with Release Metadata: Version that overrides defaultVersion as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
@sdodson points out that we get a surprising number of installs using old installers.  Especially for cases with installer-created infrastructure, this may expose users to outdated choices which are not currently managed by in-cluster operators.  With this commit, we drop an info-level log to gently remind folks using old installers that they should probably be using a more recent installer.

The mirror links aren't pretty, but the more elegant pages like [this][1] currently have links like: [Download installer](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-install-linux.tar.gz).  I dunno if they're auto-detecting my OS or if that's hard-coded.  They certainly seem to be assuming I'm using amd64.

Unfortunately, cloud.redhat.com has no platform-agnostic page linking installer binaries.  We could also link [the product page][2]; I'm agnostic.

[1]: https://cloud.redhat.com/openshift/install/aws/installer-provisioned
[2]: https://access.redhat.com/downloads/content/290/