### PR TITLE
Bug 1946506: Bootstrap no longer relies on mdns

### DIFF
--- a/data/data/bootstrap/baremetal/README.md
+++ b/data/data/bootstrap/baremetal/README.md
@@ -22,8 +22,6 @@ internal to the cluster as possible.
 There is a DNS VIP managed by `keepalived` in a manner similar to the API VIP
 discussed above.
 
-`coredns` runs with a custom `mdns` plugin (`coredns-mdns`).
-
 Relevant files:
 * **[files/etc/dhcp/dhclient.conf](files/etc/dhcp/dhclient.conf)** - Specify
   that the bootstrap VM should use `localhost` as its primary DNS server.

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -63,7 +63,6 @@ CLUSTER_BOOTSTRAP_IMAGE=$(image_for cluster-bootstrap)
 
 KEEPALIVED_IMAGE=$(image_for keepalived-ipfailover || echo "no-keepalived-image")
 COREDNS_IMAGE=$(image_for coredns)
-MDNS_PUBLISHER_IMAGE=$(image_for mdns-publisher)
 HAPROXY_IMAGE=$(image_for haproxy-router)
 BAREMETAL_RUNTIMECFG_IMAGE=$(image_for baremetal-runtimecfg)
 
@@ -299,7 +298,6 @@ then
 			--infra-image="${MACHINE_CONFIG_INFRA_IMAGE}" \
 			--keepalived-image="${KEEPALIVED_IMAGE}" \
 			--coredns-image="${COREDNS_IMAGE}" \
-			--mdns-publisher-image="${MDNS_PUBLISHER_IMAGE}" \
 			--haproxy-image="${HAPROXY_IMAGE}" \
 			--baremetal-runtimecfg-image="${BAREMETAL_RUNTIMECFG_IMAGE}" \
 			--release-image="${RELEASE_IMAGE_DIGEST}" \

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -62,17 +62,6 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
   description       = local.description
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_mdns_udp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "udp"
-  port_range_min    = 5353
-  port_range_max    = 5353
-  remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.master.id
-  description       = local.description
-}
-
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
   direction      = "ingress"
   ethertype      = "IPv4"

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -29,17 +29,6 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_ssh" {
   description       = local.description
 }
 
-resource "openstack_networking_secgroup_rule_v2" "worker_ingress_mdns_udp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "udp"
-  port_range_min    = 5353
-  port_range_max    = 5353
-  remote_ip_prefix  = var.cidr_block
-  security_group_id = openstack_networking_secgroup_v2.worker.id
-  description       = local.description
-}
-
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_http" {
   direction         = "ingress"
   ethertype         = "IPv4"

--- a/docs/design/openstack/networking-infrastructure.md
+++ b/docs/design/openstack/networking-infrastructure.md
@@ -1,7 +1,7 @@
 # OpenStack IPI Networking Infrastructure
 
-The `OpenStack` platform installer uses an internal networking solution that
-is based heavily on the [baremetal networking infrastructure](../baremetal/networking-infrastructure.md).
+The `OpenStack` platform installer uses an internal networking solution identical to
+the [baremetal networking infrastructure](../baremetal/networking-infrastructure.md).
 For an overview of the quotas required, and the entrypoints created when
 you build an OpenStack IPI cluster, see the [user docs](../../user/openstack/README.md).
 
