### PR TITLE
Bug 1867975: aws: ensure users set ami id for us-gov and cn regions

### DIFF
--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -82,6 +82,9 @@ func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolP
 			allErrs = append(allErrs, field.Invalid(f, value, fmt.Sprintf("cannot specify %q for machine pool when cluster is using %q", n, platformName)))
 		}
 	}
+	if platform.AWS != nil {
+		allErrs = append(allErrs, awsvalidation.ValidateAMIID(platform.AWS, p.AWS, fldPath.Child("aws"))...)
+	}
 	if p.AWS != nil {
 		validate(aws.Name, p.AWS, func(f *field.Path) field.ErrorList { return awsvalidation.ValidateMachinePool(platform.AWS, p.AWS, f) })
 	}


### PR DESCRIPTION
US Govcloud and China partitions do not allow copying AMI from commercial region us-east-1. Therefore the users
need to provide the AMI for control plane and compute.

/assign @jstuever 