### PR TITLE
baremetal: add units to podman wait in ironic

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -134,8 +134,8 @@ $IPTABLES -t raw -A DHCP_IRONIC -j DROP
 {{end}}
 
 # Wait for images to be downloaded/ready
-podman wait -i 1000 ipa-downloader
-podman wait -i 1000 coreos-downloader
+podman wait -i 1000ms ipa-downloader
+podman wait -i 1000ms coreos-downloader
 while ! curl --fail http://localhost/images/rhcos-ootpa-latest.qcow2.md5sum ; do sleep 1; done
 while ! curl --fail --head http://localhost/images/ironic-python-agent.initramfs ; do sleep 1; done
 while ! curl --fail --head http://localhost/images/ironic-python-agent.kernel ; do sleep 1; done


### PR DESCRIPTION
A [bug in some versions of podman](https://bugzilla.redhat.com/show_bug.cgi?id=1897282)
means that units end up being required for the podman wait command, even
though it was documented as optional. This is fixed, but the podman
requiring units shipped in RHEL 8.3 and recent Fedoras, and won't be
updated until 8.4.  This proactively adds units to baremetal's
podman-wait commands in case this broken podman ends up in RHCOS or
FCOS. It doesn't hurt to be explicit anyway.