### PR TITLE
Bug 1878758: openstack UPI: Create a router when FIPless

### DIFF
--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -106,7 +106,6 @@
       network: "{{ os_external_network }}"
       interfaces:
       - "{{ os_subnet }}"
-    when: os_external_network is defined and os_external_network|length>0
 
   - name: 'Set external router tag'
     command:


### PR DESCRIPTION
to enable outbound external connectivity.

This is a follow-up to #3755.

/cc luis5tb adduarte iamemilio mandre