### PR TITLE
Adding kubevirt-installer image

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -82,3 +82,15 @@ aliases:
     - Gal-Zaidman
     - rgolangh
     - eslutsky
+  kubevirt-approvers:
+    - bardielle
+    - chenyosef
+    - nirarg
+    - ravidbro
+    - rgolangh
+  kubevirt-reviewers:
+    - bardielle
+    - chenyosef
+    - nirarg
+    - ravidbro
+    - rgolangh

--- a/images/kubevirt/Dockerfile.ci
+++ b/images/kubevirt/Dockerfile.ci
@@ -1,0 +1,18 @@
+# This Dockerfile is used by CI to test using OpenShift Installer against an KubeVirt platform.
+# It builds an image containing the openshift-installer command but does nothing.
+# This is the first step in running end-to-end tests on kubevirt-installer before merging it.
+
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN hack/build.sh
+
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
+
+COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+
+RUN mkdir /output && chown 1000:1000 /output
+USER 1000:1000
+ENV PATH /bin
+ENV HOME /output
+WORKDIR /output

--- a/images/kubevirt/OWNERS
+++ b/images/kubevirt/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - kubevirt-approvers
+reviewers:
+  - kubevirt-approvers
+


### PR DESCRIPTION
My team is working on a new OCP IPI to enable installation of nested OCP (i.e. OCP +Openshift Virtualization (KubeVirt) is the platform to host the nodes of the nested cluster).
You can find more information here: openshift/enhancements#417

As part of that project we want to add a new workflow in the ci "e2e-kubevirt", so the first step us adding a kubevirt-installer image build that does nothing.