### PR TITLE
[release-4.8] data/rhcos.json: Update boot images

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-00df0caf086e84021"
+            "hvm": "ami-057e5df70c52dc128"
         },
         "ap-east-1": {
-            "hvm": "ami-07afaf76b7eeb39a0"
+            "hvm": "ami-006ab68917f52bb13"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0e108b4d8eb4ad535"
+            "hvm": "ami-0d236f6289c700771"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0cc32e71c7f6aba2e"
+            "hvm": "ami-040394572427a293a"
         },
         "ap-south-1": {
-            "hvm": "ami-05e1eb1b8d3752356"
+            "hvm": "ami-0838c978c0390dd75"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0d3368643a981a8db"
+            "hvm": "ami-07af688c8b65de56f"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a5c56ec05c6def9a"
+            "hvm": "ami-0a36faab6aa0a0dea"
         },
         "ca-central-1": {
-            "hvm": "ami-08fae2042c2f8e307"
+            "hvm": "ami-01284e5815ce66a95"
         },
         "eu-central-1": {
-            "hvm": "ami-0e87caf5d900f9f75"
+            "hvm": "ami-0361c06cf3e935cfe"
         },
         "eu-north-1": {
-            "hvm": "ami-048012d998687ac68"
+            "hvm": "ami-0080eb90a48d9655e"
         },
         "eu-south-1": {
-            "hvm": "ami-0839dacbad188fbb1"
+            "hvm": "ami-0a3bc89f7aadf0343"
         },
         "eu-west-1": {
-            "hvm": "ami-03e8f01e629110262"
+            "hvm": "ami-0b4024fa5cb2588bd"
         },
         "eu-west-2": {
-            "hvm": "ami-0dfb4514884432596"
+            "hvm": "ami-07376355104ab4106"
         },
         "eu-west-3": {
-            "hvm": "ami-01cb4e271312b2a55"
+            "hvm": "ami-038f4ce9ea7ac7191"
         },
         "me-south-1": {
-            "hvm": "ami-07a2ab8fbdc2d920d"
+            "hvm": "ami-025899013a24bb708"
         },
         "sa-east-1": {
-            "hvm": "ami-0608db412547002de"
+            "hvm": "ami-089e1a3dcc5a5fe08"
         },
         "us-east-1": {
-            "hvm": "ami-0f0e2048c2821f9c5"
+            "hvm": "ami-0d5f9982f029fbc14"
         },
         "us-east-2": {
-            "hvm": "ami-07aa7c22f37d5c71a"
+            "hvm": "ami-0c84b5c5255ec4777"
         },
         "us-west-1": {
-            "hvm": "ami-0d7d131b67b3be775"
+            "hvm": "ami-0b421328859954025"
         },
         "us-west-2": {
-            "hvm": "ami-062eaac9bb9396805"
+            "hvm": "ami-010de485a2ee23e5e"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202101161239-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202101161239-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202102090044-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102090044-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202101161239-0/x86_64/",
-    "buildid": "47.83.202101161239-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102090044-0/x86_64/",
+    "buildid": "47.83.202102090044-0",
     "gcp": {
-        "image": "rhcos-47-83-202101161239-0-gcp-x86-64",
+        "image": "rhcos-47-83-202102090044-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202101161239-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102090044-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202101161239-0-aws.x86_64.vmdk.gz",
-            "sha256": "85bce540df1bbfc30f4da16059253a6157ee598c40e979413c0811553cb81ca1",
-            "size": 947268663,
-            "uncompressed-sha256": "007074ccaa27b434249ccdbae615271fe57bb70e3515978327967bbb0f1fa84c",
-            "uncompressed-size": 966833152
+            "path": "rhcos-47.83.202102090044-0-aws.x86_64.vmdk.gz",
+            "sha256": "ad54945302d9aaf0c5d6a5d1ee457325a3dcd88a68067d18a4d614acef5390d4",
+            "size": 951239242,
+            "uncompressed-sha256": "fbb7fbbc6cc6161ffa5c571f1b9022fe80038eea0a7f099c5b18ceba3b82f5eb",
+            "uncompressed-size": 970902016
         },
         "azure": {
-            "path": "rhcos-47.83.202101161239-0-azure.x86_64.vhd.gz",
-            "sha256": "04c464fc6dbebcda6acd97628cc5f117287a03fdad26e6043317272139c2a0cd",
-            "size": 947597270,
-            "uncompressed-sha256": "80862bc469162225780313374cc40b4b8fc1fc9998aa3e7738d20753ae354eaa",
+            "path": "rhcos-47.83.202102090044-0-azure.x86_64.vhd.gz",
+            "sha256": "32aa9be04b7f06bfe028fc7c93443f0c742afb006e73b6076016fa897ae5f716",
+            "size": 951756228,
+            "uncompressed-sha256": "7e60c02aeebd129a99d65da48beddb99bd29ac7b31f3bb9395fb1d87e6311448",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202101161239-0-gcp.x86_64.tar.gz",
-            "sha256": "e683af174c9838ba4dab8d400f847f9a76ad3c31034fa99e7df6108b6ab4e576",
-            "size": 932920875
+            "path": "rhcos-47.83.202102090044-0-gcp.x86_64.tar.gz",
+            "sha256": "07275bf2844f0dba6296d984d293959f614cc60af9f1be4070142a8cdcc650aa",
+            "size": 937047583
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202101161239-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "685b289d9bf7730bd0a81e14b8a00d4edc9f5ad7ffee15d28f4953878dd33b10",
-            "size": 933248247,
-            "uncompressed-sha256": "d62a9e947abdf35dc8445e242d49f99700245386b60998dcc535590f85208fa8",
-            "uncompressed-size": 2355101696
+            "path": "rhcos-47.83.202102090044-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "b81b26a61d11a9c2c6fb33a94ff124f461907bff550338cfecf173cdd93c09be",
+            "size": 937381841,
+            "uncompressed-sha256": "5b6fdfb53e3ede4d264d13862bda6801d932f12e1a17309ac62ac32836bca8ff",
+            "uncompressed-size": 2360082432
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202101161239-0-live-initramfs.x86_64.img",
-            "sha256": "cf0197cf35c43156affae1bd7eb89b921b551b009e774d75efaa1fb57f791ca1"
+            "path": "rhcos-47.83.202102090044-0-live-initramfs.x86_64.img",
+            "sha256": "29ba7e12b16f143a3f036226568ce91b3f7c8bd6feab719a73b0bed1817e4444"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202101161239-0-live.x86_64.iso",
-            "sha256": "7dce3842ba51a7f2978cf790f66f7145cbdc2b4301e0cd85c6488467d75f734a"
+            "path": "rhcos-47.83.202102090044-0-live.x86_64.iso",
+            "sha256": "b765a9e99edfa0a91778a4787070c6afcaa198ba8806c8c1533c34a23d63136f"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202101161239-0-live-kernel-x86_64",
+            "path": "rhcos-47.83.202102090044-0-live-kernel-x86_64",
             "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202101161239-0-live-rootfs.x86_64.img",
-            "sha256": "8f5c10bf75d1bce7495a5fb7b715c6707302a2b330765b5d31335f333e29dc05"
+            "path": "rhcos-47.83.202102090044-0-live-rootfs.x86_64.img",
+            "sha256": "6da4ae110fc2bcea8ac0e6c40fa9d701bbde5b936a1410f75735386c8ea805bf"
         },
         "metal": {
-            "path": "rhcos-47.83.202101161239-0-metal.x86_64.raw.gz",
-            "sha256": "5d892c75bd04e1d805188e2f65f522500de54225c413922da1e544b0e0c726de",
-            "size": 934786221,
-            "uncompressed-sha256": "a08436f6e9ae681b837f0e16990cad8f70ceb939674b7f046a9b7d092812f5e3",
-            "uncompressed-size": 3711959040
+            "path": "rhcos-47.83.202102090044-0-metal.x86_64.raw.gz",
+            "sha256": "0a456b02960eeb40a102ef14f5556843c2c504358f3db21f3fe667d8346c9bdf",
+            "size": 939085053,
+            "uncompressed-sha256": "36379d083adccccb3de266d2802cfcf5079429865fa010d9b499e87042d46526",
+            "uncompressed-size": 3717201920
         },
         "metal4k": {
-            "path": "rhcos-47.83.202101161239-0-metal4k.x86_64.raw.gz",
-            "sha256": "6bb51ca132110ceaef096674a2d1479e3070e2ac431d487ad6fb7c5b32d7cb2b",
-            "size": 932475329,
-            "uncompressed-sha256": "0542fb53a52a7e4cc8b281791e525ccbef18b2c22535d86c029e821f5cdb25ee",
-            "uncompressed-size": 3711959040
+            "path": "rhcos-47.83.202102090044-0-metal4k.x86_64.raw.gz",
+            "sha256": "ff10909c5d4ffbb3a829d070dcf3ce9a8b2d2aebff2924ee464d517eb948bfba",
+            "size": 936609970,
+            "uncompressed-sha256": "d5821d7fbd20f86bab29d028855200221f316fa041e86374c5f693da9b5d7b83",
+            "uncompressed-size": 3717201920
         },
         "openstack": {
-            "path": "rhcos-47.83.202101161239-0-openstack.x86_64.qcow2.gz",
-            "sha256": "ccc2c776ce3d4bbb7585fdf497286c3694633f609bf7aeee42c5f8c274560bd2",
-            "size": 933246407,
-            "uncompressed-sha256": "f887d4cfb0cdcd459a08a37fea447ccca01fbb196399163ed58df5b2babe2893",
-            "uncompressed-size": 2355101696
+            "path": "rhcos-47.83.202102090044-0-openstack.x86_64.qcow2.gz",
+            "sha256": "e5ebb8bcf6d081e52e1e7db0e93ff960ff472e25803a5671170959212e88cad9",
+            "size": 937380970,
+            "uncompressed-sha256": "c1b93a426d0f74f0059193439e306f3356b788302a825cfadd870460e543028e",
+            "uncompressed-size": 2360082432
         },
         "ostree": {
-            "path": "rhcos-47.83.202101161239-0-ostree.x86_64.tar",
-            "sha256": "713db9420593740b5f1720f24dc992b9ee95f984a3e65236d91dc1dad9d359c1",
-            "size": 861102080
+            "path": "rhcos-47.83.202102090044-0-ostree.x86_64.tar",
+            "sha256": "3b5fc040f7493ff7dc5aef4da22077ad74eb2e12a01a9e820d5c116e58716c4f",
+            "size": 863467520
         },
         "qemu": {
-            "path": "rhcos-47.83.202101161239-0-qemu.x86_64.qcow2.gz",
-            "sha256": "ad40a0282a5c5af492d93302e5f79a2ea6673a863ac21a0fca752e7cdb099263",
-            "size": 934409208,
-            "uncompressed-sha256": "3a14ff77b4b7a5c89d145226759c71e852bd54eb8eea50866e760c801c7b623a",
-            "uncompressed-size": 2389114880
+            "path": "rhcos-47.83.202102090044-0-qemu.x86_64.qcow2.gz",
+            "sha256": "2ca82f1d762bba1cb2e5ac1386be0a1ab0264cf88b0594c9cd1e53d285833c6d",
+            "size": 938521497,
+            "uncompressed-sha256": "5d31652c7856a87450dce1bbbb561b578ee75443c190096cb977a814e5f35935",
+            "uncompressed-size": 2394030080
         },
         "vmware": {
-            "path": "rhcos-47.83.202101161239-0-vmware.x86_64.ova",
-            "sha256": "ef7366e778c14c14743bbfbb7b2a16a43a139f2ecbeb6bb73ad5b76745f034cd",
-            "size": 966850560
+            "path": "rhcos-47.83.202102090044-0-vmware.x86_64.ova",
+            "sha256": "13d92692b8eed717ff8d0d113a24add339a65ef1f12eceeb99dabcd922cc86d1",
+            "size": 970915840
         }
     },
     "oscontainer": {
-        "digest": "sha256:182c56ede5c330e7669ec2e6a6b7f54e94e92ca5983f9dbde555d0a3f500d5cd",
+        "digest": "sha256:a32077727aa2ef96a1e2371dbcc53ba06f3d9727e836b72be0f0dd4513937e1e",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "8e87a86b9444784ab29e7917fa82e00d5e356f18b19449946b687ee8dc27c51a",
-    "ostree-version": "47.83.202101161239-0"
+    "ostree-commit": "646a9832dd0dc9fe174a2fc005863a9582186518a5476522a0e9bdccc0e5252a",
+    "ostree-version": "47.83.202102090044-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202101161312-0/ppc64le/",
-    "buildid": "47.83.202101161312-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202102091015-0/ppc64le/",
+    "buildid": "47.83.202102091015-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-47.83.202101161312-0-live-initramfs.ppc64le.img",
-            "sha256": "b320df705c26b3d418523306940eb974a4ea84881f151cba8cbc42c817297069"
+            "path": "rhcos-47.83.202102091015-0-live-initramfs.ppc64le.img",
+            "sha256": "a15c4eaaf5aa0176fc475e4ec41df4ca0e83595f7a5e561e2de0a26f8a485b60"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202101161312-0-live.ppc64le.iso",
-            "sha256": "4724788d64d1bb2f838cec447984ba606e10d84bfb35b951585cfaf25c5f7997"
+            "path": "rhcos-47.83.202102091015-0-live.ppc64le.iso",
+            "sha256": "d6fb6f949569461e3f9eb67883fa00b611275bb7d7bd3d9f11beaf1c0b33d389"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202101161312-0-live-kernel-ppc64le",
+            "path": "rhcos-47.83.202102091015-0-live-kernel-ppc64le",
             "sha256": "e310166a16592a5cd1bc152b07fda84278b251dc385cf000c65ed7bb31d254ea"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202101161312-0-live-rootfs.ppc64le.img",
-            "sha256": "d7592cb35871b8ca1e42195a9a2db80be6bf80fe0086607d774f8aab8fd60822"
+            "path": "rhcos-47.83.202102091015-0-live-rootfs.ppc64le.img",
+            "sha256": "621ed54c0cb5180e7e798778c5c365f04b328aa983bc5a752ecea3a17ffd5bce"
         },
         "metal": {
-            "path": "rhcos-47.83.202101161312-0-metal.ppc64le.raw.gz",
-            "sha256": "1fb49ed22ff352c49eb5721aa10968f00d507c217d071281125654d764e669bf",
-            "size": 913491343,
-            "uncompressed-sha256": "58b06283cc4a987ae40ddf545e6b99b4a3781b9f49669de5c8e7b8167b98d317",
-            "uncompressed-size": 3880779776
+            "path": "rhcos-47.83.202102091015-0-metal.ppc64le.raw.gz",
+            "sha256": "d0fa64d744dd731ad3185b39ada8d6eb886c8dbba3e683a30176838bdf20ef9a",
+            "size": 918231587,
+            "uncompressed-sha256": "1880a77eed6741e45346102b85b5cceb071d7da5479b1075efd810767a33693c",
+            "uncompressed-size": 3888119808
         },
         "metal4k": {
-            "path": "rhcos-47.83.202101161312-0-metal4k.ppc64le.raw.gz",
-            "sha256": "48ee005f130d7958f80b6b9f7f7a00161605fbcd1a58ba9e24fbf6ac5b0305c4",
-            "size": 913860349,
-            "uncompressed-sha256": "f668c140716c0018f17e8e7d5aa79dc4d041276168818a71309c98ad383a875f",
-            "uncompressed-size": 3880779776
+            "path": "rhcos-47.83.202102091015-0-metal4k.ppc64le.raw.gz",
+            "sha256": "f6e4458958f38a7bccae4a89a73134d431b86b183ebcf76542446c959fa2d520",
+            "size": 918369582,
+            "uncompressed-sha256": "142ce5a0cb3984611a74d5d9d99ee6e320029802d2bee7c31d6b6b9455f3d293",
+            "uncompressed-size": 3888119808
         },
         "openstack": {
-            "path": "rhcos-47.83.202101161312-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "dca47bee9bd49a5550bb99329527f301926cb7043342eedc73c352c4e5db274b",
-            "size": 911768447,
-            "uncompressed-sha256": "233ce8f72fd03abdc0fce5865ae63d960dd87528418bac6503d51176f51330a0",
-            "uncompressed-size": 2487746560
+            "path": "rhcos-47.83.202102091015-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "47865a06d1ca6ae06481ab6f1d52ed6c9fca02ae539a06639c8bea65173a1550",
+            "size": 916498365,
+            "uncompressed-sha256": "443ed7133f49e36138ac7c452bedcca2d8fde02f818a43fce1d905d41d0a8cea",
+            "uncompressed-size": 2494431232
         },
         "ostree": {
-            "path": "rhcos-47.83.202101161312-0-ostree.ppc64le.tar",
-            "sha256": "7ecdf9d33518741db8734b34ef50ecdbab7be726d2b3d28c111763d8763989bb",
-            "size": 837857280
+            "path": "rhcos-47.83.202102091015-0-ostree.ppc64le.tar",
+            "sha256": "118d9f3842d60e2f21e84b4561a9faea3e1ac72948a76a2e59969ff54f288f0a",
+            "size": 840714240
         },
         "qemu": {
-            "path": "rhcos-47.83.202101161312-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "209c26570fa65ca8d88b17fb2791a4bb48ab4e0dd050427cde07b50c70cd7f90",
-            "size": 912889171,
-            "uncompressed-sha256": "25bc1592026534044c4b5f0d8a33282433d6cc91a7c4fd667fd49c11c8403b1c",
-            "uncompressed-size": 2522218496
+            "path": "rhcos-47.83.202102091015-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "dce14413bb0347ffcb793a529ed2b4e39efa2b523a3e63faf552e574752a5aac",
+            "size": 917571073,
+            "uncompressed-sha256": "2044dd7198fd1f730c3fe1d68c422be7e06ed57b4ad28bfe402f4836b84be869",
+            "uncompressed-size": 2529296384
         }
     },
     "oscontainer": {
-        "digest": "sha256:5fb0ff1e4556f25779caaf81101791688e240c55c35d7eb72274420fa22f8297",
+        "digest": "sha256:6a410508e645cb24729fd860ae53a352b3df23a11d5747b0648d2f300a37de1d",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "94f1288eb2aae903b09db03c32651f0b1e6becb822d904d10ae444bb3c3c7a56",
-    "ostree-version": "47.83.202101161312-0"
+    "ostree-commit": "b44e5d88d608175e62e95a35b59bd3e912327cfea036e5393169146af7512588",
+    "ostree-version": "47.83.202102091015-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202101160310-0/s390x/",
-    "buildid": "47.83.202101160310-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202102090311-0/s390x/",
+    "buildid": "47.83.202102090311-0",
     "images": {
         "dasd": {
-            "path": "rhcos-47.83.202101160310-0-dasd.s390x.raw.gz",
-            "sha256": "29df38c23f1865fd02d50549f0065d4efa5bac529f0bf38bf8707a547e64ca74",
-            "size": 827575478,
-            "uncompressed-sha256": "dc359cc175a2766ecf941c013aa1c93f3781cf8393952feadf7e271240970814",
-            "uncompressed-size": 3511681024
+            "path": "rhcos-47.83.202102090311-0-dasd.s390x.raw.gz",
+            "sha256": "af39f736c9cd6bec61d4f7a098adcebc0b7583cd299339859c831380256c27d4",
+            "size": 831578576,
+            "uncompressed-sha256": "a390b9b95a1381ebec1736d4aa5d193f0820a41c6af79fc7283960b91fa4a861",
+            "uncompressed-size": 3516923904
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202101160310-0-live-initramfs.s390x.img",
-            "sha256": "b2710170a7502dee1bc23a71ff9ae42cc5fe09d7444f90d94fc78a2ccdb6a101"
+            "path": "rhcos-47.83.202102090311-0-live-initramfs.s390x.img",
+            "sha256": "07e5642b818ee9582f59050657dceecad4683c6c54c2f92b071549c8a4826e05"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202101160310-0-live.s390x.iso",
-            "sha256": "cee3ac3f385bda00c0a61d59e5ddbffb0d862a2b09d47116bba15e4e260c0d26"
+            "path": "rhcos-47.83.202102090311-0-live.s390x.iso",
+            "sha256": "e64d8d66bd69e6ea7ebdd9be74abce43e10e0731527ee6662780f20863ffc71c"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202101160310-0-live-kernel-s390x",
+            "path": "rhcos-47.83.202102090311-0-live-kernel-s390x",
             "sha256": "a0f17299369b9ce9e42c874a8cc3658a00e58144fc0f54849ef96d9414d811d0"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202101160310-0-live-rootfs.s390x.img",
-            "sha256": "bfbd8dd372b443f7b76e747168d4e676e7c0c67a9bd576f340159db6ac6f7421"
+            "path": "rhcos-47.83.202102090311-0-live-rootfs.s390x.img",
+            "sha256": "79de4fb97a151b051201eb04f291a1b36f54d3968d2c3f31571066da8231945a"
         },
         "metal": {
-            "path": "rhcos-47.83.202101160310-0-metal.s390x.raw.gz",
-            "sha256": "61cd5abab805fdda4933893d48e5b60ae54d6e110518f551660f17a18088b609",
-            "size": 827509752,
-            "uncompressed-sha256": "443e65c5512620132e4925ad111fa3ec755a8faf2e94393b8a693d43ed22bfbd",
-            "uncompressed-size": 3511681024
+            "path": "rhcos-47.83.202102090311-0-metal.s390x.raw.gz",
+            "sha256": "299bcb3de103f701866904f41e316e7c375fd1e0c4434b068e578a35d11084e1",
+            "size": 831763974,
+            "uncompressed-sha256": "ab0b1f6080c472f88dc418610cb6af2dd9e8aff835c9a7b417716f67c3e2e25d",
+            "uncompressed-size": 3516923904
         },
         "metal4k": {
-            "path": "rhcos-47.83.202101160310-0-metal4k.s390x.raw.gz",
-            "sha256": "83063d210e2545181b1951499de7bdf5c20b30f13ffa7334b8db16d287c8af46",
-            "size": 827525080,
-            "uncompressed-sha256": "24ed4c191168604dc8976e9984e2343c2f8a2f7605d69a5193d4ac652fc0fb50",
-            "uncompressed-size": 3511681024
+            "path": "rhcos-47.83.202102090311-0-metal4k.s390x.raw.gz",
+            "sha256": "566bca2f1462b4d70f1d7da7a1c7d477252f2e2db6251ee61f6e810c3a450982",
+            "size": 831520327,
+            "uncompressed-sha256": "3478e62963f4b0bba45cc41a92cae33e9907cc3e4ed1206ef94a05db4e70b9fe",
+            "uncompressed-size": 3516923904
         },
         "openstack": {
-            "path": "rhcos-47.83.202101160310-0-openstack.s390x.qcow2.gz",
-            "sha256": "ed2456c9fbbff35912d7fc67210481bd28915375051e1c89f81a117d6794ac37",
-            "size": 825833588,
-            "uncompressed-sha256": "31ffcd52492788c6ace1b4b7905cabf421d7b19af7c42e7c67e47ead6559b4af",
-            "uncompressed-size": 2174091264
+            "path": "rhcos-47.83.202102090311-0-openstack.s390x.qcow2.gz",
+            "sha256": "4ebac56f35e48ff66b18ed21785f722272bc5b24573c2410f3d63a374eeab6db",
+            "size": 830070694,
+            "uncompressed-sha256": "2920cfe9a35e24302127507ab39e54d619c839d910361fe45c0c46dbd9813e7a",
+            "uncompressed-size": 2179530752
         },
         "ostree": {
-            "path": "rhcos-47.83.202101160310-0-ostree.s390x.tar",
-            "sha256": "209d55e5b979362181acbd4a815a5c8384738c7c943909c6ce592c86be7dd911",
-            "size": 777646080
+            "path": "rhcos-47.83.202102090311-0-ostree.s390x.tar",
+            "sha256": "d7ed80d612fedcca6a39017e41851acbb35c5d0a8cce9c06df8afacfe059e310",
+            "size": 779970560
         },
         "qemu": {
-            "path": "rhcos-47.83.202101160310-0-qemu.s390x.qcow2.gz",
-            "sha256": "e85d6c9fdb36c90214c13de187194fdacfdbb46f3f0f3ec8bba504dc3e0061ba",
-            "size": 826986752,
-            "uncompressed-sha256": "f5a26c9c665dd0827bfeeae30f111c87919a3e204dd3f0687730bd14ba4e9115",
-            "uncompressed-size": 2207842304
+            "path": "rhcos-47.83.202102090311-0-qemu.s390x.qcow2.gz",
+            "sha256": "80d61716f6ca97e9b5256b2202132dcac169700937b40545ce9cd8ad9e6bbcee",
+            "size": 831149363,
+            "uncompressed-sha256": "cc3b8294320a6635bfdf05a380fb931875a57fe6b18118940b1ce2f23ca069a1",
+            "uncompressed-size": 2213019648
         }
     },
     "oscontainer": {
-        "digest": "sha256:b5792e6b261828a9531a78b9329edcf800b0614886bd1fbf1cd9c81f75baa95e",
+        "digest": "sha256:0e8147407a02605f0e4f79ac5e8ddfda21b7557769a26b9f7138e82dc9558af0",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "7dcc5825dcfbef5d160c69de95eb534807bda779d931c6dfde02d6b8748a1557",
-    "ostree-version": "47.83.202101160310-0"
+    "ostree-commit": "ac18fdc352f3e1bcbf1c7d74f713f14de2c4117c869afd097432b5f8355e3781",
+    "ostree-version": "47.83.202102090311-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-00df0caf086e84021"
+            "hvm": "ami-057e5df70c52dc128"
         },
         "ap-east-1": {
-            "hvm": "ami-07afaf76b7eeb39a0"
+            "hvm": "ami-006ab68917f52bb13"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0e108b4d8eb4ad535"
+            "hvm": "ami-0d236f6289c700771"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0cc32e71c7f6aba2e"
+            "hvm": "ami-040394572427a293a"
         },
         "ap-south-1": {
-            "hvm": "ami-05e1eb1b8d3752356"
+            "hvm": "ami-0838c978c0390dd75"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0d3368643a981a8db"
+            "hvm": "ami-07af688c8b65de56f"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a5c56ec05c6def9a"
+            "hvm": "ami-0a36faab6aa0a0dea"
         },
         "ca-central-1": {
-            "hvm": "ami-08fae2042c2f8e307"
+            "hvm": "ami-01284e5815ce66a95"
         },
         "eu-central-1": {
-            "hvm": "ami-0e87caf5d900f9f75"
+            "hvm": "ami-0361c06cf3e935cfe"
         },
         "eu-north-1": {
-            "hvm": "ami-048012d998687ac68"
+            "hvm": "ami-0080eb90a48d9655e"
         },
         "eu-south-1": {
-            "hvm": "ami-0839dacbad188fbb1"
+            "hvm": "ami-0a3bc89f7aadf0343"
         },
         "eu-west-1": {
-            "hvm": "ami-03e8f01e629110262"
+            "hvm": "ami-0b4024fa5cb2588bd"
         },
         "eu-west-2": {
-            "hvm": "ami-0dfb4514884432596"
+            "hvm": "ami-07376355104ab4106"
         },
         "eu-west-3": {
-            "hvm": "ami-01cb4e271312b2a55"
+            "hvm": "ami-038f4ce9ea7ac7191"
         },
         "me-south-1": {
-            "hvm": "ami-07a2ab8fbdc2d920d"
+            "hvm": "ami-025899013a24bb708"
         },
         "sa-east-1": {
-            "hvm": "ami-0608db412547002de"
+            "hvm": "ami-089e1a3dcc5a5fe08"
         },
         "us-east-1": {
-            "hvm": "ami-0f0e2048c2821f9c5"
+            "hvm": "ami-0d5f9982f029fbc14"
         },
         "us-east-2": {
-            "hvm": "ami-07aa7c22f37d5c71a"
+            "hvm": "ami-0c84b5c5255ec4777"
         },
         "us-west-1": {
-            "hvm": "ami-0d7d131b67b3be775"
+            "hvm": "ami-0b421328859954025"
         },
         "us-west-2": {
-            "hvm": "ami-062eaac9bb9396805"
+            "hvm": "ami-010de485a2ee23e5e"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202101161239-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202101161239-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202102090044-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102090044-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202101161239-0/x86_64/",
-    "buildid": "47.83.202101161239-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102090044-0/x86_64/",
+    "buildid": "47.83.202102090044-0",
     "gcp": {
-        "image": "rhcos-47-83-202101161239-0-gcp-x86-64",
+        "image": "rhcos-47-83-202102090044-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202101161239-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102090044-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202101161239-0-aws.x86_64.vmdk.gz",
-            "sha256": "85bce540df1bbfc30f4da16059253a6157ee598c40e979413c0811553cb81ca1",
-            "size": 947268663,
-            "uncompressed-sha256": "007074ccaa27b434249ccdbae615271fe57bb70e3515978327967bbb0f1fa84c",
-            "uncompressed-size": 966833152
+            "path": "rhcos-47.83.202102090044-0-aws.x86_64.vmdk.gz",
+            "sha256": "ad54945302d9aaf0c5d6a5d1ee457325a3dcd88a68067d18a4d614acef5390d4",
+            "size": 951239242,
+            "uncompressed-sha256": "fbb7fbbc6cc6161ffa5c571f1b9022fe80038eea0a7f099c5b18ceba3b82f5eb",
+            "uncompressed-size": 970902016
         },
         "azure": {
-            "path": "rhcos-47.83.202101161239-0-azure.x86_64.vhd.gz",
-            "sha256": "04c464fc6dbebcda6acd97628cc5f117287a03fdad26e6043317272139c2a0cd",
-            "size": 947597270,
-            "uncompressed-sha256": "80862bc469162225780313374cc40b4b8fc1fc9998aa3e7738d20753ae354eaa",
+            "path": "rhcos-47.83.202102090044-0-azure.x86_64.vhd.gz",
+            "sha256": "32aa9be04b7f06bfe028fc7c93443f0c742afb006e73b6076016fa897ae5f716",
+            "size": 951756228,
+            "uncompressed-sha256": "7e60c02aeebd129a99d65da48beddb99bd29ac7b31f3bb9395fb1d87e6311448",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202101161239-0-gcp.x86_64.tar.gz",
-            "sha256": "e683af174c9838ba4dab8d400f847f9a76ad3c31034fa99e7df6108b6ab4e576",
-            "size": 932920875
+            "path": "rhcos-47.83.202102090044-0-gcp.x86_64.tar.gz",
+            "sha256": "07275bf2844f0dba6296d984d293959f614cc60af9f1be4070142a8cdcc650aa",
+            "size": 937047583
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202101161239-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "685b289d9bf7730bd0a81e14b8a00d4edc9f5ad7ffee15d28f4953878dd33b10",
-            "size": 933248247,
-            "uncompressed-sha256": "d62a9e947abdf35dc8445e242d49f99700245386b60998dcc535590f85208fa8",
-            "uncompressed-size": 2355101696
+            "path": "rhcos-47.83.202102090044-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "b81b26a61d11a9c2c6fb33a94ff124f461907bff550338cfecf173cdd93c09be",
+            "size": 937381841,
+            "uncompressed-sha256": "5b6fdfb53e3ede4d264d13862bda6801d932f12e1a17309ac62ac32836bca8ff",
+            "uncompressed-size": 2360082432
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202101161239-0-live-initramfs.x86_64.img",
-            "sha256": "cf0197cf35c43156affae1bd7eb89b921b551b009e774d75efaa1fb57f791ca1"
+            "path": "rhcos-47.83.202102090044-0-live-initramfs.x86_64.img",
+            "sha256": "29ba7e12b16f143a3f036226568ce91b3f7c8bd6feab719a73b0bed1817e4444"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202101161239-0-live.x86_64.iso",
-            "sha256": "7dce3842ba51a7f2978cf790f66f7145cbdc2b4301e0cd85c6488467d75f734a"
+            "path": "rhcos-47.83.202102090044-0-live.x86_64.iso",
+            "sha256": "b765a9e99edfa0a91778a4787070c6afcaa198ba8806c8c1533c34a23d63136f"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202101161239-0-live-kernel-x86_64",
+            "path": "rhcos-47.83.202102090044-0-live-kernel-x86_64",
             "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202101161239-0-live-rootfs.x86_64.img",
-            "sha256": "8f5c10bf75d1bce7495a5fb7b715c6707302a2b330765b5d31335f333e29dc05"
+            "path": "rhcos-47.83.202102090044-0-live-rootfs.x86_64.img",
+            "sha256": "6da4ae110fc2bcea8ac0e6c40fa9d701bbde5b936a1410f75735386c8ea805bf"
         },
         "metal": {
-            "path": "rhcos-47.83.202101161239-0-metal.x86_64.raw.gz",
-            "sha256": "5d892c75bd04e1d805188e2f65f522500de54225c413922da1e544b0e0c726de",
-            "size": 934786221,
-            "uncompressed-sha256": "a08436f6e9ae681b837f0e16990cad8f70ceb939674b7f046a9b7d092812f5e3",
-            "uncompressed-size": 3711959040
+            "path": "rhcos-47.83.202102090044-0-metal.x86_64.raw.gz",
+            "sha256": "0a456b02960eeb40a102ef14f5556843c2c504358f3db21f3fe667d8346c9bdf",
+            "size": 939085053,
+            "uncompressed-sha256": "36379d083adccccb3de266d2802cfcf5079429865fa010d9b499e87042d46526",
+            "uncompressed-size": 3717201920
         },
         "metal4k": {
-            "path": "rhcos-47.83.202101161239-0-metal4k.x86_64.raw.gz",
-            "sha256": "6bb51ca132110ceaef096674a2d1479e3070e2ac431d487ad6fb7c5b32d7cb2b",
-            "size": 932475329,
-            "uncompressed-sha256": "0542fb53a52a7e4cc8b281791e525ccbef18b2c22535d86c029e821f5cdb25ee",
-            "uncompressed-size": 3711959040
+            "path": "rhcos-47.83.202102090044-0-metal4k.x86_64.raw.gz",
+            "sha256": "ff10909c5d4ffbb3a829d070dcf3ce9a8b2d2aebff2924ee464d517eb948bfba",
+            "size": 936609970,
+            "uncompressed-sha256": "d5821d7fbd20f86bab29d028855200221f316fa041e86374c5f693da9b5d7b83",
+            "uncompressed-size": 3717201920
         },
         "openstack": {
-            "path": "rhcos-47.83.202101161239-0-openstack.x86_64.qcow2.gz",
-            "sha256": "ccc2c776ce3d4bbb7585fdf497286c3694633f609bf7aeee42c5f8c274560bd2",
-            "size": 933246407,
-            "uncompressed-sha256": "f887d4cfb0cdcd459a08a37fea447ccca01fbb196399163ed58df5b2babe2893",
-            "uncompressed-size": 2355101696
+            "path": "rhcos-47.83.202102090044-0-openstack.x86_64.qcow2.gz",
+            "sha256": "e5ebb8bcf6d081e52e1e7db0e93ff960ff472e25803a5671170959212e88cad9",
+            "size": 937380970,
+            "uncompressed-sha256": "c1b93a426d0f74f0059193439e306f3356b788302a825cfadd870460e543028e",
+            "uncompressed-size": 2360082432
         },
         "ostree": {
-            "path": "rhcos-47.83.202101161239-0-ostree.x86_64.tar",
-            "sha256": "713db9420593740b5f1720f24dc992b9ee95f984a3e65236d91dc1dad9d359c1",
-            "size": 861102080
+            "path": "rhcos-47.83.202102090044-0-ostree.x86_64.tar",
+            "sha256": "3b5fc040f7493ff7dc5aef4da22077ad74eb2e12a01a9e820d5c116e58716c4f",
+            "size": 863467520
         },
         "qemu": {
-            "path": "rhcos-47.83.202101161239-0-qemu.x86_64.qcow2.gz",
-            "sha256": "ad40a0282a5c5af492d93302e5f79a2ea6673a863ac21a0fca752e7cdb099263",
-            "size": 934409208,
-            "uncompressed-sha256": "3a14ff77b4b7a5c89d145226759c71e852bd54eb8eea50866e760c801c7b623a",
-            "uncompressed-size": 2389114880
+            "path": "rhcos-47.83.202102090044-0-qemu.x86_64.qcow2.gz",
+            "sha256": "2ca82f1d762bba1cb2e5ac1386be0a1ab0264cf88b0594c9cd1e53d285833c6d",
+            "size": 938521497,
+            "uncompressed-sha256": "5d31652c7856a87450dce1bbbb561b578ee75443c190096cb977a814e5f35935",
+            "uncompressed-size": 2394030080
         },
         "vmware": {
-            "path": "rhcos-47.83.202101161239-0-vmware.x86_64.ova",
-            "sha256": "ef7366e778c14c14743bbfbb7b2a16a43a139f2ecbeb6bb73ad5b76745f034cd",
-            "size": 966850560
+            "path": "rhcos-47.83.202102090044-0-vmware.x86_64.ova",
+            "sha256": "13d92692b8eed717ff8d0d113a24add339a65ef1f12eceeb99dabcd922cc86d1",
+            "size": 970915840
         }
     },
     "oscontainer": {
-        "digest": "sha256:182c56ede5c330e7669ec2e6a6b7f54e94e92ca5983f9dbde555d0a3f500d5cd",
+        "digest": "sha256:a32077727aa2ef96a1e2371dbcc53ba06f3d9727e836b72be0f0dd4513937e1e",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "8e87a86b9444784ab29e7917fa82e00d5e356f18b19449946b687ee8dc27c51a",
-    "ostree-version": "47.83.202101161239-0"
+    "ostree-commit": "646a9832dd0dc9fe174a2fc005863a9582186518a5476522a0e9bdccc0e5252a",
+    "ostree-version": "47.83.202102090044-0"
 }


### PR DESCRIPTION
- amd64:   47.83.202102090044-0
- s390x:   47.83.202102090311-0
- ppc64le: 47.83.202102091015-0

(cherry picked from commit e653cfd1315e0d293864292fdef4d5af0c055745)

See: https://github.com/openshift/installer/pull/4633

(sdodson) Attempting to write down testing expectations, need at least installation to complete on all of our major platforms, either ipi or upi for each, doesn't matter:

- [x] e2e-aws
- [x] e2e-vmware*
- [x] e2e-ovirt
- [x] e2e-metal-ipi
- [x] e2e-azure*
- [x] e2e-gcp
- [x] e2e-metal
- [ ] e2e-openstack -- persistent infra problem, reached out to team