### PR TITLE
Vsphere nested virt

### DIFF
--- a/upi/vsphere/README.md
+++ b/upi/vsphere/README.md
@@ -1,14 +1,16 @@
-# Pre-Requisites
+# VMware UPI install with Terraform EXAMPLE
+
+## Pre-Requisites
 
 * terraform
 * jq
 
-# Build a Cluster
+## Build a Cluster
 
 1. Create an install-config.yaml.
 The machine CIDR for the dev cluster is 139.178.89.192/26.
 
-```
+```yaml
 apiVersion: v1
 baseDomain: devcluster.openshift.com
 metadata:
@@ -27,34 +29,38 @@ pullSecret: YOUR_PULL_SECRET
 sshKey: YOUR_SSH_KEY
 ```
 
-2. Run `openshift-install create ignition-configs`.
+1. Run `openshift-install create ignition-configs`.
 
-3. Fill out a terraform.tfvars file with the ignition configs generated.
+1. Fill out a terraform.tfvars file with the ignition configs generated.
+
 There is an example terraform.tfvars file in this directory named terraform.tfvars.example. The example file is set up for use with the dev cluster running at vcsa.vmware.devcluster.openshift.com. At a minimum, you need to set values for the following variables.
+
 * cluster_id
 * cluster_domain
 * vsphere_user
 * vsphere_password
-* ipam_token OR bootstrap_ip, control_plane_ips, and compute_ips
+* ipam_token OR bootstrap_ip_address, lb_ip_address, control_plane_ip_addresses, and compute_ip_addresses
 
 The bootstrap ignition config must be placed in a location that will be accessible by the bootstrap machine. For example, you could store the bootstrap ignition config in a gist.
 
-Even if declaring static IPs a DHCP server is still required early in the boot process to download the ignition files. 
+Even if declaring static IPs a DHCP server is still required early in the boot process to download the ignition files.
 
-4. Run `terraform init`.
+1. Fetch the latest terraform ignition plugin from [here](https://github.com/community-terraform-providers/terraform-provider-ignition/releases), unpack it and place it to `/bin/terraform-provider-ignition`s
 
-5. Ensure that you have you AWS profile set and a region specified. The installation will use create AWS route53 resources for routing to the OpenShift cluster.
+1. Run `terraform init`.
 
-6. Run `terraform apply -auto-approve`.
+1. Ensure that you have you AWS profile set and a region specified. The installation will use create AWS route53 resources for routing to the OpenShift cluster.
+
+1. Run `terraform apply -auto-approve`.
 This will reserve IP addresses for the VMs.
 
-7. Run `openshift-install wait-for bootstrap-complete`. Wait for the bootstrapping to complete.
+1. Run `openshift-install wait-for bootstrap-complete`. Wait for the bootstrapping to complete.
 
-8. Run `terraform apply -auto-approve -var 'bootstrap_complete=true'`.
+1. Run `terraform apply -auto-approve -var 'bootstrap_complete=true'`.
 This will destroy the bootstrap VM.
 
-9. Run `openshift-install wait-for install-complete`. Wait for the cluster install to finish.
+1. Run `openshift-install wait-for install-complete`. Wait for the cluster install to finish.
 
-10. Enjoy your new OpenShift cluster.
+1. Enjoy your new OpenShift cluster.
 
-11. Run `terraform destroy -auto-approve`.
+1. Run `terraform destroy -auto-approve`.

--- a/upi/vsphere/cluster_domain/main.tf
+++ b/upi/vsphere/cluster_domain/main.tf
@@ -18,5 +18,6 @@ resource "aws_route53_record" "name_server" {
   ttl     = "300"
   zone_id = data.aws_route53_zone.base.zone_id
   records = aws_route53_zone.cluster.name_servers
+  allow_overwrite = true
 }
 

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -254,5 +254,5 @@ module "compute_vm" {
   dns_addresses = var.vm_dns_addresses
   gateway       = var.vm_gateway
 
-  nested_hv_enabled = var.nested_virt
+  nested_virt = var.nested_virt
 }

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -249,4 +249,6 @@ module "compute_vm" {
   num_cpus      = var.compute_num_cpus
   memory        = var.compute_memory
   dns_addresses = var.vm_dns_addresses
+
+  nested_hv_enabled = var.nested_virt
 }

--- a/upi/vsphere/main.tf
+++ b/upi/vsphere/main.tf
@@ -164,6 +164,7 @@ module "lb_vm" {
   num_cpus      = 2
   memory        = 2096
   dns_addresses = var.vm_dns_addresses
+  gateway       = var.vm_gateway
 }
 
 module "bootstrap" {
@@ -191,6 +192,7 @@ module "bootstrap" {
   num_cpus      = 2
   memory        = 8192
   dns_addresses = var.vm_dns_addresses
+  gateway       = var.vm_gateway
 }
 
 module "control_plane_vm" {
@@ -222,6 +224,7 @@ module "control_plane_vm" {
   num_cpus      = var.control_plane_num_cpus
   memory        = var.control_plane_memory
   dns_addresses = var.vm_dns_addresses
+  gateway       = var.vm_gateway
 }
 
 module "compute_vm" {
@@ -249,6 +252,7 @@ module "compute_vm" {
   num_cpus      = var.compute_num_cpus
   memory        = var.compute_memory
   dns_addresses = var.vm_dns_addresses
+  gateway       = var.vm_gateway
 
   nested_hv_enabled = var.nested_virt
 }

--- a/upi/vsphere/variables.tf
+++ b/upi/vsphere/variables.tf
@@ -170,3 +170,8 @@ variable "ssh_public_key_path" {
   type    = string
   default = "~/.ssh/id_rsa.pub"
 }
+
+variable "nested_virt" {
+  type = bool
+  default = false
+}

--- a/upi/vsphere/variables.tf
+++ b/upi/vsphere/variables.tf
@@ -62,6 +62,11 @@ variable "vm_dns_addresses" {
   default = ["1.1.1.1", "9.9.9.9"]
 }
 
+variable "vm_gateway" {
+  type    = string
+  default = null
+}
+
 /////////
 // OpenShift cluster variables
 /////////

--- a/upi/vsphere/vm/ifcfg.tmpl
+++ b/upi/vsphere/vm/ifcfg.tmpl
@@ -5,7 +5,7 @@ DEVICE=ens192
 ONBOOT=yes
 IPADDR=${ip_address}
 PREFIX=${element(split("/", machine_cidr), 1)}
-GATEWAY=${gateway != "" ? gateway : cidrhost(machine_cidr, 1)}
+GATEWAY=${gateway != null ? gateway : cidrhost(machine_cidr, 1)}
 DOMAIN=${cluster_domain}
 %{ for index, ip in dns_addresses ~}
 DNS${index+1}=${ip}

--- a/upi/vsphere/vm/ifcfg.tmpl
+++ b/upi/vsphere/vm/ifcfg.tmpl
@@ -5,7 +5,7 @@ DEVICE=ens192
 ONBOOT=yes
 IPADDR=${ip_address}
 PREFIX=${element(split("/", machine_cidr), 1)}
-GATEWAY=${cidrhost(machine_cidr, 1)}
+GATEWAY=${gateway != "" ? gateway : cidrhost(machine_cidr, 1)}
 DOMAIN=${cluster_domain}
 %{ for index, ip in dns_addresses ~}
 DNS${index+1}=${ip}

--- a/upi/vsphere/vm/ignition.tf
+++ b/upi/vsphere/vm/ignition.tf
@@ -23,6 +23,7 @@ data "ignition_file" "static_ip" {
     content = templatefile("${path.module}/ifcfg.tmpl", {
       dns_addresses = var.dns_addresses,
       machine_cidr  = var.machine_cidr
+      gateway       = var.gateway
       //ip_address     = var.hostnames_ip_addresses[count.index].value
       ip_address     = each.value
       cluster_domain = var.cluster_domain

--- a/upi/vsphere/vm/main.tf
+++ b/upi/vsphere/vm/main.tf
@@ -14,6 +14,8 @@ resource "vsphere_virtual_machine" "vm" {
   wait_for_guest_net_timeout  = "0"
   wait_for_guest_net_routable = "false"
 
+  nested_hv_enabled = var.nested_virt
+
   network_interface {
     network_id = var.network_id
   }

--- a/upi/vsphere/vm/variables.tf
+++ b/upi/vsphere/vm/variables.tf
@@ -59,3 +59,8 @@ variable "dns_addresses" {
   type = list(string)
 }
 
+variable "gateway" {
+  type = string
+  default = null
+}
+

--- a/upi/vsphere/vm/variables.tf
+++ b/upi/vsphere/vm/variables.tf
@@ -64,3 +64,8 @@ variable "gateway" {
   default = null
 }
 
+variable "nested_virt" {
+  type = bool
+  default = false
+}
+


### PR DESCRIPTION
@jcpowermac - as discussed

This will add:
* Define Gateway when setting static IPs (this is not always .1)
* Allow nested virt on worker nodes
* Tell people where to get the `terraform-provider-ignition` from
* Fix re-deploy issue where Terraform complains about already existing nameserver entry (that it created itself)