### PR TITLE
Adds platform.openstack.useHwQEMUAgentForClusterOSImage

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1097,6 +1097,9 @@ spec:
                   clusterOSImage:
                     description: ClusterOSImage is either a URL with `http(s)` or `file` scheme to override the default OS image for cluster nodes, or an existing Glance image name.
                     type: string
+                  useHwQEMUAgentForClusterOSImage:
+                    description: If true then "hw_qemu_guest_agent=yes" is added to properties metadata of the ClusterOSImage.
+                      type: boolean
                   computeFlavor:
                     description: FlavorName is the name of the compute flavor to use for instances in this cluster.
                     type: string

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -411,6 +411,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			installConfig.Config.Platform.OpenStack.APIVIP,
 			installConfig.Config.Platform.OpenStack.IngressVIP,
 			string(*rhcosImage),
+			installConfig.Config.Platform.OpenStack.UseHwQEMUAgentForClusterOSImage,
 			clusterID.InfraID,
 			caCert,
 			bootstrapIgn,

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -45,7 +45,7 @@ type config struct {
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, apiFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
+func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, apiFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, useHwQEMUAgentForClusterOSImage bool, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
 	zones := []string{}
 	seen := map[string]bool{}
 	for _, config := range masterConfigs {
@@ -103,7 +103,11 @@ func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, exter
 			return nil, errors.Errorf("Unsupported URL scheme: '%v'", url.Scheme)
 		}
 
-		err = uploadBaseImage(cloud, localFilePath, imageName, infraID)
+		var baseImageProperties = make(map[string]string)
+		if useHwQEMUAgentForClusterOSImage {
+			baseImageProperties["hw_qemu_guest_agent"] = "yes"
+		}
+		err = uploadBaseImage(cloud, localFilePath, imageName, infraID, baseImageProperties)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tfvars/openstack/rhcos_image.go
+++ b/pkg/tfvars/openstack/rhcos_image.go
@@ -16,7 +16,7 @@ import (
 )
 
 // uploadBaseImage creates a new image in Glance and uploads the RHCOS image there
-func uploadBaseImage(cloud string, localFilePath string, imageName string, clusterID string) error {
+func uploadBaseImage(cloud string, localFilePath string, imageName string, clusterID string, imageProperties map[string]string) error {
 	logrus.Debugln("Creating a Glance image for RHCOS...")
 
 	f, err := os.Open(localFilePath)
@@ -46,6 +46,7 @@ func uploadBaseImage(cloud string, localFilePath string, imageName string, clust
 		ContainerFormat: "bare",
 		DiskFormat:      diskFormat,
 		Tags:            []string{fmt.Sprintf("openshiftClusterID=%s", clusterID)},
+		Properties:     imageProperties,
 		// TODO(mfedosin): add Description when gophercloud supports it.
 	}
 

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -62,6 +62,10 @@ type Platform struct {
 	// +optional
 	ClusterOSImage string `json:"clusterOSImage,omitempty"`
 
+	// UseHwQEMUAgentForClusterOSImage indicates that the property "hw_qemu_guest_agent=yes" should be added to the Glance ClusterOSImage
+	// +optional
+	UseHwQEMUAgentForClusterOSImage bool `json:"useHwQEMUAgentForClusterOSImage,omitempty`
+
 	// APIVIP is the static IP on the nodes subnet that the api port for openshift will be assigned
 	// Default: will be set to the 5 on the first entry in the machineNetwork CIDR
 	// +optional


### PR DESCRIPTION
useHwQEMUAgentForClusterOSImage causes "hw_qemu_guest_agent=yes"
to be added to the properties metadata of the Glance image uploaded
for clusterOSImage