### PR TITLE
openstack: Bump Ansible to 2.9 in UPI

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -144,7 +144,7 @@ sudo subscription-manager repos --disable=* # if not done already
 sudo subscription-manager repos \
   --enable=rhel-8-for-x86_64-baseos-rpms \
   --enable=openstack-16-tools-for-rhel-8-x86_64-rpms \
-  --enable=ansible-2.8-for-rhel-8-x86_64-rpms \
+  --enable=ansible-2.9-for-rhel-8-x86_64-rpms \
   --enable=rhel-8-for-x86_64-appstream-rpms
 ```
 

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -25,7 +25,7 @@ RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux glibc-locale-sour
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    python3-openstackclient ansible python3-openstacksdk python3-netaddr unzip jq && \
+    python3-openstackclient ansible-2.9.14-1.el8ae python3-openstacksdk python3-netaddr unzip jq && \
     yum clean all && rm -rf /var/cache/yum/*
 
 # The Continuous Integration machinery relies on Route53 for DNS while testing the cluster.


### PR DESCRIPTION
[OSASINFRA-2127](https://issues.redhat.com/browse/OSASINFRA-2127)