### PR TITLE
Bug 1932789: Fix proxy validation when specified with port.

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -589,7 +589,7 @@ func validateIPProxy(proxy string, n *types.Networking, fldPath *field.Path) fie
 		return allErrs
 	}
 
-	proxyIP := net.ParseIP(parsed.Host)
+	proxyIP := net.ParseIP(parsed.Hostname())
 	if proxyIP == nil {
 		return nil
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -706,6 +706,16 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^proxy.httpProxy: Invalid value: "http//baduri": parse "http//baduri": invalid URI for request$`,
 		},
 		{
+			name: "HTTPProxy with port overlapping with Cluster Networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Proxy.HTTPProxy = "http://192.168.1.25:3030"
+				c.Networking = validIPv4NetworkingConfig()
+				return c
+			}(),
+			expectedError: `^proxy.httpProxy: Invalid value: "http://192.168.1.25:3030": proxy value is part of the cluster networks$`,
+		},
+		{
 			name: "overlapping HTTPProxy and Cluster Networks",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
@@ -751,6 +761,16 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 		},
 		{
+			name: "HTTPProxy with port overlapping with Service Networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Proxy.HTTPProxy = "http://172.30.0.25:3030"
+				c.Networking = validIPv4NetworkingConfig()
+				return c
+			}(),
+			expectedError: `^proxy.httpProxy: Invalid value: "http://172.30.0.25:3030": proxy value is part of the service networks$`,
+		},
+		{
 			name: "overlapping HTTPProxy and Service Networks",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
@@ -782,6 +802,16 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Networking = validIPv4NetworkingConfig()
 				return c
 			}(),
+		},
+		{
+			name: "HTTPSProxy with port overlapping with Cluster Networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Proxy.HTTPSProxy = "http://192.168.1.25:3030"
+				c.Networking = validIPv4NetworkingConfig()
+				return c
+			}(),
+			expectedError: `^proxy.httpsProxy: Invalid value: "http://192.168.1.25:3030": proxy value is part of the cluster networks$`,
 		},
 		{
 			name: "overlapping HTTPSProxy and Cluster Networks",
@@ -819,6 +849,16 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: `^proxy.httpsProxy: Invalid value: "http://172.30.0.25": proxy value is part of the service networks$`,
+		},
+		{
+			name: "HTTPSProxy with port overlapping with Service Networks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Proxy.HTTPSProxy = "http://172.30.0.25:3030"
+				c.Networking = validIPv4NetworkingConfig()
+				return c
+			}(),
+			expectedError: `^proxy.httpsProxy: Invalid value: "http://172.30.0.25:3030": proxy value is part of the service networks$`,
 		},
 		{
 			name: "overlapping HTTPSProxy and more than one Service Networks",


### PR DESCRIPTION
When the port number is specified, the validation that whether
the given proxy value overlaps with the cluster or service
networks is not done due to the port number not being a valid
value for the parseIP function used for converting string to
a valid IP.

Adding a fix to make sure that the port number part of the code
is removed from the given input proxy value before it is converted
to a vaild IP.