### PR TITLE
Bug 1924670: openstack/validation: enforce control plane size

### DIFF
--- a/pkg/asset/installconfig/openstack/validate.go
+++ b/pkg/asset/installconfig/openstack/validate.go
@@ -31,3 +31,11 @@ func Validate(ic *types.InstallConfig) error {
 
 	return allErrs.ToAggregate()
 }
+
+// ValidateForProvisioning validates that the install config is valid for provisioning the cluster.
+func ValidateForProvisioning(ic *types.InstallConfig) error {
+	if ic.ControlPlane.Replicas != nil && *ic.ControlPlane.Replicas != 3 {
+		return field.Invalid(field.NewPath("controlPlane", "replicas"), ic.ControlPlane.Replicas, "control plane must be exactly three nodes when provisioning on OpenStack")
+	}
+	return nil
+}

--- a/pkg/asset/installconfig/openstack/validate_test.go
+++ b/pkg/asset/installconfig/openstack/validate_test.go
@@ -1,0 +1,46 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+func TestValidateForProvisioning(t *testing.T) {
+	cases := []struct {
+		name           string
+		installConfig  *types.InstallConfig
+		expectedErrMsg string
+	}{
+		{
+			name: "three-node control plane",
+			installConfig: &types.InstallConfig{
+				ControlPlane: &types.MachinePool{
+					Replicas: pointer.Int64Ptr(3),
+				},
+			},
+			expectedErrMsg: "",
+		}, {
+			name: "five-node control plane",
+			installConfig: &types.InstallConfig{
+				ControlPlane: &types.MachinePool{
+					Replicas: pointer.Int64Ptr(5),
+				},
+			},
+			expectedErrMsg: `controlPlane.replicas: Invalid value: 5: control plane must be exactly three nodes when provisioning on OpenStack`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateForProvisioning(tc.installConfig)
+			if tc.expectedErrMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, tc.expectedErrMsg, err)
+			}
+		})
+	}
+}

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -8,6 +8,7 @@ import (
 	azconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	bmconfig "github.com/openshift/installer/pkg/asset/installconfig/baremetal"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
+	osconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	vsconfig "github.com/openshift/installer/pkg/asset/installconfig/vsphere"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -70,12 +71,17 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+	case openstack.Name:
+		err = osconfig.ValidateForProvisioning(ic.Config)
+		if err != nil {
+			return err
+		}
 	case vsphere.Name:
 		err = vsconfig.ValidateForProvisioning(ic.Config)
 		if err != nil {
 			return err
 		}
-	case aws.Name, libvirt.Name, none.Name, openstack.Name, ovirt.Name:
+	case aws.Name, libvirt.Name, none.Name, ovirt.Name:
 		// no special provisioning requirements to check
 	default:
 		err = fmt.Errorf("unknown platform type %q", platform)


### PR DESCRIPTION
This is a cherry-pick of commit fb94d1cd4d713ee79efa672af71b52a067cb2e36

This is a follow up to b6e3088d, which hard codes the size of the
control plane to three nodes. We have a broad policy within OpenShift to
only support three-node control planes, but that's there's nothing
technically preventing a user from using a different size. In the case
of IPI on OpenStack, however, there is a technical restriction, so this
explicitly validates that.