### PR TITLE
libvirt: allow customization of the pool path

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1078,6 +1078,10 @@ spec:
                         description: The interface make used for the network. Default is tt0.
                         type: string
                     type: object
+                  poolPath:
+                    default: /var/lib/libvirt/openshift-images
+                    description: Directory path for the libvirt storage pool
+                    type: string
                 type: object
               none:
                 description: None is the empty configuration used when installing on an unsupported platform.

--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -5,7 +5,7 @@ provider "libvirt" {
 resource "libvirt_pool" "storage_pool" {
   name = var.cluster_id
   type = "dir"
-  path = "/var/lib/libvirt/openshift-images/${var.cluster_id}"
+  path = "${var.libvirt_pool_path}/${var.cluster_id}"
 }
 
 module "volume" {
@@ -126,4 +126,3 @@ data "libvirt_network_dns_host_template" "masters_int" {
   ip       = var.libvirt_master_ips[count.index]
   hostname = "api-int.${var.cluster_domain}"
 }
-

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -58,3 +58,9 @@ variable "libvirt_master_size" {
   description = "Size of the volume in bytes"
   default     = "17179869184"
 }
+
+variable "libvirt_pool_path" {
+  type        = string
+  description = "Directory path for the libvirt storage pool"
+  default     = "/var/lib/libvirt/openshift-images"
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -369,6 +369,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			installConfig.Config.Platform.Libvirt.Network.IfName,
 			masterCount,
 			installConfig.Config.ControlPlane.Architecture,
+			installConfig.Config.Platform.Libvirt.PoolPath,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -27,10 +27,11 @@ type config struct {
 	MasterVcpu      string   `json:"libvirt_master_vcpu,omitempty"`
 	BootstrapMemory int      `json:"libvirt_bootstrap_memory,omitempty"`
 	MasterDiskSize  string   `json:"libvirt_master_size,omitempty"`
+	PoolPath        string   `json:"libvirt_pool_path"`
 }
 
 // TFVars generates libvirt-specific Terraform variables.
-func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, machineCIDR *net.IPNet, bridge string, masterCount int, architecture types.Architecture) ([]byte, error) {
+func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, machineCIDR *net.IPNet, bridge string, masterCount int, architecture types.Architecture, poolPath string) ([]byte, error) {
 	bootstrapIP, err := cidr.Host(machineCIDR, 10)
 	if err != nil {
 		return nil, errors.Errorf("failed to generate bootstrap IP: %v", err)
@@ -66,6 +67,7 @@ func TFVars(masterConfig *v1beta1.LibvirtMachineProviderConfig, osImage string, 
 		MasterIPs:    masterIPs,
 		MasterMemory: strconv.Itoa(masterConfig.DomainMemory),
 		MasterVcpu:   strconv.Itoa(masterConfig.DomainVcpu),
+		PoolPath:     poolPath,
 	}
 
 	if masterConfig.Volume.VolumeSize != nil {

--- a/pkg/types/libvirt/defaults/platform.go
+++ b/pkg/types/libvirt/defaults/platform.go
@@ -7,6 +7,8 @@ import (
 const (
 	// DefaultURI is the default URI of the libvirtd connection.
 	DefaultURI = "qemu+tcp://192.168.122.1/system"
+	// DefaultPoolPath directory path for the libvirt storage pool
+	DefaultPoolPath = "/var/lib/libvirt/openshift-images"
 )
 
 // SetPlatformDefaults sets the defaults for the platform.
@@ -18,4 +20,7 @@ func SetPlatformDefaults(p *libvirt.Platform) {
 		p.Network = &libvirt.Network{}
 	}
 	SetNetworkDefaults(p.Network)
+	if p.PoolPath == "" {
+		p.PoolPath = DefaultPoolPath
+	}
 }

--- a/pkg/types/libvirt/defaults/platform_test.go
+++ b/pkg/types/libvirt/defaults/platform_test.go
@@ -12,8 +12,9 @@ func defaultPlatform() *libvirt.Platform {
 	n := &libvirt.Network{}
 	SetNetworkDefaults(n)
 	return &libvirt.Platform{
-		URI:     DefaultURI,
-		Network: n,
+		URI:      DefaultURI,
+		Network:  n,
+		PoolPath: DefaultPoolPath,
 	}
 }
 

--- a/pkg/types/libvirt/platform.go
+++ b/pkg/types/libvirt/platform.go
@@ -23,6 +23,12 @@ type Platform struct {
 	// Network
 	// +optional
 	Network *Network `json:"network,omitempty"`
+
+	// Directory path for the libvirt storage pool
+	//
+	// +kubebuilder:default="/var/lib/libvirt/openshift-images"
+	// +optional
+	PoolPath string `json:"poolPath,omitempty"`
 }
 
 // Network is the configuration of the libvirt network.


### PR DESCRIPTION
When creating the storage pool path, that path needs to be on a file
system big enough to accommodate virtual machine images spun up by the
installer. In some cases the default `/var/lib/libvirt/openshift-images`
could reside on a file system that if filled might cause issues, for
example when `/var` resides on the root file system, as it does by
default on Fedora Linux.

This allows customizing the libvirt storage pool directory path,
allowing the user to choose where to store the virtual machine images.

The default is left to `/var/lib/libvirt/openshift-images`.