### PR TITLE
Bug 1873448: Ensure proper tagging of compute node ports

### DIFF
--- a/upi/openstack/compute-nodes.yaml
+++ b/upi/openstack/compute-nodes.yaml
@@ -24,7 +24,7 @@
 
   - name: 'Set Compute ports tag'
     command:
-      cmd: "openstack port set --tag {{ [cluster_id_tag] }} {{ item.1 }}-{{ item.0 }}"
+      cmd: "openstack port set --tag {{ cluster_id_tag }} {{ item.1 }}-{{ item.0 }}"
     with_indexed_items: "{{ [os_port_worker] * os_compute_nodes_number }}"
 
   - name: 'List the Compute Trunks'


### PR DESCRIPTION
Wrong tagging of compute node parent ports make kuryr not able
to find the precreated ports, thus breaking the kuryr ports pool
functionality