### PR TITLE
Bug 1879891: Fix cluster destroy when fip less installation happened

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -104,14 +104,14 @@ func (o *ClusterUninstaller) Run() error {
 		Cloud: o.Cloud,
 	}
 
-	err := cleanRouterRunner(opts, o.Filter, o.Logger, o.InfraID)
-	if err != nil {
-		return err
-	}
-
 	// launch goroutines
 	for name, function := range deleteFuncs {
 		go deleteRunner(name, function, opts, o.Filter, o.Logger, returnChannel)
+	}
+
+	err := cleanRouterRunner(opts, o.Filter, o.Logger, o.InfraID)
+	if err != nil {
+		return err
 	}
 
 	// wait for them to finish
@@ -552,6 +552,9 @@ func deleteCustomRouterInterfaces(opts *clientconfig.ClientOpts, filter Filter, 
 		logger.Debug(err)
 		return false, nil
 	}
+	if routerID == "" {
+		return true, nil
+	}
 
 	removed, err := removeRouterInterfaces(conn, filter, routerID, logger)
 	if err != nil {
@@ -644,7 +647,7 @@ func getRouterByPort(client *gophercloud.ServiceClient, allPorts []ports.Port) (
 			}
 		}
 	}
-	return "", errors.Errorf("No router found.")
+	return "", nil
 }
 
 func isClusterSubnet(subnets []subnets.Subnet, subnetID string) bool {


### PR DESCRIPTION
In case the machines Subnet is not connected to a Router
there is not a need to clean-up the interfaces from the
custom Router as no additional interfaces would have
been created on it. Also, when using Kuryr if a Service
of LoadBalancer type was created, a floating ip would get
created for the load balancer and the removal of the service
subnet from the router would be blocked.

This commit fixes both issues by ignoring the custom Router
clean-up when no Router is found and moving the custom
Router clean-up to after the load balancers removal.