### PR TITLE
vendor/terraform-provider-vsphere: Verify DiskPostCloneOperation patch carry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -117,7 +117,7 @@ replace (
 	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20200130220348-e5685c0cf530 // Pin MCO so it doesn't get downgraded
 	github.com/terraform-providers/terraform-provider-aws => github.com/openshift/terraform-provider-aws v1.60.1-0.20200630224953-76d1fb4e5699 // Pin to openshift fork with tag v2.67.0-openshift
 	github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.40.1-0.20200707062554-97ea089cc12a // release-2.17.0 branch
-	github.com/terraform-providers/terraform-provider-vsphere => github.com/openshift/terraform-provider-vsphere v1.18.1-openshift-1
+	github.com/terraform-providers/terraform-provider-vsphere => github.com/mtnbikenc/terraform-provider-vsphere v1.18.2-0.20200807173801-22d13c155527
 	github.com/vmware/govmomi => github.com/vmware/govmomi v0.22.2-0.20200420222347-5fceac570f29
 	google.golang.org/api => google.golang.org/api v0.13.0 // Pin to version required by tf-provider-google
 	k8s.io/api => k8s.io/api v0.17.1 // Replaced by MCO/CRI-O

--- a/go.sum
+++ b/go.sum
@@ -1353,6 +1353,8 @@ github.com/mozillazg/go-cos v0.13.0/go.mod h1:Zp6DvvXn0RUOXGJ2chmWt2bLEqRAnJnS3D
 github.com/mozillazg/go-httpheader v0.2.1/go.mod h1:jJ8xECTlalr6ValeXYdOF8fFUISeBAdw6E61aqQma60=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474/go.mod h1:OQA4XLvDbMgS8P0CevmM4m9Q3Jq4phKUzcocxuGJ5m8=
 github.com/mrunalp/fileutils v0.0.0-20171103030105-7d4729fb3618/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
+github.com/mtnbikenc/terraform-provider-vsphere v1.18.2-0.20200807173801-22d13c155527 h1:h+Ptqxl/L+CCDGMUh1KZDiXhpuRlCqlyHN/vkS7hsrg=
+github.com/mtnbikenc/terraform-provider-vsphere v1.18.2-0.20200807173801-22d13c155527/go.mod h1:a1mEaZ0sy5RL+ukbqPvY1N6dw9K0yG7EYWZZkfJUeyA=
 github.com/mtrmac/gpgme v0.0.0-20170102180018-b2432428689c/go.mod h1:GhAqVMEWnTcW2dxoD/SO3n2enrgWl3y6Dnx4m59GvcA=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -1492,8 +1494,6 @@ github.com/openshift/terraform-provider-aws v1.60.1-0.20200630224953-76d1fb4e569
 github.com/openshift/terraform-provider-aws v1.60.1-0.20200630224953-76d1fb4e5699/go.mod h1:0U3OgA2uDYSc7gNkdWA92+/BxWXwuYhWqqZ4UhM1RCw=
 github.com/openshift/terraform-provider-azurerm v1.40.1-0.20200707062554-97ea089cc12a h1:yrCt4MiDMfLRv//VnIc3lnrmBYhIIz72+ZcGq/YMIjk=
 github.com/openshift/terraform-provider-azurerm v1.40.1-0.20200707062554-97ea089cc12a/go.mod h1:9VGDn8x+Pz/j5vQ8nseuH+YsKyxpGYx+faT9b9fqCWQ=
-github.com/openshift/terraform-provider-vsphere v1.18.1-openshift-1 h1:Jvi/tGlF8xOLZ5lWjJWi8hyXOSe7NqbAqOrwjdDRE7E=
-github.com/openshift/terraform-provider-vsphere v1.18.1-openshift-1/go.mod h1:a1mEaZ0sy5RL+ukbqPvY1N6dw9K0yG7EYWZZkfJUeyA=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/vendor/github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -1008,7 +1008,7 @@ func DiskPostCloneOperation(d *schema.ResourceData, c *govmomi.Client, l object.
 			//
 			// TODO: Remove "name" after 2.0.
 			switch k {
-			case "label", "path", "name", "datastore_id", "uuid":
+			case "label", "path", "name", "datastore_id", "uuid", "thin_provisioned", "eagerly_scrub":
 				continue
 			case "io_share_count":
 				if src["io_share_level"] != string(types.SharesLevelCustom) {

--- a/vendor/github.com/terraform-providers/terraform-provider-vsphere/vsphere/resource_vsphere_virtual_machine.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-vsphere/vsphere/resource_vsphere_virtual_machine.go
@@ -902,10 +902,8 @@ func resourceVSphereVirtualMachineCustomizeDiff(d *schema.ResourceDiff, meta int
 
 	// Validate and normalize disk sub-resources when not deploying from ovf
 	if len(d.Get("ovf_deploy").([]interface{})) == 0 {
-		if len(d.Get("clone").([]interface{})) == 0 {
-			if err := virtualdevice.DiskDiffOperation(d, client); err != nil {
-				return err
-			}
+		if err := virtualdevice.DiskDiffOperation(d, client); err != nil {
+			return err
 		}
 	}
 	// When a VM is a member of a vApp container, it is no longer part of the VM

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1317,7 +1317,7 @@ github.com/terraform-providers/terraform-provider-local/local
 github.com/terraform-providers/terraform-provider-openstack/openstack
 # github.com/terraform-providers/terraform-provider-random v1.3.2-0.20190925210718-83518d96ae4f
 github.com/terraform-providers/terraform-provider-random/random
-# github.com/terraform-providers/terraform-provider-vsphere v1.16.2 => github.com/openshift/terraform-provider-vsphere v1.18.1-openshift-1
+# github.com/terraform-providers/terraform-provider-vsphere v1.16.2 => github.com/mtnbikenc/terraform-provider-vsphere v1.18.2-0.20200807173801-22d13c155527
 github.com/terraform-providers/terraform-provider-vsphere/vsphere
 github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/clustercomputeresource
 github.com/terraform-providers/terraform-provider-vsphere/vsphere/internal/helper/computeresource


### PR DESCRIPTION
Backporting #4023 to 4.5.

Generated with:

```console
$ sed -i 's|github.com/openshift/terraform-provider-vsphere v1.18.1-openshift-1|github.com/mtnbikenc/terraform-provider-vsphere v1.18.2-0.20200807173801-22d13c155527|' go.mod
$ go mod tidy
$ go mod vendor
```

using:

```console
$ go version
go version go1.14.4 linux/amd64
```