### PR TITLE
Bug 1967623: oVirt: Fix password input

### DIFF
--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -112,29 +112,19 @@ func (c *clientHTTP) checkURLResponse() error {
 // The password provided will be added in the Config struct.
 // If an error happens, it will ask again username for users.
 func askPassword(c *Config) error {
-	origPwdTpl := survey.PasswordQuestionTemplate
-	survey.PasswordQuestionTemplate = `
-{{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
-{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
-{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
-{{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[Press Ctrl+C to switch username, {{ HelpInputRune }} for help]{{color "reset"}} {{end}}`
-
 	err := survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Password{
 				Message: "Engine password",
-				Help:    "Password for the chosen username",
+				Help:    "Password for the chosen username, Press Ctrl+C to change username",
 			},
 			Validate: survey.ComposeValidators(survey.Required, authenticated(c)),
 		},
 	}, &c.Password)
 
-	survey.PasswordQuestionTemplate = origPwdTpl
-
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
The installer project updated the version of the survey package which cause the hack of editing the PasswordQuestionTemplate to break due to misssing funtions such as: HelpIcon, QuestionIcon and HelpInputRune.
There is no reason to keep this hack just to edit the inital help message, instead we will move the ctrl+c note to the help message.