### PR TITLE
Bug 1871653: baremetal: set root device hints on host resources

### DIFF
--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -80,6 +80,7 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 				BootMACAddress:  host.BootMACAddress,
 				HardwareProfile: host.HardwareProfile,
 				BootMode:        baremetalhost.BootMode(host.BootMode),
+				RootDeviceHints: host.RootDeviceHints.MakeCRDHints(),
 			},
 		}
 		if i < len(machines) {

--- a/pkg/types/baremetal/rootdevice.go
+++ b/pkg/types/baremetal/rootdevice.go
@@ -5,6 +5,8 @@ package baremetal
 
 import (
 	"fmt"
+
+	"github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 )
 
 // RootDeviceHints holds the hints for specifying the storage location
@@ -95,4 +97,24 @@ func (source *RootDeviceHints) MakeHintMap() map[string]string {
 	}
 
 	return hints
+}
+
+// MakeCRDHints returns the hints in the format needed to pass to
+// create a BareMetalHost resource.
+func (source *RootDeviceHints) MakeCRDHints() *v1alpha1.RootDeviceHints {
+	if source == nil {
+		return nil
+	}
+	return &v1alpha1.RootDeviceHints{
+		DeviceName:         source.DeviceName,
+		HCTL:               source.HCTL,
+		Model:              source.Model,
+		Vendor:             source.Vendor,
+		SerialNumber:       source.SerialNumber,
+		MinSizeGigabytes:   source.MinSizeGigabytes,
+		WWN:                source.WWN,
+		WWNWithExtension:   source.WWNWithExtension,
+		WWNVendorExtension: source.WWNVendorExtension,
+		Rotational:         source.Rotational,
+	}
 }

--- a/pkg/types/baremetal/rootdevice_test.go
+++ b/pkg/types/baremetal/rootdevice_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1"
 )
 
 func TestMakeHintMap(t *testing.T) {
@@ -149,6 +151,159 @@ func TestMakeHintMap(t *testing.T) {
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			actual := tc.Hints.MakeHintMap()
+			assert.Equal(t, tc.Expected, actual, "hint map does not match")
+		})
+	}
+}
+
+func TestMakeCRDHints(t *testing.T) {
+	addressableTrue := true
+	addressableFalse := false
+
+	for _, tc := range []struct {
+		Scenario string
+		Hints    *RootDeviceHints
+		Expected *v1alpha1.RootDeviceHints
+	}{
+		{
+			Scenario: "nil",
+			Hints:    nil,
+			Expected: nil,
+		},
+		{
+			Scenario: "device-name",
+			Hints: &RootDeviceHints{
+				DeviceName: "userd_devicename",
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				DeviceName: "userd_devicename",
+			},
+		},
+		{
+			Scenario: "hctl",
+			Hints: &RootDeviceHints{
+				HCTL: "1:2:3:4",
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				HCTL: "1:2:3:4",
+			},
+		},
+		{
+			Scenario: "model",
+			Hints: &RootDeviceHints{
+				Model: "userd_model",
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				Model: "userd_model",
+			},
+		},
+		{
+			Scenario: "vendor",
+			Hints: &RootDeviceHints{
+				Vendor: "userd_vendor",
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				Vendor: "userd_vendor",
+			},
+		},
+		{
+			Scenario: "serial-number",
+			Hints: &RootDeviceHints{
+				SerialNumber: "userd_serial",
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				SerialNumber: "userd_serial",
+			},
+		},
+		{
+			Scenario: "min-size",
+			Hints: &RootDeviceHints{
+				MinSizeGigabytes: 40,
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				MinSizeGigabytes: 40,
+			},
+		},
+		{
+			Scenario: "wwn",
+			Hints: &RootDeviceHints{
+				WWN: "userd_wwn",
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				WWN: "userd_wwn",
+			},
+		},
+		{
+			Scenario: "wwn-with-extension",
+			Hints: &RootDeviceHints{
+				WWNWithExtension: "userd_with_extension",
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				WWNWithExtension: "userd_with_extension",
+			},
+		},
+		{
+			Scenario: "wwn-extension",
+			Hints: &RootDeviceHints{
+				WWNVendorExtension: "userd_vendor_extension",
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				WWNVendorExtension: "userd_vendor_extension",
+			},
+		},
+		{
+			Scenario: "rotational-true",
+			Hints: &RootDeviceHints{
+				Rotational: &addressableTrue,
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				Rotational: &addressableTrue,
+			},
+		},
+		{
+			Scenario: "rotational-false",
+			Hints: &RootDeviceHints{
+				Rotational: &addressableFalse,
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				Rotational: &addressableFalse,
+			},
+		},
+		{
+			Scenario: "everything-bagel",
+			Hints: &RootDeviceHints{
+				DeviceName:         "userd_devicename",
+				HCTL:               "1:2:3:4",
+				Model:              "userd_model",
+				Vendor:             "userd_vendor",
+				SerialNumber:       "userd_serial",
+				MinSizeGigabytes:   40,
+				WWN:                "userd_wwn",
+				WWNWithExtension:   "userd_with_extension",
+				WWNVendorExtension: "userd_vendor_extension",
+				Rotational:         &addressableTrue,
+			},
+			Expected: &v1alpha1.RootDeviceHints{
+				DeviceName:         "userd_devicename",
+				HCTL:               "1:2:3:4",
+				Model:              "userd_model",
+				Vendor:             "userd_vendor",
+				SerialNumber:       "userd_serial",
+				MinSizeGigabytes:   40,
+				WWN:                "userd_wwn",
+				WWNWithExtension:   "userd_with_extension",
+				WWNVendorExtension: "userd_vendor_extension",
+				Rotational:         &addressableTrue,
+			},
+		},
+		{
+			Scenario: "empty",
+			Hints:    &RootDeviceHints{},
+			Expected: &v1alpha1.RootDeviceHints{},
+		},
+	} {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			actual := tc.Hints.MakeCRDHints()
 			assert.Equal(t, tc.Expected, actual, "hint map does not match")
 		})
 	}


### PR DESCRIPTION
Pass the root device hints given by the user in the install-config to
the BareMetalHost resources created in the cluster.