### PR TITLE
data/data/aws/route53: use CNAME for us-iso-east-1 region

### DIFF
--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -5,7 +5,7 @@ locals {
   // So publish_strategy serves an coordinated proxy for that decision.
   public_endpoints = var.publish_strategy == "External" ? true : false
 
-  use_cname = contains(["us-gov-west-1", "us-gov-east-1"], var.region)
+  use_cname = contains(["us-gov-west-1", "us-gov-east-1", "us-iso-east-1"], var.region)
   use_alias = ! local.use_cname
 }
 


### PR DESCRIPTION
We cannot create ALIAS records to the NLBs in C2S cloud partition, which includes `us-iso-east-1`. So we switch to using CNAME for our api records in that region.