### PR TITLE
WIP: Update AWS CloudFormation templates to closely match what an IPI installation creates

### DIFF
--- a/upi/aws/cloudformation/01_vpc.yaml
+++ b/upi/aws/cloudformation/01_vpc.yaml
@@ -14,7 +14,8 @@ Parameters:
     Type: String
 
   VpcCidr:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
+    AllowedPattern: >-
+      ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
     Default: 10.0.0.0/16
     Description: CIDR block for VPC.
@@ -45,15 +46,15 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label:
-          default: "Network Configuration"
-        Parameters:
-          - VpcCidr
-          - SubnetBits
-      - Label:
-          default: "Availability Zones"
-        Parameters:
-          - AvailabilityZoneCount
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcCidr
+      - SubnetBits
+    - Label:
+        default: "Availability Zones"
+      Parameters:
+      - AvailabilityZoneCount
     ParameterLabels:
       AvailabilityZoneCount:
         default: "Availability Zone Count"
@@ -74,10 +75,10 @@ Resources:
       EnableDnsHostnames: "true"
       CidrBlock: !Ref VpcCidr
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "vpc"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "vpc"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   PublicSubnet1:
     Type: "AWS::EC2::Subnet"
@@ -86,10 +87,10 @@ Resources:
       CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
       AvailabilityZone: !Select [0, Fn::GetAZs: !Ref "AWS::Region"]
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "public", !Select [0, Fn::GetAZs: !Ref "AWS::Region"]]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "public", !Select [0, Fn::GetAZs: !Ref "AWS::Region"]]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   PublicSubnet2:
     Type: "AWS::EC2::Subnet"
@@ -99,10 +100,10 @@ Resources:
       CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
       AvailabilityZone: !Select [1, Fn::GetAZs: !Ref "AWS::Region"]
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "public", !Select [1, Fn::GetAZs: !Ref "AWS::Region"]]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "public", !Select [1, Fn::GetAZs: !Ref "AWS::Region"]]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   PublicSubnet3:
     Type: "AWS::EC2::Subnet"
@@ -112,19 +113,19 @@ Resources:
       CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
       AvailabilityZone: !Select [2, Fn::GetAZs: !Ref "AWS::Region"]
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "public", !Select [2, Fn::GetAZs: !Ref "AWS::Region"]]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "public", !Select [2, Fn::GetAZs: !Ref "AWS::Region"]]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   InternetGateway:
     Type: "AWS::EC2::InternetGateway"
     Properties:
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "igw"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "igw"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   GatewayToInternet:
     Type: "AWS::EC2::VPCGatewayAttachment"
@@ -137,10 +138,10 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "public"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "public"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   PublicRoute:
     Type: "AWS::EC2::Route"
@@ -177,22 +178,22 @@ Resources:
       CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
       AvailabilityZone: !Select [0, Fn::GetAZs: !Ref "AWS::Region"]
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "private", !Select [0, Fn::GetAZs: !Ref "AWS::Region"]]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
-        - Key: kubernetes.io/role/internal-elb
-          Value: ""
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "private", !Select [0, Fn::GetAZs: !Ref "AWS::Region"]]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
+      - Key: kubernetes.io/role/internal-elb
+        Value: ""
 
   PrivateRouteTable1:
     Type: "AWS::EC2::RouteTable"
     Properties:
       VpcId: !Ref VPC
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "private", !GetAtt PublicSubnet1.AvailabilityZone]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "private", !GetAtt PublicSubnet1.AvailabilityZone]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   PrivateSubnetRouteTableAssociation1:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
@@ -202,26 +203,26 @@ Resources:
 
   NAT1:
     DependsOn:
-      - GatewayToInternet
+    - GatewayToInternet
     Type: "AWS::EC2::NatGateway"
     Properties:
       AllocationId: !GetAtt EIP1.AllocationId
       SubnetId: !Ref PublicSubnet1
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "nat", !GetAtt PublicSubnet1.AvailabilityZone]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "nat", !GetAtt PublicSubnet1.AvailabilityZone]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   EIP1:
     Type: "AWS::EC2::EIP"
     Properties:
       Domain: vpc
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "eip", !GetAtt PublicSubnet1.AvailabilityZone]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "eip", !GetAtt PublicSubnet1.AvailabilityZone]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   Route1:
     Type: "AWS::EC2::Route"
@@ -240,12 +241,12 @@ Resources:
       CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
       AvailabilityZone: !Select [1, Fn::GetAZs: !Ref "AWS::Region"]
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "private", !Select [1, Fn::GetAZs: !Ref "AWS::Region"]]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
-        - Key: kubernetes.io/role/internal-elb
-          Value: ""
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "private", !Select [1, Fn::GetAZs: !Ref "AWS::Region"]]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
+      - Key: kubernetes.io/role/internal-elb
+        Value: ""
 
   PrivateRouteTable2:
     Type: "AWS::EC2::RouteTable"
@@ -253,10 +254,10 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "private", !GetAtt PublicSubnet2.AvailabilityZone]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "private", !GetAtt PublicSubnet2.AvailabilityZone]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   PrivateSubnetRouteTableAssociation2:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
@@ -267,17 +268,17 @@ Resources:
 
   NAT2:
     DependsOn:
-      - GatewayToInternet
+    - GatewayToInternet
     Type: "AWS::EC2::NatGateway"
     Condition: DoAz2
     Properties:
       AllocationId: !GetAtt EIP2.AllocationId
       SubnetId: !Ref PublicSubnet2
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "nat", !GetAtt PublicSubnet2.AvailabilityZone]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "nat", !GetAtt PublicSubnet2.AvailabilityZone]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   EIP2:
     Type: "AWS::EC2::EIP"
@@ -285,10 +286,10 @@ Resources:
     Properties:
       Domain: vpc
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "eip", !GetAtt PublicSubnet2.AvailabilityZone]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "eip", !GetAtt PublicSubnet2.AvailabilityZone]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   Route2:
     Type: "AWS::EC2::Route"
@@ -308,12 +309,12 @@ Resources:
       CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
       AvailabilityZone: !Select [2, Fn::GetAZs: !Ref "AWS::Region"]
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "private", !Select [2, Fn::GetAZs: !Ref "AWS::Region"]]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
-        - Key: kubernetes.io/role/internal-elb
-          Value: ""
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "private", !Select [2, Fn::GetAZs: !Ref "AWS::Region"]]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
+      - Key: kubernetes.io/role/internal-elb
+        Value: ""
 
   PrivateRouteTable3:
     Type: "AWS::EC2::RouteTable"
@@ -321,10 +322,10 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "private", !GetAtt PublicSubnet3.AvailabilityZone]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "private", !GetAtt PublicSubnet3.AvailabilityZone]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   PrivateSubnetRouteTableAssociation3:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
@@ -335,17 +336,17 @@ Resources:
 
   NAT3:
     DependsOn:
-      - GatewayToInternet
+    - GatewayToInternet
     Type: "AWS::EC2::NatGateway"
     Condition: DoAz3
     Properties:
       AllocationId: !GetAtt EIP3.AllocationId
       SubnetId: !Ref PublicSubnet3
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "nat", !GetAtt PublicSubnet3.AvailabilityZone]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "nat", !GetAtt PublicSubnet3.AvailabilityZone]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   EIP3:
     Type: "AWS::EC2::EIP"
@@ -353,10 +354,10 @@ Resources:
     Properties:
       Domain: vpc
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "eip", !GetAtt PublicSubnet3.AvailabilityZone]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "eip", !GetAtt PublicSubnet3.AvailabilityZone]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   Route3:
     Type: "AWS::EC2::Route"
@@ -374,17 +375,17 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Effect: Allow
-            Principal: '*'
-            Action:
-              - '*'
-            Resource:
-              - '*'
+        - Effect: Allow
+          Principal: '*'
+          Action:
+          - '*'
+          Resource:
+          - '*'
       RouteTableIds:
-        - !Ref PublicRouteTable
-        - !Ref PrivateRouteTable1
-        - !If [DoAz2, !Ref PrivateRouteTable2, !Ref "AWS::NoValue"]
-        - !If [DoAz3, !Ref PrivateRouteTable3, !Ref "AWS::NoValue"]
+      - !Ref PublicRouteTable
+      - !Ref PrivateRouteTable1
+      - !If [DoAz2, !Ref PrivateRouteTable2, !Ref "AWS::NoValue"]
+      - !If [DoAz3, !Ref PrivateRouteTable3, !Ref "AWS::NoValue"]
       ServiceName: !Join [".", ["com.amazonaws", !Ref "AWS::Region", "s3"]]
       VpcId: !Ref VPC
 

--- a/upi/aws/cloudformation/01_vpc.yaml
+++ b/upi/aws/cloudformation/01_vpc.yaml
@@ -1,40 +1,59 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Template for Best Practice VPC with 1-3 AZs
+Description: Template for OpenShift cluster VPC containing 1-3 AZs
 
 Parameters:
+  InfrastructureName:
+    AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
+    MaxLength: 27
+    MinLength: 1
+    ConstraintDescription: >-
+      Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: >-
+      A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
+      use the value generated when creating the manifest files using `openshift-install create manifests`.
+    Type: String
+
   VpcCidr:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
     Default: 10.0.0.0/16
     Description: CIDR block for VPC.
     Type: String
+
   AvailabilityZoneCount:
-    ConstraintDescription: "The number of availability zones. (Min: 1, Max: 3)"
     MinValue: 1
     MaxValue: 3
-    Default: 1
-    Description: "How many AZs to create VPC subnets for. (Min: 1, Max: 3)"
+    ConstraintDescription: >-
+      The number of availability zones. (Min: 1, Max: 3)
+    Description: >-
+      How many AZs to create VPC subnets for. (Min: 1, Max: 3)
+    Default: 3
     Type: Number
+
   SubnetBits:
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/19-27.
     MinValue: 5
     MaxValue: 13
+    ConstraintDescription: >-
+      The size of each subnet in each availability zone.
+      (Min: 5 = /27, Max: 13 = /19)
+    Description: >-
+      Size of each subnet to create within the availability zones.
+      (Min: 5 = /27, Max: 13 = /19)
     Default: 12
-    Description: "Size of each subnet to create within the availability zones. (Min: 5 = /27, Max: 13 = /19)"
     Type: Number
 
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-    - Label:
-        default: "Network Configuration"
-      Parameters:
-      - VpcCidr
-      - SubnetBits
-    - Label:
-        default: "Availability Zones"
-      Parameters:
-      - AvailabilityZoneCount
+      - Label:
+          default: "Network Configuration"
+        Parameters:
+          - VpcCidr
+          - SubnetBits
+      - Label:
+          default: "Availability Zones"
+        Parameters:
+          - AvailabilityZoneCount
     ParameterLabels:
       AvailabilityZoneCount:
         default: "Availability Zone Count"
@@ -54,43 +73,75 @@ Resources:
       EnableDnsSupport: "true"
       EnableDnsHostnames: "true"
       CidrBlock: !Ref VpcCidr
-  PublicSubnet:
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "vpc"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
+  PublicSubnet1:
     Type: "AWS::EC2::Subnet"
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
-      AvailabilityZone: !Select
-      - 0
-      - Fn::GetAZs: !Ref "AWS::Region"
+      AvailabilityZone: !Select [0, Fn::GetAZs: !Ref "AWS::Region"]
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "public", !Select [0, Fn::GetAZs: !Ref "AWS::Region"]]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   PublicSubnet2:
     Type: "AWS::EC2::Subnet"
     Condition: DoAz2
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
-      AvailabilityZone: !Select
-      - 1
-      - Fn::GetAZs: !Ref "AWS::Region"
+      AvailabilityZone: !Select [1, Fn::GetAZs: !Ref "AWS::Region"]
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "public", !Select [1, Fn::GetAZs: !Ref "AWS::Region"]]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   PublicSubnet3:
     Type: "AWS::EC2::Subnet"
     Condition: DoAz3
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
-      AvailabilityZone: !Select
-      - 2
-      - Fn::GetAZs: !Ref "AWS::Region"
+      AvailabilityZone: !Select [2, Fn::GetAZs: !Ref "AWS::Region"]
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "public", !Select [2, Fn::GetAZs: !Ref "AWS::Region"]]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   InternetGateway:
     Type: "AWS::EC2::InternetGateway"
+    Properties:
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "igw"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   GatewayToInternet:
     Type: "AWS::EC2::VPCGatewayAttachment"
     Properties:
       VpcId: !Ref VPC
       InternetGatewayId: !Ref InternetGateway
+
   PublicRouteTable:
     Type: "AWS::EC2::RouteTable"
     Properties:
       VpcId: !Ref VPC
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "public"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   PublicRoute:
     Type: "AWS::EC2::Route"
     DependsOn: GatewayToInternet
@@ -98,98 +149,147 @@ Resources:
       RouteTableId: !Ref PublicRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       GatewayId: !Ref InternetGateway
-  PublicSubnetRouteTableAssociation:
+
+  PublicSubnetRouteTableAssociation1:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
     Properties:
-      SubnetId: !Ref PublicSubnet
+      SubnetId: !Ref PublicSubnet1
       RouteTableId: !Ref PublicRouteTable
+
   PublicSubnetRouteTableAssociation2:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
     Condition: DoAz2
     Properties:
       SubnetId: !Ref PublicSubnet2
       RouteTableId: !Ref PublicRouteTable
+
   PublicSubnetRouteTableAssociation3:
     Condition: DoAz3
     Type: "AWS::EC2::SubnetRouteTableAssociation"
     Properties:
       SubnetId: !Ref PublicSubnet3
       RouteTableId: !Ref PublicRouteTable
-  PrivateSubnet:
+
+  PrivateSubnet1:
     Type: "AWS::EC2::Subnet"
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
-      AvailabilityZone: !Select
-      - 0
-      - Fn::GetAZs: !Ref "AWS::Region"
-  PrivateRouteTable:
+      AvailabilityZone: !Select [0, Fn::GetAZs: !Ref "AWS::Region"]
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "private", !Select [0, Fn::GetAZs: !Ref "AWS::Region"]]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+        - Key: kubernetes.io/role/internal-elb
+          Value: ""
+
+  PrivateRouteTable1:
     Type: "AWS::EC2::RouteTable"
     Properties:
       VpcId: !Ref VPC
-  PrivateSubnetRouteTableAssociation:
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "private", !GetAtt PublicSubnet1.AvailabilityZone]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
+  PrivateSubnetRouteTableAssociation1:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
     Properties:
-      SubnetId: !Ref PrivateSubnet
-      RouteTableId: !Ref PrivateRouteTable
-  NAT:
+      SubnetId: !Ref PrivateSubnet1
+      RouteTableId: !Ref PrivateRouteTable1
+
+  NAT1:
     DependsOn:
-    - GatewayToInternet
+      - GatewayToInternet
     Type: "AWS::EC2::NatGateway"
     Properties:
-      AllocationId:
-        "Fn::GetAtt":
-        - EIP
-        - AllocationId
-      SubnetId: !Ref PublicSubnet
-  EIP:
+      AllocationId: !GetAtt EIP1.AllocationId
+      SubnetId: !Ref PublicSubnet1
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "nat", !GetAtt PublicSubnet1.AvailabilityZone]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
+  EIP1:
     Type: "AWS::EC2::EIP"
     Properties:
       Domain: vpc
-  Route:
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "eip", !GetAtt PublicSubnet1.AvailabilityZone]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
+  Route1:
     Type: "AWS::EC2::Route"
     Properties:
       RouteTableId:
