### PR TITLE
Bug 1898238: Validate the the API and Ingress FIPs are not the same

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -81,6 +81,9 @@ func validateFloatingIPs(p *openstack.Platform, ci *CloudInfo, fldPath *field.Pa
 		} else if p.ExternalNetwork == "" {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressFloatingIP"), p.IngressFloatingIP, "Cannot set floating ips when external network not specified"))
 		}
+		if p.APIFloatingIP != "" && p.APIFloatingIP == p.IngressFloatingIP {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressFloatingIP"), p.IngressFloatingIP, "ingressFloatingIP can not be the same as apiFloatingIP"))
+		}
 	}
 	return allErrs
 }

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -142,6 +142,18 @@ func TestOpenStackPlatformValidation(t *testing.T) {
 			expectedErrMsg: `[platform.openstack.ingressFloatingIP: Invalid value: "128.35.27.13": Cannot set floating ips when external network not specified, platform.openstack.apiFloatingIP: Invalid value: "128.35.27.8": Cannot set floating ips when external network not specified]`,
 		},
 		{
+			name: "ingress and API FIPs identical",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.IngressFloatingIP = p.APIFloatingIP
+				return p
+			}(),
+			cloudInfo:      validPlatformCloudInfo(),
+			networking:     validNetworking(),
+			expectedError:  true,
+			expectedErrMsg: `platform.openstack.ingressFloatingIP: Invalid value: "128.35.27.8": ingressFloatingIP can not be the same as apiFloatingIP`,
+		},
+		{
 			name: "no external network provided",
 			platform: func() *openstack.Platform {
 				p := validPlatform()


### PR DESCRIPTION
Patches  [OSASINFRA-2178](https://issues.redhat.com/browse/OSASINFRA-2178) where the user is able to pass the same floating IP to the API and Ingress FIP in the install config.

/label platform/openstack