### PR TITLE
Bug 1878243: openstack: Upgrade the CI build image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -5,9 +5,9 @@ WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 
-FROM registry.svc.ci.openshift.org/origin/4.2:cli AS cli
+FROM registry.svc.ci.openshift.org/origin/4.6:cli AS cli
 
-FROM registry.svc.ci.openshift.org/origin/4.2:base
+FROM registry.svc.ci.openshift.org/origin/4.6:base
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi


### PR DESCRIPTION
Before this patch, the CI was using the `oc` OpenShift client `v4.2.0-alpha.0-110-g1337b29`