### PR TITLE
install: increase timeout to 40 minutes

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -348,7 +348,8 @@ func waitForBootstrapConfigMap(ctx context.Context, client *kubernetes.Clientset
 // waitForInitializedCluster watches the ClusterVersion waiting for confirmation
 // that the cluster has been initialized.
 func waitForInitializedCluster(ctx context.Context, config *rest.Config) error {
-	timeout := 30 * time.Minute
+	// TODO revert this value back to 30 minutes.  It's currently at the end of 4.6 and we're trying to see if the
+	timeout := 40 * time.Minute
 
 	// Wait longer for baremetal, due to length of time it takes to boot
 	if assetStore, err := assetstore.NewStore(rootOpts.dir); err == nil {


### PR DESCRIPTION
We're seeing a significant uptick in install failures.  Many appear to actually finish successfully before
artifact collection.  We have good signal in sippy about successful install ratios.  We can increase
this timeout by 10 minutes to see if we get an improved install percentage and then continue from there.