### PR TITLE
upi/metal: add more configuration options for bare metal

### DIFF
--- a/upi/metal/README.md
+++ b/upi/metal/README.md
@@ -14,13 +14,13 @@ Create a public route53 zone using this [guide][aws-create-public-route53-zone].
 
 Setup `default` AWS cli profile on the host that will run the example terraform scripts using this [guide][aws-cli-configure-creds]
 
-### Packet
+### Equinix
 
-Setup a Project in Packet.net that will be used to deploy servers, for example using this [guide][packet-deploy-server]
+Setup a Project in Equinix.com that will be used to deploy servers, for example using this [guide][equinix-deploy-server]
 
-Setup API keys for your Project in Packet.net using this [guide][packet-api-keys]
+Setup API keys for your Project in Equinix.com using this [guide][equinix-api-keys]
 
-Store the API keys in `PACKET_AUTH_TOKEN` so that `terraform-provide-packet` can use it to deploy servers in the project. For more info see [this][terraform-provider-packet-auth]
+Store the API keys in `PACKET_AUTH_TOKEN` so that `terraform-provide-metal` can use it to deploy servers in the project. For more info see [this][terraform-provider-metal-auth]
 
 #### Terraform
 
@@ -43,8 +43,8 @@ terraform-examples config.tf > terraform.tfvars.example
 [aws-cli-configure-creds]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 [aws-create-public-route53-zone]: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html
 [coreos-matchbox-getting-started]: https://matchbox.psdn.io/getting-started/
-[packet-api-keys]: https://www.packet.com/developers/changelog/project-only-api-keys/
-[packet-deploy-server]: https://support.packet.com/kb/articles/deploy-a-server
+[equinix-api-keys]: https://metal.equinix.com/developers/docs/accounts/users/
+[equinix-deploy-server]: https://metal.equinix.com/developers/docs/deploy/
 [terraform-examples]: https://github.com/s-urbaniak/terraform-examples#terraform-examples
 [terraform-getting-started]: https://learn.hashicorp.com/terraform/getting-started/install.html
-[terraform-provider-packet-auth]: https://www.terraform.io/docs/providers/packet/index.html#auth_token
+[terraform-provider-metal-auth]: https://registry.terraform.io/providers/equinix/metal/latest/docs#auth_token

--- a/upi/metal/bootstrap/outputs.tf
+++ b/upi/metal/bootstrap/outputs.tf
@@ -1,11 +1,11 @@
 output "device_ip" {
-  value = packet_device.bootstrap.network[0].address
+  value = metal_device.bootstrap.network[0].address
 }
 
 output "device_hostname" {
-  value = packet_device.bootstrap.hostname
+  value = metal_device.bootstrap.hostname
 }
 
 output "device_id" {
-  value = packet_device.bootstrap.id
+  value = metal_device.bootstrap.id
 }

--- a/upi/metal/bootstrap/packet.tf
+++ b/upi/metal/bootstrap/packet.tf
@@ -1,11 +1,12 @@
 resource "packet_device" "bootstrap" {
-  hostname         = "${var.cluster_id}-bootstrap"
-  plan             = "c1.small.x86"
-  facilities       = [var.packet_facility]
-  operating_system = "custom_ipxe"
-  ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=bootstrap"
-  billing_cycle    = "hourly"
-  project_id       = var.packet_project_id
+  hostname                = "${var.cluster_id}-bootstrap"
+  plan                    = var.packet_plan
+  facilities              = [var.packet_facility]
+  operating_system        = "custom_ipxe"
+  ipxe_script_url         = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=bootstrap"
+  billing_cycle           = "hourly"
+  project_id              = var.packet_project_id
+  hardware_reservation_id = var.packet_hardware_reservation_id
 
   depends_on = [matchbox_group.bootstrap]
 }

