### PR TITLE
[release-4.7] Bug 1922292: data/rhcos.json: Update boot images

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-00df0caf086e84021"
+            "hvm": "ami-029fd9ed382a11391"
         },
         "ap-east-1": {
-            "hvm": "ami-07afaf76b7eeb39a0"
+            "hvm": "ami-03a430ec1fccb01b1"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0e108b4d8eb4ad535"
+            "hvm": "ami-088179bf0724886e9"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0cc32e71c7f6aba2e"
+            "hvm": "ami-0cfaea5dcc0c037f7"
         },
         "ap-south-1": {
-            "hvm": "ami-05e1eb1b8d3752356"
+            "hvm": "ami-0ced331331c538803"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0d3368643a981a8db"
+            "hvm": "ami-0514184827698d03f"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a5c56ec05c6def9a"
+            "hvm": "ami-09fe1d057fd2f9139"
         },
         "ca-central-1": {
-            "hvm": "ami-08fae2042c2f8e307"
+            "hvm": "ami-0daf4b16da559fbc6"
         },
         "eu-central-1": {
-            "hvm": "ami-0e87caf5d900f9f75"
+            "hvm": "ami-0c72c28d91b693c4e"
         },
         "eu-north-1": {
-            "hvm": "ami-048012d998687ac68"
+            "hvm": "ami-0e5916a9b75ca583a"
         },
         "eu-south-1": {
-            "hvm": "ami-0839dacbad188fbb1"
+            "hvm": "ami-0599a7dd75d0c01ee"
         },
         "eu-west-1": {
-            "hvm": "ami-03e8f01e629110262"
+            "hvm": "ami-038de9b767f4d51e7"
         },
         "eu-west-2": {
-            "hvm": "ami-0dfb4514884432596"
+            "hvm": "ami-0764422e0a0f88d20"
         },
         "eu-west-3": {
-            "hvm": "ami-01cb4e271312b2a55"
+            "hvm": "ami-0a7482fc804ffb183"
         },
         "me-south-1": {
-            "hvm": "ami-07a2ab8fbdc2d920d"
+            "hvm": "ami-0b78bf60abbce5b49"
         },
         "sa-east-1": {
-            "hvm": "ami-0608db412547002de"
+            "hvm": "ami-0311beaa527cfbf83"
         },
         "us-east-1": {
-            "hvm": "ami-0f0e2048c2821f9c5"
+            "hvm": "ami-0b0b3f1d946b39f3f"
         },
         "us-east-2": {
-            "hvm": "ami-07aa7c22f37d5c71a"
+            "hvm": "ami-01af43c98b35e079d"
         },
         "us-west-1": {
-            "hvm": "ami-0d7d131b67b3be775"
+            "hvm": "ami-0369d9ae50708c5f9"
         },
         "us-west-2": {
-            "hvm": "ami-062eaac9bb9396805"
+            "hvm": "ami-05f283e8a7da43391"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202101161239-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202101161239-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202102050944-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102050944-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202101161239-0/x86_64/",
-    "buildid": "47.83.202101161239-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102050944-0/x86_64/",
+    "buildid": "47.83.202102050944-0",
     "gcp": {
-        "image": "rhcos-47-83-202101161239-0-gcp-x86-64",
+        "image": "rhcos-47-83-202102050944-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202101161239-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102050944-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202101161239-0-aws.x86_64.vmdk.gz",
-            "sha256": "85bce540df1bbfc30f4da16059253a6157ee598c40e979413c0811553cb81ca1",
-            "size": 947268663,
-            "uncompressed-sha256": "007074ccaa27b434249ccdbae615271fe57bb70e3515978327967bbb0f1fa84c",
-            "uncompressed-size": 966833152
+            "path": "rhcos-47.83.202102050944-0-aws.x86_64.vmdk.gz",
+            "sha256": "bffc031771fb2d79d487b5ca45400d5a26ca194f9390fdc6977a3a6c0f0f7c8d",
+            "size": 951224198,
+            "uncompressed-sha256": "3ff9b1886d30479bab9d4b260f7c62ee5132e081f3c770c8a9d1aabe133ddfb3",
+            "uncompressed-size": 970817024
         },
         "azure": {
-            "path": "rhcos-47.83.202101161239-0-azure.x86_64.vhd.gz",
-            "sha256": "04c464fc6dbebcda6acd97628cc5f117287a03fdad26e6043317272139c2a0cd",
-            "size": 947597270,
-            "uncompressed-sha256": "80862bc469162225780313374cc40b4b8fc1fc9998aa3e7738d20753ae354eaa",
+            "path": "rhcos-47.83.202102050944-0-azure.x86_64.vhd.gz",
+            "sha256": "3556b0a6b81ba67ddce64e7b62c0343d2fcf40cf2b688394d4015db9e32f0b17",
+            "size": 951627368,
+            "uncompressed-sha256": "a662a21b7aa389929f44c3a9010c83be3dfa286dc727a30d0aded3d76883cbeb",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202101161239-0-gcp.x86_64.tar.gz",
-            "sha256": "e683af174c9838ba4dab8d400f847f9a76ad3c31034fa99e7df6108b6ab4e576",
-            "size": 932920875
+            "path": "rhcos-47.83.202102050944-0-gcp.x86_64.tar.gz",
+            "sha256": "f0e2941514e2feeff086e506405beb84a98713b425a896a08cdb14db0d91b6ac",
+            "size": 936926570
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202101161239-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "685b289d9bf7730bd0a81e14b8a00d4edc9f5ad7ffee15d28f4953878dd33b10",
-            "size": 933248247,
-            "uncompressed-sha256": "d62a9e947abdf35dc8445e242d49f99700245386b60998dcc535590f85208fa8",
-            "uncompressed-size": 2355101696
+            "path": "rhcos-47.83.202102050944-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "1dd0d6d1d23014cde4a662f6d7a07b8e638ef7fecadfdded0d2af01f079ab5fe",
+            "size": 937240580,
+            "uncompressed-sha256": "78049b662103e65bfd4e326f7958e77f6afc920917ee17203cc4fdb963365632",
+            "uncompressed-size": 2360279040
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202101161239-0-live-initramfs.x86_64.img",
-            "sha256": "cf0197cf35c43156affae1bd7eb89b921b551b009e774d75efaa1fb57f791ca1"
+            "path": "rhcos-47.83.202102050944-0-live-initramfs.x86_64.img",
+            "sha256": "40655a508877c8bf849745d18588aa814892ad04fd7b4a956721e7915d11638c"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202101161239-0-live.x86_64.iso",
-            "sha256": "7dce3842ba51a7f2978cf790f66f7145cbdc2b4301e0cd85c6488467d75f734a"
+            "path": "rhcos-47.83.202102050944-0-live.x86_64.iso",
+            "sha256": "01ce9b5badbb9f3aef6a34cfe3323f66dce751418325a70b707e2dc150f7da13"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202101161239-0-live-kernel-x86_64",
+            "path": "rhcos-47.83.202102050944-0-live-kernel-x86_64",
             "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202101161239-0-live-rootfs.x86_64.img",
-            "sha256": "8f5c10bf75d1bce7495a5fb7b715c6707302a2b330765b5d31335f333e29dc05"
+            "path": "rhcos-47.83.202102050944-0-live-rootfs.x86_64.img",
+            "sha256": "e7077d35ab9d483f8a5d52f81490920fe79c622d0434796d0f3a50e1890c12f7"
         },
         "metal": {
-            "path": "rhcos-47.83.202101161239-0-metal.x86_64.raw.gz",
-            "sha256": "5d892c75bd04e1d805188e2f65f522500de54225c413922da1e544b0e0c726de",
-            "size": 934786221,
-            "uncompressed-sha256": "a08436f6e9ae681b837f0e16990cad8f70ceb939674b7f046a9b7d092812f5e3",
-            "uncompressed-size": 3711959040
+            "path": "rhcos-47.83.202102050944-0-metal.x86_64.raw.gz",
+            "sha256": "df7b6e8fae5e10c9b0db041b2093b3d6fbe10820dbee7257f459e57656f12cc1",
+            "size": 938982579,
+            "uncompressed-sha256": "a152e8243f8ab9ba85ca23b2320c8448fd5b07db85fd84bf4eaaf70cd336a3d0",
+            "uncompressed-size": 3717201920
         },
         "metal4k": {
-            "path": "rhcos-47.83.202101161239-0-metal4k.x86_64.raw.gz",
-            "sha256": "6bb51ca132110ceaef096674a2d1479e3070e2ac431d487ad6fb7c5b32d7cb2b",
-            "size": 932475329,
-            "uncompressed-sha256": "0542fb53a52a7e4cc8b281791e525ccbef18b2c22535d86c029e821f5cdb25ee",
-            "uncompressed-size": 3711959040
+            "path": "rhcos-47.83.202102050944-0-metal4k.x86_64.raw.gz",
+            "sha256": "1561862c8f603a41043555e06fe3ddaf811104cf3f32e22632dd9c7f0f9e5102",
+            "size": 936677531,
+            "uncompressed-sha256": "a1766b98806497da2bd065a8124a07bdf77b8bfc5ef29a5e53d0b49dbcee329e",
+            "uncompressed-size": 3717201920
         },
         "openstack": {
-            "path": "rhcos-47.83.202101161239-0-openstack.x86_64.qcow2.gz",
-            "sha256": "ccc2c776ce3d4bbb7585fdf497286c3694633f609bf7aeee42c5f8c274560bd2",
-            "size": 933246407,
-            "uncompressed-sha256": "f887d4cfb0cdcd459a08a37fea447ccca01fbb196399163ed58df5b2babe2893",
-            "uncompressed-size": 2355101696
+            "path": "rhcos-47.83.202102050944-0-openstack.x86_64.qcow2.gz",
+            "sha256": "e1170405e9e87fa65076d2ee829baa24a06ab195fc2094a0748b83b707b3baec",
+            "size": 937237521,
+            "uncompressed-sha256": "de50ba83288a3936860d3226dd84271622aeb099924fede36777a0d599a913f5",
+            "uncompressed-size": 2360279040
         },
         "ostree": {
-            "path": "rhcos-47.83.202101161239-0-ostree.x86_64.tar",
-            "sha256": "713db9420593740b5f1720f24dc992b9ee95f984a3e65236d91dc1dad9d359c1",
-            "size": 861102080
+            "path": "rhcos-47.83.202102050944-0-ostree.x86_64.tar",
+            "sha256": "89ec8c9da5552c242f38455163b9d4dac026a69945dee3b185460a958721aa56",
+            "size": 863416320
         },
         "qemu": {
-            "path": "rhcos-47.83.202101161239-0-qemu.x86_64.qcow2.gz",
-            "sha256": "ad40a0282a5c5af492d93302e5f79a2ea6673a863ac21a0fca752e7cdb099263",
-            "size": 934409208,
-            "uncompressed-sha256": "3a14ff77b4b7a5c89d145226759c71e852bd54eb8eea50866e760c801c7b623a",
-            "uncompressed-size": 2389114880
+            "path": "rhcos-47.83.202102050944-0-qemu.x86_64.qcow2.gz",
+            "sha256": "ccc62a56eef57ae7f7ca40c044d5a1f4824f678a3d6ae30ebb7492d2a8bf61a9",
+            "size": 938443998,
+            "uncompressed-sha256": "8245c5857e6d7b961200af7fb4f3e51d379566ef8e1a306719a0a5315c21695e",
+            "uncompressed-size": 2394226688
         },
         "vmware": {
-            "path": "rhcos-47.83.202101161239-0-vmware.x86_64.ova",
-            "sha256": "ef7366e778c14c14743bbfbb7b2a16a43a139f2ecbeb6bb73ad5b76745f034cd",
-            "size": 966850560
+            "path": "rhcos-47.83.202102050944-0-vmware.x86_64.ova",
+            "sha256": "610347e2b994b0dceacc1394956348ca503ffcda34636ea61fe124dbefbdcb5f",
+            "size": 970833920
         }
     },
     "oscontainer": {
-        "digest": "sha256:182c56ede5c330e7669ec2e6a6b7f54e94e92ca5983f9dbde555d0a3f500d5cd",
+        "digest": "sha256:ff3fc4147ddb14bf6b47520467278cc380378a6921ea4ac50ebe6944f5f12fae",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "8e87a86b9444784ab29e7917fa82e00d5e356f18b19449946b687ee8dc27c51a",
-    "ostree-version": "47.83.202101161239-0"
+    "ostree-commit": "78f6ca123d034d00964bee39f61f0b4e992c6e7634fd9da475b8c61e0fddc40e",
+    "ostree-version": "47.83.202102050944-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202101161312-0/ppc64le/",
-    "buildid": "47.83.202101161312-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202102051010-0/ppc64le/",
+    "buildid": "47.83.202102051010-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-47.83.202101161312-0-live-initramfs.ppc64le.img",
-            "sha256": "b320df705c26b3d418523306940eb974a4ea84881f151cba8cbc42c817297069"
+            "path": "rhcos-47.83.202102051010-0-live-initramfs.ppc64le.img",
+            "sha256": "a2fbfacffab25c26dd0544216705f5eff4fbde323365b8e8741663b3af3cd352"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202101161312-0-live.ppc64le.iso",
-            "sha256": "4724788d64d1bb2f838cec447984ba606e10d84bfb35b951585cfaf25c5f7997"
+            "path": "rhcos-47.83.202102051010-0-live.ppc64le.iso",
+            "sha256": "c5b368856da2c4c7b4771a311d30c4d3fd9abe425cd5077d73e557a3007ccbe1"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202101161312-0-live-kernel-ppc64le",
+            "path": "rhcos-47.83.202102051010-0-live-kernel-ppc64le",
             "sha256": "e310166a16592a5cd1bc152b07fda84278b251dc385cf000c65ed7bb31d254ea"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202101161312-0-live-rootfs.ppc64le.img",
-            "sha256": "d7592cb35871b8ca1e42195a9a2db80be6bf80fe0086607d774f8aab8fd60822"
+            "path": "rhcos-47.83.202102051010-0-live-rootfs.ppc64le.img",
+            "sha256": "c32ac4470fbe88ce4b44e63c8ff4cbb5da2e3dc00d7d4b53fee60ac662dfb323"
         },
         "metal": {
-            "path": "rhcos-47.83.202101161312-0-metal.ppc64le.raw.gz",
-            "sha256": "1fb49ed22ff352c49eb5721aa10968f00d507c217d071281125654d764e669bf",
-            "size": 913491343,
-            "uncompressed-sha256": "58b06283cc4a987ae40ddf545e6b99b4a3781b9f49669de5c8e7b8167b98d317",
-            "uncompressed-size": 3880779776
+            "path": "rhcos-47.83.202102051010-0-metal.ppc64le.raw.gz",
+            "sha256": "084cfc1c9d8bb3451a5635e52c4323290e5c254be8e8dadf6c4992a40955bd7d",
+            "size": 918055191,
+            "uncompressed-sha256": "203946c6dba99ff5a7f12d1ae8249215b8a4fdae0e92ea2602f71f5e49e0fb50",
+            "uncompressed-size": 3888119808
         },
         "metal4k": {
-            "path": "rhcos-47.83.202101161312-0-metal4k.ppc64le.raw.gz",
-            "sha256": "48ee005f130d7958f80b6b9f7f7a00161605fbcd1a58ba9e24fbf6ac5b0305c4",
-            "size": 913860349,
-            "uncompressed-sha256": "f668c140716c0018f17e8e7d5aa79dc4d041276168818a71309c98ad383a875f",
-            "uncompressed-size": 3880779776
+            "path": "rhcos-47.83.202102051010-0-metal4k.ppc64le.raw.gz",
+            "sha256": "52ad52de69871ec92d23ad2783461079aed9c38dc1a22dcfaea555907b378bcf",
+            "size": 918407664,
+            "uncompressed-sha256": "b2d21c0c494755d02e28e47e2e3e863164809eb89708439c601bb5f4e655a76b",
+            "uncompressed-size": 3888119808
         },
         "openstack": {
-            "path": "rhcos-47.83.202101161312-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "dca47bee9bd49a5550bb99329527f301926cb7043342eedc73c352c4e5db274b",
-            "size": 911768447,
-            "uncompressed-sha256": "233ce8f72fd03abdc0fce5865ae63d960dd87528418bac6503d51176f51330a0",
-            "uncompressed-size": 2487746560
+            "path": "rhcos-47.83.202102051010-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "dbc18c718fa1dd5a43c19eaf279fe4465defae1fcc507b73dc71cbb6d89a227d",
+            "size": 916410815,
+            "uncompressed-sha256": "431348dacf24a59562fb6c9928a26ffd86213880ae4322ee2f3d5baf4dfc0676",
+            "uncompressed-size": 2494103552
         },
         "ostree": {
-            "path": "rhcos-47.83.202101161312-0-ostree.ppc64le.tar",
-            "sha256": "7ecdf9d33518741db8734b34ef50ecdbab7be726d2b3d28c111763d8763989bb",
-            "size": 837857280
+            "path": "rhcos-47.83.202102051010-0-ostree.ppc64le.tar",
+            "sha256": "73fe3741e14fe67fd832d7c5895b6629f082d432b2e8110ddfd0ea006ef8087d",
+            "size": 840683520
         },
         "qemu": {
-            "path": "rhcos-47.83.202101161312-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "209c26570fa65ca8d88b17fb2791a4bb48ab4e0dd050427cde07b50c70cd7f90",
-            "size": 912889171,
-            "uncompressed-sha256": "25bc1592026534044c4b5f0d8a33282433d6cc91a7c4fd667fd49c11c8403b1c",
-            "uncompressed-size": 2522218496
+            "path": "rhcos-47.83.202102051010-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "53bfc5b10f259b01a2cafadcba6ad13fc91cd5f86a925b2ce03acdf9ea3b2f1a",
+            "size": 917567512,
+            "uncompressed-sha256": "19bb1d5128da12808e28c979f82d4f6f2cdadc3b14dcda896228e29b739cc038",
+            "uncompressed-size": 2529296384
         }
     },
     "oscontainer": {
-        "digest": "sha256:5fb0ff1e4556f25779caaf81101791688e240c55c35d7eb72274420fa22f8297",
+        "digest": "sha256:4bfe8cdc55da3c62a9b766b396d45292fb12371f60d24c6e899009bce73c3b42",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "94f1288eb2aae903b09db03c32651f0b1e6becb822d904d10ae444bb3c3c7a56",
-    "ostree-version": "47.83.202101161312-0"
+    "ostree-commit": "a9b5ba5ab8442d6fff141b38e7a6c07fc58ce21f2335d7d2a1a4473c568e406c",
+    "ostree-version": "47.83.202102051010-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202101160310-0/s390x/",
-    "buildid": "47.83.202101160310-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202102051212-0/s390x/",
+    "buildid": "47.83.202102051212-0",
     "images": {
         "dasd": {
-            "path": "rhcos-47.83.202101160310-0-dasd.s390x.raw.gz",
-            "sha256": "29df38c23f1865fd02d50549f0065d4efa5bac529f0bf38bf8707a547e64ca74",
-            "size": 827575478,
-            "uncompressed-sha256": "dc359cc175a2766ecf941c013aa1c93f3781cf8393952feadf7e271240970814",
-            "uncompressed-size": 3511681024
+            "path": "rhcos-47.83.202102051212-0-dasd.s390x.raw.gz",
+            "sha256": "8045df6717ee209657f1ff0dfd5984a5f11cd531e8a00763852a4d65872f9fb0",
+            "size": 831434904,
+            "uncompressed-sha256": "e2b3c5295fd3a887bfece950cc23b2cd2b58e3dbb149a328e534c677c36115fa",
+            "uncompressed-size": 3516923904
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202101160310-0-live-initramfs.s390x.img",
-            "sha256": "b2710170a7502dee1bc23a71ff9ae42cc5fe09d7444f90d94fc78a2ccdb6a101"
+            "path": "rhcos-47.83.202102051212-0-live-initramfs.s390x.img",
+            "sha256": "ac21ed2661f87abe7712d0aa16cfe065cc1c5b6899a3f3d4956f7b8cbac5f348"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202101160310-0-live.s390x.iso",
-            "sha256": "cee3ac3f385bda00c0a61d59e5ddbffb0d862a2b09d47116bba15e4e260c0d26"
+            "path": "rhcos-47.83.202102051212-0-live.s390x.iso",
+            "sha256": "a21475538678a776ddb1a5f70e10d983359c011bebda8365d667948a256444b5"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202101160310-0-live-kernel-s390x",
+            "path": "rhcos-47.83.202102051212-0-live-kernel-s390x",
             "sha256": "a0f17299369b9ce9e42c874a8cc3658a00e58144fc0f54849ef96d9414d811d0"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202101160310-0-live-rootfs.s390x.img",
-            "sha256": "bfbd8dd372b443f7b76e747168d4e676e7c0c67a9bd576f340159db6ac6f7421"
+            "path": "rhcos-47.83.202102051212-0-live-rootfs.s390x.img",
+            "sha256": "a24d44c30180c1cfa4f08ff6ba4c90b9104fccee9fd170d1c482b5daef580feb"
         },
         "metal": {
-            "path": "rhcos-47.83.202101160310-0-metal.s390x.raw.gz",
-            "sha256": "61cd5abab805fdda4933893d48e5b60ae54d6e110518f551660f17a18088b609",
-            "size": 827509752,
-            "uncompressed-sha256": "443e65c5512620132e4925ad111fa3ec755a8faf2e94393b8a693d43ed22bfbd",
-            "uncompressed-size": 3511681024
+            "path": "rhcos-47.83.202102051212-0-metal.s390x.raw.gz",
+            "sha256": "67e1a8ed89d0b1a6d2f11e4afe5a2728da2f0df7c1358f620538bb9b12e18ceb",
+            "size": 831450881,
+            "uncompressed-sha256": "72527d5ed44e38b7c919da6bb2a2e6e72137e44a3323455d56b79ec55dcc6d69",
+            "uncompressed-size": 3516923904
         },
         "metal4k": {
-            "path": "rhcos-47.83.202101160310-0-metal4k.s390x.raw.gz",
-            "sha256": "83063d210e2545181b1951499de7bdf5c20b30f13ffa7334b8db16d287c8af46",
-            "size": 827525080,
-            "uncompressed-sha256": "24ed4c191168604dc8976e9984e2343c2f8a2f7605d69a5193d4ac652fc0fb50",
-            "uncompressed-size": 3511681024
+            "path": "rhcos-47.83.202102051212-0-metal4k.s390x.raw.gz",
+            "sha256": "e790fc0458fb34a1b19c9bdb23d0b966384eb116f4d9e9b7ff11bbdf526bb78b",
+            "size": 831431366,
+            "uncompressed-sha256": "5be648f51bcbec77ee1fe2058ceff641e56c29237fd7a9e5d243e3c6658c7b1e",
+            "uncompressed-size": 3516923904
         },
         "openstack": {
-            "path": "rhcos-47.83.202101160310-0-openstack.s390x.qcow2.gz",
-            "sha256": "ed2456c9fbbff35912d7fc67210481bd28915375051e1c89f81a117d6794ac37",
-            "size": 825833588,
-            "uncompressed-sha256": "31ffcd52492788c6ace1b4b7905cabf421d7b19af7c42e7c67e47ead6559b4af",
-            "uncompressed-size": 2174091264
+            "path": "rhcos-47.83.202102051212-0-openstack.s390x.qcow2.gz",
+            "sha256": "d71c30fe185f01fcf0755bf53c0f6196dd26d88178d563db2ed0be173bf89b84",
+            "size": 829819842,
+            "uncompressed-sha256": "a903f453d423b4bad7295007e510d96e083f5ad1cf2ad80d7900434f5f462087",
+            "uncompressed-size": 2179399680
         },
         "ostree": {
-            "path": "rhcos-47.83.202101160310-0-ostree.s390x.tar",
-            "sha256": "209d55e5b979362181acbd4a815a5c8384738c7c943909c6ce592c86be7dd911",
-            "size": 777646080
+            "path": "rhcos-47.83.202102051212-0-ostree.s390x.tar",
+            "sha256": "c3411c179f760d91b507df5968c67ec0a72038121a399f0a5204af91286b582a",
+            "size": 779909120
         },
         "qemu": {
-            "path": "rhcos-47.83.202101160310-0-qemu.s390x.qcow2.gz",
-            "sha256": "e85d6c9fdb36c90214c13de187194fdacfdbb46f3f0f3ec8bba504dc3e0061ba",
-            "size": 826986752,
-            "uncompressed-sha256": "f5a26c9c665dd0827bfeeae30f111c87919a3e204dd3f0687730bd14ba4e9115",
-            "uncompressed-size": 2207842304
+            "path": "rhcos-47.83.202102051212-0-qemu.s390x.qcow2.gz",
+            "sha256": "d06209b8f28a046e53499320225d360064ac230a93d8a16f6faa75f02c04eb44",
+            "size": 830840394,
+            "uncompressed-sha256": "57bba13c206ebb2f80409112133a17d086977446a7ac0f9e58adf722232dfa53",
+            "uncompressed-size": 2213019648
         }
     },
     "oscontainer": {
-        "digest": "sha256:b5792e6b261828a9531a78b9329edcf800b0614886bd1fbf1cd9c81f75baa95e",
+        "digest": "sha256:2f3ed0fcda0383db89b0ddb809fc9a1187d48a30d60e93c080660110fbe7bd48",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "7dcc5825dcfbef5d160c69de95eb534807bda779d931c6dfde02d6b8748a1557",
-    "ostree-version": "47.83.202101160310-0"
+    "ostree-commit": "b979ea704acff93a622bbe20bc54d6d5c616a56519a32c39dba4404a2f7df2e4",
+    "ostree-version": "47.83.202102051212-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-00df0caf086e84021"
+            "hvm": "ami-029fd9ed382a11391"
         },
         "ap-east-1": {
-            "hvm": "ami-07afaf76b7eeb39a0"
+            "hvm": "ami-03a430ec1fccb01b1"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0e108b4d8eb4ad535"
+            "hvm": "ami-088179bf0724886e9"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0cc32e71c7f6aba2e"
+            "hvm": "ami-0cfaea5dcc0c037f7"
         },
         "ap-south-1": {
-            "hvm": "ami-05e1eb1b8d3752356"
+            "hvm": "ami-0ced331331c538803"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0d3368643a981a8db"
+            "hvm": "ami-0514184827698d03f"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a5c56ec05c6def9a"
+            "hvm": "ami-09fe1d057fd2f9139"
         },
         "ca-central-1": {
-            "hvm": "ami-08fae2042c2f8e307"
+            "hvm": "ami-0daf4b16da559fbc6"
         },
         "eu-central-1": {
-            "hvm": "ami-0e87caf5d900f9f75"
+            "hvm": "ami-0c72c28d91b693c4e"
         },
         "eu-north-1": {
-            "hvm": "ami-048012d998687ac68"
+            "hvm": "ami-0e5916a9b75ca583a"
         },
         "eu-south-1": {
-            "hvm": "ami-0839dacbad188fbb1"
+            "hvm": "ami-0599a7dd75d0c01ee"
         },
         "eu-west-1": {
-            "hvm": "ami-03e8f01e629110262"
+            "hvm": "ami-038de9b767f4d51e7"
         },
         "eu-west-2": {
-            "hvm": "ami-0dfb4514884432596"
+            "hvm": "ami-0764422e0a0f88d20"
         },
         "eu-west-3": {
-            "hvm": "ami-01cb4e271312b2a55"
+            "hvm": "ami-0a7482fc804ffb183"
         },
         "me-south-1": {
-            "hvm": "ami-07a2ab8fbdc2d920d"
+            "hvm": "ami-0b78bf60abbce5b49"
         },
         "sa-east-1": {
-            "hvm": "ami-0608db412547002de"
+            "hvm": "ami-0311beaa527cfbf83"
         },
         "us-east-1": {
-            "hvm": "ami-0f0e2048c2821f9c5"
+            "hvm": "ami-0b0b3f1d946b39f3f"
         },
         "us-east-2": {
-            "hvm": "ami-07aa7c22f37d5c71a"
+            "hvm": "ami-01af43c98b35e079d"
         },
         "us-west-1": {
-            "hvm": "ami-0d7d131b67b3be775"
+            "hvm": "ami-0369d9ae50708c5f9"
         },
         "us-west-2": {
-            "hvm": "ami-062eaac9bb9396805"
+            "hvm": "ami-05f283e8a7da43391"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202101161239-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202101161239-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202102050944-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102050944-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202101161239-0/x86_64/",
-    "buildid": "47.83.202101161239-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102050944-0/x86_64/",
+    "buildid": "47.83.202102050944-0",
     "gcp": {
-        "image": "rhcos-47-83-202101161239-0-gcp-x86-64",
+        "image": "rhcos-47-83-202102050944-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202101161239-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102050944-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202101161239-0-aws.x86_64.vmdk.gz",
-            "sha256": "85bce540df1bbfc30f4da16059253a6157ee598c40e979413c0811553cb81ca1",
-            "size": 947268663,
-            "uncompressed-sha256": "007074ccaa27b434249ccdbae615271fe57bb70e3515978327967bbb0f1fa84c",
-            "uncompressed-size": 966833152
+            "path": "rhcos-47.83.202102050944-0-aws.x86_64.vmdk.gz",
+            "sha256": "bffc031771fb2d79d487b5ca45400d5a26ca194f9390fdc6977a3a6c0f0f7c8d",
+            "size": 951224198,
+            "uncompressed-sha256": "3ff9b1886d30479bab9d4b260f7c62ee5132e081f3c770c8a9d1aabe133ddfb3",
+            "uncompressed-size": 970817024
         },
         "azure": {
-            "path": "rhcos-47.83.202101161239-0-azure.x86_64.vhd.gz",
-            "sha256": "04c464fc6dbebcda6acd97628cc5f117287a03fdad26e6043317272139c2a0cd",
-            "size": 947597270,
-            "uncompressed-sha256": "80862bc469162225780313374cc40b4b8fc1fc9998aa3e7738d20753ae354eaa",
+            "path": "rhcos-47.83.202102050944-0-azure.x86_64.vhd.gz",
+            "sha256": "3556b0a6b81ba67ddce64e7b62c0343d2fcf40cf2b688394d4015db9e32f0b17",
+            "size": 951627368,
+            "uncompressed-sha256": "a662a21b7aa389929f44c3a9010c83be3dfa286dc727a30d0aded3d76883cbeb",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202101161239-0-gcp.x86_64.tar.gz",
-            "sha256": "e683af174c9838ba4dab8d400f847f9a76ad3c31034fa99e7df6108b6ab4e576",
-            "size": 932920875
+            "path": "rhcos-47.83.202102050944-0-gcp.x86_64.tar.gz",
+            "sha256": "f0e2941514e2feeff086e506405beb84a98713b425a896a08cdb14db0d91b6ac",
+            "size": 936926570
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202101161239-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "685b289d9bf7730bd0a81e14b8a00d4edc9f5ad7ffee15d28f4953878dd33b10",
-            "size": 933248247,
-            "uncompressed-sha256": "d62a9e947abdf35dc8445e242d49f99700245386b60998dcc535590f85208fa8",
-            "uncompressed-size": 2355101696
+            "path": "rhcos-47.83.202102050944-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "1dd0d6d1d23014cde4a662f6d7a07b8e638ef7fecadfdded0d2af01f079ab5fe",
+            "size": 937240580,
+            "uncompressed-sha256": "78049b662103e65bfd4e326f7958e77f6afc920917ee17203cc4fdb963365632",
+            "uncompressed-size": 2360279040
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202101161239-0-live-initramfs.x86_64.img",
-            "sha256": "cf0197cf35c43156affae1bd7eb89b921b551b009e774d75efaa1fb57f791ca1"
+            "path": "rhcos-47.83.202102050944-0-live-initramfs.x86_64.img",
+            "sha256": "40655a508877c8bf849745d18588aa814892ad04fd7b4a956721e7915d11638c"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202101161239-0-live.x86_64.iso",
-            "sha256": "7dce3842ba51a7f2978cf790f66f7145cbdc2b4301e0cd85c6488467d75f734a"
+            "path": "rhcos-47.83.202102050944-0-live.x86_64.iso",
+            "sha256": "01ce9b5badbb9f3aef6a34cfe3323f66dce751418325a70b707e2dc150f7da13"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202101161239-0-live-kernel-x86_64",
+            "path": "rhcos-47.83.202102050944-0-live-kernel-x86_64",
             "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202101161239-0-live-rootfs.x86_64.img",
-            "sha256": "8f5c10bf75d1bce7495a5fb7b715c6707302a2b330765b5d31335f333e29dc05"
+            "path": "rhcos-47.83.202102050944-0-live-rootfs.x86_64.img",
+            "sha256": "e7077d35ab9d483f8a5d52f81490920fe79c622d0434796d0f3a50e1890c12f7"
         },
         "metal": {
-            "path": "rhcos-47.83.202101161239-0-metal.x86_64.raw.gz",
-            "sha256": "5d892c75bd04e1d805188e2f65f522500de54225c413922da1e544b0e0c726de",
-            "size": 934786221,
-            "uncompressed-sha256": "a08436f6e9ae681b837f0e16990cad8f70ceb939674b7f046a9b7d092812f5e3",
-            "uncompressed-size": 3711959040
+            "path": "rhcos-47.83.202102050944-0-metal.x86_64.raw.gz",
+            "sha256": "df7b6e8fae5e10c9b0db041b2093b3d6fbe10820dbee7257f459e57656f12cc1",
+            "size": 938982579,
+            "uncompressed-sha256": "a152e8243f8ab9ba85ca23b2320c8448fd5b07db85fd84bf4eaaf70cd336a3d0",
+            "uncompressed-size": 3717201920
         },
         "metal4k": {
-            "path": "rhcos-47.83.202101161239-0-metal4k.x86_64.raw.gz",
-            "sha256": "6bb51ca132110ceaef096674a2d1479e3070e2ac431d487ad6fb7c5b32d7cb2b",
-            "size": 932475329,
-            "uncompressed-sha256": "0542fb53a52a7e4cc8b281791e525ccbef18b2c22535d86c029e821f5cdb25ee",
-            "uncompressed-size": 3711959040
+            "path": "rhcos-47.83.202102050944-0-metal4k.x86_64.raw.gz",
+            "sha256": "1561862c8f603a41043555e06fe3ddaf811104cf3f32e22632dd9c7f0f9e5102",
+            "size": 936677531,
+            "uncompressed-sha256": "a1766b98806497da2bd065a8124a07bdf77b8bfc5ef29a5e53d0b49dbcee329e",
+            "uncompressed-size": 3717201920
         },
         "openstack": {
-            "path": "rhcos-47.83.202101161239-0-openstack.x86_64.qcow2.gz",
-            "sha256": "ccc2c776ce3d4bbb7585fdf497286c3694633f609bf7aeee42c5f8c274560bd2",
-            "size": 933246407,
-            "uncompressed-sha256": "f887d4cfb0cdcd459a08a37fea447ccca01fbb196399163ed58df5b2babe2893",
-            "uncompressed-size": 2355101696
+            "path": "rhcos-47.83.202102050944-0-openstack.x86_64.qcow2.gz",
+            "sha256": "e1170405e9e87fa65076d2ee829baa24a06ab195fc2094a0748b83b707b3baec",
+            "size": 937237521,
+            "uncompressed-sha256": "de50ba83288a3936860d3226dd84271622aeb099924fede36777a0d599a913f5",
+            "uncompressed-size": 2360279040
         },
         "ostree": {
-            "path": "rhcos-47.83.202101161239-0-ostree.x86_64.tar",
-            "sha256": "713db9420593740b5f1720f24dc992b9ee95f984a3e65236d91dc1dad9d359c1",
-            "size": 861102080
+            "path": "rhcos-47.83.202102050944-0-ostree.x86_64.tar",
+            "sha256": "89ec8c9da5552c242f38455163b9d4dac026a69945dee3b185460a958721aa56",
+            "size": 863416320
         },
         "qemu": {
-            "path": "rhcos-47.83.202101161239-0-qemu.x86_64.qcow2.gz",
-            "sha256": "ad40a0282a5c5af492d93302e5f79a2ea6673a863ac21a0fca752e7cdb099263",
-            "size": 934409208,
-            "uncompressed-sha256": "3a14ff77b4b7a5c89d145226759c71e852bd54eb8eea50866e760c801c7b623a",
-            "uncompressed-size": 2389114880
+            "path": "rhcos-47.83.202102050944-0-qemu.x86_64.qcow2.gz",
+            "sha256": "ccc62a56eef57ae7f7ca40c044d5a1f4824f678a3d6ae30ebb7492d2a8bf61a9",
+            "size": 938443998,
+            "uncompressed-sha256": "8245c5857e6d7b961200af7fb4f3e51d379566ef8e1a306719a0a5315c21695e",
+            "uncompressed-size": 2394226688
         },
         "vmware": {
-            "path": "rhcos-47.83.202101161239-0-vmware.x86_64.ova",
-            "sha256": "ef7366e778c14c14743bbfbb7b2a16a43a139f2ecbeb6bb73ad5b76745f034cd",
-            "size": 966850560
+            "path": "rhcos-47.83.202102050944-0-vmware.x86_64.ova",
+            "sha256": "610347e2b994b0dceacc1394956348ca503ffcda34636ea61fe124dbefbdcb5f",
+            "size": 970833920
         }
     },
     "oscontainer": {
-        "digest": "sha256:182c56ede5c330e7669ec2e6a6b7f54e94e92ca5983f9dbde555d0a3f500d5cd",
+        "digest": "sha256:ff3fc4147ddb14bf6b47520467278cc380378a6921ea4ac50ebe6944f5f12fae",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "8e87a86b9444784ab29e7917fa82e00d5e356f18b19449946b687ee8dc27c51a",
-    "ostree-version": "47.83.202101161239-0"
+    "ostree-commit": "78f6ca123d034d00964bee39f61f0b4e992c6e7634fd9da475b8c61e0fddc40e",
+    "ostree-version": "47.83.202102050944-0"
 }


### PR DESCRIPTION
Backport of https://github.com/openshift/installer/pull/4625 to 4.7

- amd64:   47.83.202102050944-0
- s390x:   47.83.202102051212-0
- ppc64le: 47.83.202102051010-0

(cherry picked from commit c3c63b18a415602f30cc287518c9ea29959f2c30)