### PR TITLE
  Inject CoreOS stream metadata as configmap via CVO manifest

### DIFF
--- a/hack/build-coreos-manifest.go
+++ b/hack/build-coreos-manifest.go
@@ -1,0 +1,73 @@
+// We want to keep the stream metadata stored "directly"
+// in git so it's easy to read and validate.  This build
+// script is invoked as part of the container build to
+// inject the data into a ConfigMap that will be installed
+// via CVO manifests into the target cluster, and maintained
+// across upgrades.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	streamJSON = "data/data/rhcos-stream.json"
+	dest       = "bin/manifests/coreos-bootimages.json"
+)
+
+func run() error {
+	bootimages, err := ioutil.ReadFile(streamJSON)
+	if err != nil {
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-machine-config-operator",
+			Name:      "coreos-bootimages",
+			Annotations: map[string]string{
+				"include.release.openshift.io/ibm-cloud-managed":              "true",
+				"include.release.openshift.io/self-managed-high-availability": "true",
+				"include.release.openshift.io/single-node-developer":          "true",
+			},
+		},
+		Data: map[string]string{
+			"releaseVersion": "0.0.1-snapshot",
+			"stream":         string(bootimages),
+		},
+	}
+
+	b, err := json.Marshal(cm)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(dest, b, 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -5,13 +5,17 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS b
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
+RUN go run -mod=vendor hack/build-coreos-manifest.go
 
 
 FROM registry.ci.openshift.org/ocp/4.8:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
+COPY --from=builder /go/src/github.com/openshift/installer/bin/manifests/ /manifests/
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output
 WORKDIR /output
+# We're not really an operator, we're just getting some data into the release image.
+LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/bin/openshift-install"]


### PR DESCRIPTION

Split out from #4582

This copies the bits from https://github.com/cgwalters/rhel-coreos-bootimages
which builds a ConfigMap out of the stream metadata and injects
it into the cluster.

We have an `installer` image in the release image today; this adds
the "is an operator" label, even though it's not really an
operator.  We just want the CVO to inject the manifest.

Among other important semantics, this will ensure that in-place
cluster upgrades that have new pinned CoreOS stream data will
have this configmap updated.

