### PR TITLE
Bug 1895917: ovirt - check if username contains user and domain

### DIFF
--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -156,6 +156,12 @@ func askUsername(c *Config) error {
 		return err
 	}
 
+	if !strings.Contains(c.Username, "@") {
+		logrus.Info("Please use the format: username@domain. Example: admin@internal")
+		askUsername(c)
+
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
For login users require to provide user AND domain.
This patch adds such validation.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>