### PR TITLE
upi/openstack: provider network support

### DIFF
--- a/upi/openstack/common.yaml
+++ b/upi/openstack/common.yaml
@@ -10,8 +10,8 @@
       cluster_id_tag: "openshiftClusterID={{ infraID }}"
       primary_cluster_network_tag: "{{ infraID }}-primaryClusterNetwork"
       os_infra_id: "{{ infraID }}"
-      os_network: "{{ infraID }}-network"
-      os_subnet: "{{ infraID }}-nodes"
+      os_network: "{{ provider_network_name | default(infraID + '-network') }}"
+      os_subnet: "{{ provider_network_subnet_name | default(infraID + '-nodes') }}"
       os_router: "{{ infraID }}-external-router"
       # Port names
       os_port_api: "{{ infraID }}-api-port"

--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -4,7 +4,32 @@ all:
       ansible_connection: local
       ansible_python_interpreter: "{{ansible_playbook_python}}"
 
+      # Whether or not the machines will be plugged onto a provider network
+      # as a primary interface.
+      # When set to True, the network and subnets won't be created by Ansible
+      # and it's up to the operator to do so with an admin user.
+      # An example of a playbook is provided as "provider-network.yaml".
+      provider_network_primary_nic: false
+      # IP address of the Provider network gateway:
+      #   provider_network_gateway:
+      # Name of the Provider network:
+      #   provider_network_name:
+      # Name of the Provider network subnet:
+      #   provider_network_subnet_name:
+      # The type of physical network that maps to this network resource:
+      #   provider_network_type:
+      # The physical network where this network is implemented:
+      #   provider_physical_network:
+      # An isolated segment on the physical network. The network_type attribute
+      # defines the segmentation model.
+      # For example, if the network_type value is vlan, this ID is a vlan identifier.
+      # If the network_type value is gre, this ID is a gre key.
+      #    provider_segmentation_id:
+
       # User-provided values
+      # Required if you need to create the provider network from the admin tenant:
+      # os_project: <name or ID>
+      # machineNetwork subnet cidr
       os_subnet_range: '10.0.0.0/16'
       os_flavor_master: 'm1.xlarge'
       os_flavor_worker: 'm1.large'

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -14,10 +14,14 @@
   - name: 'Create the primary cluster network'
     os_network:
       name: "{{ os_network }}"
+    when:
+    - not provider_network_primary_nic|default(false)
 
   - name: 'Set tags on the  primary cluster network'
     command:
       cmd: "openstack network set --tag {{ primary_cluster_network_tag }} --tag {{ cluster_id_tag }} {{ os_network }}"
+    when:
+    - not provider_network_primary_nic|default(false)
 
   - name: 'Create the primary cluster subnet'
     os_subnet:
@@ -26,10 +30,14 @@
       cidr: "{{ os_subnet_range }}"
       allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
       allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+    when:
+    - not provider_network_primary_nic|default(false)
 
   - name: 'Set tags on  primary cluster subnet'
     command:
       cmd: "openstack subnet set --tag {{ cluster_id_tag }} {{ os_subnet }}"
+    when:
+    - not provider_network_primary_nic|default(false)
 
   - name: 'Create the service network'
     os_network:

--- a/upi/openstack/provider-network.yaml
+++ b/upi/openstack/provider-network.yaml
@@ -1,0 +1,36 @@
+# Required Python packages:
+#
+# ansible
+# openstackclient
+# openstacksdk
+# netaddr
+
+# This must be run with OpenStack admin credentials.
+
+- import_playbook: common.yaml
+
+- hosts: all
+  gather_facts: false
+
+  tasks:
+  - name: 'Create the provider network for the cluster machines'
+    os_network:
+      name: "{{ os_network }}"
+      # The network has to be "shared", see BZ for full context:
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1933047
+      shared: True
+      project: "{{ os_project }}"
+      external: True
+      provider_network_type: "{{ provider_network_type | default('flat') }}"
+      provider_physical_network: "{{ provider_physical_network }}"
+      provider_segmentation_id: "{{ provider_segmentation_id | default(omit) }}"
+
+  - name: 'Create the provider network subnet for the cluster machines'
+    os_subnet:
+      name: "{{ os_subnet }}"
+      network_name: "{{ os_network }}"
+      project: "{{ os_project }}"
+      cidr: "{{ os_subnet_range }}"
+      allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
+      allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+      gateway_ip: "{{ provider_network_gateway }}"


### PR DESCRIPTION
* Update upi playbooks to add support for provider networks:

  - New toggle to enable provider network support: `provider_network_primary_nic`
  - IP address of the Provider network gateway: `provider_network_gateway`
  - Name of the Provider network: `provider_network_name`
  - Name of the Provider network subnet: `provider_network_subnet_name`
  - The type of physical network that maps to this network resource: `provider_network_type`
  - The physical network where this network is implemented: `provider_physical_network`
  - If any, specify a segmentation ID (e.g. VLAN ID): `provider_segmentation_id`

* Update the documentation to explain how to use these parameters.

* Provide a new playbook, useful to create a provider network and its
  subnet.

https://issues.redhat.com/browse/OSASINFRA-1416
