### PR TITLE
Bug 1903055: Set default values to machine pools before validation

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -110,7 +110,7 @@ func validUUIDv4(s string) bool {
 // this function does not validate proper install config usage
 func validateFlavor(flavorName string, ci *CloudInfo, req flavorRequirements, fldPath *field.Path, storage bool) field.ErrorList {
 	if flavorName == "" {
-		return nil
+		return field.ErrorList{field.Required(fldPath, "Flavor name must be provided")}
 	}
 
 	flavor, ok := ci.Flavors[flavorName]

--- a/pkg/asset/installconfig/openstack/validation/machinepool_test.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool_test.go
@@ -185,6 +185,20 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			expectedErrMsg: `compute\[0\].platform.openstack.type: Not found: "non-existant-flavor"`,
 		},
 		{
+			name: "no flavor name",
+			mpool: func() *openstack.MachinePool {
+				mp := validMachinePool()
+				mp.FlavorName = ""
+				return mp
+			}(),
+			cloudInfo: func() *CloudInfo {
+				ci := validMpoolCloudInfo()
+				return ci
+			}(),
+			expectedError:  true,
+			expectedErrMsg: `compute\[0\].platform.openstack.type: Required value: Flavor name must be provided`,
+		},
+		{
 			name:         "invalid control plane flavorName",
 			controlPlane: true,
 			mpool: func() *openstack.MachinePool {

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -29,10 +29,6 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	// validate custom cluster os image
 	allErrs = append(allErrs, validateClusterOSImage(p, ci, fldPath)...)
 
-	if p.DefaultMachinePlatform != nil {
-		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, ci, true, fldPath.Child("defaultMachinePlatform"))...)
-	}
-
 	return allErrs
 }
 


### PR DESCRIPTION
Now we validate just the user input, but in fact we additionally set default values there if they are not provided directly. It leads
to incorrect validation of the install config.

This commit sets the default values to machine pools before validation to make them just like what we use to build a cluster.

/label platform/openstack