### PR TITLE
openstack: allow for fewer than 3 masters

### DIFF
--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -58,6 +58,7 @@ resource "openstack_compute_servergroup_v2" "master_group" {
 #
 # [1]: https://github.com/openshift/installer/tree/master/docs/user/openstack#master-nodes
 resource "openstack_compute_instance_v2" "master_conf_0" {
+  count = "${var.instance_count > 0 ? 1 : 0}"
   name = "${var.cluster_id}-master-0"
 
   flavor_id = data.openstack_compute_flavor_v2.masters_flavor.id
@@ -105,6 +106,7 @@ resource "openstack_compute_instance_v2" "master_conf_0" {
 }
 
 resource "openstack_compute_instance_v2" "master_conf_1" {
+  count = "${var.instance_count > 1 ? 1 : 0}"
   name = "${var.cluster_id}-master-1"
 
   flavor_id = data.openstack_compute_flavor_v2.masters_flavor.id
@@ -154,6 +156,7 @@ resource "openstack_compute_instance_v2" "master_conf_1" {
 }
 
 resource "openstack_compute_instance_v2" "master_conf_2" {
+  count = "${var.instance_count > 2 ? 1 : 0}"
   name = "${var.cluster_id}-master-2"
 
   flavor_id = data.openstack_compute_flavor_v2.masters_flavor.id

--- a/pkg/asset/installconfig/openstack/validate.go
+++ b/pkg/asset/installconfig/openstack/validate.go
@@ -42,8 +42,8 @@ func Validate(ic *types.InstallConfig) error {
 
 // ValidateForProvisioning validates that the install config is valid for provisioning the cluster.
 func ValidateForProvisioning(ic *types.InstallConfig) error {
-	if ic.ControlPlane.Replicas != nil && *ic.ControlPlane.Replicas != 3 {
-		return field.Invalid(field.NewPath("controlPlane", "replicas"), ic.ControlPlane.Replicas, "control plane must be exactly three nodes when provisioning on OpenStack")
+	if ic.ControlPlane.Replicas != nil && *ic.ControlPlane.Replicas > 3 {
+		return field.Invalid(field.NewPath("controlPlane", "replicas"), ic.ControlPlane.Replicas, "control plane cannot be more than three nodes when provisioning on OpenStack")
 	}
 	return nil
 }

--- a/pkg/asset/installconfig/openstack/validate_test.go
+++ b/pkg/asset/installconfig/openstack/validate_test.go
@@ -30,7 +30,7 @@ func TestValidateForProvisioning(t *testing.T) {
 					Replicas: pointer.Int64Ptr(5),
 				},
 			},
-			expectedErrMsg: `controlPlane.replicas: Invalid value: 5: control plane must be exactly three nodes when provisioning on OpenStack`,
+			expectedErrMsg: `controlPlane.replicas: Invalid value: 5: control plane cannot be more than three nodes when provisioning on OpenStack`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Modify the terraform for IPI OpenStack so that it only creates at most the number of control planes requested by the user. In other words, if the user requests only one control plane node, then the terraform will only create master-0 and not master-1 nor master-2.

Relax the provsioning validation that enforces that the number of control plane replicas must be exactly 3 to allow for the control plane replicas to be at most 3.