### PR TITLE
Bug 1934557: bump RHCOS image for LUKS fix

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-057e5df70c52dc128"
+            "hvm": "ami-01dd4193042351d0e"
         },
         "ap-east-1": {
-            "hvm": "ami-006ab68917f52bb13"
+            "hvm": "ami-06320ea2b751acf5d"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0d236f6289c700771"
+            "hvm": "ami-05368806cdd6277c7"
         },
         "ap-northeast-2": {
-            "hvm": "ami-040394572427a293a"
+            "hvm": "ami-0b2f40b281ab6903b"
         },
         "ap-south-1": {
-            "hvm": "ami-0838c978c0390dd75"
+            "hvm": "ami-0d5ce4ca4898224ec"
         },
         "ap-southeast-1": {
-            "hvm": "ami-07af688c8b65de56f"
+            "hvm": "ami-008a33d6dbd81dbcc"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a36faab6aa0a0dea"
+            "hvm": "ami-01d3b84d2c25d2717"
         },
         "ca-central-1": {
-            "hvm": "ami-01284e5815ce66a95"
+            "hvm": "ami-0ac50d7fd990f5332"
         },
         "eu-central-1": {
-            "hvm": "ami-0361c06cf3e935cfe"
+            "hvm": "ami-0b3149eff8c1b1d97"
         },
         "eu-north-1": {
-            "hvm": "ami-0080eb90a48d9655e"
+            "hvm": "ami-0d9cbf9387a9dc7e2"
         },
         "eu-south-1": {
-            "hvm": "ami-0a3bc89f7aadf0343"
+            "hvm": "ami-0d840e28d95f8e128"
         },
         "eu-west-1": {
-            "hvm": "ami-0b4024fa5cb2588bd"
+            "hvm": "ami-0558ed15ea50b830b"
         },
         "eu-west-2": {
-            "hvm": "ami-07376355104ab4106"
+            "hvm": "ami-013b367c221b23698"
         },
         "eu-west-3": {
-            "hvm": "ami-038f4ce9ea7ac7191"
+            "hvm": "ami-016224e83820dd23e"
         },
         "me-south-1": {
-            "hvm": "ami-025899013a24bb708"
+            "hvm": "ami-0ceac1bfed40e9cbf"
         },
         "sa-east-1": {
-            "hvm": "ami-089e1a3dcc5a5fe08"
+            "hvm": "ami-076cab8be8d32f123"
         },
         "us-east-1": {
-            "hvm": "ami-0d5f9982f029fbc14"
+            "hvm": "ami-08f15e9f159732a9b"
         },
         "us-east-2": {
-            "hvm": "ami-0c84b5c5255ec4777"
+            "hvm": "ami-07a0bede859e1639d"
         },
         "us-west-1": {
-            "hvm": "ami-0b421328859954025"
+            "hvm": "ami-0b8c56daaa6be3f97"
         },
         "us-west-2": {
-            "hvm": "ami-010de485a2ee23e5e"
+            "hvm": "ami-0ba922fcef999ec3d"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202102090044-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102090044-0-azure.x86_64.vhd"
+        "image": "rhcos-48.83.202103122318-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.83.202103122318-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102090044-0/x86_64/",
-    "buildid": "47.83.202102090044-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.83.202103122318-0/x86_64/",
+    "buildid": "48.83.202103122318-0",
     "gcp": {
-        "image": "rhcos-47-83-202102090044-0-gcp-x86-64",
+        "image": "rhcos-48-83-202103122318-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102090044-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-83-202103122318-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202102090044-0-aws.x86_64.vmdk.gz",
-            "sha256": "ad54945302d9aaf0c5d6a5d1ee457325a3dcd88a68067d18a4d614acef5390d4",
-            "size": 951239242,
-            "uncompressed-sha256": "fbb7fbbc6cc6161ffa5c571f1b9022fe80038eea0a7f099c5b18ceba3b82f5eb",
-            "uncompressed-size": 970902016
+            "path": "rhcos-48.83.202103122318-0-aws.x86_64.vmdk.gz",
+            "sha256": "fbe1f2571516db1b423c83b4c82385f887c7a80c28fe978e5df39bcea360a63a",
+            "size": 956011781,
+            "uncompressed-sha256": "ef749748fedcafda0bc49f159645542eac19cd49fd3dc665b19c8c24c3a378bd",
+            "uncompressed-size": 975684096
         },
         "azure": {
-            "path": "rhcos-47.83.202102090044-0-azure.x86_64.vhd.gz",
-            "sha256": "32aa9be04b7f06bfe028fc7c93443f0c742afb006e73b6076016fa897ae5f716",
-            "size": 951756228,
-            "uncompressed-sha256": "7e60c02aeebd129a99d65da48beddb99bd29ac7b31f3bb9395fb1d87e6311448",
+            "path": "rhcos-48.83.202103122318-0-azure.x86_64.vhd.gz",
+            "sha256": "f195c680a0064142497eb0e883c1127bc979e0ed595f7af3c61588beac93aa8d",
+            "size": 956294196,
+            "uncompressed-sha256": "d42a2c59bb07d76068768f98a2818bbe02b27b4d9f33320e97a724c03eac8591",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202102090044-0-gcp.x86_64.tar.gz",
-            "sha256": "07275bf2844f0dba6296d984d293959f614cc60af9f1be4070142a8cdcc650aa",
-            "size": 937047583
+            "path": "rhcos-48.83.202103122318-0-gcp.x86_64.tar.gz",
+            "sha256": "835c1188ec940cf3416fedef1297f23d1ad9fc4ccbc878ab92894b7e75db2408",
+            "size": 941572226
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202102090044-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "b81b26a61d11a9c2c6fb33a94ff124f461907bff550338cfecf173cdd93c09be",
-            "size": 937381841,
-            "uncompressed-sha256": "5b6fdfb53e3ede4d264d13862bda6801d932f12e1a17309ac62ac32836bca8ff",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-48.83.202103122318-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "4935c16039bcc1224e37c6d901783ac2858e8b8aa1f98a68320e55089f647e20",
+            "size": 941914922,
+            "uncompressed-sha256": "d8053881cb97d412a7d0279fea51a5fb67cabe9bc26051c88bd84c97038c360f",
+            "uncompressed-size": 2369781760
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202102090044-0-live-initramfs.x86_64.img",
-            "sha256": "29ba7e12b16f143a3f036226568ce91b3f7c8bd6feab719a73b0bed1817e4444"
+            "path": "rhcos-48.83.202103122318-0-live-initramfs.x86_64.img",
+            "sha256": "a761505051ec5d3833b94634031947a8c8595f3a9175358ec1259b25917b6dd8"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102090044-0-live.x86_64.iso",
-            "sha256": "b765a9e99edfa0a91778a4787070c6afcaa198ba8806c8c1533c34a23d63136f"
+            "path": "rhcos-48.83.202103122318-0-live.x86_64.iso",
+            "sha256": "fb58004d0b8abbd0a3ad7645f639f80d939e8e308fb5fe3e51f89a54f5bfe5b5"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102090044-0-live-kernel-x86_64",
-            "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
+            "path": "rhcos-48.83.202103122318-0-live-kernel-x86_64",
+            "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102090044-0-live-rootfs.x86_64.img",
-            "sha256": "6da4ae110fc2bcea8ac0e6c40fa9d701bbde5b936a1410f75735386c8ea805bf"
+            "path": "rhcos-48.83.202103122318-0-live-rootfs.x86_64.img",
+            "sha256": "dbace7d56388034b38edb645a661e7e2b2039116f70470a4a1e2577d395f124d"
         },
         "metal": {
-            "path": "rhcos-47.83.202102090044-0-metal.x86_64.raw.gz",
-            "sha256": "0a456b02960eeb40a102ef14f5556843c2c504358f3db21f3fe667d8346c9bdf",
-            "size": 939085053,
-            "uncompressed-sha256": "36379d083adccccb3de266d2802cfcf5079429865fa010d9b499e87042d46526",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-48.83.202103122318-0-metal.x86_64.raw.gz",
+            "sha256": "9009586f9d95cc19958f2259a7f33fd47fc9f1bcc498d91bf5c7432262fba067",
+            "size": 943625068,
+            "uncompressed-sha256": "66ea3ce8a73e1fd315dc7612a0f11134bb6ba96bfe5df28d1e30a67dc7d3867b",
+            "uncompressed-size": 3729784832
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102090044-0-metal4k.x86_64.raw.gz",
-            "sha256": "ff10909c5d4ffbb3a829d070dcf3ce9a8b2d2aebff2924ee464d517eb948bfba",
-            "size": 936609970,
-            "uncompressed-sha256": "d5821d7fbd20f86bab29d028855200221f316fa041e86374c5f693da9b5d7b83",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-48.83.202103122318-0-metal4k.x86_64.raw.gz",
+            "sha256": "6498ae0259bba73140fee655367181dd6214ff3d51b6dc054c236f9e2d8bda09",
+            "size": 941326627,
+            "uncompressed-sha256": "85e3e2c0222c1380b012604b9ed536328abacfe25abe201957f575fb9c2adf82",
+            "uncompressed-size": 3729784832
         },
         "openstack": {
-            "path": "rhcos-47.83.202102090044-0-openstack.x86_64.qcow2.gz",
-            "sha256": "e5ebb8bcf6d081e52e1e7db0e93ff960ff472e25803a5671170959212e88cad9",
-            "size": 937380970,
-            "uncompressed-sha256": "c1b93a426d0f74f0059193439e306f3356b788302a825cfadd870460e543028e",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-48.83.202103122318-0-openstack.x86_64.qcow2.gz",
+            "sha256": "0c6f320c4fe2e4f09442ab24bb59618928ad55001c3a00db182792f765c9ee13",
+            "size": 941914638,
+            "uncompressed-sha256": "371378fd1beaf80607736eab386d61d44e70be591556ef9c2b6cd4ae56c57d5d",
+            "uncompressed-size": 2369781760
         },
         "ostree": {
-            "path": "rhcos-47.83.202102090044-0-ostree.x86_64.tar",
-            "sha256": "3b5fc040f7493ff7dc5aef4da22077ad74eb2e12a01a9e820d5c116e58716c4f",
-            "size": 863467520
+            "path": "rhcos-48.83.202103122318-0-ostree.x86_64.tar",
+            "sha256": "4a2d8cc6d8a3846d9944c538fd41a70204db6d304e07e02143c3ed8554d47989",
+            "size": 868136960
         },
         "qemu": {
-            "path": "rhcos-47.83.202102090044-0-qemu.x86_64.qcow2.gz",
-            "sha256": "2ca82f1d762bba1cb2e5ac1386be0a1ab0264cf88b0594c9cd1e53d285833c6d",
-            "size": 938521497,
-            "uncompressed-sha256": "5d31652c7856a87450dce1bbbb561b578ee75443c190096cb977a814e5f35935",
-            "uncompressed-size": 2394030080
+            "path": "rhcos-48.83.202103122318-0-qemu.x86_64.qcow2.gz",
+            "sha256": "b7e1d1f4c9c859d12417502131b28ac5fc06aa695cc1cb68dc09886bb84997c0",
+            "size": 943081124,
+            "uncompressed-sha256": "f5bbc7ffb720f7073ec4382207bf419c38b1aa1af338aaaf7076d4a0a2c7b930",
+            "uncompressed-size": 2403794944
         },
         "vmware": {
-            "path": "rhcos-47.83.202102090044-0-vmware.x86_64.ova",
-            "sha256": "13d92692b8eed717ff8d0d113a24add339a65ef1f12eceeb99dabcd922cc86d1",
-            "size": 970915840
+            "path": "rhcos-48.83.202103122318-0-vmware.x86_64.ova",
+            "sha256": "14915912594124b114e9da64b2bafd34275c3c625f575f9a7d1f241f7b3d5b89",
+            "size": 975697920
         }
     },
     "oscontainer": {
-        "digest": "sha256:a32077727aa2ef96a1e2371dbcc53ba06f3d9727e836b72be0f0dd4513937e1e",
+        "digest": "sha256:26a56317f7a00edd94fa655d23e4ea693ca5845eb67c2fb91a0f73f9ba4f1b05",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "646a9832dd0dc9fe174a2fc005863a9582186518a5476522a0e9bdccc0e5252a",
-    "ostree-version": "47.83.202102090044-0"
+    "ostree-commit": "5f984a81182f9a1fac4c061732a4b22bee590291723d043aebbcbd922862c449",
+    "ostree-version": "48.83.202103122318-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202102091015-0/ppc64le/",
-    "buildid": "47.83.202102091015-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.83.202103131019-0/ppc64le/",
+    "buildid": "48.83.202103131019-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-47.83.202102091015-0-live-initramfs.ppc64le.img",
-            "sha256": "a15c4eaaf5aa0176fc475e4ec41df4ca0e83595f7a5e561e2de0a26f8a485b60"
+            "path": "rhcos-48.83.202103131019-0-live-initramfs.ppc64le.img",
+            "sha256": "cc5b7229f8906a9703874f8e91efbd8444d1e99d7ab91b40fea8db1947560f6f"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102091015-0-live.ppc64le.iso",
-            "sha256": "d6fb6f949569461e3f9eb67883fa00b611275bb7d7bd3d9f11beaf1c0b33d389"
+            "path": "rhcos-48.83.202103131019-0-live.ppc64le.iso",
+            "sha256": "791ccc3fa2246e0c9bb63b0e506d40c5f873e6e02602bef2643d373b20a6cafd"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102091015-0-live-kernel-ppc64le",
-            "sha256": "e310166a16592a5cd1bc152b07fda84278b251dc385cf000c65ed7bb31d254ea"
+            "path": "rhcos-48.83.202103131019-0-live-kernel-ppc64le",
+            "sha256": "75e8849d99f9eca4f408a331c332d61af1a5c40818e71d4953481f05e7384ca2"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102091015-0-live-rootfs.ppc64le.img",
-            "sha256": "621ed54c0cb5180e7e798778c5c365f04b328aa983bc5a752ecea3a17ffd5bce"
+            "path": "rhcos-48.83.202103131019-0-live-rootfs.ppc64le.img",
+            "sha256": "6e2a4baad42295b7ec8d9abb20590bc224dfa52eabf6eab1168c4f916c3a1616"
         },
         "metal": {
-            "path": "rhcos-47.83.202102091015-0-metal.ppc64le.raw.gz",
-            "sha256": "d0fa64d744dd731ad3185b39ada8d6eb886c8dbba3e683a30176838bdf20ef9a",
-            "size": 918231587,
-            "uncompressed-sha256": "1880a77eed6741e45346102b85b5cceb071d7da5479b1075efd810767a33693c",
-            "uncompressed-size": 3888119808
+            "path": "rhcos-48.83.202103131019-0-metal.ppc64le.raw.gz",
+            "sha256": "d29d8c49ed145db0534b4780fa160ac5f27e89c7a6794611145d56f20f72eb2b",
+            "size": 922632425,
+            "uncompressed-sha256": "86fc00f47b8cbfa9114cc5a337222ac5549f32b31cf29aa47488b0d4c8d5b5e3",
+            "uncompressed-size": 3904897024
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102091015-0-metal4k.ppc64le.raw.gz",
-            "sha256": "f6e4458958f38a7bccae4a89a73134d431b86b183ebcf76542446c959fa2d520",
-            "size": 918369582,
-            "uncompressed-sha256": "142ce5a0cb3984611a74d5d9d99ee6e320029802d2bee7c31d6b6b9455f3d293",
-            "uncompressed-size": 3888119808
+            "path": "rhcos-48.83.202103131019-0-metal4k.ppc64le.raw.gz",
+            "sha256": "56182cd7c4668b41de835f2cc81e7a4339537a10b19b9e17143f4685f46f36b8",
+            "size": 922929233,
+            "uncompressed-sha256": "bed30e8e30174d774971ea00073a4a7da4185d690cc1ae5c27a446fbce68ee09",
+            "uncompressed-size": 3904897024
         },
         "openstack": {
-            "path": "rhcos-47.83.202102091015-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "47865a06d1ca6ae06481ab6f1d52ed6c9fca02ae539a06639c8bea65173a1550",
-            "size": 916498365,
-            "uncompressed-sha256": "443ed7133f49e36138ac7c452bedcca2d8fde02f818a43fce1d905d41d0a8cea",
-            "uncompressed-size": 2494431232
+            "path": "rhcos-48.83.202103131019-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "82caa694feeaa9a4f5cb6bc2d4b14e52f16fb28fd35c77141313911d07b2a02d",
+            "size": 920802478,
+            "uncompressed-sha256": "5c6cce57867a3a5ed8e2e4800440510ece4b19e5f49e1c6e6ccd4329b2289829",
+            "uncompressed-size": 2505834496
         },
         "ostree": {
-            "path": "rhcos-47.83.202102091015-0-ostree.ppc64le.tar",
-            "sha256": "118d9f3842d60e2f21e84b4561a9faea3e1ac72948a76a2e59969ff54f288f0a",
-            "size": 840714240
+            "path": "rhcos-48.83.202103131019-0-ostree.ppc64le.tar",
+            "sha256": "3b5528d291694064ecb1e67be79d64b35e0c3cdc3e69a30aff2c6fdcd25f677c",
+            "size": 845230080
         },
         "qemu": {
-            "path": "rhcos-47.83.202102091015-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "dce14413bb0347ffcb793a529ed2b4e39efa2b523a3e63faf552e574752a5aac",
-            "size": 917571073,
-            "uncompressed-sha256": "2044dd7198fd1f730c3fe1d68c422be7e06ed57b4ad28bfe402f4836b84be869",
-            "uncompressed-size": 2529296384
+            "path": "rhcos-48.83.202103131019-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "7a39e5ffd68c2a8862c00e3bb831a5f202b85002aebcd0af4ec1b43403b6cde3",
+            "size": 921911958,
+            "uncompressed-sha256": "c5480ed5d5633ea302d91c46be9a777371a65fd3051f267de833cbc80bdf2602",
+            "uncompressed-size": 2541027328
         }
     },
     "oscontainer": {
-        "digest": "sha256:6a410508e645cb24729fd860ae53a352b3df23a11d5747b0648d2f300a37de1d",
+        "digest": "sha256:8b03b0363208caf73001e7371d4781672f67d0acc7804a794b0e9d8202f84d23",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "b44e5d88d608175e62e95a35b59bd3e912327cfea036e5393169146af7512588",
-    "ostree-version": "47.83.202102091015-0"
+    "ostree-commit": "52f2c914b460eaa31d63e050beb7a887693b524f57875fa393a6e8273decc86b",
+    "ostree-version": "48.83.202103131019-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202102090311-0/s390x/",
-    "buildid": "47.83.202102090311-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.83.202103130119-0/s390x/",
+    "buildid": "48.83.202103130119-0",
     "images": {
         "dasd": {
-            "path": "rhcos-47.83.202102090311-0-dasd.s390x.raw.gz",
-            "sha256": "af39f736c9cd6bec61d4f7a098adcebc0b7583cd299339859c831380256c27d4",
-            "size": 831578576,
-            "uncompressed-sha256": "a390b9b95a1381ebec1736d4aa5d193f0820a41c6af79fc7283960b91fa4a861",
-            "uncompressed-size": 3516923904
+            "path": "rhcos-48.83.202103130119-0-dasd.s390x.raw.gz",
+            "sha256": "96ba1e320ccba3d9f9f11855cbddb43b9363935491427ea210905f25cbcdfac5",
+            "size": 836102986,
+            "uncompressed-sha256": "ca1472621f8b5e3606c89f13980f33614a1c4efc5539201118e304deec8f5eea",
+            "uncompressed-size": 3534749696
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202102090311-0-live-initramfs.s390x.img",
-            "sha256": "07e5642b818ee9582f59050657dceecad4683c6c54c2f92b071549c8a4826e05"
+            "path": "rhcos-48.83.202103130119-0-live-initramfs.s390x.img",
+            "sha256": "542c00195579e2fd96d3d701f63d2bec8a2204bca5ed3c941fc448e23f704cf2"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102090311-0-live.s390x.iso",
-            "sha256": "e64d8d66bd69e6ea7ebdd9be74abce43e10e0731527ee6662780f20863ffc71c"
+            "path": "rhcos-48.83.202103130119-0-live.s390x.iso",
+            "sha256": "6156db725eb0f23db7b4fcd1de4d38da1d55f4ea7b803da864662ae542084ab9"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102090311-0-live-kernel-s390x",
-            "sha256": "a0f17299369b9ce9e42c874a8cc3658a00e58144fc0f54849ef96d9414d811d0"
+            "path": "rhcos-48.83.202103130119-0-live-kernel-s390x",
+            "sha256": "7f0356ce47a620a24dcf5e61b598dbe644f8083ab96646a12f563ee0671253cc"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102090311-0-live-rootfs.s390x.img",
-            "sha256": "79de4fb97a151b051201eb04f291a1b36f54d3968d2c3f31571066da8231945a"
+            "path": "rhcos-48.83.202103130119-0-live-rootfs.s390x.img",
+            "sha256": "35ca0742d8febe5304030cc013216588030d8374345ab1bf702a1d847dc14744"
         },
         "metal": {
-            "path": "rhcos-47.83.202102090311-0-metal.s390x.raw.gz",
-            "sha256": "299bcb3de103f701866904f41e316e7c375fd1e0c4434b068e578a35d11084e1",
-            "size": 831763974,
-            "uncompressed-sha256": "ab0b1f6080c472f88dc418610cb6af2dd9e8aff835c9a7b417716f67c3e2e25d",
-            "uncompressed-size": 3516923904
+            "path": "rhcos-48.83.202103130119-0-metal.s390x.raw.gz",
+            "sha256": "98c09eb53f692e47a7fcaea60c433e074e3b9e0910acbdba513ee0485e7e6ab7",
+            "size": 835989698,
+            "uncompressed-sha256": "06ae52e5ca7ee039f6708df7dcbf27418155c36d3eb1c8f3476df538302a08c4",
+            "uncompressed-size": 3534749696
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102090311-0-metal4k.s390x.raw.gz",
-            "sha256": "566bca2f1462b4d70f1d7da7a1c7d477252f2e2db6251ee61f6e810c3a450982",
-            "size": 831520327,
-            "uncompressed-sha256": "3478e62963f4b0bba45cc41a92cae33e9907cc3e4ed1206ef94a05db4e70b9fe",
-            "uncompressed-size": 3516923904
+            "path": "rhcos-48.83.202103130119-0-metal4k.s390x.raw.gz",
+            "sha256": "56a5cc8369c55ac60ce7a58bb7a41adf3c15a00bcf1188a57878d8dc22a61a94",
+            "size": 836106466,
+            "uncompressed-sha256": "69b2edb68f1233ca8deae4c8c82d944b47000482b29821947f98641abd8125bb",
+            "uncompressed-size": 3534749696
         },
         "openstack": {
-            "path": "rhcos-47.83.202102090311-0-openstack.s390x.qcow2.gz",
-            "sha256": "4ebac56f35e48ff66b18ed21785f722272bc5b24573c2410f3d63a374eeab6db",
-            "size": 830070694,
-            "uncompressed-sha256": "2920cfe9a35e24302127507ab39e54d619c839d910361fe45c0c46dbd9813e7a",
-            "uncompressed-size": 2179530752
+            "path": "rhcos-48.83.202103130119-0-openstack.s390x.qcow2.gz",
+            "sha256": "822a8483cacc161ea0deb0d8f276642b15ba9f06c17a32497e9f9fb097687013",
+            "size": 834429587,
+            "uncompressed-sha256": "1ca807e4a1df620923b8774e2d6dabd9e59ac5efde5fe1a9447f7ac43135c96a",
+            "uncompressed-size": 2191261696
         },
         "ostree": {
-            "path": "rhcos-47.83.202102090311-0-ostree.s390x.tar",
-            "sha256": "d7ed80d612fedcca6a39017e41851acbb35c5d0a8cce9c06df8afacfe059e310",
-            "size": 779970560
+            "path": "rhcos-48.83.202103130119-0-ostree.s390x.tar",
+            "sha256": "171e3b3ff4ea5820ed5e7a613b46bffaa370a48865d7b366112fb08622218f09",
+            "size": 784578560
         },
         "qemu": {
-            "path": "rhcos-47.83.202102090311-0-qemu.s390x.qcow2.gz",
-            "sha256": "80d61716f6ca97e9b5256b2202132dcac169700937b40545ce9cd8ad9e6bbcee",
-            "size": 831149363,
-            "uncompressed-sha256": "cc3b8294320a6635bfdf05a380fb931875a57fe6b18118940b1ce2f23ca069a1",
-            "uncompressed-size": 2213019648
+            "path": "rhcos-48.83.202103130119-0-qemu.s390x.qcow2.gz",
+            "sha256": "bd73c8372ee8778add0c58b3caad31441c60b4bb07ad7b2a878f0ab98edf3d9c",
+            "size": 835439917,
+            "uncompressed-sha256": "b6820334a28ff93e9aa4586d802eff35745874f8940cd48d84c853af722c1de9",
+            "uncompressed-size": 2224553984
         }
     },
     "oscontainer": {
-        "digest": "sha256:0e8147407a02605f0e4f79ac5e8ddfda21b7557769a26b9f7138e82dc9558af0",
+        "digest": "sha256:6b8d3d6f2dad16f8d3dcb199d007783da4b064ddf06ab2d309de9f3a57efe951",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ac18fdc352f3e1bcbf1c7d74f713f14de2c4117c869afd097432b5f8355e3781",
-    "ostree-version": "47.83.202102090311-0"
+    "ostree-commit": "ae14be52d6092ce9c752bdca53c0c447941e82eb034e3cefa4e2c68e1328a957",
+    "ostree-version": "48.83.202103130119-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-057e5df70c52dc128"
+            "hvm": "ami-01dd4193042351d0e"
         },
         "ap-east-1": {
-            "hvm": "ami-006ab68917f52bb13"
+            "hvm": "ami-06320ea2b751acf5d"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0d236f6289c700771"
+            "hvm": "ami-05368806cdd6277c7"
         },
         "ap-northeast-2": {
-            "hvm": "ami-040394572427a293a"
+            "hvm": "ami-0b2f40b281ab6903b"
         },
         "ap-south-1": {
-            "hvm": "ami-0838c978c0390dd75"
+            "hvm": "ami-0d5ce4ca4898224ec"
         },
         "ap-southeast-1": {
-            "hvm": "ami-07af688c8b65de56f"
+            "hvm": "ami-008a33d6dbd81dbcc"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a36faab6aa0a0dea"
+            "hvm": "ami-01d3b84d2c25d2717"
         },
         "ca-central-1": {
-            "hvm": "ami-01284e5815ce66a95"
+            "hvm": "ami-0ac50d7fd990f5332"
         },
         "eu-central-1": {
-            "hvm": "ami-0361c06cf3e935cfe"
+            "hvm": "ami-0b3149eff8c1b1d97"
         },
         "eu-north-1": {
-            "hvm": "ami-0080eb90a48d9655e"
+            "hvm": "ami-0d9cbf9387a9dc7e2"
         },
         "eu-south-1": {
-            "hvm": "ami-0a3bc89f7aadf0343"
+            "hvm": "ami-0d840e28d95f8e128"
         },
         "eu-west-1": {
-            "hvm": "ami-0b4024fa5cb2588bd"
+            "hvm": "ami-0558ed15ea50b830b"
         },
         "eu-west-2": {
-            "hvm": "ami-07376355104ab4106"
+            "hvm": "ami-013b367c221b23698"
         },
         "eu-west-3": {
-            "hvm": "ami-038f4ce9ea7ac7191"
+            "hvm": "ami-016224e83820dd23e"
         },
         "me-south-1": {
-            "hvm": "ami-025899013a24bb708"
+            "hvm": "ami-0ceac1bfed40e9cbf"
         },
         "sa-east-1": {
-            "hvm": "ami-089e1a3dcc5a5fe08"
+            "hvm": "ami-076cab8be8d32f123"
         },
         "us-east-1": {
-            "hvm": "ami-0d5f9982f029fbc14"
+            "hvm": "ami-08f15e9f159732a9b"
         },
         "us-east-2": {
-            "hvm": "ami-0c84b5c5255ec4777"
+            "hvm": "ami-07a0bede859e1639d"
         },
         "us-west-1": {
-            "hvm": "ami-0b421328859954025"
+            "hvm": "ami-0b8c56daaa6be3f97"
         },
         "us-west-2": {
-            "hvm": "ami-010de485a2ee23e5e"
+            "hvm": "ami-0ba922fcef999ec3d"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202102090044-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102090044-0-azure.x86_64.vhd"
+        "image": "rhcos-48.83.202103122318-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.83.202103122318-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102090044-0/x86_64/",
-    "buildid": "47.83.202102090044-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.83.202103122318-0/x86_64/",
+    "buildid": "48.83.202103122318-0",
     "gcp": {
-        "image": "rhcos-47-83-202102090044-0-gcp-x86-64",
+        "image": "rhcos-48-83-202103122318-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102090044-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-83-202103122318-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202102090044-0-aws.x86_64.vmdk.gz",
-            "sha256": "ad54945302d9aaf0c5d6a5d1ee457325a3dcd88a68067d18a4d614acef5390d4",
-            "size": 951239242,
-            "uncompressed-sha256": "fbb7fbbc6cc6161ffa5c571f1b9022fe80038eea0a7f099c5b18ceba3b82f5eb",
-            "uncompressed-size": 970902016
+            "path": "rhcos-48.83.202103122318-0-aws.x86_64.vmdk.gz",
+            "sha256": "fbe1f2571516db1b423c83b4c82385f887c7a80c28fe978e5df39bcea360a63a",
+            "size": 956011781,
+            "uncompressed-sha256": "ef749748fedcafda0bc49f159645542eac19cd49fd3dc665b19c8c24c3a378bd",
+            "uncompressed-size": 975684096
         },
         "azure": {
-            "path": "rhcos-47.83.202102090044-0-azure.x86_64.vhd.gz",
-            "sha256": "32aa9be04b7f06bfe028fc7c93443f0c742afb006e73b6076016fa897ae5f716",
-            "size": 951756228,
-            "uncompressed-sha256": "7e60c02aeebd129a99d65da48beddb99bd29ac7b31f3bb9395fb1d87e6311448",
+            "path": "rhcos-48.83.202103122318-0-azure.x86_64.vhd.gz",
+            "sha256": "f195c680a0064142497eb0e883c1127bc979e0ed595f7af3c61588beac93aa8d",
+            "size": 956294196,
+            "uncompressed-sha256": "d42a2c59bb07d76068768f98a2818bbe02b27b4d9f33320e97a724c03eac8591",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202102090044-0-gcp.x86_64.tar.gz",
-            "sha256": "07275bf2844f0dba6296d984d293959f614cc60af9f1be4070142a8cdcc650aa",
-            "size": 937047583
+            "path": "rhcos-48.83.202103122318-0-gcp.x86_64.tar.gz",
+            "sha256": "835c1188ec940cf3416fedef1297f23d1ad9fc4ccbc878ab92894b7e75db2408",
+            "size": 941572226
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202102090044-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "b81b26a61d11a9c2c6fb33a94ff124f461907bff550338cfecf173cdd93c09be",
-            "size": 937381841,
-            "uncompressed-sha256": "5b6fdfb53e3ede4d264d13862bda6801d932f12e1a17309ac62ac32836bca8ff",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-48.83.202103122318-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "4935c16039bcc1224e37c6d901783ac2858e8b8aa1f98a68320e55089f647e20",
+            "size": 941914922,
+            "uncompressed-sha256": "d8053881cb97d412a7d0279fea51a5fb67cabe9bc26051c88bd84c97038c360f",
+            "uncompressed-size": 2369781760
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202102090044-0-live-initramfs.x86_64.img",
-            "sha256": "29ba7e12b16f143a3f036226568ce91b3f7c8bd6feab719a73b0bed1817e4444"
+            "path": "rhcos-48.83.202103122318-0-live-initramfs.x86_64.img",
+            "sha256": "a761505051ec5d3833b94634031947a8c8595f3a9175358ec1259b25917b6dd8"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102090044-0-live.x86_64.iso",
-            "sha256": "b765a9e99edfa0a91778a4787070c6afcaa198ba8806c8c1533c34a23d63136f"
+            "path": "rhcos-48.83.202103122318-0-live.x86_64.iso",
+            "sha256": "fb58004d0b8abbd0a3ad7645f639f80d939e8e308fb5fe3e51f89a54f5bfe5b5"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102090044-0-live-kernel-x86_64",
-            "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
+            "path": "rhcos-48.83.202103122318-0-live-kernel-x86_64",
+            "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102090044-0-live-rootfs.x86_64.img",
-            "sha256": "6da4ae110fc2bcea8ac0e6c40fa9d701bbde5b936a1410f75735386c8ea805bf"
+            "path": "rhcos-48.83.202103122318-0-live-rootfs.x86_64.img",
+            "sha256": "dbace7d56388034b38edb645a661e7e2b2039116f70470a4a1e2577d395f124d"
         },
         "metal": {
-            "path": "rhcos-47.83.202102090044-0-metal.x86_64.raw.gz",
-            "sha256": "0a456b02960eeb40a102ef14f5556843c2c504358f3db21f3fe667d8346c9bdf",
-            "size": 939085053,
-            "uncompressed-sha256": "36379d083adccccb3de266d2802cfcf5079429865fa010d9b499e87042d46526",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-48.83.202103122318-0-metal.x86_64.raw.gz",
+            "sha256": "9009586f9d95cc19958f2259a7f33fd47fc9f1bcc498d91bf5c7432262fba067",
+            "size": 943625068,
+            "uncompressed-sha256": "66ea3ce8a73e1fd315dc7612a0f11134bb6ba96bfe5df28d1e30a67dc7d3867b",
+            "uncompressed-size": 3729784832
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102090044-0-metal4k.x86_64.raw.gz",
-            "sha256": "ff10909c5d4ffbb3a829d070dcf3ce9a8b2d2aebff2924ee464d517eb948bfba",
-            "size": 936609970,
-            "uncompressed-sha256": "d5821d7fbd20f86bab29d028855200221f316fa041e86374c5f693da9b5d7b83",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-48.83.202103122318-0-metal4k.x86_64.raw.gz",
+            "sha256": "6498ae0259bba73140fee655367181dd6214ff3d51b6dc054c236f9e2d8bda09",
+            "size": 941326627,
+            "uncompressed-sha256": "85e3e2c0222c1380b012604b9ed536328abacfe25abe201957f575fb9c2adf82",
+            "uncompressed-size": 3729784832
         },
         "openstack": {
-            "path": "rhcos-47.83.202102090044-0-openstack.x86_64.qcow2.gz",
-            "sha256": "e5ebb8bcf6d081e52e1e7db0e93ff960ff472e25803a5671170959212e88cad9",
-            "size": 937380970,
-            "uncompressed-sha256": "c1b93a426d0f74f0059193439e306f3356b788302a825cfadd870460e543028e",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-48.83.202103122318-0-openstack.x86_64.qcow2.gz",
+            "sha256": "0c6f320c4fe2e4f09442ab24bb59618928ad55001c3a00db182792f765c9ee13",
+            "size": 941914638,
+            "uncompressed-sha256": "371378fd1beaf80607736eab386d61d44e70be591556ef9c2b6cd4ae56c57d5d",
+            "uncompressed-size": 2369781760
         },
         "ostree": {
-            "path": "rhcos-47.83.202102090044-0-ostree.x86_64.tar",
-            "sha256": "3b5fc040f7493ff7dc5aef4da22077ad74eb2e12a01a9e820d5c116e58716c4f",
-            "size": 863467520
+            "path": "rhcos-48.83.202103122318-0-ostree.x86_64.tar",
+            "sha256": "4a2d8cc6d8a3846d9944c538fd41a70204db6d304e07e02143c3ed8554d47989",
+            "size": 868136960
         },
         "qemu": {
-            "path": "rhcos-47.83.202102090044-0-qemu.x86_64.qcow2.gz",
-            "sha256": "2ca82f1d762bba1cb2e5ac1386be0a1ab0264cf88b0594c9cd1e53d285833c6d",
-            "size": 938521497,
-            "uncompressed-sha256": "5d31652c7856a87450dce1bbbb561b578ee75443c190096cb977a814e5f35935",
-            "uncompressed-size": 2394030080
+            "path": "rhcos-48.83.202103122318-0-qemu.x86_64.qcow2.gz",
+            "sha256": "b7e1d1f4c9c859d12417502131b28ac5fc06aa695cc1cb68dc09886bb84997c0",
+            "size": 943081124,
+            "uncompressed-sha256": "f5bbc7ffb720f7073ec4382207bf419c38b1aa1af338aaaf7076d4a0a2c7b930",
+            "uncompressed-size": 2403794944
         },
         "vmware": {
-            "path": "rhcos-47.83.202102090044-0-vmware.x86_64.ova",
-            "sha256": "13d92692b8eed717ff8d0d113a24add339a65ef1f12eceeb99dabcd922cc86d1",
-            "size": 970915840
+            "path": "rhcos-48.83.202103122318-0-vmware.x86_64.ova",
+            "sha256": "14915912594124b114e9da64b2bafd34275c3c625f575f9a7d1f241f7b3d5b89",
+            "size": 975697920
         }
     },
     "oscontainer": {
-        "digest": "sha256:a32077727aa2ef96a1e2371dbcc53ba06f3d9727e836b72be0f0dd4513937e1e",
+        "digest": "sha256:26a56317f7a00edd94fa655d23e4ea693ca5845eb67c2fb91a0f73f9ba4f1b05",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "646a9832dd0dc9fe174a2fc005863a9582186518a5476522a0e9bdccc0e5252a",
-    "ostree-version": "47.83.202102090044-0"
+    "ostree-commit": "5f984a81182f9a1fac4c061732a4b22bee590291723d043aebbcbd922862c449",
+    "ostree-version": "48.83.202103122318-0"
 }


### PR DESCRIPTION
This bumps the RHCOS boot image address the LUKS problem described in RHBZ#1934174