### PR TITLE
Bug 1904663: Fix comparison in pointer ignition customization asset

### DIFF
--- a/pkg/asset/ignition/machine/master_ignition_customizations_test.go
+++ b/pkg/asset/ignition/machine/master_ignition_customizations_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -15,36 +16,67 @@ import (
 
 // TestMasterIgnitionCustomizationsGenerate tests generating the master ignition check asset.
 func TestMasterIgnitionCustomizationsGenerate(t *testing.T) {
-	installConfig := &installconfig.InstallConfig{
-		Config: &types.InstallConfig{
-			Networking: &types.Networking{
-				ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("10.0.1.0/24")},
-			},
-			Platform: types.Platform{
-				AWS: &aws.Platform{
-					Region: "us-east",
-				},
-			},
+	cases := []struct {
+		name          string
+		customize     bool
+		assetExpected bool
+	}{
+		{
+			name:          "not customized",
+			customize:     false,
+			assetExpected: false,
+		},
+		{
+			name:          "pointer customized",
+			customize:     true,
+			assetExpected: true,
 		},
 	}
 
-	rootCA := &tls.RootCA{}
-	err := rootCA.Generate(nil)
-	assert.NoError(t, err, "unexpected error generating root CA")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installConfig := &installconfig.InstallConfig{
+				Config: &types.InstallConfig{
+					Networking: &types.Networking{
+						ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("10.0.1.0/24")},
+					},
+					Platform: types.Platform{
+						AWS: &aws.Platform{
+							Region: "us-east",
+						},
+					},
+				},
+			}
 
-	parents := asset.Parents{}
-	parents.Add(installConfig, rootCA)
+			rootCA := &tls.RootCA{}
+			err := rootCA.Generate(nil)
+			assert.NoError(t, err, "unexpected error generating root CA")
 
-	master := &Master{}
-	err = master.Generate(parents)
-	assert.NoError(t, err, "unexpected error generating master asset")
+			parents := asset.Parents{}
+			parents.Add(installConfig, rootCA)
 
-	parents.Add(master)
-	masterIgnCheck := &MasterIgnitionCustomizations{}
-	err = masterIgnCheck.Generate(parents)
-	assert.NoError(t, err, "unexpected error generating master ignition check asset")
+			master := &Master{}
+			err = master.Generate(parents)
+			assert.NoError(t, err, "unexpected error generating master asset")
 
-	actualFiles := masterIgnCheck.Files()
-	assert.Equal(t, 1, len(actualFiles), "unexpected number of files in master state")
-	assert.Equal(t, masterMachineConfigFileName, actualFiles[0].Filename, "unexpected name for master ignition config")
+			if tc.customize == true {
+				// Modify the master config, emulating a customization to the pointer
+				master.Config.Storage.Files = append(master.Config.Storage.Files,
+					ignition.FileFromString("/etc/foo", "root", 0644, "foo"))
+			}
+
+			parents.Add(master)
+			masterIgnCheck := &MasterIgnitionCustomizations{}
+			err = masterIgnCheck.Generate(parents)
+			assert.NoError(t, err, "unexpected error generating master ignition check asset")
+
+			actualFiles := masterIgnCheck.Files()
+			if tc.assetExpected == true {
+				assert.Equal(t, 1, len(actualFiles), "unexpected number of files in master state")
+				assert.Equal(t, masterMachineConfigFileName, actualFiles[0].Filename, "unexpected name for master ignition config")
+			} else {
+				assert.Equal(t, 0, len(actualFiles), "unexpected number of files in master state")
+			}
+		})
+	}
 }

--- a/pkg/asset/ignition/machine/worker_ignition_customizations_test.go
+++ b/pkg/asset/ignition/machine/worker_ignition_customizations_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -15,36 +16,67 @@ import (
 
 // TestWorkerIgnitionCustomizationsGenerate tests generating the worker ignition check asset.
 func TestWorkerIgnitionCustomizationsGenerate(t *testing.T) {
-	installConfig := &installconfig.InstallConfig{
-		Config: &types.InstallConfig{
-			Networking: &types.Networking{
-				ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("10.0.1.0/24")},
-			},
-			Platform: types.Platform{
-				AWS: &aws.Platform{
-					Region: "us-east",
-				},
-			},
+	cases := []struct {
+		name          string
+		customize     bool
+		assetExpected bool
+	}{
+		{
+			name:          "not customized",
+			customize:     false,
+			assetExpected: false,
+		},
+		{
+			name:          "pointer customized",
+			customize:     true,
+			assetExpected: true,
 		},
 	}
 
-	rootCA := &tls.RootCA{}
-	err := rootCA.Generate(nil)
-	assert.NoError(t, err, "unexpected error generating root CA")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installConfig := &installconfig.InstallConfig{
+				Config: &types.InstallConfig{
+					Networking: &types.Networking{
+						ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("10.0.1.0/24")},
+					},
+					Platform: types.Platform{
+						AWS: &aws.Platform{
+							Region: "us-east",
+						},
+					},
+				},
+			}
 
-	parents := asset.Parents{}
-	parents.Add(installConfig, rootCA)
+			rootCA := &tls.RootCA{}
+			err := rootCA.Generate(nil)
+			assert.NoError(t, err, "unexpected error generating root CA")
 
-	worker := &Worker{}
-	err = worker.Generate(parents)
-	assert.NoError(t, err, "unexpected error generating worker asset")
+			parents := asset.Parents{}
+			parents.Add(installConfig, rootCA)
 
-	parents.Add(worker)
-	workerIgnCheck := &WorkerIgnitionCustomizations{}
-	err = workerIgnCheck.Generate(parents)
-	assert.NoError(t, err, "unexpected error generating worker ignition check asset")
+			worker := &Worker{}
+			err = worker.Generate(parents)
+			assert.NoError(t, err, "unexpected error generating worker asset")
 
-	actualFiles := workerIgnCheck.Files()
-	assert.Equal(t, 1, len(actualFiles), "unexpected number of files in worker state")
-	assert.Equal(t, workerMachineConfigFileName, actualFiles[0].Filename, "unexpected name for worker ignition config")
+			if tc.customize == true {
+				// Modify the worker config, emulating a customization to the pointer
+				worker.Config.Storage.Files = append(worker.Config.Storage.Files,
+					ignition.FileFromString("/etc/foo", "root", 0644, "foo"))
+			}
+
+			parents.Add(worker)
+			workerIgnCheck := &WorkerIgnitionCustomizations{}
+			err = workerIgnCheck.Generate(parents)
+			assert.NoError(t, err, "unexpected error generating worker ignition check asset")
+
+			actualFiles := workerIgnCheck.Files()
+			if tc.assetExpected == true {
+				assert.Equal(t, 1, len(actualFiles), "unexpected number of files in worker state")
+				assert.Equal(t, workerMachineConfigFileName, actualFiles[0].Filename, "unexpected name for worker ignition config")
+			} else {
+				assert.Equal(t, 0, len(actualFiles), "unexpected number of files in worker state")
+			}
+		})
+	}
 }


### PR DESCRIPTION
An issue was spotted after #4413 landed, the config comparison
always evaluates to true, so we're generating empty machineconfig
objects even when no customization has happened.

Update to compare a json representation of the configs, and add
a test to confirm all works as expected.