### PR TITLE
Bug 1896218: remove GCP role bindings before service accounts

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -130,7 +130,6 @@ func (o *ClusterUninstaller) destroyCluster() (bool, error) {
 		{name: "Instances", execute: o.destroyInstances},
 		{name: "Disks", execute: o.destroyDisks},
 		{name: "Service accounts", execute: o.destroyServiceAccounts},
-		{name: "Policy bindings", execute: o.destroyIAMPolicyBindings},
 		{name: "Images", execute: o.destroyImages},
 		{name: "DNS", execute: o.destroyDNS},
 		{name: "Buckets", execute: o.destroyBuckets},

--- a/pkg/destroy/gcp/serviceaccount.go
+++ b/pkg/destroy/gcp/serviceaccount.go
@@ -70,6 +70,7 @@ func (o *ClusterUninstaller) destroyServiceAccounts() error {
 		return err
 	}
 	o.insertPendingItems("serviceaccount_binding", found) // store service accounts to remove project IAM binding
+	o.destroyIAMPolicyBindings()
 
 	items := o.insertPendingItems("serviceaccount", found)
 	for _, item := range items {


### PR DESCRIPTION
Service accounts are deleted one at a time but IAM roles are deleted by rewriting the entire policy. We are seeing conflicts (with two clusters in the same project) when one cluster is rewriting the IAM policy as another cluster deletes its service accounts. There is a conflict because the state of service accounts in the newly written policy is out-of-date.  By deleting the role bindings first, we decouple the service accounts from the IAM policy and avoid the conflicts.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1896218


