### PR TITLE
Bug 1877440: oVirt UPI Assets_dir set according to env var

### DIFF
--- a/upi/ovirt/inventory.yml
+++ b/upi/ovirt/inventory.yml
@@ -4,7 +4,7 @@ all:
     ovirt_cluster: "Default"
 
     ocp:
-      assets_dir: "./wrk"
+      assets_dir: "{{ lookup('env', 'ASSETS_DIR') }}"
       ovirt_config_path: "{{ lookup('env', 'HOME') }}/.ovirt/ovirt-config.yaml"
 
     rhcos:


### PR DESCRIPTION
According to the UPI documentation recent changes the assets_dir var
value in the inventory.yml should be set looking at the env variable
ASSETS_DIR