### PR TITLE
Bug 1899161: backports for storage flavor checks

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -73,19 +73,19 @@ openstack quota set --secgroups 8 --secgroup-rules 100 <project>`
 
 ### Master Nodes
 
-The default deployment stands up 3 master nodes, which is the minimum amount required for a cluster. For each master node you stand up, you will need 1 instance, and 1 port available in your quota. They should be assigned a flavor with at least 16 GB RAM, 4 vCPUs, and 25 GB Disk. It is theoretically possible to run with a smaller flavor, but be aware that if it takes too long to stand up services, or certain essential services crash, the installer could time out, leading to a failed install.
+The default deployment stands up 3 master nodes, which is the minimum amount required for a cluster. For each master node you stand up, you will need 1 instance, and 1 port available in your quota. They should be assigned a flavor with at least 16 GB RAM, 4 vCPUs, and 25 GB Disk (or Root Volume). It is theoretically possible to run with a smaller flavor, but be aware that if it takes too long to stand up services, or certain essential services crash, the installer could time out, leading to a failed install.
 
 The Master Nodes are placed in a single Server Group with "soft anti-affinity" policy; the machines will therefore be creted on separate hosts when possible.
 
 ### Worker Nodes
 
-The default deployment stands up 3 worker nodes. Worker nodes host the applications you run on OpenShift. The flavor assigned to the worker nodes should have at least 2 vCPUs, 8 GB RAM and 25 GB Disk. However, if you are experiencing `Out Of Memory` issues, or your installs are timing out, try increasing the size of your flavor to match the master nodes: 4 vCPUs and 16 GB RAM.
+The default deployment stands up 3 worker nodes. Worker nodes host the applications you run on OpenShift. The flavor assigned to the worker nodes should have at least 2 vCPUs, 8 GB RAM and 25 GB Disk (or Root Volume). However, if you are experiencing `Out Of Memory` issues, or your installs are timing out, try increasing the size of your flavor to match the master nodes: 4 vCPUs and 16 GB RAM.
 
 See the [OpenShift documentation](https://docs.openshift.com/container-platform/4.4/architecture/control-plane.html#defining-workers_control-plane) for more information on the worker nodes.
 
 ### Bootstrap Node
 
-The bootstrap node is a temporary node that is responsible for standing up the control plane on the masters. Only one bootstrap node will be stood up and it will be deprovisioned once the production control plane is ready. To do so, you need 1 instance, and 1 port. We recommend a flavor with a minimum of 16 GB RAM, 4 vCPUs, and 25 GB Disk.
+The bootstrap node is a temporary node that is responsible for standing up the control plane on the masters. Only one bootstrap node will be stood up and it will be deprovisioned once the production control plane is ready. To do so, you need 1 instance, and 1 port. We recommend a flavor with a minimum of 16 GB RAM, 4 vCPUs, and 25 GB Disk (or Root Volume).
 
 ### Image Registry Requirements
 

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -40,7 +40,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `additionalSecurityGroupIDs` (optional list of strings): IDs of additional security groups for machines.
 * `type` (optional string): The OpenStack flavor name for machines in the pool.
 * `rootVolume` (optional object): Defines the root volume for instances in the machine pool. The instances use ephemeral disks if not set.
-  * `size` (required integer): Size of the root volume in GB.
+  * `size` (required integer): Size of the root volume in GB. Must be set to at least 25.
   * `type` (required string): The volume pool to create the volume from.
 * `zones` (optional list of strings): The names of the availability zones you want to install your nodes on. If unset, the installer will use your default compute zone.
 

--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -77,15 +77,16 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig) error {
 		return errors.Wrap(err, "failed to fetch external network info")
 	}
 
-	ci.Flavors[ic.OpenStack.FlavorName], err = ci.getFlavor(ic.OpenStack.FlavorName)
-	if err != nil {
-		return errors.Wrap(err, "failed to fetch platform flavor info")
+	if flavorName := ic.OpenStack.FlavorName; flavorName != "" {
+		ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
+		if err != nil {
+			return errors.Wrap(err, "failed to fetch platform flavor info")
+		}
 	}
 
 	if ic.ControlPlane != nil && ic.ControlPlane.Platform.OpenStack != nil {
-		crtlPlaneFlavor := ic.ControlPlane.Platform.OpenStack.FlavorName
-		if crtlPlaneFlavor != "" {
-			ci.Flavors[crtlPlaneFlavor], err = ci.getFlavor(crtlPlaneFlavor)
+		if flavorName := ic.ControlPlane.Platform.OpenStack.FlavorName; flavorName != "" {
+			ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
 			if err != nil {
 				return err
 			}
@@ -94,8 +95,7 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig) error {
 
 	for _, machine := range ic.Compute {
 		if machine.Platform.OpenStack != nil {
-			flavorName := machine.Platform.OpenStack.FlavorName
-			if flavorName != "" {
+			if flavorName := machine.Platform.OpenStack.FlavorName; flavorName != "" {
 				if _, seen := ci.Flavors[flavorName]; !seen {
 					ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
 					if err != nil {

--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -45,12 +45,12 @@ func ValidateMachinePool(p *openstack.MachinePool, ci *CloudInfo, controlPlane b
 		flavor, ok := ci.Flavors[p.FlavorName]
 		if ok {
 			if controlPlane {
-				allErrs = append(allErrs, validateMpoolFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath)...)
+				allErrs = append(allErrs, validateFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath.Child("type"))...)
 			} else {
-				allErrs = append(allErrs, validateMpoolFlavor(flavor, computeFlavorMinimums, fldPath)...)
+				allErrs = append(allErrs, validateFlavor(flavor, computeFlavorMinimums, fldPath.Child("type"))...)
 			}
 		} else {
-			allErrs = append(allErrs, field.NotFound(fldPath.Child("flavorName"), p.FlavorName))
+			allErrs = append(allErrs, field.NotFound(fldPath.Child("type"), p.FlavorName))
 		}
 	}
 
@@ -105,12 +105,11 @@ func validUUIDv4(s string) bool {
 	return true
 }
 
-func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.Path) field.ErrorList {
-
+func validateFlavor(flavor Flavor, req flavorRequirements, fldPath *field.Path) field.ErrorList {
 	// OpenStack administrators don't always fill in accurate metadata for
 	// baremetal flavors. Skipping validation.
 	if flavor.Baremetal {
-		return field.ErrorList{}
+		return nil
 	}
 
 	errs := []string{}
@@ -125,7 +124,7 @@ func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.P
 	}
 
 	if len(errs) == 0 {
-		return field.ErrorList{}
+		return nil
 	}
 
 	errString := "Flavor did not meet the following minimum requirements: "
@@ -136,5 +135,5 @@ func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.P
 		}
 	}
 
-	return field.ErrorList{field.Invalid(fldPath.Child("flavorName"), flavor.Name, errString)}
+	return field.ErrorList{field.Invalid(fldPath, flavor.Name, errString)}
 }

--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -14,16 +14,20 @@ type flavorRequirements struct {
 	RAM, VCPUs, Disk int
 }
 
+const (
+	minimumStorage = 25
+)
+
 var (
 	ctrlPlaneFlavorMinimums = flavorRequirements{
 		RAM:   16,
 		VCPUs: 4,
-		Disk:  25,
+		Disk:  minimumStorage,
 	}
 	computeFlavorMinimums = flavorRequirements{
 		RAM:   8,
 		VCPUs: 2,
-		Disk:  25,
+		Disk:  minimumStorage,
 	}
 )
 
@@ -31,20 +35,24 @@ var (
 func ValidateMachinePool(p *openstack.MachinePool, ci *CloudInfo, controlPlane bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	var checkStorageFlavor bool
 	// Validate Root Volumes
 	if p.RootVolume != nil {
 		if p.RootVolume.Type == "" {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("rootVolume").Child("type"), p.RootVolume.Type, "Volume type must be specified to use root volumes"))
 		}
-		if p.RootVolume.Size <= 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("rootVolume").Child("size"), p.RootVolume.Size, "Volume size must be greater than zero to use root volumes"))
+		if p.RootVolume.Size < minimumStorage {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("rootVolume").Child("size"), p.RootVolume.Size, fmt.Sprintf("Volume size must be greater than %d to use root volumes, had %d", minimumStorage, p.RootVolume.Size)))
 		}
+	} else {
+		// Not using root volume, so must check flavor
+		checkStorageFlavor = true
 	}
 
 	if controlPlane {
-		allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, ctrlPlaneFlavorMinimums, fldPath.Child("type"))...)
+		allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, ctrlPlaneFlavorMinimums, fldPath.Child("type"), checkStorageFlavor)...)
 	} else {
-		allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, computeFlavorMinimums, fldPath.Child("type"))...)
+		allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, computeFlavorMinimums, fldPath.Child("type"), checkStorageFlavor)...)
 	}
 
 	allErrs = append(allErrs, validateZones(p.Zones, ci.Zones, fldPath.Child("zones"))...)
@@ -100,7 +108,7 @@ func validUUIDv4(s string) bool {
 
 // validate flavor checks to make sure that a given flavor exists and meets the minimum requrement to run a cluster
 // this function does not validate proper install config usage
-func validateFlavor(flavorName string, ci *CloudInfo, req flavorRequirements, fldPath *field.Path) field.ErrorList {
+func validateFlavor(flavorName string, ci *CloudInfo, req flavorRequirements, fldPath *field.Path, storage bool) field.ErrorList {
 	if flavorName == "" {
 		return nil
 	}
@@ -123,7 +131,7 @@ func validateFlavor(flavorName string, ci *CloudInfo, req flavorRequirements, fl
 	if flavor.VCPUs < req.VCPUs {
 		errs = append(errs, fmt.Sprintf("Must have minimum of %d VCPUs, had %d", req.VCPUs, flavor.VCPUs))
 	}
-	if flavor.Disk < req.Disk {
+	if flavor.Disk < req.Disk && storage {
 		errs = append(errs, fmt.Sprintf("Must have minimum of %d GB Disk, had %d GB", req.Disk, flavor.Disk))
 	}
 

--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -8,8 +8,6 @@ import (
 
 	guuid "github.com/google/uuid"
 	"github.com/openshift/installer/pkg/types/openstack"
-
-	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 )
 
 type flavorRequirements struct {
@@ -44,10 +42,15 @@ func ValidateMachinePool(p *openstack.MachinePool, ci *CloudInfo, controlPlane b
 	}
 
 	if p.FlavorName != "" {
-		if controlPlane {
-			allErrs = append(allErrs, validateMpoolFlavor(ci.Flavors[p.FlavorName], p.FlavorName, ctrlPlaneFlavorMinimums, fldPath)...)
+		flavor, ok := ci.Flavors[p.FlavorName]
+		if ok {
+			if controlPlane {
+				allErrs = append(allErrs, validateMpoolFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath)...)
+			} else {
+				allErrs = append(allErrs, validateMpoolFlavor(flavor, computeFlavorMinimums, fldPath)...)
+			}
 		} else {
-			allErrs = append(allErrs, validateMpoolFlavor(ci.Flavors[p.FlavorName], p.FlavorName, computeFlavorMinimums, fldPath)...)
+			allErrs = append(allErrs, field.NotFound(fldPath.Child("flavorName"), p.FlavorName))
 		}
 	}
 
@@ -102,9 +105,12 @@ func validUUIDv4(s string) bool {
 	return true
 }
 
-func validateMpoolFlavor(flavor *flavors.Flavor, name string, req flavorRequirements, fldPath *field.Path) field.ErrorList {
-	if flavor == nil {
-		return field.ErrorList{field.NotFound(fldPath.Child("flavorName"), name)}
+func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.Path) field.ErrorList {
+
+	// OpenStack administrators don't always fill in accurate metadata for
+	// baremetal flavors. Skipping validation.
+	if flavor.Baremetal {
+		return field.ErrorList{}
 	}
 
 	errs := []string{}

--- a/pkg/asset/installconfig/openstack/validation/machinepool_test.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool_test.go
@@ -138,7 +138,11 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 				mp.FlavorName = notExistFlavor
 				return mp
 			}(),
-			cloudInfo:      validMpoolCloudInfo(),
+			cloudInfo: func() *CloudInfo {
+				ci := validMpoolCloudInfo()
+				ci.Flavors[notExistFlavor] = Flavor{}
+				return ci
+			}(),
 			expectedError:  true,
 			expectedErrMsg: "controlPlane.platform.openstack.type: Not found: \"non-existant-flavor\"",
 		},
@@ -149,7 +153,11 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 				mp.FlavorName = notExistFlavor
 				return mp
 			}(),
-			cloudInfo:      validMpoolCloudInfo(),
+			cloudInfo: func() *CloudInfo {
+				ci := validMpoolCloudInfo()
+				ci.Flavors[notExistFlavor] = Flavor{}
+				return ci
+			}(),
 			expectedError:  true,
 			expectedErrMsg: `compute\[0\].platform.openstack.type: Not found: "non-existant-flavor"`,
 		},

--- a/pkg/asset/installconfig/openstack/validation/machinepool_test.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool_test.go
@@ -23,12 +23,38 @@ const (
 	invalidCtrlPlaneFlavor = "invalid-control-plane-flavor"
 
 	baremetalFlavor = "baremetal-flavor"
+
+	volumeType      = "performance"
+	volumeSmallSize = 10
+	volumeLargeSize = 25
 )
 
 func validMachinePool() *openstack.MachinePool {
 	return &openstack.MachinePool{
 		FlavorName: validCtrlPlaneFlavor,
 		Zones:      []string{""},
+	}
+}
+
+func invalidMachinePoolSmallVolume() *openstack.MachinePool {
+	return &openstack.MachinePool{
+		FlavorName: validCtrlPlaneFlavor,
+		Zones:      []string{""},
+		RootVolume: &openstack.RootVolume{
+			Type: volumeType,
+			Size: volumeSmallSize,
+		},
+	}
+}
+
+func validMachinePoolLargeVolume() *openstack.MachinePool {
+	return &openstack.MachinePool{
+		FlavorName: validCtrlPlaneFlavor,
+		Zones:      []string{""},
+		RootVolume: &openstack.RootVolume{
+			Type: volumeType,
+			Size: volumeLargeSize,
+		},
 	}
 }
 
@@ -191,6 +217,30 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			mpool: func() *openstack.MachinePool {
 				mp := validMachinePool()
 				mp.FlavorName = baremetalFlavor
+				return mp
+			}(),
+			cloudInfo:      validMpoolCloudInfo(),
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name:         "volume too small",
+			controlPlane: false,
+			mpool: func() *openstack.MachinePool {
+				mp := invalidMachinePoolSmallVolume()
+				mp.FlavorName = invalidCtrlPlaneFlavor
+				return mp
+			}(),
+			cloudInfo:      validMpoolCloudInfo(),
+			expectedError:  true,
+			expectedErrMsg: "Volume size must be greater than 25 to use root volumes, had 10",
+		},
+		{
+			name:         "volume big enough",
+			controlPlane: false,
+			mpool: func() *openstack.MachinePool {
+				mp := validMachinePoolLargeVolume()
+				mp.FlavorName = invalidCtrlPlaneFlavor
 				return mp
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),

--- a/pkg/asset/installconfig/openstack/validation/machinepool_test.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool_test.go
@@ -140,7 +140,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: "controlPlane.platform.openstack.flavorName: Not found: \"non-existant-flavor\"",
+			expectedErrMsg: "controlPlane.platform.openstack.type: Not found: \"non-existant-flavor\"",
 		},
 		{
 			name: "not found compute flavorName",
@@ -151,7 +151,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: `compute\[0\].platform.openstack.flavorName: Not found: "non-existant-flavor"`,
+			expectedErrMsg: `compute\[0\].platform.openstack.type: Not found: "non-existant-flavor"`,
 		},
 		{
 			name:         "invalid control plane flavorName",
@@ -163,7 +163,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: "controlPlane.platform.openstack.flavorName: Invalid value: \"invalid-control-plane-flavor\": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2",
+			expectedErrMsg: "controlPlane.platform.openstack.type: Invalid value: \"invalid-control-plane-flavor\": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2",
 		},
 		{
 			name:         "invalid compute flavorName",
@@ -175,7 +175,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: `compute\[0\].platform.openstack.flavorName: Invalid value: "invalid-compute-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 25 GB Disk, had 10 GB`,
+			expectedErrMsg: `compute\[0\].platform.openstack.type: Invalid value: "invalid-compute-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 25 GB Disk, had 10 GB`,
 		},
 		{
 			name:         "valid baremetal compute",

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -22,12 +22,7 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	allErrs = append(allErrs, validateExternalNetwork(p, ci, fldPath)...)
 
 	// validate platform flavor
-	flavor, ok := ci.Flavors[p.FlavorName]
-	if ok {
-		allErrs = append(allErrs, validateFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath.Child("computeFlavor"))...)
-	} else {
-		allErrs = append(allErrs, field.NotFound(fldPath.Child("computeFlavor"), p.FlavorName))
-	}
+	allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, ctrlPlaneFlavorMinimums, fldPath.Child("computeFlavor"))...)
 
 	// validate floating ips
 	allErrs = append(allErrs, validateFloatingIPs(p, ci, fldPath)...)

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -22,7 +22,7 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	allErrs = append(allErrs, validateExternalNetwork(p, ci, fldPath)...)
 
 	// validate platform flavor
