### PR TITLE
WIP: bug 1955697: vsphere: use fully qualified path for datacenter

### DIFF
--- a/pkg/asset/machines/vsphere/machines.go
+++ b/pkg/asset/machines/vsphere/machines.go
@@ -64,8 +64,8 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 }
 
 func provider(clusterID string, platform *vsphere.Platform, mpool *vsphere.MachinePool, osImage string, userDataSecret string) (*vsphereapis.VSphereMachineProviderSpec, error) {
-	folder := fmt.Sprintf("/%s/vm/%s", platform.Datacenter, clusterID)
-	resourcePool := fmt.Sprintf("/%s/host/%s/Resources", platform.Datacenter, platform.Cluster)
+	folder := fmt.Sprintf("%s/vm/%s", vsphere.FullyQualifiedPath(platform.Datacenter), clusterID)
+	resourcePool := fmt.Sprintf("%s/host/%s/Resources", vsphere.FullyQualifiedPath(platform.Datacenter), platform.Cluster)
 	if platform.Folder != "" {
 		folder = platform.Folder
 	}
@@ -87,7 +87,7 @@ func provider(clusterID string, platform *vsphere.Platform, mpool *vsphere.Machi
 		},
 		Workspace: &vsphereapis.Workspace{
 			Server:       platform.VCenter,
-			Datacenter:   platform.Datacenter,
+			Datacenter:   vsphere.FullyQualifiedPath(platform.Datacenter),
 			Datastore:    platform.DefaultDatastore,
 			Folder:       folder,
 			ResourcePool: resourcePool,

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -152,8 +152,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 	case vspheretypes.Name:
 		folderPath := installConfig.Config.Platform.VSphere.Folder
 		if len(folderPath) == 0 {
-			dataCenter := installConfig.Config.Platform.VSphere.Datacenter
-			folderPath = fmt.Sprintf("/%s/vm/%s", dataCenter, clusterID.InfraID)
+			folderPath = fmt.Sprintf("%s/vm/%s", vspheretypes.FullyQualifiedPath(installConfig.Config.Platform.VSphere.Datacenter), clusterID.InfraID)
 		}
 		vsphereConfig, err := vspheremanifests.CloudProviderConfig(
 			folderPath,

--- a/pkg/asset/manifests/vsphere/cloudproviderconfig.go
+++ b/pkg/asset/manifests/vsphere/cloudproviderconfig.go
@@ -27,13 +27,13 @@ func CloudProviderConfig(folderPath string, p *vspheretypes.Platform) (string, e
 
 	fmt.Fprintln(buf, "[Workspace]")
 	printIfNotEmpty(buf, "server", p.VCenter)
-	printIfNotEmpty(buf, "datacenter", p.Datacenter)
+	printIfNotEmpty(buf, "datacenter", vspheretypes.FullyQualifiedPath(p.Datacenter))
 	printIfNotEmpty(buf, "default-datastore", p.DefaultDatastore)
 	printIfNotEmpty(buf, "folder", folderPath)
 	fmt.Fprintln(buf, "")
 
 	fmt.Fprintf(buf, "[VirtualCenter %q]\n", p.VCenter)
-	printIfNotEmpty(buf, "datacenters", p.Datacenter)
+	printIfNotEmpty(buf, "datacenters", vspheretypes.FullyQualifiedPath(p.Datacenter))
 
 	return buf.String(), nil
 }

--- a/pkg/tfvars/vsphere/vsphere.go
+++ b/pkg/tfvars/vsphere/vsphere.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
+	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
 type config struct {
@@ -52,14 +53,6 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	// /<datacenter>/vm/<folder_path> so we can split on "vm/".
 	folderRelPath := strings.SplitAfterN(controlPlaneConfig.Workspace.Folder, "vm/", 2)[1]
 
-	// The vSphere provider needs explicit path of the datacenter to avoid
-	// conflicts when multiple datacenters have the same name even though they
-	// are in different folders.
-	datacenter := controlPlaneConfig.Workspace.Datacenter
-	if !strings.HasPrefix(datacenter, "/") && !strings.HasPrefix(datacenter, "./") {
-		datacenter = "./" + datacenter
-	}
-
 	cfg := &config{
 		VSphereURL:        controlPlaneConfig.Workspace.Server,
 		VSphereUsername:   sources.Username,
@@ -69,7 +62,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		NumCPUs:           controlPlaneConfig.NumCPUs,
 		NumCoresPerSocket: controlPlaneConfig.NumCoresPerSocket,
 		Cluster:           sources.Cluster,
-		Datacenter:        datacenter,
+		Datacenter:        vsphere.FullyQualifiedPath(controlPlaneConfig.Workspace.Datacenter),
 		Datastore:         controlPlaneConfig.Workspace.Datastore,
 		Folder:            folderRelPath,
 		Network:           controlPlaneConfig.Network.Devices[0].NetworkName,

--- a/pkg/types/vsphere/client.go
+++ b/pkg/types/vsphere/client.go
@@ -3,6 +3,7 @@ package vsphere
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/vmware/govmomi"
@@ -36,4 +37,13 @@ func CreateVSphereClients(ctx context.Context, vcenter, username, password strin
 	}
 
 	return c.Client, restClient, nil
+}
+
+// FullyQualifiedPath takes a path and prepends a leading
+// '/' if it doesn't already have it.
+func FullyQualifiedPath(path string) string{
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return path
 }


### PR DESCRIPTION
This change ensures we are using the fully qualified path of the
vsphere datacenter everywhere where we interact with the vsphere API.
By doing so, we remove the errors when duplicate datacenters with the
same name exist in the environment. The change also modifies the
questionaire to set the fully qualified path for the datacenter in the
install-config. It is backwards compatible with prior install-configs in
that it will prepend a leading slash on datacenter names that do not
already have it.