### PR TITLE
baremetal: make cluster provisioning IP optional

### DIFF
--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -413,11 +413,11 @@ func TestValidateProvisioning(t *testing.T) {
 				BootstrapProvisioningIP("192.168.111.3").build(),
 		},
 		{
-			name:   "valid_provisioningDisabled_no_boostrap_ip",
+			name:   "valid_provisioningDisabled_no_provisioning_ips",
 			config: installConfig().Network(networking().Network("192.168.111.0/24")).build(),
 			platform: platform().
 				ProvisioningNetwork(baremetal.DisabledProvisioningNetwork).
-				ClusterProvisioningIP("192.168.111.2").
+				ClusterProvisioningIP("").
 				BootstrapProvisioningIP("").build(),
 		},
 		{


### PR DESCRIPTION
This makes the cluster provisioning IP optional when the provisioning
network is disabled. If no provisioning IP is provided, then we use
the host IP of the node we're running on.

This is dependent on the work in https://github.com/openshift/cluster-baremetal-operator/pull/73
and https://github.com/openshift/cluster-baremetal-operator/pull/76