### PR TITLE
rhcos[-amd64].json: Manual add of ap-northeast-3

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -12,6 +12,9 @@
         "ap-northeast-2": {
             "hvm": "ami-0fdc25c8a0273a742"
         },
+        "ap-northeast-3": {
+            "hvm": "ami-0310bc3d6eec49e56"
+        },
         "ap-south-1": {
             "hvm": "ami-09e3deb397cc526a8"
         },

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -12,6 +12,9 @@
         "ap-northeast-2": {
             "hvm": "ami-0fdc25c8a0273a742"
         },
+        "ap-northeast-3": {
+            "hvm": "ami-0310bc3d6eec49e56"
+        },
         "ap-south-1": {
             "hvm": "ami-09e3deb397cc526a8"
         },


### PR DESCRIPTION
*Manual* add of the `ap-northeast-3` for 4.6 per PM request (cc'd).

Future boot image builds will automatically populate in the region and will be picked up in the normal boot image bump flow.

There will be no bugzilla for this as it is not a backport.