### PR TITLE
Bug 1877984: Fix "OpenShiftSDN" to proper case when generating network config

### DIFF
--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -2,9 +2,11 @@ package conversion
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
@@ -60,6 +62,12 @@ func ConvertNetworking(config *types.InstallConfig) {
 	// Convert type to networkType if the latter is missing
 	if netconf.NetworkType == "" {
 		netconf.NetworkType = netconf.DeprecatedType
+	}
+
+	// Recognize the default network plugin name regardless of capitalization, for
+	// backward compatibility
+	if strings.ToLower(netconf.NetworkType) == strings.ToLower(string(operv1.NetworkTypeOpenShiftSDN)) {
+		netconf.NetworkType = string(operv1.NetworkTypeOpenShiftSDN)
 	}
 
 	// Convert hostSubnetLength to hostPrefix

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -147,6 +147,25 @@ func TestConvertInstallConfig(t *testing.T) {
 			},
 			expectedError: "no version was provided",
 		},
+		{
+			name: "deprecated OpenShiftSDN spelling",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Networking: &types.Networking{
+					NetworkType: "OpenshiftSDN",
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Networking: &types.Networking{
+					NetworkType: "OpenShiftSDN",
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -1,6 +1,7 @@
 package defaults
 
 import (
+	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
@@ -19,7 +20,7 @@ var (
 	defaultServiceNetwork = ipnet.MustParseCIDR("172.30.0.0/16")
 	defaultClusterNetwork = ipnet.MustParseCIDR("10.128.0.0/14")
 	defaultHostPrefix     = 23
-	defaultNetworkType    = "OpenShiftSDN"
+	defaultNetworkType    = string(operv1.NetworkTypeOpenShiftSDN)
 )
 
 // SetInstallConfigDefaults sets the defaults for the install config.

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
@@ -39,7 +40,7 @@ const (
 )
 
 // list of known plugins that require hostPrefix to be set
-var pluginsUsingHostPrefix = sets.NewString("OpenShiftSDN", "OVNKubernetes")
+var pluginsUsingHostPrefix = sets.NewString(string(operv1.NetworkTypeOpenShiftSDN), string(operv1.NetworkTypeOVNKubernetes))
 
 // ValidateInstallConfig checks that the specified install config is valid.
 func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
@@ -179,7 +180,7 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 
 	switch {
 	case hasIPv4 && hasIPv6:
-		if n.NetworkType == "OpenShiftSDN" {
+		if n.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking", "networkType"), n.NetworkType, "dual-stack IPv4/IPv6 is not supported for this networking plugin"))
 		}
 
@@ -206,7 +207,7 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 		}
 
 	case hasIPv6:
-		if n.NetworkType == "OpenShiftSDN" {
+		if n.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking", "networkType"), n.NetworkType, "IPv6 is not supported for this networking plugin"))
 		}
 


### PR DESCRIPTION
I forget exactly what happened, but way back in the beginning there was a disconnect between the installer and the cluster-network-operator about what the correct spelling of "OpenShiftSDN" was, and it was decided that CNO was going to have to accept both "OpenShiftSDN" and "OpenshiftSDN" for backward compatibility.

However, there are other components that look at the network config sometimes (in particular, MCO now needs to look at it before CNO even runs), so it doesn't make sense for the canonicalization to happen in CNO; we should just not generate the incorrect version of the network config in the first place.