### PR TITLE
Bug 1924140: fix a typo in an env variable name

### DIFF
--- a/hack/openstack/test-manifests.sh
+++ b/hack/openstack/test-manifests.sh
@@ -14,7 +14,7 @@ declare \
 
 # Let install-config describe a configuration that is incompatible with the
 # target CI infrastructure
-export OPENSHFIT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS=1
+export OPENSHIFT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS=1
 
 print_help() {
 	set +x

--- a/pkg/asset/installconfig/openstack/validate.go
+++ b/pkg/asset/installconfig/openstack/validate.go
@@ -12,7 +12,7 @@ import (
 
 // Validate validates the given installconfig for OpenStack platform
 func Validate(ic *types.InstallConfig) error {
-	if skip := os.Getenv("OPENSHFIT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS"); skip == "1" {
+	if skip := os.Getenv("OPENSHIFT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS"); skip == "1" {
 		logrus.Warnf("OVERRIDE: pre-flight validation disabled.")
 		return nil
 	}


### PR DESCRIPTION
It should be called OPENSHIFT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS.