### PR TITLE
Bug 1867519: make externalNetwork optional

### DIFF
--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -118,7 +118,7 @@ resource "openstack_networking_trunk_v2" "masters" {
 // step that can't always be automated (we need to support OpenStack clusters)
 // that do not have or do not want to use Octavia.
 //
-// If an external network has not bee defined then a floating IP
+// If an external network has not been defined then a floating IP
 // will not be provided or assigned to the masters.
 //
 // If the floating IP is not provided, the installer will time out waiting for

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -57,7 +57,8 @@ func validateMachinesSubnet(p *openstack.Platform, n *types.Networking, ci *Clou
 
 // validateExternalNetwork validates the user's input for the externalNetwork and returns a list of all validation errors
 func validateExternalNetwork(p *openstack.Platform, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {
-	if ci.ExternalNetwork == nil {
+	// Return an error if external network was specified in the install config, but hasn't been found
+	if p.ExternalNetwork != "" && ci.ExternalNetwork == nil {
 		allErrs = append(allErrs, field.NotFound(fldPath.Child("externalNetwork"), p.ExternalNetwork))
 	}
 	return allErrs

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -170,6 +170,47 @@ func TestOpenStackPlatformValidation(t *testing.T) {
 			expectedError:  true,
 			expectedErrMsg: `[platform.openstack.ingressFloatingIP: Invalid value: "128.35.27.13": Cannot set floating ips when external network not specified, platform.openstack.lbFloatingIP: Invalid value: "128.35.27.8": Cannot set floating ips when external network not specified]`,
 		},
+		{
+			name: "no external network provided",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.ExternalNetwork = ""
+				p.LbFloatingIP = ""
+				p.IngressFloatingIP = ""
+				p.APIVIP = ""
+				return p
+			}(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				ci.ExternalNetwork = nil
+				ci.IngressFIP = nil
+				ci.APIFIP = nil
+				return ci
+			}(),
+			networking:     validNetworking(),
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:           "valid external network",
+			platform:       validPlatform(),
+			cloudInfo:      validPlatformCloudInfo(),
+			networking:     validNetworking(),
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:     "external network not found",
+			platform: validPlatform(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				ci.ExternalNetwork = nil
+				return ci
+			}(),
+			networking:     validNetworking(),
+			expectedError:  true,
+			expectedErrMsg: "platform.openstack.externalNetwork: Not found: \"valid-external-network\"",
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -17,6 +17,7 @@ type Platform struct {
 	Cloud string `json:"cloud"`
 
 	// ExternalNetwork is name of the external network in your OpenStack cluster.
+	// +optional
 	ExternalNetwork string `json:"externalNetwork,omitempty"`
 
 	// FlavorName is the name of the compute flavor to use for instances in this cluster.
@@ -24,10 +25,12 @@ type Platform struct {
 
 	// LbFloatingIP is the IP address of an available floating IP in your OpenStack cluster
 	// to associate with the OpenShift load balancer.
+	// +optional
 	LbFloatingIP string `json:"lbFloatingIP,omitempty"`
 
 	// IngressFloatingIP is the ID of an available floating IP in your OpenStack cluster
 	// that will be associated with the OpenShift ingress port
+	// +optional
 	IngressFloatingIP string `json:"ingressFloatingIP,omitempty"`
 
 	// ExternalDNS holds the IP addresses of dns servers that will


### PR DESCRIPTION
Despite the fact `externalNetwork` is considered as an optional parameter, installations fails if it's not specified.
https://github.com/openshift/installer/pull/3822

This commit makes this and related parameters truly optional.