### PR TITLE
Bump bootstrap in place MCS master ignition to v3_2

### DIFF
--- a/data/data/bootstrap/bootstrap-in-place/files/usr/local/bin/bootstrap-in-place.sh
+++ b/data/data/bootstrap/bootstrap-in-place/files/usr/local/bin/bootstrap-in-place.sh
@@ -26,7 +26,7 @@ fi
 if [ ! -f master-ignition.done ]; then
   echo "Creating master ignition and writing it to disk"
   # Get the master ignition from MCS
-  curl --header 'Accept:application/vnd.coreos.ignition+json;version=3.1.0' \
+  curl --header 'Accept:application/vnd.coreos.ignition+json;version=3.2.0' \
     http://localhost:22624/config/master -o /opt/openshift/original-master.ign
 
   GATHER_ID="bootstrap"


### PR DESCRIPTION
A recent [PR](https://github.com/openshift/installer/pull/4653) bumped the ignition generated by the installer to v3.2.
This PR aligns the master ignition that bootstrap in place is getting from the machine config server to the same version.
This is mainly relevant for assisted-installer that might want to merge user custom Ignition (that should match the ignition version generated by the installer) with this ignition config.