### PR TITLE
cmd: diagnose problems downloading release image

### DIFF
--- a/cmd/openshift-install/analyze.go
+++ b/cmd/openshift-install/analyze.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/installer/pkg/gather/service"
+)
+
+var (
+	analyzeOpts struct {
+		gatherBundle string
+	}
+)
+
+func newAnalyzeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "analyze",
+		Short: "Analyze debugging data for a given installation failure",
+		Long: `Analyze debugging data for a given installation failure.
+
+This command helps users to analyze the reasons for an installation that failed while bootstrapping.`,
+		Args: cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			gatherBundle := analyzeOpts.gatherBundle
+			if gatherBundle == "" {
+				var err error
+				gatherBundle, err = getGatherBundleFromAssetsDirectory()
+				if err != nil {
+					logrus.Fatal(err)
+				}
+			}
+			if !filepath.IsAbs(gatherBundle) {
+				gatherBundle = filepath.Join(rootOpts.dir, gatherBundle)
+			}
+			if err := service.AnalyzeGatherBundle(gatherBundle); err != nil {
+				logrus.Fatal(err)
+			}
+		},
+	}
+	cmd.PersistentFlags().StringVar(&analyzeOpts.gatherBundle, "file", "", "Filename of the bootstrap gather bundle; either absolute or relative to the assets directory")
+	return cmd
+}
+
+func getGatherBundleFromAssetsDirectory() (string, error) {
+	matches, err := filepath.Glob(filepath.Join(rootOpts.dir, "log-bundle-*.tar.gz"))
+	if err != nil {
+		return "", errors.Wrap(err, "could not find gather bundles in assets directory")
+	}
+	switch len(matches) {
+	case 0:
+		return "", errors.New("no bootstrap gather bundles found in assets directory")
+	case 1:
+		return matches[0], nil
+	default:
+		return "", errors.New("multiple bootstrap gather bundles found in assets directory; select specific gather bundle by using the --file flag")
+	}
+}

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -32,6 +32,7 @@ import (
 	assetstore "github.com/openshift/installer/pkg/asset/store"
 	targetassets "github.com/openshift/installer/pkg/asset/targets"
 	destroybootstrap "github.com/openshift/installer/pkg/destroy/bootstrap"
+	"github.com/openshift/installer/pkg/gather/service"
 	timer "github.com/openshift/installer/pkg/metrics/timer"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
@@ -115,11 +116,15 @@ var (
 					if err2 := logClusterOperatorConditions(ctx, config); err2 != nil {
 						logrus.Error("Attempted to gather ClusterOperator status after installation failure: ", err2)
 					}
-					if err2 := runGatherBootstrapCmd(rootOpts.dir); err2 != nil {
+					bundlePath, err2 := runGatherBootstrapCmd(rootOpts.dir)
+					if err2 != nil {
 						logrus.Error("Attempted to gather debug logs after installation failure: ", err2)
 					}
 					logrus.Error("Bootstrap failed to complete: ", err.Unwrap())
 					logrus.Error(err.Error())
+					if err2 := service.AnalyzeGatherBundle(bundlePath); err2 != nil {
+						logrus.Error("Attempted to analyze the debug logs after installation failure: ", err2)
+					}
 					logrus.Fatal("Bootstrap failed to complete")
 				}
 				timer.StopTimer("Bootstrap Complete")

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -58,6 +58,7 @@ func installerMain() {
 		newDestroyCmd(),
 		newWaitForCmd(),
 		newGatherCmd(),
+		newAnalyzeCmd(),
 		newVersionCmd(),
 		newGraphCmd(),
 		newCoreOSCmd(),

--- a/pkg/gather/service/analyze.go
+++ b/pkg/gather/service/analyze.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// AnalyzeGatherBundle will analyze the bootstrap gather bundle at the specified path.
+// Analysis will be logged.
+// Returns an error if there was a problem reading the bundle.
+func AnalyzeGatherBundle(bundlePath string) error {
+	// open the bundle file for reading
+	bundleFile, err := os.Open(bundlePath)
+	if err != nil {
+		return errors.Wrap(err, "could not open the gather bundle")
+	}
+	defer bundleFile.Close()
+	return analyzeGatherBundle(bundleFile)
+}
+
+func analyzeGatherBundle(bundleFile io.Reader) error {
+	// decompress the bundle
+	uncompressedStream, err := gzip.NewReader(bundleFile)
+	if err != nil {
+		return errors.Wrap(err, "could not decompress the gather bundle")
+	}
+	defer uncompressedStream.Close()
+
+	// read through the tar for relevant files
+	tarReader := tar.NewReader(uncompressedStream)
+	var releaseImageAnalysis *analysis
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return errors.Wrap(err, "encountered an error reading from the gather bundle")
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		filenameParts := strings.SplitN(header.Name, "/", 2)
+		if len(filenameParts) != 2 {
+			continue
+		}
+		// we only care about the release-image.service for now. in the future, we will look at other services, too.
+		if filenameParts[1] == "bootstrap/services/release-image.json" {
+			var err error
+			releaseImageAnalysis, err = analyzeService(tarReader)
+			if err != nil {
+				logrus.Infof("Could not analyze the release-image.service: %v", err)
+			}
+			break
+		}
+	}
+
+	// log details about the release-image.service.
+	if releaseImageAnalysis != nil && releaseImageAnalysis.starts > 0 {
+		if !releaseImageAnalysis.successful {
+			logrus.Error("The bootstrap machine failed to download the release image")
+			for _, l := range strings.Split(releaseImageAnalysis.lastError, "\n") {
+				logrus.Info(l)
+			}
+		}
+	} else {
+		logrus.Error("The bootstrap machine did not execute the release-image.service systemd unit")
+	}
+
+	return nil
+}
+
+type analysis struct {
+	// starts is the number of times that the service started
+	starts int
+	// successful is true if the last invocation of the service ended in success
+	successful bool
+	// failingStage is the stage that failed in the last unsuccessful invocation of the service
+	failingStage string
+	// lastError is the last error recorded in the last failure of the service
+	lastError string
+}
+
+func analyzeService(r io.Reader) (*analysis, error) {
+	a := &analysis{}
+	decoder := json.NewDecoder(r)
+	t, err := decoder.Token()
+	if err != nil {
+		return a, errors.Wrap(err, "service entries file does not begin with a token")
+	}
+	delim, isDelim := t.(json.Delim)
+	if !isDelim {
+		return a, errors.New("service entries file does not begin with a delimiter")
+	}
+	if delim != '[' {
+		return a, errors.New("service entries file does not begin with an array")
+	}
+	var lastEntry *Entry
+	for decoder.More() {
+		entry := &Entry{}
+		if err := decoder.Decode(entry); err != nil {
+			return nil, errors.Wrap(err, "could not decode an entry in the service entries file")
+		}
+
+		// record a new start of the service
+		if entry.Phase == ServiceStart {
+			a.starts++
+		}
+
+		// the service is only considered considered successful if the very last entry is either the service ending
+		// successfully or a post-command ending successfully.
+		a.successful = entry.Result == Success && (entry.Phase == ServiceEnd || entry.Phase == PostCommandEnd)
+
+		// save the last error
+		if entry.Result == Failure {
+			// if a stage failure causes a service (or pre- or post-command) failure, we want to preserve the failing
+			// stage from the stage end entry.
+			if lastEntry == nil || lastEntry.Phase != StageEnd || lastEntry.Result != Failure {
+				a.failingStage = entry.Stage
+			}
+			a.lastError = entry.ErrorMessage
+		}
+		lastEntry = entry
+	}
+	return a, nil
+}

--- a/pkg/gather/service/analyze_test.go
+++ b/pkg/gather/service/analyze_test.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnalyzeGatherBundle(t *testing.T) {
+	cases := []struct {
+		name           string
+		files          map[string]string
+		expectedOutput []logrus.Entry
+	}{
+		{
+			name: "no files",
+			expectedOutput: []logrus.Entry{
+				{Level: logrus.ErrorLevel, Message: "The bootstrap machine did not execute the release-image.service systemd unit"},
+			},
+		},
+		{
+			name: "release-image not started",
+			files: map[string]string{
+				"log-bundle/bootstrap/services/release-image.json": "[]",
+			},
+			expectedOutput: []logrus.Entry{
+				{Level: logrus.ErrorLevel, Message: "The bootstrap machine did not execute the release-image.service systemd unit"},
+			},
+		},
+		{
+			name: "release-image successful",
+			files: map[string]string{
+				"log-bundle/bootstrap/services/release-image.json": `[
+{"phase":"service start"},
+{"phase":"stage start", "stage":"pull-release-image"},
+{"phase":"stage end", "stage":"pull-release-image", "result":"success"},
+{"phase":"service end", "result":"success"}
+]`,
+			},
+		},
+		{
+			name: "release-image failed",
+			files: map[string]string{
+				"log-bundle/bootstrap/services/release-image.json": `[
+{"phase":"service start"},
+{"phase":"stage start", "stage":"pull-release-image"},
+{"phase":"stage end", "stage":"pull-release-image", "result":"failure", "errorMessage":"Line 1\nLine 2\nLine 3"}
+]`,
+			},
+			expectedOutput: []logrus.Entry{
+				{Level: logrus.ErrorLevel, Message: "The bootstrap machine failed to download the release image"},
+				{Level: logrus.InfoLevel, Message: "Line 1"},
+				{Level: logrus.InfoLevel, Message: "Line 2"},
+				{Level: logrus.InfoLevel, Message: "Line 3"},
+			},
+		},
+		{
+			name: "empty release-image.json",
+			files: map[string]string{
+				"log-bundle/bootstrap/services/release-image.json": "",
+			},
+			expectedOutput: []logrus.Entry{
+				{Level: logrus.InfoLevel, Message: "Could not analyze the release-image.service: service entries file does not begin with a token: EOF"},
+				{Level: logrus.ErrorLevel, Message: "The bootstrap machine did not execute the release-image.service systemd unit"},
+			},
+		},
+		{
+			name: "malformed release-image.json",
+			files: map[string]string{
+				"log-bundle/bootstrap/services/release-image.json": "{}",
+			},
+			expectedOutput: []logrus.Entry{
+				{Level: logrus.InfoLevel, Message: "Could not analyze the release-image.service: service entries file does not begin with an array"},
+				{Level: logrus.ErrorLevel, Message: "The bootstrap machine did not execute the release-image.service systemd unit"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gatherBuilder bytes.Buffer
+			gzipWriter := gzip.NewWriter(&gatherBuilder)
+			defer gzipWriter.Close()
+			tarWriter := tar.NewWriter(gzipWriter)
+			defer tarWriter.Close()
+			for filename, contents := range tc.files {
+				contentsAsBytes := []byte(contents)
+				if err := tarWriter.WriteHeader(&tar.Header{
+					Typeflag: tar.TypeReg,
+					Name:     filename,
+					Size:     int64(len(contentsAsBytes)),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := tarWriter.Write(contentsAsBytes); err != nil {
+					t.Fatal(err)
+				}
+			}
+			gzipWriter.Close()
+			hook := test.NewLocal(logrus.StandardLogger())
+			defer hook.Reset()
+			err := analyzeGatherBundle(&gatherBuilder)
+			assert.NoError(t, err, "unexpected error from analysis")
+			for i, e := range hook.Entries {
+				hook.Entries[i] = logrus.Entry{
+					Level:   e.Level,
+					Message: e.Message,
+				}
+			}
+			assert.Equal(t, tc.expectedOutput, hook.Entries)
+		})
+	}
+}

--- a/pkg/gather/service/doc.go
+++ b/pkg/gather/service/doc.go
@@ -1,0 +1,2 @@
+// Package service is used to analyze service json files from an installation that failing to bootstrap.
+package service

--- a/pkg/gather/service/entry.go
+++ b/pkg/gather/service/entry.go
@@ -1,0 +1,58 @@
+package service
+
+// Entry is an entry in a service entries file
+type Entry struct {
+	// Timestamp is the time at which the entry was recorded
+	Timestamp string `json:"timestamp"`
+	// Phase is the phase of the service
+	Phase Phase `json:"phase"`
+	// Result is the result of either the service, the stage, the pre-command, or the post-command. This is only
+	// present when the phase is an ending phase.
+	Result Result `json:"result,omitempty"`
+	// Stage is the name of the stage being executed. This is only present when the phase is either StageStart or StageEnd.
+	Stage string `json:"string,omitempty"`
+	// PreCommand is the name of the pre-command being executed. This is only present when the phase is either
+	// PreCommandStart or PreCommandEnd.
+	PreCommand string `json:"preCommand,omitempty"`
+	// PostCommand is the name of the post-command being executed. This is only present when the phase is either
+	// PostCommandStart or PostCommandEnd.
+	PostCommand string `json:"postCommand,omitempty"`
+	// ErrorLine is the location where the error occurred that caused the failure. This is only present when the result
+	// is Failure.
+	ErrorLine string `json:"errorLine,omitempty"`
+	// ErrorMessage is the last few output messages from the service prior to the error. This is only present when the
+	// result is Failure.
+	ErrorMessage string `json:"errorMessage,omitempty"`
+}
+
+// Phase is the phase of the service.
+type Phase string
+
+const (
+	// ServiceStart is the phase when the main command of the service starts.
+	ServiceStart Phase = "service start"
+	// ServiceEnd is the phase when the main command of the service ends.
+	ServiceEnd Phase = "service end"
+	// StageStart is the phase when a stage of the service starts.
+	StageStart Phase = "stage start"
+	// StageEnd is the phase when a stage of the service ends.
+	StageEnd Phase = "stage end"
+	// PreCommandStart is the phase when a pre-command of the service starts.
+	PreCommandStart Phase = "pre-command start"
+	// PreCommandEnd is the phase when a pre-command of the service ends.
+	PreCommandEnd Phase = "pre-command end"
+	// PostCommandStart is the phase when a post-command of the service starts.
+	PostCommandStart Phase = "post-command start"
+	// PostCommandEnd is the phase when a post-command of the service ends.
+	PostCommandEnd Phase = "post-command end"
+)
+
+// Result is the result of either the service, the stage, the pre-command, or the post-command.
+type Result string
+
+const (
+	// Success indicates that the service, stage, pre-command, or post-command was successful.
+	Success Result = "success"
+	// Failure indicates that the service, stage, pre-command, or post-command ended due to a failure.
+	Failure Result = "failure"
+)

--- a/vendor/github.com/sirupsen/logrus/hooks/test/test.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/test/test.go
@@ -1,0 +1,91 @@
+// The Test package is used for testing logrus.
+// It provides a simple hooks which register logged messages.
+package test
+
+import (
+	"io/ioutil"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Hook is a hook designed for dealing with logs in test scenarios.
+type Hook struct {
+	// Entries is an array of all entries that have been received by this hook.
+	// For safe access, use the AllEntries() method, rather than reading this
+	// value directly.
+	Entries []logrus.Entry
+	mu      sync.RWMutex
+}
+
+// NewGlobal installs a test hook for the global logger.
+func NewGlobal() *Hook {
+
+	hook := new(Hook)
+	logrus.AddHook(hook)
+
+	return hook
+
+}
+
+// NewLocal installs a test hook for a given local logger.
+func NewLocal(logger *logrus.Logger) *Hook {
+
+	hook := new(Hook)
+	logger.Hooks.Add(hook)
+
+	return hook
+
+}
+
+// NewNullLogger creates a discarding logger and installs the test hook.
+func NewNullLogger() (*logrus.Logger, *Hook) {
+
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	return logger, NewLocal(logger)
+
+}
+
+func (t *Hook) Fire(e *logrus.Entry) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Entries = append(t.Entries, *e)
+	return nil
+}
+
+func (t *Hook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// LastEntry returns the last entry that was logged or nil.
+func (t *Hook) LastEntry() *logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	i := len(t.Entries) - 1
+	if i < 0 {
+		return nil
+	}
+	return &t.Entries[i]
+}
+
+// AllEntries returns all entries that were logged.
+func (t *Hook) AllEntries() []*logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	// Make a copy so the returned value won't race with future log requests
+	entries := make([]*logrus.Entry, len(t.Entries))
+	for i := 0; i < len(t.Entries); i++ {
+		// Make a copy, for safety
+		entries[i] = &t.Entries[i]
+	}
+	return entries
+}
+
+// Reset removes all Entries from this test hook.
+func (t *Hook) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Entries = make([]logrus.Entry, 0)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1219,6 +1219,7 @@ github.com/shurcooL/vfsgen
 # github.com/sirupsen/logrus v1.7.0
 ## explicit
 github.com/sirupsen/logrus
+github.com/sirupsen/logrus/hooks/test
 # github.com/spf13/afero v1.3.5
 github.com/spf13/afero
 github.com/spf13/afero/mem


### PR DESCRIPTION
When an installation fails during bootstrapping, analyze the bootstrap gather bundle for problems with downloading the release image. This analysis uses data from the new service entries files.

https://issues.redhat.com/browse/CORS-1533

Sample output when pull secret is not valid.
```
$ ./bin/openshift-install gather bootstrap
INFO Pulling debug logs from the bootstrap machine
INFO Bootstrap gather logs captured here "log-bundle-20210313180900.tar.gz"
ERROR The bootstrap machine failed to download the release image
INFO Error: unable to pull registry.ci.openshift.org/ocp/release:4.8.0-0.nightly-2021-03-12-142603: Error initializing source docker://registry.ci.openshift.org/ocp/release:4.8.0-0.nightly-2021-03-12-142603: Error reading manifest 4.8.0-0.nightly-2021-03-12-142603 in registry.ci.openshift.org/ocp/release: unauthorized: authentication required
INFO Pull failed. Retrying registry.ci.openshift.org/ocp/release:4.8.0-0.nightly-2021-03-12-142603...
INFO Error: unable to pull registry.ci.openshift.org/ocp/release:4.8.0-0.nightly-2021-03-12-142603: Error initializing source docker://registry.ci.openshift.org/ocp/release:4.8.0-0.nightly-2021-03-12-142603: Error reading manifest 4.8.0-0.nightly-2021-03-12-142603 in registry.ci.openshift.org/ocp/release: unauthorized: authentication required
```

Also, add an `analyze` command to analyze an existing bootstrap gather bundle.