### PR TITLE
Bug 1917931: Fix GCP openssl not found error

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -3,14 +3,14 @@
 # It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
 
 
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:cli as cli
+FROM registry.ci.openshift.org/ocp/4.8:cli as cli
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:base
+FROM registry.ci.openshift.org/ocp/4.8:base
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi
@@ -31,12 +31,15 @@ RUN yum update -y && \
       unzip \
       openssh-clients \
       openssl \
-      pyOpenSSL \
       PyYAML \
       util-linux && \
     yum clean all && \
     rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
+
+RUN easy_install 'pip<21'
+RUN python -m pip install pyopenssl
+ENV CLOUDSDK_PYTHON=/usr/bin/python
 
 ENV TERRAFORM_VERSION=0.12.24
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \


### PR DESCRIPTION
With the current code, yum install pyopenssl is used to install
the openssl package that gcloud sdk needs to signurl which has
stopped working because gcloud is not able to pick up the package.

Added a code to install pip of a version less than 21 (pip support
for python 2 ends with pip version 21) and installed pyopenssl
which is the recommended way to install openssl for gcloud.