### PR TITLE
[FCOS] Rebase `fcos` on release-4.6

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,6 +4,7 @@ aliases:
   installer-approvers:
     - abhinavdahiya
     - crawford
+    - staebler
     - sdodson
     - smarterclayton
     - wking

--- a/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env-godebug.conf.template
+++ b/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env-godebug.conf.template
@@ -1,0 +1,2 @@
+[Manager]
+DefaultEnvironment=GODEBUG=x509ignoreCN=0

--- a/data/data/bootstrap/vsphere/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
+++ b/data/data/bootstrap/vsphere/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
@@ -2,7 +2,7 @@
 IFACE=$1
 STATUS=$2
 case "$STATUS" in
-    up|dhcp4-change|dhcp6-change)
+    up|down|dhcp4-change|dhcp6-change)
 {{if .PlatformData.VSphere.UserProvidedVIPs}}
     logger -s "NM local-dns-prepender triggered by ${1} ${2}."
     DNS_IP="127.0.0.1"

--- a/data/data/bootstrap/vsphere/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
+++ b/data/data/bootstrap/vsphere/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
@@ -2,10 +2,21 @@
 IFACE=$1
 STATUS=$2
 case "$STATUS" in
-    up|down|dhcp4-change|dhcp6-change)
+    up|dhcp4-change|dhcp6-change)
 {{if .PlatformData.VSphere.UserProvidedVIPs}}
     logger -s "NM local-dns-prepender triggered by ${1} ${2}."
     DNS_IP="127.0.0.1"
+
+    # In DHCP connections, the resolv.conf content may be late, thus we wait for nameservers
+    timeout 45s /bin/bash <<EOF
+		if [[ "$STATUS" == dhcp* ]]; then
+			logger -s "NM resolv-prepender: Checking for nameservers in /var/run/NetworkManager/resolv.conf"
+			while ! grep nameserver /var/run/NetworkManager/resolv.conf; do
+				logger -s "NM resolv-prepender: NM resolv.conf still empty of nameserver"
+                sleep 0.5
+            done
+        fi
+EOF
     set +e
     logger -s "NM local-dns-prepender: Checking if local DNS IP is the first entry in resolv.conf"
     if grep nameserver /etc/resolv.conf | head -n 1 | grep -q "$DNS_IP" ; then

--- a/data/data/fcos-amd64.json
+++ b/data/data/fcos-amd64.json
@@ -1,142 +1,142 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-08524e45d1140449e"
+            "hvm": "ami-0515948ea738deb7d"
         },
         "ap-east-1": {
-            "hvm": "ami-09db7456079959ee0"
+            "hvm": "ami-0d04fb55daf090c15"
         },
         "ap-northeast-1": {
-            "hvm": "ami-03c6e0957d3e8c077"
+            "hvm": "ami-00761de46b64fcc30"
         },
         "ap-northeast-2": {
-            "hvm": "ami-029bcb46c5ece0a78"
+            "hvm": "ami-00585d933f2fd9603"
         },
         "ap-south-1": {
-            "hvm": "ami-0cac00c3e13c2ef42"
+            "hvm": "ami-07d02606d3dcb234f"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0ba653802178a7789"
+            "hvm": "ami-037ef6e104722a718"
         },
         "ap-southeast-2": {
-            "hvm": "ami-025c310ac1b89f0ac"
+            "hvm": "ami-027ef32b08d49ae55"
         },
         "ca-central-1": {
-            "hvm": "ami-0c9b4c1d8082e7ef6"
+            "hvm": "ami-014d70dc1149063bd"
         },
         "eu-central-1": {
-            "hvm": "ami-091d27df19b4e07f0"
+            "hvm": "ami-058160acaf1ba47bf"
         },
         "eu-north-1": {
-            "hvm": "ami-09d5d19beee0e1e85"
+            "hvm": "ami-03160accdaf96441a"
         },
         "eu-south-1": {
-            "hvm": "ami-04f9421a4082a6b37"
+            "hvm": "ami-0b35937e5d956cf50"
         },
         "eu-west-1": {
-            "hvm": "ami-087d325e793d7c8bf"
+            "hvm": "ami-0019e3a63434bf7d6"
         },
         "eu-west-2": {
-            "hvm": "ami-022f7ec6a06012fbb"
+            "hvm": "ami-043b15a6ca47c2e23"
         },
         "eu-west-3": {
-            "hvm": "ami-0fbf673f7f2ee1f44"
+            "hvm": "ami-035e6bf6246a107e3"
         },
         "me-south-1": {
-            "hvm": "ami-0c793c92e4db8073f"
+            "hvm": "ami-0f04c5beb485a69ab"
         },
         "sa-east-1": {
-            "hvm": "ami-0dbf5a489ff0963e4"
+            "hvm": "ami-0136046cdd08d10e9"
         },
         "us-east-1": {
-            "hvm": "ami-0ccae660efd585fa8"
+            "hvm": "ami-0e82d138d7345087e"
         },
         "us-east-2": {
-            "hvm": "ami-021f6004ea7b7d591"
+            "hvm": "ami-09309c738aa098d72"
         },
         "us-west-1": {
-            "hvm": "ami-0c2a493b7f47196e7"
+            "hvm": "ami-05b569e20ff9eb985"
         },
         "us-west-2": {
-            "hvm": "ami-02bef145f1a0d102a"
+            "hvm": "ami-0699a4456969d8650"
         }
     },
     "azure": {
-        "image": "fedora-coreos-32.20201004.3.0-azure.x86_64.vhd",
-        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20201004.3.0/x86_64/fedora-coreos-32.20201004.3.0-azure.x86_64.vhd.xz"
+        "image": "fedora-coreos-32.20201104.3.0-azure.x86_64.vhd",
+        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20201104.3.0/x86_64/fedora-coreos-32.20201104.3.0-azure.x86_64.vhd.xz"
     },
-    "baseURI": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20201004.3.0/x86_64/",
-    "buildid": "32.20201004.3.0",
+    "baseURI": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20201104.3.0/x86_64/",
+    "buildid": "32.20201104.3.0",
     "gcp": {
         "family": "fedora-coreos-stable",
-        "image": "fedora-coreos-32-20201004-3-0-gcp-x86-64",
+        "image": "fedora-coreos-32-20201104-3-0-gcp-x86-64",
         "project": "fedora-coreos-cloud",
-        "url": "https://storage.googleapis.com/fedora-coreos-cloud-image-uploads/image-import/fedora-coreos-32-20201004-3-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/fedora-coreos-cloud-image-uploads/image-import/fedora-coreos-32-20201104-3-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "fedora-coreos-32.20201004.3.0-aws.x86_64.vmdk.xz",
-            "sha256": "59e529bd41c455d8e8e945d5eaddb3700d60a0675216f7bacc95e338341267b3",
-            "size": 787483460,
-            "uncompressed-sha256": "c3170bbd961c9e1337a56a43404cea59f39e70e03a3749aeced1ff261800d9fc",
-            "uncompressed-size": 826963456
+            "path": "fedora-coreos-32.20201104.3.0-aws.x86_64.vmdk.xz",
+            "sha256": "b563a04d31190afc58a60cca5297fc57cb178821e6561c602e38868818b757ac",
+            "size": 797271192,
+            "uncompressed-sha256": "fa34ba8345598642cfd5d1835c54b9a7bb40d659a6b5e18dd8d0489aec1efb8f",
+            "uncompressed-size": 838730240
         },
         "azure": {
-            "path": "fedora-coreos-32.20201004.3.0-azure.x86_64.vhd.xz",
-            "sha256": "5dd76db440339afeaaedf43975b4bb265892ed752d353aea4e3ee3f29ab09cf5",
-            "size": 552118248,
-            "uncompressed-sha256": "2097032030171863505df2bb0c38727c3d70c54118a87b67fa5cb760c20f5b27",
+            "path": "fedora-coreos-32.20201104.3.0-azure.x86_64.vhd.xz",
+            "sha256": "1fb1e7de989465e17112b400db6d08bf104053d37b74a82b15d272e033159aa9",
+            "size": 557371608,
+            "uncompressed-sha256": "9e154fef0929890ffeb48992b393f7663dfa311c211c9929a7196d8a6bed7975",
             "uncompressed-size": 8589935104
         },
         "gcp": {
-            "path": "fedora-coreos-32.20201004.3.0-gcp.x86_64.tar.gz",
-            "sha256": "f6b70cd217d16f2e6a2150bc93480f99af33a4d5b3ffc3a696d4d9e02b31a324",
-            "size": 809049248
+            "path": "fedora-coreos-32.20201104.3.0-gcp.x86_64.tar.gz",
+            "sha256": "9ec7c773a9cf26ced69fb5dfe2c0d5acf0d27f6fc8115ca7d7640e0d3283f673",
+            "size": 820602047
         },
         "initramfs": {
-            "path": "fedora-coreos-32.20201004.3.0-live-initramfs.x86_64.img",
-            "sha256": "811c462b6bab670ab60fb5fbf7688e28da08c02f9aeb4c2b28de8e5a6888c385"
+            "path": "fedora-coreos-32.20201104.3.0-live-initramfs.x86_64.img",
+            "sha256": "d402b7b36420581aec22a7160f798c1cf32d76049fa54016d87d0394d83bf695"
         },
         "iso": {
-            "path": "fedora-coreos-32.20201004.3.0-live.x86_64.iso",
-            "sha256": "edabd790f706530a69c0e3b779767595c5114edf86474a91176cce16edcf0663"
+            "path": "fedora-coreos-32.20201104.3.0-live.x86_64.iso",
+            "sha256": "78b97e3f020e737e631561855984950ff7902e5ff9cb1de1abce789b7ab4e118"
         },
         "kernel": {
-            "path": "fedora-coreos-32.20201004.3.0-live-kernel-x86_64",
-            "sha256": "4eea90c4066ce1e880bcf9b2b40f46fc7f8e6238522d79ea7124efc0039015c1"
+            "path": "fedora-coreos-32.20201104.3.0-live-kernel-x86_64",
+            "sha256": "cbbb327196f67e4e48ae401357b159e0418317d97d243a4da4b6d01a4f02e0b0"
         },
         "metal": {
-            "path": "fedora-coreos-32.20201004.3.0-metal.x86_64.raw.xz",
-            "sha256": "195a082e9fd131e9a86fac15e39afdbd598b9cfa911f1ae6a8c585df8a9a9d20",
-            "size": 551195984,
-            "uncompressed-sha256": "81742a874bbde07b1e1072bda5cb04a7b3ddbfdbb56e0fdfc54b6e8e5a642ae2",
-            "uncompressed-size": 2983198720
+            "path": "fedora-coreos-32.20201104.3.0-metal.x86_64.raw.xz",
+            "sha256": "8a53190d257e26512e0106e4eec044035ff4d91290d44d6bbfd580539eae66c6",
+            "size": 556990628,
+            "uncompressed-sha256": "2f0868369b53cc502625e4d7a62e9a212792ee8e57d69f2ad983d1a7b79e7b11",
+            "uncompressed-size": 3012558848
         },
         "openstack": {
-            "path": "fedora-coreos-32.20201004.3.0-openstack.x86_64.qcow2.xz",
-            "sha256": "10bf084267454767b0a6e15d3a7a5fb76eaf9c76749239fecb463f85969ae225",
-            "size": 547970456,
-            "uncompressed-sha256": "6065c21bf6903bf72cce8c5f57c1a07232e93aa85132834baa5859d56ee4ef9a",
-            "uncompressed-size": 1850277888
+            "path": "fedora-coreos-32.20201104.3.0-openstack.x86_64.qcow2.xz",
+            "sha256": "90406972c1929a3a4f35f0086143ca47dab08180a952b3ffa23f4d4a4196136b",
+            "size": 554032320,
+            "uncompressed-sha256": "1890ff67e63af8d213acf3111d65221e7dadc0e091034a4bb70baf3291ad6254",
+            "uncompressed-size": 1870725120
         },
         "ostree": {
-            "path": "fedora-coreos-32.20201004.3.0-ostree.x86_64.tar",
-            "sha256": "83c1c7696c13a0c10707c0960bfde40770a8ba3503c2321c65b87967e364882a",
-            "size": 736358400
+            "path": "fedora-coreos-32.20201104.3.0-ostree.x86_64.tar",
+            "sha256": "57083e1fda88569f0c37a0309a8888f9c1655946da56c59a40d38c5b0859ee78",
+            "size": 747857920
         },
         "qemu": {
-            "path": "fedora-coreos-32.20201004.3.0-qemu.x86_64.qcow2.xz",
-            "sha256": "5a4f80e85b66d3c7a0d5789d3f4f65d30a57871b6fe49dc791e490763f1eacdb",
-            "size": 548685400,
-            "uncompressed-sha256": "0fcdc5dcf1a7a313a698608d33f969ab5c486ea6558071068a6c2496a9c334e5",
-            "uncompressed-size": 1859911680
+            "path": "fedora-coreos-32.20201104.3.0-qemu.x86_64.qcow2.xz",
+            "sha256": "ffe6730b3a89bc5d0216a3de52e141891e71b61bfd1c0335b73e00d5833bda46",
+            "size": 555074188,
+            "uncompressed-sha256": "025800e5d066a6130358816a963289fff410a39bbf3ebdd0d6e17176d67eb520",
+            "uncompressed-size": 1880948736
         },
         "vmware": {
-            "path": "fedora-coreos-32.20201004.3.0-vmware.x86_64.ova",
-            "sha256": "8426fc4c3972f93e248f1bc1637be42aa22cff7f55de3b0e179494fac3d93f4e",
-            "size": 826972160
+            "path": "fedora-coreos-32.20201104.3.0-vmware.x86_64.ova",
+            "sha256": "cd23c63f90c0b05922c9b1054cb73b97eeff7447606f34a33496da961ce2f5a7",
+            "size": 838737920
         }
     },
