### PR TITLE
Stop validating DefaultMachinePlatform

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -29,10 +29,6 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	// validate custom cluster os image
 	allErrs = append(allErrs, validateClusterOSImage(p, ci, fldPath)...)
 
-	if p.DefaultMachinePlatform != nil {
-		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, ci, true, fldPath.Child("defaultMachinePlatform"))...)
-	}
-
 	return allErrs
 }
 


### PR DESCRIPTION
This structure contains default values that will be inserted in machine sets for masters and workers if some values there are
omitted. Since we validate these machine sets anyway, we can stop doing it for DefaultMachinePlatform, so as not to do the
work twice.