### PR TITLE
baremetal: Add ironic logwatch containers

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -17,7 +17,7 @@ DHCP_RANGE="{{.PlatformData.BareMetal.ProvisioningDHCPRange}}"
 
 # First we stop any previously started containers, because ExecStop only runs when the ExecStart process
 # e.g this script is still running, but we exit if *any* of the containers exits unexpectedly
-for name in ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
+for name in ironic-api ironic-conductor ironic-inspector ironic-deploy-ramdisk-logs ironic-inspector-ramdisk-logs dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
     podman ps | grep -w "$name$" && podman kill $name
     podman ps --all | grep -w "$name$" && podman rm $name -f
 done
@@ -170,10 +170,18 @@ sudo podman run -d --net host --privileged --name ironic-api \
      -v $AUTH_DIR:/auth:ro \
      -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
 
+sudo podman run -d --name ironic-deploy-ramdisk-logs \
+     --entrypoint /bin/runlogwatch.sh \
+     -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
+
+podman run -d --name ironic-inspector-ramdisk-logs \
+     --entrypoint /bin/runlogwatch.sh \
+     -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_INSPECTOR_IMAGE}"
+
 # Now loop so the service remains active and restart everything should one of the containers exit unexpectedly.
 # The alternative would be RemainAfterExit=yes but then we lose the ability to restart if something crashes.
 while true; do
-    for name in ironic-api ironic-conductor ironic-inspector $dnsmasq_container_name httpd mariadb; do
+    for name in ironic-api ironic-conductor ironic-inspector ironic-deploy-ramdisk-logs ironic-inspector-ramdisk-logs $dnsmasq_container_name httpd mariadb; do
         # Note there are two levels of go templating here, the outer braces
         # are for the templating done in openshift-install, to escape the
         # templating input to the --format option of podman inspect

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/stopironic.sh
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/stopironic.sh
@@ -2,7 +2,7 @@
 
 set -x 
 
-for name in ironic-api ironic-conductor ironic-inspector dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
+for name in ironic-api ironic-conductor ironic-inspector ironic-deploy-ramdisk-logs ironic-inspector-ramdisk-logs dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
     podman ps | grep -w "$name$" && podman kill $name
     podman ps --all | grep -w "$name$" && podman rm $name -f
 done

--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -340,7 +340,8 @@ may also view the logs of the individual containers:
   - `podman logs ironic`
   - `podman logs ironic-inspector`
   - `podman logs ironic-dnsmasq`
-
+  - `podman logs ironic-deploy-ramdisk-logs`
+  - `podman logs ironic-inspector-ramdisk-logs`
 
 
 ### Control Plane


### PR DESCRIPTION
A new entrypoint has been added to the ironic containers
that watches for deploy ramdisk logs in the shared volume
and exposes them via the regular podman logs output.

https://github.com/openshift/ironic-inspector-image/pull/47/
https://github.com/openshift/ironic-image/pull/121/

This should make it easier for users debugging as they no longer
need to exec into the containers and have knowledge of the
internal logfile location.