### PR TITLE
Bug 1936443: Revert "baremetal: send full ignition to masters"

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -26,13 +26,11 @@ module "bootstrap" {
 module "masters" {
   source = "./masters"
 
-  master_count                = var.master_count
-  hosts                       = var.hosts
-  properties                  = var.properties
-  root_devices                = var.root_devices
-  driver_infos                = var.driver_infos
-  instance_infos              = var.instance_infos
-  master_ignition_url         = var.master_ignition_url
-  master_ignition_url_ca_cert = var.master_ignition_url_ca_cert
-  master_ignition_url_headers = var.master_ignition_url_headers
+  master_count   = var.master_count
+  ignition       = var.ignition_master
+  hosts          = var.hosts
+  properties     = var.properties
+  root_devices   = var.root_devices
+  driver_infos   = var.driver_infos
+  instance_infos = var.instance_infos
 }

--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -42,10 +42,8 @@ resource "ironic_deployment" "openshift-master-deployment" {
     count.index,
   )
 
-  instance_info         = var.instance_infos[count.index]
-  user_data_url         = var.master_ignition_url
-  user_data_url_ca_cert = var.master_ignition_url_ca_cert
-  user_data_url_headers = var.master_ignition_url_headers
+  instance_info = var.instance_infos[count.index]
+  user_data     = var.ignition
 }
 
 data "ironic_introspection" "openshift-master-introspection" {

--- a/data/data/baremetal/masters/variables.tf
+++ b/data/data/baremetal/masters/variables.tf
@@ -4,6 +4,11 @@ variable "master_count" {
   default     = 3
 }
 
+variable "ignition" {
+  type        = string
+  description = "The content of the master ignition file"
+}
+
 variable "hosts" {
   type        = list(map(string))
   description = "Hardware details for hosts"
@@ -27,19 +32,4 @@ variable "driver_infos" {
 variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
-}
-
-variable "master_ignition_url" {
-  type        = string
-  description = "The URL of the full ignition"
-}
-
-variable "master_ignition_url_ca_cert" {
-  type        = string
-  description = "Root CA cert of the full ignition URL"
-}
-
-variable "master_ignition_url_headers" {
-  type        = map(string)
-  description = "Headers to use when retrieving master_ignition_url"
 }

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -57,18 +57,3 @@ variable "instance_infos" {
   type        = list(map(string))
   description = "Instance information for hosts"
 }
-
-variable "master_ignition_url" {
-  type        = string
-  description = "The URL of the full ignition"
-}
-
-variable "master_ignition_url_ca_cert" {
-  type        = string
-  description = "Root CA cert of the full ignition URL"
-}
-
-variable "master_ignition_url_headers" {
-  type        = map(string)
-  description = "Headers to pass when retrieving master_ignition_url"
-}


### PR DESCRIPTION
This doesn't work for IPI baremetal deployments driven via hive,
because there are firewall rules that prevent access to the
bootstrap MCS from the pod running the installer.

This was implemented in:
https://github.com/openshift/installer/pull/4427

But we ran into problems making the same approach work for
worker machines ref:
https://github.com/openshift/installer/pull/4456

We're now looking at other approaches to resolve the
network-config requirements driving that work, so
switching back to the pointer config for masters seems
reasonable, particularly given this issue discovered for
hive deployments.

Conflicts:
  pkg/tfvars/baremetal/baremetal.go

This reverts commit 98dc38170a66d3ede7513fc01e3ccce4ff8dd93d.