### PR TITLE
Bug 1876783: oVirt UPI fix python cmd

### DIFF
--- a/docs/user/ovirt/install_upi.md
+++ b/docs/user/ovirt/install_upi.md
@@ -255,11 +255,13 @@ Machine API will not be used by the UPI to create nodes, we'll create compute no
 Therefore we'll set to zero the number of compute nodes replicas using the following python script:
 
 ```sh
-$ python -c 'import yaml;
+$ python3 -c 'import yaml;
 path = "./wrk/install-config.yaml";
 conf = yaml.safe_load(open(path));
 conf["compute"][0]["replicas"] = 0;
 open(path, "w").write(yaml.dump(conf, default_flow_style=False));'
+
+**NOTE**: All the Python snippets in this document work with both Python 3 and Python 2.
 ```
 
 ### Set machine network
@@ -267,7 +269,7 @@ OpenShift installer sets a default IP range for nodes and we need to change it a
 We'll set the range to `172.16.0.0/16` (we can use the following python script for this):
 
 ```sh
-$ python -c 'import yaml;
+$ python3 -c 'import yaml;
 path = "./wrk/install-config.yaml";
 conf = yaml.safe_load(open(path));
 conf["networking"]["machineNetwork"][0]["cidr"] = "172.16.0.0/16";
@@ -280,7 +282,7 @@ platform section in the `install-config.yaml`, all the settings needed are speci
 We'll remove the section 
 
 ```sh
-$ python -c 'import yaml;
+$ python3 -c 'import yaml;
 path = "./wrk/install-config.yaml";
 conf = yaml.safe_load(open(path));
 platform = conf["platform"];
@@ -348,7 +350,7 @@ Set the control-plan as unschedulable means modify the `manifests/cluster-schedu
 `masterSchedulable` to `False`.
 
 ```sh 
-$ python -c 'import yaml;
+$ python3 -c 'import yaml;
 path = "./wrk/manifests/cluster-scheduler-02-config.yml";
 data = yaml.safe_load(open(path));
 data["spec"]["mastersSchedulable"] = False;


### PR DESCRIPTION
In RHEL8 we need to use explicitly python3 command

Signed-off-by: Roberto Ciatti <rciatti@redhat.com>