### PR TITLE
baremetal: when networking is disabled make the bootstrap provisioning ip optional

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -25,6 +25,8 @@ done
 # Start the provisioning nic if not already started
 PROVISIONING_NIC={{.PlatformData.BareMetal.ProvisioningInterface}}
 
+{{ if .PlatformData.BareMetal.ProvisioningIP }}
+
 if ! nmcli -t device | grep "$PROVISIONING_NIC:ethernet:connected"; then
     nmcli c add type ethernet ifname $PROVISIONING_NIC con-name provisioning {{ if .PlatformData.BareMetal.ProvisioningIPv6 }} ip6 {{ else }} ip4 {{ end }} {{.PlatformData.BareMetal.ProvisioningIP}}/{{.PlatformData.BareMetal.ProvisioningCIDR}}
     nmcli c up provisioning
@@ -41,6 +43,8 @@ fi
 while [ -z "$(ip -o addr show dev $PROVISIONING_NIC | grep -v link)" ]; do
     sleep 1
 done
+
+{{ end }}
 
 # set password for ironic basic auth
 # The ironic container contains httpd (and thus httpd-tools), so rely on it to

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -425,9 +425,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Data:     data,
 		})
 	case baremetal.Name:
+		provisioningIP := installConfig.Config.Platform.BareMetal.BootstrapProvisioningIP
+		if installConfig.Config.Platform.BareMetal.ProvisioningNetwork == baremetal.DisabledProvisioningNetwork && provisioningIP == "" {
+			provisioningIP = installConfig.Config.Platform.BareMetal.APIVIP
+		}
+
 		data, err = baremetaltfvars.TFVars(
 			installConfig.Config.Platform.BareMetal.LibvirtURI,
-			installConfig.Config.Platform.BareMetal.BootstrapProvisioningIP,
+			provisioningIP,
 			string(*rhcosBootstrapImage),
 			installConfig.Config.Platform.BareMetal.ExternalBridge,
 			installConfig.Config.Platform.BareMetal.ExternalMACAddress,

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -71,14 +71,15 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 		templateData.ProvisioningInterface = "ens3"
 		templateData.ProvisioningDNSMasq = false
 
-		for _, network := range networks {
-			if network.CIDR.Contains(net.ParseIP(templateData.ProvisioningIP)) {
-				templateData.ProvisioningIPv6 = network.CIDR.IP.To4() == nil
+		if templateData.ProvisioningIP != "" {
+			for _, network := range networks {
+				if network.CIDR.Contains(net.ParseIP(templateData.ProvisioningIP)) {
+					templateData.ProvisioningIPv6 = network.CIDR.IP.To4() == nil
 
-				cidr, _ := network.CIDR.Mask.Size()
-				templateData.ProvisioningCIDR = cidr
+					cidr, _ := network.CIDR.Mask.Size()
+					templateData.ProvisioningCIDR = cidr
+				}
 			}
-
 		}
 	}
 

--- a/pkg/types/baremetal/defaults/platform_test.go
+++ b/pkg/types/baremetal/defaults/platform_test.go
@@ -2,12 +2,12 @@ package defaults
 
 import (
 	"errors"
-	"github.com/openshift/installer/pkg/ipnet"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
 )
@@ -114,6 +114,24 @@ func TestSetPlatformDefaults(t *testing.T) {
 			},
 			expected: &baremetal.Platform{
 				BootstrapProvisioningIP: "192.168.111.7",
+				ClusterProvisioningIP:   "192.168.111.8",
+				LibvirtURI:              "qemu:///system",
+				ExternalBridge:          "baremetal",
+				ProvisioningBridge:      "",
+				ProvisioningNetwork:     baremetal.DisabledProvisioningNetwork,
+				ProvisioningNetworkCIDR: machineNetwork,
+				APIVIP:                  "192.168.111.2",
+				IngressVIP:              "192.168.111.3",
+			},
+		},
+		{
+			name: "disabled_provisioning_network_no_bootstrap_ip",
+			platform: &baremetal.Platform{
+				ProvisioningNetwork:   baremetal.DisabledProvisioningNetwork,
+				ClusterProvisioningIP: "192.168.111.8",
+			},
+			expected: &baremetal.Platform{
+				BootstrapProvisioningIP: "",
 				ClusterProvisioningIP:   "192.168.111.8",
 				LibvirtURI:              "qemu:///system",
 				ExternalBridge:          "baremetal",

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -351,9 +351,11 @@ func ValidateProvisioning(p *baremetal.Platform, n *types.Networking, fldPath *f
 	// will be run on the external network. Users must provide IP's on the
 	// machine networks to host those services.
 	case baremetal.DisabledProvisioningNetwork:
-		// Ensure bootstrapProvisioningIP is in one of the machine networks
-		if err := validateIPinMachineCIDR(p.BootstrapProvisioningIP, n); err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("bootstrapProvisioningIP"), p.BootstrapProvisioningIP, fmt.Sprintf("provisioning network is disabled, %s", err.Error())))
+		// If set, ensure bootstrapProvisioningIP is in one of the machine networks
+		if p.BootstrapProvisioningIP != "" {
+			if err := validateIPinMachineCIDR(p.BootstrapProvisioningIP, n); err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("bootstrapProvisioningIP"), p.BootstrapProvisioningIP, fmt.Sprintf("provisioning network is disabled, %s", err.Error())))
+			}
 		}
 
 		// Ensure clusterProvisioningIP is in one of the machine networks

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -413,6 +413,14 @@ func TestValidateProvisioning(t *testing.T) {
 				BootstrapProvisioningIP("192.168.111.3").build(),
 		},
 		{
+			name:   "valid_provisioningDisabled_no_boostrap_ip",
+			config: installConfig().Network(networking().Network("192.168.111.0/24")).build(),
+			platform: platform().
+				ProvisioningNetwork(baremetal.DisabledProvisioningNetwork).
+				ClusterProvisioningIP("192.168.111.2").
+				BootstrapProvisioningIP("").build(),
+		},
+		{
 			name:   "invalid_provisioningDisabled_IPs_not_in_machineCIDR",
 			config: installConfig().Network(networking().Network("192.168.111.0/24")).build(),
 			platform: platform().


### PR DESCRIPTION
This is needed by the assisted installer, so that it does not have to create static ips.

/cc @zaneb @hardys 