--- a/upi/metal/bootstrap/packet.tf
+++ b/upi/metal/bootstrap/packet.tf
@@ -1,12 +1,12 @@
-resource "packet_device" "bootstrap" {
+resource "metal_device" "bootstrap" {
   hostname                = "${var.cluster_id}-bootstrap"
-  plan                    = var.packet_plan
-  facilities              = [var.packet_facility]
+  plan                    = var.metal_plan
+  facilities              = [var.metal_facility]
   operating_system        = "custom_ipxe"
   ipxe_script_url         = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=bootstrap"
   billing_cycle           = "hourly"
-  project_id              = var.packet_project_id
-  hardware_reservation_id = var.packet_hardware_reservation_id
+  project_id              = var.metal_project_id
+  hardware_reservation_id = var.metal_hardware_reservation_id
 
   depends_on = [matchbox_group.bootstrap]
 }

--- a/upi/metal/bootstrap/variables.tf
+++ b/upi/metal/bootstrap/variables.tf
@@ -29,3 +29,11 @@ variable "packet_facility" {
 variable "packet_project_id" {
   type = string
 }
+
+variable "packet_plan" {
+  type = string
+}
+
+variable "packet_hardware_reservation_id" {
+  type = string
+}

--- a/upi/metal/bootstrap/variables.tf
+++ b/upi/metal/bootstrap/variables.tf
@@ -22,18 +22,18 @@ variable "igntion_config_content" {
   type = string
 }
 
-variable "packet_facility" {
+variable "metal_facility" {
   type = string
 }
 
-variable "packet_project_id" {
+variable "metal_project_id" {
   type = string
 }
 
-variable "packet_plan" {
+variable "metal_plan" {
   type = string
 }
 
-variable "packet_hardware_reservation_id" {
+variable "metal_hardware_reservation_id" {
   type = string
 }

--- a/upi/metal/config.tf
+++ b/upi/metal/config.tf
@@ -167,41 +167,41 @@ EOF
 
 # ================PACKET=====================
 
-variable "packet_project_id" {
+variable "metal_project_id" {
   type = string
 
   description = <<EOF
-The Project ID for Packet.net where servers will be deployed.
+The Project ID for Equinix where servers will be deployed.
 EOF
 
 }
 
-variable "packet_plan" {
+variable "metal_plan" {
   type    = string
   default = "c1.small.x86"
 
   description = <<EOF
-The Packet.Net device plan slug.
+The Equinix device plan slug.
 EOF
 
 }
 
-variable "packet_facility" {
+variable "metal_facility" {
   type    = string
   default = "any"
 
   description = <<EOF
-The Packet.Net facilities code to be used.
+The Equinix facilities code to be used.
 EOF
 
 }
 
-variable "packet_hardware_reservation_id" {
+variable "metal_hardware_reservation_id" {
   type    = string
   default = ""
 
   description = <<EOF
-The UUID of the hardware reservation where you want this device deployed on Packet.net.
+The UUID of the hardware reservation where you want this device deployed on Equinix.
 EOF
 
 }

--- a/upi/metal/config.tf
+++ b/upi/metal/config.tf
@@ -133,7 +133,7 @@ EOF
 }
 
 variable "pxe_kernel_args" {
-  type = string
+  type    = string
   default = ""
 
   description = <<EOF
@@ -172,6 +172,36 @@ variable "packet_project_id" {
 
   description = <<EOF
 The Project ID for Packet.net where servers will be deployed.
+EOF
+
+}
+
+variable "packet_plan" {
+  type    = string
+  default = "c1.small.x86"
+
+  description = <<EOF
+The Packet.Net device plan slug.
+EOF
+
+}
+
+variable "packet_facility" {
+  type    = string
+  default = "any"
+
+  description = <<EOF
+The Packet.Net facilities code to be used.
+EOF
+
+}
+
+variable "packet_hardware_reservation_id" {
+  type    = string
+  default = ""
+
+  description = <<EOF
+The UUID of the hardware reservation where you want this device deployed on Packet.net.
 EOF
 
 }

--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -91,37 +91,37 @@ resource "matchbox_group" "worker" {
   }
 }
 
-# ================PACKET=====================
+# ================METAL=====================
 
-provider "packet" {
-  version = "3.2.0"
+provider "metal" {
+  version = "1.0.0"
 }
 
-resource "packet_device" "masters" {
+resource "metal_device" "masters" {
   count                   = var.master_count
   hostname                = "master-${count.index}.${var.cluster_domain}"
-  plan                    = var.packet_plan
-  facilities              = [var.packet_facility]
+  plan                    = var.metal_plan
+  facilities              = [var.metal_facility]
   operating_system        = "custom_ipxe"
   ipxe_script_url         = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=master"
   billing_cycle           = "hourly"
-  project_id              = var.packet_project_id
-  //hardware_reservation_id = var.packet_hardware_reservation_id
+  project_id              = var.metal_project_id
+  //hardware_reservation_id = var.metal_hardware_reservation_id
   hardware_reservation_id = ""
 
   depends_on = [matchbox_group.master]
 }
 
-resource "packet_device" "workers" {
+resource "metal_device" "workers" {
   count                   = var.worker_count
   hostname                = "worker-${count.index}.${var.cluster_domain}"
-  plan                    = var.packet_plan
-  facilities              = [var.packet_facility]
+  plan                    = var.metal_plan
+  facilities              = [var.metal_facility]
   operating_system        = "custom_ipxe"
   ipxe_script_url         = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=worker"
   billing_cycle           = "hourly"
-  project_id              = var.packet_project_id
-  //hardware_reservation_id = var.packet_hardware_reservation_id
+  project_id              = var.metal_project_id
+  //hardware_reservation_id = var.metal_hardware_reservation_id
   hardware_reservation_id = ""
 
   depends_on = [matchbox_group.worker]
@@ -143,12 +143,12 @@ module "bootstrap" {
 
   cluster_id = var.cluster_id
 
-  packet_facility   = var.packet_facility
-  packet_project_id = var.packet_project_id
-  packet_plan       = var.packet_plan
+  metal_facility   = var.metal_facility
+  metal_project_id = var.metal_project_id
+  metal_plan       = var.metal_plan
 
-  //packet_hardware_reservation_id = var.packet_hardware_reservation_id
-  packet_hardware_reservation_id = ""
+  //metal_hardware_reservation_id = var.metal_hardware_reservation_id
+  metal_hardware_reservation_id = ""
 }
 
 # ================AWS=====================
@@ -158,10 +158,10 @@ provider aws {
 }
 
 locals {
-  master_public_ipv4_networks = flatten(packet_device.masters.*.network)
+  master_public_ipv4_networks = flatten(metal_device.masters.*.network)
   master_public_ipv4          = data.template_file.master_ips.*.rendered
 
-  worker_public_ipv4_networks = flatten(packet_device.workers.*.network)
+  worker_public_ipv4_networks = flatten(metal_device.workers.*.network)
   worker_public_ipv4          = data.template_file.worker_ips.*.rendered
   ctrp_records                = compact(concat(var.bootstrap_dns ? [module.bootstrap.device_ip] : [], local.master_public_ipv4))
 }

--- a/upi/metal/main.tf
+++ b/upi/metal/main.tf
@@ -93,34 +93,36 @@ resource "matchbox_group" "worker" {
 
 # ================PACKET=====================
 
-provider "packet" {}
-
-locals {
-  packet_facility = "sjc1"
+provider "packet" {
+  version = "3.2.0"
 }
 
 resource "packet_device" "masters" {
-  count            = var.master_count
-  hostname         = "master-${count.index}.${var.cluster_domain}"
-  plan             = "c1.small.x86"
-  facilities       = ["any"]
-  operating_system = "custom_ipxe"
-  ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=master"
-  billing_cycle    = "hourly"
-  project_id       = var.packet_project_id
+  count                   = var.master_count
+  hostname                = "master-${count.index}.${var.cluster_domain}"
+  plan                    = var.packet_plan
+  facilities              = [var.packet_facility]
+  operating_system        = "custom_ipxe"
+  ipxe_script_url         = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=master"
+  billing_cycle           = "hourly"
+  project_id              = var.packet_project_id
+  //hardware_reservation_id = var.packet_hardware_reservation_id
+  hardware_reservation_id = ""
 
   depends_on = [matchbox_group.master]
 }
 
 resource "packet_device" "workers" {
-  count            = var.worker_count
-  hostname         = "worker-${count.index}.${var.cluster_domain}"
-  plan             = "c1.small.x86"
-  facilities       = ["any"]
-  operating_system = "custom_ipxe"
-  ipxe_script_url  = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=worker"
-  billing_cycle    = "hourly"
-  project_id       = var.packet_project_id
+  count                   = var.worker_count
+  hostname                = "worker-${count.index}.${var.cluster_domain}"
+  plan                    = var.packet_plan
+  facilities              = [var.packet_facility]
+  operating_system        = "custom_ipxe"
+  ipxe_script_url         = "${var.matchbox_http_endpoint}/ipxe?cluster_id=${var.cluster_id}&role=worker"
+  billing_cycle           = "hourly"
+  project_id              = var.packet_project_id
+  //hardware_reservation_id = var.packet_hardware_reservation_id
+  hardware_reservation_id = ""
 
   depends_on = [matchbox_group.worker]
 }
@@ -130,9 +132,9 @@ resource "packet_device" "workers" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  pxe_kernel             = local.pxe_kernel
-  pxe_initrd             = local.pxe_initrd
-  pxe_kernel_args        = concat(
+  pxe_kernel = local.pxe_kernel
+  pxe_initrd = local.pxe_initrd
+  pxe_kernel_args = concat(
     local.kernel_args,
     [var.pxe_kernel_args],
   )
@@ -141,8 +143,12 @@ module "bootstrap" {
 
   cluster_id = var.cluster_id
 
-  packet_facility   = "any"
+  packet_facility   = var.packet_facility
   packet_project_id = var.packet_project_id
+  packet_plan       = var.packet_plan
+
+  //packet_hardware_reservation_id = var.packet_hardware_reservation_id
+  packet_hardware_reservation_id = ""
 }
 
 # ================AWS=====================

--- a/upi/metal/terraform.tfvars.example
+++ b/upi/metal/terraform.tfvars.example
@@ -39,18 +39,18 @@ matchbox_rpc_endpoint = ""
 // Certificate Authority certificate to trust the matchbox endpoint.
 matchbox_trusted_ca_cert = "matchbox/tls/ca.crt"
 
-// The Project ID for Packet.net where servers will be deployed.
-packet_project_id = ""
+// The Project ID for Equinix.com where servers will be deployed.
+metal_project_id = ""
 
-// The Packet.Net device plan slug.
-packet_plan = "c1.small.x86"
+// The Equinix.com device plan slug.
+metal_plan = "c1.small.x86"
 
-// The Packet.Net facilities code(s) to be used.
-packet_facility = "any"
+// The Equinix.com facilities code(s) to be used.
+metal_facility = "any"
 
-// The UUID of the hardware reservation where you want this device deployed on Packet.net.
+// The UUID of the hardware reservation where you want this device deployed on Equinix.com.
 // The value "next-available" can also be used instead of a specific UUID. 
-packet_hardware_reservation_id = ""
+metal_hardware_reservation_id = ""
 
 // The name of the public route53 zone that should be used to create DNS records for the cluster.
 public_r53_zone = ""

--- a/upi/metal/terraform.tfvars.example
+++ b/upi/metal/terraform.tfvars.example
@@ -42,6 +42,16 @@ matchbox_trusted_ca_cert = "matchbox/tls/ca.crt"
 // The Project ID for Packet.net where servers will be deployed.
 packet_project_id = ""
 
+// The Packet.Net device plan slug.
+packet_plan = "c1.small.x86"
+
+// The Packet.Net facilities code(s) to be used.
+packet_facility = "any"
+
+// The UUID of the hardware reservation where you want this device deployed on Packet.net.
+// The value "next-available" can also be used instead of a specific UUID. 
+packet_hardware_reservation_id = ""
+
 // The name of the public route53 zone that should be used to create DNS records for the cluster.
 public_r53_zone = ""
 


### PR DESCRIPTION
Allow facilities, plan and hardware_reservation_id to be configured

Replace packet provider with new Equinix metal provider. The packet provider is now deprecated and now longer being worked on. All bugfixes now occur in the metal provider.

See https://bugzilla.redhat.com/show_bug.cgi?id=1925343