### PR TITLE
Bug 1951670: Error gathering bootstrap log after pivot: The bootstrap…

### DIFF
--- a/pkg/gather/service/analyze.go
+++ b/pkg/gather/service/analyze.go
@@ -16,7 +16,9 @@ import (
 // regex matching the path of a service entries file. The captured group is the name of the service.
 // For example, if the filename is "log-bundle-20210329190553/bootstrap/services/release-image.json",
 // then the name of the service is "release-image".
-var serviceEntriesFilePathRegex = regexp.MustCompile(`^[^\/]+\/bootstrap\/services\/([^.]+)\.json$`)
+// In case the log-bundle is from bootstrap-in-place installation the file name is:
+//"log-bundle-20210329190553/log-bundle-bootstrap/bootstrap/services/release-image.json"
+var serviceEntriesFilePathRegex = regexp.MustCompile(`^[^\/]+(?:\/log-bundle-bootstrap)?\/bootstrap\/services\/([^.]+)\.json$`)
 
 // AnalyzeGatherBundle will analyze the bootstrap gather bundle at the specified path.
 // Analysis will be logged.

--- a/pkg/gather/service/analyze_test.go
+++ b/pkg/gather/service/analyze_test.go
@@ -44,6 +44,17 @@ func TestAnalyzeGatherBundle(t *testing.T) {
 			},
 		},
 		{
+			name: "release-image successful bootstrap-in-place",
+			files: map[string]string{
+				"log-bundle/log-bundle-bootstrap/bootstrap/services/release-image.json": `[
+{"phase":"service start"},
+{"phase":"stage start", "stage":"pull-release-image"},
+{"phase":"stage end", "stage":"pull-release-image", "result":"success"},
+{"phase":"service end", "result":"success"}
+]`,
+			},
+		},
+		{
 			name: "release-image failed",
 			files: map[string]string{
 				"log-bundle/bootstrap/services/release-image.json": `[


### PR DESCRIPTION
… machine did not execute the release-image.service systemd unit

In case of installing single node OpenShift with bootstrap in place, the bootstrap gather artifacts prior to the node reboot are added to the log-bundle under "log-bundle-bootstrap"
Since the analyze code didn't expect that extra folder it failed to find them and logged the error.

Added optional "/log-bundle-bootstrap" to the serviceEntriesFilePathRegex.
This allows the rest of the analyze code to work with the bootstrap-in-place gather artifacts collected prior to the pivot