### PR TITLE
data/bootstrap: Check if release image architecture matches host architecture

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
@@ -26,3 +26,17 @@ do
         echo "Pull failed. Retrying $RELEASE_IMAGE..."
     fi
 done
+
+# Sanity check the image metadata to see if the arches match
+image_arch=$(podman inspect $RELEASE_IMAGE --format {{ "{{.Architecture}}" }})
+host_arch=$(uname -m)
+case $host_arch in
+    "x86_64")  host_arch="amd64"   ;;
+    "aarch64") host_arch="arm64"   ;; # not used, just for completeness
+esac
+
+if [[ "$image_arch" != "$host_arch" ]]; then
+    record_service_stage_failure
+    echo "ERROR: release image arch $image_arch does not match host arch $host_arch"
+    exit 1
+fi


### PR DESCRIPTION
This is a simple sanity check to see if release image architecture matches the bootstrap node's architecture. This is useful in cases of user error where an incorrect release image is specified and we error right away rather than downloading the associated images and failing in say crio when downloading the incorrect pause image.