-    "ostree-commit": "64bb377ae7e6949c26cfe819f3f0bd517596d461e437f2f6e9f1f3c24376fd30",
-    "ostree-version": "32.20201004.3.0"
+    "ostree-commit": "318de830c2f30a97333cd43aa1d500a46ccfedcb2de70a04d0c48228944346da",
+    "ostree-version": "32.20201104.3.0"
 }

--- a/data/data/fcos.json
+++ b/data/data/fcos.json
@@ -1,142 +1,142 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-08524e45d1140449e"
+            "hvm": "ami-0515948ea738deb7d"
         },
         "ap-east-1": {
-            "hvm": "ami-09db7456079959ee0"
+            "hvm": "ami-0d04fb55daf090c15"
         },
         "ap-northeast-1": {
-            "hvm": "ami-03c6e0957d3e8c077"
+            "hvm": "ami-00761de46b64fcc30"
         },
         "ap-northeast-2": {
-            "hvm": "ami-029bcb46c5ece0a78"
+            "hvm": "ami-00585d933f2fd9603"
         },
         "ap-south-1": {
-            "hvm": "ami-0cac00c3e13c2ef42"
+            "hvm": "ami-07d02606d3dcb234f"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0ba653802178a7789"
+            "hvm": "ami-037ef6e104722a718"
         },
         "ap-southeast-2": {
-            "hvm": "ami-025c310ac1b89f0ac"
+            "hvm": "ami-027ef32b08d49ae55"
         },
         "ca-central-1": {
-            "hvm": "ami-0c9b4c1d8082e7ef6"
+            "hvm": "ami-014d70dc1149063bd"
         },
         "eu-central-1": {
-            "hvm": "ami-091d27df19b4e07f0"
+            "hvm": "ami-058160acaf1ba47bf"
         },
         "eu-north-1": {
-            "hvm": "ami-09d5d19beee0e1e85"
+            "hvm": "ami-03160accdaf96441a"
         },
         "eu-south-1": {
-            "hvm": "ami-04f9421a4082a6b37"
+            "hvm": "ami-0b35937e5d956cf50"
         },
         "eu-west-1": {
-            "hvm": "ami-087d325e793d7c8bf"
+            "hvm": "ami-0019e3a63434bf7d6"
         },
         "eu-west-2": {
-            "hvm": "ami-022f7ec6a06012fbb"
+            "hvm": "ami-043b15a6ca47c2e23"
         },
         "eu-west-3": {
-            "hvm": "ami-0fbf673f7f2ee1f44"
+            "hvm": "ami-035e6bf6246a107e3"
         },
         "me-south-1": {
-            "hvm": "ami-0c793c92e4db8073f"
+            "hvm": "ami-0f04c5beb485a69ab"
         },
         "sa-east-1": {
-            "hvm": "ami-0dbf5a489ff0963e4"
+            "hvm": "ami-0136046cdd08d10e9"
         },
         "us-east-1": {
-            "hvm": "ami-0ccae660efd585fa8"
+            "hvm": "ami-0e82d138d7345087e"
         },
         "us-east-2": {
-            "hvm": "ami-021f6004ea7b7d591"
+            "hvm": "ami-09309c738aa098d72"
         },
         "us-west-1": {
-            "hvm": "ami-0c2a493b7f47196e7"
+            "hvm": "ami-05b569e20ff9eb985"
         },
         "us-west-2": {
-            "hvm": "ami-02bef145f1a0d102a"
+            "hvm": "ami-0699a4456969d8650"
         }
     },
     "azure": {
-        "image": "fedora-coreos-32.20201004.3.0-azure.x86_64.vhd",
-        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20201004.3.0/x86_64/fedora-coreos-32.20201004.3.0-azure.x86_64.vhd.xz"
+        "image": "fedora-coreos-32.20201104.3.0-azure.x86_64.vhd",
+        "url": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20201104.3.0/x86_64/fedora-coreos-32.20201104.3.0-azure.x86_64.vhd.xz"
     },
-    "baseURI": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20201004.3.0/x86_64/",
-    "buildid": "32.20201004.3.0",
+    "baseURI": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20201104.3.0/x86_64/",
+    "buildid": "32.20201104.3.0",
     "gcp": {
         "family": "fedora-coreos-stable",
-        "image": "fedora-coreos-32-20201004-3-0-gcp-x86-64",
+        "image": "fedora-coreos-32-20201104-3-0-gcp-x86-64",
         "project": "fedora-coreos-cloud",
-        "url": "https://storage.googleapis.com/fedora-coreos-cloud-image-uploads/image-import/fedora-coreos-32-20201004-3-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/fedora-coreos-cloud-image-uploads/image-import/fedora-coreos-32-20201104-3-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "fedora-coreos-32.20201004.3.0-aws.x86_64.vmdk.xz",
-            "sha256": "59e529bd41c455d8e8e945d5eaddb3700d60a0675216f7bacc95e338341267b3",
-            "size": 787483460,
-            "uncompressed-sha256": "c3170bbd961c9e1337a56a43404cea59f39e70e03a3749aeced1ff261800d9fc",
-            "uncompressed-size": 826963456
+            "path": "fedora-coreos-32.20201104.3.0-aws.x86_64.vmdk.xz",
+            "sha256": "b563a04d31190afc58a60cca5297fc57cb178821e6561c602e38868818b757ac",
+            "size": 797271192,
+            "uncompressed-sha256": "fa34ba8345598642cfd5d1835c54b9a7bb40d659a6b5e18dd8d0489aec1efb8f",
+            "uncompressed-size": 838730240
         },
         "azure": {
-            "path": "fedora-coreos-32.20201004.3.0-azure.x86_64.vhd.xz",
-            "sha256": "5dd76db440339afeaaedf43975b4bb265892ed752d353aea4e3ee3f29ab09cf5",
-            "size": 552118248,
-            "uncompressed-sha256": "2097032030171863505df2bb0c38727c3d70c54118a87b67fa5cb760c20f5b27",
+            "path": "fedora-coreos-32.20201104.3.0-azure.x86_64.vhd.xz",
+            "sha256": "1fb1e7de989465e17112b400db6d08bf104053d37b74a82b15d272e033159aa9",
+            "size": 557371608,
+            "uncompressed-sha256": "9e154fef0929890ffeb48992b393f7663dfa311c211c9929a7196d8a6bed7975",
             "uncompressed-size": 8589935104
         },
         "gcp": {
-            "path": "fedora-coreos-32.20201004.3.0-gcp.x86_64.tar.gz",
-            "sha256": "f6b70cd217d16f2e6a2150bc93480f99af33a4d5b3ffc3a696d4d9e02b31a324",
-            "size": 809049248
+            "path": "fedora-coreos-32.20201104.3.0-gcp.x86_64.tar.gz",
+            "sha256": "9ec7c773a9cf26ced69fb5dfe2c0d5acf0d27f6fc8115ca7d7640e0d3283f673",
+            "size": 820602047
         },
         "initramfs": {
-            "path": "fedora-coreos-32.20201004.3.0-live-initramfs.x86_64.img",
-            "sha256": "811c462b6bab670ab60fb5fbf7688e28da08c02f9aeb4c2b28de8e5a6888c385"
+            "path": "fedora-coreos-32.20201104.3.0-live-initramfs.x86_64.img",
+            "sha256": "d402b7b36420581aec22a7160f798c1cf32d76049fa54016d87d0394d83bf695"
         },
         "iso": {
-            "path": "fedora-coreos-32.20201004.3.0-live.x86_64.iso",
-            "sha256": "edabd790f706530a69c0e3b779767595c5114edf86474a91176cce16edcf0663"
+            "path": "fedora-coreos-32.20201104.3.0-live.x86_64.iso",
+            "sha256": "78b97e3f020e737e631561855984950ff7902e5ff9cb1de1abce789b7ab4e118"
         },
         "kernel": {
-            "path": "fedora-coreos-32.20201004.3.0-live-kernel-x86_64",
-            "sha256": "4eea90c4066ce1e880bcf9b2b40f46fc7f8e6238522d79ea7124efc0039015c1"
+            "path": "fedora-coreos-32.20201104.3.0-live-kernel-x86_64",
+            "sha256": "cbbb327196f67e4e48ae401357b159e0418317d97d243a4da4b6d01a4f02e0b0"
         },
         "metal": {
-            "path": "fedora-coreos-32.20201004.3.0-metal.x86_64.raw.xz",
-            "sha256": "195a082e9fd131e9a86fac15e39afdbd598b9cfa911f1ae6a8c585df8a9a9d20",
-            "size": 551195984,
-            "uncompressed-sha256": "81742a874bbde07b1e1072bda5cb04a7b3ddbfdbb56e0fdfc54b6e8e5a642ae2",
-            "uncompressed-size": 2983198720
+            "path": "fedora-coreos-32.20201104.3.0-metal.x86_64.raw.xz",
+            "sha256": "8a53190d257e26512e0106e4eec044035ff4d91290d44d6bbfd580539eae66c6",
+            "size": 556990628,
+            "uncompressed-sha256": "2f0868369b53cc502625e4d7a62e9a212792ee8e57d69f2ad983d1a7b79e7b11",
+            "uncompressed-size": 3012558848
         },
         "openstack": {
-            "path": "fedora-coreos-32.20201004.3.0-openstack.x86_64.qcow2.xz",
-            "sha256": "10bf084267454767b0a6e15d3a7a5fb76eaf9c76749239fecb463f85969ae225",
-            "size": 547970456,
-            "uncompressed-sha256": "6065c21bf6903bf72cce8c5f57c1a07232e93aa85132834baa5859d56ee4ef9a",
-            "uncompressed-size": 1850277888
+            "path": "fedora-coreos-32.20201104.3.0-openstack.x86_64.qcow2.xz",
+            "sha256": "90406972c1929a3a4f35f0086143ca47dab08180a952b3ffa23f4d4a4196136b",
+            "size": 554032320,
+            "uncompressed-sha256": "1890ff67e63af8d213acf3111d65221e7dadc0e091034a4bb70baf3291ad6254",
+            "uncompressed-size": 1870725120
         },
         "ostree": {
-            "path": "fedora-coreos-32.20201004.3.0-ostree.x86_64.tar",
-            "sha256": "83c1c7696c13a0c10707c0960bfde40770a8ba3503c2321c65b87967e364882a",
-            "size": 736358400
+            "path": "fedora-coreos-32.20201104.3.0-ostree.x86_64.tar",
+            "sha256": "57083e1fda88569f0c37a0309a8888f9c1655946da56c59a40d38c5b0859ee78",
+            "size": 747857920
         },
         "qemu": {
-            "path": "fedora-coreos-32.20201004.3.0-qemu.x86_64.qcow2.xz",
-            "sha256": "5a4f80e85b66d3c7a0d5789d3f4f65d30a57871b6fe49dc791e490763f1eacdb",
-            "size": 548685400,
-            "uncompressed-sha256": "0fcdc5dcf1a7a313a698608d33f969ab5c486ea6558071068a6c2496a9c334e5",
-            "uncompressed-size": 1859911680
+            "path": "fedora-coreos-32.20201104.3.0-qemu.x86_64.qcow2.xz",
+            "sha256": "ffe6730b3a89bc5d0216a3de52e141891e71b61bfd1c0335b73e00d5833bda46",
+            "size": 555074188,
+            "uncompressed-sha256": "025800e5d066a6130358816a963289fff410a39bbf3ebdd0d6e17176d67eb520",
+            "uncompressed-size": 1880948736
         },
         "vmware": {
-            "path": "fedora-coreos-32.20201004.3.0-vmware.x86_64.ova",
-            "sha256": "8426fc4c3972f93e248f1bc1637be42aa22cff7f55de3b0e179494fac3d93f4e",
-            "size": 826972160
+            "path": "fedora-coreos-32.20201104.3.0-vmware.x86_64.ova",
+            "sha256": "cd23c63f90c0b05922c9b1054cb73b97eeff7447606f34a33496da961ce2f5a7",
+            "size": 838737920
         }
     },
