### PR TITLE
WIP openstack: make security groups optional

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -658,6 +658,9 @@ spec:
                         items:
                           type: string
                         type: array
+                      disableSecurityGroups:
+                        description: Do not use security groups for this cluster.
+                        type: boolean
                     required:
                     - type
                     type: object

--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -8,7 +8,7 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
 
   admin_state_up     = "true"
   network_id         = var.private_network_id
-  security_group_ids = var.openstack_disable_sg ? null : [var.master_sg_id]
+  security_group_ids = var.openstack_disable_sg ? [] : var.master_sg_ids
   tags               = ["openshiftClusterID=${var.cluster_id}"]
 
   extra_dhcp_option {

--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -8,7 +8,7 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
 
   admin_state_up     = "true"
   network_id         = var.private_network_id
-  security_group_ids = var.master_sg_ids
+  security_group_ids = var.openstack_disable_sg ? null : [var.master_sg_id]
   tags               = ["openshiftClusterID=${var.cluster_id}"]
 
   extra_dhcp_option {
@@ -20,8 +20,12 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
     subnet_id = var.nodes_subnet_id
   }
 
-  allowed_address_pairs {
-    ip_address = var.api_int_ip
+  // find a more relevant one-item list to iterate over ?
+  dynamic "allowed_address_pairs" {
+    for_each = var.openstack_disable_sg ? [] : [1]
+    content {
+      ip_address = var.api_int_ip
+    }
   }
 
   depends_on = [var.master_port_ids]

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -3,6 +3,10 @@ variable "base_image_id" {
   description = "The identifier of the Glance image for the bootstrap node."
 }
 
+variable "openstack_disable_sg" {
+  type = bool
+}
+
 variable "extra_tags" {
   type    = map(string)
   default = {}
@@ -48,8 +52,8 @@ variable "private_network_id" {
   type = string
 }
 
-variable "master_sg_ids" {
-  type = list(string)
+variable "master_sg_id" {
+  type = string
 }
 
 variable "nodes_subnet_id" {

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -52,8 +52,8 @@ variable "private_network_id" {
   type = string
 }
 
-variable "master_sg_id" {
-  type = string
+variable "master_sg_ids" {
+  type = list(string)
 }
 
 variable "nodes_subnet_id" {

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -40,7 +40,10 @@ module "bootstrap" {
   cluster_domain          = var.cluster_domain
   nodes_subnet_id         = module.topology.nodes_subnet_id
   private_network_id      = module.topology.private_network_id
-  master_sg_id            = var.openstack_disable_sg ? null : module.topology.master_sg_id
+  master_sg_ids           = var.openstack_disable_sg ? [] : concat(
+    var.openstack_master_extra_sg_ids,
+    [module.topology.master_sg_id],
+  )
   bootstrap_shim_ignition = var.openstack_bootstrap_shim_ignition
   master_port_ids         = module.topology.master_port_ids
   root_volume_size        = var.openstack_master_root_volume_size

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -56,13 +56,12 @@ module "masters" {
   source = "./masters"
 
   base_image_id   = data.openstack_images_image_v2.base_image.id
-  openstack_disable_sg      = var.openstack_disable_sg
   cluster_id      = var.cluster_id
   flavor_name     = var.openstack_master_flavor_name
   instance_count  = var.master_count
   master_port_ids = module.topology.master_port_ids
   user_data_ign   = var.ignition_master
-  master_sg_ids   = var.openstack_disable_sg ? null : concat(
+  master_sg_ids   = module.topology.master_sg_id == null ? [] : concat(
     var.openstack_master_extra_sg_ids,
     [module.topology.master_sg_id],
   )
@@ -92,7 +91,7 @@ module "topology" {
   octavia_support       = var.openstack_octavia_support
   machines_subnet_id    = var.openstack_machines_subnet_id
   machines_network_id   = var.openstack_machines_network_id
-  master_extra_sg_ids   = var.openstack_disable_sg ? null : var.openstack_master_extra_sg_ids
+  master_extra_sg_ids   = var.openstack_master_extra_sg_ids
 }
 
 data "openstack_images_image_v2" "base_image" {

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -29,20 +29,18 @@ provider "openstack" {
 module "bootstrap" {
   source = "./bootstrap"
 
-  cluster_id         = var.cluster_id
-  extra_tags         = var.openstack_extra_tags
-  base_image_id      = data.openstack_images_image_v2.base_image.id
-  flavor_name        = var.openstack_master_flavor_name
-  ignition           = var.ignition_bootstrap
-  api_int_ip         = var.openstack_api_int_ip
-  external_network   = var.openstack_external_network
-  cluster_domain     = var.cluster_domain
-  nodes_subnet_id    = module.topology.nodes_subnet_id
-  private_network_id = module.topology.private_network_id
-  master_sg_ids = concat(
-    var.openstack_master_extra_sg_ids,
-    [module.topology.master_sg_id],
-  )
+  cluster_id              = var.cluster_id
+  openstack_disable_sg    = var.openstack_disable_sg
+  extra_tags              = var.openstack_extra_tags
+  base_image_id           = data.openstack_images_image_v2.base_image.id
+  flavor_name             = var.openstack_master_flavor_name
+  ignition                = var.ignition_bootstrap
+  api_int_ip              = var.openstack_api_int_ip
+  external_network        = var.openstack_external_network
+  cluster_domain          = var.cluster_domain
+  nodes_subnet_id         = module.topology.nodes_subnet_id
+  private_network_id      = module.topology.private_network_id
+  master_sg_id            = var.openstack_disable_sg ? null : module.topology.master_sg_id
   bootstrap_shim_ignition = var.openstack_bootstrap_shim_ignition
   master_port_ids         = module.topology.master_port_ids
   root_volume_size        = var.openstack_master_root_volume_size
@@ -55,12 +53,13 @@ module "masters" {
   source = "./masters"
 
   base_image_id   = data.openstack_images_image_v2.base_image.id
+  openstack_disable_sg      = var.openstack_disable_sg
   cluster_id      = var.cluster_id
   flavor_name     = var.openstack_master_flavor_name
   instance_count  = var.master_count
   master_port_ids = module.topology.master_port_ids
   user_data_ign   = var.ignition_master
-  master_sg_ids = concat(
+  master_sg_ids   = var.openstack_disable_sg ? null : concat(
     var.openstack_master_extra_sg_ids,
     [module.topology.master_sg_id],
   )
@@ -74,22 +73,23 @@ module "masters" {
 module "topology" {
   source = "./topology"
 
-  cidr_block          = var.machine_v4_cidrs[0]
-  cluster_id          = var.cluster_id
-  cluster_domain      = var.cluster_domain
-  external_network    = var.openstack_external_network
-  external_network_id = var.openstack_external_network_id
-  masters_count       = var.master_count
-  api_floating_ip     = var.openstack_api_floating_ip
-  ingress_floating_ip = var.openstack_ingress_floating_ip
-  api_int_ip          = var.openstack_api_int_ip
-  ingress_ip          = var.openstack_ingress_ip
-  external_dns        = var.openstack_external_dns
-  trunk_support       = var.openstack_trunk_support
-  octavia_support     = var.openstack_octavia_support
-  machines_subnet_id  = var.openstack_machines_subnet_id
-  machines_network_id = var.openstack_machines_network_id
-  master_extra_sg_ids = var.openstack_master_extra_sg_ids
+  cidr_block            = var.machine_v4_cidrs[0]
+  cluster_id            = var.cluster_id
+  openstack_disable_sg  = var.openstack_disable_sg
+  cluster_domain        = var.cluster_domain
+  external_network      = var.openstack_external_network
+  external_network_id   = var.openstack_external_network_id
+  masters_count         = var.master_count
+  api_floating_ip       = var.openstack_api_floating_ip
+  ingress_floating_ip   = var.openstack_ingress_floating_ip
+  api_int_ip            = var.openstack_api_int_ip
+  ingress_ip            = var.openstack_ingress_ip
+  external_dns          = var.openstack_external_dns
+  trunk_support         = var.openstack_trunk_support
+  octavia_support       = var.openstack_octavia_support
+  machines_subnet_id    = var.openstack_machines_subnet_id
+  machines_network_id   = var.openstack_machines_network_id
+  master_extra_sg_ids   = var.openstack_disable_sg ? null : var.openstack_master_extra_sg_ids
 }
 
 data "openstack_images_image_v2" "base_image" {

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -8,6 +8,10 @@ variable "cluster_id" {
   description = "The identifier for the cluster."
 }
 
+variable "openstack_disable_sg" {
+  type = bool
+}
+
 variable "flavor_name" {
   type = string
 }

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -8,10 +8,6 @@ variable "cluster_id" {
   description = "The identifier for the cluster."
 }
 
-variable "openstack_disable_sg" {
-  type = bool
-}
-
 variable "flavor_name" {
   type = string
 }

--- a/data/data/openstack/topology/outputs.tf
+++ b/data/data/openstack/topology/outputs.tf
@@ -1,5 +1,5 @@
 output "master_sg_id" {
-  value = openstack_networking_secgroup_v2.master.id
+  value = var.openstack_disable_sg ? null : openstack_networking_secgroup_v2.master[0].id
 }
 
 output "master_port_ids" {

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -1,23 +1,26 @@
 resource "openstack_networking_secgroup_v2" "master" {
+  count       = var.openstack_disable_sg ? 0 : 1
   name        = "${var.cluster_id}-master"
   tags        = ["openshiftClusterID=${var.cluster_id}"]
   description = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_mcs" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 22623
   port_range_max    = 22623
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 # TODO(mandre) Explicitely enable egress
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction      = "ingress"
   ethertype      = "IPv4"
   protocol       = "icmp"
@@ -25,55 +28,61 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
   port_range_max = 0
   # FIXME(mandre) AWS only allows ICMP from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = openstack_networking_secgroup_v2.master.id
-  description       = local.description
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
+  description = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ssh" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 22
-  port_range_max    = 22
-  remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  count = var.openstack_disable_sg ? 0 : 1
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "tcp"
+  port_range_min = 22
+  port_range_max = 22
+  # FIXME(mandre) AWS only allows SSH from cidr_block
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_tcp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 53
   port_range_max    = 53
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 53
   port_range_max    = 53
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_mdns_udp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 5353
   port_range_max    = 5353
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction      = "ingress"
   ethertype      = "IPv4"
   protocol       = "tcp"
@@ -81,170 +90,185 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
   port_range_max = 6443
   # FIXME(mandre) AWS only allows API port from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_vxlan" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 4789
   port_range_max    = 4789
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_geneve" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 6081
   port_range_max    = 6081
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ike" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 500
   port_range_max    = 500
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ike_nat_t" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 4500
   port_range_max    = 4500
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_esp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "esp"
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ovndb" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 6641
   port_range_max    = 6642
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 9000
   port_range_max    = 9999
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_internal_udp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 9000
   port_range_max    = 9999
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_scheduler" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 10259
   port_range_max    = 10259
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_controller_manager" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 10257
   port_range_max    = 10257
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 10250
   port_range_max    = 10250
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_etcd" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 2379
   port_range_max    = 2380
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_tcp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 30000
   port_range_max    = 32767
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 30000
   port_range_max    = 32767
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction = "ingress"
   ethertype = "IPv4"
   # Explicitly set the vrrp protocol number to prevent cases when the Neutron Plugin
   # is disabled and it cannot identify a number by name.
   protocol          = "112"
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
+  security_group_id = openstack_networking_secgroup_v2.master[0].id
   description       = local.description
 }
 

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -29,7 +29,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
   # FIXME(mandre) AWS only allows ICMP from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.master[0].id
-  description = local.description
+  description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_ssh" {

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -1,4 +1,5 @@
 resource "openstack_networking_secgroup_v2" "worker" {
+  count       = var.openstack_disable_sg ? 0 : 1
   name        = "${var.cluster_id}-worker"
   tags        = ["openshiftClusterID=${var.cluster_id}"]
   description = local.description
@@ -7,6 +8,7 @@ resource "openstack_networking_secgroup_v2" "worker" {
 # TODO(mandre) Explicitely enable egress
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction      = "ingress"
   ethertype      = "IPv4"
   protocol       = "icmp"
@@ -14,180 +16,197 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
   port_range_max = 0
   # FIXME(mandre) AWS only allows ICMP from cidr_block
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 22
-  port_range_max    = 22
-  remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  count = var.openstack_disable_sg ? 0 : 1
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "tcp"
+  port_range_min = 22
+  port_range_max = 22
+  # FIXME(mandre) AWS only allows SSH from cidr_block
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_mdns_udp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 5353
   port_range_max    = 5353
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_http" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 80
   port_range_max    = 80
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_https" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 443
   port_range_max    = 443
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_router" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 1936
   port_range_max    = 1936
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vxlan" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 4789
   port_range_max    = 4789
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_geneve" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 6081
   port_range_max    = 6081
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ike" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 500
   port_range_max    = 500
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ike_nat_t" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 4500
   port_range_max    = 4500
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_esp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "esp"
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 9000
   port_range_max    = 9999
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_internal_udp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 9000
   port_range_max    = 9999
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecure" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 10250
   port_range_max    = 10250
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
   port_range_min    = 30000
   port_range_max    = 32767
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
   port_range_min    = 30000
   port_range_max    = 32767
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_vrrp" {
+  count = var.openstack_disable_sg ? 0 : 1
   direction = "ingress"
   ethertype = "IPv4"
   # Explicitly set the vrrp protocol number to prevent cases when the Neutron Plugin
   # is disabled and it cannot identify a number by name.
   protocol          = "112"
   remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
+  security_group_id = openstack_networking_secgroup_v2.worker[0].id
   description       = local.description
 }

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -11,6 +11,10 @@ variable "cluster_domain" {
   description = "The domain name of the cluster. All DNS records must be under this domain."
 }
 
+variable "openstack_disable_sg" {
+  type = bool
+}
+
 variable "external_network" {
   description = "Name of the external network providing Floating IP addresses."
   type        = string

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -264,6 +264,16 @@ EOF
 
 }
 
+variable "openstack_disable_sg" {
+  type    = bool
+  default = false
+
+  description = <<EOF
+False if the user wants to use security groups and True to disable their creation (e.g. PowerVC)
+EOF
+
+}
+
 variable "openstack_master_extra_sg_ids" {
   type    = list(string)
   default = []

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -266,7 +266,7 @@ EOF
 
 variable "openstack_disable_sg" {
   type    = bool
-  default = false
+  default = true
 
   description = <<EOF
 False if the user wants to use security groups and True to disable their creation (e.g. PowerVC)

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -39,13 +39,14 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 * `additionalNetworkIDs` (optional list of strings): IDs of additional networks for machines.
 * `additionalSecurityGroupIDs` (optional list of strings): IDs of additional security groups for machines.
+* `disableSecurityGroups` (optional boolean): Do not use security groups for machines/networks.
 * `type` (optional string): The OpenStack flavor name for machines in the pool.
 * `rootVolume` (optional object): Defines the root volume for instances in the machine pool. The instances use ephemeral disks if not set.
   * `size` (required integer): Size of the root volume in GB. Must be set to at least 25.
   * `type` (required string): The volume pool to create the volume from.
 * `zones` (optional list of strings): The names of the availability zones you want to install your nodes on. If unset, the installer will use your default compute zone.
 
-**NOTE:** The bootstrap node follows the `type`, `rootVolume`, `additionalNetworkIDs`, and `additionalSecurityGroupIDs` parameters from the `controlPlane` machine pool.
+**NOTE:** The bootstrap node follows the `type`, `rootVolume`, `additionalNetworkIDs`, `additionalSecurityGroupIDs`, and `disableSecurityGroups` parameters from the `controlPlane` machine pool.
 
 **NOTE:** Note when deploying with `Kuryr` there is an Octavia API loadbalancer VM that will not fulfill the Availability Zones restrictions due to Octavia lack of support for it. In addition, if Octavia only has the amphora provider instead of also the OVN-Octavia provider, all the OpenShift services will be backed up by Octavia Load Balancer VMs which will not fulfill the Availability Zone restrictions either.
 

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -429,6 +429,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			bootstrapIgn,
 			installConfig.Config.ControlPlane.Platform.OpenStack,
 			installConfig.Config.Platform.OpenStack.MachinesSubnet,
+			installConfig.Config.Platform.OpenStack.DisableSecurityGroups,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -42,10 +42,11 @@ type config struct {
 	MachinesSubnet             string   `json:"openstack_machines_subnet_id,omitempty"`
 	MachinesNetwork            string   `json:"openstack_machines_network_id,omitempty"`
 	MasterAvailabilityZones    []string `json:"openstack_master_availability_zones,omitempty"`
+	DisableSecurityGroups      bool     `json:"openstack_disable_sg,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
-func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, apiFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, baseImageProperties map[string]string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string) ([]byte, error) {
+func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, apiFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, baseImageProperties map[string]string, infraID string, userCA string, bootstrapIgn string, mpool *types_openstack.MachinePool, machinesSubnet string, disableSg bool) ([]byte, error) {
 	zones := []string{}
 	seen := map[string]bool{}
 	for _, config := range masterConfigs {
@@ -66,6 +67,7 @@ func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, exter
 		ExternalDNS:             externalDNS,
 		MachinesSubnet:          machinesSubnet,
 		MasterAvailabilityZones: zones,
+		DisableSecurityGroups:   disableSg,
 	}
 
 	serviceCatalog, err := getServiceCatalog(cloud)

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -84,4 +84,8 @@ type Platform struct {
 	// The subnet and network specified in MachinesSubnet will not be deleted or modified by the installer.
 	// +optional
 	MachinesSubnet string `json:"machinesSubnet,omitempty"`
+
+	// DisableSecurityGroups will allow clusters to be created without the use of OpenStack Security Groups. Some Openstack
+	// configurations do not support security groups. This is generally not recommended where security groups are supported.
+	DisableSecurityGroups bool `json:"disableSecurityGroups,omitempty"`
 }


### PR DESCRIPTION
 Some openstack-based offerings, such as PowerVC, do not support security
 groups. Allow users to create a cluster without them. The default is to create
 the security groups (disable = false).
    
 Fixes #4555
  
Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>
