### PR TITLE
Bug 1944196: vSphere - fixes bootstrap dhcp networkmanager race

### DIFF
--- a/data/data/bootstrap/vsphere/files/etc/NetworkManager/conf.d/99-vsphere.conf
+++ b/data/data/bootstrap/vsphere/files/etc/NetworkManager/conf.d/99-vsphere.conf
@@ -1,0 +1,5 @@
+[main]
+rc-manager=unmanaged
+[connection]
+ipv6.dhcp-duid=ll
+ipv6.dhcp-iaid=mac

--- a/data/data/bootstrap/vsphere/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
+++ b/data/data/bootstrap/vsphere/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
@@ -17,6 +17,11 @@ case "$STATUS" in
             done
         fi
 EOF
+    
+    if [[ ! -e /etc/resolv.conf ]] || ! grep -q nameserver /etc/resolv.conf; then
+        cp /var/run/NetworkManager/resolv.conf /etc/resolv.conf
+    fi
+
     set +e
     logger -s "NM local-dns-prepender: Checking if local DNS IP is the first entry in resolv.conf"
     if grep nameserver /etc/resolv.conf | head -n 1 | grep -q "$DNS_IP" ; then


### PR DESCRIPTION
Taking partial working examples from MCO common
applying to bootstrap node.

When testing in VMC we were hitting a consistent race
between adding the additional loopback entry and networkmanager
updating `/etc/resolv.conf`.