### PR TITLE
Bug 1903277: destroy/aws: remove rules from default security group

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -1096,11 +1096,6 @@ func deleteEC2SecurityGroup(ctx context.Context, client *ec2.EC2, id string, log
 }
 
 func deleteEC2SecurityGroupObject(ctx context.Context, client *ec2.EC2, group *ec2.SecurityGroup, logger logrus.FieldLogger) error {
-	if group.GroupName != nil && *group.GroupName == "default" {
-		logger.Debug("Skipping default security group")
-		return nil
-	}
-
 	if len(group.IpPermissions) > 0 {
 		_, err := client.RevokeSecurityGroupIngressWithContext(ctx, &ec2.RevokeSecurityGroupIngressInput{
 			GroupId:       group.GroupId,
@@ -1121,6 +1116,11 @@ func deleteEC2SecurityGroupObject(ctx context.Context, client *ec2.EC2, group *e
 			return errors.Wrap(err, "revoking egress permissions")
 		}
 		logger.Debug("Revoked egress permissions")
+	}
+
+	if group.GroupName != nil && *group.GroupName == "default" {
+		logger.Debug("Skipping default security group")
+		return nil
 	}
 
 	_, err := client.DeleteSecurityGroupWithContext(ctx, &ec2.DeleteSecurityGroupInput{


### PR DESCRIPTION
Even though the destroyer cannot directly delete the default security group, the destroyer still needs to remove the ingress and egress rules from the default security group. There could be rules on the default security group that source another security group, which would block the destroyer from deleting that other security group.

https://bugzilla.redhat.com/show_bug.cgi?id=1903277