### PR TITLE
Revert "Check if VIP IPs overlap with machine CIDR provided during vsphere installation"

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -20,7 +20,7 @@ func Validate(ic *types.InstallConfig) error {
 		return errors.New(field.Required(field.NewPath("platform", "vsphere"), "vSphere validation requires a vSphere platform configuration").Error())
 	}
 
-	allErrs = append(allErrs, validation.ValidatePlatform(ic.Platform.VSphere, ic.Networking, field.NewPath("platform").Child("vsphere"))...)
+	allErrs = append(allErrs, validation.ValidatePlatform(ic.Platform.VSphere, field.NewPath("platform").Child("vsphere"))...)
 
 	return allErrs.ToAggregate()
 }

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -436,9 +436,7 @@ func validatePlatform(platform *types.Platform, fldPath *field.Path, network *ty
 		})
 	}
 	if platform.VSphere != nil {
-		validate(vsphere.Name, platform.VSphere, func(f *field.Path) field.ErrorList {
-			return vspherevalidation.ValidatePlatform(platform.VSphere, c.Networking, f)
-		})
+		validate(vsphere.Name, platform.VSphere, func(f *field.Path) field.ErrorList { return vspherevalidation.ValidatePlatform(platform.VSphere, f) })
 	}
 	if platform.BareMetal != nil {
 		validate(baremetal.Name, platform.BareMetal, func(f *field.Path) field.ErrorList {


### PR DESCRIPTION
Reverts openshift/installer#4754

When using the survey flow, the machine CIDR is not populated. This causes the installation to fail, unless the VIPs happen to be within the default machine CIDR.