### PR TITLE
Bug 1868748: baremetal: rename JSON field for ClusterProvisioningIP

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -845,6 +845,9 @@ spec:
                   clusterOSImage:
                     description: ClusterOSImage is a URL to override the default OS image for cluster nodes. The URL must contain a sha256 hash of the image e.g https://mirror.example.com/images/metal.qcow2.gz?sha256=3b5a8...
                     type: string
+                  clusterProvisioningIP:
+                    description: ClusterProvisioningIP is the IP on the dedicated provisioning network where the baremetal-operator pod runs provisioning services, and an http server to cache some downloaded content e.g RHCOS/IPA images
+                    type: string
                   defaultMachinePlatform:
                     description: DefaultMachinePlatform is the default configuration used when installing on bare metal for machine pools which do not define their own platform configuration.
                     type: object
@@ -950,7 +953,7 @@ spec:
                     description: ProvisioningDHCPRange is used to provide DHCP services to hosts for provisioning.
                     type: string
                   provisioningHostIP:
-                    description: ClusterProvisioningIP is the IP on the dedicated provisioning network where the baremetal-operator pod runs provisioning services, and an http server to cache some downloaded content e.g RHCOS/IPA images
+                    description: DeprecatedProvisioningHostIP is the deprecated version of clusterProvisioningIP. When the baremetal platform was initially added to the installer, the JSON field for ClusterProvisioningIP was incorrectly set to "provisioningHostIP."  This field is here to allow backwards-compatibility.
                     type: string
                   provisioningMACAddress:
                     description: ProvisioningMACAddress is used to allow setting a static unicast MAC address for the bootstrap host on the provisioning network. Consider using the QEMU vendor prefix `52:54:00`. If left blank, libvirt will generate one for you.

--- a/docs/user/metal/customization_ipi.md
+++ b/docs/user/metal/customization_ipi.md
@@ -59,7 +59,7 @@ be customized.
 * `bootstrapProvisioningIP` (optional string): Override the bootstrap
     provisioning IP. If unspecified, uses the 2nd address in the
     provisioning network's subnet.
-* `provisioningHostIP` (optional string): Override the IP used by the
+* `clusterProvisioningIP` (optional string): Override the IP used by the
     cluster's provisioning infrastructure. If unspecified, uses the 3rd
     address in the provisioning network's subnet.
 
@@ -70,7 +70,7 @@ platform:
   baremetal:
     provisioningNetworkCIDR: 172.23.0.0/16
     bootstrapProvisioningIP: 172.23.0.2
-    provisioningHostIP: 172.23.0.3
+    clusterProvisioningIP: 172.23.0.3
 ```
 
 * `provisioningDHCPRange` (optional string): By default, the installer picks a range from
@@ -91,7 +91,7 @@ use an external DHCP server, you can specify provisioningDHCPExternal,
 in which case the cluster will only run TFTP.  When using PXE boot for
 the control plane and workers, your DHCP server needs to specify the
 next-server as `bootstrapProvisioningIP` for the control plane, and
-`provisioningHostIP` for the workers.
+`clusterProvisioningIP` for the workers.
 
 Example:
 

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -69,7 +69,13 @@ type Platform struct {
 	// where the baremetal-operator pod runs provisioning services,
 	// and an http server to cache some downloaded content e.g RHCOS/IPA images
 	// +optional
-	ClusterProvisioningIP string `json:"provisioningHostIP,omitempty"`
+	ClusterProvisioningIP string `json:"clusterProvisioningIP,omitempty"`
+
+	// DeprecatedProvisioningHostIP is the deprecated version of clusterProvisioningIP. When the
+	// baremetal platform was initially added to the installer, the JSON field for ClusterProvisioningIP
+	// was incorrectly set to "provisioningHostIP."  This field is here to allow backwards-compatibility.
+	// +optional
+	DeprecatedProvisioningHostIP string `json:"provisioningHostIP,omitempty"`
 
 	// BootstrapProvisioningIP is the IP used on the bootstrap VM to
 	// bring up provisioning services that are used to create the

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -142,7 +142,7 @@ func validateDHCPRange(p *baremetal.Platform, fldPath *field.Path) (allErrs fiel
 	if start != nil && end != nil {
 		// Validate ClusterProvisioningIP is not in DHCP range
 		if clusterProvisioningIP := net.ParseIP(p.ClusterProvisioningIP); clusterProvisioningIP != nil && bytes.Compare(clusterProvisioningIP, start) >= 0 && bytes.Compare(clusterProvisioningIP, end) <= 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("provisioningHostIP"), p.ClusterProvisioningIP, fmt.Sprintf("%q overlaps with the allocated DHCP range", p.ClusterProvisioningIP)))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterProvisioningIP"), p.ClusterProvisioningIP, fmt.Sprintf("%q overlaps with the allocated DHCP range", p.ClusterProvisioningIP)))
 		}
 
 		// Validate BootstrapProvisioningIP is not in DHCP range
@@ -311,7 +311,7 @@ func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field
 
 	if p.ClusterProvisioningIP != "" {
 		if err := validate.IP(p.ClusterProvisioningIP); err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("provisioningHostIP"), p.ClusterProvisioningIP, err.Error()))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("clusterProvisioningIP"), p.ClusterProvisioningIP, err.Error()))
 		}
 	}
 

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
@@ -205,6 +206,71 @@ func TestConvertInstallConfig(t *testing.T) {
 				},
 			},
 			expectedError: "cannot specify lbFloatingIP and apiFloatingIP together",
+		},
+
+		// BareMetal platform conversions
+		{
+			name: "baremetal external DHCP",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					BareMetal: &baremetal.Platform{
+						DeprecatedProvisioningDHCPExternal: true,
+					},
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					BareMetal: &baremetal.Platform{
+						DeprecatedProvisioningDHCPExternal: true,
+						ProvisioningNetwork:                "Unmanaged",
+					},
+				},
+			},
+		},
+		{
+			name: "baremetal provisioningHostIP -> clusterProvisioningIP",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					BareMetal: &baremetal.Platform{
+						DeprecatedProvisioningHostIP: "172.22.0.3",
+					},
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					BareMetal: &baremetal.Platform{
+						ClusterProvisioningIP:        "172.22.0.3",
+						DeprecatedProvisioningHostIP: "172.22.0.3",
+					},
+				},
+			},
+		},
+		{
+			name: "baremetal provisioningHostIP mismatch clusterProvisioningIP",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					BareMetal: &baremetal.Platform{
+						ClusterProvisioningIP:        "172.22.0.4",
+						DeprecatedProvisioningHostIP: "172.22.0.3",
+					},
+				},
+			},
+			expectedError: "provisioningHostIP is deprecated; only clusterProvisioningIP needs to be specified",
 		},
 	}
 


### PR DESCRIPTION
The ClusterProvisioningIP field in the baremetal platform had an
incorrect JSON annotation for serialization/deserialization, using
"provisioningHostIP" instead of "clusterProvisioningIP." This name is
incorrect and doesn't adequately reflect it's purpose. This field is
the IP used in the cluster for provisioning.

This commit deprecates the old JSON field, and uses the correct JSON
annotation for ClusterProvisioningIP.