### PR TITLE
Bug 1882805: Bump bootimages for ppc64le and s390x to 46.82.202009240941-0 and 46.82.202009241338-0

### DIFF
--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,73 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202009010341-0/ppc64le/",
-    "buildid": "46.82.202009010341-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202009240941-0/ppc64le/",
+    "buildid": "46.82.202009240941-0",
     "images": {
-        "initramfs": {
-            "path": "rhcos-46.82.202009010341-0-installer-initramfs.ppc64le.img",
-            "sha256": "7bb871142cc448a145b430eafe2f3e9af2521d104369fe31bf27eac0e2d06c02"
-        },
-        "iso": {
-            "path": "rhcos-46.82.202009010341-0-installer.ppc64le.iso",
-            "sha256": "141ff8e8a05f639c760cf916803f0fa945418d8d61ee55936a5ee50936ca7442"
-        },
-        "kernel": {
-            "path": "rhcos-46.82.202009010341-0-installer-kernel-ppc64le",
-            "sha256": "2c37d0517ae6229cfeb93e83f0dcc7b39dd4212477783002bd9607d1171b8c9d"
-        },
         "live-initramfs": {
-            "path": "rhcos-46.82.202009010341-0-live-initramfs.ppc64le.img",
-            "sha256": "1595b1b9cd83ce6da292ef5762f04ebeee15e3e1171b88ecdaeec207db8d2172"
+            "path": "rhcos-46.82.202009240941-0-live-initramfs.ppc64le.img",
+            "sha256": "c0a52acf1c883565bff9c1ea8ab2eb9a2789f23124fdd1be78f6d2f624450445"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202009010341-0-live.ppc64le.iso",
-            "sha256": "8e2396fb9aad28aededc22a37d67ddadf6e0499f575317e4c9fecc91c2e95220"
+            "path": "rhcos-46.82.202009240941-0-live.ppc64le.iso",
+            "sha256": "90359e206905513694860f0d195af257da3db95b507e83b1f53daa6bfbe9023d"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202009010341-0-live-kernel-ppc64le",
-            "sha256": "2c37d0517ae6229cfeb93e83f0dcc7b39dd4212477783002bd9607d1171b8c9d"
+            "path": "rhcos-46.82.202009240941-0-live-kernel-ppc64le",
+            "sha256": "430755e6db588ec04fd5ba56d7973e8622eee90cc8f6d819fefb46926625d19b"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202009010341-0-live-rootfs.ppc64le.img",
-            "sha256": "2fcff703d6672152d363f74f9dd08dfbcb59909e61b636d180eb56f4cfbc3aa6"
+            "path": "rhcos-46.82.202009240941-0-live-rootfs.ppc64le.img",
+            "sha256": "3ec25712a88d1da7e60d2581677b0fde9c6b175c2fa5b6dd9ec43296e5aba2c7"
         },
         "metal": {
-            "path": "rhcos-46.82.202009010341-0-metal.ppc64le.raw.gz",
-            "sha256": "72391b7aafe408652c11da41c11356fcfca68dfe98694ddbe07d093e5a985bd4",
-            "size": 910634815,
-            "uncompressed-sha256": "024cdb188e35929f0459a6db9ad90900ad6e318a38092afcc8dae1fe6f6f106d",
-            "uncompressed-size": 3964665856
+            "path": "rhcos-46.82.202009240941-0-metal.ppc64le.raw.gz",
+            "sha256": "20288d82cb5698bae23bea7f364c046a19eb5b3fb1ca618b7a4068d1c36d6eba",
+            "size": 867240759,
+            "uncompressed-sha256": "6156add3bdfdf384d7dddbc431a2a1438f6360f92452bb862ddb229c2a84c06a",
+            "uncompressed-size": 3693084672
         },
         "metal4k": {
-            "path": "rhcos-46.82.202009010341-0-metal4k.ppc64le.raw.gz",
-            "sha256": "4c2c888ab9f5df80dc0c1f00deab1ef1a976a3fd26730e55101a497a15960205",
-            "size": 910973412,
-            "uncompressed-sha256": "74c6f936fd05c7fff37faf454adf41816b4f5ed7b7b36a218d863e819e2c70b0",
-            "uncompressed-size": 3964665856
+            "path": "rhcos-46.82.202009240941-0-metal4k.ppc64le.raw.gz",
+            "sha256": "8f519caa7429ba8d1dcfdf44a7ff4a92665381b07ab2d035ff90318e41b5ab12",
+            "size": 867334091,
+            "uncompressed-sha256": "41924484e1a93c0a47eadc19c860baf52337dd428d90a9147d773b9723ac11df",
+            "uncompressed-size": 3693084672
         },
         "openstack": {
-            "path": "rhcos-46.82.202009010341-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "bd5817a5d50d4b3ac58f16a5f9ee3ae32cdab0c7ae3c31cfbe2b39e192d4e111",
-            "size": 909419313,
-            "uncompressed-sha256": "f23ad30997f5ff2e4449e970a74fcec8391427aa8b9e5b4298218aacf9298693",
-            "uncompressed-size": 2568880128
+            "path": "rhcos-46.82.202009240941-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "96adcc9d0f01b2748eb8a86868162ec8e844288040a43e44bda11567a0249061",
+            "size": 865739613,
+            "uncompressed-sha256": "daf1c90ed5082c7da490fe666c91c65ffe74c119eac27f78bdf6216e4bb61d2f",
+            "uncompressed-size": 2361982976
         },
         "ostree": {
-            "path": "rhcos-46.82.202009010341-0-ostree.ppc64le.tar",
-            "sha256": "e9fae1040a2fc622c0da04902ebbf52a457b4a24653e822b3ccb0244030587e2",
-            "size": 831600640
+            "path": "rhcos-46.82.202009240941-0-ostree.ppc64le.tar",
+            "sha256": "11c1f85b82a418416706c1a7f7b974590e5b1b746a9727544187d5b34cabd7ef",
+            "size": 776611840
         },
         "qemu": {
-            "path": "rhcos-46.82.202009010341-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "4e560de76395f41707fe4105612b804ace56ce751d9ac6ba887cff30f616b704",
-            "size": 910228841,
-            "uncompressed-sha256": "f013399832df3e01029490c12c780d102c11d2d7fbc36adaa4b33158df02f25e",
-            "uncompressed-size": 2608267264
+            "path": "rhcos-46.82.202009240941-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "86be9dea62495d885cc0622f8025aaf56a1af26429bfa27b4ad2169d448a7668",
+            "size": 866267572,
+            "uncompressed-sha256": "ce30ae7d26ce24a04a42831ae18541f97a1cc9eb57f3bf6395a99b78ec60c1dd",
+            "uncompressed-size": 2400714752
         }
     },
     "oscontainer": {
-        "digest": "sha256:365e4ba78b43eba71f4f0021c90573da029a9a62b11c9a44bfcee2987e56f8ee",
+        "digest": "sha256:2758233e925dff411d2553ce48babed0e0608a58225455040dc3f0c4710cb08f",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "188702fede855b0b84c0d7a1ee823d4e83ebae8bcc2b37ec6a010efbd3c8a5cb",
-    "ostree-version": "46.82.202009010341-0"
+    "ostree-commit": "271c5b43ce734e38d75299e7fc1e4d331679942ad4b93a6fb2fc8fe0f34d19bd",
+    "ostree-version": "46.82.202009240941-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,80 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202009010439-0/s390x/",
-    "buildid": "46.82.202009010439-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202009241338-0/s390x/",
+    "buildid": "46.82.202009241338-0",
     "images": {
         "dasd": {
-            "path": "rhcos-46.82.202009010439-0-dasd.s390x.raw.gz",
-            "sha256": "632d5b52673c952f01d9aab9a55e018de738b9873a4b6498e3cc83f1b9b0a26a",
-            "size": 835238485,
-            "uncompressed-sha256": "4fe2014e8b733535aa3f333903d13b69222915a3ecf800a7efc8e904ca0f13bd",
-            "uncompressed-size": 3609198592
-        },
-        "initramfs": {
-            "path": "rhcos-46.82.202009010439-0-installer-initramfs.s390x.img",
-            "sha256": "cd814389a45ae93d7dba41148d87ec6d1af76be84dcc9ce0b1200296c765342c"
-        },
-        "iso": {
-            "path": "rhcos-46.82.202009010439-0-installer.s390x.iso",
-            "sha256": "69b7be622db76d626b53a82627233f83c7d0c300f48151ee780f74cb070e6c9e"
-        },
-        "kernel": {
-            "path": "rhcos-46.82.202009010439-0-installer-kernel-s390x",
-            "sha256": "7a468bd7f6f67bb156ea64f29cb23ad59eddd1a322b7cc850c5a0c26aef01e7f"
+            "path": "rhcos-46.82.202009241338-0-dasd.s390x.raw.gz",
+            "sha256": "265c05e0ad96ea939172020e030635bc91a29ea5cbdf0164f8e5f0ca19adfe8d",
+            "size": 789084259,
+            "uncompressed-sha256": "71773041b7111719b980ad7c9209f1a5766f642020bcec68b82fb58d5cb0b1fa",
+            "uncompressed-size": 3372220416
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202009010439-0-live-initramfs.s390x.img",
-            "sha256": "dcf16656bc0205315fdf848a9f22d695fa1e0b7c8c62ed57e8c6dbcda8cf90d9"
+            "path": "rhcos-46.82.202009241338-0-live-initramfs.s390x.img",
+            "sha256": "f4e0f654a200dcc61f266be476897374a33d892de20a79efab5f980a866bc814"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202009010439-0-live.s390x.iso",
-            "sha256": "0f54fccdc661503a1823734c67852809ec896626f94a79e70c5e40cfbb99d3bc"
+            "path": "rhcos-46.82.202009241338-0-live.s390x.iso",
+            "sha256": "91a65767ef52f721ad6c20b70de93116341b47ee249233a1b8b64668279efb41"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202009010439-0-live-kernel-s390x",
-            "sha256": "7a468bd7f6f67bb156ea64f29cb23ad59eddd1a322b7cc850c5a0c26aef01e7f"
+            "path": "rhcos-46.82.202009241338-0-live-kernel-s390x",
+            "sha256": "a843da4b853cc5504e3a3aaee2221e4131efc3cf356e4fa4c440031a73b87b79"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202009010439-0-live-rootfs.s390x.img",
-            "sha256": "564c9957d281e618b6175f3b9633b4743918e54424a6e20bf67a6eb7743ea2ac"
+            "path": "rhcos-46.82.202009241338-0-live-rootfs.s390x.img",
+            "sha256": "9ea69ce44f68ede52653867af9953ffd5b33f6878abe8375821351fe3a05b12d"
         },
         "metal": {
-            "path": "rhcos-46.82.202009010439-0-metal.s390x.raw.gz",
-            "sha256": "7bd60a21ac77f993306be173d31fe8ee1e6e3d96ec2adf8a55276828b31076d7",
-            "size": 835092168,
-            "uncompressed-sha256": "d8dde92945c2ab6200bd0c5cc61c0b84d10b899c892da868352b299fbdd522f1",
-            "uncompressed-size": 3609198592
+            "path": "rhcos-46.82.202009241338-0-metal.s390x.raw.gz",
+            "sha256": "6c67ce15e8ad94282bedc9490192b19f9c6d7ca38839139c92889e882ae2abdb",
+            "size": 788995446,
+            "uncompressed-sha256": "a12805e2402b2b040a97d6d1453ece4483994d4e82d883524b239bd86c8458b7",
+            "uncompressed-size": 3372220416
         },
         "metal4k": {
-            "path": "rhcos-46.82.202009010439-0-metal4k.s390x.raw.gz",
-            "sha256": "9ec4c07a2e09e7cdbac13fa6ee5c604a66b1a55473eef69c6b521b6f56f60cba",
-            "size": 835146002,
-            "uncompressed-sha256": "bf2f38c67992cd4f0a2c38dc76aa03df2f11a4e7848fa24a4960e3c85b109636",
-            "uncompressed-size": 3609198592
+            "path": "rhcos-46.82.202009241338-0-metal4k.s390x.raw.gz",
+            "sha256": "f0cc6c43eeac9be69c705f7cfbf329192d7d540c87b78631f6d09752a7235612",
+            "size": 789003375,
+            "uncompressed-sha256": "ac5ab167f8bed0fe29e4f3acaeb1437a33af51d86654c98cda01d519f4c3ab28",
+            "uncompressed-size": 3372220416
         },
         "openstack": {
-            "path": "rhcos-46.82.202009010439-0-openstack.s390x.qcow2.gz",
-            "sha256": "6145602d63201c1439d91fca99116ef3ff797fd707ee2a84964c39778b5cecb4",
-            "size": 833762787,
-            "uncompressed-sha256": "25caef791ceda857c371ab3c4b27bec7edb1c52b1df63442ff694363f258ce97",
-            "uncompressed-size": 2269249536
+            "path": "rhcos-46.82.202009241338-0-openstack.s390x.qcow2.gz",
+            "sha256": "6a780c5efbb78e987be349dcdaa57858f407c93108ce789ec2b848c75892e598",
+            "size": 787813623,
+            "uncompressed-sha256": "2c7cee4537234b0eba71ebfd2944ceaa5e78fc99a542ba9d6f4eace93136e86d",
+            "uncompressed-size": 2084765696
         },
         "ostree": {
-            "path": "rhcos-46.82.202009010439-0-ostree.s390x.tar",
-            "sha256": "bd03b23ee26de657b33d91046fef1a49a94f3abc3cd80d8dcb3002f7ba095e59",
-            "size": 777349120
+            "path": "rhcos-46.82.202009241338-0-ostree.s390x.tar",
+            "sha256": "fd7763c3ae9180df4f90b75a4e8b42066d084b97d4d93fc1a6c72f87c4219994",
+            "size": 725288960
         },
         "qemu": {
-            "path": "rhcos-46.82.202009010439-0-qemu.s390x.qcow2.gz",
-            "sha256": "ee142095611d0e9de7d5c46f4501fc71e6d2bb74e9712d615ae1ec92f6399cf3",
-            "size": 834554408,
-            "uncompressed-sha256": "6182eaf1ba493a91f6bfbbd861b9f415c4fa4065c70512dacb4861ada26289df",
-            "uncompressed-size": 2307260416
+            "path": "rhcos-46.82.202009241338-0-qemu.s390x.qcow2.gz",
+            "sha256": "961a4844a435ea99bb846d33bf45fcbd2ff8314d8b0aa0a7f19a84ac4d8d8b5f",
+            "size": 788556212,
+            "uncompressed-sha256": "1c24153899e719b0fe7d3a82c23ce2180df047cab3978941af9fdd02b3a34b6c",
+            "uncompressed-size": 2122121216
         }
     },
     "oscontainer": {
-        "digest": "sha256:aedadea840ca8b7725569357902ff6a8bf9dd45ba736c79dc185f340c9bd8f81",
+        "digest": "sha256:a2bb9d33524bb92f5059843ea87bb205d72bf2c23164090852485722682ff8e1",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "7ae32969b753f6b7071bc1a9498c04721702a9a60f050f523d50a51f0dc93281",
-    "ostree-version": "46.82.202009010439-0"
+    "ostree-commit": "d89f98fded4b2a9753f72754334ed284599597c1608b076cb6976c7ed532e15b",
+    "ostree-version": "46.82.202009241338-0"
 }


### PR DESCRIPTION
To align with the x86 images in #4206, bump bootimages for the other arches