### PR TITLE
Bug 1869329: OpenStack: Place Bootstrap in one of the master AZs

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -36,9 +36,10 @@ resource "openstack_blockstorage_volume_v3" "bootstrap_volume" {
 }
 
 resource "openstack_compute_instance_v2" "bootstrap" {
-  name      = "${var.cluster_id}-bootstrap"
-  flavor_id = data.openstack_compute_flavor_v2.bootstrap_flavor.id
-  image_id  = var.root_volume_size == null ? var.base_image_id : null
+  name              = "${var.cluster_id}-bootstrap"
+  flavor_id         = data.openstack_compute_flavor_v2.bootstrap_flavor.id
+  image_id          = var.root_volume_size == null ? var.base_image_id : null
+  availability_zone = var.zone
 
   user_data = var.bootstrap_shim_ignition
 


### PR DESCRIPTION
Provision bootstrap instance in given availability zone similar to masters. Currently bootstrap is created in default zone.

Signed-off-by: Yussuf Shaikh <yussuf@us.ibm.com>