### PR TITLE
Bug 1888378: [Azure][Destroy] Check if resource group exists

### DIFF
--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -112,6 +112,17 @@ func (o *ClusterUninstaller) Run() error {
 	waitCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	// check if resource group exists before attempting delete
+	resourceGroup, err := o.resourceGroupsClient.Get(waitCtx, o.ResourceGroupName)
+	if err != nil {
+		if resourceGroup.Response.StatusCode == http.StatusNotFound {
+			o.Logger.Debug(errors.Wrap(err, "resource group does not exist, nothing to delete"))
+			return nil
+		}
+		o.Logger.Error(err)
+		return err
+	}
+
 	wait.UntilWithContext(
 		waitCtx,
 		func(ctx context.Context) {


### PR DESCRIPTION
Azure clubs all resources for a cluster within a resource group. The
pattern for delete is to first delete all the resources and then delete
the resource group.

However, when attempting delete, we should first check if the
resource group exists and then try to delete the resources. This is to
ensure delete exits gracefully when resource group wasn't created and/or
deleted before attempting delete.