### PR TITLE
Bug 1949923: apply defaults for root volume AZs if they aren't set

### DIFF
--- a/pkg/asset/installconfig/openstack/validate.go
+++ b/pkg/asset/installconfig/openstack/validate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig/openstack/validation"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/openstack"
+	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,6 +37,9 @@ func Validate(ic *types.InstallConfig) error {
 	controlPlane := defaultOpenStackMachinePoolPlatform()
 	controlPlane.Set(ic.Platform.OpenStack.DefaultMachinePlatform)
 	controlPlane.Set(ic.ControlPlane.Platform.OpenStack)
+	if controlPlane.RootVolume != nil && controlPlane.RootVolume.Zones == nil {
+		controlPlane.RootVolume.Zones = openstackdefaults.DefaultRootVolumeAZ()
+	}
 	allErrs = append(allErrs, validation.ValidateMachinePool(&controlPlane, ci, true, field.NewPath("controlPlane", "platform", "openstack"))...)
 
 	// Validate computes
@@ -43,6 +47,9 @@ func Validate(ic *types.InstallConfig) error {
 		compute := defaultOpenStackMachinePoolPlatform()
 		compute.Set(ic.Platform.OpenStack.DefaultMachinePlatform)
 		compute.Set(ic.Compute[idx].Platform.OpenStack)
+		if compute.RootVolume != nil && compute.RootVolume.Zones == nil {
+			compute.RootVolume.Zones = openstackdefaults.DefaultRootVolumeAZ()
+		}
 		fldPath := field.NewPath("compute").Index(idx)
 		allErrs = append(allErrs, validation.ValidateMachinePool(&compute, ci, false, fldPath.Child("platform", "openstack"))...)
 	}


### PR DESCRIPTION
This commit applies default values for root volume AZs before validating control plane and compute machine pools.