### PR TITLE
Bug 1874747: ovirt: dont start the temp VM before template creation

### DIFF
--- a/data/data/ovirt/template/main.tf
+++ b/data/data/ovirt/template/main.tf
@@ -45,6 +45,7 @@ resource "ovirt_vm" "tmp_import_vm" {
   count      = length(local.existing_id) == 0 ? 1 : 0
   name       = "tmpvm-for-${ovirt_image_transfer.releaseimage.0.alias}"
   cluster_id = var.ovirt_cluster_id
+  auto_start = false
   block_device {
     disk_id   = ovirt_image_transfer.releaseimage.0.disk_id
     interface = "virtio_scsi"

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/openshift/machine-api-operator v0.2.1-0.20200429102619-d36974451290
 	github.com/openshift/machine-config-operator v0.0.0
 	github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27
-	github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200406133650-74a154c1d861
+	github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200914080915-c4444fb5c201
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db // indirect
 	github.com/pborman/uuid v1.2.0
 	github.com/pierrec/lz4 v2.3.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1485,8 +1485,8 @@ github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0 h1:9dTL3/s4HXoLerbZ
 github.com/ovirt/go-ovirt v0.0.0-20200428093010-9bcc4fd4e6c0/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
 github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27 h1:jHcZg49imi3zydtFqly5vniMnFX7HxW27L9M095eLhI=
 github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
-github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200406133650-74a154c1d861 h1:vhOqmT4WRzfUys+NBhTzkRD08waA3dNDB7G5Pty2Rns=
-github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200406133650-74a154c1d861/go.mod h1:XFDLN/srNA1s2Dq+gp4zBvql6nRnfNJzDGzI5vtK85g=
+github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200914080915-c4444fb5c201 h1:43ItTdmiCXccs0JrwcGfMrw5Md9np6NYQXIC+0U74mk=
+github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200914080915-c4444fb5c201/go.mod h1:XFDLN/srNA1s2Dq+gp4zBvql6nRnfNJzDGzI5vtK85g=
 github.com/oxtoacart/bpool v0.0.0-20150712133111-4e1c5567d7c2/go.mod h1:L3UMQOThbttwfYRNFOWLLVXMhk5Lkio4GGOtw5UrxS0=
 github.com/packer-community/winrmcp v0.0.0-20180102160824-81144009af58/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=
 github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db h1:9uViuKtx1jrlXLBW/pMnhOfzn3iSEdLase/But/IZRU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1053,7 +1053,7 @@ github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.opens
 # github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27
 ## explicit
 github.com/ovirt/go-ovirt
-# github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200406133650-74a154c1d861
+# github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200914080915-c4444fb5c201
 ## explicit
 github.com/ovirt/terraform-provider-ovirt/ovirt
 # github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db


### PR DESCRIPTION
- bump terraform provider with the `auto_start` param
- add `auto_start=false` param to the installer not to start the VM when creating template.

this PR depends on https://github.com/oVirt/terraform-provider-ovirt/pull/227
Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>