### PR TITLE
Bug 1894678: Patch Flavor Not Found validation for OpenStack Install Config

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -77,17 +77,21 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig) error {
 		return errors.Wrap(err, "failed to fetch external network info")
 	}
 
-	ci.Flavors[ic.OpenStack.FlavorName], err = ci.getFlavor(ic.OpenStack.FlavorName)
-	if err != nil {
-		return errors.Wrap(err, "failed to fetch platform flavor info")
+	// Get flavor info
+	if flavorName := ic.OpenStack.FlavorName; flavorName != "" {
+		ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
+		if err != nil {
+			return err
+		}
 	}
 
 	if ic.ControlPlane != nil && ic.ControlPlane.Platform.OpenStack != nil {
-		crtlPlaneFlavor := ic.ControlPlane.Platform.OpenStack.FlavorName
-		if crtlPlaneFlavor != "" {
-			ci.Flavors[crtlPlaneFlavor], err = ci.getFlavor(crtlPlaneFlavor)
-			if err != nil {
-				return err
+		if flavorName := ic.ControlPlane.Platform.OpenStack.FlavorName; flavorName != "" {
+			if _, seen := ci.Flavors[flavorName]; !seen {
+				ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -142,11 +146,15 @@ func (ci *CloudInfo) getSubnet(subnetID string) (*subnets.Subnet, error) {
 	return subnet, nil
 }
 
+func isNotFoundError(err error) bool {
+	var errNotFound *gophercloud.ErrResourceNotFound
+	return errors.As(err, &errNotFound) || strings.Contains(err.Error(), "Resource not found")
+}
+
 func (ci *CloudInfo) getFlavor(flavorName string) (Flavor, error) {
 	flavorID, err := flavorutils.IDFromName(ci.clients.computeClient, flavorName)
 	if err != nil {
-		var gerr *gophercloud.ErrResourceNotFound
-		if errors.As(err, &gerr) {
+		if isNotFoundError(err) {
 			return Flavor{}, nil
 		}
 		return Flavor{}, err
@@ -160,10 +168,9 @@ func (ci *CloudInfo) getFlavor(flavorName string) (Flavor, error) {
 	var baremetal bool
 	{
 		const baremetalProperty = "baremetal"
-		var errNotFound *gophercloud.ErrResourceNotFound
 
 		m, err := flavors.GetExtraSpec(ci.clients.computeClient, flavorID, baremetalProperty).Extract()
-		if err != nil && !errors.As(err, &errNotFound) && !strings.Contains(err.Error(), "Resource not found") {
+		if err != nil && !isNotFoundError(err) {
 			return Flavor{}, err
 		}
 

--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -41,17 +41,10 @@ func ValidateMachinePool(p *openstack.MachinePool, ci *CloudInfo, controlPlane b
 		}
 	}
 
-	if p.FlavorName != "" {
-		flavor, ok := ci.Flavors[p.FlavorName]
-		if ok {
-			if controlPlane {
-				allErrs = append(allErrs, validateMpoolFlavor(flavor, ctrlPlaneFlavorMinimums, fldPath)...)
-			} else {
-				allErrs = append(allErrs, validateMpoolFlavor(flavor, computeFlavorMinimums, fldPath)...)
-			}
-		} else {
-			allErrs = append(allErrs, field.NotFound(fldPath.Child("flavorName"), p.FlavorName))
-		}
+	if controlPlane {
+		allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, ctrlPlaneFlavorMinimums, fldPath.Child("type"))...)
+	} else {
+		allErrs = append(allErrs, validateFlavor(p.FlavorName, ci, computeFlavorMinimums, fldPath.Child("type"))...)
 	}
 
 	allErrs = append(allErrs, validateZones(p.Zones, ci.Zones, fldPath.Child("zones"))...)
@@ -105,7 +98,17 @@ func validUUIDv4(s string) bool {
 	return true
 }
 
-func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.Path) field.ErrorList {
+// validate flavor checks to make sure that a given flavor exists and meets the minimum requrement to run a cluster
+// this function does not validate proper install config usage
+func validateFlavor(flavorName string, ci *CloudInfo, req flavorRequirements, fldPath *field.Path) field.ErrorList {
+	if flavorName == "" {
+		return nil
+	}
+
+	flavor, _ := ci.Flavors[flavorName]
+	if flavor.Flavor == nil {
+		return field.ErrorList{field.NotFound(fldPath, flavorName)}
+	}
 
 	// OpenStack administrators don't always fill in accurate metadata for
 	// baremetal flavors. Skipping validation.
@@ -136,5 +139,5 @@ func validateMpoolFlavor(flavor Flavor, req flavorRequirements, fldPath *field.P
 		}
 	}
 
-	return field.ErrorList{field.Invalid(fldPath.Child("flavorName"), flavor.Name, errString)}
+	return field.ErrorList{field.Invalid(fldPath, flavor.Name, errString)}
 }

--- a/pkg/asset/installconfig/openstack/validation/machinepool_test.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool_test.go
@@ -138,9 +138,13 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 				mp.FlavorName = notExistFlavor
 				return mp
 			}(),
-			cloudInfo:      validMpoolCloudInfo(),
+			cloudInfo: func() *CloudInfo {
+				ci := validMpoolCloudInfo()
+				ci.Flavors[notExistFlavor] = Flavor{}
+				return ci
+			}(),
 			expectedError:  true,
-			expectedErrMsg: "controlPlane.platform.openstack.flavorName: Not found: \"non-existant-flavor\"",
+			expectedErrMsg: "controlPlane.platform.openstack.type: Not found: \"non-existant-flavor\"",
 		},
 		{
 			name: "not found compute flavorName",
@@ -149,9 +153,13 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 				mp.FlavorName = notExistFlavor
 				return mp
 			}(),
-			cloudInfo:      validMpoolCloudInfo(),
+			cloudInfo: func() *CloudInfo {
+				ci := validMpoolCloudInfo()
+				ci.Flavors[notExistFlavor] = Flavor{}
+				return ci
+			}(),
 			expectedError:  true,
-			expectedErrMsg: `compute\[0\].platform.openstack.flavorName: Not found: "non-existant-flavor"`,
+			expectedErrMsg: `compute\[0\].platform.openstack.type: Not found: "non-existant-flavor"`,
 		},
 		{
 			name:         "invalid control plane flavorName",
@@ -163,7 +171,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: "controlPlane.platform.openstack.flavorName: Invalid value: \"invalid-control-plane-flavor\": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2",
+			expectedErrMsg: "controlPlane.platform.openstack.type: Invalid value: \"invalid-control-plane-flavor\": Flavor did not meet the following minimum requirements: Must have minimum of 16 GB RAM, had 8 GB; Must have minimum of 4 VCPUs, had 2",
 		},
 		{
 			name:         "invalid compute flavorName",
@@ -175,7 +183,7 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			}(),
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
-			expectedErrMsg: `compute\[0\].platform.openstack.flavorName: Invalid value: "invalid-compute-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 25 GB Disk, had 10 GB`,
+			expectedErrMsg: `compute\[0\].platform.openstack.type: Invalid value: "invalid-compute-flavor": Flavor did not meet the following minimum requirements: Must have minimum of 25 GB Disk, had 10 GB`,
 		},
 		{
 			name:         "valid baremetal compute",


### PR DESCRIPTION
Flavors are always added to the Flavors map, however if they are not found
the flavor pointer is nil. Corrected the code logic to account for this.

Bug 1894678
Backports https://github.com/openshift/installer/pull/4289