### PR TITLE
Bug 1862044: deleting servers using metadata-based filtering

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -58,6 +58,11 @@ resource "openstack_compute_instance_v2" "bootstrap" {
   }
 
   tags = ["openshiftClusterID=${var.cluster_id}"]
+
+  metadata = {
+    Name               = "${var.cluster_id}-bootstrap"
+    openshiftClusterID = var.cluster_id
+  }
 }
 
 resource "openstack_networking_floatingip_v2" "bootstrap_fip" {

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -81,4 +81,9 @@ resource "openstack_compute_instance_v2" "master_conf" {
   }
 
   tags = ["openshiftClusterID=${var.cluster_id}"]
+
+  metadata = {
+    Name = "${var.cluster_id}-master"
+    openshiftClusterID = var.cluster_id
+  }
 }

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -156,6 +156,10 @@ func generateProvider(clusterID string, platform *openstack.Platform, mpool *ope
 		Tags: []string{
 			fmt.Sprintf("openshiftClusterID=%s", clusterID),
 		},
+		ServerMetadata: map[string]string{
+			"Name":               fmt.Sprintf("%s-%s", clusterID, role),
+			"openshiftClusterID": clusterID,
+		},
 	}
 	if mpool.RootVolume != nil {
 		spec.RootVolume = &openstackprovider.RootVolume{


### PR DESCRIPTION
In https://github.com/openshift/installer/pull/3818 we introduced tag-based server delition. Unfortunately it turned out we can destroy servers, created by previous versions, as no tags were set there.

To fix this situation we come back to the previous solution - deleting servers by metadata.

This reverts commit e7bf767b96f71ae7c3be210d536b64dda28e4e37