### PR TITLE
Bug 1880393: OpenStack UPI: Trim EOLs from the cacert trustbundle

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -540,7 +540,7 @@ files.append(
 ca_cert_path = os.environ.get('OS_CACERT', '')
 if ca_cert_path:
     with open(ca_cert_path, 'r') as f:
-        ca_cert = f.read().encode()
+        ca_cert = f.read().encode().strip()
         ca_cert_b64 = base64.standard_b64encode(ca_cert).decode().strip()
 
     files.append(

--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -675,7 +675,7 @@ Change the `ignition.config.merge.source` field to the URL hosting the `bootstra
 
 #### Ignition file served by server using self-signed certificate
 
-In order for the bootstrap node to retrieve the ignition file when it is served by a server using self-signed certificate, it is necessary to add the CA certificate to the `ignition.security.tls.certificateAuthorities` in the ignition file. For instance:
+In order for the bootstrap node to retrieve the ignition file when it is served by a server using self-signed certificate, it is necessary to add the CA certificate to the `ignition.security.tls.certificateAuthorities` in the ignition file. Make sure the certificate does not include trailing new lines before it is encoded in base64. For instance:
 
 ```json
 {


### PR DESCRIPTION
Similar to 0bf09af3bc45e6724e210fce7a0743c9a3cab8bf that fixed the same
issue for IPI, we need to trim EOLs from the ca-cert bundle in the UPI
scripts otherwise ignition might not accept it as valid.