### PR TITLE
Bug 1813012: Remove unused etcd discovery domain

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -80,7 +80,6 @@ then
 		--etcd-ca=/assets/tls/etcd-ca-bundle.crt \
 		--etcd-ca-key=/assets/tls/etcd-signer.key \
 		--manifest-etcd-image="${MACHINE_CONFIG_ETCD_IMAGE}" \
-		--etcd-discovery-domain={{.ClusterDomain}} \
 		--manifest-cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}" \
 		--manifest-setup-etcd-env-image="${MACHINE_CONFIG_OPERATOR_IMAGE}" \
 		--manifest-kube-client-agent-image="${MACHINE_CONFIG_KUBE_CLIENT_AGENT_IMAGE}" \

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -53,7 +53,6 @@ type bootstrapTemplateData struct {
 	Proxy                 *configv1.ProxyStatus
 	Registries            []sysregistriesv2.Registry
 	BootImage             string
-	ClusterDomain         string
 	PlatformData          platformTemplateData
 }
 
@@ -259,7 +258,6 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 		Proxy:                 &proxy.Status,
 		Registries:            registries,
 		BootImage:             string(*rhcosImage),
-		ClusterDomain:         installConfig.ClusterDomain(),
 		PlatformData:          platformData,
 	}, nil
 }

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -76,7 +76,6 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 			InfrastructureName:   clusterID.InfraID,
 			APIServerURL:         getAPIServerURL(installConfig.Config),
 			APIServerInternalURL: getInternalAPIServerURL(installConfig.Config),
-			EtcdDiscoveryDomain:  getEtcdDiscoveryDomain(installConfig.Config),
 			PlatformStatus:       &configv1.PlatformStatus{},
 		},
 	}

--- a/pkg/asset/manifests/utils.go
+++ b/pkg/asset/manifests/utils.go
@@ -40,7 +40,3 @@ func getAPIServerURL(ic *types.InstallConfig) string {
 func getInternalAPIServerURL(ic *types.InstallConfig) string {
 	return fmt.Sprintf("https://api-int.%s:6443", ic.ClusterDomain())
 }
-
-func getEtcdDiscoveryDomain(ic *types.InstallConfig) string {
-	return ic.ClusterDomain()
-}


### PR DESCRIPTION
etcd has not been using DNS entries since 4.4 and EtcdDiscoveryDomain has been a redundant flag. This PR attempts to get rid of the unused flag.

This is an attempt to get https://github.com/openshift/installer/pull/4024 split into smaller PRs to understand the build errors.