-        Ref: PrivateRouteTable
+        Ref: PrivateRouteTable1
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
-        Ref: NAT
+        Ref: NAT1
+
   PrivateSubnet2:
     Type: "AWS::EC2::Subnet"
     Condition: DoAz2
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
-      AvailabilityZone: !Select
-      - 1
-      - Fn::GetAZs: !Ref "AWS::Region"
+      AvailabilityZone: !Select [1, Fn::GetAZs: !Ref "AWS::Region"]
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "private", !Select [1, Fn::GetAZs: !Ref "AWS::Region"]]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+        - Key: kubernetes.io/role/internal-elb
+          Value: ""
+
   PrivateRouteTable2:
     Type: "AWS::EC2::RouteTable"
     Condition: DoAz2
     Properties:
       VpcId: !Ref VPC
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "private", !GetAtt PublicSubnet2.AvailabilityZone]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   PrivateSubnetRouteTableAssociation2:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
     Condition: DoAz2
     Properties:
       SubnetId: !Ref PrivateSubnet2
       RouteTableId: !Ref PrivateRouteTable2
+
   NAT2:
     DependsOn:
-    - GatewayToInternet
+      - GatewayToInternet
     Type: "AWS::EC2::NatGateway"
     Condition: DoAz2
     Properties:
-      AllocationId:
-        "Fn::GetAtt":
-        - EIP2
-        - AllocationId
+      AllocationId: !GetAtt EIP2.AllocationId
       SubnetId: !Ref PublicSubnet2
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "nat", !GetAtt PublicSubnet2.AvailabilityZone]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   EIP2:
     Type: "AWS::EC2::EIP"
     Condition: DoAz2
     Properties:
       Domain: vpc
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "eip", !GetAtt PublicSubnet2.AvailabilityZone]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   Route2:
     Type: "AWS::EC2::Route"
     Condition: DoAz2
@@ -199,42 +299,65 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NAT2
+
   PrivateSubnet3:
     Type: "AWS::EC2::Subnet"
     Condition: DoAz3
     Properties:
       VpcId: !Ref VPC
       CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
-      AvailabilityZone: !Select
-      - 2
-      - Fn::GetAZs: !Ref "AWS::Region"
+      AvailabilityZone: !Select [2, Fn::GetAZs: !Ref "AWS::Region"]
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "private", !Select [2, Fn::GetAZs: !Ref "AWS::Region"]]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+        - Key: kubernetes.io/role/internal-elb
+          Value: ""
+
   PrivateRouteTable3:
     Type: "AWS::EC2::RouteTable"
     Condition: DoAz3
     Properties:
       VpcId: !Ref VPC
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "private", !GetAtt PublicSubnet3.AvailabilityZone]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   PrivateSubnetRouteTableAssociation3:
     Type: "AWS::EC2::SubnetRouteTableAssociation"
     Condition: DoAz3
     Properties:
       SubnetId: !Ref PrivateSubnet3
       RouteTableId: !Ref PrivateRouteTable3
+
   NAT3:
     DependsOn:
-    - GatewayToInternet
+      - GatewayToInternet
     Type: "AWS::EC2::NatGateway"
     Condition: DoAz3
     Properties:
-      AllocationId:
-        "Fn::GetAtt":
-        - EIP3
-        - AllocationId
+      AllocationId: !GetAtt EIP3.AllocationId
       SubnetId: !Ref PublicSubnet3
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "nat", !GetAtt PublicSubnet3.AvailabilityZone]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   EIP3:
     Type: "AWS::EC2::EIP"
     Condition: DoAz3
     Properties:
       Domain: vpc
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "eip", !GetAtt PublicSubnet3.AvailabilityZone]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
+
   Route3:
     Type: "AWS::EC2::Route"
     Condition: DoAz3
@@ -244,45 +367,52 @@ Resources:
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId:
         Ref: NAT3
+
   S3Endpoint:
     Type: AWS::EC2::VPCEndpoint
     Properties:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-        - Effect: Allow
-          Principal: '*'
-          Action:
-          - '*'
-          Resource:
-          - '*'
+          - Effect: Allow
+            Principal: '*'
+            Action:
+              - '*'
+            Resource:
+              - '*'
       RouteTableIds:
-      - !Ref PublicRouteTable
-      - !Ref PrivateRouteTable
-      - !If [DoAz2, !Ref PrivateRouteTable2, !Ref "AWS::NoValue"]
-      - !If [DoAz3, !Ref PrivateRouteTable3, !Ref "AWS::NoValue"]
-      ServiceName: !Join
-      - ''
-      - - com.amazonaws.
-        - !Ref 'AWS::Region'
-        - .s3
+        - !Ref PublicRouteTable
+        - !Ref PrivateRouteTable1
+        - !If [DoAz2, !Ref PrivateRouteTable2, !Ref "AWS::NoValue"]
+        - !If [DoAz3, !Ref PrivateRouteTable3, !Ref "AWS::NoValue"]
+      ServiceName: !Join [".", ["com.amazonaws", !Ref "AWS::Region", "s3"]]
       VpcId: !Ref VPC
 
 Outputs:
   VpcId:
     Description: ID of the new VPC.
     Value: !Ref VPC
+
   PublicSubnetIds:
     Description: Subnet IDs of the public subnets.
     Value:
       !Join [
         ",",
-        [!Ref PublicSubnet, !If [DoAz2, !Ref PublicSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PublicSubnet3, !Ref "AWS::NoValue"]]
+        [
+          !Ref PublicSubnet1,
+          !If [DoAz2, !Ref PublicSubnet2, !Ref "AWS::NoValue"],
+          !If [DoAz3, !Ref PublicSubnet3, !Ref "AWS::NoValue"]
+        ]
       ]
+
   PrivateSubnetIds:
     Description: Subnet IDs of the private subnets.
     Value:
       !Join [
         ",",
-        [!Ref PrivateSubnet, !If [DoAz2, !Ref PrivateSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PrivateSubnet3, !Ref "AWS::NoValue"]]
+        [
+          !Ref PrivateSubnet1,
+          !If [DoAz2, !Ref PrivateSubnet2, !Ref "AWS::NoValue"],
+          !If [DoAz3, !Ref PrivateSubnet3, !Ref "AWS::NoValue"]
+        ]
       ]

--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -46,22 +46,22 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label:
-          default: "Cluster Information"
-        Parameters:
-          - ClusterName
-          - InfrastructureName
-      - Label:
-          default: "Network Configuration"
-        Parameters:
-          - VpcId
-          - PublicSubnets
-          - PrivateSubnets
-      - Label:
-          default: "DNS"
-        Parameters:
-          - HostedZoneName
-          - HostedZoneId
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - ClusterName
+      - InfrastructureName
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcId
+      - PublicSubnets
+      - PrivateSubnets
+    - Label:
+        default: "DNS"
+      Parameters:
+      - HostedZoneName
+      - HostedZoneId
     ParameterLabels:
       ClusterName:
         default: "Cluster Name"
@@ -87,10 +87,10 @@ Resources:
       Subnets: !Ref PublicSubnets
       Type: network
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "ext"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "ext"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   IntApiElb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -101,10 +101,10 @@ Resources:
       Subnets: !Ref PrivateSubnets
       Type: network
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "int"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "int"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   IntDns:
     Type: "AWS::Route53::HostedZone"
@@ -113,13 +113,13 @@ Resources:
         Comment: "Managed by CloudFormation"
       Name: !Join [".", [!Ref ClusterName, !Ref HostedZoneName]]
       VPCs:
-        - VPCId: !Ref VpcId
-          VPCRegion: !Ref "AWS::Region"
+      - VPCId: !Ref VpcId
+        VPCRegion: !Ref "AWS::Region"
       HostedZoneTags:
-        - Key: Name
-          Value: !Join ["-", [!Ref InfrastructureName, "int"]]
-        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-          Value: "owned"
+      - Key: Name
+        Value: !Join ["-", [!Ref InfrastructureName, "int"]]
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "owned"
 
   ExternalApiServerRecord:
     Type: AWS::Route53::RecordSetGroup
@@ -127,19 +127,19 @@ Resources:
       Comment: Alias record for the API server
       HostedZoneId: !Ref HostedZoneId
       RecordSets:
