### PR TITLE
azure: allow VM image to be overriden

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1176,6 +1176,28 @@ spec:
                           type: string
                         type: array
                     type: object
+                  image:
+                    description: Image specifies the image parameters with which a
+                      cluster should be built. Either ResourceID or Publisher/Offer/SKU/Version
+                      should be set.
+                    properties:
+                      offer:
+                        description: Offer is the image offer
+                        type: string
+                      publisher:
+                        description: Publisher is the image publisher
+                        type: string
+                      resourceId:
+                        description: ResourceID is the resource ID of an existing
+                          Image resource
+                        type: string
+                      sku:
+                        description: SKU is the image SKU
+                        type: string
+                      version:
+                        description: Version is the image version
+                        type: string
+                    type: object
                   networkResourceGroupName:
                     description: NetworkResourceGroupName specifies the network resource
                       group that contains an existing VNet

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -106,6 +106,24 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		managedIdentity = ""
 	}
 
+	image := azureprovider.Image{
+		ResourceID: fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/images/%s", rg, clusterID),
+	}
+	if platform.Image != nil {
+		if platform.Image.ResourceID != "" {
+			image = azureprovider.Image{
+				ResourceID: platform.Image.ResourceID,
+			}
+		} else {
+			image = azureprovider.Image{
+				Publisher: platform.Image.Publisher,
+				Offer:     platform.Image.Offer,
+				SKU:       platform.Image.SKU,
+				Version:   platform.Image.Version,
+			}
+		}
+	}
+
 	return &azureprovider.AzureMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "azureproviderconfig.openshift.io/v1beta1",
@@ -115,9 +133,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		CredentialsSecret: &corev1.SecretReference{Name: cloudsSecret, Namespace: cloudsSecretNamespace},
 		Location:          platform.Region,
 		VMSize:            mpool.InstanceType,
