### PR TITLE
Bug 1874248: types/vsphere/validation: ensure vcenter is all lower case

### DIFF
--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -29,6 +29,10 @@ func ValidatePlatform(p *vsphere.Platform, fldPath *field.Path) field.ErrorList 
 		allErrs = append(allErrs, field.Required(fldPath.Child("defaultDatastore"), "must specify the default datastore"))
 	}
 
+	if strings.ToLower(p.VCenter) != p.VCenter {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("vCenter"), p.VCenter, "must be all lower case"))
+	}
+
 	// If all VIPs are empty, skip IP validation.  All VIPs are required to be defined together.
 	if strings.Join([]string{p.APIVIP, p.IngressVIP}, "") != "" {
 		allErrs = append(allErrs, validateVIPs(p, fldPath)...)

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -134,6 +134,15 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 			expectedError: `^test-path.apiVIP: Invalid value: "192.168.111.1": IPs for both API and Ingress should not be the same`,
 		},
+		{
+			name: "Capital letters in vCenter",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.VCenter = "tEsT-vCenter"
+				return p
+			}(),
+			expectedError: `^test-path.vCenter: Invalid value: "tEsT-vCenter": must be all lower case`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
the vCenter hostname must be all lower case because otherwise the cluster components cannot accurately connect with vCenter.