-        - Name:
-            !Join [
-              ".",
-              [
-                "api",
-                !Ref ClusterName,
-                !Join ["", [!Ref HostedZoneName, "."]]
-              ]
+      - Name:
+          !Join [
+            ".",
+            [
+              "api",
+              !Ref ClusterName,
+              !Join ["", [!Ref HostedZoneName, "."]]
             ]
-          Type: A
-          AliasTarget:
-            HostedZoneId: !GetAtt ExtApiElb.CanonicalHostedZoneID
-            DNSName: !GetAtt ExtApiElb.DNSName
+          ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt ExtApiElb.CanonicalHostedZoneID
+          DNSName: !GetAtt ExtApiElb.DNSName
 
   InternalApiServerRecord:
     Type: AWS::Route53::RecordSetGroup
@@ -147,40 +147,40 @@ Resources:
       Comment: Alias record for the API server
       HostedZoneId: !Ref IntDns
       RecordSets:
-        - Name:
-            !Join [
-              ".",
-              [
-                "api",
-                !Ref ClusterName,
-                !Join ["", [!Ref HostedZoneName, "."]]
-              ]
+      - Name:
+          !Join [
+            ".",
+            [
+              "api",
+              !Ref ClusterName,
+              !Join ["", [!Ref HostedZoneName, "."]]
             ]
-          Type: A
-          AliasTarget:
-            HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
-            DNSName: !GetAtt IntApiElb.DNSName
-        - Name:
-            !Join [
-              ".",
-              [
-                "api-int",
-                !Ref ClusterName,
-                !Join ["", [!Ref HostedZoneName, "."]]
-              ]
+          ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
+          DNSName: !GetAtt IntApiElb.DNSName
+      - Name:
+          !Join [
+            ".",
+            [
+              "api-int",
+              !Ref ClusterName,
+              !Join ["", [!Ref HostedZoneName, "."]]
             ]
-          Type: A
-          AliasTarget:
-            HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
-            DNSName: !GetAtt IntApiElb.DNSName
+          ]
+        Type: A
+        AliasTarget:
+          HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
+          DNSName: !GetAtt IntApiElb.DNSName
 
   ExternalApiListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
-        - Type: forward
-          TargetGroupArn:
-            Ref: ExternalApiTargetGroup
+      - Type: forward
+        TargetGroupArn:
+          Ref: ExternalApiTargetGroup
       LoadBalancerArn:
         Ref: ExtApiElb
       Port: 6443
@@ -202,21 +202,21 @@ Resources:
       VpcId:
         Ref: VpcId
       TargetGroupAttributes:
-        - Key: deregistration_delay.timeout_seconds
-          Value: 60
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "aext"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "aext"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   InternalApiListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
-        - Type: forward
-          TargetGroupArn:
-            Ref: InternalApiTargetGroup
+      - Type: forward
+        TargetGroupArn:
+          Ref: InternalApiTargetGroup
       LoadBalancerArn:
         Ref: IntApiElb
       Port: 6443
@@ -238,21 +238,21 @@ Resources:
       VpcId:
         Ref: VpcId
       TargetGroupAttributes:
-        - Key: deregistration_delay.timeout_seconds
-          Value: 60
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "aint"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "aint"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   InternalServiceInternalListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
-        - Type: forward
-          TargetGroupArn:
-            Ref: InternalServiceTargetGroup
+      - Type: forward
+        TargetGroupArn:
+          Ref: InternalServiceTargetGroup
       LoadBalancerArn:
         Ref: IntApiElb
       Port: 22623
@@ -274,13 +274,13 @@ Resources:
       VpcId:
         Ref: VpcId
       TargetGroupAttributes:
-        - Key: deregistration_delay.timeout_seconds
-          Value: 60
+      - Key: deregistration_delay.timeout_seconds
+        Value: 60
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "sint"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "sint"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   RegisterTargetLambdaIamRole:
     Type: AWS::IAM::Role
@@ -289,44 +289,44 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "lambda.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "lambda.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
       Path: "/"
       Policies:
-        - PolicyName: !Join ["-", [!Ref InfrastructureName, "nlb", "lambda", "policy"]]
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: "Allow"
-                Action:
-                  [
-                    "elasticloadbalancing:RegisterTargets",
-                    "elasticloadbalancing:DeregisterTargets"
-                  ]
-                Resource: !Ref InternalApiTargetGroup
-              - Effect: "Allow"
-                Action:
-                  [
-                    "elasticloadbalancing:RegisterTargets",
-                    "elasticloadbalancing:DeregisterTargets"
-                  ]
-                Resource: !Ref InternalServiceTargetGroup
-              - Effect: "Allow"
-                Action:
-                  [
-                    "elasticloadbalancing:RegisterTargets",
-                    "elasticloadbalancing:DeregisterTargets"
-                  ]
-                Resource: !Ref ExternalApiTargetGroup
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "nlb", "lambda", "policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+              [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+              ]
+            Resource: !Ref InternalApiTargetGroup
+          - Effect: "Allow"
+            Action:
+              [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+              ]
+            Resource: !Ref InternalServiceTargetGroup
+          - Effect: "Allow"
+            Action:
+              [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+              ]
+            Resource: !Ref ExternalApiTargetGroup
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "nlb", "lambda", "role"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "nlb", "lambda", "role"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   RegisterNlbIpTargets:
     Type: "AWS::Lambda::Function"
@@ -342,18 +342,30 @@ Resources:
           def handler(event, context):
             elb = boto3.client('elbv2')
             if event['RequestType'] == 'Delete':
-              elb.deregister_targets(TargetGroupArn=event['ResourceProperties']['TargetArn'],Targets=[{'Id': event['ResourceProperties']['TargetIp']}])
+              elb.deregister_targets(
+                TargetGroupArn=event['ResourceProperties']['TargetArn'],
+                Targets=[{'Id': event['ResourceProperties']['TargetIp']}]
+              )
             elif event['RequestType'] == 'Create':
-              elb.register_targets(TargetGroupArn=event['ResourceProperties']['TargetArn'],Targets=[{'Id': event['ResourceProperties']['TargetIp']}])
+              elb.register_targets(
+                TargetGroupArn=event['ResourceProperties']['TargetArn'],
+                Targets=[{'Id': event['ResourceProperties']['TargetIp']}]
+              )
             responseData = {}
-            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['TargetArn']+event['ResourceProperties']['TargetIp'])
+            cfnresponse.send(
+              event,
+              context,
+              cfnresponse.SUCCESS,
+              responseData,
+              event['ResourceProperties']['TargetArn']+event['ResourceProperties']['TargetIp']
+            )
       Runtime: "python3.7"
       Timeout: 120
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "register", "target"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "register", "target"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   RegisterSubnetTagsLambdaIamRole:
     Type: AWS::IAM::Role
@@ -362,37 +374,37 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "lambda.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "lambda.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
       Path: "/"
       Policies:
-        - PolicyName: !Join ["-", [!Ref InfrastructureName, "subnet", "tags", "policy"]]
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: "Allow"
-                Action:
-                  [
-                    "ec2:DeleteTags",
-                    "ec2:CreateTags"
-                  ]
-                Resource: "arn:aws:ec2:*:*:subnet/*"
-              - Effect: "Allow"
-                Action:
-                  [
-                    "ec2:DescribeSubnets",
-                    "ec2:DescribeTags"
-                  ]
-                Resource: "*"
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "subnet", "tags", "policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+              [
+                "ec2:DeleteTags",
+                "ec2:CreateTags"
+              ]
+            Resource: "arn:aws:ec2:*:*:subnet/*"
+          - Effect: "Allow"
+            Action:
+              [
+                "ec2:DescribeSubnets",
+                "ec2:DescribeTags"
+              ]
+            Resource: "*"
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "subnet", "tags", "lambda", "role"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "subnet", "tags", "lambda", "role"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   RegisterSubnetTags:
     Type: "AWS::Lambda::Function"
@@ -409,19 +421,36 @@ Resources:
             ec2_client = boto3.client('ec2')
             if event['RequestType'] == 'Delete':
               for subnet_id in event['ResourceProperties']['Subnets']:
-                ec2_client.delete_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName']}]);
+                ec2_client.delete_tags(
+                  Resources=[subnet_id],
+                  Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName']}]
+                );
             elif event['RequestType'] == 'Create':
               for subnet_id in event['ResourceProperties']['Subnets']:
-                ec2_client.create_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName'], 'Value': 'shared'}]);
+                ec2_client.create_tags(
+                  Resources=[subnet_id],
+                  Tags=[
+                    {
+                      'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName'],
+                      'Value': 'shared'
+                    }
+                  ]
+                );
             responseData = {}
-            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['InfrastructureName']+event['ResourceProperties']['Subnets'][0])
+            cfnresponse.send(
+              event,
+              context,
+              cfnresponse.SUCCESS,
+              responseData,
+              event['ResourceProperties']['InfrastructureName']+event['ResourceProperties']['Subnets'][0]
+            )
       Runtime: "python3.7"
       Timeout: 120
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "subnet", "tags"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "subnet", "tags"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   RegisterPublicSubnetTags:
     Type: Custom::SubnetRegister

--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -7,28 +7,38 @@ Parameters:
     MaxLength: 27
     MinLength: 1
     ConstraintDescription: Cluster name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
-    Description: A short, representative cluster name to use for host names and other identifying names.
+    Description: >-
+      A short, representative cluster name to use for host names and other identifying names. You should use the value
+      specified when generating the install-config.yaml file using `openshift-install create install-config`.
     Type: String
+
   InfrastructureName:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
-    Description: A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster.
+    ConstraintDescription: >-
+      Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    Description: >-
+      A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
+      use the value generated when creating the manifest files using `openshift-install create manifests`.
     Type: String
+
   HostedZoneId:
     Description: The Route53 public zone ID to register the targets with, such as Z21IXYZABCZ2A4.
     Type: String
+
   HostedZoneName:
-    Description: The Route53 zone to register the targets with, such as example.com. Omit the trailing period.
+    Description: The Route53 zone to register the targets with, such as "example.com".
     Type: String
-    Default: "example.com"
+
   PublicSubnets:
     Description: The internet-facing subnets.
     Type: List<AWS::EC2::Subnet::Id>
+
   PrivateSubnets:
     Description: The internal subnets.
     Type: List<AWS::EC2::Subnet::Id>
+
   VpcId:
     Description: The VPC-scoped resources will belong to this VPC.
     Type: AWS::EC2::VPC::Id
@@ -36,22 +46,22 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-    - Label:
-        default: "Cluster Information"
-      Parameters:
-      - ClusterName
-      - InfrastructureName
-    - Label:
-        default: "Network Configuration"
-      Parameters:
-      - VpcId
-      - PublicSubnets
-      - PrivateSubnets
-    - Label:
-        default: "DNS"
-      Parameters:
-      - HostedZoneName
-      - HostedZoneId
+      - Label:
+          default: "Cluster Information"
+        Parameters:
+          - ClusterName
+          - InfrastructureName
+      - Label:
+          default: "Network Configuration"
+        Parameters:
+          - VpcId
+          - PublicSubnets
+          - PrivateSubnets
+      - Label:
+          default: "DNS"
+        Parameters:
+          - HostedZoneName
+          - HostedZoneId
     ParameterLabels:
       ClusterName:
         default: "Cluster Name"
@@ -76,6 +86,11 @@ Resources:
       IpAddressType: ipv4
       Subnets: !Ref PublicSubnets
       Type: network
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "ext"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   IntApiElb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -85,6 +100,11 @@ Resources:
       IpAddressType: ipv4
       Subnets: !Ref PrivateSubnets
       Type: network
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "int"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   IntDns:
     Type: "AWS::Route53::HostedZone"
@@ -92,14 +112,14 @@ Resources:
       HostedZoneConfig:
         Comment: "Managed by CloudFormation"
       Name: !Join [".", [!Ref ClusterName, !Ref HostedZoneName]]
-      HostedZoneTags:
-      - Key: Name
-        Value: !Join ["-", [!Ref InfrastructureName, "int"]]
-      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-        Value: "owned"
       VPCs:
-      - VPCId: !Ref VpcId
-        VPCRegion: !Ref "AWS::Region"
+        - VPCId: !Ref VpcId
+          VPCRegion: !Ref "AWS::Region"
+      HostedZoneTags:
+        - Key: Name
+          Value: !Join ["-", [!Ref InfrastructureName, "int"]]
+        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+          Value: "owned"
 
   ExternalApiServerRecord:
     Type: AWS::Route53::RecordSetGroup
@@ -107,15 +127,19 @@ Resources:
       Comment: Alias record for the API server
       HostedZoneId: !Ref HostedZoneId
       RecordSets:
-      - Name:
-          !Join [
-            ".",
-            ["api", !Ref ClusterName, !Join ["", [!Ref HostedZoneName, "."]]],
-          ]
-        Type: A
-        AliasTarget:
-          HostedZoneId: !GetAtt ExtApiElb.CanonicalHostedZoneID
-          DNSName: !GetAtt ExtApiElb.DNSName
+        - Name:
+            !Join [
+              ".",
+              [
+                "api",
+                !Ref ClusterName,
+                !Join ["", [!Ref HostedZoneName, "."]]
+              ]
+            ]
+          Type: A
+          AliasTarget:
+            HostedZoneId: !GetAtt ExtApiElb.CanonicalHostedZoneID
+            DNSName: !GetAtt ExtApiElb.DNSName
 
   InternalApiServerRecord:
     Type: AWS::Route53::RecordSetGroup
@@ -123,32 +147,40 @@ Resources:
       Comment: Alias record for the API server
       HostedZoneId: !Ref IntDns
       RecordSets:
-      - Name:
-          !Join [
-            ".",
-            ["api", !Ref ClusterName, !Join ["", [!Ref HostedZoneName, "."]]],
-          ]
-        Type: A
-        AliasTarget:
-          HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
-          DNSName: !GetAtt IntApiElb.DNSName
-      - Name:
-          !Join [
-            ".",
-            ["api-int", !Ref ClusterName, !Join ["", [!Ref HostedZoneName, "."]]],
-          ]
-        Type: A
-        AliasTarget:
-          HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
-          DNSName: !GetAtt IntApiElb.DNSName
+        - Name:
+            !Join [
+              ".",
+              [
+                "api",
+                !Ref ClusterName,
+                !Join ["", [!Ref HostedZoneName, "."]]
+              ]
+            ]
+          Type: A
+          AliasTarget:
+            HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
+            DNSName: !GetAtt IntApiElb.DNSName
+        - Name:
+            !Join [
+              ".",
+              [
+                "api-int",
+                !Ref ClusterName,
+                !Join ["", [!Ref HostedZoneName, "."]]
+              ]
+            ]
+          Type: A
+          AliasTarget:
+            HostedZoneId: !GetAtt IntApiElb.CanonicalHostedZoneID
+            DNSName: !GetAtt IntApiElb.DNSName
 
   ExternalApiListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
-      - Type: forward
-        TargetGroupArn:
-          Ref: ExternalApiTargetGroup
+        - Type: forward
+          TargetGroupArn:
+            Ref: ExternalApiTargetGroup
       LoadBalancerArn:
         Ref: ExtApiElb
       Port: 6443
@@ -157,6 +189,7 @@ Resources:
   ExternalApiTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      Name: !Join ["-", [!Ref InfrastructureName, "aext"]]
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: "/readyz"
       HealthCheckPort: 6443
@@ -169,16 +202,21 @@ Resources:
       VpcId:
         Ref: VpcId
       TargetGroupAttributes:
-      - Key: deregistration_delay.timeout_seconds
-        Value: 60
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "aext"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   InternalApiListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
-      - Type: forward
-        TargetGroupArn:
-          Ref: InternalApiTargetGroup
+        - Type: forward
+          TargetGroupArn:
+            Ref: InternalApiTargetGroup
       LoadBalancerArn:
         Ref: IntApiElb
       Port: 6443
@@ -187,6 +225,7 @@ Resources:
   InternalApiTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      Name: !Join ["-", [!Ref InfrastructureName, "aint"]]
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: "/readyz"
       HealthCheckPort: 6443
@@ -199,16 +238,21 @@ Resources:
       VpcId:
         Ref: VpcId
       TargetGroupAttributes:
-      - Key: deregistration_delay.timeout_seconds
-        Value: 60
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "aint"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   InternalServiceInternalListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       DefaultActions:
-      - Type: forward
-        TargetGroupArn:
-          Ref: InternalServiceTargetGroup
+        - Type: forward
+          TargetGroupArn:
+            Ref: InternalServiceTargetGroup
       LoadBalancerArn:
         Ref: IntApiElb
       Port: 22623
@@ -217,6 +261,7 @@ Resources:
   InternalServiceTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      Name: !Join ["-", [!Ref InfrastructureName, "sint"]]
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: "/healthz"
       HealthCheckPort: 22623
@@ -229,8 +274,13 @@ Resources:
       VpcId:
         Ref: VpcId
       TargetGroupAttributes:
-      - Key: deregistration_delay.timeout_seconds
-        Value: 60
+        - Key: deregistration_delay.timeout_seconds
+          Value: 60
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "sint"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   RegisterTargetLambdaIamRole:
     Type: AWS::IAM::Role
@@ -239,48 +289,51 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-        - Effect: "Allow"
-          Principal:
-            Service:
-            - "lambda.amazonaws.com"
-          Action:
-          - "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
       Path: "/"
       Policies:
-      - PolicyName: !Join ["-", [!Ref InfrastructureName, "master", "policy"]]
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-          - Effect: "Allow"
-            Action:
-              [
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:DeregisterTargets",
-              ]
-            Resource: !Ref InternalApiTargetGroup
-          - Effect: "Allow"
-            Action:
-              [
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:DeregisterTargets",
-              ]
-            Resource: !Ref InternalServiceTargetGroup
-          - Effect: "Allow"
-            Action:
-              [
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:DeregisterTargets",
-              ]
-            Resource: !Ref ExternalApiTargetGroup
+        - PolicyName: !Join ["-", [!Ref InfrastructureName, "nlb", "lambda", "policy"]]
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  [
+                    "elasticloadbalancing:RegisterTargets",
+                    "elasticloadbalancing:DeregisterTargets"
+                  ]
+                Resource: !Ref InternalApiTargetGroup
+              - Effect: "Allow"
+                Action:
+                  [
+                    "elasticloadbalancing:RegisterTargets",
+                    "elasticloadbalancing:DeregisterTargets"
+                  ]
+                Resource: !Ref InternalServiceTargetGroup
+              - Effect: "Allow"
+                Action:
+                  [
+                    "elasticloadbalancing:RegisterTargets",
+                    "elasticloadbalancing:DeregisterTargets"
+                  ]
+                Resource: !Ref ExternalApiTargetGroup
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "nlb", "lambda", "role"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   RegisterNlbIpTargets:
     Type: "AWS::Lambda::Function"
     Properties:
+      FunctionName: !Join ["-", [!Ref InfrastructureName, "register", "target"]]
       Handler: "index.handler"
-      Role:
-        Fn::GetAtt:
-        - "RegisterTargetLambdaIamRole"
-        - "Arn"
+      Role: !GetAtt RegisterTargetLambdaIamRole.Arn
       Code:
         ZipFile: |
           import json
@@ -296,49 +349,57 @@ Resources:
             cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['TargetArn']+event['ResourceProperties']['TargetIp'])
       Runtime: "python3.7"
       Timeout: 120
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "register", "target"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   RegisterSubnetTagsLambdaIamRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Join ["-", [!Ref InfrastructureName, "subnet-tags-lambda-role"]]
+      RoleName: !Join ["-", [!Ref InfrastructureName, "subnet", "tags", "lambda", "role"]]
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-        - Effect: "Allow"
-          Principal:
-            Service:
-            - "lambda.amazonaws.com"
-          Action:
-          - "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
       Path: "/"
       Policies:
-      - PolicyName: !Join ["-", [!Ref InfrastructureName, "subnet-tagging-policy"]]
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-          - Effect: "Allow"
-            Action:
-              [
-                "ec2:DeleteTags",
-                "ec2:CreateTags"
-              ]
-            Resource: "arn:aws:ec2:*:*:subnet/*"
-          - Effect: "Allow"
-            Action:
-              [
-                "ec2:DescribeSubnets",
-                "ec2:DescribeTags"
-              ]
-            Resource: "*"
+        - PolicyName: !Join ["-", [!Ref InfrastructureName, "subnet", "tags", "policy"]]
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  [
+                    "ec2:DeleteTags",
+                    "ec2:CreateTags"
+                  ]
+                Resource: "arn:aws:ec2:*:*:subnet/*"
+              - Effect: "Allow"
+                Action:
+                  [
+                    "ec2:DescribeSubnets",
+                    "ec2:DescribeTags"
+                  ]
+                Resource: "*"
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "subnet", "tags", "lambda", "role"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   RegisterSubnetTags:
     Type: "AWS::Lambda::Function"
     Properties:
+      FunctionName: !Join ["-", [!Ref InfrastructureName, "subnet", "tags"]]
       Handler: "index.handler"
-      Role:
-        Fn::GetAtt:
-        - "RegisterSubnetTagsLambdaIamRole"
-        - "Arn"
+      Role: !GetAtt RegisterSubnetTagsLambdaIamRole.Arn
       Code:
         ZipFile: |
           import json
@@ -356,6 +417,11 @@ Resources:
             cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['InfrastructureName']+event['ResourceProperties']['Subnets'][0])
       Runtime: "python3.7"
       Timeout: 120
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "subnet", "tags"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   RegisterPublicSubnetTags:
     Type: Custom::SubnetRegister
@@ -375,24 +441,31 @@ Outputs:
   PrivateHostedZoneId:
     Description: Hosted zone ID for the private DNS, which is required for private records.
     Value: !Ref IntDns
+
   ExternalApiLoadBalancerName:
     Description: Full name of the external API load balancer.
     Value: !GetAtt ExtApiElb.LoadBalancerFullName
+
   InternalApiLoadBalancerName:
     Description: Full name of the internal API load balancer.
     Value: !GetAtt IntApiElb.LoadBalancerFullName
+
   ApiServerDnsName:
     Description: Full hostname of the API server, which is required for the Ignition config files.
     Value: !Join [".", ["api-int", !Ref ClusterName, !Ref HostedZoneName]]
+
   RegisterNlbIpTargetsLambda:
-    Description: Lambda ARN useful to help register or deregister IP targets for these load balancers.
+    Description: Lambda ARN useful to help register or deregister IP targets for the load balancers.
     Value: !GetAtt RegisterNlbIpTargets.Arn
+
   ExternalApiTargetGroupArn:
     Description: ARN of the external API target group.
     Value: !Ref ExternalApiTargetGroup
+
   InternalApiTargetGroupArn:
     Description: ARN of the internal API target group.
     Value: !Ref InternalApiTargetGroup
