### PR TITLE
*: add InstallType to InstallConfig

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -672,6 +672,10 @@ spec:
               - source
               type: object
             type: array
+          installType:
+            description: InstallType provides signal to the cluster that the installation
+              will not follow the default installer workflow.
+            type: string
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -62,6 +62,7 @@ The following `install-config.yaml` properties are available:
     * `noProxy` (optional string): A comma-separated list of domains and [CIDRs][cidr-notation] for which the proxy should not be used.
 * `pullSecret` (required string): The secret to use when pulling images.
 * `sshKey` (optional string): The public Secure Shell (SSH) key to provide access to instances.
+* `installType` (optional string): The name of the non standard installation type used to bootstrap the cluster.
 
 ### IP networks
 
@@ -152,6 +153,22 @@ networking:
 platform: ...
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
+```
+
+### Custom installation type
+
+An example install config with custom install type:
+
+```yaml
+apiVersion: v1
+baseDomain: example.com
+controlPlane:
+  name: master
+  replicas: 2
+metadata:
+  name: test-cluster
+platform: ...
+installType: assisted
 ```
 
 ### Image content sources

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -50,6 +50,9 @@ func Test_PrintFields(t *testing.T) {
       ImageContentSources lists sources/repositories for the release-image content.
       ImageContentSource defines a list of sources/repositories that can be used to pull content.
 
+    installType <string>
+      InstallType provides signal to the cluster that the installation will not follow the default installer workflow.
+
     kind <string>
       Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -120,6 +120,11 @@ type InstallConfig struct {
 	// +optional
 	FIPS bool `json:"fips,omitempty"`
 
+	// InstallType provides signal to the cluster that the installation will not follow the default installer workflow.
+	//
+	// +optional
+	InstallType string `json:"installType,omitempty"`
+
 	// CredentialsMode is used to explicitly set the mode with which CredentialRequests are satisfied.
 	//
 	// If this field is set, then the installer will not attempt to query the cloud permissions before attempting


### PR DESCRIPTION
As OpenShift 4 extends its use cases additional workflows for how the bootstrapping of the cluster will evolve. For example, assisted-installer uses the `openshift-installer` to generate manifests and then independently manages the bootstrapping of the cluster after install complete. Because these alternative workflows require in many cases the cluster and operators to observe these changes clear signal is required.

This PR introduces an optional field to the `InstallConfig` `InstallType`. This type which will be embedded into the `cluster-config-v1` ConfigMap in the `kube-system` namespace. I feel this change requires very little overhead for maintenance meanwhile providing very important signal to the cluster.

Other uses for this flag could include for example `CRC` single node cluster [1] and new future edge installations. This allows the logic for how these installs are managed to be handled by the cluster operators instead of additional knobs to the installer itself.

[1] https://github.com/openshift/enhancements/pull/302

enhancement: https://github.com/openshift/enhancements/pull/480
blocking 4.7 epic: https://issues.redhat.com/browse/ETCD-94