### PR TITLE
Bug 1874656: Bump RHCOS for s390x/ppc64le to fix SSH authentication

### DIFF
--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,73 +1,73 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202008061241-0/ppc64le/",
-    "buildid": "46.82.202008061241-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202009010341-0/ppc64le/",
+    "buildid": "46.82.202009010341-0",
     "images": {
         "initramfs": {
-            "path": "rhcos-46.82.202008061241-0-installer-initramfs.ppc64le.img",
-            "sha256": "770ebbd141bbd858dc2754fbf8caab861dcdb4c9ffabfacf726e2f0cffc4d1b6"
+            "path": "rhcos-46.82.202009010341-0-installer-initramfs.ppc64le.img",
+            "sha256": "7bb871142cc448a145b430eafe2f3e9af2521d104369fe31bf27eac0e2d06c02"
         },
         "iso": {
-            "path": "rhcos-46.82.202008061241-0-installer.ppc64le.iso",
-            "sha256": "3771a65184377d248c7c0a120f945c042787cba5dd1733325505e8ef0d6c0874"
+            "path": "rhcos-46.82.202009010341-0-installer.ppc64le.iso",
+            "sha256": "141ff8e8a05f639c760cf916803f0fa945418d8d61ee55936a5ee50936ca7442"
         },
         "kernel": {
-            "path": "rhcos-46.82.202008061241-0-installer-kernel-ppc64le",
+            "path": "rhcos-46.82.202009010341-0-installer-kernel-ppc64le",
             "sha256": "2c37d0517ae6229cfeb93e83f0dcc7b39dd4212477783002bd9607d1171b8c9d"
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202008061241-0-live-initramfs.ppc64le.img",
-            "sha256": "21c12cdbd3faa9ffd05e137393f3895fdd578865507bbe6fc9ed9dd852506122"
+            "path": "rhcos-46.82.202009010341-0-live-initramfs.ppc64le.img",
+            "sha256": "1595b1b9cd83ce6da292ef5762f04ebeee15e3e1171b88ecdaeec207db8d2172"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202008061241-0-live.ppc64le.iso",
-            "sha256": "54f65b237eade700ec1a1e4003c886cf23000fe894e74fc5cc696918e2316327"
+            "path": "rhcos-46.82.202009010341-0-live.ppc64le.iso",
+            "sha256": "8e2396fb9aad28aededc22a37d67ddadf6e0499f575317e4c9fecc91c2e95220"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202008061241-0-live-kernel-ppc64le",
+            "path": "rhcos-46.82.202009010341-0-live-kernel-ppc64le",
             "sha256": "2c37d0517ae6229cfeb93e83f0dcc7b39dd4212477783002bd9607d1171b8c9d"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202008061241-0-live-rootfs.ppc64le.img",
-            "sha256": "5dfc12946c1e8f5e4ac04f7164f423d66e27ccffcba884efe7744ea4e3be11ed"
+            "path": "rhcos-46.82.202009010341-0-live-rootfs.ppc64le.img",
+            "sha256": "2fcff703d6672152d363f74f9dd08dfbcb59909e61b636d180eb56f4cfbc3aa6"
         },
         "metal": {
-            "path": "rhcos-46.82.202008061241-0-metal.ppc64le.raw.gz",
-            "sha256": "c2c9e7f3c7fc12f77d184d0c02b1c9a95ab395cc1dfd26e9ce933c97a77c6b0a",
-            "size": 907876871,
-            "uncompressed-sha256": "84bf60e537eb56a3c550be68c393bcfa5b5d25622e03140b9065faf68fe3049a",
-            "uncompressed-size": 3963617280
+            "path": "rhcos-46.82.202009010341-0-metal.ppc64le.raw.gz",
+            "sha256": "72391b7aafe408652c11da41c11356fcfca68dfe98694ddbe07d093e5a985bd4",
+            "size": 910634815,
+            "uncompressed-sha256": "024cdb188e35929f0459a6db9ad90900ad6e318a38092afcc8dae1fe6f6f106d",
+            "uncompressed-size": 3964665856
         },
         "metal4k": {
-            "path": "rhcos-46.82.202008061241-0-metal4k.ppc64le.raw.gz",
-            "sha256": "0662be4ce312fe739507706ad9a03e31a53ef622a1b5e77becc85f12284c671c",
-            "size": 908339593,
-            "uncompressed-sha256": "10c345ff84a3992f456b2f47b9765143158e796c871060e1f18bc5c684f6df22",
-            "uncompressed-size": 3963617280
+            "path": "rhcos-46.82.202009010341-0-metal4k.ppc64le.raw.gz",
+            "sha256": "4c2c888ab9f5df80dc0c1f00deab1ef1a976a3fd26730e55101a497a15960205",
+            "size": 910973412,
+            "uncompressed-sha256": "74c6f936fd05c7fff37faf454adf41816b4f5ed7b7b36a218d863e819e2c70b0",
+            "uncompressed-size": 3964665856
         },
         "openstack": {
-            "path": "rhcos-46.82.202008061241-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "423f9c8ffe3b0538acb5dd58c9bd30d7918ac1f7770fdd9e0ca4f95367184cc1",
-            "size": 906865097,
-            "uncompressed-sha256": "e1c569b7232a718b1b8bcf1aeb387093ea9380e823da9133eab5f1e36560a710",
-            "uncompressed-size": 2566324224
+            "path": "rhcos-46.82.202009010341-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "bd5817a5d50d4b3ac58f16a5f9ee3ae32cdab0c7ae3c31cfbe2b39e192d4e111",
+            "size": 909419313,
+            "uncompressed-sha256": "f23ad30997f5ff2e4449e970a74fcec8391427aa8b9e5b4298218aacf9298693",
+            "uncompressed-size": 2568880128
         },
         "ostree": {
-            "path": "rhcos-46.82.202008061241-0-ostree.ppc64le.tar",
-            "sha256": "f5027b370207c5466010f90cb8c6a98a69294a1cb1a16e01171185ecd71e3f3b",
-            "size": 830156800
+            "path": "rhcos-46.82.202009010341-0-ostree.ppc64le.tar",
+            "sha256": "e9fae1040a2fc622c0da04902ebbf52a457b4a24653e822b3ccb0244030587e2",
+            "size": 831600640
         },
         "qemu": {
-            "path": "rhcos-46.82.202008061241-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "3d400b8ed7d4e56e1e34ca5b455585a194cdd4807f97e7b7ec13c937fa6f3e96",
-            "size": 907638476,
-            "uncompressed-sha256": "b31a132832fe30ed71fe8edfc9a23c5e02671c8523a2bc06e1de0d3cde4afc93",
-            "uncompressed-size": 2605449216
+            "path": "rhcos-46.82.202009010341-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "4e560de76395f41707fe4105612b804ace56ce751d9ac6ba887cff30f616b704",
+            "size": 910228841,
+            "uncompressed-sha256": "f013399832df3e01029490c12c780d102c11d2d7fbc36adaa4b33158df02f25e",
+            "uncompressed-size": 2608267264
         }
     },
     "oscontainer": {
-        "digest": "sha256:965e687aba7bfd61bb07ff0a969fabc4abe9bc633cd8b04e006bb7d122ac1fc2",
+        "digest": "sha256:365e4ba78b43eba71f4f0021c90573da029a9a62b11c9a44bfcee2987e56f8ee",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "86ff024dd3b32c0648c195c0ed18d96f3119e73920c201d892e7bfb609c26ea8",
-    "ostree-version": "46.82.202008061241-0"
+    "ostree-commit": "188702fede855b0b84c0d7a1ee823d4e83ebae8bcc2b37ec6a010efbd3c8a5cb",
+    "ostree-version": "46.82.202009010341-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,80 +1,80 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202008121739-0/s390x/",
-    "buildid": "46.82.202008121739-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202009010439-0/s390x/",
+    "buildid": "46.82.202009010439-0",
     "images": {
         "dasd": {
-            "path": "rhcos-46.82.202008121739-0-dasd.s390x.raw.gz",
-            "sha256": "26d43652caae5cdccb41826e099283fe0064488094e4387cf0a1ee89f12058e5",
-            "size": 834798434,
-            "uncompressed-sha256": "dd85ecfd2afb5a4522b903b3cd3b88f003b413f2f07b5cffeee1fcd6956a4f4f",
+            "path": "rhcos-46.82.202009010439-0-dasd.s390x.raw.gz",
+            "sha256": "632d5b52673c952f01d9aab9a55e018de738b9873a4b6498e3cc83f1b9b0a26a",
+            "size": 835238485,
+            "uncompressed-sha256": "4fe2014e8b733535aa3f333903d13b69222915a3ecf800a7efc8e904ca0f13bd",
             "uncompressed-size": 3609198592
         },
         "initramfs": {
-            "path": "rhcos-46.82.202008121739-0-installer-initramfs.s390x.img",
-            "sha256": "1d7cd19e3e982c6af91094654f1f8c1fa3708d64b0c0c8bcfad3c3437b80cadb"
+            "path": "rhcos-46.82.202009010439-0-installer-initramfs.s390x.img",
+            "sha256": "cd814389a45ae93d7dba41148d87ec6d1af76be84dcc9ce0b1200296c765342c"
         },
         "iso": {
-            "path": "rhcos-46.82.202008121739-0-installer.s390x.iso",
-            "sha256": "60ae5d74e4187ef74778abb128d488997489779ef76563d07ccfd30f14737ed1"
+            "path": "rhcos-46.82.202009010439-0-installer.s390x.iso",
+            "sha256": "69b7be622db76d626b53a82627233f83c7d0c300f48151ee780f74cb070e6c9e"
         },
         "kernel": {
-            "path": "rhcos-46.82.202008121739-0-installer-kernel-s390x",
+            "path": "rhcos-46.82.202009010439-0-installer-kernel-s390x",
             "sha256": "7a468bd7f6f67bb156ea64f29cb23ad59eddd1a322b7cc850c5a0c26aef01e7f"
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202008121739-0-live-initramfs.s390x.img",
-            "sha256": "1599e922c32ab75ca85bdb276f9cdb05415d83b9ef8fdb4d0a3929d044a867f6"
+            "path": "rhcos-46.82.202009010439-0-live-initramfs.s390x.img",
+            "sha256": "dcf16656bc0205315fdf848a9f22d695fa1e0b7c8c62ed57e8c6dbcda8cf90d9"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202008121739-0-live.s390x.iso",
-            "sha256": "07f6b476d6987397035b2a46292306f59c1878cb77701a0ec472443f6d608e90"
+            "path": "rhcos-46.82.202009010439-0-live.s390x.iso",
+            "sha256": "0f54fccdc661503a1823734c67852809ec896626f94a79e70c5e40cfbb99d3bc"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202008121739-0-live-kernel-s390x",
+            "path": "rhcos-46.82.202009010439-0-live-kernel-s390x",
             "sha256": "7a468bd7f6f67bb156ea64f29cb23ad59eddd1a322b7cc850c5a0c26aef01e7f"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202008121739-0-live-rootfs.s390x.img",
-            "sha256": "9dbf88144a579d02317a23be91768f851a73c81a2c950863016f3d9ca3c4f001"
+            "path": "rhcos-46.82.202009010439-0-live-rootfs.s390x.img",
+            "sha256": "564c9957d281e618b6175f3b9633b4743918e54424a6e20bf67a6eb7743ea2ac"
         },
         "metal": {
-            "path": "rhcos-46.82.202008121739-0-metal.s390x.raw.gz",
-            "sha256": "6f4a881a65e3f7d3b95d858e4d074e6ff29272b1eed76c9cc8c676d1490c1b89",
-            "size": 834940523,
-            "uncompressed-sha256": "015b8095d7a12a2b171ce3d079d130bf7b7ac984dd6966e1239150ed357613d9",
+            "path": "rhcos-46.82.202009010439-0-metal.s390x.raw.gz",
+            "sha256": "7bd60a21ac77f993306be173d31fe8ee1e6e3d96ec2adf8a55276828b31076d7",
+            "size": 835092168,
+            "uncompressed-sha256": "d8dde92945c2ab6200bd0c5cc61c0b84d10b899c892da868352b299fbdd522f1",
             "uncompressed-size": 3609198592
         },
         "metal4k": {
-            "path": "rhcos-46.82.202008121739-0-metal4k.s390x.raw.gz",
-            "sha256": "23b12937d2882bd3e5f93f6b7f16cb270cd292ae0abbfe268541a931df0ecf79",
-            "size": 834786079,
-            "uncompressed-sha256": "0596150b5722bb693cf68f8195151a0877a9ce8cdd25f5ff16db9da6e1d62e0d",
+            "path": "rhcos-46.82.202009010439-0-metal4k.s390x.raw.gz",
+            "sha256": "9ec4c07a2e09e7cdbac13fa6ee5c604a66b1a55473eef69c6b521b6f56f60cba",
+            "size": 835146002,
+            "uncompressed-sha256": "bf2f38c67992cd4f0a2c38dc76aa03df2f11a4e7848fa24a4960e3c85b109636",
             "uncompressed-size": 3609198592
         },
         "openstack": {
-            "path": "rhcos-46.82.202008121739-0-openstack.s390x.qcow2.gz",
-            "sha256": "9672bbce91f3d11615d547e9462d75b4267cfe4c2e746c9928d53149a9ec1969",
-            "size": 833617262,
-            "uncompressed-sha256": "11eddb4784f7cfe3acf2a33678ed0b7e7a66bab0453f7e16e1b7462b9d4320e8",
+            "path": "rhcos-46.82.202009010439-0-openstack.s390x.qcow2.gz",
+            "sha256": "6145602d63201c1439d91fca99116ef3ff797fd707ee2a84964c39778b5cecb4",
+            "size": 833762787,
+            "uncompressed-sha256": "25caef791ceda857c371ab3c4b27bec7edb1c52b1df63442ff694363f258ce97",
             "uncompressed-size": 2269249536
         },
         "ostree": {
-            "path": "rhcos-46.82.202008121739-0-ostree.s390x.tar",
-            "sha256": "a1e1ee4e7407588fad32016c2be5a0e76a4025c3e2b5a60cf79cb6eaf53a7118",
-            "size": 777277440
+            "path": "rhcos-46.82.202009010439-0-ostree.s390x.tar",
+            "sha256": "bd03b23ee26de657b33d91046fef1a49a94f3abc3cd80d8dcb3002f7ba095e59",
+            "size": 777349120
         },
         "qemu": {
-            "path": "rhcos-46.82.202008121739-0-qemu.s390x.qcow2.gz",
-            "sha256": "85f8d152ce0d6062afc22110a046b793815f7dbdd4a5f3543abdb1508589be71",
-            "size": 834475750,
-            "uncompressed-sha256": "98f796bf9cc28fde8a158e2d7ea4bbd0bfe5ca2736fab0eeaf858c5cc83e33a8",
-            "uncompressed-size": 2307129344
+            "path": "rhcos-46.82.202009010439-0-qemu.s390x.qcow2.gz",
+            "sha256": "ee142095611d0e9de7d5c46f4501fc71e6d2bb74e9712d615ae1ec92f6399cf3",
+            "size": 834554408,
+            "uncompressed-sha256": "6182eaf1ba493a91f6bfbbd861b9f415c4fa4065c70512dacb4861ada26289df",
+            "uncompressed-size": 2307260416
         }
     },
     "oscontainer": {
-        "digest": "sha256:fadff7fba98c43a787d3db0f82d913cbd950f5f7e75593e1d41af61d15b73d40",
+        "digest": "sha256:aedadea840ca8b7725569357902ff6a8bf9dd45ba736c79dc185f340c9bd8f81",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "e605c9ebc20706424b5aac2958e18f405f8ccfdac80938445b7375c7ee655ecb",
-    "ostree-version": "46.82.202008121739-0"
+    "ostree-commit": "7ae32969b753f6b7071bc1a9498c04721702a9a60f050f523d50a51f0dc93281",
+    "ostree-version": "46.82.202009010439-0"
 }


### PR DESCRIPTION
Just like #4095 but for multi-arch