### PR TITLE
Bug 1937085: ovirt UPI - add memory_guaranteed

### DIFF
--- a/upi/ovirt/inventory.yml
+++ b/upi/ovirt/inventory.yml
@@ -15,6 +15,7 @@ all:
     control_plane:
       cluster: "{{ ovirt_cluster }}"
       memory: 16GiB
+      memory_guaranteed: 3G
       sockets: 4
       cores: 1
       template: rhcos_tpl
@@ -38,6 +39,7 @@ all:
     compute:
       cluster: "{{ ovirt_cluster }}"
       memory: 16GiB
+      memory_guaranteed: 3G
       sockets: 4
       cores: 1
       template: worker_rhcos_tpl


### PR DESCRIPTION
Avoid possible failures during the install due the lack of
memory.

Signed-off-by: Douglas Schilling Landgraf <dougsland@redhat.com>