### PR TITLE
Remove 4.3.0 reference from Azure UPI docs

### DIFF
--- a/docs/user/azure/install_upi.md
+++ b/docs/user/azure/install_upi.md
@@ -11,7 +11,7 @@ example.
 * all prerequisites from [README](README.md)
 * the following binaries installed and in $PATH:
   * [openshift-install][openshiftinstall]
-    * It is recommended that the OpenShift installer CLI version is the same of the cluster being deployed. The version used in this example is 4.3.0 GA.
+    * It is recommended that the OpenShift installer CLI version is the same of the cluster being deployed.
   * [az (Azure CLI)][azurecli] installed and aunthenticated
     * Commands flags and structure may vary between `az` versions. The recommended version used in this example is 2.0.80.
   * python3


### PR DESCRIPTION
Removing a reference to version of 4.3.0 of OCP. This documentation is no longer compatible with 4.3, because ignition versions have changed.