### PR TITLE
gather-bootstrap: Gather logs before bootstrap shuts down

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -4,6 +4,7 @@ set -euoE pipefail ## -E option will cause functions to inherit trap
 . /usr/local/bin/bootstrap-service-record.sh
 
 . /usr/local/bin/release-image.sh
+. /usr/local/bin/bootstrap-cluster-gather.sh
 
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
 
@@ -377,19 +378,28 @@ then
 fi
 
 echo "Starting cluster-bootstrap..."
-
-if [ ! -f cb-bootstrap.done ]
-then
-    record_service_stage_start "cb-bootstrap"
-    bootkube_podman_run \
+run_cluster_bootstrap() {
+	record_service_stage_start "cb-bootstrap"
+	bootkube_podman_run \
         --rm \
         --volume "$PWD:/assets:z" \
         --volume /etc/kubernetes:/etc/kubernetes:z \
         "${CLUSTER_BOOTSTRAP_IMAGE}" \
         start --tear-down-early=false --asset-dir=/assets --required-pods="${REQUIRED_PODS}"
-
-    touch cb-bootstrap.done
-    record_service_stage_success
+}
+    
+if [ ! -f cb-bootstrap.done ]
+then
+    if run_cluster_bootstrap
+    then
+        touch cb-bootstrap.done
+        record_service_stage_success
+    else
+        ret=$?
+        set +u
+        cluster_bootstrap_gather
+        exit $ret
+    fi
 fi
 
 if [ "$BOOTSTRAP_INPLACE" = true ]

--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-cluster-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-cluster-gather.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+API_SERVER_ARTIFACTS_DIR="/tmp/artifacts-api-server-temp"
+function queue() {
+    local TARGET="${ARTIFACTS_TEMP}/${1}"
+    shift
+    # shellcheck disable=SC2155
+    local LIVE="$(jobs | wc -l)"
+    while [[ "${LIVE}" -ge 45 ]]; do
+        sleep 1
+        LIVE="$(jobs | wc -l)"
+    done
+    if [[ -n "${FILTER-}" ]]; then
+        # shellcheck disable=SC2024
+        sudo KUBECONFIG="${GATHER_KUBECONFIG}" "${@}" | "${FILTER}" >"${TARGET}" &
+    else
+        # shellcheck disable=SC2024
+        sudo KUBECONFIG="${GATHER_KUBECONFIG}" "${@}" >"${TARGET}" &
+    fi
+}
+
+function cluster_bootstrap_gather() {
+    GATHER_KUBECONFIG="/opt/openshift/auth/kubeconfig"
+
+    ALTERNATIVE_KUBECONFIG="/etc/kubernetes/bootstrap-secrets/kubeconfig"
+    if [[ -f ${ALTERNATIVE_KUBECONFIG} ]]; then
+        GATHER_KUBECONFIG=${ALTERNATIVE_KUBECONFIG}
+    fi
+
+    echo "Using ${GATHER_KUBECONFIG} as KUBECONFIG"
+
+    ARTIFACTS_TEMP="$(mktemp -d)"
+
+    mkdir -p "${ARTIFACTS_TEMP}/resources"
+
+    echo "Gathering cluster resources ..."
+    queue resources/nodes.list oc --request-timeout=5s get nodes -o jsonpath --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
+    queue resources/masters.list oc --request-timeout=5s get nodes -o jsonpath -l 'node-role.kubernetes.io/master' --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
+    # ShellCheck doesn't realize that $ns is for the Go template, not something we're trying to expand in the shell
+    # shellcheck disable=2016
+    queue resources/containers oc --request-timeout=5s get pods --all-namespaces --template '{{ range .items }}{{ $name := .metadata.name }}{{ $ns := .metadata.namespace }}{{ range .spec.containers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ range .spec.initContainers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ end }}'
+    queue resources/api-pods oc --request-timeout=5s get pods -l apiserver=true --all-namespaces --template '{{ range .items }}-n {{ .metadata.namespace }} {{ .metadata.name }}{{ "\n" }}{{ end }}'
+
+    queue resources/apiservices.json oc --request-timeout=5s get apiservices -o json
+    queue resources/clusteroperators.json oc --request-timeout=5s get clusteroperators -o json
+    queue resources/clusterversion.json oc --request-timeout=5s get clusterversion -o json
+    queue resources/configmaps.json oc --request-timeout=5s get configmaps --all-namespaces -o json
+    queue resources/csr.json oc --request-timeout=5s get csr -o json
+    queue resources/endpoints.json oc --request-timeout=5s get endpoints --all-namespaces -o json
+    queue resources/events.json oc --request-timeout=5s get events --all-namespaces -o json
+    queue resources/kubeapiserver.json oc --request-timeout=5s get kubeapiserver -o json
+    queue resources/kubecontrollermanager.json oc --request-timeout=5s get kubecontrollermanager -o json
+    queue resources/machineconfigpools.json oc --request-timeout=5s get machineconfigpools -o json
+    queue resources/machineconfigs.json oc --request-timeout=5s get machineconfigs -o json
+    queue resources/namespaces.json oc --request-timeout=5s get namespaces -o json
+    queue resources/nodes.json oc --request-timeout=5s get nodes -o json
+    queue resources/openshiftapiserver.json oc --request-timeout=5s get openshiftapiserver -o json
+    queue resources/pods.json oc --request-timeout=5s get pods --all-namespaces -o json
+    queue resources/rolebindings.json oc --request-timeout=5s get rolebindings --all-namespaces -o json
+    queue resources/roles.json oc --request-timeout=5s get roles --all-namespaces -o json
+    # this just lists names and number of keys
+    queue resources/secrets-names.txt oc --request-timeout=5s get secrets --all-namespaces
+    # this adds annotations, but strips out the SA tokens and dockercfg secrets which are noisy and may contain secrets in the annotations
+    queue resources/secrets-names-with-annotations.txt oc --request-timeout=5s get secrets --all-namespaces -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,TYPE:.type,ANNOTATIONS:.metadata.annotations | grep -v -- '-token-' | grep -v -- '-dockercfg-'
+    queue resources/services.json oc --request-timeout=5s get services --all-namespaces -o json
+
+    FILTER=gzip queue resources/openapi.json.gz oc --request-timeout=5s get --raw /openapi/v2
+
+    echo "Waiting for logs ..."
+    wait
+
+    if (( $(stat -c%s "${ARTIFACTS_TEMP}/resources/openapi.json.gz") <= 20 ))
+    then
+        rm -rf "${ARTIFACTS_TEMP}"
+    else
+        rm -rf "${API_SERVER_ARTIFACTS_DIR}"
+        mkdir -p "${API_SERVER_ARTIFACTS_DIR}"
+        mv "${ARTIFACTS_TEMP}/resources" "${API_SERVER_ARTIFACTS_DIR}"
+    fi
+}

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC1091
+. /usr/local/bin/bootstrap-cluster-gather.sh
+
 if test "x${1}" = 'x--id'
 then
 	GATHER_ID="${2}"
