### PR TITLE
Dockerfile.upi.ci: Explicitly use rhel7 for now

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -10,7 +10,7 @@ RUN hack/build.sh
 
 FROM registry.svc.ci.openshift.org/ocp/4.1:cli as cli
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:base
+FROM registry.access.redhat.com/ubi7/ubi:latest
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi


### PR DESCRIPTION
It looks like the base image switched to RHEL8, but that
lost things like python2 that this image uses.  Keep this
code on life support by explicitly using rhel7 for now.