+
   InternalServiceTargetGroupArn:
     Description: ARN of the internal service target group.
     Value: !Ref InternalServiceTargetGroup

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -6,14 +6,16 @@ Parameters:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    ConstraintDescription: >-
+      Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
     Description: >-
       A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
       use the value generated when creating the manifest files using `openshift-install create manifests`.
     Type: String
 
   VpcCidr:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
+    AllowedPattern: >-
+      ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
     Description: CIDR block for VPC.
     Default: 10.0.0.0/16
@@ -30,16 +32,16 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label:
-          default: "Cluster Information"
-        Parameters:
-          - InfrastructureName
-      - Label:
-          default: "Network Configuration"
-        Parameters:
-          - VpcId
-          - VpcCidr
-          - PrivateSubnets
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcId
+      - VpcCidr
+      - PrivateSubnets
     ParameterLabels:
       InfrastructureName:
         default: "Infrastructure Name"
@@ -57,28 +59,28 @@ Resources:
       GroupName: !Join ["-", [!Ref InfrastructureName, "master", "sg"]]
       GroupDescription: Cluster Master Security Group
       SecurityGroupIngress:
-        - IpProtocol: icmp
-          FromPort: 0
-          ToPort: 0
-          CidrIp: !Ref VpcCidr
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref VpcCidr
-        - IpProtocol: tcp
-          ToPort: 6443
-          FromPort: 6443
-          CidrIp: !Ref VpcCidr
-        - IpProtocol: tcp
-          FromPort: 22623
-          ToPort: 22623
-          CidrIp: !Ref VpcCidr
+      - IpProtocol: icmp
+        FromPort: 0
+        ToPort: 0
+        CidrIp: !Ref VpcCidr
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: !Ref VpcCidr
+      - IpProtocol: tcp
+        ToPort: 6443
+        FromPort: 6443
+        CidrIp: !Ref VpcCidr
+      - IpProtocol: tcp
+        FromPort: 22623
+        ToPort: 22623
+        CidrIp: !Ref VpcCidr
       VpcId: !Ref VpcId
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "master", "sg"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "master", "sg"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   WorkerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -86,20 +88,20 @@ Resources:
       GroupName: !Join ["-", [!Ref InfrastructureName, "worker", "sg"]]
       GroupDescription: Cluster Worker Security Group
       SecurityGroupIngress:
-        - IpProtocol: icmp
-          FromPort: 0
-          ToPort: 0
-          CidrIp: !Ref VpcCidr
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref VpcCidr
+      - IpProtocol: icmp
+        FromPort: 0
+        ToPort: 0
+        CidrIp: !Ref VpcCidr
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: !Ref VpcCidr
       VpcId: !Ref VpcId
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "worker", "sg"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "worker", "sg"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   MasterIngressEtcd:
     Type: AWS::EC2::SecurityGroupIngress
@@ -510,70 +512,70 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "ec2.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "ec2.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
       Policies:
-        - PolicyName: !Join ["-", [!Ref InfrastructureName, "master", "policy"]]
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: "Allow"
-                Action:
-                  - "ec2:AttachVolume"
-                  - "ec2:AuthorizeSecurityGroupIngress"
-                  - "ec2:CreateSecurityGroup"
-                  - "ec2:CreateTags"
-                  - "ec2:CreateVolume"
-                  - "ec2:DeleteSecurityGroup"
-                  - "ec2:DeleteVolume"
-                  - "ec2:Describe*"
-                  - "ec2:DetachVolume"
-                  - "ec2:ModifyInstanceAttribute"
-                  - "ec2:ModifyVolume"
-                  - "ec2:RevokeSecurityGroupIngress"
-                  - "elasticloadbalancing:AddTags"
-                  - "elasticloadbalancing:AttachLoadBalancerToSubnets"
-                  - "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer"
-                  - "elasticloadbalancing:CreateListener"
-                  - "elasticloadbalancing:CreateLoadBalancer"
-                  - "elasticloadbalancing:CreateLoadBalancerPolicy"
-                  - "elasticloadbalancing:CreateLoadBalancerListeners"
-                  - "elasticloadbalancing:CreateTargetGroup"
-                  - "elasticloadbalancing:ConfigureHealthCheck"
-                  - "elasticloadbalancing:DeleteListener"
-                  - "elasticloadbalancing:DeleteLoadBalancer"
-                  - "elasticloadbalancing:DeleteLoadBalancerListeners"
-                  - "elasticloadbalancing:DeleteTargetGroup"
-                  - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
-                  - "elasticloadbalancing:DeregisterTargets"
-                  - "elasticloadbalancing:Describe*"
-                  - "elasticloadbalancing:DetachLoadBalancerFromSubnets"
-                  - "elasticloadbalancing:ModifyListener"
-                  - "elasticloadbalancing:ModifyLoadBalancerAttributes"
-                  - "elasticloadbalancing:ModifyTargetGroup"
-                  - "elasticloadbalancing:ModifyTargetGroupAttributes"
-                  - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
-                  - "elasticloadbalancing:RegisterTargets"
-                  - "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
-                  - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
-                  - "kms:DescribeKey"
-                Resource: "*"
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "master", "policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+            - "ec2:AttachVolume"
+            - "ec2:AuthorizeSecurityGroupIngress"
+            - "ec2:CreateSecurityGroup"
+            - "ec2:CreateTags"
+            - "ec2:CreateVolume"
+            - "ec2:DeleteSecurityGroup"
+            - "ec2:DeleteVolume"
+            - "ec2:Describe*"
+            - "ec2:DetachVolume"
+            - "ec2:ModifyInstanceAttribute"
+            - "ec2:ModifyVolume"
+            - "ec2:RevokeSecurityGroupIngress"
+            - "elasticloadbalancing:AddTags"
+            - "elasticloadbalancing:AttachLoadBalancerToSubnets"
+            - "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer"
+            - "elasticloadbalancing:CreateListener"
+            - "elasticloadbalancing:CreateLoadBalancer"
+            - "elasticloadbalancing:CreateLoadBalancerPolicy"
+            - "elasticloadbalancing:CreateLoadBalancerListeners"
+            - "elasticloadbalancing:CreateTargetGroup"
+            - "elasticloadbalancing:ConfigureHealthCheck"
+            - "elasticloadbalancing:DeleteListener"
+            - "elasticloadbalancing:DeleteLoadBalancer"
+            - "elasticloadbalancing:DeleteLoadBalancerListeners"
+            - "elasticloadbalancing:DeleteTargetGroup"
+            - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
+            - "elasticloadbalancing:DeregisterTargets"
+            - "elasticloadbalancing:Describe*"
+            - "elasticloadbalancing:DetachLoadBalancerFromSubnets"
+            - "elasticloadbalancing:ModifyListener"
+            - "elasticloadbalancing:ModifyLoadBalancerAttributes"
+            - "elasticloadbalancing:ModifyTargetGroup"
+            - "elasticloadbalancing:ModifyTargetGroupAttributes"
+            - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+            - "elasticloadbalancing:RegisterTargets"
+            - "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
+            - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
+            - "kms:DescribeKey"
+            Resource: "*"
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "master", "role"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "master", "role"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   MasterInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
       InstanceProfileName: !Join ["-", [!Ref InfrastructureName, "master", "profile"]]
       Roles:
-        - Ref: "MasterIamRole"
+      - Ref: "MasterIamRole"
 
   WorkerIamRole:
     Type: AWS::IAM::Role
@@ -582,34 +584,34 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "ec2.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "ec2.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
       Policies:
-        - PolicyName: !Join ["-", [!Ref InfrastructureName, "worker", "policy"]]
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: "Allow"
-                Action:
-                  - "ec2:DescribeInstances"
-                  - "ec2:DescribeRegions"
-                Resource: "*"
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "worker", "policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action:
+            - "ec2:DescribeInstances"
+            - "ec2:DescribeRegions"
+            Resource: "*"
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "worker", "role"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "worker", "role"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   WorkerInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
       InstanceProfileName: !Join ["-", [!Ref InfrastructureName, "worker", "profile"]]
       Roles:
-        - Ref: "WorkerIamRole"
+      - Ref: "WorkerIamRole"
 
 Outputs:
   MasterSecurityGroupId:

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -7,17 +7,22 @@ Parameters:
     MaxLength: 27
     MinLength: 1
     ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
-    Description: A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster.
+    Description: >-
+      A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
+      use the value generated when creating the manifest files using `openshift-install create manifests`.
     Type: String
+
   VpcCidr:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
-    Default: 10.0.0.0/16
     Description: CIDR block for VPC.
+    Default: 10.0.0.0/16
     Type: String
+
   VpcId:
     Description: The VPC-scoped resources will belong to this VPC.
     Type: AWS::EC2::VPC::Id
+
   PrivateSubnets:
     Description: The internal subnets.
     Type: List<AWS::EC2::Subnet::Id>
@@ -25,16 +30,16 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-    - Label:
-        default: "Cluster Information"
-      Parameters:
-      - InfrastructureName
-    - Label:
-        default: "Network Configuration"
-      Parameters:
-      - VpcId
-      - VpcCidr
-      - PrivateSubnets
+      - Label:
+          default: "Cluster Information"
+        Parameters:
+          - InfrastructureName
+      - Label:
+          default: "Network Configuration"
+        Parameters:
+          - VpcId
+          - VpcCidr
+          - PrivateSubnets
     ParameterLabels:
       InfrastructureName:
         default: "Infrastructure Name"
@@ -49,40 +54,52 @@ Resources:
   MasterSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupName: !Join ["-", [!Ref InfrastructureName, "master", "sg"]]
       GroupDescription: Cluster Master Security Group
       SecurityGroupIngress:
-      - IpProtocol: icmp
-        FromPort: 0
-        ToPort: 0
-        CidrIp: !Ref VpcCidr
-      - IpProtocol: tcp
-        FromPort: 22
-        ToPort: 22
-        CidrIp: !Ref VpcCidr
-      - IpProtocol: tcp
-        ToPort: 6443
-        FromPort: 6443
-        CidrIp: !Ref VpcCidr
-      - IpProtocol: tcp
-        FromPort: 22623
-        ToPort: 22623
-        CidrIp: !Ref VpcCidr
+        - IpProtocol: icmp
+          FromPort: 0
+          ToPort: 0
+          CidrIp: !Ref VpcCidr
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref VpcCidr
+        - IpProtocol: tcp
+          ToPort: 6443
+          FromPort: 6443
+          CidrIp: !Ref VpcCidr
+        - IpProtocol: tcp
+          FromPort: 22623
+          ToPort: 22623
+          CidrIp: !Ref VpcCidr
       VpcId: !Ref VpcId
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "master", "sg"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   WorkerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupName: !Join ["-", [!Ref InfrastructureName, "worker", "sg"]]
       GroupDescription: Cluster Worker Security Group
       SecurityGroupIngress:
-      - IpProtocol: icmp
-        FromPort: 0
-        ToPort: 0
-        CidrIp: !Ref VpcCidr
-      - IpProtocol: tcp
-        FromPort: 22
-        ToPort: 22
-        CidrIp: !Ref VpcCidr
+        - IpProtocol: icmp
+          FromPort: 0
+          ToPort: 0
+          CidrIp: !Ref VpcCidr
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref VpcCidr
       VpcId: !Ref VpcId
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "worker", "sg"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   MasterIngressEtcd:
     Type: AWS::EC2::SecurityGroupIngress
@@ -489,96 +506,110 @@ Resources:
   MasterIamRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Join ["-", [!Ref InfrastructureName, "master", "role"]]
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-        - Effect: "Allow"
-          Principal:
-            Service:
-            - "ec2.amazonaws.com"
-          Action:
-          - "sts:AssumeRole"
-      Policies:
-      - PolicyName: !Join ["-", [!Ref InfrastructureName, "master", "policy"]]
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
           - Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
             Action:
-            - "ec2:AttachVolume"
-            - "ec2:AuthorizeSecurityGroupIngress"
-            - "ec2:CreateSecurityGroup"
-            - "ec2:CreateTags"
-            - "ec2:CreateVolume"
-            - "ec2:DeleteSecurityGroup"
-            - "ec2:DeleteVolume"
-            - "ec2:Describe*"
-            - "ec2:DetachVolume"
-            - "ec2:ModifyInstanceAttribute"
-            - "ec2:ModifyVolume"
-            - "ec2:RevokeSecurityGroupIngress"
-            - "elasticloadbalancing:AddTags"
-            - "elasticloadbalancing:AttachLoadBalancerToSubnets"
-            - "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer"
-            - "elasticloadbalancing:CreateListener"
-            - "elasticloadbalancing:CreateLoadBalancer"
-            - "elasticloadbalancing:CreateLoadBalancerPolicy"
-            - "elasticloadbalancing:CreateLoadBalancerListeners"
-            - "elasticloadbalancing:CreateTargetGroup"
-            - "elasticloadbalancing:ConfigureHealthCheck"
-            - "elasticloadbalancing:DeleteListener"
-            - "elasticloadbalancing:DeleteLoadBalancer"
-            - "elasticloadbalancing:DeleteLoadBalancerListeners"
-            - "elasticloadbalancing:DeleteTargetGroup"
-            - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
-            - "elasticloadbalancing:DeregisterTargets"
-            - "elasticloadbalancing:Describe*"
-            - "elasticloadbalancing:DetachLoadBalancerFromSubnets"
-            - "elasticloadbalancing:ModifyListener"
-            - "elasticloadbalancing:ModifyLoadBalancerAttributes"
-            - "elasticloadbalancing:ModifyTargetGroup"
-            - "elasticloadbalancing:ModifyTargetGroupAttributes"
-            - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
-            - "elasticloadbalancing:RegisterTargets"
-            - "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
-            - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
-            - "kms:DescribeKey"
-            Resource: "*"
+              - "sts:AssumeRole"
+      Policies:
+        - PolicyName: !Join ["-", [!Ref InfrastructureName, "master", "policy"]]
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "ec2:AttachVolume"
+                  - "ec2:AuthorizeSecurityGroupIngress"
+                  - "ec2:CreateSecurityGroup"
+                  - "ec2:CreateTags"
+                  - "ec2:CreateVolume"
+                  - "ec2:DeleteSecurityGroup"
+                  - "ec2:DeleteVolume"
+                  - "ec2:Describe*"
+                  - "ec2:DetachVolume"
+                  - "ec2:ModifyInstanceAttribute"
+                  - "ec2:ModifyVolume"
+                  - "ec2:RevokeSecurityGroupIngress"
+                  - "elasticloadbalancing:AddTags"
+                  - "elasticloadbalancing:AttachLoadBalancerToSubnets"
+                  - "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer"
+                  - "elasticloadbalancing:CreateListener"
+                  - "elasticloadbalancing:CreateLoadBalancer"
+                  - "elasticloadbalancing:CreateLoadBalancerPolicy"
+                  - "elasticloadbalancing:CreateLoadBalancerListeners"
+                  - "elasticloadbalancing:CreateTargetGroup"
+                  - "elasticloadbalancing:ConfigureHealthCheck"
+                  - "elasticloadbalancing:DeleteListener"
+                  - "elasticloadbalancing:DeleteLoadBalancer"
+                  - "elasticloadbalancing:DeleteLoadBalancerListeners"
+                  - "elasticloadbalancing:DeleteTargetGroup"
+                  - "elasticloadbalancing:DeregisterInstancesFromLoadBalancer"
+                  - "elasticloadbalancing:DeregisterTargets"
+                  - "elasticloadbalancing:Describe*"
+                  - "elasticloadbalancing:DetachLoadBalancerFromSubnets"
+                  - "elasticloadbalancing:ModifyListener"
+                  - "elasticloadbalancing:ModifyLoadBalancerAttributes"
+                  - "elasticloadbalancing:ModifyTargetGroup"
+                  - "elasticloadbalancing:ModifyTargetGroupAttributes"
+                  - "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+                  - "elasticloadbalancing:RegisterTargets"
+                  - "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer"
+                  - "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
+                  - "kms:DescribeKey"
+                Resource: "*"
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "master", "role"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   MasterInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
+      InstanceProfileName: !Join ["-", [!Ref InfrastructureName, "master", "profile"]]
       Roles:
