### PR TITLE
Bug 1888464: add tag:UnTagResource perm for aws shared networks

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -25,6 +25,9 @@ const (
 
 	// PermissionDeleteNetworking is a set of permissions required when the installer destroys networking resources.
 	PermissionDeleteNetworking PermissionGroup = "delete-networking"
+
+	// PermissionDeleteSharedNetworking is a set of permissions required when the installer destroys resources from a shared-network cluster.
+	PermissionDeleteSharedNetworking PermissionGroup = "delete-shared-networking"
 )
 
 var permissions = map[PermissionGroup][]string{
@@ -214,6 +217,10 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:DetachInternetGateway",
 		"ec2:DisassociateRouteTable",
 		"ec2:ReplaceRouteTableAssociation",
+	},
+	// Permissions required for deleting a cluster with shared network resources
+	PermissionDeleteSharedNetworking: {
+		"tag:UnTagResources",
 	},
 }
 

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -48,10 +48,21 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 	platform := ic.Config.Platform.Name()
 	switch platform {
 	case aws.Name:
-		permissionGroups := []awsconfig.PermissionGroup{awsconfig.PermissionCreateBase, awsconfig.PermissionDeleteBase}
-		// If subnets are not provided in install-config.yaml, include network permissions
-		if len(ic.Config.AWS.Subnets) == 0 {
-			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateNetworking, awsconfig.PermissionDeleteNetworking)
+		permissionGroups := []awsconfig.PermissionGroup{awsconfig.PermissionCreateBase}
+		usingExistingVPC := len(ic.Config.AWS.Subnets) != 0
+
+		if !usingExistingVPC {
+			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateNetworking)
+		}
+
+		// Add delete permissions for non-C2S installs.
+		if !aws.C2SRegions.Has(ic.Config.AWS.Region) {
+			permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteBase)
+			if usingExistingVPC {
+				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteSharedNetworking)
+			} else {
+				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteNetworking)
+			}
 		}
 
 		ssn, err := ic.AWS.Session(ctx)


### PR DESCRIPTION
Create a new permissions group for destroying a shared-network cluster. These clusters require permissions to untag the shared networks. This check is skipped in the case of C2S, because delete is not supported.

The solution will need to be slightly different for pre 4.7 as Tags are needed for cluster create and obviously there is no C2S support.