### PR TITLE
Bug 1867972: destroy/aws: setup the resourcetagging api with correct region for gov cloud

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -139,7 +139,12 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) error {
 			tagClients = append(tagClients, tagClient)
 			tagClientNames[tagClient] = endpoints.CnNorthwest1RegionID
 		}
-
+	case endpoints.UsGovEast1RegionID, endpoints.UsGovWest1RegionID:
+		if o.Region != endpoints.UsGovWest1RegionID {
+			tagClient := resourcegroupstaggingapi.New(awsSession, aws.NewConfig().WithRegion(endpoints.UsGovWest1RegionID))
+			tagClients = append(tagClients, tagClient)
+			tagClientNames[tagClient] = endpoints.UsGovWest1RegionID
+		}
 	default:
 		if o.Region != endpoints.UsEast1RegionID {
 			tagClient := resourcegroupstaggingapi.New(awsSession, aws.NewConfig().WithRegion(endpoints.UsEast1RegionID))


### PR DESCRIPTION
Similar to https://github.com/openshift/installer/commit/2ef70a98679f62dc6fe9965ac7ca79b1c7dd09c6 resourcetaggingapi needs to be congifured with
additional region that would allow listing the Route53 resources for the partition. For GovCloud that region is `us-west-gov-1`