### PR TITLE
Bug 1908171: fix Terraform issue with GCP custom machine types

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -82,7 +82,8 @@ resource "google_compute_instance" "bootstrap" {
     # In GCP TF apply is run a second time to remove bootstrap node from LB.
     # If machine_type = n2-standard series, install will error as TF tries to
     # switch min_cpu_platform = "Intel Cascade Lake" -> null. BZ-1746119.
-    ignore_changes = [min_cpu_platform]
+    # Also fails similarly with custom machine types: BZ-1908171.
+    ignore_changes = [machine_type, min_cpu_platform]
   }
 }
 

--- a/data/data/gcp/master/main.tf
+++ b/data/data/gcp/master/main.tf
@@ -65,7 +65,8 @@ resource "google_compute_instance" "master" {
     # In GCP TF apply is run a second time to remove bootstrap node from LB.
     # If machine_type = n2-standard series, install will error as TF tries to
     # switch min_cpu_platform = "Intel Cascade Lake" -> null. BZ-1746119.
-    ignore_changes = [min_cpu_platform]
+    # Also fails similarly with custom machine types: BZ-1908171.
+    ignore_changes = [machine_type, min_cpu_platform]
   }
 }
 


### PR DESCRIPTION
Similar to previous bug (see below) but in this case for custom machine types. In the previous bz, the config generated by Terraform did not match the resource that was ultimately created. So when apply is run a second time for bootstrap destroy, an error occurs when TF tries to switch the resource back to match the config.

Similar: fdefcca25cb12fc241198b0688f421411c9a580a

The error message states:
```
"Error: Changing the machine_type, min_cpu_platform, service_account, or enable display on a started instance requires stopping it.
```
We could potentially add `service_account` and `enable display` (however that is handled in TF) to prevent this error from happening in those cases, but I chose to opt for the minimal change and wait and see if those become a problem.