### PR TITLE
Bug 1916938: tolerate equal APIFloatingIP and LbFloatingIP

### DIFF
--- a/pkg/types/conversion/installconfig.go
+++ b/pkg/types/conversion/installconfig.go
@@ -115,7 +115,7 @@ func convertOpenStack(config *types.InstallConfig) error {
 	if config.Platform.OpenStack.DeprecatedLbFloatingIP != "" {
 		if config.Platform.OpenStack.APIFloatingIP == "" {
 			config.Platform.OpenStack.APIFloatingIP = config.Platform.OpenStack.DeprecatedLbFloatingIP
-		} else {
+		} else if config.Platform.OpenStack.DeprecatedLbFloatingIP != config.Platform.OpenStack.APIFloatingIP {
 			// Return error if both LbFloatingIP and APIFloatingIP are specified in the config
 			return field.Forbidden(field.NewPath("platform").Child("openstack").Child("lbFloatingIP"), "cannot specify lbFloatingIP and apiFloatingIP together")
 		}

--- a/pkg/types/conversion/installconfig_test.go
+++ b/pkg/types/conversion/installconfig_test.go
@@ -193,7 +193,7 @@ func TestConvertInstallConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "deprecated OpenStack LbFloatingIP with APIFloatingIP",
+			name: "deprecated OpenStack LbFloatingIP is the same as APIFloatingIP",
 			config: &types.InstallConfig{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: types.InstallConfigVersion,
@@ -202,6 +202,31 @@ func TestConvertInstallConfig(t *testing.T) {
 					OpenStack: &openstack.Platform{
 						DeprecatedLbFloatingIP: "10.0.109.1",
 						APIFloatingIP:          "10.0.109.1",
+					},
+				},
+			},
+			expected: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					OpenStack: &openstack.Platform{
+						DeprecatedLbFloatingIP: "10.0.109.1",
+						APIFloatingIP:          "10.0.109.1",
+					},
+				},
+			},
+		},
+		{
+			name: "deprecated OpenStack LbFloatingIP with APIFloatingIP",
+			config: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				Platform: types.Platform{
+					OpenStack: &openstack.Platform{
+						DeprecatedLbFloatingIP: "10.0.109.1",
+						APIFloatingIP:          "10.0.109.2",
 					},
 				},
 			},


### PR DESCRIPTION
In 4.7 LbFloatingIP was deprecated and renamed to APIFloatingIP.
But if we regenerate a config from 4.6 version, it doesn't unset the deprecated LbFloatingIP and both values are present in the new config, which leads to an error.

This commit allows to set both parameters in the config, but only if their values are equal.

/label platform/openstack