### PR TITLE
data/bootstrap/files/usr/local/bin/installer-gather: Tee logs into tarball

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -9,6 +9,8 @@ fi
 ARTIFACTS="/tmp/artifacts-${GATHER_ID}"
 mkdir -p "${ARTIFACTS}"
 
+exec &> >(tee "${ARTIFACTS}/gather.log")
+
 echo "Gathering bootstrap systemd summary ..."
 LANG=POSIX systemctl list-units --state=failed >& "${ARTIFACTS}/failed-units.txt"
 


### PR DESCRIPTION
Using [`exec`][1] and [Bash's process substitution][2] to redirect both stdout and stderr into [`tee`][3].  `tee` will copy them to the original stdout, and will also write them to a file in the artifacts directory.   The artifacts directory is subsequently tarred up, and the tarball will contain the tee-written copy of the script's logs.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#exec
[2]: https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html#Process-Substitution
[3]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/tee.html