### PR TITLE
Bug 1916593: OpenStack UPI: Tag all resources with clusterID

### DIFF
--- a/upi/openstack/bootstrap.yaml
+++ b/upi/openstack/bootstrap.yaml
@@ -39,3 +39,4 @@
       auto_ip: "{{ bootstrap_auto_ip | default(omit) }}"
       nics:
       - port-name: "{{ os_port_bootstrap }}"
+      meta: "{{ cluster_id_tag }}"

--- a/upi/openstack/compute-nodes.yaml
+++ b/upi/openstack/compute-nodes.yaml
@@ -50,4 +50,5 @@
       userdata: "{{ lookup('file', 'worker.ign') | string }}"
       nics:
       - port-name: "{{ os_port_worker }}-{{ item.0 }}"
+      meta: "{{ cluster_id_tag }}"
     with_indexed_items: "{{ [os_compute_server_name] * os_compute_nodes_number }}"

--- a/upi/openstack/control-plane.yaml
+++ b/upi/openstack/control-plane.yaml
@@ -83,4 +83,5 @@
       - port-name: "{{ os_port_master }}-{{ item.0 }}"
       scheduler_hints:
         group: "{{ server_group_id }}"
+      meta: "{{ cluster_id_tag }}"
     with_indexed_items: "{{ [os_cp_server_name] * os_cp_nodes_number }}"

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -111,9 +111,7 @@
   - name: 'Set external router tag'
     command:
       cmd: "openstack router set --tag {{ cluster_id_tag }} {{ os_router }}"
-    when:
-    - os_networking_type == "Kuryr"
-    - os_external_network is defined and os_external_network|length>0
+    when: os_external_network is defined and os_external_network|length>0
 
   - name: 'Create the API port'
     os_port:


### PR DESCRIPTION
Without the openshiftClusterID tag, the `destroy` command can't properly identify the resources and that might cause the destroy to loop over resource deletion until it reaches the timeout.