### PR TITLE
OpenStack UPI: Custom API and Ingress vip addresses

### DIFF
--- a/upi/openstack/bootstrap.yaml
+++ b/upi/openstack/bootstrap.yaml
@@ -18,8 +18,7 @@
       security_groups:
       - "{{ os_sg_master }}"
       allowed_address_pairs:
-      - ip_address: "{{ os_subnet_range | next_nth_usable(5) }}"
-      - ip_address: "{{ os_subnet_range | next_nth_usable(6) }}"
+      - ip_address: "{{ os_apiVIP }}"
 
   - name: 'Set bootstrap port tag'
     command:

--- a/upi/openstack/compute-nodes.yaml
+++ b/upi/openstack/compute-nodes.yaml
@@ -18,7 +18,7 @@
       security_groups:
       - "{{ os_sg_worker }}"
       allowed_address_pairs:
-      - ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
+      - ip_address: "{{ os_ingressVIP }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
     register: ports
 

--- a/upi/openstack/control-plane.yaml
+++ b/upi/openstack/control-plane.yaml
@@ -18,9 +18,8 @@
       security_groups:
       - "{{ os_sg_master }}"
       allowed_address_pairs:
-      - ip_address: "{{ os_subnet_range | next_nth_usable(5) }}"
-      - ip_address: "{{ os_subnet_range | next_nth_usable(6) }}"
-      - ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
+      - ip_address: "{{ os_apiVIP }}"
+      - ip_address: "{{ os_ingressVIP }}"
     with_indexed_items: "{{ [os_port_master] * os_cp_nodes_number }}"
     register: ports
 

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -49,3 +49,13 @@ all:
       # attached to the bootstrap machine. This is needed for collecting logs
       # in case of install failure.
       os_bootstrap_fip: '203.0.113.20'
+
+      # An IP address that will be assigned to the API VIP.
+      # Be aware that the 10 and 11 of the machineNetwork will
+      # be taken by neutron dhcp by default, and wont be available.
+      os_apiVIP: "{{ os_subnet_range | next_nth_usable(5) }}"
+
+      # An IP address that will be assigned to the ingress VIP.
+      # Be aware that the 10 and 11 of the machineNetwork will
+      # be taken by neutron dhcp by default, and wont be available.
+      os_ingressVIP: "{{ os_subnet_range | next_nth_usable(7) }}"

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -123,7 +123,7 @@
       - "{{ os_sg_master }}"
       fixed_ips:
       - subnet: "{{ os_subnet }}"
-        ip_address: "{{ os_subnet_range | next_nth_usable(5) }}"
+        ip_address: "{{ os_apiVIP }}"
 
   - name: 'Set API port tag'
     command:
@@ -137,7 +137,7 @@
       - "{{ os_sg_worker }}"
       fixed_ips:
       - subnet: "{{ os_subnet }}"
-        ip_address: "{{ os_subnet_range | next_nth_usable(7) }}"
+        ip_address: "{{ os_ingressVIP }}"
 
   - name: 'Set the Ingress port tag'
     command:


### PR DESCRIPTION
This feature allows the customer to select fixed IP addresses
that they can reach the API and apps ingress at in their OpenShift cluster.
Note that the default values have not changed. APIVIP still defaults
to the 5 on the machineNetwork, and IngressVIP still defaults to the 7.