### PR TITLE
OpenStack UPI: Add options for network types

### DIFF
--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -9,6 +9,7 @@ all:
       os_flavor_master: 'm1.xlarge'
       os_flavor_worker: 'm1.large'
       os_image_rhcos: 'rhcos'
+      os_network_type: "vlan"
       os_external_network: 'external'
       # OpenShift API floating IP address
       os_api_fip: '203.0.113.23'

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -14,6 +14,7 @@
   - name: 'Create the cluster network'
     os_network:
       name: "{{ os_network }}"
+      provider_network_type: "{{ os_network_type }}"
 
   - name: 'Set the cluster network tag'
     command:


### PR DESCRIPTION
This change allows users to chose openstack network type between vlan and flat.