### PR TITLE
WIP: Bug 1936450: OCP 4.7: Passing oVirt certificate information to Terraform

### DIFF
--- a/data/data/ovirt/variables-ovirt.tf
+++ b/data/data/ovirt/variables-ovirt.tf
@@ -19,6 +19,21 @@ variable "ovirt_password" {
   description = "The plain password of user to access Engine API"
 }
 
+variable "ovirt_cafile" {
+  type        = string
+  description = "Path to a file containing the CA certificate for the oVirt engine API in PEM format"
+}
+
+variable "ovirt_ca_bundle" {
+  type        = string
+  description = "The CA certificate for the oVirt engine API in PEM format"
+}
+
+variable "ovirt_insecure" {
+  type        = bool
+  description = "Disable oVirt engine certificate verification"
+}
+
 variable "ovirt_tmp_template_vm_id" {
   type        = string
   default     = ""

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -492,6 +492,8 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				Username: config.Username,
 				Password: config.Password,
 				Cafile:   config.CAFile,
+				Cabundle: config.CABundle,
+				Insecure: config.Insecure,
 			},
 			installConfig.Config.Platform.Ovirt.ClusterID,
 			installConfig.Config.Platform.Ovirt.StorageDomainID,

--- a/pkg/tfvars/ovirt/ovirt.go
+++ b/pkg/tfvars/ovirt/ovirt.go
@@ -10,12 +10,14 @@ import (
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
 )
 
-// Auth is the collection of credentials that will be used by terrform.
+// Auth is the collection of credentials that will be used by terraform.
 type Auth struct {
 	URL      string `json:"ovirt_url"`
 	Username string `json:"ovirt_username"`
 	Password string `json:"ovirt_password"`
 	Cafile   string `json:"ovirt_cafile,omitempty"`
+	Cabundle string `json:"ovirt_ca_bundle,omitempty"`
+	Insecure bool   `json:"ovirt_insecure"`
 }
 
 type config struct {


### PR DESCRIPTION
This PR fixes BZ 1936450. For details please see that BZ.