-		Image: azureprovider.Image{
-			ResourceID: fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/images/%s", rg, clusterID),
-		},
+		Image:             image,
 		OSDisk: azureprovider.OSDisk{
 			OSType:     "Linux",
 			DiskSizeGB: mpool.OSDisk.DiskSizeGB,

--- a/pkg/asset/machines/azure/machines_test.go
+++ b/pkg/asset/machines/azure/machines_test.go
@@ -1,0 +1,186 @@
+package azure
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	azureprovider "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
+)
+
+func TestProvider(t *testing.T) {
+	clusterID := "00000000-0000-0000-0000-000000000000"
+	rg := fmt.Sprintf("%s-rg", clusterID)
+	zone := "1"
+
+	expectedMachineProviderSpec := func() *azureprovider.AzureMachineProviderSpec {
+		return &azureprovider.AzureMachineProviderSpec{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "azureproviderconfig.openshift.io/v1beta1",
+				Kind:       "AzureMachineProviderSpec",
+			},
+			UserDataSecret:    &corev1.SecretReference{Name: ""},
+			CredentialsSecret: &corev1.SecretReference{Name: cloudsSecret, Namespace: cloudsSecretNamespace},
+			Location:          "fake-region",
+			VMSize:            "",
+			Image: azureprovider.Image{
+				ResourceID: fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/images/%s", rg, clusterID),
+			},
+			OSDisk: azureprovider.OSDisk{
+				OSType:     "Linux",
+				DiskSizeGB: 123,
+				ManagedDisk: azureprovider.ManagedDiskParameters{
+					StorageAccountType: "Premium_LRS",
+				},
+			},
+			Zone:                 &zone,
+			Subnet:               fmt.Sprintf("%s-master-subnet", clusterID),
+			ManagedIdentity:      fmt.Sprintf("%s-identity", clusterID),
+			Vnet:                 fmt.Sprintf("%s-vnet", clusterID),
+			ResourceGroup:        rg,
+			NetworkResourceGroup: rg,
+			PublicLoadBalancer:   clusterID,
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mocks  func(platform *azure.Platform, mpool *azure.MachinePool)
+		expect func(spec *azureprovider.AzureMachineProviderSpec)
+	}{
+		{
+			name: "no customisations",
+		},
+		{
+			name: "DiskType specified",
+			mocks: func(platform *azure.Platform, mpool *azure.MachinePool) {
+				mpool.OSDisk.DiskType = "Standard_LRS"
+			},
+			expect: func(spec *azureprovider.AzureMachineProviderSpec) {
+				spec.OSDisk.ManagedDisk.StorageAccountType = "Standard_LRS"
+			},
+		},
+		{
+			name: "OutboundType set to UserDefinedRouting",
+			mocks: func(platform *azure.Platform, mpool *azure.MachinePool) {
+				platform.OutboundType = azure.UserDefinedRoutingOutboundType
+			},
+			expect: func(spec *azureprovider.AzureMachineProviderSpec) {
+				spec.PublicLoadBalancer = ""
+			},
+		},
+		{
+			name: "Image from ResourceID",
+			mocks: func(platform *azure.Platform, mpool *azure.MachinePool) {
+				platform.Image = &azure.Image{
+					ResourceID: "/resourceGroups/fake-rg/providers/Microsoft.Compute/images/fake-image",
+				}
+			},
+			expect: func(spec *azureprovider.AzureMachineProviderSpec) {
+				spec.Image = azureprovider.Image{
+					ResourceID: "/resourceGroups/fake-rg/providers/Microsoft.Compute/images/fake-image",
+				}
+			},
+		},
+		{
+			name: "Image from marketplace",
+			mocks: func(platform *azure.Platform, mpool *azure.MachinePool) {
+				platform.Image = &azure.Image{
+					Publisher: "fake-publisher",
+					Offer:     "fake-offer",
+					SKU:       "fake-sku",
+					Version:   "fake-version",
+				}
+			},
+			expect: func(spec *azureprovider.AzureMachineProviderSpec) {
+				spec.Image = azureprovider.Image{
+					Publisher: "fake-publisher",
+					Offer:     "fake-offer",
+					SKU:       "fake-sku",
+					Version:   "fake-version",
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			platform := &azure.Platform{
+				Region: "fake-region",
+			}
+			mpool := &azure.MachinePool{
+				Zones: []string{"0", "1", "2"},
+				OSDisk: azure.OSDisk{
+					DiskSizeGB: 123,
+				},
+			}
+			azIdx := 1
+
+			if tt.mocks != nil {
+				tt.mocks(platform, mpool)
+			}
+
+			spec, err := provider(platform, mpool, "", "", clusterID, "master", &azIdx)
+			if err != nil {
+				t.Error(err)
+			}
+
+			expectedSpec := expectedMachineProviderSpec()
+			if tt.expect != nil {
+				tt.expect(expectedSpec)
+			}
+
+			assert.Equal(t, expectedSpec, spec)
+		})
+	}
+}
+
+func TestGetNetworkInfo(t *testing.T) {
+	clusterID := "00000000-0000-0000-0000-000000000000"
+
+	for _, role := range []string{"master", "worker"} {
+		tests := []struct {
+			name                       string
+			platform                   *azure.Platform
+			expectNetworkResourceGroup string
+			expectVirtualNetwork       string
+			expectSubnet               string
+		}{
+			{
+				name:                       "no VirtualNetwork customisation",
+				platform:                   &azure.Platform{},
+				expectNetworkResourceGroup: fmt.Sprintf("%s-rg", clusterID),
+				expectVirtualNetwork:       fmt.Sprintf("%s-vnet", clusterID),
+				expectSubnet:               fmt.Sprintf("%s-%s-subnet", clusterID, role),
+			},
+			{
+				name: "VirtualNetwork customisation",
+				platform: &azure.Platform{
+					NetworkResourceGroupName: "fake-vnet-rg",
+					VirtualNetwork:           "fake-vnet",
+					ControlPlaneSubnet:       "fake-master-subnet",
+					ComputeSubnet:            "fake-worker-subnet",
+				},
+				expectNetworkResourceGroup: "fake-vnet-rg",
+				expectVirtualNetwork:       "fake-vnet",
+				expectSubnet:               fmt.Sprintf("fake-%s-subnet", role),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%s: %s", role, tt.name), func(t *testing.T) {
+				networkResourceGroup, virtualNetwork, subnet, err := getNetworkInfo(tt.platform, clusterID, role)
+				if err != nil {
+					t.Error(err)
+				}
+
+				assert.Equal(t, tt.expectNetworkResourceGroup, networkResourceGroup)
+				assert.Equal(t, tt.expectVirtualNetwork, virtualNetwork)
+				assert.Equal(t, tt.expectSubnet, subnet)
+			})
+		}
+	}
+}

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -162,6 +162,9 @@ func Test_PrintFields(t *testing.T) {
     defaultMachinePlatform <object>
       DefaultMachinePlatform is the default configuration used when installing on Azure for machine pools which do not define their own platform configuration.
 
+    image <object>
+      Image specifies the image parameters with which a cluster should be built. Either ResourceID or Publisher/Offer/SKU/Version should be set.
+
     networkResourceGroupName <string>
       NetworkResourceGroupName specifies the network resource group that contains an existing VNet
 

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -78,6 +78,31 @@ type Platform struct {
 	//
 	// +optional
 	ResourceGroupName string `json:"resourceGroupName,omitempty"`
+
+	// Image specifies the image parameters with which a cluster should be built.
+	// Either ResourceID or Publisher/Offer/SKU/Version should be set.
+	//
+	// +optional
+	Image *Image `json:"image,omitempty"`
+}
+
+// Image specifies the image parameters with which a cluster should be built.
+// Either ResourceID or Publisher/Offer/SKU/Version should be set.
+type Image struct {
+	// ResourceID is the resource ID of an existing Image resource
+	ResourceID string `json:"resourceId,omitempty"`
+
+	// Publisher is the image publisher
+	Publisher string `json:"publisher,omitempty"`
+
+	// Offer is the image offer
+	Offer string `json:"offer,omitempty"`
+
+	// SKU is the image SKU
+	SKU string `json:"sku,omitempty"`
+
+	// Version is the image version
+	Version string `json:"version,omitempty"`
 }
 
 // CloudEnvironment is the name of the Azure cloud environment


### PR DESCRIPTION
* Allows VM image to be overriden
* Adds some unit tests for `provider` and `getNetworkInfo` from `pkg/asset/machines/azure/machines.go`

---

This PR doesn't change default behaviour of the installer: `openshift-install create manifests` will generate same manifests compared to manifests generated by the installer compiled from the commit before this PR. In general, all `openshift-install create` subcommands should not be affected.

This PR however adds an ability to specifiy a custom VM image for Azure. To do so:

1. Run
    ```yaml
    openshift-install create install-config
    ```
1. Under `platform.azure` add `image` object and specify an image by either refering to it by `resourceID` or `publisher`/`offer`/`sku`/`version`. For example:
    ```yaml
    platform:
      azure:
        # ...
        image:
          offer: aro4
          publisher: azureopenshift
          sku: aro_43
          version: 43.81.20200311
    ```
    or 
    ```yaml
    platform:
      azure:
        # ...
        image:
          resourceID: /resourceGroups/test-rg/providers/Microsoft.Compute/images/test-image
    ```
1. Run `openshift-install create manifests` to generate manifests
2. Check master `Machine` and worker `MachineSet` manifests: the change should be reflected in the `spec.providerSpec.value.image`.

Also see:
```
openshift-install explain installconfig.platform.azure.image
```