### PR TITLE
Bug 1946307: gcp: install google cloud sdk with yum the recommended way

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -19,10 +19,13 @@ COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json 
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
 RUN sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" >/etc/yum.repos.d/azure-cli.repo'
 
+RUN sh -c 'echo -e "[google-cloud-sdk]\nname=Google Cloud SDK\nbaseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg\n       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" > /etc/yum.repos.d/google-cloud-sdk.repo'
+
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
       azure-cli \
       gettext \
+      google-cloud-sdk \
       gzip \
       jq \
       unzip \
@@ -54,16 +57,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     unzip awscliv2.zip && \
     ./aws/install -b /bin && \
     rm -rf ./aws awscliv2.zip
-RUN mkdir -p /usr/local/gcloud && \
-    cd /usr/local/gcloud && \
-    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-334.0.0-linux-x86_64.tar.gz && \
-    tar xzf google-cloud-sdk-334.0.0-linux-x86_64.tar.gz && \
-    ./google-cloud-sdk/install.sh --usage-reporting false --path-update true --quiet && \
-    rm -rf google-cloud-sdk-334.0.0-linux-x86_64.tar.gz
-    
+
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 ENV HOME /output
 WORKDIR /output

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -19,7 +19,7 @@ COPY --from=builder /go/src/github.com/openshift/installer/data/data/rhcos.json 
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
 RUN sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" >/etc/yum.repos.d/azure-cli.repo'
 
-RUN sh -c 'echo -e "[google-cloud-sdk]\nname=Google Cloud SDK\nbaseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\ngpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg\n       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" > /etc/yum.repos.d/google-cloud-sdk.repo'
+RUN sh -c 'echo -e "[google-cloud-sdk]\nname=Google Cloud SDK\nbaseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg\n       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" > /etc/yum.repos.d/google-cloud-sdk.repo'
 
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \


### PR DESCRIPTION
Google recommends to use disable repository GPG key
checking in the yum repo configuration by setting
repo_gpgcheck=0. Yum repositories do not usually
use GPG keys for repository validation.
Instead, the https endpoint is trusted.