### PR TITLE
Bug 1931217: add affinity groups to oVirt installer

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -327,6 +327,14 @@ spec:
                       description: Ovirt is the configuration used when installing
                         on oVirt.
                       properties:
+                        affinityGroupsNames:
+                          description: AffinityGroupsNames contains a list of oVirt
+                            affinity group names that the newly created machines will
+                            join. The affinity groups should exist on the oVirt cluster
+                            or created by the OpenShift installer.
+                          items:
+                            type: string
+                          type: array
                         cpu:
                           description: CPU defines the VM CPU.
                           properties:
@@ -691,6 +699,14 @@ spec:
                     description: Ovirt is the configuration used when installing on
                       oVirt.
                     properties:
+                      affinityGroupsNames:
+                        description: AffinityGroupsNames contains a list of oVirt
+                          affinity group names that the newly created machines will
+                          join. The affinity groups should exist on the oVirt cluster
+                          or created by the OpenShift installer.
+                        items:
+                          type: string
+                        type: array
                       cpu:
                         description: CPU defines the VM CPU.
                         properties:
@@ -1708,6 +1724,32 @@ spec:
               ovirt:
                 description: Ovirt is the configuration used when installing on oVirt.
                 properties:
+                  affinityGroups:
+                    description: AffinityGroups contains the RHV affinity groups that
+                      the installer will create.
+                    items:
+                      description: AffinityGroup defines the affinity group that the
+                        installer will create
+                      properties:
+                        description:
+                          description: Description of the affinity group
+                          type: string
+                        enforcing:
+                          description: Enforcing whether to create a hard affinity
+                            rule, default is false
+                          type: boolean
+                        name:
+                          description: Name name of the affinity group
+                          type: string
+                        priority:
+                          description: Priority of the affinity group, needs to be
+                            between 1 (lowest) - 5 (highest)
+                          type: integer
+                      required:
+                      - name
+                      - priority
+                      type: object
+                    type: array
                   api_vip:
                     description: APIVIP is an IP which will be served by bootstrap
                       and then pivoted masters, using keepalived
@@ -1718,6 +1760,14 @@ spec:
                       define their own platform configuration. Default will set the
                       image field to the latest RHCOS image.
                     properties:
+                      affinityGroupsNames:
+                        description: AffinityGroupsNames contains a list of oVirt
+                          affinity group names that the newly created machines will
+                          join. The affinity groups should exist on the oVirt cluster
+                          or created by the OpenShift installer.
+                        items:
+                          type: string
+                        type: array
                       cpu:
                         description: CPU defines the VM CPU.
                         properties:

--- a/data/data/ovirt/affinity_group/main.tf
+++ b/data/data/ovirt/affinity_group/main.tf
@@ -1,0 +1,12 @@
+resource "ovirt_affinity_group" "affinity_groups" {
+  count        = length(var.ovirt_affinity_groups)
+  name         = var.ovirt_affinity_groups[count.index]["name"]
+  description  = var.ovirt_affinity_groups[count.index]["description"]
+  cluster_id   = var.ovirt_cluster_id
+  priority     = var.ovirt_affinity_groups[count.index]["priority"]
+  vm_positive  = false
+  vm_enforcing = var.ovirt_affinity_groups[count.index]["enforcing"]
+  lifecycle {
+    ignore_changes = [vm_list]
+  }
+}

--- a/data/data/ovirt/affinity_group/outputs.tf
+++ b/data/data/ovirt/affinity_group/outputs.tf
@@ -1,0 +1,3 @@
+output "ovirt_affinity_group_count" {
+  value = length(ovirt_affinity_group.affinity_groups)
+}

--- a/data/data/ovirt/affinity_group/variables.tf
+++ b/data/data/ovirt/affinity_group/variables.tf
@@ -1,0 +1,11 @@
+variable "ovirt_cluster_id" {
+  type        = string
+  description = "The ID of Cluster"
+}
+
+variable "ovirt_affinity_groups" {
+  type        = list(object({ name = string, priority = number, description = string, enforcing = string }))
+  description = "Control plane affinity groups that will be created."
+  default     = []
+}
+

--- a/data/data/ovirt/main.tf
+++ b/data/data/ovirt/main.tf
@@ -30,6 +30,12 @@ module "bootstrap" {
   openstack_base_image_local_file_path = var.openstack_base_image_local_file_path
 }
 
