### PR TITLE
Fix OWNERS for openstack

### DIFF
--- a/hack/openstack/OWNERS
+++ b/hack/openstack/OWNERS
@@ -1,1 +1,7 @@
-../../pkg/types/openstack/OWNERS
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - openstack-approvers
+reviewers:
+  - openstack-reviewers


### PR DESCRIPTION
Now OWNERS is a symbolic link and looks like github doesn't accept it. This commit makes OWNERS a regular text file.

/label platform/openstack