### PR TITLE
aws: switch to HTTP /readyz probe to work with FIPS mode

### DIFF
--- a/data/data/aws/vpc/master-elb.tf
+++ b/data/data/aws/vpc/master-elb.tf
@@ -62,8 +62,8 @@ resource "aws_lb_target_group" "api_internal" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10
-    port                = 6443
-    protocol            = "HTTPS"
+    port                = 6080
+    protocol            = "HTTP"
     path                = "/readyz"
   }
 }
@@ -90,8 +90,8 @@ resource "aws_lb_target_group" "api_external" {
     healthy_threshold   = 2
     unhealthy_threshold = 2
     interval            = 10
-    port                = 6443
-    protocol            = "HTTPS"
+    port                = 6080
+    protocol            = "HTTP"
     path                = "/readyz"
   }
 }


### PR DESCRIPTION
In FIPS mode we have the suspicion that the AWS health checker fails because the API server does not offer all ciphers as usually expected. This PR switches it to HTTP port 6080 like it's done in GCP too.