### PR TITLE
Bug 1932799: baremetal: always use API VIP for installer communication

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -3,8 +3,8 @@ provider "libvirt" {
 }
 
 provider "ironic" {
-  url                = "http://${var.bootstrap_provisioning_ip}:6385/v1"
-  inspector          = "http://${var.bootstrap_provisioning_ip}:5050/v1"
+  url                = var.ironic_uri
+  inspector          = var.inspector_uri
   microversion       = "1.56"
   timeout            = 3600
   auth_strategy      = "http_basic"

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -1,6 +1,11 @@
-variable "bootstrap_provisioning_ip" {
+variable "ironic_uri" {
   type        = string
-  description = "IP for the bootstrap VM provisioning nic"
+  description = "URI for accessing the Ironic REST API"
+}
+
+variable "inspector_uri" {
+  type        = string
+  description = "URI for accessing the Ironic Inspector REST API"
 }
 
 variable "libvirt_uri" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -438,14 +438,17 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Data:     data,
 		})
 	case baremetal.Name:
-		provisioningIP := installConfig.Config.Platform.BareMetal.BootstrapProvisioningIP
-		if installConfig.Config.Platform.BareMetal.ProvisioningNetwork == baremetal.DisabledProvisioningNetwork && provisioningIP == "" {
-			provisioningIP = installConfig.Config.Platform.BareMetal.APIVIP
+		var imageCacheIP string
+		if installConfig.Config.Platform.BareMetal.ProvisioningNetwork == baremetal.DisabledProvisioningNetwork {
+			imageCacheIP = installConfig.Config.Platform.BareMetal.APIVIP
+		} else {
+			imageCacheIP = installConfig.Config.Platform.BareMetal.BootstrapProvisioningIP
 		}
 
 		data, err = baremetaltfvars.TFVars(
 			installConfig.Config.Platform.BareMetal.LibvirtURI,
-			provisioningIP,
+			installConfig.Config.Platform.BareMetal.APIVIP,
+			imageCacheIP,
 			string(*rhcosBootstrapImage),
 			installConfig.Config.Platform.BareMetal.ExternalBridge,
 			installConfig.Config.Platform.BareMetal.ExternalMACAddress,


### PR DESCRIPTION
The installer's terraform provider needs to talk to Ironic running on
the bootstrap VM. That communication path always used the provisioning
network, which means when using Hive from a remote cluster, the
provisioning network must be routable.

Since 4.7, with the disabled provisioning network feature, the installer
uses the API VIP for installer communication and image cache. It makes
sense to remove the dependency that the installer talks to the
provisioning network at all.  This PR makes the installer always use the
API VIP to talk to Ironic, but maintains the provisioning network for
bare metal host <-> image cache communications when it's enabled.