### PR TITLE
Add support for passwordHash for bootstrap

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -194,12 +194,26 @@ func (a *Bootstrap) Generate(dependencies asset.Parents) error {
 
 	a.addParentFiles(dependencies)
 
+	var core igntypes.PasswdUser
+
+	if installConfig.Config.PasswordHash == "" {
+		core = igntypes.PasswdUser{Name: "core",
+			SSHAuthorizedKeys: []igntypes.SSHAuthorizedKey{
+				igntypes.SSHAuthorizedKey(installConfig.Config.SSHKey),
+				igntypes.SSHAuthorizedKey(string(bootstrapSSHKeyPair.Public())),
+			}}
+	} else {
+		core = igntypes.PasswdUser{Name: "core",
+			PasswordHash: &installConfig.Config.PasswordHash,
+			SSHAuthorizedKeys: []igntypes.SSHAuthorizedKey{
+				igntypes.SSHAuthorizedKey(installConfig.Config.SSHKey),
+				igntypes.SSHAuthorizedKey(string(bootstrapSSHKeyPair.Public())),
+			}}
+	}
+
 	a.Config.Passwd.Users = append(
 		a.Config.Passwd.Users,
-		igntypes.PasswdUser{Name: "core", SSHAuthorizedKeys: []igntypes.SSHAuthorizedKey{
-			igntypes.SSHAuthorizedKey(installConfig.Config.SSHKey),
-			igntypes.SSHAuthorizedKey(string(bootstrapSSHKeyPair.Public())),
-		}},
+		core,
 	)
 
 	data, err := ignition.Marshal(a.Config)

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -42,6 +42,7 @@ var _ asset.WritableAsset = (*InstallConfig)(nil)
 func (a *InstallConfig) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&sshPublicKey{},
+		&passwordHash{},
 		&baseDomain{},
 		&clusterName{},
 		&networking{},
@@ -53,6 +54,7 @@ func (a *InstallConfig) Dependencies() []asset.Asset {
 // Generate generates the install-config.yaml file.
 func (a *InstallConfig) Generate(parents asset.Parents) error {
 	sshPublicKey := &sshPublicKey{}
+	passwordHash := &passwordHash{}
 	baseDomain := &baseDomain{}
 	clusterName := &clusterName{}
 	networking := &networking{}
@@ -60,6 +62,7 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 	platform := &platform{}
 	parents.Get(
 		sshPublicKey,
+		passwordHash,
 		baseDomain,
 		clusterName,
 		networking,
@@ -74,9 +77,10 @@ func (a *InstallConfig) Generate(parents asset.Parents) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterName.ClusterName,
 		},
-		SSHKey:     sshPublicKey.Key,
-		BaseDomain: baseDomain.BaseDomain,
-		PullSecret: pullSecret.PullSecret,
+		SSHKey:       sshPublicKey.Key,
+		PasswordHash: passwordHash.Hash,
+		BaseDomain:   baseDomain.BaseDomain,
+		PullSecret:   pullSecret.PullSecret,
 		Networking: &types.Networking{
 			MachineNetwork: networking.machineNetwork,
 		},

--- a/pkg/asset/installconfig/passwordhash.go
+++ b/pkg/asset/installconfig/passwordhash.go
@@ -1,0 +1,47 @@
+package installconfig
+
+import (
+	"github.com/pkg/errors"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+
+	"github.com/openshift/installer/pkg/asset"
+)
+
+const (
+	noPasswordHash = ""
+)
+
+type passwordHash struct {
+	Hash string
+}
+
+var _ asset.Asset = (*passwordHash)(nil)
+
+// Dependencies returns no dependencies.
+func (a *passwordHash) Dependencies() []asset.Asset {
+	return nil
+}
+
+// Generate generates the SSH public key asset.
+func (a *passwordHash) Generate(asset.Parents) error {
+	var hash string
+
+	if err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "Password Hash",
+				Help:    "The password hash is used to access the bootstrap node from a console. This is optional.",
+				Default: noPasswordHash,
+			},
+		},
+	}, &hash); err != nil {
+		return errors.Wrap(err, "failed UserInput for Password Hash")
+	}
+	a.Hash = hash
+	return nil
+}
+
+// Name returns the human-friendly name of the asset.
+func (a passwordHash) Name() string {
+	return "Password Hash"
+}

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -77,6 +77,10 @@ type InstallConfig struct {
 	// +optional
 	SSHKey string `json:"sshKey,omitempty"`
 
+	// PasswordHash is the hash of the core user password
+	// +optional
+	PasswordHash string `json:"passwordHash,omitempty"`
+
 	// BaseDomain is the base domain to which the cluster should belong.
 	BaseDomain string `json:"baseDomain"`
 


### PR DESCRIPTION
There is a use case in debugging an initial deployment where
the networking does not work.  If you have access to the VM's
console, then setting the passwordHash value for the core
user allows you to access the VM for debugging.