-    "ostree-commit": "64bb377ae7e6949c26cfe819f3f0bd517596d461e437f2f6e9f1f3c24376fd30",
-    "ostree-version": "32.20201004.3.0"
+    "ostree-commit": "318de830c2f30a97333cd43aa1d500a46ccfedcb2de70a04d0c48228944346da",
+    "ostree-version": "32.20201104.3.0"
 }

--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,147 +1,147 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-0d6e98846a85acf1d"
+            "hvm": "ami-0cb46ba6945dbfebe"
         },
         "ap-northeast-2": {
-            "hvm": "ami-06f14832100209a68"
+            "hvm": "ami-01e554d608de6087a"
         },
         "ap-south-1": {
-            "hvm": "ami-00e4ed0fe8de223e2"
+            "hvm": "ami-09253ba33f828d47f"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0224bb3fb42e4217d"
+            "hvm": "ami-0a6a0f1f6106708c4"
         },
         "ap-southeast-2": {
-            "hvm": "ami-06c3ab5202323d006"
+            "hvm": "ami-0e3e2b2ea00c35823"
         },
         "ca-central-1": {
-            "hvm": "ami-0d61e0308208ba1e6"
+            "hvm": "ami-0f5825ef10c76de32"
         },
         "eu-central-1": {
-            "hvm": "ami-0f142f5cc084c173f"
+            "hvm": "ami-0a51f61236e6fc6f2"
         },
         "eu-north-1": {
-            "hvm": "ami-081516e373803941f"
+            "hvm": "ami-06d01bfaf14ad66a3"
         },
         "eu-west-1": {
-            "hvm": "ami-0aded2fab8dfcf6f0"
+            "hvm": "ami-0e514a30ad261c978"
         },
         "eu-west-2": {
-            "hvm": "ami-0aeca025866a91960"
+            "hvm": "ami-0291fd4543d6940f4"
         },
         "eu-west-3": {
-            "hvm": "ami-0a1b0321c7403b687"
+            "hvm": "ami-083f281d2864a71de"
         },
         "me-south-1": {
-            "hvm": "ami-0d0bacf4ffc6711dc"
+            "hvm": "ami-05a6ae5eadb5b244d"
         },
         "sa-east-1": {
-            "hvm": "ami-0c25edaecfe2ddc13"
+            "hvm": "ami-081f13881a31af160"
         },
         "us-east-1": {
-            "hvm": "ami-0ac468de0431bd41f"
+            "hvm": "ami-009cbe327d180d666"
         },
         "us-east-2": {
-            "hvm": "ami-0ed3e654e70e297c3"
+            "hvm": "ami-0346f64579665ce3c"
         },
         "us-west-1": {
-            "hvm": "ami-0a2d15392c181e2b2"
+            "hvm": "ami-07c185c787029b522"
         },
         "us-west-2": {
-            "hvm": "ami-04cb8492cba4b5261"
+            "hvm": "ami-01105d480bb47353f"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202009222340-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202009222340-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202010011740-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202010011740-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202009222340-0/x86_64/",
-    "buildid": "46.82.202009222340-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202010011740-0/x86_64/",
+    "buildid": "46.82.202010011740-0",
     "gcp": {
-        "image": "rhcos-46-82-202009222340-0-gcp-x86-64",
+        "image": "rhcos-46-82-202010011740-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202009222340-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202010011740-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202009222340-0-aws.x86_64.vmdk.gz",
-            "sha256": "95de712e20669e6d291ed1af347547e4768e707849b8f6287db061a6dfeecc92",
-            "size": 901333262,
-            "uncompressed-sha256": "b538de7fe539767a1a841cab03a5241650d04b4016aae45a935f985907c2e9a6",
-            "uncompressed-size": 920471040
+            "path": "rhcos-46.82.202010011740-0-aws.x86_64.vmdk.gz",
+            "sha256": "21fbefcbb3e1ca9c479e49ba45700026c636ee48f1d1c84a84dabaff2d944f87",
+            "size": 899198828,
+            "uncompressed-sha256": "3af7a3ba4d3963f5e4368cadef9bfe8c1e005218ab42d65b226db17a8bd0f4c8",
+            "uncompressed-size": 918272000
         },
         "azure": {
-            "path": "rhcos-46.82.202009222340-0-azure.x86_64.vhd.gz",
-            "sha256": "9df7b07e23fec7bf8790bb7b9ded8e53c4ab26d6abf69b1c9418ff08af256eeb",
-            "size": 902605097,
-            "uncompressed-sha256": "8cbeb3f96916ec6477d12709b0dcec88b2f06ce553960e7fb78ede3406a0a370",
+            "path": "rhcos-46.82.202010011740-0-azure.x86_64.vhd.gz",
+            "sha256": "c6f233a04aacf9c17602e58a52aaa5f315cbc61254d3447c4ef77f22c9b13403",
+            "size": 900405493,
+            "uncompressed-sha256": "14a37a346dba5a8b49a36dc3eab369f061086ae57be72260d967f55dc9700435",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202009222340-0-gcp.x86_64.tar.gz",
-            "sha256": "d338c3dd0c3972852e6c943a427afbe8423ff20148bb70d87b5dc12bbd3dc27f",
-            "size": 887806732
+            "path": "rhcos-46.82.202010011740-0-gcp.x86_64.tar.gz",
+            "sha256": "e32127985523d442ad01f21fa5ced3fbac3bbb8c19ecf58dda74eacacf971612",
+            "size": 885597213
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202009222340-0-live-initramfs.x86_64.img",
-            "sha256": "94f60eb09f7b0892ecc9aae90338a3823af457b21a0b3ca8665c2c9282f168a4"
+            "path": "rhcos-46.82.202010011740-0-live-initramfs.x86_64.img",
+            "sha256": "ef3fc87f1d6685a3540bf48c570151b30c2d70b75a3d0642e405097e6cdc051f"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202009222340-0-live.x86_64.iso",
-            "sha256": "173f99d1b2ca5fbb1d4ba26a6b35befb58a388fdb0f8870c3ae5a054c3260bb1"
+            "path": "rhcos-46.82.202010011740-0-live.x86_64.iso",
+            "sha256": "67094260aed6f2ceade815c6882fed7b27b628bead50121f066c2bba02e977e1"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202009222340-0-live-kernel-x86_64",
-            "sha256": "c9559bc7f82de6cf4c08dd945bdf992daa91bd53150eb048b6455d78799ad2c8"
+            "path": "rhcos-46.82.202010011740-0-live-kernel-x86_64",
+            "sha256": "e4d0a63c135b37d569ebdec9b8fb9116eccf4e0e0346859b25b2efabd360b8ec"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202009222340-0-live-rootfs.x86_64.img",
-            "sha256": "de276e4f86925b83c4572d01961423ac1af64c21f81e07d792af1d375ccdd68d"
+            "path": "rhcos-46.82.202010011740-0-live-rootfs.x86_64.img",
+            "sha256": "79561bda394499b4a1488b7f40c2f28af7d3565fdabe584c6d6ba8c7ae857c23"
         },
         "metal": {
-            "path": "rhcos-46.82.202009222340-0-metal.x86_64.raw.gz",
-            "sha256": "c8c456802fbdbbe19a54801132e7e3384b8658f610bea76df1e15d61ccbf3af1",
-            "size": 889375686,
-            "uncompressed-sha256": "ac0339b52978a8866bcf1e7030e1418d8285412646c085852dee357d574f4e32",
-            "uncompressed-size": 3552575488
+            "path": "rhcos-46.82.202010011740-0-metal.x86_64.raw.gz",
+            "sha256": "6c7f1f58df61d366fa9ff12c2fa424480068147a6b05b31e11e61ec95960431d",
+            "size": 887126299,
+            "uncompressed-sha256": "f35b1ae5b71bcf4d1d380195a0a6d4c0963f0c5ed1f2454536f1408e66a35185",
+            "uncompressed-size": 3553624064
         },
         "metal4k": {
-            "path": "rhcos-46.82.202009222340-0-metal4k.x86_64.raw.gz",
-            "sha256": "15b3979026778ee469f733b37d25f56b6a51414449c5d0f5b4579ee3692b28c6",
-            "size": 886999253,
-            "uncompressed-sha256": "321455fcfed706d0f58bc4dc5e0c7e739307e991ec051f184524a07b28dd2e88",
-            "uncompressed-size": 3552575488
+            "path": "rhcos-46.82.202010011740-0-metal4k.x86_64.raw.gz",
+            "sha256": "360be1dd39e90011602a6155933f2e9d86afd2153b62fc32a9c27fca85a0fd51",
+            "size": 884961888,
+            "uncompressed-sha256": "24609d1e889fd148576431edaf4cd619f9cb5381d5dc1cfc7a0c7be81c8e1e85",
+            "uncompressed-size": 3553624064
         },
         "openstack": {
-            "path": "rhcos-46.82.202009222340-0-openstack.x86_64.qcow2.gz",
-            "sha256": "fac04b7708eb34eaa3e249ac5f7fc407b1e8f77343d80af9db245c0e3c2bc0a4",
-            "size": 888110693,
-            "uncompressed-sha256": "cc8c4be1bd1c537c5b236a217901f9cd708a15b05010410d74e63632304a121e",
-            "uncompressed-size": 2256928768
+            "path": "rhcos-46.82.202010011740-0-openstack.x86_64.qcow2.gz",
+            "sha256": "9d88edcacbdf31db9cb9418ee3721c74a3f5bbfc4904db9e383e674a86335bd1",
+            "size": 885915737,
+            "uncompressed-sha256": "95a5c2dafca2dd1a59e5e99dc1b3809c9b925cd94e37acf52e29f7e694ce30ab",
+            "uncompressed-size": 2251489280
         },
         "ostree": {
-            "path": "rhcos-46.82.202009222340-0-ostree.x86_64.tar",
-            "sha256": "0c0fcfee25a86994c91e73dd1ef625de2343ceb4b22af884527d5c5939819ee3",
-            "size": 801546240
+            "path": "rhcos-46.82.202010011740-0-ostree.x86_64.tar",
+            "sha256": "5c98466ba5578a8e93744fe332ce3fcd00438a88643eec5f09dc35b7698e9c04",
+            "size": 801597440
         },
         "qemu": {
-            "path": "rhcos-46.82.202009222340-0-qemu.x86_64.qcow2.gz",
-            "sha256": "1e9512b46372e838a2f9ea1d7195462321f065d03d555d64cca21a0667e12f75",
-            "size": 888762748,
-            "uncompressed-sha256": "c9cd1e7b259f4c463b2e5b7e388a20461168b7f0829bae0c59c3d0534f9ef9d1",
-            "uncompressed-size": 2295463936
+            "path": "rhcos-46.82.202010011740-0-qemu.x86_64.qcow2.gz",
+            "sha256": "f0fcdd7690d4212bad5b94c91308afe51727104ce40febf0708517989c2be4e5",
+            "size": 886664696,
+            "uncompressed-sha256": "cbaf2e5548af2d1d1153d9a1beca118042e770725166de427792c33a875137cc",
+            "uncompressed-size": 2288910336
         },
         "vmware": {
-            "path": "rhcos-46.82.202009222340-0-vmware.x86_64.ova",
-            "sha256": "1e4c4bd1ef66973f2289a23e8f570309a93c209be4b354c1ab873c494fcad332",
-            "size": 920483840
+            "path": "rhcos-46.82.202010011740-0-vmware.x86_64.ova",
+            "sha256": "935164c1b85e603a5bea5c50960613a5c24fd43106948abab9213550efcbad95",
+            "size": 918282240
         }
     },
     "oscontainer": {
-        "digest": "sha256:b973b2f9e432b12388874a9c8d191e699106bcbf12d962c729b4e16307dbd83f",
+        "digest": "sha256:fcac8cf37634553a1d87ed57b77ec1c39b727af06f0e6345d60554b45191dd27",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "5d65bddfb072101a84501cd87b8abc650beb8dc0aa2bfeff022fc750cde52f1d",
-    "ostree-version": "46.82.202009222340-0"
+    "ostree-commit": "ce0233ed167e2496ed0806af43984cbd063222ddd8229de8b09741fbce414b81",
+    "ostree-version": "46.82.202010011740-0"
 }