@@ -71,62 +74,11 @@ fi
 
 echo "Using ${GATHER_KUBECONFIG} as KUBECONFIG"
 
-function queue() {
-    local TARGET="${ARTIFACTS}/${1}"
-    shift
-    # shellcheck disable=SC2155
-    local LIVE="$(jobs | wc -l)"
-    while [[ "${LIVE}" -ge 45 ]]; do
-        sleep 1
-        LIVE="$(jobs | wc -l)"
-    done
-    # echo "${@}"
-    if [[ -n "${FILTER}" ]]; then
-        # shellcheck disable=SC2024
-        sudo KUBECONFIG="${GATHER_KUBECONFIG}" "${@}" | "${FILTER}" >"${TARGET}" &
-    else
-        # shellcheck disable=SC2024
-        sudo KUBECONFIG="${GATHER_KUBECONFIG}" "${@}" >"${TARGET}" &
-    fi
-}
-mkdir -p "${ARTIFACTS}/control-plane" "${ARTIFACTS}/resources"
-
-echo "Gathering cluster resources ..."
-queue resources/nodes.list oc --request-timeout=5s get nodes -o jsonpath --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
-queue resources/masters.list oc --request-timeout=5s get nodes -o jsonpath -l 'node-role.kubernetes.io/master' --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
-# ShellCheck doesn't realize that $ns is for the Go template, not something we're trying to expand in the shell
-# shellcheck disable=2016
-queue resources/containers oc --request-timeout=5s get pods --all-namespaces --template '{{ range .items }}{{ $name := .metadata.name }}{{ $ns := .metadata.namespace }}{{ range .spec.containers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ range .spec.initContainers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ end }}'
-queue resources/api-pods oc --request-timeout=5s get pods -l apiserver=true --all-namespaces --template '{{ range .items }}-n {{ .metadata.namespace }} {{ .metadata.name }}{{ "\n" }}{{ end }}'
-
-queue resources/apiservices.json oc --request-timeout=5s get apiservices -o json
-queue resources/clusteroperators.json oc --request-timeout=5s get clusteroperators -o json
-queue resources/clusterversion.json oc --request-timeout=5s get clusterversion -o json
-queue resources/configmaps.json oc --request-timeout=5s get configmaps --all-namespaces -o json
-queue resources/csr.json oc --request-timeout=5s get csr -o json
-queue resources/endpoints.json oc --request-timeout=5s get endpoints --all-namespaces -o json
-queue resources/events.json oc --request-timeout=5s get events --all-namespaces -o json
-queue resources/kubeapiserver.json oc --request-timeout=5s get kubeapiserver -o json
-queue resources/kubecontrollermanager.json oc --request-timeout=5s get kubecontrollermanager -o json
-queue resources/machineconfigpools.json oc --request-timeout=5s get machineconfigpools -o json
-queue resources/machineconfigs.json oc --request-timeout=5s get machineconfigs -o json
-queue resources/namespaces.json oc --request-timeout=5s get namespaces -o json
-queue resources/nodes.json oc --request-timeout=5s get nodes -o json
-queue resources/openshiftapiserver.json oc --request-timeout=5s get openshiftapiserver -o json
-queue resources/pods.json oc --request-timeout=5s get pods --all-namespaces -o json
-queue resources/rolebindings.json oc --request-timeout=5s get rolebindings --all-namespaces -o json
-queue resources/roles.json oc --request-timeout=5s get roles --all-namespaces -o json
-# this just lists names and number of keys
-queue resources/secrets-names.txt oc --request-timeout=5s get secrets --all-namespaces
-# this adds annotations, but strips out the SA tokens and dockercfg secrets which are noisy and may contain secrets in the annotations
-queue resources/secrets-names-with-annotations.txt oc --request-timeout=5s get secrets --all-namespaces -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,TYPE:.type,ANNOTATIONS:.metadata.annotations | grep -v -- '-token-' | grep -v -- '-dockercfg-'
-queue resources/services.json oc --request-timeout=5s get services --all-namespaces -o json
-
-FILTER=gzip queue resources/openapi.json.gz oc --request-timeout=5s get --raw /openapi/v2
-
-echo "Waiting for logs ..."
-wait
-
+cluster_bootstrap_gather
+if [ -d "${API_SERVER_ARTIFACTS_DIR}/resources" ]
+then
+    cp -r "${API_SERVER_ARTIFACTS_DIR}/resources" "${ARTIFACTS}"
+fi
 # The existence of the file located in LOG_BUNDLE_BOOTSTRAP_ARCHIVE_NAME is used
 # as indication that a bootstrap process has already previously taken place and the resulting
 # bundle already exists in the filesystem. In that case, we include said bundle inside the log
