### PR TITLE
bring example in line with the default value

### DIFF
--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -25,7 +25,7 @@ variable "azure_bootstrap_vm_type" {
 
 variable "azure_master_vm_type" {
   type = string
-  description = "Instance type for the master node(s). Example: `Standard_DS4_v3`."
+  description = "Instance type for the master node(s). Example: `Standard_D8s_v3`."
 }
 
 variable "azure_extra_tags" {


### PR DESCRIPTION
It is confusing that the example is different than the value,
which is the case since the default value changed: 120a9a35af715385c75ad9e246a4df9b103e12e6