### PR TITLE
Bug 1930240: baremetal: Set missing IP in clouds.yaml

### DIFF
--- a/data/data/bootstrap/baremetal/files/opt/metal3/auth/clouds.yaml.template
+++ b/data/data/bootstrap/baremetal/files/opt/metal3/auth/clouds.yaml.template
@@ -3,5 +3,5 @@ clouds:
     auth_type: http_basic
     username: {{.PlatformData.BareMetal.IronicUsername}}
     password: {{.PlatformData.BareMetal.IronicPassword}}
-    baremetal_endpoint_override: http://{{if .PlatformData.BareMetal.ProvisioningIPv6}}[{{end}}{{.PlatformData.BareMetal.ProvisioningIP}}{{if .PlatformData.BareMetal.ProvisioningIPv6}}]{{end}}:6385/v1
-    baremetal_introspection_endpoint_override: http://{{if .PlatformData.BareMetal.ProvisioningIPv6}}[{{end}}{{.PlatformData.BareMetal.ProvisioningIP}}{{if .PlatformData.BareMetal.ProvisioningIPv6}}]{{end}}:5050/v1
+    baremetal_endpoint_override: http://{{if .PlatformData.BareMetal.APIVIPv6}}[{{end}}{{.PlatformData.BareMetal.APIVIP}}{{if .PlatformData.BareMetal.APIVIPv6}}]{{end}}:6385/v1
+    baremetal_introspection_endpoint_override: http://{{if .PlatformData.BareMetal.APIVIPv6}}[{{end}}{{.PlatformData.BareMetal.APIVIP}}{{if .PlatformData.BareMetal.APIVIPv6}}]{{end}}:5050/v1

--- a/data/data/bootstrap/baremetal/files/opt/metal3/auth/clouds.yaml.template
+++ b/data/data/bootstrap/baremetal/files/opt/metal3/auth/clouds.yaml.template
@@ -3,5 +3,5 @@ clouds:
     auth_type: http_basic
     username: {{.PlatformData.BareMetal.IronicUsername}}
     password: {{.PlatformData.BareMetal.IronicPassword}}
-    baremetal_endpoint_override: http://{{if .PlatformData.BareMetal.APIVIPv6}}[{{end}}{{.PlatformData.BareMetal.APIVIP}}{{if .PlatformData.BareMetal.APIVIPv6}}]{{end}}:6385/v1
-    baremetal_introspection_endpoint_override: http://{{if .PlatformData.BareMetal.APIVIPv6}}[{{end}}{{.PlatformData.BareMetal.APIVIP}}{{if .PlatformData.BareMetal.APIVIPv6}}]{{end}}:5050/v1
+    baremetal_endpoint_override: {{ .PlatformData.BareMetal.BaremetalEndpointOverride }}
+    baremetal_introspection_endpoint_override: {{ .PlatformData.BareMetal.BaremetalIntrospectionEndpointOverride }}

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -47,16 +47,6 @@ while [ -z "$(ip -o addr show dev $PROVISIONING_NIC | grep -v link)" ]; do
     sleep 1
 done
 
-{{ else }}
-PROVISION_NIC_DATA="$(ip -o  addr show "$PROVISIONING_NIC" scope global | head -n1)"
-PROVISION_NIC_IP="$(echo "$PROVISION_NIC_DATA" | awk '{print $4}' | cut -d '/' -f1)"
-PROVISION_NIC_IP_VERSION="$(echo "$PROVISION_NIC_DATA" | awk '{print $3}')"
-if [ "$PROVISION_NIC_IP_VERSION" = "inet6" ] ; then
-       # For ipv6 we need to wrap our IP address in brackets to differentiate between the IP and port
-       PROVISION_NIC_IP="[$PROVISION_NIC_IP]"
-fi
-sed -i "s/baremetal_endpoint_override: http:\/\/:/baremetal_endpoint_override: http:\/\/$PROVISION_NIC_IP:/" /opt/metal3/auth/clouds.yaml
-sed -i "s/baremetal_introspection_endpoint_override: http:\/\/:/baremetal_introspection_endpoint_override: http:\/\/$PROVISION_NIC_IP:/" /opt/metal3/auth/clouds.yaml
 {{ end }}
 
 # set password for ironic basic auth

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -47,6 +47,16 @@ while [ -z "$(ip -o addr show dev $PROVISIONING_NIC | grep -v link)" ]; do
     sleep 1
 done
 
