### PR TITLE
Bug 1899176: Bump RHCOS bootimages to 46.82.202011260640-0

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,156 +1,156 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-02f4a2c7b9a3a6840"
+            "hvm": "ami-09921c9c1c36e695c"
         },
         "ap-east-1": {
-            "hvm": "ami-06a0695694b6c3e8d"
+            "hvm": "ami-01ee8446e9af6b197"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0cb46ba6945dbfebe"
+            "hvm": "ami-04e5b5722a55846ea"
         },
         "ap-northeast-2": {
-            "hvm": "ami-01e554d608de6087a"
+            "hvm": "ami-0fdc25c8a0273a742"
         },
         "ap-south-1": {
-            "hvm": "ami-09253ba33f828d47f"
+            "hvm": "ami-09e3deb397cc526a8"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0a6a0f1f6106708c4"
+            "hvm": "ami-0630e03f75e02eec4"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0e3e2b2ea00c35823"
+            "hvm": "ami-069450613262ba03c"
         },
         "ca-central-1": {
-            "hvm": "ami-0f5825ef10c76de32"
+            "hvm": "ami-012518cdbd3057dfd"
         },
         "eu-central-1": {
-            "hvm": "ami-0a51f61236e6fc6f2"
+            "hvm": "ami-0bd7175ff5b1aef0c"
         },
         "eu-north-1": {
-            "hvm": "ami-06d01bfaf14ad66a3"
+            "hvm": "ami-06c9ec42d0a839ad2"
         },
         "eu-south-1": {
-            "hvm": "ami-031c7e2567f507746"
+            "hvm": "ami-0614d7440a0363d71"
         },
         "eu-west-1": {
-            "hvm": "ami-0e514a30ad261c978"
+            "hvm": "ami-01b89df58b5d4d5fa"
         },
         "eu-west-2": {
-            "hvm": "ami-0291fd4543d6940f4"
+            "hvm": "ami-06f6e31ddd554f89d"
         },
         "eu-west-3": {
-            "hvm": "ami-083f281d2864a71de"
+            "hvm": "ami-0dc82e2517ded15a1"
         },
         "me-south-1": {
-            "hvm": "ami-05a6ae5eadb5b244d"
+            "hvm": "ami-07d181e3aa0f76067"
         },
         "sa-east-1": {
-            "hvm": "ami-081f13881a31af160"
+            "hvm": "ami-0cd44e6dd20e6c7fa"
         },
         "us-east-1": {
-            "hvm": "ami-009cbe327d180d666"
+            "hvm": "ami-04a16d506e5b0e246"
         },
         "us-east-2": {
-            "hvm": "ami-0346f64579665ce3c"
+            "hvm": "ami-0a1f868ad58ea59a7"
         },
         "us-west-1": {
-            "hvm": "ami-07c185c787029b522"
+            "hvm": "ami-0a65d76e3a6f6622f"
         },
         "us-west-2": {
-            "hvm": "ami-01105d480bb47353f"
+            "hvm": "ami-0dd9008abadc519f1"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202010011740-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202010011740-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202011260640-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202011260640-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202010011740-0/x86_64/",
-    "buildid": "46.82.202010011740-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202011260640-0/x86_64/",
+    "buildid": "46.82.202011260640-0",
     "gcp": {
-        "image": "rhcos-46-82-202010011740-0-gcp-x86-64",
+        "image": "rhcos-46-82-202011260640-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202010011740-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202011260640-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202010011740-0-aws.x86_64.vmdk.gz",
-            "sha256": "21fbefcbb3e1ca9c479e49ba45700026c636ee48f1d1c84a84dabaff2d944f87",
-            "size": 899198828,
-            "uncompressed-sha256": "3af7a3ba4d3963f5e4368cadef9bfe8c1e005218ab42d65b226db17a8bd0f4c8",
-            "uncompressed-size": 918272000
+            "path": "rhcos-46.82.202011260640-0-aws.x86_64.vmdk.gz",
+            "sha256": "6e0f720077ac20fae46c16159d03fd51f66cd318155dcd14f0f5d7dc79bfd8ad",
+            "size": 900764628,
+            "uncompressed-sha256": "b38713b80bbcc41d18efcec93d241da48533225e0ce073c2a26235993ffc4166",
+            "uncompressed-size": 919795200
         },
         "azure": {
-            "path": "rhcos-46.82.202010011740-0-azure.x86_64.vhd.gz",
-            "sha256": "c6f233a04aacf9c17602e58a52aaa5f315cbc61254d3447c4ef77f22c9b13403",
-            "size": 900405493,
-            "uncompressed-sha256": "14a37a346dba5a8b49a36dc3eab369f061086ae57be72260d967f55dc9700435",
+            "path": "rhcos-46.82.202011260640-0-azure.x86_64.vhd.gz",
+            "sha256": "5255c675ecff4f8932db24b68a7ef451dfc4e502326128931ccd39acf27c6c77",
+            "size": 901953565,
+            "uncompressed-sha256": "0fd7ab096c7ac4b8d807371d1c4a13b3a665b5d2938ff814bd3e46257193941b",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202010011740-0-gcp.x86_64.tar.gz",
-            "sha256": "e32127985523d442ad01f21fa5ced3fbac3bbb8c19ecf58dda74eacacf971612",
-            "size": 885597213
+            "path": "rhcos-46.82.202011260640-0-gcp.x86_64.tar.gz",
+            "sha256": "f470a98c1fc7a4e0226ed4258fdd0b6edcddbb2356e7992bea4b98843cd94d9a",
+            "size": 887140241
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202010011740-0-live-initramfs.x86_64.img",
-            "sha256": "ef3fc87f1d6685a3540bf48c570151b30c2d70b75a3d0642e405097e6cdc051f"
+            "path": "rhcos-46.82.202011260640-0-live-initramfs.x86_64.img",
+            "sha256": "8ff220c6f4bbca35dd071c5f1802566290b70081faeb06fb07f72c4583f8facf"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202010011740-0-live.x86_64.iso",
-            "sha256": "67094260aed6f2ceade815c6882fed7b27b628bead50121f066c2bba02e977e1"
+            "path": "rhcos-46.82.202011260640-0-live.x86_64.iso",
+            "sha256": "161046d6275cda89a3f44582bc2b850cd09b987807d3b20090eeab279b7e0550"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202010011740-0-live-kernel-x86_64",
-            "sha256": "e4d0a63c135b37d569ebdec9b8fb9116eccf4e0e0346859b25b2efabd360b8ec"
+            "path": "rhcos-46.82.202011260640-0-live-kernel-x86_64",
+            "sha256": "9bbb496410c04f54d30eb56f76f769bccec7e81b91271ae72261ecc54db9c63d"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202010011740-0-live-rootfs.x86_64.img",
-            "sha256": "79561bda394499b4a1488b7f40c2f28af7d3565fdabe584c6d6ba8c7ae857c23"
+            "path": "rhcos-46.82.202011260640-0-live-rootfs.x86_64.img",
+            "sha256": "007f9c376e1282b77ed662509a3a81b624dfcf28aa971a9e80b33fc06cf9c4fd"
         },
         "metal": {
-            "path": "rhcos-46.82.202010011740-0-metal.x86_64.raw.gz",
-            "sha256": "6c7f1f58df61d366fa9ff12c2fa424480068147a6b05b31e11e61ec95960431d",
-            "size": 887126299,
-            "uncompressed-sha256": "f35b1ae5b71bcf4d1d380195a0a6d4c0963f0c5ed1f2454536f1408e66a35185",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202011260640-0-metal.x86_64.raw.gz",
+            "sha256": "bcd9871c373c02898675ec407e83f9ccd107077ff30008ecb601c9869c4a501a",
+            "size": 888607273,
+            "uncompressed-sha256": "a769991d850064ef078ba4dae9050e34a820bf9eba792a2b7922fb7a15315b57",
+            "uncompressed-size": 3555721216
         },
         "metal4k": {
-            "path": "rhcos-46.82.202010011740-0-metal4k.x86_64.raw.gz",
-            "sha256": "360be1dd39e90011602a6155933f2e9d86afd2153b62fc32a9c27fca85a0fd51",
-            "size": 884961888,
-            "uncompressed-sha256": "24609d1e889fd148576431edaf4cd619f9cb5381d5dc1cfc7a0c7be81c8e1e85",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202011260640-0-metal4k.x86_64.raw.gz",
+            "sha256": "ff4ed9d58a286185abdc4be0faaa4cd621c088121133b9b5952d2da320149fad",
+            "size": 886276538,
+            "uncompressed-sha256": "1e57d643969306e84b945c6355eed2793daa3e7675b0daa63defd6f5f8b5a43d",
+            "uncompressed-size": 3555721216
         },
         "openstack": {
-            "path": "rhcos-46.82.202010011740-0-openstack.x86_64.qcow2.gz",
-            "sha256": "9d88edcacbdf31db9cb9418ee3721c74a3f5bbfc4904db9e383e674a86335bd1",
-            "size": 885915737,
-            "uncompressed-sha256": "95a5c2dafca2dd1a59e5e99dc1b3809c9b925cd94e37acf52e29f7e694ce30ab",
-            "uncompressed-size": 2251489280
+            "path": "rhcos-46.82.202011260640-0-openstack.x86_64.qcow2.gz",
+            "sha256": "a8a28cfe5f5e5dadedb3442afcb447f85bddf2e82dcd558813a985a4d495782a",
+            "size": 887473972,
+            "uncompressed-sha256": "2bd648e09f086973accd8ac1e355ce0fcd7dfcc16bc9708c938801fcf10e219e",
+            "uncompressed-size": 2254045184
         },
         "ostree": {
-            "path": "rhcos-46.82.202010011740-0-ostree.x86_64.tar",
-            "sha256": "5c98466ba5578a8e93744fe332ce3fcd00438a88643eec5f09dc35b7698e9c04",
-            "size": 801597440
+            "path": "rhcos-46.82.202011260640-0-ostree.x86_64.tar",
+            "sha256": "1b15017685292447ebb2dc8bfe8a4f216ea1c42f871f666c65d4b98e9998d549",
+            "size": 802641920
         },
         "qemu": {
-            "path": "rhcos-46.82.202010011740-0-qemu.x86_64.qcow2.gz",
-            "sha256": "f0fcdd7690d4212bad5b94c91308afe51727104ce40febf0708517989c2be4e5",
-            "size": 886664696,
-            "uncompressed-sha256": "cbaf2e5548af2d1d1153d9a1beca118042e770725166de427792c33a875137cc",
-            "uncompressed-size": 2288910336
+            "path": "rhcos-46.82.202011260640-0-qemu.x86_64.qcow2.gz",
+            "sha256": "0ea6f0852c3e0f8e4182e705561fdccd998503ef423c441e182241cd6a278730",
+            "size": 888353176,
+            "uncompressed-sha256": "99928ff40c2d8e3aa358d9bd453102e3d1b5e9694fb5d54febc56e275f35da51",
+            "uncompressed-size": 2290221056
         },
         "vmware": {
-            "path": "rhcos-46.82.202010011740-0-vmware.x86_64.ova",
-            "sha256": "935164c1b85e603a5bea5c50960613a5c24fd43106948abab9213550efcbad95",
-            "size": 918282240
+            "path": "rhcos-46.82.202011260640-0-vmware.x86_64.ova",
+            "sha256": "d73c7bdfd22e5a1231e23663266744c98c10de6f08f6d1fc718e7f72d0490c4a",
+            "size": 919808000
         }
     },
     "oscontainer": {
-        "digest": "sha256:fcac8cf37634553a1d87ed57b77ec1c39b727af06f0e6345d60554b45191dd27",
+        "digest": "sha256:54f1ab852c6592d6ca453cabb855b5c9f5ced35b1aadbb5d8161d4ca2d3623cc",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ce0233ed167e2496ed0806af43984cbd063222ddd8229de8b09741fbce414b81",
-    "ostree-version": "46.82.202010011740-0"
+    "ostree-commit": "cb0327325553e6922ff25822ea7eb1a2ec213e70c7cf6880965e7e2bb5ee7dea",
+    "ostree-version": "46.82.202011260640-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202009240941-0/ppc64le/",
-    "buildid": "46.82.202009240941-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202011260639-0/ppc64le/",
+    "buildid": "46.82.202011260639-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-46.82.202009240941-0-live-initramfs.ppc64le.img",
-            "sha256": "c0a52acf1c883565bff9c1ea8ab2eb9a2789f23124fdd1be78f6d2f624450445"
+            "path": "rhcos-46.82.202011260639-0-live-initramfs.ppc64le.img",
+            "sha256": "a63a99b3183d85d2772031ecb5d472c8f709dd55609a27b3f158938b9d34d798"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202009240941-0-live.ppc64le.iso",
-            "sha256": "90359e206905513694860f0d195af257da3db95b507e83b1f53daa6bfbe9023d"
+            "path": "rhcos-46.82.202011260639-0-live.ppc64le.iso",
+            "sha256": "a1de1afef9d7d624b8b982c5b940ac05dfd50160ea028d71098a72ce02a95310"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202009240941-0-live-kernel-ppc64le",
-            "sha256": "430755e6db588ec04fd5ba56d7973e8622eee90cc8f6d819fefb46926625d19b"
+            "path": "rhcos-46.82.202011260639-0-live-kernel-ppc64le",
+            "sha256": "4f33503357e6847d5ddba97d7f3ee0773cbc1046b4121e15f7233eccade092f7"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202009240941-0-live-rootfs.ppc64le.img",
-            "sha256": "3ec25712a88d1da7e60d2581677b0fde9c6b175c2fa5b6dd9ec43296e5aba2c7"
+            "path": "rhcos-46.82.202011260639-0-live-rootfs.ppc64le.img",
+            "sha256": "ec0af7540cb6d7266424874bd5aec0ac60183f94b3da9e30ad2911492981efcd"
         },
         "metal": {
-            "path": "rhcos-46.82.202009240941-0-metal.ppc64le.raw.gz",
-            "sha256": "20288d82cb5698bae23bea7f364c046a19eb5b3fb1ca618b7a4068d1c36d6eba",
-            "size": 867240759,
-            "uncompressed-sha256": "6156add3bdfdf384d7dddbc431a2a1438f6360f92452bb862ddb229c2a84c06a",
-            "uncompressed-size": 3693084672
+            "path": "rhcos-46.82.202011260639-0-metal.ppc64le.raw.gz",
+            "sha256": "99fc11c699403ccf26610954b27dbbae94a0831a4c39a5c498f808e43cfbdb70",
+            "size": 873495765,
+            "uncompressed-sha256": "e72a39b888c44bd5b7fc276b7a23ae7e8a9facd53abbf59301419dfc4dcd0d46",
+            "uncompressed-size": 3725590528
         },
         "metal4k": {
-            "path": "rhcos-46.82.202009240941-0-metal4k.ppc64le.raw.gz",
-            "sha256": "8f519caa7429ba8d1dcfdf44a7ff4a92665381b07ab2d035ff90318e41b5ab12",
-            "size": 867334091,
-            "uncompressed-sha256": "41924484e1a93c0a47eadc19c860baf52337dd428d90a9147d773b9723ac11df",
-            "uncompressed-size": 3693084672
+            "path": "rhcos-46.82.202011260639-0-metal4k.ppc64le.raw.gz",
+            "sha256": "ce17fd2bc612fee6ea5d99895fc6a3f3aaa2b8a1f7bdc05fddf7e3e1acea3f77",
+            "size": 873975134,
+            "uncompressed-sha256": "a04c711706cc15ee90f5e8143d01e6616e6556e7510d168464e16de7f3f66556",
+            "uncompressed-size": 3725590528
         },
         "openstack": {
-            "path": "rhcos-46.82.202009240941-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "96adcc9d0f01b2748eb8a86868162ec8e844288040a43e44bda11567a0249061",
-            "size": 865739613,
-            "uncompressed-sha256": "daf1c90ed5082c7da490fe666c91c65ffe74c119eac27f78bdf6216e4bb61d2f",
-            "uncompressed-size": 2361982976
+            "path": "rhcos-46.82.202011260639-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "2a7fea1b87a0878363aefc97d0834d6bdf9b80f9ff5696d33bb22938e1102924",
+            "size": 871975342,
+            "uncompressed-sha256": "d4055dee26ddc5ba04fc9e788807238843754f83bb959e0c6bc3ed173b960394",
+            "uncompressed-size": 2387279872
         },
         "ostree": {
-            "path": "rhcos-46.82.202009240941-0-ostree.ppc64le.tar",
-            "sha256": "11c1f85b82a418416706c1a7f7b974590e5b1b746a9727544187d5b34cabd7ef",
-            "size": 776611840
+            "path": "rhcos-46.82.202011260639-0-ostree.ppc64le.tar",
+            "sha256": "2454454574b96b75d2a8aef8b1cad393c79558aa66cc1cee5093688c8b3224e6",
+            "size": 784117760
         },
         "qemu": {
-            "path": "rhcos-46.82.202009240941-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "86be9dea62495d885cc0622f8025aaf56a1af26429bfa27b4ad2169d448a7668",
-            "size": 866267572,
-            "uncompressed-sha256": "ce30ae7d26ce24a04a42831ae18541f97a1cc9eb57f3bf6395a99b78ec60c1dd",
-            "uncompressed-size": 2400714752
+            "path": "rhcos-46.82.202011260639-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "bb9611f2d988088fa6dc1d9082f43b719f16f4c84aad669674ada0a59699c288",
+            "size": 872555277,
+            "uncompressed-sha256": "08879b33ac4d46e04824735e283b549b9f03daae150dffb7fd3265d8c5d2d598",
+            "uncompressed-size": 2424307712
         }
     },
     "oscontainer": {
-        "digest": "sha256:2758233e925dff411d2553ce48babed0e0608a58225455040dc3f0c4710cb08f",
+        "digest": "sha256:af789c7d73b7de9136cc734f05164c692b0b27c738ecedd0f8bd970a182d2848",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "271c5b43ce734e38d75299e7fc1e4d331679942ad4b93a6fb2fc8fe0f34d19bd",
-    "ostree-version": "46.82.202009240941-0"
+    "ostree-commit": "e11b8d8ca1ab07c8428158fce6c14b6adcaf819cf7353e7a17ac99451bdd5dbf",
+    "ostree-version": "46.82.202011260639-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202009241338-0/s390x/",
-    "buildid": "46.82.202009241338-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202011261339-0/s390x/",
+    "buildid": "46.82.202011261339-0",
     "images": {
         "dasd": {
-            "path": "rhcos-46.82.202009241338-0-dasd.s390x.raw.gz",
-            "sha256": "265c05e0ad96ea939172020e030635bc91a29ea5cbdf0164f8e5f0ca19adfe8d",
-            "size": 789084259,
-            "uncompressed-sha256": "71773041b7111719b980ad7c9209f1a5766f642020bcec68b82fb58d5cb0b1fa",
-            "uncompressed-size": 3372220416
+            "path": "rhcos-46.82.202011261339-0-dasd.s390x.raw.gz",
+            "sha256": "6f9b92054667c84dec33dfd724444b74d0e3d241c7e7e2b9583165918114e22d",
+            "size": 788978205,
+            "uncompressed-sha256": "0c6627eb4dbc25cfa16e8ba6ef4975d580e403929a2450b05e69477b97111744",
+            "uncompressed-size": 3370123264
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202009241338-0-live-initramfs.s390x.img",
-            "sha256": "f4e0f654a200dcc61f266be476897374a33d892de20a79efab5f980a866bc814"
+            "path": "rhcos-46.82.202011261339-0-live-initramfs.s390x.img",
+            "sha256": "ca544ccce11a9d43b4478c9e6193faf77c6ed8f9996fb58d110fc3a9ec0db471"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202009241338-0-live.s390x.iso",
-            "sha256": "91a65767ef52f721ad6c20b70de93116341b47ee249233a1b8b64668279efb41"
+            "path": "rhcos-46.82.202011261339-0-live.s390x.iso",
+            "sha256": "75c7ab592f4a64c844f1bb2486586f5baabed7a791341d9def5246ab8363f92f"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202009241338-0-live-kernel-s390x",
-            "sha256": "a843da4b853cc5504e3a3aaee2221e4131efc3cf356e4fa4c440031a73b87b79"
+            "path": "rhcos-46.82.202011261339-0-live-kernel-s390x",
+            "sha256": "54d180071776bb989163897079c2652b0c7106f9c41d7187de4d015204aae8c4"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202009241338-0-live-rootfs.s390x.img",
-            "sha256": "9ea69ce44f68ede52653867af9953ffd5b33f6878abe8375821351fe3a05b12d"
+            "path": "rhcos-46.82.202011261339-0-live-rootfs.s390x.img",
+            "sha256": "7e9bfea2c4f76c51540e49413ff5d79290905c18745561183c736309ede3d6bb"
         },
         "metal": {
-            "path": "rhcos-46.82.202009241338-0-metal.s390x.raw.gz",
-            "sha256": "6c67ce15e8ad94282bedc9490192b19f9c6d7ca38839139c92889e882ae2abdb",
-            "size": 788995446,
-            "uncompressed-sha256": "a12805e2402b2b040a97d6d1453ece4483994d4e82d883524b239bd86c8458b7",
-            "uncompressed-size": 3372220416
+            "path": "rhcos-46.82.202011261339-0-metal.s390x.raw.gz",
+            "sha256": "70a7f86de36e25883a92956de73db8dc68b51e5881804984868eebf103fac0c9",
+            "size": 788865133,
+            "uncompressed-sha256": "b66d9b48b8d92df4da71296f2eb5fec9cee25b3c36e3a066ceb685c16c889b8e",
+            "uncompressed-size": 3370123264
         },
         "metal4k": {
-            "path": "rhcos-46.82.202009241338-0-metal4k.s390x.raw.gz",
-            "sha256": "f0cc6c43eeac9be69c705f7cfbf329192d7d540c87b78631f6d09752a7235612",
-            "size": 789003375,
-            "uncompressed-sha256": "ac5ab167f8bed0fe29e4f3acaeb1437a33af51d86654c98cda01d519f4c3ab28",
-            "uncompressed-size": 3372220416
+            "path": "rhcos-46.82.202011261339-0-metal4k.s390x.raw.gz",
+            "sha256": "38dabda95ea6c5ed25edaf7b3daa1e844ab4eeaab94623ca407b0b03eb97e5f8",
+            "size": 788950764,
+            "uncompressed-sha256": "6acc28b0f1c40cb6ee653534def9267a20f2043c8091c3e94478409a424ebe68",
+            "uncompressed-size": 3370123264
         },
         "openstack": {
-            "path": "rhcos-46.82.202009241338-0-openstack.s390x.qcow2.gz",
-            "sha256": "6a780c5efbb78e987be349dcdaa57858f407c93108ce789ec2b848c75892e598",
-            "size": 787813623,
-            "uncompressed-sha256": "2c7cee4537234b0eba71ebfd2944ceaa5e78fc99a542ba9d6f4eace93136e86d",
+            "path": "rhcos-46.82.202011261339-0-openstack.s390x.qcow2.gz",
+            "sha256": "5877ecaf2fda46399260a6b410dda2493a842c92629666dff0bddd4bba5d4265",
+            "size": 787779116,
+            "uncompressed-sha256": "debc4c4bce89ee388de8ae20ad5f3f6f84a51b60d5341380651c661ee86df597",
             "uncompressed-size": 2084765696
         },
         "ostree": {
-            "path": "rhcos-46.82.202009241338-0-ostree.s390x.tar",
-            "sha256": "fd7763c3ae9180df4f90b75a4e8b42066d084b97d4d93fc1a6c72f87c4219994",
-            "size": 725288960
+            "path": "rhcos-46.82.202011261339-0-ostree.s390x.tar",
+            "sha256": "64bdf909a35f8f039a3cb6df9a2c2ef942f36309f701c143031cb111816c332a",
+            "size": 725104640
         },
         "qemu": {
-            "path": "rhcos-46.82.202009241338-0-qemu.s390x.qcow2.gz",
-            "sha256": "961a4844a435ea99bb846d33bf45fcbd2ff8314d8b0aa0a7f19a84ac4d8d8b5f",
-            "size": 788556212,
-            "uncompressed-sha256": "1c24153899e719b0fe7d3a82c23ce2180df047cab3978941af9fdd02b3a34b6c",
-            "uncompressed-size": 2122121216
+            "path": "rhcos-46.82.202011261339-0-qemu.s390x.qcow2.gz",
+            "sha256": "a487fa710176c5540f94fa145e6dc47c5d554594a84da917d22c35c46d782125",
+            "size": 788427226,
+            "uncompressed-sha256": "4f874dd740fe639c37319d78af6100eaa55023cfab081c1e1db55b65d60a3b0f",
+            "uncompressed-size": 2120679424
         }
     },
     "oscontainer": {
-        "digest": "sha256:a2bb9d33524bb92f5059843ea87bb205d72bf2c23164090852485722682ff8e1",
+        "digest": "sha256:8247d9e6ce2ca2d081df2d7dc53304f69d17cd09e313c8af393bed7704f289a9",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "d89f98fded4b2a9753f72754334ed284599597c1608b076cb6976c7ed532e15b",
-    "ostree-version": "46.82.202009241338-0"
+    "ostree-commit": "6dd3045c4e2fad3cf4d15a43116a522cf7686accbd548839783795b74d6f7cb7",
+    "ostree-version": "46.82.202011261339-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,156 +1,156 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-02f4a2c7b9a3a6840"
+            "hvm": "ami-09921c9c1c36e695c"
         },
         "ap-east-1": {
-            "hvm": "ami-06a0695694b6c3e8d"
+            "hvm": "ami-01ee8446e9af6b197"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0cb46ba6945dbfebe"
+            "hvm": "ami-04e5b5722a55846ea"
         },
         "ap-northeast-2": {
-            "hvm": "ami-01e554d608de6087a"
+            "hvm": "ami-0fdc25c8a0273a742"
         },
         "ap-south-1": {
-            "hvm": "ami-09253ba33f828d47f"
+            "hvm": "ami-09e3deb397cc526a8"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0a6a0f1f6106708c4"
+            "hvm": "ami-0630e03f75e02eec4"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0e3e2b2ea00c35823"
+            "hvm": "ami-069450613262ba03c"
         },
         "ca-central-1": {
-            "hvm": "ami-0f5825ef10c76de32"
+            "hvm": "ami-012518cdbd3057dfd"
         },
         "eu-central-1": {
-            "hvm": "ami-0a51f61236e6fc6f2"
+            "hvm": "ami-0bd7175ff5b1aef0c"
         },
         "eu-north-1": {
-            "hvm": "ami-06d01bfaf14ad66a3"
+            "hvm": "ami-06c9ec42d0a839ad2"
         },
         "eu-south-1": {
-            "hvm": "ami-031c7e2567f507746"
+            "hvm": "ami-0614d7440a0363d71"
         },
         "eu-west-1": {
-            "hvm": "ami-0e514a30ad261c978"
+            "hvm": "ami-01b89df58b5d4d5fa"
         },
         "eu-west-2": {
-            "hvm": "ami-0291fd4543d6940f4"
+            "hvm": "ami-06f6e31ddd554f89d"
         },
         "eu-west-3": {
-            "hvm": "ami-083f281d2864a71de"
+            "hvm": "ami-0dc82e2517ded15a1"
         },
         "me-south-1": {
-            "hvm": "ami-05a6ae5eadb5b244d"
+            "hvm": "ami-07d181e3aa0f76067"
         },
         "sa-east-1": {
-            "hvm": "ami-081f13881a31af160"
+            "hvm": "ami-0cd44e6dd20e6c7fa"
         },
         "us-east-1": {
-            "hvm": "ami-009cbe327d180d666"
+            "hvm": "ami-04a16d506e5b0e246"
         },
         "us-east-2": {
-            "hvm": "ami-0346f64579665ce3c"
+            "hvm": "ami-0a1f868ad58ea59a7"
         },
         "us-west-1": {
-            "hvm": "ami-07c185c787029b522"
+            "hvm": "ami-0a65d76e3a6f6622f"
         },
         "us-west-2": {
-            "hvm": "ami-01105d480bb47353f"
+            "hvm": "ami-0dd9008abadc519f1"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202010011740-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202010011740-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202011260640-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202011260640-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202010011740-0/x86_64/",
-    "buildid": "46.82.202010011740-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202011260640-0/x86_64/",
+    "buildid": "46.82.202011260640-0",
     "gcp": {
-        "image": "rhcos-46-82-202010011740-0-gcp-x86-64",
+        "image": "rhcos-46-82-202011260640-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202010011740-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202011260640-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202010011740-0-aws.x86_64.vmdk.gz",
-            "sha256": "21fbefcbb3e1ca9c479e49ba45700026c636ee48f1d1c84a84dabaff2d944f87",
-            "size": 899198828,
-            "uncompressed-sha256": "3af7a3ba4d3963f5e4368cadef9bfe8c1e005218ab42d65b226db17a8bd0f4c8",
-            "uncompressed-size": 918272000
+            "path": "rhcos-46.82.202011260640-0-aws.x86_64.vmdk.gz",
+            "sha256": "6e0f720077ac20fae46c16159d03fd51f66cd318155dcd14f0f5d7dc79bfd8ad",
+            "size": 900764628,
+            "uncompressed-sha256": "b38713b80bbcc41d18efcec93d241da48533225e0ce073c2a26235993ffc4166",
+            "uncompressed-size": 919795200
         },
         "azure": {
-            "path": "rhcos-46.82.202010011740-0-azure.x86_64.vhd.gz",
-            "sha256": "c6f233a04aacf9c17602e58a52aaa5f315cbc61254d3447c4ef77f22c9b13403",
-            "size": 900405493,
-            "uncompressed-sha256": "14a37a346dba5a8b49a36dc3eab369f061086ae57be72260d967f55dc9700435",
+            "path": "rhcos-46.82.202011260640-0-azure.x86_64.vhd.gz",
+            "sha256": "5255c675ecff4f8932db24b68a7ef451dfc4e502326128931ccd39acf27c6c77",
+            "size": 901953565,
+            "uncompressed-sha256": "0fd7ab096c7ac4b8d807371d1c4a13b3a665b5d2938ff814bd3e46257193941b",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202010011740-0-gcp.x86_64.tar.gz",
-            "sha256": "e32127985523d442ad01f21fa5ced3fbac3bbb8c19ecf58dda74eacacf971612",
-            "size": 885597213
+            "path": "rhcos-46.82.202011260640-0-gcp.x86_64.tar.gz",
+            "sha256": "f470a98c1fc7a4e0226ed4258fdd0b6edcddbb2356e7992bea4b98843cd94d9a",
+            "size": 887140241
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202010011740-0-live-initramfs.x86_64.img",
-            "sha256": "ef3fc87f1d6685a3540bf48c570151b30c2d70b75a3d0642e405097e6cdc051f"
+            "path": "rhcos-46.82.202011260640-0-live-initramfs.x86_64.img",
+            "sha256": "8ff220c6f4bbca35dd071c5f1802566290b70081faeb06fb07f72c4583f8facf"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202010011740-0-live.x86_64.iso",
-            "sha256": "67094260aed6f2ceade815c6882fed7b27b628bead50121f066c2bba02e977e1"
+            "path": "rhcos-46.82.202011260640-0-live.x86_64.iso",
+            "sha256": "161046d6275cda89a3f44582bc2b850cd09b987807d3b20090eeab279b7e0550"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202010011740-0-live-kernel-x86_64",
-            "sha256": "e4d0a63c135b37d569ebdec9b8fb9116eccf4e0e0346859b25b2efabd360b8ec"
+            "path": "rhcos-46.82.202011260640-0-live-kernel-x86_64",
+            "sha256": "9bbb496410c04f54d30eb56f76f769bccec7e81b91271ae72261ecc54db9c63d"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202010011740-0-live-rootfs.x86_64.img",
-            "sha256": "79561bda394499b4a1488b7f40c2f28af7d3565fdabe584c6d6ba8c7ae857c23"
+            "path": "rhcos-46.82.202011260640-0-live-rootfs.x86_64.img",
+            "sha256": "007f9c376e1282b77ed662509a3a81b624dfcf28aa971a9e80b33fc06cf9c4fd"
         },
         "metal": {
-            "path": "rhcos-46.82.202010011740-0-metal.x86_64.raw.gz",
-            "sha256": "6c7f1f58df61d366fa9ff12c2fa424480068147a6b05b31e11e61ec95960431d",
-            "size": 887126299,
-            "uncompressed-sha256": "f35b1ae5b71bcf4d1d380195a0a6d4c0963f0c5ed1f2454536f1408e66a35185",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202011260640-0-metal.x86_64.raw.gz",
+            "sha256": "bcd9871c373c02898675ec407e83f9ccd107077ff30008ecb601c9869c4a501a",
+            "size": 888607273,
+            "uncompressed-sha256": "a769991d850064ef078ba4dae9050e34a820bf9eba792a2b7922fb7a15315b57",
+            "uncompressed-size": 3555721216
         },
         "metal4k": {
-            "path": "rhcos-46.82.202010011740-0-metal4k.x86_64.raw.gz",
-            "sha256": "360be1dd39e90011602a6155933f2e9d86afd2153b62fc32a9c27fca85a0fd51",
-            "size": 884961888,
-            "uncompressed-sha256": "24609d1e889fd148576431edaf4cd619f9cb5381d5dc1cfc7a0c7be81c8e1e85",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202011260640-0-metal4k.x86_64.raw.gz",
+            "sha256": "ff4ed9d58a286185abdc4be0faaa4cd621c088121133b9b5952d2da320149fad",
+            "size": 886276538,
+            "uncompressed-sha256": "1e57d643969306e84b945c6355eed2793daa3e7675b0daa63defd6f5f8b5a43d",
+            "uncompressed-size": 3555721216
         },
         "openstack": {
-            "path": "rhcos-46.82.202010011740-0-openstack.x86_64.qcow2.gz",
-            "sha256": "9d88edcacbdf31db9cb9418ee3721c74a3f5bbfc4904db9e383e674a86335bd1",
-            "size": 885915737,
-            "uncompressed-sha256": "95a5c2dafca2dd1a59e5e99dc1b3809c9b925cd94e37acf52e29f7e694ce30ab",
-            "uncompressed-size": 2251489280
+            "path": "rhcos-46.82.202011260640-0-openstack.x86_64.qcow2.gz",
+            "sha256": "a8a28cfe5f5e5dadedb3442afcb447f85bddf2e82dcd558813a985a4d495782a",
+            "size": 887473972,
+            "uncompressed-sha256": "2bd648e09f086973accd8ac1e355ce0fcd7dfcc16bc9708c938801fcf10e219e",
+            "uncompressed-size": 2254045184
         },
         "ostree": {
-            "path": "rhcos-46.82.202010011740-0-ostree.x86_64.tar",
-            "sha256": "5c98466ba5578a8e93744fe332ce3fcd00438a88643eec5f09dc35b7698e9c04",
-            "size": 801597440
+            "path": "rhcos-46.82.202011260640-0-ostree.x86_64.tar",
+            "sha256": "1b15017685292447ebb2dc8bfe8a4f216ea1c42f871f666c65d4b98e9998d549",
+            "size": 802641920
         },
         "qemu": {
-            "path": "rhcos-46.82.202010011740-0-qemu.x86_64.qcow2.gz",
-            "sha256": "f0fcdd7690d4212bad5b94c91308afe51727104ce40febf0708517989c2be4e5",
-            "size": 886664696,
-            "uncompressed-sha256": "cbaf2e5548af2d1d1153d9a1beca118042e770725166de427792c33a875137cc",
-            "uncompressed-size": 2288910336
+            "path": "rhcos-46.82.202011260640-0-qemu.x86_64.qcow2.gz",
+            "sha256": "0ea6f0852c3e0f8e4182e705561fdccd998503ef423c441e182241cd6a278730",
+            "size": 888353176,
+            "uncompressed-sha256": "99928ff40c2d8e3aa358d9bd453102e3d1b5e9694fb5d54febc56e275f35da51",
+            "uncompressed-size": 2290221056
         },
         "vmware": {
-            "path": "rhcos-46.82.202010011740-0-vmware.x86_64.ova",
-            "sha256": "935164c1b85e603a5bea5c50960613a5c24fd43106948abab9213550efcbad95",
-            "size": 918282240
+            "path": "rhcos-46.82.202011260640-0-vmware.x86_64.ova",
+            "sha256": "d73c7bdfd22e5a1231e23663266744c98c10de6f08f6d1fc718e7f72d0490c4a",
+            "size": 919808000
         }
     },
     "oscontainer": {
-        "digest": "sha256:fcac8cf37634553a1d87ed57b77ec1c39b727af06f0e6345d60554b45191dd27",
+        "digest": "sha256:54f1ab852c6592d6ca453cabb855b5c9f5ced35b1aadbb5d8161d4ca2d3623cc",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ce0233ed167e2496ed0806af43984cbd063222ddd8229de8b09741fbce414b81",
-    "ostree-version": "46.82.202010011740-0"
+    "ostree-commit": "cb0327325553e6922ff25822ea7eb1a2ec213e70c7cf6880965e7e2bb5ee7dea",
+    "ostree-version": "46.82.202011260640-0"
 }


### PR DESCRIPTION
This includes fixes for the following bugs:
- https://bugzilla.redhat.com/show_bug.cgi?id=1899289
- https://bugzilla.redhat.com/show_bug.cgi?id=1899361
- https://bugzilla.redhat.com/show_bug.cgi?id=1899286
- https://bugzilla.redhat.com/show_bug.cgi?id=1901021

```
$ ./differ.py --first-endpoint art --first-release [rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0 \
              --second-endpoint art --second-release [rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0
{
    "sources": {
        "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.6/46.82.202010011740-0/x86_64/commitmeta.json",
        "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "https://releases-rhcos-art.cloud.privileged.psi.redhat.com/storage/releases/rhcos-4.6/46.82.202011260640-0/x86_64/commitmeta.json"
    },
    "diff": {
        "NetworkManager": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "NetworkManager-1.22.8-6.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "NetworkManager-1.22.8-7.el8_2.x86_64"
        },
        "NetworkManager-libnm": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "NetworkManager-libnm-1.22.8-6.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "NetworkManager-libnm-1.22.8-7.el8_2.x86_64"
        },
        "NetworkManager-ovs": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "NetworkManager-ovs-1.22.8-6.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "NetworkManager-ovs-1.22.8-7.el8_2.x86_64"
        },
        "NetworkManager-team": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "NetworkManager-team-1.22.8-6.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "NetworkManager-team-1.22.8-7.el8_2.x86_64"
        },
        "NetworkManager-tui": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "NetworkManager-tui-1.22.8-6.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "NetworkManager-tui-1.22.8-7.el8_2.x86_64"
        },
        "console-login-helper-messages": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "console-login-helper-messages-0.19-1.rhaos4.6.el8.noarch",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "console-login-helper-messages-0.19-3.rhaos4.6.el8.noarch"
        },
        "console-login-helper-messages-issuegen": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "console-login-helper-messages-issuegen-0.19-1.rhaos4.6.el8.noarch",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "console-login-helper-messages-issuegen-0.19-3.rhaos4.6.el8.noarch"
        },
        "console-login-helper-messages-profile": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "console-login-helper-messages-profile-0.19-1.rhaos4.6.el8.noarch",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "console-login-helper-messages-profile-0.19-3.rhaos4.6.el8.noarch"
        },
        "cri-o": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "cri-o-1.19.0-19.rhaos4.6.gitda1d894.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "cri-o-1.19.0-25.rhaos4.6.gitf51f94a.el8.x86_64"
        },
        "cri-tools": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "cri-tools-1.18.0-3.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "cri-tools-1.19.0-4.el8.x86_64"
        },
        "criu": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "criu-3.14-2.module+el8.2.1+6750+e53a300c.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "criu-3.12-9.module+el8.2.0+7659+b700d80e.x86_64"
        },
        "freetype": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "freetype-2.9.1-4.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "freetype-2.9.1-4.el8_2.1.x86_64"
        },
        "fuse-overlayfs": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "fuse-overlayfs-1.0.0-2.module+el8.2.1+6465+1a51e8b6.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "fuse-overlayfs-0.7.2-5.module+el8.2.0+7659+b700d80e.x86_64"
        },
        "glusterfs": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "glusterfs-6.0-37.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "glusterfs-6.0-20.el8.x86_64"
        },
        "glusterfs-client-xlators": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "glusterfs-client-xlators-6.0-37.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "glusterfs-client-xlators-6.0-20.el8.x86_64"
        },
        "glusterfs-fuse": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "glusterfs-fuse-6.0-37.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "glusterfs-fuse-6.0-20.el8.x86_64"
        },
        "glusterfs-libs": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "glusterfs-libs-6.0-37.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "glusterfs-libs-6.0-20.el8.x86_64"
        },
        "grub2-common": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "grub2-common-2.02-87.el8_2.noarch",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "grub2-common-2.02-87.el8_2.2.noarch"
        },
        "grub2-efi-x64": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "grub2-efi-x64-2.02-87.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "grub2-efi-x64-2.02-87.el8_2.2.x86_64"
        },
        "grub2-pc": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "grub2-pc-2.02-87.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "grub2-pc-2.02-87.el8_2.2.x86_64"
        },
        "grub2-pc-modules": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "grub2-pc-[modules-2](https://issues.redhat.com/browse/modules-2).02-87.el8_2.noarch",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "grub2-pc-[modules-2](https://issues.redhat.com/browse/modules-2).02-87.el8_2.2.noarch"
        },
        "grub2-tools": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "grub2-tools-2.02-87.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "grub2-tools-2.02-87.el8_2.2.x86_64"
        },
        "grub2-tools-extra": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "grub2-tools-extra-2.02-87.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "grub2-tools-extra-2.02-87.el8_2.2.x86_64"
        },
        "grub2-tools-minimal": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "grub2-tools-minimal-2.02-87.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "grub2-tools-minimal-2.02-87.el8_2.2.x86_64"
        },
        "ignition": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "ignition-2.6.0-5.rhaos4.6.git947598e.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "ignition-2.6.0-6.rhaos4.6.git947598e.el8.x86_64"
        },
        "iptables": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "iptables-1.8.4-10.el8_2.1.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "iptables-1.8.4-10.el8_2.4.x86_64"
        },
        "iptables-libs": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "iptables-libs-1.8.4-10.el8_2.1.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "iptables-libs-1.8.4-10.el8_2.4.x86_64"
        },
        "kernel": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "kernel-4.18.0-193.24.1.el8_2.dt1.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "kernel-4.18.0-193.29.1.el8_2.x86_64"
        },
        "kernel-core": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "kernel-core-4.18.0-193.24.1.el8_2.dt1.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "kernel-core-4.18.0-193.29.1.el8_2.x86_64"
        },
        "kernel-modules": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "kernel-[modules-4](https://issues.redhat.com/browse/modules-4).18.0-193.24.1.el8_2.dt1.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "kernel-[modules-4](https://issues.redhat.com/browse/modules-4).18.0-193.29.1.el8_2.x86_64"
        },
        "kernel-modules-extra": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "kernel-modules-extra-4.18.0-193.24.1.el8_2.dt1.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "kernel-modules-extra-4.18.0-193.29.1.el8_2.x86_64"
        },
        "libslirp": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "libslirp-4.3.0-3.module+el8.2.1+6816+bedf4f91.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "Not present"
        },
        "microcode_ctl": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "microcode_ctl-20191115-4.20200609.1.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "microcode_ctl-20191115-4.20201112.1.el8_2.x86_64"
        },
        "nftables": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "nftables-0.9.3-12.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "nftables-0.9.3-12.el8_2.1.x86_64"
        },
        "open-vm-tools": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "open-vm-tools-11.0.5-3.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "open-vm-tools-11.0.0-4.el8.x86_64"
        },
        "openshift-clients": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "openshift-clients-4.6.0-202009302026.p0.git.3788.4b35f95.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "openshift-clients-4.6.0-202011260456.p0.git.3798.fcf58ff.el8.x86_64"
        },
        "openshift-hyperkube": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "openshift-hyperkube-4.6.0-202009292315.p0.git.94026.088ba37.el8.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "openshift-hyperkube-4.6.0-202011260456.p0.git.94222.2edb87d.el8.x86_64"
        },
        "openvswitch2.13": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "openvswitch2.13-2.13.0-57.el8fdp.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "openvswitch2.13-2.13.0-71.el8fdp.x86_64"
        },
        "selinux-policy": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "selinux-policy-3.14.3-41.el8_2.6.noarch",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "selinux-policy-3.14.3-41.el8_2.8.noarch"
        },
        "selinux-policy-targeted": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "selinux-policy-targeted-3.14.3-41.el8_2.6.noarch",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "selinux-policy-targeted-3.14.3-41.el8_2.8.noarch"
        },
        "shim-x64": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "shim-x64-15-15.el8_2.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "shim-x64-15-16.el8.x86_64"
        },
        "slirp4netns": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "slirp4netns-1.0.1-1.module+el8.2.1+6595+03641d72.x86_64",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "slirp4netns-0.4.2-3.git21fdece.module+el8.2.0+7659+b700d80e.x86_64"
        },
        "tzdata": {
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202010011740-0": "tzdata-2020a-1.el8.noarch",
            "[rhcos-4](https://issues.redhat.com/browse/rhcos-4).6/46.82.202011260640-0": "tzdata-2020d-1.el8.noarch"
        }
    }
}
```