### PR TITLE
Bug 1810438: oVirt: Add missing piece for gathering bootstrap IP info

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -225,11 +225,15 @@ func extractHostAddresses(config *types.InstallConfig, tfstate *terraform.State)
 			logrus.Error(err)
 		}
 	case ovirttypes.Name:
-		bootstrap, err := gatherovirt.BootstrapIP(tfstate)
+		bootstrap, err = gatherovirt.BootstrapIP(tfstate)
 		if err != nil {
 			return bootstrap, port, masters, err
 		}
 		masters, err = gatherovirt.ControlPlaneIPs(tfstate)
+		if err != nil {
+			logrus.Error(err)
+		}
+
 	case vspheretypes.Name:
 		bootstrap, err = gathervsphere.BootstrapIP(config, tfstate)
 		if err != nil {

--- a/pkg/terraform/gather/ovirt/ip.go
+++ b/pkg/terraform/gather/ovirt/ip.go
@@ -2,13 +2,115 @@
 package ovirt
 
 import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	"github.com/openshift/installer/pkg/terraform"
+	ovirtsdk4 "github.com/ovirt/go-ovirt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
+
+const bootstrapSSHPort = "22"
+
+func checkPortIsOpen(host string, port string) bool {
+	timeout := time.Second
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), timeout)
+	if err != nil {
+		logrus.Debugf("connection error: %v", err)
+		return false
+	}
+	if conn != nil {
+		defer conn.Close()
+	}
+	return conn != nil
+}
+
+func getReportedDevices(c *ovirtsdk4.Connection, vmID string) (*ovirtsdk4.ReportedDeviceSlice, error) {
+
+	vmsService := c.SystemService().VmsService()
+	// Look up the vm by id:
+	vmResp, err := vmsService.VmService(vmID).Get().Send()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find VM, by id %v, reason: %v", vmID, err)
+	}
+	vm := vmResp.MustVm()
+
+	// Get the reported-devices service for this vm:
+	reportedDevicesService := vmsService.VmService(vm.MustId()).ReportedDevicesService()
+
+	// Get the guest reported devices
+	reportedDeviceResp, err := reportedDevicesService.List().Send()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get reported devices list, reason: %v", err)
+	}
+	reportedDeviceSlice, _ := reportedDeviceResp.ReportedDevice()
+
+	if len(reportedDeviceSlice.Slice()) == 0 {
+		return nil, fmt.Errorf("cannot find IPs for vmId: %s", vmID)
+	}
+	return reportedDeviceSlice, nil
+}
+
+func findVirtualMachineIP(c *ovirtsdk4.Connection, moRefValue string) (string, error) {
+
+	reportedDeviceSlice, err := getReportedDevices(c, moRefValue)
+	if err != nil {
+		return "", err
+	}
+
+	for _, reportedDevice := range reportedDeviceSlice.Slice() {
+		ips, hasIps := reportedDevice.Ips()
+		if hasIps {
+			for _, ip := range ips.Slice() {
+				ipres, hasAddress := ip.Address()
+				if hasAddress {
+					if checkPortIsOpen(ipres, bootstrapSSHPort) {
+						logrus.Debugf("ovirt vm id: %s , found usable bootstrap IP %s", moRefValue, ipres)
+						return ipres, nil
+					}
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("could not find usable bootstrap IP address for vm id: %s", moRefValue)
+}
 
 // BootstrapIP returns the ip address for bootstrap host.
 // still unsupported, because qemu-ga is not available - see https://bugzilla.redhat.com/show_bug.cgi?id=1764804
 func BootstrapIP(tfs *terraform.State) (string, error) {
-	return "", nil
+
+	client, err := ovirt.NewConnection()
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize connection to ovirt-engine's %s", err)
+	}
+	defer client.Close()
+
+	br, err := terraform.LookupResource(tfs, "module.bootstrap", "ovirt_vm", "bootstrap")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup bootstrap")
+	}
+
+	if len(br.Instances) == 0 {
+		return "", errors.New("no bootstrap instance found")
+	}
+
+	vmid, found, err := unstructured.NestedString(br.Instances[0].Attributes, "id")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup bootstrap managed object reference")
+	}
+	if !found {
+		return "", errors.Errorf("failed to lookup bootstrap by vmID: %s", vmid)
+	}
+
+	ip, err := findVirtualMachineIP(client, vmid)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to lookup bootstrap ipv4 address")
+	}
+	return ip, nil
 }
 
 // ControlPlaneIPs returns the ip addresses for control plane hosts.


### PR DESCRIPTION
during gather-bootstrap logs need to be gathered from the bootstrap node using ssh,
oVirt engine collects  node  IP information using the qemu-agent,
we are using oVirt SDK to retrieve this information and choose the correct IP which allows ssh connection.

Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>