### PR TITLE
OVirt master memory to 16384 from 16348 to meet ppc64 requirements

### DIFF
--- a/data/data/ovirt/masters/main.tf
+++ b/data/data/ovirt/masters/main.tf
@@ -10,7 +10,7 @@ resource "ovirt_vm" "master" {
   // if instance type is declared then memory is redundant. Since terraform
   // doesn't allow to condionally omit it, it must be passed.
   // The number passed is multiplied by 4 and becomes the maximum memory the VM can have.
-  memory = var.ovirt_master_instance_type_id != "" ? 16348 : var.ovirt_master_memory
+  memory = var.ovirt_master_instance_type_id != "" ? 16384 : var.ovirt_master_memory
 
   initialization {
     host_name     = "${var.cluster_id}-master-${count.index}"

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -122,7 +122,7 @@ func defaultOvirtMachinePoolPlatform() ovirttypes.MachinePool {
 			Cores:   4,
 			Sockets: 1,
 		},
-		MemoryMB: 16348,
+		MemoryMB: 16384,
 		OSDisk: &ovirttypes.Disk{
 			SizeGB: 120,
 		},


### PR DESCRIPTION
Changing ovirt's memory to 16384 from 16348 to meet ppc64 requirements
of being a multiple of 256.  An error is thrown when executing against
ppc64 with a memory value of 16348.