### PR TITLE
Bug 1926364: baremetal: update terraform diagnosis for API timeout

### DIFF
--- a/pkg/terraform/diagnose.go
+++ b/pkg/terraform/diagnose.go
@@ -82,7 +82,7 @@ var conditions = []condition{{
 	match: regexp.MustCompile(`Error: could not contact Ironic API: timeout reached`),
 
 	reason:  "BaremetalIronicAPITimeout",
-	message: `Timed out waiting for provisioning service. This failure can be caused by misconfiguration or inability to download the machine operating system images. Please check the bootstrap host for failing services.`,
+	message: `Unable to the reach provisioning service. This failure can be caused by incorrect network/proxy settings, inability to download the machine operating system images, or other misconfiguration. Please check access to the bootstrap host, and for any failing services.`,
 }, {
 	match: regexp.MustCompile(`Error: could not inspect: could not inspect node, node is currently 'inspect failed', last error was 'timeout reached while inspecting the node'`),
 

--- a/pkg/terraform/diagnose_test.go
+++ b/pkg/terraform/diagnose_test.go
@@ -97,7 +97,7 @@ Error: could not contact Ironic API: timeout reached
    1: resource "ironic_node_v1" "openshift-master-host" {
 `,
 
-		err: `error\(BaremetalIronicAPITimeout\) from Infrastructure Provider: Timed out waiting for provisioning service\. This failure can be caused by misconfiguration or inability to download the machine operating system images\. Please check the bootstrap host for failing services\.`,
+		err: `error\(BaremetalIronicAPITimeout\) from Infrastructure Provider: Unable to the reach provisioning service\. This failure can be caused by incorrect network/proxy settings, inability to download the machine operating system images, or other misconfiguration\. Please check access to the bootstrap host, and for any failing services\.`,
 	}, {
 		input: `
 Error: could not inspect: could not inspect node, node is currently 'inspect failed', last error was 'timeout reached while inspecting the node'


### PR DESCRIPTION
A customer encountered a timeout when the installer was trying to reach
the baremetal provisioning services due to incorrect proxy settings in
the environment from which the installer was run. This updates the
diagnosis helper for this API timeout to include a suggestion to check
network and proxy settings.