### PR TITLE
Bug 1853418: Ignore trailing dots in baseDomain

### DIFF
--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/aws"
@@ -142,7 +143,7 @@ type InstallConfig struct {
 
 // ClusterDomain returns the DNS domain that all records for a cluster must belong to.
 func (c *InstallConfig) ClusterDomain() string {
-	return fmt.Sprintf("%s.%s", c.ObjectMeta.Name, c.BaseDomain)
+	return fmt.Sprintf("%s.%s", c.ObjectMeta.Name, strings.TrimSuffix(c.BaseDomain, "."))
 }
 
 // Platform is the configuration for the specific platform upon which to perform


### PR DESCRIPTION
Users might provide the base domain in its canonical form, with the
trailing dot. With this change, the baseDomain trailing dot is ignored
both in the interactive prompt, and when loading an install-config file
from the filesystem.