### PR TITLE
docs/user/aws/install: Update cloud install links

### DIFF
--- a/docs/user/aws/install.md
+++ b/docs/user/aws/install.md
@@ -68,5 +68,5 @@ The OpenShift console is available via the kubeadmin login provided by the insta
 
 ![OpenShift web console](images/install_console.png)
 
-[cloud-install]: https://cloud.openshift.com/clusters/install
+[cloud-install]: https://cloud.redhat.com/openshift/create
 [encrypted-copy]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIEncryption.html#create-ami-encrypted-root-snapshot

--- a/docs/user/azure/install.md
+++ b/docs/user/azure/install.md
@@ -58,5 +58,5 @@ The OpenShift console is available via the kubeadmin login provided by the insta
 
 ![OpenShift web console](images/install_console.png)
 
-[cloud-install]: https://cloud.openshift.com/clusters/install
+[cloud-install]: https://cloud.redhat.com/openshift/create
 [rhcos]: https://github.com/openshift/os

--- a/docs/user/gcp/install.md
+++ b/docs/user/gcp/install.md
@@ -57,4 +57,4 @@ The OpenShift console is available via the kubeadmin login provided by the insta
 
 ![OpenShift web console](images/install_console.png)
 
-[cloud-install]: https://cloud.openshift.com/clusters/install
+[cloud-install]: https://cloud.redhat.com/openshift/create

--- a/docs/user/vsphere/install.md
+++ b/docs/user/vsphere/install.md
@@ -100,6 +100,4 @@ The OpenShift console is available via the kubeadmin login provided by the insta
 
 ![OpenShift web console](images/install_console.png)
 
-[cloud-install]: https://cloud.openshift.com/clusters/install
-
-[cloud-install]: https://cloud.openshift.com/clusters/install
+[cloud-install]: https://cloud.redhat.com/openshift/create


### PR DESCRIPTION
This patch updates the "cloud-install" links in the documentation to
point to the current location.