-      - Ref: "MasterIamRole"
+        - Ref: "MasterIamRole"
 
   WorkerIamRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Join ["-", [!Ref InfrastructureName, "worker", "role"]]
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-        - Effect: "Allow"
-          Principal:
-            Service:
-            - "ec2.amazonaws.com"
-          Action:
-          - "sts:AssumeRole"
-      Policies:
-      - PolicyName: !Join ["-", [!Ref InfrastructureName, "worker", "policy"]]
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
           - Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
             Action:
-            - "ec2:DescribeInstances"
-            - "ec2:DescribeRegions"
-            Resource: "*"
+              - "sts:AssumeRole"
+      Policies:
+        - PolicyName: !Join ["-", [!Ref InfrastructureName, "worker", "policy"]]
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - "ec2:DescribeInstances"
+                  - "ec2:DescribeRegions"
+                Resource: "*"
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "worker", "role"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   WorkerInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
+      InstanceProfileName: !Join ["-", [!Ref InfrastructureName, "worker", "profile"]]
       Roles:
-      - Ref: "WorkerIamRole"
+        - Ref: "WorkerIamRole"
 
 Outputs:
   MasterSecurityGroupId:

--- a/upi/aws/cloudformation/04_cluster_bootstrap.yaml
+++ b/upi/aws/cloudformation/04_cluster_bootstrap.yaml
@@ -6,39 +6,35 @@ Parameters:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    ConstraintDescription: >-
+      Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
     Description: >-
       A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
       use the value generated when creating the manifest files using `openshift-install create manifests`.
     Type: String
 
   RhcosAmi:
-    Description: >-
-      Current Red Hat Enterprise Linux CoreOS AMI to use for bootstrap.
+    Description: Current Red Hat Enterprise Linux CoreOS AMI to use for bootstrap.
     Type: AWS::EC2::Image::Id
 
   AllowedBootstrapSshCidr:
-    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|1[0-9]|2[0-9]|3[0-2]))$
-    ConstraintDescription: >-
-      CIDR block parameter must be in the form x.x.x.x/0-32.
-    Description: >-
-      CIDR block to allow SSH access to the bootstrap node.
+    AllowedPattern: >-
+      ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|1[0-9]|2[0-9]|3[0-2]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/0-32.
+    Description: CIDR block to allow SSH access to the bootstrap node.
     Default: 0.0.0.0/0
     Type: String
 
   PublicSubnet:
-    Description: >-
-      The public subnet to launch the bootstrap node into.
+    Description: The public subnet to launch the bootstrap node into.
     Type: AWS::EC2::Subnet::Id
 
   MasterSecurityGroupId:
-    Description: >-
-      The master security group ID.
+    Description: The master security group ID.
     Type: AWS::EC2::SecurityGroup::Id
 
   VpcId:
-    Description: >-
-      The VPC-scoped resources will belong to this VPC.
+    Description: The VPC-scoped resources will belong to this VPC.
     Type: AWS::EC2::VPC::Id
 
   BootstrapIgnitionLocation:
@@ -48,60 +44,55 @@ Parameters:
 
   AutoRegisterELB:
     AllowedValues:
-      - "yes"
-      - "no"
-    Description: >-
-      Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
+    - "yes"
+    - "no"
+    Description: Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
     Default: "yes"
     Type: String
 
   RegisterNlbIpTargetsLambdaArn:
-    Description: >-
-      ARN for NLB IP target registration lambda.
+    Description: ARN for NLB IP target registration lambda.
     Type: String
 
   ExternalApiTargetGroupArn:
-    Description: >-
-      ARN for external API load balancer target group.
+    Description: ARN for external API load balancer target group.
     Type: String
 
   InternalApiTargetGroupArn:
-    Description: >-
-      ARN for internal API load balancer target group.
+    Description: ARN for internal API load balancer target group.
     Type: String
 
   InternalServiceTargetGroupArn:
-    Description: >-
-      ARN for internal service load balancer target group.
+    Description: ARN for internal service load balancer target group.
     Type: String
 
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label:
-          default: "Cluster Information"
-        Parameters:
-          - InfrastructureName
-      - Label:
-          default: "Host Information"
-        Parameters:
-          - RhcosAmi
-          - BootstrapIgnitionLocation
-          - MasterSecurityGroupId
-      - Label:
-          default: "Network Configuration"
-        Parameters:
-          - VpcId
-          - AllowedBootstrapSshCidr
-          - PublicSubnet
-      - Label:
-          default: "Load Balancer Automation"
-        Parameters:
-          - AutoRegisterELB
-          - RegisterNlbIpTargetsLambdaArn
-          - ExternalApiTargetGroupArn
-          - InternalApiTargetGroupArn
-          - InternalServiceTargetGroupArn
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
+        default: "Host Information"
+      Parameters:
+      - RhcosAmi
+      - BootstrapIgnitionLocation
+      - MasterSecurityGroupId
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcId
+      - AllowedBootstrapSshCidr
+      - PublicSubnet
+    - Label:
+        default: "Load Balancer Automation"
+      Parameters:
+      - AutoRegisterELB
+      - RegisterNlbIpTargetsLambdaArn
+      - ExternalApiTargetGroupArn
+      - InternalApiTargetGroupArn
+      - InternalServiceTargetGroupArn
     ParameterLabels:
       InfrastructureName:
         default: "Infrastructure Name"
@@ -131,35 +122,35 @@ Resources:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Effect: "Allow"
-            Principal:
-              Service:
-                - "ec2.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
+        - Effect: "Allow"
+          Principal:
+            Service:
+            - "ec2.amazonaws.com"
+          Action:
+          - "sts:AssumeRole"
       Path: "/"
       Policies:
-        - PolicyName: !Join ["-", [!Ref InfrastructureName, "bootstrap", "policy"]]
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: "Allow"
-                Action: "ec2:Describe*"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "ec2:AttachVolume"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "ec2:DetachVolume"
-                Resource: "*"
-              - Effect: "Allow"
-                Action: "s3:GetObject"
-                Resource: "*"
+      - PolicyName: !Join ["-", [!Ref InfrastructureName, "bootstrap", "policy"]]
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: "Allow"
+            Action: "ec2:Describe*"
+            Resource: "*"
+          - Effect: "Allow"
+            Action: "ec2:AttachVolume"
+            Resource: "*"
+          - Effect: "Allow"
+            Action: "ec2:DetachVolume"
+            Resource: "*"
+          - Effect: "Allow"
+            Action: "s3:GetObject"
+            Resource: "*"
       Tags:
-        - Key: "Name"
-          Value: !Join ["-", [!Ref InfrastructureName, "bootstrap", "role"]]
-        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
-          Value: owned
+      - Key: "Name"
+        Value: !Join ["-", [!Ref InfrastructureName, "bootstrap", "role"]]
+      - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+        Value: owned
 
   BootstrapInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
@@ -174,14 +165,14 @@ Resources:
       GroupName: !Join ["-", [!Ref InfrastructureName, "bootstrap", "sg"]]
       GroupDescription: Cluster Bootstrap Security Group
       SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref AllowedBootstrapSshCidr
-        - IpProtocol: tcp
-          ToPort: 19531
-          FromPort: 19531
-          CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: !Ref AllowedBootstrapSshCidr
+      - IpProtocol: tcp
+        ToPort: 19531
+        FromPort: 19531
+        CidrIp: 0.0.0.0/0
       VpcId: !Ref VpcId
 
   BootstrapInstance:
@@ -191,12 +182,12 @@ Resources:
       IamInstanceProfile: !Ref BootstrapInstanceProfile
       InstanceType: "i3.large"
       NetworkInterfaces:
-        - AssociatePublicIpAddress: "true"
-          DeviceIndex: "0"
-          GroupSet:
-            - !Ref "BootstrapSecurityGroup"
-            - !Ref "MasterSecurityGroupId"
-          SubnetId: !Ref "PublicSubnet"
+      - AssociatePublicIpAddress: "true"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "BootstrapSecurityGroup"
+        - !Ref "MasterSecurityGroupId"
+        SubnetId: !Ref "PublicSubnet"
       UserData:
         Fn::Base64: !Sub [
           '{"ignition":{"config":{"replace":{"source":"${S3Loc}"}},"version":"3.1.0"}}',
@@ -205,10 +196,10 @@ Resources:
           }
         ]
       Tags:
-        - Key: Name
-          Value: !Join ["-", [!Ref InfrastructureName, "bootstrap"]]
-        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-          Value: "owned"
+      - Key: Name
+        Value: !Join ["-", [!Ref InfrastructureName, "bootstrap"]]
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "owned"
 
   RegisterBootstrapApiTarget:
     Condition: DoRegistration

--- a/upi/aws/cloudformation/04_cluster_bootstrap.yaml
+++ b/upi/aws/cloudformation/04_cluster_bootstrap.yaml
@@ -7,77 +7,101 @@ Parameters:
     MaxLength: 27
     MinLength: 1
     ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
-    Description: A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster.
+    Description: >-
+      A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
+      use the value generated when creating the manifest files using `openshift-install create manifests`.
     Type: String
+
   RhcosAmi:
-    Description: Current Red Hat Enterprise Linux CoreOS AMI to use for bootstrap.
+    Description: >-
+      Current Red Hat Enterprise Linux CoreOS AMI to use for bootstrap.
     Type: AWS::EC2::Image::Id
+
   AllowedBootstrapSshCidr:
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|1[0-9]|2[0-9]|3[0-2]))$
-    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/0-32.
+    ConstraintDescription: >-
+      CIDR block parameter must be in the form x.x.x.x/0-32.
+    Description: >-
+      CIDR block to allow SSH access to the bootstrap node.
     Default: 0.0.0.0/0
-    Description: CIDR block to allow SSH access to the bootstrap node.
     Type: String
+
   PublicSubnet:
-    Description: The public subnet to launch the bootstrap node into.
+    Description: >-
+      The public subnet to launch the bootstrap node into.
     Type: AWS::EC2::Subnet::Id
+
   MasterSecurityGroupId:
-    Description: The master security group ID for registering temporary rules.
+    Description: >-
+      The master security group ID.
     Type: AWS::EC2::SecurityGroup::Id
+
   VpcId:
-    Description: The VPC-scoped resources will belong to this VPC.
+    Description: >-
+      The VPC-scoped resources will belong to this VPC.
     Type: AWS::EC2::VPC::Id
+
   BootstrapIgnitionLocation:
