### PR TITLE
bug 1959920: baremetal: Do not use ironic allocation

### DIFF
--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -27,18 +27,10 @@ resource "ironic_node_v1" "openshift-master-host" {
   vendor_interface     = var.hosts[count.index]["vendor_interface"]
 }
 
-resource "ironic_allocation_v1" "openshift-master-allocation" {
-  name           = "master-${count.index}"
-  count          = var.master_count
-  resource_class = "baremetal"
-
-  candidate_nodes = ironic_node_v1.openshift-master-host.*.id
-}
-
 resource "ironic_deployment" "openshift-master-deployment" {
   count = var.master_count
   node_uuid = element(
-    ironic_allocation_v1.openshift-master-allocation.*.node_uuid,
+    ironic_node_v1.openshift-master-host.*.id,
     count.index,
   )
 


### PR DESCRIPTION
While testing secure boot scenario where only 1 master is using,
we found that the instance_info capabilities for secure_boot was set
in a different master.
This was happening because in all allocations we were considering
all nodes, since we need to match 1-1 the information we don't need
to create allocations for each node.