### PR TITLE
hack/update-rhcos-bootimage: update usage example

### DIFF
--- a/hack/update-rhcos-bootimage.py
+++ b/hack/update-rhcos-bootimage.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Usage: ./hack/update-rhcos-bootimage.py https://releases-art-rhcos.svc.ci.openshift.org/storage/releases/ootpa/410.8.20190401.0/meta.json amd64
+# Usage: ./hack/update-rhcos-bootimage.py https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202008260918-0/x86_64/meta.json amd64
 import codecs,os,sys,json,argparse
 import urllib.parse
 import urllib.request


### PR DESCRIPTION
Automatically convert RHT-internal `meta.json` URL (from the RHCOS ART build browser) to the external openshift.org URL, so the caller doesn't have to do it manually.

cc @cgwalters 