### PR TITLE
Bug 1907628: Consistently Set Primary Subnet OpenStack

### DIFF
--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -140,6 +140,11 @@ func generateProvider(clusterID string, platform *openstack.Platform, mpool *ope
 		})
 	}
 
+	primarySubnet := platform.MachinesSubnet
+	if primarySubnet == "" {
+		primarySubnet = fmt.Sprintf("%s-openshift", clusterID)
+	}
+
 	spec := openstackprovider.OpenstackProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: openstackprovider.SchemeGroupVersion.String(),
@@ -150,7 +155,7 @@ func generateProvider(clusterID string, platform *openstack.Platform, mpool *ope
 		CloudsSecret:     &corev1.SecretReference{Name: cloudsSecret, Namespace: cloudsSecretNamespace},
 		UserDataSecret:   &corev1.SecretReference{Name: userDataSecret},
 		Networks:         networks,
-		PrimarySubnet:    platform.MachinesSubnet,
+		PrimarySubnet:    primarySubnet,
 		AvailabilityZone: az,
 		SecurityGroups:   securityGroups,
 		Trunk:            trunkSupport,


### PR DESCRIPTION
The primary subnet was only set in the machine set when the user was
using the bring your own network feature, and this inconsistent usage
was confusing. This changes things so that it's always set.

/label platform/openstack