### PR TITLE
Bug 1878900: openstack: Fix error messages in flavor validation

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -83,15 +83,16 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig) error {
 		return errors.Wrap(err, "failed to fetch external network info")
 	}
 
-	ci.Flavors[ic.OpenStack.FlavorName], err = ci.getFlavor(ic.OpenStack.FlavorName)
-	if err != nil {
-		return errors.Wrap(err, "failed to fetch platform flavor info")
+	if flavorName := ic.OpenStack.FlavorName; flavorName != "" {
+		ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
+		if err != nil {
+			return errors.Wrap(err, "failed to fetch platform flavor info")
+		}
 	}
 
 	if ic.ControlPlane != nil && ic.ControlPlane.Platform.OpenStack != nil {
-		crtlPlaneFlavor := ic.ControlPlane.Platform.OpenStack.FlavorName
-		if crtlPlaneFlavor != "" {
-			ci.Flavors[crtlPlaneFlavor], err = ci.getFlavor(crtlPlaneFlavor)
+		if flavorName := ic.ControlPlane.Platform.OpenStack.FlavorName; flavorName != "" {
+			ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
 			if err != nil {
 				return err
 			}
@@ -100,8 +101,7 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig) error {
 
 	for _, machine := range ic.Compute {
 		if machine.Platform.OpenStack != nil {
-			flavorName := machine.Platform.OpenStack.FlavorName
-			if flavorName != "" {
+			if flavorName := machine.Platform.OpenStack.FlavorName; flavorName != "" {
 				if _, seen := ci.Flavors[flavorName]; !seen {
 					ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
 					if err != nil {

--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -45,12 +45,12 @@ func ValidateMachinePool(p *openstack.MachinePool, ci *CloudInfo, controlPlane b
 		flavor, ok := ci.Flavors[p.FlavorName]
 		if ok {
 			if controlPlane {
-				allErrs = append(allErrs, validateMpoolFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath)...)
+				allErrs = append(allErrs, validateFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath.Child("type"))...)
 			} else {
-				allErrs = append(allErrs, validateMpoolFlavor(flavor, computeFlavorMinimums, fldPath)...)
+				allErrs = append(allErrs, validateFlavor(flavor, computeFlavorMinimums, fldPath.Child("type"))...)
 			}
 		} else {
-			allErrs = append(allErrs, field.NotFound(fldPath.Child("flavorName"), p.FlavorName))
+			allErrs = append(allErrs, field.NotFound(fldPath.Child("type"), p.FlavorName))
 		}
 	}
 
@@ -105,12 +105,11 @@ func validUUIDv4(s string) bool {
 	return true
 }
 
-func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.Path) field.ErrorList {
-
+func validateFlavor(flavor Flavor, req flavorRequirements, fldPath *field.Path) field.ErrorList {
 	// OpenStack administrators don't always fill in accurate metadata for
 	// baremetal flavors. Skipping validation.
 	if flavor.Baremetal {
-		return field.ErrorList{}
+		return nil
 	}
 
 	errs := []string{}
@@ -125,7 +124,7 @@ func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.P
 	}
 
 	if len(errs) == 0 {
-		return field.ErrorList{}
+		return nil
 	}
 
 	errString := "Flavor did not meet the following minimum requirements: "
@@ -136,5 +135,5 @@ func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.P
 		}
 	}
 
-	return field.ErrorList{field.Invalid(fldPath.Child("flavorName"), flavor.Name, errString)}
+	return field.ErrorList{field.Invalid(fldPath, flavor.Name, errString)}
 }

--- a/pkg/asset/installconfig/openstack/validation/machinepool_test.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool_test.go
@@ -139,7 +139,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: "controlPlane.platform.openstack.flavorName: Not found: \"non-existant-flavor\"",
+			expectedErrMsg: "controlPlane.platform.openstack.type: Not found: \"non-existant-flavor\"",
 		},
 		{
 			name: "not found compute flavorName",
@@ -150,7 +150,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: `compute\[0\].platform.openstack.flavorName: Not found: "non-existant-flavor"`,
+			expectedErrMsg: `compute\[0\].platform.openstack.type: Not found: "non-existant-flavor"`,
 		},
 		{
 			name:         "invalid control plane flavorName",
@@ -162,7 +162,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: "controlPlane.platform.openstack.flavorName: Invalid value: \"invalid-control-plane-flavor\": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2",
+			expectedErrMsg: "controlPlane.platform.openstack.type: Invalid value: \"invalid-control-plane-flavor\": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2",
 		},
 		{
 			name:         "invalid compute flavorName",
@@ -174,7 +174,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: `compute\[0\].platform.openstack.flavorName: Invalid value: "invalid-compute-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 25 GB Disk, had 10 GB`,
+			expectedErrMsg: `compute\[0\].platform.openstack.type: Invalid value: "invalid-compute-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 25 GB Disk, had 10 GB`,
 		},
 		{
 			name:         "valid baremetal compute",

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -22,7 +22,12 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	allErrs = append(allErrs, validateExternalNetwork(p, ci, fldPath)...)
 
 	// validate platform flavor
-	allErrs = append(allErrs, validatePlatformFlavor(p, ci, fldPath)...)
+	flavor, ok := ci.Flavors[p.FlavorName]
+	if ok {
+		allErrs = append(allErrs, validateFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath.Child("computeFlavor"))...)
+	} else {
+		allErrs = append(allErrs, field.NotFound(fldPath.Child("computeFlavor"), p.FlavorName))
+	}
 
 	// validate floating ips
 	allErrs = append(allErrs, validateFloatingIPs(p, ci, fldPath)...)
@@ -62,47 +67,6 @@ func validateExternalNetwork(p *openstack.Platform, ci *CloudInfo, fldPath *fiel
 		allErrs = append(allErrs, field.NotFound(fldPath.Child("externalNetwork"), p.ExternalNetwork))
 	}
 	return allErrs
-}
-
-// validatePlatformFlavor validates the platform flavor and returns a list of all validation errors
-func validatePlatformFlavor(p *openstack.Platform, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {
-	flavor, ok := ci.Flavors[p.FlavorName]
-	if !ok {
-		allErrs = append(allErrs, field.NotFound(fldPath.Child("computeFlavor"), p.FlavorName))
-		return allErrs
-	}
-
-	// OpenStack administrators don't always fill in accurate metadata for
-	// baremetal flavors. Skipping validation.
-	if flavor.Baremetal {
-		return allErrs
-	}
-
-	errs := []string{}
-	req := ctrlPlaneFlavorMinimums
-	if flavor.RAM < req.RAM {
-		errs = append(errs, fmt.Sprintf("Must have minimum of %d GB RAM, had %d GB", req.RAM, flavor.RAM))
-	}
-	if flavor.VCPUs < req.VCPUs {
-		errs = append(errs, fmt.Sprintf("Must have minimum of %d VCPUs, had %d", req.VCPUs, flavor.VCPUs))
-	}
-	if flavor.Disk < req.Disk {
-		errs = append(errs, fmt.Sprintf("Must have minimum of %d GB Disk, had %d GB", req.Disk, flavor.Disk))
-	}
-
-	if len(errs) == 0 {
-		return field.ErrorList{}
-	}
-
-	errString := "Flavor did not meet the following minimum requirements: "
-	for i, err := range errs {
-		errString = errString + err
-		if i != len(errs)-1 {
-			errString = errString + "; "
-		}
-	}
-
-	return append(allErrs, field.Invalid(fldPath.Child("flavorName"), flavor.Name, errString))
 }
 
 func validateFloatingIPs(p *openstack.Platform, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -120,7 +120,7 @@ func TestOpenStackPlatformValidation(t *testing.T) {
 			cloudInfo:      validPlatformCloudInfo(),
 			networking:     validNetworking(),
 			expectedError:  true,
-			expectedErrMsg: `platform.openstack.flavorName: Invalid value: "invalid-control-plane-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2; Must have minimum of 25 GB Disk, had 20 GB`,
+			expectedErrMsg: `platform.openstack.computeFlavor: Invalid value: "invalid-control-plane-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2; Must have minimum of 25 GB Disk, had 20 GB`,
 		},
 		{
 			name:     "not found api FIP",


### PR DESCRIPTION
Flavor validation was reporting issues with wrong `install-config.yaml`
property names.

/label platform/openstack