### PR TITLE
Mgmt 2794 sno bootstrap inplace

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -314,7 +314,7 @@ fi
 
 # Wait for the etcd cluster to come up.
 until bootkube_podman_run \
-		--rm \
+        --rm \
 		--name etcdctl \
 		--env ETCDCTL_API=3 \
 		--volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
@@ -325,14 +325,126 @@ until bootkube_podman_run \
 		--cert=/opt/openshift/tls/etcd-client.crt \
 		--key=/opt/openshift/tls/etcd-client.key \
 		--endpoints="${ETCD_ENDPOINTS}" \
-		endpoint health
+		 endpoint health
 do
 	echo "etcdctl failed. Retrying in 5 seconds..."
 	sleep 5
 done
 
-echo "Starting cluster-bootstrap..."
 
+{{if .SingleNode}}
+if [ ! -f create-master-data.done ]
+then
+
+    curl -k https://localhost:22623/config/master -o master.ign
+    # Apply the master ignition to FS
+    bootkube_podman_run \
+        --volume /:/rootfs:rw \
+        --volume /usr/bin/rpm-ostree:/usr/bin/rpm-ostree \
+        --privileged --entrypoint /usr/bin/machine-config-daemon \
+        "${MACHINE_CONFIG_OPERATOR_IMAGE}" \
+        start --node-name localhost --root-mount /rootfs --once-from /opt/openshift/master.ign --skip-reboot
+
+    # Restart required services
+    echo "starting systemd services"
+    systemctl daemon-reload
+    systemctl restart ovsdb-server.service \
+        ovs-configuration.service \
+        openvswitch.service \
+        nodeip-configuration.service \
+        node-valid-hostname.service \
+        machine-config-daemon-pull.service \
+        machine-config-daemon-firstboot.service \
+        kubelet.service \
+        NetworkManager.service
+
+    # stop the MCS, need need for it once we polled the ignition
+    echo "Stopping MCS"
+    rm -rf /etc/kubernetes/manifests/machineconfigoperator-bootstrap-pod.yaml
+
+
+    # Backup master ignition
+    cp /etc/kubernetes/kubeconfig ./master-kubeconfig
+    ## Restore: CVO should use `/etc/kubernetes/bootstrap-secrets/kubeconfig` instead
+    cp auth/kubeconfig-loopback /etc/kubernetes/kubeconfig
+
+    # The files under /opt/openshift/bootstrap-manifests/ will be deployed as static pods by the cluster bootstrap
+
+    echo "Rename bootstrap static pods"
+    # Rename the manifests files
+    ls bootstrap-manifests/ | xargs -I {} mv bootstrap-manifests/{} bootstrap-manifests/bootstrap-{}
+
+    # Rename the temporary control plane containers
+    sed -i 's/name: cluster-version-operator/name: bootstrap-cluster-version-operator/g' bootstrap-manifests/bootstrap-bootstrap-pod.yaml
+    sed -i 's/name: cloud-credential-operator/name: bootstrap-cloud-credential-operator/g' bootstrap-manifests/bootstrap-cloud-credential-operator-pod.yaml
+    sed -i 's/name: kube-apiserver/name: bootstrap-kube-apiserver/g' bootstrap-manifests/bootstrap-kube-apiserver-pod.yaml
+    sed -i 's/name: kube-controller-manager/name: bootstrap-kube-controller-manager/g' bootstrap-manifests/bootstrap-kube-controller-manager-pod.yaml
+    sed -i 's/name: kube-controller-manager/name: bootstrap-kube-controller-manager/g' bootstrap-manifests/bootstrap-kube-controller-manager-pod.yaml
+    sed -i 's/name: kube-scheduler/name: bootstrap-kube-scheduler/g' bootstrap-manifests/bootstrap-kube-scheduler-pod.yaml
+
+    echo "create-master-data done"
+    touch create-master-data.done
+fi
+
+
+if [ ! -f cb-bootstrap.done ]
+then
+    bootkube_podman_run \
+        --rm \
+        --volume "$PWD:/assets:z" \
+        --detach \
+        --volume /etc/kubernetes:/etc/kubernetes:z \
+        "${CLUSTER_BOOTSTRAP_IMAGE}" \
+        start --tear-down-early=false --asset-dir=/assets --required-pods="openshift-kube-apiserver/kube-apiserver,openshift-kube-scheduler/openshift-kube-scheduler,openshift-kube-controller-manager/kube-controller-manager,openshift-cluster-version/cluster-version-operator"
+    # TODO: handle cluster-bootstrap better - replace "--detach" with a flag that tells cb to wait for the static pods and exit
+    # TODO: need to check if the timeout is enough
+    # Wait for control plane static pods
+    for file_name in etcd-pod.yaml  kube-apiserver-pod.yaml  kube-controller-manager-pod.yaml  kube-scheduler-pod.yaml
+    do
+        until ls /etc/kubernetes/manifests/$file_name; do echo "waiting for $file_name"
+        sleep 5
+        done
+    done
+    # TODO: cluster-bootstrap doesn't finish so we need to send the bootstrap-finished event ourselves
+
+    touch cb-bootstrap.done
+fi
+
+# Cleanup bootstrap
+echo "cleaning up bootstrap"
+for service in release-image.service chown-gatewayd-key.service crio-configure.service patch.service approve-csr.service progress.service systemd-journal-gatewayd.service
+do
+    echo "Stop $service"
+    systemctl stop $service
+    echo "Disable $service"
+    systemctl disable $service
+done
+systemctl disable bootkube.service
+
+
+mv /opt/openshift/master-kubeconfig /etc/kubernetes/kubeconfig
+
+echo "Remove the bootstrap control plane"
+rm -rf /etc/kubernetes/bootstrap-*
+rm -rf /etc/kubernetes/manifests/etcd-member-pod.yaml
+rm -rf /etc/kubernetes/manifests/bootstrap-*
+
+# Remove bootstrap files
+rm -rf /opt/openshift
+for file in approve-csr.sh bootkube.sh crio-configure.sh installer-gather.sh installer-masters-gather.sh \
+    kubelet-pause-image.sh patch.sh release-image-download.sh release-image.sh report-progress.sh
+do
+    rm -f /usr/local/bin/$file
+done
+
+echo "These are the static pods:"
+ls /etc/kubernetes/manifests/
+
+echo "Going to reboot"
+shutdown -r +1 "Bootstrap completed, server is going to reboot."
+
+
+{{else}}
 if [ ! -f cb-bootstrap.done ]
 then
     bootkube_podman_run \
