### PR TITLE
[ovirt]: Removed '0' from machineset name

### DIFF
--- a/pkg/asset/machines/ovirt/machinesets.go
+++ b/pkg/asset/machines/ovirt/machinesets.go
@@ -31,7 +31,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	}
 
 	provider := provider(platform, pool, userDataSecret, osImage)
-	name := fmt.Sprintf("%s-%s-%d", clusterID, pool.Name, 0)
+	name := fmt.Sprintf("%s-%s", clusterID, pool.Name)
 	mset := &machineapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machine.openshift.io/v1beta1",


### PR DESCRIPTION
Machineset: Removed '0' from the name 

worker nodes created by the installer have number '0' suffixed

Fixes [bz-1817954](https://bugzilla.redhat.com/show_bug.cgi?id=1817954)