@@ -143,7 +95,7 @@ if [[ -f ${LOG_BUNDLE_BOOTSTRAP_ARCHIVE_NAME} ]]; then
     echo "Including existing bootstrap bundle ${LOG_BUNDLE_BOOTSTRAP_ARCHIVE_NAME}"
     tar -xzf ${LOG_BUNDLE_BOOTSTRAP_ARCHIVE_NAME} --directory "${ARTIFACTS}"
 fi
-
+mkdir -p "${ARTIFACTS}/control-plane"
 echo "Gather remote logs"
 export MASTERS=()
 if [[ -f ${LOG_BUNDLE_BOOTSTRAP_ARCHIVE_NAME} ]]; then


### PR DESCRIPTION
The bootkube tries to keep the bootstrap control-plane on for
30 minutes before it shuts down due to a timeout. In which case,
the bootkube tries to re-run the control-plane to gather the logs.
The re-run is not guaranteed by the api team and hence there is
a possibility the logs for the control-plane will not be gathered.

Adding a check to trap the error message from the run bootstrap
command in the bootkube to run installer-gather script to gather
the logs in case of any error before the resources get deleted.
The logs will be stored in a folder with a default name temporarily.
Then the size of the openapi.json.gz file will be checked to see
if there was any extra information was logged from the control-
plane and if there was not a change, the tar file and the folder
will be removed as the bootstrap control-plane did not come up.
If it has been changed, the folder is moved from temporary to
permanent folder (removing the temp part of the name).

Also adding a mechanism to pull the created logs with the default
folder name to get the latest information about the control-plane.