### PR TITLE
Enable forward compatibility with kcmo rendering of signing keypair

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -198,6 +198,15 @@ then
 	cp kube-controller-manager-bootstrap/bootstrap-manifests/* bootstrap-manifests/
 	cp kube-controller-manager-bootstrap/manifests/* manifests/
 
+	# Temporary check to provide forwards compatibility with ckcmo taking
+	# over responsibility for rendering the token signing keypair.
+	if [ -d kube-controller-manager-bootstrap/tls ]
+	then
+		# Copy the service account signing keypair for use by the
+		# bootstrap controller manager and apiserver.
+		cp kube-controller-manager-bootstrap/tls/* tls/
+	fi
+
 	touch kube-controller-manager-bootstrap.done
 fi
 


### PR DESCRIPTION
This change is the first step in migrating responsibility for token keypair generation from the installer to operator render. This will ensure parity with ckao which already renders the bound token keypair.

/cc @staebler @soltysh  