### PR TITLE
data/manifests/bootkube/cvo-overrides: Drop the explicit upstream

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -4,6 +4,5 @@ metadata:
   namespace: openshift-cluster-version
   name: version
 spec:
-  upstream: https://api.openshift.com/api/upgrades_info/v1/graph
   channel: stable-4.6
   clusterID: {{.CVOClusterID}}

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -113,7 +113,6 @@ The installer uses the [cluster-version-operator] to create all the components o
     spec:
       channel: stable-4.1
       clusterID: 5ec312f9-f729-429d-a454-61d4906896ca
-      upstream: https://api.openshift.com/api/upgrades_info/v1/graph
     status:
       availableUpdates: null
       conditions:


### PR DESCRIPTION
Not bug-worthy, but floating now for 4.7 to centralize discussion.

The cluster-version operator has been falling back to a default URI when the ClusterVersion upstream is empty since [way][1] [back][2], and this behavior is [enshrined in the API][3].  Drop the installer-side
opinion, so:

* There is a single location where we version-control the default upstream (the CVO).
* Folks consuming in-cluster ClusterVersion objects have one less property to distract them (unless they want to override the default, in which case it's not distracting).

Related to openshift/openshift-docs#22252.

CC @vrutkovs , since I'm not sure how this will square with FCOS and a71f4245a.  FCOS options:

1. Continue to override the CVO default with explicit ClusterVersion.  No change from today, but breaks [nominal API][3] of:

    > By default it will use the appropriate update server for the cluster"

2. Teach the CVO to recognize FCOS vs. OCP and use the right default for each.
3. Fork the CVO and add an fcos branch, as you currently do for the installer.

Thoughts?

[1]: https://github.com/openshift/cluster-version-operator/blame/2c4931dc283c551938be1a00fee290de0b79d99c/pkg/cvo/availableupdates.go#L27-L31
[2]: https://github.com/openshift/cluster-version-operator/commit/ab4d84a021c38fea5e5973287e1f5580928907c1#diff-78f2af341fa49292dd6930f378018867R24
[3]: https://github.com/openshift/api/blame/0422dc17083e9e8df18d029f3f34322e96e9c326/config/v1/types_cluster_version.go#L56-L57