### PR TITLE
Bug 1921627: Shorten instance group suffix to ig

### DIFF
--- a/docs/user/gcp/install_upi.md
+++ b/docs/user/gcp/install_upi.md
@@ -549,13 +549,13 @@ Manager, so we must add the bootstrap node manually.
 ### Add bootstrap instance to internal load balancer instance group
 
 ```sh
-gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-bootstrap-instance-group --zone=${ZONE_0} --instances=${INFRA_ID}-bootstrap
+gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-bootstrap-ig --zone=${ZONE_0} --instances=${INFRA_ID}-bootstrap
 ```
 
 ### Add bootstrap instance group to the internal load balancer backend service
 
 ```sh
-gcloud compute backend-services add-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-instance-group --instance-group-zone=${ZONE_0}
+gcloud compute backend-services add-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-ig --instance-group-zone=${ZONE_0}
 ```
 
 ## Launch permanent control plane
@@ -646,9 +646,9 @@ Manager, so we must add the control plane nodes manually.
 ### Add control plane instances to internal load balancer instance groups
 
 ```sh
-gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_0}-instance-group --zone=${ZONE_0} --instances=${INFRA_ID}-master-0
-gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_1}-instance-group --zone=${ZONE_1} --instances=${INFRA_ID}-master-1
-gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_2}-instance-group --zone=${ZONE_2} --instances=${INFRA_ID}-master-2
+gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_0}-ig --zone=${ZONE_0} --instances=${INFRA_ID}-master-0
+gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_1}-ig --zone=${ZONE_1} --instances=${INFRA_ID}-master-1
+gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_2}-ig --zone=${ZONE_2} --instances=${INFRA_ID}-master-2
 ```
 
 ### Add control plane instances to external load balancer target pools (optional)

--- a/upi/gcp/02_lb_int.py
+++ b/upi/gcp/02_lb_int.py
@@ -3,7 +3,7 @@ def GenerateConfig(context):
     backends = []
     for zone in context.properties['zones']:
         backends.append({
-            'group': '$(ref.' + context.properties['infra_id'] + '-master-' + zone + '-instance-group' + '.selfLink)'
+            'group': '$(ref.' + context.properties['infra_id'] + '-master-' + zone + '-ig' + '.selfLink)'
         })
 
     resources = [{
@@ -51,7 +51,7 @@ def GenerateConfig(context):
 
     for zone in context.properties['zones']:
         resources.append({
-            'name': context.properties['infra_id'] + '-master-' + zone + '-instance-group',
+            'name': context.properties['infra_id'] + '-master-' + zone + '-ig',
             'type': 'compute.v1.instanceGroup',
             'properties': {
                 'namedPorts': [

--- a/upi/gcp/04_bootstrap.py
+++ b/upi/gcp/04_bootstrap.py
@@ -40,7 +40,7 @@ def GenerateConfig(context):
             'zone': context.properties['zone']
         }
     }, {
-        'name': context.properties['infra_id'] + '-bootstrap-instance-group',
+        'name': context.properties['infra_id'] + '-bootstrap-ig',
         'type': 'compute.v1.instanceGroup',
         'properties': {
             'namedPorts': [


### PR DESCRIPTION
GCP has a size restriction of 63 for the instance group name which
is mostly taken up by the suffix -instance-group that is being added
to make sure the resources have unique name. Reducing the size
of the suffix from -instance-group to -ig would help in restricting
the size of the name and would also help in keeping the names
unique.