### PR TITLE
OpenStack: Adds clusterOSImageProperties to install-config.yaml

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1097,6 +1097,11 @@ spec:
                   clusterOSImage:
                     description: ClusterOSImage is either a URL with `http(s)` or `file` scheme to override the default OS image for cluster nodes, or an existing Glance image name.
                     type: string
+                  clusterOSImageProperties:
+                    additionalProperties:
+                      type: string
+                    description: 'ClusterOSImageProperties is a list of properties to be added to the metadata of the uploaded Glance ClusterOSImage. Default: the default is to not set any properties.'
+                    type: object
                   computeFlavor:
                     description: FlavorName is the name of the compute flavor to use for instances in this cluster.
                     type: string

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -30,6 +30,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `region` (deprecated string): The OpenStack region where the cluster will be created. Currently this value is not used by the installer.
 * `trunkSupport` (deprecated string): Whether OpenStack ports can be trunked (`1` for true or `0` for false)
 * `clusterOSImage` (optional string): Either a URL with `http(s)` or `file` scheme to override the default OS image for cluster nodes or an existing Glance image name.
+* `clusterOSImageProperties` (optional list of strings): a list of properties to be added to the installer-uploaded ClusterOSImage in Glance. The default is to not set any properties. `clusterOSImageProperties` is ignored when `clusterOSImage` points to an existing image in Glance.
 * `apiVIP` (optional string): An IP address on the machineNetwork that will be assigned to the API VIP. Be aware that the `10` and `11` of the machineNetwork will be taken by neutron dhcp by default, and wont be available.
 * `ingressVIP` (optional string): An IP address on the machineNetwork that will be assigned to the ingress VIP. Be aware that the `10` and `11` of the machineNetwork will be taken by neutron dhcp by default, and wont be available.
 * `machinesSubnet` (optional string): the UUID of an OpenStack subnet to install the nodes of the cluster onto. For more information on how to install with a custom subnet, see the [custom subnets](#custom-subnets) section of the docs.

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -411,6 +411,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			installConfig.Config.Platform.OpenStack.APIVIP,
 			installConfig.Config.Platform.OpenStack.IngressVIP,
 			string(*rhcosImage),
+			installConfig.Config.Platform.OpenStack.ClusterOSImageProperties,
 			clusterID.InfraID,
 			caCert,
 			bootstrapIgn,

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -45,7 +45,7 @@ type config struct {
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, apiFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
+func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, apiFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, baseImageProperties map[string]string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
 	zones := []string{}
 	seen := map[string]bool{}
 	for _, config := range masterConfigs {
@@ -103,7 +103,7 @@ func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, exter
 			return nil, errors.Errorf("Unsupported URL scheme: '%v'", url.Scheme)
 		}
 
-		err = uploadBaseImage(cloud, localFilePath, imageName, infraID)
+		err = uploadBaseImage(cloud, localFilePath, imageName, infraID, baseImageProperties)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tfvars/openstack/rhcos_image.go
+++ b/pkg/tfvars/openstack/rhcos_image.go
@@ -16,7 +16,7 @@ import (
 )
 
 // uploadBaseImage creates a new image in Glance and uploads the RHCOS image there
-func uploadBaseImage(cloud string, localFilePath string, imageName string, clusterID string) error {
+func uploadBaseImage(cloud string, localFilePath string, imageName string, clusterID string, imageProperties map[string]string) error {
 	logrus.Debugln("Creating a Glance image for RHCOS...")
 
 	f, err := os.Open(localFilePath)
@@ -46,6 +46,7 @@ func uploadBaseImage(cloud string, localFilePath string, imageName string, clust
 		ContainerFormat: "bare",
 		DiskFormat:      diskFormat,
 		Tags:            []string{fmt.Sprintf("openshiftClusterID=%s", clusterID)},
+		Properties:      imageProperties,
 		// TODO(mfedosin): add Description when gophercloud supports it.
 	}
 

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -62,6 +62,11 @@ type Platform struct {
 	// +optional
 	ClusterOSImage string `json:"clusterOSImage,omitempty"`
 
+	// ClusterOSImageProperties is a list of properties to be added to the metadata of the uploaded Glance ClusterOSImage.
+	// Default: the default is to not set any properties.
+	// +optional
+	ClusterOSImageProperties map[string]string `json:"clusterOSImageProperties,omitempty"`
+
 	// APIVIP is the static IP on the nodes subnet that the api port for openshift will be assigned
 	// Default: will be set to the 5 on the first entry in the machineNetwork CIDR
 	// +optional


### PR DESCRIPTION
 ClusterOSImageProperty is a list of properties to be added to the cluster OS glance image metadata. 
example usage
platform:
  openstack:
      clusterOSImageProperties:
           hw_qemu_guest_agent: yes
           hw_scsi_model: virtio-scsi

implementes [OSASINFRA-1980](https://issues.redhat.com/browse/OSASINFRA-1980)