### PR TITLE
OpenStack: add cinder client to the ci image

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -25,7 +25,7 @@ RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux glibc-locale-sour
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    python3-openstackclient ansible-2.9.14-1.el8ae unzip jq && \
+    python3-openstackclient python3-cinderclient ansible-2.9.14-1.el8ae unzip jq && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN ansible-galaxy collection install ansible.netcommon openstack.cloud


### PR DESCRIPTION
To support CSI tests we need OpenStack Cinder client to be installed[1] in the CI image.

[1] https://github.com/openshift/release/pull/13317#issuecomment-732866652