### PR TITLE
aws/session.go: include another internal provider name for static creds

### DIFF
--- a/pkg/asset/installconfig/aws/session.go
+++ b/pkg/asset/installconfig/aws/session.go
@@ -142,7 +142,7 @@ func getCredentialsFromSession(options session.Options) (*credentials.Credential
 // static credentials safe for installer to transfer to cluster for use as-is.
 func IsStaticCredentials(credsValue credentials.Value) bool {
 	switch credsValue.ProviderName {
-	case credentials.EnvProviderName, credentials.StaticProviderName, credentials.SharedCredsProviderName:
+	case credentials.EnvProviderName, credentials.StaticProviderName, credentials.SharedCredsProviderName, session.EnvProviderName:
 		return credsValue.SessionToken == ""
 	}
 	if strings.HasPrefix(credsValue.ProviderName, "SharedConfigCredentials") {


### PR DESCRIPTION
AWS SDK session uses another const for loading credentials from the ennvironment
see [1]. This is same as the env provider and should be treated like one.

[1]: https://github.com/aws/aws-sdk-go/blob/v1.37.10/aws/session/env_config.go#L16

/assign @staebler 
/cc @patrickdillon 