### PR TITLE
bug 1871030: data/data/gcp: be pedantic about setting the region

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -1,5 +1,6 @@
 resource "google_storage_bucket" "ignition" {
-  name = "${var.cluster_id}-bootstrap-ignition"
+  name     = "${var.cluster_id}-bootstrap-ignition"
+  location = var.region
 }
 
 resource "google_storage_bucket_object" "ignition" {

--- a/data/data/gcp/bootstrap/variables.tf
+++ b/data/data/gcp/bootstrap/variables.tf
@@ -63,3 +63,8 @@ variable "zone" {
   type        = string
   description = "The zone for the bootstrap node."
 }
+
+variable "region" {
+  type        = string
+  description = "The region for the bootstrap node."
+}

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -28,6 +28,7 @@ module "bootstrap" {
   public_endpoints = local.public_endpoints
   subnet           = module.network.master_subnet
   zone             = var.gcp_master_availability_zones[0]
+  region           = var.gcp_region
 
   root_volume_size = var.gcp_master_root_volume_size
   root_volume_type = var.gcp_master_root_volume_type


### PR DESCRIPTION
Specify region for all terraform resources. This prevents the default of "US" from being used. 