### PR TITLE
Revert "[Azure][Destroy] Check if resource group exists"

### DIFF
--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -112,17 +112,6 @@ func (o *ClusterUninstaller) Run() error {
 	waitCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// check if resource group exists before attempting delete
-	resourceGroup, err := o.resourceGroupsClient.Get(waitCtx, o.ResourceGroupName)
-	if err != nil {
-		if resourceGroup.Response.StatusCode == http.StatusNotFound {
-			o.Logger.Debug(errors.Wrap(err, "resource group does not exist, nothing to delete"))
-			return nil
-		}
-		o.Logger.Error(err)
-		return err
-	}
-
 	wait.UntilWithContext(
 		waitCtx,
 		func(ctx context.Context) {


### PR DESCRIPTION
Reverts openshift/installer#4320

I concur with the sentiment expressed by @abhinavdahiya [here](https://github.com/openshift/installer/pull/4320#issuecomment-718153041)