### PR TITLE
Enable re-use of existing private hosted zone in AWS

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -89,6 +89,7 @@ module "dns" {
   vpc_id                   = module.vpc.vpc_id
   region                   = var.aws_region
   publish_strategy         = var.aws_publish_strategy
+  zone_id                  = var.aws_private_zone_id
 }
 
 module "vpc" {
@@ -128,4 +129,3 @@ resource "aws_ami_copy" "imported" {
     local.tags,
   )
 }
-

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -58,3 +58,8 @@ variable "region" {
   type = string
   description = "The target AWS region for the cluster."
 }
+
+variable "zone_id" {
+  type = string
+  description = "The existing private zone ID to use. If left empty, then a new zone will be created (default)."
+}

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -148,3 +148,8 @@ The stub Ignition config that should be used to boot the bootstrap instance. Thi
 specified in aws_ignition_bucket.
 EOF
 }
+
+variable "aws_private_zone_id" {
+  type = string
+  description = "The existing private zone ID to use. If left empty, then a new zone will be created (default)."
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -9,16 +9,16 @@ import (
 	"strings"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/ghodss/yaml"
+	configv1 "github.com/openshift/api/config/v1"
 	gcpprovider "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
 	kubevirtprovider "github.com/openshift/cluster-api-provider-kubevirt/pkg/apis/kubevirtprovider/v1alpha1"
 	kubevirtutils "github.com/openshift/cluster-api-provider-kubevirt/pkg/utils"
 	libvirtprovider "github.com/openshift/cluster-api-provider-libvirt/pkg/apis/libvirtproviderconfig/v1beta1"
 	ovirtprovider "github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1"
-	configv1 "github.com/openshift/api/config/v1"
 	vsphereprovider "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/ghodss/yaml"
 	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1"
 	azureprovider "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
 	openstackprovider "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
@@ -29,12 +29,12 @@ import (
 	baremetalbootstrap "github.com/openshift/installer/pkg/asset/ignition/bootstrap/baremetal"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	"github.com/openshift/installer/pkg/asset/manifests"
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	openstackconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	ovirtconfig "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	"github.com/openshift/installer/pkg/asset/machines"
+	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/openshiftinstall"
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	rhcospkg "github.com/openshift/installer/pkg/rhcos"
@@ -206,14 +206,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			}
 		}
 
-		privateHostedZoneId := ""
+		privateHostedZoneID := ""
 		for _, manifestFile := range manifestsInDirectory.Files() {
-			if manifestFile.Filename == manifests.GetDnsCfgFilename() {
-				var clusterDnsFileStruct configv1.DNS
-				if err := yaml.Unmarshal(manifestFile.Data, &clusterDnsFileStruct); err != nil {
-					return errors.Wrapf(err, "Unable to parse manifests/cluster-dns-02-config.yml as proper YAML file", platform)
+			if manifestFile.Filename == manifests.GetDNSCfgFilename() {
+				var clusterDNSFileStruct configv1.DNS
+				if err := yaml.Unmarshal(manifestFile.Data, &clusterDNSFileStruct); err != nil {
+					return errors.Wrapf(err, "Unable to parse manifests/cluster-dns-02-config.yml as proper YAML file")
 				}
-				privateHostedZoneId = clusterDnsFileStruct.Spec.PrivateZone.ID
+				privateHostedZoneID = clusterDNSFileStruct.Spec.PrivateZone.ID
 				break
 			}
 		}
@@ -263,7 +263,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			IgnitionBucket:        bucket,
 			IgnitionPresignedURL:  url,
 			AdditionalTrustBundle: installConfig.Config.AdditionalTrustBundle,
-			PrivateZoneId:         privateHostedZoneId,
+			PrivateZoneID:         privateHostedZoneID,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -45,6 +45,11 @@ func (*DNS) Name() string {
 	return "DNS Config"
 }
 
+// returns the dnsCfgFilename variable
+func GetDnsCfgFilename() string {
+	return dnsCfgFilename
+}
+
 // Dependencies returns all of the dependencies directly needed to generate
 // the asset.
 func (*DNS) Dependencies() []asset.Asset {

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -45,8 +45,8 @@ func (*DNS) Name() string {
 	return "DNS Config"
 }
 
-// returns the dnsCfgFilename variable
-func GetDnsCfgFilename() string {
+// GetDNSCfgFilename returns the dnsCfgFilename variable
+func GetDNSCfgFilename() string {
 	return dnsCfgFilename
 }
 

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -36,11 +36,13 @@ type config struct {
 	SkipRegionCheck         bool              `json:"aws_skip_region_validation"`
 	IgnitionBucket          string            `json:"aws_ignition_bucket"`
 	BootstrapIgnitionStub   string            `json:"aws_bootstrap_stub_ignition"`
+	PrivateZoneId           string            `json:"aws_private_zone_id"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
 	VPC                           string
+	PrivateZoneId                 string
 	PrivateSubnets, PublicSubnets []string
 	Services                      []typesaws.ServiceEndpoint
 
@@ -123,6 +125,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		PublishStrategy:         string(sources.Publish),
 		SkipRegionCheck:         !configaws.IsKnownRegion(masterConfig.Placement.Region),
 		IgnitionBucket:          sources.IgnitionBucket,
+		PrivateZoneId:           sources.PrivateZoneId,
 	}
 
 	stubIgn, err := generateIgnitionShim(sources.IgnitionPresignedURL, sources.AdditionalTrustBundle)

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -36,13 +36,13 @@ type config struct {
 	SkipRegionCheck         bool              `json:"aws_skip_region_validation"`
 	IgnitionBucket          string            `json:"aws_ignition_bucket"`
 	BootstrapIgnitionStub   string            `json:"aws_bootstrap_stub_ignition"`
-	PrivateZoneId           string            `json:"aws_private_zone_id"`
+	PrivateZoneID           string            `json:"aws_private_zone_id"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
 	VPC                           string
-	PrivateZoneId                 string
+	PrivateZoneID                 string
 	PrivateSubnets, PublicSubnets []string
 	Services                      []typesaws.ServiceEndpoint
 
@@ -125,7 +125,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		PublishStrategy:         string(sources.Publish),
 		SkipRegionCheck:         !configaws.IsKnownRegion(masterConfig.Placement.Region),
 		IgnitionBucket:          sources.IgnitionBucket,
-		PrivateZoneId:           sources.PrivateZoneId,
+		PrivateZoneID:           sources.PrivateZoneID,
 	}
 
 	stubIgn, err := generateIgnitionShim(sources.IgnitionPresignedURL, sources.AdditionalTrustBundle)


### PR DESCRIPTION
This modification allows by modifying the cluster-dns-02-config.yml manifest
file to ask the installer to re-use an already existing private AWS
hosted zone in Route53.

In the data/data/aws/route53/base.tf file a new "data" section was
added and based on the value of a TF variable either the "data" section
or the "ressource" section is being used. If the TF variable is set
to Golang's string zero value ("") then a new hosted zone will be
created (default behavior), otherwise, if not string zero, then TF will
try to use the hosted zone, which ID corresponds to the one specified
in the TF variable.

In order to activate the mechanism:
1) specify "publish: Internal" inside the install-config.yaml
2) generate the manifests
3) modify manifests/cluster-dns-02-config.yml by:
3.1) removing the "tags" section from "privateZone"
3.2) adding "id" string value inside the "privateZone". Set the value
     of this string to the hosted zone ID ("Z0123QQQZXX..."), you
     wish to reuse
4) execute "openshift-install create cluster ..."

This is exactly what is described in this file:
docs/user/aws/install_upi.md
under the chapter "Identify the internal DNS zone"

This mechanism could be extended for other cloud providers, e.g.
Azure or GCP, but I don't have the resources to do it.