### PR TITLE
openstack: add networking quota checks

### DIFF
--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -126,7 +126,7 @@ func (a *PlatformQuotaCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to get cloud info")
 		}
-		reports, err := quota.Check(ci.Quotas, openstack.Constraints(ci, masters, workers))
+		reports, err := quota.Check(ci.Quotas, openstack.Constraints(ci, masters, workers, ic.Config.NetworkType))
 		if err != nil {
 			return summarizeFailingReport(reports)
 		}


### PR DESCRIPTION
We now check the quotas for:

* Ports, with a base number + growing for each machine and its number of
attached networks.
* Routers
* Subnets
* Networks
* Security Groups
* Security Group Rules

We make the difference between requirements when Kuryr is the networking
backend or not, since the quotas aren't the same.

Note: this PR also includes vendoring for both gophercloud and
      terraform-openstack, which is required to get quota details for networking
      resources.

JIRA: [OSASINFRA-2006](https://issues.redhat.com/browse/OSASINFRA-2006)
/label platform/openstack
