### PR TITLE
Bug 1879616: openstack: install-config additionalTrustBundle

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -223,7 +223,9 @@ sudo cp ca.crt.pem /etc/pki/ca-trust/source/anchors/
 sudo update-ca-trust extract
 ```
 
-Next, you should add the `cacert` key to your `clouds.yaml`. Its value should be a valid path to your CA cert that does not require root privilege to read. The path can be either absolute, or relative to the current working directory while running the installer.
+The additional trust bundle will be fetched from [the `additionalTrustBundle` property of `install-config.yaml`](https://github.com/openshift/installer/blob/master/docs/user/customization.md#platform-customization).
+
+Alternatively, the Installer will use the `cacert` property of the corresponding cloud in `clouds.yaml`. This value should be a valid path to your CA cert that does not require root privilege to read. The path can be either absolute, or relative to the current working directory while running the installer.
 
 ```yaml
 clouds:

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -389,6 +389,12 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			caCert = string(caFile)
 		}
 
+		// If additionalTrustBundle is set in install-config, use it
+		// possibly overwriting the clouds.yaml cacert property
+		if installConfig.Config.AdditionalTrustBundle != "" {
+			caCert = installConfig.Config.AdditionalTrustBundle
+		}
+
 		masters, err := mastersAsset.Machines()
 		if err != nil {
 			return err

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -139,7 +139,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 			return err
 		}
 
-		cloudProviderConf, err := openstackmanifests.CloudProviderConfigSecret(cloud)
+		cloudProviderConf, err := openstackmanifests.CloudProviderConfigSecret(cloud, *installConfig.Config)
 		if err != nil {
 			return err
 		}

--- a/pkg/tfvars/openstack/bootstrap_ignition.go
+++ b/pkg/tfvars/openstack/bootstrap_ignition.go
@@ -68,7 +68,7 @@ func parseCertificateBundle(userCA []byte) ([]igntypes.Resource, error) {
 		var block *pem.Block
 		block, userCA = pem.Decode(userCA)
 		if block == nil {
-			return nil, fmt.Errorf("unable to parse certificate, please check the cacert section of clouds.yaml")
+			return nil, fmt.Errorf("failed to parse the certificate with index %d from the additional trustbundle", len(carefs))
 		}
 
 		carefs = append(carefs, igntypes.Resource{Source: ignutil.StrToPtr(dataurl.EncodeBytes(pem.EncodeToMemory(block)))})


### PR DESCRIPTION
Prior to this patch, the addtional trust bundle passed in
install-config.yaml was ignored in OpenStack.

With this change, the `additionalTrustBundle` property in
`install-config.yaml` overrides the `cacert` property of `clouds.yaml`.