### PR TITLE
hack/verify-vendor.sh: Fail early if error

### DIFF
--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if [ "$IS_CONTAINER" != "" ]; then
+  set -euxo pipefail
   go mod vendor
   go mod verify
   git diff --exit-code


### PR DESCRIPTION
Prior to this patch, errors in vendoring or verification were ignored.

With this patch, `verify-vendor` fails if the dependency files are
corrupted.
