### PR TITLE
[FCOS] okdextensions: ensure minimal ignition config is set

### DIFF
--- a/data/data/bootstrap/gcp/files/opt/libexec/openshift-gcp-routes.sh
+++ b/data/data/bootstrap/gcp/files/opt/libexec/openshift-gcp-routes.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Update iptables rules based on google cloud load balancer VIPS
 #
 # This is needed because the GCP L3 load balancer doesn't actually do DNAT;
@@ -12,57 +11,45 @@
 # existing connections when the vip is removed. This is useful for draining
 # connections - take ourselves out of the vip, but service existing conns.
 #
-# Additionally, clients can write a file to /run/gcp-routes/$IP.down to force
+# Additionally, clients can write a file to /run/cloud-routes/$IP.down to force
 # a VIP as down. This is useful for graceful shutdown / upgrade.
 #
 # ~cdc~
-
 set -e
-
 # the list of load balancer IPs that are assigned to this node
 declare -A vips
-
 curler() {
-  curl --silent -L -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/${1}"
+    curl --silent -L -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/${1}"
 }
-
 CHAIN_NAME="gcp-vips"
-RUN_DIR="/run/gcp-routes"
-
+RUN_DIR="/run/cloud-routes"
 # Create a chan if it doesn't exist
 ensure_chain() {
     local table="${1}"
     local chain="${2}"
-
     if ! iptables -w -t "${table}" -S "${chain}" &> /dev/null ; then
         iptables -w -t "${table}" -N "${chain}";
     fi;
 }
-
 ensure_rule() {
     local table="${1}"
     local chain="${2}"
     shift 2
-
     if ! iptables -w -t "${table}" -C "${chain}" "$@" &> /dev/null; then
         iptables -w -t "${table}" -A "${chain}" "$@"
     fi
 }
-
 # set the chain, ensure entry rules, ensure ESTABLISHED rule
 initialize() {
     ensure_chain nat "${CHAIN_NAME}"
     ensure_chain nat "${CHAIN_NAME}-local"
     ensure_rule nat PREROUTING -m comment --comment 'gcp LB vip DNAT' -j ${CHAIN_NAME}
     ensure_rule nat OUTPUT -m comment --comment 'gcp LB vip DNAT for local clients' -j ${CHAIN_NAME}-local
-
     # Need this so that existing flows (with an entry in conntrack) continue to be
     # balanced, even if the DNAT entry is removed
     ensure_rule filter INPUT -m comment --comment 'gcp LB vip existing' -m addrtype ! --dst-type LOCAL -m state --state ESTABLISHED,RELATED -j ACCEPT
-
     mkdir -p "${RUN_DIR}"
 }
-
 remove_stale() {
     ## find extra iptables rules
     for ipt_vip in $(iptables -w -t nat -S "${CHAIN_NAME}" | awk '$4{print $4}' | awk -F/ '{print $1}'); do
@@ -78,30 +65,25 @@ remove_stale() {
         fi
     done
 }
-
 add_rules() {
     for vip in "${!vips[@]}"; do
         echo "ensuring rule for ${vip} for external clients"
         ensure_rule nat "${CHAIN_NAME}" --dst "${vip}" -j REDIRECT
-
         if [[ "${vips[${vip}]}" != down ]]; then
             echo "ensuring rule for ${vip} for internal clients"
             ensure_rule nat "${CHAIN_NAME}-local" --dst "${vip}" -j REDIRECT
         fi
     done
 }
-
 clear_rules() {
     iptables -t nat -F "${CHAIN_NAME}" || true
     iptables -t nat -F "${CHAIN_NAME}-local" || true
 }
-
 # out paramater: vips
 list_lb_ips() {
     for k in "${!vips[@]}"; do
         unset vips["${k}"]
     done
-
     local net_path="network-interfaces/"
     for vif in $(curler ${net_path}); do
         local hw_addr; hw_addr=$(curler "${net_path}${vif}mac")
@@ -119,7 +101,6 @@ list_lb_ips() {
         done
     done
 }
-
 sleep_or_watch() {
     if hash inotifywait &> /dev/null; then
         inotifywait -t 30 -r "${RUN_DIR}" &> /dev/null || true
@@ -135,26 +116,25 @@ sleep_or_watch() {
                     break 2
                 fi
             done
-            sleep 5
+            sleep 1 # keep this small enough to not make gcp-routes slower than LBs on recovery
         done
     fi
 }
-
 case "$1" in
-  start)
+    start)
     initialize
     while :; do
-      list_lb_ips
-      remove_stale
-      add_rules
-      echo "done applying vip rules"
-      sleep_or_watch
+        list_lb_ips
+        remove_stale
+        add_rules
+        echo "done applying vip rules"
+        sleep_or_watch
     done
     ;;
-  cleanup)
+    cleanup)
     clear_rules
     ;;
-  *)
+    *)
     echo $"Usage: $0 {start|cleanup}"
     exit 1
 esac

--- a/pkg/asset/machines/machineconfig/okdextensions.go
+++ b/pkg/asset/machines/machineconfig/okdextensions.go
@@ -18,7 +18,7 @@ func ForOKDExtensions(role string) (*mcfgv1.MachineConfig, error) {
 		},
 	}
 
-	_, err := ignition.ConvertToRawExtension(ignConfig)
+	rawExt, err := ignition.ConvertToRawExtension(ignConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -35,6 +35,7 @@ func ForOKDExtensions(role string) (*mcfgv1.MachineConfig, error) {
 			},
 		},
 		Spec: mcfgv1.MachineConfigSpec{
+			Config: rawExt,
 			Extensions: []string{
 				"glusterfs",
 				"glusterfs-fuse",


### PR DESCRIPTION
MC is invalid without Ignition version set:
```
"99_openshift-machineconfig_99-worker-okd-extensions.yaml": failed to create machineconfigs.v1.machineconfiguration.openshift.io/99-worker-okd-extensions -n : MachineConfig.machineconfiguration.openshift.io "99-worker-okd-extensions" is invalid: spec.config: Invalid value: "null": spec.config in body must be of type object: "null"
```

This also syncs gcp-routes with latest code in MCO