### PR TITLE
Bug 1940337: openstack: Report missing flavor

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -140,9 +140,12 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig, opts *clientconfig.Cli
 	if ic.Platform.OpenStack.DefaultMachinePlatform != nil {
 		if flavorName := ic.Platform.OpenStack.DefaultMachinePlatform.FlavorName; flavorName != "" {
 			if _, seen := ci.Flavors[flavorName]; !seen {
-				ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
-				if err != nil {
-					return err
+				flavor, err := ci.getFlavor(flavorName)
+				if !isNotFoundError(err) {
+					if err != nil {
+						return err
+					}
+					ci.Flavors[flavorName] = flavor
 				}
 			}
 		}
@@ -151,9 +154,12 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig, opts *clientconfig.Cli
 	if ic.ControlPlane != nil && ic.ControlPlane.Platform.OpenStack != nil {
 		if flavorName := ic.ControlPlane.Platform.OpenStack.FlavorName; flavorName != "" {
 			if _, seen := ci.Flavors[flavorName]; !seen {
-				ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
-				if err != nil {
-					return err
+				flavor, err := ci.getFlavor(flavorName)
+				if !isNotFoundError(err) {
+					if err != nil {
+						return err
+					}
+					ci.Flavors[flavorName] = flavor
 				}
 			}
 		}
@@ -163,9 +169,12 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig, opts *clientconfig.Cli
 		if machine.Platform.OpenStack != nil {
 			if flavorName := machine.Platform.OpenStack.FlavorName; flavorName != "" {
 				if _, seen := ci.Flavors[flavorName]; !seen {
-					ci.Flavors[flavorName], err = ci.getFlavor(flavorName)
-					if err != nil {
-						return err
+					flavor, err := ci.getFlavor(flavorName)
+					if !isNotFoundError(err) {
+						if err != nil {
+							return err
+						}
+						ci.Flavors[flavorName] = flavor
 					}
 				}
 			}
@@ -245,9 +254,6 @@ func isNotFoundError(err error) bool {
 func (ci *CloudInfo) getFlavor(flavorName string) (Flavor, error) {
 	flavorID, err := flavorutils.IDFromName(ci.clients.computeClient, flavorName)
 	if err != nil {
-		if isNotFoundError(err) {
-			return Flavor{}, nil
-		}
 		return Flavor{}, err
 	}
 


### PR DESCRIPTION
Before this patch, when the user provided a non-existant flavor name in
install-config, the error message was about missing GB of RAM or disk.

This happened because when a flavor was not found in the OpenStack
cloud, the "cloud info collector" code created an empty Flavor object
that responded to the name of the missing flavor.

In this patch, the absence of a flavor is signaled in the pre-flight
checks by avoiding to populate the "cloudinfo" object, so that an
explicit error message can correctly be output to the user.