### PR TITLE
Bug 1898172: add tagging perms for aws shared networks

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -25,6 +25,12 @@ const (
 
 	// PermissionDeleteNetworking is a set of permissions required when the installer destroys networking resources.
 	PermissionDeleteNetworking PermissionGroup = "delete-networking"
+
+	// PermissionCreateSharedNetworking is a set of permissions required when the installer creates resources in a shared-network cluster.
+	PermissionCreateSharedNetworking PermissionGroup = "create-shared-networking"
+
+	// PermissionDeleteSharedNetworking is a set of permissions required when the installer destroys resources from a shared-network cluster.
+	PermissionDeleteSharedNetworking PermissionGroup = "delete-shared-networking"
 )
 
 var permissions = map[PermissionGroup][]string{
@@ -214,6 +220,14 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:DetachInternetGateway",
 		"ec2:DisassociateRouteTable",
 		"ec2:ReplaceRouteTableAssociation",
+	},
+	// Permissions required for deleting a cluster with shared network resources
+	PermissionCreateSharedNetworking: {
+		"tag:TagResources",
+	},
+	// Permissions required for deleting a cluster with shared network resources
+	PermissionDeleteSharedNetworking: {
+		"tag:UnTagResources",
 	},
 }
 

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -49,8 +49,11 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 	switch platform {
 	case aws.Name:
 		permissionGroups := []awsconfig.PermissionGroup{awsconfig.PermissionCreateBase, awsconfig.PermissionDeleteBase}
-		// If subnets are not provided in install-config.yaml, include network permissions
-		if len(ic.Config.AWS.Subnets) == 0 {
+		usingExistingVPC := len(ic.Config.AWS.Subnets) != 0
+
+		if usingExistingVPC {
+			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateSharedNetworking, awsconfig.PermissionDeleteSharedNetworking)
+		} else {
 			permissionGroups = append(permissionGroups, awsconfig.PermissionCreateNetworking, awsconfig.PermissionDeleteNetworking)
 		}
 


### PR DESCRIPTION
This is a small rewrite of #4371 for release-4.6 
Create a new permissions group for creating & destroying a shared-network cluster.
These clusters require permissions to tag and untag the shared networks.

This could be cherry picked to previous branches.