### PR TITLE
Workaround golang linux/arm64 link error

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -42,5 +42,11 @@ if (echo "${TAGS}" | grep -q 'libvirt')
 then
 	export CGO_ENABLED=1
 fi
+if test "$(go env GOARCH)" = "arm64"
+then
+	# https://github.com/golang/go/issues/40492
+	LDFLAGS="${LDFLAGS} -linkmode external"
+	export CGO_ENABLED=1
+fi
 
 go build "${GOFLAGS}" -ldflags "${LDFLAGS}" -tags "${TAGS}" -o "${OUTPUT}" ./cmd/openshift-install


### PR DESCRIPTION
There is a bug with the golang internal linker for the linux/arm64 target
that has yet to be fixed:

https://github.com/golang/go/issues/40492