### PR TITLE
BUG 1872646: oVirt, remove tmp VM disk on destroy

### DIFF
--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -82,6 +82,7 @@ func Destroy(dir string) (err error) {
 		}
 	case ovirt.Name:
 		extraArgs = append(extraArgs, "-target=module.template.ovirt_vm.tmp_import_vm")
+		extraArgs = append(extraArgs, "-target=module.template.ovirt_image_transfer.releaseimage")
 	}
 
 	extraArgs = append(extraArgs, "-target=module.bootstrap")


### PR DESCRIPTION
When calling terraform destroy the tmpVM disk is not removed from the engine. This is because the tmp VM unlike any other VM is not created from an oVirt template, and we create a separate disk for it with ovirt_image_transfer.
This PR removes the disk resource when calling destroy

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>