### PR TITLE
Revert "Dockerfile.upi.ci: Drop pip+pyopenssl installs"

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -37,6 +37,8 @@ RUN yum update -y && \
     rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 
+RUN easy_install 'pip<21'
+RUN python -m pip install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python
 
 ENV TERRAFORM_VERSION=0.12.24


### PR DESCRIPTION
This reverts commit 9aeadb0ccef278538bf007afd0c0b405722c7ce9.

- pyopenssl is still required to use signurl with gcloud
- we still end up using python2 with the image used by prow
- the ssl certificate for files.pythonhosted.org appears to work now