### PR TITLE
Bug 1868439: openstack upi: fix Ignition key error

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -632,9 +632,11 @@ $ for index in $(seq 0 2); do
     MASTER_HOSTNAME="$INFRA_ID-master-$index\n"
     python -c "import base64, json, sys;
 ignition = json.load(sys.stdin);
-files = ignition['storage'].get('files', []);
-files.append({'path': '/etc/hostname', 'mode': 420, 'contents': {'source': 'data:text/plain;charset=utf-8;base64,' + base64.standard_b64encode(b'$MASTER_HOSTNAME').decode().strip()}});
-ignition['storage']['files'] = files;
+storage = ignition.get('storage', {});
+files = storage.get('files', []);
+files.append({'path': '/etc/hostname', 'mode': 420, 'contents': {'source': 'data:text/plain;charset=utf-8;base64,' + base64.standard_b64encode(b'$MASTER_HOSTNAME').decode().strip(), 'verification': {}}, 'filesystem': 'root'});
+storage['files'] = files;
+ignition['storage'] = storage
 json.dump(ignition, sys.stdout)" <master.ign >"$INFRA_ID-master-$index-ignition.json"
 done
 ```


### PR DESCRIPTION
Make the script modifying masters' Ignition more resilient by accounting
for a missing 'storage' property.