### PR TITLE
do not generate the cloud cred secret when credentialsMode is Manual

### DIFF
--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -220,7 +220,9 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 
 	switch platform {
 	case awstypes.Name, openstacktypes.Name, vspheretypes.Name, azuretypes.Name, gcptypes.Name, ovirttypes.Name, kubevirttypes.Name:
-		assetData["99_cloud-creds-secret.yaml"] = applyTemplateData(cloudCredsSecret.Files()[0].Data, templateData)
+		if installConfig.Config.CredentialsMode != types.ManualCredentialsMode {
+			assetData["99_cloud-creds-secret.yaml"] = applyTemplateData(cloudCredsSecret.Files()[0].Data, templateData)
+		}
 		assetData["99_role-cloud-creds-secret-reader.yaml"] = applyTemplateData(roleCloudCredsSecretReader.Files()[0].Data, templateData)
 	case baremetaltypes.Name:
 		bmTemplateData := baremetalTemplateData{


### PR DESCRIPTION
When `credentialsMode` is set to `Manual` the user is responsible for providing the credentials into the cluster. Do not create the cloud Secret when the install-config indicates `Manual`.
For installing on AWS with temporary credentials, this means we no longer install a Secret with creds that will expire and never be updated.

Ref: https://issues.redhat.com/browse/CO-1249