### PR TITLE
pkg: validation for previously existing ovirt configuration

### DIFF
--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
+	ovirtsdk "github.com/ovirt/go-ovirt"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -84,4 +86,18 @@ func (c *Config) Save() error {
 		return err
 	}
 	return ioutil.WriteFile(path, out, 0600)
+}
+
+// getValidatedConnection will create a connection and validate it before returning.
+func (c *Config) getValidatedConnection() (*ovirtsdk.Connection, error) {
+	connection, err := getConnection(*c)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to build configuration for ovirt connection validation")
+	}
+
+	if err := connection.Test(); err != nil {
+		_ = connection.Close()
+		return nil, err
+	}
+	return connection, nil
 }

--- a/pkg/asset/installconfig/ovirt/ovirt.go
+++ b/pkg/asset/installconfig/ovirt/ovirt.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/installer/pkg/types/ovirt"
 )
 
-const PlatformValidationMaxTries = 3
+const platformValidationMaxTries = 3
 
 // Platform collects ovirt-specific configuration.
 func Platform() (*ovirt.Platform, error) {
@@ -19,7 +19,7 @@ func Platform() (*ovirt.Platform, error) {
 
 	// Fetch config from file
 	ovirtConfig, err := NewConfig()
-	for tries := 0; tries < PlatformValidationMaxTries; tries++ {
+	for tries := 0; tries < platformValidationMaxTries; tries++ {
 		if err == nil {
 			// If no error happened previously (loading file or configuration), validate the connection.
 			c, err = ovirtConfig.getValidatedConnection()

--- a/pkg/asset/installconfig/ovirt/ovirt.go
+++ b/pkg/asset/installconfig/ovirt/ovirt.go
@@ -17,27 +17,21 @@ func Platform() (*ovirt.Platform, error) {
 
 	var c *ovirtsdk4.Connection
 
-	// Fetch config from file
 	ovirtConfig, err := NewConfig()
 	for tries := 0; tries < platformValidationMaxTries; tries++ {
-		if err == nil {
-			// If no error happened previously (loading file or configuration), validate the connection.
-			c, err = ovirtConfig.getValidatedConnection()
+		if err != nil {
+			ovirtConfig, err = engineSetup()
 			if err != nil {
-				// If validation failed log and drop into reconfig below.
-				logrus.Error(errors.Wrap(err, "failed to validate oVirt configuration"))
-			} else {
-				// If connection is valid, break
-				break
+				logrus.Error(errors.Wrap(err, "oVirt configuration failed"))
 			}
 		}
 
-		if err != nil {
-			// If a previous error happened (validation or loading from file), rerun the setup.
-			ovirtConfig, err = engineSetup()
+		if err == nil {
+			c, err = ovirtConfig.getValidatedConnection()
 			if err != nil {
-				// If validation failed log and loop back to engineSetup()
-				logrus.Error(errors.Wrap(err, "oVirt configuration failed"))
+				logrus.Error(errors.Wrap(err, "failed to validate oVirt configuration"))
+			} else {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue when running the installer on ovirt with an already existing, but invalid `ovirt-config.yaml`. Previously, the installer did not allow the user to re-enter the credentials in this case. This patch fixes that.

## Previous behavior

```
? Platform ovirt
FATAL failed to fetch Install Config: failed to fetch dependency of "Install Config": failed to fetch dependency of "Base Domain": failed to generate asset "Platform": The Password must not be empty
```

## New behavior

```
? Platform ovirt
{{WARNING found invalid existing ovirt configuration (Error during SSO authentication access_denied : Cannot authenticate user 'admin@N/A': No valid profile found in credentials..) }}
? Engine FQDN[:PORT] [? for help]
```