### PR TITLE
Bug 1887525: baremetal: Wait for master-bmh-update script to succeed

### DIFF
--- a/data/data/bootstrap/baremetal/systemd/units/master-bmh-update.service
+++ b/data/data/bootstrap/baremetal/systemd/units/master-bmh-update.service
@@ -2,6 +2,7 @@
 Description=Update master BareMetalHosts with introspection data
 Wants=bootkube.service
 After=release-image.service
+Before=progress.service
 
 [Service]
 Type=oneshot

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -22,7 +22,7 @@ done
 
 echo "Gathering bootstrap journals ..."
 mkdir -p "${ARTIFACTS}/bootstrap/journals"
-for service in release-image crio-configure bootkube kubelet crio approve-csr ironic master-update-bmh
+for service in release-image crio-configure bootkube kubelet crio approve-csr ironic master-bmh-update
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"
 done


### PR DESCRIPTION
Allow users to debug failures in the master-bmh-update script.

We are not done with the bootstrap host until the `master-bmh-update.sh`
script has successfully completed, adding the IP address data needed by
the master nodes, and enabling reconciliation on the master Host
objects. To ensure the bootstrap cannot go away before this is done,
delay signalling that bootstrapping is complete until it is finished.

Correct the name of the unit in the log gathering script, so that users
can see the output without logging in to the bootstrap host.