### PR TITLE
Bug 1878758: openstack UPI: Allow for no FIP or router

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -73,7 +73,7 @@ The requirements for UPI are broadly similar to the [ones for OpenStack IPI][ipi
   - input in the `openshift-install` wizard
 - Nova flavors
   - inventory: `os_flavor_master` and `os_flavor_worker`
-- An external subnet you want to use for floating IP addresses (if FIPs are used)
+- An external subnet for external connectivity. Required if any of the floating IPs is set in the inventory.
   - inventory: `os_external_network`
 - The `openshift-install` binary
 - A subnet range for the Nova servers / OpenShift Nodes, that does not conflict with your existing network
@@ -210,15 +210,17 @@ $ openstack image show rhcos
 
 ## API and Ingress Floating IP Addresses
 
-If the variables `os_api_fip` and `os_ingress_fip` are found in `inventory.yaml`, the corresponding floating IPs will be attached to the API load balancer and to the worker nodes load balancer respectively. Note that `os_external_network` is a requirement for those. If `os_external_network` is found in `inventory.yaml`, the playbooks will create and attach an additional floating IP to the bootstrap machine.
+If the variables `os_api_fip`, `os_ingress_fip` and `os_bootstrap_fip` are found in `inventory.yaml`, the corresponding floating IPs will be attached to the API load balancer, to the worker nodes load balancer and to the temporary machine used for the install process, respectively. Note that `os_external_network` is a requirement for those.
 
-**NOTE**: throughout this document, we will use `203.0.113.23` as the public IP address for the OpenShift API endpoint and `203.0.113.19` as the public IP for the ingress (`*.apps`) endpoint.
+**NOTE**: throughout this document, we will use `203.0.113.23` as the public IP address for the OpenShift API endpoint and `203.0.113.19` as the public IP for the ingress (`*.apps`) endpoint. `203.0.113.20` will be the public IP used for the bootstrap machine.
 
 ```sh
 $ openstack floating ip create --description "OpenShift API" <external>
 => 203.0.113.23
 $ openstack floating ip create --description "OpenShift Ingress" <external>
 => 203.0.113.19
+$ openstack floating ip create --description "bootstrap machine" <external>
+=> 203.0.113.20
 ```
 
 The OpenShift API (for the OpenShift administrators and app developers) will be at `api.<cluster name>.<cluster domain>` and the Ingress (for the apps' end users) at `*.apps.<cluster name>.<cluster domain>`.
@@ -854,7 +856,9 @@ $ oc get pods -A
 $ ansible-playbook -i inventory.yaml down-bootstrap.yaml
 ```
 
-The teardown playbook deletes the bootstrap port, server and floating IP address.
+The teardown playbook deletes the bootstrap port and server.
+
+Now the bootstrap floating IP can also be destroyed.
 
 If you haven't done so already, you should also disable the bootstrap Ignition URL.
 
@@ -981,3 +985,5 @@ The playbook `down-load-balancers.yaml` idempotently deletes the load balancers 
 `down-load-balancers.yaml` playbook once the load balancers have transitioned to `ACTIVE`.
 
 Then, remove the `api` and `*.apps` DNS records.
+
+The floating IPs can also be deleted if not useful any more.

--- a/upi/openstack/bootstrap.yaml
+++ b/upi/openstack/bootstrap.yaml
@@ -25,20 +25,18 @@
     command:
       cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_bootstrap }}"
 
+  - name: 'Set bootstrap auto_ip to false'
+    ansible.builtin.set_fact:
+      bootstrap_auto_ip: false
+    when: os_bootstrap_fip is not defined
+
   - name: 'Create the bootstrap server'
     os_server:
       name: "{{ os_bootstrap_server_name }}"
       image: "{{ os_image_rhcos }}"
       flavor: "{{ os_flavor_master }}"
       userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
-      auto_ip: no
+      floating_ips: "{{ os_bootstrap_fip | default(omit) }}"
+      auto_ip: "{{ bootstrap_auto_ip | default(omit) }}"
       nics:
       - port-name: "{{ os_port_bootstrap }}"
-
-  - name: 'Create the bootstrap floating IP'
-    os_floating_ip:
-      state: present
-      nat_destination: "{{ os_network }}"
-      network: "{{ os_external_network }}"
-      server: "{{ os_bootstrap_server_name }}"
-    when: os_external_network is defined and os_external_network|length>0

--- a/upi/openstack/down-bootstrap.yaml
+++ b/upi/openstack/down-bootstrap.yaml
@@ -13,7 +13,6 @@
     os_server:
       name: "{{ os_bootstrap_server_name }}"
       state: absent
-      delete_fip: yes
 
   - name: 'Remove the bootstrap server port'
     os_port:

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -28,11 +28,11 @@ all:
       # 3 is the minimum number for a fully-functional cluster.
       os_compute_nodes_number: 3
 
-      # The public network, if available. Required for os_api_fip and
-      # os_ingress_fip.
-      # If non-empty, an additional floating IP will be created and attached to
-      # the bootstrap machine to allow the retrieval of a log bundle in case of
-      # install failure ('must-gather').
+      # The public network providing connectivity to the cluster. If not
+      # provided, the cluster external connectivity must be provided in another
+      # way.
+      #
+      # Required for os_api_fip, os_ingress_fip, os_bootstrap_fip.
       os_external_network: 'external'
 
       # OpenShift API floating IP address. If this value is non-empty, the
@@ -44,3 +44,8 @@ all:
       # corresponding floating IP will be attached to the worker nodes to serve
       # the applications.
       os_ingress_fip: '203.0.113.19'
+
+      # If this value is non-empty, the corresponding floating IP will be
+      # attached to the bootstrap machine. This is needed for collecting logs
+      # in case of install failure.
+      os_bootstrap_fip: '203.0.113.20'


### PR DESCRIPTION
If the external network is not provided, the router will not be created
and external connectivity will be a respopnsibility of the operator.

Floating IPs will be set if available, on an individual basis. The
external network is a requirement for FIPs; if not provided, the
playbooks will error.

The bootstrap FIP is now required to be created manually like the other
FIPs.

This is a follow-up to #3755.

/cc luis5tb adduarte iamemilio mandre