### PR TITLE
Bug 1937460: Update gophercloud module from master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible // indirect
 	github.com/google/uuid v1.1.2
-	github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055
+	github.com/gophercloud/gophercloud v0.16.1-0.20210311194000-69f51f2f086c
 	github.com/gophercloud/utils v0.0.0-20210216074907-f6de111f2eae
 	github.com/h2non/filetype v1.0.12
 	github.com/hashicorp/go-azure-helpers v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -686,6 +686,8 @@ github.com/gophercloud/gophercloud v0.7.1-0.20191210042042-7aa2e52d21f9/go.mod h
 github.com/gophercloud/gophercloud v0.12.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
 github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055 h1:/wFA5WAzWcHNjpUs/Vuf4g2Sbv0wj3MUkZdeYgU4RkI=
 github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
+github.com/gophercloud/gophercloud v0.16.1-0.20210311194000-69f51f2f086c h1:CbAMSN8mQ/SVUFk8zTXwM5thC6L2ZFvl95UPF5tLTS4=
+github.com/gophercloud/gophercloud v0.16.1-0.20210311194000-69f51f2f086c/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
 github.com/gophercloud/utils v0.0.0-20190124231947-9c3b9f2457ef/go.mod h1:wjDF8z83zTeg5eMLml5EBSlAhbF7G8DobyI1YsMuyzw=
 github.com/gophercloud/utils v0.0.0-20190313033024-0bcc8e728cb5/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
 github.com/gophercloud/utils v0.0.0-20191129022341-463e26ffa30d/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=

