### PR TITLE
Bug 1953551: Revert "Link ppc64le binary dynamically"

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -42,13 +42,11 @@ if (echo "${TAGS}" | grep -q 'libvirt')
 then
 	export CGO_ENABLED=1
 fi
-case "$(go env GOARCH)" in
-arm64|ppc64le)
-	# arm64: https://github.com/golang/go/issues/40492
-	# ppc64le: https://github.com/golang/go/issues/45564
+if test "$(go env GOARCH)" = "arm64"
+then
+	# https://github.com/golang/go/issues/40492
 	LDFLAGS="${LDFLAGS} -linkmode external"
 	export CGO_ENABLED=1
-	;;
-esac
+fi
 
 go build "${GOFLAGS}" -ldflags "${LDFLAGS}" -tags "${TAGS}" -o "${OUTPUT}" ./cmd/openshift-install


### PR DESCRIPTION
This unblocked the build on other architectures, but the resulting
ppc64le binary had issues.  The golang bug which affected static linking
has been fixed with a one-line patch, which we are carrying downstream
until the upstream backports land.

This reverts commit 24ac0a15e785b2cabcdd4af2c1281efe8d29eed6.

/cc @joepvd @wking @sosiouxme