@@ -360,3 +472,5 @@ fi
 # Workaround for https://github.com/opencontainers/runc/pull/1807
 touch /opt/openshift/.bootkube.done
 echo "bootkube.service complete"
+
+{{end}}

--- a/data/data/bootstrap/files/usr/local/bin/patch.sh
+++ b/data/data/bootstrap/files/usr/local/bin/patch.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -x
+
+function patchit {
+    # allow etcd-operator to start the etcd cluster without minimum of 3 master nodes
+    oc --kubeconfig ./auth/kubeconfig-loopback patch etcd cluster -p='{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}' --type=merge || return 1
+
+    # allow cluster-authentication-operator to deploy OAuthServer without minimum of 3 master nodes
+    oc --kubeconfig ./auth/kubeconfig-loopback patch authentications.operator.openshift.io cluster -p='{"spec": {"managementState": "Managed", "unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableOAuthServer": true}}}' --type=merge || return 1
+
+    # patch ingress operator to run a single router pod
+    oc patch --kubeconfig ./auth/kubeconfig-loopback -n openshift-ingress-operator ingresscontroller/default --patch '{"spec":{"replicas": 1}}' --type=merge || return 1
+
+    # Mark etcd-quorum-guard as unmanaged
+    oc patch --kubeconfig ./auth/kubeconfig-loopback clusterversion/version -p="$(cat <<- EOF
+spec:
+   overrides:
+     - group: apps/v1
+       kind: Deployment
+       name: etcd-quorum-guard
+       namespace: openshift-etcd
+       unmanaged: true
+EOF
+)" --type=merge || return 1
+
+    # scale down etcd-quorum-guard
+    oc scale --kubeconfig ./auth/kubeconfig-loopback --replicas=1 deployment/etcd-quorum-guard -n openshift-etcd || return 1
+
+    return 0
+}
+
+while ! patchit; do
+    echo "Waiting to try again..."
+    sleep 10
+done
+touch patch.done
+

--- a/data/data/bootstrap/systemd/units/patch.service
+++ b/data/data/bootstrap/systemd/units/patch.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Patch single node OpenShift cluster
+Wants=bootkube.service
+ConditionPathExists=!/opt/openshift/patch.done
+
+[Service]
+WorkingDirectory=/opt/openshift
+ExecStart=/usr/local/bin/patch.sh
+
+Restart=on-failure
+RestartSec=5s
+
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -57,6 +57,7 @@ type bootstrapTemplateData struct {
 	Registries            []sysregistriesv2.Registry
 	BootImage             string
 	PlatformData          platformTemplateData
+	SingleNode            bool
 }
 
 // platformTemplateData is the data to use to replace values in bootstrap
@@ -265,6 +266,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 		Registries:            registries,
 		BootImage:             string(*rhcosImage),
 		PlatformData:          platformData,
+		SingleNode:            *installConfig.ControlPlane.Replicas == 1,
 	}, nil
 }
 
@@ -336,6 +338,7 @@ func (a *Bootstrap) addSystemdUnits(uri string, templateData *bootstrapTemplateD
 		"chown-gatewayd-key.service":      {},
 		"systemd-journal-gatewayd.socket": {},
 		"approve-csr.service":             {},
+		"patch.service":                   {},
 		// baremetal & openstack platform services
 		"keepalived.service":        {},
 		"coredns.service":           {},


### PR DESCRIPTION
This is the code I got while exploring options for [installing Single Node Openshift (SNO) without an auxiliary bootstrap node](https://issues.redhat.com/browse/MGMT-2794).

In essence, you can use the bootstrap ignition generated with this installer to spinup SNO.
It will setup bootstrap on the node you are installing and then pivot the node to become a master node.

How to and more details are [here](https://docs.google.com/document/d/17ANid5OmjPd2MWhhPxCv-Lw3_3jvfC6S5GBK5Y-CxxM/edit?usp=sharing)