### PR TITLE
Fix Authentication manifest for SNO

### DIFF
--- a/pkg/asset/machines/singlemaster.go
+++ b/pkg/asset/machines/singlemaster.go
@@ -24,6 +24,7 @@ kind: Authentication
 metadata:
   name: cluster
 spec:
+  managementState: Managed
   unsupportedConfigOverrides:
     useUnsupportedUnsafeNonHANonProductionUnstableOAuthServer: true
 `)


### PR DESCRIPTION
Somehow this manifest avoided validation and created an invalid CR that got openshift-authentication-operator stuck permanently.
```
  - lastTransitionTime: "2021-01-21T15:26:42Z"
    message: |-
      ManagementStateDegraded: Unsupported management state "" for authentication operator
      OAuthAPIServerConfigObservationDegraded: error writing updated observed config: Authentication.operator.openshift.io "cluster" is invalid: spec.managementState: Invalid value: "": spec.managementState in body should match '^(Managed|Unmanaged|Force|Removed)$'
      OAuthServerConfigObservationDegraded: error writing updated observed config: Authentication.operator.openshift.io "cluster" is invalid: spec.managementState: Invalid value: "": spec.managementState in body should match '^(Managed|Unmanaged|Force|Removed)$'
    reason: ManagementState_Unknown::OAuthAPIServerConfigObservation_Error::OAuthServerConfigObservation_Error
    status: "True"
    type: Degraded
```
```
E0121 16:52:17.830714       1 base_controller.go:250] "ConfigObserver" controller failed to sync "key", err: error writing updated observed config: Authentication.operator.openshift.io "cluster" is invalid: spec.managementState: Invalid value: "": spec.managementState in body should match '^(Managed|Unmanaged|Force|Removed)$'
```

/cc @vrutkovs 

/kind bug
/priority critical-urgent