### PR TITLE
Bug 1956483: Bump boot images for RHCOS fixes

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,166 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0401d6ad383dba55c"
+            "hvm": "ami-0d543735dc9affc0a"
         },
         "ap-east-1": {
-            "hvm": "ami-03ac23c984c812cb4"
+            "hvm": "ami-0ebc3e0e299b8cc6f"
         },
         "ap-northeast-1": {
-            "hvm": "ami-09cc1da8a6fa42c4e"
+            "hvm": "ami-0414b946fab7988d6"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0adf87370198caaed"
+            "hvm": "ami-0e76f835edab2456a"
         },
         "ap-northeast-3": {
-            "hvm": "ami-0591a1337ebe93646"
+            "hvm": "ami-013efa73b7ab96b3a"
         },
         "ap-south-1": {
-            "hvm": "ami-08dfa06820a4fb482"
+            "hvm": "ami-072abf84ada409d74"
         },
         "ap-southeast-1": {
-            "hvm": "ami-05345a132d89bd2b6"
+            "hvm": "ami-0d5d683c086fdf8c1"
         },
         "ap-southeast-2": {
-            "hvm": "ami-00274925d47c6e015"
+            "hvm": "ami-0f0cfbf037d999802"
         },
         "ca-central-1": {
-            "hvm": "ami-0baeff23c4cc6ddf5"
+            "hvm": "ami-03dab1b5a66487443"
         },
         "eu-central-1": {
-            "hvm": "ami-083ab4c282bac44b5"
+            "hvm": "ami-0ce189a55f836b366"
         },
         "eu-north-1": {
-            "hvm": "ami-0791daa430c70ff09"
+            "hvm": "ami-01c5839bea4fb59bb"
         },
         "eu-south-1": {
-            "hvm": "ami-093ccc9e024810fc8"
+            "hvm": "ami-0e40f2f7d66f23b6e"
         },
         "eu-west-1": {
-            "hvm": "ami-07323d56fb932c84c"
+            "hvm": "ami-0141183673ded9f18"
         },
         "eu-west-2": {
-            "hvm": "ami-0cabefac75acfd8e3"
+            "hvm": "ami-09a265f0e546fd5bb"
         },
         "eu-west-3": {
-            "hvm": "ami-01f9af256e3213df9"
+            "hvm": "ami-00481fd3c31538be2"
         },
         "me-south-1": {
-            "hvm": "ami-0e5d014111ee32e16"
+            "hvm": "ami-080484bf2e2d5745e"
         },
         "sa-east-1": {
-            "hvm": "ami-0dd8411ece8c06dae"
+            "hvm": "ami-082784fa843993f42"
         },
         "us-east-1": {
-            "hvm": "ami-03d1c2cba04df838c"
+            "hvm": "ami-093573e55a618974b"
         },
         "us-east-2": {
-            "hvm": "ami-0ddab715d6b88a315"
+            "hvm": "ami-0ce061fbb35d84fc1"
         },
         "us-west-1": {
-            "hvm": "ami-09b797de07577bf33"
+            "hvm": "ami-078f97d297c64c66e"
         },
         "us-west-2": {
-            "hvm": "ami-0617611237b58ac93"
+            "hvm": "ami-064366969d8336325"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202103251640-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202103251640-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202105220305-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202105220305-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202103251640-0/x86_64/",
-    "buildid": "47.83.202103251640-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202105220305-0/x86_64/",
+    "buildid": "47.83.202105220305-0",
     "gcp": {
-        "image": "rhcos-47-83-202103251640-0-gcp-x86-64",
+        "image": "rhcos-47-83-202105220305-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202103251640-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202105220305-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202103251640-0-aws.x86_64.vmdk.gz",
-            "sha256": "09f2376c33681b2e0f19209bc9e1b15c36a1635ad68e2670d774c5d017b8f29e",
-            "size": 954887101,
-            "uncompressed-sha256": "ef228bb22f647194da8c8261ddfc5a14b1694cb7585ab7d21bbf33a44652b3e4",
-            "uncompressed-size": 974496768
+            "path": "rhcos-47.83.202105220305-0-aws.x86_64.vmdk.gz",
+            "sha256": "62e55bf5bc40a62598a4089d6798cf137a0d71b00d849d7c94d26c566349fd11",
+            "size": 954799795,
+            "uncompressed-sha256": "d472fe825249f267b4ac529f82b5baad323e71cbe553c28478ece83765f0cfe2",
+            "uncompressed-size": 974443008
         },
         "azure": {
-            "path": "rhcos-47.83.202103251640-0-azure.x86_64.vhd.gz",
-            "sha256": "a02679f9e3507ca39456e8813dcab69f07c7ee7bf7232a652a28183d7bc73697",
-            "size": 955225715,
-            "uncompressed-sha256": "5245c2b529b92458cde9ea7e55934cc870a23d09a17aa083be4537ac0b1caab1",
+            "path": "rhcos-47.83.202105220305-0-azure.x86_64.vhd.gz",
+            "sha256": "da927bd6dcafd567dda92c0089a3104355fc2f94a8ef6fcd08140f0de1fcae9b",
+            "size": 955131805,
+            "uncompressed-sha256": "a176d6c9781f8f3caa406808d8c69e9a30158af4a492db9a597fe877ddb2aebe",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202103251640-0-gcp.x86_64.tar.gz",
-            "sha256": "7570868619d51639a17bdceb7ab57f6adb7b20a78e49b32434537a0ed0e1f155",
-            "size": 940531637
+            "path": "rhcos-47.83.202105220305-0-gcp.x86_64.tar.gz",
+            "sha256": "70fd680a066f66df897ea69825ef61bb7a9ba3754652f528fa897857d8dcab58",
+            "size": 940425889
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202103251640-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "aa3bfde23a7af8f112f6b43273729011484a154b78bcac52a2d79cfc013b5c19",
-            "size": 940837877,
-            "uncompressed-sha256": "18b34659654b0870b4807c374385766e9e7bad4d29e64e7e05b06ca3574d569b",
-            "uncompressed-size": 2366177280
+            "path": "rhcos-47.83.202105220305-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "69f03b9892a9012e84c53382eea6901063ed3df0dabf02aa72ca2b0850b0f01a",
+            "size": 940770169,
+            "uncompressed-sha256": "b9d8d24dfbb22e38fc15b34ed98abb001544b2ab9895bcb22ffeeaebf41d20cd",
+            "uncompressed-size": 2366046208
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202103251640-0-live-initramfs.x86_64.img",
-            "sha256": "18f9a94a02a7eae8fe70dd465279dc2851ce14055d7725d22d2092d2ef54475c"
+            "path": "rhcos-47.83.202105220305-0-live-initramfs.x86_64.img",
+            "sha256": "da9620ffb5f9c9025c7b26dddd2364ca60e745165eb650f944aa9163141ff390"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202103251640-0-live.x86_64.iso",
-            "sha256": "e763b79edc4c7958bffdb222cc4e5e8acbf6b7e447d4342009f908ab071b7c95"
+            "path": "rhcos-47.83.202105220305-0-live.x86_64.iso",
+            "sha256": "2bf11b6a81b022c02f052f9f600b5d7520a6bfb925ed60f2417a64eac38b2ff8"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202103251640-0-live-kernel-x86_64",
-            "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
+            "path": "rhcos-47.83.202105220305-0-live-kernel-x86_64",
+            "sha256": "9f2a35ee745e32584d9671d0098f523f4264ff41ad0cfc620b254bc2f5b256a4"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202103251640-0-live-rootfs.x86_64.img",
-            "sha256": "e9f38678e1508012ee9135723370357799b35f7c564d66b1d2a46232089a7477"
+            "path": "rhcos-47.83.202105220305-0-live-rootfs.x86_64.img",
+            "sha256": "353fc501690ccf1836383a0f43f815551b099bcb8ba7ca964b6a322e28f5def1"
         },
         "metal": {
-            "path": "rhcos-47.83.202103251640-0-metal.x86_64.raw.gz",
-            "sha256": "a252c10f27e436e0ff17713703ac57134552d628fe3df03acec043aacb3c96ee",
-            "size": 942543852,
-            "uncompressed-sha256": "f0e658b58ab1aa654b7d09bf5810cb6c7e44cfaae5def27c3bf2bd9207a8c981",
-            "uncompressed-size": 3725590528
+            "path": "rhcos-47.83.202105220305-0-metal.x86_64.raw.gz",
+            "sha256": "f830f9dea3be56ee73a084af4e517000bd2f560c1b150c3169417fd802c7b705",
+            "size": 942479567,
+            "uncompressed-sha256": "a5d731e3119b487f05d4660df6678771e5270ee6b8111f1fbb84a0f35c26fdd7",
+            "uncompressed-size": 3724541952
         },
         "metal4k": {
-            "path": "rhcos-47.83.202103251640-0-metal4k.x86_64.raw.gz",
-            "sha256": "d010fbcb2615240d9c9797c7b9de678b330dfa0ad59190c0b14947437f411974",
-            "size": 940148936,
-            "uncompressed-sha256": "f8af1ae038af3ddec00f244e4ecf47916a7aaa1ba561dacf28cb52dc5f8099d7",
-            "uncompressed-size": 3725590528
+            "path": "rhcos-47.83.202105220305-0-metal4k.x86_64.raw.gz",
+            "sha256": "16a0e2c8b894abb39e864fe183f6e732526124b3a7989a4d272b50c8304f9e06",
+            "size": 940027922,
+            "uncompressed-sha256": "9d71fa9b060f9388ccf5b3efa8ef5b5136e556f85174f8cf1934ccec63e23396",
+            "uncompressed-size": 3724541952
         },
         "openstack": {
-            "path": "rhcos-47.83.202103251640-0-openstack.x86_64.qcow2.gz",
-            "sha256": "a1eaea5e994c0fe7000865780ea5d0cc89980943330357eb64df333c1fad224d",
-            "size": 940839325,
-            "uncompressed-sha256": "f8ac2f68c0d7fbabd15cc3e88e29fcbd581c0250fe4e2ee4d5f56eb5b2f6af87",
-            "uncompressed-size": 2366177280
+            "path": "rhcos-47.83.202105220305-0-openstack.x86_64.qcow2.gz",
+            "sha256": "156e695b0a834cc9efe1ef95609cec078c65f8030be8c68b8fe946f82a65dd3a",
+            "size": 940770428,
+            "uncompressed-sha256": "94058cc4cff50e63ebeba8e044215c1591d0a4daea2ffdb778836d013290868e",
+            "uncompressed-size": 2366046208
         },
         "ostree": {
-            "path": "rhcos-47.83.202103251640-0-ostree.x86_64.tar",
-            "sha256": "76f59de2809a80332c95a8f1635df0b1be9ba1ec6fd43c7a90e703fe03c9cf82",
-            "size": 867020800
+            "path": "rhcos-47.83.202105220305-0-ostree.x86_64.tar",
+            "sha256": "36bc6b6b187c803ad6a8c641c9e8051d383761a747296d58450a1b299b96ca08",
+            "size": 866938880
         },
         "qemu": {
-            "path": "rhcos-47.83.202103251640-0-qemu.x86_64.qcow2.gz",
-            "sha256": "2925d6182753f19275b0a9b09079199dcee36310fdbbdb1760b8e822fb821e4f",
-            "size": 941977173,
-            "uncompressed-sha256": "2cc7c8841e6b2b0f5d3573b82453fddad3c44972c080969458af85c7097e9bc5",
+            "path": "rhcos-47.83.202105220305-0-qemu.x86_64.qcow2.gz",
+            "sha256": "4be67c5c1a3ac7ca67154244325f2bbf4d2ca872716e650c79e52eff4c512140",
+            "size": 941849543,
+            "uncompressed-sha256": "d3e6f4e1182789480dcb81fc8cdf37416ec9afa34b4be1056426b21b62272248",
             "uncompressed-size": 2399993856
         },
         "vmware": {
-            "path": "rhcos-47.83.202103251640-0-vmware.x86_64.ova",
-            "sha256": "6ac67b43ed6fe25cbe4b01b8f8900a9a5bc0bb6a9894d40be46b994cda906efd",
-            "size": 974510080
+            "path": "rhcos-47.83.202105220305-0-vmware.x86_64.ova",
+            "sha256": "bb7d5f4246aa7b2985e1f49a2aafde8df0bf56789814647221a3a374393702e8",
+            "size": 974458880
         }
     },
     "oscontainer": {
-        "digest": "sha256:0ad297b22e7b96e04e45aefcc57f571361c87bdc3110e692bb239f2dfbe64050",
+        "digest": "sha256:5649fe979b5ebe2615344d398ee0a841c9ea49d72be9edaf4048ccea5a729c32",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "3fdd1488024f054e39b1be508781d535d1ac7ed423bb3b4b656c2f345934220d",
-    "ostree-version": "47.83.202103251640-0"
+    "ostree-commit": "59309c0148b29cb5149b72a58de019e0236b8dc3b499e3015887f73aa325a409",
+    "ostree-version": "47.83.202105220305-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202103232314-0/ppc64le/",
-    "buildid": "47.83.202103232314-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202105211710-0/ppc64le/",
+    "buildid": "47.83.202105211710-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-47.83.202103232314-0-live-initramfs.ppc64le.img",
-            "sha256": "0b9960179c174e9387a26eeb89eaadf4e8729a8256f1297d791efa2e9e4b6199"
+            "path": "rhcos-47.83.202105211710-0-live-initramfs.ppc64le.img",
+            "sha256": "22bc784a5595d9cfb84a0e31935457dd3ebd934fc5dd8a408b2e1bd0bcbfe603"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202103232314-0-live.ppc64le.iso",
-            "sha256": "30d65f1be268e3f7bd1048e7310b95e1771dec7c8f3f1afa63fdd93c533aab4c"
+            "path": "rhcos-47.83.202105211710-0-live.ppc64le.iso",
+            "sha256": "d89b985f1aa88c6065509423a2d6db34adfc90ac7f3791136f9340754d346508"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202103232314-0-live-kernel-ppc64le",
-            "sha256": "75e8849d99f9eca4f408a331c332d61af1a5c40818e71d4953481f05e7384ca2"
+            "path": "rhcos-47.83.202105211710-0-live-kernel-ppc64le",
+            "sha256": "a462d86726c8b96d6db7c2b76ec0efdfddab7627203abdeb114df6aa4e31802a"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202103232314-0-live-rootfs.ppc64le.img",
-            "sha256": "3e185fea9f51cb03effaa8ca515355115c3aefedac9afa7fc0d77a469b6850bf"
+            "path": "rhcos-47.83.202105211710-0-live-rootfs.ppc64le.img",
+            "sha256": "daae7746be162106f3c0b0b8279df1f9a1dcef142a4da133c2baf18350073b8c"
         },
         "metal": {
-            "path": "rhcos-47.83.202103232314-0-metal.ppc64le.raw.gz",
-            "sha256": "4c99726eb1a29633fe35a822a79b20dbbced4e99883de3e9fdea84a2df4e18b8",
-            "size": 921576379,
-            "uncompressed-sha256": "e60b6365effbaedeaf6bfe414a52070d20b2a23eaab47c377915ebf8cd43343b",
+            "path": "rhcos-47.83.202105211710-0-metal.ppc64le.raw.gz",
+            "sha256": "0ef28e0bd0ba30461bcdd136ca1afff2c92aff82edeb2fb6a3f972009300ebea",
+            "size": 921458959,
+            "uncompressed-sha256": "a5bcddf178f3f5545bbaf4b146cde1c040abbd9d532de7cd81eda28195ea24cb",
             "uncompressed-size": 3898605568
         },
         "metal4k": {
-            "path": "rhcos-47.83.202103232314-0-metal4k.ppc64le.raw.gz",
-            "sha256": "e8e68685ee031b28c2dd0162cfa99ad436f274848ae170e8047ed60b92d543a2",
-            "size": 921704341,
-            "uncompressed-sha256": "871d186440a38f36399a980abd3d95acd9c959ee34ed642c348db7344b3745ec",
+            "path": "rhcos-47.83.202105211710-0-metal4k.ppc64le.raw.gz",
+            "sha256": "af647ca46c5de1e5164218726d567363eaf748a9f91b835c20c0480fa9caa661",
+            "size": 921786483,
+            "uncompressed-sha256": "ed26695d26e7aca47c5873a74ca9a3310e003b4e9e4f35be70b85c45287519b9",
             "uncompressed-size": 3898605568
         },
         "openstack": {
-            "path": "rhcos-47.83.202103232314-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "e1bb7f64a0d54f703d61b42320808a7284a45dbaf1bf6b2581457c562f57a936",
-            "size": 919772699,
-            "uncompressed-sha256": "f3e636cb494685b37a1fc5a8e05706102d6b323804523c2faf8f93bab5032d67",
-            "uncompressed-size": 2501705728
+            "path": "rhcos-47.83.202105211710-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "4f6f55a39c39787531fb5ded8a3b1549e3bdd4a6cfa0e6ff11a1aef3c3141c26",
+            "size": 919782638,
+            "uncompressed-sha256": "c68b0b1c68e78b06bef30536826b03c96f6988074ed752bf4fce16b1eef9f99a",
+            "uncompressed-size": 2501771264
         },
         "ostree": {
-            "path": "rhcos-47.83.202103232314-0-ostree.ppc64le.tar",
-            "sha256": "59c4ac0cb0bba706b5d8acf5beb78e7b80d1c1bdc597bc3e369a4603ccbad4d6",
-            "size": 844072960
+            "path": "rhcos-47.83.202105211710-0-ostree.ppc64le.tar",
+            "sha256": "e0bf27f331fa07cd213c60b48b2cd5d1cc1f75a122228b0b92016add5f778d02",
+            "size": 844042240
         },
         "qemu": {
-            "path": "rhcos-47.83.202103232314-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "1998f4c3f9e4aff3195ff5e691108c9c94492307c73461ad4bfe0f914720fde3",
-            "size": 920821673,
-            "uncompressed-sha256": "dc3e3ebc83b166ccded7425fb15a26766ce0e7224e3b5bbd5aa0b50e6f7e132c",
-            "uncompressed-size": 2536308736
+            "path": "rhcos-47.83.202105211710-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "f8cc5e97632465f28d30416458ef4f714d20ff04ddf155cfa9a3ef393a80b019",
+            "size": 920911987,
+            "uncompressed-sha256": "7af9fa2bf98209a6fc75c0e6261147b070f9a3109b95637727fc8cdcfc3b34f0",
+            "uncompressed-size": 2536767488
         }
     },
     "oscontainer": {
-        "digest": "sha256:c8b40a8fe9ca152bf019233c7410d41656b3e126bbddbc98212a4d4695842733",
+        "digest": "sha256:dad6f0afc4df270b8a850ca046ff3746ffdeee41203cca0eedc3652fae397d0b",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "5bcaf6616d9f0501ad8252c28d561e16e34960780983f55cf73012ca7504af1d",
-    "ostree-version": "47.83.202103232314-0"
+    "ostree-commit": "f906c5718681ab7e3c30804398201fee4f09d8f0942eb69c67dfdabf52db4fa7",
+    "ostree-version": "47.83.202105211710-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202103251513-0/s390x/",
-    "buildid": "47.83.202103251513-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202105211211-0/s390x/",
+    "buildid": "47.83.202105211211-0",
     "images": {
         "dasd": {
-            "path": "rhcos-47.83.202103251513-0-dasd.s390x.raw.gz",
-            "sha256": "a9ad45a2b8c01177af19aa0520cc0e56bf626c3ff28b325665ba0228ddc32d4a",
-            "size": 834919789,
-            "uncompressed-sha256": "cba39aec5d43458f81b4773e2582524aa3b3ef575ea2c685fb8d7a9323c52c97",
+            "path": "rhcos-47.83.202105211211-0-dasd.s390x.raw.gz",
+            "sha256": "3279fc8734ed9afadf0e16fbb9375fa57102cf52b38962cb16ee122370ede554",
+            "size": 834720536,
+            "uncompressed-sha256": "5f36e272c453d68c55ca19f70b0187ccdb9cc92c18e13a43442fe4da1f1124be",
             "uncompressed-size": 3527409664
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202103251513-0-live-initramfs.s390x.img",
-            "sha256": "9a776910b8e44e12965a2ea025340ffd1f5ccc79b4855e062e02e29b65ad4536"
+            "path": "rhcos-47.83.202105211211-0-live-initramfs.s390x.img",
+            "sha256": "df401d091a005020a20c1372ef762e21e1194ccb2eee5935db42a412a57e64ae"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202103251513-0-live.s390x.iso",
-            "sha256": "b5d3304d58e48e65991e91a5b23e6149e69b26efcd1d07cfa3c30002a3c24970"
+            "path": "rhcos-47.83.202105211211-0-live.s390x.iso",
+            "sha256": "e78282823928a3f748f0b7215eea482a37fb8550f1ab7b3c20595111ea125121"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202103251513-0-live-kernel-s390x",
-            "sha256": "7f0356ce47a620a24dcf5e61b598dbe644f8083ab96646a12f563ee0671253cc"
+            "path": "rhcos-47.83.202105211211-0-live-kernel-s390x",
+            "sha256": "eb158cac93d50122699ffe015b14ae8a93c822d4a02536adfa6bcaec304cc713"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202103251513-0-live-rootfs.s390x.img",
-            "sha256": "9c5fb9ca4697c65b5c9906f6b478035dedf6249779e408d83d920c73033ba47f"
+            "path": "rhcos-47.83.202105211211-0-live-rootfs.s390x.img",
+            "sha256": "3ace8333d4f04287d192aff03e6afa0c3941f895fa651eab3e05e0d6b2d30ec3"
         },
         "metal": {
-            "path": "rhcos-47.83.202103251513-0-metal.s390x.raw.gz",
-            "sha256": "1761308c7103d63660ac99249abb95bfc5c43b49ffbd167f047b460c2acb55a7",
-            "size": 834860082,
-            "uncompressed-sha256": "9c1f7ddb505a450981a0254755c8f0b976a2e912273c55705198f04ce35a9c64",
+            "path": "rhcos-47.83.202105211211-0-metal.s390x.raw.gz",
+            "sha256": "1114152ecd15599d18ce06aad01ff7dd333b0a382dfb515f5b266ddaf77e2f4e",
+            "size": 834721805,
+            "uncompressed-sha256": "58f53a8b55a4b7362c6331fe026220061de763a407638b2de01aa7e60c042c88",
             "uncompressed-size": 3527409664
         },
         "metal4k": {
-            "path": "rhcos-47.83.202103251513-0-metal4k.s390x.raw.gz",
-            "sha256": "a649fab3cee516cd4e9535bc85aa41a2979e6f3f256dd1d564ba11ad9c5ebbaa",
-            "size": 835170504,
-            "uncompressed-sha256": "6225d64138fc6fc30ac0bf3a72be3d1a51f2cc554d2ab52e9992145b1081d5d7",
+            "path": "rhcos-47.83.202105211211-0-metal4k.s390x.raw.gz",
+            "sha256": "7a87c85221e70db66e7cb994431a6ff1ab170c594616b04339f42515d4eca407",
+            "size": 834640951,
+            "uncompressed-sha256": "78147559f06a76b6c929bec3f1e48864bf04df9e7f663a11a879bf9184dfdb9a",
             "uncompressed-size": 3527409664
         },
         "openstack": {
-            "path": "rhcos-47.83.202103251513-0-openstack.s390x.qcow2.gz",
-            "sha256": "4ce30b1214f99c2a6152aa957920060186587620c997d2225e77691b20462e9c",
-            "size": 833360472,
-            "uncompressed-sha256": "f3fcaf7398bc59956a04b7d22ac8a15cda5fd62f50e155ab19ee09f8e56c0d04",
-            "uncompressed-size": 2187264000
+            "path": "rhcos-47.83.202105211211-0-openstack.s390x.qcow2.gz",
+            "sha256": "9bd38f9fc2ef76cec9854b1a322f4fbd787feefd101c31fc89f35e5a20a44f56",
+            "size": 833097217,
+            "uncompressed-sha256": "0d5158a22c957d1ae1dda852a278250b7c853de4893e9b9350faf72eb4d07620",
+            "uncompressed-size": 2187591680
         },
         "ostree": {
-            "path": "rhcos-47.83.202103251513-0-ostree.s390x.tar",
-            "sha256": "c9e6fcfbf185d3a5154ceb17c3485030a70990d5f7d4312fa0475171336b23e4",
-            "size": 783472640
+            "path": "rhcos-47.83.202105211211-0-ostree.s390x.tar",
+            "sha256": "4edf8f68a69308e3e62d70109d93487acbe4bc32000d15abe48a33a77d46d169",
+            "size": 783390720
         },
         "qemu": {
-            "path": "rhcos-47.83.202103251513-0-qemu.s390x.qcow2.gz",
-            "sha256": "7aeec967bb5aa45cdde618a003c6bd55552e97154e7a9e6a57110445309ed285",
-            "size": 834463024,
-            "uncompressed-sha256": "1ebc19c66fc10c01e4ec25f0ccf1a7127837f8a7d0f8bbf42a386c67b9c9c413",
-            "uncompressed-size": 2221146112
+            "path": "rhcos-47.83.202105211211-0-qemu.s390x.qcow2.gz",
+            "sha256": "9aa07ca4e7abf220aeaac41ef8366dbdc9e5cca386a396bd922143bc375cd5ee",
+            "size": 834160448,
+            "uncompressed-sha256": "587ffb58d67f68fa0bd2fbc6cc573d15be8651a33d7eb806dcf2caf9e2f80608",
+            "uncompressed-size": 2220752896
         }
     },
     "oscontainer": {
-        "digest": "sha256:68747ed40a2aec6c37b2c0f631b10f4177046660ac599a7372edd60345f55440",
+        "digest": "sha256:d9e97f78460b287ffb6fcc0d609767fa57f02050b41c9fa7ecffafceb316ebf0",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "32c6cf0224470de4839c99cb8eb476113b29c6a521577b7d21413eec75b6d9e3",
-    "ostree-version": "47.83.202103251513-0"
+    "ostree-commit": "27fb045ec373cd41cec517ff3c1074ad3db22c774e5638208daf7e5dd82ef829",
+    "ostree-version": "47.83.202105211211-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,166 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0401d6ad383dba55c"
+            "hvm": "ami-0d543735dc9affc0a"
         },
         "ap-east-1": {
-            "hvm": "ami-03ac23c984c812cb4"
+            "hvm": "ami-0ebc3e0e299b8cc6f"
         },
         "ap-northeast-1": {
-            "hvm": "ami-09cc1da8a6fa42c4e"
+            "hvm": "ami-0414b946fab7988d6"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0adf87370198caaed"
+            "hvm": "ami-0e76f835edab2456a"
         },
         "ap-northeast-3": {
-            "hvm": "ami-0591a1337ebe93646"
+            "hvm": "ami-013efa73b7ab96b3a"
         },
         "ap-south-1": {
-            "hvm": "ami-08dfa06820a4fb482"
+            "hvm": "ami-072abf84ada409d74"
         },
         "ap-southeast-1": {
-            "hvm": "ami-05345a132d89bd2b6"
+            "hvm": "ami-0d5d683c086fdf8c1"
         },
         "ap-southeast-2": {
-            "hvm": "ami-00274925d47c6e015"
+            "hvm": "ami-0f0cfbf037d999802"
         },
         "ca-central-1": {
-            "hvm": "ami-0baeff23c4cc6ddf5"
+            "hvm": "ami-03dab1b5a66487443"
         },
         "eu-central-1": {
-            "hvm": "ami-083ab4c282bac44b5"
+            "hvm": "ami-0ce189a55f836b366"
         },
         "eu-north-1": {
-            "hvm": "ami-0791daa430c70ff09"
+            "hvm": "ami-01c5839bea4fb59bb"
         },
         "eu-south-1": {
-            "hvm": "ami-093ccc9e024810fc8"
+            "hvm": "ami-0e40f2f7d66f23b6e"
         },
         "eu-west-1": {
-            "hvm": "ami-07323d56fb932c84c"
+            "hvm": "ami-0141183673ded9f18"
         },
         "eu-west-2": {
-            "hvm": "ami-0cabefac75acfd8e3"
+            "hvm": "ami-09a265f0e546fd5bb"
         },
         "eu-west-3": {
-            "hvm": "ami-01f9af256e3213df9"
+            "hvm": "ami-00481fd3c31538be2"
         },
         "me-south-1": {
-            "hvm": "ami-0e5d014111ee32e16"
+            "hvm": "ami-080484bf2e2d5745e"
         },
         "sa-east-1": {
-            "hvm": "ami-0dd8411ece8c06dae"
+            "hvm": "ami-082784fa843993f42"
         },
         "us-east-1": {
-            "hvm": "ami-03d1c2cba04df838c"
+            "hvm": "ami-093573e55a618974b"
         },
         "us-east-2": {
-            "hvm": "ami-0ddab715d6b88a315"
+            "hvm": "ami-0ce061fbb35d84fc1"
         },
         "us-west-1": {
-            "hvm": "ami-09b797de07577bf33"
+            "hvm": "ami-078f97d297c64c66e"
         },
         "us-west-2": {
-            "hvm": "ami-0617611237b58ac93"
+            "hvm": "ami-064366969d8336325"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202103251640-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202103251640-0-azure.x86_64.vhd"
+        "image": "rhcos-47.83.202105220305-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202105220305-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202103251640-0/x86_64/",
-    "buildid": "47.83.202103251640-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202105220305-0/x86_64/",
+    "buildid": "47.83.202105220305-0",
     "gcp": {
-        "image": "rhcos-47-83-202103251640-0-gcp-x86-64",
+        "image": "rhcos-47-83-202105220305-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202103251640-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202105220305-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202103251640-0-aws.x86_64.vmdk.gz",
-            "sha256": "09f2376c33681b2e0f19209bc9e1b15c36a1635ad68e2670d774c5d017b8f29e",
-            "size": 954887101,
-            "uncompressed-sha256": "ef228bb22f647194da8c8261ddfc5a14b1694cb7585ab7d21bbf33a44652b3e4",
-            "uncompressed-size": 974496768
+            "path": "rhcos-47.83.202105220305-0-aws.x86_64.vmdk.gz",
+            "sha256": "62e55bf5bc40a62598a4089d6798cf137a0d71b00d849d7c94d26c566349fd11",
+            "size": 954799795,
+            "uncompressed-sha256": "d472fe825249f267b4ac529f82b5baad323e71cbe553c28478ece83765f0cfe2",
+            "uncompressed-size": 974443008
         },
         "azure": {
-            "path": "rhcos-47.83.202103251640-0-azure.x86_64.vhd.gz",
-            "sha256": "a02679f9e3507ca39456e8813dcab69f07c7ee7bf7232a652a28183d7bc73697",
-            "size": 955225715,
-            "uncompressed-sha256": "5245c2b529b92458cde9ea7e55934cc870a23d09a17aa083be4537ac0b1caab1",
+            "path": "rhcos-47.83.202105220305-0-azure.x86_64.vhd.gz",
+            "sha256": "da927bd6dcafd567dda92c0089a3104355fc2f94a8ef6fcd08140f0de1fcae9b",
+            "size": 955131805,
+            "uncompressed-sha256": "a176d6c9781f8f3caa406808d8c69e9a30158af4a492db9a597fe877ddb2aebe",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202103251640-0-gcp.x86_64.tar.gz",
-            "sha256": "7570868619d51639a17bdceb7ab57f6adb7b20a78e49b32434537a0ed0e1f155",
-            "size": 940531637
+            "path": "rhcos-47.83.202105220305-0-gcp.x86_64.tar.gz",
+            "sha256": "70fd680a066f66df897ea69825ef61bb7a9ba3754652f528fa897857d8dcab58",
+            "size": 940425889
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202103251640-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "aa3bfde23a7af8f112f6b43273729011484a154b78bcac52a2d79cfc013b5c19",
-            "size": 940837877,
-            "uncompressed-sha256": "18b34659654b0870b4807c374385766e9e7bad4d29e64e7e05b06ca3574d569b",
-            "uncompressed-size": 2366177280
+            "path": "rhcos-47.83.202105220305-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "69f03b9892a9012e84c53382eea6901063ed3df0dabf02aa72ca2b0850b0f01a",
+            "size": 940770169,
+            "uncompressed-sha256": "b9d8d24dfbb22e38fc15b34ed98abb001544b2ab9895bcb22ffeeaebf41d20cd",
+            "uncompressed-size": 2366046208
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202103251640-0-live-initramfs.x86_64.img",
-            "sha256": "18f9a94a02a7eae8fe70dd465279dc2851ce14055d7725d22d2092d2ef54475c"
+            "path": "rhcos-47.83.202105220305-0-live-initramfs.x86_64.img",
+            "sha256": "da9620ffb5f9c9025c7b26dddd2364ca60e745165eb650f944aa9163141ff390"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202103251640-0-live.x86_64.iso",
-            "sha256": "e763b79edc4c7958bffdb222cc4e5e8acbf6b7e447d4342009f908ab071b7c95"
+            "path": "rhcos-47.83.202105220305-0-live.x86_64.iso",
+            "sha256": "2bf11b6a81b022c02f052f9f600b5d7520a6bfb925ed60f2417a64eac38b2ff8"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202103251640-0-live-kernel-x86_64",
-            "sha256": "806623984883fee24f94bb2f5944d87bbc380c43bbf8ca1f40d5b0f1981af8f5"
+            "path": "rhcos-47.83.202105220305-0-live-kernel-x86_64",
+            "sha256": "9f2a35ee745e32584d9671d0098f523f4264ff41ad0cfc620b254bc2f5b256a4"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202103251640-0-live-rootfs.x86_64.img",
-            "sha256": "e9f38678e1508012ee9135723370357799b35f7c564d66b1d2a46232089a7477"
+            "path": "rhcos-47.83.202105220305-0-live-rootfs.x86_64.img",
+            "sha256": "353fc501690ccf1836383a0f43f815551b099bcb8ba7ca964b6a322e28f5def1"
         },
         "metal": {
-            "path": "rhcos-47.83.202103251640-0-metal.x86_64.raw.gz",
-            "sha256": "a252c10f27e436e0ff17713703ac57134552d628fe3df03acec043aacb3c96ee",
-            "size": 942543852,
-            "uncompressed-sha256": "f0e658b58ab1aa654b7d09bf5810cb6c7e44cfaae5def27c3bf2bd9207a8c981",
-            "uncompressed-size": 3725590528
+            "path": "rhcos-47.83.202105220305-0-metal.x86_64.raw.gz",
+            "sha256": "f830f9dea3be56ee73a084af4e517000bd2f560c1b150c3169417fd802c7b705",
+            "size": 942479567,
+            "uncompressed-sha256": "a5d731e3119b487f05d4660df6678771e5270ee6b8111f1fbb84a0f35c26fdd7",
+            "uncompressed-size": 3724541952
         },
         "metal4k": {
-            "path": "rhcos-47.83.202103251640-0-metal4k.x86_64.raw.gz",
-            "sha256": "d010fbcb2615240d9c9797c7b9de678b330dfa0ad59190c0b14947437f411974",
-            "size": 940148936,
-            "uncompressed-sha256": "f8af1ae038af3ddec00f244e4ecf47916a7aaa1ba561dacf28cb52dc5f8099d7",
-            "uncompressed-size": 3725590528
+            "path": "rhcos-47.83.202105220305-0-metal4k.x86_64.raw.gz",
+            "sha256": "16a0e2c8b894abb39e864fe183f6e732526124b3a7989a4d272b50c8304f9e06",
+            "size": 940027922,
+            "uncompressed-sha256": "9d71fa9b060f9388ccf5b3efa8ef5b5136e556f85174f8cf1934ccec63e23396",
+            "uncompressed-size": 3724541952
         },
         "openstack": {
-            "path": "rhcos-47.83.202103251640-0-openstack.x86_64.qcow2.gz",
-            "sha256": "a1eaea5e994c0fe7000865780ea5d0cc89980943330357eb64df333c1fad224d",
-            "size": 940839325,
-            "uncompressed-sha256": "f8ac2f68c0d7fbabd15cc3e88e29fcbd581c0250fe4e2ee4d5f56eb5b2f6af87",
-            "uncompressed-size": 2366177280
+            "path": "rhcos-47.83.202105220305-0-openstack.x86_64.qcow2.gz",
+            "sha256": "156e695b0a834cc9efe1ef95609cec078c65f8030be8c68b8fe946f82a65dd3a",
+            "size": 940770428,
+            "uncompressed-sha256": "94058cc4cff50e63ebeba8e044215c1591d0a4daea2ffdb778836d013290868e",
+            "uncompressed-size": 2366046208
         },
         "ostree": {
-            "path": "rhcos-47.83.202103251640-0-ostree.x86_64.tar",
-            "sha256": "76f59de2809a80332c95a8f1635df0b1be9ba1ec6fd43c7a90e703fe03c9cf82",
-            "size": 867020800
+            "path": "rhcos-47.83.202105220305-0-ostree.x86_64.tar",
+            "sha256": "36bc6b6b187c803ad6a8c641c9e8051d383761a747296d58450a1b299b96ca08",
+            "size": 866938880
         },
         "qemu": {
-            "path": "rhcos-47.83.202103251640-0-qemu.x86_64.qcow2.gz",
-            "sha256": "2925d6182753f19275b0a9b09079199dcee36310fdbbdb1760b8e822fb821e4f",
-            "size": 941977173,
-            "uncompressed-sha256": "2cc7c8841e6b2b0f5d3573b82453fddad3c44972c080969458af85c7097e9bc5",
+            "path": "rhcos-47.83.202105220305-0-qemu.x86_64.qcow2.gz",
+            "sha256": "4be67c5c1a3ac7ca67154244325f2bbf4d2ca872716e650c79e52eff4c512140",
+            "size": 941849543,
+            "uncompressed-sha256": "d3e6f4e1182789480dcb81fc8cdf37416ec9afa34b4be1056426b21b62272248",
             "uncompressed-size": 2399993856
         },
         "vmware": {
-            "path": "rhcos-47.83.202103251640-0-vmware.x86_64.ova",
-            "sha256": "6ac67b43ed6fe25cbe4b01b8f8900a9a5bc0bb6a9894d40be46b994cda906efd",
-            "size": 974510080
+            "path": "rhcos-47.83.202105220305-0-vmware.x86_64.ova",
+            "sha256": "bb7d5f4246aa7b2985e1f49a2aafde8df0bf56789814647221a3a374393702e8",
+            "size": 974458880
         }
     },
     "oscontainer": {
-        "digest": "sha256:0ad297b22e7b96e04e45aefcc57f571361c87bdc3110e692bb239f2dfbe64050",
+        "digest": "sha256:5649fe979b5ebe2615344d398ee0a841c9ea49d72be9edaf4048ccea5a729c32",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "3fdd1488024f054e39b1be508781d535d1ac7ed423bb3b4b656c2f345934220d",
-    "ostree-version": "47.83.202103251640-0"
+    "ostree-commit": "59309c0148b29cb5149b72a58de019e0236b8dc3b499e3015887f73aa325a409",
+    "ostree-version": "47.83.202105220305-0"
 }


### PR DESCRIPTION
This brings in the following fixes:

BZ 1956489 - CVE-2021-3114 ignition: golang: crypto/elliptic: incorrect operations on the P-224 curve
BZ 1960748 - RHCOS PXE deployment script coreos-livepxe-rootfs randomly fails to download and verify the image with bonding LACP active-active

Changes generated with:

```
$ hack/update-rhcos-bootimage.py https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202105220305-0/x86_64/meta.json amd64
$ hack/update-rhcos-bootimage.py https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202105211710-0/ppc64le/meta.json ppc64le
$ hack/update-rhcos-bootimage.py https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202105211211-0/s390x/meta.json s390x
```