-	allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, ctrlPlaneFlavorMinimums, fldPath.Child("computeFlavor"))...)
+	allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, ctrlPlaneFlavorMinimums, fldPath.Child("computeFlavor"), true)...)
 
 	// validate floating ips
 	allErrs = append(allErrs, validateFloatingIPs(p, ci, fldPath)...)

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -22,7 +22,12 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	allErrs = append(allErrs, validateExternalNetwork(p, ci, fldPath)...)
 
 	// validate platform flavor
-	allErrs = append(allErrs, validatePlatformFlavor(p, ci, fldPath)...)
+	flavor, ok := ci.Flavors[p.FlavorName]
+	if ok {
+		allErrs = append(allErrs, validateFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath.Child("computeFlavor"))...)
+	} else {
+		allErrs = append(allErrs, field.NotFound(fldPath.Child("computeFlavor"), p.FlavorName))
+	}
 
 	// validate floating ips
 	allErrs = append(allErrs, validateFloatingIPs(p, ci, fldPath)...)
@@ -62,47 +67,6 @@ func validateExternalNetwork(p *openstack.Platform, ci *CloudInfo, fldPath *fiel
 		allErrs = append(allErrs, field.NotFound(fldPath.Child("externalNetwork"), p.ExternalNetwork))
 	}
 	return allErrs
