### PR TITLE
Bug 1931974: Prefer IPv6 hostIP on bootstrap IPv6 deployments

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/kubelet.sh.template
@@ -9,6 +9,9 @@
     --container-runtime=remote \
     --container-runtime-endpoint=/var/run/crio/crio.sock \
     --runtime-request-timeout="${KUBELET_RUNTIME_REQUEST_TIMEOUT}" \
+{{- if .UseIPv6ForNodeIP }}
+    --node-ip=:: \
+{{- end}}
     --pod-manifest-path=/etc/kubernetes/manifests \
     --minimum-container-ttl-duration=6m0s \
     --cluster-domain=cluster.local \


### PR DESCRIPTION
Kubelet can end up choosing IPv4 addresses as its hostIP, which after:

https://github.com/openshift/cluster-kube-apiserver-operator/pull/1042/files

mean that the kubernetes API service ends up with an endpoint being an
IPv4 address.  This breaks the kubernetes API loadbalancer in the
service network and prevent the deployment from succeeding.