### PR TITLE
Bug 1926558: [release-4.4]: rhcos.json: Update bootimages for ppc64le/s390x to fix kubelet error

### DIFF
--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,50 +1,50 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.4-ppc64le/44.81.202004252240-0/ppc64le/",
-    "buildid": "44.81.202004252240-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.4-ppc64le/44.82.202012010439-0/ppc64le/",
+    "buildid": "44.82.202012010439-0",
     "images": {
         "initramfs": {
-            "path": "rhcos-44.81.202004252240-0-installer-initramfs.ppc64le.img",
-            "sha256": "73cc22be85df4ec764f2b6284695fa594dff06af4718d6eb7668b77b560cefd8"
+            "path": "rhcos-44.82.202012010439-0-installer-initramfs.ppc64le.img",
+            "sha256": "d52ab57ad262fc9f7dfe4d3abd59c43c36bce40c6df2fb21bdfc988135b69f41"
         },
         "iso": {
-            "path": "rhcos-44.81.202004252240-0-installer.ppc64le.iso",
-            "sha256": "9175dea605c2ef49ae250b976478b8685ccbc6035f2b3bd26e925947004bcf2b"
+            "path": "rhcos-44.82.202012010439-0-installer.ppc64le.iso",
+            "sha256": "6a54ee3b3a7fcda6b38cb41b0a29b4f2850f96fce3285f4cf47c066df8f4fe76"
         },
         "kernel": {
-            "path": "rhcos-44.81.202004252240-0-installer-kernel-ppc64le",
-            "sha256": "447777af2b5136b555548ac674f0823148f1faf986df3e54b1119774a80621a5"
+            "path": "rhcos-44.82.202012010439-0-installer-kernel-ppc64le",
+            "sha256": "4f33503357e6847d5ddba97d7f3ee0773cbc1046b4121e15f7233eccade092f7"
         },
         "metal": {
-            "path": "rhcos-44.81.202004252240-0-metal.ppc64le.raw.gz",
-            "sha256": "ad866e9e31209ed2f248e2815e9eaea792d2ddfe1537231ab58f1ca00f57f9e6",
-            "size": 814734845,
-            "uncompressed-sha256": "6d6346cd108a35e4de84baa41901c45064bc45dde93a48d4fa79e76d18bcb016",
-            "uncompressed-size": 3700424704
+            "path": "rhcos-44.82.202012010439-0-metal.ppc64le.raw.gz",
+            "sha256": "72d3947f66c045e91d9a6e99b86ea04c41493a54f8aa2b90216233f5cee35098",
+            "size": 869823834,
+            "uncompressed-sha256": "abaa2f20ca6cdea1f184997f4ff44a257105407921f16bfbea2b09d4d24e0f46",
+            "uncompressed-size": 3916431360
         },
         "openstack": {
-            "path": "rhcos-44.81.202004252240-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "27a2947aea1039621747a2e4f4ff75a5a614f3977ca94a6f28b06591e01aa047",
-            "size": 813348296,
-            "uncompressed-sha256": "b7228af46822f0deeef5bd06e1e78d6188e57bb74ec98f17b3f5bd82e596349f",
-            "uncompressed-size": 2354970624
+            "path": "rhcos-44.82.202012010439-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "745d9cf579b81eff5cffdc0388122d5388dfd87bfc450234c27f90590e87e780",
+            "size": 868330916,
+            "uncompressed-sha256": "15caa9cf6b1c7e8e42769f88237d1b3309016d49f3c4e1437bf34111d32a4889",
+            "uncompressed-size": 2510553088
         },
         "ostree": {
-            "path": "rhcos-44.81.202004252240-0-ostree.ppc64le.tar",
-            "sha256": "49cefb03446ebd3249f22036f179a67bb6670d80f915826330f667aa7025a36f",
-            "size": 731453440
+            "path": "rhcos-44.82.202012010439-0-ostree.ppc64le.tar",
+            "sha256": "a703a4af303ea2bc976579975171f693e3420124ec22034b19e3f744baa1431b",
+            "size": 799989760
         },
         "qemu": {
-            "path": "rhcos-44.81.202004252240-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "06c0d56581358f6d149466ba2c113b5132e5390eb68cfc4c3c9834ad6c69d796",
-            "size": 813896314,
-            "uncompressed-sha256": "1f435d7ba80b8339d01552e7138dfcb0001626ced589e96c4e19ce5d2c66a5cf",
-            "uncompressed-size": 2400976896
+            "path": "rhcos-44.82.202012010439-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "8d34d0a9d28f80d6e0f0616749f5385f43d7c467f16f1898a818e20c6997460d",
+            "size": 869118242,
+            "uncompressed-sha256": "494bf1df5488fca42d97747be580e7495cf8e688bfe35047f5e060b92e7b7a3b",
+            "uncompressed-size": 2560032768
         }
     },
     "oscontainer": {
-        "digest": "sha256:fd1567de4bdca01d95ab8e5eb9b4ab9c9e8259d256f753ba4061c531d6b8f6bc",
+        "digest": "sha256:9f97f1e1b16b4b9683888daab1c43f67b03749e2a88a1c590c3aa2c895b57426",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "21173fcbd7cc29aa270b8037c6c77869c7b2945a45d896e80c0b8db63f3c2b50",
-    "ostree-version": "44.81.202004252240-0"
+    "ostree-commit": "1c2e406408f006f4d15a42e2b347ced444c199123b7e88745ba3a40937b786c1",
+    "ostree-version": "44.82.202012010439-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,57 +1,57 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.4-s390x/44.81.202004252140-0/s390x/",
-    "buildid": "44.81.202004252140-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.4-s390x/44.82.202011122341-0/s390x/",
+    "buildid": "44.82.202011122341-0",
     "images": {
         "dasd": {
-            "path": "rhcos-44.81.202004252140-0-dasd.s390x.raw.gz",
-            "sha256": "b84b38fcd4040e02906ffb0d6f2c7d07f02e87cad80c1860b91a308422348364",
-            "size": 746433534,
-            "uncompressed-sha256": "00886fa8a5e2decf85763d5e41fe9c08248cc9f4dd6b635b581fee1b254a8432",
-            "uncompressed-size": 3388997632
+            "path": "rhcos-44.82.202011122341-0-dasd.s390x.raw.gz",
+            "sha256": "3b702fa7b9de37ae5cd3a56fb3490b37659488a1143dada8ae05bdc8b9e1bef3",
+            "size": 795897608,
+            "uncompressed-sha256": "890fc6a76482f0c7911967f3a2790722d4e37daaa4caece2d5219714a2cbc51d",
+            "uncompressed-size": 3555721216
         },
         "initramfs": {
-            "path": "rhcos-44.81.202004252140-0-installer-initramfs.s390x.img",
-            "sha256": "2e13f35a3a9e472675b6b915fc1084f8dd82f065813dcb89f05db71e7a12295d"
+            "path": "rhcos-44.82.202011122341-0-installer-initramfs.s390x.img",
+            "sha256": "fc5e45edabd75ba01c67d829d0cdf5e8e7abfd0c8112df084f4f520f5da4ba11"
         },
         "iso": {
-            "path": "rhcos-44.81.202004252140-0-installer.s390x.iso",
-            "sha256": "b57a42438feece1faade14ca5436c35d7e92b1018faa133278be33815d51efe9"
+            "path": "rhcos-44.82.202011122341-0-installer.s390x.iso",
+            "sha256": "80f76b8ca41af855409d167ef519c0371eac297978d83d3e51d5e3e53fd656b2"
         },
         "kernel": {
-            "path": "rhcos-44.81.202004252140-0-installer-kernel-s390x",
-            "sha256": "1ebb79ccaab68e9b0e18eee44e7fb92300ada7e4937ecc3c37052ae62db94c85"
+            "path": "rhcos-44.82.202011122341-0-installer-kernel-s390x",
+            "sha256": "54d180071776bb989163897079c2652b0c7106f9c41d7187de4d015204aae8c4"
         },
         "metal": {
-            "path": "rhcos-44.81.202004252140-0-metal.s390x.raw.gz",
-            "sha256": "68a5356ae34235ba950ee64851993e8cf2505edc8212663cf1c7ee92b52f96eb",
-            "size": 746461543,
-            "uncompressed-sha256": "4f83deb98fcf4afc1771c7d06ad432fa3fb8ab8f561a50b05e629fd87c628c1d",
-            "uncompressed-size": 3388997632
+            "path": "rhcos-44.82.202011122341-0-metal.s390x.raw.gz",
+            "sha256": "ed6d3aad0309c2e504ac3a6240010ba4702ae728e00e47d82dd1edd4af5418fa",
+            "size": 795900163,
+            "uncompressed-sha256": "a7e68c15dcb3c529fda947c40de91e128140460ed0172e75c8d8234a6525ea97",
+            "uncompressed-size": 3555721216
         },
         "openstack": {
-            "path": "rhcos-44.81.202004252140-0-openstack.s390x.qcow2.gz",
-            "sha256": "3018b631693dfc5d5ee91ba2d8eeec774ab801556996e39a68ae5bd79fc0657d",
-            "size": 745137519,
-            "uncompressed-sha256": "5eb06dfa9ab0d8064fd947afa393f0e0524c7d82a17f7353de4783591ab04fbc",
-            "uncompressed-size": 2088828928
+            "path": "rhcos-44.82.202011122341-0-openstack.s390x.qcow2.gz",
+            "sha256": "1d12600fa463b353695e52a974a2249cbfc79d7bfb75003e7a18dd46ab2f58c1",
+            "size": 794699273,
+            "uncompressed-sha256": "2b818bb5a708d96b00a6c71275ece422aef2dccdade8c7ebac36107c6023c680",
+            "uncompressed-size": 2215706624
         },
         "ostree": {
-            "path": "rhcos-44.81.202004252140-0-ostree.s390x.tar",
-            "sha256": "77b3f54fa88da11756994e72f2231452d801748acb452a549fff2c4975fc8e89",
-            "size": 686766080
+            "path": "rhcos-44.82.202011122341-0-ostree.s390x.tar",
+            "sha256": "e65097ab76edbcb2c9fe661beb6980116c406401ae526dc1697f241af4aa5166",
+            "size": 744847360
         },
         "qemu": {
-            "path": "rhcos-44.81.202004252140-0-qemu.s390x.qcow2.gz",
-            "sha256": "7a51f9858f1a9c7c2812c5c3516ad1aca3054192814b85143378778eab9db095",
-            "size": 746006738,
-            "uncompressed-sha256": "cf1f8da465ee970395757b488f1281446101adf2fbd5a3fdec859f706de43596",
-            "uncompressed-size": 2134376448
+            "path": "rhcos-44.82.202011122341-0-qemu.s390x.qcow2.gz",
+            "sha256": "9ad1bd3e6f1fb00ac612c17cf3f48cbdc44e126806424f01a1eee518778d3387",
+            "size": 795424066,
+            "uncompressed-sha256": "65ec07ee975923a15ceb019d885abcf9c35af99c42159837f94aa28990bf084f",
+            "uncompressed-size": 2263547904
         }
     },
     "oscontainer": {
-        "digest": "sha256:eb003f57224d25f57b3a1d7afe79fbf9d20817e823fca92c2d9457896ee912a4",
+        "digest": "sha256:6306c5834f09cd7ea3a4c5020e71602a4e604784edd6b92927daf8b36f2ce0f4",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "0af5951ba6139e849321b4949750a42ff3997eb1da464e65c0cf251b24317ceb",
-    "ostree-version": "44.81.202004252140-0"
+    "ostree-commit": "c8b2aee4b094b86ccacb9a5f07a51da2a2429b598c8d59bef0c45eade281b308",
+    "ostree-version": "44.82.202011122341-0"
 }


### PR DESCRIPTION
Refer to https://bugzilla.redhat.com/show_bug.cgi?id=1926558. After https://github.com/openshift/installer/pull/4604 landed in 4.4, the multi-arch CI runs started failing because the hyperkube package was old. This was not an issue for x86 as the rhcos images were bumped for a CVE (https://github.com/openshift/installer/pull/3985), resulting in a newer hyperkube package which did not have this issue with the kubelet erroring out on `anonymous-auth=false`

Logs of error:

```
Feb 08 22:02:17 psundara-ocp-ptj44-bootstrap hyperkube[2888]: I0208 22:02:17.946044    2888 server.go:540] No cloud provider specified: "" from the config file: ""
Feb 08 22:02:17 psundara-ocp-ptj44-bootstrap hyperkube[2888]: W0208 22:02:17.946082    2888 server.go:563] standalone mode, no API client
Feb 08 22:02:17 psundara-ocp-ptj44-bootstrap hyperkube[2888]: F0208 22:02:17.946123    2888 server.go:273] failed to run Kubelet: No authentication method configured
```

These are the builds that were closest in parity to x86:
https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.4-s390x/44.82.202011122341-0/s390x/meta.json for s390x
https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.4-ppc64le/44.82.202012010439-0/ppc64le/meta.json for ppc64le