### PR TITLE
Bug 1956978: install-gather: use names in pod logs too

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -86,6 +86,7 @@ then
 	rm --recursive --force cvo-bootstrap
 
 	bootkube_podman_run \
+		--name cvo-render \
 		--volume "$PWD:/assets:z" \
 {{- if .ClusterProfile}}
 		--env CLUSTER_PROFILE="{{.ClusterProfile}}" \
@@ -110,6 +111,7 @@ then
     record_service_stage_start "etcd-bootstrap"
 	echo "Rendering CEO Manifests..."
 	bootkube_podman_run \
+		--name etcd-render \
 		--volume "$PWD:/assets:z" \
 		"${CLUSTER_ETCD_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-etcd-operator render \
@@ -143,6 +145,7 @@ then
 	fi
 
 	bootkube_podman_run \
+		--name config-render \
 		--volume "$PWD:/assets:z" \
 		"${CONFIG_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-config-operator render \
@@ -167,6 +170,7 @@ then
 	rm --recursive --force kube-apiserver-bootstrap
 
 	bootkube_podman_run  \
+		--name kube-apiserver-render \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_APISERVER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-apiserver-operator render \
@@ -196,6 +200,7 @@ then
 	rm --recursive --force kube-controller-manager-bootstrap
 
 	bootkube_podman_run \
+		--name kube-controller-render \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-controller-manager-operator render \
@@ -233,6 +238,7 @@ then
 	rm --recursive --force kube-scheduler-bootstrap
 
 	bootkube_podman_run \
+		--name kube-scheduler-render \
 		--volume "$PWD:/assets:z" \
 		"${KUBE_SCHEDULER_OPERATOR_IMAGE}" \
 		/usr/bin/cluster-kube-scheduler-operator render \
@@ -257,6 +263,7 @@ then
 	rm --recursive --force ingress-operator-bootstrap
 
 	bootkube_podman_run \
+		--name ingress-render \
 		--volume "$PWD:/assets:z" \
 		"${INGRESS_OPERATOR_IMAGE}" \
 		render \
@@ -285,6 +292,7 @@ then
 	fi
 
 	bootkube_podman_run \
+		--name mco-render \
 		--user 0 \
 		--volume "$PWD:/assets:z" \
 		"${MACHINE_CONFIG_OPERATOR_IMAGE}" \
@@ -352,6 +360,7 @@ then
 
 	# shellcheck disable=SC2154
 	bootkube_podman_run \
+		--name cco-render \
 		--quiet \
 		--user 0 \
 		--volume "$PWD:/assets:z" \
