### PR TITLE
Add resource filter that matches Label or ClusterID

### DIFF
--- a/pkg/destroy/gcp/disk.go
+++ b/pkg/destroy/gcp/disk.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (o *ClusterUninstaller) listDisks() ([]cloudResource, error) {
-	return o.listDisksWithFilter("items/*/disks(name,zone),nextPageToken", o.clusterIDFilter(), nil)
+	return o.listDisksWithFilter("items/*/disks(name,zone),nextPageToken", o.clusterLabelOrClusterIDFilter(), nil)
 }
 
 // listDisksWithFilter lists disks in the project that satisfy the filter criteria.

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -177,11 +177,15 @@ func (o *ClusterUninstaller) isClusterResource(name string) bool {
 }
 
 func (o *ClusterUninstaller) clusterIDFilter() string {
-	return fmt.Sprintf("name eq \"%s-.*\"", o.ClusterID)
+	return fmt.Sprintf("name : \"%s-*\"", o.ClusterID)
 }
 
 func (o *ClusterUninstaller) clusterLabelFilter() string {
-	return fmt.Sprintf("labels.kubernetes-io-cluster-%s eq \"owned\"", o.ClusterID)
+	return fmt.Sprintf("labels.kubernetes-io-cluster-%s = \"owned\"", o.ClusterID)
+}
+
+func (o *ClusterUninstaller) clusterLabelOrClusterIDFilter() string {
+	return fmt.Sprintf("(%s) OR (%s)", o.clusterIDFilter(), o.clusterLabelFilter())
 }
 
 func isNoOp(err error) bool {


### PR DESCRIPTION
With the introduction of CSI volumes in GCE it is no longer possible to find GCE PDs belonging to a particular cluster by their name. Therefore the CSI provisioned disks are to be labelled and the installer can find the disks to destroy also by the label.

Related patches:
Extra label support in the GCE CSI driver: https://github.com/openshift/gcp-pd-csi-driver/pull/11
GCP CSI operator: https://github.com/openshift/gcp-pd-csi-driver-operator/pull/16