### PR TITLE
Cleanup argument usage in bootkube.sh for ceo

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -82,11 +82,10 @@ then
 		--etcd-ca=/assets/tls/etcd-ca-bundle.crt \
 		--etcd-ca-key=/assets/tls/etcd-signer.key \
 		--manifest-etcd-image="${MACHINE_CONFIG_ETCD_IMAGE}" \
-		--manifest-cluster-etcd-operator-image="${CLUSTER_ETCD_OPERATOR_IMAGE}" \
 		--asset-input-dir=/assets/tls \
 		--asset-output-dir=/assets/etcd-bootstrap \
 		--config-output-file=/assets/etcd-bootstrap/config \
-		--cluster-config-file=/assets/manifests/cluster-network-02-config.yml
+		--network-config-file=/assets/manifests/cluster-network-02-config.yml
 
 	cp etcd-bootstrap/manifests/* manifests/
 	cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/


### PR DESCRIPTION
 - `--manifest-cluster-etcd-operator-image` has been deprecated and is unused
 - `--cluster-config-file` has been replaced by `--network-config-file`

/cc @hexfusion 