### PR TITLE
Fix ipv6/dual-stack validation with Azure

### DIFF
--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -89,11 +89,6 @@ variable "use_ipv6" {
   description = "This value determines if this is cluster should use IPv6 networking."
 }
 
-variable "emulate_single_stack_ipv6" {
-  type        = bool
-  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
-}
-
 variable "outbound_udr" {
   type    = bool
   default = false

--- a/data/data/azure/dns/dns.tf
+++ b/data/data/azure/dns/dns.tf
@@ -18,8 +18,6 @@ resource "azureprivatedns_zone_virtual_network_link" "network" {
 }
 
 resource "azureprivatedns_a_record" "apiint_internal" {
-  // TODO: internal LB should block v4 for better single stack emulation (&& ! var.emulate_single_stack_ipv6)
-  //   but RHCoS initramfs can't do v6 and so fails to ignite. https://issues.redhat.com/browse/GRPA-1343 
   count = var.use_ipv4 ? 1 : 0
 
   name                = "api-int"
@@ -40,8 +38,6 @@ resource "azureprivatedns_aaaa_record" "apiint_internal_v6" {
 }
 
 resource "azureprivatedns_a_record" "api_internal" {
-  // TODO: internal LB should block v4 for better single stack emulation (&& ! var.emulate_single_stack_ipv6)
-  //   but RHCoS initramfs can't do v6 and so fails to ignite. https://issues.redhat.com/browse/GRPA-1343 
   count = var.use_ipv4 ? 1 : 0
 
   name                = "api"

--- a/data/data/azure/dns/variables.tf
+++ b/data/data/azure/dns/variables.tf
@@ -68,8 +68,3 @@ variable "use_ipv6" {
   type        = bool
   description = "This value determines if this is cluster should use IPv6 networking."
 }
-
-variable "emulate_single_stack_ipv6" {
-  type        = bool
-  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
-}

--- a/data/data/azure/main.tf
+++ b/data/data/azure/main.tf
@@ -45,9 +45,8 @@ module "bootstrap" {
   private                = module.vnet.private
   outbound_udr           = var.azure_outbound_user_defined_routing
 
-  use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
-  use_ipv6                  = var.use_ipv6
-  emulate_single_stack_ipv6 = var.azure_emulate_single_stack_ipv6
+  use_ipv4 = var.use_ipv4
+  use_ipv6 = var.use_ipv6
 }
 
 module "vnet" {
@@ -67,9 +66,8 @@ module "vnet" {
   private                     = var.azure_private
   outbound_udr                = var.azure_outbound_user_defined_routing
 
-  use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
-  use_ipv6                  = var.use_ipv6
-  emulate_single_stack_ipv6 = var.azure_emulate_single_stack_ipv6
+  use_ipv4 = var.use_ipv4
+  use_ipv6 = var.use_ipv6
 }
 
 module "master" {
@@ -94,9 +92,8 @@ module "master" {
   private                = module.vnet.private
   outbound_udr           = var.azure_outbound_user_defined_routing
 
-  use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
-  use_ipv6                  = var.use_ipv6
-  emulate_single_stack_ipv6 = var.azure_emulate_single_stack_ipv6
+  use_ipv4 = var.use_ipv4
+  use_ipv6 = var.use_ipv6
 }
 
 module "dns" {
@@ -113,9 +110,8 @@ module "dns" {
   base_domain_resource_group_name = var.azure_base_domain_resource_group_name
   private                         = module.vnet.private
 
-  use_ipv4                  = var.use_ipv4 || var.azure_emulate_single_stack_ipv6
-  use_ipv6                  = var.use_ipv6
-  emulate_single_stack_ipv6 = var.azure_emulate_single_stack_ipv6
+  use_ipv4 = var.use_ipv4
+  use_ipv6 = var.use_ipv6
 }
 
 resource "random_string" "storage_suffix" {

--- a/data/data/azure/master/variables.tf
+++ b/data/data/azure/master/variables.tf
@@ -106,11 +106,6 @@ variable "use_ipv6" {
   description = "This value determines if this is cluster should use IPv6 networking."
 }
 
-variable "emulate_single_stack_ipv6" {
-  type        = bool
-  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
-}
-
 variable "outbound_udr" {
   type    = bool
   default = false

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -125,11 +125,6 @@ variable "azure_private" {
   description = "This determines if this is a private cluster or not."
 }
 
-variable "azure_emulate_single_stack_ipv6" {
-  type = bool
-  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
-}
-
 variable "azure_outbound_user_defined_routing" {
   type = bool
   default = false

--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -11,8 +11,6 @@ resource "azurerm_lb" "internal" {
 
   dynamic "frontend_ip_configuration" {
     for_each = [for ip in [
-      // TODO: internal LB should block v4 for better single stack emulation (&& ! var.emulate_single_stack_ipv6)
-      //   but RHCoS initramfs can't do v6 and so fails to ignite. https://issues.redhat.com/browse/GRPA-1343 
       { name : local.internal_lb_frontend_ip_v4_configuration_name, ipv6 : false, include : var.use_ipv4 },
       { name : local.internal_lb_frontend_ip_v6_configuration_name, ipv6 : true, include : var.use_ipv6 },
       ] : {

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -31,8 +31,6 @@ output "internal_lb_ip_v4_address" {
 }
 
 output "internal_lb_ip_v6_address" {
-  // TODO: internal LB should block v4 for better single stack emulation (&& ! var.emulate_single_stack_ipv6)
-  //   but RHCoS initramfs can't do v6 and so fails to ignite. https://issues.redhat.com/browse/GRPA-1343 
   value = var.use_ipv6 ? azurerm_lb.internal.private_ip_addresses[1] : null
 }
 

--- a/data/data/azure/vnet/variables.tf
+++ b/data/data/azure/vnet/variables.tf
@@ -72,11 +72,6 @@ variable "use_ipv6" {
   description = "This value determines if this is cluster should use IPv6 networking."
 }
 
-variable "emulate_single_stack_ipv6" {
-  type        = bool
-  description = "This determines whether a dual-stack cluster is configured to emulate single-stack IPv6."
-}
-
 variable "outbound_udr" {
   type    = bool
   default = false

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"encoding/json"
-	"os"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
@@ -42,7 +41,6 @@ type config struct {
 	PreexistingNetwork          bool              `json:"azure_preexisting_network"`
 	Private                     bool              `json:"azure_private"`
 	OutboundUDR                 bool              `json:"azure_outbound_user_defined_routing"`
-	EmulateSingleStackIPv6      bool              `json:"azure_emulate_single_stack_ipv6"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -71,11 +69,6 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		masterAvailabilityZones[i] = to.String(c.Zone)
 	}
 
-	var emulateSingleStackIPv6 bool
-	if os.Getenv("OPENSHIFT_INSTALL_AZURE_EMULATE_SINGLESTACK_IPV6") == "true" {
-		emulateSingleStackIPv6 = true
-	}
-
 	environment, err := environment(sources.CloudName)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not determine Azure environment to use for Terraform")
@@ -100,7 +93,6 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ControlPlaneSubnet:          masterConfig.Subnet,
 		ComputeSubnet:               workerConfig.Subnet,
 		PreexistingNetwork:          sources.PreexistingNetwork,
-		EmulateSingleStackIPv6:      emulateSingleStackIPv6,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 	"sort"
 	"strings"
 
@@ -221,12 +220,6 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 		switch {
 		case p.BareMetal != nil:
 		case p.None != nil:
-
-		case p.Azure != nil && os.Getenv("OPENSHIFT_INSTALL_AZURE_EMULATE_SINGLESTACK_IPV6") == "true":
-			if !presence["machineNetwork"].IPv4 || !presence["machineNetwork"].IPv6 {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "IPv6", "OPENSHIFT_INSTALL_AZURE_EMULATE_SINGLESTACK_IPV6 requires both IPv4 and IPv6 machineNetwork values"))
-			}
-
 		default:
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "IPv6", "single-stack IPv6 is not supported for this platform"))
 		}

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	dockerref "github.com/containers/image/docker/reference"
@@ -194,8 +196,10 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking", "serviceNetwork"), strings.Join(ipnetworksToStrings(n.ServiceNetwork), ", "), "when installing dual-stack IPv4/IPv6 you must provide two service networks, one for each IP address type"))
 		}
 
+		experimentalDualStackEnabled, _ := strconv.ParseBool(os.Getenv("OPENSHIFT_INSTALL_EXPERIMENTAL_DUAL_STACK"))
 		switch {
-		case p.Azure != nil:
+		case p.Azure != nil && experimentalDualStackEnabled:
+			logrus.Warnf("Using experimental Azure dual-stack support")
 		case p.BareMetal != nil:
 		case p.None != nil:
 		default:


### PR DESCRIPTION
The installer considers Azure to be a supported platform for IPv6 and dual-stack because of our early plans for testing, but single-stack IPv6 on Azure never worked, and dual-stack on Azure has never been tested and is not supported in 4.8.