+module "affinity_group" {
+  source                = "./affinity_group"
+  ovirt_cluster_id      = var.ovirt_cluster_id
+  ovirt_affinity_groups = var.ovirt_affinity_groups
+}
+
 module "masters" {
   source                        = "./masters"
   master_count                  = var.master_count
@@ -44,4 +50,7 @@ module "masters" {
   ovirt_master_memory           = var.ovirt_master_memory
   ovirt_master_vm_type          = var.ovirt_master_vm_type
   ovirt_master_os_disk_size_gb  = var.ovirt_master_os_disk_gb
+  ovirt_master_affinity_groups  = var.ovirt_master_affinity_groups
+  ovirt_affinity_group_count    = module.affinity_group.ovirt_affinity_group_count
 }
+

--- a/data/data/ovirt/masters/main.tf
+++ b/data/data/ovirt/masters/main.tf
@@ -10,7 +10,8 @@ resource "ovirt_vm" "master" {
   // if instance type is declared then memory is redundant. Since terraform
   // doesn't allow to condionally omit it, it must be passed.
   // The number passed is multiplied by 4 and becomes the maximum memory the VM can have.
-  memory = var.ovirt_master_instance_type_id != "" ? 16348 : var.ovirt_master_memory
+  memory          = var.ovirt_master_instance_type_id != "" ? 16348 : var.ovirt_master_memory
+  affinity_groups = var.ovirt_master_affinity_groups
 
   initialization {
     host_name     = "${var.cluster_id}-master-${count.index}"
@@ -21,6 +22,7 @@ resource "ovirt_vm" "master" {
     interface = "virtio_scsi"
     size      = var.ovirt_master_os_disk_size_gb
   }
+  depends_on = [var.ovirt_affinity_group_count]
 }
 
 resource "ovirt_tag" "cluster_tag" {

--- a/data/data/ovirt/masters/variables.tf
+++ b/data/data/ovirt/masters/variables.tf
@@ -56,3 +56,14 @@ variable "ovirt_master_instance_type_id" {
   type        = string
   description = "master VM instance type ID"
 }
+
+variable "ovirt_master_affinity_groups" {
+  type        = list(string)
+  description = "master VMs affinity groups names"
+}
+
+//TODO: REMOVE once we port to TF 0.13 and can use depends_on modules
+variable "ovirt_affinity_group_count" {
+  type        = string
+  description = "create a dependency between affinity_group module to masters module"
+}

--- a/data/data/ovirt/variables-ovirt.tf
+++ b/data/data/ovirt/variables-ovirt.tf
@@ -72,6 +72,12 @@ variable "ovirt_vnic_profile_id" {
   description = "The ID of the vNIC profile of Logical Network."
 }
 
+variable "ovirt_affinity_groups" {
+  type        = list(object({ name = string, priority = number, description = string, enforcing = string }))
+  description = "Affinity groups that will be created"
+  default     = []
+}
+
 variable "ovirt_master_memory" {
   type        = string
   description = "master VM memory in MiB"
@@ -100,4 +106,9 @@ variable "ovirt_master_vm_type" {
 variable "ovirt_master_instance_type_id" {
   type        = string
   description = "master VM instance type ID"
+}
+
+variable "ovirt_master_affinity_groups" {
+  type        = list(string)
+  description = "master VMs affinity groups names"
 }

--- a/go.mod
+++ b/go.mod
@@ -61,12 +61,12 @@ require (
 	github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201203141909-4dc702fd57a5
 	github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20201214114543-e5aed9c73f1f
 	github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603
-	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210315122142-893a4db3909a
+	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210406154451-1ea59ab6b543
 	github.com/openshift/library-go v0.0.0-20201215165635-4ee79b1caed5
 	github.com/openshift/machine-api-operator v0.2.1-0.20210104142355-8e6ae0acdfcf
 	github.com/openshift/machine-config-operator v0.0.0
 	github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c
-	github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210326142716-4545f80e61cd
+	github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210419101841-5d3f6567ce90
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db // indirect
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1237,8 +1237,8 @@ github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-233678
 github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603/go.mod h1:7pQ9Bzha+ug/5zd+0ufbDEcnn2OnNlPwRwYrzhXk4NM=
 github.com/openshift/cluster-api-provider-openstack v0.0.0-20210302164104-8498241fa4bd h1:5mq9/JftiO9u/RknQ5iR9Nkd09R1XFfUPS1nO11Wth0=
 github.com/openshift/cluster-api-provider-openstack v0.0.0-20210302164104-8498241fa4bd/go.mod h1:ONl4R7ziQtgnsBjR59fcZbOLjBEPVeZ69C1TPKevynw=
-github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210315122142-893a4db3909a h1:ZVGkVxyKM00gzdJRC7LYEBGgL4CfK8W50uOjj0fX1/E=
-github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210315122142-893a4db3909a/go.mod h1:pqKflzzmag/YrCHzJw5rpjk9o+rArgPn9qEVEe4ULP8=
+github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210406154451-1ea59ab6b543 h1:rzPiPUccXtMbXuOlgIXU8Qhhn9zQpTLeuyDcOfZc2MA=
+github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210406154451-1ea59ab6b543/go.mod h1:PDoRQIKJb/XT14ebzBoNH0I6ZV2yA7G+jJCk1gCsXB0=
 github.com/openshift/cluster-autoscaler-operator v0.0.0-20190521201101-62768a6ba480/go.mod h1:/XmV44Fh28Vo3Ye93qFrxAbcFJ/Uy+7LPD+jGjmfJYc=
 github.com/openshift/custom-resource-status v0.0.0-20190822192428-e62f2f3b79f3 h1:XuAys09+XqT5/FjdR23G/UtbBLII89dFe9XIi73EKIQ=
 github.com/openshift/custom-resource-status v0.0.0-20190822192428-e62f2f3b79f3/go.mod h1:GDjWl0tX6FNIj82vIxeudWeSx2Ff6nDZ8uJn0ohUFvo=
@@ -1278,11 +1278,10 @@ github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b/
 github.com/oracle/oci-go-sdk v7.0.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
 github.com/ory/dockertest v3.3.4+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
-github.com/ovirt/go-ovirt v0.0.0-20210112072624-e4d3b104de71/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
 github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c h1:2SbYZedeIawU8sGFnohfrdEcEMBA4V8SDouG6hly+H4=
 github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
-github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210326142716-4545f80e61cd h1:dG/VniPIWmJbiCunCA2S85QULDPQhXkUhlKo1T3MOYo=
-github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210326142716-4545f80e61cd/go.mod h1:xiMZ4bXb5VDorJN++WoqRbxLQ6k4sSlw59jqs5R08JQ=
+github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210419101841-5d3f6567ce90 h1:7URZwDm8pcQukU2VH69h8eI1DQDLZtfCKkKtuvQ9/DA=
+github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210419101841-5d3f6567ce90/go.mod h1:wnTGn9+USQJ51TMV5brymzjxUfmYmnOQZuNfYeuqky8=
 github.com/oxtoacart/bpool v0.0.0-20150712133111-4e1c5567d7c2/go.mod h1:L3UMQOThbttwfYRNFOWLLVXMhk5Lkio4GGOtw5UrxS0=
 github.com/packer-community/winrmcp v0.0.0-20180102160824-81144009af58/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=
 github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db h1:9uViuKtx1jrlXLBW/pMnhOfzn3iSEdLase/But/IZRU=

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -553,6 +553,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			string(*rhcosImage),
 			clusterID.InfraID,
 			masters[0].Spec.ProviderSpec.Value.Object.(*ovirtprovider.OvirtMachineProviderSpec),
+			installConfig.Config.Platform.Ovirt.AffinityGroups,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/asset/machines/ovirt/machinesets.go
+++ b/pkg/asset/machines/ovirt/machinesets.go
@@ -30,7 +30,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		total = *pool.Replicas
 	}
 
-	provider := provider(platform, pool, userDataSecret, osImage)
+	provider := provider(platform, pool, userDataSecret, clusterID, osImage)
 	name := fmt.Sprintf("%s-%s", clusterID, pool.Name)
 	mset := &machineapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/destroy/ovirt/destroyer.go
+++ b/pkg/destroy/ovirt/destroyer.go
@@ -2,6 +2,7 @@ package ovirt
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,6 +43,9 @@ func (uninstaller *ClusterUninstaller) Run() error {
 	}
 	if err := uninstaller.removeTemplate(con); err != nil {
 		uninstaller.Logger.Errorf("Failed to remove template: %s", err)
+	}
+	if err := uninstaller.removeAffinityGroups(con); err != nil {
+		uninstaller.Logger.Errorf("Failed to removing Affinity Groups: %s", err)
 	}
 
 	return nil
@@ -138,6 +142,25 @@ func (uninstaller *ClusterUninstaller) removeTemplate(con *ovirtsdk.Connection) 
 				if err != nil {
 					return err
 				}
+			}
+		}
+	}
+	return nil
+}
+
+func (uninstaller *ClusterUninstaller) removeAffinityGroups(con *ovirtsdk.Connection) error {
+	cID := uninstaller.Metadata.Ovirt.ClusterID
+	affinityGroupService := con.SystemService().ClustersService().ClusterService(cID).AffinityGroupsService()
+	res, err := affinityGroupService.List().Send()
+	if err != nil {
+		return err
+	}
+	for _, ag := range res.MustGroups().Slice() {
+		if strings.HasPrefix(ag.MustName(), fmt.Sprintf("%s-", uninstaller.Metadata.InfraID)) {
+			uninstaller.Logger.Infof("Removing AffinityGroup %s", ag.MustName())
+			_, err := affinityGroupService.GroupService(ag.MustId()).Remove().Send()
+			if err != nil {
+				uninstaller.Logger.Errorf("failed to remove AffinityGroup: %s", err)
 			}
 		}
 	}

--- a/pkg/terraform/exec/plugins/ovirt.go
+++ b/pkg/terraform/exec/plugins/ovirt.go
@@ -8,7 +8,7 @@ import (
 func init() {
 	exec := func() {
 		plugin.Serve(&plugin.ServeOpts{
-			ProviderFunc: ovirt.Provider,
+			ProviderFunc: ovirt.ProviderContext(),
 		})
 	}
 	KnownPlugins["terraform-provider-ovirt"] = exec

--- a/pkg/tfvars/ovirt/ovirt.go
+++ b/pkg/tfvars/ovirt/ovirt.go
@@ -3,11 +3,13 @@ package ovirt
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1"
 
 	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
+	"github.com/openshift/installer/pkg/types/ovirt"
 )
 
 // Auth is the collection of credentials that will be used by terraform.
@@ -22,18 +24,20 @@ type Auth struct {
 
 type config struct {
 	Auth                   `json:",inline"`
-	ClusterID              string `json:"ovirt_cluster_id"`
-	StorageDomainID        string `json:"ovirt_storage_domain_id"`
-	NetworkName            string `json:"ovirt_network_name,omitempty"`
-	VNICProfileID          string `json:"ovirt_vnic_profile_id,omitempty"`
-	BaseImageName          string `json:"openstack_base_image_name,omitempty"`
-	BaseImageLocalFilePath string `json:"openstack_base_image_local_file_path,omitempty"`
-	MasterInstanceTypeID   string `json:"ovirt_master_instance_type_id"`
-	MasterVMType           string `json:"ovirt_master_vm_type,omitempty"`
-	MasterMemory           int32  `json:"ovirt_master_memory"`
-	MasterCores            int32  `json:"ovirt_master_cores"`
-	MasterSockets          int32  `json:"ovirt_master_sockets"`
-	MasterOsDiskGB         int64  `json:"ovirt_master_os_disk_gb"`
+	ClusterID              string                   `json:"ovirt_cluster_id"`
+	StorageDomainID        string                   `json:"ovirt_storage_domain_id"`
+	NetworkName            string                   `json:"ovirt_network_name,omitempty"`
+	VNICProfileID          string                   `json:"ovirt_vnic_profile_id,omitempty"`
+	AffinityGroups         []map[string]interface{} `json:"ovirt_affinity_groups,omitempty"`
+	BaseImageName          string                   `json:"openstack_base_image_name,omitempty"`
+	BaseImageLocalFilePath string                   `json:"openstack_base_image_local_file_path,omitempty"`
+	MasterInstanceTypeID   string                   `json:"ovirt_master_instance_type_id"`
+	MasterVMType           string                   `json:"ovirt_master_vm_type,omitempty"`
+	MasterMemory           int32                    `json:"ovirt_master_memory"`
+	MasterCores            int32                    `json:"ovirt_master_cores"`
+	MasterSockets          int32                    `json:"ovirt_master_sockets"`
+	MasterOsDiskGB         int64                    `json:"ovirt_master_os_disk_gb"`
+	MasterAffinityGroups   []string                 `json:"ovirt_master_affinity_groups"`
 }
 
 // TFVars generates ovirt-specific Terraform variables.
@@ -45,8 +49,9 @@ func TFVars(
 	vnicProfileID string,
 	baseImage string,
 	infraID string,
-	masterSpec *v1beta1.OvirtMachineProviderSpec) ([]byte, error) {
-
+	masterSpec *v1beta1.OvirtMachineProviderSpec,
+	affinityGroups []ovirt.AffinityGroup,
+) ([]byte, error) {
 	cfg := config{
 		Auth:                 auth,
 		ClusterID:            clusterID,
@@ -58,6 +63,7 @@ func TFVars(
 		MasterVMType:         masterSpec.VMType,
 		MasterOsDiskGB:       masterSpec.OSDisk.SizeGB,
 		MasterMemory:         masterSpec.MemoryMB,
+		MasterAffinityGroups: masterSpec.AffinityGroupsNames,
 	}
 	if masterSpec.CPU != nil {
 		cfg.MasterCores = masterSpec.CPU.Cores
@@ -73,6 +79,21 @@ func TFVars(
 		}
 		cfg.BaseImageLocalFilePath = imageFilePath
 	}
-
+	if len(affinityGroups) > 0 {
+		cfg.AffinityGroups = handleAffinityGroups(affinityGroups, infraID)
+	}
 	return json.MarshalIndent(cfg, "", "  ")
+}
+
+func handleAffinityGroups(ags []ovirt.AffinityGroup, infraID string) []map[string]interface{} {
+	tfAffinityGroups := make([]map[string]interface{}, len(ags))
+	for i, ag := range ags {
+		tfAffinityGroups[i] = map[string]interface{}{
+			"name":        fmt.Sprintf("%s-%s", infraID, ag.Name),
+			"priority":    ag.Priority,
+			"description": ag.Description,
+			"enforcing":   ag.Enforcing,
+		}
+	}
+	return tfAffinityGroups
 }

--- a/pkg/tfvars/ovirt/ovirt_test.go
+++ b/pkg/tfvars/ovirt/ovirt_test.go
@@ -1,0 +1,121 @@
+package ovirt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1"
+	"github.com/openshift/installer/pkg/types/ovirt"
+)
+
+func defaultMachineSpec() *v1beta1.OvirtMachineProviderSpec {
+	return &v1beta1.OvirtMachineProviderSpec{
+		InstanceTypeId: "",
+		CPU: &v1beta1.CPU{
+			Sockets: 1,
+			Cores:   8,
+			Threads: 1,
+		},
+		MemoryMB:            16000,
+		OSDisk:              &v1beta1.Disk{SizeGB: 31},
+		VMType:              "high_performance",
+		AffinityGroupsNames: []string{"clusterName-xxxxx-controlplane"},
+	}
+}
+
+var defaultTerraformOvirtVarsJSON = `{
+  "ovirt_url": "https://ovirt-engine.com",
+  "ovirt_username": "admin",
+  "ovirt_password": "test",
+  "ovirt_cafile": "ca-file-content",
+  "ovirt_ca_bundle": "",
+  "ovirt_insecure": false,
+  "ovirt_cluster_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "ovirt_storage_domain_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "ovirt_network_name": "ovirt-network",
+  "ovirt_vnic_profile_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "ovirt_affinity_groups": [
+    {
+      "description": "AffinityGroup for spreading each control plane machines to a different host",
+      "enforcing": true,
+      "name": "clusterName-xxxxx-controlplane",
+      "priority": 5
+    },
+    {
+      "description": "AffinityGroup for spreading each compute machine to a different host",
+      "enforcing": true,
+      "name": "clusterName-xxxxx-compute",
+      "priority": 3
+    }
+  ],
+  "openstack_base_image_name": "some-base-image",
+  "ovirt_master_instance_type_id": "",
+  "ovirt_master_vm_type": "high_performance",
+  "ovirt_master_memory": 16000,
+  "ovirt_master_cores": 8,
+  "ovirt_master_sockets": 1,
+  "ovirt_master_os_disk_gb": 31,
+  "ovirt_master_affinity_groups": [
+    "clusterName-xxxxx-controlplane"
+  ]
+}`
+
+func TestSetPlatformDefaults(t *testing.T) {
+	cases := []struct {
+		name            string
+		auth            Auth
+		clusterID       string
+		storageDomainID string
+		networkName     string
+		vnicProfileID   string
+		baseImage       string
+		infraID         string
+		masterSpec      *v1beta1.OvirtMachineProviderSpec
+		affinityGroups  []ovirt.AffinityGroup
+		masterCount     int
+		expected        []byte
+	}{
+		{
+			name: "default",
+			auth: Auth{
+				URL:      "https://ovirt-engine.com",
+				Username: "admin",
+				Password: "test",
+				Cafile:   "ca-file-content",
+			},
+			clusterID:       "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			storageDomainID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			networkName:     "ovirt-network",
+			vnicProfileID:   "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+			baseImage:       "some-base-image",
+			infraID:         "clusterName-xxxxx",
+			masterSpec:      defaultMachineSpec(),
+			affinityGroups: []ovirt.AffinityGroup{{
+				Name:        "controlplane",
+				Priority:    5,
+				Description: "AffinityGroup for spreading each control plane machines to a different host",
+				Enforcing:   true,
+			}, {
+				Name:        "compute",
+				Priority:    3,
+				Description: "AffinityGroup for spreading each compute machine to a different host",
+				Enforcing:   true,
+			}},
+			masterCount: 3,
+			expected:    []byte(defaultTerraformOvirtVarsJSON),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tfVar, err := TFVars(
+				tc.auth, tc.clusterID, tc.storageDomainID, tc.networkName,
+				tc.vnicProfileID, tc.baseImage, tc.infraID, tc.masterSpec,
+				tc.affinityGroups)
+			if err != nil {
+				t.Fatalf("failed during test case %s: %v", tc.name, err)
+			}
+			assert.Equal(t, tc.expected, tfVar, "unexpected ovirt-specific Terraform variables file")
+		})
+	}
+}

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -86,6 +86,10 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		baremetaldefaults.SetPlatformDefaults(c.Platform.BareMetal, c)
 	case c.Platform.Ovirt != nil:
 		ovirtdefaults.SetPlatformDefaults(c.Platform.Ovirt)
+		ovirtdefaults.SetControlPlaneDefaults(c.Platform.Ovirt, c.ControlPlane)
+		for i := range c.Compute {
+			ovirtdefaults.SetComputeDefaults(c.Platform.Ovirt, &c.Compute[i])
+		}
 	case c.Platform.Kubevirt != nil:
 		kubevirtdefaults.SetPlatformDefaults(c.Platform.Kubevirt)
 	case c.Platform.None != nil:

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -18,6 +18,8 @@ import (
 	nonedefaults "github.com/openshift/installer/pkg/types/none/defaults"
 	"github.com/openshift/installer/pkg/types/openstack"
 	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
+	"github.com/openshift/installer/pkg/types/ovirt"
+	ovirtdefaults "github.com/openshift/installer/pkg/types/ovirt/defaults"
 )
 
 func defaultInstallConfig() *types.InstallConfig {
@@ -69,6 +71,17 @@ func defaultOpenStackInstallConfig() *types.InstallConfig {
 	c := defaultInstallConfig()
 	c.Platform.OpenStack = &openstack.Platform{}
 	openstackdefaults.SetPlatformDefaults(c.Platform.OpenStack, c.Networking)
+	return c
+}
+
+func defaultOvirtInstallConfig() *types.InstallConfig {
+	c := defaultInstallConfig()
+	c.Platform.Ovirt = &ovirt.Platform{}
+	ovirtdefaults.SetPlatformDefaults(c.Platform.Ovirt)
+	ovirtdefaults.SetControlPlaneDefaults(c.Platform.Ovirt, c.ControlPlane)
+	for i := range c.Compute {
+		ovirtdefaults.SetComputeDefaults(c.Platform.Ovirt, &c.Compute[i])
+	}
 	return c
 }
 
@@ -125,6 +138,15 @@ func TestSetInstallConfigDefaults(t *testing.T) {
 				},
 			},
 			expected: defaultOpenStackInstallConfig(),
+		},
+		{
+			name: "empty oVirt",
+			config: &types.InstallConfig{
+				Platform: types.Platform{
+					Ovirt: &ovirt.Platform{},
+				},
+			},
+			expected: defaultOvirtInstallConfig(),
 		},
 		{
 			name: "Networking present",

--- a/pkg/types/ovirt/defaults/machinepools.go
+++ b/pkg/types/ovirt/defaults/machinepools.go
@@ -1,0 +1,34 @@
+package defaults
+
+import (
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/ovirt"
+)
+
+func setMachinePool(p *types.MachinePool) {
+	if p.Platform.Ovirt == nil {
+		p.Platform.Ovirt = &ovirt.MachinePool{}
+	}
+}
+
+func setDefaultAffinityGroups(p *ovirt.Platform, mp *types.MachinePool, agName string) {
+	if len(mp.Platform.Ovirt.AffinityGroupsNames) == 0 {
+		for _, ag := range p.AffinityGroups {
+			if ag.Name == agName {
+				mp.Platform.Ovirt.AffinityGroupsNames = []string{agName}
+			}
+		}
+	}
+}
+
+// SetControlPlaneDefaults sets the defaults for the ControlPlane Machines.
+func SetControlPlaneDefaults(p *ovirt.Platform, mp *types.MachinePool) {
+	setMachinePool(mp)
+	setDefaultAffinityGroups(p, mp, DefaultControlPlaneAffinityGroupName)
+}
+
+// SetComputeDefaults sets the defaults for the Compute Machines.
+func SetComputeDefaults(p *ovirt.Platform, mp *types.MachinePool) {
+	setMachinePool(mp)
+	setDefaultAffinityGroups(p, mp, DefaultComputeAffinityGroupName)
+}

--- a/pkg/types/ovirt/defaults/platform.go
+++ b/pkg/types/ovirt/defaults/platform.go
@@ -4,12 +4,42 @@ import (
 	"github.com/openshift/installer/pkg/types/ovirt"
 )
 
-// DefaultNetworkName is the default network name to use in a cluster
+// DefaultNetworkName is the default network name to use in a cluster.
 const DefaultNetworkName = "ovirtmgmt"
+
+// DefaultControlPlaneAffinityGroupName is the default affinity group name for the control plane VMs.
+const DefaultControlPlaneAffinityGroupName = "controlplane"
+
+// DefaultComputeAffinityGroupName is the default affinity group name for the compute VMs.
+const DefaultComputeAffinityGroupName = "compute"
+
+func defaultControlPlaneAffinityGroup() ovirt.AffinityGroup {
+	return ovirt.AffinityGroup{
+		Name:        DefaultControlPlaneAffinityGroupName,
+		Priority:    5,
+		Description: "AffinityGroup for spreading each control plane machine to a different host",
+		Enforcing:   true,
+	}
+}
+
+func defaultComputeAffinityGroup() ovirt.AffinityGroup {
+	return ovirt.AffinityGroup{
+		Name:        DefaultComputeAffinityGroupName,
+		Priority:    3,
+		Description: "AffinityGroup for spreading each compute machine to a different host",
+		Enforcing:   true,
+	}
+}
 
 // SetPlatformDefaults sets the defaults for the platform.
 func SetPlatformDefaults(p *ovirt.Platform) {
 	if p.NetworkName == "" {
 		p.NetworkName = DefaultNetworkName
+	}
+	if p.AffinityGroups == nil {
+		// No affinity group field, using the default settings
+		p.AffinityGroups = []ovirt.AffinityGroup{
+			defaultComputeAffinityGroup(),
+			defaultControlPlaneAffinityGroup()}
 	}
 }

--- a/pkg/types/ovirt/defaults/platform_test.go
+++ b/pkg/types/ovirt/defaults/platform_test.go
@@ -11,6 +11,10 @@ import (
 func defaultPlatform() *ovirt.Platform {
 	return &ovirt.Platform{
 		NetworkName: DefaultNetworkName,
+		AffinityGroups: []ovirt.AffinityGroup{
+			defaultComputeAffinityGroup(),
+			defaultControlPlaneAffinityGroup(),
+		},
 	}
 }
 

--- a/pkg/types/ovirt/machinepool.go
+++ b/pkg/types/ovirt/machinepool.go
@@ -24,6 +24,11 @@ type MachinePool struct {
 	// +kubebuilder:validation:Enum="";desktop;server;high_performance
 	// +optional
 	VMType VMType `json:"vmType,omitempty"`
+
+	// AffinityGroupsNames contains a list of oVirt affinity group names that the newly created machines will join.
+	// The affinity groups should exist on the oVirt cluster or created by the OpenShift installer.
+	// +optional
+	AffinityGroupsNames []string `json:"affinityGroupsNames,omitempty"`
 }
 
 // Disk defines a VM disk
@@ -89,5 +94,9 @@ func (p *MachinePool) Set(required *MachinePool) {
 
 	if required.OSDisk != nil {
 		p.OSDisk = required.OSDisk
+	}
+
+	if len(required.AffinityGroupsNames) > 0 {
+		p.AffinityGroupsNames = required.AffinityGroupsNames
 	}
 }

--- a/pkg/types/ovirt/platform.go
+++ b/pkg/types/ovirt/platform.go
@@ -33,4 +33,22 @@ type Platform struct {
 	// Default will set the image field to the latest RHCOS image.
 	// +optional
 	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// AffinityGroups contains the RHV affinity groups that the installer will create.
+	// +optional
+	AffinityGroups []AffinityGroup `json:"affinityGroups"`
+}
+
+// AffinityGroup defines the affinity group that the installer will create
+type AffinityGroup struct {
+	// Name name of the affinity group
+	Name string `json:"name"`
+	// Priority of the affinity group, needs to be between 1 (lowest) - 5 (highest)
+	Priority int `json:"priority"`
+	// Description of the affinity group
+	// +optional
+	Description string `json:"description,omitempty"`
+	// Enforcing whether to create a hard affinity rule, default is false
+	// +optional
+	Enforcing bool `json:"enforcing"`
 }

--- a/pkg/types/ovirt/validation/platform.go
+++ b/pkg/types/ovirt/validation/platform.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"fmt"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/ovirt"
@@ -27,8 +29,56 @@ func ValidatePlatform(p *ovirt.Platform, fldPath *field.Path) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("vnicProfileID"), p.IngressVIP, err.Error()))
 		}
 	}
