### PR TITLE
baremetal:  pass an sshKey to ironic

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -15,6 +15,9 @@ RHCOS_BOOT_IMAGE_URL="{{.BootImage}}"
 # dnsmasq will only serve TFTP, and DHCP will be disabled.
 DHCP_RANGE="{{.PlatformData.BareMetal.ProvisioningDHCPRange}}"
 
+# Used by ironic to allow ssh to running IPA instances
+IRONIC_RAMDISK_SSH_KEY="{{.SSHKey}}"
+
 # First we stop any previously started containers, because ExecStop only runs when the ExecStart process
 # e.g this script is still running, but we exit if *any* of the containers exits unexpectedly
 for name in ironic-api ironic-conductor ironic-inspector ironic-deploy-ramdisk-logs ironic-inspector-ramdisk-logs dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
@@ -84,6 +87,7 @@ podman run -d --net host --privileged --name mariadb \
      --env MARIADB_PASSWORD=$mariadb_password ${IRONIC_IMAGE}
 
 podman run -d --net host --privileged --name httpd \
+     --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      -v $IRONIC_SHARED_VOLUME:/shared:z --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
 
@@ -145,6 +149,7 @@ while ! curl --fail --head http://localhost/images/ironic-python-agent.initramfs
 while ! curl --fail --head http://localhost/images/ironic-python-agent.kernel ; do sleep 1; done
 
 sudo podman run -d --net host --privileged --name ironic-conductor \
+     --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
      --env MARIADB_PASSWORD=$mariadb_password \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120 \

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -67,6 +67,7 @@ type bootstrapTemplateData struct {
 	FIPS                  bool
 	EtcdCluster           string
 	PullSecret            string
+	SSHKey                string
 	ReleaseImage          string
 	ClusterProfile        string
 	Proxy                 *configv1.ProxyStatus
@@ -280,6 +281,7 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		AdditionalTrustBundle: installConfig.Config.AdditionalTrustBundle,
 		FIPS:                  installConfig.Config.FIPS,
 		PullSecret:            installConfig.Config.PullSecret,
+		SSHKey:                installConfig.Config.SSHKey,
 		ReleaseImage:          releaseImage.PullSpec,
 		EtcdCluster:           strings.Join(etcdEndpoints, ","),
 		Proxy:                 &proxy.Config.Status,


### PR DESCRIPTION
Use the ssh key from install-config to allow ssh to
running IPA instance on master nodes.


Makes use of the recently added IRONIC_RAMDISK_SSH_KEY parameter
https://github.com/openshift/ironic-image/pull/151

