### PR TITLE
Bug 1873649: Validate noProxy input and add prefix for proxy urls

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -65,7 +65,7 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 		p.Config.Spec = configv1.ProxySpec{
 			HTTPProxy:  installConfig.Config.Proxy.HTTPProxy,
 			HTTPSProxy: installConfig.Config.Proxy.HTTPSProxy,
-			NoProxy:    trimSpaceNoProxy(installConfig.Config.Proxy.NoProxy),
+			NoProxy:    installConfig.Config.Proxy.NoProxy,
 		}
 
 		if installConfig.Config.AdditionalTrustBundle != "" {
@@ -86,7 +86,7 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 		p.Config.Status = configv1.ProxyStatus{
 			HTTPProxy:  installConfig.Config.Proxy.HTTPProxy,
 			HTTPSProxy: installConfig.Config.Proxy.HTTPSProxy,
-			NoProxy:    trimSpaceNoProxy(noProxy),
+			NoProxy:    noProxy,
 		}
 	}
 
@@ -184,13 +184,4 @@ func (p *Proxy) Files() []*asset.File {
 // Load loads the already-rendered files back from disk.
 func (p *Proxy) Load(f asset.FileFetcher) (bool, error) {
 	return false, nil
-}
-
-// trimSpaceNoProxy removes the space from comma separated items.
-func trimSpaceNoProxy(noProxy string) string {
-	split := strings.Split(noProxy, ",")
-	for idx, v := range split {
-		split[idx] = strings.TrimSpace(v)
-	}
-	return strings.Join(split, ",")
 }


### PR DESCRIPTION
The installer currently trims the spaces for the noProxy URLs
provided by the user but the Cluster Network Operator does not which
causes the machine config operator to fail with invalid proxy urls.
Adding a validation check to reject the input from the user if there
are spaces in the noProxy input.

Also added validation checks for the HTTPProxy and the HTTPSProxy
similar to the cluster network operator for the same.