### PR TITLE
Bug 1948359: aws: add permissions for untagging shared byo instance roles

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -28,6 +28,10 @@ const (
 
 	// PermissionDeleteSharedNetworking is a set of permissions required when the installer destroys resources from a shared-network cluster.
 	PermissionDeleteSharedNetworking PermissionGroup = "delete-shared-networking"
+
+	// PermissionDeleteSharedInstanceRole is a set of permissions required when the installer destroys resources from a
+	// cluster with user-supplied IAM roles for instances.
+	PermissionDeleteSharedInstanceRole PermissionGroup = "delete-shared-instance-role"
 )
 
 var permissions = map[PermissionGroup][]string{
@@ -222,6 +226,11 @@ var permissions = map[PermissionGroup][]string{
 	// Permissions required for deleting a cluster with shared network resources
 	PermissionDeleteSharedNetworking: {
 		"tag:UnTagResources",
+	},
+	// Permissions required for deleting a cluster with shared instance roles
+	PermissionDeleteSharedInstanceRole: {
+		"tag:UnTagResources",
+		"iam:UntagRole",
 	},
 }
 

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -10,6 +10,7 @@ import (
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	kubevirtconfig "github.com/openshift/installer/pkg/asset/installconfig/kubevirt"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
@@ -65,6 +66,9 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 			} else {
 				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteNetworking)
 			}
+			if awsIncludesUserSuppliedInstanceRole(ic.Config) {
+				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteSharedInstanceRole)
+			}
 		}
 
 		ssn, err := ic.AWS.Session(ctx)
@@ -106,4 +110,22 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 // Name returns the human-friendly name of the asset.
 func (a *PlatformPermsCheck) Name() string {
 	return "Platform Permissions Check"
+}
+
+func awsIncludesUserSuppliedInstanceRole(installConfig *types.InstallConfig) bool {
+	mp := &aws.MachinePool{}
+	mp.Set(installConfig.Platform.AWS.DefaultMachinePlatform)
+	mp.Set(installConfig.ControlPlane.Platform.AWS)
+	if mp.IAMRole != "" {
+		return true
+	}
+	for _, c := range installConfig.Compute {
+		mp := &aws.MachinePool{}
+		mp.Set(installConfig.Platform.AWS.DefaultMachinePlatform)
+		mp.Set(c.Platform.AWS)
+		if mp.IAMRole != "" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Add checks to the Platform Permissions Check asset to verify that the user has the necessary permissions to remove the shared tag from the IAM roles that the user is supplying.
