### PR TITLE
use vendored mockgen for generating mock clients

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -295,7 +295,6 @@ github.com/coreos/ignition v0.34.0/go.mod h1:WJQapxzEn9DE0ryxsGvm8QnBajm/XsS/Pkr
 github.com/coreos/ignition v0.35.0 h1:UFodoYq1mOPrbEjtxIsZbThcDyQwAI1owczRDqWmKkQ=
 github.com/coreos/ignition v0.35.0/go.mod h1:WJQapxzEn9DE0ryxsGvm8QnBajm/XsS/PkrDqSpz+bA=
 github.com/coreos/ignition/v2 v2.1.1/go.mod h1:RqmqU64zxarUJa3l4cHtbhcSwfQLpUhv0WVziZwoXvE=
-github.com/coreos/ignition/v2 v2.3.0 h1:TK+STbzVe6KZp4tQ2IaNSRMiWX4/diNngep1F7tP7Zk=
 github.com/coreos/ignition/v2 v2.3.0/go.mod h1:85dmM/CERMZXNrJsXqtNLIxR/dn8G9qlL1CmEjCugp0=
 github.com/coreos/ignition/v2 v2.9.0 h1:Zl5N08OyqlECB8BrBlMDp3Jf1ShwVTtREPcUq/YO034=
 github.com/coreos/ignition/v2 v2.9.0/go.mod h1:A5lFFzA2/zvZQPVEvI1lR5WPLWRb7KZ7Q1QOeUMtcAc=
@@ -305,7 +304,6 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/prometheus-operator v0.35.0/go.mod h1:XHYZUStZWcwd1yk/1DjZv/fywqKIyAJ6pSwvIr+v9BQ=
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068/go.mod h1:E+6hug9bFSe0KZ2ZAzr8M9F5JlArJjv5D1JS7KSkPKE=
 github.com/coreos/vcontext v0.0.0-20191017033345-260217907eb5/go.mod h1:E+6hug9bFSe0KZ2ZAzr8M9F5JlArJjv5D1JS7KSkPKE=
-github.com/coreos/vcontext v0.0.0-20200225161404-ee043618d38d h1:Nu473BdYOxcnhFfPrl1ihpCtxI/VZr2IfhVIHDGP43Y=
 github.com/coreos/vcontext v0.0.0-20200225161404-ee043618d38d/go.mod h1:z4pMVvaUrxs98RROlIYdAQCKhEicjnTirOaVyDRH5h8=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c h1:jA28WeORitsxGFVWhyWB06sAG2HbLHPQuHwDydhU2CQ=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c/go.mod h1:z4pMVvaUrxs98RROlIYdAQCKhEicjnTirOaVyDRH5h8=
@@ -590,7 +588,6 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
-github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
@@ -690,7 +687,6 @@ github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055/go.mod 
 github.com/gophercloud/utils v0.0.0-20190124231947-9c3b9f2457ef/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
 github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
-github.com/gophercloud/utils v0.0.0-20210202040619-eca783186fc4 h1:cMAAW/VtHAO72V4r1qlLOJ0bCHPaQrZB8j5aK7XcpSg=
 github.com/gophercloud/utils v0.0.0-20210202040619-eca783186fc4/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
 github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae h1:Hi3IgB9RQDE15Kfovd8MTZrcana+UlQqNbOif8dLpA0=
 github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
@@ -973,7 +969,6 @@ github.com/klauspost/cpuid v0.0.0-20180405133222-e7e905edc00e/go.mod h1:Pj4uuM52
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/hack/go-genmock.sh
+++ b/hack/go-genmock.sh
@@ -2,13 +2,13 @@
 # Example:  ./hack/go-genmock.sh
 
 if [ "$IS_CONTAINER" != "" ]; then
+  go install github.com/golang/mock/mockgen
   go generate ./pkg/asset/installconfig/... "${@}"
 else
-  podman build -t openshift-install-mock ./images/mock
   podman run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    openshift-install-mock \
+    docker.io/openshift/origin-release:golang-1.14 \
     ./hack/go-genmock.sh "${@}"
 fi

--- a/images/mock/Dockerfile
+++ b/images/mock/Dockerfile
@@ -1,3 +1,0 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
-
-RUN go get github.com/golang/mock/gomock github.com/golang/mock/mockgen

