### PR TITLE
Bug 1935174: bump RHCOS boot image for LUKS fixes

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-057e5df70c52dc128"
+            "hvm": "ami-0b4034b17be5a58e3"
         },
         "ap-east-1": {
-            "hvm": "ami-006ab68917f52bb13"
+            "hvm": "ami-0a72d5a92bfd16eb7"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0d236f6289c700771"
+            "hvm": "ami-011614749813955fc"
         },
         "ap-northeast-2": {
-            "hvm": "ami-040394572427a293a"
+            "hvm": "ami-0a2bf61499093d163"
         },
         "ap-south-1": {
-            "hvm": "ami-0838c978c0390dd75"
+            "hvm": "ami-0f52179be573dfde3"
         },
         "ap-southeast-1": {
-            "hvm": "ami-07af688c8b65de56f"
+            "hvm": "ami-018a25f7ea7ef044b"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a36faab6aa0a0dea"
+            "hvm": "ami-00ad10008a23980c5"
         },
         "ca-central-1": {
-            "hvm": "ami-01284e5815ce66a95"
+            "hvm": "ami-06f0b2a41abe6a02b"
         },
         "eu-central-1": {
-            "hvm": "ami-0361c06cf3e935cfe"
+            "hvm": "ami-009da52f46b591c9a"
         },
         "eu-north-1": {
-            "hvm": "ami-0080eb90a48d9655e"
+            "hvm": "ami-0b80f9365dd969010"
         },
         "eu-south-1": {
-            "hvm": "ami-0a3bc89f7aadf0343"
+            "hvm": "ami-0a2b8df219329cb9c"
         },
         "eu-west-1": {
-            "hvm": "ami-0b4024fa5cb2588bd"
+            "hvm": "ami-0d679aaea9d858720"
         },
         "eu-west-2": {
-            "hvm": "ami-07376355104ab4106"
+            "hvm": "ami-01a2124b25ffb5f9c"
         },
         "eu-west-3": {
-            "hvm": "ami-038f4ce9ea7ac7191"
+            "hvm": "ami-0bc023cc5ea1c7555"
         },
         "me-south-1": {
-            "hvm": "ami-025899013a24bb708"
+            "hvm": "ami-0f2d8c88021872d4e"
         },
         "sa-east-1": {
-            "hvm": "ami-089e1a3dcc5a5fe08"
+            "hvm": "ami-027237185f916ed13"
         },
         "us-east-1": {
-            "hvm": "ami-0d5f9982f029fbc14"
+            "hvm": "ami-0dc6b80559e7fddc3"
         },
         "us-east-2": {
-            "hvm": "ami-0c84b5c5255ec4777"
+            "hvm": "ami-0832c3a05ba97f423"
         },
         "us-west-1": {
-            "hvm": "ami-0b421328859954025"
+            "hvm": "ami-0255bba4587b27db0"
         },
         "us-west-2": {
-            "hvm": "ami-010de485a2ee23e5e"
+            "hvm": "ami-0b6c080a4b8013e9b"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202102090044-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102090044-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202103112143-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202103112143-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102090044-0/x86_64/",
-    "buildid": "47.83.202102090044-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202103112143-0/x86_64/",
+    "buildid": "47.83.202103112143-0",
     "gcp": {
-        "image": "rhcos-47-83-202102090044-0-gcp-x86-64",
+        "image": "rhcos-47-83-202103112143-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102090044-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202103112143-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202102090044-0-aws.x86_64.vmdk.gz",
-            "sha256": "ad54945302d9aaf0c5d6a5d1ee457325a3dcd88a68067d18a4d614acef5390d4",
-            "size": 951239242,
-            "uncompressed-sha256": "fbb7fbbc6cc6161ffa5c571f1b9022fe80038eea0a7f099c5b18ceba3b82f5eb",
-            "uncompressed-size": 970902016
+            "path": "rhcos-47.83.202103112143-0-aws.x86_64.vmdk.gz",
+            "sha256": "faceb209ca9eab8806d59ab54272ac23e298ef89dfc78c457b4a7c9db1bbadc2",
+            "size": 954900488,
+            "uncompressed-sha256": "3a0d5115ede83af21979d9304540a59b2a0c45a00dff300898f27324ba0a58eb",
+            "uncompressed-size": 974498304
         },
         "azure": {
-            "path": "rhcos-47.83.202102090044-0-azure.x86_64.vhd.gz",
-            "sha256": "32aa9be04b7f06bfe028fc7c93443f0c742afb006e73b6076016fa897ae5f716",
-            "size": 951756228,
-            "uncompressed-sha256": "7e60c02aeebd129a99d65da48beddb99bd29ac7b31f3bb9395fb1d87e6311448",
+            "path": "rhcos-47.83.202103112143-0-azure.x86_64.vhd.gz",
+            "sha256": "5380efdfc9df0190589b891e04cc6ffde11bc95e260a99639516430a80850420",
+            "size": 955244333,
+            "uncompressed-sha256": "45ec1ef53bc724eb11633957299dd90e59d14b89f1d586bbabc0fea968db15ba",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202102090044-0-gcp.x86_64.tar.gz",
-            "sha256": "07275bf2844f0dba6296d984d293959f614cc60af9f1be4070142a8cdcc650aa",
-            "size": 937047583
+            "path": "rhcos-47.83.202103112143-0-gcp.x86_64.tar.gz",
+            "sha256": "aefb93c0b656a9d6951d438caa0d65911ddcfee722e8163a075348c2a7c65030",
+            "size": 940577837
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202102090044-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "b81b26a61d11a9c2c6fb33a94ff124f461907bff550338cfecf173cdd93c09be",
-            "size": 937381841,
-            "uncompressed-sha256": "5b6fdfb53e3ede4d264d13862bda6801d932f12e1a17309ac62ac32836bca8ff",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-47.83.202103112143-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "e089ab281e582d7fd8e99fb8fe0a9f281b151d06e8abe978b4ce178fea6ed3e6",
+            "size": 940887746,
+            "uncompressed-sha256": "90053adb9ad0598195946a65df921cfd093038c872fc018ef3623ccf24f3cb49",
+            "uncompressed-size": 2366111744
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202102090044-0-live-initramfs.x86_64.img",
-            "sha256": "29ba7e12b16f143a3f036226568ce91b3f7c8bd6feab719a73b0bed1817e4444"
+            "path": "rhcos-47.83.202103112143-0-live-initramfs.x86_64.img",
+            "sha256": "2019f15015adf772cc0d6fd78704488f999b30475831b29271f2d11e573e9c67"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102090044-0-live.x86_64.iso",
-            "sha256": "b765a9e99edfa0a91778a4787070c6afcaa198ba8806c8c1533c34a23d63136f"
+            "path": "rhcos-47.83.202103112143-0-live.x86_64.iso",
+            "sha256": "cb09051b8ba9f475de5c1c782bf07994d08c68b114fa2f24ed177e5d233ec5dd"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102090044-0-live-kernel-x86_64",
-            "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
+            "path": "rhcos-47.83.202103112143-0-live-kernel-x86_64",
+            "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102090044-0-live-rootfs.x86_64.img",
-            "sha256": "6da4ae110fc2bcea8ac0e6c40fa9d701bbde5b936a1410f75735386c8ea805bf"
+            "path": "rhcos-47.83.202103112143-0-live-rootfs.x86_64.img",
+            "sha256": "bd2bda6a7bfc8de83496a17007c59455897b4dbcb311c445e00fedc97643e65f"
         },
         "metal": {
-            "path": "rhcos-47.83.202102090044-0-metal.x86_64.raw.gz",
-            "sha256": "0a456b02960eeb40a102ef14f5556843c2c504358f3db21f3fe667d8346c9bdf",
-            "size": 939085053,
-            "uncompressed-sha256": "36379d083adccccb3de266d2802cfcf5079429865fa010d9b499e87042d46526",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-47.83.202103112143-0-metal.x86_64.raw.gz",
+            "sha256": "fdbc1a588c6e002a243d6fa0e562f8b8aa8214e374b4840f85328e58e51ed130",
+            "size": 942500237,
+            "uncompressed-sha256": "4ec6255d61e9fd10465e1093d46aaa58d086a3ffed09d44ca352783fbded55db",
+            "uncompressed-size": 3725590528
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102090044-0-metal4k.x86_64.raw.gz",
-            "sha256": "ff10909c5d4ffbb3a829d070dcf3ce9a8b2d2aebff2924ee464d517eb948bfba",
-            "size": 936609970,
-            "uncompressed-sha256": "d5821d7fbd20f86bab29d028855200221f316fa041e86374c5f693da9b5d7b83",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-47.83.202103112143-0-metal4k.x86_64.raw.gz",
+            "sha256": "c3b26cdc6ece7cde71c24fd528a9a69f286eaa7fe843244979059094fa4f65c4",
+            "size": 940062632,
+            "uncompressed-sha256": "da281fa95f52296b7d9e75fe17d54f5519dc612b3badf7d94d5ed470ac6e1d9d",
+            "uncompressed-size": 3725590528
         },
         "openstack": {
-            "path": "rhcos-47.83.202102090044-0-openstack.x86_64.qcow2.gz",
-            "sha256": "e5ebb8bcf6d081e52e1e7db0e93ff960ff472e25803a5671170959212e88cad9",
-            "size": 937380970,
-            "uncompressed-sha256": "c1b93a426d0f74f0059193439e306f3356b788302a825cfadd870460e543028e",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-47.83.202103112143-0-openstack.x86_64.qcow2.gz",
+            "sha256": "0eba173e16554524354dc65446907fe87eec9bbb5d71f89035879e02f5a6b455",
+            "size": 940887400,
+            "uncompressed-sha256": "a3d97e57d05a956b2f04d8afee8503b220d91ca6c0067878020fb523504aec27",
+            "uncompressed-size": 2366111744
         },
         "ostree": {
-            "path": "rhcos-47.83.202102090044-0-ostree.x86_64.tar",
-            "sha256": "3b5fc040f7493ff7dc5aef4da22077ad74eb2e12a01a9e820d5c116e58716c4f",
-            "size": 863467520
+            "path": "rhcos-47.83.202103112143-0-ostree.x86_64.tar",
+            "sha256": "854ed627548c34840ec5ce7e8dc8005f180bd8b1bc7b73e34775dde8a9fc1a3a",
+            "size": 866979840
         },
         "qemu": {
-            "path": "rhcos-47.83.202102090044-0-qemu.x86_64.qcow2.gz",
-            "sha256": "2ca82f1d762bba1cb2e5ac1386be0a1ab0264cf88b0594c9cd1e53d285833c6d",
-            "size": 938521497,
-            "uncompressed-sha256": "5d31652c7856a87450dce1bbbb561b578ee75443c190096cb977a814e5f35935",
-            "uncompressed-size": 2394030080
+            "path": "rhcos-47.83.202103112143-0-qemu.x86_64.qcow2.gz",
+            "sha256": "220cf160c3b57edfae2a72b47106aece4aeb840cf0ccdb56eff6b1f569e779ba",
+            "size": 942055192,
+            "uncompressed-sha256": "041eb8df792d457264d70362f3fa4cf0f0a03d53c6cf11ea579177acfcb3a750",
+            "uncompressed-size": 2399993856
         },
         "vmware": {
-            "path": "rhcos-47.83.202102090044-0-vmware.x86_64.ova",
-            "sha256": "13d92692b8eed717ff8d0d113a24add339a65ef1f12eceeb99dabcd922cc86d1",
-            "size": 970915840
+            "path": "rhcos-47.83.202103112143-0-vmware.x86_64.ova",
+            "sha256": "f74077e50267f93b1df5a632c97b480c688d9528982a790646d0d1a23d0d9ba4",
+            "size": 974510080
         }
     },
     "oscontainer": {
-        "digest": "sha256:a32077727aa2ef96a1e2371dbcc53ba06f3d9727e836b72be0f0dd4513937e1e",
+        "digest": "sha256:0fd211adc21145555e63138789b5d59bd19a6487cab640e8ba9f95019f9e0b57",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "646a9832dd0dc9fe174a2fc005863a9582186518a5476522a0e9bdccc0e5252a",
-    "ostree-version": "47.83.202102090044-0"
+    "ostree-commit": "c4cac7df1dfebc7a5ae77ec1d6355294bd896970273f1a5c75717b2b8b0b1249",
+    "ostree-version": "47.83.202103112143-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202102091015-0/ppc64le/",
-    "buildid": "47.83.202102091015-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202103121110-0/ppc64le/",
+    "buildid": "47.83.202103121110-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-47.83.202102091015-0-live-initramfs.ppc64le.img",
-            "sha256": "a15c4eaaf5aa0176fc475e4ec41df4ca0e83595f7a5e561e2de0a26f8a485b60"
+            "path": "rhcos-47.83.202103121110-0-live-initramfs.ppc64le.img",
+            "sha256": "652d4ab254ccfbbed0d06f19f1c8987e5e115175a4280f7043921936c701c445"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102091015-0-live.ppc64le.iso",
-            "sha256": "d6fb6f949569461e3f9eb67883fa00b611275bb7d7bd3d9f11beaf1c0b33d389"
+            "path": "rhcos-47.83.202103121110-0-live.ppc64le.iso",
+            "sha256": "b249a364c6ec3456ada1fbd9175bc867025d415e8afdf68cba78a6113d5a0838"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102091015-0-live-kernel-ppc64le",
-            "sha256": "e310166a16592a5cd1bc152b07fda84278b251dc385cf000c65ed7bb31d254ea"
+            "path": "rhcos-47.83.202103121110-0-live-kernel-ppc64le",
+            "sha256": "75e8849d99f9eca4f408a331c332d61af1a5c40818e71d4953481f05e7384ca2"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102091015-0-live-rootfs.ppc64le.img",
-            "sha256": "621ed54c0cb5180e7e798778c5c365f04b328aa983bc5a752ecea3a17ffd5bce"
+            "path": "rhcos-47.83.202103121110-0-live-rootfs.ppc64le.img",
+            "sha256": "76108448ca1a96c6ec171bddfe1ade31f5c92f9804ac9263ff926077c04499a5"
         },
         "metal": {
-            "path": "rhcos-47.83.202102091015-0-metal.ppc64le.raw.gz",
-            "sha256": "d0fa64d744dd731ad3185b39ada8d6eb886c8dbba3e683a30176838bdf20ef9a",
-            "size": 918231587,
-            "uncompressed-sha256": "1880a77eed6741e45346102b85b5cceb071d7da5479b1075efd810767a33693c",
-            "uncompressed-size": 3888119808
+            "path": "rhcos-47.83.202103121110-0-metal.ppc64le.raw.gz",
+            "sha256": "13d654bf2ba2bca41e51912c63a754b58aa4d8b76acb49c154f375e8654a8190",
+            "size": 921373618,
+            "uncompressed-sha256": "41f6a2f559f0f6271f0873d0f4285793df6538203d0771adbc1112f4e1231064",
+            "uncompressed-size": 3898605568
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102091015-0-metal4k.ppc64le.raw.gz",
-            "sha256": "f6e4458958f38a7bccae4a89a73134d431b86b183ebcf76542446c959fa2d520",
-            "size": 918369582,
-            "uncompressed-sha256": "142ce5a0cb3984611a74d5d9d99ee6e320029802d2bee7c31d6b6b9455f3d293",
-            "uncompressed-size": 3888119808
+            "path": "rhcos-47.83.202103121110-0-metal4k.ppc64le.raw.gz",
+            "sha256": "1decca49cb5a983849e11237fce74db91fd64f660fb690594b9d8dba5adf9bba",
+            "size": 921680288,
+            "uncompressed-sha256": "70817946d34ecc097f8ca9c0177aa4c8dd2b023c013c4e552a762ada59173e0a",
+            "uncompressed-size": 3898605568
         },
         "openstack": {
-            "path": "rhcos-47.83.202102091015-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "47865a06d1ca6ae06481ab6f1d52ed6c9fca02ae539a06639c8bea65173a1550",
-            "size": 916498365,
-            "uncompressed-sha256": "443ed7133f49e36138ac7c452bedcca2d8fde02f818a43fce1d905d41d0a8cea",
-            "uncompressed-size": 2494431232
+            "path": "rhcos-47.83.202103121110-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "ad69eefe0de71e3ef78de59f65d95bfadc61d6a28085ea1a5ad4e3af905f4e56",
+            "size": 919711231,
+            "uncompressed-sha256": "975b79710df072a9eabdd618ce120dc3d682c6f1fa43fe4191a7d7a166db97c1",
+            "uncompressed-size": 2501509120
         },
         "ostree": {
-            "path": "rhcos-47.83.202102091015-0-ostree.ppc64le.tar",
-            "sha256": "118d9f3842d60e2f21e84b4561a9faea3e1ac72948a76a2e59969ff54f288f0a",
-            "size": 840714240
+            "path": "rhcos-47.83.202103121110-0-ostree.ppc64le.tar",
+            "sha256": "d2cf88cde86f5eb8625851c520d96fe6a8d5ed67c45eadfea887e47b7b5f0030",
+            "size": 844032000
         },
         "qemu": {
-            "path": "rhcos-47.83.202102091015-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "dce14413bb0347ffcb793a529ed2b4e39efa2b523a3e63faf552e574752a5aac",
-            "size": 917571073,
-            "uncompressed-sha256": "2044dd7198fd1f730c3fe1d68c422be7e06ed57b4ad28bfe402f4836b84be869",
-            "uncompressed-size": 2529296384
+            "path": "rhcos-47.83.202103121110-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "efde976517098638b35f8a6b22463a64725ed6b310a2a9c39e2fa5b5cdce7618",
+            "size": 920713690,
+            "uncompressed-sha256": "ca0911285b220927e79ccaf4b4669b321d25ecc9679b15e7773b493653f4617a",
+            "uncompressed-size": 2536374272
         }
     },
     "oscontainer": {
-        "digest": "sha256:6a410508e645cb24729fd860ae53a352b3df23a11d5747b0648d2f300a37de1d",
+        "digest": "sha256:e021a41971207da51592b9e2a45a2893b28c76813dc0c81b53998231f35238f6",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "b44e5d88d608175e62e95a35b59bd3e912327cfea036e5393169146af7512588",
-    "ostree-version": "47.83.202102091015-0"
+    "ostree-commit": "9b71bb774c809ebf1421747da1eb2d198f1168fb4948efb5bfb76efe93ad33aa",
+    "ostree-version": "47.83.202103121110-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202102090311-0/s390x/",
-    "buildid": "47.83.202102090311-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202103120011-0/s390x/",
+    "buildid": "47.83.202103120011-0",
     "images": {
         "dasd": {
-            "path": "rhcos-47.83.202102090311-0-dasd.s390x.raw.gz",
-            "sha256": "af39f736c9cd6bec61d4f7a098adcebc0b7583cd299339859c831380256c27d4",
-            "size": 831578576,
-            "uncompressed-sha256": "a390b9b95a1381ebec1736d4aa5d193f0820a41c6af79fc7283960b91fa4a861",
-            "uncompressed-size": 3516923904
+            "path": "rhcos-47.83.202103120011-0-dasd.s390x.raw.gz",
+            "sha256": "7238c3e423ce311b2b109304a55a35e3519c0047d29d8fa1ab2d2b4cdac731fe",
+            "size": 834984547,
+            "uncompressed-sha256": "af9b19bca1513a3d2b9aa17f465fc57bc487769890b178456a0a84e0ed13109a",
+            "uncompressed-size": 3527409664
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202102090311-0-live-initramfs.s390x.img",
-            "sha256": "07e5642b818ee9582f59050657dceecad4683c6c54c2f92b071549c8a4826e05"
+            "path": "rhcos-47.83.202103120011-0-live-initramfs.s390x.img",
+            "sha256": "ccd67e3fbf0e957fe5438510f1197188d65719b37555ca55d393496d3d3404ad"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102090311-0-live.s390x.iso",
-            "sha256": "e64d8d66bd69e6ea7ebdd9be74abce43e10e0731527ee6662780f20863ffc71c"
+            "path": "rhcos-47.83.202103120011-0-live.s390x.iso",
+            "sha256": "88526a6b0882e2e9c734de45649cdca5ce88459530aef89151a36dd32fc8304e"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102090311-0-live-kernel-s390x",
-            "sha256": "a0f17299369b9ce9e42c874a8cc3658a00e58144fc0f54849ef96d9414d811d0"
+            "path": "rhcos-47.83.202103120011-0-live-kernel-s390x",
+            "sha256": "7f0356ce47a620a24dcf5e61b598dbe644f8083ab96646a12f563ee0671253cc"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102090311-0-live-rootfs.s390x.img",
-            "sha256": "79de4fb97a151b051201eb04f291a1b36f54d3968d2c3f31571066da8231945a"
+            "path": "rhcos-47.83.202103120011-0-live-rootfs.s390x.img",
+            "sha256": "19be2f87ec775ad954a1ed6d78e40dfff9df0c009010dce67dc87acabf6b343b"
         },
         "metal": {
-            "path": "rhcos-47.83.202102090311-0-metal.s390x.raw.gz",
-            "sha256": "299bcb3de103f701866904f41e316e7c375fd1e0c4434b068e578a35d11084e1",
-            "size": 831763974,
-            "uncompressed-sha256": "ab0b1f6080c472f88dc418610cb6af2dd9e8aff835c9a7b417716f67c3e2e25d",
-            "uncompressed-size": 3516923904
+            "path": "rhcos-47.83.202103120011-0-metal.s390x.raw.gz",
+            "sha256": "2953c07e47c396d33d3fa74d8de50152065cc85914df1b9bc02ea158cf0b7bb8",
+            "size": 834871159,
+            "uncompressed-sha256": "63cfc26cdaed94c6a6c274af94d48f2beb1d1ee831c923c005d3e9aaa6006ad7",
+            "uncompressed-size": 3527409664
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102090311-0-metal4k.s390x.raw.gz",
-            "sha256": "566bca2f1462b4d70f1d7da7a1c7d477252f2e2db6251ee61f6e810c3a450982",
-            "size": 831520327,
-            "uncompressed-sha256": "3478e62963f4b0bba45cc41a92cae33e9907cc3e4ed1206ef94a05db4e70b9fe",
-            "uncompressed-size": 3516923904
+            "path": "rhcos-47.83.202103120011-0-metal4k.s390x.raw.gz",
+            "sha256": "d374069a312f71aadd51db217e6005e37162d8897016db4941c3ca40c25506fa",
+            "size": 835019104,
+            "uncompressed-sha256": "c6527dd849e2efc8c6bae42091da7a9db440f0481f82f0c780da85fd5622bb6d",
+            "uncompressed-size": 3527409664
         },
         "openstack": {
-            "path": "rhcos-47.83.202102090311-0-openstack.s390x.qcow2.gz",
-            "sha256": "4ebac56f35e48ff66b18ed21785f722272bc5b24573c2410f3d63a374eeab6db",
-            "size": 830070694,
-            "uncompressed-sha256": "2920cfe9a35e24302127507ab39e54d619c839d910361fe45c0c46dbd9813e7a",
-            "uncompressed-size": 2179530752
+            "path": "rhcos-47.83.202103120011-0-openstack.s390x.qcow2.gz",
+            "sha256": "b50f9066b5c9d86c0ffd7b4bafb201f3dcbd7f062163b2c9492376fccbe1754d",
+            "size": 833265597,
+            "uncompressed-sha256": "6d204e444a557b58d579e8cf001aff15ce3ea3fb8cdb00b55be87717e12c0570",
+            "uncompressed-size": 2187264000
         },
         "ostree": {
-            "path": "rhcos-47.83.202102090311-0-ostree.s390x.tar",
-            "sha256": "d7ed80d612fedcca6a39017e41851acbb35c5d0a8cce9c06df8afacfe059e310",
-            "size": 779970560
+            "path": "rhcos-47.83.202103120011-0-ostree.s390x.tar",
+            "sha256": "ccd078e77241fd766619dc463affed78608148ed13b3ab56adce97d960fe59e2",
+            "size": 783431680
         },
         "qemu": {
-            "path": "rhcos-47.83.202102090311-0-qemu.s390x.qcow2.gz",
-            "sha256": "80d61716f6ca97e9b5256b2202132dcac169700937b40545ce9cd8ad9e6bbcee",
-            "size": 831149363,
-            "uncompressed-sha256": "cc3b8294320a6635bfdf05a380fb931875a57fe6b18118940b1ce2f23ca069a1",
-            "uncompressed-size": 2213019648
+            "path": "rhcos-47.83.202103120011-0-qemu.s390x.qcow2.gz",
+            "sha256": "c2275e63b04728ce0dd78ca889ad246185b46bb7896822bef7d70f8adaf57719",
+            "size": 834418462,
+            "uncompressed-sha256": "7b01e9e90f568ca2d1a50416dccbb1bb5f41809a670bb75f45cf46ee695aef7d",
+            "uncompressed-size": 2220949504
         }
     },
     "oscontainer": {
-        "digest": "sha256:0e8147407a02605f0e4f79ac5e8ddfda21b7557769a26b9f7138e82dc9558af0",
+        "digest": "sha256:4bdd2e33c23b476a48ccdbeb510bf51a9bcaf7492feaefdd8b1d43fde3bf0b99",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ac18fdc352f3e1bcbf1c7d74f713f14de2c4117c869afd097432b5f8355e3781",
-    "ostree-version": "47.83.202102090311-0"
+    "ostree-commit": "15cfe26b138be814908ac7f5e819b307e6ca136c39f691c475c5fe60f4e23d0e",
+    "ostree-version": "47.83.202103120011-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,163 +1,163 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-057e5df70c52dc128"
+            "hvm": "ami-0b4034b17be5a58e3"
         },
         "ap-east-1": {
-            "hvm": "ami-006ab68917f52bb13"
+            "hvm": "ami-0a72d5a92bfd16eb7"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0d236f6289c700771"
+            "hvm": "ami-011614749813955fc"
         },
         "ap-northeast-2": {
-            "hvm": "ami-040394572427a293a"
+            "hvm": "ami-0a2bf61499093d163"
         },
         "ap-south-1": {
-            "hvm": "ami-0838c978c0390dd75"
+            "hvm": "ami-0f52179be573dfde3"
         },
         "ap-southeast-1": {
-            "hvm": "ami-07af688c8b65de56f"
+            "hvm": "ami-018a25f7ea7ef044b"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a36faab6aa0a0dea"
+            "hvm": "ami-00ad10008a23980c5"
         },
         "ca-central-1": {
-            "hvm": "ami-01284e5815ce66a95"
+            "hvm": "ami-06f0b2a41abe6a02b"
         },
         "eu-central-1": {
-            "hvm": "ami-0361c06cf3e935cfe"
+            "hvm": "ami-009da52f46b591c9a"
         },
         "eu-north-1": {
-            "hvm": "ami-0080eb90a48d9655e"
+            "hvm": "ami-0b80f9365dd969010"
         },
         "eu-south-1": {
-            "hvm": "ami-0a3bc89f7aadf0343"
+            "hvm": "ami-0a2b8df219329cb9c"
         },
         "eu-west-1": {
-            "hvm": "ami-0b4024fa5cb2588bd"
+            "hvm": "ami-0d679aaea9d858720"
         },
         "eu-west-2": {
-            "hvm": "ami-07376355104ab4106"
+            "hvm": "ami-01a2124b25ffb5f9c"
         },
         "eu-west-3": {
-            "hvm": "ami-038f4ce9ea7ac7191"
+            "hvm": "ami-0bc023cc5ea1c7555"
         },
         "me-south-1": {
-            "hvm": "ami-025899013a24bb708"
+            "hvm": "ami-0f2d8c88021872d4e"
         },
         "sa-east-1": {
-            "hvm": "ami-089e1a3dcc5a5fe08"
+            "hvm": "ami-027237185f916ed13"
         },
         "us-east-1": {
-            "hvm": "ami-0d5f9982f029fbc14"
+            "hvm": "ami-0dc6b80559e7fddc3"
         },
         "us-east-2": {
-            "hvm": "ami-0c84b5c5255ec4777"
+            "hvm": "ami-0832c3a05ba97f423"
         },
         "us-west-1": {
-            "hvm": "ami-0b421328859954025"
+            "hvm": "ami-0255bba4587b27db0"
         },
         "us-west-2": {
-            "hvm": "ami-010de485a2ee23e5e"
+            "hvm": "ami-0b6c080a4b8013e9b"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202102090044-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102090044-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202103112143-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202103112143-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102090044-0/x86_64/",
-    "buildid": "47.83.202102090044-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202103112143-0/x86_64/",
+    "buildid": "47.83.202103112143-0",
     "gcp": {
-        "image": "rhcos-47-83-202102090044-0-gcp-x86-64",
+        "image": "rhcos-47-83-202103112143-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102090044-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202103112143-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202102090044-0-aws.x86_64.vmdk.gz",
-            "sha256": "ad54945302d9aaf0c5d6a5d1ee457325a3dcd88a68067d18a4d614acef5390d4",
-            "size": 951239242,
-            "uncompressed-sha256": "fbb7fbbc6cc6161ffa5c571f1b9022fe80038eea0a7f099c5b18ceba3b82f5eb",
-            "uncompressed-size": 970902016
+            "path": "rhcos-47.83.202103112143-0-aws.x86_64.vmdk.gz",
+            "sha256": "faceb209ca9eab8806d59ab54272ac23e298ef89dfc78c457b4a7c9db1bbadc2",
+            "size": 954900488,
+            "uncompressed-sha256": "3a0d5115ede83af21979d9304540a59b2a0c45a00dff300898f27324ba0a58eb",
+            "uncompressed-size": 974498304
         },
         "azure": {
-            "path": "rhcos-47.83.202102090044-0-azure.x86_64.vhd.gz",
-            "sha256": "32aa9be04b7f06bfe028fc7c93443f0c742afb006e73b6076016fa897ae5f716",
-            "size": 951756228,
-            "uncompressed-sha256": "7e60c02aeebd129a99d65da48beddb99bd29ac7b31f3bb9395fb1d87e6311448",
+            "path": "rhcos-47.83.202103112143-0-azure.x86_64.vhd.gz",
+            "sha256": "5380efdfc9df0190589b891e04cc6ffde11bc95e260a99639516430a80850420",
+            "size": 955244333,
+            "uncompressed-sha256": "45ec1ef53bc724eb11633957299dd90e59d14b89f1d586bbabc0fea968db15ba",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202102090044-0-gcp.x86_64.tar.gz",
-            "sha256": "07275bf2844f0dba6296d984d293959f614cc60af9f1be4070142a8cdcc650aa",
-            "size": 937047583
+            "path": "rhcos-47.83.202103112143-0-gcp.x86_64.tar.gz",
+            "sha256": "aefb93c0b656a9d6951d438caa0d65911ddcfee722e8163a075348c2a7c65030",
+            "size": 940577837
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202102090044-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "b81b26a61d11a9c2c6fb33a94ff124f461907bff550338cfecf173cdd93c09be",
-            "size": 937381841,
-            "uncompressed-sha256": "5b6fdfb53e3ede4d264d13862bda6801d932f12e1a17309ac62ac32836bca8ff",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-47.83.202103112143-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "e089ab281e582d7fd8e99fb8fe0a9f281b151d06e8abe978b4ce178fea6ed3e6",
+            "size": 940887746,
+            "uncompressed-sha256": "90053adb9ad0598195946a65df921cfd093038c872fc018ef3623ccf24f3cb49",
+            "uncompressed-size": 2366111744
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202102090044-0-live-initramfs.x86_64.img",
-            "sha256": "29ba7e12b16f143a3f036226568ce91b3f7c8bd6feab719a73b0bed1817e4444"
+            "path": "rhcos-47.83.202103112143-0-live-initramfs.x86_64.img",
+            "sha256": "2019f15015adf772cc0d6fd78704488f999b30475831b29271f2d11e573e9c67"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102090044-0-live.x86_64.iso",
-            "sha256": "b765a9e99edfa0a91778a4787070c6afcaa198ba8806c8c1533c34a23d63136f"
+            "path": "rhcos-47.83.202103112143-0-live.x86_64.iso",
+            "sha256": "cb09051b8ba9f475de5c1c782bf07994d08c68b114fa2f24ed177e5d233ec5dd"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102090044-0-live-kernel-x86_64",
-            "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
+            "path": "rhcos-47.83.202103112143-0-live-kernel-x86_64",
+            "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102090044-0-live-rootfs.x86_64.img",
-            "sha256": "6da4ae110fc2bcea8ac0e6c40fa9d701bbde5b936a1410f75735386c8ea805bf"
+            "path": "rhcos-47.83.202103112143-0-live-rootfs.x86_64.img",
+            "sha256": "bd2bda6a7bfc8de83496a17007c59455897b4dbcb311c445e00fedc97643e65f"
         },
         "metal": {
-            "path": "rhcos-47.83.202102090044-0-metal.x86_64.raw.gz",
-            "sha256": "0a456b02960eeb40a102ef14f5556843c2c504358f3db21f3fe667d8346c9bdf",
-            "size": 939085053,
-            "uncompressed-sha256": "36379d083adccccb3de266d2802cfcf5079429865fa010d9b499e87042d46526",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-47.83.202103112143-0-metal.x86_64.raw.gz",
+            "sha256": "fdbc1a588c6e002a243d6fa0e562f8b8aa8214e374b4840f85328e58e51ed130",
+            "size": 942500237,
+            "uncompressed-sha256": "4ec6255d61e9fd10465e1093d46aaa58d086a3ffed09d44ca352783fbded55db",
+            "uncompressed-size": 3725590528
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102090044-0-metal4k.x86_64.raw.gz",
-            "sha256": "ff10909c5d4ffbb3a829d070dcf3ce9a8b2d2aebff2924ee464d517eb948bfba",
-            "size": 936609970,
-            "uncompressed-sha256": "d5821d7fbd20f86bab29d028855200221f316fa041e86374c5f693da9b5d7b83",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-47.83.202103112143-0-metal4k.x86_64.raw.gz",
+            "sha256": "c3b26cdc6ece7cde71c24fd528a9a69f286eaa7fe843244979059094fa4f65c4",
+            "size": 940062632,
+            "uncompressed-sha256": "da281fa95f52296b7d9e75fe17d54f5519dc612b3badf7d94d5ed470ac6e1d9d",
+            "uncompressed-size": 3725590528
         },
         "openstack": {
-            "path": "rhcos-47.83.202102090044-0-openstack.x86_64.qcow2.gz",
-            "sha256": "e5ebb8bcf6d081e52e1e7db0e93ff960ff472e25803a5671170959212e88cad9",
-            "size": 937380970,
-            "uncompressed-sha256": "c1b93a426d0f74f0059193439e306f3356b788302a825cfadd870460e543028e",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-47.83.202103112143-0-openstack.x86_64.qcow2.gz",
+            "sha256": "0eba173e16554524354dc65446907fe87eec9bbb5d71f89035879e02f5a6b455",
+            "size": 940887400,
+            "uncompressed-sha256": "a3d97e57d05a956b2f04d8afee8503b220d91ca6c0067878020fb523504aec27",
+            "uncompressed-size": 2366111744
         },
         "ostree": {
-            "path": "rhcos-47.83.202102090044-0-ostree.x86_64.tar",
-            "sha256": "3b5fc040f7493ff7dc5aef4da22077ad74eb2e12a01a9e820d5c116e58716c4f",
-            "size": 863467520
+            "path": "rhcos-47.83.202103112143-0-ostree.x86_64.tar",
+            "sha256": "854ed627548c34840ec5ce7e8dc8005f180bd8b1bc7b73e34775dde8a9fc1a3a",
+            "size": 866979840
         },
         "qemu": {
-            "path": "rhcos-47.83.202102090044-0-qemu.x86_64.qcow2.gz",
-            "sha256": "2ca82f1d762bba1cb2e5ac1386be0a1ab0264cf88b0594c9cd1e53d285833c6d",
-            "size": 938521497,
-            "uncompressed-sha256": "5d31652c7856a87450dce1bbbb561b578ee75443c190096cb977a814e5f35935",
-            "uncompressed-size": 2394030080
+            "path": "rhcos-47.83.202103112143-0-qemu.x86_64.qcow2.gz",
+            "sha256": "220cf160c3b57edfae2a72b47106aece4aeb840cf0ccdb56eff6b1f569e779ba",
+            "size": 942055192,
+            "uncompressed-sha256": "041eb8df792d457264d70362f3fa4cf0f0a03d53c6cf11ea579177acfcb3a750",
+            "uncompressed-size": 2399993856
         },
         "vmware": {
-            "path": "rhcos-47.83.202102090044-0-vmware.x86_64.ova",
-            "sha256": "13d92692b8eed717ff8d0d113a24add339a65ef1f12eceeb99dabcd922cc86d1",
-            "size": 970915840
+            "path": "rhcos-47.83.202103112143-0-vmware.x86_64.ova",
+            "sha256": "f74077e50267f93b1df5a632c97b480c688d9528982a790646d0d1a23d0d9ba4",
+            "size": 974510080
         }
     },
     "oscontainer": {
-        "digest": "sha256:a32077727aa2ef96a1e2371dbcc53ba06f3d9727e836b72be0f0dd4513937e1e",
+        "digest": "sha256:0fd211adc21145555e63138789b5d59bd19a6487cab640e8ba9f95019f9e0b57",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "646a9832dd0dc9fe174a2fc005863a9582186518a5476522a0e9bdccc0e5252a",
-    "ostree-version": "47.83.202102090044-0"
+    "ostree-commit": "c4cac7df1dfebc7a5ae77ec1d6355294bd896970273f1a5c75717b2b8b0b1249",
+    "ostree-version": "47.83.202103112143-0"
 }


### PR DESCRIPTION
This bumps the RHCOS boot images to address the LUKS problem
described in RHBZ#1934863