### PR TITLE
Bug 1943219: azure: remove bootstrap ssh rule on private clusters

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -216,6 +216,8 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
 }
 
 resource "azurerm_network_security_rule" "bootstrap_ssh_in" {
+  count = var.private ? 0 : 1
+
   name                        = "bootstrap_ssh_in"
   priority                    = 103
   direction                   = "Inbound"


### PR DESCRIPTION
Removes ssh from source ANY to destination ANY on azure
private clusters. The private cluster design should not
include SSH access to the bootstrap unless you're on the
same local network.

https://bugzilla.redhat.com/show_bug.cgi?id=1943219