### PR TITLE
WIP: [fcos] Azure TF fixup

### DIFF
--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -183,8 +183,8 @@ resource "azurerm_storage_blob" "rhcos_image" {
   storage_account_name   = azurerm_storage_account.cluster.name
   storage_container_name = azurerm_storage_container.vhd.name
   type                   = "Page"
-  source                 = var.azure_image_url
-  metadata               = map("source", var.azure_image_url)
+  source_uri             = var.azure_image_url
+  metadata               = map("source_uri", var.azure_image_url)
 }
 
 resource "azurerm_image" "cluster" {


### PR DESCRIPTION
The source_uri field on the rhcos_image resource was renamed to source
in a prior change on the fcos branch. The source field name however
might have special functionality and would thus not be usable here.