### PR TITLE
openstack UPI: Use ansible-galaxy

### DIFF
--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -150,7 +150,11 @@ sudo subscription-manager repos \
 
 Then install the packages:
 ```sh
-sudo dnf install python3-openstackclient ansible python3-openstacksdk python3-netaddr
+sudo dnf install python3-openstackclient ansible
+
+sudo ansible-galaxy collection install \
+  ansible.netcommon \
+  openstack.cloud
 ```
 
 Make sure that `python` points to Python3:
@@ -163,7 +167,11 @@ sudo alternatives --set python /usr/bin/python3
 This command installs all required dependencies on Fedora:
 
 ```sh
-sudo dnf install python3-openstackclient ansible python3-openstacksdk python3-netaddr
+sudo dnf install python3-openstackclient ansible
+
+sudo ansible-galaxy collection install \
+  ansible.netcommon \
+  openstack.cloud
 ```
 
 [ansible-upi]: ../../../upi/openstack "Ansible Playbooks for Openstack UPI"

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -25,8 +25,10 @@ RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux glibc-locale-sour
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    python3-openstackclient ansible-2.9.14-1.el8ae python3-openstacksdk python3-netaddr unzip jq && \
+    python3-openstackclient ansible-2.9.14-1.el8ae unzip jq && \
     yum clean all && rm -rf /var/cache/yum/*
+
+RUN ansible-galaxy collection install ansible.netcommon openstack.cloud
 
 # The Continuous Integration machinery relies on Route53 for DNS while testing the cluster.
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \


### PR DESCRIPTION
Document the use of ansible-galaxy as a dependency manager for the
Ansible playbooks in UPI.

Implements [OSASINFRA-2169](https://issues.redhat.com/browse/OSASINFRA-2169)