### PR TITLE
Bug 1896218: remove GCP role bindings before service accounts

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -129,8 +129,8 @@ func (o *ClusterUninstaller) destroyCluster() (bool, error) {
 	}, {
 		{name: "Instances", execute: o.destroyInstances},
 		{name: "Disks", execute: o.destroyDisks},
-		{name: "Service accounts", execute: o.destroyServiceAccounts},
 		{name: "Policy bindings", execute: o.destroyIAMPolicyBindings},
+		{name: "Service accounts", execute: o.destroyServiceAccounts},
 		{name: "Images", execute: o.destroyImages},
 		{name: "DNS", execute: o.destroyDNS},
 		{name: "Buckets", execute: o.destroyBuckets},


### PR DESCRIPTION
This updates GCP destroy code to remove IAM roles before deleting service accounts.

Service accounts are deleted one at a time but IAM roles are deleted by rewriting the entire policy. We are seeing conflicts (with two clusters in the same project) when one cluster is rewriting the IAM policy as another cluster deletes its service accounts. There is a conflict because the state of service accounts in the newly written policy is out-of-date.  By deleting the role bindings first, we decouple the service accounts from the IAM policy and avoid the conflicts.

