### PR TITLE
Bug 1873079: openstack: restrict SSH to machineNetwork CIDR

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -27,13 +27,12 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ssh" {
-  direction      = "ingress"
-  ethertype      = "IPv4"
-  protocol       = "tcp"
-  port_range_min = 22
-  port_range_max = 22
-  # FIXME(mandre) AWS only allows SSH from cidr_block
-  remote_ip_prefix  = "0.0.0.0/0"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -17,13 +17,12 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
-  direction      = "ingress"
-  ethertype      = "IPv4"
-  protocol       = "tcp"
-  port_range_min = 22
-  port_range_max = 22
-  # FIXME(mandre) AWS only allows SSH from cidr_block
-  remote_ip_prefix  = "0.0.0.0/0"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
 }
 

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -43,6 +43,7 @@
     os_security_group_rule:
       security_group: "{{ os_sg_master }}"
       protocol: tcp
+      remote_ip_prefix: "{{ os_subnet_range }}"
       port_range_min: 22
       port_range_max: 22
 
@@ -197,6 +198,7 @@
     os_security_group_rule:
       security_group: "{{ os_sg_worker }}"
       protocol: tcp
+      remote_ip_prefix: "{{ os_subnet_range }}"
       port_range_min: 22
       port_range_max: 22
 


### PR DESCRIPTION
TL;DR: SSH shouldn't be exposed to the public by default and if an
operator explicitly wants it, they should do it by modifying the
security group on day 2.

Reasons to not open SSH to all networks:

* SSH to an OCP cluster should be done only by advanced operators and
  shouldn't be encouraged, therefore not open by default that easily. Instead, an experienced operator should make configuration changes via `machineconfig` objects.

* Operators who know what they do should reach the nodes from a secure
  network (e.g. provider network or tenant network, ie internal). Not
  from a public network (e.g. Internet or any public faced network).

* Other cloud providers don't allow SSH from 0.0.0.0/0, we shouldn't be
  the one doing it.

* Running `oc debug` doesn't require SSH to be open from the client.
