### PR TITLE
Bug 1876815: unset OS_CLOUD during config generator

### DIFF
--- a/pkg/asset/installconfig/openstack/openstack.go
+++ b/pkg/asset/installconfig/openstack/openstack.go
@@ -2,6 +2,7 @@
 package openstack
 
 import (
+	"os"
 	"sort"
 	"strings"
 
@@ -44,6 +45,11 @@ func Platform() (*openstack.Platform, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// We should unset OS_CLOUD env variable here, because the real cloud name was defined
+	// on the previous step. OS_CLOUD has more priority, so the value from "cloud" variable
+	// will be ignored if OS_CLOUD contains something.
+	os.Unsetenv("OS_CLOUD")
 
 	networkNames, err := getNetworkNames(cloud)
 	if err != nil {


### PR DESCRIPTION
We should unset OS_CLOUD env variable during interactive install-config generation, because the real cloud name is defined by user in the interactive session. OS_CLOUD has more priority, so the user-defined value will be ignored if OS_CLOUD contains something.

/label platform/openstack