### PR TITLE
WIP: pkg: validation for AWS credentials

### DIFF
--- a/pkg/asset/installconfig/aws/platform.go
+++ b/pkg/asset/installconfig/aws/platform.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	survey "gopkg.in/AlecAivazis/survey.v1"
@@ -32,6 +34,11 @@ func Platform() (*aws.Platform, error) {
 
 	ssn, err := GetSession()
 	if err != nil {
+		return nil, err
+	}
+	quickSsn := ssn.Copy(&awssdk.Config{MaxRetries: awssdk.Int(3)})
+	svc := sts.New(quickSsn)
+	if _, err = svc.GetCallerIdentity(&sts.GetCallerIdentityInput{}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This pull request fixes issue #4151 whereas running the installer with expired AWS credentials result in the installer hanging rather than printing an error message.

The fix introduces a validation step in session.go where it calls the [`GetCallerIdentity`](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html) API call to validate that the credentials are indeed valid. It does so before the number of maximum retries is set to 25 to provide a speedy response to the user. 

The implementation contains no tests to cover this specific case as a real, working AWS API would be needed for any meaningful test.

Please let me know if any further changes are needed.