### PR TITLE
Bug 1958216: libvirt: Allow duplicate dnsmasq options

### DIFF
--- a/data/data/libvirt/main.tf
+++ b/data/data/libvirt/main.tf
@@ -142,7 +142,7 @@ data "libvirt_network_dns_host_template" "masters_int" {
 
 data "libvirt_network_dnsmasq_options_template" "options" {
   count        = length(var.libvirt_dnsmasq_options)
-  option_name  = keys(var.libvirt_dnsmasq_options)[count.index]
-  option_value = values(var.libvirt_dnsmasq_options)[count.index]
+  option_name  = var.libvirt_dnsmasq_options[count.index]["option_name"]
+  option_value = var.libvirt_dnsmasq_options[count.index]["option_value"]
 }
 

--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -60,7 +60,8 @@ variable "libvirt_master_size" {
 }
 
 variable "libvirt_dnsmasq_options" {
-  type        = map(string)
-  description = "Dnsmasq options to be applied to the libvirt network"
-  default     = {}
+  type        = list(map(string))
+  description = "A list of Dnsmasq options to be applied to the libvirt network"
+  default     = []
 }
+

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -404,11 +404,15 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		if err != nil {
 			return err
 		}
-		// convert options list to a map which can be consumed by terraform
-		dnsmasqoptions := make(map[string]string)
+		// convert options list to a list of mappings which can be consumed by terraform
+		var dnsmasqoptions []map[string]string
 		for _, option := range installConfig.Config.Platform.Libvirt.Network.DnsmasqOptions {
-			dnsmasqoptions[option.Name] = option.Value
+			dnsmasqoptions = append(dnsmasqoptions,
+				map[string]string{
+					"option_name":  option.Name,
+					"option_value": option.Value})
 		}
+
 		data, err = libvirttfvars.TFVars(
 			libvirttfvars.TFVarsSources{
 				MasterConfig:   masters[0].Spec.ProviderSpec.Value.Object.(*libvirtprovider.LibvirtMachineProviderConfig),

--- a/pkg/tfvars/libvirt/libvirt.go
+++ b/pkg/tfvars/libvirt/libvirt.go
@@ -18,16 +18,16 @@ import (
 )
 
 type config struct {
-	URI             string            `json:"libvirt_uri,omitempty"`
-	Image           string            `json:"os_image,omitempty"`
-	IfName          string            `json:"libvirt_network_if"`
-	MasterIPs       []string          `json:"libvirt_master_ips,omitempty"`
-	BootstrapIP     string            `json:"libvirt_bootstrap_ip,omitempty"`
-	MasterMemory    string            `json:"libvirt_master_memory,omitempty"`
-	MasterVcpu      string            `json:"libvirt_master_vcpu,omitempty"`
-	BootstrapMemory int               `json:"libvirt_bootstrap_memory,omitempty"`
-	MasterDiskSize  string            `json:"libvirt_master_size,omitempty"`
-	DnsmasqOptions  map[string]string `json:"libvirt_dnsmasq_options,omitempty"`
+	URI             string              `json:"libvirt_uri,omitempty"`
+	Image           string              `json:"os_image,omitempty"`
+	IfName          string              `json:"libvirt_network_if"`
+	MasterIPs       []string            `json:"libvirt_master_ips,omitempty"`
+	BootstrapIP     string              `json:"libvirt_bootstrap_ip,omitempty"`
+	MasterMemory    string              `json:"libvirt_master_memory,omitempty"`
+	MasterVcpu      string              `json:"libvirt_master_vcpu,omitempty"`
+	BootstrapMemory int                 `json:"libvirt_bootstrap_memory,omitempty"`
+	MasterDiskSize  string              `json:"libvirt_master_size,omitempty"`
+	DnsmasqOptions  []map[string]string `json:"libvirt_dnsmasq_options,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -38,7 +38,7 @@ type TFVarsSources struct {
 	Bridge         string
 	MasterCount    int
 	Architecture   types.Architecture
-	DnsmasqOptions map[string]string
+	DnsmasqOptions []map[string]string
 }
 
 // TFVars generates libvirt-specific Terraform variables.


### PR DESCRIPTION
A corner case was discovered where if a sepcific option is specified multiple times(for example the
"address" option could be specified multiple times for different domains), only one of the options is
set. This is a bug and an oversight when adding the original code for the dnsmasq options. Fixed by using
a list instead of a map.