### PR TITLE
[WIP] baremetal: Docs - clarify usage of provisioningNetwork

### DIFF
--- a/docs/user/metal/customization_ipi.md
+++ b/docs/user/metal/customization_ipi.md
@@ -12,7 +12,7 @@
 `externalBridge` | `baremetal` | The name of the bridge of the hypervisor attached to the external network. |
 `provisioningBridge` | `provisioning` | The name of the bridge on the hypervisor attached to the provisioning network. |
 `provisioningNetworkCIDR` | `172.22.0.0/24` | The CIDR for the network to use for provisioning. |
-`provisioningNetwork` | `Managed` | ProvisioningNetwork is used to indicate if we will have a provisioning network, and how it will be managed. May be "Managed" (default), "Unmanaged," or "Disabled."
+`provisioningNetwork` | `Managed` | ProvisioningNetwork is used to indicate if there is a network dedicated to provisioning traffic, and how it will be managed. Valid values are `Managed` (default), `Unmanaged`, and `Disabled`. See <link to new section describing the options in more detail> for more detail.
 `provisioningDHCPExternal` | `false` | *DEPRECATED* use provisioningNetwork: Unmanaged instead.
 `provisioningDHCPRange` | The tenth through the second last IP on the provisioning network. `172.22.0.10,172.22.0.254` | The IP range to use for hosts on the provisioning network. |
 `defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration. |

--- a/docs/user/metal/customization_ipi.md
+++ b/docs/user/metal/customization_ipi.md
@@ -12,7 +12,8 @@
 `externalBridge` | `baremetal` | The name of the bridge of the hypervisor attached to the external network. |
 `provisioningBridge` | `provisioning` | The name of the bridge on the hypervisor attached to the provisioning network. |
 `provisioningNetworkCIDR` | `172.22.0.0/24` | The CIDR for the network to use for provisioning. |
-`provisioningDHCPExternal` | `false` | Flag indicating that DHCP for the provisioning network is managed outside of the cluster by existing infrastructure services. |
+`provisioningNetwork` | `Managed` | ProvisioningNetwork is used to indicate if we will have a provisioning network, and how it will be managed. May be "Managed" (default), "Unmanaged," or "Disabled."
+`provisioningDHCPExternal` | `false` | *DEPRECATED* use provisioningNetwork: Unmanaged instead.
 `provisioningDHCPRange` | The tenth through the second last IP on the provisioning network. `172.22.0.10,172.22.0.254` | The IP range to use for hosts on the provisioning network. |
 `defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration. |
 `bootstrapOSImage` | *based on the release image* | A URL to override the default operating system image for the bootstrap node. The URL must contain a sha256 hash of the image. Example `https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd...` |

--- a/docs/user/metal/customization_ipi.md
+++ b/docs/user/metal/customization_ipi.md
@@ -13,7 +13,7 @@
 `provisioningBridge` | `provisioning` | The name of the bridge on the hypervisor attached to the provisioning network. |
 `provisioningNetworkCIDR` | `172.22.0.0/24` | The CIDR for the network to use for provisioning. |
 `provisioningNetwork` | `Managed` | ProvisioningNetwork is used to indicate if there is a network dedicated to provisioning traffic, and how it will be managed. Valid values are `Managed` (default), `Unmanaged`, and `Disabled`. See <link to new section describing the options in more detail> for more detail.
-`provisioningDHCPExternal` | `false` | *DEPRECATED* use provisioningNetwork: Unmanaged instead.
+`provisioningDHCPExternal` | `false` | *DEPRECATED* use `provisioningNetwork: Unmanaged` instead.
 `provisioningDHCPRange` | The tenth through the second last IP on the provisioning network. `172.22.0.10,172.22.0.254` | The IP range to use for hosts on the provisioning network. |
 `defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration. |
 `bootstrapOSImage` | *based on the release image* | A URL to override the default operating system image for the bootstrap node. The URL must contain a sha256 hash of the image. Example `https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd...` |

--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -36,8 +36,8 @@ accessible over the external network which may not be desirable.
   * ***NTP***
     * A time source must be accessible from this network.
   * ***Reserved VIPs (Virtual IPs)*** - 3 IP addresses must be reserved on this
-	network for use by the cluster. These Virtual IPs are managed using VRRP
-	(v2 for IPv4 and v3 for IPv6). Specifically, these IPs will serve the
+    network for use by the cluster. These Virtual IPs are managed using VRRP
+    (v2 for IPv4 and v3 for IPv6). Specifically, these IPs will serve the
     following purposes:
     * API - This IP will be used to reach the cluster API.
     * Ingress - This IP will be used by cluster ingress traffic
@@ -52,11 +52,13 @@ accessible over the external network which may not be desirable.
   * A private network used for PXE based provisioning.
   * You must specify `provisioningNetworkInterface` to indicate which
     interface is connected to this network on the control plane nodes.
-  * The provisioning network may be "Managed" (default), "Unmanaged," or
+  * The `provisioningNetwork` may be "Managed" (default), "Unmanaged," or
     "Disabled."
-  * In managed mode, DHCP and TFTP are configured to run in the cluster. In
+  * In `Managed` mode, DHCP and TFTP are configured to run in the cluster. In
     unmanaged mode, TFTP is still available but you must configure DHCP
     externally.
+  * In `Disabled` mode, no second NIC is required, but an additional controlplane
+    IP must be specified by the `clusterProvisioningIP`.
   * Addressing for this network defaults to `172.22.0.0/24`, but is
     configurable by setting the `provisioningNetworkCIDR` option.
   * Two IP's are required to be available for use, one for the bootstrap


### PR DESCRIPTION
Add some additional details about the new option, and highlight that
the old DHCPExternal option is now deprecated