### PR TITLE
Bug 1878900: openstack: Skip validation for baremetal flavors

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -8,8 +8,6 @@ import (
 
 	guuid "github.com/google/uuid"
 	"github.com/openshift/installer/pkg/types/openstack"
-
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 )
 
 type flavorRequirements struct {
@@ -44,10 +42,15 @@ func ValidateMachinePool(p *openstack.MachinePool, ci *CloudInfo, controlPlane b
 	}
 
 	if p.FlavorName != "" {
-		if controlPlane {
-			allErrs = append(allErrs, validateMpoolFlavor(ci.Flavors[p.FlavorName], p.FlavorName, ctrlPlaneFlavorMinimums, fldPath)...)
+		flavor, ok := ci.Flavors[p.FlavorName]
+		if ok {
+			if controlPlane {
+				allErrs = append(allErrs, validateMpoolFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath)...)
+			} else {
+				allErrs = append(allErrs, validateMpoolFlavor(flavor, computeFlavorMinimums, fldPath)...)
+			}
 		} else {
-			allErrs = append(allErrs, validateMpoolFlavor(ci.Flavors[p.FlavorName], p.FlavorName, computeFlavorMinimums, fldPath)...)
+			allErrs = append(allErrs, field.NotFound(fldPath.Child("flavorName"), p.FlavorName))
 		}
 	}
 
@@ -102,9 +105,12 @@ func validUUIDv4(s string) bool {
 	return true
 }
 
-func validateMpoolFlavor(flavor *flavors.Flavor, name string, req flavorRequirements, fldPath *field.Path) field.ErrorList {
-	if flavor == nil {
-		return field.ErrorList{field.NotFound(fldPath.Child("flavorName"), name)}
+func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.Path) field.ErrorList {
+
+	// OpenStack administrators don't always fill in accurate metadata for
+	// baremetal flavors. Skipping validation.
+	if flavor.Baremetal {
+		return field.ErrorList{}
 	}
 
 	errs := []string{}

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -41,18 +41,31 @@ func validPlatformCloudInfo() *CloudInfo {
 			AdminStateUp: true,
 			Status:       "ACTIVE",
 		},
-		Flavors: map[string]*flavors.Flavor{
+		Flavors: map[string]Flavor{
 			validCtrlPlaneFlavor: {
-				Name:  validCtrlPlaneFlavor,
-				RAM:   16,
-				Disk:  25,
-				VCPUs: 4,
+				Flavor: &flavors.Flavor{
+					Name:  validCtrlPlaneFlavor,
+					RAM:   16,
+					Disk:  25,
+					VCPUs: 4,
+				},
 			},
 			invalidCtrlPlaneFlavor: {
-				Name:  invalidCtrlPlaneFlavor,
-				RAM:   8,  // too low
-				Disk:  20, // too low
-				VCPUs: 2,  // too low
+				Flavor: &flavors.Flavor{
+					Name:  invalidCtrlPlaneFlavor,
+					RAM:   8,  // too low
+					Disk:  20, // too low
+					VCPUs: 2,  // too low
+				},
+			},
+			baremetalFlavor: {
+				Flavor: &flavors.Flavor{
+					Name:  baremetalFlavor,
+					RAM:   8,  // too low
+					Disk:  20, // too low
+					VCPUs: 2,  // too low
+				},
+				Baremetal: true,
 			},
 		},
 		APIFIP: &floatingips.FloatingIP{
@@ -78,6 +91,18 @@ func TestOpenStackPlatformValidation(t *testing.T) {
 		{
 			name:           "valid platform",
 			platform:       validPlatform(),
+			cloudInfo:      validPlatformCloudInfo(),
+			networking:     validNetworking(),
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name: "baremetal flavor",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.FlavorName = baremetalFlavor
+				return p
+			}(),
 			cloudInfo:      validPlatformCloudInfo(),
 			networking:     validNetworking(),
 			expectedError:  false,


### PR DESCRIPTION
Baremetal flavor metadata in Glance often contains placeholder
information. With this change, pre-flight validation is no longer
performed for flavors itentified as baremetal.