### PR TITLE
Bug 1954803: aws: support for bring-your-own hosted zone

### DIFF
--- a/data/data/aws/main.tf
+++ b/data/data/aws/main.tf
@@ -86,6 +86,7 @@ module "dns" {
   cluster_domain           = var.cluster_domain
   cluster_id               = var.cluster_id
   tags                     = local.tags
+  internal_zone            = var.aws_internal_zone
   vpc_id                   = module.vpc.vpc_id
   region                   = var.aws_region
   publish_strategy         = var.aws_publish_strategy

--- a/data/data/aws/route53/base.tf
+++ b/data/data/aws/route53/base.tf
@@ -15,7 +15,13 @@ data "aws_route53_zone" "public" {
   name = var.base_domain
 }
 
-resource "aws_route53_zone" "int" {
+data "aws_route53_zone" "int" {
+  zone_id = var.internal_zone == null ? aws_route53_zone.new_int[0].id : var.internal_zone
+}
+
+resource "aws_route53_zone" "new_int" {
+  count = var.internal_zone == null ? 1 : 0
+
   name          = var.cluster_domain
   force_destroy = true
 
@@ -50,7 +56,7 @@ resource "aws_route53_record" "api_external_alias" {
 resource "aws_route53_record" "api_internal_alias" {
   count = local.use_alias ? 1 : 0
 
-  zone_id = aws_route53_zone.int.zone_id
+  zone_id = data.aws_route53_zone.int.zone_id
   name    = "api-int.${var.cluster_domain}"
   type    = "A"
 
@@ -64,7 +70,7 @@ resource "aws_route53_record" "api_internal_alias" {
 resource "aws_route53_record" "api_external_internal_zone_alias" {
   count = local.use_alias ? 1 : 0
 
-  zone_id = aws_route53_zone.int.zone_id
+  zone_id = data.aws_route53_zone.int.zone_id
   name    = "api.${var.cluster_domain}"
   type    = "A"
 
@@ -89,7 +95,7 @@ resource "aws_route53_record" "api_external_cname" {
 resource "aws_route53_record" "api_internal_cname" {
   count = local.use_cname ? 1 : 0
 
-  zone_id = aws_route53_zone.int.zone_id
+  zone_id = data.aws_route53_zone.int.zone_id
   name    = "api-int.${var.cluster_domain}"
   type    = "CNAME"
   ttl     = 10
@@ -100,7 +106,7 @@ resource "aws_route53_record" "api_internal_cname" {
 resource "aws_route53_record" "api_external_internal_zone_cname" {
   count = local.use_cname ? 1 : 0
 
-  zone_id = aws_route53_zone.int.zone_id
+  zone_id = data.aws_route53_zone.int.zone_id
   name    = "api.${var.cluster_domain}"
   type    = "CNAME"
   ttl     = 10

--- a/data/data/aws/route53/variables.tf
+++ b/data/data/aws/route53/variables.tf
@@ -23,6 +23,11 @@ variable "tags" {
   description = "AWS tags to be applied to created resources."
 }
 
+variable "internal_zone" {
+  type        = string
+  description = "An existing hosted zone (zone ID) to use for the internal API."
+}
+
 variable "api_external_lb_dns_name" {
   description = "External API's LB DNS name"
   type        = string

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -126,6 +126,12 @@ variable "aws_private_subnets" {
   description = "(optional) Existing private subnets into which the cluster should be installed."
 }
 
+variable "aws_internal_zone" {
+  type        = string
+  default     = null
+  description = "(optional) An existing hosted zone (zone ID) to use for the internal API."
+}
+
 variable "aws_publish_strategy" {
   type        = string
   description = "The cluster publishing strategy, either Internal or External"

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -954,6 +954,14 @@ spec:
                       user tags in the tags of the AWS resources that the operators
                       create.
                     type: boolean
+                  hostedZone:
+                    description: HostedZone is the ID of an existing hosted zone into
+                      which to add DNS records for the cluster's internal API. An
+                      existing hosted zone can only be used when also using existing
+                      subnets. The hosted zone must be associated with the VPC containing
+                      the subnets. Leave the hosted zone unset to have the installer
+                      create the hosted zone on your behalf.
+                    type: string
                   region:
                     description: Region specifies the AWS region where the cluster
                       will be created.

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -237,6 +237,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			VPC:                   vpc,
 			PrivateSubnets:        privateSubnets,
 			PublicSubnets:         publicSubnets,
+			InternalZone:          installConfig.Config.AWS.HostedZone,
 			Services:              installConfig.Config.AWS.ServiceEndpoints,
 			Publish:               installConfig.Config.Publish,
 			MasterConfigs:         masterConfigs,

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/installer/pkg/asset"
+	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	azconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	bmconfig "github.com/openshift/installer/pkg/asset/installconfig/baremetal"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
@@ -44,6 +45,12 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 	var err error
 	platform := ic.Config.Platform.Name()
 	switch platform {
+	case aws.Name:
+		session, err := ic.AWS.Session(context.TODO())
+		if err != nil {
+			return err
+		}
+		return awsconfig.ValidateForProvisioning(session, ic.Config, ic.AWS)
 	case azure.Name:
 		dnsConfig, err := ic.Azure.DNSConfig()
 		if err != nil {
@@ -82,7 +89,7 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
-	case aws.Name, libvirt.Name, none.Name, ovirt.Name, kubevirt.Name:
+	case libvirt.Name, none.Name, ovirt.Name, kubevirt.Name:
 		// no special provisioning requirements to check
 	default:
 		err = fmt.Errorf("unknown platform type %q", platform)

--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -91,10 +91,14 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 			}
 			config.Spec.PublicZone = &configv1.DNSZone{ID: strings.TrimPrefix(*zone.Id, "/hostedzone/")}
 		}
-		config.Spec.PrivateZone = &configv1.DNSZone{Tags: map[string]string{
-			fmt.Sprintf("kubernetes.io/cluster/%s", clusterID.InfraID): "owned",
-			"Name": fmt.Sprintf("%s-int", clusterID.InfraID),
-		}}
+		if hostedZone := installConfig.Config.AWS.HostedZone; hostedZone == "" {
+			config.Spec.PrivateZone = &configv1.DNSZone{Tags: map[string]string{
+				fmt.Sprintf("kubernetes.io/cluster/%s", clusterID.InfraID): "owned",
+				"Name": fmt.Sprintf("%s-int", clusterID.InfraID),
+			}}
+		} else {
+			config.Spec.PrivateZone = &configv1.DNSZone{ID: hostedZone}
+		}
 	case azuretypes.Name:
 		dnsConfig, err := installConfig.Azure.DNSConfig()
 		if err != nil {

--- a/pkg/destroy/aws/shared.go
+++ b/pkg/destroy/aws/shared.go
@@ -1,0 +1,240 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func (o *ClusterUninstaller) removeSharedTags(
+	ctx context.Context,
+	session *session.Session,
+	tagClients []*resourcegroupstaggingapi.ResourceGroupsTaggingAPI,
+	tracker *errorTracker,
+) error {
+	for _, key := range o.clusterOwnedKeys() {
+		if err := o.removeSharedTag(ctx, session, tagClients, key, tracker); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (o *ClusterUninstaller) clusterOwnedKeys() []string {
+	var keys []string
+	for _, filter := range o.Filters {
+		for key, value := range filter {
+			if !strings.HasPrefix(key, "kubernetes.io/cluster/") {
+				continue
+			}
+			if value != "owned" {
+				o.Logger.Warnf("Ignoring non-owned cluster key %s: %s for shared-tag removal", key, value)
+			}
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+func (o *ClusterUninstaller) removeSharedTag(ctx context.Context, session *session.Session, tagClients []*resourcegroupstaggingapi.ResourceGroupsTaggingAPI, key string, tracker *errorTracker) error {
+	request := &resourcegroupstaggingapi.UntagResourcesInput{
+		TagKeys: []*string{aws.String(key)},
+	}
+
+	removed := map[string]struct{}{}
+	tagClients = append([]*resourcegroupstaggingapi.ResourceGroupsTaggingAPI(nil), tagClients...)
+	for len(tagClients) > 0 {
+		nextTagClients := tagClients[:0]
+		for _, tagClient := range tagClients {
+			o.Logger.Debugf("Search for and remove tags in %s matching %s: shared", *tagClient.Config.Region, key)
+			var arns []string
+			err := tagClient.GetResourcesPagesWithContext(
+				ctx,
+				&resourcegroupstaggingapi.GetResourcesInput{TagFilters: []*resourcegroupstaggingapi.TagFilter{{
+					Key:    aws.String(key),
+					Values: []*string{aws.String("shared")},
+				}}},
+				func(results *resourcegroupstaggingapi.GetResourcesOutput, lastPage bool) bool {
+					for _, resource := range results.ResourceTagMappingList {
+						arnString := aws.StringValue(resource.ResourceARN)
+						logger := o.Logger.WithField("arn", arnString)
+						parsedARN, err := arn.Parse(arnString)
+						if err != nil {
+							logger.WithError(err).Debug("could not parse ARN")
+							continue
+						}
+						if _, ok := removed[arnString]; !ok {
+							if err := o.cleanSharedARN(ctx, session, parsedARN, logger); err != nil {
+								tracker.suppressWarning(arnString, err, logger)
+								if err := ctx.Err(); err != nil {
+									return false
+								}
+								continue
+							}
+							arns = append(arns, arnString)
+						}
+					}
+
+					return !lastPage
+				},
+			)
+			if err != nil {
+				err = errors.Wrap(err, "get tagged resources")
+				o.Logger.Info(err)
+				nextTagClients = append(nextTagClients, tagClient)
+				continue
+			}
+			if len(arns) == 0 {
+				o.Logger.Debugf("No matches in %s for %s: shared, removing client", *tagClient.Config.Region, key)
+				continue
+			}
+			nextTagClients = append(nextTagClients, tagClient)
+
+			for i := 0; i < len(arns); i += 20 {
+				request.ResourceARNList = make([]*string, 0, 20)
+				for j := 0; i+j < len(arns) && j < 20; j++ {
+					request.ResourceARNList = append(request.ResourceARNList, aws.String(arns[i+j]))
+				}
+				_, err = tagClient.UntagResourcesWithContext(ctx, request)
+				if err != nil {
+					err = errors.Wrap(err, "untag shared resources")
+					o.Logger.Info(err)
+					continue
+				}
+				for j := 0; i+j < len(arns) && j < 20; j++ {
+					arn := arns[i+j]
+					o.Logger.WithField("arn", arn).Infof("Removed tag %s: shared", key)
+					removed[arn] = exists
+				}
+			}
+		}
+		tagClients = nextTagClients
+	}
+
+	return nil
+}
+
+func (o *ClusterUninstaller) cleanSharedARN(ctx context.Context, session *session.Session, arn arn.ARN, logger logrus.FieldLogger) error {
+	switch service := arn.Service; service {
+	case "route53":
+		return o.cleanSharedRoute53(ctx, session, arn, logger)
+	default:
+		logger.Debugf("Nothing to clean for shared %s resource", service)
+		return nil
+	}
+}
+
+func (o *ClusterUninstaller) cleanSharedRoute53(ctx context.Context, session *session.Session, arn arn.ARN, logger logrus.FieldLogger) error {
+	client := route53.New(session)
+
+	resourceType, id, err := splitSlash("resource", arn.Resource)
+	if err != nil {
+		return err
+	}
+	logger = logger.WithField("id", id)
+
+	switch resourceType {
+	case "hostedzone":
+		return o.cleanSharedHostedZone(ctx, client, id, logger)
+	default:
+		logger.Debugf("Nothing to clean for shared %s resource", resourceType)
+		return nil
+	}
+}
+
+func (o *ClusterUninstaller) cleanSharedHostedZone(ctx context.Context, client *route53.Route53, id string, logger logrus.FieldLogger) error {
+	if o.ClusterDomain == "" {
+		logger.Debug("No cluster domain specified in metadata; cannot clean the shared hosted zone")
+		return nil
+	}
+	dottedClusterDomain := o.ClusterDomain + "."
+
+	publicZoneID, err := findAncestorPublicRoute53(ctx, client, o.ClusterDomain, logger)
+	if err != nil {
+		return err
+	}
+
+	var lastError error
+	err = client.ListResourceRecordSetsPagesWithContext(
+		ctx,
+		&route53.ListResourceRecordSetsInput{HostedZoneId: aws.String(id)},
+		func(results *route53.ListResourceRecordSetsOutput, lastPage bool) bool {
+			for _, recordSet := range results.ResourceRecordSets {
+				// skip record sets that are not part of the cluster
+				name := aws.StringValue(recordSet.Name)
+				if !strings.HasSuffix(name, dottedClusterDomain) {
+					continue
+				}
+				if len(name) == len(dottedClusterDomain) {
+					continue
+				}
+				recordSetLogger := logger.WithField(
+					"recordset",
+					fmt.Sprintf("%s (%s)", aws.StringValue(recordSet.Name), aws.StringValue(recordSet.Type)),
+				)
+				// delete any matching record sets in the public hosted zone
+				if publicZoneID != "" {
+					if err := deleteMatchingRecordSetInPublicZone(ctx, client, publicZoneID, recordSet, logger); err != nil {
+						if lastError != nil {
+							logger.Debug(lastError)
+						}
+						lastError = errors.Wrapf(err, "deleting record set matching %#v from public zone %s", recordSet, publicZoneID)
+						// do not delete the record set in the private zone if the delete failed in the public zone;
+						// otherwise the record set in the public zone will get leaked
+						continue
+					}
+					recordSetLogger.Debug("Deleted from public zone")
+				}
+				// delete the record set
+				if err := deleteRoute53RecordSet(ctx, client, id, recordSet, logger); err != nil {
+					if lastError != nil {
+						logger.Debug(lastError)
+					}
+					lastError = errors.Wrapf(err, "deleting record set %#v from zone %s", recordSet, id)
+				}
+				recordSetLogger.Debug("Deleted")
+			}
+			return !lastPage
+		},
+	)
+
+	if lastError != nil {
+		return lastError
+	}
+	if err != nil {
+		return err
+	}
+
+	logger.Info("Cleaned record sets from hosted zone")
+	return nil
+}
+
+func deleteMatchingRecordSetInPublicZone(ctx context.Context, client *route53.Route53, zoneID string, recordSet *route53.ResourceRecordSet, logger logrus.FieldLogger) error {
+	in := &route53.ListResourceRecordSetsInput{
+		HostedZoneId:    aws.String(zoneID),
+		MaxItems:        aws.String("1"),
+		StartRecordName: recordSet.Name,
+		StartRecordType: recordSet.Type,
+	}
+	out, err := client.ListResourceRecordSetsWithContext(ctx, in)
+	if err != nil {
+		return err
+	}
+	if len(out.ResourceRecordSets) == 0 {
+		return nil
+	}
+	matchingRecordSet := out.ResourceRecordSets[0]
+	if aws.StringValue(matchingRecordSet.Name) != aws.StringValue(recordSet.Name) ||
+		aws.StringValue(matchingRecordSet.Type) != aws.StringValue(recordSet.Type) {
+		return nil
+	}
+	return deleteRoute53RecordSet(ctx, client, zoneID, matchingRecordSet, logger)
+}

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -122,6 +122,9 @@ func Test_PrintFields(t *testing.T) {
     experimentalPropagateUserTags <boolean>
       ExperimentalPropagateUserTags is an experimental flag that directs in-cluster operators to include the specified user tags in the tags of the AWS resources that the operators create.
 
+    hostedZone <string>
+      HostedZone is the ID of an existing hosted zone into which to add DNS records for the cluster's internal API. An existing hosted zone can only be used when also using existing subnets. The hosted zone must be associated with the VPC containing the subnets. Leave the hosted zone unset to have the installer create the hosted zone on your behalf.
+
     region <string> -required-
       Region specifies the AWS region where the cluster will be created.
 

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -32,6 +32,7 @@ type config struct {
 	VPC                     string            `json:"aws_vpc,omitempty"`
 	PrivateSubnets          []string          `json:"aws_private_subnets,omitempty"`
 	PublicSubnets           *[]string         `json:"aws_public_subnets,omitempty"`
+	InternalZone            string            `json:"aws_internal_zone,omitempty"`
 	PublishStrategy         string            `json:"aws_publish_strategy,omitempty"`
 	SkipRegionCheck         bool              `json:"aws_skip_region_validation"`
 	IgnitionBucket          string            `json:"aws_ignition_bucket"`
@@ -42,6 +43,7 @@ type config struct {
 type TFVarsSources struct {
 	VPC                           string
 	PrivateSubnets, PublicSubnets []string
+	InternalZone                  string
 	Services                      []typesaws.ServiceEndpoint
 
 	Publish types.PublishingStrategy
@@ -120,6 +122,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Type:                    *rootVolume.EBS.VolumeType,
 		VPC:                     sources.VPC,
 		PrivateSubnets:          sources.PrivateSubnets,
+		InternalZone:            sources.InternalZone,
 		PublishStrategy:         string(sources.Publish),
 		SkipRegionCheck:         !configaws.IsKnownRegion(masterConfig.Placement.Region),
 		IgnitionBucket:          sources.IgnitionBucket,

--- a/pkg/types/aws/metadata.go
+++ b/pkg/types/aws/metadata.go
@@ -15,4 +15,7 @@ type Metadata struct {
 	// resource matches the map if all of the key/value pairs are in its
 	// tags.  A resource matches Identifier if it matches any of the maps.
 	Identifier []map[string]string `json:"identifier"`
+
+	// ClusterDomain is the domain for the cluster.
+	ClusterDomain string `json:"clusterDomain"`
 }

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -26,6 +26,15 @@ type Platform struct {
 	// +optional
 	Subnets []string `json:"subnets,omitempty"`
 
+	// HostedZone is the ID of an existing hosted zone into which to add DNS
+	// records for the cluster's internal API. An existing hosted zone can
+	// only be used when also using existing subnets. The hosted zone must be
+	// associated with the VPC containing the subnets.
+	// Leave the hosted zone unset to have the installer create the hosted zone
+	// on your behalf.
+	// +optional
+	HostedZone string `json:"hostedZone,omitempty"`
+
 	// UserTags additional keys and values that the installer will add
 	// as tags to all resources that it creates. Resources created by the
 	// cluster itself may not include these tags.

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -28,6 +28,12 @@ func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "region must be specified"))
 	}
 
+	if p.HostedZone != "" {
+		if len(p.Subnets) == 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("hostedZone"), p.HostedZone, "may not use an existing hosted zone when not using existing subnets"))
+		}
+	}
+
 	allErrs = append(allErrs, validateServiceEndpoints(p.ServiceEndpoints, fldPath.Child("serviceEndpoints"))...)
 	allErrs = append(allErrs, validateUserTags(p.UserTags, p.ExperimentalPropagateUserTag, fldPath.Child("userTags"))...)
 

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -30,6 +30,22 @@ func TestValidatePlatform(t *testing.T) {
 			expected: `^test-path\.region: Required value: region must be specified$`,
 		},
 		{
+			name: "hosted zone with subnets",
+			platform: &aws.Platform{
+				Region:     "us-east-1",
+				Subnets:    []string{"test-subnet"},
+				HostedZone: "test-hosted-zone",
+			},
+		},
+		{
+			name: "hosted zone without subnets",
+			platform: &aws.Platform{
+				Region:     "us-east-1",
+				HostedZone: "test-hosted-zone",
+			},
+			expected: `^test-path\.hostedZone: Invalid value: "test-hosted-zone": may not use an existing hosted zone when not using existing subnets$`,
+		},
+		{
 			name: "invalid url for service endpoint",
 			platform: &aws.Platform{
 				Region: "us-east-1",


### PR DESCRIPTION
Add the .aws.hostedZone field to the install config to support the user supplying an existing hosted zone for the internal private hosted zone for the cluster. This can only be used when the user is also supplying their own VPC. The hosted zone must already be associated with the user-provided VPC.

Add validation in the "Platform Provisioning Check" asset for the user-provided internal hosted zone. The validation checks that
(1) the hosted zone is associated with the user-provided VPC and that (2) the hosted zone does not contain any record sets for subdomains of the cluster's domain.

The latter of these checks is meant to provide a modicum of protection against the user accidentally trying to install again a cluster that they have already installed. When it comes time to destroy the second failed installation, the destroyer will not be able to tell that the records sets in the hosted zone are actually being used by a different cluster.

When the user provides the private hosted zone to use for the cluster, the destroyer still needs to delete the recordsets for the cluster when the cluster is destroyed. There is no way to tag recordsets, so we must rely on tagging the hosted zone as shared. When the destroyer encounters a hosted zone tagged as shared by the cluster, the destroyer will delete all recordsets in that hosted zone that are strict subdomains of the cluster's domain. The cluster domain is added to the AWS cluster metadata so that it is available to the destroyer.