### PR TITLE
[FCOS] pkg/asset/machines: include authentication setting for single master

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -371,7 +371,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	}
 
 	if pool.Replicas != nil && *pool.Replicas == 1 && ic.IsOKD() {
-		m.SingleMasterFiles = make([]*asset.File, 2)
+		m.SingleMasterFiles = make([]*asset.File, 3)
 		m.SingleMasterFiles[0] = &asset.File{
 			Filename: filepath.Join(directory, fmt.Sprintf(singleMasterFileName, "etcd")),
 			Data:     etcdSingleMasterData,
@@ -379,6 +379,10 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		m.SingleMasterFiles[1] = &asset.File{
 			Filename: filepath.Join(directory, fmt.Sprintf(singleMasterFileName, "ingress")),
 			Data:     ingressSingleMasterData,
+		}
+		m.SingleMasterFiles[2] = &asset.File{
+			Filename: filepath.Join(directory, fmt.Sprintf(singleMasterFileName, "authentication")),
+			Data:     authSingleMasterData,
 		}
 	}
 

--- a/pkg/asset/machines/singlemaster.go
+++ b/pkg/asset/machines/singlemaster.go
@@ -18,3 +18,12 @@ metadata:
 spec:
   replicas: 1
 `)
+
+var authSingleMasterData = []byte(`apiVersion: operator.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+spec:
+  unsupportedConfigOverrides:
+    useUnsupportedUnsafeNonHANonProductionUnstableOAuthServer: true
+`)


### PR DESCRIPTION
In 4.6+ `authentication` operator needs additional setting to allow single kube-apiserver instance.

Fixes https://github.com/openshift/okd/issues/465