### PR TITLE
Bug 1925291: baremetal: include netmask in DNSMasq dhcp range

### DIFF
--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -1,6 +1,7 @@
 package baremetal
 
 import (
+	"fmt"
 	"net"
 	"strings"
 
@@ -57,8 +58,11 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 
 	switch config.ProvisioningNetwork {
 	case baremetal.ManagedProvisioningNetwork:
-		// When provisioning network is managed, we set a DHCP range:
-		templateData.ProvisioningDHCPRange = config.ProvisioningDHCPRange
+		cidr, _ := config.ProvisioningNetworkCIDR.Mask.Size()
+
+		// When provisioning network is managed, we set a DHCP range including
+		// netmask for dnsmasq.
+		templateData.ProvisioningDHCPRange = fmt.Sprintf("%s,%d", config.ProvisioningDHCPRange, cidr)
 
 		var dhcpAllowList []string
 		for _, host := range config.Hosts {

--- a/pkg/asset/ignition/bootstrap/baremetal/template_test.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template_test.go
@@ -35,7 +35,7 @@ func TestTemplatingIPv4(t *testing.T) {
 
 	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd")
 
-	assert.Equal(t, result.ProvisioningDHCPRange, "172.22.0.10,172.22.0.100")
+	assert.Equal(t, result.ProvisioningDHCPRange, "172.22.0.10,172.22.0.100,24")
 	assert.Equal(t, result.ProvisioningCIDR, 24)
 	assert.Equal(t, result.ProvisioningIPv6, false)
 	assert.Equal(t, result.ProvisioningIP, "172.22.0.2")
@@ -44,7 +44,25 @@ func TestTemplatingIPv4(t *testing.T) {
 	assert.Equal(t, result.IronicPassword, "passw0rd")
 }
 
-func TestTemplatingIPv6(t *testing.T) {
+func TestTemplatingManagedIPv6(t *testing.T) {
+	bareMetalConfig := baremetal.Platform{
+		ProvisioningNetworkCIDR: ipnet.MustParseCIDR("fd2e:6f44:5dd8:b856::0/80"),
+		ProvisioningDHCPRange:   "fd2e:6f44:5dd8:b856::1,fd2e:6f44:5dd8::ff",
+		BootstrapProvisioningIP: "fd2e:6f44:5dd8:b856::2",
+		ProvisioningNetwork:     baremetal.ManagedProvisioningNetwork,
+	}
+
+	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd")
+
+	assert.Equal(t, result.ProvisioningDHCPRange, "fd2e:6f44:5dd8:b856::1,fd2e:6f44:5dd8::ff,80")
+	assert.Equal(t, result.ProvisioningCIDR, 80)
+	assert.Equal(t, result.ProvisioningIPv6, true)
+	assert.Equal(t, result.ProvisioningIP, "fd2e:6f44:5dd8:b856::2")
+	assert.Equal(t, result.IronicUsername, "bootstrap-ironic-user")
+	assert.Equal(t, result.IronicPassword, "passw0rd")
+}
+
+func TestTemplatingUnmanagedIPv6(t *testing.T) {
 	bareMetalConfig := baremetal.Platform{
 		ProvisioningNetworkCIDR: ipnet.MustParseCIDR("fd2e:6f44:5dd8:b856::0/64"),
 		BootstrapProvisioningIP: "fd2e:6f44:5dd8:b856::2",


### PR DESCRIPTION
While deploying with IPv6 provision network with subnet other than /64
control plane hosts fail to PXE boot - this is due to DNSmasq defaulting
to /64. This updates the installer's bootstrap dnsmasq config to specify
the netmask.