### PR TITLE
aws: ensure default resource created for vpcs are tagged

### DIFF
--- a/data/data/aws/vpc/vpc.tf
+++ b/data/data/aws/vpc/vpc.tf
@@ -46,3 +46,27 @@ resource "aws_vpc_dhcp_options_association" "main" {
   vpc_id          = data.aws_vpc.cluster_vpc.id
   dhcp_options_id = aws_vpc_dhcp_options.main[0].id
 }
+
+resource "aws_ec2_tag" "new_vpc_default_network_acl" {
+  for_each = var.vpc == null ? var.tags : {}
+
+  resource_id = aws_vpc.new_vpc[0].default_network_acl_id
+  key         = each.key
+  value       = each.value
+}
+
+resource "aws_ec2_tag" "new_vpc_default_route_table" {
+  for_each = var.vpc == null ? var.tags : {}
+
+  resource_id = aws_vpc.new_vpc[0].default_route_table_id
+  key         = each.key
+  value       = each.value
+}
+
+resource "aws_ec2_tag" "new_vpc_default_security_group" {
+  for_each = var.vpc == null ? var.tags : {}
+
+  resource_id = aws_vpc.new_vpc[0].default_security_group_id
+  key         = each.key
+  value       = each.value
+}


### PR DESCRIPTION
When an AWS VPC is created, a default network ACL, route table, and security group are created for the VPC. The installer
has not been tagging those resources. This commit adds to code in the terraform to add all of the tags to those three resources after the VPC is created.

Since the network acl is now being tagged, the AWS destroyer needs to know how to handle network acls. This commit adds
code to delete network acls, skipping the default one since it cannot be deleted. Ultimately, there are no additional deletions performed by the destroyer as the network acl that is newly tagged is the default for the VPC and so is skipped.

https://issues.redhat.com/browse/CORS-1657