### PR TITLE
Bug 1900138: Removed support for insecure mode for oVirt/RHV installation

### DIFF
--- a/docs/user/ovirt/install_ipi.md
+++ b/docs/user/ovirt/install_ipi.md
@@ -226,3 +226,24 @@ $ oc get nodes
 ```
 
 [Bare Metal IPI Networking Infrastructure]: https://github.com/openshift/installer/blob/master/docs/design/baremetal/networking-infrastructure.md
+
+#### Installing OpenShift on RHV/oVirt in *insecure* mode
+
+<!-- Do not change this title as it is used in the code to point users to the right place -->
+
+Starting OpenShift 4.7 we are sunsetting the “insecure” option from the OpenShift Installer. Starting with this version, the installer only supports installation methods from the user interface that lead to using verified certificates.
+
+This change also means that setting up the CA certificate for RHV is no longer required before running the installer. The installer will ask you for confirmation about the certificate and store the CA certificate for use during the installation.
+
+Should you, nevertheless, require an installation without certificate verification you can create a file named ovirt-config.yaml in the .ovirt directory in your home directory (~/.ovirt/ovirt-config.yaml) before running the installer with the following content:
+
+```yaml
+ovirt_url: https://ovirt.example.com/ovirt-engine/api
+ovirt_fqdn: ovirt.example.com
+ovirt_pem_url: ""
+ovirt_username: admin@internal
+ovirt_password: super-secret-password
+ovirt_insecure: true
+```
+
+Please note that this option is **not recommended** as it will allow a potential attacker to perform a Man-in-the-Middle attack and capture sensitive credentials on the network.

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -366,9 +366,19 @@ func engineSetup() (Config, error) {
 	}
 
 	if engineConfig.Insecure {
-		logrus.Warning(
-			"cannot detect Engine CA cert imported in the system. ",
-			"Communication with the Engine will be insecure.")
+		logrus.Error(
+			"****************************************************************************\n",
+			"* Could not configure secure communication to the oVirt engine.            *\n",
+			"* As of 4.7 insecure mode for oVirt is no longer supported in the          *\n",
+			"* installer. Please see the help article titled \"Installing OpenShift on   *\n",
+			"* RHV/oVirt in insecure mode\" for details how to configure insecure mode   *\n",
+			"* manually.                                                                *\n",
+			"****************************************************************************",
+		)
+		return engineConfig,
+			errors.New(
+				"cannot detect engine ca cert imported in the system",
+			)
 	}
 	return askCredentials(engineConfig)
 }


### PR DESCRIPTION
[This change](https://bugzilla.redhat.com/show_bug.cgi?id=1900138) removes support for the insecure mode from the oVirt installer. Previously, when no certificate could be obtained from the oVirt engine the installer would proceed without certificate verification. This PR is based on #4387 and **depends on [OCPRHV-426](https://issues.redhat.com/browse/OCPRHV-426)**.

Due to recent improvements this is no longer a valid use case and is being deprecated. The user is instead presented with a message explaining the situation and linking to the to-be-written documentation. If the user wants to use insecure mode they have to create a file named `~/.ovirt/ovirt-config.yaml` with the following contents before running the installer:

```yaml
ovirt_url: https://ovirt.example.com/ovirt-engine/api
ovirt_fqdn: ovirt.example.com
ovirt_pem_url: ""
ovirt_username: admin@internal
ovirt_password: super-secret-password
ovirt_insecure: true
```

## User experience

```
$ bin/openshift-install create install-config
? SSH Public Key /home/janoszen/.ssh/id_rsa.pub
? Platform ovirt
? Engine FQDN[:PORT] vm-10-208.lab.eng.tlv2.redhat.com
INFO Loaded the following PEM file:
INFO    Version: 3
INFO    Signature Algorithm: SHA256-RSA
INFO    Serial Number: 4096
INFO    Issuer: CN=ovirt.example.com.39197,O=example.com,C=US
INFO    Validity:
INFO            Not Before: 2020-08-11 13:50:26 +0000 UTC
INFO            Not After: 2030-08-10 13:50:26 +0000 UTC
INFO    Subject: CN=ovirt.example.com.39197,O=example.com,C=US
? Would you like to use the above certificate to connect to Engine?  No
? Would you like to import another PEM bundle? No
ERROR ****************************************************************************
ERROR * Could not configure secure communication to the oVirt engine.            *
ERROR * As of 4.7 insecure mode for oVirt is no longer supported from the        *
ERROR * installer. Please see ____LINK____ for details how to configure insecure *
ERROR * mode manually.                                                           *
ERROR ****************************************************************************
ERROR oVirt configuration failed: cannot detect Engine CA cert imported in the system.
? Engine FQDN[:PORT]
```