### PR TITLE
Bug 1903055: OpenStack: move platform validations to cluster asset

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -382,6 +382,11 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Data:     data,
 		})
 	case openstack.Name:
+		err = openstackconfig.Validate(installConfig.Config)
+		if err != nil {
+			return err
+		}
+
 		cloud, err := openstackconfig.GetSession(installConfig.Config.Platform.OpenStack.Cloud)
 		if err != nil {
 			return errors.Wrap(err, "failed to get cloud config for openstack")

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -14,7 +14,6 @@ import (
 	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	ickubevirt "github.com/openshift/installer/pkg/asset/installconfig/kubevirt"
-	icopenstack "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	icovirt "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	icvsphere "github.com/openshift/installer/pkg/asset/installconfig/vsphere"
 	"github.com/openshift/installer/pkg/types"
@@ -191,9 +190,6 @@ func (a *InstallConfig) platformValidation() error {
 	}
 	if a.Config.Platform.Ovirt != nil {
 		return icovirt.Validate(a.Config)
-	}
-	if a.Config.Platform.OpenStack != nil {
-		return icopenstack.Validate(a.Config)
 	}
 	if a.Config.Platform.Kubevirt != nil {
 		client, err := ickubevirt.NewClient()

--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -109,10 +109,6 @@ func validUUIDv4(s string) bool {
 // validate flavor checks to make sure that a given flavor exists and meets the minimum requrement to run a cluster
 // this function does not validate proper install config usage
 func validateFlavor(flavorName string, ci *CloudInfo, req flavorRequirements, fldPath *field.Path, storage bool) field.ErrorList {
-	if flavorName == "" {
-		return nil
-	}
-
 	flavor, ok := ci.Flavors[flavorName]
 	if !ok {
 		return field.ErrorList{field.NotFound(fldPath, flavorName)}

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -29,10 +29,6 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	// validate custom cluster os image
 	allErrs = append(allErrs, validateClusterOSImage(p, ci, fldPath)...)
 
-	if p.DefaultMachinePlatform != nil {
-		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, ci, true, fldPath.Child("defaultMachinePlatform"))...)
-	}
-
 	return allErrs
 }
 


### PR DESCRIPTION
Now we perform validations of install-config asset right after its generation. Unfortunately, later this asset is modified during "machines" generation. It leads to the fact that even if the validation succeeds, installation may fail after that.

To prevent this we move the validation to "cluster" asset, because there are no install-config modifications after that.

Also this commit removes defaultMachinePlatform validation, because it's not used for the cluster provisioning and just contains default values for the real machine pools.