### PR TITLE
Enable bootkube compatibility for ceo rendering improvements

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -114,22 +114,20 @@ then
 		--network-config-file=/assets/manifests/cluster-network-02-config.yml
 
 	cp etcd-bootstrap/manifests/* manifests/
-	cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
 
-	mkdir --parents /etc/kubernetes/static-pod-resources/etcd-member
-	cp tls/etcd-ca-bundle.crt /etc/kubernetes/static-pod-resources/etcd-member/ca.crt
-	# Temporarily ensure compatibility with both the new single cert secret and
-	# legacy multiple secrets. Support for copying the legacy secrets can be
-	# removed once https://github.com/openshift/cluster-etcd-operator/pull/544
-	# merges.
-	if [ -d "etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-certs" ]
+	# If the etc-kubernetes path is present, all files and their paths are intended to be
+	# recursively copied to /etc/kubernetes.  This conditional ensures temporary backwards
+	# compatibility for the operator as it transitions to generating the tls assets it
+	# requires and owning where its rendered bootstrap assets should be copied to.
+	if [ -d "etcd-bootstrap/etc-kubernetes/" ]
 	then
-		# Copy the contents of the single aggregated cert secret if it is present.
-		cp --recursive etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-certs /etc/kubernetes/static-pod-resources/etcd-member
+		cp --recursive etcd-bootstrap/etc-kubernetes/* /etc/kubernetes/
+		cp etcd-bootstrap/tls/* tls/
 	else
-		# Copy the contents of the legacy secrets
-		cp --recursive etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-serving /etc/kubernetes/static-pod-resources/etcd-member
-		cp --recursive etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-peer /etc/kubernetes/static-pod-resources/etcd-member
+		cp etcd-bootstrap/bootstrap-manifests/etcd-member-pod.yaml /etc/kubernetes/manifests/
+		mkdir --parents /etc/kubernetes/static-pod-resources/etcd-member
+		cp tls/etcd-ca-bundle.crt /etc/kubernetes/static-pod-resources/etcd-member/ca.crt
+		cp --recursive etcd-bootstrap/bootstrap-manifests/secrets/etcd-all-certs /etc/kubernetes/static-pod-resources/etcd-member
 	fi
 
 	touch etcd-bootstrap.done


### PR DESCRIPTION
The cluster-etcd-operator is intended to take over responsibility for rendering all of its tls assets and owning where its boostrap assets are copied to. This change ensures compatibility with the current strategy and the new one to allow the operator changes to be tested before merge.

/cc @staebler @hexfusion 