### PR TITLE
Renaming unit-status directory to failed-unit-status in installer-gather.

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -15,11 +15,11 @@ echo "Gathering bootstrap systemd summary ..."
 LANG=POSIX systemctl list-units --state=failed >& "${ARTIFACTS}/failed-units.txt"
 
 echo "Gathering bootstrap failed systemd unit status ..."
-mkdir -p "${ARTIFACTS}/unit-status"
+mkdir -p "${ARTIFACTS}/failed-unit-status"
 sed -n 's/^\* \([^ ]*\) .*/\1/p' < "${ARTIFACTS}/failed-units.txt" | while read -r UNIT
 do
-    systemctl status --full "${UNIT}" >& "${ARTIFACTS}/unit-status/${UNIT}.txt"
-    journalctl -u "${UNIT}" > "${ARTIFACTS}/unit-status/${UNIT}.log"
+    systemctl status --full "${UNIT}" >& "${ARTIFACTS}/failed-unit-status/${UNIT}.txt"
+    journalctl -u "${UNIT}" > "${ARTIFACTS}/failed-unit-status/${UNIT}.log"
 done
 
 echo "Gathering bootstrap journals ..."

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -13,11 +13,11 @@ echo "Gathering master systemd summary ..."
 LANG=POSIX systemctl list-units --state=failed >& "${ARTIFACTS}/failed-units.txt"
 
 echo "Gathering master failed systemd unit status ..."
-mkdir -p "${ARTIFACTS}/unit-status"
+mkdir -p "${ARTIFACTS}/failed-unit-status"
 sed -n 's/^\* \([^ ]*\) .*/\1/p' < "${ARTIFACTS}/failed-units.txt" | while read -r UNIT
 do
-    systemctl status --full "${UNIT}" >& "${ARTIFACTS}/unit-status/${UNIT}.txt"
-    journalctl -u "${UNIT}" > "${ARTIFACTS}/unit-status/${UNIT}.log"
+    systemctl status --full "${UNIT}" >& "${ARTIFACTS}/failed-unit-status/${UNIT}.txt"
+    journalctl -u "${UNIT}" > "${ARTIFACTS}/failed-unit-status/${UNIT}.log"
 done
 
 echo "Gathering master journals ..."

--- a/docs/user/troubleshootingbootstrap.md
+++ b/docs/user/troubleshootingbootstrap.md
@@ -63,7 +63,7 @@ Here's what a log bundle looks like,
 ├── failed-units.txt
 ├── rendered-assets
 ├── resources
-└── unit-status
+└── failed-unit-status
 
 5 directories, 1 file
 ```
@@ -72,9 +72,9 @@ Here's what a log bundle looks like,
 
 The failed-units.txt contains a list of all the **failed** systemd units on the bootstrap host.
 
-### directory: unit-status
+### directory: failed-unit-status
 
-The unit-status directory contains the details of each failed systemd unit from [failed-units](#file-failed-units-txt),
+The failed-unit-status directory contains the details of each failed systemd unit from [failed-units](#file-failed-units-txt),
 
 ### directory: bootstrap
 
@@ -138,17 +138,17 @@ control-plane
 │   ├── containers
 │   ├── failed-units.txt
 │   ├── journals
-│   └── unit-status
+│   └── failed-unit-status
 ├── 10.0.142.138
 │   ├── containers
 │   ├── failed-units.txt
 │   ├── journals
-│   └── unit-status
+│   └── failed-unit-status
 └── 10.0.148.48
     ├── containers
     ├── failed-units.txt
     ├── journals
-    └── unit-status
+    └── failed-unit-status
 
 12 directories, 3 files
 ```


### PR DESCRIPTION
The name is misleading and may make you think the directory is empty
because an error occurred while gathering the logs, which is not the
case.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>