### PR TITLE
Bug 1866818: Set proxy.config/cluster spec.trustedCA if have CA

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -67,11 +67,11 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 			HTTPSProxy: installConfig.Config.Proxy.HTTPSProxy,
 			NoProxy:    installConfig.Config.Proxy.NoProxy,
 		}
+	}
 
-		if installConfig.Config.AdditionalTrustBundle != "" {
-			p.Config.Spec.TrustedCA = configv1.ConfigMapNameReference{
-				Name: additionalTrustBundleConfigMapName,
-			}
+	if installConfig.Config.AdditionalTrustBundle != "" {
+		p.Config.Spec.TrustedCA = configv1.ConfigMapNameReference{
+			Name: additionalTrustBundleConfigMapName,
 		}
 	}
 


### PR DESCRIPTION
An install config may specify an additional trusted bundle without specifying any proxy configuration.  Before this change, such an install config would produce a `user-ca-bundle` configmap but would not configure anything to use it.  After this change, such an install config produces the `user-ca-bundle` configmap and also adds a reference to the configmap in the `spec.trustedCA` field of the `proxy.config/cluster` object.  As a result, cluster-network-operator will read `user-ca-bundle` and inject the additional trusted bundle into the `trusted-ca-bundle` configmap, which other operators, such as the authentication operator, use.

* `pkg/asset/manifests/proxy.go` (`Generate`): Set `spec.trustedCA` if the install config specifies an additional trusted bundle, irrespective of whether proxy configuration is specified.