### PR TITLE
OWNERS: Remove ehashman and asalkeld from azure reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -71,8 +71,6 @@ aliases:
     - fabianofranz
     - jhixson74
   azure-reviewers:
-    - asalkeld
-    - ehashman
     - fabianofranz
     - jhixson74
     - jim-minter


### PR DESCRIPTION
Neither of us are on the ARO team anymore.