### PR TITLE
Bug 1777224: pkg/asset: metadata to depend on ignition

### DIFF
--- a/pkg/asset/cluster/metadata.go
+++ b/pkg/asset/cluster/metadata.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/cluster/openstack"
 	"github.com/openshift/installer/pkg/asset/cluster/ovirt"
 	"github.com/openshift/installer/pkg/asset/cluster/vsphere"
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
@@ -51,6 +52,7 @@ func (m *Metadata) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&installconfig.ClusterID{},
 		&installconfig.InstallConfig{},
+		&bootstrap.Bootstrap{},
 	}
 }
 


### PR DESCRIPTION
Prior to this change, the Metadata asset was only regenerated when the
install-config or install-config.infraID was determined to have changed.
However, in the case that the install-config was updated, the installer
was invoked with `create manifests`, and then the installer was invoked
a second time with `create ignition-configs`, the second invokation had
no way of knowing the install-config had changed. As a result, the
Metadata would not be regenerated. This caused the clusterID in the
metadata.json to not match that of the cluster.

This change solves this specific case by making the Metadata asset
dependent on the bootstrap ignition asset. It in turn is dependent on
the manifests asset. As a result, when the manifests are regenerated
in the first invocation, and the bootstrap ignition is regenerated in
the second invocation, the Metadata will also be regenerated.