### PR TITLE
Bug 1890228: pkg/destroy/aws: Pass destroy if HostedZone does not exist

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -1896,6 +1896,9 @@ func deleteRoute53(ctx context.Context, session *session.Session, arn arn.ARN, l
 		Id: aws.String(id),
 	})
 	if err != nil {
+		if err.(awserr.Error).Code() == "NoSuchHostedZone" {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
HostedZone may already be removed and causes destroy to get stuck.