-    Default: s3://my-s3-bucket/bootstrap.ign
-    Description: Ignition config file location.
+    Description: >-
+      Ignition config file location. (Ex: s3://my-s3-bucket/bootstrap.ign)
     Type: String
+
   AutoRegisterELB:
-    Default: "yes"
     AllowedValues:
-    - "yes"
-    - "no"
-    Description: Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
+      - "yes"
+      - "no"
+    Description: >-
+      Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
+    Default: "yes"
     Type: String
+
   RegisterNlbIpTargetsLambdaArn:
-    Description: ARN for NLB IP target registration lambda.
+    Description: >-
+      ARN for NLB IP target registration lambda.
     Type: String
+
   ExternalApiTargetGroupArn:
-    Description: ARN for external API load balancer target group.
+    Description: >-
+      ARN for external API load balancer target group.
     Type: String
+
   InternalApiTargetGroupArn:
-    Description: ARN for internal API load balancer target group.
+    Description: >-
+      ARN for internal API load balancer target group.
     Type: String
+
   InternalServiceTargetGroupArn:
-    Description: ARN for internal service load balancer target group.
+    Description: >-
+      ARN for internal service load balancer target group.
     Type: String
 
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-    - Label:
-        default: "Cluster Information"
-      Parameters:
-      - InfrastructureName
-    - Label:
-        default: "Host Information"
-      Parameters:
-      - RhcosAmi
-      - BootstrapIgnitionLocation
-      - MasterSecurityGroupId
-    - Label:
-        default: "Network Configuration"
-      Parameters:
-      - VpcId
-      - AllowedBootstrapSshCidr
-      - PublicSubnet
-    - Label:
-        default: "Load Balancer Automation"
-      Parameters:
-      - AutoRegisterELB
-      - RegisterNlbIpTargetsLambdaArn
-      - ExternalApiTargetGroupArn
-      - InternalApiTargetGroupArn
-      - InternalServiceTargetGroupArn
+      - Label:
+          default: "Cluster Information"
+        Parameters:
+          - InfrastructureName
+      - Label:
+          default: "Host Information"
+        Parameters:
+          - RhcosAmi
+          - BootstrapIgnitionLocation
+          - MasterSecurityGroupId
+      - Label:
+          default: "Network Configuration"
+        Parameters:
+          - VpcId
+          - AllowedBootstrapSshCidr
+          - PublicSubnet
+      - Label:
+          default: "Load Balancer Automation"
+        Parameters:
+          - AutoRegisterELB
+          - RegisterNlbIpTargetsLambdaArn
+          - ExternalApiTargetGroupArn
+          - InternalApiTargetGroupArn
+          - InternalServiceTargetGroupArn
     ParameterLabels:
       InfrastructureName:
         default: "Infrastructure Name"
@@ -103,54 +127,61 @@ Resources:
   BootstrapIamRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Join ["-", [!Ref InfrastructureName, "bootstrap", "role"]]
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-        - Effect: "Allow"
-          Principal:
-            Service:
-            - "ec2.amazonaws.com"
-          Action:
-          - "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "ec2.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
       Path: "/"
       Policies:
-      - PolicyName: !Join ["-", [!Ref InfrastructureName, "bootstrap", "policy"]]
-        PolicyDocument:
-          Version: "2012-10-17"
-          Statement:
-          - Effect: "Allow"
-            Action: "ec2:Describe*"
-            Resource: "*"
-          - Effect: "Allow"
-            Action: "ec2:AttachVolume"
-            Resource: "*"
-          - Effect: "Allow"
-            Action: "ec2:DetachVolume"
-            Resource: "*"
-          - Effect: "Allow"
-            Action: "s3:GetObject"
-            Resource: "*"
+        - PolicyName: !Join ["-", [!Ref InfrastructureName, "bootstrap", "policy"]]
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: "ec2:Describe*"
+                Resource: "*"
+              - Effect: "Allow"
+                Action: "ec2:AttachVolume"
+                Resource: "*"
+              - Effect: "Allow"
+                Action: "ec2:DetachVolume"
+                Resource: "*"
+              - Effect: "Allow"
+                Action: "s3:GetObject"
+                Resource: "*"
+      Tags:
+        - Key: "Name"
+          Value: !Join ["-", [!Ref InfrastructureName, "bootstrap", "role"]]
+        - Key: !Join ["", [kubernetes.io/cluster/, !Ref InfrastructureName]]
+          Value: owned
 
   BootstrapInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
-      Path: "/"
+      InstanceProfileName: !Join ["-", [!Ref InfrastructureName, "bootstrap", "profile"]]
       Roles:
       - Ref: "BootstrapIamRole"
 
   BootstrapSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupName: !Join ["-", [!Ref InfrastructureName, "bootstrap", "sg"]]
       GroupDescription: Cluster Bootstrap Security Group
       SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: 22
-        ToPort: 22
-        CidrIp: !Ref AllowedBootstrapSshCidr
-      - IpProtocol: tcp
-        ToPort: 19531
-        FromPort: 19531
-        CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref AllowedBootstrapSshCidr
+        - IpProtocol: tcp
+          ToPort: 19531
+          FromPort: 19531
+          CidrIp: 0.0.0.0/0
       VpcId: !Ref VpcId
 
   BootstrapInstance:
@@ -160,18 +191,24 @@ Resources:
       IamInstanceProfile: !Ref BootstrapInstanceProfile
       InstanceType: "i3.large"
       NetworkInterfaces:
-      - AssociatePublicIpAddress: "true"
-        DeviceIndex: "0"
-        GroupSet:
-        - !Ref "BootstrapSecurityGroup"
-        - !Ref "MasterSecurityGroupId"
-        SubnetId: !Ref "PublicSubnet"
+        - AssociatePublicIpAddress: "true"
+          DeviceIndex: "0"
+          GroupSet:
+            - !Ref "BootstrapSecurityGroup"
+            - !Ref "MasterSecurityGroupId"
+          SubnetId: !Ref "PublicSubnet"
       UserData:
-        Fn::Base64: !Sub
-        - '{"ignition":{"config":{"replace":{"source":"${S3Loc}"}},"version":"3.1.0"}}'
-        - {
-          S3Loc: !Ref BootstrapIgnitionLocation
-        }
+        Fn::Base64: !Sub [
+          '{"ignition":{"config":{"replace":{"source":"${S3Loc}"}},"version":"3.1.0"}}',
+          {
+            S3Loc: !Ref BootstrapIgnitionLocation
+          }
+        ]
+      Tags:
+        - Key: Name
+          Value: !Join ["-", [!Ref InfrastructureName, "bootstrap"]]
+        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+          Value: "owned"
 
   RegisterBootstrapApiTarget:
     Condition: DoRegistration

--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -6,7 +6,8 @@ Parameters:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    ConstraintDescription: >-
+      Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
     Description: >-
       A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
       use the value generated when creating the manifest files using `openshift-install create manifests`.
@@ -18,8 +19,8 @@ Parameters:
 
   AutoRegisterELB:
     AllowedValues:
-      - "yes"
-      - "no"
+    - "yes"
+    - "no"
     Description: Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
     Default: "yes"
     Type: String
@@ -46,8 +47,9 @@ Parameters:
 
   CertificateAuthorities:
     Description: >-
-      Base64 encoded certificate authority string to use, such as data:text/plain;charset=utf-8;base64,ABC...xYz==. You
-      should use the value generated when creating the ignition config files using `openshift-install create ignition-configs`.
+      Base64 encoded certificate authority string to use, such as data:text/plain;charset=utf-8;base64,ABC...xYz==.
+      You should use the value generated when creating the ignition config files using
+      `openshift-install create ignition-configs`.
     Type: String
 
   MasterInstanceProfileName:
@@ -56,58 +58,58 @@ Parameters:
 
   MasterInstanceType:
     AllowedValues:
-      - "m4.xlarge"
-      - "m4.2xlarge"
-      - "m4.4xlarge"
-      - "m4.8xlarge"
-      - "m4.10xlarge"
-      - "m4.16xlarge"
-      - "m5.xlarge"
-      - "m5.2xlarge"
-      - "m5.4xlarge"
-      - "m5.8xlarge"
-      - "m5.10xlarge"
-      - "m5.16xlarge"
-      - "m5a.xlarge"
-      - "m5a.2xlarge"
-      - "m5a.4xlarge"
-      - "m5a.8xlarge"
-      - "m5a.10xlarge"
-      - "m5a.16xlarge"
-      - "c4.2xlarge"
-      - "c4.4xlarge"
-      - "c4.8xlarge"
-      - "c5.2xlarge"
-      - "c5.4xlarge"
-      - "c5.9xlarge"
-      - "c5.12xlarge"
-      - "c5.18xlarge"
-      - "c5.24xlarge"
-      - "c5a.2xlarge"
-      - "c5a.4xlarge"
-      - "c5a.8xlarge"
-      - "c5a.12xlarge"
-      - "c5a.16xlarge"
-      - "c5a.24xlarge"
-      - "r4.xlarge"
-      - "r4.2xlarge"
-      - "r4.4xlarge"
-      - "r4.8xlarge"
-      - "r4.16xlarge"
-      - "r5.xlarge"
-      - "r5.2xlarge"
-      - "r5.4xlarge"
-      - "r5.8xlarge"
-      - "r5.12xlarge"
-      - "r5.16xlarge"
-      - "r5.24xlarge"
-      - "r5a.xlarge"
-      - "r5a.2xlarge"
-      - "r5a.4xlarge"
-      - "r5a.8xlarge"
-      - "r5a.12xlarge"
-      - "r5a.16xlarge"
-      - "r5a.24xlarge"
+    - "m4.xlarge"
+    - "m4.2xlarge"
+    - "m4.4xlarge"
+    - "m4.8xlarge"
+    - "m4.10xlarge"
+    - "m4.16xlarge"
+    - "m5.xlarge"
+    - "m5.2xlarge"
+    - "m5.4xlarge"
+    - "m5.8xlarge"
+    - "m5.10xlarge"
+    - "m5.16xlarge"
+    - "m5a.xlarge"
+    - "m5a.2xlarge"
+    - "m5a.4xlarge"
+    - "m5a.8xlarge"
+    - "m5a.10xlarge"
+    - "m5a.16xlarge"
+    - "c4.2xlarge"
+    - "c4.4xlarge"
+    - "c4.8xlarge"
+    - "c5.2xlarge"
+    - "c5.4xlarge"
+    - "c5.9xlarge"
+    - "c5.12xlarge"
+    - "c5.18xlarge"
+    - "c5.24xlarge"
+    - "c5a.2xlarge"
+    - "c5a.4xlarge"
+    - "c5a.8xlarge"
+    - "c5a.12xlarge"
+    - "c5a.16xlarge"
+    - "c5a.24xlarge"
+    - "r4.xlarge"
+    - "r4.2xlarge"
+    - "r4.4xlarge"
+    - "r4.8xlarge"
+    - "r4.16xlarge"
+    - "r5.xlarge"
+    - "r5.2xlarge"
+    - "r5.4xlarge"
+    - "r5.8xlarge"
+    - "r5.12xlarge"
+    - "r5.16xlarge"
+    - "r5.24xlarge"
+    - "r5a.xlarge"
+    - "r5a.2xlarge"
+    - "r5a.4xlarge"
+    - "r5a.8xlarge"
+    - "r5a.12xlarge"
+    - "r5a.16xlarge"
+    - "r5a.24xlarge"
     Default: m5.xlarge
     Type: String
 
@@ -130,35 +132,35 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label:
-          default: "Cluster Information"
-        Parameters:
-          - InfrastructureName
-      - Label:
-          default: "Host Information"
-        Parameters:
-          - MasterInstanceType
-          - RhcosAmi
-          - IgnitionLocation
-          - CertificateAuthorities
-          - MasterSecurityGroupId
-          - MasterInstanceProfileName
-      - Label:
-          default: "Network Configuration"
-        Parameters:
-          - VpcId
-          - AllowedBootstrapSshCidr
-          - Master0Subnet
-          - Master1Subnet
-          - Master2Subnet
-      - Label:
-          default: "Load Balancer Automation"
-        Parameters:
-          - AutoRegisterELB
-          - RegisterNlbIpTargetsLambdaArn
-          - ExternalApiTargetGroupArn
-          - InternalApiTargetGroupArn
-          - InternalServiceTargetGroupArn
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
+        default: "Host Information"
+      Parameters:
+      - MasterInstanceType
+      - RhcosAmi
+      - IgnitionLocation
+      - CertificateAuthorities
+      - MasterSecurityGroupId
+      - MasterInstanceProfileName
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcId
+      - AllowedBootstrapSshCidr
+      - Master0Subnet
+      - Master1Subnet
+      - Master2Subnet
+    - Label:
+        default: "Load Balancer Automation"
+      Parameters:
+      - AutoRegisterELB
+      - RegisterNlbIpTargetsLambdaArn
+      - ExternalApiTargetGroupArn
+      - InternalApiTargetGroupArn
+      - InternalServiceTargetGroupArn
     ParameterLabels:
       InfrastructureName:
         default: "Infrastructure Name"
@@ -207,11 +209,11 @@ Resources:
       IamInstanceProfile: !Ref MasterInstanceProfileName
       InstanceType: !Ref MasterInstanceType
       NetworkInterfaces:
-        - AssociatePublicIpAddress: "false"
-          DeviceIndex: "0"
-          GroupSet:
-            - !Ref "MasterSecurityGroupId"
-          SubnetId: !Ref "Master0Subnet"
+      - AssociatePublicIpAddress: "false"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "MasterSecurityGroupId"
+        SubnetId: !Ref "Master0Subnet"
       UserData:
         Fn::Base64: !Sub [
           '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}',
@@ -221,10 +223,10 @@ Resources:
           }
         ]
       Tags:
-        - Key: Name
-          Value: !Join ["-", [!Ref InfrastructureName, "master", "0"]]
-        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-          Value: "owned"
+      - Key: Name
+        Value: !Join ["-", [!Ref InfrastructureName, "master", "0"]]
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "owned"
 
   RegisterMaster0:
     Condition: DoRegistration
@@ -255,18 +257,18 @@ Resources:
     Properties:
       ImageId: !Ref RhcosAmi
       BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: "120"
-            VolumeType: "gp2"
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
       IamInstanceProfile: !Ref MasterInstanceProfileName
       InstanceType: !Ref MasterInstanceType
       NetworkInterfaces:
-        - AssociatePublicIpAddress: "false"
-          DeviceIndex: "0"
-          GroupSet:
-            - !Ref "MasterSecurityGroupId"
-          SubnetId: !Ref "Master1Subnet"
+      - AssociatePublicIpAddress: "false"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "MasterSecurityGroupId"
+        SubnetId: !Ref "Master1Subnet"
       UserData:
         Fn::Base64: !Sub [
           '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}',
@@ -276,10 +278,10 @@ Resources:
           }
         ]
       Tags:
-        - Key: Name
-          Value: !Join ["-", [!Ref InfrastructureName, "master", "1"]]
-        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-          Value: "owned"
+      - Key: Name
+        Value: !Join ["-", [!Ref InfrastructureName, "master", "1"]]
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "owned"
 
   RegisterMaster1:
     Condition: DoRegistration
@@ -310,18 +312,18 @@ Resources:
     Properties:
       ImageId: !Ref RhcosAmi
       BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: "120"
-            VolumeType: "gp2"
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
       IamInstanceProfile: !Ref MasterInstanceProfileName
       InstanceType: !Ref MasterInstanceType
       NetworkInterfaces:
-        - AssociatePublicIpAddress: "false"
-          DeviceIndex: "0"
-          GroupSet:
-            - !Ref "MasterSecurityGroupId"
-          SubnetId: !Ref "Master2Subnet"
+      - AssociatePublicIpAddress: "false"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "MasterSecurityGroupId"
+        SubnetId: !Ref "Master2Subnet"
       UserData:
         Fn::Base64: !Sub [
           '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}',
@@ -331,10 +333,10 @@ Resources:
           }
         ]
       Tags:
-        - Key: Name
-          Value: !Join ["-", [!Ref InfrastructureName, "master", "2"]]
-        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-          Value: "owned"
+      - Key: Name
+        Value: !Join ["-", [!Ref InfrastructureName, "master", "2"]]
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "owned"
 
   RegisterMaster2:
     Condition: DoRegistration

--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -7,162 +7,158 @@ Parameters:
     MaxLength: 27
     MinLength: 1
     ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
-    Description: A short, unique cluster ID used to tag nodes for the kubelet cloud provider.
+    Description: >-
+      A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
+      use the value generated when creating the manifest files using `openshift-install create manifests`.
     Type: String
+
   RhcosAmi:
     Description: Current Red Hat Enterprise Linux CoreOS AMI to use for bootstrap.
     Type: AWS::EC2::Image::Id
-  AutoRegisterDNS:
-    Default: "yes"
+
+  AutoRegisterELB:
     AllowedValues:
-    - "yes"
-    - "no"
-    Description: Do you want to invoke DNS etcd registration, which requires Hosted Zone information?
+      - "yes"
+      - "no"
+    Description: Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
+    Default: "yes"
     Type: String
-  PrivateHostedZoneId:
-    Description: The Route53 private zone ID to register the etcd targets with, such as Z21IXYZABCZ2A4.
-    Type: String
-  PrivateHostedZoneName:
-    Description: The Route53 zone to register the targets with, such as cluster.example.com. Omit the trailing period.
-    Type: String
+
   Master0Subnet:
-    Description: The subnets, recommend private, to launch the master nodes into.
+    Description: The subnet to launch the first master node into.
     Type: AWS::EC2::Subnet::Id
+
   Master1Subnet:
-    Description: The subnets, recommend private, to launch the master nodes into.
+    Description: The subnet to launch the second master node into.
     Type: AWS::EC2::Subnet::Id
+
   Master2Subnet:
-    Description: The subnets, recommend private, to launch the master nodes into.
+    Description: The subnet to launch the third master node into.
     Type: AWS::EC2::Subnet::Id
+
   MasterSecurityGroupId:
-    Description: The master security group ID to associate with master nodes.
+    Description: The master security group ID.
     Type: AWS::EC2::SecurityGroup::Id
+
   IgnitionLocation:
-    Default: https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/master
-    Description: Ignition config file location.
+    Description: Ignition config file location, such as https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/master
     Type: String
+
   CertificateAuthorities:
-    Default: data:text/plain;charset=utf-8;base64,ABC...xYz==
-    Description: Base64 encoded certificate authority string to use.
+    Description: >-
+      Base64 encoded certificate authority string to use, such as data:text/plain;charset=utf-8;base64,ABC...xYz==. You
+      should use the value generated when creating the ignition config files using `openshift-install create ignition-configs`.
     Type: String
+
   MasterInstanceProfileName:
     Description: IAM profile to associate with master nodes.
     Type: String
+
   MasterInstanceType:
+    AllowedValues:
+      - "m4.xlarge"
+      - "m4.2xlarge"
+      - "m4.4xlarge"
+      - "m4.8xlarge"
+      - "m4.10xlarge"
+      - "m4.16xlarge"
+      - "m5.xlarge"
+      - "m5.2xlarge"
+      - "m5.4xlarge"
+      - "m5.8xlarge"
+      - "m5.10xlarge"
+      - "m5.16xlarge"
+      - "m5a.xlarge"
+      - "m5a.2xlarge"
+      - "m5a.4xlarge"
+      - "m5a.8xlarge"
+      - "m5a.10xlarge"
+      - "m5a.16xlarge"
+      - "c4.2xlarge"
+      - "c4.4xlarge"
+      - "c4.8xlarge"
+      - "c5.2xlarge"
+      - "c5.4xlarge"
+      - "c5.9xlarge"
+      - "c5.12xlarge"
+      - "c5.18xlarge"
+      - "c5.24xlarge"
+      - "c5a.2xlarge"
+      - "c5a.4xlarge"
+      - "c5a.8xlarge"
+      - "c5a.12xlarge"
+      - "c5a.16xlarge"
+      - "c5a.24xlarge"
+      - "r4.xlarge"
+      - "r4.2xlarge"
+      - "r4.4xlarge"
+      - "r4.8xlarge"
+      - "r4.16xlarge"
+      - "r5.xlarge"
+      - "r5.2xlarge"
+      - "r5.4xlarge"
+      - "r5.8xlarge"
+      - "r5.12xlarge"
+      - "r5.16xlarge"
+      - "r5.24xlarge"
+      - "r5a.xlarge"
+      - "r5a.2xlarge"
+      - "r5a.4xlarge"
+      - "r5a.8xlarge"
+      - "r5a.12xlarge"
+      - "r5a.16xlarge"
+      - "r5a.24xlarge"
     Default: m5.xlarge
     Type: String
