### PR TITLE
vSphere Docs: Update to include Permissions

### DIFF
--- a/docs/user/vsphere/privileges.md
+++ b/docs/user/vsphere/privileges.md
@@ -1,10 +1,10 @@
-# Required Privileges
-In order to install an OpenShift cluster to a vCenter, the user provided to the installer needs privileges to read and create the necessary resources. The easiest way to achieve this level of permission and ensure success is to install with a user who has administrative privileges.
+# Required Privileges & Permissions
+In order to install an OpenShift cluster to a vCenter, the user provided to the installer needs privileges to read and create the necessary resources. The easiest way to achieve this level of permission and ensure success is to install with a user who has global administrative privileges.
 
-If the provided user has admin privileges, no action is required and you can skip to the next step. Otherwise, the rest of this document can be used as a resource to create a user with more fine-grained privileges.
+If the provided user has global admin privileges, no further action for permissions is required. Otherwise, the rest of this document can be used as a resource to create a user with more fine-grained privileges.
 
 ## Privileges
-In order to create an OpenShift cluster, a user needs permissions for the following categories: _Datastore_, _Folder_, _Host_, _vSphere Tagging_, _Network_, _Resource_, _Profile-driven storage_, _vApp_, and _Virtual machine_.
+In order to create an OpenShift cluster, a user needs privileges in the following categories: _Datastore_, _Folder_, _vSphere Tagging_, _Network_, _Resource_, _Profile-driven storage_, _vApp_, and _Virtual machine_.
 
 Here is an example summary of privileges that could be used to install a cluster:
 
@@ -28,6 +28,13 @@ Here is an example summary of privileges that could be used to install a cluster
 
 It may be possible to further refine the categories where _All privileges_ have been granted.
 
+The user also needs the privileges from the `Read-Only` role. 
+## Permissions
+
+The easiest way to ensure proper permissions is to grant Global Permissions to the user with the privileges above (both the listed privileges and `Read Only` role). Otherwise, it is necessary to ensure that the user with the listed privileges has permissions granted on all necessary entities in the vCenter. In addition, the user must have `Read-Only` privileges on the compute-node VM and all parent entities (`vCenter`, `Datacenter`, `Datastore Cluster`, and `Datastore Storage Folder`).
+
+For more information, consult [vSphere Permissions and User Management Tasks][vsphere-perms]
+
 ## Walkthrough: Creating and Assigning Global Roles
 The following is a visual walkthrough of creating and assigning global roles in the vSphere 6 web client. Roles can be similarly created for specific clusters. For more information, refer to the [vSphere docs][vsphere-docs].
 
@@ -48,3 +55,4 @@ To assign the newly created role, click the `+` for Add Permission:
 ![Assign role](images/assign-role.png)
 
 [vsphere-docs]: https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-5372F580-5C23-4E9C-8A4E-EF1B4DD9033E.html
+[vsphere-perms]: https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.security.doc/GUID-5372F580-5C23-4E9C-8A4E-EF1B4DD9033E.html


### PR DESCRIPTION
This updates vSphere docs to provide more information about permissions. We can see in a lot of cases (https://bugzilla.redhat.com/show_bug.cgi?id=1869035) that when admins are not granting Global Permissions they are neglecting
to assign minimum priveleges to the vSphere itself.

cc @jcpowermac @gnufied @bobfuru 

related to openshift/openshift-docs#27328