### PR TITLE
Add support for configuring OVN as the network plugin via the installer

### DIFF
--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -45,6 +45,7 @@ func (a *InstallConfig) Dependencies() []asset.Asset {
 		&clusterName{},
 		&pullSecret{},
 		&platform{},
+		&networking{},
 	}
 }
 
@@ -55,12 +56,14 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 	clusterName := &clusterName{}
 	pullSecret := &pullSecret{}
 	platform := &platform{}
+	networking := &networking{}
 	parents.Get(
 		sshPublicKey,
 		baseDomain,
 		clusterName,
 		pullSecret,
 		platform,
+		networking,
 	)
 
 	a.Config = &types.InstallConfig{
@@ -73,6 +76,7 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 		SSHKey:     sshPublicKey.Key,
 		BaseDomain: baseDomain.BaseDomain,
 		PullSecret: pullSecret.PullSecret,
+		Networking: &networking.Networking,
 	}
 
 	a.Config.AWS = platform.AWS

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -44,6 +44,11 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 	platform := &platform{
 		Platform: types.Platform{None: &none.Platform{}},
 	}
+	networking := &networking{
+		Networking: types.Networking{
+			NetworkType: "OpenShiftSDN",
+		},
+	}
 	installConfig := &InstallConfig{}
 	parents := asset.Parents{}
 	parents.Add(
@@ -52,6 +57,7 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 		clusterName,
 		pullSecret,
 		platform,
+		networking,
 	)
 	if err := installConfig.Generate(parents); err != nil {
 		t.Errorf("unexpected error generating install config: %v", err)

--- a/pkg/asset/installconfig/networking.go
+++ b/pkg/asset/installconfig/networking.go
@@ -1,0 +1,65 @@
+package installconfig
+
+import (
+	"sort"
+
+	"github.com/pkg/errors"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/types"
+)
+
+// Networking is an asset that queries the user for the networking on which to install
+// the cluster.
+type networking struct {
+	types.Networking
+}
+
+var _ asset.Asset = (*networking)(nil)
+
+// Dependencies returns no dependencies.
+func (a *networking) Dependencies() []asset.Asset {
+	return []asset.Asset{}
+}
+
+// Generate queries for input from the user.
+func (a *networking) Generate(asset.Parents) error {
+	networkplugin, err := a.queryUserForNetworkPlugin()
+	if err != nil {
+		return err
+	}
+	a.Networking.NetworkType = networkplugin
+	return nil
+}
+
+// Name returns the human-friendly name of the asset.
+func (a *networking) Name() string {
+	return "Network Plugin Configuration"
+}
+
+func (a *networking) queryUserForNetworkPlugin() (networking string, err error) {
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Select{
+				Message: "Network Plugin Configuration",
+				Options: types.NetworkPluginNames,
+				Default: "OpenShiftSDN",
+				Help:    "The network plugin on which the cluster will run.  For a full list of networking plugins, including those not supported by this wizard, see https://github.com/openshift/installer",
+			},
+			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				choice := ans.(string)
+				i := sort.SearchStrings(types.NetworkPluginNames, choice)
+				if i == len(types.NetworkPluginNames) || types.NetworkPluginNames[i] != choice {
+					return errors.Errorf("invalid network plugin %q", choice)
+				}
+				return nil
+			}),
+		},
+	}, &networking)
+	return
+}
+
+func (a *networking) CurrentName() string {
+	return a.Networking.NetworkType
+}

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -23,6 +23,9 @@ const userProvidedAssets = `{
   "*installconfig.clusterName": {
     "ClusterName": "test-cluster"
   },
+  "*installconfig.networking": {
+    "Networking": "{\"networkType\": \"OpenShiftSDN\" }"
+  },
   "*installconfig.platform": {
     "none": {}
   },

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -42,6 +42,13 @@ var (
 		baremetal.Name,
 		none.Name,
 	}
+	// NetworkPluginNames is a slice of all available network plugins
+	// supported by the installer out-of-box. This is the list of
+	// network plugins presented to the user in the interactive wizard.
+	NetworkPluginNames = []string{
+		"OVNKubernetes",
+		"OpenShiftSDN",
+	}
 )
 
 // PublishingStrategy is a strategy for how various endpoints for the cluster are exposed.


### PR DESCRIPTION
In OCP 4.6, we will have support for configuring OVN as the network plugin.
However, so far the installer didn't have support for doing so in the
create install-config and create cluster commands. This change adds support
for creating a install-config with OVN/OpenshiftSDN as the network plugin
choices.

Signed-off-by: Aniket Bhat <anbhat@redhat.com>