### PR TITLE
vSphere IPI: Enable thin provisioning via the OVA import

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2110,6 +2110,10 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  diskType:
+                    description: Disk Type Thin specifies if thin disks should be
+                      use instead of thick
+                    type: string
                   folder:
                     description: Folder is the absolute path of the folder that will
                       be used and/or created for virtual machines. The absolute path
@@ -2132,9 +2136,6 @@ spec:
                     type: string
                   vCenter:
                     description: VCenter is the domain name or IP address of the vCenter.
-                    type: string
-                  diskType:
-                    description: DiskType is the name of the disk provisioning type for vsphere, for e.g eagerZeroedThick or thin, by default it will be thick.
                     type: string
                 required:
                 - datacenter

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2133,6 +2133,9 @@ spec:
                   vCenter:
                     description: VCenter is the domain name or IP address of the vCenter.
                     type: string
+                  diskType:
+                    description: DiskType is the name of the disk provisioning type for vsphere, for e.g eagerZeroedThick or thin, by default it will be thick.
+                    type: string
                 required:
                 - datacenter
                 - defaultDatastore

--- a/data/data/vsphere/pre-bootstrap/main.tf
+++ b/data/data/vsphere/pre-bootstrap/main.tf
@@ -50,6 +50,7 @@ resource "vsphereprivate_import_ova" "import" {
   network    = var.vsphere_network
   folder     = local.folder
   tag        = vsphere_tag.tag.id
+  thin       = var.template_thin_vmdk
 }
 
 resource "vsphere_tag_category" "category" {

--- a/data/data/vsphere/pre-bootstrap/main.tf
+++ b/data/data/vsphere/pre-bootstrap/main.tf
@@ -50,7 +50,7 @@ resource "vsphereprivate_import_ova" "import" {
   network    = var.vsphere_network
   folder     = local.folder
   tag        = vsphere_tag.tag.id
-  thin       = var.template_thin_vmdk
+  diskType   = var.disk_type
 }
 
 resource "vsphere_tag_category" "category" {

--- a/data/data/vsphere/pre-bootstrap/main.tf
+++ b/data/data/vsphere/pre-bootstrap/main.tf
@@ -50,7 +50,7 @@ resource "vsphereprivate_import_ova" "import" {
   network    = var.vsphere_network
   folder     = local.folder
   tag        = vsphere_tag.tag.id
-  diskType   = var.disk_type
+  disk_type  = var.vsphere_disk_type
 }
 
 resource "vsphere_tag_category" "category" {

--- a/data/data/vsphere/variables-vsphere.tf
+++ b/data/data/vsphere/variables-vsphere.tf
@@ -76,7 +76,6 @@ variable "vsphere_control_plane_num_cpus" {
 variable "vsphere_control_plane_cores_per_socket" {
   type = number
 }
-
-variable "template_thin_vmdk" {
-  type = bool
+variable "disk_type" {
+  type = string
 }

--- a/data/data/vsphere/variables-vsphere.tf
+++ b/data/data/vsphere/variables-vsphere.tf
@@ -77,3 +77,6 @@ variable "vsphere_control_plane_cores_per_socket" {
   type = number
 }
 
+variable "template_thin_vmdk" {
+  type = bool
+}

--- a/data/data/vsphere/variables-vsphere.tf
+++ b/data/data/vsphere/variables-vsphere.tf
@@ -76,6 +76,7 @@ variable "vsphere_control_plane_num_cpus" {
 variable "vsphere_control_plane_cores_per_socket" {
   type = number
 }
-variable "disk_type" {
-  type = string
+variable "vsphere_disk_type" {
+  type    = string
+  default = "eagerZeroedThick"
 }

--- a/docs/user/vsphere/customization.md
+++ b/docs/user/vsphere/customization.md
@@ -18,6 +18,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `cpus` (optional integer): The total number of virtual processor cores to assign a vm.
 * `coresPerSocket` (optional integer): The number of cores per socket in a vm. The number of vCPUs on the vm will be cpus/coresPerSocket (default is 1).
 * `memoryMB` (optional integer): The size of a VM's memory in megabytes.
+* `disk_type` (optional string): DiskType is the name of the disk provisioning type for vsphere, for e.g thick or thin, by default it will be eagerZeroedThick.
 
 ## Examples
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -628,6 +628,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				Cluster:             installConfig.Config.VSphere.Cluster,
 				ImageURL:            string(*rhcosImage),
 				PreexistingFolder:   preexistingFolder,
+				Thin:                installConfig.Config.Platform.VSphere.Thin,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -628,7 +628,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				Cluster:             installConfig.Config.VSphere.Cluster,
 				ImageURL:            string(*rhcosImage),
 				PreexistingFolder:   preexistingFolder,
-				Thin:                installConfig.Config.Platform.VSphere.Thin,
+				DiskType:            installConfig.Config.Platform.VSphere.DiskType,
 			},
 		)
 		if err != nil {

--- a/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
+++ b/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
@@ -93,10 +93,10 @@ func resourceVSpherePrivateImportOva() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
-			"thin": {
-				Type:        schema.TypeBool,
-				Description: "If set to True then the OVA will be imported as a Thin provisioned VMDK.",
-				Required:    true,
+			"diskType": {
+				Type:        schema.TypeString,
+				Description: "The name of the disk provisioning, for e.g eagerZeroedThick or thin, by default it will be thick.",
+				Required:    false,
 				ForceNew:    true,
 			},
 		},
@@ -356,10 +356,12 @@ func resourceVSpherePrivateImportOvaCreate(d *schema.ResourceData, meta interfac
 
 	var diskType types.OvfCreateImportSpecParamsDiskProvisioningType
 
-	if d.Get("thin").(bool) {
+	if d.Get("diskType").(string) == "thin" {
 		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThin
-	} else {
+	} else if d.Get("diskType").(string) == "eagerZeroedThick" {
 		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeEagerZeroedThick
+	} else {
+		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThick
 	}
 	// This is a very minimal spec for importing
 	// an OVF.

--- a/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
+++ b/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
@@ -93,10 +93,10 @@ func resourceVSpherePrivateImportOva() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
-			"diskType": {
+			"disk_type": {
 				Type:        schema.TypeString,
 				Description: "The name of the disk provisioning, for e.g eagerZeroedThick or thin, by default it will be thick.",
-				Required:    false,
+				Required:    true,
 				ForceNew:    true,
 			},
 		},
@@ -356,12 +356,12 @@ func resourceVSpherePrivateImportOvaCreate(d *schema.ResourceData, meta interfac
 
 	var diskType types.OvfCreateImportSpecParamsDiskProvisioningType
 
-	if d.Get("diskType").(string) == "thin" {
+	if d.Get("disk_type") == "thin" {
 		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThin
-	} else if d.Get("diskType").(string) == "eagerZeroedThick" {
-		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeEagerZeroedThick
-	} else {
+	} else if d.Get("disk_type") == "thick" {
 		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThick
+	} else {
+		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeEagerZeroedThick
 	}
 	// This is a very minimal spec for importing
 	// an OVF.

--- a/pkg/tfvars/vsphere/vsphere.go
+++ b/pkg/tfvars/vsphere/vsphere.go
@@ -26,7 +26,7 @@ type config struct {
 	Template          string `json:"vsphere_template"`
 	OvaFilePath       string `json:"vsphere_ova_filepath"`
 	PreexistingFolder bool   `json:"vsphere_preexisting_folder"`
-	Thin              bool   `json:"template_thin_vmdk"`
+	DiskType          string `json:"disk_type"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -37,7 +37,7 @@ type TFVarsSources struct {
 	Cluster             string
 	ImageURL            string
 	PreexistingFolder   bool
-	Thin                bool
+	DiskType            string
 }
 
 //TFVars generate vSphere-specific Terraform variables
@@ -70,7 +70,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Template:          controlPlaneConfig.Template,
 		OvaFilePath:       cachedImage,
 		PreexistingFolder: sources.PreexistingFolder,
-		Thin:              sources.Thin,
+		DiskType:          sources.DiskType,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/tfvars/vsphere/vsphere.go
+++ b/pkg/tfvars/vsphere/vsphere.go
@@ -8,25 +8,26 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
+	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
 type config struct {
-	VSphereURL        string `json:"vsphere_url"`
-	VSphereUsername   string `json:"vsphere_username"`
-	VSpherePassword   string `json:"vsphere_password"`
-	MemoryMiB         int64  `json:"vsphere_control_plane_memory_mib"`
-	DiskGiB           int32  `json:"vsphere_control_plane_disk_gib"`
-	NumCPUs           int32  `json:"vsphere_control_plane_num_cpus"`
-	NumCoresPerSocket int32  `json:"vsphere_control_plane_cores_per_socket"`
-	Cluster           string `json:"vsphere_cluster"`
-	Datacenter        string `json:"vsphere_datacenter"`
-	Datastore         string `json:"vsphere_datastore"`
-	Folder            string `json:"vsphere_folder"`
-	Network           string `json:"vsphere_network"`
-	Template          string `json:"vsphere_template"`
-	OvaFilePath       string `json:"vsphere_ova_filepath"`
-	PreexistingFolder bool   `json:"vsphere_preexisting_folder"`
-	DiskType          string `json:"disk_type"`
+	VSphereURL        string           `json:"vsphere_url"`
+	VSphereUsername   string           `json:"vsphere_username"`
+	VSpherePassword   string           `json:"vsphere_password"`
+	MemoryMiB         int64            `json:"vsphere_control_plane_memory_mib"`
+	DiskGiB           int32            `json:"vsphere_control_plane_disk_gib"`
+	NumCPUs           int32            `json:"vsphere_control_plane_num_cpus"`
+	NumCoresPerSocket int32            `json:"vsphere_control_plane_cores_per_socket"`
+	Cluster           string           `json:"vsphere_cluster"`
+	Datacenter        string           `json:"vsphere_datacenter"`
+	Datastore         string           `json:"vsphere_datastore"`
+	Folder            string           `json:"vsphere_folder"`
+	Network           string           `json:"vsphere_network"`
+	Template          string           `json:"vsphere_template"`
+	OvaFilePath       string           `json:"vsphere_ova_filepath"`
+	PreexistingFolder bool             `json:"vsphere_preexisting_folder"`
+	DiskType          vsphere.DiskType `json:"vsphere_disk_type"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -37,7 +38,7 @@ type TFVarsSources struct {
 	Cluster             string
 	ImageURL            string
 	PreexistingFolder   bool
-	DiskType            string
+	DiskType            vsphere.DiskType
 }
 
 //TFVars generate vSphere-specific Terraform variables

--- a/pkg/tfvars/vsphere/vsphere.go
+++ b/pkg/tfvars/vsphere/vsphere.go
@@ -26,6 +26,7 @@ type config struct {
 	Template          string `json:"vsphere_template"`
 	OvaFilePath       string `json:"vsphere_ova_filepath"`
 	PreexistingFolder bool   `json:"vsphere_preexisting_folder"`
+	Thin              bool   `json:"template_thin_vmdk"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -36,6 +37,7 @@ type TFVarsSources struct {
 	Cluster             string
 	ImageURL            string
 	PreexistingFolder   bool
+	Thin                bool
 }
 
 //TFVars generate vSphere-specific Terraform variables
@@ -68,6 +70,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Template:          controlPlaneConfig.Template,
 		OvaFilePath:       cachedImage,
 		PreexistingFolder: sources.PreexistingFolder,
+		Thin:              sources.Thin,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -48,6 +48,6 @@ type Platform struct {
 	// Network specifies the name of the network to be used by the cluster.
 	Network string `json:"network,omitempty"`
 
-	// Thin specifies if thin disks should be use instead of thick
-	Thin bool `json:"thin,omitempty"`
+	// Disk Type Thin specifies if thin disks should be use instead of thick
+	DiskType string `json:"diskType,omitempty"`
 }

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -1,6 +1,20 @@
 package vsphere
 
-// Platform stores any global configuration used for vsphere platforms.
+// DiskType is a disk provisioning type for vsphere.
+type DiskType string
+
+const (
+	// DiskTypeThin uses Thin disk type for vsphere in the cluster.
+	DiskTypeThin DiskType = "thin"
+
+	// DiskTypeThick uses Thick disk type for vsphere in the cluster.
+	DiskTypeThick DiskType = "thick"
+
+	// DiskTypeEagerZeroedThick uses EagerZeroedThick disk type for vsphere in the cluster.
+	DiskTypeEagerZeroedThick DiskType = "eagerZeroedThick"
+)
+
+// Platform stores any global configuration used for vsphere platforms
 type Platform struct {
 	// VCenter is the domain name or IP address of the vCenter.
 	VCenter string `json:"vCenter"`
@@ -49,5 +63,5 @@ type Platform struct {
 	Network string `json:"network,omitempty"`
 
 	// Disk Type Thin specifies if thin disks should be use instead of thick
-	DiskType string `json:"diskType,omitempty"`
+	DiskType DiskType `json:"diskType,omitempty"`
 }

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -47,4 +47,7 @@ type Platform struct {
 
 	// Network specifies the name of the network to be used by the cluster.
 	Network string `json:"network,omitempty"`
+
+	// Thin specifies if thin disks should be use instead of thick
+	Thin bool `json:"thin,omitempty"`
 }


### PR DESCRIPTION
This PR enables thin provisioning via the importing process
of the RHCOS ova. Terraform will then clone the virtual machine
based on the existing template disk type.

This adds an additional option in the vsphere platform struct `Thin`.

- [x] Performance testing needs to be completed before offering this as an option
- [ ] Virtual machine provisioning with storage options can be problematic, additional testing in a nested environment is required.