### PR TITLE
    Bug 1934557: RHCOS boot image bump for LUKS fixes

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,163 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-01dd4193042351d0e"
+            "hvm": "ami-0b5c3b497fe4bc2ea"
         },
         "ap-east-1": {
-            "hvm": "ami-06320ea2b751acf5d"
+            "hvm": "ami-0a6976bcfac70580e"
         },
         "ap-northeast-1": {
-            "hvm": "ami-05368806cdd6277c7"
+            "hvm": "ami-06cbc55d814a971e4"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0b2f40b281ab6903b"
+            "hvm": "ami-045e0e1127cf9d4ff"
+        },
+        "ap-northeast-3": {
+            "hvm": "ami-0afb77eabb999b7bc"
         },
         "ap-south-1": {
-            "hvm": "ami-0d5ce4ca4898224ec"
+            "hvm": "ami-0c0ac18b571fa1298"
         },
         "ap-southeast-1": {
-            "hvm": "ami-008a33d6dbd81dbcc"
+            "hvm": "ami-06c10f60b7fff5dd1"
         },
         "ap-southeast-2": {
-            "hvm": "ami-01d3b84d2c25d2717"
+            "hvm": "ami-0da31b1166a996615"
         },
         "ca-central-1": {
-            "hvm": "ami-0ac50d7fd990f5332"
+            "hvm": "ami-044a1b0f991f4d652"
         },
         "eu-central-1": {
-            "hvm": "ami-0b3149eff8c1b1d97"
+            "hvm": "ami-0202025e3392eec53"
         },
         "eu-north-1": {
-            "hvm": "ami-0d9cbf9387a9dc7e2"
+            "hvm": "ami-02a90294ae67d27a6"
         },
         "eu-south-1": {
-            "hvm": "ami-0d840e28d95f8e128"
+            "hvm": "ami-09873171555f02ad5"
         },
         "eu-west-1": {
-            "hvm": "ami-0558ed15ea50b830b"
+            "hvm": "ami-0bc1151abfa614bf4"
         },
         "eu-west-2": {
-            "hvm": "ami-013b367c221b23698"
+            "hvm": "ami-0be1650f9c65ad6d1"
         },
         "eu-west-3": {
-            "hvm": "ami-016224e83820dd23e"
+            "hvm": "ami-0007ebc2005ce3bc0"
         },
         "me-south-1": {
-            "hvm": "ami-0ceac1bfed40e9cbf"
+            "hvm": "ami-0330aad497d9769a4"
         },
         "sa-east-1": {
-            "hvm": "ami-076cab8be8d32f123"
+            "hvm": "ami-06fb2c7c2b7ec3ff4"
         },
         "us-east-1": {
-            "hvm": "ami-08f15e9f159732a9b"
+            "hvm": "ami-0146091f9e1b5ec3f"
         },
         "us-east-2": {
-            "hvm": "ami-07a0bede859e1639d"
+            "hvm": "ami-04e591bf6aa86fd31"
         },
         "us-west-1": {
-            "hvm": "ami-0b8c56daaa6be3f97"
+            "hvm": "ami-02b960e0d5a5dc325"
         },
         "us-west-2": {
-            "hvm": "ami-0ba922fcef999ec3d"
+            "hvm": "ami-0c6da162537298ad6"
         }
     },
     "azure": {
-        "image": "rhcos-48.83.202103122318-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.83.202103122318-0-azure.x86_64.vhd"
+        "image": "rhcos-48.83.202103221318-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.83.202103221318-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.83.202103122318-0/x86_64/",
-    "buildid": "48.83.202103122318-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.83.202103221318-0/x86_64/",
+    "buildid": "48.83.202103221318-0",
     "gcp": {
-        "image": "rhcos-48-83-202103122318-0-gcp-x86-64",
+        "image": "rhcos-48-83-202103221318-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-83-202103122318-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-83-202103221318-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.83.202103122318-0-aws.x86_64.vmdk.gz",
-            "sha256": "fbe1f2571516db1b423c83b4c82385f887c7a80c28fe978e5df39bcea360a63a",
-            "size": 956011781,
-            "uncompressed-sha256": "ef749748fedcafda0bc49f159645542eac19cd49fd3dc665b19c8c24c3a378bd",
-            "uncompressed-size": 975684096
+            "path": "rhcos-48.83.202103221318-0-aws.x86_64.vmdk.gz",
+            "sha256": "df74c7d7e063101efdc0ef2c54dcc780dba52aea744f2166acf32c0de27a2187",
+            "size": 955986915,
+            "uncompressed-sha256": "e2cf1919cd67832a2dff5936403a148793214b86b3e1930369db9ae79810bc0e",
+            "uncompressed-size": 975638528
         },
         "azure": {
-            "path": "rhcos-48.83.202103122318-0-azure.x86_64.vhd.gz",
-            "sha256": "f195c680a0064142497eb0e883c1127bc979e0ed595f7af3c61588beac93aa8d",
-            "size": 956294196,
-            "uncompressed-sha256": "d42a2c59bb07d76068768f98a2818bbe02b27b4d9f33320e97a724c03eac8591",
+            "path": "rhcos-48.83.202103221318-0-azure.x86_64.vhd.gz",
+            "sha256": "97a5928cc65cee6500233525f6519c6fee61222a0874eb49de26eccdbe92ab97",
+            "size": 956392217,
+            "uncompressed-sha256": "4b8bac9c2f576a1d9845b52c227e731abd22d317baa91fb88b58ccb8aef13530",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.83.202103122318-0-gcp.x86_64.tar.gz",
-            "sha256": "835c1188ec940cf3416fedef1297f23d1ad9fc4ccbc878ab92894b7e75db2408",
-            "size": 941572226
+            "path": "rhcos-48.83.202103221318-0-gcp.x86_64.tar.gz",
+            "sha256": "e37d44e41fba4e0854896cc9fe932e2ea87bf7292fb436f14c54074d50145276",
+            "size": 941690377
         },
         "ibmcloud": {
-            "path": "rhcos-48.83.202103122318-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "4935c16039bcc1224e37c6d901783ac2858e8b8aa1f98a68320e55089f647e20",
-            "size": 941914922,
-            "uncompressed-sha256": "d8053881cb97d412a7d0279fea51a5fb67cabe9bc26051c88bd84c97038c360f",
-            "uncompressed-size": 2369781760
+            "path": "rhcos-48.83.202103221318-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "e6400e3385e7d27de7a14ebd2faa77a41967c5722431f591e206741ffb7e47b8",
+            "size": 942010183,
+            "uncompressed-sha256": "9b697d882e78750f7b5cca6198bf7f2d7f83fad72459705548025b378a618dc2",
+            "uncompressed-size": 2370437120
         },
         "live-initramfs": {
-            "path": "rhcos-48.83.202103122318-0-live-initramfs.x86_64.img",
-            "sha256": "a761505051ec5d3833b94634031947a8c8595f3a9175358ec1259b25917b6dd8"
+            "path": "rhcos-48.83.202103221318-0-live-initramfs.x86_64.img",
+            "sha256": "15047567c01e189ae17e9ba5d1a35fecac3f5cfe724b59b13bbddd0cfefea6b6"
         },
         "live-iso": {
-            "path": "rhcos-48.83.202103122318-0-live.x86_64.iso",
-            "sha256": "fb58004d0b8abbd0a3ad7645f639f80d939e8e308fb5fe3e51f89a54f5bfe5b5"
+            "path": "rhcos-48.83.202103221318-0-live.x86_64.iso",
+            "sha256": "671b2055eb7cbf35172a591b668d67e49db95f6b48f46264a48d2ea57c56529d"
         },
         "live-kernel": {
-            "path": "rhcos-48.83.202103122318-0-live-kernel-x86_64",
+            "path": "rhcos-48.83.202103221318-0-live-kernel-x86_64",
             "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
         },
         "live-rootfs": {
-            "path": "rhcos-48.83.202103122318-0-live-rootfs.x86_64.img",
-            "sha256": "dbace7d56388034b38edb645a661e7e2b2039116f70470a4a1e2577d395f124d"
+            "path": "rhcos-48.83.202103221318-0-live-rootfs.x86_64.img",
+            "sha256": "0a8dc2ec128d1979cff024311a63c3651e5027b4edb636ecaf103a30eed12a99"
         },
         "metal": {
-            "path": "rhcos-48.83.202103122318-0-metal.x86_64.raw.gz",
-            "sha256": "9009586f9d95cc19958f2259a7f33fd47fc9f1bcc498d91bf5c7432262fba067",
-            "size": 943625068,
-            "uncompressed-sha256": "66ea3ce8a73e1fd315dc7612a0f11134bb6ba96bfe5df28d1e30a67dc7d3867b",
+            "path": "rhcos-48.83.202103221318-0-metal.x86_64.raw.gz",
+            "sha256": "5535e22dd5ea4c5174058bea8e4392941811f3b2a0409112c67a4ca77f8ec0fe",
+            "size": 943825625,
+            "uncompressed-sha256": "7b374a6da510f8b392ff8ab384777d79e636d4fcf782f897cea7512557208698",
             "uncompressed-size": 3729784832
         },
         "metal4k": {
-            "path": "rhcos-48.83.202103122318-0-metal4k.x86_64.raw.gz",
-            "sha256": "6498ae0259bba73140fee655367181dd6214ff3d51b6dc054c236f9e2d8bda09",
-            "size": 941326627,
-            "uncompressed-sha256": "85e3e2c0222c1380b012604b9ed536328abacfe25abe201957f575fb9c2adf82",
+            "path": "rhcos-48.83.202103221318-0-metal4k.x86_64.raw.gz",
+            "sha256": "2aa4cd8fa051d46857936040341d8ce38f851f230bb3cb991795a9de021d5a9e",
+            "size": 941369865,
+            "uncompressed-sha256": "b10222db6717752acbbb7b7396e26f43d2bab8193128736fcf91da3cba29d9b8",
             "uncompressed-size": 3729784832
         },
         "openstack": {
-            "path": "rhcos-48.83.202103122318-0-openstack.x86_64.qcow2.gz",
-            "sha256": "0c6f320c4fe2e4f09442ab24bb59618928ad55001c3a00db182792f765c9ee13",
-            "size": 941914638,
-            "uncompressed-sha256": "371378fd1beaf80607736eab386d61d44e70be591556ef9c2b6cd4ae56c57d5d",
-            "uncompressed-size": 2369781760
+            "path": "rhcos-48.83.202103221318-0-openstack.x86_64.qcow2.gz",
+            "sha256": "323e7ba4ba3448e340946543c963823136e1367ed0b229d2a05e1cf537642bb8",
+            "size": 942011087,
+            "uncompressed-sha256": "10f55ea6f71d4dc382183597f9360aad6c6551fcc94aa100bbdadaecfe888452",
+            "uncompressed-size": 2370437120
         },
         "ostree": {
-            "path": "rhcos-48.83.202103122318-0-ostree.x86_64.tar",
-            "sha256": "4a2d8cc6d8a3846d9944c538fd41a70204db6d304e07e02143c3ed8554d47989",
-            "size": 868136960
+            "path": "rhcos-48.83.202103221318-0-ostree.x86_64.tar",
+            "sha256": "f5779b639151af682902f86d2d2b55604391bb7a2736d281701cc60e1f264967",
+            "size": 868270080
         },
         "qemu": {
-            "path": "rhcos-48.83.202103122318-0-qemu.x86_64.qcow2.gz",
-            "sha256": "b7e1d1f4c9c859d12417502131b28ac5fc06aa695cc1cb68dc09886bb84997c0",
-            "size": 943081124,
-            "uncompressed-sha256": "f5bbc7ffb720f7073ec4382207bf419c38b1aa1af338aaaf7076d4a0a2c7b930",
-            "uncompressed-size": 2403794944
+            "path": "rhcos-48.83.202103221318-0-qemu.x86_64.qcow2.gz",
+            "sha256": "795bb00f37fc797517eb29fe4032ae4211ce4c23590e4605899ec07a51818776",
+            "size": 943124225,
+            "uncompressed-sha256": "7a84fe943cf7eaed8d500b0aabd8386df07af9d7092e45b5554fa68ebf166505",
+            "uncompressed-size": 2404188160
         },
         "vmware": {
-            "path": "rhcos-48.83.202103122318-0-vmware.x86_64.ova",
-            "sha256": "14915912594124b114e9da64b2bafd34275c3c625f575f9a7d1f241f7b3d5b89",
-            "size": 975697920
+            "path": "rhcos-48.83.202103221318-0-vmware.x86_64.ova",
+            "sha256": "19d15c0815dce4448c6edcca36eebff18f56f829594568f954c0ca914639bafb",
+            "size": 975646720
         }
     },
     "oscontainer": {
-        "digest": "sha256:26a56317f7a00edd94fa655d23e4ea693ca5845eb67c2fb91a0f73f9ba4f1b05",
+        "digest": "sha256:3f0c628ec5d669a574ad114c89f4af9e669e7da89e7a2705c95fe83e98eaf570",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "5f984a81182f9a1fac4c061732a4b22bee590291723d043aebbcbd922862c449",
-    "ostree-version": "48.83.202103122318-0"
+    "ostree-commit": "328a44d7c259ca1e3ed31ae020f09d922f460be998657a92f684f6760443077b",
+    "ostree-version": "48.83.202103221318-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.83.202103131019-0/ppc64le/",
-    "buildid": "48.83.202103131019-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.83.202103221319-0/ppc64le/",
+    "buildid": "48.83.202103221319-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-48.83.202103131019-0-live-initramfs.ppc64le.img",
-            "sha256": "cc5b7229f8906a9703874f8e91efbd8444d1e99d7ab91b40fea8db1947560f6f"
+            "path": "rhcos-48.83.202103221319-0-live-initramfs.ppc64le.img",
+            "sha256": "5fc821205a2e91fa26575da916c7f267b0c1b43873f1c14917339e80337c6a71"
         },
         "live-iso": {
-            "path": "rhcos-48.83.202103131019-0-live.ppc64le.iso",
-            "sha256": "791ccc3fa2246e0c9bb63b0e506d40c5f873e6e02602bef2643d373b20a6cafd"
+            "path": "rhcos-48.83.202103221319-0-live.ppc64le.iso",
+            "sha256": "6084ddfb76dde60799753574e76ae0d10fc9e4207aad768085e4d3a5d4b79349"
         },
         "live-kernel": {
-            "path": "rhcos-48.83.202103131019-0-live-kernel-ppc64le",
+            "path": "rhcos-48.83.202103221319-0-live-kernel-ppc64le",
             "sha256": "75e8849d99f9eca4f408a331c332d61af1a5c40818e71d4953481f05e7384ca2"
         },
         "live-rootfs": {
-            "path": "rhcos-48.83.202103131019-0-live-rootfs.ppc64le.img",
-            "sha256": "6e2a4baad42295b7ec8d9abb20590bc224dfa52eabf6eab1168c4f916c3a1616"
+            "path": "rhcos-48.83.202103221319-0-live-rootfs.ppc64le.img",
+            "sha256": "76b7aa2ca23a0495fd7c343d90429a868b37b511918f7d2cbeb919eca7bd9f0b"
         },
         "metal": {
-            "path": "rhcos-48.83.202103131019-0-metal.ppc64le.raw.gz",
-            "sha256": "d29d8c49ed145db0534b4780fa160ac5f27e89c7a6794611145d56f20f72eb2b",
-            "size": 922632425,
-            "uncompressed-sha256": "86fc00f47b8cbfa9114cc5a337222ac5549f32b31cf29aa47488b0d4c8d5b5e3",
-            "uncompressed-size": 3904897024
+            "path": "rhcos-48.83.202103221319-0-metal.ppc64le.raw.gz",
+            "sha256": "a2256b02555f541e71c65f60e4d093b71d3274219821c0f2a2957af9a53661fe",
+            "size": 922711689,
+            "uncompressed-sha256": "5720a6415b59b380ea181a874e984cde5c1744992f7507e2a6f48f129aa21dfb",
+            "uncompressed-size": 3905945600
         },
         "metal4k": {
-            "path": "rhcos-48.83.202103131019-0-metal4k.ppc64le.raw.gz",
-            "sha256": "56182cd7c4668b41de835f2cc81e7a4339537a10b19b9e17143f4685f46f36b8",
-            "size": 922929233,
-            "uncompressed-sha256": "bed30e8e30174d774971ea00073a4a7da4185d690cc1ae5c27a446fbce68ee09",
-            "uncompressed-size": 3904897024
+            "path": "rhcos-48.83.202103221319-0-metal4k.ppc64le.raw.gz",
+            "sha256": "242a621defccc248d04a44e47e8c06a94fbdf3beda4d2e96bffc34d87cc77b48",
+            "size": 922917418,
+            "uncompressed-sha256": "f34b7e2f457994b92bdef391fa24d7df11c19e7d8fe791d7d61aa34f4c058438",
+            "uncompressed-size": 3905945600
         },
         "openstack": {
-            "path": "rhcos-48.83.202103131019-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "82caa694feeaa9a4f5cb6bc2d4b14e52f16fb28fd35c77141313911d07b2a02d",
-            "size": 920802478,
-            "uncompressed-sha256": "5c6cce57867a3a5ed8e2e4800440510ece4b19e5f49e1c6e6ccd4329b2289829",
-            "uncompressed-size": 2505834496
+            "path": "rhcos-48.83.202103221319-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "6c6b3d447b2632ec6123b1230d1a8f6edfc54284bf3185bcca6f517d7952759f",
+            "size": 921011273,
+            "uncompressed-sha256": "37eec71b9bfee48427a239ed485592371d109fed20d5474b413a519830f2f9d2",
+            "uncompressed-size": 2506489856
         },
         "ostree": {
-            "path": "rhcos-48.83.202103131019-0-ostree.ppc64le.tar",
-            "sha256": "3b5528d291694064ecb1e67be79d64b35e0c3cdc3e69a30aff2c6fdcd25f677c",
-            "size": 845230080
+            "path": "rhcos-48.83.202103221319-0-ostree.ppc64le.tar",
+            "sha256": "f106b1b3184023508f1364e217853def3fa3e6e2425df6b8101830705d1be625",
+            "size": 845342720
         },
         "qemu": {
-            "path": "rhcos-48.83.202103131019-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "7a39e5ffd68c2a8862c00e3bb831a5f202b85002aebcd0af4ec1b43403b6cde3",
-            "size": 921911958,
-            "uncompressed-sha256": "c5480ed5d5633ea302d91c46be9a777371a65fd3051f267de833cbc80bdf2602",
-            "uncompressed-size": 2541027328
+            "path": "rhcos-48.83.202103221319-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "317ba084fc6c36984afde29681f32cb17bb1f1889c69337952a896b463ee9941",
+            "size": 922086392,
+            "uncompressed-sha256": "c6505d472befec45254f08e844272233016e607c3328e3a10f1a8df1968ef7f9",
+            "uncompressed-size": 2541355008
         }
     },
     "oscontainer": {
-        "digest": "sha256:8b03b0363208caf73001e7371d4781672f67d0acc7804a794b0e9d8202f84d23",
+        "digest": "sha256:8b103e2604544bb4d5bf44f630b6181c104e4cc2f607755ba42811de6ea905ae",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "52f2c914b460eaa31d63e050beb7a887693b524f57875fa393a6e8273decc86b",
-    "ostree-version": "48.83.202103131019-0"
+    "ostree-commit": "457cbab6803f4f72157ee540615d141f9792018654bd4a7ec50f5ccb0ba8e9cf",
+    "ostree-version": "48.83.202103221319-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.83.202103130119-0/s390x/",
-    "buildid": "48.83.202103130119-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.83.202103221320-0/s390x/",
+    "buildid": "48.83.202103221320-0",
     "images": {
         "dasd": {
-            "path": "rhcos-48.83.202103130119-0-dasd.s390x.raw.gz",
-            "sha256": "96ba1e320ccba3d9f9f11855cbddb43b9363935491427ea210905f25cbcdfac5",
-            "size": 836102986,
-            "uncompressed-sha256": "ca1472621f8b5e3606c89f13980f33614a1c4efc5539201118e304deec8f5eea",
+            "path": "rhcos-48.83.202103221320-0-dasd.s390x.raw.gz",
+            "sha256": "6712d912c9618d1392d2e3ed6f9c4016af480e9607f6db151a19b0f38fe5812e",
+            "size": 836151666,
+            "uncompressed-sha256": "f2d6d358269c9fe7c7ff58b80161cf8d536b4927d5eac62a49e9da0840148a0d",
             "uncompressed-size": 3534749696
         },
         "live-initramfs": {
-            "path": "rhcos-48.83.202103130119-0-live-initramfs.s390x.img",
-            "sha256": "542c00195579e2fd96d3d701f63d2bec8a2204bca5ed3c941fc448e23f704cf2"
+            "path": "rhcos-48.83.202103221320-0-live-initramfs.s390x.img",
+            "sha256": "781a381b49246f0af315f00dd0b5303c6a8185fe8022fe1aab800923ea66b472"
         },
         "live-iso": {
-            "path": "rhcos-48.83.202103130119-0-live.s390x.iso",
-            "sha256": "6156db725eb0f23db7b4fcd1de4d38da1d55f4ea7b803da864662ae542084ab9"
+            "path": "rhcos-48.83.202103221320-0-live.s390x.iso",
+            "sha256": "dbfa509ed52434c4b5a70ea128835a0a14f722b6062fe0c77811217396bef812"
         },
         "live-kernel": {
-            "path": "rhcos-48.83.202103130119-0-live-kernel-s390x",
+            "path": "rhcos-48.83.202103221320-0-live-kernel-s390x",
             "sha256": "7f0356ce47a620a24dcf5e61b598dbe644f8083ab96646a12f563ee0671253cc"
         },
         "live-rootfs": {
-            "path": "rhcos-48.83.202103130119-0-live-rootfs.s390x.img",
-            "sha256": "35ca0742d8febe5304030cc013216588030d8374345ab1bf702a1d847dc14744"
+            "path": "rhcos-48.83.202103221320-0-live-rootfs.s390x.img",
+            "sha256": "79c726f90127f157f484ea755aa8c878d8275460affe077edee2b8cd661984e6"
         },
         "metal": {
-            "path": "rhcos-48.83.202103130119-0-metal.s390x.raw.gz",
-            "sha256": "98c09eb53f692e47a7fcaea60c433e074e3b9e0910acbdba513ee0485e7e6ab7",
-            "size": 835989698,
-            "uncompressed-sha256": "06ae52e5ca7ee039f6708df7dcbf27418155c36d3eb1c8f3476df538302a08c4",
+            "path": "rhcos-48.83.202103221320-0-metal.s390x.raw.gz",
+            "sha256": "619c48db4c4997953887dc2067089233860f108e160fed410decc207e7f2768a",
+            "size": 836277226,
+            "uncompressed-sha256": "174f4258ee09f1398023c8d28ab69e9812734e8f939136343769ac3e41694e69",
             "uncompressed-size": 3534749696
         },
         "metal4k": {
-            "path": "rhcos-48.83.202103130119-0-metal4k.s390x.raw.gz",
-            "sha256": "56a5cc8369c55ac60ce7a58bb7a41adf3c15a00bcf1188a57878d8dc22a61a94",
-            "size": 836106466,
-            "uncompressed-sha256": "69b2edb68f1233ca8deae4c8c82d944b47000482b29821947f98641abd8125bb",
+            "path": "rhcos-48.83.202103221320-0-metal4k.s390x.raw.gz",
+            "sha256": "5681666083ffac7f28f26c8988a9dbc1f9cdc75c147347b20df8ac5feb2c9a24",
+            "size": 836223258,
+            "uncompressed-sha256": "78f08b6b22565cab1ff8f41043a88622c4646f9c3c3b7d3a828d3ac4f2bcce73",
             "uncompressed-size": 3534749696
         },
         "openstack": {
-            "path": "rhcos-48.83.202103130119-0-openstack.s390x.qcow2.gz",
-            "sha256": "822a8483cacc161ea0deb0d8f276642b15ba9f06c17a32497e9f9fb097687013",
-            "size": 834429587,
-            "uncompressed-sha256": "1ca807e4a1df620923b8774e2d6dabd9e59ac5efde5fe1a9447f7ac43135c96a",
-            "uncompressed-size": 2191261696
+            "path": "rhcos-48.83.202103221320-0-openstack.s390x.qcow2.gz",
+            "sha256": "8885f2f7df392ccb9e98ae6fb94931b25ce544c1368549b6d3b104de438335a2",
+            "size": 834534914,
+            "uncompressed-sha256": "ad9b39c3a6068a839da349e2094dab4a8d6c28d5e48890e9a490335a018f3eb4",
+            "uncompressed-size": 2191196160
         },
         "ostree": {
-            "path": "rhcos-48.83.202103130119-0-ostree.s390x.tar",
-            "sha256": "171e3b3ff4ea5820ed5e7a613b46bffaa370a48865d7b366112fb08622218f09",
-            "size": 784578560
+            "path": "rhcos-48.83.202103221320-0-ostree.s390x.tar",
+            "sha256": "0fdb9640dd6f6c6f98567ed260c506f5599ab575523d0685fade2cbe7f61c2fc",
+            "size": 784691200
         },
         "qemu": {
-            "path": "rhcos-48.83.202103130119-0-qemu.s390x.qcow2.gz",
-            "sha256": "bd73c8372ee8778add0c58b3caad31441c60b4bb07ad7b2a878f0ab98edf3d9c",
-            "size": 835439917,
-            "uncompressed-sha256": "b6820334a28ff93e9aa4586d802eff35745874f8940cd48d84c853af722c1de9",
-            "uncompressed-size": 2224553984
+            "path": "rhcos-48.83.202103221320-0-qemu.s390x.qcow2.gz",
+            "sha256": "a4f9f5eb5248d462dbdc221532757cde1e047dc85a5c93de5b2e9cb4bde537d3",
+            "size": 835735649,
+            "uncompressed-sha256": "75f316f587f539bd0b90d594ee06c297a93160f555c24b0664c9d37809d9dc5f",
+            "uncompressed-size": 2224685056
         }
     },
     "oscontainer": {
-        "digest": "sha256:6b8d3d6f2dad16f8d3dcb199d007783da4b064ddf06ab2d309de9f3a57efe951",
+        "digest": "sha256:84b9b5eb59d0dba56a8b9c4510c83a394f57c91645617b0c8f260c5027748f7f",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ae14be52d6092ce9c752bdca53c0c447941e82eb034e3cefa4e2c68e1328a957",
-    "ostree-version": "48.83.202103130119-0"
+    "ostree-commit": "255d8beb89d20ca0e89d4492aacb635bda9d31860d741ef1a57c42417b0406d6",
+    "ostree-version": "48.83.202103221320-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,163 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-01dd4193042351d0e"
+            "hvm": "ami-0b5c3b497fe4bc2ea"
         },
         "ap-east-1": {
-            "hvm": "ami-06320ea2b751acf5d"
+            "hvm": "ami-0a6976bcfac70580e"
         },
         "ap-northeast-1": {
-            "hvm": "ami-05368806cdd6277c7"
+            "hvm": "ami-06cbc55d814a971e4"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0b2f40b281ab6903b"
+            "hvm": "ami-045e0e1127cf9d4ff"
+        },
+        "ap-northeast-3": {
+            "hvm": "ami-0afb77eabb999b7bc"
         },
         "ap-south-1": {
-            "hvm": "ami-0d5ce4ca4898224ec"
+            "hvm": "ami-0c0ac18b571fa1298"
         },
         "ap-southeast-1": {
-            "hvm": "ami-008a33d6dbd81dbcc"
+            "hvm": "ami-06c10f60b7fff5dd1"
         },
         "ap-southeast-2": {
-            "hvm": "ami-01d3b84d2c25d2717"
+            "hvm": "ami-0da31b1166a996615"
         },
         "ca-central-1": {
-            "hvm": "ami-0ac50d7fd990f5332"
+            "hvm": "ami-044a1b0f991f4d652"
         },
         "eu-central-1": {
-            "hvm": "ami-0b3149eff8c1b1d97"
+            "hvm": "ami-0202025e3392eec53"
         },
         "eu-north-1": {
-            "hvm": "ami-0d9cbf9387a9dc7e2"
+            "hvm": "ami-02a90294ae67d27a6"
         },
         "eu-south-1": {
-            "hvm": "ami-0d840e28d95f8e128"
+            "hvm": "ami-09873171555f02ad5"
         },
         "eu-west-1": {
-            "hvm": "ami-0558ed15ea50b830b"
+            "hvm": "ami-0bc1151abfa614bf4"
         },
         "eu-west-2": {
-            "hvm": "ami-013b367c221b23698"
+            "hvm": "ami-0be1650f9c65ad6d1"
         },
         "eu-west-3": {
-            "hvm": "ami-016224e83820dd23e"
+            "hvm": "ami-0007ebc2005ce3bc0"
         },
         "me-south-1": {
-            "hvm": "ami-0ceac1bfed40e9cbf"
+            "hvm": "ami-0330aad497d9769a4"
         },
         "sa-east-1": {
-            "hvm": "ami-076cab8be8d32f123"
+            "hvm": "ami-06fb2c7c2b7ec3ff4"
         },
         "us-east-1": {
-            "hvm": "ami-08f15e9f159732a9b"
+            "hvm": "ami-0146091f9e1b5ec3f"
         },
         "us-east-2": {
-            "hvm": "ami-07a0bede859e1639d"
+            "hvm": "ami-04e591bf6aa86fd31"
         },
         "us-west-1": {
-            "hvm": "ami-0b8c56daaa6be3f97"
+            "hvm": "ami-02b960e0d5a5dc325"
         },
         "us-west-2": {
-            "hvm": "ami-0ba922fcef999ec3d"
+            "hvm": "ami-0c6da162537298ad6"
         }
     },
     "azure": {
-        "image": "rhcos-48.83.202103122318-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.83.202103122318-0-azure.x86_64.vhd"
+        "image": "rhcos-48.83.202103221318-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.83.202103221318-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.83.202103122318-0/x86_64/",
-    "buildid": "48.83.202103122318-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.83.202103221318-0/x86_64/",
+    "buildid": "48.83.202103221318-0",
     "gcp": {
-        "image": "rhcos-48-83-202103122318-0-gcp-x86-64",
+        "image": "rhcos-48-83-202103221318-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-83-202103122318-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-83-202103221318-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.83.202103122318-0-aws.x86_64.vmdk.gz",
-            "sha256": "fbe1f2571516db1b423c83b4c82385f887c7a80c28fe978e5df39bcea360a63a",
-            "size": 956011781,
-            "uncompressed-sha256": "ef749748fedcafda0bc49f159645542eac19cd49fd3dc665b19c8c24c3a378bd",
-            "uncompressed-size": 975684096
+            "path": "rhcos-48.83.202103221318-0-aws.x86_64.vmdk.gz",
+            "sha256": "df74c7d7e063101efdc0ef2c54dcc780dba52aea744f2166acf32c0de27a2187",
+            "size": 955986915,
+            "uncompressed-sha256": "e2cf1919cd67832a2dff5936403a148793214b86b3e1930369db9ae79810bc0e",
+            "uncompressed-size": 975638528
         },
         "azure": {
-            "path": "rhcos-48.83.202103122318-0-azure.x86_64.vhd.gz",
-            "sha256": "f195c680a0064142497eb0e883c1127bc979e0ed595f7af3c61588beac93aa8d",
-            "size": 956294196,
-            "uncompressed-sha256": "d42a2c59bb07d76068768f98a2818bbe02b27b4d9f33320e97a724c03eac8591",
+            "path": "rhcos-48.83.202103221318-0-azure.x86_64.vhd.gz",
+            "sha256": "97a5928cc65cee6500233525f6519c6fee61222a0874eb49de26eccdbe92ab97",
+            "size": 956392217,
+            "uncompressed-sha256": "4b8bac9c2f576a1d9845b52c227e731abd22d317baa91fb88b58ccb8aef13530",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.83.202103122318-0-gcp.x86_64.tar.gz",
-            "sha256": "835c1188ec940cf3416fedef1297f23d1ad9fc4ccbc878ab92894b7e75db2408",
-            "size": 941572226
+            "path": "rhcos-48.83.202103221318-0-gcp.x86_64.tar.gz",
+            "sha256": "e37d44e41fba4e0854896cc9fe932e2ea87bf7292fb436f14c54074d50145276",
+            "size": 941690377
         },
         "ibmcloud": {
-            "path": "rhcos-48.83.202103122318-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "4935c16039bcc1224e37c6d901783ac2858e8b8aa1f98a68320e55089f647e20",
-            "size": 941914922,
-            "uncompressed-sha256": "d8053881cb97d412a7d0279fea51a5fb67cabe9bc26051c88bd84c97038c360f",
-            "uncompressed-size": 2369781760
+            "path": "rhcos-48.83.202103221318-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "e6400e3385e7d27de7a14ebd2faa77a41967c5722431f591e206741ffb7e47b8",
+            "size": 942010183,
+            "uncompressed-sha256": "9b697d882e78750f7b5cca6198bf7f2d7f83fad72459705548025b378a618dc2",
+            "uncompressed-size": 2370437120
         },
         "live-initramfs": {
-            "path": "rhcos-48.83.202103122318-0-live-initramfs.x86_64.img",
-            "sha256": "a761505051ec5d3833b94634031947a8c8595f3a9175358ec1259b25917b6dd8"
+            "path": "rhcos-48.83.202103221318-0-live-initramfs.x86_64.img",
+            "sha256": "15047567c01e189ae17e9ba5d1a35fecac3f5cfe724b59b13bbddd0cfefea6b6"
         },
         "live-iso": {
-            "path": "rhcos-48.83.202103122318-0-live.x86_64.iso",
-            "sha256": "fb58004d0b8abbd0a3ad7645f639f80d939e8e308fb5fe3e51f89a54f5bfe5b5"
+            "path": "rhcos-48.83.202103221318-0-live.x86_64.iso",
+            "sha256": "671b2055eb7cbf35172a591b668d67e49db95f6b48f46264a48d2ea57c56529d"
         },
         "live-kernel": {
-            "path": "rhcos-48.83.202103122318-0-live-kernel-x86_64",
+            "path": "rhcos-48.83.202103221318-0-live-kernel-x86_64",
             "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
         },
         "live-rootfs": {
-            "path": "rhcos-48.83.202103122318-0-live-rootfs.x86_64.img",
-            "sha256": "dbace7d56388034b38edb645a661e7e2b2039116f70470a4a1e2577d395f124d"
+            "path": "rhcos-48.83.202103221318-0-live-rootfs.x86_64.img",
+            "sha256": "0a8dc2ec128d1979cff024311a63c3651e5027b4edb636ecaf103a30eed12a99"
         },
         "metal": {
-            "path": "rhcos-48.83.202103122318-0-metal.x86_64.raw.gz",
-            "sha256": "9009586f9d95cc19958f2259a7f33fd47fc9f1bcc498d91bf5c7432262fba067",
-            "size": 943625068,
-            "uncompressed-sha256": "66ea3ce8a73e1fd315dc7612a0f11134bb6ba96bfe5df28d1e30a67dc7d3867b",
+            "path": "rhcos-48.83.202103221318-0-metal.x86_64.raw.gz",
+            "sha256": "5535e22dd5ea4c5174058bea8e4392941811f3b2a0409112c67a4ca77f8ec0fe",
+            "size": 943825625,
+            "uncompressed-sha256": "7b374a6da510f8b392ff8ab384777d79e636d4fcf782f897cea7512557208698",
             "uncompressed-size": 3729784832
         },
         "metal4k": {
-            "path": "rhcos-48.83.202103122318-0-metal4k.x86_64.raw.gz",
-            "sha256": "6498ae0259bba73140fee655367181dd6214ff3d51b6dc054c236f9e2d8bda09",
-            "size": 941326627,
-            "uncompressed-sha256": "85e3e2c0222c1380b012604b9ed536328abacfe25abe201957f575fb9c2adf82",
+            "path": "rhcos-48.83.202103221318-0-metal4k.x86_64.raw.gz",
+            "sha256": "2aa4cd8fa051d46857936040341d8ce38f851f230bb3cb991795a9de021d5a9e",
+            "size": 941369865,
+            "uncompressed-sha256": "b10222db6717752acbbb7b7396e26f43d2bab8193128736fcf91da3cba29d9b8",
             "uncompressed-size": 3729784832
         },
         "openstack": {
-            "path": "rhcos-48.83.202103122318-0-openstack.x86_64.qcow2.gz",
-            "sha256": "0c6f320c4fe2e4f09442ab24bb59618928ad55001c3a00db182792f765c9ee13",
-            "size": 941914638,
-            "uncompressed-sha256": "371378fd1beaf80607736eab386d61d44e70be591556ef9c2b6cd4ae56c57d5d",
-            "uncompressed-size": 2369781760
+            "path": "rhcos-48.83.202103221318-0-openstack.x86_64.qcow2.gz",
+            "sha256": "323e7ba4ba3448e340946543c963823136e1367ed0b229d2a05e1cf537642bb8",
+            "size": 942011087,
+            "uncompressed-sha256": "10f55ea6f71d4dc382183597f9360aad6c6551fcc94aa100bbdadaecfe888452",
+            "uncompressed-size": 2370437120
         },
         "ostree": {
-            "path": "rhcos-48.83.202103122318-0-ostree.x86_64.tar",
-            "sha256": "4a2d8cc6d8a3846d9944c538fd41a70204db6d304e07e02143c3ed8554d47989",
-            "size": 868136960
+            "path": "rhcos-48.83.202103221318-0-ostree.x86_64.tar",
+            "sha256": "f5779b639151af682902f86d2d2b55604391bb7a2736d281701cc60e1f264967",
+            "size": 868270080
         },
         "qemu": {
-            "path": "rhcos-48.83.202103122318-0-qemu.x86_64.qcow2.gz",
-            "sha256": "b7e1d1f4c9c859d12417502131b28ac5fc06aa695cc1cb68dc09886bb84997c0",
-            "size": 943081124,
-            "uncompressed-sha256": "f5bbc7ffb720f7073ec4382207bf419c38b1aa1af338aaaf7076d4a0a2c7b930",
-            "uncompressed-size": 2403794944
+            "path": "rhcos-48.83.202103221318-0-qemu.x86_64.qcow2.gz",
+            "sha256": "795bb00f37fc797517eb29fe4032ae4211ce4c23590e4605899ec07a51818776",
+            "size": 943124225,
+            "uncompressed-sha256": "7a84fe943cf7eaed8d500b0aabd8386df07af9d7092e45b5554fa68ebf166505",
+            "uncompressed-size": 2404188160
         },
         "vmware": {
-            "path": "rhcos-48.83.202103122318-0-vmware.x86_64.ova",
-            "sha256": "14915912594124b114e9da64b2bafd34275c3c625f575f9a7d1f241f7b3d5b89",
-            "size": 975697920
+            "path": "rhcos-48.83.202103221318-0-vmware.x86_64.ova",
+            "sha256": "19d15c0815dce4448c6edcca36eebff18f56f829594568f954c0ca914639bafb",
+            "size": 975646720
         }
     },
     "oscontainer": {
-        "digest": "sha256:26a56317f7a00edd94fa655d23e4ea693ca5845eb67c2fb91a0f73f9ba4f1b05",
+        "digest": "sha256:3f0c628ec5d669a574ad114c89f4af9e669e7da89e7a2705c95fe83e98eaf570",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "5f984a81182f9a1fac4c061732a4b22bee590291723d043aebbcbd922862c449",
-    "ostree-version": "48.83.202103122318-0"
+    "ostree-commit": "328a44d7c259ca1e3ed31ae020f09d922f460be998657a92f684f6760443077b",
+    "ostree-version": "48.83.202103221318-0"
 }

--- a/pkg/rhcos/ami_regions.go
+++ b/pkg/rhcos/ami_regions.go
@@ -8,6 +8,7 @@ var AMIRegions = []string{
 	"ap-east-1",
 	"ap-northeast-1",
 	"ap-northeast-2",
+	"ap-northeast-3",
 	"ap-south-1",
 	"ap-southeast-1",
 	"ap-southeast-2",


### PR DESCRIPTION
This boot image bump brings in fixes for the following BZs on the
RHCOS side:
    
BZ#1934174 - rootfs too small when enabling NBDE
BZ#1940704 - prjquota is dropped from rootflags if rootfs is reprovisioned
    
It also brings in support for the new ap-northeast-3 region in AWS.
    
BZ#1939661 - support new AWS region ap-northeast-3
