### PR TITLE
Bug 1868773: Libvirt: Bump bootstrap memory to 4G

### DIFF
--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -47,7 +47,7 @@ variable "libvirt_master_vcpu" {
 variable "libvirt_bootstrap_memory" {
   type        = number
   description = "RAM in MiB allocated to the bootstrap node"
-  default     = 2048
+  default     = 4096
 }
 
 # Currently RHCOS maintain its default 16G size if that

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -72,10 +72,6 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, 
 		cfg.MasterDiskSize = masterConfig.Volume.VolumeSize.String()
 	}
 
-	if architecture == types.ArchitecturePPC64LE {
-		cfg.BootstrapMemory = 5120
-	}
-
 	return json.MarshalIndent(cfg, "", "  ")
 }
 


### PR DESCRIPTION
Noticed on 4.6 libvirt installs that processes on the bootstrap node were getting OOM killed. This was mainly due to
large memory consumption on by the kube-apiserver (https://bugzilla.redhat.com/show_bug.cgi?id=1868773) although
this looks to be normal as other platforms have a bigger memory limit for the bootstrap node.