### PR TITLE
Bug 1946119: aws: support setting IAM role in the default AWS machine platform

### DIFF
--- a/pkg/asset/cluster/aws/aws.go
+++ b/pkg/asset/cluster/aws/aws.go
@@ -86,16 +86,22 @@ func tagSubnetEC2Instances(ctx context.Context, clusterID string, installConfig 
 }
 
 func tagIamRoles(ctx context.Context, clusterID string, installConfig *installconfig.InstallConfig) error {
-	workerMachinePool := installConfig.Config.WorkerMachinePool()
-
 	var iamRoleNames []*string
-
-	if installConfig.Config.ControlPlane.Platform.AWS.IAMRole != "" {
-		iamRoleNames = append(iamRoleNames, &installConfig.Config.ControlPlane.Platform.AWS.IAMRole)
+	if mp := installConfig.Config.ControlPlane; mp != nil {
+		awsMP := &awstypes.MachinePool{}
+		awsMP.Set(installConfig.Config.AWS.DefaultMachinePlatform)
+		awsMP.Set(mp.Platform.AWS)
+		if iamRole := awsMP.IAMRole; iamRole != "" {
+			iamRoleNames = append(iamRoleNames, &iamRole)
+		}
 	}
-
-	if workerMachinePool.Platform.AWS.IAMRole != "" {
-		iamRoleNames = append(iamRoleNames, &workerMachinePool.Platform.AWS.IAMRole)
+	if mp := installConfig.Config.WorkerMachinePool(); mp != nil {
+		awsMP := &awstypes.MachinePool{}
+		awsMP.Set(installConfig.Config.AWS.DefaultMachinePlatform)
+		awsMP.Set(mp.Platform.AWS)
+		if iamRole := awsMP.IAMRole; iamRole != "" {
+			iamRoleNames = append(iamRoleNames, &iamRole)
+		}
 	}
 
 	if len(iamRoleNames) == 0 {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -235,15 +235,20 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			osImageRegion = osImage[1]
 		}
 
-		workerMachinePool := installConfig.Config.WorkerMachinePool()
 		workerIAMRoleName := ""
-		if workerMachinePool.Platform.AWS != nil {
-			workerIAMRoleName = workerMachinePool.Platform.AWS.IAMRole
+		if mp := installConfig.Config.WorkerMachinePool(); mp != nil {
+			awsMP := &aws.MachinePool{}
+			awsMP.Set(installConfig.Config.AWS.DefaultMachinePlatform)
+			awsMP.Set(mp.Platform.AWS)
+			workerIAMRoleName = awsMP.IAMRole
 		}
 
 		masterIAMRoleName := ""
-		if installConfig.Config.ControlPlane.Platform.AWS != nil {
-			masterIAMRoleName = installConfig.Config.ControlPlane.Platform.AWS.IAMRole
+		if mp := installConfig.Config.ControlPlane; mp != nil {
+			awsMP := &aws.MachinePool{}
+			awsMP.Set(installConfig.Config.AWS.DefaultMachinePlatform)
+			awsMP.Set(mp.Platform.AWS)
+			masterIAMRoleName = awsMP.IAMRole
 		}
 
 		data, err := awstfvars.TFVars(awstfvars.TFVarsSources{


### PR DESCRIPTION
If the IAM role is set in the default AWS machine platform but not in the machine platform for a specific machine pool, then the IAM role from the default AWS machine platform should be used for that machine pool.

These changes also fix a bug where if the AWS machine platform were omitted from a particular machine pool, the installer would panic when trying to find IAM roles to tag.

https://bugzilla.redhat.com/show_bug.cgi?id=1946119