### PR TITLE
Bug 1895099: Create empty vSphere infra PlatformStatus in UPI

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -147,11 +147,10 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		}
 	case vsphere.Name:
 		config.Spec.PlatformSpec.Type = configv1.VSpherePlatformType
+		config.Status.PlatformStatus.VSphere = &configv1.VSpherePlatformStatus{}
 		if installConfig.Config.VSphere.APIVIP != "" {
-			config.Status.PlatformStatus.VSphere = &configv1.VSpherePlatformStatus{
-				APIServerInternalIP: installConfig.Config.VSphere.APIVIP,
-				IngressIP:           installConfig.Config.VSphere.IngressVIP,
-			}
+			config.Status.PlatformStatus.VSphere.APIServerInternalIP = installConfig.Config.VSphere.APIVIP
+			config.Status.PlatformStatus.VSphere.IngressIP = installConfig.Config.VSphere.IngressVIP
 		}
 	case ovirt.Name:
 		config.Spec.PlatformSpec.Type = configv1.OvirtPlatformType


### PR DESCRIPTION
This creates an empty infrastructure.Status.PlatformStatus.VSphere object during UPI installs. Prior to this change, the object has been nil during UPI installs. **The object is optional,** but a recent change to MCO templating[0] has a dependency on the object.

[0]: https://github.com/openshift/machine-config-operator/pull/2079

cc @jcpowermac 