### PR TITLE
Pass CLUSTER_PROFILE env var to CVO render

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -55,6 +55,9 @@ then
 
 	bootkube_podman_run \
 		--volume "$PWD:/assets:z" \
+{{- if .ClusterProfile}}
+		--env CLUSTER_PROFILE="{{.ClusterProfile}}" \
+{{- end}}
 		"${RELEASE_IMAGE_DIGEST}" \
 		render \
 			--output-dir=/assets/cvo-bootstrap \

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -54,6 +54,7 @@ type bootstrapTemplateData struct {
 	EtcdCluster           string
 	PullSecret            string
 	ReleaseImage          string
+	ClusterProfile        string
 	Proxy                 *configv1.ProxyStatus
 	Registries            []sysregistriesv2.Registry
 	BootImage             string
@@ -259,6 +260,13 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 		platformData.VSphere = vsphere.GetTemplateData(installConfig.Platform.VSphere)
 	}
 
+	// Set cluster profile
+	clusterProfile := ""
+	if cp := os.Getenv("OPENSHIFT_INSTALL_EXPERIMENTAL_CLUSTER_PROFILE"); cp != "" {
+		logrus.Warnf("Found override for Cluster Profile: %q", cp)
+		clusterProfile = cp
+	}
+
 	return &bootstrapTemplateData{
 		AdditionalTrustBundle: installConfig.AdditionalTrustBundle,
 		FIPS:                  installConfig.FIPS,
@@ -269,6 +277,7 @@ func (a *Bootstrap) getTemplateData(installConfig *types.InstallConfig, releaseI
 		Registries:            registries,
 		BootImage:             string(*rhcosImage),
 		PlatformData:          platformData,
+		ClusterProfile:        clusterProfile,
 	}, nil
 }
 


### PR DESCRIPTION
This PR adds the ability to pass CLUSTER_PROFILE as env var to the installer which will be propagated as env var to the CVO rendering.

Following the enhancements:
 https://github.com/openshift/enhancements/pull/200
 https://github.com/openshift/enhancements/pull/543

Signed-off-by: Ravid Brown <ravid@redhat.com>