### PR TITLE
openstack: fix nil pointer panic when machinessubnets is not found

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -218,7 +218,7 @@ func (ci *CloudInfo) getSubnet(subnetID string) (*subnets.Subnet, error) {
 	subnet, err := subnets.Get(ci.clients.networkClient, subnetID).Extract()
 	if err != nil {
 		if isNotFoundError(err) {
-			return nil, nil
+			return nil, err
 		}
 		return nil, err
 	}


### PR DESCRIPTION
When MachinesSubnet configured in install-config.yaml is not found in openstack, a panic will be triggered:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1f20d74]

goroutine 1 [running]:
github.com/openshift/installer/pkg/asset/installconfig/openstack/validation.validateMachinesSubnet(0xc000365a00, 0xc00084f0e0, 0xc001000600, 0xc000c7ff50, 0x1, 0xc000c7ff50, 0x15f85830)
	/root/gyo/installer/pkg/asset/installconfig/openstack/validation/platform.go:49 +0x284
github.com/openshift/installer/pkg/asset/installconfig/openstack/validation.ValidatePlatform(0xc000365a00, 0xc00084f0e0, 0xc001000600, 0x0, 0x0, 0x0)
	/root/gyo/installer/pkg/asset/installconfig/openstack/validation/platform.go:22 +0x94
github.com/openshift/installer/pkg/asset/installconfig/openstack.Validate(0xc000457680, 0x0, 0x0)
	/root/gyo/installer/pkg/asset/installconfig/openstack/validate.go:34 +0xb2
github.com/openshift/installer/pkg/asset/installconfig.(*InstallConfig).platformValidation(0xc000a821a0, 0x0, 0x0)
	/root/gyo/installer/pkg/asset/installconfig/installconfig.go:196 +0x152
github.com/openshift/installer/pkg/asset/installconfig.(*InstallConfig).finish(0xc000a821a0, 0xd4e498c, 0x13, 0x1062, 0xd1ddb40)
	/root/gyo/installer/pkg/asset/installconfig/installconfig.go:156 +0x1d8
github.com/openshift/installer/pkg/asset/installconfig.(*InstallConfig).Load(0xc000a821a0, 0xe908258, 0xc000272570, 0xea000d8, 0xc000a821a0, 0xc000a821a0)
	/root/gyo/installer/pkg/asset/installconfig/installconfig.go:133 +0x1c2
github.com/openshift/installer/pkg/asset/store.(*storeImpl).load(0xc000f1ced0, 0xe932308, 0xc00122df80, 0xd468b38, 0x2, 0xd468b38, 0x2, 0x0)
	/root/gyo/installer/pkg/asset/store/store.go:264 +0x3c0
github.com/openshift/installer/pkg/asset/store.(*storeImpl).load(0xc000f1ced0, 0x3ff86455318, 0x15f238b0, 0x0, 0x0, 0x2, 0x2, 0x0)
	/root/gyo/installer/pkg/asset/store/store.go:247 +0x256
github.com/openshift/installer/pkg/asset/store.(*storeImpl).fetch(0xc000f1ced0, 0x3ff86455318, 0x15f238b0, 0x0, 0x0, 0x3ff86455318, 0xa65314e)
	/root/gyo/installer/pkg/asset/store/store.go:201 +0x902
github.com/openshift/installer/pkg/asset/store.(*storeImpl).Fetch(0xc000f1ced0, 0x3ff86455318, 0x15f238b0, 0x15eec6e0, 0x6, 0x6, 0xed826ec46, 0x15f33ee0)
	/root/gyo/installer/pkg/asset/store/store.go:77 +0x42
main.runTargetCmd.func1(0x3ffcab7f4cd, 0x3, 0xc00044bb30, 0x0)
	/root/gyo/installer/cmd/openshift-install/create.go:238 +0x116
main.runTargetCmd.func2(0x15ef6bc0, 0xc00108cfc0, 0x0, 0x4)
	/root/gyo/installer/cmd/openshift-install/create.go:265 +0xa0
github.com/spf13/cobra.(*Command).execute(0x15ef6bc0, 0xc00108cf80, 0x4, 0x4, 0x15ef6bc0, 0xc00108cf80)
	/root/gyo/installer/vendor/github.com/spf13/cobra/command.go:854 +0x25c
github.com/spf13/cobra.(*Command).ExecuteC(0xc000379080, 0xc000d07df8, 0x1, 0x1)
	/root/gyo/installer/vendor/github.com/spf13/cobra/command.go:958 +0x2e2
github.com/spf13/cobra.(*Command).Execute(...)
	/root/gyo/installer/vendor/github.com/spf13/cobra/command.go:895
main.installerMain()
	/root/gyo/installer/cmd/openshift-install/main.go:72 +0x2b8
main.main()
	/root/gyo/installer/cmd/openshift-install/main.go:50 +0x1da
```

The ci.MachinesSubnet  is nil here: 
https://github.com/openshift/installer/blob/10522df9e07533c601dda5ccd2aa1fb153ef2215/pkg/asset/installconfig/openstack/validation/platform.go#L44
because nil is returned here when MachinesSubnet is not found: https://github.com/openshift/installer/blob/10522df9e07533c601dda5ccd2aa1fb153ef2215/pkg/asset/installconfig/openstack/validation/cloudinfo.go#L221

After this change, err will be returned to point out that subnet is not found. And output will be below:
```
DEBUG     Loading Pull Secret...                   
DEBUG     Loading Platform...                      
WARNING Failed to generate OpenStack cloud info: failed to fetch machine subnet info: Resource not found 
WARNING Empty OpenStack cloud info and therefore will skip pre-flight validation. 
DEBUG   Using Install Config loaded from target directory 
DEBUG   Fetching Certificate (admin-kubeconfig-client)... 
DEBUG     Fetching Certificate (admin-kubeconfig-signer)... 
DEBUG     Generating Certificate (admin-kubeconfig-signer)... 
DEBUG   Generating Certificate (admin-kubeconfig-client)... 
```
