### PR TITLE
WIP: build upi image without specific pip version

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -37,7 +37,7 @@ RUN yum update -y && \
     rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 
-RUN easy_install 'pip<21'
+RUN easy_install 'pip'
 RUN python -m pip install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python
 


### PR DESCRIPTION
"RUN easy_install 'pip<21'" is failing.

Let's just install pip without specifying the version and see if our tests fail.