### PR TITLE
Bug 1931115: Azure: Check Azure disk Instance Type for PremiumIO Capabilities

### DIFF
--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -94,7 +94,7 @@ func defaultAzureMachinePoolPlatform() azuretypes.MachinePool {
 	return azuretypes.MachinePool{
 		OSDisk: azuretypes.OSDisk{
 			DiskSizeGB: 128,
-			DiskType:   "Premium_LRS",
+			DiskType:   azuretypes.DefaultDiskType,
 		},
 	}
 }

--- a/pkg/types/azure/machinepool.go
+++ b/pkg/types/azure/machinepool.go
@@ -36,6 +36,9 @@ type OSDisk struct {
 	DiskType string `json:"diskType"`
 }
 
+// DefaultDiskType holds the default Azure disk type used by the VMs.
+const DefaultDiskType string = "Premium_LRS"
+
 // Set sets the values from `required` to `a`.
 func (a *MachinePool) Set(required *MachinePool) {
 	if required == nil || a == nil {


### PR DESCRIPTION
If the Azure disktype is Premium_LRS, a check must be made to see
if the given InstanceType has the PremiumIO capabilities which when
not present causes creation of clusters to fail. Adding the check
which iterates through all the capabilities of the given instance
type disk to find the PremiumIO, check if it is set to True and
return error otherwise.