### PR TITLE
Bug 1894144: baremetal: pin libvirt to 4.5.0

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -2,7 +2,7 @@
 # It builds an image containing openshift-install.
 
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
-RUN yum install -y libvirt-devel && \
+RUN yum install -y libvirt-devel-4.5.0 && \
     yum clean all && rm -rf /var/cache/yum/*
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
@@ -15,7 +15,7 @@ COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json 
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    libvirt-libs openssl unzip jq openssh-clients && \
+    libvirt-libs-4.5.0 openssl unzip jq openssh-clients && \
     yum clean all && rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 


### PR DESCRIPTION
The latest version of RHEL ships with libvirt 6.x, which are now in
yum repositories used to build the CI containers. However, when running
an installer built that's linked against it on an older RHEL host, the
installer fails:

```
$ ocp/ostest/openshift-baremetal-install --dir ocp/ostest --log-level=debug create manifests
ocp/ostest/openshift-baremetal-install: /lib64/libvirt.so.0: version
```LIBVIRT_5.2.0' not found (required by
ocp/ostest/openshift-baremetal-install)
[...snip...]
```

According to the [RHEL 8 ABI Guarantees](access.redhat.com/articles/rhel8-abi-compatibility),
"an application is only guaranteed to run correctly if it executes in an
environment that is as new as the environment it was built in or newer."
Therefore, we must build openshift baremetal installer against the
oldest version of the libvirt libraries we expect it to run against,
which is 4.5.x.

Long term, the libvirt team is looking at not linking to libvirt at
compile time, but rather use `dlopen("libvirt.so")` at runtime, and then
`dlsym("funcname")` to resolve functions at time they are first invoked.