### PR TITLE
openstack: Allow to skip pre-flight validations

### DIFF
--- a/pkg/asset/installconfig/openstack/validate.go
+++ b/pkg/asset/installconfig/openstack/validate.go
@@ -1,14 +1,22 @@
 package openstack
 
 import (
+	"os"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/asset/installconfig/openstack/validation"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/sirupsen/logrus"
 )
 
 // Validate validates the given installconfig for OpenStack platform
 func Validate(ic *types.InstallConfig) error {
+	if skip := os.Getenv("OPENSHFIT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS"); skip == "1" {
+		logrus.Warnf("OVERRIDE: pre-flight validation disabled.")
+		return nil
+	}
+
 	ci, err := validation.GetCloudInfo(ic)
 	if err != nil {
 		return err


### PR DESCRIPTION
Skip pre-flight validations when the development-only variable
`OS_SKIP_PREFLIGHT_VALIDATIONS=1` is found in the environment.

Skipping pre-flight validations is essential to testing manifest
generation when the exotic settings under test are not available in the
CI infrastructure.

Implements [OSASINFRA-2194](https://issues.redhat.com/browse/OSASINFRA-2194)

/label platform/openstack