### PR TITLE
Bug 1841381: oVirt, add memoryMB validation

### DIFF
--- a/pkg/types/ovirt/validation/machinepool.go
+++ b/pkg/types/ovirt/validation/machinepool.go
@@ -22,6 +22,10 @@ func ValidateMachinePool(p *ovirt.MachinePool, fldPath *field.Path) field.ErrorL
 		}
 	}
 
+	if p.MemoryMB < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("memoryMB"), p.MemoryMB, "Memory value must be nonnegative"))
+	}
+
 	if p.VMType != "" && !ValidVMType(p.VMType) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("vmType"), p.VMType, fmt.Sprintf("VM type must be one of %s", supportedVMTypes())))
 	}


### PR DESCRIPTION
To align with other platforms and our own validation, we added a validation on the memoryMB field to make sure it is a positive valuei

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>