### PR TITLE
OpenStack: reuse auth token

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -6,8 +6,6 @@ import (
 	"github.com/gophercloud/gophercloud"
 	computequotasets "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
-	tokensv2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
-	tokensv3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
@@ -321,12 +319,7 @@ func (ci *CloudInfo) getZones() ([]string, error) {
 func loadLimits(opts *clientconfig.ClientOpts) ([]record, error) {
 	var limits []record
 
-	projectID, err := getProjectID(opts)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get keystone project ID")
-	}
-
-	computeRecords, err := getComputeLimits(opts, projectID)
+	computeRecords, err := getComputeLimits(opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get compute quota records")
 	}
@@ -337,12 +330,12 @@ func loadLimits(opts *clientconfig.ClientOpts) ([]record, error) {
 	return limits, nil
 }
 
-func getComputeLimits(opts *clientconfig.ClientOpts, projectID string) ([]record, error) {
+func getComputeLimits(opts *clientconfig.ClientOpts) ([]record, error) {
 	computeClient, err := clientconfig.NewServiceClient("compute", opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to connect against OpenStack Comute v2 API")
 	}
-	qs, err := computequotasets.GetDetail(computeClient, projectID).Extract()
+	qs, err := computequotasets.GetDetail(computeClient, opts.AuthInfo.ProjectID).Extract()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get QuotaSets from OpenStack Compute API")
 	}
@@ -365,37 +358,6 @@ func getComputeLimits(opts *clientconfig.ClientOpts, projectID string) ([]record
 	addRecord("RAM", qs.RAM)
 
 	return records, nil
-}
-
-func getProjectID(opts *clientconfig.ClientOpts) (string, error) {
-	keystoneClient, err := clientconfig.NewServiceClient("identity", opts)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to conect against OpenStack Keystone API")
-	}
-	authResult := keystoneClient.GetAuthResult()
-	if authResult == nil {
-		return "", errors.Errorf("Client did not use openstack.Authenticate()")
-	}
-
-	switch authResult.(type) {
-	case tokensv2.CreateResult:
-		// Gophercloud has support for v2, but keystone has deprecated
-		// and it's not even documented.
-		return "", errors.Errorf("Extracting project ID using the keystone v2 API is not supported")
-
-	case tokensv3.CreateResult:
-		v3Result := authResult.(tokensv3.CreateResult)
-		project, err := v3Result.ExtractProject()
-		if err != nil {
-			return "", errors.Wrap(err, "Extracting project from v3 authResult")
-		} else if project == nil {
-			return "", errors.Errorf("Token is not scoped to a project")
-		}
-		return project.ID, nil
-
-	default:
-		return "", errors.Errorf("Unsupported AuthResult type: %T", authResult)
-	}
 }
 
 // loadQuotas loads the quota information for a project and provided services. It provides information

--- a/pkg/types/openstack/defaults/clientopts.go
+++ b/pkg/types/openstack/defaults/clientopts.go
@@ -1,16 +1,65 @@
 package defaults
 
 import (
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/sirupsen/logrus"
 )
 
-// DefaultClientOpts generates default client opts based on cloud name
+// We explicitly disable reading auth data from env variables by setting an invalid EnvPrefix.
+// By doing this, we make sure that the data from clouds.yaml is enough to authenticate.
+// For more information: https://github.com/gophercloud/utils/blob/8677e053dcf1f05d0fa0a616094aace04690eb94/openstack/clientconfig/requests.go#L508
+const envPrefix = "NO_ENV_VARIABLES_"
+
+var serviceClientOpts *clientconfig.ClientOpts
+
+// DefaultClientOpts generates default client opts based on cloud name. First, it tries to create
+// and reuse an existing auth token to prevent multiple reauthentications during installation.
+// If it's not possible the function returns static client opts with "password" authentication.
 func DefaultClientOpts(cloudName string) *clientconfig.ClientOpts {
+	if serviceClientOpts != nil {
+		return serviceClientOpts
+	}
+
+	conn, err := clientconfig.NewServiceClient("identity", staticClientOpts(cloudName))
+	if err != nil {
+		logrus.Warnf("Cannot authenticate with given credentials: %v", err)
+		return staticClientOpts(cloudName)
+	}
+
+	authResult := conn.GetAuthResult()
+	auth, ok := authResult.(tokens.CreateResult)
+	if !ok {
+		logrus.Warn("Unable to find auth token in the response")
+		return staticClientOpts(cloudName)
+	}
+
+	tokenID, err := auth.ExtractTokenID()
+	if err != nil {
+		logrus.Warnf("Unable to extract auth token: %v", err)
+		return staticClientOpts(cloudName)
+	}
+
+	project, err := auth.ExtractProject()
+	if err != nil {
+		logrus.Warnf("Unable to extract project: %v", err)
+		return staticClientOpts(cloudName)
+	}
+
+	serviceClientOpts = staticClientOpts(cloudName)
+	serviceClientOpts.AuthType = clientconfig.AuthV3Token
+	serviceClientOpts.AuthInfo = &clientconfig.AuthInfo{
+		Token:     tokenID,
+		AuthURL:   conn.IdentityEndpoint,
+		ProjectID: project.ID,
+	}
+
+	return serviceClientOpts
+}
+
+func staticClientOpts(cloudName string) *clientconfig.ClientOpts {
 	opts := new(clientconfig.ClientOpts)
 	opts.Cloud = cloudName
-	// We explicitly disable reading auth data from env variables by setting an invalid EnvPrefix.
-	// By doing this, we make sure that the data from clouds.yaml is enough to authenticate.
-	// For more information: https://github.com/gophercloud/utils/blob/8677e053dcf1f05d0fa0a616094aace04690eb94/openstack/clientconfig/requests.go#L508
-	opts.EnvPrefix = "NO_ENV_VARIABLES_"
+	opts.EnvPrefix = envPrefix
 	return opts
 }


### PR DESCRIPTION
Now during installation we create mutiple service clients, and each creation requires authentication. It imposes a useless load on the Identity service.

To prevent this we try to reuse an existing auth token for each service client.