### PR TITLE
Bug 1926547: pkg/destroy/aws: Log errors untagging shared resources

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -180,6 +180,7 @@ var permissions = map[PermissionGroup][]string{
 	PermissionDeleteBase: {
 		"autoscaling:DescribeAutoScalingGroups",
 		"ec2:DeleteNetworkInterface",
+		"ec2:DeleteTags",
 		"ec2:DeleteVolume",
 		"elasticloadbalancing:DeleteTargetGroup",
 		"elasticloadbalancing:DescribeTargetGroups",


### PR DESCRIPTION
UntagResorucesWithContext will retun without errors even when resources
cannot be untagged.  The untagging failures are retuned in the
FailedResourcesMap.  This commit will log the failure to untag the
resource and not incorrectly log the tag was removed.