+	if p.AffinityGroups != nil {
+		allErrs = append(allErrs, validateAffinityGroupFields(p, fldPath.Child("affinityGroups"))...)
+		allErrs = append(allErrs, validateAffinityGroupDuplicate(p.AffinityGroups)...)
+	}
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
+	}
+	return allErrs
+}
+
+func validateAffinityGroupFields(platform *ovirt.Platform, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for _, ag := range platform.AffinityGroups {
+		if ag.Name == "" {
+			allErrs = append(
+				allErrs,
+				field.Required(fldPath,
+					fmt.Sprintf("Invalid affinity group %v: name must be not empty", ag.Name)))
+		}
+		if ag.Priority < 0 || ag.Priority > 5 {
+			allErrs = append(
+				allErrs,
+				field.Invalid(fldPath, ag,
+					fmt.Sprintf(
+						"Invalid affinity group %v: priority value must be between 0-5 found priority %v",
+						ag.Name,
+						ag.Priority)))
+		}
+	}
+	return allErrs
+}
+
+// validateAffinityGroupDuplicate checks that there is no duplicated affinity group with different fields
+func validateAffinityGroupDuplicate(agList []ovirt.AffinityGroup) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for i, ag1 := range agList {
+		for _, ag2 := range agList[i+1:] {
+			if ag1.Name == ag2.Name {
+				if ag1.Priority != ag2.Priority ||
+					ag1.Description != ag2.Description ||
+					ag1.Enforcing != ag2.Enforcing {
+					allErrs = append(
+						allErrs,
+						&field.Error{
+							Type: field.ErrorTypeDuplicate,
+							BadValue: errors.Errorf("Error validating affinity groups: found same "+
+								"affinity group defined twice with different fields %v anf %v", ag1, ag2)})
+				}
+			}
+		}
 	}
 	return allErrs
 }

