### PR TITLE
azure: don't require BaseDomainResourceGroupName on ARO

### DIFF
--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -33,7 +33,7 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 	if p.Region == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "region should be set to one of the supported Azure regions"))
 	}
-	if publish == types.ExternalPublishingStrategy {
+	if !p.IsARO() && publish == types.ExternalPublishingStrategy {
 		if p.BaseDomainResourceGroupName == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("baseDomainResourceGroupName"), "baseDomainResourceGroupName is the resource group name where the azure dns zone is deployed"))
 		}


### PR DESCRIPTION
This prevents a validating failure when omitting `BaseDomainResourceGroupName` configurable which is never used in ARO.