### PR TITLE
Bug 1870038: vmware upi: haproxy.service to rm haproxy pod on ExecStop

### DIFF
--- a/upi/vsphere/lb/haproxy.service
+++ b/upi/vsphere/lb/haproxy.service
@@ -14,6 +14,7 @@ ExecStart=/bin/podman run --name haproxy \
   --entrypoint=/usr/sbin/haproxy \
   -v /etc/haproxy/haproxy.conf:/var/lib/haproxy/conf/haproxy.conf:Z \
   quay.io/openshift/origin-haproxy-router -f /var/lib/haproxy/conf/haproxy.conf
+ExecStop=/bin/podman rm -f haproxy
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change allows the haproxy.service to restart cleanly by removing
the haproxy pod on ExecStop.