-}
-
-// validatePlatformFlavor validates the platform flavor and returns a list of all validation errors
-func validatePlatformFlavor(p *openstack.Platform, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {
-	flavor, ok := ci.Flavors[p.FlavorName]
-	if !ok {
-		allErrs = append(allErrs, field.NotFound(fldPath.Child("computeFlavor"), p.FlavorName))
-		return allErrs
-	}
-
-	// OpenStack administrators don't always fill in accurate metadata for
-	// baremetal flavors. Skipping validation.
-	if flavor.Baremetal {
-		return allErrs
-	}
-
-	errs := []string{}
-	req := ctrlPlaneFlavorMinimums
-	if flavor.RAM < req.RAM {
-		errs = append(errs, fmt.Sprintf("Must have minimum of %d GB RAM, had %d GB", req.RAM, flavor.RAM))
-	}
-	if flavor.VCPUs < req.VCPUs {
-		errs = append(errs, fmt.Sprintf("Must have minimum of %d VCPUs, had %d", req.VCPUs, flavor.VCPUs))
-	}
-	if flavor.Disk < req.Disk {
-		errs = append(errs, fmt.Sprintf("Must have minimum of %d GB Disk, had %d GB", req.Disk, flavor.Disk))
-	}
-
-	if len(errs) == 0 {
-		return field.ErrorList{}
-	}
-
-	errString := "Flavor did not meet the following minimum requirements: "
-	for i, err := range errs {
-		errString = errString + err
-		if i != len(errs)-1 {
-			errString = errString + "; "
-		}
-	}
-
-	return append(allErrs, field.Invalid(fldPath.Child("flavorName"), flavor.Name, errString))
 }
 
 func validateFloatingIPs(p *openstack.Platform, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -120,7 +120,7 @@ func TestOpenStackPlatformValidation(t *testing.T) {
 			cloudInfo:      validPlatformCloudInfo(),
 			networking:     validNetworking(),
 			expectedError:  true,
-			expectedErrMsg: `platform.openstack.flavorName: Invalid value: "invalid-control-plane-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2; Must have minimum of 25 GB Disk, had 20 GB`,
+			expectedErrMsg: `platform.openstack.computeFlavor: Invalid value: "invalid-control-plane-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2; Must have minimum of 25 GB Disk, had 20 GB`,
 		},
 		{
 			name:     "not found api FIP",

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -41,18 +41,31 @@ func validPlatformCloudInfo() *CloudInfo {
 			AdminStateUp: true,
 			Status:       "ACTIVE",
 		},
-		Flavors: map[string]*flavors.Flavor{
+		Flavors: map[string]Flavor{
 			validCtrlPlaneFlavor: {
-				Name:  validCtrlPlaneFlavor,
-				RAM:   16,
-				Disk:  25,
-				VCPUs: 4,
+				Flavor: &flavors.Flavor{
+					Name:  validCtrlPlaneFlavor,
+					RAM:   16,
+					Disk:  25,
+					VCPUs: 4,
+				},
 			},
 			invalidCtrlPlaneFlavor: {
-				Name:  invalidCtrlPlaneFlavor,
-				RAM:   8,  // too low
-				Disk:  20, // too low
-				VCPUs: 2,  // too low
+				Flavor: &flavors.Flavor{
+					Name:  invalidCtrlPlaneFlavor,
+					RAM:   8,  // too low
+					Disk:  20, // too low
+					VCPUs: 2,  // too low
+				},
+			},
+			baremetalFlavor: {
+				Flavor: &flavors.Flavor{
+					Name:  baremetalFlavor,
+					RAM:   8,  // too low
+					Disk:  20, // too low
+					VCPUs: 2,  // too low
+				},
+				Baremetal: true,
 			},
 		},
 		APIFIP: &floatingips.FloatingIP{
@@ -78,6 +91,18 @@ func TestOpenStackPlatformValidation(t *testing.T) {
 		{
 			name:           "valid platform",
 			platform:       validPlatform(),
+			cloudInfo:      validPlatformCloudInfo(),
+			networking:     validNetworking(),
+			expectedError:  false,
+			expectedErrMsg: "",
+		},
+		{
+			name: "baremetal flavor",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.FlavorName = baremetalFlavor
+				return p
+			}(),
 			cloudInfo:      validPlatformCloudInfo(),
 			networking:     validNetworking(),
 			expectedError:  false,

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -117,7 +117,11 @@ func TestOpenStackPlatformValidation(t *testing.T) {
 				p.FlavorName = invalidCtrlPlaneFlavor
 				return p
 			}(),
-			cloudInfo:      validPlatformCloudInfo(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				ci.Flavors[notExistFlavor] = Flavor{}
+				return ci
+			}(),
 			networking:     validNetworking(),
 			expectedError:  true,
 			expectedErrMsg: `platform.openstack.computeFlavor: Invalid value: "invalid-control-plane-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2; Must have minimum of 25 GB Disk, had 20 GB`,


### PR DESCRIPTION
This PR is a combination of multiple cherry-picks that
will help to use rootVolume in 4.6:

* Bug 1878900: openstack: Skip validation for baremetal flavors
* Bug 1878900: openstack: Fix error messages in flavor validation
* Bug 1887863: Patch Flavor Not Found validation for OpenStack Install Config
* Bug 1891543: openstack: consider volumes for storage requirements checks

Note: without applying these cherry-picks, the resolution of bz#1899161 would
      involve a rewrite of the patch which isn't ideal. The backports here
      are all bugfixes.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1899161