--- a/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
@@ -1,4 +1,19 @@
-## 0.16.0 (Unreleased)
+## 0.17.0 (Unreleased)
+
+IMPROVEMENTS
+
+* `networking/v2/extensions/quotas.QuotaDetail.Reserved` can handle both `int` and `string` values [GH-2126](https://github.com/gophercloud/gophercloud/pull/2126)
+* Added `blockstorage/v3/volumetypes.ListExtraSpecs` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+* Added `blockstorage/v3/volumetypes.GetExtraSpec` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+* Added `blockstorage/v3/volumetypes.CreateExtraSpecs` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+* Added `blockstorage/v3/volumetypes.UpdateExtraSpec` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+* Added `blockstorage/v3/volumetypes.DeleteExtraSpec` [GH-2123](https://github.com/gophercloud/gophercloud/pull/2123)
+
+## 0.16.0 (February 23, 2021)
+
+UPGRADE NOTES
+
+* `baremetal/v1/nodes.CleanStep.Interface` has changed from `string` to `StepInterface` [GH-2120](https://github.com/gophercloud/gophercloud/pull/2120)
 
 BUG FIXES
 
@@ -21,6 +36,11 @@ IMPROVEMENTS
 * Added `containerinfra/v1/clusters.CreateOpts.MasterLBEnabled` [GH-2102](https://github.com/gophercloud/gophercloud/pull/2102)
 * Added the ability to define a custom function to handle "Retry-After" (429) responses [GH-2097](https://github.com/gophercloud/gophercloud/pull/2097)
 * Added `baremetal/v1/nodes.JBOD` constant for the `RAIDLevel` type [GH-2103](https://github.com/gophercloud/gophercloud/pull/2103)
+* Added support for Block Storage quotas of volume typed resources [GH-2109](https://github.com/gophercloud/gophercloud/pull/2109)
+* Added `blockstorage/extensions/volumeactions.ChangeType` [GH-2113](https://github.com/gophercloud/gophercloud/pull/2113)
+* Added `baremetal/v1/nodes.DeployStep` [GH-2120](https://github.com/gophercloud/gophercloud/pull/2120)
+* Added `baremetal/v1/nodes.ProvisionStateOpts.DeploySteps` [GH-2120](https://github.com/gophercloud/gophercloud/pull/2120)
+* Added `baremetal/v1/nodes.CreateOpts.AutomatedClean` [GH-2122](https://github.com/gophercloud/gophercloud/pull/2122)
 
 ## 0.15.0 (December 27, 2020)
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/results.go
@@ -50,6 +50,10 @@ func ExtractNodesInto(r pagination.Page, v interface{}) error {
 
 // Node represents a node in the OpenStack Bare Metal API.
 type Node struct {
+	// Whether automated cleaning is enabled or disabled on this node.
+	// Requires microversion 1.47 or later.
+	AutomatedClean *bool `json:"automated_clean"`
+
 	// UUID for the resource.
 	UUID string `json:"uuid"`
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/doc.go
@@ -32,6 +32,25 @@ Example to Update a Quota Set
 
 	fmt.Printf("%+v\n", quotaset)
 
+Example to Update a Quota set with volume_type quotas
+
+	updateOpts := quotasets.UpdateOpts{
+		Volumes: gophercloud.IntToPointer(100),
+		Extra: map[string]interface{}{
+			"gigabytes_foo": gophercloud.IntToPointer(100),
+			"snapshots_foo": gophercloud.IntToPointer(10),
+			"volumes_foo":   gophercloud.IntToPointer(10),
+		},
+	}
+
+	quotaset, err := quotasets.Update(blockStorageClient, "project-id", updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", quotaset)
+
+
 Example to Delete a Quota Set
 
 	err := quotasets.Delete(blockStorageClient, "project-id").ExtractErr()

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets/requests.go
@@ -43,7 +43,7 @@ func Update(client *gophercloud.ServiceClient, projectID string, opts UpdateOpts
 	return
 }
 
-// UpdateOptsBuilder enables extensins to add parameters to the update request.
+// UpdateOptsBuilder enables extensions to add parameters to the update request.
 type UpdateOptsBuilder interface {
 	// Extra specific name to prevent collisions with interfaces for other quotas
 	// (e.g. neutron)
@@ -53,7 +53,20 @@ type UpdateOptsBuilder interface {
 // ToBlockStorageQuotaUpdateMap builds the update options into a serializable
 // format.
 func (opts UpdateOpts) ToBlockStorageQuotaUpdateMap() (map[string]interface{}, error) {
-	return gophercloud.BuildRequestBody(opts, "quota_set")
+	b, err := gophercloud.BuildRequestBody(opts, "quota_set")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Extra != nil {
+		if v, ok := b["quota_set"].(map[string]interface{}); ok {
+			for key, value := range opts.Extra {
+				v[key] = value
+			}
+		}
+	}
+
+	return b, nil
 }
 
 // Options for Updating the quotas of a Tenant.
@@ -87,6 +100,10 @@ type UpdateOpts struct {
 	// Force will update the quotaset even if the quota has already been used
 	// and the reserved quota exceeds the new quota.
 	Force bool `json:"force,omitempty"`
+
+	// Extra is a collection of miscellaneous key/values used to set
+	// quota per volume_type
+	Extra map[string]interface{} `json:"-"`
 }
 
 // Resets the quotas for the given tenant to their default values.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/doc.go
@@ -93,5 +93,17 @@ Example of Setting a Volume's Bootable status
 	if err != nil {
 		panic(err)
 	}
+
+Example of Changing Type of a Volume
+
+	changeTypeOpts := volumeactions.ChangeTypeOpts{
+		NewType:         "ssd",
+		MigrationPolicy: volumeactions.MigrationPolicyOnDemand,
+	}
+
+	err = volumeactions.ChangeType(client, volumeID, changeTypeOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
 */
 package volumeactions

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -54,7 +54,7 @@ func Attach(client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder
 	return
 }
 
-// BeginDetach will mark the volume as detaching.
+// BeginDetaching will mark the volume as detaching.
 func BeginDetaching(client *gophercloud.ServiceClient, id string) (r BeginDetachingResult) {
 	b := map[string]interface{}{"os-begin_detaching": make(map[string]interface{})}
 	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
@@ -339,6 +339,54 @@ func SetBootable(client *gophercloud.ServiceClient, id string, opts BootableOpts
 	}
 	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// MigrationPolicy type represents a migration_policy when changing types.
+type MigrationPolicy string
+
+// Supported attributes for MigrationPolicy attribute for changeType operations.
+const (
+	MigrationPolicyNever    MigrationPolicy = "never"
+	MigrationPolicyOnDemand MigrationPolicy = "on-demand"
+)
+
+// ChangeTypeOptsBuilder allows extensions to add additional parameters to the
+// ChangeType request.
+type ChangeTypeOptsBuilder interface {
+	ToVolumeChangeTypeMap() (map[string]interface{}, error)
+}
+
+// ChangeTypeOpts contains options for changing the type of an existing Volume.
+// This object is passed to the volumes.ChangeType function.
+type ChangeTypeOpts struct {
+	// NewType is the name of the new volume type of the volume.
+	NewType string `json:"new_type" required:"true"`
+
+	// MigrationPolicy specifies if the volume should be migrated when it is
+	// re-typed. Possible values are "on-demand" or "never". If not specified,
+	// the default is "never".
+	MigrationPolicy MigrationPolicy `json:"migration_policy,omitempty"`
+}
+
+// ToVolumeChangeTypeMap assembles a request body based on the contents of an
+// ChangeTypeOpts.
+func (opts ChangeTypeOpts) ToVolumeChangeTypeMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-retype")
+}
+
+// ChangeType will change the volume type of the volume based on the provided information.
+// This operation does not return a response body.
+func ChangeType(client *gophercloud.ServiceClient, id string, opts ChangeTypeOptsBuilder) (r ChangeTypeResult) {
+	b, err := opts.ToVolumeChangeTypeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(actionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/results.go
@@ -209,3 +209,8 @@ func (r UploadImageResult) Extract() (VolumeImage, error) {
 type ForceDeleteResult struct {
 	gophercloud.ErrResult
 }
+
+// ChangeTypeResult contains the response body and error from an ChangeType request.
+type ChangeTypeResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -549,7 +549,7 @@ github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/jsonschema
 github.com/googleapis/gnostic/openapiv2
-# github.com/gophercloud/gophercloud v0.15.1-0.20210202035223-633d73521055
+# github.com/gophercloud/gophercloud v0.16.1-0.20210311194000-69f51f2f086c
 ## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack


### PR DESCRIPTION
We found a workaround in gophercloud to unmarschal json if "reserved" is
a string, we deal with it in the gophercloud library until this is
solved in OpenStack Neutron:
https://review.opendev.org/c/openstack/neutron/+/779878

BZ#1937460
Signed-off-by: Emilien Macchi <emilien@redhat.com>
