### PR TITLE
vSphere: add missing destroy OWNERS & update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -40,10 +40,12 @@ aliases:
     - mtnbikenc
     - jcpowermac
     - patrickdillon
+    - jstuever
   vsphere-reviewers:
     - mtnbikenc
     - jcpowermac
     - patrickdillon
+    - jstuever
   baremetal-approvers:
     - dhellmann
     - hardys

--- a/pkg/destroy/vsphere/OWNERS
+++ b/pkg/destroy/vsphere/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - vsphere-approvers
+reviewers:
+  - vsphere-reviewers


### PR DESCRIPTION
Adds missing owners file for vsphere destroy package. e.g. I should be able to `/approve` #4579 

Updates reviewers/approvers to add @jstuever 

