### PR TITLE
Bug 1842071: Add ppc64le and s390x documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@
 * [Libvirt with KVM](docs/dev/libvirt/README.md) (development only)
 * [OpenStack](docs/user/openstack/README.md)
 * [OpenStack (UPI)](docs/user/openstack/install_upi.md)
+* [Power](docs/user/power/install_upi.md)
 * [oVirt](docs/user/ovirt/install_ipi.md)
 * [oVirt (UPI)](docs/user/ovirt/install_upi.md)
 * [vSphere](docs/user/vsphere/README.md)
 * [vSphere (UPI)](docs/user/vsphere/install_upi.md)
+* [z/VM](docs/user/zvm/install_upi.md)
 
 ## Quick Start
 


### PR DESCRIPTION
Adding the documentation links, that have been available for a while.