### PR TITLE
Bug 1945659: remove ovirt_cafile from ovirt-credentials secret

### DIFF
--- a/data/data/manifests/openshift/cloud-creds-secret.yaml.template
+++ b/data/data/manifests/openshift/cloud-creds-secret.yaml.template
@@ -41,7 +41,6 @@ data:
   ovirt_url: {{.CloudCreds.Ovirt.Base64encodeURL}}
   ovirt_username: {{.CloudCreds.Ovirt.Base64encodeUsername}}
   ovirt_password: {{.CloudCreds.Ovirt.Base64encodePassword}}
-  ovirt_cafile: {{.CloudCreds.Ovirt.Base64encodeCAFile}}
   ovirt_insecure: {{.CloudCreds.Ovirt.Base64encodeInsecure}}
   ovirt_ca_bundle: {{.CloudCreds.Ovirt.Base64encodeCABundle}}
 {{- else if .CloudCreds.Kubevirt}}

--- a/docs/user/ovirt/install_ipi.md
+++ b/docs/user/ovirt/install_ipi.md
@@ -102,6 +102,8 @@ Below the description of all config options in ovirt-config.yaml.
 | ovirt_password | Password for the user provided | string   | superpass                                                                                              |
 | ovirt_insecure | TLS verification disabled      | boolean  | false                                                                                                  |
 | ovirt_ca_bundle| CA Bundle                      | string   | -----BEGIN CERTIFICATE----- MIIDvTCCAqWgAwIBAgICEAA.... ----- END CERTIFICATE -----                    |
+| ovirt_cafile   | path to a file containing the  | string   | /path/to/ca.pm                                                                                         |
+|                | engine cert                    |          |                                                                                                        |
 | ovirt_pem_url  | PEM URL                        | string   | https://engine.fqdn.home/ovirt-engine/services/pki-resource?resource=ca-certificate&format=X509-PEM-CA |
 
 ### ovirt-credentials

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -3,8 +3,10 @@ package manifests
 import (
 	"context"
 	"encoding/base64"
+	"io/ioutil"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/gophercloud/utils/openstack/clientconfig"
@@ -183,12 +185,19 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 			return err
 		}
 
+		if len(conf.CABundle) == 0 && len(conf.CAFile) > 0 {
+			content, err := ioutil.ReadFile(conf.CAFile)
+			if err != nil {
+				return errors.Wrapf(err, "failed to read the cert file: %s", conf.CAFile)
+			}
+			conf.CABundle = strings.TrimSpace(string(content))
+		}
+
 		cloudCreds = cloudCredsSecretData{
 			Ovirt: &OvirtCredsSecretData{
 				Base64encodeURL:      base64.StdEncoding.EncodeToString([]byte(conf.URL)),
 				Base64encodeUsername: base64.StdEncoding.EncodeToString([]byte(conf.Username)),
 				Base64encodePassword: base64.StdEncoding.EncodeToString([]byte(conf.Password)),
-				Base64encodeCAFile:   base64.StdEncoding.EncodeToString([]byte(conf.CAFile)),
 				Base64encodeInsecure: base64.StdEncoding.EncodeToString([]byte(strconv.FormatBool(conf.Insecure))),
 				Base64encodeCABundle: base64.StdEncoding.EncodeToString([]byte(conf.CABundle)),
 			},

--- a/pkg/asset/manifests/template.go
+++ b/pkg/asset/manifests/template.go
@@ -42,7 +42,6 @@ type OvirtCredsSecretData struct {
 	Base64encodeURL      string
 	Base64encodeUsername string
 	Base64encodePassword string
-	Base64encodeCAFile   string
 	Base64encodeInsecure string
 	Base64encodeCABundle string
 }


### PR DESCRIPTION
When the user tried to use an ovirt.config with a ca_file the ca_file path is written to the secret but this will not be the path of the file in the created machines.
This problem will cause connection errors in the machine object that tries to find the file that doesn't exist.
Instead, we should read the file content and write it as the ovirt_ca_bundle in case the ovirt_ca_bundle is not set on the ovirt.config file.