### PR TITLE
asset/tls: fixes certkey unit test for Go >= 1.15

### DIFF
--- a/pkg/asset/tls/certkey_test.go
+++ b/pkg/asset/tls/certkey_test.go
@@ -24,6 +24,7 @@ func TestSignedCertKeyGenerate(t *testing.T) {
 				Subject:   pkix.Name{CommonName: "test0-ca", OrganizationalUnit: []string{"openshift"}},
 				KeyUsages: x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 				Validity:  ValidityTenYears,
+				DNSNames:  []string{"test.openshift.io"},
 			},
 			filenameBase: "test0-ca",
 			appendParent: DoNotAppendParent,


### PR DESCRIPTION
In Go 1.15 treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is now disabled by default (see [release notes](https://golang.org/doc/go1.15#commonname)).

This leads to the following error in the "simple ca" test case when running with Go >=1.15:

```
x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

I think it is safe to amend this test csae. I didn't manage to find any instances where certs without SAN values (`DNSNames`) are being verified against `x509.VerifyOptions` with hostnames. I'm however not 100% sure that I found everytinhg and would like to hear feedback from someone with more experience in this area.