### PR TITLE
Bug 1908489: azure: adhere to new regex requirements for nic names

### DIFF
--- a/data/data/azure/master/master.tf
+++ b/data/data/azure/master/master.tf
@@ -9,7 +9,12 @@ locals {
 resource "azurerm_network_interface" "master" {
   count = var.instance_count
 
-  name                = "${var.cluster_id}-master${count.index}-nic"
+  // https://github.com/kubernetes/kubernetes/pull/95542 requires that the NIC name matches the regex (.+)-nic-(.+),
+  // where the node name is $1-$2 from the regex capture.
+  // For example, let's say that the cluster ID is abcde.
+  // The node names will be abcde-master-0, abcde-master-1, and abcde-master-2.
+  // The NIC names must be abcde-master-nic-0, abcde-master-nic-1, and abcde-master-nic-2.
+  name                = "${var.cluster_id}-master-nic-${count.index}"
   location            = var.region
   resource_group_name = var.resource_group_name
 

--- a/docs/user/azure/install_upi.md
+++ b/docs/user/azure/install_upi.md
@@ -396,7 +396,7 @@ az vm stop -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap
 az vm deallocate -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap
 az vm delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap --yes
 az disk delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap_OSDisk --no-wait --yes
-az network nic delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap-nic --no-wait
+az network nic delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap-nic-1 --no-wait
 az storage blob delete --account-key $ACCOUNT_KEY --account-name ${CLUSTER_NAME}sa --container-name files --name bootstrap.ign
 az network public-ip delete -g $RESOURCE_GROUP --name ${INFRA_ID}-bootstrap-ssh-pip
 ```

--- a/upi/azure/05_masters.json
+++ b/upi/azure/05_masters.json
@@ -136,6 +136,13 @@
         "count" :  "[parameters('numberOfMasters')]",
         "input" : "[concat(parameters('baseName'), '-master-', copyIndex('vmNames'))]"
       }
+    ],
+    "copy" : [
+      {
+        "name" : "nicNames",
+        "count" : "[parameters('numberOfMasters')]",
+        "input" : "[concat(parameters('baseName'), '-master-nic-', copyIndex('nicNames'))]"
+      }
     ]
   },
   "resources" : [
@@ -146,7 +153,7 @@
         "name" : "nicCopy",
         "count" : "[length(variables('vmNames'))]"
       },
-      "name" : "[concat(variables('vmNames')[copyIndex()], '-nic')]",
+      "name" : "[variables('nicNames')[copyIndex()]]",
       "location" : "[variables('location')]",
       "properties" : {
         "ipConfigurations" : [
@@ -199,13 +206,13 @@
       "name": "[concat(parameters('privateDNSZoneName'), '/etcd-', copyIndex())]",
       "location" : "[variables('location')]",
       "dependsOn" : [
-        "[concat('Microsoft.Network/networkInterfaces/', concat(variables('vmNames')[copyIndex()], '-nic'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicNames')[copyIndex()])]"
       ],
       "properties": {
         "ttl": 60,
         "aRecords": [
           {
-            "ipv4Address": "[reference(concat(variables('vmNames')[copyIndex()], '-nic')).ipConfigurations[0].properties.privateIPAddress]"
+            "ipv4Address": "[reference(variables('nicNames')[copyIndex()]).ipConfigurations[0].properties.privateIPAddress]"
           }
         ]
       }
@@ -226,7 +233,7 @@
         }
       },
       "dependsOn" : [
-        "[concat('Microsoft.Network/networkInterfaces/', concat(variables('vmNames')[copyIndex()], '-nic'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicNames')[copyIndex()])]",
         "[concat('Microsoft.Network/privateDnsZones/', parameters('privateDNSZoneName'), '/A/etcd-', copyIndex())]",
         "[concat('Microsoft.Network/privateDnsZones/', parameters('privateDNSZoneName'), '/SRV/_etcd-server-ssl._tcp')]"
       ],
@@ -269,7 +276,7 @@
         "networkProfile" : {
           "networkInterfaces" : [
             {
-              "id" : "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmNames')[copyIndex()], '-nic'))]",
+              "id" : "[resourceId('Microsoft.Network/networkInterfaces', variables('nicNames')[copyIndex()])]",
               "properties": {
                 "primary": false
               }

--- a/upi/azure/06_workers.json
+++ b/upi/azure/06_workers.json
@@ -122,6 +122,13 @@
         "count" :  "[parameters('numberOfNodes')]",
         "input" : "[concat(parameters('baseName'), '-worker-', variables('location'), '-', copyIndex('vmNames', 1))]"
       }
+    ],
+    "copy" : [
+      {
+        "name" : "nicNames",
+        "count" : "[parameters('numberOfNodes')]",
+        "input" : "[concat(parameters('baseName'), '-worker-nic-', copyIndex('nicNames'))]"
+      }
     ]
   },
   "resources" : [
@@ -142,7 +149,7 @@
             {
               "apiVersion" : "2018-06-01",
               "type" : "Microsoft.Network/networkInterfaces",
-              "name" : "[concat(variables('vmNames')[copyIndex()], '-nic')]",
+              "name" : "[variables('nicNames')[copyIndex()]]",
               "location" : "[variables('location')]",
               "properties" : {
                 "ipConfigurations" : [
@@ -173,7 +180,7 @@
                 }
               },
               "dependsOn" : [
-                "[concat('Microsoft.Network/networkInterfaces/', concat(variables('vmNames')[copyIndex()], '-nic'))]"
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicNames')[copyIndex()])]"
               ],
               "properties" : {
                 "hardwareProfile" : {
@@ -212,7 +219,7 @@
                 "networkProfile" : {
                   "networkInterfaces" : [
                     {
-                      "id" : "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmNames')[copyIndex()], '-nic'))]",
+                      "id" : "[resourceId('Microsoft.Network/networkInterfaces', variables('nicNames')[copyIndex()])]",
                       "properties": {
                         "primary": true
                       }


### PR DESCRIPTION
With https://github.com/kubernetes/kubernetes/pull/95542, NIC names must matches the regex (.+)-nic-(.+).