### PR TITLE
OpenStack: limit icmp traffic to control-plane

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -21,8 +21,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
   protocol       = "icmp"
   port_range_min = 0
   port_range_max = 0
-  # FIXME(mandre) AWS only allows ICMP from cidr_block
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
 }
 


### PR DESCRIPTION
Only icmp traffic from ips in the machineNetwork
subnet is alllowed to reach the control plane.