### PR TITLE
pkg/asset/cluster/aws: fix dropped error

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -39,6 +39,9 @@ func PreTerraform(ctx context.Context, clusterID string, installConfig *installc
 	}
 
 	publicSubnets, err := installConfig.AWS.PublicSubnets(ctx)
+	if err != nil {
+		return err
+	}
 
 	//arns := make([]*string, 0, len(privateSubnets)+len(publicSubnets))
 	ids := make([]*string, 0, len(privateSubnets)+len(publicSubnets))


### PR DESCRIPTION
This fixes a dropped error in `pkg/asset/cluster/aws`.