### PR TITLE
Bug 1939513: KubeVirt platform: Add the immediate request annotation to the source PVC

### DIFF
--- a/data/data/kubevirt/datavolume/main.tf
+++ b/data/data/kubevirt/datavolume/main.tf
@@ -3,6 +3,9 @@ resource "kubevirt_data_volume" "data_volume" {
     name      = var.pvc_name
     namespace = var.namespace
     labels    = var.labels
+    annotations = {
+      "cdi.kubevirt.io/storage.bind.immediate.requested" = "true"
+    }
   }
   spec {
     source {


### PR DESCRIPTION
This change is done in order to support CDI behavior change and
prevent from having "WaitForFirstConsumer" phase on the dv - source PVC