### PR TITLE
Bug 1882649: Determine Glance disk format based on file extension

### DIFF
--- a/pkg/tfvars/openstack/rhcos_image.go
+++ b/pkg/tfvars/openstack/rhcos_image.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -33,10 +34,17 @@ func uploadBaseImage(cloud string, localFilePath string, imageName string, clust
 		return err
 	}
 
+	// By default we use "qcow2" disk format, but if the file extension is "raw",
+	// then we set the disk format as "raw".
+	diskFormat := "qcow2"
+	if extension := filepath.Ext(localFilePath); extension == "raw" {
+		diskFormat = "raw"
+	}
+
 	imageCreateOpts := images.CreateOpts{
 		Name:            imageName,
 		ContainerFormat: "bare",
-		DiskFormat:      "qcow2",
+		DiskFormat:      diskFormat,
 		Tags:            []string{fmt.Sprintf("openshiftClusterID=%s", clusterID)},
 		// TODO(mfedosin): add Description when gophercloud supports it.
 	}


### PR DESCRIPTION
Now we always use "qcow2" disk format for Glance images. This is not correct if a user wants to upload a raw format image (with "raw" file extension).
This commit checks the extension and allows to set disk format accordingly.