### PR TITLE
baremetal: Allow IPA kernel console to be configured

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -18,6 +18,12 @@ DHCP_RANGE="{{.PlatformData.BareMetal.ProvisioningDHCPRange}}"
 # Used by ironic to allow ssh to running IPA instances
 IRONIC_RAMDISK_SSH_KEY="{{.SSHKey}}"
 
+# Used by ironic to set kernel options on running IPA instances
+IRONIC_KERNEL_PARAMS=
+{{ if .PlatformData.BareMetal.ProvisioningConsole }}
+    IRONIC_KERNEL_PARAMS="console={{.PlatformData.BareMetal.ProvisioningConsole}}"
+{{ end }}
+
 # First we stop any previously started containers, because ExecStop only runs when the ExecStart process
 # e.g this script is still running, but we exit if *any* of the containers exits unexpectedly
 for name in ironic-api ironic-conductor ironic-inspector ironic-deploy-ramdisk-logs ironic-inspector-ramdisk-logs dnsmasq httpd mariadb ipa-downloader coreos-downloader; do
@@ -88,6 +94,7 @@ podman run -d --net host --privileged --name mariadb \
 
 podman run -d --net host --privileged --name httpd \
      --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
+     --env IRONIC_KERNEL_PARAMS="$IRONIC_KERNEL_PARAMS" \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      -v $IRONIC_SHARED_VOLUME:/shared:z --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
 
@@ -150,6 +157,7 @@ while ! curl --fail --head http://localhost/images/ironic-python-agent.kernel ; 
 
 sudo podman run -d --net host --privileged --name ironic-conductor \
      --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
+     --env IRONIC_KERNEL_PARAMS="$IRONIC_KERNEL_PARAMS" \
      --env MARIADB_PASSWORD=$mariadb_password \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120 \

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -35,6 +35,10 @@ type TemplateData struct {
 	// MAC addresses. Requests to bootstrap DHCP from other hosts will be ignored.
 	ProvisioningDHCPAllowList string
 
+	// ProvisioningConsole is a device which should be passed to the IPA kernel to use as its console as
+	// kernel ... console=<ProvisioningConsole>
+	ProvisioningConsole string
+
 	// IronicUsername contains the username for authentication to Ironic
 	IronicUsername string
 
@@ -47,6 +51,7 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 	var templateData TemplateData
 
 	templateData.ProvisioningIP = config.BootstrapProvisioningIP
+	templateData.ProvisioningConsole = config.ProvisioningConsole
 
 	if config.ProvisioningNetwork != baremetal.DisabledProvisioningNetwork {
 		cidr, _ := config.ProvisioningNetworkCIDR.Mask.Size()

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -163,4 +163,10 @@ type Platform struct {
 	//
 	// +optional
 	ClusterOSImage string `json:"clusterOSImage,omitempty" validate:"omitempty,osimageuri,urlexist"`
+
+	// ProvisioningConsole is a device which should be passed to the IPA
+	// kernel to use as its console
+	//
+	// +optional
+	ProvisioningConsole string `json:"provisioningConsole,omitempty" validate:"alphanum"`
 }


### PR DESCRIPTION
Add a new baremetal platform config option "provisioningConsole"
this can be used to pass a console to ironic to be used by the
kernel running IPA. A value of "ttyS0" would result in IPA
running on a virtual CI environment which can then be logged.

Makes use of the recently added IRONIC_KERNEL_PARAMS  parameter
openshift/ironic-image#151