### PR TITLE
Add docs about issues on UPI with Kuryr

### DIFF
--- a/docs/user/openstack/known-issues.md
+++ b/docs/user/openstack/known-issues.md
@@ -112,3 +112,20 @@ When anti-affinity is a requirement, it is advised to rely on the more stable
 control plane replicas only. Add more nodes as a day-2 operation by assigning
 them a new Server group with "anti-affinity" policy. Use the `ServerGroupID`
 property of the Machine ProviderSpec.
+
+## Requirement to create Control Plane Machines manifests (Kuryr SDN)
+
+Installations with Kuryr SDN can timeout due to changes in the way Kuryr detects
+the OpenStack Subnet used by the cluster's nodes. Kuryr relied on the Network of
+the cluster's nodes Subnet having a specific tag, but the tag was removed for IPI
+Installations causing the need to discover it from the OpenShift Machine objects,
+which the creation is removed on one of the UPI steps. Until the fix for
+[the issue][bugzilla-upi] is available, as a workaround, only the compute machine
+manifests should be removed in the [Remove machines and machinesets][manifests-removal]
+section of the UPI guide. The command to run is:
+
+```console
+$ rm -f openshift/99_openshift-cluster-api_worker-machineset-*.yaml
+```
+[bugzilla-upi]: https://bugzilla.redhat.com/show_bug.cgi?id=1927244
+[manifests-removal]:../openstack/install_upi.md#remove-machines-and-machinesets


### PR DESCRIPTION
Installations with Kuryr can timeout because of
recent changes on the way the nodes' subnet is retrieved.
This commit adds a section to the know issues describing
why the issue occour and how to avoid it.