### PR TITLE
Bug 1904125: Ensure the bootstrap ignition libvirt pool defaults to <clustername>.<id>.bootstrap rather than 'default'

### DIFF
--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -21,6 +21,7 @@ resource "libvirt_volume" "bootstrap" {
 
 resource "libvirt_ignition" "bootstrap" {
   name    = "${var.cluster_id}-bootstrap.ign"
+  pool    = libvirt_pool.bootstrap.name
   content = var.ignition
 }
 


### PR DESCRIPTION
Currently in the 'baremetal' platform, we use a customized TF-created storage volume with the following naming convention: `<clustername>.<id>.bootstrap` and this volume is used to store the bootstrap VM images. Since the libvirt_ignition resources was introduced, it has been defaulting to the `default` libvirt storage pool.

This PR ensures that the libvirt_ignition TF resource uses the above mentioned customized libvirt storage pool.