### PR TITLE
bootstrap: Ensure temp compat for old and new ceo secret structure

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -93,8 +93,19 @@ then
 
 	mkdir --parents /etc/kubernetes/static-pod-resources/etcd-member
 	cp tls/etcd-ca-bundle.crt /etc/kubernetes/static-pod-resources/etcd-member/ca.crt
-	cp --recursive etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-serving /etc/kubernetes/static-pod-resources/etcd-member
-	cp --recursive etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-peer /etc/kubernetes/static-pod-resources/etcd-member
+	# Temporarily ensure compatibility with both the new single cert secret and
+	# legacy multiple secrets. Support for copying the legacy secrets can be
+	# removed once https://github.com/openshift/cluster-etcd-operator/pull/544
+	# merges.
+	if [ -d "etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-certs" ]
+	then
+		# Copy the contents of the single aggregated cert secret if it is present.
+		cp --recursive etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-certs /etc/kubernetes/static-pod-resources/etcd-member
+	else
+		# Copy the contents of the legacy secrets
+		cp --recursive etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-serving /etc/kubernetes/static-pod-resources/etcd-member
+		cp --recursive etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-peer /etc/kubernetes/static-pod-resources/etcd-member
+	fi
 
 	touch etcd-bootstrap.done
 fi


### PR DESCRIPTION
This will allow the change introducing the new secret structure to merge to ceo, after which the compatibility for the legacy structure can be removed.

CEO change requiring this PR: https://github.com/openshift/cluster-etcd-operator/pull/544

/cc @hexfusion 