### PR TITLE
Baremetal: Remove the -openstack rename in the os image.

### DIFF
--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -71,8 +71,8 @@ func provider(platform *baremetal.Platform, osImage string, userDataSecret strin
 	// compresses it to speed up deployments and makes it available on platform.ClusterProvisioningIP, via http
 	// osImage looks like:
 	//   https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.2/42.80.20190725.1/rhcos-42.80.20190725.1-openstack.qcow2?sha256sum=123
-	// But the cached URL looks like:
-	//   http://172.22.0.3:6180/images/rhcos-42.80.20190725.1-openstack.qcow2/rhcos-42.80.20190725.1-compressed.qcow2
+	// And the cached URL looks like:
+	//   http://172.22.0.3:6180/images/rhcos-42.80.20190725.1-openstack.qcow2/cached-rhcos-42.80.20190725.1-openstack.qcow2
 	// See https://github.com/openshift/ironic-rhcos-downloader for more details
 	// The image is now formatted with a query string containing the sha256sum, we strip that here
 	// and it will be consumed for validation in ironic-machine-os-downloader
@@ -86,7 +86,7 @@ func provider(platform *baremetal.Platform, osImage string, userDataSecret strin
 	// ref https://github.com/openshift/ironic-rhcos-downloader/pull/12
 	imageFilename := path.Base(strings.TrimSuffix(imageURL.String(), ".gz"))
 	imageFilename = strings.TrimSuffix(imageFilename, ".xz")
-	compressedImageFilename := strings.Replace(imageFilename, "openstack", "compressed", 1)
+	cachedImageFilename := "cached-" + imageFilename
 
 	cacheImageIP := platform.ClusterProvisioningIP
 	cacheImagePort := "6180"
@@ -94,7 +94,7 @@ func provider(platform *baremetal.Platform, osImage string, userDataSecret strin
 		cacheImageIP = platform.APIVIP
 		cacheImagePort = "6181"
 	}
-	cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(cacheImageIP, cacheImagePort), imageFilename, compressedImageFilename)
+	cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(cacheImageIP, cacheImagePort), imageFilename, cachedImageFilename)
 	cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)
 	config := &baremetalprovider.BareMetalMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -136,8 +136,8 @@ func TFVars(libvirtURI, apiVIP, imageCacheIP, bootstrapOSImage, externalBridge, 
 		// ref https://github.com/openshift/ironic-rhcos-downloader/pull/12
 		imageFilename := path.Base(strings.TrimSuffix(imageURL.String(), ".gz"))
 		imageFilename = strings.TrimSuffix(imageFilename, ".xz")
-		compressedImageFilename := strings.Replace(imageFilename, "openstack", "compressed", 1)
-		cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(imageCacheIP, "80"), imageFilename, compressedImageFilename)
+		cachedImageFilename := "cached-" + imageFilename
+		cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(imageCacheIP, "80"), imageFilename, cachedImageFilename)
 		cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)
 		instanceInfo := map[string]interface{}{
 			"image_source":   cacheImageURL,


### PR DESCRIPTION
Change the way we handle the image filename so that we aren't requiring
that '-openstack' be in the image name.  This allows the use of any
filename that meets the rest of the validations.

This can be merged now that this is in:

https://github.com/openshift/ironic-rhcos-downloader/pull/26