### PR TITLE
docs/user/aws/customization: Fix KMS-key link format

### DIFF
--- a/docs/user/aws/customization.md
+++ b/docs/user/aws/customization.md
@@ -20,7 +20,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
         This is only valid for `type` `io1`.
     * `size` (optional integer): Size of the root volume in gibibytes (GiB).
     * `type` (optional string):  The [type of volume][volume-type].
-    * `kmsKeyARN` (optional string): The [ARN of KMS key][ebs-kms-key] that should be used to encrypt the EBS volume.
+    * `kmsKeyARN` (optional string): The [ARN of KMS key][kms-key] that should be used to encrypt the EBS volume.
         When no key is specified by user, the account's [default KMS Key][kms-key-default] for the region will be used.
         Example ARN values are: `arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab` or `arn:aws:kms:us-east-1:111122223333:alias/my-key`
 * `type` (optional string): The [EC2 instance type][instance-type].


### PR DESCRIPTION
Fix a disconnect about the slug to use for the reference link from 17030b3bdb (#3293).