### PR TITLE
Bug 1876815: OpenStack: unset OS_CLOUD

### DIFF
--- a/pkg/asset/installconfig/openstack/session.go
+++ b/pkg/asset/installconfig/openstack/session.go
@@ -2,6 +2,7 @@
 package openstack
 
 import (
+	"os"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -21,6 +22,12 @@ type Session struct {
 // GetSession returns an OpenStack session for a given cloud name in clouds.yaml.
 func GetSession(cloudName string) (*Session, error) {
 	opts := defaultClientOpts(cloudName)
+
+	// We should unset OS_CLOUD env variable here, because the real cloud name was
+	// defined on the previous step. OS_CLOUD has more priority, so the value from
+	// "opts" variable will be ignored if OS_CLOUD contains something.
+	os.Unsetenv("OS_CLOUD")
+
 	cloudConfig, err := clientconfig.GetCloudFromYAML(opts)
 	if err != nil {
 		return nil, err

--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"os"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -50,6 +51,11 @@ func GetCloudInfo(ic *types.InstallConfig) (*CloudInfo, error) {
 	}
 
 	opts := &clientconfig.ClientOpts{Cloud: ic.OpenStack.Cloud}
+
+	// We should unset OS_CLOUD env variable here, because the real cloud name was
+	// defined on the previous step. OS_CLOUD has more priority, so the value from
+	// "opts" variable will be ignored if OS_CLOUD contains something.
+	os.Unsetenv("OS_CLOUD")
 
 	ci.clients.networkClient, err = clientconfig.NewServiceClient("network", opts)
 	if err != nil {

--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"os"
 	"strings"
 	"time"
 
@@ -103,6 +104,11 @@ func (o *ClusterUninstaller) Run() error {
 	opts := &clientconfig.ClientOpts{
 		Cloud: o.Cloud,
 	}
+
+	// We should unset OS_CLOUD env variable here, because the real cloud name was
+	// defined on the previous step. OS_CLOUD has more priority, so the value from
+	// "opts" variable will be ignored if OS_CLOUD contains something.
+	os.Unsetenv("OS_CLOUD")
 
 	// launch goroutines
 	for name, function := range deleteFuncs {


### PR DESCRIPTION
We should unset OS_CLOUD env variable during cloudinfo and session generation, and cluster destruction. We have to do it because the real cloud name is defined by user in the install-config. OS_CLOUD has more priority, so the user-defined value will be ignored if OS_CLOUD contains something.

/label platform/openstack