### PR TITLE
Bug 1886553: GCP - Increase worker NAT min ports

### DIFF
--- a/data/data/gcp/network/network.tf
+++ b/data/data/gcp/network/network.tf
@@ -50,7 +50,7 @@ resource "google_compute_router_nat" "worker_nat" {
   name                               = "${var.cluster_id}-nat-worker"
   router                             = google_compute_router.router[0].name
   nat_ip_allocate_option             = "AUTO_ONLY"
-  min_ports_per_vm                   = 512
+  min_ports_per_vm                   = 4096
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {


### PR DESCRIPTION
Our worker nodes NAT instances are configured on GCP to allow for 512 ports per VM instance.
Master nodes have the same setting set to 7168 ports. However worker nodes usually run the load
(i.e pods) which instantiate a huge amount of open connections, we thus need to increase this
value to avoid NAT packet drops on GCP when running high load. This has been a big cause of
connection timeout problems on GCP clusters.

Slack channel for incident which took 2 weeks to solve: https://coreos.slack.com/archives/C01BQ9UR5J9
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1886553

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>