### PR TITLE
Bug 1786314: bump gophercloud/utils

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible // indirect
 	github.com/google/uuid v1.1.2
 	github.com/gophercloud/gophercloud v0.12.1-0.20200827191144-bb4781e9de45
-	github.com/gophercloud/utils v0.0.0-20201203161420-f41c1768a042
+	github.com/gophercloud/utils v0.0.0-20201212031956-9dc30e126fea
 	github.com/h2non/filetype v1.0.12
 	github.com/hashicorp/go-azure-helpers v0.10.0
 	github.com/hashicorp/go-plugin v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -775,6 +775,8 @@ github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d/go.mod h1:SZ9FTK
 github.com/gophercloud/utils v0.0.0-20201101202656-8677e053dcf1/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gophercloud/utils v0.0.0-20201203161420-f41c1768a042 h1:R/+WaNsfMEc3WAljyhQVkBJ9UsyBYxbOEqYCMUx4GiM=
 github.com/gophercloud/utils v0.0.0-20201203161420-f41c1768a042/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
+github.com/gophercloud/utils v0.0.0-20201212031956-9dc30e126fea h1:wDICyEwMkBqdMMEjm+6QdI7xGV32mha/Z4hgC/SPlU0=
+github.com/gophercloud/utils v0.0.0-20201212031956-9dc30e126fea/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gopherjs/gopherjs v0.0.0-20180628210949-0892b62f0d9f/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de h1:F7WD09S8QB4LrkEpka0dFPLSotH11HRpCsLIbIcJ7sU=

--- a/vendor/github.com/gophercloud/utils/internal/util.go
+++ b/vendor/github.com/gophercloud/utils/internal/util.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -50,7 +51,9 @@ func PrepareTLSConfig(caCertFile, clientCertFile, clientKeyFile string, insecure
 		}
 
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
+		if ok := caCertPool.AppendCertsFromPEM(bytes.TrimSpace(caCert)); !ok {
+			return nil, fmt.Errorf("Error parsing CA Cert from %s", caCertFile)
+		}
 		config.RootCAs = caCertPool
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -680,7 +680,7 @@ github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares
 github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
-# github.com/gophercloud/utils v0.0.0-20201203161420-f41c1768a042
+# github.com/gophercloud/utils v0.0.0-20201212031956-9dc30e126fea
 ## explicit
 github.com/gophercloud/utils/client
 github.com/gophercloud/utils/env


### PR DESCRIPTION
This patch introduces recent optimizations for tls config generation.
1. Now the library ignores the fact the CA certificate can be broken
(if it can't parse it for some reason, it just leaves an empty string
without a notice). From now we raise an error in this case.
2. It tries to prevent some obvious formatting errors in the certificate
like leading and trailing spaces, additional new lines etc.