### PR TITLE
Bug 1876825: generate lbFloatingIP in OpenStack config

### DIFF
--- a/pkg/asset/installconfig/openstack/openstack.go
+++ b/pkg/asset/installconfig/openstack/openstack.go
@@ -77,14 +77,13 @@ func Platform() (*openstack.Platform, error) {
 		return nil, err
 	}
 
-	lbFloatingIP := ""
+	var lbFloatingIP string
 	if extNet != "" {
 		floatingIPNames, err := getFloatingIPNames(cloud, extNet)
 		if err != nil {
 			return nil, err
 		}
 		sort.Strings(floatingIPNames)
-		var lbFloatingIP string
 		err = survey.Ask([]*survey.Question{
 			{
 				Prompt: &survey.Select{


### PR DESCRIPTION
Now, during install config generation, we cannot set lbFloatingIP value because there is a variable redeclaration in the code.

This patch removes the nested variable declaration, which allows the installer to assign the value to the right variable.