### PR TITLE
baremetal: automatic UEFI secure boot configuration

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1172,10 +1172,13 @@ spec:
                         bootMACAddress:
                           type: string
                         bootMode:
-                          description: BootMode puts the server in legacy (BIOS) or
-                            UEFI mode for booting. The default is UEFI.
+                          description: BootMode puts the server in legacy (BIOS),
+                            UEFI secure boot or UEFI mode for booting. Secure boot
+                            is only enabled during the final instance boot. The default
+                            is UEFI.
                           enum:
                           - UEFI
+                          - UEFISecureBoot
                           - legacy
                           type: string
                         hardwareProfile:

--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -157,7 +157,8 @@ include:
   https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md
 
 * *bootMode* -- Put the server in legacy (BIOS) or UEFI mode for
-  booting. The default is UEFI.
+  booting. Use UEFISecureBoot to enable UEFI and secure boot on the server.
+  The default is UEFI.
 
 ```yaml
 apiVersion: v1

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -88,9 +88,14 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		// it is not set. We use the capabilities field instead of
 		// instance_info to ensure the host is in the right mode for
 		// virtualmedia-based introspection.
-		bootMode := "boot_mode:uefi"
-		if host.BootMode == baremetal.Legacy {
+		var bootMode string
+		switch host.BootMode {
+		case baremetal.Legacy:
 			bootMode = "boot_mode:bios"
+		case baremetal.UEFISecureBoot:
+			bootMode = "boot_mode:uefi,secure_boot:true"
+		default:
+			bootMode = "boot_mode:uefi"
 		}
 
 		// Properties
@@ -136,6 +141,12 @@ func TFVars(libvirtURI, bootstrapProvisioningIP, bootstrapOSImage, externalBridg
 		instanceInfo := map[string]interface{}{
 			"image_source":   cacheImageURL,
 			"image_checksum": cacheChecksumURL,
+		}
+
+		if host.BootMode == baremetal.UEFISecureBoot {
+			instanceInfo["capabilities"] = map[string]string{
+				"secure_boot": "true",
+			}
 		}
 
 		hosts = append(hosts, hostMap)

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -12,15 +12,17 @@ type BMC struct {
 	DisableCertificateVerification bool   `json:"disableCertificateVerification"`
 }
 
-// BootMode puts the server in legacy (BIOS) or UEFI mode for
-// booting. The default is UEFI.
-// +kubebuilder:validation:Enum=UEFI;legacy
+// BootMode puts the server in legacy (BIOS), UEFI secure boot or UEFI mode for
+// booting. Secure boot is only enabled during the final instance boot.
+// The default is UEFI.
+// +kubebuilder:validation:Enum=UEFI;UEFISecureBoot;legacy
 type BootMode string
 
 // Allowed boot mode from metal3
 const (
-	UEFI   BootMode = "UEFI"
-	Legacy BootMode = "legacy"
+	UEFI           BootMode = "UEFI"
+	UEFISecureBoot BootMode = "UEFISecureBoot"
+	Legacy         BootMode = "legacy"
 )
 
 // Host stores all the configuration data for a baremetal host.

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -283,9 +283,10 @@ func validateHostsCount(hosts []*baremetal.Host, installConfig *types.InstallCon
 func validateBootMode(hosts []*baremetal.Host, fldPath *field.Path) (errors field.ErrorList) {
 	for idx, host := range hosts {
 		switch host.BootMode {
-		case "", baremetal.UEFI, baremetal.Legacy:
+		case "", baremetal.UEFI, baremetal.UEFISecureBoot, baremetal.Legacy:
 		default:
-			errors = append(errors, field.Invalid(fldPath.Index(idx).Child("bootMode"), host.BootMode, "bootMode must be one of \"UEFI\" or \"legacy\""))
+			valid := []string{string(baremetal.UEFI), string(baremetal.UEFISecureBoot), string(baremetal.Legacy)}
+			errors = append(errors, field.NotSupported(fldPath.Index(idx).Child("bootMode"), host.BootMode, valid))
 		}
 	}
 	return

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -114,12 +114,18 @@ func TestValidatePlatform(t *testing.T) {
 			name: "invalid_boot_mode",
 			platform: platform().
 				Hosts(host1().BootMode("not-a-valid-value")).build(),
-			expected: "baremetal.Hosts\\[0\\].bootMode: Invalid value: \"not-a-valid-value\": bootMode must be one of \"UEFI\" or \"legacy\"",
+			expected: "baremetal.Hosts\\[0\\].bootMode: Unsupported value: \"not-a-valid-value\": supported values: \"UEFI\", \"UEFISecureBoot\", \"legacy\"",
 		},
 		{
 			name: "uefi_boot_mode",
 			platform: platform().
 				Hosts(host1().BootMode("UEFI")).build(),
+			expected: "",
+		},
+		{
+			name: "uefi_secure_boot_mode",
+			platform: platform().
+				Hosts(host1().BootMode("UEFISecureBoot")).build(),
 			expected: "",
 		},
 		{


### PR DESCRIPTION
Uses the new baremetal-operator BootMode value UEFISecureBoot to request
Ironic to automatically configure secure boot during the instance start.

Metal3 design: https://github.com/metal3-io/metal3-docs/pull/161