### PR TITLE
error if no zones in openstack machine pool

### DIFF
--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -52,6 +52,9 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	machines := make([]machineapi.Machine, 0, total)
 	providerConfigs := map[string]*openstackprovider.OpenstackProviderSpec{}
 	for idx := int64(0); idx < total; idx++ {
+		if len(mpool.Zones) == 0 {
+			return nil, fmt.Errorf("no zones in OpenStack machine-pool")
+		}
 		zone := mpool.Zones[int(idx)%len(mpool.Zones)]
 		var provider *openstackprovider.OpenstackProviderSpec
 


### PR DESCRIPTION
if a machine pool does not have zones configured, you end up with a go
panic: `panic: runtime error: integer divide by zero`

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>