### PR TITLE
Bug 1909978: update ignore-volume-az documentation

### DIFF
--- a/docs/user/openstack/known-issues.md
+++ b/docs/user/openstack/known-issues.md
@@ -70,7 +70,7 @@ oc edit cm cloud-provider-config -n openshift-config
 ignore-volume-az = yes
 ```
 
-Then it is required to create and use a new Storage Class that has the availability parameter set to `nova`, as below:
+Then it is required to create and use a new Storage Class that has the `availability` parameter set to your Cinder availability zone name, as below:
 
 ```txt
 allowVolumeExpansion: true
@@ -80,7 +80,7 @@ metadata:
   name: sc-availability
 provisioner: kubernetes.io/cinder
 parameters:
-  availability: nova
+  availability: <Cinder_AZ>
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 ```


### PR DESCRIPTION
Now in the documentation we assume that the Cinder AZ is always called "nova". This commit replaces the hardcoded "nova" string with "<Cinder_AZ>", which then will be changed by users to the real Cinder AZ name.

/label platform/openstack