### PR TITLE
Bug 1862209: aws: fix validation for user tags

### DIFF
--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -43,8 +43,8 @@ func validateUserTags(tags map[string]string, fldPath *field.Path) field.ErrorLi
 		if strings.EqualFold(key, "Name") {
 			allErrs = append(allErrs, field.Invalid(fldPath.Key(key), tags[key], "Name key is not allowed for user defined tags"))
 		}
-		if strings.HasPrefix(key, "kubernetes.io/clustername/") {
-			allErrs = append(allErrs, field.Invalid(fldPath.Key(key), tags[key], "Keys with prefix 'kubernetes.io/clustername/' are not allowed for user defined tags"))
+		if strings.HasPrefix(key, "kubernetes.io/cluster/") {
+			allErrs = append(allErrs, field.Invalid(fldPath.Key(key), tags[key], "Keys with prefix 'kubernetes.io/cluster/' are not allowed for user defined tags"))
 		}
 	}
 	return allErrs

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -128,14 +128,14 @@ func TestValidatePlatform(t *testing.T) {
 			expected: `^\Qtest-path.userTags[Name]: Invalid value: "test-cluster": Name key is not allowed for user defined tags\E$`,
 		},
 		{
-			name: "invalid userTags, key with kubernetes.io/clustername/",
+			name: "invalid userTags, key with kubernetes.io/cluster/",
 			platform: &aws.Platform{
 				Region: "us-east-1",
 				UserTags: map[string]string{
-					"kubernetes.io/clustername/test-cluster": "shared",
+					"kubernetes.io/cluster/test-cluster": "shared",
 				},
 			},
-			expected: `^\Qtest-path.userTags[kubernetes.io/clustername/test-cluster]: Invalid value: "shared": Keys with prefix 'kubernetes.io/clustername/' are not allowed for user defined tags\E$`,
+			expected: `^\Qtest-path.userTags[kubernetes.io/cluster/test-cluster]: Invalid value: "shared": Keys with prefix 'kubernetes.io/cluster/' are not allowed for user defined tags\E$`,
 		},
 		{
 			name: "valid userTags",


### PR DESCRIPTION
The validation was checking for kubernetes.io/clustername/ prefix in tag keys when it should have been kubernetes.io/cluster/ prefix