### PR TITLE
Bug 1882191: Add GODEBUG=x509ignoreCN=0 to systemd DefaultEnvironment

### DIFF
--- a/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env-godebug.conf.template
+++ b/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env-godebug.conf.template
@@ -1,0 +1,2 @@
+[Manager]
+DefaultEnvironment=GODEBUG=x509ignoreCN=0


### PR DESCRIPTION
Go 1.15 no longer falls back to the common name for hostname validation
requiring that a DNS SAN exist. We need more time to deprecate this so
revert back to previous behavior for the time being.