### PR TITLE
Bug 1866925: display Azure destroy auth error

### DIFF
--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -121,6 +121,7 @@ func (o *ClusterUninstaller) Run() error {
 				o.Logger.Debug(err)
 				if isAuthError(err) {
 					cancel()
+					errs = append(errs, errors.Wrap(err, "unable to authenticate when deleting public DNS records"))
 				}
 				return
 			}
@@ -149,6 +150,7 @@ func (o *ClusterUninstaller) Run() error {
 				o.Logger.Debug(err)
 				if isAuthError(err) {
 					cancel()
+					errs = append(errs, errors.Wrap(err, "unable to authenticate when deleting resource group"))
 				}
 				return
 			}
@@ -177,6 +179,7 @@ func (o *ClusterUninstaller) Run() error {
 				o.Logger.Debug(err)
 				if isAuthError(err) {
 					cancel()
+					errs = append(errs, errors.Wrap(err, "unable to authenticate when deleting application registrations and their service principals"))
 				}
 				return
 			}


### PR DESCRIPTION
This appends Azure auth errors to the error list, so destroy is properly terminated and an error shown to the user. Without this, the metadata.json is deleted (along with other artifacts) and no error is shown to the user.

With this change, users (with incorrect credentials) will see:
```
$ ./openshift-install destroy cluster --dir azure-delete/cluster/
INFO Credentials loaded from file "/home/padillon/.azure/osServicePrincipal.json" 
FATAL Failed to destroy cluster: [unable to authenticate when deleting public DNS records: azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to [...]
```
Without this change, users (at standard log level)  see only:
```
$ ./openshift-install destroy cluster --dir azure-delete/cluster/
INFO Credentials loaded from file "/home/padillon/.azure/osServicePrincipal.json" 
INFO Time elapsed: 1s    
```
(and more importantly, as noted before, the artifacts are deleted)

cc @jhixson74 