### PR TITLE
upi/metal: remove deprecated coreos-installer kernel arguments

### DIFF
--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -14,9 +14,7 @@ locals {
     "rd.neednet=1",
 
     # "rd.break=initqueue"
-    "coreos.inst=yes",
-    "coreos.inst.install_dev=sda",
-    "coreos.inst.skip_media_check",
+    "coreos.inst.install_dev=/dev/sda",
   ]
 
   pxe_kernel = var.pxe_kernel_url


### PR DESCRIPTION
A follow-up to https://github.com/openshift/installer/pull/3865 address few comments
xref: https://github.com/openshift/installer/pull/3865/files#r461057804