### PR TITLE
Bug 1908782: terraform: Add rules to allow internal IPsec traffic

### DIFF
--- a/data/data/aws/vpc/sg-master.tf
+++ b/data/data/aws/vpc/sg-master.tf
@@ -93,6 +93,36 @@ resource "aws_security_group_rule" "master_ingress_geneve" {
   self      = true
 }
 
+resource "aws_security_group_rule" "master_ingress_ike" {
+  type              = "ingress"
+  security_group_id = aws_security_group.master.id
+
+  protocol  = "udp"
+  from_port = 500
+  to_port   = 500
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_ike_nat_t" {
+  type              = "ingress"
+  security_group_id = aws_security_group.master.id
+
+  protocol  = "udp"
+  from_port = 4500
+  to_port   = 4500
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_esp" {
+  type              = "ingress"
+  security_group_id = aws_security_group.master.id
+
+  protocol  = 50
+  from_port = 0
+  to_port   = 0
+  self      = true
+}
+
 resource "aws_security_group_rule" "master_ingress_geneve_from_worker" {
   type                     = "ingress"
   security_group_id        = aws_security_group.master.id
@@ -101,6 +131,36 @@ resource "aws_security_group_rule" "master_ingress_geneve_from_worker" {
   protocol  = "udp"
   from_port = 6081
   to_port   = 6081
+}
+
+resource "aws_security_group_rule" "master_ingress_ike_from_worker" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
+
+  protocol  = "udp"
+  from_port = 500
+  to_port   = 500
+}
+
+resource "aws_security_group_rule" "master_ingress_ike_nat_t_from_worker" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
+
+  protocol  = "udp"
+  from_port = 4500
+  to_port   = 4500
+}
+
+resource "aws_security_group_rule" "master_ingress_esp_from_worker" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
+
+  protocol  = 50
+  from_port = 0
+  to_port   = 0
 }
 
 resource "aws_security_group_rule" "master_ingress_ovndb" {

--- a/data/data/aws/vpc/sg-worker.tf
+++ b/data/data/aws/vpc/sg-worker.tf
@@ -73,6 +73,36 @@ resource "aws_security_group_rule" "worker_ingress_geneve" {
   self      = true
 }
 
+resource "aws_security_group_rule" "worker_ingress_ike" {
+  type              = "ingress"
+  security_group_id = aws_security_group.worker.id
+
+  protocol  = "udp"
+  from_port = 500
+  to_port   = 500
+  self      = true
+}
+
+resource "aws_security_group_rule" "worker_ingress_ike_nat_t" {
+  type              = "ingress"
+  security_group_id = aws_security_group.worker.id
+
+  protocol  = "udp"
+  from_port = 4500
+  to_port   = 4500
+  self      = true
+}
+
+resource "aws_security_group_rule" "worker_ingress_esp" {
+  type              = "ingress"
+  security_group_id = aws_security_group.worker.id
+
+  protocol  = 50
+  from_port = 0
+  to_port   = 0
+  self      = true
+}
+
 resource "aws_security_group_rule" "worker_ingress_geneve_from_master" {
   type                     = "ingress"
   security_group_id        = aws_security_group.worker.id

--- a/data/data/gcp/network/firewall.tf
+++ b/data/data/gcp/network/firewall.tf
@@ -101,6 +101,17 @@ resource "google_compute_firewall" "internal_cluster" {
     ports    = ["4789", "6081"]
   }
 
+  # ESP
+  allow {
+    protocol = "esp"
+  }
+
+  # IKE and IKE(NAT-T)
+  allow {
+    protocol = "udp"
+    ports    = ["500", "4500"]
+  }
+
   # internal tcp
   allow {
     protocol = "tcp"

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -98,6 +98,34 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_geneve" {
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_ike" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 500
+  port_range_max    = 500
+  remote_ip_prefix  = var.cidr_block
+  security_group_id = openstack_networking_secgroup_v2.master.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_ike_nat_t" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 4500
+  port_range_max    = 4500
+  remote_ip_prefix  = var.cidr_block
+  security_group_id = openstack_networking_secgroup_v2.master.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_esp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "esp"
+  remote_ip_prefix  = var.cidr_block
+  security_group_id = openstack_networking_secgroup_v2.master.id
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ovndb" {
   direction         = "ingress"
   ethertype         = "IPv4"

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -87,6 +87,34 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_geneve" {
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ike" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 500
+  port_range_max    = 500
+  remote_ip_prefix  = var.cidr_block
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ike_nat_t" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 4500
+  port_range_max    = 4500
+  remote_ip_prefix  = var.cidr_block
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "worker_ingress_esp" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "esp"
+  remote_ip_prefix  = var.cidr_block
+  security_group_id = openstack_networking_secgroup_v2.worker.id
+}
+
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal" {
   direction         = "ingress"
   ethertype         = "IPv4"


### PR DESCRIPTION
Enable ESP and IKE traffic across all installer targets between
worker and master nodes.

This is required to resolve https://bugzilla.redhat.com/show_bug.cgi?id=1908782 which is required to enable key feature for OCP 4.7 (OVN Kubernetes IPsec)

Signed-off-by: Mark Gray <mark.d.gray@redhat.com>