### PR TITLE
oVirt: change owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -75,11 +75,10 @@ aliases:
     - mjudeikis
   ovirt-approvers:
     - rgolangh
-    - dougsland
     - Gal-Zaidman
-    - gekorob
+    - eslutsky
   ovirt-reviewers:
     - dougsland
     - Gal-Zaidman
-    - gekorob
     - rgolangh
+    - eslutsky


### PR DESCRIPTION
This PR changes the ovirt approvers and reviewers
- remove gekorob that is not working at red hat any more
- remove dougsland approver
- add eslutsky as approver and reviewer

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>