### PR TITLE
update append iamRoleNames only if Platform.AWS not nil

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -89,9 +89,10 @@ func tagIamRoles(ctx context.Context, clusterID string, installConfig *installco
 	workerMachinePool := installConfig.Config.WorkerMachinePool()
 
 	var iamRoleNames []*string
-
-	if installConfig.Config.ControlPlane.Platform.AWS.IAMRole != "" {
-		iamRoleNames = append(iamRoleNames, &installConfig.Config.ControlPlane.Platform.AWS.IAMRole)
+	if installConfig.Config.ControlPlane.Platform.AWS != nil {
+		if installConfig.Config.ControlPlane.Platform.AWS.IAMRole != "" {
+			iamRoleNames = append(iamRoleNames, &installConfig.Config.ControlPlane.Platform.AWS.IAMRole)
+		}
 	}
 
 	if workerMachinePool.Platform.AWS.IAMRole != "" {


### PR DESCRIPTION
I noticed this issue: https://github.com/openshift/installer/issues/4816 and this will resolve it, unless the fix should be to require the ControlPlane.Platform type to be populated in the install-config. 

Signed-off-by: Sally O'Malley <somalley@redhat.com>