### PR TITLE
OpenStack: Add Unit Tests for validation of platform.openstack.machineSubnet

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -52,9 +52,6 @@ func validateMachinesSubnet(p *openstack.Platform, n *types.Networking, ci *Clou
 		}
 	}
 
-	if len(p.ExternalDNS) > 0 && p.MachinesSubnet != "" {
-		allErrs = append(allErrs, field.InternalError(fldPath.Child("machinesSubnet"), fmt.Errorf("externalDNS can't be set when using a custom machinesSubnet")))
-	}
 	return allErrs
 }
 

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/openstack"
 	"github.com/stretchr/testify/assert"
@@ -315,6 +317,122 @@ func TestClusterOSImage(t *testing.T) {
 			cloudInfo:      validPlatformCloudInfo(),
 			networking:     validNetworking(),
 			expectedErrMsg: "platform.openstack.clusterOSImage: Invalid value: \"s3://mybucket/myrhcos.iso\": URL scheme should be either http\\(s\\) or file but it is 's3'",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			aggregatedErrors := ValidatePlatform(tc.platform, tc.networking, tc.cloudInfo).ToAggregate()
+			if tc.expectedErrMsg != "" {
+				assert.Regexp(t, tc.expectedErrMsg, aggregatedErrors)
+			} else {
+				assert.NoError(t, aggregatedErrors)
+			}
+		})
+	}
+}
+
+func TestMachineSubnet(t *testing.T) {
+	cases := []struct {
+		name           string
+		platform       *openstack.Platform
+		cloudInfo      *CloudInfo
+		networking     *types.Networking
+		expectedErrMsg string // NOTE: this is a REGEXP
+	}{
+		{
+			name: "external dns is not supported",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.MachinesSubnet = "031a5b9d-5a89-4465-8d54-3517ec2bad48"
+				p.ExternalDNS = append(p.ExternalDNS, "1.2.3.4")
+				return p
+			}(),
+			cloudInfo:      validPlatformCloudInfo(),
+			networking:     validNetworking(),
+			expectedErrMsg: `platform.openstack.externalDNS: Invalid value: \[\]string{"1.2.3.4"}: externalDNS is set, externalDNS is not supported when machinesSubnet is set`,
+		},
+		{
+			name: "machine subnet not found",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.MachinesSubnet = "031a5b9d-5a89-4465-8d54-3517ec2bad48"
+				return p
+			}(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				ci.MachinesSubnet = nil
+				return ci
+			}(),
+			networking:     validNetworking(),
+			expectedErrMsg: `platform.openstack.machinesSubnet: Not found: "031a5b9d-5a89-4465-8d54-3517ec2bad48"`,
+		},
+		{
+			name: "invalid subnet ID",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.MachinesSubnet = "fake"
+				return p
+			}(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				ci.MachinesSubnet = &subnets.Subnet{
+					ID: "031a5b9d-5a89-4465-8d54-3517ec2bad48",
+				}
+				return ci
+			}(),
+			networking:     validNetworking(),
+			expectedErrMsg: `platform.openstack.machinesSubnet: Internal error: invalid subnet ID`,
+		},
+		{
+			name: "doesn't match the CIDR",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.MachinesSubnet = "031a5b9d-5a89-4465-8d54-3517ec2bad48"
+				return p
+			}(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				ci.MachinesSubnet = &subnets.Subnet{
+					ID: "031a5b9d-5a89-4465-8d54-3517ec2bad48",
+				}
+				ci.MachinesSubnet.CIDR = "172.0.0.1/16"
+				return ci
+			}(),
+			networking: func() *types.Networking {
+				n := validNetworking()
+				machineNetworkEntry := &types.MachineNetworkEntry{
+					CIDR: *ipnet.MustParseCIDR("172.0.0.1/24"),
+				}
+				n.MachineNetwork = []types.MachineNetworkEntry{*machineNetworkEntry}
+				return n
+			}(),
+			expectedErrMsg: `platform.openstack.machinesSubnet: Internal error: the first CIDR in machineNetwork, 172.0.0.1/24, doesn't match the CIDR of the machineSubnet, 172.0.0.1/16`,
+		},
+		{
+			name: "valid machine subnet",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.MachinesSubnet = "031a5b9d-5a89-4465-8d54-3517ec2bad48"
+				return p
+			}(),
+			cloudInfo: func() *CloudInfo {
+				ci := validPlatformCloudInfo()
+				ci.MachinesSubnet = &subnets.Subnet{
+					ID: "031a5b9d-5a89-4465-8d54-3517ec2bad48",
+				}
+				ci.MachinesSubnet.CIDR = "172.0.0.1/24"
+				return ci
+			}(),
+			networking: func() *types.Networking {
+				n := validNetworking()
+				machineNetworkEntry := &types.MachineNetworkEntry{
+					CIDR: *ipnet.MustParseCIDR("172.0.0.1/24"),
+				}
+				n.MachineNetwork = []types.MachineNetworkEntry{*machineNetworkEntry}
+				return n
+			}(),
+			expectedErrMsg: "",
 		},
 	}
 


### PR DESCRIPTION
1. Add Unit Tests for validation of platform.openstack.machineSubnet.
2. Delete the duplicate logic in platform.openstack.machineSubnet
https://github.com/openshift/installer/blob/aba60410f3530cdf18cc73dfe290c2bd546ed357/pkg/asset/installconfig/openstack/validation/platform.go#L52-L54
