### PR TITLE
Baremetal: Explicitly set watchAllNamespaces

### DIFF
--- a/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
+++ b/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
@@ -9,3 +9,4 @@ spec:
   provisioningNetwork: "{{.Baremetal.ProvisioningNetwork}}"
   provisioningDHCPRange: "{{.Baremetal.ProvisioningDHCPRange}}"
   provisioningOSDownloadURL: "{{.ProvisioningOSDownloadURL}}"
+  watchAllNamespaces: false


### PR DESCRIPTION
A new value has been added to the baremetal provisioning CRD that allows
it to watch more namespaces to support deploying remote single node
OpenShift instances.  This patch explicitly sets this value to false.

We do not want to expose this in the installer at this time.  This is
a day 2 option.