### PR TITLE
Bug 1876581: upi/aws Define load balancer health checks

### DIFF
--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -218,7 +218,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 10
-      HealthCheckPath: "/readyz"
+      HealthCheckPath: "/healthz"
       HealthCheckPort: 22623
       HealthCheckProtocol: HTTPS
       HealthyThresholdCount: 2

--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -157,6 +157,12 @@ Resources:
   ExternalApiTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: "/readyz"
+      HealthCheckPort: 6443
+      HealthCheckProtocol: HTTPS
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
       Port: 6443
       Protocol: TCP
       TargetType: ip
@@ -181,6 +187,12 @@ Resources:
   InternalApiTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: "/readyz"
+      HealthCheckPort: 6443
+      HealthCheckProtocol: HTTPS
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
       Port: 6443
       Protocol: TCP
       TargetType: ip
@@ -205,6 +217,12 @@ Resources:
   InternalServiceTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: "/readyz"
+      HealthCheckPort: 22623
+      HealthCheckProtocol: HTTPS
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 2
       Port: 22623
       Protocol: TCP
       TargetType: ip


### PR DESCRIPTION
Docs for UPI installations are now auto-updated from the reference implementation in this repo. So add the health checks which are called out in the [release notes](https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-notable-technical-changes).

This backports #3709 and #3757 
/cc @mtnbikenc @codyhoag 