### PR TITLE
gcp: add support for labeling resources

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -1,6 +1,7 @@
 resource "google_storage_bucket" "ignition" {
   name     = "${var.cluster_id}-bootstrap-ignition"
   location = var.region
+  labels   = var.labels
 }
 
 resource "google_storage_bucket_object" "ignition" {
@@ -50,9 +51,10 @@ resource "google_compute_instance" "bootstrap" {
 
   boot_disk {
     initialize_params {
-      type  = var.root_volume_type
-      size  = var.root_volume_size
-      image = var.image
+      type   = var.root_volume_type
+      size   = var.root_volume_size
+      image  = var.image
+      labels = var.labels
     }
   }
 

--- a/data/data/gcp/dns/base.tf
+++ b/data/data/gcp/dns/base.tf
@@ -2,6 +2,7 @@ resource "google_dns_managed_zone" "int" {
   name       = "${var.cluster_id}-private-zone"
   dns_name   = "${var.cluster_domain}."
   visibility = "private"
+  labels     = var.labels
 
   private_visibility_config {
     networks {

--- a/data/data/gcp/dns/variables.tf
+++ b/data/data/gcp/dns/variables.tf
@@ -32,3 +32,9 @@ variable "public_endpoints" {
   type        = bool
   description = "If the cluster should have externally accessible resources."
 }
+
+variable "labels" {
+  type        = map(string)
+  description = "GCP labels to be applied to created resources."
+  default     = {}
+}

--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -91,6 +91,7 @@ module "dns" {
   api_external_lb_ip   = module.network.cluster_public_ip
   api_internal_lb_ip   = module.network.cluster_ip
   public_endpoints     = local.public_endpoints
+  labels               = local.labels
 }
 
 resource "google_compute_image" "cluster" {
@@ -111,4 +112,6 @@ resource "google_compute_image" "cluster" {
   }
 
   licenses = var.gcp_image_licenses
+
+  labels = local.labels
 }

--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -37,9 +37,10 @@ resource "google_compute_instance" "master" {
 
   boot_disk {
     initialize_params {
-      type  = var.root_volume_type
-      size  = var.root_volume_size
-      image = var.image
+      type   = var.root_volume_type
+      size   = var.root_volume_size
+      image  = var.image
+      labels = var.labels
     }
   }
 

--- a/docs/user/gcp/customization.md
+++ b/docs/user/gcp/customization.md
@@ -9,6 +9,11 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `computeSubnet` (optional string): The name of an existing GCP subnet which should be used by the cluster nodes.
 * `defaultMachinePlatform` (optional object): Default [GCP-specific machine pool properties](#machine-pools) which apply to [machine pools](../customization.md#machine-pools) that do not define their own GCP-specific properties.
 * `licenses` (optional list of strings): A list of license URLs (https) that should be applied to the compute images (as defined in [the API][compute-images]). The use of this property in combination with any mechanism that results in using pre-built images (such as the current OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE) is forbidden. Also, note that use of these URLs will force the installer to copy the source image before being used. An example of this license is the one that enables [nested virtualization][gcp-nested]. A full list of available licenses can be retrieved using [the license API][license-api].
+* `labels` (optional object): A map of key-value pairs to apply to resources that are created. Not all GCP resources support labels.
+  Additionally, the following requirements apply:
+    * Keys and values cannot be longer than be 63 characters each.
+    * Keys and values can only contain lowercase letters, numeric characters, underscores, and hyphens. International characters are allowed.
+    * Keys must start with a lowercase letter and cannot be empty.
 
 ## Machine pools
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -345,6 +345,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				PublicZoneName:     publicZoneName,
 				PublishStrategy:    installConfig.Config.Publish,
 				PreexistingNetwork: preexistingnetwork,
+				Labels:             installConfig.Config.GCP.Labels,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -91,6 +91,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 			Type:       mpool.OSDisk.DiskType,
 			Image:      osImage,
 		}},
+		Labels: platform.Labels,
 		NetworkInterfaces: []*gcpprovider.GCPNetworkInterface{{
 			Network:    network,
 			Subnetwork: subnetwork,

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -16,22 +16,23 @@ type Auth struct {
 
 type config struct {
 	Auth                    `json:",inline"`
-	Region                  string   `json:"gcp_region,omitempty"`
-	BootstrapInstanceType   string   `json:"gcp_bootstrap_instance_type,omitempty"`
-	MasterInstanceType      string   `json:"gcp_master_instance_type,omitempty"`
-	MasterAvailabilityZones []string `json:"gcp_master_availability_zones"`
-	ImageURI                string   `json:"gcp_image_uri,omitempty"`
-	Image                   string   `json:"gcp_image,omitempty"`
-	PreexistingImage        bool     `json:"gcp_preexisting_image"`
-	ImageLicenses           []string `json:"gcp_image_licenses,omitempty"`
-	VolumeType              string   `json:"gcp_master_root_volume_type"`
-	VolumeSize              int64    `json:"gcp_master_root_volume_size"`
-	PublicZoneName          string   `json:"gcp_public_dns_zone_name,omitempty"`
-	PublishStrategy         string   `json:"gcp_publish_strategy,omitempty"`
-	PreexistingNetwork      bool     `json:"gcp_preexisting_network,omitempty"`
-	ClusterNetwork          string   `json:"gcp_cluster_network,omitempty"`
-	ControlPlaneSubnet      string   `json:"gcp_control_plane_subnet,omitempty"`
-	ComputeSubnet           string   `json:"gcp_compute_subnet,omitempty"`
+	Region                  string            `json:"gcp_region,omitempty"`
+	BootstrapInstanceType   string            `json:"gcp_bootstrap_instance_type,omitempty"`
+	MasterInstanceType      string            `json:"gcp_master_instance_type,omitempty"`
+	MasterAvailabilityZones []string          `json:"gcp_master_availability_zones"`
+	ImageURI                string            `json:"gcp_image_uri,omitempty"`
+	Image                   string            `json:"gcp_image,omitempty"`
+	PreexistingImage        bool              `json:"gcp_preexisting_image"`
+	ImageLicenses           []string          `json:"gcp_image_licenses,omitempty"`
+	VolumeType              string            `json:"gcp_master_root_volume_type"`
+	VolumeSize              int64             `json:"gcp_master_root_volume_size"`
+	PublicZoneName          string            `json:"gcp_public_dns_zone_name,omitempty"`
+	PublishStrategy         string            `json:"gcp_publish_strategy,omitempty"`
+	PreexistingNetwork      bool              `json:"gcp_preexisting_network,omitempty"`
+	ClusterNetwork          string            `json:"gcp_cluster_network,omitempty"`
+	ControlPlaneSubnet      string            `json:"gcp_control_plane_subnet,omitempty"`
+	ComputeSubnet           string            `json:"gcp_compute_subnet,omitempty"`
+	Labels                  map[string]string `json:"gcp_extra_labels,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -44,6 +45,7 @@ type TFVarsSources struct {
 	PublicZoneName     string
 	PublishStrategy    types.PublishingStrategy
 	PreexistingNetwork bool
+	Labels             map[string]string
 }
 
 // TFVars generates gcp-specific Terraform variables launching the cluster.
@@ -72,6 +74,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ControlPlaneSubnet:      masterConfig.NetworkInterfaces[0].Subnetwork,
 		ComputeSubnet:           workerConfig.NetworkInterfaces[0].Subnetwork,
 		PreexistingNetwork:      sources.PreexistingNetwork,
+		Labels:                  sources.Labels,
 	}
 	cfg.PreexistingImage = true
 	if len(sources.ImageLicenses) > 0 {

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -37,4 +37,14 @@ type Platform struct {
 	// such as the current env OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE
 	// +optional
 	Licenses []string `json:"licenses,omitempty"`
+
+	// Labels is a map of key-value pairs to apply to resources that are created.
+	// Not all GCP resources support labels.
+	// Additionally, the following requirements apply:
+	// Keys and values cannot be longer than be 63 characters each.
+	// Keys and values can only contain lowercase letters, numeric characters, underscores,
+	// and hyphens. International characters are allowed.
+	// Keys must start with a lowercase letter and cannot be empty.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
 }

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -88,10 +88,206 @@ func TestValidatePlatform(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			name: "valid labels",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				Labels: map[string]string{
+					"foo":       "bar",
+					"test-name": "v4l1d",
+				},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid label",
+			platform: &gcp.Platform{
+				Region: "us-east1",
+				Labels: map[string]string{
+					"UpperCase": "disallowed",
+				},
+			},
+			valid: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidatePlatform(tc.platform, field.NewPath("test-path")).ToAggregate()
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateLabels(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		valid  bool
+	}{
+		{
+			name: "valid labels",
+			labels: map[string]string{
+				"owner":         "1337_one",
+				"this-is-fine":  "",
+				"i_like_snakes": "hissssss---__",
+				"a123":          "0",
+				"тестовая":      "да",
+				"κυβερνήτης":    "its-all-greek-to-me",
+
+				"key-that-is-really-long-but-is-still-only-63-characters-so-fine": "value-that-is-also-63-characters-long-hooray_______123456789abc",
+			},
+			valid: true,
+		},
+		{
+			name: "invalid: uppercase in key",
+			labels: map[string]string{
+				"camelCase": "disallowed",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid: uppercase in value",
+			labels: map[string]string{
+				"camel": "Case",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid: disallowed symbols in key",
+			labels: map[string]string{
+				"test.openshift.io/foo": "bar",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid: disallowed symbols in value",
+			labels: map[string]string{
+				"localhost": "127.0.0.1",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid: empty key",
+			labels: map[string]string{
+				"": "empty",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid: key too long",
+			labels: map[string]string{
+				"k234567890123456789012345678901234567890123456789012345678901234": "test",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid: value too long",
+			labels: map[string]string{
+				"test": "v234567890123456789012345678901234567890123456789012345678901234",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid: key doesn't start with letter",
+			labels: map[string]string{
+				"_private": "fails",
+			},
+			valid: false,
+		},
+		{
+			name: "invalid: uppercase greek",
+			labels: map[string]string{
+				"Κυβερνήτης": "Kubernetes",
+			},
+			valid: false,
+		},
+		{
+			name: "valid and invalid labels",
+			labels: map[string]string{
+				"a-valid-label":  "perfectly-fine",
+				"4n1nv4l1dl4b3l": "1337haxx0r",
+			},
+			valid: false,
+		},
+		{
+			name: "too many labels",
+			labels: map[string]string{
+				"a1": "value",
+				"a2": "value",
+				"a3": "value",
+				"a4": "value",
+				"a5": "value",
+				"a6": "value",
+				"a7": "value",
+				"a8": "value",
+				"a9": "value",
+				"a0": "value",
+				"b1": "value",
+				"b2": "value",
+				"b3": "value",
+				"b4": "value",
+				"b5": "value",
+				"b6": "value",
+				"b7": "value",
+				"b8": "value",
+				"b9": "value",
+				"b0": "value",
+				"c1": "value",
+				"c2": "value",
+				"c3": "value",
+				"c4": "value",
+				"c5": "value",
+				"c6": "value",
+				"c7": "value",
+				"c8": "value",
+				"c9": "value",
+				"c0": "value",
+				"d1": "value",
+				"d2": "value",
+				"d3": "value",
+				"d4": "value",
+				"d5": "value",
+				"d6": "value",
+				"d7": "value",
+				"d8": "value",
+				"d9": "value",
+				"d0": "value",
+				"e1": "value",
+				"e2": "value",
+				"e3": "value",
+				"e4": "value",
+				"e5": "value",
+				"e6": "value",
+				"e7": "value",
+				"e8": "value",
+				"e9": "value",
+				"e0": "value",
+				"f1": "value",
+				"f2": "value",
+				"f3": "value",
+				"f4": "value",
+				"f5": "value",
+				"f6": "value",
+				"f7": "value",
+				"f8": "value",
+				"f9": "value",
+				"f0": "value",
+				"g1": "value",
+				"g2": "value",
+				"g3": "value",
+				"g4": "value",
+				"g5": "value",
+			},
+			valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateLabels(tc.labels, field.NewPath("test-labels")).ToAggregate()
 			if tc.valid {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
GCP supports labeling resources [1] to help group them together in a
lightweight way. These labels should not be confused with tags, which
are a different but related concept.

This change adds support for user-specified labels that should be
applied to GCP resources. Similar functionality in the installer is
already available for other cloud providers (such as AWS).

[1] https://cloud.google.com/compute/docs/labeling-resources