### PR TITLE
[CORS-1577] Add Encryption Key reference to GCP MachinePool API

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -143,6 +143,33 @@ spec:
                               - pd-ssd
                               - pd-standard
                               type: string
+                            encryptionKey:
+                              description: EncryptionKey defines the KMS key to be used to encrypt the disk.
+                              properties:
+                                kmsKey:
+                                  description: KMSKey is a reference to a KMS Key to use for the encryption.
+                                  properties:
+                                    keyRing:
+                                      description: KeyRing is the name of the KMS Key Ring which the KMS Key belongs to.
+                                      type: string
+                                    location:
+                                      description: Location is the GCP location in which the Key Ring exists.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the customer managed encryption key to be used for the disk encryption.
+                                      type: string
+                                    projectID:
+                                      description: ProjectID is the ID of the Project in which the KMS Key Ring exists. Defaults to the VM ProjectID if not set.
+                                      type: string
+                                  required:
+                                  - keyRing
+                                  - location
+                                  - name
+                                  type: object
+                                kmsKeyServiceAccount:
+                                  description: KMSKeyServiceAccount is the service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used. See https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account for details on the default service account.
+                                  type: string
+                              type: object
                           required:
                           - DiskSizeGB
                           type: object
@@ -384,6 +411,33 @@ spec:
                             - pd-ssd
                             - pd-standard
                             type: string
+                          encryptionKey:
+                            description: EncryptionKey defines the KMS key to be used to encrypt the disk.
+                            properties:
+                              kmsKey:
+                                description: KMSKey is a reference to a KMS Key to use for the encryption.
+                                properties:
+                                  keyRing:
+                                    description: KeyRing is the name of the KMS Key Ring which the KMS Key belongs to.
+                                    type: string
+                                  location:
+                                    description: Location is the GCP location in which the Key Ring exists.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the customer managed encryption key to be used for the disk encryption.
+                                    type: string
+                                  projectID:
+                                    description: ProjectID is the ID of the Project in which the KMS Key Ring exists. Defaults to the VM ProjectID if not set.
+                                    type: string
+                                required:
+                                - keyRing
+                                - location
+                                - name
+                                type: object
+                              kmsKeyServiceAccount:
+                                description: KMSKeyServiceAccount is the service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used. See https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account for details on the default service account.
+                                type: string
+                            type: object
                         required:
                         - DiskSizeGB
                         type: object
@@ -943,6 +997,33 @@ spec:
                             - pd-ssd
                             - pd-standard
                             type: string
+                          encryptionKey:
+                            description: EncryptionKey defines the KMS key to be used to encrypt the disk.
+                            properties:
+                              kmsKey:
+                                description: KMSKey is a reference to a KMS Key to use for the encryption.
+                                properties:
+                                  keyRing:
+                                    description: KeyRing is the name of the KMS Key Ring which the KMS Key belongs to.
+                                    type: string
+                                  location:
+                                    description: Location is the GCP location in which the Key Ring exists.
+                                    type: string
+                                  name:
+                                    description: Name is the name of the customer managed encryption key to be used for the disk encryption.
+                                    type: string
+                                  projectID:
+                                    description: ProjectID is the ID of the Project in which the KMS Key Ring exists. Defaults to the VM ProjectID if not set.
+                                    type: string
+                                required:
+                                - keyRing
+                                - location
+                                - name
+                                type: object
+                              kmsKeyServiceAccount:
+                                description: KMSKeyServiceAccount is the service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used. See https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account for details on the default service account.
+                                type: string
+                            type: object
                         required:
                         - DiskSizeGB
                         type: object

--- a/pkg/types/gcp/machinepools.go
+++ b/pkg/types/gcp/machinepools.go
@@ -33,6 +33,11 @@ type OSDisk struct {
 	// +kubebuilder:validation:Minimum=16
 	// +kubebuilder:validation:Maximum=65536
 	DiskSizeGB int64 `json:"DiskSizeGB"`
+
+	// EncryptionKey defines the KMS key to be used to encrypt the disk.
+	//
+	// +optional
+	EncryptionKey *EncryptionKeyReference `json:"encryptionKey,omitempty"`
 }
 
 // Set sets the values from `required` to `a`.
@@ -55,5 +60,88 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.OSDisk.DiskType != "" {
 		a.OSDisk.DiskType = required.OSDisk.DiskType
+	}
+
+	if required.EncryptionKey != nil {
+		if a.EncryptionKey == nil {
+			a.EncryptionKey = &EncryptionKeyReference{}
+		}
+		a.EncryptionKey.Set(required.EncryptionKey)
+	}
+}
+
+// EncryptionKeyReference describes the encryptionKey to use for a disk's encryption.
+type EncryptionKeyReference struct {
+	// KMSKey is a reference to a KMS Key to use for the encryption.
+	//
+	// +optional
+	KMSKey *KMSKeyReference `json:"kmsKey,omitempty"`
+
+	// KMSKeyServiceAccount is the service account being used for the
+	// encryption request for the given KMS key. If absent, the Compute
+	// Engine default service account is used.
+	// See https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account
+	// for details on the default service account.
+	//
+	// +optional
+	KMSKeyServiceAccount string `json:"kmsKeyServiceAccount,omitempty"`
+}
+
+// Set sets the values from `required` to `e`.
+func (e *EncryptionKeyReference) Set(required *EncryptionKeyReference) {
+	if required == nil || e == nil {
+		return
+	}
+
+	if required.KMSKeyServiceAccount != "" {
+		e.KMSKeyServiceAccount = required.KMSKeyServiceAccount
+	}
+
+	if required.KMSKey != nil {
+		if e.KMSKey == nil {
+			e.KMSKey = &KMSKeyReference{}
+		}
+		e.KMSKey.Set(required.KMSKey)
+	}
+}
+
+// KMSKeyReference gathers required fields for looking up a GCP KMS Key
+type KMSKeyReference struct {
+	// Name is the name of the customer managed encryption key to be used for the disk encryption.
+	Name string `json:"name"`
+
+	// KeyRing is the name of the KMS Key Ring which the KMS Key belongs to.
+	KeyRing string `json:"keyRing"`
+
+	// ProjectID is the ID of the Project in which the KMS Key Ring exists.
+	// Defaults to the VM ProjectID if not set.
+	//
+	// +optional
+	ProjectID string `json:"projectID,omitempty"`
+
+	// Location is the GCP location in which the Key Ring exists.
+	Location string `json:"location"`
+}
+
+// Set sets the values from `required` to `k`.
+func (k *KMSKeyReference) Set(required *KMSKeyReference) {
+	if required == nil || k == nil {
+		return
+	}
+
+	if required.Name != "" {
+		k.Name = required.Name
+	}
+
+	if required.KeyRing != "" {
+		k.KeyRing = required.KeyRing
+	}
+
+	if required.ProjectID != "" {
+		k.ProjectID = required.ProjectID
+	}
+
+	if required.Location != "" {
+		k.Location = required.Location
 	}
 }


### PR DESCRIPTION
This adds the API fields to enable GCP customer managed encryption keys from the MachinePool configuration at installation.

I wasn't sure whether at this stage we wanted to document this in `docs/user/gcp/customization.md` or wait until the implementation is done so I've left it out for now, I can add it if you'd rather we keep that in this PR with the API changes.

This API should match the Machine API changes introduced in https://github.com/openshift/cluster-api-provider-gcp/pull/132

CC @katherinedube, you mentioned about adding just to the MachinePool on the call yesterday to match what was done in AWS, I believe I've done it that way but would appreciate a double check