@@ -390,6 +399,7 @@ echo "Starting cluster-bootstrap..."
 run_cluster_bootstrap() {
 	record_service_stage_start "cb-bootstrap"
 	bootkube_podman_run \
+        --name cluster-bootstrap \
         --rm \
         --volume "$PWD:/assets:z" \
         --volume /etc/kubernetes:/etc/kubernetes:z \
@@ -422,6 +432,7 @@ else
         record_service_stage_start "wait-for-ceo"
         echo "Waiting for CEO to finish..."
         bootkube_podman_run \
+            --name wait-for-ceo \
             --volume "$PWD:/assets:z" \
             "${CLUSTER_ETCD_OPERATOR_IMAGE}" \
             /usr/bin/cluster-etcd-operator \

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -53,10 +53,10 @@ do
 done
 sudo cp -r /var/log/bootstrap-control-plane/ "${ARTIFACTS}/bootstrap/containers"
 mkdir -p "${ARTIFACTS}/bootstrap/pods"
-sudo podman ps --all --quiet | while read -r container
+sudo podman ps --all --format "{{ .ID }} {{ .Names }}" | while read -r container_id container_name
 do
-    sudo podman logs "${container}" >& "${ARTIFACTS}/bootstrap/pods/${container}.log"
-    sudo podman inspect "${container}" >& "${ARTIFACTS}/bootstrap/pods/${container}.inspect"
+    sudo podman logs "${container_id}" >& "${ARTIFACTS}/bootstrap/pods/${container_name}-${container_id}.log"
+    sudo podman inspect "${container_id}" >& "${ARTIFACTS}/bootstrap/pods/${container_name}-${container_id}.inspect"
 done
 
 echo "Gathering rendered assets..."

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -42,10 +42,11 @@ do
     crictl logs "${container}" >& "${ARTIFACTS}/containers/${container_name}-${container}.log"
     crictl inspect "${container}" >& "${ARTIFACTS}/containers/${container_name}-${container}.inspect"
 done
-for container in $(podman ps --all --quiet)
+
+podman ps --all --format "{{ .ID }} {{ .Names }}" | while read -r container_id container_name
 do
-    podman logs "${container}" >& "${ARTIFACTS}/containers/${container}.log"
-    podman inspect "${container}" >& "${ARTIFACTS}/containers/${container}.inspect"
+    podman logs "${container_id}" >& "${ARTIFACTS}/containers/${container_name}-${container_id}.log"
+    podman inspect "${container_id}" >& "${ARTIFACTS}/containers/${container_name}-${container_id}.inspect"
 done
 
 echo "Waiting for logs ..."


### PR DESCRIPTION
This adds names for all bootkube podman containers, and then ensures
they are used in the logfile names.

This change adds the name to the filename too to make it easier to find
the log you want.  We already do this for the info gathered from crictl.

Before:

```
048ef60a5c98.inspect  19469a52f7ad.log      37295b9146d0.inspect  47a6928aec07.log      9f0336ed4472.inspect  adc089be665d.log      de3b81bae57f.inspect  e87f59adff94.log
048ef60a5c98.log      28df02fb561a.inspect  37295b9146d0.log      7cf3eb0e9c83.inspect  9f0336ed4472.log      afc6dbef0228.inspect  de3b81bae57f.log      efae86fe1adf.inspect
0eafc3264794.inspect  28df02fb561a.log      39c7564d80ee.inspect  7cf3eb0e9c83.log      a3dbad8cdd94.inspect  afc6dbef0228.log      e7154648c31d.inspect  efae86fe1adf.log
0eafc3264794.log      3108024d2973.inspect  39c7564d80ee.log      88c5ac23359d.inspect  a3dbad8cdd94.log      dbf2f389ffa8.inspect  e7154648c31d.log      fd51af06a0ea.inspect
19469a52f7ad.inspect  3108024d2973.log      47a6928aec07.inspect  88c5ac23359d.log      adc089be665d.inspect  dbf2f389ffa8.log      e87f59adff94.inspect  fd51af06a0ea.log
```

After this change:

```
cco-render-f027f5600c77.inspect         cvo-bootstrap-342990afc1c5.log    ingress-render-4b77a59d26d5.inspect    ironic-conductor-f701ba8e1fd6.log                   kube-apiserver-render-7c7c61284be8.inspect   mariadb-b83c376ccc72.log
cco-render-f027f5600c77.log             dnsmasq-6872307ade52.inspect      ingress-render-4b77a59d26d5.log        ironic-deploy-ramdisk-logs-438e2b335494.inspect     kube-apiserver-render-7c7c61284be8.log       mco-4f3bbe705e85.inspect
config-render-ae5e5d60cda9.inspect      dnsmasq-6872307ade52.log          ipa-downloader-fe64b25d1d60.inspect    ironic-deploy-ramdisk-logs-438e2b335494.log         kube-controller-render-be8a76178da9.inspect  mco-4f3bbe705e85.log
config-render-ae5e5d60cda9.log          etcd-render-d73c371da8a8.inspect  ipa-downloader-fe64b25d1d60.log        ironic-inspector-7246ea3df39d.inspect               kube-controller-render-be8a76178da9.log
coreos-downloader-9e085d715fab.inspect  etcd-render-d73c371da8a8.log      ironic-api-f7c1c053a69a.inspect        ironic-inspector-7246ea3df39d.log                   kube-scheduler-render-8a476cfedcb1.inspect
coreos-downloader-9e085d715fab.log      httpd-28731f185da3.inspect        ironic-api-f7c1c053a69a.log            ironic-inspector-ramdisk-logs-428db00fcdb5.inspect  kube-scheduler-render-8a476cfedcb1.log
cvo-bootstrap-342990afc1c5.inspect      httpd-28731f185da3.log            ironic-conductor-f701ba8e1fd6.inspect  ironic-inspector-ramdisk-logs-428db00fcdb5.log      mariadb-b83c376ccc72.inspect
```
