### PR TITLE
Bug 1880443: allow providing client options when generating OpenStack MachineSets

### DIFF
--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -40,7 +40,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 
 	mpool := pool.Platform.OpenStack
 	platform := config.Platform.OpenStack
-	trunkSupport, err := checkNetworkExtensionAvailability(platform.Cloud, "trunk")
+	trunkSupport, err := checkNetworkExtensionAvailability(platform.Cloud, "trunk", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -174,10 +174,11 @@ func generateProvider(clusterID string, platform *openstack.Platform, mpool *ope
 	return &spec, nil
 }
 
-func checkNetworkExtensionAvailability(cloud, alias string) (bool, error) {
-	opts := &clientconfig.ClientOpts{
-		Cloud: cloud,
+func checkNetworkExtensionAvailability(cloud, alias string, opts *clientconfig.ClientOpts) (bool, error) {
+	if opts == nil {
+		opts = &clientconfig.ClientOpts{}
 	}
+	opts.Cloud = cloud
 
 	conn, err := clientconfig.NewServiceClient("network", opts)
 	if err != nil {

--- a/pkg/asset/machines/openstack/machinesets.go
+++ b/pkg/asset/machines/openstack/machinesets.go
@@ -4,6 +4,7 @@ package openstack
 import (
 	"fmt"
 
+	"github.com/gophercloud/utils/openstack/clientconfig"
 	clusterapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,7 +14,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]*clusterapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, clientOpts *clientconfig.ClientOpts) ([]*clusterapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != openstack.Name {
 		return nil, fmt.Errorf("non-OpenStack configuration: %q", configPlatform)
 	}
@@ -22,7 +23,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	}
 	platform := config.Platform.OpenStack
 	mpool := pool.Platform.OpenStack
-	trunkSupport, err := checkNetworkExtensionAvailability(platform.Cloud, "trunk")
+	trunkSupport, err := checkNetworkExtensionAvailability(platform.Cloud, "trunk", clientOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
+	openstackclientconfig "github.com/gophercloud/utils/openstack/clientconfig"
 	baremetalapi "github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis"
 	baremetalprovider "github.com/metal3-io/cluster-api-provider-baremetal/pkg/apis/baremetal/v1alpha1"
 	gcpapi "github.com/openshift/cluster-api-provider-gcp/pkg/apis"
@@ -352,7 +353,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 
 			imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-			sets, err := openstack.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", "worker-user-data")
+			sets, err := openstack.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", "worker-user-data", &openstackclientconfig.ClientOpts{})
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}


### PR DESCRIPTION
Hive calls into the installer's functions for converting MachinePools to MachineSets.
As Hive can be reconciling multiple cluster states simultaneously, we cannot rely on setting shared `OS_*` environment variables.
Extend the installer's functions for OpenStack to allow providing custom versions of reading in the OpenStack credentials.