### PR TITLE
Remove the secrets directory recursively

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -52,7 +52,7 @@ sudo chown -R "${USER}":"${USER}" "${ARTIFACTS}/rendered-assets"
 sudo find "${ARTIFACTS}/rendered-assets" -type d -print0 | xargs -0 sudo chmod u+x
 # remove sensitive information
 # TODO leave tls.crt inside of secret yaml files
-find "${ARTIFACTS}/rendered-assets" -name "*secret*" -print0 | xargs -0 rm
+find "${ARTIFACTS}/rendered-assets" -name "*secret*" -print0 | xargs -0 rm -rf
 find "${ARTIFACTS}/rendered-assets" -name "*kubeconfig*" -print0 | xargs -0 rm
 find "${ARTIFACTS}/rendered-assets" -name "*.key" -print0 | xargs -0 rm
 find "${ARTIFACTS}/rendered-assets" -name ".kube" -print0 | xargs -0 rm -rf


### PR DESCRIPTION
In installer log-gathers, we see this error:

```
rm: cannot remove '/tmp/artifacts-20201104213542/rendered-assets/openshift/etcd-bootstrap/bootstrap-manifests/secrets': Is a directory
```

The secrets directory is attempted to be removed by simple `rm` command which cannot remove directories without the recursive flag. 