### PR TITLE
Bug 1895874: Use oVirt Engine certificate verified by the user for installation

### DIFF
--- a/pkg/asset/installconfig/ovirt/client.go
+++ b/pkg/asset/installconfig/ovirt/client.go
@@ -15,6 +15,7 @@ func getConnection(ovirtConfig Config) (*ovirtsdk.Connection, error) {
 		Username(ovirtConfig.Username).
 		Password(ovirtConfig.Password).
 		CAFile(ovirtConfig.CAFile).
+		CACert([]byte(ovirtConfig.CABundle)).
 		Insecure(ovirtConfig.Insecure).
 		Build()
 	if err != nil {

--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -2,7 +2,6 @@ package ovirt
 
 import (
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -2,6 +2,7 @@ package ovirt
 
 import (
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/pkg/asset/installconfig/ovirt/validation.go
+++ b/pkg/asset/installconfig/ovirt/validation.go
@@ -86,6 +86,7 @@ func authenticated(c *Config) survey.Validator {
 			Username(c.Username).
 			Password(fmt.Sprint(val)).
 			CAFile(c.CAFile).
+			CACert([]byte(c.CABundle)).
 			Insecure(c.Insecure).
 			Build()
 


### PR DESCRIPTION
## Abstract

This pull request changes the oVirt/RVH installer to use the certificate downloaded from the oVirt engine and verified by the user. It eliminates the need for the user to add the certificate to the trust root on their system.

This PR is based on #4354 and fixes [Bugzilla#1895874](https://bugzilla.redhat.com/show_bug.cgi?id=1895874).

## Behavior before this change

> $ openshift-install create install-config
> ? Platform ovirt
> ? Engine FQDN[:PORT] engine.example.com
> INFO Loaded the following PEM file:
> INFO    Version: 3
> INFO    Signature Algorithm: SHA256-RSA
> INFO    Serial Number: 4096
> INFO    Issuer: CN=engine.example.com.39197,O=example.com,C=US
> INFO    Validity:
> INFO            Not Before: 2020-08-11 13:50:26 +0000 UTC
> INFO            Not After: 2030-08-10 13:50:26 +0000 UTC
> INFO    Subject: CN=engine.example.com.39197,O=example.com,C=US
> ? Would you like to use the above certificate to connect to Engine?  Yes
> ? Engine username admin
> ? Engine password [Press Ctrl+C to switch username, ? for help] ***********
> X Sorry, your reply was invalid: failed to connect to Engine platform Post "https://engine.example.com/ovirt-engine/sso/oauth/token": x509: certificate signed by unknown authority

## Behavior after this change

The installation no longer fails.

## Verification

I have verified the installation process against the 4.7.0-0.ci-2020-11-17-102916 image up to the point that the bootstrap node comes up and starts installing the cluster.