### PR TITLE
baremetal: set default boot mode explicitly

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1177,6 +1177,7 @@ spec:
                             is only enabled during the final instance boot. The default
                             is UEFI.
                           enum:
+                          - ""
                           - UEFI
                           - UEFISecureBoot
                           - legacy

--- a/pkg/types/baremetal/defaults/platform.go
+++ b/pkg/types/baremetal/defaults/platform.go
@@ -19,6 +19,7 @@ const (
 	HardwareProfile         = "default"
 	APIVIP                  = ""
 	IngressVIP              = ""
+	BootMode                = baremetal.UEFI
 )
 
 // Wrapper for net.LookupHost so we can override in the test
@@ -87,6 +88,10 @@ func SetPlatformDefaults(p *baremetal.Platform, c *types.InstallConfig) {
 	for _, host := range p.Hosts {
 		if host.HardwareProfile == "" {
 			host.HardwareProfile = HardwareProfile
+		}
+
+		if host.BootMode == "" {
+			host.BootMode = BootMode
 		}
 	}
 

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -15,7 +15,7 @@ type BMC struct {
 // BootMode puts the server in legacy (BIOS), UEFI secure boot or UEFI mode for
 // booting. Secure boot is only enabled during the final instance boot.
 // The default is UEFI.
-// +kubebuilder:validation:Enum=UEFI;UEFISecureBoot;legacy
+// +kubebuilder:validation:Enum="";UEFI;UEFISecureBoot;legacy
 type BootMode string
 
 // Allowed boot mode from metal3


### PR DESCRIPTION
Implicitly, tfvars makes the default value for BootMode "UEFI." This
should instead be done by pkg/types/baremetal/defaults, and so that
`explain` shows an empty value as being allowed.