### PR TITLE
Cleanup: make conversion functions private

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -664,7 +664,7 @@ spec:
                 description: NetworkType is the type of network to install. The default is OpenShiftSDN
                 type: string
               serviceCIDR:
-                description: Depcreated name for ServiceNetwork
+                description: Deprecated name for ServiceNetwork
                 type: Any
               serviceNetwork:
                 description: 'ServiceNetwork is the list of IP address pools for services. Default is 172.30.0.0/16. NOTE: currently only one entry is supported.'

--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -27,11 +27,11 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 	default:
 		return field.Invalid(field.NewPath("apiVersion"), config.APIVersion, fmt.Sprintf("cannot upconvert from version %s", config.APIVersion))
 	}
-	ConvertNetworking(config)
+	convertNetworking(config)
 
 	switch config.Platform.Name() {
 	case baremetal.Name:
-		ConvertBaremetal(config)
+		convertBaremetal(config)
 	case openstack.Name:
 		err := convertOpenStack(config)
 		if err != nil {
@@ -43,8 +43,8 @@ func ConvertInstallConfig(config *types.InstallConfig) error {
 	return nil
 }
 
-// ConvertNetworking upconverts deprecated fields in networking
-func ConvertNetworking(config *types.InstallConfig) {
+// convertNetworking upconverts deprecated fields in networking
+func convertNetworking(config *types.InstallConfig) {
 	if config.Networking == nil {
 		return
 	}
@@ -85,10 +85,10 @@ func ConvertNetworking(config *types.InstallConfig) {
 	}
 }
 
-// ConvertBaremetal upconverts deprecated fields in the baremetal
+// convertBaremetal upconverts deprecated fields in the baremetal
 // platform. ProvisioningDHCPExternal has been replaced by setting
 // the ProvisioningNetwork field to "Unmanaged"
-func ConvertBaremetal(config *types.InstallConfig) {
+func convertBaremetal(config *types.InstallConfig) {
 	if config.Platform.BareMetal.DeprecatedProvisioningDHCPExternal && config.Platform.BareMetal.ProvisioningNetwork == "" {
 		config.Platform.BareMetal.ProvisioningNetwork = baremetal.UnmanagedProvisioningNetwork
 	}

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -247,7 +247,7 @@ type Networking struct {
 	// +optional
 	ServiceNetwork []ipnet.IPNet `json:"serviceNetwork,omitempty"`
 
-	// Deprected types, scheduled to be removed
+	// Deprecated types, scheduled to be removed
 
 	// Deprecated name for MachineCIDRs. If set, MachineCIDRs must
 	// be empty or the first index must match.
@@ -258,7 +258,7 @@ type Networking struct {
 	// +optional
 	DeprecatedType string `json:"type,omitempty"`
 
-	// Depcreated name for ServiceNetwork
+	// Deprecated name for ServiceNetwork
 	// +optional
 	DeprecatedServiceCIDR *ipnet.IPNet `json:"serviceCIDR,omitempty"`
 


### PR DESCRIPTION
Now some functions in "conversion" module are public but they are used only inside the module, so it is reasonable to make them
private.

Also this commit fixes typos in deprecated properties descriptions.