### PR TITLE
Bug 1906517: OpenStack: Skip collecting info for empty subnet IDs

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -186,6 +186,9 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig, opts *clientconfig.Cli
 }
 
 func (ci *CloudInfo) getSubnet(subnetID string) (*subnets.Subnet, error) {
+	if subnetID == "" {
+		return nil, nil
+	}
 	subnet, err := subnets.Get(ci.clients.networkClient, subnetID).Extract()
 	if err != nil {
 		var gerr *gophercloud.ErrResourceNotFound


### PR DESCRIPTION
Some clouds may return a generic 404 error instead of an
`ErrResourceNotFound` error, causing the installer to fail with:

    FATAL failed to fetch Install Config: failed to generate asset "Install Config": failed to generate OpenStack cloud info: failed to fetch machine subnet info: Resource not found

We need to not gather subnet information unless a machine subnet was
provided.