### PR TITLE
Bug 1871048: OpenStack: dynamically set end of DHCP allocation pool

### DIFF
--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -29,13 +29,11 @@ resource "openstack_networking_subnet_v2" "nodes" {
   dns_nameservers = var.external_dns
 
   # We reserve some space at the beginning of the CIDR to use for the VIPs
-  # It would be good to make this more dynamic by calculating the number of
-  # addresses in the provided CIDR. This currently assumes at least a /18.
   # FIXME(mandre) if we let the ports pick up VIPs automatically, we don't have
   # to do any of this.
   allocation_pool {
     start = cidrhost(local.nodes_cidr_block, 10)
-    end   = cidrhost(local.nodes_cidr_block, 16000)
+    end   = cidrhost(local.nodes_cidr_block, pow(2, (32 - split("/", local.nodes_cidr_block)[1])) - 2)
   }
 }
 


### PR DESCRIPTION
By dynamically calculating the end of DHCP allocation pool, this allows
deploying OpenShift with machine CIDR smaller than `/18`.