### PR TITLE
[FCOS] Fix Terraform for Azure

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -51,7 +51,7 @@ resource "azurerm_storage_blob" "ignition" {
   source                 = local_file.ignition_bootstrap.filename
   storage_account_name   = var.storage_account.name
   storage_container_name = azurerm_storage_container.ignition.name
-  type                   = "Page"
+  type                   = "Block"
 }
 
 data "ignition_config" "redirect" {

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -170,8 +170,8 @@ resource "azurerm_storage_blob" "rhcos_image" {
   storage_account_name   = azurerm_storage_account.cluster.name
   storage_container_name = azurerm_storage_container.vhd.name
   type                   = "Page"
-  source_uri             = var.azure_image_url
-  metadata               = map("source_uri", var.azure_image_url)
+  source                 = var.azure_image_url
+  metadata               = map("source", var.azure_image_url)
 }
 
 resource "azurerm_image" "cluster" {


### PR DESCRIPTION
Set blob type for ignition file for Bootstrap VM to 'Block' instead of 'Page'.

Change source_uri to source because on OKD we download the FCOS image locally before uploading it to Azure.