### PR TITLE
Bug 1962274: oVirt move affinity groups validations to ValidateForProvisioning

### DIFF
--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -11,6 +11,7 @@ import (
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	kubevirtconfig "github.com/openshift/installer/pkg/asset/installconfig/kubevirt"
 	osconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
+	ovirtconfig "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	vsconfig "github.com/openshift/installer/pkg/asset/installconfig/vsphere"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -42,7 +43,6 @@ func (a *PlatformProvisionCheck) Dependencies() []asset.Asset {
 func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 	ic := &InstallConfig{}
 	dependencies.Get(ic)
-
 	var err error
 	platform := ic.Config.Platform.Name()
 	switch platform {
@@ -99,7 +99,12 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
-	case libvirt.Name, none.Name, ovirt.Name:
+	case ovirt.Name:
+		err = ovirtconfig.ValidateForProvisioning(ic.Config)
+		if err != nil {
+			return err
+		}
+	case libvirt.Name, none.Name:
 		// no special provisioning requirements to check
 	default:
 		err = fmt.Errorf("unknown platform type %q", platform)


### PR DESCRIPTION
Currently, we validate existing affinity groups and cluster resources on the install-config creation.
This is a problem since the user may want to generate the install config using questions and then edit the affinity groups field.
Currently, if the user env does not have enough resources for the default affinity group settings then the install config generation will fail due to validations and the user will not get an install-config to edit.
This patch moves the validations to the ValidateForProvisioning to validate affinity group on cluster creation, meaning after the install config was generated and edited