### PR TITLE
openstack: refactor getZones() to use gophercloud/utils

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
 	computequotasets "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	tokensv2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
@@ -16,6 +15,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	azutils "github.com/gophercloud/utils/openstack/compute/v2/availabilityzones"
 	flavorutils "github.com/gophercloud/utils/openstack/compute/v2/flavors"
 	imageutils "github.com/gophercloud/utils/openstack/imageservice/v2/images"
 	networkutils "github.com/gophercloud/utils/openstack/networking/v2/networks"
@@ -300,21 +300,9 @@ func (ci *CloudInfo) getImage(imageName string) (*images.Image, error) {
 }
 
 func (ci *CloudInfo) getZones() ([]string, error) {
-	zones := []string{}
-	allPages, err := availabilityzones.List(ci.clients.computeClient).AllPages()
+	zones, err := azutils.ListAvailableAvailabilityZones(ci.clients.computeClient)
 	if err != nil {
-		return nil, err
-	}
-
-	availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, zoneInfo := range availabilityZoneInfo {
-		if zoneInfo.ZoneState.Available {
-			zones = append(zones, zoneInfo.ZoneName)
-		}
+		return nil, errors.Wrap(err, "failed to list compute availability zones")
 	}
 
 	if len(zones) == 0 {

--- a/vendor/github.com/gophercloud/utils/openstack/compute/v2/availabilityzones/utils.go
+++ b/vendor/github.com/gophercloud/utils/openstack/compute/v2/availabilityzones/utils.go
@@ -1,0 +1,27 @@
+package availabilityzones
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"
+)
+
+// ListAvailableAvailabilityZones is a convenience function that return a slice of available Availability Zones.
+func ListAvailableAvailabilityZones(client *gophercloud.ServiceClient) ([]string, error) {
+	var ret []string
+	allPages, err := availabilityzones.List(client).AllPages()
+	if err != nil {
+		return ret, err
+	}
+
+	availabilityZoneInfo, err := availabilityzones.ExtractAvailabilityZones(allPages)
+	if err != nil {
+		return ret, err
+	}
+
+	for _, zoneInfo := range availabilityZoneInfo {
+		if zoneInfo.ZoneState.Available {
+			ret = append(ret, zoneInfo.ZoneName)
+		}
+	}
+	return ret, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -688,6 +688,7 @@ github.com/gophercloud/utils/gnocchi
 github.com/gophercloud/utils/internal
 github.com/gophercloud/utils/openstack/baremetal/v1/nodes
 github.com/gophercloud/utils/openstack/clientconfig
+github.com/gophercloud/utils/openstack/compute/v2/availabilityzones
 github.com/gophercloud/utils/openstack/compute/v2/flavors
 github.com/gophercloud/utils/openstack/compute/v2/images
 github.com/gophercloud/utils/openstack/imageservice/v2/images


### PR DESCRIPTION
A new helper was added into gophercloud/utils to list the available
availability zones.

Switch the getZones() function in cloudinfo to use it, so we don't
have the carry that logic in the installer anymore.

Related bug: https://issues.redhat.com/browse/OSASINFRA-1848

Signed-off-by: Emilien Macchi <emilien@redhat.com>
