### PR TITLE
vsphere: Validate vcenter user input to match RFC standards

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation_test.go
+++ b/pkg/asset/installconfig/vsphere/validation_test.go
@@ -30,7 +30,7 @@ func validIPIInstallConfig() *types.InstallConfig {
 				Network:          "valid_network",
 				Password:         "valid_password",
 				Username:         "valid_username",
-				VCenter:          "valid_vcenter",
+				VCenter:          "valid-vcenter",
 				APIVIP:           "192.168.111.0",
 				IngressVIP:       "192.168.111.1",
 			},
@@ -52,7 +52,7 @@ func validUPIInstallConfig() *types.InstallConfig {
 				DefaultDatastore: "valid_ds",
 				Password:         "valid_password",
 				Username:         "valid_username",
-				VCenter:          "valid_vcenter",
+				VCenter:          "valid-vcenter",
 			},
 		},
 	}

--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -102,9 +102,11 @@ func getClients() (*vCenterClient, error) {
 		{
 			Prompt: &survey.Input{
 				Message: "vCenter",
-				Help:    "The hostname of the vCenter to be used for installation.",
+				Help:    "The domain name or IP address of the vCenter to be used for installation.",
 			},
-			Validate: survey.Required,
+			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				return validate.Host(ans.(string))
+			}),
 		},
 	}, &vcenter); err != nil {
 		return nil, errors.Wrap(err, "failed UserInput")

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -29,8 +29,10 @@ func ValidatePlatform(p *vsphere.Platform, fldPath *field.Path) field.ErrorList 
 		allErrs = append(allErrs, field.Required(fldPath.Child("defaultDatastore"), "must specify the default datastore"))
 	}
 
-	if strings.ToLower(p.VCenter) != p.VCenter {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("vCenter"), p.VCenter, "must be all lower case"))
+	if len(p.VCenter) != 0 {
+		if err := validate.Host(p.VCenter); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("vCenter"), p.VCenter, "must be the domain name or IP address of the vCenter"))
+		}
 	}
 
 	// If all VIPs are empty, skip IP validation.  All VIPs are required to be defined together.

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -141,7 +141,16 @@ func TestValidatePlatform(t *testing.T) {
 				p.VCenter = "tEsT-vCenter"
 				return p
 			}(),
-			expectedError: `^test-path.vCenter: Invalid value: "tEsT-vCenter": must be all lower case`,
+			expectedError: `^test-path\.vCenter: Invalid value: "tEsT-vCenter": must be the domain name or IP address of the vCenter`,
+		},
+		{
+			name: "URL as vCenter",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.VCenter = "https://test-center"
+				return p
+			}(),
+			expectedError: `^test-path\.vCenter: Invalid value: "https://test-center": must be the domain name or IP address of the vCenter$`,
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -238,3 +238,16 @@ func UUID(val string) error {
 	_, err := uuid.Parse(val)
 	return err
 }
+
+// Host validates that a given string is a valid URI host.
+func Host(v string) error {
+	proxyIP := net.ParseIP(v)
+	if proxyIP != nil {
+		return nil
+	}
+	re := regexp.MustCompile("^[a-z]")
+	if !re.MatchString(v) {
+		return errors.New("domain name must begin with a lower-case letter")
+	}
+	return validateSubdomain(v)
+}

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -49,6 +49,86 @@ func TestClusterName(t *testing.T) {
 	}
 }
 
+func TestClusterName1035(t *testing.T) {
+	maxSizeName := "a" + strings.Repeat("123456789.", 5) + "123"
+
+	cases := []struct {
+		name        string
+		clusterName string
+		valid       bool
+	}{
+		{"empty", "", false},
+		{"only whitespace", " ", false},
+		{"single lowercase", "a", true},
+		{"single uppercase", "A", false},
+		{"contains whitespace", "abc D", false},
+		{"single number", "1", false},
+		{"single dot", ".", false},
+		{"ends with dot", "a.", false},
+		{"starts with dot", ".a", false},
+		{"multiple labels", "a.a", true},
+		{"starts with dash", "-a", false},
+		{"ends with dash", "a-", false},
+		{"label starts with dash", "a.-a", false},
+		{"label ends with dash", "a-.a", false},
+		{"invalid percent", "a%a", false},
+		{"only non-ascii", "日本語", false},
+		{"contains non-ascii", "a日本語a", false},
+		{"max size", maxSizeName, true},
+		{"too long", maxSizeName + "a", false},
+		{"URLs", "https://hello.openshift.org", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ClusterName1035(tc.clusterName)
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestVCenter(t *testing.T) {
+	cases := []struct {
+		name        string
+		clusterName string
+		valid       bool
+	}{
+		{"empty", "", false},
+		{"only whitespace", " ", false},
+		{"single lowercase", "a", true},
+		{"single uppercase", "A", false},
+		{"contains whitespace", "abc D", false},
+		{"single number", "1", false},
+		{"single dot", ".", false},
+		{"ends with dot", "a.", false},
+		{"starts with dot", ".a", false},
+		{"multiple labels", "a.a", true},
+		{"starts with dash", "-a", false},
+		{"ends with dash", "a-", false},
+		{"label starts with dash", "a.-a", false},
+		{"label ends with dash", "a-.a", false},
+		{"invalid percent", "a%a", false},
+		{"only non-ascii", "日本語", false},
+		{"contains non-ascii", "a日本語a", false},
+		{"URLs", "https://hello.openshift.org", false},
+		{"IP", "192.168.1.1", true},
+		{"invalid IP", "192.168.1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Host(tc.clusterName)
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestSubnetCIDR(t *testing.T) {
 	cases := []struct {
 		cidr   string


### PR DESCRIPTION
Vcenter input must always only be the hostname yet it is possible
for the user to provide other types of input like URLs. URLs would
cause an error to occur only during the time of cluster creation
as connection to the vcenter would succeed.

Adding a validation check for the user input for the vcenter value
so that it conforms to the RFC-1035 standard and forces the user
to re-enter the value rather than throw an error during cluster
creation.