### PR TITLE
[wip] [do not merge] vsphere - force to hardware 15

### DIFF
--- a/data/data/vsphere/master/main.tf
+++ b/data/data/vsphere/master/main.tf
@@ -16,6 +16,8 @@ resource "vsphere_virtual_machine" "vm" {
   enable_disk_uuid     = "true"
   annotation           = local.description
 
+  hardware_version     = 15
+
   wait_for_guest_net_timeout  = "0"
   wait_for_guest_net_routable = "false"
 


### PR DESCRIPTION
There looks to be an issue with hardware version greater than 13
and tx checksum offload.

Just submitting this to test.