### PR TITLE
doc: fix `oc get pods` usage

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -412,7 +412,7 @@ oc get clusteroperator
 Finally, to see all the running pods in your cluster, you can do:
 
 ```sh
-oc get pods -A
+oc get pods --all-namespaces
 ```
 ### Destroying The Cluster
 

--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -843,7 +843,7 @@ You can use the `oc` or `kubectl` commands to talk to the OpenShift API. The adm
 ```sh
 $ export KUBECONFIG="$PWD/auth/kubeconfig"
 $ oc get nodes
-$ oc get pods -A
+$ oc get pods --all-namespaces
 ```
 
 **NOTE**: Only the API will be up at this point. The OpenShift UI will run on the compute nodes.

--- a/docs/user/ovirt/install_upi.md
+++ b/docs/user/ovirt/install_upi.md
@@ -707,7 +707,7 @@ in the file `auth/kubeconfig`:
 ```sh
 $ export KUBECONFIG=$ASSETS_DIR/auth/kubeconfig
 $ oc get nodes
-$ oc get pods -A
+$ oc get pods --all-namespaces
 ```
 ## Retire Bootstrap
 After the `wait-for` command says that the bootstrap process is complete, it is possible to remove the bootstrap VM


### PR DESCRIPTION
`oc get pods` doesn't have "-A" option.
The intent is to list all pods from all namespaces to see that our
cluster have successfuly created pods, we can therefore use
the following option:

```
  --all-namespaces: If present, list the requested object(s)
  across all namespaces. Namespace in current context is ignored even if
  specified with --namespace.
```

This patch updates the doc for OpenStack and ovirt running this command.