### PR TITLE
Bug 1901034: manifests: restore setting of etcdDiscoveryDomain in infrastructure

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -76,6 +76,7 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 			InfrastructureName:   clusterID.InfraID,
 			APIServerURL:         getAPIServerURL(installConfig.Config),
 			APIServerInternalURL: getInternalAPIServerURL(installConfig.Config),
+			EtcdDiscoveryDomain:  getEtcdDiscoveryDomain(installConfig.Config),
 			PlatformStatus:       &configv1.PlatformStatus{},
 		},
 	}

--- a/pkg/asset/manifests/utils.go
+++ b/pkg/asset/manifests/utils.go
@@ -40,3 +40,7 @@ func getAPIServerURL(ic *types.InstallConfig) string {
 func getInternalAPIServerURL(ic *types.InstallConfig) string {
 	return fmt.Sprintf("https://api-int.%s:6443", ic.ClusterDomain())
 }
+
+func getEtcdDiscoveryDomain(ic *types.InstallConfig) string {
+	return ic.ClusterDomain()
+}


### PR DESCRIPTION
With https://github.com/openshift/installer/pull/4067, the etcdDiscoveryDomain field is no longer set in the infrastructure.config.openshift.io manifest. However, the cluster-network-operator relies on that field when syncing the status of proxy.config.openshift.io [1].

[1] https://github.com/openshift/cluster-network-operator/blob/c23495cf6e6ffeffc0290c85ee4608102f7b47d1/pkg/util/proxyconfig/no_proxy.go#L113