### PR TITLE
vSphere: mark imported virtual machines as template

### DIFF
--- a/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
+++ b/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
@@ -363,6 +363,18 @@ func resourceVSpherePrivateImportOvaCreate(d *schema.ResourceData, meta interfac
 
 	log.Printf("[DEBUG] %s: ova import complete", d.Get("name").(string))
 
+	vm := object.NewVirtualMachine(client, info.Entity)
+	if vm == nil {
+		return fmt.Errorf("error VirtualMachine not found, managed object id: %s", d.Id())
+	}
+	log.Printf("[DEBUG] %s: mark as template", vm.Name())
+
+	err = vm.MarkAsTemplate(ctx)
+	if err != nil {
+		return errors.Errorf("failed to mark vm as template: %s", err)
+	}
+	log.Printf("[DEBUG] %s: mark as template complete", vm.Name())
+
 	return resourceVSpherePrivateImportOvaRead(d, meta)
 }
 


### PR DESCRIPTION
From internal forums it was suggested that marking
the imported RHCOS virtual machines as a template
would be better than leaving it as a virtual machine.

This PR adds to the end of the `resourceVSpherePrivateImportOvaCreate`
fuction:

- From `info.Entity` get the VirtualMachine
- If the VirtualMachine exists, mark as a template