### PR TITLE
Modify GCP api_internal to omit masters during bootstrap.

### DIFF
--- a/data/data/gcp/network/lb-private.tf
+++ b/data/data/gcp/network/lb-private.tf
@@ -27,7 +27,7 @@ resource "google_compute_region_backend_service" "api_internal" {
   timeout_sec           = 120
 
   dynamic "backend" {
-    for_each = var.bootstrap_lb ? concat(var.bootstrap_instance_groups, var.master_instance_groups) : var.master_instance_groups
+    for_each = var.bootstrap_lb ? var.bootstrap_instance_groups : var.master_instance_groups
 
     content {
       group = backend.value


### PR DESCRIPTION
Master nodes do not provision because they an not connect to the internal api endpoint with logged errors like this:

.//control-plane/10.124.0.3/journals/kubelaet.log:Oct 13 15:02:01 fedora hyperkube[1290]: E1013 15:02:01.565148    1290 certificate_manager.go:437] Failed while requesting a signed certificate from the master: cannot create certificate signing request: Post "https://api-int.mycluster.mycompany.com:6443/apis/certificates.k8s.io/v1/certificatesigningrequests": dial tcp 10.124.0.4:6443: connect: connection refused

I could hit port 6443 on the bootstrap node from master-0 directly but not through the load balancer (connection refused).  When I updated the gca-dev4-497xf-api-internal load balancer to remove the master nodes from the available backends I could get hit port 6443 both to the bootstrap node directly and through the endpoint.

I have seen this before where when a backend tries to hit a load balancer it is reflected back to the backend regardless of health check status. This behavior is documented in [1] and [2]. I believe this is what is happening.  I was not able to install tcpdump on the bootstrap node or the master-0 node to confirm this was what was happening.

[1] https://cloud.google.com/load-balancing/docs/internal#single_client_tests

[2] https://cloud.google.com/load-balancing/docs/internal/setting-up-internal#test-from-backend-vms

To work around this limitation with the smallest changeset I modified the gcp/network/lb-private.tf template for the api_internal backend service initially only contains the bootstrap instance group.  Later when we set var.bootstrap_lb to false during bootstrap teardown the bootstrap instance group is replace with the master instance groups.