### PR TITLE
[gcp] Change bootstrap ignition storage bucket access

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -1,6 +1,6 @@
 resource "google_storage_bucket" "ignition" {
-  name     = "${var.cluster_id}-bootstrap-ignition"
-  location = var.region
+  name               = "${var.cluster_id}-bootstrap-ignition"
+  location           = var.region
   bucket_policy_only = true
 }
 

--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -1,6 +1,7 @@
 resource "google_storage_bucket" "ignition" {
   name     = "${var.cluster_id}-bootstrap-ignition"
   location = var.region
+  bucket_policy_only = true
 }
 
 resource "google_storage_bucket_object" "ignition" {


### PR DESCRIPTION
As requested from this RFE:

https://issues.redhat.com/browse/RFE-1516

`uniform_bucket_level_access` is unavailable in the currently vendored
terraform-provider-google. Using `bucket_policy_only` instead.