### PR TITLE
Bug 1951571: registry.svc.ci.openshift.org is no longer valid

### DIFF
--- a/images/installer/Dockerfile.ci.rhel7
+++ b/images/installer/Dockerfile.ci.rhel7
@@ -1,13 +1,13 @@
 # This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:base
+FROM registry.ci.openshift.org/ocp/4.1:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -3,14 +3,14 @@
 # It also contains the `upi` directory that contains various terraform and cloud formation templates that are used to create infrastructure resources.
 
 
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:cli as cli
+FROM registry.ci.openshift.org/ocp/4.6:cli as cli
 
-FROM registry.svc.ci.openshift.org/ocp/4.1:base
+FROM registry.ci.openshift.org/ocp/4.1:base
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi

--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -1,7 +1,7 @@
 # This Dockerfile is a used by CI to publish an installer image for creating libvirt clusters
 # It builds an image containing openshift-install and nss-wrapper for remote deployments, as well as the google cloud-sdk for nested GCE environments.
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.14 AS builder
 RUN yum install -y libvirt-devel && \
     yum clean all && rm -rf /var/cache/yum/*
 WORKDIR /go/src/github.com/openshift/installer

--- a/images/mock/Dockerfile
+++ b/images/mock/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.14 AS builder
 
 RUN go get github.com/golang/mock/gomock github.com/golang/mock/mockgen

--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -1,13 +1,13 @@
 # This Dockerfile is used by CI to test using OpenShift Installer against an OpenStack cloud.
 # It builds an image containing the openshift-install command as well as the openstack cli.
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.14 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.14 AS builder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN hack/build.sh
 
-FROM registry.svc.ci.openshift.org/origin/4.7:cli AS cli
+FROM registry.ci.openshift.org/origin/4.7:cli AS cli
 
-FROM registry.svc.ci.openshift.org/origin/4.7:base
+FROM registry.ci.openshift.org/origin/4.7:base
 COPY --from=cli /usr/bin/oc /bin/oc
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 COPY --from=builder /go/src/github.com/openshift/installer/upi /var/lib/openshift-install/upi

--- a/pkg/asset/releaseimage/default.go
+++ b/pkg/asset/releaseimage/default.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.svc.ci.openshift.org/origin/release:4.7"
+	defaultReleaseImageOriginal = "registry.ci.openshift.org/origin/release:4.7"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
registry.svc.ci.openshift.org has been moved to registry.ci.openshift.org.  The old
one was on a 3.x cluster and the new one is on a 4.x cluser.