### PR TITLE
azure: Adds a gate for ARO-only modifications

### DIFF
--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// aro is a setting to enable aro-only modifications
+var aro bool
+
 // OutboundType is a strategy for how egress from cluster is achieved.
 // +kubebuilder:validation:Enum="";Loadbalancer;UserDefinedRouting
 type OutboundType string
@@ -114,4 +117,9 @@ func (p *Platform) ClusterResourceGroupName(infraID string) string {
 		return p.ResourceGroupName
 	}
 	return fmt.Sprintf("%s-rg", infraID)
+}
+
+// IsARO returns true if ARO-only modifications are enabled
+func (p *Platform) IsARO() bool {
+	return aro
 }

--- a/pkg/types/azure/platform_aro.go
+++ b/pkg/types/azure/platform_aro.go
@@ -1,0 +1,7 @@
+// +build aro
+
+package azure
+
+func init() {
+	aro = true
+}


### PR DESCRIPTION
* Adds a new aro build tag which is going to be used by ARO when vendoring the installer
* Adds `IsARO()` method to gate ARO-only modifications

---

Spliting #4843 into smaller pieces