### PR TITLE
Bug 1899853: openstack: CP nodes port to use addtional SGs

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -81,6 +81,7 @@ module "topology" {
   octavia_support     = var.openstack_octavia_support
   machines_subnet_id  = var.openstack_machines_subnet_id
   machines_network_id = var.openstack_machines_network_id
+  master_extra_sg_ids = var.openstack_master_extra_sg_ids
 }
 
 data "openstack_images_image_v2" "base_image" {

--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -41,10 +41,13 @@ resource "openstack_networking_port_v2" "masters" {
   name  = "${var.cluster_id}-master-port-${count.index}"
   count = var.masters_count
 
-  admin_state_up     = "true"
-  network_id         = local.nodes_network_id
-  security_group_ids = [openstack_networking_secgroup_v2.master.id]
-  tags               = ["openshiftClusterID=${var.cluster_id}"]
+  admin_state_up = "true"
+  network_id     = local.nodes_network_id
+  security_group_ids = concat(
+    var.master_extra_sg_ids,
+    [openstack_networking_secgroup_v2.master.id],
+  )
+  tags = ["openshiftClusterID=${var.cluster_id}"]
 
   extra_dhcp_option {
     name  = "domain-search"

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -68,3 +68,8 @@ variable "machines_network_id" {
   type    = string
   default = ""
 }
+
+variable "master_extra_sg_ids" {
+  description = "(optional) IDs of additional security groups for masters."
+  type        = list(string)
+}


### PR DESCRIPTION
Assign the user-defined additional security groups to the Control Plane
port.

Fixes [Bug 1899853](https://bugzilla.redhat.com/show_bug.cgi?id=1899853)