### PR TITLE
Bug 1908583: Set same additional networks on Bootstrap as Control Plane

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -58,6 +58,14 @@ resource "openstack_compute_instance_v2" "bootstrap" {
     port = openstack_networking_port_v2.bootstrap_port.id
   }
 
+  dynamic network {
+    for_each = var.additional_network_ids
+
+    content {
+      uuid = network.value
+    }
+  }
+
   tags = ["openshiftClusterID=${var.cluster_id}"]
 
   metadata = {

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -78,3 +78,8 @@ variable "zone" {
   type = string
   description = "Availability Zone to schedule the bootstrap node onto"
 }
+
+variable "additional_network_ids" {
+  type = list(string)
+  description = "IDs of additional networks for the bootstrap node."
+}

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -41,6 +41,7 @@ module "bootstrap" {
   root_volume_size        = var.openstack_master_root_volume_size
   root_volume_type        = var.openstack_master_root_volume_type
   zone                    = var.openstack_master_availability_zones[0]
+  additional_network_ids  = var.openstack_additional_network_ids
 }
 
 module "masters" {


### PR DESCRIPTION
The bootstrap node was only being attached to the private network created by the installer,
causing deployments with more advanced networking topologies that made use of the additional
networking feature to fail. The bootstrap needs to be attached to the same networks as the
control plane nodes in order to guarantee the install will succeed.

Fixes Bug 1908583

/label platform/openstack