@@ -14,21 +14,6 @@ cluster is load-balanced across control plane machines.
 These services are initially hosted by the bootstrap node until the control
 plane is up. Then, control is pivoted to the control plane machines. We will go into further detail on
 that process in the [Virtual IPs section](#virtual-ips).
-
-## CoreDNS-mDNS
-
-https://github.com/openshift/CoreDNS-mdns/
-
-The `mDNS` plugin for `CoreDNS` was developed to perform DNS lookups
-based on discoverable information from mDNS. This plugin will resolve both the
-`etcd-NNN` records, as well as the `_etcd-server-ssl._tcp.` SRV record. It is also
-able to resolve the name of the nodes.
-
-The list of `etcd` hosts included in the SRV record is based on the list of
-control plane nodes currently running.
-
-The IP addresses that the `etcd-NNN` host records resolve to comes from the
-mDNS advertisement sent out by the `mDNS-publisher` on that control plane node.
 
 ## Virtual IPs
 
@@ -61,9 +46,9 @@ The bootstrap node is responsible for running temporary networking infrastructur
 nodes are still coming up. The bootstrap node will run a CoreDNS instance, as well as
 Keepalived. While the bootstrap node is up, it will have priority running the API VIP.
 
-The Master nodes run dhcp, HAProxy, CoreDNS, mDNS-publisher, and Keepalived. Haproxy loadbalances incoming requests
+The Master nodes run dhcp, HAProxy, CoreDNS, and Keepalived. Haproxy loadbalances incoming requests
 to the API across all running masters. It also runs a stats and healthcheck server. Keepalived manages both VIPs on the master, where each
 master has an equal chance of being assigned one of the VIPs. Initially, the bootstrap node has the highest priority for hosting the API VIP, so they will point to addresses there at startup. Meanwhile, the master nodes will try to get the control plane, and the OpenShift API up. Keepalived implements periodic health checks for each VIP that are used to determine the weight assigned to each server. The server with the highest weight is assigned the VIP. Keepalived has two seperate healthchecks that attempt to reach the OpenShift API and CoreDNS on the localhost of each master node. When the API on a master node is reachable, Keepalived substantially increases it's weight for that VIP, making its priority higher than that of the bootstrap node and any node that does not yet have the that service running. This ensures that nodes that are incapable of serving DNS records or the OpenShift API do not get assigned the respective VIP. The Ingress VIP is also managed by a healthcheck that queries for an OCP Router HAProxy healthcheck, not the HAProxy we stand up in  static pods for the API. This makes sure that the Ingress VIP is pointing to a server that is running the necessary OpenShift Ingress Operator resources to enable external access to the node.
 
-The Worker Nodes run dhcp, CoreDNS, mDNS-publisher, and Keepalived. On workers, Keepalived is only responsible for managing
+The Worker Nodes run dhcp, CoreDNS, and Keepalived. On workers, Keepalived is only responsible for managing
 the Ingress VIP. It's algorithm is the same as the one run on the masters.

--- a/docs/user/openstack/known-issues.md
+++ b/docs/user/openstack/known-issues.md
@@ -2,10 +2,6 @@
 
 We have been tracking a few issues and FAQs from our users, and are documenting them here along with the known workarounds and solutions. For issues that still have open bugs, we have attached the links to where the engineering team is tracking their progress. As changes occur, we will update both this document and the issue trackers with the latest information.
 
-## Long Cluster Names
-
-If the mDNS service name of a server is too long, it will exceed the character limit and cause the installer to fail. To prevent this from happening, please restrict the `metadata.name` field in the `install-config.yaml` to 14 characters. The installer validates this in your install config and throws an error to prevent you from triggering this install time bug. This is being tracked in this [github issue](https://github.com/openshift/installer/issues/2243).
-
 ## Resources With Duplicate Names
 
 Since the installer requires the *Name* of your external network and Red Hat Core OS image, if you have other networks or images with the same name, it will choose one randomly from the set. This is not a reliable way to run the installer. We highly recommend that you resolve this with your cluster administrator by creating unique names for your resources in openstack.

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -63,14 +63,6 @@
       port_range_min: 53
       port_range_max: 53
 
-  - name: 'Create master-sg rule "mDNS"'
-    os_security_group_rule:
-      security_group: "{{ os_sg_master }}"
-      remote_ip_prefix: "{{ os_subnet_range }}"
-      protocol: udp
-      port_range_min: 5353
-      port_range_max: 5353
-
   - name: 'Create master-sg rule "OpenShift API"'
     os_security_group_rule:
       security_group: "{{ os_sg_master }}"
@@ -201,14 +193,6 @@
       remote_ip_prefix: "{{ os_subnet_range }}"
       port_range_min: 22
       port_range_max: 22
-
-  - name: 'Create worker-sg rule "mDNS"'
-    os_security_group_rule:
-      security_group: "{{ os_sg_worker }}"
-      protocol: udp
-      remote_ip_prefix: "{{ os_subnet_range }}"
-      port_range_min: 5353
-      port_range_max: 5353
 
   - name: 'Create worker-sg rule "Ingress HTTP"'
     os_security_group_rule:


### PR DESCRIPTION
Bootstrap no longer rely on mdns for name resolution. We can remove the `--mdns-publisher-image` flag for the bootstrap and remove the security group rules for mdns.

These rules where only defined for OpenStack plaform. This PR removes the rules for both UPI and IPI.

Also remove obsolete comment about coredns running with mdns plugin in documentation.

Depends on https://github.com/openshift/machine-config-operator/pull/2465, to remove dependency on the coredns's mdns plugin.