### PR TITLE
WIP: specify container log location on bootstrap node

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -3,14 +3,21 @@ set -euoE pipefail ## -E option will cause functions to inherit trap
 
 . /usr/local/bin/release-image.sh
 
-mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
+LOG_PATH=/var/log/container-logs/
+
+mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests,container-logs}
+mkdir --parents "$LOG_PATH"
 
 ETCD_ENDPOINTS=
 
 bootkube_podman_run() {
     # we run all commands in the host-network to prevent IP conflicts with
     # end-user infrastructure.
-    podman run --quiet --net=host "${@}"
+    podman run \
+		--quiet \
+		--log-opt=path="$LOG_PATH$1" \
+		--net=host \
+		"${@:2}" 
 }
 
 MACHINE_CONFIG_OPERATOR_IMAGE=$(image_for machine-config-operator)
@@ -54,6 +61,7 @@ then
 	rm --recursive --force cvo-bootstrap
 
 	bootkube_podman_run \
+		release-image-digest.log \
 		--volume "$PWD:/assets:z" \
 		"${RELEASE_IMAGE_DIGEST}" \
 		render \
@@ -73,6 +81,7 @@ if [ ! -f etcd-bootstrap.done ]
 then
 	echo "Rendering CEO Manifests..."
 	bootkube_podman_run \
+		cluster-etcd-operator.log \
 		--volume "$PWD:/assets:z" \
 		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-etcd-operator render \
@@ -108,6 +117,7 @@ then
 	fi
 
 	bootkube_podman_run \
+		cluster-config-operator.log \
 		--volume "$PWD:/assets:z" \
 		"${CONFIG_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-config-operator render \
@@ -130,6 +140,7 @@ then
 	rm --recursive --force kube-apiserver-bootstrap
 
 	bootkube_podman_run  \
+		cluster-kube-apiserver-operator.log \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_APISERVER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-apiserver-operator render \
@@ -156,6 +167,7 @@ then
 	rm --recursive --force kube-controller-manager-bootstrap
 
 	bootkube_podman_run \
+		cluster-kube-controller-manager-operator.log \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-controller-manager-operator render \
@@ -182,6 +194,7 @@ then
 	rm --recursive --force kube-scheduler-bootstrap
 
 	bootkube_podman_run \
+		cluster-kube-scheduler-operator.log \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_SCHEDULER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-scheduler-operator render \
@@ -204,6 +217,7 @@ then
 	rm --recursive --force ingress-operator-bootstrap
 
 	bootkube_podman_run \
+		cloud-ingress-operator.log \
 		--volume "$PWD:/assets:z" \
 		"${INGRESS_OPERATOR_IMAGE}" \
 		render \
@@ -230,6 +244,7 @@ then
 	fi
 
 	bootkube_podman_run \
+		machine-config-operator.log \
 		--user 0 \
 		--volume "$PWD:/assets:z" \
 		"${MACHINE_CONFIG_OPERATOR_IMAGE}" \
@@ -294,6 +309,7 @@ then
 
 	# shellcheck disable=SC2154
 	bootkube_podman_run \
+		cloud-credential-operator.log \
 		--quiet \
 		--user 0 \
 		--volume "$PWD:/assets:z" \
@@ -314,6 +330,7 @@ fi
 
 # Wait for the etcd cluster to come up.
 until bootkube_podman_run \
+		machine-config-etcd.log \
 		--rm \
 		--name etcdctl \
 		--env ETCDCTL_API=3 \
@@ -336,6 +353,7 @@ echo "Starting cluster-bootstrap..."
 if [ ! -f cb-bootstrap.done ]
 then
     bootkube_podman_run \
+		cluster-bootstrap.log \
         --rm \
         --volume "$PWD:/assets:z" \
         --volume /etc/kubernetes:/etc/kubernetes:z \
@@ -350,6 +368,7 @@ if [ ! -z "$CLUSTER_ETCD_OPERATOR_IMAGE" ]
 then
 	echo "Waiting for CEO to finish..."
 	bootkube_podman_run \
+		machine-config-etcd.log \
 		--volume "$PWD:/assets:z" \
 		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-etcd-operator \


### PR DESCRIPTION
This is a PoC of an idea for [CORS-1544](https://issues.redhat.com/browse/CORS-1544). This is a different approach than suggested in the card, so I wanted to get some early feedback. 

My idea here is that we specify the log output location when running with podman. Am I missing some scope in the card? I need to test the multiple runs, but I assume logs are appended. 

The results on the bootstrap node look like this:

```shell
[core@padillon-bkvmc-bootstrap container-logs]$ ls
cloud-credential-operator.log  cluster-etcd-operator.log                     machine-config-etcd.log
cloud-ingress-operator.log     cluster-kube-apiserver-operator.log           machine-config-operator.log
cluster-bootstrap.log          cluster-kube-controller-manager-operator.log  release-image-digest.log
cluster-config-operator.log    cluster-kube-scheduler-operator.log

[core@padillon-bkvmc-bootstrap container-logs]$ sudo cat cluster-etcd-operator.log 
2020-11-21T16:43:47.134538345+00:00 stderr F I1121 16:43:47.134296       1 bootstrap_ip_linux.go:35] retrieved Address map map[0xc0009deb60:[127.0.0.1/8 lo ::1/128] 0xc0009dec30:[10.0.0.6/32 ens4 fe80::4001:aff:fe00:6/64]]
2020-11-21T16:43:47.134953390+00:00 stderr F I1121 16:43:47.134874       1 bootstrap_ip_linux.go:54] Ignoring route non Router advertisement route {Ifindex: 1 Dst: ::1/128 Src: <nil> Gw: <nil> Flags: [] Table: 254}
2020-11-21T16:43:47.135092743+00:00 stderr F I1121 16:43:47.135017       1 bootstrap_ip_linux.go:54] Ignoring route non Router advertisement route {Ifindex: 2 Dst: fe80::/64 Src: <nil> Gw: <nil> Flags: [] Table: 254}
2020-11-21T16:43:47.135092743+00:00 stderr F I1121 16:43:47.135052       1 bootstrap_ip_linux.go:64] Retrieved route map map[]
2020-11-21T16:43:47.135192206+00:00 stderr F I1121 16:43:47.135157       1 bootstrap_ip.go:158] Filtered address 127.0.0.1/8 lo
2020-11-21T16:43:47.135263344+00:00 stderr F I1121 16:43:47.135243       1 bootstrap_ip.go:158] Filtered address ::1/128
2020-11-21T16:43:47.135319165+00:00 stderr F I1121 16:43:47.135299       1 bootstrap_ip.go:187] Checking whether address 10.0.0.6/32 ens4 contains VIP 10.0.0.6
2020-11-21T16:43:47.135402687+00:00 stderr F I1121 16:43:47.135360       1 bootstrap_ip.go:189] Address 10.0.0.6/32 ens4 contains VIP 10.0.0.6
2020-11-21T16:43:47.135509173+00:00 stderr F I1121 16:43:47.135469       1 bootstrap_ip.go:158] Filtered address fe80::4001:aff:fe00:6/64
2020-11-21T16:43:47.135509173+00:00 stderr F I1121 16:43:47.135501       1 bootstrap_ip.go:200] Found routable IPs [10.0.0.6]
2020-11-21T16:43:47.135535029+00:00 stderr F I1121 16:43:47.135512       1 render.go:371] using bootstrap IP 10.0.0.6
2020-11-21T16:43:47.560159764+00:00 stdout F Writing asset: /assets/etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml
[...]

```