### PR TITLE
 Dockerfile.upi.ci: Drop pip+pyopenssl installs

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -37,8 +37,6 @@ RUN yum update -y && \
     rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 
-RUN easy_install 'pip<21'
-RUN python -m pip install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python
 
 ENV TERRAFORM_VERSION=0.12.24


### PR DESCRIPTION

We shouldn't need this anymore, see
https://cloud.google.com/sdk/crypto

We have a larger conflict here because the gcloud sdk wants
python2, azure wants python3.

Something changed in the pip CDN that broke our use of the
older pip.

(hopefully)
Closes: #4783