### PR TITLE
Bug 1913151: KubeVirt user docs: change role example - add "update" verb to VM

### DIFF
--- a/docs/user/kubevirt/role.yaml
+++ b/docs/user/kubevirt/role.yaml
@@ -12,7 +12,7 @@ rules:
   verbs: ["get"]
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachines"]
-  verbs: ["get", "list", "create", "delete"]
+  verbs: ["get", "list", "create", "delete", "update"]
 - apiGroups: ["cdi.kubevirt.io"]
   resources: ["datavolumes"]
   verbs: ["get", "list", "create", "delete"]


### PR DESCRIPTION
When this verb is missing, although the cluster is created successfully,
the cluster behavior after the installation is wrong
(machine-controllers use the infra cluster credentials provided by the user)