### PR TITLE
Bug 1956208: openstack: add validation for volume types

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/machinepool_test.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool_test.go
@@ -25,6 +25,7 @@ const (
 	baremetalFlavor = "baremetal-flavor"
 
 	volumeType      = "performance"
+	invalidType     = "invalid-type"
 	volumeSmallSize = 10
 	volumeLargeSize = 25
 )
@@ -110,6 +111,9 @@ func validMpoolCloudInfo() *CloudInfo {
 		},
 		VolumeZones: []string{
 			validZone,
+		},
+		VolumeTypes: []string{
+			volumeType,
 		},
 	}
 }
@@ -298,6 +302,30 @@ func TestOpenStackMachinepoolValidation(t *testing.T) {
 			cloudInfo:      validMpoolCloudInfo(),
 			expectedError:  true,
 			expectedErrMsg: `compute\[0\].platform.openstack.rootVolume.zones: Invalid value: \[\]string{"AZ1", "AZ2"}: there must be either just one volume availability zone common to all nodes or the number of compute and volume availability zones must be equal`,
+		},
+		{
+			name:         "empty volume type",
+			controlPlane: false,
+			mpool: func() *openstack.MachinePool {
+				mp := validMachinePoolLargeVolume()
+				mp.RootVolume.Type = ""
+				return mp
+			}(),
+			cloudInfo:      validMpoolCloudInfo(),
+			expectedError:  true,
+			expectedErrMsg: `compute\[0\].platform.openstack.rootVolume.type: Invalid value: \"\": Volume type must be specified to use root volumes`,
+		},
+		{
+			name:         "invalid volume type",
+			controlPlane: false,
+			mpool: func() *openstack.MachinePool {
+				mp := validMachinePoolLargeVolume()
+				mp.RootVolume.Type = invalidType
+				return mp
+			}(),
+			cloudInfo:      validMpoolCloudInfo(),
+			expectedError:  true,
+			expectedErrMsg: `compute\[0\].platform.openstack.rootVolume.type: Invalid value: \"invalid-type\": Volume Type either does not exist in this cloud, or is not available`,
 		},
 	}
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/doc.go
@@ -1,0 +1,165 @@
+/*
+Package volumetypes provides information and interaction with volume types in the
+OpenStack Block Storage service. A volume type is a collection of specs used to
+define the volume capabilities.
+
+Example to list Volume Types
+
+	allPages, err := volumetypes.List(client, volumetypes.ListOpts{}).AllPages()
+	if err != nil{
+		panic(err)
+	}
+	volumeTypes, err := volumetypes.ExtractVolumeTypes(allPages)
+	if err != nil{
+		panic(err)
+	}
+	for _,vt := range volumeTypes{
+		fmt.Println(vt)
+	}
+
+Example to show a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumeType, err := volumetypes.Get(client, typeID).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+
+Example to create a Volume Type
+
+	volumeType, err := volumetypes.Create(client, volumetypes.CreateOpts{
+		Name:"volume_type_001",
+		IsPublic:true,
+		Description:"description_001",
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumeType)
+
+Example to delete a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	err := volumetypes.Delete(client, typeID).ExtractErr()
+	if err != nil{
+		panic(err)
+	}
+
+Example to update a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	volumetype, err = volumetypes.Update(client, typeID, volumetypes.UpdateOpts{
+		Name: "volume_type_002",
+		Description:"description_002",
+		IsPublic:false,
+	}).Extract()
+	if err != nil{
+		panic(err)
+	}
+	fmt.Println(volumetype)
+
+Example to Create Extra Specs for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	createOpts := volumetypes.ExtraSpecsOpts{
+		"capabilities": "gpu",
+	}
+	createdExtraSpecs, err := volumetypes.CreateExtraSpecs(client, typeID, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", createdExtraSpecs)
+
+Example to Get Extra Specs for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	extraSpecs, err := volumetypes.ListExtraSpecs(client, typeID).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", extraSpecs)
+
+Example to Get specific Extra Spec for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	extraSpec, err := volumetypes.GetExtraSpec(client, typeID, "capabilities").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", extraSpec)
+
+Example to Update Extra Specs for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+
+	updateOpts := volumetypes.ExtraSpecsOpts{
+		"capabilities": "capabilities-updated",
+	}
+	updatedExtraSpec, err := volumetypes.UpdateExtraSpec(client, typeID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v", updatedExtraSpec)
+
+Example to Delete an Extra Spec for a Volume Type
+
+	typeID := "7ffaca22-f646-41d4-b79d-d7e4452ef8cc"
+	err := volumetypes.DeleteExtraSpec(client, typeID, "capabilities").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to List Volume Type Access
+
+	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	allPages, err := volumetypes.ListAccesses(client, typeID).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allAccesses, err := volumetypes.ExtractAccesses(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, access := range allAccesses {
+		fmt.Printf("%+v", access)
+	}
+
+Example to Grant Access to a Volume Type
+
+	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	accessOpts := volumetypes.AddAccessOpts{
+		Project: "15153a0979884b59b0592248ef947921",
+	}
+
+	err := volumetypes.AddAccess(client, typeID, accessOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Remove/Revoke Access to a Volume Type
+
+	typeID := "e91758d6-a54a-4778-ad72-0c73a1cb695b"
+
+	accessOpts := volumetypes.RemoveAccessOpts{
+		Project: "15153a0979884b59b0592248ef947921",
+	}
+
+	err := volumetypes.RemoveAccess(client, typeID, accessOpts).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+*/
+package volumetypes

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/requests.go
@@ -1,0 +1,306 @@
+package volumetypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToVolumeTypeCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Volume Type. This object is passed to
+// the volumetypes.Create function. For more information about these parameters,
+// see the Volume Type object.
+type CreateOpts struct {
+	// The name of the volume type
+	Name string `json:"name" required:"true"`
+	// The volume type description
+	Description string `json:"description,omitempty"`
+	// the ID of the existing volume snapshot
+	IsPublic *bool `json:"os-volume-type-access:is_public,omitempty"`
+	// Extra spec key-value pairs defined by the user.
+	ExtraSpecs map[string]string `json:"extra_specs,omitempty"`
+}
+
+// ToVolumeTypeCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToVolumeTypeCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Create will create a new Volume Type based on the values in CreateOpts. To extract
+// the Volume Type object from the response, call the Extract method on the
+// CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToVolumeTypeCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will delete the existing Volume Type with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := client.Delete(deleteURL(client, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves the Volume Type with the provided ID. To extract the Volume Type object
+// from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(getURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToVolumeTypeListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Volume Types. It is passed to the volumetypes.List
+// function.
+type ListOpts struct {
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToVolumeTypeListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToVolumeTypeListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Volume types.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+
+	if opts != nil {
+		query, err := opts.ToVolumeTypeListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return VolumeTypePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToVolumeTypeUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contain options for updating an existing Volume Type. This object is passed
+// to the volumetypes.Update function. For more information about the parameters, see
+// the Volume Type object.
+type UpdateOpts struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	IsPublic    *bool   `json:"is_public,omitempty"`
+}
+
+// ToVolumeTypeUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToVolumeTypeUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "volume_type")
+}
+
+// Update will update the Volume Type with provided information. To extract the updated
+// Volume Type from the response, call the Extract method on the UpdateResult.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToVolumeTypeUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListExtraSpecs requests all the extra-specs for the given volume type ID.
+func ListExtraSpecs(client *gophercloud.ServiceClient, volumeTypeID string) (r ListExtraSpecsResult) {
+	resp, err := client.Get(extraSpecsListURL(client, volumeTypeID), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetExtraSpec requests an extra-spec specified by key for the given volume type ID
+func GetExtraSpec(client *gophercloud.ServiceClient, volumeTypeID string, key string) (r GetExtraSpecResult) {
+	resp, err := client.Get(extraSpecsGetURL(client, volumeTypeID, key), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateExtraSpecsOptsBuilder allows extensions to add additional parameters to the
+// CreateExtraSpecs requests.
+type CreateExtraSpecsOptsBuilder interface {
+	ToVolumeTypeExtraSpecsCreateMap() (map[string]interface{}, error)
+}
+
+// ExtraSpecsOpts is a map that contains key-value pairs.
+type ExtraSpecsOpts map[string]string
+
+// ToVolumeTypeExtraSpecsCreateMap assembles a body for a Create request based on
+// the contents of ExtraSpecsOpts.
+func (opts ExtraSpecsOpts) ToVolumeTypeExtraSpecsCreateMap() (map[string]interface{}, error) {
+	return map[string]interface{}{"extra_specs": opts}, nil
+}
+
+// CreateExtraSpecs will create or update the extra-specs key-value pairs for
+// the specified volume type.
+func CreateExtraSpecs(client *gophercloud.ServiceClient, volumeTypeID string, opts CreateExtraSpecsOptsBuilder) (r CreateExtraSpecsResult) {
+	b, err := opts.ToVolumeTypeExtraSpecsCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(extraSpecsCreateURL(client, volumeTypeID), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateExtraSpecOptsBuilder allows extensions to add additional parameters to
+// the Update request.
+type UpdateExtraSpecOptsBuilder interface {
+	ToVolumeTypeExtraSpecUpdateMap() (map[string]string, string, error)
+}
+
+// ToVolumeTypeExtraSpecUpdateMap assembles a body for an Update request based on
+// the contents of a ExtraSpecOpts.
+func (opts ExtraSpecsOpts) ToVolumeTypeExtraSpecUpdateMap() (map[string]string, string, error) {
+	if len(opts) != 1 {
+		err := gophercloud.ErrInvalidInput{}
+		err.Argument = "volumetypes.ExtraSpecOpts"
+		err.Info = "Must have one and only one key-value pair"
+		return nil, "", err
+	}
+
+	var key string
+	for k := range opts {
+		key = k
+	}
+
+	return opts, key, nil
+}
+
+// UpdateExtraSpec will updates the value of the specified volume type's extra spec
+// for the key in opts.
+func UpdateExtraSpec(client *gophercloud.ServiceClient, volumeTypeID string, opts UpdateExtraSpecOptsBuilder) (r UpdateExtraSpecResult) {
+	b, key, err := opts.ToVolumeTypeExtraSpecUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(extraSpecUpdateURL(client, volumeTypeID, key), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteExtraSpec will delete the key-value pair with the given key for the given
+// volume type ID.
+func DeleteExtraSpec(client *gophercloud.ServiceClient, volumeTypeID, key string) (r DeleteExtraSpecResult) {
+	resp, err := client.Delete(extraSpecDeleteURL(client, volumeTypeID, key), &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListAccesses retrieves the tenants which have access to a volume type.
+func ListAccesses(client *gophercloud.ServiceClient, id string) pagination.Pager {
+	url := accessURL(client, id)
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return AccessPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// AddAccessOptsBuilder allows extensions to add additional parameters to the
+// AddAccess requests.
+type AddAccessOptsBuilder interface {
+	ToVolumeTypeAddAccessMap() (map[string]interface{}, error)
+}
+
+// AddAccessOpts represents options for adding access to a volume type.
+type AddAccessOpts struct {
+	// Project is the project/tenant ID to grant access.
+	Project string `json:"project"`
+}
+
+// ToVolumeTypeAddAccessMap constructs a request body from AddAccessOpts.
+func (opts AddAccessOpts) ToVolumeTypeAddAccessMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "addProjectAccess")
+}
+
+// AddAccess grants a tenant/project access to a volume type.
+func AddAccess(client *gophercloud.ServiceClient, id string, opts AddAccessOptsBuilder) (r AddAccessResult) {
+	b, err := opts.ToVolumeTypeAddAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(accessActionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// RemoveAccessOptsBuilder allows extensions to add additional parameters to the
+// RemoveAccess requests.
+type RemoveAccessOptsBuilder interface {
+	ToVolumeTypeRemoveAccessMap() (map[string]interface{}, error)
+}
+
+// RemoveAccessOpts represents options for removing access to a volume type.
+type RemoveAccessOpts struct {
+	// Project is the project/tenant ID to remove access.
+	Project string `json:"project"`
+}
+
+// ToVolumeTypeRemoveAccessMap constructs a request body from RemoveAccessOpts.
+func (opts RemoveAccessOpts) ToVolumeTypeRemoveAccessMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "removeProjectAccess")
+}
+
+// RemoveAccess removes/revokes a tenant/project access to a volume type.
+func RemoveAccess(client *gophercloud.ServiceClient, id string, opts RemoveAccessOptsBuilder) (r RemoveAccessResult) {
+	b, err := opts.ToVolumeTypeRemoveAccessMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(accessActionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/results.go
@@ -1,0 +1,194 @@
+package volumetypes
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// VolumeType contains all the information associated with an OpenStack Volume Type.
+type VolumeType struct {
+	// Unique identifier for the volume type.
+	ID string `json:"id"`
+	// Human-readable display name for the volume type.
+	Name string `json:"name"`
+	// Human-readable description for the volume type.
+	Description string `json:"description"`
+	// Arbitrary key-value pairs defined by the user.
+	ExtraSpecs map[string]string `json:"extra_specs"`
+	// Whether the volume type is publicly visible.
+	IsPublic bool `json:"is_public"`
+	// Qos Spec ID
+	QosSpecID string `json:"qos_specs_id"`
+	// Volume Type access public attribute
+	PublicAccess bool `json:"os-volume-type-access:is_public"`
+}
+
+// VolumeTypePage is a pagination.pager that is returned from a call to the List function.
+type VolumeTypePage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Volume Types.
+func (r VolumeTypePage) IsEmpty() (bool, error) {
+	volumetypes, err := ExtractVolumeTypes(r)
+	return len(volumetypes) == 0, err
+}
+
+func (page VolumeTypePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"volume_type_links"`
+	}
+	err := page.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractVolumeTypes extracts and returns Volumes. It is used while iterating over a volumetypes.List call.
+func ExtractVolumeTypes(r pagination.Page) ([]VolumeType, error) {
+	var s []VolumeType
+	err := ExtractVolumeTypesInto(r, &s)
+	return s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Volume Type object out of the commonResult object.
+func (r commonResult) Extract() (*VolumeType, error) {
+	var s VolumeType
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a volume type struct
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "volume_type")
+}
+
+// ExtractVolumeTypesInto similar to ExtractInto but operates on a `list` of volume types
+func ExtractVolumeTypesInto(r pagination.Page, v interface{}) error {
+	return r.(VolumeTypePage).Result.ExtractIntoSlicePtr(v, "volume_types")
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
+// extraSpecsResult contains the result of a call for (potentially) multiple
+// key-value pairs. Call its Extract method to interpret it as a
+// map[string]interface.
+type extraSpecsResult struct {
+	gophercloud.Result
+}
+
+// ListExtraSpecsResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type ListExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// CreateExtraSpecsResult contains the result of a Create operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type CreateExtraSpecsResult struct {
+	extraSpecsResult
+}
+
+// Extract interprets any extraSpecsResult as ExtraSpecs, if possible.
+func (r extraSpecsResult) Extract() (map[string]string, error) {
+	var s struct {
+		ExtraSpecs map[string]string `json:"extra_specs"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ExtraSpecs, err
+}
+
+// extraSpecResult contains the result of a call for individual a single
+// key-value pair.
+type extraSpecResult struct {
+	gophercloud.Result
+}
+
+// GetExtraSpecResult contains the result of a Get operation. Call its Extract
+// method to interpret it as a map[string]interface.
+type GetExtraSpecResult struct {
+	extraSpecResult
+}
+
+// UpdateExtraSpecResult contains the result of an Update operation. Call its
+// Extract method to interpret it as a map[string]interface.
+type UpdateExtraSpecResult struct {
+	extraSpecResult
+}
+
+// DeleteExtraSpecResult contains the result of a Delete operation. Call its
+// ExtractErr method to determine if the call succeeded or failed.
+type DeleteExtraSpecResult struct {
+	gophercloud.ErrResult
+}
+
+// Extract interprets any extraSpecResult as an ExtraSpec, if possible.
+func (r extraSpecResult) Extract() (map[string]string, error) {
+	var s map[string]string
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// VolumeTypeAccess represents an ACL of project access to a specific Volume Type.
+type VolumeTypeAccess struct {
+	// VolumeTypeID is the unique ID of the volume type.
+	VolumeTypeID string `json:"volume_type_id"`
+
+	// ProjectID is the unique ID of the project.
+	ProjectID string `json:"project_id"`
+}
+
+// AccessPage contains a single page of all VolumeTypeAccess entries for a volume type.
+type AccessPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty indicates whether an AccessPage is empty.
+func (page AccessPage) IsEmpty() (bool, error) {
+	v, err := ExtractAccesses(page)
+	return len(v) == 0, err
+}
+
+// ExtractAccesses interprets a page of results as a slice of VolumeTypeAccess.
+func ExtractAccesses(r pagination.Page) ([]VolumeTypeAccess, error) {
+	var s struct {
+		VolumeTypeAccesses []VolumeTypeAccess `json:"volume_type_access"`
+	}
+	err := (r.(AccessPage)).ExtractInto(&s)
+	return s.VolumeTypeAccesses, err
+}
+
+// AddAccessResult is the response from a AddAccess request. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type AddAccessResult struct {
+	gophercloud.ErrResult
+}
+
+// RemoveAccessResult is the response from a RemoveAccess request. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type RemoveAccessResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes/urls.go
@@ -1,0 +1,51 @@
+package volumetypes
+
+import "github.com/gophercloud/gophercloud"
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("types")
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("types", id)
+}
+
+func extraSpecsListURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "extra_specs")
+}
+
+func extraSpecsGetURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "extra_specs", key)
+}
+
+func extraSpecsCreateURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "extra_specs")
+}
+
+func extraSpecUpdateURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "extra_specs", key)
+}
+
+func extraSpecDeleteURL(client *gophercloud.ServiceClient, id, key string) string {
+	return client.ServiceURL("types", id, "extra_specs", key)
+}
+
+func accessURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "os-volume-type-access")
+}
+
+func accessActionURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("types", id, "action")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -574,6 +574,7 @@ github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots
 github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes
 github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots
 github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes
+github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes
 github.com/gophercloud/gophercloud/openstack/common/extensions
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/aggregates


### PR DESCRIPTION
When an user wants to deploy with rootVolume, they need to specify
a volume type.
We already checked that the volume type was set but we didn't check that
the type was actually existing.

With this patch, we now check that the type exists.

If the Volume Type doesn't exist, it'll show this error message:
```
FATAL failed to fetch Metadata: failed to load asset "Install Config": compute[0].platform.openstack.rootVolume.type.type: Invalid value: "wrong": Volume Type either does not exist in this cloud, or is not available
```

Note: this patch also adds test coverage when the type is an empty string, which wasn't done before.