### PR TITLE
Bump library-go to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603
 	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200504092944-27473ea1ae43
 	github.com/openshift/library-go v0.0.0-20200917093739-70fa806b210a
-	github.com/openshift/machine-api-operator v0.2.1-0.20200429102619-d36974451290
+	github.com/openshift/machine-api-operator v0.2.1-0.20200922150054-e0db6b65ba71
 	github.com/openshift/machine-config-operator v0.0.0
 	github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27
 	github.com/ovirt/terraform-provider-ovirt v0.4.3-0.20200914080915-c4444fb5c201
@@ -150,5 +150,4 @@ replace (
 	sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200506073438-9d49428ff837 // Pin OpenShift fork
 	sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b // Pin OpenShift fork
 	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200526112135-319a35b2e38e // Pin OpenShift fork
-	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20200917093739-70fa806b210a // Pin libarary-go	
 )

--- a/go.mod
+++ b/go.mod
@@ -150,4 +150,5 @@ replace (
 	sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200506073438-9d49428ff837 // Pin OpenShift fork
 	sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b // Pin OpenShift fork
 	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200526112135-319a35b2e38e // Pin OpenShift fork
+	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20200917093739-70fa806b210a // Pin libarary-go	
 )

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200120152131-1b09fd9e7156
 	github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603
 	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200504092944-27473ea1ae43
-	github.com/openshift/library-go v0.0.0-20200324092245-db2a8546af81
+	github.com/openshift/library-go v0.0.0-20200917093739-70fa806b210a
 	github.com/openshift/machine-api-operator v0.2.1-0.20200429102619-d36974451290
 	github.com/openshift/machine-config-operator v0.0.0
 	github.com/ovirt/go-ovirt v0.0.0-20200613023950-320a86f9df27


### PR DESCRIPTION
Current version adds a dependency for `bitbucket.org/ww/goautoneg@v0.0.0-20120707110453-75cd24fc2f2c` which is an unstable path and is often not available. This dependency was removed from library-go a while back in [this commit](https://github.com/openshift/library-go/commit/c1de486c7d47605416673079735c41703b03b7b4#diff-37aff102a57d3d7b797f152915a6dc16).

This fixes #4162 