### PR TITLE
manifests: migrate CRDs to use apiextensions/v1

### DIFF
--- a/data/data/manifests/openshift/cluster-networkconfig-crd.yaml
+++ b/data/data/manifests/openshift/cluster-networkconfig-crd.yaml
@@ -1,7 +1,7 @@
 # This is the advanced network configuration CRD
 # Only necessary if you need to tweak certain settings.
 # See https://github.com/openshift/cluster-network-operator#configuring
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networks.operator.openshift.io


### PR DESCRIPTION
The `networks.operator.openshift.io` CRD created by the manifests is using the deprecated apiextensions.k8s.io/v1alpha1 version.
These changes update to apiextensions.k8s.io/v1. The CRD is not using any fields that have been removed in v1, so no changes are needed other than changing the API version.