### PR TITLE
Bug 1953035: Disallow publish internal for non-cloud installations

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -115,6 +115,14 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 	}
 	allErrs = append(allErrs, validateCloudCredentialsMode(c.CredentialsMode, field.NewPath("credentialsMode"), c.Platform.Name())...)
 
+	if c.Publish == types.InternalPublishingStrategy {
+		switch platformName := c.Platform.Name(); platformName {
+		case aws.Name, azure.Name, gcp.Name:
+		default:
+			allErrs = append(allErrs, field.Invalid(field.NewPath("publish"), c.Publish, fmt.Sprintf("Internal publish strategy is not supported on %q platform", platformName)))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1208,6 +1208,25 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 			expectedError: `\Q[networking.machineNewtork[0]: Invalid value: "172.17.64.0/18": overlaps with default Docker Bridge subnet, platform: Invalid value: "libvirt": must specify one of the platforms (\E.*\Q)]\E`,
 		},
+		{
+			name: "publish internal for non-cloud platform",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{VSphere: validVSpherePlatform()}
+				c.Publish = types.InternalPublishingStrategy
+				return c
+			}(),
+			expectedError: `publish: Invalid value: "Internal": Internal publish strategy is not supported on "vsphere" platform`,
+		},
+		{
+			name: "publish internal for cloud platform",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{GCP: validGCPPlatform()}
+				c.Publish = types.InternalPublishingStrategy
+				return c
+			}(),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The publish: internal strategy is only available in cloud platforms,
GCP, Azure, AWS, Alibaba and IBM cloud, and should not be allowed as a
strategy for the other platforms.

Added a validation check to check if the strategy is internal and
the platform used is one of the valid cloud platforms. Check for IBM
and Alibaba is not yet added as they are not supported yet.