### PR TITLE
Bug 1906459: openstack: fix quota checks when they're unlimited

### DIFF
--- a/pkg/quota/quota.go
+++ b/pkg/quota/quota.go
@@ -15,6 +15,8 @@ type Quota struct {
 
 	InUse int64
 	Limit int64
+
+	Unlimited bool
 }
 
 // Constraint defines a check against availablity
@@ -75,6 +77,13 @@ func Check(quotas []Quota, checks []Constraint) ([]ConstraintReport, error) {
 		if !ok {
 			report.Result = Unknown
 			report.Message = "No matching quota found for the constraint"
+			reports = append(reports, report)
+			continue
+		}
+
+		if matched.Unlimited {
+			report.Result = Available
+			report.Message = "Unlimited quota found for the constraint"
 			reports = append(reports, report)
 			continue
 		}


### PR DESCRIPTION
In OpenStack, if a quota resource is limited to "-1", it means that it's
unlimited. It's the case of a lot of OpenStack clouds, were quotas
aren't defined for all projects and by default "-1" is used.

This patch will ignore a quota record if its limit is set to "-1".

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1906459
Signed-off-by: Emilien Macchi <emilien@redhat.com>
