### PR TITLE
Bug 1954873: CoreOS only supports three dns namservers

### DIFF
--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -21,7 +21,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 * `cloud` (required string): The name of the OpenStack cloud to use from `clouds.yaml`.
 * `computeFlavor` (deprecated string): The OpenStack flavor to use for compute and control-plane machines.
-* `externalDNS` (optional list of strings): The IP addresses of DNS servers to be used for the DNS resolution of all instances in the cluster
+* `externalDNS` (optional list of strings): The IP addresses of DNS servers to be used for the DNS resolution of all instances in the cluster. The total number of dns servers supported by an instance is three. That total includes any dns server provided by the underlying openstack infrastructure.
 * `externalNetwork` (optional string): Name of external network the installer will use to provide access to the cluster. If defined, a floating IP from this network will be created and associated with the bootstrap node to facilitate debugging and connection to the bootstrap node during installation. The `apiFloatingIP` property is a floating IP address selected from this network.
 * `apiFloatingIP` (optional string): Address of existing Floating IP from externalNetwork the installer will associate with the OpenShift API. This property is only valid if externalNetwork is defined. If externalNetwork is not defined, the installer will throw an error.
 * `ingressFloatingIP` (optional string): Address of an existing Floating IP from externalNetwork the installer will associate with the ingress port. This property is only valid if externalNetwork is defined. If externalNetwork is not defined, the installer will throw an error.


### PR DESCRIPTION
Documentation of this limitation under the externalDNS entry.