### PR TITLE
Bug 1884558: do not use local cacert path in generated clouds.yaml

### DIFF
--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -129,6 +129,12 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+
+		// We need to replace the local cacert path with one that is used in OpenShift
+		if cloud.CACertFile != "" {
+			cloud.CACertFile = "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"
+		}
+
 		clouds := make(map[string]map[string]*clientconfig.Cloud)
 		clouds["clouds"] = map[string]*clientconfig.Cloud{
 			osmachine.CloudName: cloud,


### PR DESCRIPTION
When we generate an OpenShift cred secret with clouds.yaml, we keep the local cacert path there. In other words, path to cacert on the user's machine.

This is wrong, because this value is useless after the installation. To avoid this we need to use the predefined const value, like we do with cloud config:  https://github.com/openshift/installer/blob/4aac205a59a9102ddf1ae329b3c4c6f0dff7e330/pkg/asset/manifests/openstack/cloudproviderconfig.go#L21

/label platform/openstack