### PR TITLE
aws: block cluster destroy in c2s region

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -98,6 +98,10 @@ func (o *ClusterUninstaller) validate() error {
 	if len(o.Filters) == 0 {
 		return errors.Errorf("you must specify at least one tag filter")
 	}
+	switch r := o.Region; r {
+	case "us-iso-east-1":
+		return errors.Errorf("cannot destroy cluster in region %q", r)
+	}
 	return nil
 }
 


### PR DESCRIPTION
The C2S partition does not have resourcetaggingapi. Consequently, the aws destroyer is not able to find resources to clean up when the cluster is installed in that partition. Rather than making the user wait through numerous timeouts and backoffs, fail the destroy command early when the region used for the cluster is the C2S region.

https://issues.redhat.com/browse/CORS-1581