### PR TITLE
Bug 1889779: vSphere destroy: handle failed clusters

### DIFF
--- a/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
+++ b/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
@@ -339,6 +339,13 @@ func resourceVSpherePrivateImportOvaCreate(d *schema.ResourceData, meta interfac
 		return errors.Errorf("failed to lease wait: %s", err)
 	}
 
+	d.SetId(info.Entity.Value)
+
+	err = attachTag(d, meta)
+	if err != nil {
+		return errors.Errorf("failed to attach tag to virtual machine: %s", err)
+	}
+
 	u := lease.StartUpdater(ctx, info)
 	defer u.Done()
 
@@ -356,12 +363,6 @@ func resourceVSpherePrivateImportOvaCreate(d *schema.ResourceData, meta interfac
 		return errors.Errorf("failed to lease complete: %s", err)
 	}
 
-	d.SetId(info.Entity.Value)
-
-	err = attachTag(d, meta)
-	if err != nil {
-		return errors.Errorf("failed to attach tag to virtual machine: %s", err)
-	}
 	log.Printf("[DEBUG] %s: ova import complete", d.Get("name").(string))
 
 	return resourceVSpherePrivateImportOvaRead(d, meta)


### PR DESCRIPTION
Adjusts vSphere destroy code to handle cases when cluster create was  terminated early, particularly if interrupted before OVA is completely downloaded. This commit moves the tagging of the OVA template before the data upload, because the template was not getting tagged if the upload did not commit. See details below.

Also, prior to this change, destroy would stop if no VMs or folders were found, but this updates the flow to allow best effort to destroy all resources.

Finally, updates caps to be consistent with other standard logger output.

Import OVA & Destroy Details:
If one hard terminates the installer during a template import, the import continues in the vCenter for some period of time afterward (I would estimate at five minutes).

This will block the deletion of the template, but in my testing the code gracefully handles this and spins until the lock is resolved and then deletion completes successfully.