### PR TITLE
Bug 1868755: vsphereprivate: tf plugin to no longer error if no network found.

### DIFF
--- a/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
+++ b/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
@@ -151,6 +151,9 @@ func findImportOvaParams(client *vim25.Client, datacenter, cluster, datastore, n
 			break
 		}
 	}
+	if importOvaParams.Network == nil {
+		return nil, errors.Errorf("failed to find a host in the cluster that contains the provided network")
+	}
 
 	// Find all the datastores that are configured under the cluster
 	datastores, err := clusterComputeResource.Datastores(ctx)
@@ -168,6 +171,9 @@ func findImportOvaParams(client *vim25.Client, datacenter, cluster, datastore, n
 			importOvaParams.Datastore = datastoreObj
 			break
 		}
+	}
+	if importOvaParams.Datastore == nil {
+		return nil, errors.Errorf("failed to find a host in the cluster that contains the provided datastore")
 	}
 
 	// Find all the HostSystem(s) under cluster


### PR DESCRIPTION
Prior to this change, the vsphereprivate Terraform plugin would fatally
error if the specified network was not found on any hosts when importing
the ova. Because the error was a common pointer reference error, it was
difficult to determine what caused the error. This change adds a more
clear error when this situation happens.