### PR TITLE
Correcting normal typos

### DIFF
--- a/data/data/bootstrap/baremetal/README.md
+++ b/data/data/bootstrap/baremetal/README.md
@@ -25,5 +25,5 @@ discussed above.
 `coredns` runs with a custom `mdns` plugin (`coredns-mdns`).
 
 Relevant files:
-* **[files/etc/dhcp/dhclient.conf](files/etc/dhcp/dhclient.conf)** - Sepcify
+* **[files/etc/dhcp/dhclient.conf](files/etc/dhcp/dhclient.conf)** - Specify
   that the bootstrap VM should use `localhost` as its primary DNS server.


### PR DESCRIPTION
Fixed the typo under data/data/bootstrap/baremetal/README.md 

To have a better reader experience  fixed this typo.