### PR TITLE
Bug 1881757: tls: set mcs cert common name to not-valid-hostname

### DIFF
--- a/pkg/asset/tls/mcscertkey.go
+++ b/pkg/asset/tls/mcscertkey.go
@@ -39,7 +39,7 @@ func (a *MCSCertKey) Generate(dependencies asset.Parents) error {
 	hostname := internalAPIAddress(installConfig.Config)
 
 	cfg := &CertCfg{
-		Subject:      pkix.Name{CommonName: hostname},
+		Subject:      pkix.Name{CommonName: "system:machine-config-server"},
 		ExtKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		Validity:     ValidityTenYears,
 	}
@@ -55,9 +55,10 @@ func (a *MCSCertKey) Generate(dependencies asset.Parents) error {
 		cfg.IPAddresses = []net.IP{net.ParseIP(installConfig.Config.Ovirt.APIVIP)}
 		cfg.DNSNames = []string{hostname, installConfig.Config.Ovirt.APIVIP}
 	case vspheretypes.Name:
+		cfg.DNSNames = []string{hostname}
 		if installConfig.Config.VSphere.APIVIP != "" {
 			cfg.IPAddresses = []net.IP{net.ParseIP(installConfig.Config.VSphere.APIVIP)}
-			cfg.DNSNames = []string{hostname, installConfig.Config.VSphere.APIVIP}
+			cfg.DNSNames = append(cfg.DNSNames, installConfig.Config.VSphere.APIVIP)
 		}
 	default:
 		cfg.DNSNames = []string{hostname}


### PR DESCRIPTION
go1.15 clients do not like server certs with common name set to a valid hostname. casuing failures like
```
x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

So, looking at the go 1.15 release notes
https://golang.org/doc/go1.15
```
X.509 CommonName deprecation ¶
The deprecated, legacy behavior of treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is now disabled by default.
It can be temporarily re-enabled by adding the value x509ignoreCN=0 to the GODEBUG environment variable.Note that if the CommonName is an invalid host name, it's always ignored, regardless of GODEBUG settings.

Invalid names include those with any characters other than letters, digits, hyphens and underscores, and those with empty labels or trailing dots.
```

Setting the common name for MCS cert to `system:machine-config-server` like other kube-apiserver server certificates to make sure the common name is not a valid hostname.