### PR TITLE
Bug 1952632: data/manifests/bootkube/cvo-overrides: Bump default to stable-4.8

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -4,5 +4,5 @@ metadata:
   namespace: openshift-cluster-version
   name: version
 spec:
-  channel: stable-4.7
+  channel: stable-4.8
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
Like bd146989d3 (#4347), but for 4.8 (now that release-4.7 is no longer being fast-forwarded to track master).