### PR TITLE
Bug 1894432: oVirt, add timeout to tmp_import_vm

### DIFF
--- a/data/data/ovirt/template/main.tf
+++ b/data/data/ovirt/template/main.tf
@@ -60,6 +60,9 @@ resource "ovirt_vm" "tmp_import_vm" {
     name            = "nic1"
     vnic_profile_id = var.ovirt_vnic_profile_id
   }
+  timeouts {
+    create = "20m"
+  }
   depends_on = [ovirt_image_transfer.releaseimage]
 }
 


### PR DESCRIPTION
This PR adds a timeout of 20m to the tmp_import_vm resource

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>