### PR TITLE
gcp: divide machine CIDR into 2 networks for subnets

### DIFF
--- a/data/data/gcp/main.tf
+++ b/data/data/gcp/main.tf
@@ -1,8 +1,8 @@
 locals {
   labels = var.gcp_extra_labels
 
-  master_subnet_cidr = cidrsubnet(var.machine_v4_cidrs[0], 3, 0) #master subnet is a smaller subnet within the vnet. i.e from /21 to /24
-  worker_subnet_cidr = cidrsubnet(var.machine_v4_cidrs[0], 3, 1) #worker subnet is a smaller subnet within the vnet. i.e from /21 to /24
+  master_subnet_cidr = cidrsubnet(var.machine_v4_cidrs[0], 1, 0) #master subnet is a smaller subnet within the vnet. e.g., from /21 to /22
+  worker_subnet_cidr = cidrsubnet(var.machine_v4_cidrs[0], 1, 1) #worker subnet is a smaller subnet within the vnet. e.g., from /21 to /22
   public_endpoints   = var.gcp_publish_strategy == "External" ? true : false
 
   gcp_image   = var.gcp_preexisting_image ? var.gcp_image : google_compute_image.cluster[0].self_link

--- a/docs/user/gcp/install_upi.md
+++ b/docs/user/gcp/install_upi.md
@@ -237,8 +237,8 @@ openshift-vw9j6
 export BASE_DOMAIN='example.com'
 export BASE_DOMAIN_ZONE_NAME='example'
 export NETWORK_CIDR='10.0.0.0/16'
-export MASTER_SUBNET_CIDR='10.0.0.0/19'
-export WORKER_SUBNET_CIDR='10.0.32.0/19'
+export MASTER_SUBNET_CIDR='10.0.0.0/17'
+export WORKER_SUBNET_CIDR='10.0.128.0/17'
 
 export KUBECONFIG=auth/kubeconfig
 export CLUSTER_NAME=$(jq -r .clusterName metadata.json)
@@ -277,8 +277,8 @@ EOF
 ```
 - `infra_id`: the infrastructure name (INFRA_ID above)
 - `region`: the region to deploy the cluster into (for example us-east1)
-- `master_subnet_cidr`: the CIDR for the master subnet (for example 10.0.0.0/19)
-- `worker_subnet_cidr`: the CIDR for the worker subnet (for example 10.0.32.0/19)
+- `master_subnet_cidr`: the CIDR for the master subnet (for example 10.0.0.0/17)
+- `worker_subnet_cidr`: the CIDR for the worker subnet (for example 10.0.128.0/17)
 
 Create the deployment using gcloud.
 


### PR DESCRIPTION
Instead of dividing the IPv4 machine CIDR into 8 networks and only using 2 of those 8, divide into only 2 networks.

https://issues.redhat.com/browse/CORS-1660