### PR TITLE
Bug 1959703: Avoid scp wildcard recursion with installer-masters-gather.sh

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -98,9 +98,9 @@ fi
 mkdir -p "${ARTIFACTS}/control-plane"
 echo "Gather remote logs"
 export MASTERS=()
+MASTER_GATHER_ID="master-${GATHER_ID}"
 if [[ -f ${LOG_BUNDLE_BOOTSTRAP_ARCHIVE_NAME} ]]; then
     # Instead of running installer-masters-gather.sh on remote masters, run it on the current node
-    MASTER_GATHER_ID="master-${GATHER_ID}"
     MASTER_ARTIFACTS="/tmp/artifacts-${MASTER_GATHER_ID}"
     mkdir -p "${ARTIFACTS}/control-plane/master"
     sudo /usr/local/bin/installer-masters-gather.sh --id "${MASTER_GATHER_ID}" </dev/null
@@ -118,8 +118,8 @@ do
     echo "Collecting info from ${master}"
     scp -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -q /usr/local/bin/installer-masters-gather.sh "core@[${master}]:"
     mkdir -p "${ARTIFACTS}/control-plane/${master}"
-    ssh -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null "core@${master}" -C "sudo ./installer-masters-gather.sh --id '${GATHER_ID}'" </dev/null
-    scp -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -r -q "core@[${master}]:/tmp/artifacts-${GATHER_ID}/*" "${ARTIFACTS}/control-plane/${master}/"
+    ssh -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null "core@${master}" -C "sudo ./installer-masters-gather.sh --id '${MASTER_GATHER_ID}'" </dev/null
+    scp -o PreferredAuthentications=publickey -o StrictHostKeyChecking=false -o UserKnownHostsFile=/dev/null -r -q "core@[${master}]:/tmp/artifacts-${MASTER_GATHER_ID}/*" "${ARTIFACTS}/control-plane/${master}/"
 done
 
 TAR_FILE="${TAR_FILE:-${HOME}/log-bundle-${GATHER_ID}.tar.gz}"


### PR DESCRIPTION
# Issue background
When `openshift-install gather bootstrap` is passed the bootstrap node as
`--master`, the bootstrap node will attempt to run `installer-masters-gather.sh` on itself, via ssh.

Then when it tries to copy the resulting artifacts via `scp`, it does so
with a wildcard `scp` source parameter. Since it attempts to perform the
recursive copy with a wildcard source that is the same as the
destination (same because this is the bootstrap node actually copying from
itself to itself), `scp` starts behaving weirdly.

The weird scp behavior can be demonstrated by running the following 2 lines:
(warning, this will recursively create a nested directory until the file
system gives up. Seems to be harmless on my machine, but I can't
guarantee it won't break anything on yours)
```bash
mkdir -p scploop/loop
scp -r 'localhost:scploop/*' scploop/loop/
```

Which results in the following output:
```
scp: scploop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/loop/looprotocol error: expected control record
```

# Issue solution
The `installer-masters-gather.sh` script launched by
`installer-gather.sh` will now use a different ID than
the bootstrap ID (same ID as bootstrap but with a
`master-` prefix) to make sure the `scp` source and
target directories are always different, even when the
bootstrap node gets passed itself as a master node.

# Why fix this
Currently, in order to perfrom installer bootstrap gather on a UPI
bootstrap-in-place single node cluster, the installer gather command
has to be run like in the following example:
```bash
BOOTSTRAP_NODE_IP=192.168.0.50
openshift-install gather bootstrap --bootstrap ${BOOTSTRAP_NODE_IP} --master ${BOOTSTRAP_NODE_IP} --key my/ssh/key
```

This is because:
1) The gather bootstrap command won't have it any other way, the way
it's currently implemented.
2) It's technically true - the same IP belongs to both the bootstrap and
master node.

Prior to running the gather command, the user does not care whether the pivot
between bootstrap and master has already occurred - they just want the
current log bundle. If the node happens to still be in the bootstrap phase, the
`installer-gather.sh` will attempt to collect master logs on itself,
and the bug will get triggered, creating a nested directory mess which
cause CI failures (https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-master-e2e-metal-single-node-live-iso-periodic/1388644544341348352).

There may be other ways to resolve this, but this seemed to be the simplest for now