+{{ else }}
+PROVISION_NIC_DATA="$(ip -o  addr show "$PROVISIONING_NIC" scope global | head -n1)"
+PROVISION_NIC_IP="$(echo "$PROVISION_NIC_DATA" | awk '{print $4}' | cut -d '/' -f1)"
+PROVISION_NIC_IP_VERSION="$(echo "$PROVISION_NIC_DATA" | awk '{print $3}')"
+if [ "$PROVISION_NIC_IP_VERSION" = "inet6" ] ; then
+       # For ipv6 we need to wrap our IP address in brackets to differentiate between the IP and port
+       PROVISION_NIC_IP="[$PROVISION_NIC_IP]"
+fi
+sed -i "s/baremetal_endpoint_override: http:\/\/:/baremetal_endpoint_override: http:\/\/$PROVISION_NIC_IP:/" /opt/metal3/auth/clouds.yaml
+sed -i "s/baremetal_introspection_endpoint_override: http:\/\/:/baremetal_introspection_endpoint_override: http:\/\/$PROVISION_NIC_IP:/" /opt/metal3/auth/clouds.yaml
 {{ end }}
 
 # set password for ironic basic auth

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -41,11 +41,11 @@ type TemplateData struct {
 	// IronicUsername contains the password for authentication to Ironic
 	IronicPassword string
 
-	// APIVIP is the VIP to use for internal API communication
-	APIVIP string
+	// BaremetalEndpointOverride contains the url for the baremetal endpoint
+	BaremetalEndpointOverride string
 
-	// APIVIPv6 determines if our APIVIP is IPv6 or not
-	APIVIPv6 bool
+	// BaremetalIntrospectionEndpointOverride contains the url for the baremetal introspection endpoint
+	BaremetalIntrospectionEndpointOverride string
 }
 
 // GetTemplateData returns platform-specific data for bootstrap templates.
@@ -53,8 +53,8 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 	var templateData TemplateData
 
 	templateData.ProvisioningIP = config.BootstrapProvisioningIP
-	templateData.APIVIP = config.APIVIP
-	templateData.APIVIPv6 = net.ParseIP(config.APIVIP).To4() == nil
+	templateData.BaremetalEndpointOverride = fmt.Sprintf("http://%s/v1", net.JoinHostPort(config.APIVIP, "6385"))
+	templateData.BaremetalIntrospectionEndpointOverride = fmt.Sprintf("http://%s/v1", net.JoinHostPort(config.APIVIP, "5050"))
 
 	if config.ProvisioningNetwork != baremetal.DisabledProvisioningNetwork {
 		cidr, _ := config.ProvisioningNetworkCIDR.Mask.Size()

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -40,6 +40,12 @@ type TemplateData struct {
 
 	// IronicUsername contains the password for authentication to Ironic
 	IronicPassword string
+
+	// APIVIP is the VIP to use for internal API communication
+	APIVIP string
+
+	// APIVIPv6 determines if our APIVIP is IPv6 or not
+	APIVIPv6 bool
 }
 
 // GetTemplateData returns platform-specific data for bootstrap templates.
@@ -47,6 +53,8 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 	var templateData TemplateData
 
 	templateData.ProvisioningIP = config.BootstrapProvisioningIP
+	templateData.APIVIP = config.APIVIP
+	templateData.APIVIPv6 = net.ParseIP(config.APIVIP).To4() == nil
 
 	if config.ProvisioningNetwork != baremetal.DisabledProvisioningNetwork {
 		cidr, _ := config.ProvisioningNetworkCIDR.Mask.Size()


### PR DESCRIPTION
The clouds.yaml baremetal_endpoint_override and
baremetal_introspection_endpoint_override fields were missing an IP
address when provisioning network was disabled. This adds some bash
that grabs the PROVISIONING_NIC IP address in startironic.sh.template
and inserts it into those fields.