### PR TITLE
Bug 1887863: Patch Flavor Not Found validation for OpenStack Install Config

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/machinepool_test.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool_test.go
@@ -137,7 +137,11 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 				mp.FlavorName = notExistFlavor
 				return mp
 			}(),
-			cloudInfo:      validMpoolCloudInfo(),
+			cloudInfo: func() *CloudInfo {
+				ci := validMpoolCloudInfo()
+				ci.Flavors[notExistFlavor] = Flavor{}
+				return ci
+			}(),
 			expectedError:  true,
 			expectedErrMsg: "controlPlane.platform.openstack.type: Not found: \"non-existant-flavor\"",
 		},
@@ -148,7 +152,11 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 				mp.FlavorName = notExistFlavor
 				return mp
 			}(),
-			cloudInfo:      validMpoolCloudInfo(),
+			cloudInfo: func() *CloudInfo {
+				ci := validMpoolCloudInfo()
+				ci.Flavors[notExistFlavor] = Flavor{}
+				return ci
+			}(),
 			expectedError:  true,
 			expectedErrMsg: `compute\[0\].platform.openstack.type: Not found: "non-existant-flavor"`,
 		},

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -24,12 +24,7 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	allErrs = append(allErrs, validateExternalNetwork(p, ci, fldPath)...)
 
 	// validate platform flavor
-	flavor, ok := ci.Flavors[p.FlavorName]
-	if ok {
-		allErrs = append(allErrs, validateFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath.Child("computeFlavor"))...)
-	} else {
-		allErrs = append(allErrs, field.NotFound(fldPath.Child("computeFlavor"), p.FlavorName))
-	}
+	allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, ctrlPlaneFlavorMinimums, fldPath.Child("computeFlavor"))...)
 
 	// validate floating ips
 	allErrs = append(allErrs, validateFloatingIPs(p, ci, fldPath)...)

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -118,7 +118,11 @@ func TestOpenStackPlatformValidation(t *testing.T) {
 				p.FlavorName = invalidCtrlPlaneFlavor
 				return p
 			}(),
-			cloudInfo:      validPlatformCloudInfo(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				ci.Flavors[notExistFlavor] = Flavor{}
+				return ci
+			}(),
 			networking:     validNetworking(),
 			expectedError:  true,
 			expectedErrMsg: `platform.openstack.computeFlavor: Invalid value: "invalid-control-plane-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2; Must have minimum of 25 GB Disk, had 20 GB`,


### PR DESCRIPTION
Fixes an issue where we expected cloudInfo to not have a
key for the flavorName if it was not found. In the code and the unit tests, cloudInfo's flavor map now has a pointer value
instead of a struct. This allows us to set it to nil when the flavor is not found in openstack.

/label platform/openstack