### PR TITLE
Bug 1915998: Set Additional Control Plane Security Groups on Bootstrap Node

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -3,7 +3,7 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
 
   admin_state_up     = "true"
   network_id         = var.private_network_id
-  security_group_ids = [var.master_sg_id]
+  security_group_ids = var.master_sg_ids
   tags               = ["openshiftClusterID=${var.cluster_id}"]
 
   extra_dhcp_option {

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -48,8 +48,8 @@ variable "private_network_id" {
   type = string
 }
 
-variable "master_sg_id" {
-  type = string
+variable "master_sg_ids" {
+  type = list(string)
 }
 
 variable "nodes_subnet_id" {

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -25,17 +25,20 @@ provider "openstack" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  cluster_id              = var.cluster_id
-  extra_tags              = var.openstack_extra_tags
-  base_image_id           = data.openstack_images_image_v2.base_image.id
-  flavor_name             = var.openstack_master_flavor_name
-  ignition                = var.ignition_bootstrap
-  api_int_ip              = var.openstack_api_int_ip
-  external_network        = var.openstack_external_network
-  cluster_domain          = var.cluster_domain
-  nodes_subnet_id         = module.topology.nodes_subnet_id
-  private_network_id      = module.topology.private_network_id
-  master_sg_id            = module.topology.master_sg_id
+  cluster_id         = var.cluster_id
+  extra_tags         = var.openstack_extra_tags
+  base_image_id      = data.openstack_images_image_v2.base_image.id
+  flavor_name        = var.openstack_master_flavor_name
+  ignition           = var.ignition_bootstrap
+  api_int_ip         = var.openstack_api_int_ip
+  external_network   = var.openstack_external_network
+  cluster_domain     = var.cluster_domain
+  nodes_subnet_id    = module.topology.nodes_subnet_id
+  private_network_id = module.topology.private_network_id
+  master_sg_ids = concat(
+    var.openstack_master_extra_sg_ids,
+    [module.topology.master_sg_id],
+  )
   bootstrap_shim_ignition = var.openstack_bootstrap_shim_ignition
   master_port_ids         = module.topology.master_port_ids
   root_volume_size        = var.openstack_master_root_volume_size

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -45,7 +45,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
   * `type` (required string): The volume pool to create the volume from.
 * `zones` (optional list of strings): The names of the availability zones you want to install your nodes on. If unset, the installer will use your default compute zone.
 
-**NOTE:** The bootstrap node follows the `type` and `rootVolume` parameters from the `controlPlane` machine pool.
+**NOTE:** The bootstrap node follows the `type`, `rootVolume`, `additionalNetworkIDs`, and `additionalSecurityGroupIDs` parameters from the `controlPlane` machine pool.
 
 **NOTE:** Note when deploying with `Kuryr` there is an Octavia API loadbalancer VM that will not fulfill the Availability Zones restrictions due to Octavia lack of support for it. In addition, if Octavia only has the amphora provider instead of also the OVN-Octavia provider, all the OpenShift services will be backed up by Octavia Load Balancer VMs which will not fulfill the Availability Zone restrictions either.
 
@@ -192,7 +192,9 @@ controlPlane:
       - fa806b2f-ac49-4bce-b9db-124bc64209bf
 ```
 
-**NOTE:** Allowed address pairs won't be created for the additional networks.
+**NOTES:**
+* Allowed address pairs won't be created for the additional networks.
+* The additional networks attached to the Control Plane machine will also be attached to the bootstrap node.
 
 ## Additional Security Groups
 
@@ -222,6 +224,8 @@ controlPlane:
       additionalSecurityGroupIDs:
       - 7ee219f3-d2e9-48a1-96c2-e7429f1b0da7
 ```
+
+**NOTE:** The additional security groups attached to the Control Plane machine will also be attached to the bootstrap node.
 
 ## Further customization
 


### PR DESCRIPTION
The bootstrap node in the installer does not have any way to set additional
networks and security groups. The installer currently adds additional control
plane networks to the bootrap node, and should do the same for security groups.
Since the bootstrap is an ephemeral node that has the same networking requirements
as the master nodes, this logically makes sense and makes the user experience more
consistent.

Fixes: Bug 1915998

/label platform/openstack