### PR TITLE
pkg/types/validation/installconfig: Cap cluster domain at 184 characters

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -79,6 +79,8 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 		clusterDomain := c.ClusterDomain()
 		if err := validate.DomainName(clusterDomain, true); err != nil {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("baseDomain"), clusterDomain, err.Error()))
+		} else if maxLength := 184; len(clusterDomain) > maxLength {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("baseDomain"), clusterDomain, fmt.Sprintf("contains %d characters, but the cluster domain is limited to %d to allow room for subdomains.", len(clusterDomain), maxLength)))
 		}
 	}
 	if c.Networking != nil {


### PR DESCRIPTION
DNS names are limited to 255 octets.  Allocate some space for

    {subdomain}.apps.{clusterDomain}

~255 - 1 - 4 - 1 - 63 = 186.  I dunno if we're supposed to count a terminal dot in the full domain.  But a risk at off-by-one is still better than no guard at all ;).~ [edit: actually 184, see [below][2])  And folks can still slip through if they try to create a route with multiple long subdomains, but again, some guard is better than no guard.

The cap will be unnecessarily harsh for folks who will never need long route subdomains, but ~186~ still seems plenty long, and having to use short, randomized route names to stay under a smaller subdomain cap seems sufficiently tedious to deserve a guard here.

Related to, but distinct from, [rhbz#1896977](https://bugzilla.redhat.com/show_bug.cgi?id=1896977).

[1]: https://tools.ietf.org/html/rfc1035#section-2.3.4
[2]: https://github.com/openshift/installer/pull/4368#issuecomment-725769767