### PR TITLE
Bug 1945467: aws: allow use of unknown regions in known partitions

### DIFF
--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
 )
@@ -55,7 +56,7 @@ func Validate(ctx context.Context, meta *Metadata, config *types.InstallConfig) 
 func validatePlatform(ctx context.Context, meta *Metadata, fldPath *field.Path, platform *awstypes.Platform, networking *types.Networking, publish types.PublishingStrategy) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if !isAWSSDKRegion(platform.Region) && platform.AMIID == "" {
+	if !sets.NewString(rhcos.AMIRegions...).Has(platform.Region) && platform.AMIID == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("amiID"), "AMI must be provided"))
 	}
 
@@ -211,7 +212,7 @@ func validateDuplicateSubnetZones(fldPath *field.Path, subnets map[string]Subnet
 }
 
 func validateServiceEndpoints(fldPath *field.Path, region string, services []awstypes.ServiceEndpoint) error {
-	if isAWSSDKRegion(region) {
+	if _, partitionFound := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); partitionFound {
 		return nil
 	}
 
@@ -224,17 +225,6 @@ func validateServiceEndpoints(fldPath *field.Path, region string, services []aws
 		}
 	}
 	return utilerrors.NewAggregate(errs)
-}
-
-func isAWSSDKRegion(region string) bool {
-	for _, partition := range endpoints.DefaultPartitions() {
-		for _, partitionRegion := range partition.Regions() {
-			if region == partitionRegion.ID() {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 var requiredServices = []string{

--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -39,6 +39,7 @@ func Validate(ctx context.Context, meta *Metadata, config *types.InstallConfig) 
 	if config.Platform.AWS == nil {
 		return errors.New(field.Required(field.NewPath("platform", "aws"), "AWS validation requires an AWS platform configuration").Error())
 	}
+	allErrs = append(allErrs, validateAMI(ctx, config)...)
 	allErrs = append(allErrs, validatePlatform(ctx, meta, field.NewPath("platform", "aws"), config.Platform.AWS, config.Networking, config.Publish)...)
 
 	if config.ControlPlane != nil && config.ControlPlane.Platform.AWS != nil {
@@ -56,10 +57,6 @@ func Validate(ctx context.Context, meta *Metadata, config *types.InstallConfig) 
 func validatePlatform(ctx context.Context, meta *Metadata, fldPath *field.Path, platform *awstypes.Platform, networking *types.Networking, publish types.PublishingStrategy) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if !sets.NewString(rhcos.AMIRegions...).Has(platform.Region) && platform.AMIID == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("amiID"), "AMI must be provided"))
-	}
-
 	if len(platform.Subnets) > 0 {
 		allErrs = append(allErrs, validateSubnets(ctx, meta, fldPath.Child("subnets"), platform.Subnets, networking, publish)...)
 	}
@@ -70,6 +67,53 @@ func validatePlatform(ctx context.Context, meta *Metadata, fldPath *field.Path, 
 		allErrs = append(allErrs, validateMachinePool(ctx, meta, fldPath.Child("defaultMachinePlatform"), platform, platform.DefaultMachinePlatform, controlPlaneReq)...)
 	}
 	return allErrs
+}
+
+func validateAMI(ctx context.Context, config *types.InstallConfig) field.ErrorList {
+	// accept AMI from the rhcos stream metadata
+	if sets.NewString(rhcos.AMIRegions...).Has(config.Platform.AWS.Region) {
+		return nil
+	}
+
+	// accept AMI specified at the platform level
+	if config.Platform.AWS.AMIID != "" {
+		return nil
+	}
+
+	// accept AMI specified for the default machine platform
+	if config.Platform.AWS.DefaultMachinePlatform != nil {
+		if config.Platform.AWS.DefaultMachinePlatform.AMIID != "" {
+			return nil
+		}
+	}
+
+	// accept AMIs specified specifically for each machine pool
+	controlPlaneHasAMISpecified := false
+	if config.ControlPlane != nil && config.ControlPlane.Platform.AWS != nil {
+		controlPlaneHasAMISpecified = config.ControlPlane.Platform.AWS.AMIID != ""
+	}
+	computesHaveAMISpecified := true
+	for _, c := range config.Compute {
+		if c.Replicas != nil && *c.Replicas == 0 {
+			continue
+		}
+		if c.Platform.AWS == nil || c.Platform.AWS.AMIID == "" {
+			computesHaveAMISpecified = false
+		}
+	}
+	if controlPlaneHasAMISpecified && computesHaveAMISpecified {
+		return nil
+	}
+
+	// accept AMI that can be copied from us-east-1 if the region is in the standard AWS partition
+	if partition, partitionFound := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), config.Platform.AWS.Region); partitionFound {
+		if partition.ID() == endpoints.AwsPartitionID {
+			return nil
+		}
+	}
+
+	// fail validation since we do not have an AMI to use
+	return field.ErrorList{field.Required(field.NewPath("platform", "aws", "amiID"), "AMI must be provided")}
 }
 
 func validateSubnets(ctx context.Context, meta *Metadata, fldPath *field.Path, subnets []string, networking *types.Networking, publish types.PublishingStrategy) field.ErrorList {


### PR DESCRIPTION
This is a manual cherry-pick of #4801.

Allow the user to specify a region that is not known to the instatller but does match the regex of a known partition without requiring the user to specify custom service endpoints. This is needed to support new regions that are added to known partitions.

Without this, it is not possible to use an unknown region is the standard partition. Terraform will not create the IAM roles correctly when specifying custom endpoints for a region in the standard partition because the request will try to create the role in the  cluster's region rather than in us-east-1.

This seems like the behavior that was desired when the check for whether custom service endpoints are needed was added in https://github.com/openshift/installer/commit/cf79a75308faf38e11f758457ca40748b797e56a.

In addition to relaxing the service endpoint validation, the validation around whether an AMI must be specified has been tightened. The user must specify an AMI when the RHCOS stream does not contain an AMI for the region, rather than when the ASK SDK knows about the region.

https://bugzilla.redhat.com/show_bug.cgi?id=1944268