### PR TITLE
use 'None' caching for OSDisk

### DIFF
--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -104,7 +104,7 @@ resource "azurerm_linux_virtual_machine" "master" {
 
   os_disk {
     name                 = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
-    caching              = "ReadOnly"
+    caching              = "None"
     storage_account_type = var.os_volume_type
     disk_size_gb         = var.os_volume_size
   }


### PR DESCRIPTION
use 'None' caching for OSDisk

Changed Host Caching to ‘None’, throughput will increase to 192 MB/s, 
it will reduce the chance of throttling