### PR TITLE
cmd: split newlines in logrus stderr output to new entry

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -512,8 +512,8 @@ func waitForInstallComplete(ctx context.Context, config *rest.Config, directory 
 }
 
 func logTroubleshootingLink() {
-	logrus.Error("Cluster initialization failed because one or more operators are not functioning properly.")
-	logrus.Error("The cluster should be accessible for troublsehooting as detailed in the documentation linked below.")
-	logrus.Error("The 'wait-for install-complete' subcommand can then be used to continue the installation.")
-	logrus.Error("https://docs.openshift.com/container-platform/latest/support/troubleshooting/troubleshooting-installations.html")
+	logrus.Error(`Cluster initialization failed because one or more operators are not functioning properly.
+The cluster should be accessible for troublsehooting as detailed in the documentation linked below,
+https://docs.openshift.com/container-platform/latest/support/troubleshooting/troubleshooting-installations.html
+The 'wait-for install-complete' subcommand can then be used to continue the installation`)
 }

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -95,7 +95,7 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 		level = logrus.InfoLevel
 	}
 
-	logrus.AddHook(newFileHook(os.Stderr, level, &logrus.TextFormatter{
+	logrus.AddHook(newFileHookWithNewlineTruncate(os.Stderr, level, &logrus.TextFormatter{
 		// Setting ForceColors is necessary because logrus.TextFormatter determines
 		// whether or not to enable colors by looking at the output of the logger.
 		// In this case, the output is ioutil.Discard, which is not a terminal.
@@ -104,6 +104,7 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 		ForceColors:            terminal.IsTerminal(int(os.Stderr.Fd())),
 		DisableTimestamp:       true,
 		DisableLevelTruncation: true,
+		DisableQuote:           true,
 	}))
 
 	if err != nil {


### PR DESCRIPTION
Currently the logrus hook runs formatter once for each entry, which causes newlines to be escaped see sirupsen/logrus#608
Because of this multiline messages end up looking like

```go
logrus.Info(`some message
same mesage multiline 1`)
logrus.Info("next meesage")
```

```
LEVEL some message
same message multiline 1
LEVEL next messsage
```

With this change the hook will format each entry's message split on newlines so that,

```go
logrus.Info(`some message
same mesage multiline 1`)
logrus.Info("next meesage")
```

```
LEVEL some message
LEVEL same message multiline 1
LEVEL next messsage
```

This will help 2 cases,
- af9b49c like informational messages that are require multiple lines to be more user-friendly.
- meesages from cluster operators on install-complete failure see #4242

/cc @deads2k @jstuever 