### PR TITLE
Bug 1948359: destroy: remove shared tag from byo aws iam role

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -229,7 +229,6 @@ var permissions = map[PermissionGroup][]string{
 	},
 	// Permissions required for deleting a cluster with shared instance roles
 	PermissionDeleteSharedInstanceRole: {
-		"tag:UnTagResources",
 		"iam:UntagRole",
 	},
 }


### PR DESCRIPTION
Remove the kubernetes.io/cluster/xxx=shared tag from user-supplied AWS IAM roles.