### PR TITLE
[OCPCLOUD-1171] Implement CCCMO render to run CCM on bootstrap node

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -51,6 +51,7 @@ CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
 CONFIG_OPERATOR_IMAGE=$(image_for cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
 KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(image_for cluster-kube-controller-manager-operator)
+CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(image_for cluster-cloud-controller-manager-operator)
 KUBE_SCHEDULER_OPERATOR_IMAGE=$(image_for cluster-kube-scheduler-operator)
 INGRESS_OPERATOR_IMAGE=$(image_for cluster-ingress-operator)
 
@@ -227,6 +228,36 @@ then
 	fi
 
 	touch kube-controller-manager-bootstrap.done
+    record_service_stage_success
+fi
+
+if [ ! -f cloud-controller-manager-bootstrap.done ]
+then
+    record_service_stage_start "cluster-cloud-controller-manager-bootstrap"
+	echo "Rendering Cloud Controller Manager core manifests..."
+
+	rm --recursive --force cloud-controller-manager-bootstrap
+
+	# Copy the CCCMO images configMap to resolve pod images from internal registry in CCCMO render run
+	# Source config map is located in https://github.com/openshift/cluster-cloud-controller-manager-operator/blob/master/manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml
+	bootkube_podman_run \
+	--name copy-cloud-controller-manager-images \
+	--entrypoint /bin/bash "${RELEASE_IMAGE_DIGEST}" \
+	-c "cat /release-manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml" > manifests/ccm-images.yaml
+
+	bootkube_podman_run \
+		--name cloud-controller-render \
+		--volume "$PWD:/assets:z" \
+		"${CLUSTER_CLOUD_CONTROLLER_MANAGER_OPERATOR_IMAGE}" \
+		/render run \
+		--images-file=/assets/manifests/ccm-images.yaml \
+		--dest-dir=/assets/cloud-controller-manager-bootstrap \
+		--cluster-infrastructure-file=/assets/manifests/cluster-infrastructure-02-config.yml
+
+	# Copy rendered resources to manifests folder
+	cp cloud-controller-manager-bootstrap/manifests/* manifests/
+
+	touch cloud-controller-manager-bootstrap.done
     record_service_stage_success
 fi
 

--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -245,6 +245,11 @@ then
 	--entrypoint /bin/bash "${RELEASE_IMAGE_DIGEST}" \
 	-c "cat /release-manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml" > manifests/ccm-images.yaml
 
+	ADDITIONAL_FLAGS=""
+	if [ -f "$PWD/manifests/cloud-provider-config.yaml" ]; then
+		ADDITIONAL_FLAGS="--cloud-config-file=/assets/manifests/cloud-provider-config.yaml"
+	fi
+
 	bootkube_podman_run \
 		--name cloud-controller-render \
 		--volume "$PWD:/assets:z" \
@@ -252,10 +257,14 @@ then
 		/render run \
 		--images-file=/assets/manifests/ccm-images.yaml \
 		--dest-dir=/assets/cloud-controller-manager-bootstrap \
-		--cluster-infrastructure-file=/assets/manifests/cluster-infrastructure-02-config.yml
+		--cluster-infrastructure-file=/assets/manifests/cluster-infrastructure-02-config.yml \
+		${ADDITIONAL_FLAGS}
 
 	# Copy rendered resources to manifests folder
-	cp cloud-controller-manager-bootstrap/manifests/* manifests/
+	cp -r cloud-controller-manager-bootstrap/bootstrap/. bootstrap-manifests/
+	# Copy cloud config to /etc/kubernetes/bootstrap-configs
+	cp -r cloud-controller-manager-bootstrap/config/. /etc/kubernetes/bootstrap-configs
+
 
 	touch cloud-controller-manager-bootstrap.done
     record_service_stage_success


### PR DESCRIPTION
This allows master nodes to be initialized with CCM replica from
bootstrap, speeding up process of cluster installation.

Without CCM running on bootstrap node, most of the cluster operator
and operand pods would have to tolerate new taint and a different
configuration of node.kubernetes.io/not-ready (NoSchedule) taint:

- effect: NoSchedule
  key: node.cloudprovider.kubernetes.io/uninitialized
  value: "true"

Without this bootstrap addition or taint toleration the cluster with CCM
would never become ready.

To test this feature on AWS build installer and deploy on AWS.

To create a cluster run:
```bash
./hack/build.sh
./bin/openshift-install create manifests
cat <<EOF > manifests/manifest_feature_gate.yaml
---
apiVersion: config.openshift.io/v1
kind: FeatureGate
metadata:
  annotations:
    include.release.openshift.io/self-managed-high-availability: "true"
    include.release.openshift.io/single-node-developer: "true"
    release.openshift.io/create-only: "true"
  name: cluster
spec:
  customNoUpgrade:
    enabled:
    - ExternalCloudProvider
    - CSIMigrationAWS
    - CSIMigrationOpenStack
  featureSet: CustomNoUpgrade
EOF

OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/dgrigore/release:cccmo-render ./bin/openshift-install create cluster
```

Gist with files CCCMO render outputs for AWS: https://gist.github.com/Danil-Grigorev/5732fd375dba7affff54eda267c4cd47
