### PR TITLE
Bug 1953551: Link ppc64le binary dynamically

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -42,11 +42,13 @@ if (echo "${TAGS}" | grep -q 'libvirt')
 then
 	export CGO_ENABLED=1
 fi
-if test "$(go env GOARCH)" = "arm64"
-then
-	# https://github.com/golang/go/issues/40492
+case "$(go env GOARCH)" in
+arm64|ppc64le)
+	# arm64: https://github.com/golang/go/issues/40492
+	# ppc64le: https://github.com/golang/go/issues/45564
 	LDFLAGS="${LDFLAGS} -linkmode external"
 	export CGO_ENABLED=1
-fi
+	;;
+esac
 
 go build "${GOFLAGS}" -ldflags "${LDFLAGS}" -tags "${TAGS}" -o "${OUTPUT}" ./cmd/openshift-install


### PR DESCRIPTION
Recent versions of Go have had issues statically linking some ppc64le
binaries:

https://github.com/golang/go/issues/45564

/cc @joepvd
