### PR TITLE
Bug 1955336: Check cluster name for similarities with word 'google'

### DIFF
--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -35,7 +35,13 @@ func (a *clusterName) Generate(parents asset.Parents) error {
 		validator = survey.ComposeValidators(validator, func(ans interface{}) error {
 			return validate.ClusterName1035(ans.(string))
 		})
+		if platform.GCP != nil {
+			validator = survey.ComposeValidators(validator, func(ans interface{}) error {
+				return validate.GCPClusterName(ans.(string))
+			})
+		}
 	}
+
 	if platform.Ovirt != nil {
 		// FIX-ME: As soon bz#1915122 get resolved remove the limitation of 14 chars for the clustername
 		validator = survey.ComposeValidators(validator, func(ans interface{}) error {

--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/validate"
 )
 
 type resourceRequirements struct {
@@ -35,6 +36,10 @@ var computeReq = resourceRequirements{
 // Validate executes platform-specific validation.
 func Validate(client API, ic *types.InstallConfig) error {
 	allErrs := field.ErrorList{}
+
+	if err := validate.GCPClusterName(ic.ObjectMeta.Name); err != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("clusterName"), ic.ObjectMeta.Name, err.Error()))
+	}
 
 	allErrs = append(allErrs, validateProject(client, ic, field.NewPath("platform").Child("gcp"))...)
 	allErrs = append(allErrs, validateNetworks(client, ic, field.NewPath("platform").Child("gcp"))...)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -115,6 +115,17 @@ func ClusterName1035(v string) error {
 	return ClusterName(v)
 }
 
+// GCPClusterName checks if the provided cluster name has words similar to the word 'google'
+// since resources with that name are not allowed in GCP.
+func GCPClusterName(v string) error {
+	reStartsWith := regexp.MustCompile("^goog")
+	reContains := regexp.MustCompile(".*g[o0]{2}gle.*")
+	if reStartsWith.MatchString(v) || reContains.MatchString(v) {
+		return errors.New("cluster name must not start with \"goog\" or contain variations of \"google\"")
+	}
+	return nil
+}
+
 // ClusterNameMaxLength validates if the string provided length is
 // greater than maxlen argument.
 func ClusterNameMaxLength(v string, maxlen int) error {


### PR DESCRIPTION
GCP does not allow certain resources to have names with words
similar to 'google'. Adding a regex check for known invalid
cluster names in GCP to inform the user before trying to create
the cluster.

Tested values:
Passed: test-googl, testgoogl-test, testgoogl, goo-test
Failed: goog-test, test-google, testgoogletest