### PR TITLE
data/manifests/bootkube/cvo-overrides: Bump default to stable-4.7

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -4,5 +4,5 @@ metadata:
   namespace: openshift-cluster-version
   name: version
 spec:
-  channel: stable-4.6
+  channel: stable-4.7
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
Like f8a0f7b069 (#3848), but for 4.7 (now that release-4.6 is no longer being fast-forwarded to track master).