### PR TITLE
WIP: baremetal: Add privLevel to bmc data

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1202,6 +1202,8 @@ spec:
                               type: string
                             username:
                               type: string
+                            privLevel:
+                              type: string
                           required:
                           - address
                           - disableCertificateVerification

--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -57,6 +57,7 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 			bmc.Address = host.BMC.Address
 			bmc.CredentialsName = secret.Name
 			bmc.DisableCertificateVerification = host.BMC.DisableCertificateVerification
+			bmc.PrivLevel = host.BMC.PrivLevel
 			settings.Secrets = append(settings.Secrets, secret)
 		}
 

--- a/pkg/tfvars/baremetal/baremetal.go
+++ b/pkg/tfvars/baremetal/baremetal.go
@@ -55,7 +55,7 @@ func TFVars(libvirtURI, apiVIP, imageCacheIP, bootstrapOSImage, externalBridge, 
 		}
 
 		// BMC Driver Info
-		accessDetails, err := bmc.NewAccessDetails(host.BMC.Address, host.BMC.DisableCertificateVerification)
+		accessDetails, err := bmc.NewAccessDetails(host.BMC.Address, host.BMC.DisableCertificateVerification, host.BMC.PrivLevel)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -10,6 +10,9 @@ type BMC struct {
 	Password                       string `json:"password" validate:"required"`
 	Address                        string `json:"address" validate:"required,uniqueField"`
 	DisableCertificateVerification bool   `json:"disableCertificateVerification"`
+	// privLevel is the ipmi privilage level to use when authenicating, it is ignore
+	// when not using ipmi
+	PrivLevel                      string `json:"privLevel"`
 }
 
 // BootMode puts the server in legacy (BIOS), UEFI secure boot or UEFI mode for

