### PR TITLE
Make copies of machine pools in machines asset

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -147,7 +147,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 	ic := installConfig.Config
 
-	pool := ic.ControlPlane
+	pool := *ic.ControlPlane
 	var err error
 	machines := []machineapi.Machine{}
 	switch ic.Platform.Name() {
@@ -199,7 +199,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			clusterID.InfraID,
 			installConfig.Config.Platform.AWS.Region,
 			subnets,
-			pool,
+			&pool,
 			"master",
 			"master-user-data",
 			installConfig.Config.Platform.AWS.UserTags,
@@ -220,7 +220,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			mpool.Zones = azs
 		}
 		pool.Platform.GCP = &mpool
-		machines, err = gcp.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data")
+		machines, err = gcp.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -230,7 +230,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.Set(ic.Platform.Libvirt.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Libvirt)
 		pool.Platform.Libvirt = &mpool
-		machines, err = libvirt.Machines(clusterID.InfraID, ic, pool, "master", "master-user-data")
+		machines, err = libvirt.Machines(clusterID.InfraID, ic, &pool, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -242,7 +242,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 		imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-		machines, err = openstack.Machines(clusterID.InfraID, ic, pool, imageName, "master", "master-user-data")
+		machines, err = openstack.Machines(clusterID.InfraID, ic, &pool, imageName, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -272,7 +272,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 		pool.Platform.Azure = &mpool
 
-		machines, err = azure.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data")
+		machines, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -283,7 +283,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.Set(pool.Platform.BareMetal)
 		pool.Platform.BareMetal = &mpool
 
-		machines, err = baremetal.Machines(clusterID.InfraID, ic, pool, string(*rhcosImage), "master", "master-user-data")
+		machines, err = baremetal.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -335,7 +335,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 		imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-		machines, err = ovirt.Machines(clusterID.InfraID, ic, pool, imageName, "master", "master-user-data")
+		machines, err = ovirt.Machines(clusterID.InfraID, ic, &pool, imageName, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects for ovirt provider")
 		}
@@ -348,7 +348,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		pool.Platform.VSphere = &mpool
 		templateName := clusterID.InfraID + "-rhcos"
 
-		machines, err = vsphere.Machines(clusterID.InfraID, ic, pool, templateName, "master", "master-user-data")
+		machines, err = vsphere.Machines(clusterID.InfraID, ic, &pool, templateName, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
@@ -361,7 +361,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 
 		imageName, _ := rhcosutils.GenerateOpenStackImageName(string(*rhcosImage), clusterID.InfraID)
 
-		machines, err = kubevirt.Machines(clusterID.InfraID, ic, pool, imageName, "master", "master-user-data")
+		machines, err = kubevirt.Machines(clusterID.InfraID, ic, &pool, imageName, "master", "master-user-data")
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects for kubevirt provider")
 		}

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -152,12 +152,12 @@ func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, exter
 	}
 
 	cfg.AdditionalNetworkIDs = []string{}
-	if mpool.AdditionalNetworkIDs != nil {
+	if mpool != nil {
 		cfg.AdditionalNetworkIDs = append(cfg.AdditionalNetworkIDs, mpool.AdditionalNetworkIDs...)
 	}
 
 	cfg.AdditionalSecurityGroupIDs = []string{}
-	if mpool.AdditionalSecurityGroupIDs != nil {
+	if mpool != nil {
 		cfg.AdditionalSecurityGroupIDs = append(cfg.AdditionalSecurityGroupIDs, mpool.AdditionalSecurityGroupIDs...)
 	}
 


### PR DESCRIPTION
Now, during generation of machines, we modify machine pools in the install config. It's not correct because by contract all assets are immutable after generation.

To prevent this, this commit creates copies of existing machine pools and all changes are made to it, leaving the original values intact.