### PR TITLE
WIP: Embed rhcos*.json as /bootimage/rhcos*.json in container image

### DIFF
--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -9,3 +9,5 @@ RUN go generate ./data && \
 
 FROM registry.svc.ci.openshift.org/ocp/4.1:installer
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac/openshift-install
+# Temporary (ideally 4.6 only) place for https://github.com/openshift/enhancements/pull/201#issuecomment-665183467
+COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos*.json /bootimage/

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -9,6 +9,8 @@ RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/origin/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+# Temporary (ideally 4.6 only) place for https://github.com/openshift/enhancements/pull/201#issuecomment-665183467
+COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos*.json /bootimage/
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin


### PR DESCRIPTION
This is intended as a short term tweak on the (long) road
to https://github.com/openshift/enhancements/pull/201

See specifically this subthread:
https://github.com/openshift/enhancements/pull/201#discussion_r375546207
And https://github.com/openshift/enhancements/pull/201#issuecomment-665183467

TL;DR we want `oc` to be the frontend to this data, via something like
`oc adm release info --bootimage-json` or so, and not `openshift-install`.

We want to move towards having the data as part of the release image.
But the installer will have RHCOS pinned for the near future because
of the bootstrap node - we need an RHCOS for that too.

And it's going to be very problematic to have "two sources of truth"
for RHCOS even temporarily.

This small change puts the RHCOS json inside the `installer` container
image which is already part of the release payload and built from
this repository; then we can patch `oc` to have `oc adm bootimages --json`
which would do the equivalent of:
`oc image extract /bootimage:. $(oc adm release info --image-for=installer))`