### PR TITLE
Bug 1899161: Cherry-Pick: openstack: remove platform flavor validation

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -21,9 +21,6 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	// validate the externalNetwork
 	allErrs = append(allErrs, validateExternalNetwork(p, ci, fldPath)...)
 
-	// validate platform flavor
-	allErrs = append(allErrs, validatePlatformFlavor(p, ci, fldPath)...)
-
 	// validate floating ips
 	allErrs = append(allErrs, validateFloatingIPs(p, ci, fldPath)...)
 


### PR DESCRIPTION
Flavors are validated in machine pools already, therefore it is
redundant to also check computeFlavor at the platform level.

This patch removes the computeFlavor validation at the platform
level, since this flavor would already be checked during machine
pool validation.

The installer generates machine pools for both masters and workers.
If the flavor isn't found at the machine pool level, it'll take
platform.computeFlavor, so we don't loose validation coverage.

Reference: #4383
JIRA: [OSASINFRA-2146](https://issues.redhat.com/browse/OSASINFRA-2146)
[BZ#1899161](https://bugzilla.redhat.com/show_bug.cgi?id=1899161)