### PR TITLE
Bug 1935174: RHCOS bump for LUKS, prjquota, etc

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,163 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-057e5df70c52dc128"
+            "hvm": "ami-0401d6ad383dba55c"
         },
         "ap-east-1": {
-            "hvm": "ami-006ab68917f52bb13"
+            "hvm": "ami-03ac23c984c812cb4"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0d236f6289c700771"
+            "hvm": "ami-09cc1da8a6fa42c4e"
         },
         "ap-northeast-2": {
-            "hvm": "ami-040394572427a293a"
+            "hvm": "ami-0adf87370198caaed"
+        },
+        "ap-northeast-3": {
+            "hvm": "ami-0591a1337ebe93646"
         },
         "ap-south-1": {
-            "hvm": "ami-0838c978c0390dd75"
+            "hvm": "ami-08dfa06820a4fb482"
         },
         "ap-southeast-1": {
-            "hvm": "ami-07af688c8b65de56f"
+            "hvm": "ami-05345a132d89bd2b6"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a36faab6aa0a0dea"
+            "hvm": "ami-00274925d47c6e015"
         },
         "ca-central-1": {
-            "hvm": "ami-01284e5815ce66a95"
+            "hvm": "ami-0baeff23c4cc6ddf5"
         },
         "eu-central-1": {
-            "hvm": "ami-0361c06cf3e935cfe"
+            "hvm": "ami-083ab4c282bac44b5"
         },
         "eu-north-1": {
-            "hvm": "ami-0080eb90a48d9655e"
+            "hvm": "ami-0791daa430c70ff09"
         },
         "eu-south-1": {
-            "hvm": "ami-0a3bc89f7aadf0343"
+            "hvm": "ami-093ccc9e024810fc8"
         },
         "eu-west-1": {
-            "hvm": "ami-0b4024fa5cb2588bd"
+            "hvm": "ami-07323d56fb932c84c"
         },
         "eu-west-2": {
-            "hvm": "ami-07376355104ab4106"
+            "hvm": "ami-0cabefac75acfd8e3"
         },
         "eu-west-3": {
-            "hvm": "ami-038f4ce9ea7ac7191"
+            "hvm": "ami-01f9af256e3213df9"
         },
         "me-south-1": {
-            "hvm": "ami-025899013a24bb708"
+            "hvm": "ami-0e5d014111ee32e16"
         },
         "sa-east-1": {
-            "hvm": "ami-089e1a3dcc5a5fe08"
+            "hvm": "ami-0dd8411ece8c06dae"
         },
         "us-east-1": {
-            "hvm": "ami-0d5f9982f029fbc14"
+            "hvm": "ami-03d1c2cba04df838c"
         },
         "us-east-2": {
-            "hvm": "ami-0c84b5c5255ec4777"
+            "hvm": "ami-0ddab715d6b88a315"
         },
         "us-west-1": {
-            "hvm": "ami-0b421328859954025"
+            "hvm": "ami-09b797de07577bf33"
         },
         "us-west-2": {
-            "hvm": "ami-010de485a2ee23e5e"
+            "hvm": "ami-0617611237b58ac93"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202102090044-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102090044-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202103251640-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202103251640-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102090044-0/x86_64/",
-    "buildid": "47.83.202102090044-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202103251640-0/x86_64/",
+    "buildid": "47.83.202103251640-0",
     "gcp": {
-        "image": "rhcos-47-83-202102090044-0-gcp-x86-64",
+        "image": "rhcos-47-83-202103251640-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102090044-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202103251640-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202102090044-0-aws.x86_64.vmdk.gz",
-            "sha256": "ad54945302d9aaf0c5d6a5d1ee457325a3dcd88a68067d18a4d614acef5390d4",
-            "size": 951239242,
-            "uncompressed-sha256": "fbb7fbbc6cc6161ffa5c571f1b9022fe80038eea0a7f099c5b18ceba3b82f5eb",
-            "uncompressed-size": 970902016
+            "path": "rhcos-47.83.202103251640-0-aws.x86_64.vmdk.gz",
+            "sha256": "09f2376c33681b2e0f19209bc9e1b15c36a1635ad68e2670d774c5d017b8f29e",
+            "size": 954887101,
+            "uncompressed-sha256": "ef228bb22f647194da8c8261ddfc5a14b1694cb7585ab7d21bbf33a44652b3e4",
+            "uncompressed-size": 974496768
         },
         "azure": {
-            "path": "rhcos-47.83.202102090044-0-azure.x86_64.vhd.gz",
-            "sha256": "32aa9be04b7f06bfe028fc7c93443f0c742afb006e73b6076016fa897ae5f716",
-            "size": 951756228,
-            "uncompressed-sha256": "7e60c02aeebd129a99d65da48beddb99bd29ac7b31f3bb9395fb1d87e6311448",
+            "path": "rhcos-47.83.202103251640-0-azure.x86_64.vhd.gz",
+            "sha256": "a02679f9e3507ca39456e8813dcab69f07c7ee7bf7232a652a28183d7bc73697",
+            "size": 955225715,
+            "uncompressed-sha256": "5245c2b529b92458cde9ea7e55934cc870a23d09a17aa083be4537ac0b1caab1",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202102090044-0-gcp.x86_64.tar.gz",
-            "sha256": "07275bf2844f0dba6296d984d293959f614cc60af9f1be4070142a8cdcc650aa",
-            "size": 937047583
+            "path": "rhcos-47.83.202103251640-0-gcp.x86_64.tar.gz",
+            "sha256": "7570868619d51639a17bdceb7ab57f6adb7b20a78e49b32434537a0ed0e1f155",
+            "size": 940531637
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202102090044-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "b81b26a61d11a9c2c6fb33a94ff124f461907bff550338cfecf173cdd93c09be",
-            "size": 937381841,
-            "uncompressed-sha256": "5b6fdfb53e3ede4d264d13862bda6801d932f12e1a17309ac62ac32836bca8ff",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-47.83.202103251640-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "aa3bfde23a7af8f112f6b43273729011484a154b78bcac52a2d79cfc013b5c19",
+            "size": 940837877,
+            "uncompressed-sha256": "18b34659654b0870b4807c374385766e9e7bad4d29e64e7e05b06ca3574d569b",
+            "uncompressed-size": 2366177280
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202102090044-0-live-initramfs.x86_64.img",
-            "sha256": "29ba7e12b16f143a3f036226568ce91b3f7c8bd6feab719a73b0bed1817e4444"
+            "path": "rhcos-47.83.202103251640-0-live-initramfs.x86_64.img",
+            "sha256": "18f9a94a02a7eae8fe70dd465279dc2851ce14055d7725d22d2092d2ef54475c"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102090044-0-live.x86_64.iso",
-            "sha256": "b765a9e99edfa0a91778a4787070c6afcaa198ba8806c8c1533c34a23d63136f"
+            "path": "rhcos-47.83.202103251640-0-live.x86_64.iso",
+            "sha256": "e763b79edc4c7958bffdb222cc4e5e8acbf6b7e447d4342009f908ab071b7c95"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102090044-0-live-kernel-x86_64",
-            "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
+            "path": "rhcos-47.83.202103251640-0-live-kernel-x86_64",
+            "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102090044-0-live-rootfs.x86_64.img",
-            "sha256": "6da4ae110fc2bcea8ac0e6c40fa9d701bbde5b936a1410f75735386c8ea805bf"
+            "path": "rhcos-47.83.202103251640-0-live-rootfs.x86_64.img",
+            "sha256": "e9f38678e1508012ee9135723370357799b35f7c564d66b1d2a46232089a7477"
         },
         "metal": {
-            "path": "rhcos-47.83.202102090044-0-metal.x86_64.raw.gz",
-            "sha256": "0a456b02960eeb40a102ef14f5556843c2c504358f3db21f3fe667d8346c9bdf",
-            "size": 939085053,
-            "uncompressed-sha256": "36379d083adccccb3de266d2802cfcf5079429865fa010d9b499e87042d46526",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-47.83.202103251640-0-metal.x86_64.raw.gz",
+            "sha256": "a252c10f27e436e0ff17713703ac57134552d628fe3df03acec043aacb3c96ee",
+            "size": 942543852,
+            "uncompressed-sha256": "f0e658b58ab1aa654b7d09bf5810cb6c7e44cfaae5def27c3bf2bd9207a8c981",
+            "uncompressed-size": 3725590528
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102090044-0-metal4k.x86_64.raw.gz",
-            "sha256": "ff10909c5d4ffbb3a829d070dcf3ce9a8b2d2aebff2924ee464d517eb948bfba",
-            "size": 936609970,
-            "uncompressed-sha256": "d5821d7fbd20f86bab29d028855200221f316fa041e86374c5f693da9b5d7b83",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-47.83.202103251640-0-metal4k.x86_64.raw.gz",
+            "sha256": "d010fbcb2615240d9c9797c7b9de678b330dfa0ad59190c0b14947437f411974",
+            "size": 940148936,
+            "uncompressed-sha256": "f8af1ae038af3ddec00f244e4ecf47916a7aaa1ba561dacf28cb52dc5f8099d7",
+            "uncompressed-size": 3725590528
         },
         "openstack": {
-            "path": "rhcos-47.83.202102090044-0-openstack.x86_64.qcow2.gz",
-            "sha256": "e5ebb8bcf6d081e52e1e7db0e93ff960ff472e25803a5671170959212e88cad9",
-            "size": 937380970,
-            "uncompressed-sha256": "c1b93a426d0f74f0059193439e306f3356b788302a825cfadd870460e543028e",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-47.83.202103251640-0-openstack.x86_64.qcow2.gz",
+            "sha256": "a1eaea5e994c0fe7000865780ea5d0cc89980943330357eb64df333c1fad224d",
+            "size": 940839325,
+            "uncompressed-sha256": "f8ac2f68c0d7fbabd15cc3e88e29fcbd581c0250fe4e2ee4d5f56eb5b2f6af87",
+            "uncompressed-size": 2366177280
         },
         "ostree": {
-            "path": "rhcos-47.83.202102090044-0-ostree.x86_64.tar",
-            "sha256": "3b5fc040f7493ff7dc5aef4da22077ad74eb2e12a01a9e820d5c116e58716c4f",
-            "size": 863467520
+            "path": "rhcos-47.83.202103251640-0-ostree.x86_64.tar",
+            "sha256": "76f59de2809a80332c95a8f1635df0b1be9ba1ec6fd43c7a90e703fe03c9cf82",
+            "size": 867020800
         },
         "qemu": {
-            "path": "rhcos-47.83.202102090044-0-qemu.x86_64.qcow2.gz",
-            "sha256": "2ca82f1d762bba1cb2e5ac1386be0a1ab0264cf88b0594c9cd1e53d285833c6d",
-            "size": 938521497,
-            "uncompressed-sha256": "5d31652c7856a87450dce1bbbb561b578ee75443c190096cb977a814e5f35935",
-            "uncompressed-size": 2394030080
+            "path": "rhcos-47.83.202103251640-0-qemu.x86_64.qcow2.gz",
+            "sha256": "2925d6182753f19275b0a9b09079199dcee36310fdbbdb1760b8e822fb821e4f",
+            "size": 941977173,
+            "uncompressed-sha256": "2cc7c8841e6b2b0f5d3573b82453fddad3c44972c080969458af85c7097e9bc5",
+            "uncompressed-size": 2399993856
         },
         "vmware": {
-            "path": "rhcos-47.83.202102090044-0-vmware.x86_64.ova",
-            "sha256": "13d92692b8eed717ff8d0d113a24add339a65ef1f12eceeb99dabcd922cc86d1",
-            "size": 970915840
+            "path": "rhcos-47.83.202103251640-0-vmware.x86_64.ova",
+            "sha256": "6ac67b43ed6fe25cbe4b01b8f8900a9a5bc0bb6a9894d40be46b994cda906efd",
+            "size": 974510080
         }
     },
     "oscontainer": {
-        "digest": "sha256:a32077727aa2ef96a1e2371dbcc53ba06f3d9727e836b72be0f0dd4513937e1e",
+        "digest": "sha256:0ad297b22e7b96e04e45aefcc57f571361c87bdc3110e692bb239f2dfbe64050",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "646a9832dd0dc9fe174a2fc005863a9582186518a5476522a0e9bdccc0e5252a",
-    "ostree-version": "47.83.202102090044-0"
+    "ostree-commit": "3fdd1488024f054e39b1be508781d535d1ac7ed423bb3b4b656c2f345934220d",
+    "ostree-version": "47.83.202103251640-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202102091015-0/ppc64le/",
-    "buildid": "47.83.202102091015-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202103232314-0/ppc64le/",
+    "buildid": "47.83.202103232314-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-47.83.202102091015-0-live-initramfs.ppc64le.img",
-            "sha256": "a15c4eaaf5aa0176fc475e4ec41df4ca0e83595f7a5e561e2de0a26f8a485b60"
+            "path": "rhcos-47.83.202103232314-0-live-initramfs.ppc64le.img",
+            "sha256": "0b9960179c174e9387a26eeb89eaadf4e8729a8256f1297d791efa2e9e4b6199"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102091015-0-live.ppc64le.iso",
-            "sha256": "d6fb6f949569461e3f9eb67883fa00b611275bb7d7bd3d9f11beaf1c0b33d389"
+            "path": "rhcos-47.83.202103232314-0-live.ppc64le.iso",
+            "sha256": "30d65f1be268e3f7bd1048e7310b95e1771dec7c8f3f1afa63fdd93c533aab4c"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102091015-0-live-kernel-ppc64le",
-            "sha256": "e310166a16592a5cd1bc152b07fda84278b251dc385cf000c65ed7bb31d254ea"
+            "path": "rhcos-47.83.202103232314-0-live-kernel-ppc64le",
+            "sha256": "75e8849d99f9eca4f408a331c332d61af1a5c40818e71d4953481f05e7384ca2"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102091015-0-live-rootfs.ppc64le.img",
-            "sha256": "621ed54c0cb5180e7e798778c5c365f04b328aa983bc5a752ecea3a17ffd5bce"
+            "path": "rhcos-47.83.202103232314-0-live-rootfs.ppc64le.img",
+            "sha256": "3e185fea9f51cb03effaa8ca515355115c3aefedac9afa7fc0d77a469b6850bf"
         },
         "metal": {
-            "path": "rhcos-47.83.202102091015-0-metal.ppc64le.raw.gz",
-            "sha256": "d0fa64d744dd731ad3185b39ada8d6eb886c8dbba3e683a30176838bdf20ef9a",
-            "size": 918231587,
-            "uncompressed-sha256": "1880a77eed6741e45346102b85b5cceb071d7da5479b1075efd810767a33693c",
-            "uncompressed-size": 3888119808
+            "path": "rhcos-47.83.202103232314-0-metal.ppc64le.raw.gz",
+            "sha256": "4c99726eb1a29633fe35a822a79b20dbbced4e99883de3e9fdea84a2df4e18b8",
+            "size": 921576379,
+            "uncompressed-sha256": "e60b6365effbaedeaf6bfe414a52070d20b2a23eaab47c377915ebf8cd43343b",
+            "uncompressed-size": 3898605568
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102091015-0-metal4k.ppc64le.raw.gz",
-            "sha256": "f6e4458958f38a7bccae4a89a73134d431b86b183ebcf76542446c959fa2d520",
-            "size": 918369582,
-            "uncompressed-sha256": "142ce5a0cb3984611a74d5d9d99ee6e320029802d2bee7c31d6b6b9455f3d293",
-            "uncompressed-size": 3888119808
+            "path": "rhcos-47.83.202103232314-0-metal4k.ppc64le.raw.gz",
+            "sha256": "e8e68685ee031b28c2dd0162cfa99ad436f274848ae170e8047ed60b92d543a2",
+            "size": 921704341,
+            "uncompressed-sha256": "871d186440a38f36399a980abd3d95acd9c959ee34ed642c348db7344b3745ec",
+            "uncompressed-size": 3898605568
         },
         "openstack": {
-            "path": "rhcos-47.83.202102091015-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "47865a06d1ca6ae06481ab6f1d52ed6c9fca02ae539a06639c8bea65173a1550",
-            "size": 916498365,
-            "uncompressed-sha256": "443ed7133f49e36138ac7c452bedcca2d8fde02f818a43fce1d905d41d0a8cea",
-            "uncompressed-size": 2494431232
+            "path": "rhcos-47.83.202103232314-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "e1bb7f64a0d54f703d61b42320808a7284a45dbaf1bf6b2581457c562f57a936",
+            "size": 919772699,
+            "uncompressed-sha256": "f3e636cb494685b37a1fc5a8e05706102d6b323804523c2faf8f93bab5032d67",
+            "uncompressed-size": 2501705728
         },
         "ostree": {
-            "path": "rhcos-47.83.202102091015-0-ostree.ppc64le.tar",
-            "sha256": "118d9f3842d60e2f21e84b4561a9faea3e1ac72948a76a2e59969ff54f288f0a",
-            "size": 840714240
+            "path": "rhcos-47.83.202103232314-0-ostree.ppc64le.tar",
+            "sha256": "59c4ac0cb0bba706b5d8acf5beb78e7b80d1c1bdc597bc3e369a4603ccbad4d6",
+            "size": 844072960
         },
         "qemu": {
-            "path": "rhcos-47.83.202102091015-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "dce14413bb0347ffcb793a529ed2b4e39efa2b523a3e63faf552e574752a5aac",
-            "size": 917571073,
-            "uncompressed-sha256": "2044dd7198fd1f730c3fe1d68c422be7e06ed57b4ad28bfe402f4836b84be869",
-            "uncompressed-size": 2529296384
+            "path": "rhcos-47.83.202103232314-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "1998f4c3f9e4aff3195ff5e691108c9c94492307c73461ad4bfe0f914720fde3",
+            "size": 920821673,
+            "uncompressed-sha256": "dc3e3ebc83b166ccded7425fb15a26766ce0e7224e3b5bbd5aa0b50e6f7e132c",
+            "uncompressed-size": 2536308736
         }
     },
     "oscontainer": {
-        "digest": "sha256:6a410508e645cb24729fd860ae53a352b3df23a11d5747b0648d2f300a37de1d",
+        "digest": "sha256:c8b40a8fe9ca152bf019233c7410d41656b3e126bbddbc98212a4d4695842733",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "b44e5d88d608175e62e95a35b59bd3e912327cfea036e5393169146af7512588",
-    "ostree-version": "47.83.202102091015-0"
+    "ostree-commit": "5bcaf6616d9f0501ad8252c28d561e16e34960780983f55cf73012ca7504af1d",
+    "ostree-version": "47.83.202103232314-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202102090311-0/s390x/",
-    "buildid": "47.83.202102090311-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202103251513-0/s390x/",
+    "buildid": "47.83.202103251513-0",
     "images": {
         "dasd": {
-            "path": "rhcos-47.83.202102090311-0-dasd.s390x.raw.gz",
-            "sha256": "af39f736c9cd6bec61d4f7a098adcebc0b7583cd299339859c831380256c27d4",
-            "size": 831578576,
-            "uncompressed-sha256": "a390b9b95a1381ebec1736d4aa5d193f0820a41c6af79fc7283960b91fa4a861",
-            "uncompressed-size": 3516923904
+            "path": "rhcos-47.83.202103251513-0-dasd.s390x.raw.gz",
+            "sha256": "a9ad45a2b8c01177af19aa0520cc0e56bf626c3ff28b325665ba0228ddc32d4a",
+            "size": 834919789,
+            "uncompressed-sha256": "cba39aec5d43458f81b4773e2582524aa3b3ef575ea2c685fb8d7a9323c52c97",
+            "uncompressed-size": 3527409664
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202102090311-0-live-initramfs.s390x.img",
-            "sha256": "07e5642b818ee9582f59050657dceecad4683c6c54c2f92b071549c8a4826e05"
+            "path": "rhcos-47.83.202103251513-0-live-initramfs.s390x.img",
+            "sha256": "9a776910b8e44e12965a2ea025340ffd1f5ccc79b4855e062e02e29b65ad4536"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102090311-0-live.s390x.iso",
-            "sha256": "e64d8d66bd69e6ea7ebdd9be74abce43e10e0731527ee6662780f20863ffc71c"
+            "path": "rhcos-47.83.202103251513-0-live.s390x.iso",
+            "sha256": "b5d3304d58e48e65991e91a5b23e6149e69b26efcd1d07cfa3c30002a3c24970"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102090311-0-live-kernel-s390x",
-            "sha256": "a0f17299369b9ce9e42c874a8cc3658a00e58144fc0f54849ef96d9414d811d0"
+            "path": "rhcos-47.83.202103251513-0-live-kernel-s390x",
+            "sha256": "7f0356ce47a620a24dcf5e61b598dbe644f8083ab96646a12f563ee0671253cc"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102090311-0-live-rootfs.s390x.img",
-            "sha256": "79de4fb97a151b051201eb04f291a1b36f54d3968d2c3f31571066da8231945a"
+            "path": "rhcos-47.83.202103251513-0-live-rootfs.s390x.img",
+            "sha256": "9c5fb9ca4697c65b5c9906f6b478035dedf6249779e408d83d920c73033ba47f"
         },
         "metal": {
-            "path": "rhcos-47.83.202102090311-0-metal.s390x.raw.gz",
-            "sha256": "299bcb3de103f701866904f41e316e7c375fd1e0c4434b068e578a35d11084e1",
-            "size": 831763974,
-            "uncompressed-sha256": "ab0b1f6080c472f88dc418610cb6af2dd9e8aff835c9a7b417716f67c3e2e25d",
-            "uncompressed-size": 3516923904
+            "path": "rhcos-47.83.202103251513-0-metal.s390x.raw.gz",
+            "sha256": "1761308c7103d63660ac99249abb95bfc5c43b49ffbd167f047b460c2acb55a7",
+            "size": 834860082,
+            "uncompressed-sha256": "9c1f7ddb505a450981a0254755c8f0b976a2e912273c55705198f04ce35a9c64",
+            "uncompressed-size": 3527409664
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102090311-0-metal4k.s390x.raw.gz",
-            "sha256": "566bca2f1462b4d70f1d7da7a1c7d477252f2e2db6251ee61f6e810c3a450982",
-            "size": 831520327,
-            "uncompressed-sha256": "3478e62963f4b0bba45cc41a92cae33e9907cc3e4ed1206ef94a05db4e70b9fe",
-            "uncompressed-size": 3516923904
+            "path": "rhcos-47.83.202103251513-0-metal4k.s390x.raw.gz",
+            "sha256": "a649fab3cee516cd4e9535bc85aa41a2979e6f3f256dd1d564ba11ad9c5ebbaa",
+            "size": 835170504,
+            "uncompressed-sha256": "6225d64138fc6fc30ac0bf3a72be3d1a51f2cc554d2ab52e9992145b1081d5d7",
+            "uncompressed-size": 3527409664
         },
         "openstack": {
-            "path": "rhcos-47.83.202102090311-0-openstack.s390x.qcow2.gz",
-            "sha256": "4ebac56f35e48ff66b18ed21785f722272bc5b24573c2410f3d63a374eeab6db",
-            "size": 830070694,
-            "uncompressed-sha256": "2920cfe9a35e24302127507ab39e54d619c839d910361fe45c0c46dbd9813e7a",
-            "uncompressed-size": 2179530752
+            "path": "rhcos-47.83.202103251513-0-openstack.s390x.qcow2.gz",
+            "sha256": "4ce30b1214f99c2a6152aa957920060186587620c997d2225e77691b20462e9c",
+            "size": 833360472,
+            "uncompressed-sha256": "f3fcaf7398bc59956a04b7d22ac8a15cda5fd62f50e155ab19ee09f8e56c0d04",
+            "uncompressed-size": 2187264000
         },
         "ostree": {
-            "path": "rhcos-47.83.202102090311-0-ostree.s390x.tar",
-            "sha256": "d7ed80d612fedcca6a39017e41851acbb35c5d0a8cce9c06df8afacfe059e310",
-            "size": 779970560
+            "path": "rhcos-47.83.202103251513-0-ostree.s390x.tar",
+            "sha256": "c9e6fcfbf185d3a5154ceb17c3485030a70990d5f7d4312fa0475171336b23e4",
+            "size": 783472640
         },
         "qemu": {
-            "path": "rhcos-47.83.202102090311-0-qemu.s390x.qcow2.gz",
-            "sha256": "80d61716f6ca97e9b5256b2202132dcac169700937b40545ce9cd8ad9e6bbcee",
-            "size": 831149363,
-            "uncompressed-sha256": "cc3b8294320a6635bfdf05a380fb931875a57fe6b18118940b1ce2f23ca069a1",
-            "uncompressed-size": 2213019648
+            "path": "rhcos-47.83.202103251513-0-qemu.s390x.qcow2.gz",
+            "sha256": "7aeec967bb5aa45cdde618a003c6bd55552e97154e7a9e6a57110445309ed285",
+            "size": 834463024,
+            "uncompressed-sha256": "1ebc19c66fc10c01e4ec25f0ccf1a7127837f8a7d0f8bbf42a386c67b9c9c413",
+            "uncompressed-size": 2221146112
         }
     },
     "oscontainer": {
-        "digest": "sha256:0e8147407a02605f0e4f79ac5e8ddfda21b7557769a26b9f7138e82dc9558af0",
+        "digest": "sha256:68747ed40a2aec6c37b2c0f631b10f4177046660ac599a7372edd60345f55440",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ac18fdc352f3e1bcbf1c7d74f713f14de2c4117c869afd097432b5f8355e3781",
-    "ostree-version": "47.83.202102090311-0"
+    "ostree-commit": "32c6cf0224470de4839c99cb8eb476113b29c6a521577b7d21413eec75b6d9e3",
+    "ostree-version": "47.83.202103251513-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,163 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-057e5df70c52dc128"
+            "hvm": "ami-0401d6ad383dba55c"
         },
         "ap-east-1": {
-            "hvm": "ami-006ab68917f52bb13"
+            "hvm": "ami-03ac23c984c812cb4"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0d236f6289c700771"
+            "hvm": "ami-09cc1da8a6fa42c4e"
         },
         "ap-northeast-2": {
-            "hvm": "ami-040394572427a293a"
+            "hvm": "ami-0adf87370198caaed"
+        },
+        "ap-northeast-3": {
+            "hvm": "ami-0591a1337ebe93646"
         },
         "ap-south-1": {
-            "hvm": "ami-0838c978c0390dd75"
+            "hvm": "ami-08dfa06820a4fb482"
         },
         "ap-southeast-1": {
-            "hvm": "ami-07af688c8b65de56f"
+            "hvm": "ami-05345a132d89bd2b6"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0a36faab6aa0a0dea"
+            "hvm": "ami-00274925d47c6e015"
         },
         "ca-central-1": {
-            "hvm": "ami-01284e5815ce66a95"
+            "hvm": "ami-0baeff23c4cc6ddf5"
         },
         "eu-central-1": {
-            "hvm": "ami-0361c06cf3e935cfe"
+            "hvm": "ami-083ab4c282bac44b5"
         },
         "eu-north-1": {
-            "hvm": "ami-0080eb90a48d9655e"
+            "hvm": "ami-0791daa430c70ff09"
         },
         "eu-south-1": {
-            "hvm": "ami-0a3bc89f7aadf0343"
+            "hvm": "ami-093ccc9e024810fc8"
         },
         "eu-west-1": {
-            "hvm": "ami-0b4024fa5cb2588bd"
+            "hvm": "ami-07323d56fb932c84c"
         },
         "eu-west-2": {
-            "hvm": "ami-07376355104ab4106"
+            "hvm": "ami-0cabefac75acfd8e3"
         },
         "eu-west-3": {
-            "hvm": "ami-038f4ce9ea7ac7191"
+            "hvm": "ami-01f9af256e3213df9"
         },
         "me-south-1": {
-            "hvm": "ami-025899013a24bb708"
+            "hvm": "ami-0e5d014111ee32e16"
         },
         "sa-east-1": {
-            "hvm": "ami-089e1a3dcc5a5fe08"
+            "hvm": "ami-0dd8411ece8c06dae"
         },
         "us-east-1": {
-            "hvm": "ami-0d5f9982f029fbc14"
+            "hvm": "ami-03d1c2cba04df838c"
         },
         "us-east-2": {
-            "hvm": "ami-0c84b5c5255ec4777"
+            "hvm": "ami-0ddab715d6b88a315"
         },
         "us-west-1": {
-            "hvm": "ami-0b421328859954025"
+            "hvm": "ami-09b797de07577bf33"
         },
         "us-west-2": {
-            "hvm": "ami-010de485a2ee23e5e"
+            "hvm": "ami-0617611237b58ac93"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202102090044-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202102090044-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202103251640-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202103251640-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202102090044-0/x86_64/",
-    "buildid": "47.83.202102090044-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202103251640-0/x86_64/",
+    "buildid": "47.83.202103251640-0",
     "gcp": {
-        "image": "rhcos-47-83-202102090044-0-gcp-x86-64",
+        "image": "rhcos-47-83-202103251640-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202102090044-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202103251640-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202102090044-0-aws.x86_64.vmdk.gz",
-            "sha256": "ad54945302d9aaf0c5d6a5d1ee457325a3dcd88a68067d18a4d614acef5390d4",
-            "size": 951239242,
-            "uncompressed-sha256": "fbb7fbbc6cc6161ffa5c571f1b9022fe80038eea0a7f099c5b18ceba3b82f5eb",
-            "uncompressed-size": 970902016
+            "path": "rhcos-47.83.202103251640-0-aws.x86_64.vmdk.gz",
+            "sha256": "09f2376c33681b2e0f19209bc9e1b15c36a1635ad68e2670d774c5d017b8f29e",
+            "size": 954887101,
+            "uncompressed-sha256": "ef228bb22f647194da8c8261ddfc5a14b1694cb7585ab7d21bbf33a44652b3e4",
+            "uncompressed-size": 974496768
         },
         "azure": {
-            "path": "rhcos-47.83.202102090044-0-azure.x86_64.vhd.gz",
-            "sha256": "32aa9be04b7f06bfe028fc7c93443f0c742afb006e73b6076016fa897ae5f716",
-            "size": 951756228,
-            "uncompressed-sha256": "7e60c02aeebd129a99d65da48beddb99bd29ac7b31f3bb9395fb1d87e6311448",
+            "path": "rhcos-47.83.202103251640-0-azure.x86_64.vhd.gz",
+            "sha256": "a02679f9e3507ca39456e8813dcab69f07c7ee7bf7232a652a28183d7bc73697",
+            "size": 955225715,
+            "uncompressed-sha256": "5245c2b529b92458cde9ea7e55934cc870a23d09a17aa083be4537ac0b1caab1",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202102090044-0-gcp.x86_64.tar.gz",
-            "sha256": "07275bf2844f0dba6296d984d293959f614cc60af9f1be4070142a8cdcc650aa",
-            "size": 937047583
+            "path": "rhcos-47.83.202103251640-0-gcp.x86_64.tar.gz",
+            "sha256": "7570868619d51639a17bdceb7ab57f6adb7b20a78e49b32434537a0ed0e1f155",
+            "size": 940531637
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202102090044-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "b81b26a61d11a9c2c6fb33a94ff124f461907bff550338cfecf173cdd93c09be",
-            "size": 937381841,
-            "uncompressed-sha256": "5b6fdfb53e3ede4d264d13862bda6801d932f12e1a17309ac62ac32836bca8ff",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-47.83.202103251640-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "aa3bfde23a7af8f112f6b43273729011484a154b78bcac52a2d79cfc013b5c19",
+            "size": 940837877,
+            "uncompressed-sha256": "18b34659654b0870b4807c374385766e9e7bad4d29e64e7e05b06ca3574d569b",
+            "uncompressed-size": 2366177280
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202102090044-0-live-initramfs.x86_64.img",
-            "sha256": "29ba7e12b16f143a3f036226568ce91b3f7c8bd6feab719a73b0bed1817e4444"
+            "path": "rhcos-47.83.202103251640-0-live-initramfs.x86_64.img",
+            "sha256": "18f9a94a02a7eae8fe70dd465279dc2851ce14055d7725d22d2092d2ef54475c"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202102090044-0-live.x86_64.iso",
-            "sha256": "b765a9e99edfa0a91778a4787070c6afcaa198ba8806c8c1533c34a23d63136f"
+            "path": "rhcos-47.83.202103251640-0-live.x86_64.iso",
+            "sha256": "e763b79edc4c7958bffdb222cc4e5e8acbf6b7e447d4342009f908ab071b7c95"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202102090044-0-live-kernel-x86_64",
-            "sha256": "7da6617f6bb7b29c0a8cba002642f2fa23d954874e0d3641e61dd59573563381"
+            "path": "rhcos-47.83.202103251640-0-live-kernel-x86_64",
+            "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202102090044-0-live-rootfs.x86_64.img",
-            "sha256": "6da4ae110fc2bcea8ac0e6c40fa9d701bbde5b936a1410f75735386c8ea805bf"
+            "path": "rhcos-47.83.202103251640-0-live-rootfs.x86_64.img",
+            "sha256": "e9f38678e1508012ee9135723370357799b35f7c564d66b1d2a46232089a7477"
         },
         "metal": {
-            "path": "rhcos-47.83.202102090044-0-metal.x86_64.raw.gz",
-            "sha256": "0a456b02960eeb40a102ef14f5556843c2c504358f3db21f3fe667d8346c9bdf",
-            "size": 939085053,
-            "uncompressed-sha256": "36379d083adccccb3de266d2802cfcf5079429865fa010d9b499e87042d46526",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-47.83.202103251640-0-metal.x86_64.raw.gz",
+            "sha256": "a252c10f27e436e0ff17713703ac57134552d628fe3df03acec043aacb3c96ee",
+            "size": 942543852,
+            "uncompressed-sha256": "f0e658b58ab1aa654b7d09bf5810cb6c7e44cfaae5def27c3bf2bd9207a8c981",
+            "uncompressed-size": 3725590528
         },
         "metal4k": {
-            "path": "rhcos-47.83.202102090044-0-metal4k.x86_64.raw.gz",
-            "sha256": "ff10909c5d4ffbb3a829d070dcf3ce9a8b2d2aebff2924ee464d517eb948bfba",
-            "size": 936609970,
-            "uncompressed-sha256": "d5821d7fbd20f86bab29d028855200221f316fa041e86374c5f693da9b5d7b83",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-47.83.202103251640-0-metal4k.x86_64.raw.gz",
+            "sha256": "d010fbcb2615240d9c9797c7b9de678b330dfa0ad59190c0b14947437f411974",
+            "size": 940148936,
+            "uncompressed-sha256": "f8af1ae038af3ddec00f244e4ecf47916a7aaa1ba561dacf28cb52dc5f8099d7",
+            "uncompressed-size": 3725590528
         },
         "openstack": {
-            "path": "rhcos-47.83.202102090044-0-openstack.x86_64.qcow2.gz",
-            "sha256": "e5ebb8bcf6d081e52e1e7db0e93ff960ff472e25803a5671170959212e88cad9",
-            "size": 937380970,
-            "uncompressed-sha256": "c1b93a426d0f74f0059193439e306f3356b788302a825cfadd870460e543028e",
-            "uncompressed-size": 2360082432
+            "path": "rhcos-47.83.202103251640-0-openstack.x86_64.qcow2.gz",
+            "sha256": "a1eaea5e994c0fe7000865780ea5d0cc89980943330357eb64df333c1fad224d",
+            "size": 940839325,
+            "uncompressed-sha256": "f8ac2f68c0d7fbabd15cc3e88e29fcbd581c0250fe4e2ee4d5f56eb5b2f6af87",
+            "uncompressed-size": 2366177280
         },
         "ostree": {
-            "path": "rhcos-47.83.202102090044-0-ostree.x86_64.tar",
-            "sha256": "3b5fc040f7493ff7dc5aef4da22077ad74eb2e12a01a9e820d5c116e58716c4f",
-            "size": 863467520
+            "path": "rhcos-47.83.202103251640-0-ostree.x86_64.tar",
+            "sha256": "76f59de2809a80332c95a8f1635df0b1be9ba1ec6fd43c7a90e703fe03c9cf82",
+            "size": 867020800
         },
         "qemu": {
-            "path": "rhcos-47.83.202102090044-0-qemu.x86_64.qcow2.gz",
-            "sha256": "2ca82f1d762bba1cb2e5ac1386be0a1ab0264cf88b0594c9cd1e53d285833c6d",
-            "size": 938521497,
-            "uncompressed-sha256": "5d31652c7856a87450dce1bbbb561b578ee75443c190096cb977a814e5f35935",
-            "uncompressed-size": 2394030080
+            "path": "rhcos-47.83.202103251640-0-qemu.x86_64.qcow2.gz",
+            "sha256": "2925d6182753f19275b0a9b09079199dcee36310fdbbdb1760b8e822fb821e4f",
+            "size": 941977173,
+            "uncompressed-sha256": "2cc7c8841e6b2b0f5d3573b82453fddad3c44972c080969458af85c7097e9bc5",
+            "uncompressed-size": 2399993856
         },
         "vmware": {
-            "path": "rhcos-47.83.202102090044-0-vmware.x86_64.ova",
-            "sha256": "13d92692b8eed717ff8d0d113a24add339a65ef1f12eceeb99dabcd922cc86d1",
-            "size": 970915840
+            "path": "rhcos-47.83.202103251640-0-vmware.x86_64.ova",
+            "sha256": "6ac67b43ed6fe25cbe4b01b8f8900a9a5bc0bb6a9894d40be46b994cda906efd",
+            "size": 974510080
         }
     },
     "oscontainer": {
-        "digest": "sha256:a32077727aa2ef96a1e2371dbcc53ba06f3d9727e836b72be0f0dd4513937e1e",
+        "digest": "sha256:0ad297b22e7b96e04e45aefcc57f571361c87bdc3110e692bb239f2dfbe64050",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "646a9832dd0dc9fe174a2fc005863a9582186518a5476522a0e9bdccc0e5252a",
-    "ostree-version": "47.83.202102090044-0"
+    "ostree-commit": "3fdd1488024f054e39b1be508781d535d1ac7ed423bb3b4b656c2f345934220d",
+    "ostree-version": "47.83.202103251640-0"
 }

--- a/pkg/rhcos/ami_regions.go
+++ b/pkg/rhcos/ami_regions.go
@@ -8,6 +8,7 @@ var AMIRegions = []string{
 	"ap-east-1",
 	"ap-northeast-1",
 	"ap-northeast-2",
+	"ap-northeast-3",
 	"ap-south-1",
 	"ap-southeast-1",
 	"ap-southeast-2",


### PR DESCRIPTION
This bumps the boot image to to include fixes for the following:

BZ#1922417 - Issue configuring nodes with VLAN and teaming
BZ#1940966 - [4.7.z] prjquota is dropped from rootflags if rootfs is reprovisioned
BZ#1941760 - [4.7.z] rootfs too small when enabling NBDE (redo)
BZ#1942706 - [4.7.z] support new AWS region ap-northeast-3