### PR TITLE
pkg/destroy/gcp: fix dropped error

### DIFF
--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -114,6 +114,10 @@ func (o *ClusterUninstaller) Run() error {
 		time.Second*10,
 		o.destroyCluster,
 	)
+	if err != nil {
+		return errors.Wrap(err, "failed to destroy cluster")
+	}
+
 	return nil
 
 }


### PR DESCRIPTION
This fixes a dropped error in `pkg/destroy/gcp`.