--- a/pkg/asset/installconfig/azure/mock/azureclient_generated.go
+++ b/pkg/asset/installconfig/azure/mock/azureclient_generated.go
@@ -6,39 +6,38 @@ package mock
 
 import (
 	context "context"
-	reflect "reflect"
-
 	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-12-01/network"
 	resources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	subscriptions "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-06-01/subscriptions"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockAPI is a mock of API interface.
+// MockAPI is a mock of API interface
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI.
+// MockAPIMockRecorder is the mock recorder for MockAPI
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance.
+// NewMockAPI creates a new mock instance
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// GetVirtualNetwork mocks base method.
+// GetVirtualNetwork mocks base method
 func (m *MockAPI) GetVirtualNetwork(ctx context.Context, resourceGroupName, virtualNetwork string) (*network.VirtualNetwork, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVirtualNetwork", ctx, resourceGroupName, virtualNetwork)
@@ -47,13 +46,13 @@ func (m *MockAPI) GetVirtualNetwork(ctx context.Context, resourceGroupName, virt
 	return ret0, ret1
 }
 
-// GetVirtualNetwork indicates an expected call of GetVirtualNetwork.
+// GetVirtualNetwork indicates an expected call of GetVirtualNetwork
 func (mr *MockAPIMockRecorder) GetVirtualNetwork(ctx, resourceGroupName, virtualNetwork interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualNetwork", reflect.TypeOf((*MockAPI)(nil).GetVirtualNetwork), ctx, resourceGroupName, virtualNetwork)
 }
 
-// GetComputeSubnet mocks base method.
+// GetComputeSubnet mocks base method
 func (m *MockAPI) GetComputeSubnet(ctx context.Context, resourceGroupName, virtualNetwork, subnet string) (*network.Subnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetComputeSubnet", ctx, resourceGroupName, virtualNetwork, subnet)
@@ -62,13 +61,13 @@ func (m *MockAPI) GetComputeSubnet(ctx context.Context, resourceGroupName, virtu
 	return ret0, ret1
 }
 
-// GetComputeSubnet indicates an expected call of GetComputeSubnet.
+// GetComputeSubnet indicates an expected call of GetComputeSubnet
 func (mr *MockAPIMockRecorder) GetComputeSubnet(ctx, resourceGroupName, virtualNetwork, subnet interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetComputeSubnet", reflect.TypeOf((*MockAPI)(nil).GetComputeSubnet), ctx, resourceGroupName, virtualNetwork, subnet)
 }
 
-// GetControlPlaneSubnet mocks base method.
+// GetControlPlaneSubnet mocks base method
 func (m *MockAPI) GetControlPlaneSubnet(ctx context.Context, resourceGroupName, virtualNetwork, subnet string) (*network.Subnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetControlPlaneSubnet", ctx, resourceGroupName, virtualNetwork, subnet)
@@ -77,13 +76,13 @@ func (m *MockAPI) GetControlPlaneSubnet(ctx context.Context, resourceGroupName, 
 	return ret0, ret1
 }
 
-// GetControlPlaneSubnet indicates an expected call of GetControlPlaneSubnet.
+// GetControlPlaneSubnet indicates an expected call of GetControlPlaneSubnet
 func (mr *MockAPIMockRecorder) GetControlPlaneSubnet(ctx, resourceGroupName, virtualNetwork, subnet interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneSubnet", reflect.TypeOf((*MockAPI)(nil).GetControlPlaneSubnet), ctx, resourceGroupName, virtualNetwork, subnet)
 }
 
-// ListLocations mocks base method.
+// ListLocations mocks base method
 func (m *MockAPI) ListLocations(ctx context.Context) (*[]subscriptions.Location, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListLocations", ctx)
@@ -92,13 +91,13 @@ func (m *MockAPI) ListLocations(ctx context.Context) (*[]subscriptions.Location,
 	return ret0, ret1
 }
 
-// ListLocations indicates an expected call of ListLocations.
+// ListLocations indicates an expected call of ListLocations
 func (mr *MockAPIMockRecorder) ListLocations(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLocations", reflect.TypeOf((*MockAPI)(nil).ListLocations), ctx)
 }
 
-// GetResourcesProvider mocks base method.
+// GetResourcesProvider mocks base method
 func (m *MockAPI) GetResourcesProvider(ctx context.Context, resourceProviderNamespace string) (*resources.Provider, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesProvider", ctx, resourceProviderNamespace)
@@ -107,13 +106,13 @@ func (m *MockAPI) GetResourcesProvider(ctx context.Context, resourceProviderName
 	return ret0, ret1
 }
 
-// GetResourcesProvider indicates an expected call of GetResourcesProvider.
+// GetResourcesProvider indicates an expected call of GetResourcesProvider
 func (mr *MockAPIMockRecorder) GetResourcesProvider(ctx, resourceProviderNamespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesProvider", reflect.TypeOf((*MockAPI)(nil).GetResourcesProvider), ctx, resourceProviderNamespace)
 }
 
-// GetVirtualMachineSku mocks base method.
+// GetVirtualMachineSku mocks base method
 func (m *MockAPI) GetVirtualMachineSku(ctx context.Context, name, region string) (*compute.ResourceSku, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVirtualMachineSku", ctx, name, region)
@@ -122,13 +121,13 @@ func (m *MockAPI) GetVirtualMachineSku(ctx context.Context, name, region string)
 	return ret0, ret1
 }
 
-// GetVirtualMachineSku indicates an expected call of GetVirtualMachineSku.
+// GetVirtualMachineSku indicates an expected call of GetVirtualMachineSku
 func (mr *MockAPIMockRecorder) GetVirtualMachineSku(ctx, name, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualMachineSku", reflect.TypeOf((*MockAPI)(nil).GetVirtualMachineSku), ctx, name, region)
 }
 
-// GetDiskSkus mocks base method.
+// GetDiskSkus mocks base method
 func (m *MockAPI) GetDiskSkus(ctx context.Context, region string) ([]compute.ResourceSku, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDiskSkus", ctx, region)
@@ -137,13 +136,13 @@ func (m *MockAPI) GetDiskSkus(ctx context.Context, region string) ([]compute.Res
 	return ret0, ret1
 }
 
-// GetDiskSkus indicates an expected call of GetDiskSkus.
+// GetDiskSkus indicates an expected call of GetDiskSkus
 func (mr *MockAPIMockRecorder) GetDiskSkus(ctx, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskSkus", reflect.TypeOf((*MockAPI)(nil).GetDiskSkus), ctx, region)
 }
 
-// GetGroup mocks base method.
+// GetGroup mocks base method
 func (m *MockAPI) GetGroup(ctx context.Context, groupName string) (*resources.Group, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGroup", ctx, groupName)
@@ -152,13 +151,13 @@ func (m *MockAPI) GetGroup(ctx context.Context, groupName string) (*resources.Gr
 	return ret0, ret1
 }
 
-// GetGroup indicates an expected call of GetGroup.
+// GetGroup indicates an expected call of GetGroup
 func (mr *MockAPIMockRecorder) GetGroup(ctx, groupName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroup", reflect.TypeOf((*MockAPI)(nil).GetGroup), ctx, groupName)
 }
 
-// ListResourceIDsByGroup mocks base method.
+// ListResourceIDsByGroup mocks base method
 func (m *MockAPI) ListResourceIDsByGroup(ctx context.Context, groupName string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceIDsByGroup", ctx, groupName)
@@ -167,7 +166,7 @@ func (m *MockAPI) ListResourceIDsByGroup(ctx context.Context, groupName string) 
 	return ret0, ret1
 }
 
-// ListResourceIDsByGroup indicates an expected call of ListResourceIDsByGroup.
+// ListResourceIDsByGroup indicates an expected call of ListResourceIDsByGroup
 func (mr *MockAPIMockRecorder) ListResourceIDsByGroup(ctx, groupName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceIDsByGroup", reflect.TypeOf((*MockAPI)(nil).ListResourceIDsByGroup), ctx, groupName)

--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -6,37 +6,36 @@ package mock
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	compute "google.golang.org/api/compute/v1"
 	dns "google.golang.org/api/dns/v1"
+	reflect "reflect"
 )
 
-// MockAPI is a mock of API interface.
+// MockAPI is a mock of API interface
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI.
+// MockAPIMockRecorder is the mock recorder for MockAPI
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance.
+// NewMockAPI creates a new mock instance
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// GetNetwork mocks base method.
+// GetNetwork mocks base method
 func (m *MockAPI) GetNetwork(ctx context.Context, network, project string) (*compute.Network, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNetwork", ctx, network, project)
@@ -45,13 +44,13 @@ func (m *MockAPI) GetNetwork(ctx context.Context, network, project string) (*com
 	return ret0, ret1
 }
 
-// GetNetwork indicates an expected call of GetNetwork.
+// GetNetwork indicates an expected call of GetNetwork
 func (mr *MockAPIMockRecorder) GetNetwork(ctx, network, project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetwork", reflect.TypeOf((*MockAPI)(nil).GetNetwork), ctx, network, project)
 }
 
-// GetMachineType mocks base method.
+// GetMachineType mocks base method
 func (m *MockAPI) GetMachineType(ctx context.Context, project, zone, machineType string) (*compute.MachineType, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineType", ctx, project, zone, machineType)
@@ -60,13 +59,13 @@ func (m *MockAPI) GetMachineType(ctx context.Context, project, zone, machineType
 	return ret0, ret1
 }
 
-// GetMachineType indicates an expected call of GetMachineType.
+// GetMachineType indicates an expected call of GetMachineType
 func (mr *MockAPIMockRecorder) GetMachineType(ctx, project, zone, machineType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineType", reflect.TypeOf((*MockAPI)(nil).GetMachineType), ctx, project, zone, machineType)
 }
 
-// GetPublicDomains mocks base method.
+// GetPublicDomains mocks base method
 func (m *MockAPI) GetPublicDomains(ctx context.Context, project string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPublicDomains", ctx, project)
@@ -75,13 +74,13 @@ func (m *MockAPI) GetPublicDomains(ctx context.Context, project string) ([]strin
 	return ret0, ret1
 }
 
-// GetPublicDomains indicates an expected call of GetPublicDomains.
+// GetPublicDomains indicates an expected call of GetPublicDomains
 func (mr *MockAPIMockRecorder) GetPublicDomains(ctx, project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicDomains", reflect.TypeOf((*MockAPI)(nil).GetPublicDomains), ctx, project)
 }
 
-// GetPublicDNSZone mocks base method.
+// GetPublicDNSZone mocks base method
 func (m *MockAPI) GetPublicDNSZone(ctx context.Context, project, baseDomain string) (*dns.ManagedZone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPublicDNSZone", ctx, project, baseDomain)
@@ -90,13 +89,13 @@ func (m *MockAPI) GetPublicDNSZone(ctx context.Context, project, baseDomain stri
 	return ret0, ret1
 }
 
-// GetPublicDNSZone indicates an expected call of GetPublicDNSZone.
+// GetPublicDNSZone indicates an expected call of GetPublicDNSZone
 func (mr *MockAPIMockRecorder) GetPublicDNSZone(ctx, project, baseDomain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicDNSZone", reflect.TypeOf((*MockAPI)(nil).GetPublicDNSZone), ctx, project, baseDomain)
 }
 
-// GetSubnetworks mocks base method.
+// GetSubnetworks mocks base method
 func (m *MockAPI) GetSubnetworks(ctx context.Context, network, project, region string) ([]*compute.Subnetwork, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubnetworks", ctx, network, project, region)
@@ -105,13 +104,13 @@ func (m *MockAPI) GetSubnetworks(ctx context.Context, network, project, region s
 	return ret0, ret1
 }
 
-// GetSubnetworks indicates an expected call of GetSubnetworks.
+// GetSubnetworks indicates an expected call of GetSubnetworks
 func (mr *MockAPIMockRecorder) GetSubnetworks(ctx, network, project, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetworks", reflect.TypeOf((*MockAPI)(nil).GetSubnetworks), ctx, network, project, region)
 }
 
-// GetProjects mocks base method.
+// GetProjects mocks base method
 func (m *MockAPI) GetProjects(ctx context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProjects", ctx)
@@ -120,13 +119,13 @@ func (m *MockAPI) GetProjects(ctx context.Context) (map[string]string, error) {
 	return ret0, ret1
 }
 
-// GetProjects indicates an expected call of GetProjects.
+// GetProjects indicates an expected call of GetProjects
 func (mr *MockAPIMockRecorder) GetProjects(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockAPI)(nil).GetProjects), ctx)
 }
 
-// GetRecordSets mocks base method.
+// GetRecordSets mocks base method
 func (m *MockAPI) GetRecordSets(ctx context.Context, project, zone string) ([]*dns.ResourceRecordSet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRecordSets", ctx, project, zone)
@@ -135,13 +134,13 @@ func (m *MockAPI) GetRecordSets(ctx context.Context, project, zone string) ([]*d
 	return ret0, ret1
 }
 
-// GetRecordSets indicates an expected call of GetRecordSets.
+// GetRecordSets indicates an expected call of GetRecordSets
 func (mr *MockAPIMockRecorder) GetRecordSets(ctx, project, zone interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecordSets", reflect.TypeOf((*MockAPI)(nil).GetRecordSets), ctx, project, zone)
 }
 
-// GetZones mocks base method.
+// GetZones mocks base method
 func (m *MockAPI) GetZones(ctx context.Context, project, filter string) ([]*compute.Zone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetZones", ctx, project, filter)
@@ -150,13 +149,13 @@ func (m *MockAPI) GetZones(ctx context.Context, project, filter string) ([]*comp
 	return ret0, ret1
 }
 
-// GetZones indicates an expected call of GetZones.
+// GetZones indicates an expected call of GetZones
 func (mr *MockAPIMockRecorder) GetZones(ctx, project, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetZones", reflect.TypeOf((*MockAPI)(nil).GetZones), ctx, project, filter)
 }
 
-// GetEnabledServices mocks base method.
+// GetEnabledServices mocks base method
 func (m *MockAPI) GetEnabledServices(ctx context.Context, project string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEnabledServices", ctx, project)
@@ -165,7 +164,7 @@ func (m *MockAPI) GetEnabledServices(ctx context.Context, project string) ([]str
 	return ret0, ret1
 }
 
-// GetEnabledServices indicates an expected call of GetEnabledServices.
+// GetEnabledServices indicates an expected call of GetEnabledServices
 func (mr *MockAPIMockRecorder) GetEnabledServices(ctx, project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledServices", reflect.TypeOf((*MockAPI)(nil).GetEnabledServices), ctx, project)

--- a/tools.go
+++ b/tools.go
@@ -11,4 +11,7 @@ import (
 
 	// dependency of generating CRD for install-config
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
+
+	// used to generate mocks
+	_ "github.com/golang/mock/mockgen"
 )

--- a/vendor/github.com/golang/mock/mockgen/mockgen.go
+++ b/vendor/github.com/golang/mock/mockgen/mockgen.go
@@ -1,0 +1,659 @@
+// Copyright 2010 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// MockGen generates mock implementations of Go interfaces.
+package main
+
+// TODO: This does not support recursive embedded interfaces.
+// TODO: This does not support embedding package-local interfaces in a separate file.
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/build"
+	"go/format"
+	"go/token"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/golang/mock/mockgen/model"
+)
+
+const (
+	gomockImportPath = "github.com/golang/mock/gomock"
+)
+
+var (
+	version = ""
+	commit  = "none"
+	date    = "unknown"
+)
+
+var (
+	source          = flag.String("source", "", "(source mode) Input Go source file; enables source mode.")
+	destination     = flag.String("destination", "", "Output file; defaults to stdout.")
+	mockNames       = flag.String("mock_names", "", "Comma-separated interfaceName=mockName pairs of explicit mock names to use. Mock names default to 'Mock'+ interfaceName suffix.")
+	packageOut      = flag.String("package", "", "Package of the generated code; defaults to the package of the input with a 'mock_' prefix.")
+	selfPackage     = flag.String("self_package", "", "The full package import path for the generated code. The purpose of this flag is to prevent import cycles in the generated code by trying to include its own package. This can happen if the mock's package is set to one of its inputs (usually the main one) and the output is stdio so mockgen cannot detect the final output package. Setting this flag will then tell mockgen which import to exclude.")
+	writePkgComment = flag.Bool("write_package_comment", true, "Writes package documentation comment (godoc) if true.")
+	copyrightFile   = flag.String("copyright_file", "", "Copyright file used to add copyright header")
+
+	debugParser = flag.Bool("debug_parser", false, "Print out parser results only.")
+	showVersion = flag.Bool("version", false, "Print version.")
+)
+
+func main() {
+	flag.Usage = usage
+	flag.Parse()
+
+	if *showVersion {
+		printVersion()
+		return
+	}
+
+	var pkg *model.Package
+	var err error
+	var packageName string
+	if *source != "" {
+		pkg, err = sourceMode(*source)
+	} else {
+		if flag.NArg() != 2 {
+			usage()
+			log.Fatal("Expected exactly two arguments")
+		}
+		packageName = flag.Arg(0)
+		if packageName == "." {
+			dir, err := os.Getwd()
+			if err != nil {
+				log.Fatalf("Get current directory failed: %v", err)
+			}
+			packageName, err = packageNameOfDir(dir)
+			if err != nil {
+				log.Fatalf("Parse package name failed: %v", err)
+			}
+		}
+		pkg, err = reflectMode(packageName, strings.Split(flag.Arg(1), ","))
+	}
+	if err != nil {
+		log.Fatalf("Loading input failed: %v", err)
+	}
+
+	if *debugParser {
+		pkg.Print(os.Stdout)
+		return
+	}
+
+	dst := os.Stdout
+	if len(*destination) > 0 {
+		if err := os.MkdirAll(filepath.Dir(*destination), os.ModePerm); err != nil {
+			log.Fatalf("Unable to create directory: %v", err)
+		}
+		f, err := os.Create(*destination)
+		if err != nil {
+			log.Fatalf("Failed opening destination file: %v", err)
+		}
+		defer f.Close()
+		dst = f
+	}
+
+	outputPackageName := *packageOut
+	if outputPackageName == "" {
+		// pkg.Name in reflect mode is the base name of the import path,
+		// which might have characters that are illegal to have in package names.
+		outputPackageName = "mock_" + sanitize(pkg.Name)
+	}
+
+	// outputPackagePath represents the fully qualified name of the package of
+	// the generated code. Its purposes are to prevent the module from importing
+	// itself and to prevent qualifying type names that come from its own
+	// package (i.e. if there is a type called X then we want to print "X" not
+	// "package.X" since "package" is this package). This can happen if the mock
+	// is output into an already existing package.
+	outputPackagePath := *selfPackage
+	if len(outputPackagePath) == 0 && len(*destination) > 0 {
+		dst, _ := filepath.Abs(filepath.Dir(*destination))
+		for _, prefix := range build.Default.SrcDirs() {
+			if strings.HasPrefix(dst, prefix) {
+				if rel, err := filepath.Rel(prefix, dst); err == nil {
+					outputPackagePath = rel
+					break
+				}
+			}
+		}
+	}
+
+	g := new(generator)
+	if *source != "" {
+		g.filename = *source
+	} else {
+		g.srcPackage = packageName
+		g.srcInterfaces = flag.Arg(1)
+	}
+
+	if *mockNames != "" {
+		g.mockNames = parseMockNames(*mockNames)
+	}
+	if *copyrightFile != "" {
+		header, err := ioutil.ReadFile(*copyrightFile)
+		if err != nil {
+			log.Fatalf("Failed reading copyright file: %v", err)
+		}
+
+		g.copyrightHeader = string(header)
+	}
+	if err := g.Generate(pkg, outputPackageName, outputPackagePath); err != nil {
+		log.Fatalf("Failed generating mock: %v", err)
+	}
+	if _, err := dst.Write(g.Output()); err != nil {
+		log.Fatalf("Failed writing to destination: %v", err)
+	}
+}
+
+func parseMockNames(names string) map[string]string {
+	mocksMap := make(map[string]string)
+	for _, kv := range strings.Split(names, ",") {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 || parts[1] == "" {
+			log.Fatalf("bad mock names spec: %v", kv)
+		}
+		mocksMap[parts[0]] = parts[1]
+	}
+	return mocksMap
+}
+
+func usage() {
+	_, _ = io.WriteString(os.Stderr, usageText)
+	flag.PrintDefaults()
+}
+
+const usageText = `mockgen has two modes of operation: source and reflect.
+
+Source mode generates mock interfaces from a source file.
+It is enabled by using the -source flag. Other flags that
+may be useful in this mode are -imports and -aux_files.
+Example:
+	mockgen -source=foo.go [other options]
+
+Reflect mode generates mock interfaces by building a program
+that uses reflection to understand interfaces. It is enabled
+by passing two non-flag arguments: an import path, and a
+comma-separated list of symbols.
+Example:
+	mockgen database/sql/driver Conn,Driver
+
+`
+
+type generator struct {
+	buf                       bytes.Buffer
+	indent                    string
+	mockNames                 map[string]string // may be empty
+	filename                  string            // may be empty
+	srcPackage, srcInterfaces string            // may be empty
+	copyrightHeader           string
+
+	packageMap map[string]string // map from import path to package name
+}
+
+func (g *generator) p(format string, args ...interface{}) {
+	fmt.Fprintf(&g.buf, g.indent+format+"\n", args...)
+}
+
+func (g *generator) in() {
+	g.indent += "\t"
+}
+
+func (g *generator) out() {
+	if len(g.indent) > 0 {
+		g.indent = g.indent[0 : len(g.indent)-1]
+	}
+}
+
+func removeDot(s string) string {
+	if len(s) > 0 && s[len(s)-1] == '.' {
+		return s[0 : len(s)-1]
+	}
+	return s
+}
+
+// sanitize cleans up a string to make a suitable package name.
+func sanitize(s string) string {
+	t := ""
+	for _, r := range s {
+		if t == "" {
+			if unicode.IsLetter(r) || r == '_' {
+				t += string(r)
+				continue
+			}
+		} else {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+				t += string(r)
+				continue
+			}
+		}
+		t += "_"
+	}
+	if t == "_" {
+		t = "x"
+	}
+	return t
+}
+
+func (g *generator) Generate(pkg *model.Package, outputPkgName string, outputPackagePath string) error {
+	if outputPkgName != pkg.Name && *selfPackage == "" {
+		// reset outputPackagePath if it's not passed in through -self_package
+		outputPackagePath = ""
+	}
+
+	if g.copyrightHeader != "" {
+		lines := strings.Split(g.copyrightHeader, "\n")
+		for _, line := range lines {
+			g.p("// %s", line)
+		}
+		g.p("")
+	}
+
+	g.p("// Code generated by MockGen. DO NOT EDIT.")
+	if g.filename != "" {
+		g.p("// Source: %v", g.filename)
+	} else {
+		g.p("// Source: %v (interfaces: %v)", g.srcPackage, g.srcInterfaces)
+	}
+	g.p("")
+
+	// Get all required imports, and generate unique names for them all.
+	im := pkg.Imports()
+	im[gomockImportPath] = true
+
+	// Only import reflect if it's used. We only use reflect in mocked methods
+	// so only import if any of the mocked interfaces have methods.
+	for _, intf := range pkg.Interfaces {
+		if len(intf.Methods) > 0 {
+			im["reflect"] = true
+			break
+		}
+	}
+
+	// Sort keys to make import alias generation predictable
+	sortedPaths := make([]string, len(im))
+	x := 0
+	for pth := range im {
+		sortedPaths[x] = pth
+		x++
+	}
+	sort.Strings(sortedPaths)
+
+	packagesName := createPackageMap(sortedPaths)
+
+	g.packageMap = make(map[string]string, len(im))
+	localNames := make(map[string]bool, len(im))
+	for _, pth := range sortedPaths {
+		base, ok := packagesName[pth]
+		if !ok {
+			base = sanitize(path.Base(pth))
+		}
+
+		// Local names for an imported package can usually be the basename of the import path.
+		// A couple of situations don't permit that, such as duplicate local names
+		// (e.g. importing "html/template" and "text/template"), or where the basename is
+		// a keyword (e.g. "foo/case").
+		// try base0, base1, ...
+		pkgName := base
+		i := 0
+		for localNames[pkgName] || token.Lookup(pkgName).IsKeyword() {
+			pkgName = base + strconv.Itoa(i)
+			i++
+		}
+
+		// Avoid importing package if source pkg == output pkg
+		if pth == pkg.PkgPath && outputPkgName == pkg.Name {
+			continue
+		}
+
+		g.packageMap[pth] = pkgName
+		localNames[pkgName] = true
+	}
+
+	if *writePkgComment {
+		g.p("// Package %v is a generated GoMock package.", outputPkgName)
+	}
+	g.p("package %v", outputPkgName)
+	g.p("")
+	g.p("import (")
+	g.in()
+	for pkgPath, pkgName := range g.packageMap {
+		if pkgPath == outputPackagePath {
+			continue
+		}
+		g.p("%v %q", pkgName, pkgPath)
+	}
+	for _, pkgPath := range pkg.DotImports {
+		g.p(". %q", pkgPath)
+	}
+	g.out()
+	g.p(")")
+
+	for _, intf := range pkg.Interfaces {
+		if err := g.GenerateMockInterface(intf, outputPackagePath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// The name of the mock type to use for the given interface identifier.
+func (g *generator) mockName(typeName string) string {
+	if mockName, ok := g.mockNames[typeName]; ok {
+		return mockName
+	}
+
+	return "Mock" + typeName
+}
+
+func (g *generator) GenerateMockInterface(intf *model.Interface, outputPackagePath string) error {
+	mockType := g.mockName(intf.Name)
+
+	g.p("")
+	g.p("// %v is a mock of %v interface", mockType, intf.Name)
+	g.p("type %v struct {", mockType)
+	g.in()
+	g.p("ctrl     *gomock.Controller")
+	g.p("recorder *%vMockRecorder", mockType)
+	g.out()
+	g.p("}")
+	g.p("")
+
+	g.p("// %vMockRecorder is the mock recorder for %v", mockType, mockType)
+	g.p("type %vMockRecorder struct {", mockType)
+	g.in()
+	g.p("mock *%v", mockType)
+	g.out()
+	g.p("}")
+	g.p("")
+
+	// TODO: Re-enable this if we can import the interface reliably.
+	// g.p("// Verify that the mock satisfies the interface at compile time.")
+	// g.p("var _ %v = (*%v)(nil)", typeName, mockType)
+	// g.p("")
+
+	g.p("// New%v creates a new mock instance", mockType)
+	g.p("func New%v(ctrl *gomock.Controller) *%v {", mockType, mockType)
+	g.in()
+	g.p("mock := &%v{ctrl: ctrl}", mockType)
+	g.p("mock.recorder = &%vMockRecorder{mock}", mockType)
+	g.p("return mock")
+	g.out()
+	g.p("}")
+	g.p("")
+
+	// XXX: possible name collision here if someone has EXPECT in their interface.
+	g.p("// EXPECT returns an object that allows the caller to indicate expected use")
+	g.p("func (m *%v) EXPECT() *%vMockRecorder {", mockType, mockType)
+	g.in()
+	g.p("return m.recorder")
+	g.out()
+	g.p("}")
+
+	g.GenerateMockMethods(mockType, intf, outputPackagePath)
+
+	return nil
+}
+
+func (g *generator) GenerateMockMethods(mockType string, intf *model.Interface, pkgOverride string) {
+	for _, m := range intf.Methods {
+		g.p("")
+		_ = g.GenerateMockMethod(mockType, m, pkgOverride)
+		g.p("")
+		_ = g.GenerateMockRecorderMethod(mockType, m)
+	}
+}
+
+func makeArgString(argNames, argTypes []string) string {
+	args := make([]string, len(argNames))
+	for i, name := range argNames {
+		// specify the type only once for consecutive args of the same type
+		if i+1 < len(argTypes) && argTypes[i] == argTypes[i+1] {
+			args[i] = name
+		} else {
+			args[i] = name + " " + argTypes[i]
+		}
+	}
+	return strings.Join(args, ", ")
+}
+
+// GenerateMockMethod generates a mock method implementation.
+// If non-empty, pkgOverride is the package in which unqualified types reside.
+func (g *generator) GenerateMockMethod(mockType string, m *model.Method, pkgOverride string) error {
+	argNames := g.getArgNames(m)
+	argTypes := g.getArgTypes(m, pkgOverride)
+	argString := makeArgString(argNames, argTypes)
+
+	rets := make([]string, len(m.Out))
+	for i, p := range m.Out {
+		rets[i] = p.Type.String(g.packageMap, pkgOverride)
+	}
+	retString := strings.Join(rets, ", ")
+	if len(rets) > 1 {
+		retString = "(" + retString + ")"
+	}
+	if retString != "" {
+		retString = " " + retString
+	}
+
+	ia := newIdentifierAllocator(argNames)
+	idRecv := ia.allocateIdentifier("m")
+
+	g.p("// %v mocks base method", m.Name)
+	g.p("func (%v *%v) %v(%v)%v {", idRecv, mockType, m.Name, argString, retString)
+	g.in()
+	g.p("%s.ctrl.T.Helper()", idRecv)
+
+	var callArgs string
+	if m.Variadic == nil {
+		if len(argNames) > 0 {
+			callArgs = ", " + strings.Join(argNames, ", ")
+		}
+	} else {
+		// Non-trivial. The generated code must build a []interface{},
+		// but the variadic argument may be any type.
+		idVarArgs := ia.allocateIdentifier("varargs")
+		idVArg := ia.allocateIdentifier("a")
+		g.p("%s := []interface{}{%s}", idVarArgs, strings.Join(argNames[:len(argNames)-1], ", "))
+		g.p("for _, %s := range %s {", idVArg, argNames[len(argNames)-1])
+		g.in()
+		g.p("%s = append(%s, %s)", idVarArgs, idVarArgs, idVArg)
+		g.out()
+		g.p("}")
+		callArgs = ", " + idVarArgs + "..."
+	}
+	if len(m.Out) == 0 {
+		g.p(`%v.ctrl.Call(%v, %q%v)`, idRecv, idRecv, m.Name, callArgs)
+	} else {
+		idRet := ia.allocateIdentifier("ret")
+		g.p(`%v := %v.ctrl.Call(%v, %q%v)`, idRet, idRecv, idRecv, m.Name, callArgs)
+
+		// Go does not allow "naked" type assertions on nil values, so we use the two-value form here.
+		// The value of that is either (x.(T), true) or (Z, false), where Z is the zero value for T.
+		// Happily, this coincides with the semantics we want here.
+		retNames := make([]string, len(rets))
+		for i, t := range rets {
+			retNames[i] = ia.allocateIdentifier(fmt.Sprintf("ret%d", i))
+			g.p("%s, _ := %s[%d].(%s)", retNames[i], idRet, i, t)
+		}
+		g.p("return " + strings.Join(retNames, ", "))
+	}
+
+	g.out()
+	g.p("}")
+	return nil
+}
+
+func (g *generator) GenerateMockRecorderMethod(mockType string, m *model.Method) error {
+	argNames := g.getArgNames(m)
+
+	var argString string
+	if m.Variadic == nil {
+		argString = strings.Join(argNames, ", ")
+	} else {
+		argString = strings.Join(argNames[:len(argNames)-1], ", ")
+	}
+	if argString != "" {
+		argString += " interface{}"
+	}
+
+	if m.Variadic != nil {
+		if argString != "" {
+			argString += ", "
+		}
+		argString += fmt.Sprintf("%s ...interface{}", argNames[len(argNames)-1])
+	}
+
+	ia := newIdentifierAllocator(argNames)
+	idRecv := ia.allocateIdentifier("mr")
+
+	g.p("// %v indicates an expected call of %v", m.Name, m.Name)
+	g.p("func (%s *%vMockRecorder) %v(%v) *gomock.Call {", idRecv, mockType, m.Name, argString)
+	g.in()
+	g.p("%s.mock.ctrl.T.Helper()", idRecv)
+
+	var callArgs string
+	if m.Variadic == nil {
+		if len(argNames) > 0 {
+			callArgs = ", " + strings.Join(argNames, ", ")
+		}
+	} else {
+		if len(argNames) == 1 {
+			// Easy: just use ... to push the arguments through.
+			callArgs = ", " + argNames[0] + "..."
+		} else {
+			// Hard: create a temporary slice.
+			idVarArgs := ia.allocateIdentifier("varargs")
+			g.p("%s := append([]interface{}{%s}, %s...)",
+				idVarArgs,
+				strings.Join(argNames[:len(argNames)-1], ", "),
+				argNames[len(argNames)-1])
+			callArgs = ", " + idVarArgs + "..."
+		}
+	}
+	g.p(`return %s.mock.ctrl.RecordCallWithMethodType(%s.mock, "%s", reflect.TypeOf((*%s)(nil).%s)%s)`, idRecv, idRecv, m.Name, mockType, m.Name, callArgs)
+
+	g.out()
+	g.p("}")
+	return nil
+}
+
+func (g *generator) getArgNames(m *model.Method) []string {
+	argNames := make([]string, len(m.In))
+	for i, p := range m.In {
+		name := p.Name
+		if name == "" || name == "_" {
+			name = fmt.Sprintf("arg%d", i)
+		}
+		argNames[i] = name
+	}
+	if m.Variadic != nil {
+		name := m.Variadic.Name
+		if name == "" {
+			name = fmt.Sprintf("arg%d", len(m.In))
+		}
+		argNames = append(argNames, name)
+	}
+	return argNames
+}
+
+func (g *generator) getArgTypes(m *model.Method, pkgOverride string) []string {
+	argTypes := make([]string, len(m.In))
+	for i, p := range m.In {
+		argTypes[i] = p.Type.String(g.packageMap, pkgOverride)
+	}
+	if m.Variadic != nil {
+		argTypes = append(argTypes, "..."+m.Variadic.Type.String(g.packageMap, pkgOverride))
+	}
+	return argTypes
+}
+
+type identifierAllocator map[string]struct{}
+
+func newIdentifierAllocator(taken []string) identifierAllocator {
+	a := make(identifierAllocator, len(taken))
+	for _, s := range taken {
+		a[s] = struct{}{}
+	}
+	return a
+}
+
+func (o identifierAllocator) allocateIdentifier(want string) string {
+	id := want
+	for i := 2; ; i++ {
+		if _, ok := o[id]; !ok {
+			o[id] = struct{}{}
+			return id
+		}
+		id = want + "_" + strconv.Itoa(i)
+	}
+}
+
+// Output returns the generator's output, formatted in the standard Go style.
+func (g *generator) Output() []byte {
+	src, err := format.Source(g.buf.Bytes())
+	if err != nil {
+		log.Fatalf("Failed to format generated source code: %s\n%s", err, g.buf.String())
+	}
+	return src
+}
+
+// createPackageMap returns a map of import path to package name
+// for specified importPaths.
+func createPackageMap(importPaths []string) map[string]string {
+	var pkg struct {
+		Name       string
+		ImportPath string
+	}
+	pkgMap := make(map[string]string)
+	b := bytes.NewBuffer(nil)
+	args := []string{"list", "-json"}
+	args = append(args, importPaths...)
+	cmd := exec.Command("go", args...)
+	cmd.Stdout = b
+	cmd.Run()
+	dec := json.NewDecoder(b)
+	for dec.More() {
+		err := dec.Decode(&pkg)
+		if err != nil {
+			log.Printf("failed to decode 'go list' output: %v", err)
+			continue
+		}
+		pkgMap[pkg.ImportPath] = pkg.Name
+	}
+	return pkgMap
+}
+
+func printVersion() {
+	if version != "" {
+		fmt.Printf("v%s\nCommit: %s\nDate: %s\n", version, commit, date)
+	} else {
+		printModuleVersion()
+	}
+}

--- a/vendor/github.com/golang/mock/mockgen/model/model.go
+++ b/vendor/github.com/golang/mock/mockgen/model/model.go
@@ -1,0 +1,470 @@
+// Copyright 2012 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package model contains the data model necessary for generating mock implementations.
+package model
+
+import (
+	"encoding/gob"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+)
+
+// pkgPath is the importable path for package model
+const pkgPath = "github.com/golang/mock/mockgen/model"
+
+// Package is a Go package. It may be a subset.
+type Package struct {
+	Name       string
+	PkgPath    string
+	Interfaces []*Interface
+	DotImports []string
+}
+
+// Print writes the package name and its exported interfaces.
+func (pkg *Package) Print(w io.Writer) {
+	_, _ = fmt.Fprintf(w, "package %s\n", pkg.Name)
+	for _, intf := range pkg.Interfaces {
+		intf.Print(w)
+	}
+}
+
+// Imports returns the imports needed by the Package as a set of import paths.
+func (pkg *Package) Imports() map[string]bool {
+	im := make(map[string]bool)
+	for _, intf := range pkg.Interfaces {
+		intf.addImports(im)
+	}
+	return im
+}
+
+// Interface is a Go interface.
+type Interface struct {
+	Name    string
+	Methods []*Method
+}
+
+// Print writes the interface name and its methods.
+func (intf *Interface) Print(w io.Writer) {
+	_, _ = fmt.Fprintf(w, "interface %s\n", intf.Name)
+	for _, m := range intf.Methods {
+		m.Print(w)
+	}
+}
+
+func (intf *Interface) addImports(im map[string]bool) {
+	for _, m := range intf.Methods {
+		m.addImports(im)
+	}
+}
+
+// Method is a single method of an interface.
+type Method struct {
+	Name     string
+	In, Out  []*Parameter
+	Variadic *Parameter // may be nil
+}
+
+// Print writes the method name and its signature.
+func (m *Method) Print(w io.Writer) {
+	_, _ = fmt.Fprintf(w, "  - method %s\n", m.Name)
+	if len(m.In) > 0 {
+		_, _ = fmt.Fprintf(w, "    in:\n")
+		for _, p := range m.In {
+			p.Print(w)
+		}
+	}
+	if m.Variadic != nil {
+		_, _ = fmt.Fprintf(w, "    ...:\n")
+		m.Variadic.Print(w)
+	}
+	if len(m.Out) > 0 {
+		_, _ = fmt.Fprintf(w, "    out:\n")
+		for _, p := range m.Out {
+			p.Print(w)
+		}
+	}
+}
+
+func (m *Method) addImports(im map[string]bool) {
+	for _, p := range m.In {
+		p.Type.addImports(im)
+	}
+	if m.Variadic != nil {
+		m.Variadic.Type.addImports(im)
+	}
+	for _, p := range m.Out {
+		p.Type.addImports(im)
+	}
+}
+
+// Parameter is an argument or return parameter of a method.
+type Parameter struct {
+	Name string // may be empty
+	Type Type
+}
+
+// Print writes a method parameter.
+func (p *Parameter) Print(w io.Writer) {
+	n := p.Name
+	if n == "" {
+		n = `""`
+	}
+	_, _ = fmt.Fprintf(w, "    - %v: %v\n", n, p.Type.String(nil, ""))
+}
+
+// Type is a Go type.
+type Type interface {
+	String(pm map[string]string, pkgOverride string) string
+	addImports(im map[string]bool)
+}
+
+func init() {
+	gob.Register(&ArrayType{})
+	gob.Register(&ChanType{})
+	gob.Register(&FuncType{})
+	gob.Register(&MapType{})
+	gob.Register(&NamedType{})
+	gob.Register(&PointerType{})
+
+	// Call gob.RegisterName to make sure it has the consistent name registered
+	// for both gob decoder and encoder.
+	//
+	// For a non-pointer type, gob.Register will try to get package full path by
+	// calling rt.PkgPath() for a name to register. If your project has vendor
+	// directory, it is possible that PkgPath will get a path like this:
+	//     ../../../vendor/github.com/golang/mock/mockgen/model
+	gob.RegisterName(pkgPath+".PredeclaredType", PredeclaredType(""))
+}
+
+// ArrayType is an array or slice type.
+type ArrayType struct {
+	Len  int // -1 for slices, >= 0 for arrays
+	Type Type
+}
+
+func (at *ArrayType) String(pm map[string]string, pkgOverride string) string {
+	s := "[]"
+	if at.Len > -1 {
+		s = fmt.Sprintf("[%d]", at.Len)
+	}
+	return s + at.Type.String(pm, pkgOverride)
+}
+
+func (at *ArrayType) addImports(im map[string]bool) { at.Type.addImports(im) }
+
+// ChanType is a channel type.
+type ChanType struct {
+	Dir  ChanDir // 0, 1 or 2
+	Type Type
+}
+
+func (ct *ChanType) String(pm map[string]string, pkgOverride string) string {
+	s := ct.Type.String(pm, pkgOverride)
+	if ct.Dir == RecvDir {
+		return "<-chan " + s
+	}
+	if ct.Dir == SendDir {
+		return "chan<- " + s
+	}
+	return "chan " + s
+}
+
+func (ct *ChanType) addImports(im map[string]bool) { ct.Type.addImports(im) }
+
+// ChanDir is a channel direction.
+type ChanDir int
+
+// Constants for channel directions.
+const (
+	RecvDir ChanDir = 1
+	SendDir ChanDir = 2
+)
+
+// FuncType is a function type.
+type FuncType struct {
+	In, Out  []*Parameter
+	Variadic *Parameter // may be nil
+}
+
+func (ft *FuncType) String(pm map[string]string, pkgOverride string) string {
+	args := make([]string, len(ft.In))
+	for i, p := range ft.In {
+		args[i] = p.Type.String(pm, pkgOverride)
+	}
+	if ft.Variadic != nil {
+		args = append(args, "..."+ft.Variadic.Type.String(pm, pkgOverride))
+	}
+	rets := make([]string, len(ft.Out))
+	for i, p := range ft.Out {
+		rets[i] = p.Type.String(pm, pkgOverride)
+	}
+	retString := strings.Join(rets, ", ")
+	if nOut := len(ft.Out); nOut == 1 {
+		retString = " " + retString
+	} else if nOut > 1 {
+		retString = " (" + retString + ")"
+	}
+	return "func(" + strings.Join(args, ", ") + ")" + retString
+}
+
+func (ft *FuncType) addImports(im map[string]bool) {
+	for _, p := range ft.In {
+		p.Type.addImports(im)
+	}
+	if ft.Variadic != nil {
+		ft.Variadic.Type.addImports(im)
+	}
+	for _, p := range ft.Out {
+		p.Type.addImports(im)
+	}
+}
+
+// MapType is a map type.
+type MapType struct {
+	Key, Value Type
+}
+
+func (mt *MapType) String(pm map[string]string, pkgOverride string) string {
+	return "map[" + mt.Key.String(pm, pkgOverride) + "]" + mt.Value.String(pm, pkgOverride)
+}
+
+func (mt *MapType) addImports(im map[string]bool) {
+	mt.Key.addImports(im)
+	mt.Value.addImports(im)
+}
+
+// NamedType is an exported type in a package.
+type NamedType struct {
+	Package string // may be empty
+	Type    string // TODO: should this be typed Type?
+}
+
+func (nt *NamedType) String(pm map[string]string, pkgOverride string) string {
+	// TODO: is this right?
+	if pkgOverride == nt.Package {
+		return nt.Type
+	}
+	prefix := pm[nt.Package]
+	if prefix != "" {
+		return prefix + "." + nt.Type
+	}
+
+	return nt.Type
+}
+
+func (nt *NamedType) addImports(im map[string]bool) {
+	if nt.Package != "" {
+		im[nt.Package] = true
+	}
+}
+
+// PointerType is a pointer to another type.
+type PointerType struct {
+	Type Type
+}
+
+func (pt *PointerType) String(pm map[string]string, pkgOverride string) string {
+	return "*" + pt.Type.String(pm, pkgOverride)
+}
+func (pt *PointerType) addImports(im map[string]bool) { pt.Type.addImports(im) }
+
+// PredeclaredType is a predeclared type such as "int".
+type PredeclaredType string
+
+func (pt PredeclaredType) String(map[string]string, string) string { return string(pt) }
+func (pt PredeclaredType) addImports(map[string]bool)              {}
+
+// The following code is intended to be called by the program generated by ../reflect.go.
+
+// InterfaceFromInterfaceType returns a pointer to an interface for the
+// given reflection interface type.
+func InterfaceFromInterfaceType(it reflect.Type) (*Interface, error) {
+	if it.Kind() != reflect.Interface {
+		return nil, fmt.Errorf("%v is not an interface", it)
+	}
+	intf := &Interface{}
+
+	for i := 0; i < it.NumMethod(); i++ {
+		mt := it.Method(i)
+		// TODO: need to skip unexported methods? or just raise an error?
+		m := &Method{
+			Name: mt.Name,
+		}
+
+		var err error
+		m.In, m.Variadic, m.Out, err = funcArgsFromType(mt.Type)
+		if err != nil {
+			return nil, err
+		}
+
+		intf.Methods = append(intf.Methods, m)
+	}
+
+	return intf, nil
+}
+
+// t's Kind must be a reflect.Func.
+func funcArgsFromType(t reflect.Type) (in []*Parameter, variadic *Parameter, out []*Parameter, err error) {
+	nin := t.NumIn()
+	if t.IsVariadic() {
+		nin--
+	}
+	var p *Parameter
+	for i := 0; i < nin; i++ {
+		p, err = parameterFromType(t.In(i))
+		if err != nil {
+			return
+		}
+		in = append(in, p)
+	}
+	if t.IsVariadic() {
+		p, err = parameterFromType(t.In(nin).Elem())
+		if err != nil {
+			return
+		}
+		variadic = p
+	}
+	for i := 0; i < t.NumOut(); i++ {
+		p, err = parameterFromType(t.Out(i))
+		if err != nil {
+			return
+		}
+		out = append(out, p)
+	}
+	return
+}
+
+func parameterFromType(t reflect.Type) (*Parameter, error) {
+	tt, err := typeFromType(t)
+	if err != nil {
+		return nil, err
+	}
+	return &Parameter{Type: tt}, nil
+}
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+var byteType = reflect.TypeOf(byte(0))
+
+func typeFromType(t reflect.Type) (Type, error) {
+	// Hack workaround for https://golang.org/issue/3853.
+	// This explicit check should not be necessary.
+	if t == byteType {
+		return PredeclaredType("byte"), nil
+	}
+
+	if imp := t.PkgPath(); imp != "" {
+		return &NamedType{
+			Package: impPath(imp),
+			Type:    t.Name(),
+		}, nil
+	}
+
+	// only unnamed or predeclared types after here
+
+	// Lots of types have element types. Let's do the parsing and error checking for all of them.
+	var elemType Type
+	switch t.Kind() {
+	case reflect.Array, reflect.Chan, reflect.Map, reflect.Ptr, reflect.Slice:
+		var err error
+		elemType, err = typeFromType(t.Elem())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	switch t.Kind() {
+	case reflect.Array:
+		return &ArrayType{
+			Len:  t.Len(),
+			Type: elemType,
+		}, nil
+	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128, reflect.String:
+		return PredeclaredType(t.Kind().String()), nil
+	case reflect.Chan:
+		var dir ChanDir
+		switch t.ChanDir() {
+		case reflect.RecvDir:
+			dir = RecvDir
+		case reflect.SendDir:
+			dir = SendDir
+		}
+		return &ChanType{
+			Dir:  dir,
+			Type: elemType,
+		}, nil
+	case reflect.Func:
+		in, variadic, out, err := funcArgsFromType(t)
+		if err != nil {
+			return nil, err
+		}
+		return &FuncType{
+			In:       in,
+			Out:      out,
+			Variadic: variadic,
+		}, nil
+	case reflect.Interface:
+		// Two special interfaces.
+		if t.NumMethod() == 0 {
+			return PredeclaredType("interface{}"), nil
+		}
+		if t == errorType {
+			return PredeclaredType("error"), nil
+		}
+	case reflect.Map:
+		kt, err := typeFromType(t.Key())
+		if err != nil {
+			return nil, err
+		}
+		return &MapType{
+			Key:   kt,
+			Value: elemType,
+		}, nil
+	case reflect.Ptr:
+		return &PointerType{
+			Type: elemType,
+		}, nil
+	case reflect.Slice:
+		return &ArrayType{
+			Len:  -1,
+			Type: elemType,
+		}, nil
+	case reflect.Struct:
+		if t.NumField() == 0 {
+			return PredeclaredType("struct{}"), nil
+		}
+	}
+
+	// TODO: Struct, UnsafePointer
+	return nil, fmt.Errorf("can't yet turn %v (%v) into a model.Type", t, t.Kind())
+}
+
+// impPath sanitizes the package path returned by `PkgPath` method of a reflect Type so that
+// it is importable. PkgPath might return a path that includes "vendor". These paths do not
+// compile, so we need to remove everything up to and including "/vendor/".
+// See https://github.com/golang/go/issues/12019.
+func impPath(imp string) string {
+	if strings.HasPrefix(imp, "vendor/") {
+		imp = "/" + imp
+	}
+	if i := strings.LastIndex(imp, "/vendor/"); i != -1 {
+		imp = imp[i+len("/vendor/"):]
+	}
+	return imp
+}

--- a/vendor/github.com/golang/mock/mockgen/parse.go
+++ b/vendor/github.com/golang/mock/mockgen/parse.go
@@ -1,0 +1,565 @@
+// Copyright 2012 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// This file contains the model construction by parsing source files.
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"log"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/golang/mock/mockgen/model"
+	"golang.org/x/tools/go/packages"
+)
+
+var (
+	imports  = flag.String("imports", "", "(source mode) Comma-separated name=path pairs of explicit imports to use.")
+	auxFiles = flag.String("aux_files", "", "(source mode) Comma-separated pkg=path pairs of auxiliary Go source files.")
+)
+
+// TODO: simplify error reporting
+
+// sourceMode generates mocks via source file.
+func sourceMode(source string) (*model.Package, error) {
+	srcDir, err := filepath.Abs(filepath.Dir(source))
+	if err != nil {
+		return nil, fmt.Errorf("failed getting source directory: %v", err)
+	}
+
+	packageImport, err := parsePackageImport(source, srcDir)
+	if err != nil {
+		return nil, err
+	}
+
+	fs := token.NewFileSet()
+	file, err := parser.ParseFile(fs, source, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed parsing source file %v: %v", source, err)
+	}
+
+	p := &fileParser{
+		fileSet:            fs,
+		imports:            make(map[string]string),
+		importedInterfaces: make(map[string]map[string]*ast.InterfaceType),
+		auxInterfaces:      make(map[string]map[string]*ast.InterfaceType),
+		srcDir:             srcDir,
+	}
+
+	// Handle -imports.
+	dotImports := make(map[string]bool)
+	if *imports != "" {
+		for _, kv := range strings.Split(*imports, ",") {
+			eq := strings.Index(kv, "=")
+			k, v := kv[:eq], kv[eq+1:]
+			if k == "." {
+				// TODO: Catch dupes?
+				dotImports[v] = true
+			} else {
+				// TODO: Catch dupes?
+				p.imports[k] = v
+			}
+		}
+	}
+
+	// Handle -aux_files.
+	if err := p.parseAuxFiles(*auxFiles); err != nil {
+		return nil, err
+	}
+	p.addAuxInterfacesFromFile(packageImport, file) // this file
+
+	pkg, err := p.parseFile(packageImport, file)
+	if err != nil {
+		return nil, err
+	}
+	for pkgPath := range dotImports {
+		pkg.DotImports = append(pkg.DotImports, pkgPath)
+	}
+	return pkg, nil
+}
+
+type fileParser struct {
+	fileSet            *token.FileSet
+	imports            map[string]string                        // package name => import path
+	importedInterfaces map[string]map[string]*ast.InterfaceType // package (or "") => name => interface
+
+	auxFiles      []*ast.File
+	auxInterfaces map[string]map[string]*ast.InterfaceType // package (or "") => name => interface
+
+	srcDir string
+}
+
+func (p *fileParser) errorf(pos token.Pos, format string, args ...interface{}) error {
+	ps := p.fileSet.Position(pos)
+	format = "%s:%d:%d: " + format
+	args = append([]interface{}{ps.Filename, ps.Line, ps.Column}, args...)
+	return fmt.Errorf(format, args...)
+}
+
+func (p *fileParser) parseAuxFiles(auxFiles string) error {
+	auxFiles = strings.TrimSpace(auxFiles)
+	if auxFiles == "" {
+		return nil
+	}
+	for _, kv := range strings.Split(auxFiles, ",") {
+		parts := strings.SplitN(kv, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("bad aux file spec: %v", kv)
+		}
+		pkg, fpath := parts[0], parts[1]
+
+		file, err := parser.ParseFile(p.fileSet, fpath, nil, 0)
+		if err != nil {
+			return err
+		}
+		p.auxFiles = append(p.auxFiles, file)
+		p.addAuxInterfacesFromFile(pkg, file)
+	}
+	return nil
+}
+
+func (p *fileParser) addAuxInterfacesFromFile(pkg string, file *ast.File) {
+	if _, ok := p.auxInterfaces[pkg]; !ok {
+		p.auxInterfaces[pkg] = make(map[string]*ast.InterfaceType)
+	}
+	for ni := range iterInterfaces(file) {
+		p.auxInterfaces[pkg][ni.name.Name] = ni.it
+	}
+}
+
+// parseFile loads all file imports and auxiliary files import into the
+// fileParser, parses all file interfaces and returns package model.
+func (p *fileParser) parseFile(importPath string, file *ast.File) (*model.Package, error) {
+	allImports, dotImports := importsOfFile(file)
+	// Don't stomp imports provided by -imports. Those should take precedence.
+	for pkg, pkgPath := range allImports {
+		if _, ok := p.imports[pkg]; !ok {
+			p.imports[pkg] = pkgPath
+		}
+	}
+	// Add imports from auxiliary files, which might be needed for embedded interfaces.
+	// Don't stomp any other imports.
+	for _, f := range p.auxFiles {
+		auxImports, _ := importsOfFile(f)
+		for pkg, pkgPath := range auxImports {
+			if _, ok := p.imports[pkg]; !ok {
+				p.imports[pkg] = pkgPath
+			}
+		}
+	}
+
+	var is []*model.Interface
+	for ni := range iterInterfaces(file) {
+		i, err := p.parseInterface(ni.name.String(), importPath, ni.it)
+		if err != nil {
+			return nil, err
+		}
+		is = append(is, i)
+	}
+	return &model.Package{
+		Name:       file.Name.String(),
+		PkgPath:    importPath,
+		Interfaces: is,
+		DotImports: dotImports,
+	}, nil
+}
+
+// parsePackage loads package specified by path, parses it and populates
+// corresponding imports and importedInterfaces into the fileParser.
+func (p *fileParser) parsePackage(path string) error {
+	var pkgs map[string]*ast.Package
+	if imp, err := build.Import(path, p.srcDir, build.FindOnly); err != nil {
+		return err
+	} else if pkgs, err = parser.ParseDir(p.fileSet, imp.Dir, nil, 0); err != nil {
+		return err
+	}
+	for _, pkg := range pkgs {
+		file := ast.MergePackageFiles(pkg, ast.FilterFuncDuplicates|ast.FilterUnassociatedComments|ast.FilterImportDuplicates)
+		if _, ok := p.importedInterfaces[path]; !ok {
+			p.importedInterfaces[path] = make(map[string]*ast.InterfaceType)
+		}
+		for ni := range iterInterfaces(file) {
+			p.importedInterfaces[path][ni.name.Name] = ni.it
+		}
+		imports, _ := importsOfFile(file)
+		for pkgName, pkgPath := range imports {
+			if _, ok := p.imports[pkgName]; !ok {
+				p.imports[pkgName] = pkgPath
+			}
+		}
+	}
+	return nil
+}
+
+func (p *fileParser) parseInterface(name, pkg string, it *ast.InterfaceType) (*model.Interface, error) {
+	intf := &model.Interface{Name: name}
+	for _, field := range it.Methods.List {
+		switch v := field.Type.(type) {
+		case *ast.FuncType:
+			if nn := len(field.Names); nn != 1 {
+				return nil, fmt.Errorf("expected one name for interface %v, got %d", intf.Name, nn)
+			}
+			m := &model.Method{
+				Name: field.Names[0].String(),
+			}
+			var err error
+			m.In, m.Variadic, m.Out, err = p.parseFunc(pkg, v)
+			if err != nil {
+				return nil, err
+			}
+			intf.Methods = append(intf.Methods, m)
+		case *ast.Ident:
+			// Embedded interface in this package.
+			ei := p.auxInterfaces[pkg][v.String()]
+			if ei == nil {
+				if ei = p.importedInterfaces[pkg][v.String()]; ei == nil {
+					return nil, p.errorf(v.Pos(), "unknown embedded interface %s", v.String())
+				}
+			}
+			eintf, err := p.parseInterface(v.String(), pkg, ei)
+			if err != nil {
+				return nil, err
+			}
+			// Copy the methods.
+			// TODO: apply shadowing rules.
+			intf.Methods = append(intf.Methods, eintf.Methods...)
+		case *ast.SelectorExpr:
+			// Embedded interface in another package.
+			fpkg, sel := v.X.(*ast.Ident).String(), v.Sel.String()
+			epkg, ok := p.imports[fpkg]
+			if !ok {
+				return nil, p.errorf(v.X.Pos(), "unknown package %s", fpkg)
+			}
+			ei := p.auxInterfaces[fpkg][sel]
+			if ei == nil {
+				fpkg = epkg
+				if _, ok = p.importedInterfaces[epkg]; !ok {
+					if err := p.parsePackage(epkg); err != nil {
+						return nil, p.errorf(v.Pos(), "could not parse package %s: %v", fpkg, err)
+					}
+				}
+				if ei = p.importedInterfaces[epkg][sel]; ei == nil {
+					return nil, p.errorf(v.Pos(), "unknown embedded interface %s.%s", fpkg, sel)
+				}
+			}
+			eintf, err := p.parseInterface(sel, fpkg, ei)
+			if err != nil {
+				return nil, err
+			}
+			// Copy the methods.
+			// TODO: apply shadowing rules.
+			intf.Methods = append(intf.Methods, eintf.Methods...)
+		default:
+			return nil, fmt.Errorf("don't know how to mock method of type %T", field.Type)
+		}
+	}
+	return intf, nil
+}
+
+func (p *fileParser) parseFunc(pkg string, f *ast.FuncType) (in []*model.Parameter, variadic *model.Parameter, out []*model.Parameter, err error) {
+	if f.Params != nil {
+		regParams := f.Params.List
+		if isVariadic(f) {
+			n := len(regParams)
+			varParams := regParams[n-1:]
+			regParams = regParams[:n-1]
+			vp, err := p.parseFieldList(pkg, varParams)
+			if err != nil {
+				return nil, nil, nil, p.errorf(varParams[0].Pos(), "failed parsing variadic argument: %v", err)
+			}
+			variadic = vp[0]
+		}
+		in, err = p.parseFieldList(pkg, regParams)
+		if err != nil {
+			return nil, nil, nil, p.errorf(f.Pos(), "failed parsing arguments: %v", err)
+		}
+	}
+	if f.Results != nil {
+		out, err = p.parseFieldList(pkg, f.Results.List)
+		if err != nil {
+			return nil, nil, nil, p.errorf(f.Pos(), "failed parsing returns: %v", err)
+		}
+	}
+	return
+}
+
+func (p *fileParser) parseFieldList(pkg string, fields []*ast.Field) ([]*model.Parameter, error) {
+	nf := 0
+	for _, f := range fields {
+		nn := len(f.Names)
+		if nn == 0 {
+			nn = 1 // anonymous parameter
+		}
+		nf += nn
+	}
+	if nf == 0 {
+		return nil, nil
+	}
+	ps := make([]*model.Parameter, nf)
+	i := 0 // destination index
+	for _, f := range fields {
+		t, err := p.parseType(pkg, f.Type)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(f.Names) == 0 {
+			// anonymous arg
+			ps[i] = &model.Parameter{Type: t}
+			i++
+			continue
+		}
+		for _, name := range f.Names {
+			ps[i] = &model.Parameter{Name: name.Name, Type: t}
+			i++
+		}
+	}
+	return ps, nil
+}
+
+func (p *fileParser) parseType(pkg string, typ ast.Expr) (model.Type, error) {
+	switch v := typ.(type) {
+	case *ast.ArrayType:
+		ln := -1
+		if v.Len != nil {
+			x, err := strconv.Atoi(v.Len.(*ast.BasicLit).Value)
+			if err != nil {
+				return nil, p.errorf(v.Len.Pos(), "bad array size: %v", err)
+			}
+			ln = x
+		}
+		t, err := p.parseType(pkg, v.Elt)
+		if err != nil {
+			return nil, err
+		}
+		return &model.ArrayType{Len: ln, Type: t}, nil
+	case *ast.ChanType:
+		t, err := p.parseType(pkg, v.Value)
+		if err != nil {
+			return nil, err
+		}
+		var dir model.ChanDir
+		if v.Dir == ast.SEND {
+			dir = model.SendDir
+		}
+		if v.Dir == ast.RECV {
+			dir = model.RecvDir
+		}
+		return &model.ChanType{Dir: dir, Type: t}, nil
+	case *ast.Ellipsis:
+		// assume we're parsing a variadic argument
+		return p.parseType(pkg, v.Elt)
+	case *ast.FuncType:
+		in, variadic, out, err := p.parseFunc(pkg, v)
+		if err != nil {
+			return nil, err
+		}
+		return &model.FuncType{In: in, Out: out, Variadic: variadic}, nil
+	case *ast.Ident:
+		if v.IsExported() {
+			// `pkg` may be an aliased imported pkg
+			// if so, patch the import w/ the fully qualified import
+			maybeImportedPkg, ok := p.imports[pkg]
+			if ok {
+				pkg = maybeImportedPkg
+			}
+			// assume type in this package
+			return &model.NamedType{Package: pkg, Type: v.Name}, nil
+		}
+
+		// assume predeclared type
+		return model.PredeclaredType(v.Name), nil
+	case *ast.InterfaceType:
+		if v.Methods != nil && len(v.Methods.List) > 0 {
+			return nil, p.errorf(v.Pos(), "can't handle non-empty unnamed interface types")
+		}
+		return model.PredeclaredType("interface{}"), nil
+	case *ast.MapType:
+		key, err := p.parseType(pkg, v.Key)
+		if err != nil {
+			return nil, err
+		}
+		value, err := p.parseType(pkg, v.Value)
+		if err != nil {
+			return nil, err
+		}
+		return &model.MapType{Key: key, Value: value}, nil
+	case *ast.SelectorExpr:
+		pkgName := v.X.(*ast.Ident).String()
+		pkg, ok := p.imports[pkgName]
+		if !ok {
+			return nil, p.errorf(v.Pos(), "unknown package %q", pkgName)
+		}
+		return &model.NamedType{Package: pkg, Type: v.Sel.String()}, nil
+	case *ast.StarExpr:
+		t, err := p.parseType(pkg, v.X)
+		if err != nil {
+			return nil, err
+		}
+		return &model.PointerType{Type: t}, nil
+	case *ast.StructType:
+		if v.Fields != nil && len(v.Fields.List) > 0 {
+			return nil, p.errorf(v.Pos(), "can't handle non-empty unnamed struct types")
+		}
+		return model.PredeclaredType("struct{}"), nil
+	}
+
+	return nil, fmt.Errorf("don't know how to parse type %T", typ)
+}
+
+// importsOfFile returns a map of package name to import path
+// of the imports in file.
+func importsOfFile(file *ast.File) (normalImports map[string]string, dotImports []string) {
+	var importPaths []string
+	for _, is := range file.Imports {
+		if is.Name != nil {
+			continue
+		}
+		importPath := is.Path.Value[1 : len(is.Path.Value)-1] // remove quotes
+		importPaths = append(importPaths, importPath)
+	}
+	packagesName := createPackageMap(importPaths)
+	normalImports = make(map[string]string)
+	dotImports = make([]string, 0)
+	for _, is := range file.Imports {
+		var pkgName string
+		importPath := is.Path.Value[1 : len(is.Path.Value)-1] // remove quotes
+
+		if is.Name != nil {
+			// Named imports are always certain.
+			if is.Name.Name == "_" {
+				continue
+			}
+			pkgName = is.Name.Name
+		} else {
+			pkg, ok := packagesName[importPath]
+			if !ok {
+				// Fallback to import path suffix. Note that this is uncertain.
+				_, last := path.Split(importPath)
+				// If the last path component has dots, the first dot-delimited
+				// field is used as the name.
+				pkgName = strings.SplitN(last, ".", 2)[0]
+			} else {
+				pkgName = pkg
+			}
+		}
+
+		if pkgName == "." {
+			dotImports = append(dotImports, importPath)
+		} else {
+
+			if _, ok := normalImports[pkgName]; ok {
+				log.Fatalf("imported package collision: %q imported twice", pkgName)
+			}
+			normalImports[pkgName] = importPath
+		}
+	}
+	return
+}
+
+type namedInterface struct {
+	name *ast.Ident
+	it   *ast.InterfaceType
+}
+
+// Create an iterator over all interfaces in file.
+func iterInterfaces(file *ast.File) <-chan namedInterface {
+	ch := make(chan namedInterface)
+	go func() {
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok {
+					continue
+				}
+				it, ok := ts.Type.(*ast.InterfaceType)
+				if !ok {
+					continue
+				}
+
+				ch <- namedInterface{ts.Name, it}
+			}
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+// isVariadic returns whether the function is variadic.
+func isVariadic(f *ast.FuncType) bool {
+	nargs := len(f.Params.List)
+	if nargs == 0 {
+		return false
+	}
+	_, ok := f.Params.List[nargs-1].Type.(*ast.Ellipsis)
+	return ok
+}
+
+// packageNameOfDir get package import path via dir
+func packageNameOfDir(srcDir string) (string, error) {
+	files, err := ioutil.ReadDir(srcDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var goFilePath string
+	for _, file := range files {
+		if !file.IsDir() && strings.HasSuffix(file.Name(), ".go") {
+			goFilePath = file.Name()
+			break
+		}
+	}
+	if goFilePath == "" {
+		return "", fmt.Errorf("go source file not found %s", srcDir)
+	}
+
+	packageImport, err := parsePackageImport(goFilePath, srcDir)
+	if err != nil {
+		return "", err
+	}
+	return packageImport, nil
+}
+
+// parseImportPackage get package import path via source file
+func parsePackageImport(source, srcDir string) (string, error) {
+	cfg := &packages.Config{Mode: packages.LoadFiles, Tests: true, Dir: srcDir}
+	pkgs, err := packages.Load(cfg, "file="+source)
+	if err != nil {
+		return "", err
+	}
+	if packages.PrintErrors(pkgs) > 0 || len(pkgs) == 0 {
+		return "", errors.New("loading package failed")
+	}
+
+	packageImport := pkgs[0].PkgPath
+
+	// It is illegal to import a _test package.
+	packageImport = strings.TrimSuffix(packageImport, "_test")
+	return packageImport, nil
+}

--- a/vendor/github.com/golang/mock/mockgen/reflect.go
+++ b/vendor/github.com/golang/mock/mockgen/reflect.go
@@ -1,0 +1,249 @@
+// Copyright 2012 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// This file contains the model construction by reflection.
+
+import (
+	"bytes"
+	"encoding/gob"
+	"flag"
+	"go/build"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"github.com/golang/mock/mockgen/model"
+)
+
+var (
+	progOnly   = flag.Bool("prog_only", false, "(reflect mode) Only generate the reflection program; write it to stdout and exit.")
+	execOnly   = flag.String("exec_only", "", "(reflect mode) If set, execute this reflection program.")
+	buildFlags = flag.String("build_flags", "", "(reflect mode) Additional flags for go build.")
+)
+
+func writeProgram(importPath string, symbols []string) ([]byte, error) {
+	var program bytes.Buffer
+	data := reflectData{
+		ImportPath: importPath,
+		Symbols:    symbols,
+	}
+	if err := reflectProgram.Execute(&program, &data); err != nil {
+		return nil, err
+	}
+	return program.Bytes(), nil
+}
+
+// run the given program and parse the output as a model.Package.
+func run(program string) (*model.Package, error) {
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		return nil, err
+	}
+
+	filename := f.Name()
+	defer os.Remove(filename)
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+
+	// Run the program.
+	cmd := exec.Command(program, "-output", filename)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	f, err = os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	// Process output.
+	var pkg model.Package
+	if err := gob.NewDecoder(f).Decode(&pkg); err != nil {
+		return nil, err
+	}
+
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+
+	return &pkg, nil
+}
+
+// runInDir writes the given program into the given dir, runs it there, and
+// parses the output as a model.Package.
+func runInDir(program []byte, dir string) (*model.Package, error) {
+	// We use TempDir instead of TempFile so we can control the filename.
+	tmpDir, err := ioutil.TempDir(dir, "gomock_reflect_")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.Printf("failed to remove temp directory: %s", err)
+		}
+	}()
+	const progSource = "prog.go"
+	var progBinary = "prog.bin"
+	if runtime.GOOS == "windows" {
+		// Windows won't execute a program unless it has a ".exe" suffix.
+		progBinary += ".exe"
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(tmpDir, progSource), program, 0600); err != nil {
+		return nil, err
+	}
+
+	cmdArgs := []string{}
+	cmdArgs = append(cmdArgs, "build")
+	if *buildFlags != "" {
+		cmdArgs = append(cmdArgs, strings.Split(*buildFlags, " ")...)
+	}
+	cmdArgs = append(cmdArgs, "-o", progBinary, progSource)
+
+	// Build the program.
+	cmd := exec.Command("go", cmdArgs...)
+	cmd.Dir = tmpDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	return run(filepath.Join(tmpDir, progBinary))
+}
+
+// reflectMode generates mocks via reflection on an interface.
+func reflectMode(importPath string, symbols []string) (*model.Package, error) {
+	// TODO: sanity check arguments
+
+	if *execOnly != "" {
+		return run(*execOnly)
+	}
+
+	program, err := writeProgram(importPath, symbols)
+	if err != nil {
+		return nil, err
+	}
+
+	if *progOnly {
+		if _, err := os.Stdout.Write(program); err != nil {
+			return nil, err
+		}
+		os.Exit(0)
+	}
+
+	wd, _ := os.Getwd()
+
+	// Try to run the reflection program  in the current working directory.
+	if p, err := runInDir(program, wd); err == nil {
+		return p, nil
+	}
+
+	// Try to run the program in the same directory as the input package.
+	if p, err := build.Import(importPath, wd, build.FindOnly); err == nil {
+		dir := p.Dir
+		if p, err := runInDir(program, dir); err == nil {
+			return p, nil
+		}
+	}
+
+	// Try to run it in a standard temp directory.
+	return runInDir(program, "")
+}
+
+type reflectData struct {
+	ImportPath string
+	Symbols    []string
+}
+
+// This program reflects on an interface value, and prints the
+// gob encoding of a model.Package to standard output.
+// JSON doesn't work because of the model.Type interface.
+var reflectProgram = template.Must(template.New("program").Parse(`
+package main
+
+import (
+	"encoding/gob"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"reflect"
+
+	"github.com/golang/mock/mockgen/model"
+
+	pkg_ {{printf "%q" .ImportPath}}
+)
+
+var output = flag.String("output", "", "The output file name, or empty to use stdout.")
+
+func main() {
+	flag.Parse()
+
+	its := []struct{
+		sym string
+		typ reflect.Type
+	}{
+		{{range .Symbols}}
+		{ {{printf "%q" .}}, reflect.TypeOf((*pkg_.{{.}})(nil)).Elem()},
+		{{end}}
+	}
+	pkg := &model.Package{
+		// NOTE: This behaves contrary to documented behaviour if the
+		// package name is not the final component of the import path.
+		// The reflect package doesn't expose the package name, though.
+		Name: path.Base({{printf "%q" .ImportPath}}),
+	}
+
+	for _, it := range its {
+		intf, err := model.InterfaceFromInterfaceType(it.typ)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Reflection: %v\n", err)
+			os.Exit(1)
+		}
+		intf.Name = it.sym
+		pkg.Interfaces = append(pkg.Interfaces, intf)
+	}
+
+	outfile := os.Stdout
+	if len(*output) != 0 {
+		var err error
+		outfile, err = os.Create(*output)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to open output file %q", *output)
+		}
+		defer func() {
+			if err := outfile.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to close output file %q", *output)
+				os.Exit(1)
+			}
+		}()
+	}
+
+	if err := gob.NewEncoder(outfile).Encode(pkg); err != nil {
+		fmt.Fprintf(os.Stderr, "gob encode: %v\n", err)
+		os.Exit(1)
+	}
+}
+`))

--- a/vendor/github.com/golang/mock/mockgen/version.1.11.go
+++ b/vendor/github.com/golang/mock/mockgen/version.1.11.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.12
+
+package main
+
+import (
+	"log"
+)
+
+func printModuleVersion() {
+	log.Printf("No version information is available for Mockgen compiled with " +
+		"version 1.11")
+}

--- a/vendor/github.com/golang/mock/mockgen/version.1.12.go
+++ b/vendor/github.com/golang/mock/mockgen/version.1.12.go
@@ -1,0 +1,35 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// +build go1.12
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"runtime/debug"
+)
+
+func printModuleVersion() {
+	if bi, exists := debug.ReadBuildInfo(); exists {
+		fmt.Println(bi.Main.Version)
+	} else {
+		log.Printf("No version information found. Make sure to use " +
+			"GO111MODULE=on when running 'go get' in order to use specific " +
+			"version of the binary.")
+	}
+
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -508,6 +508,8 @@ github.com/golang/groupcache/lru
 # github.com/golang/mock v1.4.4
 ## explicit
 github.com/golang/mock/gomock
+github.com/golang/mock/mockgen
+github.com/golang/mock/mockgen/model
 # github.com/golang/protobuf v1.4.3
 ## explicit
 github.com/golang/protobuf/internal/gengogrpc


### PR DESCRIPTION
Rather than building an image to run mockgen and having that image always get the latest verion of mockgen, use the mockgen from the vendor directory. This has a couple benefits.
 1) We do not get changes to the client mocks that pop up in random PRs when a new version of mockgen is released.
 2) Contributors that do not have access to the CI registry can generate the mock clients.