### PR TITLE
Bug: 1947293 Baremetal: Validate provisioning network size

### DIFF
--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -399,6 +399,14 @@ func TestValidateProvisioning(t *testing.T) {
 				LibvirtURI("bad").build(),
 			expected: "invalid URI \"bad\"",
 		},
+		{
+			name: "ipv6_CIDR_too_large",
+			platform: platform().
+				ProvisioningNetworkCIDR("fd2e:6f44:5dd8:b856::/32").
+				ClusterProvisioningIP("fd2e:6f44:5dd8:b856::3").
+				BootstrapProvisioningIP("fd2e:6f44:5dd8:b856::2").build(),
+			expected: "provisioningNetworkCIDR mask must be greater than or equal to 64 for IPv6 networks",
+		},
 
 		// Disabled provisioning network
 		{


### PR DESCRIPTION
Due to a limitation in dnsmasq an IPv6 provisioning network cannot be
larger than a /64 network.

bug: https://bugzilla.redhat.com/show_bug.cgi?id=1947293