### PR TITLE
Bug 1956079: gather: collect networking information in log bundle

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -36,6 +36,13 @@ do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"
 done
 
+echo "Gathering bootstrap networking ..."
+mkdir -p "${ARTIFACTS}/bootstrap/network"
+ip addr >& "${ARTIFACTS}/bootstrap/network/ip-addr.txt"
+ip route >& "${ARTIFACTS}/bootstrap/network/ip-route.txt"
+hostname >& "${ARTIFACTS}/bootstrap/network/hostname.txt"
+cp -r /etc/resolv.conf "${ARTIFACTS}/bootstrap/network/"
+
 echo "Gathering bootstrap containers ..."
 mkdir -p "${ARTIFACTS}/bootstrap/containers"
 sudo crictl ps --all --quiet | while read -r container

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -27,6 +27,13 @@ do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
 done
 
+echo "Gathering master networking ..."
+mkdir -p "${ARTIFACTS}/network"
+ip addr >& "${ARTIFACTS}/network/ip-addr.txt"
+ip route >& "${ARTIFACTS}/network/ip-route.txt"
+hostname >& "${ARTIFACTS}/network/hostname.txt"
+cp -r /etc/resolv.conf "${ARTIFACTS}/network/"
+
 echo "Gathering master containers ..."
 mkdir -p "${ARTIFACTS}/containers"
 for container in $(crictl ps --all --quiet)


### PR DESCRIPTION
This collects some rudimentary networking information (ip a, ip r,
hostname, resolv.conf) on the bootstrap and masters in the log bundle.
For on-premise platforms, we've had a variety of reasons to want to look
at this information due to various networking problems.