### PR TITLE
Bug 1953803: aws: validate byo hostedzone is parent of cluster domain

### DIFF
--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -345,8 +345,15 @@ func validateExistingHostedZone(session *session.Session, ic *types.InstallConfi
 		allErrs = append(allErrs, field.Invalid(hostedZonePath, ic.AWS.HostedZone, "no VPC found"))
 	}
 
-	// validate that the hosted zone does not already have any record sets for the cluster domain
 	dottedClusterDomain := ic.ClusterDomain() + "."
+
+	// validate that the domain of the hosted zone is the cluster domain or a parent of the cluster domain
+	if !isHostedZoneDomainParentOfClusterDomain(zone.HostedZone, dottedClusterDomain) {
+		allErrs = append(allErrs, field.Invalid(hostedZonePath, ic.AWS.HostedZone,
+			fmt.Sprintf("hosted zone domain %q is not a parent of the cluster domain %q", *zone.HostedZone.Name, dottedClusterDomain)))
+	}
+
+	// validate that the hosted zone does not already have any record sets for the cluster domain
 	var problematicRecords []string
 	if err := client.ListResourceRecordSetsPages(
 		&route53.ListResourceRecordSetsInput{HostedZoneId: zone.HostedZone.Id},
@@ -393,4 +400,11 @@ func isHostedZoneAssociatedWithVPC(hostedZone *route53.GetHostedZoneOutput, vpcI
 		}
 	}
 	return false
+}
+
+func isHostedZoneDomainParentOfClusterDomain(hostedZone *route53.HostedZone, dottedClusterDomain string) bool {
+	if *hostedZone.Name == dottedClusterDomain {
+		return true
+	}
+	return strings.HasSuffix(dottedClusterDomain, "."+*hostedZone.Name)
 }


### PR DESCRIPTION
Validate that the user-supplied private HostedZone has a domain that is the cluster domain or a parent of the cluster domain. This
is necessary so that records added to the HostedZone have the correct value.