### PR TITLE
Bug 1923038: OpenStack: cache cloud info

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -59,10 +59,17 @@ type record struct {
 	Value   int64
 }
 
+var ci *CloudInfo
+
 // GetCloudInfo fetches and caches metadata from openstack
 func GetCloudInfo(ic *types.InstallConfig) (*CloudInfo, error) {
 	var err error
-	ci := CloudInfo{
+
+	if ci != nil {
+		return ci, nil
+	}
+
+	ci = &CloudInfo{
 		clients: &clients{},
 		Flavors: map[string]Flavor{},
 	}
@@ -89,7 +96,7 @@ func GetCloudInfo(ic *types.InstallConfig) (*CloudInfo, error) {
 		return nil, errors.Wrap(err, "failed to generate OpenStack cloud info")
 	}
 
-	return &ci, nil
+	return ci, nil
 }
 
 func (ci *CloudInfo) collectInfo(ic *types.InstallConfig, opts *clientconfig.ClientOpts) error {


### PR DESCRIPTION
Now Installer loads cloud info for OpenStack platform twice: for base validations and for quota checking. This is not reasonable, because we just double the number of requests to OpenStack cloud.

This commit caches cloud info, which allows to reuse what we get from the first time.

/label platform/openstack