### PR TITLE
gcp: Remove support for Licenses, only use public image

### DIFF
--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -5,7 +5,7 @@ locals {
   worker_subnet_cidr = cidrsubnet(var.machine_v4_cidrs[0], 3, 1) #worker subnet is a smaller subnet within the vnet. i.e from /21 to /24
   public_endpoints   = var.gcp_publish_strategy == "External" ? true : false
 
-  gcp_image = var.gcp_preexisting_image ? var.gcp_image : google_compute_image.cluster[0].self_link
+  gcp_image = var.gcp_image
 }
 
 provider "google" {
@@ -93,24 +93,4 @@ module "dns" {
   api_external_lb_ip   = module.network.cluster_public_ip
   api_internal_lb_ip   = module.network.cluster_ip
   public_endpoints     = local.public_endpoints
-}
-
-resource "google_compute_image" "cluster" {
-  count = var.gcp_preexisting_image ? 0 : 1
-
-  name = "${var.cluster_id}-rhcos-image"
-
-  # See https://github.com/openshift/installer/issues/2546
-  guest_os_features {
-    type = "SECURE_BOOT"
-  }
-  guest_os_features {
-    type = "UEFI_COMPATIBLE"
-  }
-
-  raw_disk {
-    source = var.gcp_image_uri
-  }
-
-  licenses = var.gcp_image_licenses
 }

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -56,12 +56,6 @@ variable "gcp_image" {
   description = "URL to the Image for all nodes."
 }
 
-variable "gcp_preexisting_image" {
-  type = bool
-  default = true
-  description = "Specifies whether an existing GCP Image should be used or a new one created for installation"
-}
-
 variable "gcp_master_root_volume_type" {
   type = string
   description = "The type of volume for the root block device of master nodes."
@@ -107,12 +101,6 @@ variable "gcp_compute_subnet" {
 variable "gcp_publish_strategy" {
   type = string
   description = "The cluster publishing strategy, either Internal or External"
-}
-
-variable "gcp_image_licenses" {
-  type = list(string)
-  description = "The licenses to use when creating compute instances"
-  default = []
 }
 
 variable "gcp_root_volume_kms_key_link" {

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1392,12 +1392,9 @@ spec:
                         type: array
                     type: object
                   licenses:
-                    description: Licenses is a list of licenses to apply to the compute
-                      images The value should a list of strings (https URLs only)
-                      representing the license keys. When set, this will cause the
-                      installer to copy the image into user's project. This option
-                      is incompatible with any mechanism that makes use of pre-built
-                      images such as the current env OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE
+                    description: Licenses support has been removed; nested virtualization
+                      is enabled by default.  Specifying the nested virtualization
+                      license will be silently ignored.  Any other licenses are a fatal error.
                     items:
                       type: string
                     type: array

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -338,17 +338,16 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		preexistingnetwork := installConfig.Config.GCP.Network != ""
 
-		imageRaw, err := rhcospkg.GCPRaw(ctx, installConfig.Config.ControlPlane.Architecture)
+		osimage, err := rhcospkg.GCP(ctx, installConfig.Config.ControlPlane.Architecture)
 		if err != nil {
-			return errors.Wrap(err, "failed to find Raw GCP image URL")
+			return errors.Wrap(err, "failed to find GCP image URL")
 		}
 		data, err := gcptfvars.TFVars(
 			gcptfvars.TFVarsSources{
 				Auth:               auth,
 				MasterConfigs:      masterConfigs,
 				WorkerConfigs:      workerConfigs,
-				ImageURI:           imageRaw,
-				ImageLicenses:      installConfig.Config.GCP.Licenses,
+				ImageURI:           osimage,
 				PublicZoneName:     publicZoneName,
 				PublishStrategy:    installConfig.Config.Publish,
 				PreexistingNetwork: preexistingnetwork,

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -69,9 +69,6 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 
 func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, osImage string, azIdx int, role, userDataSecret string) (*gcpprovider.GCPMachineProviderSpec, error) {
 	az := mpool.Zones[azIdx]
-	if len(platform.Licenses) > 0 {
-		osImage = fmt.Sprintf("%s-rhcos-image", clusterID)
-	}
 	network, subnetwork, err := getNetworks(platform, clusterID, role)
 	if err != nil {
 		return nil, err

--- a/pkg/rhcos/gcp.go
+++ b/pkg/rhcos/gcp.go
@@ -18,13 +18,3 @@ func GCP(ctx context.Context, arch types.Architecture) (string, error) {
 
 	return fmt.Sprintf("projects/%s/global/images/%s", meta.GCP.Project, meta.GCP.Image), nil
 }
-
-// GCPRaw fetches the URL of the public GCP storage bucket containing the RHCOS image
-func GCPRaw(ctx context.Context, arch types.Architecture) (string, error) {
-	meta, err := fetchRHCOSBuild(ctx, arch)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to fetch RHCOS metadata")
-	}
-
-	return meta.GCP.URL, nil
-}

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -27,8 +27,6 @@ type config struct {
 	MasterAvailabilityZones []string `json:"gcp_master_availability_zones"`
 	ImageURI                string   `json:"gcp_image_uri,omitempty"`
 	Image                   string   `json:"gcp_image,omitempty"`
-	PreexistingImage        bool     `json:"gcp_preexisting_image"`
-	ImageLicenses           []string `json:"gcp_image_licenses,omitempty"`
 	VolumeType              string   `json:"gcp_master_root_volume_type"`
 	VolumeSize              int64    `json:"gcp_master_root_volume_size"`
 	VolumeKMSKeyLink        string   `json:"gcp_root_volume_kms_key_link"`
@@ -44,7 +42,6 @@ type config struct {
 type TFVarsSources struct {
 	Auth               Auth
 	ImageURI           string
-	ImageLicenses      []string
 	MasterConfigs      []*gcpprovider.GCPMachineProviderSpec
 	WorkerConfigs      []*gcpprovider.GCPMachineProviderSpec
 	PublicZoneName     string
@@ -71,17 +68,12 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		VolumeSize:              masterConfig.Disks[0].SizeGb,
 		ImageURI:                sources.ImageURI,
 		Image:                   masterConfig.Disks[0].Image,
-		ImageLicenses:           sources.ImageLicenses,
 		PublicZoneName:          sources.PublicZoneName,
 		PublishStrategy:         string(sources.PublishStrategy),
 		ClusterNetwork:          masterConfig.NetworkInterfaces[0].Network,
 		ControlPlaneSubnet:      masterConfig.NetworkInterfaces[0].Subnetwork,
 		ComputeSubnet:           workerConfig.NetworkInterfaces[0].Subnetwork,
 		PreexistingNetwork:      sources.PreexistingNetwork,
-	}
-	cfg.PreexistingImage = true
-	if len(sources.ImageLicenses) > 0 {
-		cfg.PreexistingImage = false
 	}
 
 	if masterConfig.Disks[0].EncryptionKey != nil {

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -30,11 +30,7 @@ type Platform struct {
 	// +optional
 	ComputeSubnet string `json:"computeSubnet,omitempty"`
 
-	// Licenses is a list of licenses to apply to the compute images
-	// The value should a list of strings (https URLs only) representing the license keys.
-	// When set, this will cause the installer to copy the image into user's project.
-	// This option is incompatible with any mechanism that makes use of pre-built images
-	// such as the current env OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE
+	// Licenses is no longer used and should be either empty or contain the nested virt license.
 	// +optional
 	Licenses []string `json:"licenses,omitempty"`
 }

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -2,14 +2,16 @@ package validation
 
 import (
 	"os"
-
 	"sort"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/gcp"
+)
 
-	"github.com/openshift/installer/pkg/validate"
+const (
+	// nestedVirtLicense is enabled by default, see https://github.com/coreos/coreos-assembler/pull/1618/commits/73320cf633e362f96de5f9d9aabb02b8647d4156
+	nestedVirtLicense = "https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
 )
 
 var (
@@ -82,8 +84,8 @@ func ValidatePlatform(p *gcp.Platform, fldPath *field.Path) field.ErrorList {
 	}
 
 	for i, license := range p.Licenses {
-		if validate.URIWithProtocol(license, "https") != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("licenses").Index(i), license, "licenses must be URLs (https) only"))
+		if license != nestedVirtLicense {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("licenses").Index(i), license, "only accepted license is enable-vmx"))
 		}
 	}
 


### PR DESCRIPTION
gcp: Ignore Licenses: vmx, only use public image

The history here is basically that originally for GCP, we
cloned a disk image, just like how Azure works today.

Then later, GCP cracked down on the allowable frequency of image
creation and told us to use public bootable images, so we started
uploading a public RHCOS base image.

But we originally did that without the nested virt license, so
the KubeVirt team added a PR to clone the image and add the
nested virt license.

And then finally, in 4.6 we fixed the CoreOS public image
to add the nested virt license by default (which also, GCP
recommended we do):
https://github.com/coreos/coreos-assembler/pull/1618/commits/73320cf633e362f96de5f9d9aabb02b8647d4156

So there's no need for any of this image cloning or license
stuff anymore.  For compatibility (with e.g. the KubeVirt CI)
we silently ignore the `enable-vmx` licenses because it's
implicitly enabled by default anyways.  Copying the image
to enable it is a pessimization in fact!

Other licenses are a fatal error - I am not aware of
any that anyone would want.  And anyone who wants to
do something truly custom can use
the image override variable anyways; they don't *have*
to use our Terraform code.  Or they can hack the installer
code.

Prep for using the stream metadata in
https://github.com/openshift/installer/pull/4582