--- a/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1/baremetalhost_types.go
@@ -39,6 +39,10 @@ const (
 	// an immediate requeue)
 	PausedAnnotation = "baremetalhost.metal3.io/paused"
 
+	// Detached is the annotation which stops provisioner management of the host
+	// unlike in the paused case, the host status may be updated
+	DetachedAnnotation = "baremetalhost.metal3.io/detached"
+
 	// StatusAnnotation is the annotation that keeps a copy of the Status of BMH
 	// This is particularly useful when we pivot BMH. If the status
 	// annotation is present and status is empty, BMO will reconstruct BMH Status
@@ -118,7 +122,13 @@ const (
 	// has any sort of error.
 	OperationalStatusError OperationalStatus = "error"
 
+	// OperationalStatusDelayed is the status value for when the host
+	// deployment needs to be delayed to limit simultaneous hosts provisioning
 	OperationalStatusDelayed = "delayed"
+
+	// OperationalStatusDetached is the status value when the host is
+	// marked unmanaged via the detached annotation
+	OperationalStatusDetached OperationalStatus = "detached"
 )
 
 // ErrorType indicates the class of problem that has caused the Host resource
@@ -145,6 +155,9 @@ const (
 	// PowerManagementError is an error condition occurring when the
 	// controller is unable to modify the power state of the Host.
 	PowerManagementError ErrorType = "power management error"
+	// DetachError is an error condition occurring when the
+	// controller is unable to detatch the host from the provisioner
+	DetachError ErrorType = "detach error"
 )
 
 // ProvisioningState defines the states the provisioner will report
@@ -218,6 +231,10 @@ type BMCDetails struct {
 	// insecure because it allows a man-in-the-middle to intercept the
 	// connection.
 	DisableCertificateVerification bool `json:"disableCertificateVerification,omitempty"`
+
+	// privLevel is the ipmi privilage level to used when authenicating, it is ignore
+	// when not using ipmi
+	PrivLevel string `json:"privLevel,omitempty"`
 }
 
 // HardwareRAIDVolume defines the desired configuration of volume in hardware RAID
@@ -344,7 +361,24 @@ type BareMetalHostSpec struct {
 	// the power status and hardware inventory inspection. If the
 	// Image field is filled in, this field is ignored.
 	ExternallyProvisioned bool `json:"externallyProvisioned,omitempty"`
+
+	// When set to disabled, automated cleaning will be avoided
+	// during provisioning and deprovisioning.
+	// +optional
+	// +kubebuilder:default:=metadata
+	// +kubebuilder:validation:Optional
+	AutomatedCleaningMode AutomatedCleaningMode `json:"automatedCleaningMode,omitempty"`
 }
+
+// AutomatedCleaningMode is the interface to enable/disable automated cleaning
+// +kubebuilder:validation:Enum:=metadata;disabled
+type AutomatedCleaningMode string
+
+// Allowed automated cleaning modes
+const (
+	CleaningModeDisabled AutomatedCleaningMode = "disabled"
+	CleaningModeMetadata AutomatedCleaningMode = "metadata"
+)
 
 // ChecksumType holds the algorithm name for the checksum
 // +kubebuilder:validation:Enum=md5;sha256;sha512
@@ -546,10 +580,13 @@ type CredentialsStatus struct {
 type RebootMode string
 
 const (
+	// RebootModeHard defined for hard reset of a node
 	RebootModeHard RebootMode = "hard"
+	// RebootModeSoft defined for soft reset of a node
 	RebootModeSoft RebootMode = "soft"
 )
 
+// RebootAnnotationArguments defines the arguments of the RebootAnnotation type
 type RebootAnnotationArguments struct {
 	Mode RebootMode `json:"mode"`
 }
@@ -603,7 +640,7 @@ type BareMetalHostStatus struct {
 	// after modifying this file
 
 	// OperationalStatus holds the status of the host
-	// +kubebuilder:validation:Enum="";OK;discovered;error;delayed
+	// +kubebuilder:validation:Enum="";OK;discovered;error;delayed;detached
 	OperationalStatus OperationalStatus `json:"operationalStatus"`
 
 	// ErrorType indicates the type of failure encountered when the
@@ -891,11 +928,7 @@ func (host *BareMetalHost) OperationMetricForState(operation ProvisioningState) 
 	return
 }
 
-// GetImageChecksum returns the hash value and its algo.
-func (host *BareMetalHost) GetImageChecksum() (string, string, bool) {
-	return host.Spec.Image.GetChecksum()
-}
-
+// GetChecksum method returns the checksum of an image
 func (image *Image) GetChecksum() (checksum, checksumType string, ok bool) {
 	if image == nil {
 		return

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/access.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/access.go
@@ -11,7 +11,7 @@ import (
 
 // AccessDetailsFactory describes a callable that returns a new
 // AccessDetails based on the input parameters.
-type AccessDetailsFactory func(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error)
+type AccessDetailsFactory func(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error)
 
 var factories = map[string]AccessDetailsFactory{}
 
@@ -110,7 +110,7 @@ func getParsedURL(address string) (parsedURL *url.URL, err error) {
 
 // NewAccessDetails creates an AccessDetails structure from the URL
 // for a BMC.
-func NewAccessDetails(address string, disableCertificateVerification bool) (AccessDetails, error) {
+func NewAccessDetails(address string, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 
 	if address == "" {
 		return nil, errors.New("missing BMC address")
@@ -126,5 +126,5 @@ func NewAccessDetails(address string, disableCertificateVerification bool) (Acce
 		return nil, &UnknownBMCTypeError{address, parsedURL.Scheme}
 	}
 
-	return factory(parsedURL, disableCertificateVerification)
+	return factory(parsedURL, disableCertificateVerification, privLevel)
 }

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ibmc.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ibmc.go
@@ -9,12 +9,13 @@ func init() {
 	RegisterFactory("ibmc", newIbmcAccessDetails, []string{"http", "https"})
 }
 
-func newIbmcAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newIbmcAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &ibmcAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		host:                           parsedURL.Host,
 		path:                           parsedURL.Path,
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -23,6 +24,7 @@ type ibmcAccessDetails struct {
 	host                           string
 	path                           string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *ibmcAccessDetails) Type() string {
@@ -91,7 +93,7 @@ func (a *ibmcAccessDetails) PowerInterface() string {
 }
 
 func (a *ibmcAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *ibmcAccessDetails) VendorInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac.go
@@ -9,13 +9,14 @@ func init() {
 	RegisterFactory("idrac", newIDRACAccessDetails, []string{"http", "https"})
 }
 
-func newIDRACAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newIDRACAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &iDracAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		path:                           parsedURL.Path,
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -25,6 +26,7 @@ type iDracAccessDetails struct {
 	hostname                       string
 	path                           string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *iDracAccessDetails) Type() string {
@@ -87,7 +89,7 @@ func (a *iDracAccessDetails) PowerInterface() string {
 }
 
 func (a *iDracAccessDetails) RAIDInterface() string {
-	return ""
+	return "idrac-wsman"
 }
 
 func (a *iDracAccessDetails) VendorInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac_virtualmedia.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/idrac_virtualmedia.go
@@ -9,12 +9,13 @@ func init() {
 	RegisterFactory("idrac-virtualmedia", newRedfishiDracVirtualMediaAccessDetails, schemes)
 }
 
-func newRedfishiDracVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newRedfishiDracVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &redfishiDracVirtualMediaAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		host:                           parsedURL.Host,
 		path:                           parsedURL.Path,
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -23,6 +24,7 @@ type redfishiDracVirtualMediaAccessDetails struct {
 	host                           string
 	path                           string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *redfishiDracVirtualMediaAccessDetails) Type() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ilo4.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ilo4.go
@@ -10,12 +10,13 @@ func init() {
 	RegisterFactory("ilo4", newILOAccessDetails, []string{"https"})
 }
 
-func newILOAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newILOAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &iLOAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -24,6 +25,7 @@ type iLOAccessDetails struct {
 	portNum                        string
 	hostname                       string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *iLOAccessDetails) Type() string {
@@ -83,7 +85,7 @@ func (a *iLOAccessDetails) PowerInterface() string {
 }
 
 func (a *iLOAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *iLOAccessDetails) VendorInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ilo5.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ilo5.go
@@ -10,12 +10,13 @@ func init() {
 	RegisterFactory("ilo5", newILO5AccessDetails, []string{"https"})
 }
 
-func newILO5AccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newILO5AccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &iLO5AccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -24,6 +25,7 @@ type iLO5AccessDetails struct {
 	portNum                        string
 	hostname                       string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *iLO5AccessDetails) Type() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ipmi.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/ipmi.go
@@ -9,12 +9,13 @@ func init() {
 	RegisterFactory("libvirt", newIPMIAccessDetails, []string{})
 }
 
-func newIPMIAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newIPMIAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &ipmiAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -23,6 +24,7 @@ type ipmiAccessDetails struct {
 	portNum                        string
 	hostname                       string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 const ipmiDefaultPort = "623"
@@ -70,6 +72,9 @@ func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfac
 	if a.portNum == "" {
 		result["ipmi_port"] = ipmiDefaultPort
 	}
+	if len(a.privLevel) > 0 {
+		result["ipmi_priv_level"] = a.privLevel
+	}
 	return result
 }
 
@@ -86,7 +91,7 @@ func (a *ipmiAccessDetails) PowerInterface() string {
 }
 
 func (a *ipmiAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *ipmiAccessDetails) VendorInterface() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/irmc.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/irmc.go
@@ -8,12 +8,13 @@ func init() {
 	RegisterFactory("irmc", newIRMCAccessDetails, []string{})
 }
 
-func newIRMCAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newIRMCAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &iRMCAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		portNum:                        parsedURL.Port(),
 		hostname:                       parsedURL.Hostname(),
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -22,6 +23,7 @@ type iRMCAccessDetails struct {
 	portNum                        string
 	hostname                       string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *iRMCAccessDetails) Type() string {

--- a/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/redfish_virtualmedia.go
+++ b/vendor/github.com/metal3-io/baremetal-operator/pkg/bmc/redfish_virtualmedia.go
@@ -10,12 +10,13 @@ func init() {
 	RegisterFactory("ilo5-virtualmedia", newRedfishVirtualMediaAccessDetails, schemes)
 }
 
-func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+func newRedfishVirtualMediaAccessDetails(parsedURL *url.URL, disableCertificateVerification bool, privLevel string) (AccessDetails, error) {
 	return &redfishVirtualMediaAccessDetails{
 		bmcType:                        parsedURL.Scheme,
 		host:                           parsedURL.Host,
 		path:                           parsedURL.Path,
 		disableCertificateVerification: disableCertificateVerification,
+		privLevel:                      privLevel,
 	}, nil
 }
 
@@ -24,6 +25,7 @@ type redfishVirtualMediaAccessDetails struct {
 	host                           string
 	path                           string
 	disableCertificateVerification bool
+	privLevel                      string
 }
 
 func (a *redfishVirtualMediaAccessDetails) Type() string {
@@ -79,7 +81,7 @@ func (a *redfishVirtualMediaAccessDetails) PowerInterface() string {
 }
 
 func (a *redfishVirtualMediaAccessDetails) RAIDInterface() string {
-	return ""
+	return "no-raid"
 }
 
 func (a *redfishVirtualMediaAccessDetails) VendorInterface() string {


### PR DESCRIPTION
/hold

Currently works on bootstrap node but not in the metal3 pod, so I'm missing something
tested with
https://github.com/openshift/baremetal-operator/pull/143