### PR TITLE
Bug 1877486: proxy: allow * for noProxy

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -65,7 +65,7 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 		p.Config.Spec = configv1.ProxySpec{
 			HTTPProxy:  installConfig.Config.Proxy.HTTPProxy,
 			HTTPSProxy: installConfig.Config.Proxy.HTTPSProxy,
-			NoProxy:    installConfig.Config.Proxy.NoProxy,
+			NoProxy:    trimSpaceNoProxy(installConfig.Config.Proxy.NoProxy),
 		}
 
 		if installConfig.Config.AdditionalTrustBundle != "" {
@@ -80,10 +80,13 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+		if installConfig.Config.Proxy.NoProxy == "*" {
+			noProxy = installConfig.Config.Proxy.NoProxy
+		}
 		p.Config.Status = configv1.ProxyStatus{
 			HTTPProxy:  installConfig.Config.Proxy.HTTPProxy,
 			HTTPSProxy: installConfig.Config.Proxy.HTTPSProxy,
-			NoProxy:    noProxy,
+			NoProxy:    trimSpaceNoProxy(noProxy),
 		}
 	}
 
@@ -186,4 +189,13 @@ func (p *Proxy) Files() []*asset.File {
 // Load loads the already-rendered files back from disk.
 func (p *Proxy) Load(f asset.FileFetcher) (bool, error) {
 	return false, nil
+}
+
+// trimSpaceNoProxy removes the space from comma separated items.
+func trimSpaceNoProxy(noProxy string) string {
+	split := strings.Split(noProxy, ",")
+	for idx, v := range split {
+		split[idx] = strings.TrimSpace(v)
+	}
+	return strings.Join(split, ",")
 }

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -451,21 +451,21 @@ func validateProxy(p *types.Proxy, fldPath *field.Path) field.ErrorList {
 	}
 	if p.HTTPProxy != "" {
 		if err := validate.URI(p.HTTPProxy); err != nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("HTTPProxy"), p.HTTPProxy, err.Error()))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("httpProxy"), p.HTTPProxy, err.Error()))
 		}
 	}
 	if p.HTTPSProxy != "" {
 		if err := validate.URI(p.HTTPSProxy); err != nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("HTTPSProxy"), p.HTTPSProxy, err.Error()))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("httpsProxy"), p.HTTPSProxy, err.Error()))
 		}
 	}
-	if p.NoProxy != "" {
-		for _, v := range strings.Split(p.NoProxy, ",") {
+	if p.NoProxy != "" && p.NoProxy != "*" {
+		for idx, v := range strings.Split(p.NoProxy, ",") {
 			v = strings.TrimSpace(v)
 			errDomain := validate.NoProxyDomainName(v)
 			_, _, errCIDR := net.ParseCIDR(v)
 			if errDomain != nil && errCIDR != nil {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("NoProxy"), v, "must be a CIDR or domain, without wildcard characters"))
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("noProxy").Index(idx), v, "must be a CIDR or domain, without wildcard characters"))
 			}
 		}
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -700,7 +700,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.HTTPProxy = "http://bad%20uri"
 				return c
 			}(),
-			expectedError: `^HTTPProxy: Invalid value: "http://bad%20uri": parse .*: invalid URL escape "%20"$`,
+			expectedError: `^proxy.httpProxy: Invalid value: "http://bad%20uri": parse .*: invalid URL escape "%20"$`,
 		},
 		{
 			name: "invalid HTTPSProxy",
@@ -709,7 +709,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.HTTPSProxy = "https://bad%20uri"
 				return c
 			}(),
-			expectedError: `^HTTPSProxy: Invalid value: "https://bad%20uri": parse .*: invalid URL escape "%20"$`,
+			expectedError: `^proxy.httpsProxy: Invalid value: "https://bad%20uri": parse .*: invalid URL escape "%20"$`,
 		},
 		{
 			name: "invalid NoProxy domain",
@@ -718,7 +718,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.NoProxy = "good-no-proxy.com, *.bad-proxy"
 				return c
 			}(),
-			expectedError: `^\QNoProxy: Invalid value: "*.bad-proxy": must be a CIDR or domain, without wildcard characters\E$`,
+			expectedError: `^\Qproxy.noProxy[1]: Invalid value: "*.bad-proxy": must be a CIDR or domain, without wildcard characters\E$`,
 		},
 		{
 			name: "invalid NoProxy CIDR",
@@ -727,7 +727,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.NoProxy = "good-no-proxy.com, 172.bad.CIDR.0/16"
 				return c
 			}(),
-			expectedError: `^\QNoProxy: Invalid value: "172.bad.CIDR.0/16": must be a CIDR or domain, without wildcard characters\E$`,
+			expectedError: `^\Qproxy.noProxy[1]: Invalid value: "172.bad.CIDR.0/16": must be a CIDR or domain, without wildcard characters\E$`,
 		},
 		{
 			name: "invalid NoProxy domain & CIDR",
@@ -736,7 +736,15 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.NoProxy = "good-no-proxy.com, a-good-one, *.bad-proxy., another,   172.bad.CIDR.0/16, good-end"
 				return c
 			}(),
-			expectedError: `^\Q[NoProxy: Invalid value: "*.bad-proxy.": must be a CIDR or domain, without wildcard characters, NoProxy: Invalid value: "172.bad.CIDR.0/16": must be a CIDR or domain, without wildcard characters]\E$`,
+			expectedError: `^\Q[proxy.noProxy[2]: Invalid value: "*.bad-proxy.": must be a CIDR or domain, without wildcard characters, proxy.noProxy[4]: Invalid value: "172.bad.CIDR.0/16": must be a CIDR or domain, without wildcard characters]\E$`,
+		},
+		{
+			name: "valid * NoProxy",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Proxy.NoProxy = "*"
+				return c
+			}(),
 		},
 		{
 			name: "valid GCP platform",


### PR DESCRIPTION
"*" is considered to be a valid value for noProxy according to [1]
So the installer allows setting "*" for noProxy and matches the network operator for configuring .status.noProxy when such a value is set based on [2] i.e. as-is set the noProxy to "*"
without adding any default noProxy values.

[1]: https://docs.openshift.com/container-platform/4.5/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-configure-proxy_installing-restricted-networks-bare-metal
[2]: https://github.com/openshift/cluster-network-operator/blob/210e2dea2a60c18c277a7249d04085472a6b9a8c/pkg/controller/proxyconfig/status.go#L21-L28