--- a/vendor/github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1/types.go
+++ b/vendor/github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1/types.go
@@ -75,7 +75,12 @@ type OvirtMachineProviderSpec struct {
 
 	// VMAffinityGroup contains the name of the OpenShift cluster affinity groups
 	// It will be used to add the newly created machine to the affinity groups
-	AffinityGroupsNames []string `json:"affinity_groups_names,omitempty`
+	AffinityGroupsNames []string `json:"affinity_groups_names,omitempty"`
+
+	// AutoPinningPolicy defines the policy to automatically set the CPU
+	// and NUMA including pinning to the host for the instance.
+	// One of "disabled, existing, adjust"
+	AutoPinningPolicy string `json:"auto_pinning_policy,omitempty"`
 }
 
 // CPU defines the VM cpu, made of (Sockets * Cores * Threads)

--- a/vendor/github.com/ovirt/terraform-provider-ovirt/ovirt/resource_ovirt_affinity_group.go
+++ b/vendor/github.com/ovirt/terraform-provider-ovirt/ovirt/resource_ovirt_affinity_group.go
@@ -106,23 +106,29 @@ func resourceOvirtAffinityGroupCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	vmRuleBuilder := ovirtsdk4.NewAffinityRuleBuilder()
-	if _, ok := d.GetOk("vm_list"); ok {
+	vmRuleBuilder.Enabled(false)
+	if vmPositive, ok := d.GetOkExists("vm_positive"); ok {
 		vmRuleBuilder.Enabled(true)
-		vmRuleBuilder.Positive(d.Get("vm_positive").(bool))
-		vmRuleBuilder.Enforcing(d.Get("vm_enforcing").(bool))
-	} else {
-		vmRuleBuilder.Enabled(false)
+		vmRuleBuilder.Positive(vmPositive.(bool))
 	}
+	if vmEnforcing, ok := d.GetOk("vm_enforcing"); ok {
+		vmRuleBuilder.Enabled(true)
+		vmRuleBuilder.Enforcing(vmEnforcing.(bool))
+	}
+
 	agBuilder.VmsRule(vmRuleBuilder.MustBuild())
 
 	hostRuleBuilder := ovirtsdk4.NewAffinityRuleBuilder()
-	if _, ok := d.GetOk("host_list"); ok {
+	hostRuleBuilder.Enabled(false)
+	if hostPositive, ok := d.GetOkExists("host_positive"); ok {
 		hostRuleBuilder.Enabled(true)
-		hostRuleBuilder.Positive(d.Get("host_positive").(bool))
-		hostRuleBuilder.Enforcing(d.Get("host_enforcing").(bool))
-	} else {
-		hostRuleBuilder.Enabled(false)
+		hostRuleBuilder.Positive(hostPositive.(bool))
 	}
+	if hostEnforcing, ok := d.GetOk("host_enforcing"); ok {
+		hostRuleBuilder.Enabled(true)
+		hostRuleBuilder.Enforcing(hostEnforcing.(bool))
+	}
+
 	agBuilder.HostsRule(hostRuleBuilder.MustBuild())
 
 	log.Printf("Creating %#v", agBuilder.MustBuild())

--- a/vendor/github.com/ovirt/terraform-provider-ovirt/ovirt/utils.go
+++ b/vendor/github.com/ovirt/terraform-provider-ovirt/ovirt/utils.go
@@ -64,3 +64,19 @@ func parseResourceID(id string, count int) ([]string, error) {
 	}
 	return parts, nil
 }
+
+//Converts an array of type []interface{} to []string, notice that all the interface elements needs to be strings
+func convInterfaceArrToStringArr(arr []interface{}) ([]string, error) {
+	var newArr []string
+	for _, val := range arr {
+		if s, ok := val.(string); ok {
+			newArr = append(newArr, s)
+		} else {
+			return nil, fmt.Errorf(
+				"error converting []interface{} to []string, "+
+					"provided interface array %v contains non string elements %v",
+				arr, val)
+		}
+	}
+	return newArr, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1131,7 +1131,7 @@ github.com/openshift/cluster-api-provider-kubevirt/pkg/utils
 ## explicit
 github.com/openshift/cluster-api-provider-libvirt/pkg/apis
 github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1
-# github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210315122142-893a4db3909a
+# github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210406154451-1ea59ab6b543
 ## explicit
 github.com/openshift/cluster-api-provider-ovirt/pkg/apis
 github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1
@@ -1153,7 +1153,7 @@ github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.opens
 # github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c
 ## explicit
 github.com/ovirt/go-ovirt
-# github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210326142716-4545f80e61cd
+# github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210419101841-5d3f6567ce90
 ## explicit
 github.com/ovirt/terraform-provider-ovirt/ovirt
 # github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db


### PR DESCRIPTION
We want the installer to have the following behavior:

Default:
Create 2 unique affinity groups with a hard negative affinity rule:
- ovirt11-****-controlplane - contain the masters only and have a higher priority(5).
- ovirt11-****-compute - contain the compute only, priority(3).

Customizations:
1. No Affinity groups:
To not create any AffinityGroups the user needs to have an empty field on the install config for the platform Like:
```yaml
...
platform:
  ovirt:
    api_vip: xxx.xxx.xxx.xxx
    ingress_vip: xxx.xxx.xxx.xxx
    ovirt_cluster_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    ovirt_storage_domain_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    affinityGroups: []
...
```

2. Customize created affinity Groups:
The user can define the affinity groups that the installer will create by editing the affinityGroups field, for example:
```yaml
platform:
  ovirt:
    api_vip: xxx.xxx.xxx.xxx
    ingress_vip: xxx.xxx.xxx.xxx
    ovirt_cluster_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    ovirt_storage_domain_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    affinityGroups:
    - description: test1
      enforcing: true
      name: test1
      priority: 3
    - description: test2
        host
      enforcing: true
      name: test2
      priority: 5
...
```

3. Decide which machine pools will be added to the affinity groups:
The user can specify on the machine pool the affinity groups that those machines will join on creation, by editing the affinityGroupsNames field, those groups need to be created by the installer or existing in the ovirt cluster.
```yaml
...
compute:
- name: worker
  platform:
    ovirt:
      affinityGroupsNames:
      - test1
...
  replicas: 2
controlPlane:
...
  name: master
  platform:
    ovirt:
      affinityGroupsNames:
      - test1
      - test2
...
  replicas: 3
...
