### PR TITLE
OpenStack: limit icmp traffic to control-plane

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -23,8 +23,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_icmp" {
   protocol       = "icmp"
   port_range_min = 0
   port_range_max = 0
-  # FIXME(mandre) AWS only allows ICMP from cidr_block
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -12,8 +12,7 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_icmp" {
   protocol       = "icmp"
   port_range_min = 0
   port_range_max = 0
-  # FIXME(mandre) AWS only allows ICMP from cidr_block
-  remote_ip_prefix  = "0.0.0.0/0"
+  remote_ip_prefix  = var.cidr_block
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }


### PR DESCRIPTION
Limits icmp traffic destined to the control-plane
to only traffic sourced from ip addresses in the
machineSubnet CIDR