### PR TITLE
Bug 1928948: openstack: Allow to skip master replica validation

### DIFF
--- a/pkg/asset/installconfig/openstack/validate.go
+++ b/pkg/asset/installconfig/openstack/validate.go
@@ -42,6 +42,11 @@ func Validate(ic *types.InstallConfig) error {
 
 // ValidateForProvisioning validates that the install config is valid for provisioning the cluster.
 func ValidateForProvisioning(ic *types.InstallConfig) error {
+	if skip := os.Getenv("OPENSHIFT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS"); skip == "1" {
+		logrus.Warnf("OVERRIDE: pre-flight validation disabled.")
+		return nil
+	}
+
 	if ic.ControlPlane.Replicas != nil && *ic.ControlPlane.Replicas != 3 {
 		return field.Invalid(field.NewPath("controlPlane", "replicas"), ic.ControlPlane.Replicas, "control plane must be exactly three nodes when provisioning on OpenStack")
 	}


### PR DESCRIPTION
With this patch, when the environment variable
OPENSHIFT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS is set to "1", the
Installer skips the validation of the number of Control plane replicas.