-    AllowedValues:
-    - "m4.xlarge"
-    - "m4.2xlarge"
-    - "m4.4xlarge"
-    - "m4.8xlarge"
-    - "m4.10xlarge"
-    - "m4.16xlarge"
-    - "m5.xlarge"
-    - "m5.2xlarge"
-    - "m5.4xlarge"
-    - "m5.8xlarge"
-    - "m5.10xlarge"
-    - "m5.16xlarge"
-    - "m5a.xlarge"
-    - "m5a.2xlarge"
-    - "m5a.4xlarge"
-    - "m5a.8xlarge"
-    - "m5a.10xlarge"
-    - "m5a.16xlarge"
-    - "c4.2xlarge"
-    - "c4.4xlarge"
-    - "c4.8xlarge"
-    - "c5.2xlarge"
-    - "c5.4xlarge"
-    - "c5.9xlarge"
-    - "c5.12xlarge"
-    - "c5.18xlarge"
-    - "c5.24xlarge"
-    - "c5a.2xlarge"
-    - "c5a.4xlarge"
-    - "c5a.8xlarge"
-    - "c5a.12xlarge"
-    - "c5a.16xlarge"
-    - "c5a.24xlarge"
-    - "r4.xlarge"
-    - "r4.2xlarge"
-    - "r4.4xlarge"
-    - "r4.8xlarge"
-    - "r4.16xlarge"
-    - "r5.xlarge"
-    - "r5.2xlarge"
-    - "r5.4xlarge"
-    - "r5.8xlarge"
-    - "r5.12xlarge"
-    - "r5.16xlarge"
-    - "r5.24xlarge"
-    - "r5a.xlarge"
-    - "r5a.2xlarge"
-    - "r5a.4xlarge"
-    - "r5a.8xlarge"
-    - "r5a.12xlarge"
-    - "r5a.16xlarge"
-    - "r5a.24xlarge"
 
-  AutoRegisterELB:
-    Default: "yes"
-    AllowedValues:
-    - "yes"
-    - "no"
-    Description: Do you want to invoke NLB registration, which requires a Lambda ARN parameter?
-    Type: String
   RegisterNlbIpTargetsLambdaArn:
-    Description: ARN for NLB IP target registration lambda. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
+    Description: ARN for NLB IP target registration lambda.
     Type: String
+
   ExternalApiTargetGroupArn:
-    Description: ARN for external API load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
+    Description: ARN for external API load balancer target group.
     Type: String
+
   InternalApiTargetGroupArn:
-    Description: ARN for internal API load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
+    Description: ARN for internal API load balancer target group.
     Type: String
+
   InternalServiceTargetGroupArn:
-    Description: ARN for internal service load balancer target group. Supply the value from the cluster infrastructure or select "no" for AutoRegisterELB.
+    Description: ARN for internal service load balancer target group.
     Type: String
 
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-    - Label:
-        default: "Cluster Information"
-      Parameters:
-      - InfrastructureName
-    - Label:
-        default: "Host Information"
-      Parameters:
-      - MasterInstanceType
-      - RhcosAmi
-      - IgnitionLocation
-      - CertificateAuthorities
-      - MasterSecurityGroupId
-      - MasterInstanceProfileName
-    - Label:
-        default: "Network Configuration"
-      Parameters:
-      - VpcId
-      - AllowedBootstrapSshCidr
-      - Master0Subnet
-      - Master1Subnet
-      - Master2Subnet
-    - Label:
-        default: "DNS"
-      Parameters:
-      - AutoRegisterDNS
-      - PrivateHostedZoneName
-      - PrivateHostedZoneId
-    - Label:
-        default: "Load Balancer Automation"
-      Parameters:
-      - AutoRegisterELB
-      - RegisterNlbIpTargetsLambdaArn
-      - ExternalApiTargetGroupArn
-      - InternalApiTargetGroupArn
-      - InternalServiceTargetGroupArn
+      - Label:
+          default: "Cluster Information"
+        Parameters:
+          - InfrastructureName
+      - Label:
+          default: "Host Information"
+        Parameters:
+          - MasterInstanceType
+          - RhcosAmi
+          - IgnitionLocation
+          - CertificateAuthorities
+          - MasterSecurityGroupId
+          - MasterInstanceProfileName
+      - Label:
+          default: "Network Configuration"
+        Parameters:
+          - VpcId
+          - AllowedBootstrapSshCidr
+          - Master0Subnet
+          - Master1Subnet
+          - Master2Subnet
+      - Label:
+          default: "Load Balancer Automation"
+        Parameters:
+          - AutoRegisterELB
+          - RegisterNlbIpTargetsLambdaArn
+          - ExternalApiTargetGroupArn
+          - InternalApiTargetGroupArn
+          - InternalServiceTargetGroupArn
     ParameterLabels:
       InfrastructureName:
         default: "Infrastructure Name"
@@ -197,7 +193,6 @@ Metadata:
 
 Conditions:
   DoRegistration: !Equals ["yes", !Ref AutoRegisterELB]
-  DoDns: !Equals ["yes", !Ref AutoRegisterDNS]
 
 Resources:
   Master0:
@@ -212,21 +207,24 @@ Resources:
       IamInstanceProfile: !Ref MasterInstanceProfileName
       InstanceType: !Ref MasterInstanceType
       NetworkInterfaces:
-      - AssociatePublicIpAddress: "false"
-        DeviceIndex: "0"
-        GroupSet:
-        - !Ref "MasterSecurityGroupId"
-        SubnetId: !Ref "Master0Subnet"
+        - AssociatePublicIpAddress: "false"
+          DeviceIndex: "0"
+          GroupSet:
+            - !Ref "MasterSecurityGroupId"
+          SubnetId: !Ref "Master0Subnet"
       UserData:
-        Fn::Base64: !Sub
-        - '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}'
-        - {
-          SOURCE: !Ref IgnitionLocation,
-          CA_BUNDLE: !Ref CertificateAuthorities,
-        }
+        Fn::Base64: !Sub [
+          '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}',
+          {
+            SOURCE: !Ref IgnitionLocation,
+            CA_BUNDLE: !Ref CertificateAuthorities
+          }
+        ]
       Tags:
-      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-        Value: "shared"
+        - Key: Name
+          Value: !Join ["-", [!Ref InfrastructureName, "master", "0"]]
+        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+          Value: "owned"
 
   RegisterMaster0:
     Condition: DoRegistration
@@ -257,28 +255,31 @@ Resources:
     Properties:
       ImageId: !Ref RhcosAmi
       BlockDeviceMappings:
-      - DeviceName: /dev/xvda
-        Ebs:
-          VolumeSize: "120"
-          VolumeType: "gp2"
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: "120"
+            VolumeType: "gp2"
       IamInstanceProfile: !Ref MasterInstanceProfileName
       InstanceType: !Ref MasterInstanceType
       NetworkInterfaces:
-      - AssociatePublicIpAddress: "false"
-        DeviceIndex: "0"
-        GroupSet:
-        - !Ref "MasterSecurityGroupId"
-        SubnetId: !Ref "Master1Subnet"
+        - AssociatePublicIpAddress: "false"
+          DeviceIndex: "0"
+          GroupSet:
+            - !Ref "MasterSecurityGroupId"
+          SubnetId: !Ref "Master1Subnet"
       UserData:
-        Fn::Base64: !Sub
-        - '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}'
-        - {
-          SOURCE: !Ref IgnitionLocation,
-          CA_BUNDLE: !Ref CertificateAuthorities,
-        }
+        Fn::Base64: !Sub [
+          '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}',
+          {
+            SOURCE: !Ref IgnitionLocation,
+            CA_BUNDLE: !Ref CertificateAuthorities
+          }
+        ]
       Tags:
-      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-        Value: "shared"
+        - Key: Name
+          Value: !Join ["-", [!Ref InfrastructureName, "master", "1"]]
+        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+          Value: "owned"
 
   RegisterMaster1:
     Condition: DoRegistration
@@ -309,28 +310,31 @@ Resources:
     Properties:
       ImageId: !Ref RhcosAmi
       BlockDeviceMappings:
-      - DeviceName: /dev/xvda
-        Ebs:
-          VolumeSize: "120"
-          VolumeType: "gp2"
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: "120"
+            VolumeType: "gp2"
       IamInstanceProfile: !Ref MasterInstanceProfileName
       InstanceType: !Ref MasterInstanceType
       NetworkInterfaces:
-      - AssociatePublicIpAddress: "false"
-        DeviceIndex: "0"
-        GroupSet:
-        - !Ref "MasterSecurityGroupId"
-        SubnetId: !Ref "Master2Subnet"
+        - AssociatePublicIpAddress: "false"
+          DeviceIndex: "0"
+          GroupSet:
+            - !Ref "MasterSecurityGroupId"
+          SubnetId: !Ref "Master2Subnet"
       UserData:
-        Fn::Base64: !Sub
-        - '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}'
-        - {
-          SOURCE: !Ref IgnitionLocation,
-          CA_BUNDLE: !Ref CertificateAuthorities,
-        }
+        Fn::Base64: !Sub [
+          '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}',
+          {
+            SOURCE: !Ref IgnitionLocation,
+            CA_BUNDLE: !Ref CertificateAuthorities
+          }
+        ]
       Tags:
-      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-        Value: "shared"
+        - Key: Name
+          Value: !Join ["-", [!Ref InfrastructureName, "master", "2"]]
+        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+          Value: "owned"
 
   RegisterMaster2:
     Condition: DoRegistration
@@ -356,66 +360,15 @@ Resources:
       TargetArn: !Ref InternalServiceTargetGroupArn
       TargetIp: !GetAtt Master2.PrivateIp
 
-  EtcdSrvRecords:
-    Condition: DoDns
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneId: !Ref PrivateHostedZoneId
-      Name: !Join [".", ["_etcd-server-ssl._tcp", !Ref PrivateHostedZoneName]]
-      ResourceRecords:
-      - !Join [
-        " ",
-        ["0 10 2380", !Join [".", ["etcd-0", !Ref PrivateHostedZoneName]]],
-      ]
-      - !Join [
-        " ",
-        ["0 10 2380", !Join [".", ["etcd-1", !Ref PrivateHostedZoneName]]],
-      ]
-      - !Join [
-        " ",
-        ["0 10 2380", !Join [".", ["etcd-2", !Ref PrivateHostedZoneName]]],
-      ]
-      TTL: 60
-      Type: SRV
-
-  Etcd0Record:
-    Condition: DoDns
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneId: !Ref PrivateHostedZoneId
-      Name: !Join [".", ["etcd-0", !Ref PrivateHostedZoneName]]
-      ResourceRecords:
-      - !GetAtt Master0.PrivateIp
-      TTL: 60
-      Type: A
-
-  Etcd1Record:
-    Condition: DoDns
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneId: !Ref PrivateHostedZoneId
-      Name: !Join [".", ["etcd-1", !Ref PrivateHostedZoneName]]
-      ResourceRecords:
-      - !GetAtt Master1.PrivateIp
-      TTL: 60
-      Type: A
-
-  Etcd2Record:
-    Condition: DoDns
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneId: !Ref PrivateHostedZoneId
-      Name: !Join [".", ["etcd-2", !Ref PrivateHostedZoneName]]
-      ResourceRecords:
-      - !GetAtt Master2.PrivateIp
-      TTL: 60
-      Type: A
-
 Outputs:
   PrivateIPs:
     Description: The control-plane node private IP addresses.
     Value:
       !Join [
         ",",
-        [!GetAtt Master0.PrivateIp, !GetAtt Master1.PrivateIp, !GetAtt Master2.PrivateIp]
+        [
+          !GetAtt Master0.PrivateIp,
+          !GetAtt Master1.PrivateIp,
+          !GetAtt Master2.PrivateIp
+        ]
       ]

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -6,7 +6,8 @@ Parameters:
     AllowedPattern: ^([a-zA-Z][a-zA-Z0-9\-]{0,26})$
     MaxLength: 27
     MinLength: 1
-    ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
+    ConstraintDescription: >-
+      Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
     Description: >-
       A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
       use the value generated when creating the manifest files using `openshift-install create manifests`.
@@ -30,8 +31,9 @@ Parameters:
 
   CertificateAuthorities:
     Description: >-
-      Base64 encoded certificate authority string to use, such as data:text/plain;charset=utf-8;base64,ABC...xYz==. You
-      should use the value generated when creating the ignition config files using `openshift-install create ignition-configs`.
+      Base64 encoded certificate authority string to use, such as data:text/plain;charset=utf-8;base64,ABC...xYz==.
+      You should use the value generated when creating the ignition config files using
+      `openshift-install create ignition-configs`.
     Type: String
 
   WorkerInstanceProfileName:
@@ -40,99 +42,99 @@ Parameters:
 
   WorkerInstanceType:
     AllowedValues:
