### PR TITLE
Bug 1889855: additional AWS regions for RHCOS AMIs

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,5 +1,11 @@
 {
     "amis": {
+        "af-south-1": {
+            "hvm": "ami-02f4a2c7b9a3a6840"
+        },
+        "ap-east-1": {
+            "hvm": "ami-06a0695694b6c3e8d"
+        },
         "ap-northeast-1": {
             "hvm": "ami-0cb46ba6945dbfebe"
         },
@@ -23,6 +29,9 @@
         },
         "eu-north-1": {
             "hvm": "ami-06d01bfaf14ad66a3"
+        },
+        "eu-south-1": {
+            "hvm": "ami-031c7e2567f507746"
         },
         "eu-west-1": {
             "hvm": "ami-0e514a30ad261c978"

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,5 +1,11 @@
 {
     "amis": {
+        "af-south-1": {
+            "hvm": "ami-02f4a2c7b9a3a6840"
+        },
+        "ap-east-1": {
+            "hvm": "ami-06a0695694b6c3e8d"
+        },
         "ap-northeast-1": {
             "hvm": "ami-0cb46ba6945dbfebe"
         },
@@ -23,6 +29,9 @@
         },
         "eu-north-1": {
             "hvm": "ami-06d01bfaf14ad66a3"
+        },
+        "eu-south-1": {
+            "hvm": "ami-031c7e2567f507746"
         },
         "eu-west-1": {
             "hvm": "ami-0e514a30ad261c978"

--- a/pkg/rhcos/ami_regions.go
+++ b/pkg/rhcos/ami_regions.go
@@ -4,6 +4,8 @@ package rhcos
 
 // AMIRegoins is a list of regions where the RHEL CoreOS is published.
 var AMIRegions = []string{
+	"af-south-1",
+	"ap-east-1",
 	"ap-northeast-1",
 	"ap-northeast-2",
 	"ap-south-1",
@@ -12,6 +14,7 @@ var AMIRegions = []string{
 	"ca-central-1",
 	"eu-central-1",
 	"eu-north-1",
+	"eu-south-1",
 	"eu-west-1",
 	"eu-west-2",
 	"eu-west-3",


### PR DESCRIPTION
There are RFEs requesting support for additional AWS regions:
ap-east-1, af-south-1, and eu-south-1

https://issues.redhat.com/browse/RFE-903
https://issues.redhat.com/browse/RFE-1267

The existing 4.6 RHCOS AMI was manually copied to these regions by the
ART team.