### PR TITLE
libvirt: Bump bootstrap size (primarily for OKD)

### DIFF
--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -4,10 +4,19 @@ resource "libvirt_pool" "bootstrap" {
   path = "/var/lib/libvirt/openshift-images/${var.cluster_id}-bootstrap"
 }
 
-resource "libvirt_volume" "bootstrap" {
-  name   = "${var.cluster_id}-bootstrap"
+resource "libvirt_volume" "bootstrap-base" {
+  name   = "${var.cluster_id}-bootstrap-base"
   pool   = libvirt_pool.bootstrap.name
   source = var.image
+}
+
+resource "libvirt_volume" "bootstrap" {
+  name           = "${var.cluster_id}-bootstrap"
+  pool           = libvirt_pool.bootstrap.name
+  base_volume_id = libvirt_volume.bootstrap-base.id
+  # Keep this in sync with the main libvirt size in
+  # data/data/libvirt/bootstrap/main.tf
+  size = "21474836480"
 }
 
 resource "libvirt_ignition" "bootstrap" {

--- a/data/data/libvirt/bootstrap/main.tf
+++ b/data/data/libvirt/bootstrap/main.tf
@@ -2,6 +2,8 @@ resource "libvirt_volume" "bootstrap" {
   name           = "${var.cluster_id}-bootstrap"
   base_volume_id = var.base_volume_id
   pool           = var.pool
+  # Bump this so it works for OKD/FCOS too
+  size = "21474836480"
 }
 
 resource "libvirt_ignition" "bootstrap" {


### PR DESCRIPTION
The FCOS/RHCOS difference of 8GB vs 16GB is something
I'd eventually like to fix by making RHCOS 8GB too for
consistency.

The installer can easily resize.