### PR TITLE
Bug 1933414: openstack: Consistent port names

### DIFF
--- a/data/data/openstack/topology/private-network.tf
+++ b/data/data/openstack/topology/private-network.tf
@@ -40,7 +40,7 @@ resource "openstack_networking_subnet_v2" "nodes" {
 }
 
 resource "openstack_networking_port_v2" "masters" {
-  name        = "${var.cluster_id}-master-port-${count.index}"
+  name        = "${var.cluster_id}-master-${count.index}"
   count       = var.masters_count
   description = local.description
 


### PR DESCRIPTION
Before this patch, [Terraform][1] and [cluster-api-provider-openstack][2]
created Neutron ports for the master machines with a slightly different
pattern:

`<infra-id>-master-port-<n>`
versus
`<infra-id>-master-<n>`

This resulted in an inconsistency in live clusters: the machines created
at install-time had ports named one way, while machines created
day-2 the other way.

In particular, this different behaviour hits logic like Kuryr that has
on occasion to depend on OpenStack resource names.

This patch does not aim at fixing the Kuryr bug specifically, as a
change in the Installer code can't affect upgrades. Rather, it
introduces some more consistency.

---

The variable name is chosen to reflect CAPO's, given that [the upstream
code][3] is also using the same pattern.

[1]: https://github.com/openshift/installer/blob/78c0350c6293be0159fd857012189e289216a099/data/data/openstack/topology/private-network.tf#L43
[2]: https://github.com/openshift/cluster-api-provider-openstack/blob/2999d3deccff5ec3f65b490c3e6f859561c1e432/pkg/cloud/openstack/clients/machineservice.go#L503-L505
[3]: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/b0d1c44f77e827a5a785a1054d77af70166c29f4/pkg/cloud/services/compute/instance.go#L180