### PR TITLE
[WIP] Test BZ 1907770 on IPI installs

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-03dc8417bfb54885e"
+            "hvm": "ami-0af2aca40a19b1ae2"
         },
         "ap-east-1": {
-            "hvm": "ami-055665dc9e9799296"
+            "hvm": "ami-000d9e30619db8c85"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0f67d9a2324e93380"
+            "hvm": "ami-0a0454ae5766f0bd1"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0af7d134b7362c59c"
+            "hvm": "ami-0d8b73cee790117b9"
         },
         "ap-south-1": {
-            "hvm": "ami-0bfb5d254a69b7419"
+            "hvm": "ami-0a1f39e43274a509a"
         },
         "ap-southeast-1": {
-            "hvm": "ami-08e130fb7b06c0d5d"
+            "hvm": "ami-05f928d09c03a08f2"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0bec9aae9292db769"
+            "hvm": "ami-0c6cf9f37751bbe61"
         },
         "ca-central-1": {
-            "hvm": "ami-0f0d4fd027aafa9ec"
+            "hvm": "ami-05b9c100674f62b59"
         },
         "eu-central-1": {
-            "hvm": "ami-0b299978f75c6fab7"
+            "hvm": "ami-0c1f704ed179c9e6b"
         },
         "eu-north-1": {
-            "hvm": "ami-0a9cf69e21ee6efa7"
+            "hvm": "ami-03b18889a7a5eca97"
         },
         "eu-south-1": {
-            "hvm": "ami-00813d96eb14a5a94"
+            "hvm": "ami-0fcd549235287035f"
         },
         "eu-west-1": {
-            "hvm": "ami-01e09e74477d926f3"
+            "hvm": "ami-0349cc593d5029fac"
         },
         "eu-west-2": {
-            "hvm": "ami-09009bcbfb3ffc566"
+            "hvm": "ami-055e431acbab438b5"
         },
         "eu-west-3": {
-            "hvm": "ami-052ce7993e1a51903"
+            "hvm": "ami-051557194eb6157d5"
         },
         "me-south-1": {
-            "hvm": "ami-08d9bf8527beecee4"
+            "hvm": "ami-0ba21ee8ed0a779aa"
         },
         "sa-east-1": {
-            "hvm": "ami-07eec7d9a8e420ea1"
+            "hvm": "ami-0f445064098242ebd"
         },
         "us-east-1": {
-            "hvm": "ami-0996bc3576195a2f0"
+            "hvm": "ami-06ad0f2e28603bcce"
         },
         "us-east-2": {
-            "hvm": "ami-0c0b5ea0a4ebe87d5"
+            "hvm": "ami-05a379cf042ab1983"
         },
         "us-west-1": {
-            "hvm": "ami-067abd73d16691225"
+            "hvm": "ami-0b9d4ec3ac5d6a257"
         },
         "us-west-2": {
-            "hvm": "ami-055cdcaf3b4d54a91"
+            "hvm": "ami-0798c5c5c7acd16e0"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202012030221-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202012030221-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202101071343-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202101071343-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202012030221-0/x86_64/",
-    "buildid": "47.83.202012030221-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202101071343-0/x86_64/",
+    "buildid": "47.83.202101071343-0",
     "gcp": {
-        "image": "rhcos-47-83-202012030221-0-gcp-x86-64",
+        "image": "rhcos-47-83-202101071343-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202012030221-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202101071343-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202012030221-0-aws.x86_64.vmdk.gz",
-            "sha256": "c8b741671cf4f2c13a1de4068ed2bb2d3f09479c89d205789c1cc58e76bd7eda",
-            "size": 940924861,
-            "uncompressed-sha256": "732e2d6b4745fae4dd9385bee75f199af2121e4d3a8eae92600c8c826119388c",
-            "uncompressed-size": 960320000
+            "path": "rhcos-47.83.202101071343-0-aws.x86_64.vmdk.gz",
+            "sha256": "c6ccc6b25bc33027b91028183e1cd96b245dc14e93a66ae67e40894fbd16ebb6",
+            "size": 943365637,
+            "uncompressed-sha256": "af7e2fa345491540e2296850999937e325bd3af789599d75352d4bb37e96cac6",
+            "uncompressed-size": 962804736
         },
         "azure": {
-            "path": "rhcos-47.83.202012030221-0-azure.x86_64.vhd.gz",
-            "sha256": "f1da54a42b2178e8ab0eda2a3d8aa613b3cf1809c0a92e0b94124a27370dea9c",
-            "size": 941546542,
-            "uncompressed-sha256": "6201d201935e9e1cc144ae77d151ea736dd601ecbad246edc9cc1d75a1d93e41",
+            "path": "rhcos-47.83.202101071343-0-azure.x86_64.vhd.gz",
+            "sha256": "3ad64de438e94289444d254dc2f6fa85d03911b57f50a1114784e86011f1a447",
+            "size": 943928322,
+            "uncompressed-sha256": "0803a7d3af6972a6a811027f0e2d4f9f8a4aee99ef54880fe8e15918ac765a21",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202012030221-0-gcp.x86_64.tar.gz",
-            "sha256": "5837067659ad7055f0614bd0feb867322b1832f901dd513520beada7f5ba6b09",
-            "size": 926832318
+            "path": "rhcos-47.83.202101071343-0-gcp.x86_64.tar.gz",
+            "sha256": "aa8ffcee26819a6ab4a5cb889d29863d1ef632d2f02fd0e6ae9800b847f896f7",
+            "size": 929205083
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202012030221-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "515f13f6d78d6b1e0f52656d49754345ec6fc8a5c64f53c18d8577c907929118",
-            "size": 927133006,
-            "uncompressed-sha256": "b12038dfc63f0816b1dc459278eda266eed3eca228bf771ec005b8a7407fc469",
-            "uncompressed-size": 2328952832
+            "path": "rhcos-47.83.202101071343-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "d9924976d561df1c8d0e7128e2db49bb60ebf64c06244ecb7c0e12163b965758",
+            "size": 929540205,
+            "uncompressed-sha256": "11f10ab80b3fd09c2894db78a44369b6a45633ecdb45bba7d5b3ca689091cc1b",
+            "uncompressed-size": 2339373056
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202012030221-0-live-initramfs.x86_64.img",
-            "sha256": "36eb33777fa768fa8de0a862265e553d952bb7636b800cbdd1fc4ac3d4cb03db"
+            "path": "rhcos-47.83.202101071343-0-live-initramfs.x86_64.img",
+            "sha256": "1fbc4a58a0ba036b9bcb23bd482f2ebfa7fa1f7c7e00eca9208c85c439cdd03d"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202012030221-0-live.x86_64.iso",
-            "sha256": "21a05f87fc7e4609d635481dc4d09d061cc32acd09657b050fd62a9b4f42677b"
+            "path": "rhcos-47.83.202101071343-0-live.x86_64.iso",
+            "sha256": "beaf646b970088973e634ea49144c78aec3d89e488f12c7b1f2f61d644b974af"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202012030221-0-live-kernel-x86_64",
-            "sha256": "7c297b7daee6a01c7a09b68f9fe4a655580168113e8730917f061fecbe8ceb32"
+            "path": "rhcos-47.83.202101071343-0-live-kernel-x86_64",
+            "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202012030221-0-live-rootfs.x86_64.img",
-            "sha256": "b52a5197c5db12971ce7e52f217f3fa6da30ffe04150a3eaa4c8319db7072ca5"
+            "path": "rhcos-47.83.202101071343-0-live-rootfs.x86_64.img",
+            "sha256": "5f61129760429abb6531ac50257ba3f9ba284b8ef08802da150249ee45bcab52"
         },
         "metal": {
-            "path": "rhcos-47.83.202012030221-0-metal.x86_64.raw.gz",
-            "sha256": "77702ef31e3a15042df51f36a83f8b5afcb15576858482c32a15fb9cfa0424b6",
-            "size": 928823703,
-            "uncompressed-sha256": "983293a570e30ed50fe07b51bb5ed5ef798810a022e24e65ae5f3290b38d7ceb",
-            "uncompressed-size": 3677356032
+            "path": "rhcos-47.83.202101071343-0-metal.x86_64.raw.gz",
+            "sha256": "9a254de65b6ac9920d9fb3a697006bb9fc1a0b7f3a760d8750176c05ad6154f9",
+            "size": 931259170,
+            "uncompressed-sha256": "ff239fb2c2aede9eae2088e1caffd50609c98725d197d2ecf017e20a66499621",
+            "uncompressed-size": 3692036096
         },
         "metal4k": {
-            "path": "rhcos-47.83.202012030221-0-metal4k.x86_64.raw.gz",
-            "sha256": "81b63723a643530f2a50f656baa097894d8a064c89c7468ed570cec1dbb6157f",
-            "size": 926496277,
-            "uncompressed-sha256": "e94fbd8615d1790ab39ac6ad29eaf0ddd5f726d65fab4a31b71b2c66cf507d47",
-            "uncompressed-size": 3677356032
+            "path": "rhcos-47.83.202101071343-0-metal4k.x86_64.raw.gz",
+            "sha256": "47683ef53d5004bfdec0a236d1fc932bc185daae3d1ad81dbeadbe2fbd88220a",
+            "size": 928839229,
+            "uncompressed-sha256": "197cc2f34acac86742c1e950ca01ee05ae143822fdb53a45e78382400aebe1ff",
+            "uncompressed-size": 3692036096
         },
         "openstack": {
-            "path": "rhcos-47.83.202012030221-0-openstack.x86_64.qcow2.gz",
-            "sha256": "cde9caedbe67d921ab9ff76a71f62b0172f863f1a984d2ce5aa0fccac090b3f8",
-            "size": 927133474,
-            "uncompressed-sha256": "b487344e1e104f9f34985ec5015ffd8b532df4c357137c38c7cbbd7289fb881a",
-            "uncompressed-size": 2328952832
+            "path": "rhcos-47.83.202101071343-0-openstack.x86_64.qcow2.gz",
+            "sha256": "5ac146e8d2bd93fe683e42483a389cbeffd85e9bb4870e5980da5fb6db7743a6",
+            "size": 929539403,
+            "uncompressed-sha256": "4db412ecddbb03e868b1b8000d4b9d445af8d35e9d06f9f4735c7d63ba819fc6",
+            "uncompressed-size": 2339373056
         },
         "ostree": {
-            "path": "rhcos-47.83.202012030221-0-ostree.x86_64.tar",
-            "sha256": "c2680bc83e76ca764b6e5ff623e27fa72b28636262234b6b8d6e1c204e203438",
-            "size": 855152640
+            "path": "rhcos-47.83.202101071343-0-ostree.x86_64.tar",
+            "sha256": "035b375510381705c2b890a0bc56e6608a4fe98429012528ef2dbf5b344edc07",
+            "size": 857518080
         },
         "qemu": {
-            "path": "rhcos-47.83.202012030221-0-qemu.x86_64.qcow2.gz",
-            "sha256": "4104496474292789b7ef5414a5678cd886d9e22895e3227b14f2c93408a0af26",
-            "size": 928245521,
-            "uncompressed-sha256": "f0a028820a263ed4156104a5ae57ae96ca4a8ec93c5b879843ef378a43e6a993",
-            "uncompressed-size": 2364473344
+            "path": "rhcos-47.83.202101071343-0-qemu.x86_64.qcow2.gz",
+            "sha256": "7a53b563ac6474765d19b209a4f3ab823c8d08f509d3d2f68b8bdab584adbea0",
+            "size": 930711179,
+            "uncompressed-sha256": "35ad3fd6a1682a4e71811b43f15fe44aad39fb6496744abb945716a707f9e9e1",
+            "uncompressed-size": 2375155712
         },
         "vmware": {
-            "path": "rhcos-47.83.202012030221-0-vmware.x86_64.ova",
-            "sha256": "d9c480df7d5545b86e32cfd711de3c1a682bed255b7fd9b8075f58c38bd41c1d",
-            "size": 960327680
+            "path": "rhcos-47.83.202101071343-0-vmware.x86_64.ova",
+            "sha256": "94a92693ade55f9a35d3e89d29c9b99fdee38cef6cb94850f17addb3301f2127",
+            "size": 962816000
         }
     },
     "oscontainer": {
-        "digest": "sha256:26010f016399cb5859b1c37d1c1a2726e6fe2c2f7277b8c2b8262629d2677018",
+        "digest": "sha256:8bb5226631c914ab4ae7e1d8a44c9dde65e054492f071caf15b132370fb46d2e",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "950ea2dee9038fd09c88883ad258b4c3fa91cde7155409fb385e348387074d46",
-    "ostree-version": "47.83.202012030221-0"
+    "ostree-commit": "a709dd48ef7631284509165e5976ffb62218e20282ffb78850df552f36f07e1d",
+    "ostree-version": "47.83.202101071343-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202012030110-0/ppc64le/",
-    "buildid": "47.83.202012030110-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202101042210-0/ppc64le/",
+    "buildid": "47.83.202101042210-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-47.83.202012030110-0-live-initramfs.ppc64le.img",
-            "sha256": "6f3e5156bc204fa7edd9b49385e8a3d7ffbc60268d87c29e9e657ddf579ced94"
+            "path": "rhcos-47.83.202101042210-0-live-initramfs.ppc64le.img",
+            "sha256": "fdaad68811ed88acce9eb341079b4f9cb17b679c0d055ed885e82e6b74409c08"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202012030110-0-live.ppc64le.iso",
-            "sha256": "fb85bef88fc81f199da5765a414805383cafe40aac1e381173dda4b4021bab35"
+            "path": "rhcos-47.83.202101042210-0-live.ppc64le.iso",
+            "sha256": "a48b2f34f2fe55328a5b6a47a4e4835d4cc2dbf2775f34d850e00d0a1bbadb7f"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202012030110-0-live-kernel-ppc64le",
-            "sha256": "46377308591b8d1ce65a1f1f158e0134c8a0834630bc514d9dea69954ff29248"
+            "path": "rhcos-47.83.202101042210-0-live-kernel-ppc64le",
+            "sha256": "e310166a16592a5cd1bc152b07fda84278b251dc385cf000c65ed7bb31d254ea"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202012030110-0-live-rootfs.ppc64le.img",
-            "sha256": "e84bebcd2ba296b1d4297cd3ea2ac1cd5a75f1d7687d2a961d0fa41fcdebe4b5"
+            "path": "rhcos-47.83.202101042210-0-live-rootfs.ppc64le.img",
+            "sha256": "e8c2d5b31951e379794e0f2fe1563fdfbd32b2d7a24071e6b00536231fa1c6d6"
         },
         "metal": {
-            "path": "rhcos-47.83.202012030110-0-metal.ppc64le.raw.gz",
-            "sha256": "2aa229f42b49621db4766f34a1e962a35883ce0756ff2f713c8f8679fba02c55",
-            "size": 908711861,
-            "uncompressed-sha256": "be7b023a865c55df6fd49210db2995a12a8d69c37f7fd26658d8ee7521cdab9d",
-            "uncompressed-size": 3850371072
+            "path": "rhcos-47.83.202101042210-0-metal.ppc64le.raw.gz",
+            "sha256": "c77c064c818d4ee98c5f9912e26e3830864dd45df0447e6127cdd7781caa1234",
+            "size": 910158786,
+            "uncompressed-sha256": "61e8228c83be69f0fb2ddbbd56f894c128073cb81e36d2697e0f8bfe002253ca",
+            "uncompressed-size": 3864002560
         },
         "metal4k": {
-            "path": "rhcos-47.83.202012030110-0-metal4k.ppc64le.raw.gz",
-            "sha256": "aa1b0735a68a3de4cc05319ab9bcec09f98d8bdf2edc626c687200a4ab98cfda",
-            "size": 908999766,
-            "uncompressed-sha256": "b41281ae579ab91fb24cde22c1c3fc2e0ebadc3ff4852f9437e4d73c8f462074",
-            "uncompressed-size": 3850371072
+            "path": "rhcos-47.83.202101042210-0-metal4k.ppc64le.raw.gz",
+            "sha256": "6661589840cf00734b973d69cfc15f52ba7a590b15d6ff5747151ee60fc1f44b",
+            "size": 910424780,
+            "uncompressed-sha256": "61d2c9866e32b1f19379a67f43418dd5e33229dd2aec389bb722565f733a1de8",
+            "uncompressed-size": 3864002560
         },
         "openstack": {
-            "path": "rhcos-47.83.202012030110-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "e70df39ee48c8757420a5d16c55dbdbf825e7ee44b0673924c10e38a72356ae2",
-            "size": 907054575,
-            "uncompressed-sha256": "2fbfc80e255e43fa537b07d6464129ef55e6e581e5bd12a18218a25c811ee349",
-            "uncompressed-size": 2463760384
+            "path": "rhcos-47.83.202101042210-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "396d5201f1c5138f2d8d054046bfd9687e03ad4ba396d9a556a8cf99d1fa9171",
+            "size": 908510625,
+            "uncompressed-sha256": "9b325cbd960815ae940c5b2ae6035de832e64bcda9284ee46f59da26b5be3461",
+            "uncompressed-size": 2473525248
         },
         "ostree": {
-            "path": "rhcos-47.83.202012030110-0-ostree.ppc64le.tar",
-            "sha256": "dc0cdee67faf3f445a54ecbb1ab4e97c66476084ca4436faea66d4f598e55b06",
-            "size": 833280000
+            "path": "rhcos-47.83.202101042210-0-ostree.ppc64le.tar",
+            "sha256": "ebf338a089156d32e592bd25711f7b231919dcd012c4a110ed31731f19c9e01b",
+            "size": 834693120
         },
         "qemu": {
-            "path": "rhcos-47.83.202012030110-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "867fda98602ab2926f5f160e00dfb34b71a80e273227b9132a225fd9eb845799",
-            "size": 908074995,
-            "uncompressed-sha256": "d52e47ea828049e81f63212a5ecd24d56c11328474afd9b7dea0f14985d3766a",
-            "uncompressed-size": 2499936256
+            "path": "rhcos-47.83.202101042210-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "86f4c2515fde336ce941edaf9c76cb6dbb4e39232c2a24a9190820d8be6bf65d",
+            "size": 909612420,
+            "uncompressed-sha256": "71122f4b21180ad1f3498d89e0f281ce467e78de30ff54ddb2af3e7a63b113c7",
+            "uncompressed-size": 2509373440
         }
     },
     "oscontainer": {
-        "digest": "sha256:e4dfb8d5269bf1481056ae4fee48d14b25b23c71b7b9d89621c091dcaf0a80f2",
+        "digest": "sha256:86f7bc02f7121d5a682dff48d8550060cdebb83c2d1b15dcb2e7da9028e94dd4",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "a8ae77e6d1c9660a5a5f29a40a3959a02bdc0841d7a4d387927951497c27a4dd",
-    "ostree-version": "47.83.202012030110-0"
+    "ostree-commit": "71aef832c7b2a1facef156305c0343f85866f58e260b89a776b2c1e1eb33fa30",
+    "ostree-version": "47.83.202101042210-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202012030410-0/s390x/",
-    "buildid": "47.83.202012030410-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202101071310-0/s390x/",
+    "buildid": "47.83.202101071310-0",
     "images": {
         "dasd": {
-            "path": "rhcos-47.83.202012030410-0-dasd.s390x.raw.gz",
-            "sha256": "50cddc79277a6572b50bdeb62e76cddf341a9fccca37a59676cec3b646f49f81",
-            "size": 821545301,
-            "uncompressed-sha256": "ea933d7df5227f90994699cfae975c6d38acc523848f867ca8b859cdcb46eb94",
-            "uncompressed-size": 3480223744
+            "path": "rhcos-47.83.202101071310-0-dasd.s390x.raw.gz",
+            "sha256": "84e40177f944bc7cbc3c796ff2534839b32ace2419d0ebe005829ab4297df7c5",
+            "size": 824083490,
+            "uncompressed-sha256": "f8db94ff383963fa8c03269188e89a97cfcabbd8bdbded67445b872400729259",
+            "uncompressed-size": 3493855232
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202012030410-0-live-initramfs.s390x.img",
-            "sha256": "f26152f0502766ac19d9458d4b30bd1400ae0fb1e39d722cff0b9920625df4b6"
+            "path": "rhcos-47.83.202101071310-0-live-initramfs.s390x.img",
+            "sha256": "ad3179fdd27abb2712430ecbea92c271f6a2e6cc323a7bb792680e7df3feaf4e"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202012030410-0-live.s390x.iso",
-            "sha256": "4d6fcc88d551d9f9a10825d4b79551bb09b3a2e70cf3b7bed5246a341a84e3c7"
+            "path": "rhcos-47.83.202101071310-0-live.s390x.iso",
+            "sha256": "a6626985b67531cd92510888c0f68c428a41a5f2c310591c4253f9a78df7dff9"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202012030410-0-live-kernel-s390x",
-            "sha256": "282d4370d7345499fde6b326a0e0f6d86b88e34befe8df07bd2810e4d13be12d"
+            "path": "rhcos-47.83.202101071310-0-live-kernel-s390x",
+            "sha256": "a0f17299369b9ce9e42c874a8cc3658a00e58144fc0f54849ef96d9414d811d0"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202012030410-0-live-rootfs.s390x.img",
-            "sha256": "db26203391e3e884c59ba44c6d3024c9d540c4ef47f2e4ddf2353dc23b4ec0fe"
+            "path": "rhcos-47.83.202101071310-0-live-rootfs.s390x.img",
+            "sha256": "0dc0c013f34a007575838bd5c4b850e1eab7d30c9789f1c12e531bc054fde729"
         },
         "metal": {
-            "path": "rhcos-47.83.202012030410-0-metal.s390x.raw.gz",
-            "sha256": "33482ebaedfdb0ebc1b9467d65f68782bc1f2075636cd00276a8df841b4c0276",
-            "size": 821589306,
-            "uncompressed-sha256": "5be1a997fd76e9c14bb357a919d2b5f64f52d54dcaeb1831529f3c0bfd3f1634",
-            "uncompressed-size": 3480223744
+            "path": "rhcos-47.83.202101071310-0-metal.s390x.raw.gz",
+            "sha256": "acadf1079f6a9146ff0ec72b2b91ccb05e45e083bdfac167ee613e48ce2b479b",
+            "size": 824189808,
+            "uncompressed-sha256": "e5ea0bed778d02db93e75f20d8c45ed674d8d007ffd6e62a60a957b0a035b9ee",
+            "uncompressed-size": 3493855232
         },
         "metal4k": {
-            "path": "rhcos-47.83.202012030410-0-metal4k.s390x.raw.gz",
-            "sha256": "db55eaec34100c205157f2564fcce6db27fdc92c5254167bcf92d1ea75cab2cf",
-            "size": 821622304,
-            "uncompressed-sha256": "83087d1f5c52244956b2f6370feaa14e942bd118941d8aadf7fe3d400f2a8c14",
-            "uncompressed-size": 3480223744
+            "path": "rhcos-47.83.202101071310-0-metal4k.s390x.raw.gz",
+            "sha256": "231b45b3ee633f8d906f5dc24aaf72b083c75a8421d232ced9440b65b826962f",
+            "size": 824144563,
+            "uncompressed-sha256": "c1d704701173a23ebea4b99cd116d5c3183a5ad2a8d42be9022e361a516ac48f",
+            "uncompressed-size": 3493855232
         },
         "openstack": {
-            "path": "rhcos-47.83.202012030410-0-openstack.s390x.qcow2.gz",
-            "sha256": "47edb317a664a31d7ad7f56175cc0713fd05ad3c5ffa00543afc8a12ca3e108f",
-            "size": 819775112,
-            "uncompressed-sha256": "c280bece847a0c1761b14d9a8dab8b19d43e273df2b19a5b25ca702331ce4918",
-            "uncompressed-size": 2149449728
+            "path": "rhcos-47.83.202101071310-0-openstack.s390x.qcow2.gz",
+            "sha256": "c4e5936c1450b4068d608d4231bf8ed7deadfe150a36ad2e1e9c7e9d5804f91e",
+            "size": 822377092,
+            "uncompressed-sha256": "5ff341706bf2830b70e7e6914016e4d1b3d8f5a71fd93410d01c9163f66d5c8a",
+            "uncompressed-size": 2160328704
         },
         "ostree": {
-            "path": "rhcos-47.83.202012030410-0-ostree.s390x.tar",
-            "sha256": "154ee18d179d4eb03607ce082cbd7aa6b86917d862e817d6b9da036d60b53dc5",
-            "size": 771788800
+            "path": "rhcos-47.83.202101071310-0-ostree.s390x.tar",
+            "sha256": "102999e87e97769c3a1afe8ac1e646516653c158b50826cf2163111a2f87d142",
+            "size": 774256640
         },
         "qemu": {
-            "path": "rhcos-47.83.202012030410-0-qemu.s390x.qcow2.gz",
-            "sha256": "cac144c75245060bf2e50e862465114e7f0cf8fb309e876e9fc006544b7f554f",
-            "size": 820871192,
-            "uncompressed-sha256": "02aa99f7e4eb086b3f15bb678d2efc43383bf2922763475295f7e6d7252d58b5",
-            "uncompressed-size": 2184839168
+            "path": "rhcos-47.83.202101071310-0-qemu.s390x.qcow2.gz",
+            "sha256": "6f180d0bb5b466e758590699e394b9ad13b359486117e4ea83b4a169412776a6",
+            "size": 823532578,
+            "uncompressed-sha256": "2edfb8f21d87c24cb15fdcca32d12c08cb9e840ac0eb4ff5ff695df57fe123a3",
+            "uncompressed-size": 2195259392
         }
     },
     "oscontainer": {
-        "digest": "sha256:4c0ada8fcc31d718300427d72ebc361eaf29a76f6a6be22cb7132564ca167213",
+        "digest": "sha256:2ac7fb11f03b1699ddb0172033d312e5b8520d7e1cdbbc0ffd6361aaf5fa100f",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ced831d6ea1f1b41f2da92c7e2bb9350f280c52f9c86699ebc1ddb827f5ed6db",
-    "ostree-version": "47.83.202012030410-0"
+    "ostree-commit": "464b857fc98f9a92ab67311c13b44e6739820aec32aecf7262f29b9b169e5677",
+    "ostree-version": "47.83.202101071310-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-03dc8417bfb54885e"
+            "hvm": "ami-0af2aca40a19b1ae2"
         },
         "ap-east-1": {
-            "hvm": "ami-055665dc9e9799296"
+            "hvm": "ami-000d9e30619db8c85"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0f67d9a2324e93380"
+            "hvm": "ami-0a0454ae5766f0bd1"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0af7d134b7362c59c"
+            "hvm": "ami-0d8b73cee790117b9"
         },
         "ap-south-1": {
-            "hvm": "ami-0bfb5d254a69b7419"
+            "hvm": "ami-0a1f39e43274a509a"
         },
         "ap-southeast-1": {
-            "hvm": "ami-08e130fb7b06c0d5d"
+            "hvm": "ami-05f928d09c03a08f2"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0bec9aae9292db769"
+            "hvm": "ami-0c6cf9f37751bbe61"
         },
         "ca-central-1": {
-            "hvm": "ami-0f0d4fd027aafa9ec"
+            "hvm": "ami-05b9c100674f62b59"
         },
         "eu-central-1": {
-            "hvm": "ami-0b299978f75c6fab7"
+            "hvm": "ami-0c1f704ed179c9e6b"
         },
         "eu-north-1": {
-            "hvm": "ami-0a9cf69e21ee6efa7"
+            "hvm": "ami-03b18889a7a5eca97"
         },
         "eu-south-1": {
-            "hvm": "ami-00813d96eb14a5a94"
+            "hvm": "ami-0fcd549235287035f"
         },
         "eu-west-1": {
-            "hvm": "ami-01e09e74477d926f3"
+            "hvm": "ami-0349cc593d5029fac"
         },
         "eu-west-2": {
-            "hvm": "ami-09009bcbfb3ffc566"
+            "hvm": "ami-055e431acbab438b5"
         },
         "eu-west-3": {
-            "hvm": "ami-052ce7993e1a51903"
+            "hvm": "ami-051557194eb6157d5"
         },
         "me-south-1": {
-            "hvm": "ami-08d9bf8527beecee4"
+            "hvm": "ami-0ba21ee8ed0a779aa"
         },
         "sa-east-1": {
-            "hvm": "ami-07eec7d9a8e420ea1"
+            "hvm": "ami-0f445064098242ebd"
         },
         "us-east-1": {
-            "hvm": "ami-0996bc3576195a2f0"
+            "hvm": "ami-06ad0f2e28603bcce"
         },
         "us-east-2": {
-            "hvm": "ami-0c0b5ea0a4ebe87d5"
+            "hvm": "ami-05a379cf042ab1983"
         },
         "us-west-1": {
-            "hvm": "ami-067abd73d16691225"
+            "hvm": "ami-0b9d4ec3ac5d6a257"
         },
         "us-west-2": {
-            "hvm": "ami-055cdcaf3b4d54a91"
+            "hvm": "ami-0798c5c5c7acd16e0"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202012030221-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202012030221-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202101071343-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202101071343-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202012030221-0/x86_64/",
-    "buildid": "47.83.202012030221-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202101071343-0/x86_64/",
+    "buildid": "47.83.202101071343-0",
     "gcp": {
-        "image": "rhcos-47-83-202012030221-0-gcp-x86-64",
+        "image": "rhcos-47-83-202101071343-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202012030221-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202101071343-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202012030221-0-aws.x86_64.vmdk.gz",
-            "sha256": "c8b741671cf4f2c13a1de4068ed2bb2d3f09479c89d205789c1cc58e76bd7eda",
-            "size": 940924861,
-            "uncompressed-sha256": "732e2d6b4745fae4dd9385bee75f199af2121e4d3a8eae92600c8c826119388c",
-            "uncompressed-size": 960320000
+            "path": "rhcos-47.83.202101071343-0-aws.x86_64.vmdk.gz",
+            "sha256": "c6ccc6b25bc33027b91028183e1cd96b245dc14e93a66ae67e40894fbd16ebb6",
+            "size": 943365637,
+            "uncompressed-sha256": "af7e2fa345491540e2296850999937e325bd3af789599d75352d4bb37e96cac6",
+            "uncompressed-size": 962804736
         },
         "azure": {
-            "path": "rhcos-47.83.202012030221-0-azure.x86_64.vhd.gz",
-            "sha256": "f1da54a42b2178e8ab0eda2a3d8aa613b3cf1809c0a92e0b94124a27370dea9c",
-            "size": 941546542,
-            "uncompressed-sha256": "6201d201935e9e1cc144ae77d151ea736dd601ecbad246edc9cc1d75a1d93e41",
+            "path": "rhcos-47.83.202101071343-0-azure.x86_64.vhd.gz",
+            "sha256": "3ad64de438e94289444d254dc2f6fa85d03911b57f50a1114784e86011f1a447",
+            "size": 943928322,
+            "uncompressed-sha256": "0803a7d3af6972a6a811027f0e2d4f9f8a4aee99ef54880fe8e15918ac765a21",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202012030221-0-gcp.x86_64.tar.gz",
-            "sha256": "5837067659ad7055f0614bd0feb867322b1832f901dd513520beada7f5ba6b09",
-            "size": 926832318
+            "path": "rhcos-47.83.202101071343-0-gcp.x86_64.tar.gz",
+            "sha256": "aa8ffcee26819a6ab4a5cb889d29863d1ef632d2f02fd0e6ae9800b847f896f7",
+            "size": 929205083
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202012030221-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "515f13f6d78d6b1e0f52656d49754345ec6fc8a5c64f53c18d8577c907929118",
-            "size": 927133006,
-            "uncompressed-sha256": "b12038dfc63f0816b1dc459278eda266eed3eca228bf771ec005b8a7407fc469",
-            "uncompressed-size": 2328952832
+            "path": "rhcos-47.83.202101071343-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "d9924976d561df1c8d0e7128e2db49bb60ebf64c06244ecb7c0e12163b965758",
+            "size": 929540205,
+            "uncompressed-sha256": "11f10ab80b3fd09c2894db78a44369b6a45633ecdb45bba7d5b3ca689091cc1b",
+            "uncompressed-size": 2339373056
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202012030221-0-live-initramfs.x86_64.img",
-            "sha256": "36eb33777fa768fa8de0a862265e553d952bb7636b800cbdd1fc4ac3d4cb03db"
+            "path": "rhcos-47.83.202101071343-0-live-initramfs.x86_64.img",
+            "sha256": "1fbc4a58a0ba036b9bcb23bd482f2ebfa7fa1f7c7e00eca9208c85c439cdd03d"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202012030221-0-live.x86_64.iso",
-            "sha256": "21a05f87fc7e4609d635481dc4d09d061cc32acd09657b050fd62a9b4f42677b"
+            "path": "rhcos-47.83.202101071343-0-live.x86_64.iso",
+            "sha256": "beaf646b970088973e634ea49144c78aec3d89e488f12c7b1f2f61d644b974af"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202012030221-0-live-kernel-x86_64",
-            "sha256": "7c297b7daee6a01c7a09b68f9fe4a655580168113e8730917f061fecbe8ceb32"
+            "path": "rhcos-47.83.202101071343-0-live-kernel-x86_64",
+            "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202012030221-0-live-rootfs.x86_64.img",
-            "sha256": "b52a5197c5db12971ce7e52f217f3fa6da30ffe04150a3eaa4c8319db7072ca5"
+            "path": "rhcos-47.83.202101071343-0-live-rootfs.x86_64.img",
+            "sha256": "5f61129760429abb6531ac50257ba3f9ba284b8ef08802da150249ee45bcab52"
         },
         "metal": {
-            "path": "rhcos-47.83.202012030221-0-metal.x86_64.raw.gz",
-            "sha256": "77702ef31e3a15042df51f36a83f8b5afcb15576858482c32a15fb9cfa0424b6",
-            "size": 928823703,
-            "uncompressed-sha256": "983293a570e30ed50fe07b51bb5ed5ef798810a022e24e65ae5f3290b38d7ceb",
-            "uncompressed-size": 3677356032
+            "path": "rhcos-47.83.202101071343-0-metal.x86_64.raw.gz",
+            "sha256": "9a254de65b6ac9920d9fb3a697006bb9fc1a0b7f3a760d8750176c05ad6154f9",
+            "size": 931259170,
+            "uncompressed-sha256": "ff239fb2c2aede9eae2088e1caffd50609c98725d197d2ecf017e20a66499621",
+            "uncompressed-size": 3692036096
         },
         "metal4k": {
-            "path": "rhcos-47.83.202012030221-0-metal4k.x86_64.raw.gz",
-            "sha256": "81b63723a643530f2a50f656baa097894d8a064c89c7468ed570cec1dbb6157f",
-            "size": 926496277,
-            "uncompressed-sha256": "e94fbd8615d1790ab39ac6ad29eaf0ddd5f726d65fab4a31b71b2c66cf507d47",
-            "uncompressed-size": 3677356032
+            "path": "rhcos-47.83.202101071343-0-metal4k.x86_64.raw.gz",
+            "sha256": "47683ef53d5004bfdec0a236d1fc932bc185daae3d1ad81dbeadbe2fbd88220a",
+            "size": 928839229,
+            "uncompressed-sha256": "197cc2f34acac86742c1e950ca01ee05ae143822fdb53a45e78382400aebe1ff",
+            "uncompressed-size": 3692036096
         },
         "openstack": {
-            "path": "rhcos-47.83.202012030221-0-openstack.x86_64.qcow2.gz",
-            "sha256": "cde9caedbe67d921ab9ff76a71f62b0172f863f1a984d2ce5aa0fccac090b3f8",
-            "size": 927133474,
-            "uncompressed-sha256": "b487344e1e104f9f34985ec5015ffd8b532df4c357137c38c7cbbd7289fb881a",
-            "uncompressed-size": 2328952832
+            "path": "rhcos-47.83.202101071343-0-openstack.x86_64.qcow2.gz",
+            "sha256": "5ac146e8d2bd93fe683e42483a389cbeffd85e9bb4870e5980da5fb6db7743a6",
+            "size": 929539403,
+            "uncompressed-sha256": "4db412ecddbb03e868b1b8000d4b9d445af8d35e9d06f9f4735c7d63ba819fc6",
+            "uncompressed-size": 2339373056
         },
         "ostree": {
-            "path": "rhcos-47.83.202012030221-0-ostree.x86_64.tar",
-            "sha256": "c2680bc83e76ca764b6e5ff623e27fa72b28636262234b6b8d6e1c204e203438",
-            "size": 855152640
+            "path": "rhcos-47.83.202101071343-0-ostree.x86_64.tar",
+            "sha256": "035b375510381705c2b890a0bc56e6608a4fe98429012528ef2dbf5b344edc07",
+            "size": 857518080
         },
         "qemu": {
-            "path": "rhcos-47.83.202012030221-0-qemu.x86_64.qcow2.gz",
-            "sha256": "4104496474292789b7ef5414a5678cd886d9e22895e3227b14f2c93408a0af26",
-            "size": 928245521,
-            "uncompressed-sha256": "f0a028820a263ed4156104a5ae57ae96ca4a8ec93c5b879843ef378a43e6a993",
-            "uncompressed-size": 2364473344
+            "path": "rhcos-47.83.202101071343-0-qemu.x86_64.qcow2.gz",
+            "sha256": "7a53b563ac6474765d19b209a4f3ab823c8d08f509d3d2f68b8bdab584adbea0",
+            "size": 930711179,
+            "uncompressed-sha256": "35ad3fd6a1682a4e71811b43f15fe44aad39fb6496744abb945716a707f9e9e1",
+            "uncompressed-size": 2375155712
         },
         "vmware": {
-            "path": "rhcos-47.83.202012030221-0-vmware.x86_64.ova",
-            "sha256": "d9c480df7d5545b86e32cfd711de3c1a682bed255b7fd9b8075f58c38bd41c1d",
-            "size": 960327680
+            "path": "rhcos-47.83.202101071343-0-vmware.x86_64.ova",
+            "sha256": "94a92693ade55f9a35d3e89d29c9b99fdee38cef6cb94850f17addb3301f2127",
+            "size": 962816000
         }
     },
     "oscontainer": {
-        "digest": "sha256:26010f016399cb5859b1c37d1c1a2726e6fe2c2f7277b8c2b8262629d2677018",
+        "digest": "sha256:8bb5226631c914ab4ae7e1d8a44c9dde65e054492f071caf15b132370fb46d2e",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "950ea2dee9038fd09c88883ad258b4c3fa91cde7155409fb385e348387074d46",
-    "ostree-version": "47.83.202012030221-0"
+    "ostree-commit": "a709dd48ef7631284509165e5976ffb62218e20282ffb78850df552f36f07e1d",
+    "ostree-version": "47.83.202101071343-0"
 }


### PR DESCRIPTION
BZ 1907770 raises an issue with crio that will cause deployment failures
when using a newer boot image - so far this hasn't impacted IPI installs
using the older boot image. This PR should test the BZ, and provide
further details.

https://bugzilla.redhat.com/show_bug.cgi?id=1907770