### PR TITLE
Bug 1872861: Update cli container image for UPI

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -8,7 +8,7 @@ WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:cli as cli
+FROM registry.svc.ci.openshift.org/ocp/4.6:cli as cli
 
 FROM registry.svc.ci.openshift.org/ocp/4.1:base
 COPY --from=cli /usr/bin/oc /bin/oc


### PR DESCRIPTION
Before this change the container that was being used to
grab the `oc` command was v4.1. This is too old for
CSR requests and causes vSphere UPI CI to fail.
Updates to v4.6.