### PR TITLE
Bug 1915460: ovirt: validate cluster name during install

### DIFF
--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -36,6 +36,12 @@ func (a *clusterName) Generate(parents asset.Parents) error {
 			return validate.ClusterName1035(ans.(string))
 		})
 	}
+	if platform.Ovirt != nil {
+		// FIX-ME: As soon bz#1915122 get resolved remove the limitation of 14 chars for the clustername
+		validator = survey.ComposeValidators(validator, func(ans interface{}) error {
+			return validate.ClusterNameMaxLength(ans.(string), 14)
+		})
+	}
 	validator = survey.ComposeValidators(validator, func(ans interface{}) error {
 		installConfig := &types.InstallConfig{BaseDomain: bd.BaseDomain}
 		installConfig.ObjectMeta.Name = ans.(string)

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -70,6 +70,10 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 	if c.Platform.GCP != nil || c.Platform.Azure != nil {
 		nameErr = validate.ClusterName1035(c.ObjectMeta.Name)
 	}
+	if c.Platform.Ovirt != nil {
+		// FIX-ME: As soon bz#1915122 get resolved remove the limitation of 14 chars for the clustername
+		nameErr = validate.ClusterNameMaxLength(c.ObjectMeta.Name, 14)
+	}
 	if nameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, nameErr.Error()))
 	}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -115,13 +115,23 @@ func ClusterName1035(v string) error {
 	return ClusterName(v)
 }
 
+// ClusterNameMaxLength validates if the string provided length is
+// greater than maxlen argument.
+func ClusterNameMaxLength(v string, maxlen int) error {
+	if len(v) > maxlen {
+		return errors.New(validation.MaxLenError(maxlen))
+	}
+	return nil
+}
+
 // ClusterName checks if the given string is a valid name for a cluster and returns an error if not.
 // The max length of the DNS label is `DNS1123LabelMaxLength + 9` because the public DNS zones have records
 // `api.clustername`, `*.apps.clustername`, and *.apps is rendered as the nine-character \052.apps in DNS records.
 func ClusterName(v string) error {
-	maxlen := validation.DNS1123LabelMaxLength - 9
-	if len(v) > maxlen {
-		return errors.New(validation.MaxLenError(maxlen))
+	const maxlen = validation.DNS1123LabelMaxLength - 9
+	err := ClusterNameMaxLength(v, maxlen)
+	if err != nil {
+		return err
 	}
 	return validateSubdomain(v)
 }


### PR DESCRIPTION
Similar to OpenStack platform, we require to
validate cluster name size to avoid DNS resolution
issues in the deploy.

See also: https://github.com/openshift/installer/pull/2270/commits

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>