### PR TITLE
cloudproviderconfig: Refactor openstack

### DIFF
--- a/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
@@ -108,6 +108,6 @@ secret-name = openstack-credentials
 secret-namespace = kube-system
 region = my_region
 `
-	actualConfig := CloudProviderConfig(&cloud)
+	actualConfig, _, _ := generateCloudProviderConfig(&cloud)
 	assert.Equal(t, expectedConfig, string(actualConfig), "unexpected cloud provider config")
 }


### PR DESCRIPTION
Move OpenStack platform-specific code in the platform package to
increase ownership and leave a clean API footprint on the orchestrating
logic.

Implements [OSASINFRA-2195](https://issues.redhat.com/browse/OSASINFRA-2195)