### PR TITLE
openstack: check quotas before creating cluster

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -72,6 +72,8 @@ For a successful installation it is required:
 - Depending on the type of [image registry backend](#image-registry-requirements) either 1 Swift container or an additional 100 GB volume.
 - OpenStack resource tagging
 
+**NOTE:** The installer will check OpenStack quota limits to make sure that the requested resources can be created. Note that it won't check for resource availability in the cloud, but only on the quotas.
+
 You may need to increase the security group related quotas from their default values. For example (as an OpenStack administrator):
 
 ```sh

--- a/pkg/asset/quota/openstack/OWNERS
+++ b/pkg/asset/quota/openstack/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers
+reviewers:
+  - openstack-reviewers

--- a/pkg/asset/quota/openstack/openstack.go
+++ b/pkg/asset/quota/openstack/openstack.go
@@ -1,0 +1,86 @@
+package openstack
+
+import (
+	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	"github.com/openshift/installer/pkg/asset/installconfig/openstack/validation"
+	"github.com/openshift/installer/pkg/quota"
+	openstackprovider "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
+)
+
+// Constraints returns a list of quota constraints based on the InstallConfig.
+// These constraints can be used to check if there is enough quota for creating a cluster
+// for the install config.
+func Constraints(ci *validation.CloudInfo, controlPlanes []machineapi.Machine, computes []machineapi.MachineSet) []quota.Constraint {
+	ctrplConfigs := make([]*openstackprovider.OpenstackProviderSpec, len(controlPlanes))
+	for i, m := range controlPlanes {
+		ctrplConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec)
+	}
+	computeReplicas := make([]int64, len(computes))
+	computeConfigs := make([]*openstackprovider.OpenstackProviderSpec, len(computes))
+	for i, m := range computes {
+		computeReplicas[i] = int64(*m.Spec.Replicas)
+		computeConfigs[i] = m.Spec.Template.Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec)
+	}
+
+	var ret []quota.Constraint
+	ret = controlPlane(ci, ctrplConfigs)
+	ret = append(ret, compute(ci, computeReplicas, computeConfigs)...)
+	return aggregate(ret)
+}
+
+func controlPlane(ci *validation.CloudInfo, machines []*openstackprovider.OpenstackProviderSpec) []quota.Constraint {
+	var ret []quota.Constraint
+	for _, m := range machines {
+		flavorInfo := ci.Flavors[m.Flavor]
+		ret = append(ret, machineFlavorCoresToQuota(flavorInfo, ci), machineFlavorRAMToQuota(flavorInfo, ci))
+	}
+	ret = append(ret, instanceConstraint(int64(len(machines))))
+	return ret
+}
+
+func compute(ci *validation.CloudInfo, replicas []int64, machines []*openstackprovider.OpenstackProviderSpec) []quota.Constraint {
+	var ret []quota.Constraint
+	for idx, m := range machines {
+		flavorInfo := ci.Flavors[m.Flavor]
+		coresConstraint := machineFlavorCoresToQuota(flavorInfo, ci)
+		coresConstraint.Count = coresConstraint.Count * replicas[idx]
+		ramConstraint := machineFlavorRAMToQuota(flavorInfo, ci)
+		ramConstraint.Count = ramConstraint.Count * replicas[idx]
+		ret = append(ret, instanceConstraint(int64(replicas[idx])), coresConstraint, ramConstraint)
+	}
+	return ret
+}
+
+func aggregate(quotas []quota.Constraint) []quota.Constraint {
+	counts := map[string]int64{}
+	for _, q := range quotas {
+		counts[q.Name] = counts[q.Name] + q.Count
+	}
+	aggregatedQuotas := make([]quota.Constraint, 0, len(counts))
+	for n, c := range counts {
+		aggregatedQuotas = append(aggregatedQuotas, quota.Constraint{Name: n, Count: c})
+	}
+	return aggregatedQuotas
+}
+
+//constraintGenerator generates a list of constraints.
+type constraintGenerator func() []quota.Constraint
+
+func machineFlavorCoresToQuota(f validation.Flavor, ci *validation.CloudInfo) quota.Constraint {
+	return generateConstraint("Cores", int64(f.VCPUs))
+}
+
+func machineFlavorRAMToQuota(f validation.Flavor, ci *validation.CloudInfo) quota.Constraint {
+	return generateConstraint("RAM", int64(f.RAM))
+}
+
+func instanceConstraint(count int64) quota.Constraint {
+	return generateConstraint("Instances", count)
+}
+
+func generateConstraint(name string, count int64) quota.Constraint {
+	return quota.Constraint{
+		Name:  name,
+		Count: count,
+	}
+}

--- a/pkg/quota/quota.go
+++ b/pkg/quota/quota.go
@@ -81,7 +81,7 @@ func Check(quotas []Quota, checks []Constraint) ([]ConstraintReport, error) {
 
 		if check.Count > matched.Limit {
 			report.Result = NotAvailable
-			report.Message = fmt.Sprintf("The required number of resources (%d) is more than the limit of %d", check.Count, matched.Limit)
+			report.Message = fmt.Sprintf("the required number of resources (%d) is more than the limit of %d", check.Count, matched.Limit)
 			reports = append(reports, report)
 			continue
 		}
@@ -91,18 +91,18 @@ func Check(quotas []Quota, checks []Constraint) ([]ConstraintReport, error) {
 		headroom := int64(math.Ceil(0.2 * float64(matched.Limit)))
 		if check.Count > avail {
 			report.Result = NotAvailable
-			report.Message = fmt.Sprintf("The required number of resources (%d) is more than remaining quota of %d", check.Count, avail)
+			report.Message = fmt.Sprintf("the required number of resources (%d) is more than remaining quota of %d", check.Count, avail)
 			reports = append(reports, report)
 			continue
 		}
 		if availAfterUse <= headroom {
 			report.Result = AvailableButLow
-			report.Message = fmt.Sprintf("The required number of resources is available but only %d will be leftover", availAfterUse)
+			report.Message = fmt.Sprintf("the required number of resources is available but only %d will be leftover", availAfterUse)
 			reports = append(reports, report)
 			continue
 		}
 		report.Result = Available
-		report.Message = "The required number of resources is available"
+		report.Message = "the required number of resources is available"
 		reports = append(reports, report)
 	}
 


### PR DESCRIPTION
Note: openshift-installer already check quotas for AWS and GCP.

1) Calculate the quota constraints based on the InstallConfig.
   For both ControlPlane and workers, get the flavors and
   create a list of quota resources that will be needed to
   successfully deploy the cluster.
   Note: for now, only instances, CPUs and RAM are supported.
   In the future, we'll add networking and storage resources.

2) Fetch project quotas by using OpenStack API (via gophercloud)
   and create the constraints (for instances, CPUs and RAM only
   for now).
   The Quota constraints will be stored in the CloudInfo struct,
   for caching so we avoid multiple calls to the OpenStack APIs
   to get quotas.

3) The logging is improved when there is no region name for
   a cloud provider.

Fixes: [OSASINFRA-1141](https://issues.redhat.com/browse/OSASINFRA-1141)

Co-Authored-By: Matthew Booth <mbooth@redhat.com>
Signed-off-by: Emilien Macchi <emilien@redhat.com>
