### PR TITLE
Bug 1959981: oVirt: fix empty AffinityGroupsNames handling

### DIFF
--- a/pkg/types/ovirt/defaults/machinepools.go
+++ b/pkg/types/ovirt/defaults/machinepools.go
@@ -12,7 +12,7 @@ func setMachinePool(p *types.MachinePool) {
 }
 
 func setDefaultAffinityGroups(p *ovirt.Platform, mp *types.MachinePool, agName string) {
-	if len(mp.Platform.Ovirt.AffinityGroupsNames) == 0 {
+	if mp.Platform.Ovirt.AffinityGroupsNames == nil {
 		for _, ag := range p.AffinityGroups {
 			if ag.Name == agName {
 				mp.Platform.Ovirt.AffinityGroupsNames = []string{agName}

--- a/pkg/types/ovirt/machinepool.go
+++ b/pkg/types/ovirt/machinepool.go
@@ -28,7 +28,7 @@ type MachinePool struct {
 	// AffinityGroupsNames contains a list of oVirt affinity group names that the newly created machines will join.
 	// The affinity groups should exist on the oVirt cluster or created by the OpenShift installer.
 	// +optional
-	AffinityGroupsNames []string `json:"affinityGroupsNames,omitempty"`
+	AffinityGroupsNames []string `json:"affinityGroupsNames"`
 }
 
 // Disk defines a VM disk


### PR DESCRIPTION
- Handle empty affinity group names field
