### PR TITLE
Bug 1941759: Make failure to fetch cloud info non-fatal

### DIFF
--- a/pkg/asset/installconfig/openstack/validate.go
+++ b/pkg/asset/installconfig/openstack/validate.go
@@ -21,6 +21,10 @@ func Validate(ic *types.InstallConfig) error {
 	if err != nil {
 		return err
 	}
+	if ci == nil {
+		logrus.Warnf("Empty OpenStack cloud info and therefore will skip pre-flight validation.")
+		return nil
+	}
 
 	allErrs := field.ErrorList{}
 

--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -100,7 +100,8 @@ func GetCloudInfo(ic *types.InstallConfig) (*CloudInfo, error) {
 
 	err = ci.collectInfo(ic, opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate OpenStack cloud info")
+		logrus.Warnf("Failed to generate OpenStack cloud info: %v", err)
+		return nil, nil
 	}
 
 	return ci, nil

--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -126,6 +126,10 @@ func (a *PlatformQuotaCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to get cloud info")
 		}
+		if ci == nil {
+			logrus.Warnf("Empty OpenStack cloud info and therefore will skip checking quota validation.")
+			return nil
+		}
 		reports, err := quota.Check(ci.Quotas, openstack.Constraints(ci, masters, workers, ic.Config.NetworkType))
 		if err != nil {
 			return summarizeFailingReport(reports)


### PR DESCRIPTION
It is possible that under some circumstance we fail to gather the
necessary information to validate the underlying cloud meets the
requirements. Recently, this was a neutron bug [1] that caused it to
return an unexpected variable type.

Our inability to perform pre-flight validation shouldn't prevent the
installer from running.

This commit makes the installer more tolerant to failures to run
validations, for OpenStack platform only. Legitimate validation
failures still block the installation.

[1] https://bugs.launchpad.net/neutron/+bug/1918565