### PR TITLE
bug 1956281: crio: fix bootstrap given new crio config behavior

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/crio-configure.sh.template
@@ -14,6 +14,17 @@ set -euo pipefail
 
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
-sed --in-place --expression "s,pause_image *=.*,pause_image = \"${MACHINE_CONFIG_INFRA_IMAGE}\"," /etc/crio/crio.conf
-sed --in-place --expression 's,pause_command *=.*,pause_command = "/usr/bin/pod",' /etc/crio/crio.conf
-sed --in-place --expression 's,"/usr/share/containers/oci/hooks.d","/etc/containers/oci/hooks.d",' /etc/crio/crio.conf
+# make the drop-in directory if that hasn't been done yet
+mkdir -p /etc/crio/crio.conf.d
+
+cat <<EOF > /etc/crio/crio.conf.d/50-bootstrap-override.conf
+[crio]
+[crio.runtime]
+hooks_dir = [
+	"/usr/share/containers/oci/hooks.d",
+	"/etc/containers/oci/hooks.d",
+]
+[crio.image]
+pause_image = "$MACHINE_CONFIG_INFRA_IMAGE"
+pause_command = "/usr/bin/pod"
+EOF


### PR DESCRIPTION
now, it's not guaranteed that crio will print out every field in the config
this is good, it allows us to iterate on default values quicker. However, this means we can't use simple tools like sed to update the config
luckily, `crio config` is now primed to create new drop-in files to configure itself. Use this behavior to set the override

Signed-off-by: Peter Hunt <pehunt@redhat.com>