-      - "m4.large"
-      - "m4.xlarge"
-      - "m4.2xlarge"
-      - "m4.4xlarge"
-      - "m4.8xlarge"
-      - "m4.10xlarge"
-      - "m4.16xlarge"
-      - "m5.large"
-      - "m5.xlarge"
-      - "m5.2xlarge"
-      - "m5.4xlarge"
-      - "m5.8xlarge"
-      - "m5.10xlarge"
-      - "m5.16xlarge"
-      - "m5a.large"
-      - "m5a.xlarge"
-      - "m5a.2xlarge"
-      - "m5a.4xlarge"
-      - "m5a.8xlarge"
-      - "m5a.10xlarge"
-      - "m5a.16xlarge"
-      - "c4.large"
-      - "c4.xlarge"
-      - "c4.2xlarge"
-      - "c4.4xlarge"
-      - "c4.8xlarge"
-      - "c5.large"
-      - "c5.xlarge"
-      - "c5.2xlarge"
-      - "c5.4xlarge"
-      - "c5.9xlarge"
-      - "c5.12xlarge"
-      - "c5.18xlarge"
-      - "c5.24xlarge"
-      - "c5a.large"
-      - "c5a.xlarge"
-      - "c5a.2xlarge"
-      - "c5a.4xlarge"
-      - "c5a.8xlarge"
-      - "c5a.12xlarge"
-      - "c5a.16xlarge"
-      - "c5a.24xlarge"
-      - "r4.large"
-      - "r4.xlarge"
-      - "r4.2xlarge"
-      - "r4.4xlarge"
-      - "r4.8xlarge"
-      - "r4.16xlarge"
-      - "r5.large"
-      - "r5.xlarge"
-      - "r5.2xlarge"
-      - "r5.4xlarge"
-      - "r5.8xlarge"
-      - "r5.12xlarge"
-      - "r5.16xlarge"
-      - "r5.24xlarge"
-      - "r5a.large"
-      - "r5a.xlarge"
-      - "r5a.2xlarge"
-      - "r5a.4xlarge"
-      - "r5a.8xlarge"
-      - "r5a.12xlarge"
-      - "r5a.16xlarge"
-      - "r5a.24xlarge"
-      - "t3.large"
-      - "t3.xlarge"
-      - "t3.2xlarge"
-      - "t3a.large"
-      - "t3a.xlarge"
-      - "t3a.2xlarge"
+    - "m4.large"
+    - "m4.xlarge"
+    - "m4.2xlarge"
+    - "m4.4xlarge"
+    - "m4.8xlarge"
+    - "m4.10xlarge"
+    - "m4.16xlarge"
+    - "m5.large"
+    - "m5.xlarge"
+    - "m5.2xlarge"
+    - "m5.4xlarge"
+    - "m5.8xlarge"
+    - "m5.10xlarge"
+    - "m5.16xlarge"
+    - "m5a.large"
+    - "m5a.xlarge"
+    - "m5a.2xlarge"
+    - "m5a.4xlarge"
+    - "m5a.8xlarge"
+    - "m5a.10xlarge"
+    - "m5a.16xlarge"
+    - "c4.large"
+    - "c4.xlarge"
+    - "c4.2xlarge"
+    - "c4.4xlarge"
+    - "c4.8xlarge"
+    - "c5.large"
+    - "c5.xlarge"
+    - "c5.2xlarge"
+    - "c5.4xlarge"
+    - "c5.9xlarge"
+    - "c5.12xlarge"
+    - "c5.18xlarge"
+    - "c5.24xlarge"
+    - "c5a.large"
+    - "c5a.xlarge"
+    - "c5a.2xlarge"
+    - "c5a.4xlarge"
+    - "c5a.8xlarge"
+    - "c5a.12xlarge"
+    - "c5a.16xlarge"
+    - "c5a.24xlarge"
+    - "r4.large"
+    - "r4.xlarge"
+    - "r4.2xlarge"
+    - "r4.4xlarge"
+    - "r4.8xlarge"
+    - "r4.16xlarge"
+    - "r5.large"
+    - "r5.xlarge"
+    - "r5.2xlarge"
+    - "r5.4xlarge"
+    - "r5.8xlarge"
+    - "r5.12xlarge"
+    - "r5.16xlarge"
+    - "r5.24xlarge"
+    - "r5a.large"
+    - "r5a.xlarge"
+    - "r5a.2xlarge"
+    - "r5a.4xlarge"
+    - "r5a.8xlarge"
+    - "r5a.12xlarge"
+    - "r5a.16xlarge"
+    - "r5a.24xlarge"
+    - "t3.large"
+    - "t3.xlarge"
+    - "t3.2xlarge"
+    - "t3a.large"
+    - "t3a.xlarge"
+    - "t3a.2xlarge"
     Default: m5.large
     Type: String
 
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-      - Label:
-          default: "Cluster Information"
-        Parameters:
-          - InfrastructureName
-      - Label:
-          default: "Host Information"
-        Parameters:
-          - WorkerInstanceType
-          - RhcosAmi
-          - IgnitionLocation
-          - CertificateAuthorities
-          - WorkerSecurityGroupId
-          - WorkerInstanceProfileName
-      - Label:
-          default: "Network Configuration"
-        Parameters:
-          - Subnet
+    - Label:
+        default: "Cluster Information"
+      Parameters:
+      - InfrastructureName
+    - Label:
+        default: "Host Information"
+      Parameters:
+      - WorkerInstanceType
+      - RhcosAmi
+      - IgnitionLocation
+      - CertificateAuthorities
+      - WorkerSecurityGroupId
+      - WorkerInstanceProfileName
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - Subnet
     ParameterLabels:
       Subnet:
         default: "Subnet"
@@ -157,18 +159,18 @@ Resources:
     Properties:
       ImageId: !Ref RhcosAmi
       BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: "120"
-            VolumeType: "gp2"
+      - DeviceName: /dev/xvda
+        Ebs:
+          VolumeSize: "120"
+          VolumeType: "gp2"
       IamInstanceProfile: !Ref WorkerInstanceProfileName
       InstanceType: !Ref WorkerInstanceType
       NetworkInterfaces:
-        - AssociatePublicIpAddress: "false"
-          DeviceIndex: "0"
-          GroupSet:
-            - !Ref "WorkerSecurityGroupId"
-          SubnetId: !Ref "Subnet"
+      - AssociatePublicIpAddress: "false"
+        DeviceIndex: "0"
+        GroupSet:
+        - !Ref "WorkerSecurityGroupId"
+        SubnetId: !Ref "Subnet"
       UserData:
         Fn::Base64: !Sub [
           '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}',
@@ -178,10 +180,10 @@ Resources:
           }
         ]
       Tags:
-        - Key: Name
-          Value: !Join ["-", [!Ref InfrastructureName, "worker"]]
-        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-          Value: "owned"
+      - Key: Name
+        Value: !Join ["-", [!Ref InfrastructureName, "worker"]]
+      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+        Value: "owned"
 
 Outputs:
   PrivateIP:

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -26,7 +26,7 @@ Parameters:
     Type: AWS::EC2::SecurityGroup::Id
 
   IgnitionLocation:
-    Description: Ignition config file location, such as https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/master
+    Description: Ignition config file location, such as https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/worker
     Type: String
 
   CertificateAuthorities:
@@ -175,8 +175,8 @@ Resources:
         Fn::Base64: !Sub [
           '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}',
           {
-            Source: !Ref IgnitionLocation,
-            CaBundle: !Ref CertificateAuthorities
+            SOURCE: !Ref IgnitionLocation,
+            CA_BUNDLE: !Ref CertificateAuthorities
           }
         ]
       Tags:

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -7,123 +7,132 @@ Parameters:
     MaxLength: 27
     MinLength: 1
     ConstraintDescription: Infrastructure name must be alphanumeric, start with a letter, and have a maximum of 27 characters.
-    Description: A short, unique cluster ID used to tag nodes for the kubelet cloud provider.
+    Description: >-
+      A short, unique cluster ID used to tag cloud resources and identify items owned or used by the cluster. You should
+      use the value generated when creating the manifest files using `openshift-install create manifests`.
     Type: String
+
   RhcosAmi:
     Description: Current Red Hat Enterprise Linux CoreOS AMI to use for bootstrap.
     Type: AWS::EC2::Image::Id
+
   Subnet:
-    Description: The subnets, recommend private, to launch the master nodes into.
+    Description: The subnet to launch the worker node into.
     Type: AWS::EC2::Subnet::Id
+
   WorkerSecurityGroupId:
-    Description: The master security group ID to associate with master nodes.
+    Description: The master security group ID.
     Type: AWS::EC2::SecurityGroup::Id
+
   IgnitionLocation:
-    Default: https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/worker
-    Description: Ignition config file location.
+    Description: Ignition config file location, such as https://api-int.$CLUSTER_NAME.$DOMAIN:22623/config/master
     Type: String
+
   CertificateAuthorities:
-    Default: data:text/plain;charset=utf-8;base64,ABC...xYz==
-    Description: Base64 encoded certificate authority string to use.
+    Description: >-
+      Base64 encoded certificate authority string to use, such as data:text/plain;charset=utf-8;base64,ABC...xYz==. You
+      should use the value generated when creating the ignition config files using `openshift-install create ignition-configs`.
     Type: String
+
   WorkerInstanceProfileName:
-    Description: IAM profile to associate with master nodes.
+    Description: IAM profile to associate with worker nodes.
     Type: String
+
   WorkerInstanceType:
+    AllowedValues:
+      - "m4.large"
+      - "m4.xlarge"
+      - "m4.2xlarge"
+      - "m4.4xlarge"
+      - "m4.8xlarge"
+      - "m4.10xlarge"
+      - "m4.16xlarge"
+      - "m5.large"
+      - "m5.xlarge"
+      - "m5.2xlarge"
+      - "m5.4xlarge"
+      - "m5.8xlarge"
+      - "m5.10xlarge"
+      - "m5.16xlarge"
+      - "m5a.large"
+      - "m5a.xlarge"
+      - "m5a.2xlarge"
+      - "m5a.4xlarge"
+      - "m5a.8xlarge"
+      - "m5a.10xlarge"
+      - "m5a.16xlarge"
+      - "c4.large"
+      - "c4.xlarge"
+      - "c4.2xlarge"
+      - "c4.4xlarge"
+      - "c4.8xlarge"
+      - "c5.large"
+      - "c5.xlarge"
+      - "c5.2xlarge"
+      - "c5.4xlarge"
+      - "c5.9xlarge"
+      - "c5.12xlarge"
+      - "c5.18xlarge"
+      - "c5.24xlarge"
+      - "c5a.large"
+      - "c5a.xlarge"
+      - "c5a.2xlarge"
+      - "c5a.4xlarge"
+      - "c5a.8xlarge"
+      - "c5a.12xlarge"
+      - "c5a.16xlarge"
+      - "c5a.24xlarge"
+      - "r4.large"
+      - "r4.xlarge"
+      - "r4.2xlarge"
+      - "r4.4xlarge"
+      - "r4.8xlarge"
+      - "r4.16xlarge"
+      - "r5.large"
+      - "r5.xlarge"
+      - "r5.2xlarge"
+      - "r5.4xlarge"
+      - "r5.8xlarge"
+      - "r5.12xlarge"
+      - "r5.16xlarge"
+      - "r5.24xlarge"
+      - "r5a.large"
+      - "r5a.xlarge"
+      - "r5a.2xlarge"
+      - "r5a.4xlarge"
+      - "r5a.8xlarge"
+      - "r5a.12xlarge"
+      - "r5a.16xlarge"
+      - "r5a.24xlarge"
+      - "t3.large"
+      - "t3.xlarge"
+      - "t3.2xlarge"
+      - "t3a.large"
+      - "t3a.xlarge"
+      - "t3a.2xlarge"
     Default: m5.large
     Type: String
-    AllowedValues:
-    - "m4.large"
-    - "m4.xlarge"
-    - "m4.2xlarge"
-    - "m4.4xlarge"
-    - "m4.8xlarge"
-    - "m4.10xlarge"
-    - "m4.16xlarge"
-    - "m5.large"
-    - "m5.xlarge"
-    - "m5.2xlarge"
-    - "m5.4xlarge"
-    - "m5.8xlarge"
-    - "m5.10xlarge"
-    - "m5.16xlarge"
-    - "m5a.large"
-    - "m5a.xlarge"
-    - "m5a.2xlarge"
-    - "m5a.4xlarge"
-    - "m5a.8xlarge"
-    - "m5a.10xlarge"
-    - "m5a.16xlarge"
-    - "c4.large"
-    - "c4.xlarge"
-    - "c4.2xlarge"
-    - "c4.4xlarge"
-    - "c4.8xlarge"
-    - "c5.large"
-    - "c5.xlarge"
-    - "c5.2xlarge"
-    - "c5.4xlarge"
-    - "c5.9xlarge"
-    - "c5.12xlarge"
-    - "c5.18xlarge"
-    - "c5.24xlarge"
-    - "c5a.large"
-    - "c5a.xlarge"
-    - "c5a.2xlarge"
-    - "c5a.4xlarge"
-    - "c5a.8xlarge"
-    - "c5a.12xlarge"
-    - "c5a.16xlarge"
-    - "c5a.24xlarge"
-    - "r4.large"
-    - "r4.xlarge"
-    - "r4.2xlarge"
-    - "r4.4xlarge"
-    - "r4.8xlarge"
-    - "r4.16xlarge"
-    - "r5.large"
-    - "r5.xlarge"
-    - "r5.2xlarge"
-    - "r5.4xlarge"
-    - "r5.8xlarge"
-    - "r5.12xlarge"
-    - "r5.16xlarge"
-    - "r5.24xlarge"
-    - "r5a.large"
-    - "r5a.xlarge"
-    - "r5a.2xlarge"
-    - "r5a.4xlarge"
-    - "r5a.8xlarge"
-    - "r5a.12xlarge"
-    - "r5a.16xlarge"
-    - "r5a.24xlarge"
-    - "t3.large"
-    - "t3.xlarge"
-    - "t3.2xlarge"
-    - "t3a.large"
-    - "t3a.xlarge"
-    - "t3a.2xlarge"
 
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-    - Label:
-        default: "Cluster Information"
-      Parameters:
-      - InfrastructureName
-    - Label:
-        default: "Host Information"
-      Parameters:
-      - WorkerInstanceType
-      - RhcosAmi
-      - IgnitionLocation
-      - CertificateAuthorities
-      - WorkerSecurityGroupId
-      - WorkerInstanceProfileName
-    - Label:
-        default: "Network Configuration"
-      Parameters:
-      - Subnet
+      - Label:
+          default: "Cluster Information"
+        Parameters:
+          - InfrastructureName
+      - Label:
+          default: "Host Information"
+        Parameters:
+          - WorkerInstanceType
+          - RhcosAmi
+          - IgnitionLocation
+          - CertificateAuthorities
+          - WorkerSecurityGroupId
+          - WorkerInstanceProfileName
+      - Label:
+          default: "Network Configuration"
+        Parameters:
+          - Subnet
     ParameterLabels:
       Subnet:
         default: "Subnet"
@@ -143,35 +152,38 @@ Metadata:
         default: "Worker Security Group ID"
 
 Resources:
-  Worker0:
+  Worker:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Ref RhcosAmi
       BlockDeviceMappings:
-      - DeviceName: /dev/xvda
-        Ebs:
-          VolumeSize: "120"
-          VolumeType: "gp2"
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: "120"
+            VolumeType: "gp2"
       IamInstanceProfile: !Ref WorkerInstanceProfileName
       InstanceType: !Ref WorkerInstanceType
       NetworkInterfaces:
-      - AssociatePublicIpAddress: "false"
-        DeviceIndex: "0"
-        GroupSet:
-        - !Ref "WorkerSecurityGroupId"
-        SubnetId: !Ref "Subnet"
+        - AssociatePublicIpAddress: "false"
+          DeviceIndex: "0"
+          GroupSet:
+            - !Ref "WorkerSecurityGroupId"
+          SubnetId: !Ref "Subnet"
       UserData:
-        Fn::Base64: !Sub
-        - '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}'
-        - {
-          SOURCE: !Ref IgnitionLocation,
-          CA_BUNDLE: !Ref CertificateAuthorities,
-        }
+        Fn::Base64: !Sub [
+          '{"ignition":{"config":{"merge":[{"source":"${SOURCE}"}]},"security":{"tls":{"certificateAuthorities":[{"source":"${CA_BUNDLE}"}]}},"version":"3.1.0"}}',
+          {
+            Source: !Ref IgnitionLocation,
+            CaBundle: !Ref CertificateAuthorities
+          }
+        ]
       Tags:
-      - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
-        Value: "shared"
+        - Key: Name
+          Value: !Join ["-", [!Ref InfrastructureName, "worker"]]
+        - Key: !Join ["", ["kubernetes.io/cluster/", !Ref InfrastructureName]]
+          Value: "owned"
 
 Outputs:
   PrivateIP:
     Description: The compute node private IP address.
-    Value: !GetAtt Worker0.PrivateIp
+    Value: !GetAtt Worker.PrivateIp


### PR DESCRIPTION
Update the CloudFormation templates to create the infrastructure in a way that matches how the IPI install would create the infrastructure. By having these match by default, this gives the user a common starting place before they make any customizations that are required during their UPI install.

The bulk of these changes are related to ensuring that objects created are named and tagged in the way that OpenShift expects them to be. This will enable things such as MachineSets to work out of the box (and even at install time for the default set of worker nodes).

These changes also include a bit of formatting update to provide consistency across the template files and for readability.