### PR TITLE
Bug 1957597: aws: using dotted domain when looking for public hosted zone

### DIFF
--- a/pkg/destroy/aws/shared.go
+++ b/pkg/destroy/aws/shared.go
@@ -196,7 +196,7 @@ func (o *ClusterUninstaller) cleanSharedHostedZone(ctx context.Context, client *
 	}
 	dottedClusterDomain := o.ClusterDomain + "."
 
-	publicZoneID, err := findAncestorPublicRoute53(ctx, client, o.ClusterDomain, logger)
+	publicZoneID, err := findAncestorPublicRoute53(ctx, client, dottedClusterDomain, logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When destroying a cluster that has a bring-your-own private hosted zone, the search for the public hosted zone should be using the dotted domain (i.e., the domain that ends in a dot). Since the search was incorrectly using the un-dotted domain, the search was never able to find a match.