### PR TITLE
Set default release image to 4.6

### DIFF
--- a/pkg/asset/releaseimage/default.go
+++ b/pkg/asset/releaseimage/default.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:4.5"
+	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:4.6"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
Align the default release image with the current release version.

This is the 4.6 counterpart of the [patch](https://github.com/openshift/installer/pull/4409) on `master`.

Please let me know if this patch needs a BZ, or feel free to directly close it if it is not worth the effort!