### PR TITLE
baremetal: remove root_gb from tfvars

### DIFF
--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -125,7 +125,6 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(bootstrapProvisioningIP, "80"), imageFilename, compressedImageFilename)
 		cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)
 		instanceInfo := map[string]interface{}{
-			"root_gb":        25, // FIXME(stbenjam): Needed until https://storyboard.openstack.org/#!/story/2005165
 			"image_source":   cacheImageURL,
 			"image_checksum": cacheChecksumURL,
 		}


### PR DESCRIPTION
This setting is no longer required as the linked ironic issue that
required specifying a root disk size when using whole disk images
has been fixed.