--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,5 +1,11 @@
 {
     "amis": {
+        "af-south-1": {
+            "hvm": "ami-02f4a2c7b9a3a6840"
+        },
+        "ap-east-1": {
+            "hvm": "ami-06a0695694b6c3e8d"
+        },
         "ap-northeast-1": {
             "hvm": "ami-0cb46ba6945dbfebe"
         },
@@ -23,6 +29,9 @@
         },
         "eu-north-1": {
             "hvm": "ami-06d01bfaf14ad66a3"
+        },
+        "eu-south-1": {
+            "hvm": "ami-031c7e2567f507746"
         },
         "eu-west-1": {
             "hvm": "ami-0e514a30ad261c978"

--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,156 +1,156 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-02f4a2c7b9a3a6840"
+            "hvm": "ami-09921c9c1c36e695c"
         },
         "ap-east-1": {
-            "hvm": "ami-06a0695694b6c3e8d"
+            "hvm": "ami-01ee8446e9af6b197"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0cb46ba6945dbfebe"
+            "hvm": "ami-04e5b5722a55846ea"
         },
         "ap-northeast-2": {
-            "hvm": "ami-01e554d608de6087a"
+            "hvm": "ami-0fdc25c8a0273a742"
         },
         "ap-south-1": {
-            "hvm": "ami-09253ba33f828d47f"
+            "hvm": "ami-09e3deb397cc526a8"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0a6a0f1f6106708c4"
+            "hvm": "ami-0630e03f75e02eec4"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0e3e2b2ea00c35823"
+            "hvm": "ami-069450613262ba03c"
         },
         "ca-central-1": {
-            "hvm": "ami-0f5825ef10c76de32"
+            "hvm": "ami-012518cdbd3057dfd"
         },
         "eu-central-1": {
-            "hvm": "ami-0a51f61236e6fc6f2"
+            "hvm": "ami-0bd7175ff5b1aef0c"
         },
         "eu-north-1": {
-            "hvm": "ami-06d01bfaf14ad66a3"
+            "hvm": "ami-06c9ec42d0a839ad2"
         },
         "eu-south-1": {
-            "hvm": "ami-031c7e2567f507746"
+            "hvm": "ami-0614d7440a0363d71"
         },
         "eu-west-1": {
-            "hvm": "ami-0e514a30ad261c978"
+            "hvm": "ami-01b89df58b5d4d5fa"
         },
         "eu-west-2": {
-            "hvm": "ami-0291fd4543d6940f4"
+            "hvm": "ami-06f6e31ddd554f89d"
         },
         "eu-west-3": {
-            "hvm": "ami-083f281d2864a71de"
+            "hvm": "ami-0dc82e2517ded15a1"
         },
         "me-south-1": {
-            "hvm": "ami-05a6ae5eadb5b244d"
+            "hvm": "ami-07d181e3aa0f76067"
         },
         "sa-east-1": {
-            "hvm": "ami-081f13881a31af160"
+            "hvm": "ami-0cd44e6dd20e6c7fa"
         },
         "us-east-1": {
-            "hvm": "ami-009cbe327d180d666"
+            "hvm": "ami-04a16d506e5b0e246"
         },
         "us-east-2": {
-            "hvm": "ami-0346f64579665ce3c"
+            "hvm": "ami-0a1f868ad58ea59a7"
         },
         "us-west-1": {
-            "hvm": "ami-07c185c787029b522"
+            "hvm": "ami-0a65d76e3a6f6622f"
         },
         "us-west-2": {
-            "hvm": "ami-01105d480bb47353f"
+            "hvm": "ami-0dd9008abadc519f1"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202010011740-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202010011740-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202011260640-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202011260640-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202010011740-0/x86_64/",
-    "buildid": "46.82.202010011740-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202011260640-0/x86_64/",
+    "buildid": "46.82.202011260640-0",
     "gcp": {
-        "image": "rhcos-46-82-202010011740-0-gcp-x86-64",
+        "image": "rhcos-46-82-202011260640-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202010011740-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202011260640-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202010011740-0-aws.x86_64.vmdk.gz",
-            "sha256": "21fbefcbb3e1ca9c479e49ba45700026c636ee48f1d1c84a84dabaff2d944f87",
-            "size": 899198828,
-            "uncompressed-sha256": "3af7a3ba4d3963f5e4368cadef9bfe8c1e005218ab42d65b226db17a8bd0f4c8",
-            "uncompressed-size": 918272000
+            "path": "rhcos-46.82.202011260640-0-aws.x86_64.vmdk.gz",
+            "sha256": "6e0f720077ac20fae46c16159d03fd51f66cd318155dcd14f0f5d7dc79bfd8ad",
+            "size": 900764628,
+            "uncompressed-sha256": "b38713b80bbcc41d18efcec93d241da48533225e0ce073c2a26235993ffc4166",
+            "uncompressed-size": 919795200
         },
         "azure": {
-            "path": "rhcos-46.82.202010011740-0-azure.x86_64.vhd.gz",
-            "sha256": "c6f233a04aacf9c17602e58a52aaa5f315cbc61254d3447c4ef77f22c9b13403",
-            "size": 900405493,
-            "uncompressed-sha256": "14a37a346dba5a8b49a36dc3eab369f061086ae57be72260d967f55dc9700435",
+            "path": "rhcos-46.82.202011260640-0-azure.x86_64.vhd.gz",
+            "sha256": "5255c675ecff4f8932db24b68a7ef451dfc4e502326128931ccd39acf27c6c77",
+            "size": 901953565,
+            "uncompressed-sha256": "0fd7ab096c7ac4b8d807371d1c4a13b3a665b5d2938ff814bd3e46257193941b",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202010011740-0-gcp.x86_64.tar.gz",
-            "sha256": "e32127985523d442ad01f21fa5ced3fbac3bbb8c19ecf58dda74eacacf971612",
-            "size": 885597213
+            "path": "rhcos-46.82.202011260640-0-gcp.x86_64.tar.gz",
+            "sha256": "f470a98c1fc7a4e0226ed4258fdd0b6edcddbb2356e7992bea4b98843cd94d9a",
+            "size": 887140241
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202010011740-0-live-initramfs.x86_64.img",
-            "sha256": "ef3fc87f1d6685a3540bf48c570151b30c2d70b75a3d0642e405097e6cdc051f"
+            "path": "rhcos-46.82.202011260640-0-live-initramfs.x86_64.img",
+            "sha256": "8ff220c6f4bbca35dd071c5f1802566290b70081faeb06fb07f72c4583f8facf"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202010011740-0-live.x86_64.iso",
-            "sha256": "67094260aed6f2ceade815c6882fed7b27b628bead50121f066c2bba02e977e1"
+            "path": "rhcos-46.82.202011260640-0-live.x86_64.iso",
+            "sha256": "161046d6275cda89a3f44582bc2b850cd09b987807d3b20090eeab279b7e0550"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202010011740-0-live-kernel-x86_64",
-            "sha256": "e4d0a63c135b37d569ebdec9b8fb9116eccf4e0e0346859b25b2efabd360b8ec"
+            "path": "rhcos-46.82.202011260640-0-live-kernel-x86_64",
+            "sha256": "9bbb496410c04f54d30eb56f76f769bccec7e81b91271ae72261ecc54db9c63d"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202010011740-0-live-rootfs.x86_64.img",
-            "sha256": "79561bda394499b4a1488b7f40c2f28af7d3565fdabe584c6d6ba8c7ae857c23"
+            "path": "rhcos-46.82.202011260640-0-live-rootfs.x86_64.img",
+            "sha256": "007f9c376e1282b77ed662509a3a81b624dfcf28aa971a9e80b33fc06cf9c4fd"
         },
         "metal": {
-            "path": "rhcos-46.82.202010011740-0-metal.x86_64.raw.gz",
-            "sha256": "6c7f1f58df61d366fa9ff12c2fa424480068147a6b05b31e11e61ec95960431d",
-            "size": 887126299,
-            "uncompressed-sha256": "f35b1ae5b71bcf4d1d380195a0a6d4c0963f0c5ed1f2454536f1408e66a35185",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202011260640-0-metal.x86_64.raw.gz",
+            "sha256": "bcd9871c373c02898675ec407e83f9ccd107077ff30008ecb601c9869c4a501a",
+            "size": 888607273,
+            "uncompressed-sha256": "a769991d850064ef078ba4dae9050e34a820bf9eba792a2b7922fb7a15315b57",
+            "uncompressed-size": 3555721216
         },
         "metal4k": {
-            "path": "rhcos-46.82.202010011740-0-metal4k.x86_64.raw.gz",
-            "sha256": "360be1dd39e90011602a6155933f2e9d86afd2153b62fc32a9c27fca85a0fd51",
-            "size": 884961888,
-            "uncompressed-sha256": "24609d1e889fd148576431edaf4cd619f9cb5381d5dc1cfc7a0c7be81c8e1e85",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202011260640-0-metal4k.x86_64.raw.gz",
+            "sha256": "ff4ed9d58a286185abdc4be0faaa4cd621c088121133b9b5952d2da320149fad",
+            "size": 886276538,
+            "uncompressed-sha256": "1e57d643969306e84b945c6355eed2793daa3e7675b0daa63defd6f5f8b5a43d",
+            "uncompressed-size": 3555721216
         },
         "openstack": {
-            "path": "rhcos-46.82.202010011740-0-openstack.x86_64.qcow2.gz",
-            "sha256": "9d88edcacbdf31db9cb9418ee3721c74a3f5bbfc4904db9e383e674a86335bd1",
-            "size": 885915737,
-            "uncompressed-sha256": "95a5c2dafca2dd1a59e5e99dc1b3809c9b925cd94e37acf52e29f7e694ce30ab",
-            "uncompressed-size": 2251489280
+            "path": "rhcos-46.82.202011260640-0-openstack.x86_64.qcow2.gz",
+            "sha256": "a8a28cfe5f5e5dadedb3442afcb447f85bddf2e82dcd558813a985a4d495782a",
+            "size": 887473972,
+            "uncompressed-sha256": "2bd648e09f086973accd8ac1e355ce0fcd7dfcc16bc9708c938801fcf10e219e",
+            "uncompressed-size": 2254045184
         },
         "ostree": {
-            "path": "rhcos-46.82.202010011740-0-ostree.x86_64.tar",
-            "sha256": "5c98466ba5578a8e93744fe332ce3fcd00438a88643eec5f09dc35b7698e9c04",
-            "size": 801597440
+            "path": "rhcos-46.82.202011260640-0-ostree.x86_64.tar",
+            "sha256": "1b15017685292447ebb2dc8bfe8a4f216ea1c42f871f666c65d4b98e9998d549",
+            "size": 802641920
         },
         "qemu": {
-            "path": "rhcos-46.82.202010011740-0-qemu.x86_64.qcow2.gz",
-            "sha256": "f0fcdd7690d4212bad5b94c91308afe51727104ce40febf0708517989c2be4e5",
-            "size": 886664696,
-            "uncompressed-sha256": "cbaf2e5548af2d1d1153d9a1beca118042e770725166de427792c33a875137cc",
-            "uncompressed-size": 2288910336
+            "path": "rhcos-46.82.202011260640-0-qemu.x86_64.qcow2.gz",
+            "sha256": "0ea6f0852c3e0f8e4182e705561fdccd998503ef423c441e182241cd6a278730",
+            "size": 888353176,
+            "uncompressed-sha256": "99928ff40c2d8e3aa358d9bd453102e3d1b5e9694fb5d54febc56e275f35da51",
+            "uncompressed-size": 2290221056
         },
         "vmware": {
-            "path": "rhcos-46.82.202010011740-0-vmware.x86_64.ova",
-            "sha256": "935164c1b85e603a5bea5c50960613a5c24fd43106948abab9213550efcbad95",
-            "size": 918282240
+            "path": "rhcos-46.82.202011260640-0-vmware.x86_64.ova",
+            "sha256": "d73c7bdfd22e5a1231e23663266744c98c10de6f08f6d1fc718e7f72d0490c4a",
+            "size": 919808000
         }
     },
     "oscontainer": {
-        "digest": "sha256:fcac8cf37634553a1d87ed57b77ec1c39b727af06f0e6345d60554b45191dd27",
+        "digest": "sha256:54f1ab852c6592d6ca453cabb855b5c9f5ced35b1aadbb5d8161d4ca2d3623cc",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ce0233ed167e2496ed0806af43984cbd063222ddd8229de8b09741fbce414b81",
-    "ostree-version": "46.82.202010011740-0"
+    "ostree-commit": "cb0327325553e6922ff25822ea7eb1a2ec213e70c7cf6880965e7e2bb5ee7dea",
+    "ostree-version": "46.82.202011260640-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202009240941-0/ppc64le/",
-    "buildid": "46.82.202009240941-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202011260639-0/ppc64le/",
+    "buildid": "46.82.202011260639-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-46.82.202009240941-0-live-initramfs.ppc64le.img",
-            "sha256": "c0a52acf1c883565bff9c1ea8ab2eb9a2789f23124fdd1be78f6d2f624450445"
+            "path": "rhcos-46.82.202011260639-0-live-initramfs.ppc64le.img",
+            "sha256": "a63a99b3183d85d2772031ecb5d472c8f709dd55609a27b3f158938b9d34d798"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202009240941-0-live.ppc64le.iso",
-            "sha256": "90359e206905513694860f0d195af257da3db95b507e83b1f53daa6bfbe9023d"
+            "path": "rhcos-46.82.202011260639-0-live.ppc64le.iso",
+            "sha256": "a1de1afef9d7d624b8b982c5b940ac05dfd50160ea028d71098a72ce02a95310"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202009240941-0-live-kernel-ppc64le",
-            "sha256": "430755e6db588ec04fd5ba56d7973e8622eee90cc8f6d819fefb46926625d19b"
+            "path": "rhcos-46.82.202011260639-0-live-kernel-ppc64le",
+            "sha256": "4f33503357e6847d5ddba97d7f3ee0773cbc1046b4121e15f7233eccade092f7"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202009240941-0-live-rootfs.ppc64le.img",
-            "sha256": "3ec25712a88d1da7e60d2581677b0fde9c6b175c2fa5b6dd9ec43296e5aba2c7"
+            "path": "rhcos-46.82.202011260639-0-live-rootfs.ppc64le.img",
+            "sha256": "ec0af7540cb6d7266424874bd5aec0ac60183f94b3da9e30ad2911492981efcd"
         },
         "metal": {
-            "path": "rhcos-46.82.202009240941-0-metal.ppc64le.raw.gz",
-            "sha256": "20288d82cb5698bae23bea7f364c046a19eb5b3fb1ca618b7a4068d1c36d6eba",
-            "size": 867240759,
-            "uncompressed-sha256": "6156add3bdfdf384d7dddbc431a2a1438f6360f92452bb862ddb229c2a84c06a",
-            "uncompressed-size": 3693084672
+            "path": "rhcos-46.82.202011260639-0-metal.ppc64le.raw.gz",
+            "sha256": "99fc11c699403ccf26610954b27dbbae94a0831a4c39a5c498f808e43cfbdb70",
+            "size": 873495765,
+            "uncompressed-sha256": "e72a39b888c44bd5b7fc276b7a23ae7e8a9facd53abbf59301419dfc4dcd0d46",
+            "uncompressed-size": 3725590528
         },
         "metal4k": {
-            "path": "rhcos-46.82.202009240941-0-metal4k.ppc64le.raw.gz",
-            "sha256": "8f519caa7429ba8d1dcfdf44a7ff4a92665381b07ab2d035ff90318e41b5ab12",
-            "size": 867334091,
-            "uncompressed-sha256": "41924484e1a93c0a47eadc19c860baf52337dd428d90a9147d773b9723ac11df",
-            "uncompressed-size": 3693084672
+            "path": "rhcos-46.82.202011260639-0-metal4k.ppc64le.raw.gz",
+            "sha256": "ce17fd2bc612fee6ea5d99895fc6a3f3aaa2b8a1f7bdc05fddf7e3e1acea3f77",
+            "size": 873975134,
+            "uncompressed-sha256": "a04c711706cc15ee90f5e8143d01e6616e6556e7510d168464e16de7f3f66556",
+            "uncompressed-size": 3725590528
         },
         "openstack": {
-            "path": "rhcos-46.82.202009240941-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "96adcc9d0f01b2748eb8a86868162ec8e844288040a43e44bda11567a0249061",
-            "size": 865739613,
-            "uncompressed-sha256": "daf1c90ed5082c7da490fe666c91c65ffe74c119eac27f78bdf6216e4bb61d2f",
-            "uncompressed-size": 2361982976
+            "path": "rhcos-46.82.202011260639-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "2a7fea1b87a0878363aefc97d0834d6bdf9b80f9ff5696d33bb22938e1102924",
+            "size": 871975342,
+            "uncompressed-sha256": "d4055dee26ddc5ba04fc9e788807238843754f83bb959e0c6bc3ed173b960394",
+            "uncompressed-size": 2387279872
         },
         "ostree": {
-            "path": "rhcos-46.82.202009240941-0-ostree.ppc64le.tar",
-            "sha256": "11c1f85b82a418416706c1a7f7b974590e5b1b746a9727544187d5b34cabd7ef",
-            "size": 776611840
+            "path": "rhcos-46.82.202011260639-0-ostree.ppc64le.tar",
+            "sha256": "2454454574b96b75d2a8aef8b1cad393c79558aa66cc1cee5093688c8b3224e6",
+            "size": 784117760
         },
         "qemu": {
-            "path": "rhcos-46.82.202009240941-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "86be9dea62495d885cc0622f8025aaf56a1af26429bfa27b4ad2169d448a7668",
-            "size": 866267572,
-            "uncompressed-sha256": "ce30ae7d26ce24a04a42831ae18541f97a1cc9eb57f3bf6395a99b78ec60c1dd",
-            "uncompressed-size": 2400714752
+            "path": "rhcos-46.82.202011260639-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "bb9611f2d988088fa6dc1d9082f43b719f16f4c84aad669674ada0a59699c288",
+            "size": 872555277,
+            "uncompressed-sha256": "08879b33ac4d46e04824735e283b549b9f03daae150dffb7fd3265d8c5d2d598",
+            "uncompressed-size": 2424307712
         }
     },
     "oscontainer": {
-        "digest": "sha256:2758233e925dff411d2553ce48babed0e0608a58225455040dc3f0c4710cb08f",
+        "digest": "sha256:af789c7d73b7de9136cc734f05164c692b0b27c738ecedd0f8bd970a182d2848",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "271c5b43ce734e38d75299e7fc1e4d331679942ad4b93a6fb2fc8fe0f34d19bd",
-    "ostree-version": "46.82.202009240941-0"
+    "ostree-commit": "e11b8d8ca1ab07c8428158fce6c14b6adcaf819cf7353e7a17ac99451bdd5dbf",
+    "ostree-version": "46.82.202011260639-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202009241338-0/s390x/",
-    "buildid": "46.82.202009241338-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202011261339-0/s390x/",
+    "buildid": "46.82.202011261339-0",
     "images": {
         "dasd": {
-            "path": "rhcos-46.82.202009241338-0-dasd.s390x.raw.gz",
-            "sha256": "265c05e0ad96ea939172020e030635bc91a29ea5cbdf0164f8e5f0ca19adfe8d",
-            "size": 789084259,
-            "uncompressed-sha256": "71773041b7111719b980ad7c9209f1a5766f642020bcec68b82fb58d5cb0b1fa",
-            "uncompressed-size": 3372220416
+            "path": "rhcos-46.82.202011261339-0-dasd.s390x.raw.gz",
+            "sha256": "6f9b92054667c84dec33dfd724444b74d0e3d241c7e7e2b9583165918114e22d",
+            "size": 788978205,
+            "uncompressed-sha256": "0c6627eb4dbc25cfa16e8ba6ef4975d580e403929a2450b05e69477b97111744",
+            "uncompressed-size": 3370123264
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202009241338-0-live-initramfs.s390x.img",
-            "sha256": "f4e0f654a200dcc61f266be476897374a33d892de20a79efab5f980a866bc814"
+            "path": "rhcos-46.82.202011261339-0-live-initramfs.s390x.img",
+            "sha256": "ca544ccce11a9d43b4478c9e6193faf77c6ed8f9996fb58d110fc3a9ec0db471"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202009241338-0-live.s390x.iso",
-            "sha256": "91a65767ef52f721ad6c20b70de93116341b47ee249233a1b8b64668279efb41"
+            "path": "rhcos-46.82.202011261339-0-live.s390x.iso",
+            "sha256": "75c7ab592f4a64c844f1bb2486586f5baabed7a791341d9def5246ab8363f92f"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202009241338-0-live-kernel-s390x",
-            "sha256": "a843da4b853cc5504e3a3aaee2221e4131efc3cf356e4fa4c440031a73b87b79"
+            "path": "rhcos-46.82.202011261339-0-live-kernel-s390x",
+            "sha256": "54d180071776bb989163897079c2652b0c7106f9c41d7187de4d015204aae8c4"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202009241338-0-live-rootfs.s390x.img",
-            "sha256": "9ea69ce44f68ede52653867af9953ffd5b33f6878abe8375821351fe3a05b12d"
+            "path": "rhcos-46.82.202011261339-0-live-rootfs.s390x.img",
+            "sha256": "7e9bfea2c4f76c51540e49413ff5d79290905c18745561183c736309ede3d6bb"
         },
         "metal": {
-            "path": "rhcos-46.82.202009241338-0-metal.s390x.raw.gz",
-            "sha256": "6c67ce15e8ad94282bedc9490192b19f9c6d7ca38839139c92889e882ae2abdb",
-            "size": 788995446,
-            "uncompressed-sha256": "a12805e2402b2b040a97d6d1453ece4483994d4e82d883524b239bd86c8458b7",
-            "uncompressed-size": 3372220416
+            "path": "rhcos-46.82.202011261339-0-metal.s390x.raw.gz",
+            "sha256": "70a7f86de36e25883a92956de73db8dc68b51e5881804984868eebf103fac0c9",
+            "size": 788865133,
+            "uncompressed-sha256": "b66d9b48b8d92df4da71296f2eb5fec9cee25b3c36e3a066ceb685c16c889b8e",
+            "uncompressed-size": 3370123264
         },
         "metal4k": {
-            "path": "rhcos-46.82.202009241338-0-metal4k.s390x.raw.gz",
-            "sha256": "f0cc6c43eeac9be69c705f7cfbf329192d7d540c87b78631f6d09752a7235612",
-            "size": 789003375,
-            "uncompressed-sha256": "ac5ab167f8bed0fe29e4f3acaeb1437a33af51d86654c98cda01d519f4c3ab28",
-            "uncompressed-size": 3372220416
+            "path": "rhcos-46.82.202011261339-0-metal4k.s390x.raw.gz",
+            "sha256": "38dabda95ea6c5ed25edaf7b3daa1e844ab4eeaab94623ca407b0b03eb97e5f8",
+            "size": 788950764,
+            "uncompressed-sha256": "6acc28b0f1c40cb6ee653534def9267a20f2043c8091c3e94478409a424ebe68",
+            "uncompressed-size": 3370123264
         },
         "openstack": {
-            "path": "rhcos-46.82.202009241338-0-openstack.s390x.qcow2.gz",
-            "sha256": "6a780c5efbb78e987be349dcdaa57858f407c93108ce789ec2b848c75892e598",
-            "size": 787813623,
-            "uncompressed-sha256": "2c7cee4537234b0eba71ebfd2944ceaa5e78fc99a542ba9d6f4eace93136e86d",
+            "path": "rhcos-46.82.202011261339-0-openstack.s390x.qcow2.gz",
+            "sha256": "5877ecaf2fda46399260a6b410dda2493a842c92629666dff0bddd4bba5d4265",
+            "size": 787779116,
+            "uncompressed-sha256": "debc4c4bce89ee388de8ae20ad5f3f6f84a51b60d5341380651c661ee86df597",
             "uncompressed-size": 2084765696
         },
         "ostree": {
-            "path": "rhcos-46.82.202009241338-0-ostree.s390x.tar",
-            "sha256": "fd7763c3ae9180df4f90b75a4e8b42066d084b97d4d93fc1a6c72f87c4219994",
-            "size": 725288960
+            "path": "rhcos-46.82.202011261339-0-ostree.s390x.tar",
+            "sha256": "64bdf909a35f8f039a3cb6df9a2c2ef942f36309f701c143031cb111816c332a",
+            "size": 725104640
         },
         "qemu": {
-            "path": "rhcos-46.82.202009241338-0-qemu.s390x.qcow2.gz",
-            "sha256": "961a4844a435ea99bb846d33bf45fcbd2ff8314d8b0aa0a7f19a84ac4d8d8b5f",
-            "size": 788556212,
-            "uncompressed-sha256": "1c24153899e719b0fe7d3a82c23ce2180df047cab3978941af9fdd02b3a34b6c",
-            "uncompressed-size": 2122121216
+            "path": "rhcos-46.82.202011261339-0-qemu.s390x.qcow2.gz",
+            "sha256": "a487fa710176c5540f94fa145e6dc47c5d554594a84da917d22c35c46d782125",
+            "size": 788427226,
+            "uncompressed-sha256": "4f874dd740fe639c37319d78af6100eaa55023cfab081c1e1db55b65d60a3b0f",
+            "uncompressed-size": 2120679424
         }
     },
     "oscontainer": {
-        "digest": "sha256:a2bb9d33524bb92f5059843ea87bb205d72bf2c23164090852485722682ff8e1",
+        "digest": "sha256:8247d9e6ce2ca2d081df2d7dc53304f69d17cd09e313c8af393bed7704f289a9",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "d89f98fded4b2a9753f72754334ed284599597c1608b076cb6976c7ed532e15b",
-    "ostree-version": "46.82.202009241338-0"
+    "ostree-commit": "6dd3045c4e2fad3cf4d15a43116a522cf7686accbd548839783795b74d6f7cb7",
+    "ostree-version": "46.82.202011261339-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,147 +1,147 @@
 {
     "amis": {
         "ap-northeast-1": {
-            "hvm": "ami-0d6e98846a85acf1d"
+            "hvm": "ami-0cb46ba6945dbfebe"
         },
         "ap-northeast-2": {
-            "hvm": "ami-06f14832100209a68"
+            "hvm": "ami-01e554d608de6087a"
         },
         "ap-south-1": {
-            "hvm": "ami-00e4ed0fe8de223e2"
+            "hvm": "ami-09253ba33f828d47f"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0224bb3fb42e4217d"
+            "hvm": "ami-0a6a0f1f6106708c4"
         },
         "ap-southeast-2": {
-            "hvm": "ami-06c3ab5202323d006"
+            "hvm": "ami-0e3e2b2ea00c35823"
         },
         "ca-central-1": {
-            "hvm": "ami-0d61e0308208ba1e6"
+            "hvm": "ami-0f5825ef10c76de32"
         },
         "eu-central-1": {
-            "hvm": "ami-0f142f5cc084c173f"
+            "hvm": "ami-0a51f61236e6fc6f2"
         },
         "eu-north-1": {
-            "hvm": "ami-081516e373803941f"
+            "hvm": "ami-06d01bfaf14ad66a3"
         },
         "eu-west-1": {
-            "hvm": "ami-0aded2fab8dfcf6f0"
+            "hvm": "ami-0e514a30ad261c978"
         },
         "eu-west-2": {
-            "hvm": "ami-0aeca025866a91960"
+            "hvm": "ami-0291fd4543d6940f4"
         },
         "eu-west-3": {
-            "hvm": "ami-0a1b0321c7403b687"
+            "hvm": "ami-083f281d2864a71de"
         },
         "me-south-1": {
-            "hvm": "ami-0d0bacf4ffc6711dc"
+            "hvm": "ami-05a6ae5eadb5b244d"
         },
         "sa-east-1": {
-            "hvm": "ami-0c25edaecfe2ddc13"
+            "hvm": "ami-081f13881a31af160"
         },
         "us-east-1": {
-            "hvm": "ami-0ac468de0431bd41f"
+            "hvm": "ami-009cbe327d180d666"
         },
         "us-east-2": {
-            "hvm": "ami-0ed3e654e70e297c3"
+            "hvm": "ami-0346f64579665ce3c"
         },
         "us-west-1": {
-            "hvm": "ami-0a2d15392c181e2b2"
+            "hvm": "ami-07c185c787029b522"
         },
         "us-west-2": {
-            "hvm": "ami-04cb8492cba4b5261"
+            "hvm": "ami-01105d480bb47353f"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202009222340-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202009222340-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202010011740-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202010011740-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202009222340-0/x86_64/",
-    "buildid": "46.82.202009222340-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202010011740-0/x86_64/",
+    "buildid": "46.82.202010011740-0",
     "gcp": {
-        "image": "rhcos-46-82-202009222340-0-gcp-x86-64",
+        "image": "rhcos-46-82-202010011740-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202009222340-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202010011740-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202009222340-0-aws.x86_64.vmdk.gz",
-            "sha256": "95de712e20669e6d291ed1af347547e4768e707849b8f6287db061a6dfeecc92",
-            "size": 901333262,
-            "uncompressed-sha256": "b538de7fe539767a1a841cab03a5241650d04b4016aae45a935f985907c2e9a6",
-            "uncompressed-size": 920471040
+            "path": "rhcos-46.82.202010011740-0-aws.x86_64.vmdk.gz",
+            "sha256": "21fbefcbb3e1ca9c479e49ba45700026c636ee48f1d1c84a84dabaff2d944f87",
+            "size": 899198828,
+            "uncompressed-sha256": "3af7a3ba4d3963f5e4368cadef9bfe8c1e005218ab42d65b226db17a8bd0f4c8",
+            "uncompressed-size": 918272000
         },
         "azure": {
-            "path": "rhcos-46.82.202009222340-0-azure.x86_64.vhd.gz",
-            "sha256": "9df7b07e23fec7bf8790bb7b9ded8e53c4ab26d6abf69b1c9418ff08af256eeb",
-            "size": 902605097,
-            "uncompressed-sha256": "8cbeb3f96916ec6477d12709b0dcec88b2f06ce553960e7fb78ede3406a0a370",
+            "path": "rhcos-46.82.202010011740-0-azure.x86_64.vhd.gz",
+            "sha256": "c6f233a04aacf9c17602e58a52aaa5f315cbc61254d3447c4ef77f22c9b13403",
+            "size": 900405493,
+            "uncompressed-sha256": "14a37a346dba5a8b49a36dc3eab369f061086ae57be72260d967f55dc9700435",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202009222340-0-gcp.x86_64.tar.gz",
-            "sha256": "d338c3dd0c3972852e6c943a427afbe8423ff20148bb70d87b5dc12bbd3dc27f",
-            "size": 887806732
+            "path": "rhcos-46.82.202010011740-0-gcp.x86_64.tar.gz",
+            "sha256": "e32127985523d442ad01f21fa5ced3fbac3bbb8c19ecf58dda74eacacf971612",
+            "size": 885597213
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202009222340-0-live-initramfs.x86_64.img",
-            "sha256": "94f60eb09f7b0892ecc9aae90338a3823af457b21a0b3ca8665c2c9282f168a4"
+            "path": "rhcos-46.82.202010011740-0-live-initramfs.x86_64.img",
+            "sha256": "ef3fc87f1d6685a3540bf48c570151b30c2d70b75a3d0642e405097e6cdc051f"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202009222340-0-live.x86_64.iso",
-            "sha256": "173f99d1b2ca5fbb1d4ba26a6b35befb58a388fdb0f8870c3ae5a054c3260bb1"
+            "path": "rhcos-46.82.202010011740-0-live.x86_64.iso",
+            "sha256": "67094260aed6f2ceade815c6882fed7b27b628bead50121f066c2bba02e977e1"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202009222340-0-live-kernel-x86_64",
-            "sha256": "c9559bc7f82de6cf4c08dd945bdf992daa91bd53150eb048b6455d78799ad2c8"
+            "path": "rhcos-46.82.202010011740-0-live-kernel-x86_64",
+            "sha256": "e4d0a63c135b37d569ebdec9b8fb9116eccf4e0e0346859b25b2efabd360b8ec"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202009222340-0-live-rootfs.x86_64.img",
-            "sha256": "de276e4f86925b83c4572d01961423ac1af64c21f81e07d792af1d375ccdd68d"
+            "path": "rhcos-46.82.202010011740-0-live-rootfs.x86_64.img",
+            "sha256": "79561bda394499b4a1488b7f40c2f28af7d3565fdabe584c6d6ba8c7ae857c23"
         },
         "metal": {
-            "path": "rhcos-46.82.202009222340-0-metal.x86_64.raw.gz",
-            "sha256": "c8c456802fbdbbe19a54801132e7e3384b8658f610bea76df1e15d61ccbf3af1",
-            "size": 889375686,
-            "uncompressed-sha256": "ac0339b52978a8866bcf1e7030e1418d8285412646c085852dee357d574f4e32",
-            "uncompressed-size": 3552575488
+            "path": "rhcos-46.82.202010011740-0-metal.x86_64.raw.gz",
+            "sha256": "6c7f1f58df61d366fa9ff12c2fa424480068147a6b05b31e11e61ec95960431d",
+            "size": 887126299,
+            "uncompressed-sha256": "f35b1ae5b71bcf4d1d380195a0a6d4c0963f0c5ed1f2454536f1408e66a35185",
+            "uncompressed-size": 3553624064
         },
         "metal4k": {
-            "path": "rhcos-46.82.202009222340-0-metal4k.x86_64.raw.gz",
-            "sha256": "15b3979026778ee469f733b37d25f56b6a51414449c5d0f5b4579ee3692b28c6",
-            "size": 886999253,
-            "uncompressed-sha256": "321455fcfed706d0f58bc4dc5e0c7e739307e991ec051f184524a07b28dd2e88",
-            "uncompressed-size": 3552575488
+            "path": "rhcos-46.82.202010011740-0-metal4k.x86_64.raw.gz",
+            "sha256": "360be1dd39e90011602a6155933f2e9d86afd2153b62fc32a9c27fca85a0fd51",
+            "size": 884961888,
+            "uncompressed-sha256": "24609d1e889fd148576431edaf4cd619f9cb5381d5dc1cfc7a0c7be81c8e1e85",
+            "uncompressed-size": 3553624064
         },
         "openstack": {
-            "path": "rhcos-46.82.202009222340-0-openstack.x86_64.qcow2.gz",
-            "sha256": "fac04b7708eb34eaa3e249ac5f7fc407b1e8f77343d80af9db245c0e3c2bc0a4",
-            "size": 888110693,
-            "uncompressed-sha256": "cc8c4be1bd1c537c5b236a217901f9cd708a15b05010410d74e63632304a121e",
-            "uncompressed-size": 2256928768
+            "path": "rhcos-46.82.202010011740-0-openstack.x86_64.qcow2.gz",
+            "sha256": "9d88edcacbdf31db9cb9418ee3721c74a3f5bbfc4904db9e383e674a86335bd1",
+            "size": 885915737,
+            "uncompressed-sha256": "95a5c2dafca2dd1a59e5e99dc1b3809c9b925cd94e37acf52e29f7e694ce30ab",
+            "uncompressed-size": 2251489280
         },
         "ostree": {
-            "path": "rhcos-46.82.202009222340-0-ostree.x86_64.tar",
-            "sha256": "0c0fcfee25a86994c91e73dd1ef625de2343ceb4b22af884527d5c5939819ee3",
-            "size": 801546240
+            "path": "rhcos-46.82.202010011740-0-ostree.x86_64.tar",
+            "sha256": "5c98466ba5578a8e93744fe332ce3fcd00438a88643eec5f09dc35b7698e9c04",
+            "size": 801597440
         },
         "qemu": {
-            "path": "rhcos-46.82.202009222340-0-qemu.x86_64.qcow2.gz",
-            "sha256": "1e9512b46372e838a2f9ea1d7195462321f065d03d555d64cca21a0667e12f75",
-            "size": 888762748,
-            "uncompressed-sha256": "c9cd1e7b259f4c463b2e5b7e388a20461168b7f0829bae0c59c3d0534f9ef9d1",
-            "uncompressed-size": 2295463936
+            "path": "rhcos-46.82.202010011740-0-qemu.x86_64.qcow2.gz",
+            "sha256": "f0fcdd7690d4212bad5b94c91308afe51727104ce40febf0708517989c2be4e5",
+            "size": 886664696,
+            "uncompressed-sha256": "cbaf2e5548af2d1d1153d9a1beca118042e770725166de427792c33a875137cc",
+            "uncompressed-size": 2288910336
         },
         "vmware": {
-            "path": "rhcos-46.82.202009222340-0-vmware.x86_64.ova",
-            "sha256": "1e4c4bd1ef66973f2289a23e8f570309a93c209be4b354c1ab873c494fcad332",
-            "size": 920483840
+            "path": "rhcos-46.82.202010011740-0-vmware.x86_64.ova",
+            "sha256": "935164c1b85e603a5bea5c50960613a5c24fd43106948abab9213550efcbad95",
+            "size": 918282240
         }
     },
     "oscontainer": {
-        "digest": "sha256:b973b2f9e432b12388874a9c8d191e699106bcbf12d962c729b4e16307dbd83f",
+        "digest": "sha256:fcac8cf37634553a1d87ed57b77ec1c39b727af06f0e6345d60554b45191dd27",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "5d65bddfb072101a84501cd87b8abc650beb8dc0aa2bfeff022fc750cde52f1d",
-    "ostree-version": "46.82.202009222340-0"
+    "ostree-commit": "ce0233ed167e2496ed0806af43984cbd063222ddd8229de8b09741fbce414b81",
+    "ostree-version": "46.82.202010011740-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,5 +1,11 @@
 {
     "amis": {
+        "af-south-1": {
+            "hvm": "ami-02f4a2c7b9a3a6840"
+        },
+        "ap-east-1": {
+            "hvm": "ami-06a0695694b6c3e8d"
+        },
         "ap-northeast-1": {
             "hvm": "ami-0cb46ba6945dbfebe"
         },
@@ -23,6 +29,9 @@
         },
         "eu-north-1": {
             "hvm": "ami-06d01bfaf14ad66a3"
+        },
+        "eu-south-1": {
+            "hvm": "ami-031c7e2567f507746"
         },
         "eu-west-1": {
             "hvm": "ami-0e514a30ad261c978"

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,156 +1,156 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-02f4a2c7b9a3a6840"
+            "hvm": "ami-09921c9c1c36e695c"
         },
         "ap-east-1": {
-            "hvm": "ami-06a0695694b6c3e8d"
+            "hvm": "ami-01ee8446e9af6b197"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0cb46ba6945dbfebe"
+            "hvm": "ami-04e5b5722a55846ea"
         },
         "ap-northeast-2": {
-            "hvm": "ami-01e554d608de6087a"
+            "hvm": "ami-0fdc25c8a0273a742"
         },
         "ap-south-1": {
-            "hvm": "ami-09253ba33f828d47f"
+            "hvm": "ami-09e3deb397cc526a8"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0a6a0f1f6106708c4"
+            "hvm": "ami-0630e03f75e02eec4"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0e3e2b2ea00c35823"
+            "hvm": "ami-069450613262ba03c"
         },
         "ca-central-1": {
-            "hvm": "ami-0f5825ef10c76de32"
+            "hvm": "ami-012518cdbd3057dfd"
         },
         "eu-central-1": {
-            "hvm": "ami-0a51f61236e6fc6f2"
+            "hvm": "ami-0bd7175ff5b1aef0c"
         },
         "eu-north-1": {
-            "hvm": "ami-06d01bfaf14ad66a3"
+            "hvm": "ami-06c9ec42d0a839ad2"
         },
         "eu-south-1": {
-            "hvm": "ami-031c7e2567f507746"
+            "hvm": "ami-0614d7440a0363d71"
         },
         "eu-west-1": {
-            "hvm": "ami-0e514a30ad261c978"
+            "hvm": "ami-01b89df58b5d4d5fa"
         },
         "eu-west-2": {
-            "hvm": "ami-0291fd4543d6940f4"
+            "hvm": "ami-06f6e31ddd554f89d"
         },
         "eu-west-3": {
-            "hvm": "ami-083f281d2864a71de"
+            "hvm": "ami-0dc82e2517ded15a1"
         },
         "me-south-1": {
-            "hvm": "ami-05a6ae5eadb5b244d"
+            "hvm": "ami-07d181e3aa0f76067"
         },
         "sa-east-1": {
-            "hvm": "ami-081f13881a31af160"
+            "hvm": "ami-0cd44e6dd20e6c7fa"
         },
         "us-east-1": {
-            "hvm": "ami-009cbe327d180d666"
+            "hvm": "ami-04a16d506e5b0e246"
         },
         "us-east-2": {
-            "hvm": "ami-0346f64579665ce3c"
+            "hvm": "ami-0a1f868ad58ea59a7"
         },
         "us-west-1": {
-            "hvm": "ami-07c185c787029b522"
+            "hvm": "ami-0a65d76e3a6f6622f"
         },
         "us-west-2": {
-            "hvm": "ami-01105d480bb47353f"
+            "hvm": "ami-0dd9008abadc519f1"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202010011740-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202010011740-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202011260640-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202011260640-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202010011740-0/x86_64/",
-    "buildid": "46.82.202010011740-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202011260640-0/x86_64/",
+    "buildid": "46.82.202011260640-0",
     "gcp": {
-        "image": "rhcos-46-82-202010011740-0-gcp-x86-64",
+        "image": "rhcos-46-82-202011260640-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202010011740-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202011260640-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202010011740-0-aws.x86_64.vmdk.gz",
-            "sha256": "21fbefcbb3e1ca9c479e49ba45700026c636ee48f1d1c84a84dabaff2d944f87",
-            "size": 899198828,
-            "uncompressed-sha256": "3af7a3ba4d3963f5e4368cadef9bfe8c1e005218ab42d65b226db17a8bd0f4c8",
-            "uncompressed-size": 918272000
+            "path": "rhcos-46.82.202011260640-0-aws.x86_64.vmdk.gz",
+            "sha256": "6e0f720077ac20fae46c16159d03fd51f66cd318155dcd14f0f5d7dc79bfd8ad",
+            "size": 900764628,
+            "uncompressed-sha256": "b38713b80bbcc41d18efcec93d241da48533225e0ce073c2a26235993ffc4166",
+            "uncompressed-size": 919795200
         },
         "azure": {
-            "path": "rhcos-46.82.202010011740-0-azure.x86_64.vhd.gz",
-            "sha256": "c6f233a04aacf9c17602e58a52aaa5f315cbc61254d3447c4ef77f22c9b13403",
-            "size": 900405493,
-            "uncompressed-sha256": "14a37a346dba5a8b49a36dc3eab369f061086ae57be72260d967f55dc9700435",
+            "path": "rhcos-46.82.202011260640-0-azure.x86_64.vhd.gz",
+            "sha256": "5255c675ecff4f8932db24b68a7ef451dfc4e502326128931ccd39acf27c6c77",
+            "size": 901953565,
+            "uncompressed-sha256": "0fd7ab096c7ac4b8d807371d1c4a13b3a665b5d2938ff814bd3e46257193941b",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202010011740-0-gcp.x86_64.tar.gz",
-            "sha256": "e32127985523d442ad01f21fa5ced3fbac3bbb8c19ecf58dda74eacacf971612",
-            "size": 885597213
+            "path": "rhcos-46.82.202011260640-0-gcp.x86_64.tar.gz",
+            "sha256": "f470a98c1fc7a4e0226ed4258fdd0b6edcddbb2356e7992bea4b98843cd94d9a",
+            "size": 887140241
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202010011740-0-live-initramfs.x86_64.img",
-            "sha256": "ef3fc87f1d6685a3540bf48c570151b30c2d70b75a3d0642e405097e6cdc051f"
+            "path": "rhcos-46.82.202011260640-0-live-initramfs.x86_64.img",
+            "sha256": "8ff220c6f4bbca35dd071c5f1802566290b70081faeb06fb07f72c4583f8facf"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202010011740-0-live.x86_64.iso",
-            "sha256": "67094260aed6f2ceade815c6882fed7b27b628bead50121f066c2bba02e977e1"
+            "path": "rhcos-46.82.202011260640-0-live.x86_64.iso",
+            "sha256": "161046d6275cda89a3f44582bc2b850cd09b987807d3b20090eeab279b7e0550"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202010011740-0-live-kernel-x86_64",
-            "sha256": "e4d0a63c135b37d569ebdec9b8fb9116eccf4e0e0346859b25b2efabd360b8ec"
+            "path": "rhcos-46.82.202011260640-0-live-kernel-x86_64",
+            "sha256": "9bbb496410c04f54d30eb56f76f769bccec7e81b91271ae72261ecc54db9c63d"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202010011740-0-live-rootfs.x86_64.img",
-            "sha256": "79561bda394499b4a1488b7f40c2f28af7d3565fdabe584c6d6ba8c7ae857c23"
+            "path": "rhcos-46.82.202011260640-0-live-rootfs.x86_64.img",
+            "sha256": "007f9c376e1282b77ed662509a3a81b624dfcf28aa971a9e80b33fc06cf9c4fd"
         },
         "metal": {
-            "path": "rhcos-46.82.202010011740-0-metal.x86_64.raw.gz",
-            "sha256": "6c7f1f58df61d366fa9ff12c2fa424480068147a6b05b31e11e61ec95960431d",
-            "size": 887126299,
-            "uncompressed-sha256": "f35b1ae5b71bcf4d1d380195a0a6d4c0963f0c5ed1f2454536f1408e66a35185",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202011260640-0-metal.x86_64.raw.gz",
+            "sha256": "bcd9871c373c02898675ec407e83f9ccd107077ff30008ecb601c9869c4a501a",
+            "size": 888607273,
+            "uncompressed-sha256": "a769991d850064ef078ba4dae9050e34a820bf9eba792a2b7922fb7a15315b57",
+            "uncompressed-size": 3555721216
         },
         "metal4k": {
-            "path": "rhcos-46.82.202010011740-0-metal4k.x86_64.raw.gz",
-            "sha256": "360be1dd39e90011602a6155933f2e9d86afd2153b62fc32a9c27fca85a0fd51",
-            "size": 884961888,
-            "uncompressed-sha256": "24609d1e889fd148576431edaf4cd619f9cb5381d5dc1cfc7a0c7be81c8e1e85",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202011260640-0-metal4k.x86_64.raw.gz",
+            "sha256": "ff4ed9d58a286185abdc4be0faaa4cd621c088121133b9b5952d2da320149fad",
+            "size": 886276538,
+            "uncompressed-sha256": "1e57d643969306e84b945c6355eed2793daa3e7675b0daa63defd6f5f8b5a43d",
+            "uncompressed-size": 3555721216
         },
         "openstack": {
-            "path": "rhcos-46.82.202010011740-0-openstack.x86_64.qcow2.gz",
-            "sha256": "9d88edcacbdf31db9cb9418ee3721c74a3f5bbfc4904db9e383e674a86335bd1",
-            "size": 885915737,
-            "uncompressed-sha256": "95a5c2dafca2dd1a59e5e99dc1b3809c9b925cd94e37acf52e29f7e694ce30ab",
-            "uncompressed-size": 2251489280
+            "path": "rhcos-46.82.202011260640-0-openstack.x86_64.qcow2.gz",
+            "sha256": "a8a28cfe5f5e5dadedb3442afcb447f85bddf2e82dcd558813a985a4d495782a",
+            "size": 887473972,
+            "uncompressed-sha256": "2bd648e09f086973accd8ac1e355ce0fcd7dfcc16bc9708c938801fcf10e219e",
+            "uncompressed-size": 2254045184
         },
         "ostree": {
-            "path": "rhcos-46.82.202010011740-0-ostree.x86_64.tar",
-            "sha256": "5c98466ba5578a8e93744fe332ce3fcd00438a88643eec5f09dc35b7698e9c04",
-            "size": 801597440
+            "path": "rhcos-46.82.202011260640-0-ostree.x86_64.tar",
+            "sha256": "1b15017685292447ebb2dc8bfe8a4f216ea1c42f871f666c65d4b98e9998d549",
+            "size": 802641920
         },
         "qemu": {
-            "path": "rhcos-46.82.202010011740-0-qemu.x86_64.qcow2.gz",
-            "sha256": "f0fcdd7690d4212bad5b94c91308afe51727104ce40febf0708517989c2be4e5",
-            "size": 886664696,
-            "uncompressed-sha256": "cbaf2e5548af2d1d1153d9a1beca118042e770725166de427792c33a875137cc",
-            "uncompressed-size": 2288910336
+            "path": "rhcos-46.82.202011260640-0-qemu.x86_64.qcow2.gz",
+            "sha256": "0ea6f0852c3e0f8e4182e705561fdccd998503ef423c441e182241cd6a278730",
+            "size": 888353176,
+            "uncompressed-sha256": "99928ff40c2d8e3aa358d9bd453102e3d1b5e9694fb5d54febc56e275f35da51",
+            "uncompressed-size": 2290221056
         },
         "vmware": {
-            "path": "rhcos-46.82.202010011740-0-vmware.x86_64.ova",
-            "sha256": "935164c1b85e603a5bea5c50960613a5c24fd43106948abab9213550efcbad95",
-            "size": 918282240
+            "path": "rhcos-46.82.202011260640-0-vmware.x86_64.ova",
+            "sha256": "d73c7bdfd22e5a1231e23663266744c98c10de6f08f6d1fc718e7f72d0490c4a",
+            "size": 919808000
         }
     },
     "oscontainer": {
-        "digest": "sha256:fcac8cf37634553a1d87ed57b77ec1c39b727af06f0e6345d60554b45191dd27",
+        "digest": "sha256:54f1ab852c6592d6ca453cabb855b5c9f5ced35b1aadbb5d8161d4ca2d3623cc",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ce0233ed167e2496ed0806af43984cbd063222ddd8229de8b09741fbce414b81",
-    "ostree-version": "46.82.202010011740-0"
+    "ostree-commit": "cb0327325553e6922ff25822ea7eb1a2ec213e70c7cf6880965e7e2bb5ee7dea",
+    "ostree-version": "46.82.202011260640-0"
 }

--- a/docs/user/openstack/install_upi.md
+++ b/docs/user/openstack/install_upi.md
@@ -629,11 +629,13 @@ $ openstack catalog show image
 
 By default Glance service doesn't allow anonymous access to the data. So, if you use Glance to store the ignition config, then you also need to provide a valid auth token in the `ignition.config.merge.httpHeaders` field.
 
-To obtain the token execute:
+The token can be obtained with this command:
 
 ```sh
 openstack token issue -c id -f value
 ```
+
+Note that this token can be generated as any OpenStack user with Glance read access; this particular token will only be used for downloading the Ignition file.
 
 The command will return the token to be added to the `ignition.config.merge[0].httpHeaders` property in the Bootstrap Ignition Shim (see [below](#create-the-bootstrap-ignition-shim)):
 

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -2,7 +2,7 @@
 # It builds an image containing openshift-install.
 
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
-RUN yum install -y libvirt-devel && \
+RUN yum install -y libvirt-devel-4.5.0 && \
     yum clean all && rm -rf /var/cache/yum/*
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
@@ -15,7 +15,7 @@ COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json 
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    libvirt-libs openssl unzip jq openssh-clients && \
+    libvirt-libs-4.5.0 openssl unzip jq openssh-clients && \
     yum clean all && rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -21,9 +21,6 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	// validate the externalNetwork
 	allErrs = append(allErrs, validateExternalNetwork(p, ci, fldPath)...)
 
-	// validate platform flavor
-	allErrs = append(allErrs, validatePlatformFlavor(p, ci, fldPath)...)
-
 	// validate floating ips
 	allErrs = append(allErrs, validateFloatingIPs(p, ci, fldPath)...)
 

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -203,7 +203,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			subnets,
 			pool,
 			"master",
-			"master-user-data-managed",
+			"master-user-data",
 			installConfig.Config.Platform.AWS.UserTags,
 		)
 		if err != nil {
@@ -222,7 +222,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			mpool.Zones = azs
 		}
 		pool.Platform.GCP = &mpool
-		machines, err = gcp.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data-managed")
+		machines, err = gcp.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -232,7 +232,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.Set(ic.Platform.Libvirt.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Libvirt)
 		pool.Platform.Libvirt = &mpool
-		machines, err = libvirt.Machines(clusterID.InfraID, ic, pool, "master", "master-user-data-managed")
+		machines, err = libvirt.Machines(clusterID.InfraID, ic, pool, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -244,7 +244,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 		imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-		machines, err = openstack.Machines(clusterID.InfraID, ic, pool, imageName, "master", "master-user-data-managed")
+		machines, err = openstack.Machines(clusterID.InfraID, ic, pool, imageName, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -274,7 +274,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 		pool.Platform.Azure = &mpool
 
-		machines, err = azure.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data-managed")
+		machines, err = azure.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -285,7 +285,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.Set(pool.Platform.BareMetal)
 		pool.Platform.BareMetal = &mpool
 
-		machines, err = baremetal.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data-managed")
+		machines, err = baremetal.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -337,7 +337,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 		imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-		machines, err = ovirt.Machines(clusterID.InfraID, ic, pool, imageName, "master", "master-user-data-managed")
+		machines, err = ovirt.Machines(clusterID.InfraID, ic, pool, imageName, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects for ovirt provider")
 		}
@@ -350,7 +350,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		pool.Platform.VSphere = &mpool
 		templateName := clusterID.InfraID + "-rhcos"
 
-		machines, err = vsphere.Machines(clusterID.InfraID, ic, pool, templateName, "master", "master-user-data-managed")
+		machines, err = vsphere.Machines(clusterID.InfraID, ic, pool, templateName, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -360,7 +360,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		return fmt.Errorf("invalid Platform")
 	}
 
-	data, err := userDataSecret("master-user-data-managed", mign.File.Data)
+	data, err := userDataSecret("master-user-data", mign.File.Data)
 	if err != nil {
 		return errors.Wrap(err, "failed to create user-data secret for master machines")
 	}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -274,7 +274,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				subnets,
 				&pool,
 				"worker",
-				"worker-user-data-managed",
+				"worker-user-data",
 				installConfig.Config.Platform.AWS.UserTags,
 			)
 			if err != nil {
@@ -306,7 +306,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			}
 
 			pool.Platform.Azure = &mpool
-			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data-managed")
+			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data")
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}
@@ -318,7 +318,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			mpool.Set(ic.Platform.BareMetal.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.BareMetal)
 			pool.Platform.BareMetal = &mpool
-			sets, err := baremetal.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data-managed")
+			sets, err := baremetal.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data")
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}
@@ -337,7 +337,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				mpool.Zones = azs
 			}
 			pool.Platform.GCP = &mpool
-			sets, err := gcp.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data-managed")
+			sets, err := gcp.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", "worker-user-data")
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}
@@ -349,7 +349,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			mpool.Set(ic.Platform.Libvirt.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.Libvirt)
 			pool.Platform.Libvirt = &mpool
-			sets, err := libvirt.MachineSets(clusterID.InfraID, ic, &pool, "worker", "worker-user-data-managed")
+			sets, err := libvirt.MachineSets(clusterID.InfraID, ic, &pool, "worker", "worker-user-data")
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}
@@ -364,7 +364,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 
 			imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-			sets, err := openstack.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", "worker-user-data-managed")
+			sets, err := openstack.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", "worker-user-data")
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}
@@ -378,7 +378,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			pool.Platform.VSphere = &mpool
 			templateName := clusterID.InfraID + "-rhcos"
 
-			sets, err := vsphere.MachineSets(clusterID.InfraID, ic, &pool, templateName, "worker", "worker-user-data-managed")
+			sets, err := vsphere.MachineSets(clusterID.InfraID, ic, &pool, templateName, "worker", "worker-user-data")
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}
@@ -393,7 +393,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 
 			imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-			sets, err := ovirt.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", "worker-user-data-managed")
+			sets, err := ovirt.MachineSets(clusterID.InfraID, ic, &pool, imageName, "worker", "worker-user-data")
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects for ovirt provider")
 			}
@@ -406,7 +406,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 		}
 	}
 
-	data, err := userDataSecret("worker-user-data-managed", wign.File.Data)
+	data, err := userDataSecret("worker-user-data", wign.File.Data)
 	if err != nil {
 		return errors.Wrap(err, "failed to create user-data secret for worker machines")
 	}

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -130,6 +130,12 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+
+		// We need to replace the local cacert path with one that is used in OpenShift
+		if cloud.CACertFile != "" {
+			cloud.CACertFile = "/etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem"
+		}
+
 		clouds := make(map[string]map[string]*clientconfig.Cloud)
 		clouds["clouds"] = map[string]*clientconfig.Cloud{
 			osmachine.CloudName: cloud,

--- a/pkg/rhcos/ami_regions.go
+++ b/pkg/rhcos/ami_regions.go
@@ -4,6 +4,8 @@ package rhcos
 
 // AMIRegoins is a list of regions where the RHEL CoreOS is published.
 var AMIRegions = []string{
+	"af-south-1",
+	"ap-east-1",
 	"ap-northeast-1",
 	"ap-northeast-2",
 	"ap-south-1",
@@ -12,6 +14,7 @@ var AMIRegions = []string{
 	"ca-central-1",
 	"eu-central-1",
 	"eu-north-1",
+	"eu-south-1",
 	"eu-west-1",
 	"eu-west-2",
 	"eu-west-3",

--- a/upi/openstack/bootstrap.yaml
+++ b/upi/openstack/bootstrap.yaml
@@ -25,20 +25,18 @@
     command:
       cmd: "openstack port set --tag {{ cluster_id_tag }} {{ os_port_bootstrap }}"
 
+  - name: 'Set bootstrap auto_ip to false'
+    ansible.builtin.set_fact:
+      bootstrap_auto_ip: false
+    when: os_bootstrap_fip is not defined
+
   - name: 'Create the bootstrap server'
     os_server:
       name: "{{ os_bootstrap_server_name }}"
       image: "{{ os_image_rhcos }}"
       flavor: "{{ os_flavor_master }}"
       userdata: "{{ lookup('file', os_bootstrap_ignition) | string }}"
-      auto_ip: no
+      floating_ips: "{{ os_bootstrap_fip | default(omit) }}"
+      auto_ip: "{{ bootstrap_auto_ip | default(omit) }}"
       nics:
       - port-name: "{{ os_port_bootstrap }}"
-
-  - name: 'Create the bootstrap floating IP'
-    os_floating_ip:
-      state: present
-      nat_destination: "{{ os_network }}"
-      network: "{{ os_external_network }}"
-      server: "{{ os_bootstrap_server_name }}"
-    when: os_external_network is defined and os_external_network|length>0

--- a/upi/openstack/down-bootstrap.yaml
+++ b/upi/openstack/down-bootstrap.yaml
@@ -13,7 +13,6 @@
     os_server:
       name: "{{ os_bootstrap_server_name }}"
       state: absent
-      delete_fip: yes
 
   - name: 'Remove the bootstrap server port'
     os_port:

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -28,11 +28,11 @@ all:
       # 3 is the minimum number for a fully-functional cluster.
       os_compute_nodes_number: 3
 
-      # The public network, if available. Required for os_api_fip and
-      # os_ingress_fip.
-      # If non-empty, an additional floating IP will be created and attached to
-      # the bootstrap machine to allow the retrieval of a log bundle in case of
-      # install failure ('must-gather').
+      # The public network providing connectivity to the cluster. If not
+      # provided, the cluster external connectivity must be provided in another
+      # way.
+      #
+      # Required for os_api_fip, os_ingress_fip, os_bootstrap_fip.
       os_external_network: 'external'
 
       # OpenShift API floating IP address. If this value is non-empty, the
@@ -44,3 +44,8 @@ all:
       # corresponding floating IP will be attached to the worker nodes to serve
       # the applications.
       os_ingress_fip: '203.0.113.19'
+
+      # If this value is non-empty, the corresponding floating IP will be
+      # attached to the bootstrap machine. This is needed for collecting logs
+      # in case of install failure.
+      os_bootstrap_fip: '203.0.113.20'


### PR DESCRIPTION
Created with
```
TARGET_COMMIT=$(git describe --tags fcos | sed 's/.*-g//')
git checkout -b fcos-rebase-dec5 origin/release-4.6
git rebase --onto fcos $TARGET_COMMIT
```

This also updates FCOS images to latest stable (32.20201104.3.0)

/cc @LorbusChris 