### PR TITLE
Bug 1866949: data/data/aws/route53: use CNAME for gov cloud partition

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -87,6 +87,7 @@ module "dns" {
   cluster_id               = var.cluster_id
   tags                     = local.tags
   vpc_id                   = module.vpc.vpc_id
+  region                   = var.aws_region
   publish_strategy         = var.aws_publish_strategy
 }
 

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -53,3 +53,8 @@ based on if api_external_lb_dns_name for example, which will be null when there 
 So publish_strategy serves an coordinated proxy for that decision.
 EOF
 }
+
+variable "region" {
+  type = string
+  description = "The target AWS region for the cluster."
+}


### PR DESCRIPTION
Based on the documentation https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-r53.html
```
You can create private hosted zones in the AWS GovCloud (US). In general, the functionality is the same as for private hosted zones in the global version of Route 53. However, you can create alias records only when the alias target is another record in the same hosted zone. To route traffic to another AWS resource, such as an ELB load balancer or an S3 bucket, you can use a CNAME record instead of an alias record unless you're creating a record at the zone apex.
```

We cannot create ALIAS records to the NLBs in gov clouds partition, which includes `us-gov-west-1` and `us-gov-east-1`. So we switch to using CNAME for our api records in those regions and continue to use ALIAS for other regions.

/assign @jstuever 