### PR TITLE
install-complete: provide troubleshooting info when operators fail

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -131,6 +131,7 @@ var (
 					if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
 						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
 					}
+					logTroubleshootingLink()
 					logrus.Fatal(err)
 				}
 				timer.StopTimer(timer.TotalTimeElapsed)
@@ -508,4 +509,11 @@ func waitForInstallComplete(ctx context.Context, config *rest.Config, directory 
 	}
 
 	return logComplete(rootOpts.dir, consoleURL)
+}
+
+func logTroubleshootingLink() {
+	logrus.Error("Cluster initialization failed because one or more operators are not functioning properly.")
+	logrus.Error("The cluster should be accessible for troublsehooting as detailed in the documentation linked below.")
+	logrus.Error("The 'wait-for install-complete' subcommand can then be used to continue the installation.")
+	logrus.Error("https://docs.openshift.com/container-platform/latest/support/troubleshooting/troubleshooting-installations.html")
 }

--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -87,7 +87,7 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 				if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
 					logrus.Error("Attempted to gather ClusterOperator status after wait failure: ", err2)
 				}
-
+				logTroubleshootingLink()
 				logrus.Fatal(err)
 			}
 			timer.StopTimer(timer.TotalTimeElapsed)


### PR DESCRIPTION
This change provides a link to the documentation when operators are
reporting failures during install-complete. It also gives instructions
to reinvoke with wait-for install-complete once all issues have been
resolved.