### PR TITLE
baremetal: send full ignition to masters

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -26,11 +26,13 @@ module "bootstrap" {
 module "masters" {
   source = "./masters"
 
-  master_count   = var.master_count
-  ignition       = var.ignition_master
-  hosts          = var.hosts
-  properties     = var.properties
-  root_devices   = var.root_devices
-  driver_infos   = var.driver_infos
-  instance_infos = var.instance_infos
+  master_count                = var.master_count
+  hosts                       = var.hosts
+  properties                  = var.properties
+  root_devices                = var.root_devices
+  driver_infos                = var.driver_infos
+  instance_infos              = var.instance_infos
+  master_ignition_url         = var.master_ignition_url
+  master_ignition_url_ca_cert = var.master_ignition_url_ca_cert
+  master_ignition_url_headers = var.master_ignition_url_headers
 }

--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -42,8 +42,10 @@ resource "ironic_deployment" "openshift-master-deployment" {
     count.index,
   )
 
-  instance_info = var.instance_infos[count.index]
-  user_data     = var.ignition
+  instance_info         = var.instance_infos[count.index]
+  user_data_url         = var.master_ignition_url
+  user_data_url_ca_cert = var.master_ignition_url_ca_cert
+  user_data_url_headers = var.master_ignition_url_headers
 }
 
 data "ironic_introspection" "openshift-master-introspection" {

--- a/data/data/baremetal/masters/variables.tf
+++ b/data/data/baremetal/masters/variables.tf
@@ -4,11 +4,6 @@ variable "master_count" {
   default     = 3
 }
 
-variable "ignition" {
-  type        = string
-  description = "The content of the master ignition file"
-}
-
 variable "hosts" {
   type        = list(map(string))
   description = "Hardware details for hosts"
@@ -32,4 +27,19 @@ variable "driver_infos" {
 variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
+}
+
+variable "master_ignition_url" {
+  type        = string
+  description = "The URL of the full ignition"
+}
+
+variable "master_ignition_url_ca_cert" {
+  type        = string
+  description = "Root CA cert of the full ignition URL"
+}
+
+variable "master_ignition_url_headers" {
+  type        = map(string)
+  description = "Headers to use when retrieving master_ignition_url"
 }

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -52,3 +52,18 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
+
+variable "master_ignition_url" {
+  type        = string
+  description = "The URL of the full ignition"
+}
+
+variable "master_ignition_url_ca_cert" {
+  type        = string
+  description = "Root CA cert of the full ignition URL"
+}
+
+variable "master_ignition_url_headers" {
+  type        = map(string)
+  description = "Headers to pass when retrieving master_ignition_url"
+}

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/metal3-io/baremetal-operator v0.0.0
 	github.com/metal3-io/cluster-api-provider-baremetal v0.0.0
 	github.com/mitchellh/cli v1.1.1
-	github.com/openshift-metal3/terraform-provider-ironic v0.2.3
+	github.com/openshift-metal3/terraform-provider-ironic v0.2.4
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c
 	github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e

--- a/go.sum
+++ b/go.sum
@@ -1396,6 +1396,8 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/openshift-metal3/terraform-provider-ironic v0.2.3 h1:16pF9y0RN+8jz9h4EUBz5Uv1dhUTPcHrTKz4nzQdd3Q=
 github.com/openshift-metal3/terraform-provider-ironic v0.2.3/go.mod h1:ux2W6gsCIYsY/fX5N0V0ZgwFEBNN7P8g6RlH6ACi97k=
+github.com/openshift-metal3/terraform-provider-ironic v0.2.4 h1:AThAHxSvN18rdK3PqWJS73gMpOvjPka60LRu3IkIiR8=
+github.com/openshift-metal3/terraform-provider-ironic v0.2.4/go.mod h1:ux2W6gsCIYsY/fX5N0V0ZgwFEBNN7P8g6RlH6ACi97k=
 github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422 h1:tgKcQVgHscJFBji1uLH5KjA81fGxNQkom5lETA5VURs=
 github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422/go.mod h1:l6TGeqJ92DrZBuWMNKcot1iZUHfbYSJyBWHGgg6Dn6s=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe h1:bu99IMkaN6o/JcxpWEb1eT8gDdL9hLcwOmfiVIbXWj8=

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -442,6 +442,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			string(*rhcosImage),
 			ironicCreds.Username,
 			ironicCreds.Password,
+			masterIgn,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -9,6 +9,8 @@ import (
 	"path"
 	"strings"
 
+	igntypes "github.com/coreos/ignition/v2/config/v3_1/types"
+
 	"github.com/metal3-io/baremetal-operator/pkg/bmc"
 	"github.com/metal3-io/baremetal-operator/pkg/hardware"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
@@ -25,6 +27,10 @@ type config struct {
 	IronicUsername string `json:"ironic_username"`
 	IronicPassword string `json:"ironic_password"`
 
+	MasterIgnitionURL        string            `json:"master_ignition_url,omitempty"`
+	MasterIgnitionURLCACert  string            `json:"master_ignition_url_ca_cert,omitempty"`
+	MasterIgnitionURLHeaders map[string]string `json:"master_ignition_url_headers,omitempty"`
+
 	// Data required for control plane deployment - several maps per host, because of terraform's limitations
 	Hosts         []map[string]interface{} `json:"hosts"`
 	RootDevices   []map[string]interface{} `json:"root_devices"`
@@ -34,7 +40,7 @@ type config struct {
 }
 
 // TFVars generates bare metal specific Terraform variables.
-func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridge, externalMAC, provisioningBridge, provisioningMAC string, platformHosts []*baremetal.Host, image, ironicUsername, ironicPassword string) ([]byte, error) {
+func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridge, externalMAC, provisioningBridge, provisioningMAC string, platformHosts []*baremetal.Host, image, ironicUsername, ironicPassword, ignition string) ([]byte, error) {
 	bootstrapOSImage, err := cache.DownloadImageFile(bootstrapOSImage)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to use cached bootstrap libvirt image")
@@ -156,18 +162,43 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 			})
 	}
 
+	var masterIgn igntypes.Config
+	if err := json.Unmarshal([]byte(ignition), &masterIgn); err != nil {
+		return nil, err
+	}
+	if len(masterIgn.Ignition.Config.Merge) == 0 {
+		return nil, errors.Wrap(err, "Empty Merge section in master pointer ignition")
+	}
+	ignitionURL := *masterIgn.Ignition.Config.Merge[0].Source
+	if len(masterIgn.Ignition.Security.TLS.CertificateAuthorities) == 0 {
+		return nil, errors.Wrap(err, "Empty CertificateAuthorities section in master pointer ignition")
+	}
+	ignitionURLCACert := strings.TrimPrefix(
+		*masterIgn.Ignition.Security.TLS.CertificateAuthorities[0].Source,
+		"data:text/plain;charset=utf-8;base64,")
+	// To return the same version as the stub config, the MCS requires a
+	// header, otherwise we get 2.2.0, e.g:
+	// "Accept: application/vnd.coreos.ignition+json; version=3.1.0"
+	ignitionURLHeaders := map[string]string{
+		"Accept": fmt.Sprintf("application/vnd.coreos.ignition+json;version=%s",
+			masterIgn.Ignition.Version),
+	}
+
 	cfg := &config{
-		LibvirtURI:              libvirtURI,
-		BootstrapProvisioningIP: bootstrapProvisioningIP,
-		BootstrapOSImage:        bootstrapOSImage,
-		IronicUsername:          ironicUsername,
-		IronicPassword:          ironicPassword,
-		Hosts:                   hosts,
-		Bridges:                 bridges,
-		Properties:              properties,
-		DriverInfos:             driverInfos,
-		RootDevices:             rootDevices,
-		InstanceInfos:           instanceInfos,
+		LibvirtURI:               libvirtURI,
+		BootstrapProvisioningIP:  bootstrapProvisioningIP,
+		BootstrapOSImage:         bootstrapOSImage,
+		IronicUsername:           ironicUsername,
+		IronicPassword:           ironicPassword,
+		Hosts:                    hosts,
+		Bridges:                  bridges,
+		Properties:               properties,
+		DriverInfos:              driverInfos,
+		RootDevices:              rootDevices,
+		InstanceInfos:            instanceInfos,
+		MasterIgnitionURL:        ignitionURL,
+		MasterIgnitionURLCACert:  ignitionURLCACert,
+		MasterIgnitionURLHeaders: ignitionURLHeaders,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_deployment.go
+++ b/vendor/github.com/openshift-metal3/terraform-provider-ironic/ironic/resource_ironic_deployment.go
@@ -53,6 +53,11 @@ func resourceDeployment() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"user_data_url_headers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 			"network_data": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -105,9 +110,13 @@ func resourceDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
 	userData := d.Get("user_data").(string)
 	userDataURL := d.Get("user_data_url").(string)
 	userDataCaCert := d.Get("user_data_url_ca_cert").(string)
+	userDataHeaders := d.Get("user_data_url_headers").(map[string]interface{})
 
 	// if user_data_url is specified in addition to user_data, use the former
-	ignitionData := fetchFullIgnition(userDataURL, userDataCaCert)
+	ignitionData, err := fetchFullIgnition(userDataURL, userDataCaCert, userDataHeaders)
+	if err != nil {
+		return fmt.Errorf("could not fetch data from user_data_url: %s", err)
+	}
 	if ignitionData != "" {
 		userData = ignitionData
 	}
@@ -125,7 +134,7 @@ func resourceDeploymentCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 // fetchFullIgnition gets full igntion from the URL and cert passed to it and returns userdata as a string
-func fetchFullIgnition(userDataURL string, userDataCaCert string) string {
+func fetchFullIgnition(userDataURL string, userDataCaCert string, userDataHeaders map[string]interface{}) (string, error) {
 	// Send full ignition, if the URL is specified
 	if userDataURL != "" {
 		caCertPool := x509.NewCertPool()
@@ -135,7 +144,7 @@ func fetchFullIgnition(userDataURL string, userDataCaCert string) string {
 			caCert, err := base64.StdEncoding.DecodeString(userDataCaCert)
 			if err != nil {
 				log.Printf("could not decode user_data_url_ca_cert: %s", err)
-				return ""
+				return "", err
 			}
 			caCertPool.AppendCertsFromPEM(caCert)
 
@@ -149,21 +158,31 @@ func fetchFullIgnition(userDataURL string, userDataCaCert string) string {
 		client.HTTPClient.Transport = transport
 
 		// Get the data
-		resp, err := client.Get(userDataURL)
+		req, err := retryablehttp.NewRequest("GET", userDataURL, nil)
 		if err != nil {
 			log.Printf("could not get user_data_url: %s", err)
-			return ""
+			return "", err
+		}
+		if userDataHeaders != nil {
+			for k, v := range userDataHeaders {
+				req.Header.Add(k, v.(string))
+			}
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			log.Printf("could not get user_data_url: %s", err)
+			return "", err
 		}
 		defer resp.Body.Close()
 		var userData []byte
 		userData, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("could not read user_data_url: %s", err)
-			return ""
+			return "", err
 		}
-		return string(userData)
+		return string(userData), nil
 	}
-	return ""
+	return "", nil
 }
 
 // buildConfigDrive handles building a config drive appropriate for the Ironic version we are using.  Newer versions

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1005,7 +1005,7 @@ github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/openshift-metal3/terraform-provider-ironic v0.2.3
+# github.com/openshift-metal3/terraform-provider-ironic v0.2.4
 ## explicit
 github.com/openshift-metal3/terraform-provider-ironic/ironic
 # github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible => github.com/openshift/api v0.0.0-20200601094953-95abe2d2f422


### PR DESCRIPTION
This restores the work which was previously done via #3276 but then reverted via #3589 due to breaking users who customized the pointer ignition config in IPI deployments.

A solution to that has been proposed via https://github.com/openshift/installer/pull/4413 which this PR depends on, so when that lands this work can safely be restored, see openshift/enhancements#540 for more details.

Note that some additional changes beyond the initial implementation were required due to the MCO now supporting multiple
ignition versions, thus this PR depends on https://github.com/openshift-metal3/terraform-provider-ironic/pull/46 which will need to land and be vendored here before the PR merges.

This replaces https://github.com/openshift/installer/pull/4359