### PR TITLE
baremetal: send full ignition to masters

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -26,11 +26,13 @@ module "bootstrap" {
 module "masters" {
   source = "./masters"
 
-  master_count   = var.master_count
-  ignition       = var.ignition_master
-  hosts          = var.hosts
-  properties     = var.properties
-  root_devices   = var.root_devices
-  driver_infos   = var.driver_infos
-  instance_infos = var.instance_infos
+  master_count         = var.master_count
+  ignition             = var.ignition_master
+  hosts                = var.hosts
+  properties           = var.properties
+  root_devices         = var.root_devices
+  driver_infos         = var.driver_infos
+  instance_infos       = var.instance_infos
+  ignition_url         = var.ignition_url
+  ignition_url_ca_cert = var.ignition_url_ca_cert
 }

--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -42,8 +42,9 @@ resource "ironic_deployment" "openshift-master-deployment" {
     count.index,
   )
 
-  instance_info = var.instance_infos[count.index]
-  user_data     = var.ignition
+  instance_info         = var.instance_infos[count.index]
+  user_data_url         = var.ignition_url
+  user_data_url_ca_cert = var.ignition_url_ca_cert
 }
 
 data "ironic_introspection" "openshift-master-introspection" {

--- a/data/data/baremetal/masters/variables.tf
+++ b/data/data/baremetal/masters/variables.tf
@@ -33,3 +33,13 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
+
+variable "ignition_url" {
+  type        = string
+  description = "The URL of the full ignition"
+}
+
+variable "ignition_url_ca_cert" {
+  type        = string
+  description = "Root CA cert of the full ignition URL"
+}

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -52,3 +52,13 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
+
+variable "ignition_url" {
+  type        = string
+  description = "The URL of the full ignition"
+}
+
+variable "ignition_url_ca_cert" {
+  type        = string
+  description = "Root CA cert of the full ignition URL"
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/openshiftinstall"
 	"github.com/openshift/installer/pkg/asset/rhcos"
+	"github.com/openshift/installer/pkg/asset/tls"
 	rhcospkg "github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/tfvars"
 	awstfvars "github.com/openshift/installer/pkg/tfvars/aws"
@@ -92,6 +93,7 @@ func (t *TerraformVariables) Dependencies() []asset.Asset {
 		&machines.Master{},
 		&machines.Worker{},
 		&baremetalbootstrap.IronicCreds{},
+		&tls.RootCA{},
 	}
 }
 
@@ -442,6 +444,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			string(*rhcosImage),
 			ironicCreds.Username,
 			ironicCreds.Password,
+			masterIgn,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)


### PR DESCRIPTION
This PR is an old revert which sends full ignition to the masters via the ironic terraform provider.

See PR: https://github.com/openshift/installer/pull/3276

co-authored-by: Steve Hardy <shardy@redhat.com>