### PR TITLE
aws: ensure users set ami id for c2s regions

### DIFF
--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -37,7 +37,7 @@ func ValidateAMIID(platform *aws.Platform, p *aws.MachinePool, fldPath *field.Pa
 
 	// regions is a list of regions for which the user should set AMI ID as copying the AMI to these regions
 	// is known to not be supported.
-	regions := sets.NewString("us-gov-west-1", "us-gov-east-1", "cn-north-1", "cn-northwest-1")
+	regions := sets.NewString("us-gov-west-1", "us-gov-east-1", "us-iso-east-1", "cn-north-1", "cn-northwest-1")
 	if pool.AMIID == "" && regions.Has(platform.Region) {
 		allErrs = append(allErrs, field.Required(fldPath, fmt.Sprintf("AMI ID must be provided for regions %s", strings.Join(regions.List(), ", "))))
 	}


### PR DESCRIPTION
As with US Govcloud and China partitions, C2S partitions do not allow copying AMI from commercial region us-east-1. Therefore the users need to provide the AMI for control plane and compute.

https://issues.redhat.com/browse/CORS-1582