### PR TITLE
WIP: OCVRHV-45: Allow preallocated disk

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1226,6 +1226,9 @@ spec:
                   ovirt_cluster_id:
                     description: The target cluster under which all VMs will run
                     type: string
+                  ovirt_master_clone:
+                    description: MasterClone indicates that the disk of the master node should be cloned (thick provisioning)
+                    type: boolean
                   ovirt_network_name:
                     description: NetworkName is the target network of all the network interfaces of the nodes. When no ovirt_network_name is provided it defaults to `ovirtmgmt` network, which is a default network for every ovirt cluster.
                     type: string
@@ -1239,6 +1242,7 @@ spec:
                 - api_vip
                 - ingress_vip
                 - ovirt_cluster_id
+                - ovirt_master_clone
                 - ovirt_storage_domain_id
                 type: object
               vsphere:

--- a/data/data/ovirt/main.tf
+++ b/data/data/ovirt/main.tf
@@ -41,4 +41,5 @@ module "masters" {
   ovirt_master_memory           = var.ovirt_master_memory
   ovirt_master_vm_type          = var.ovirt_master_vm_type
   ovirt_master_os_disk_size_gb  = var.ovirt_master_os_disk_gb
+  ovirt_master_clone            = var.ovirt_master_clone
 }

--- a/data/data/ovirt/masters/main.tf
+++ b/data/data/ovirt/masters/main.tf
@@ -7,6 +7,7 @@ resource "ovirt_vm" "master" {
   type             = var.ovirt_master_vm_type
   cores            = var.ovirt_master_cores
   sockets          = var.ovirt_master_sockets
+  clone            = var.ovirt_master_clone
   // if instance type is declared then memory is redundant. Since terraform
   // doesn't allow to condionally omit it, it must be passed.
   // The number passed is multiplied by 4 and becomes the maximum memory the VM can have.

--- a/data/data/ovirt/masters/variables.tf
+++ b/data/data/ovirt/masters/variables.tf
@@ -22,6 +22,11 @@ variable "ovirt_template_id" {
   description = "The ID of VM template"
 }
 
+variable "ovirt_master_clone" {
+  type        = bool
+  description = "Clone the full disk on master creation"
+}
+
 variable "ignition_master" {
   type        = string
   description = "master ignition config"

--- a/data/data/ovirt/variables-ovirt.tf
+++ b/data/data/ovirt/variables-ovirt.tf
@@ -86,3 +86,8 @@ variable "ovirt_master_instance_type_id" {
   type        = string
   description = "master VM instance type ID"
 }
+
+variable "ovirt_master_clone" {
+  type        = bool
+  description = "Clone the full disk on master creation"
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -493,6 +493,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			installConfig.Config.Platform.Ovirt.VNICProfileID,
 			string(*rhcosImage),
 			clusterID.InfraID,
+			installConfig.Config.Platform.Ovirt.MasterClone,
 			masters[0].Spec.ProviderSpec.Value.Object.(*ovirtprovider.OvirtMachineProviderSpec),
 		)
 		if err != nil {

--- a/pkg/asset/installconfig/ovirt/ovirt.go
+++ b/pkg/asset/installconfig/ovirt/ovirt.go
@@ -92,5 +92,19 @@ func Platform() (*ovirt.Platform, error) {
 		return nil, errors.Wrap(err, "failed UserInput")
 	}
 
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Confirm{
+				Message: "Use thick disk provisioning for master nodes?",
+				Help:    "Thick provisioning improves master node performance, but makes the installation process slower and will consume the entire disk up-front on the oVirt cluster.",
+				Default: true,
+			},
+			Validate: survey.ComposeValidators(survey.Required),
+		},
+	}, &p.MasterClone)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed UserInput")
+	}
+
 	return &p, nil
 }

--- a/pkg/tfvars/ovirt/ovirt.go
+++ b/pkg/tfvars/ovirt/ovirt.go
@@ -32,6 +32,7 @@ type config struct {
 	MasterCores            int32  `json:"ovirt_master_cores"`
 	MasterSockets          int32  `json:"ovirt_master_sockets"`
 	MasterOsDiskGB         int64  `json:"ovirt_master_os_disk_gb"`
+	MasterClone            bool   `json:"ovirt_master_clone"`
 }
 
 // TFVars generates ovirt-specific Terraform variables.
@@ -43,6 +44,7 @@ func TFVars(
 	vnicProfileID string,
 	baseImage string,
 	infraID string,
+	masterClone bool,
 	masterSpec *v1beta1.OvirtMachineProviderSpec) ([]byte, error) {
 
 	cfg := config{
@@ -56,6 +58,7 @@ func TFVars(
 		MasterVMType:         masterSpec.VMType,
 		MasterOsDiskGB:       masterSpec.OSDisk.SizeGB,
 		MasterMemory:         masterSpec.MemoryMB,
+		MasterClone:          masterClone,
 	}
 	if masterSpec.CPU != nil {
 		cfg.MasterCores = masterSpec.CPU.Cores

--- a/pkg/types/ovirt/platform.go
+++ b/pkg/types/ovirt/platform.go
@@ -33,4 +33,7 @@ type Platform struct {
 	// Default will set the image field to the latest RHCOS image.
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// MasterClone indicates that the disk of the master node should be cloned (thick provisioning)
+	MasterClone bool `json:"ovirt_master_clone"`
 }


### PR DESCRIPTION
This change adds the option to use full clones instead of thin provisioning for the master nodes. Full provisioning increases the performance at the cost of up-front disk usage. The default is now on, but can be turned off by the user in the survey.

The install config can be set to the old behavior (thin provisioning) by setting the `ovirt_master_clone` option to `false`.

**Jira issue:** https://issues.redhat.com/browse/OCPRHV-45

## User experience

```
$ bin/openshift-install create install-config
? SSH Public Key /home/janoszen/.ssh/id_rsa.pub
? Platform ovirt
? Cluster ocp-on-rhv
? Storage domain vserver-spider-nfs-lif1
? Network ovn-vmnet-11
? Internal API virtual IP 192.168.211.30
? Ingress virtual IP 192.168.211.32
? Thick provisioning improves master node performance, but makes the installation process slower
and will consume the entire disk up-front on the oVirt cluster.
? Use thick disk provisioning for master nodes? (Y/n)
```

## Disabling thick provisioning from the install-config

Please add the following option to your YAML:

```yaml
platform:
  ovirt:
    ovirt_master_clone: false
```
