### PR TITLE
Bug 1955697: Revert "tfvars/vsphere: use explicit path for datacenter."

### DIFF
--- a/pkg/tfvars/vsphere/vsphere.go
+++ b/pkg/tfvars/vsphere/vsphere.go
@@ -52,14 +52,6 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	// /<datacenter>/vm/<folder_path> so we can split on "vm/".
 	folderRelPath := strings.SplitAfterN(controlPlaneConfig.Workspace.Folder, "vm/", 2)[1]
 
-	// The vSphere provider needs explicit path of the datacenter to avoid
-	// conflicts when multiple datacenters have the same name even though they
-	// are in different folders.
-	datacenter := controlPlaneConfig.Workspace.Datacenter
-	if !strings.HasPrefix(datacenter, "/") && !strings.HasPrefix(datacenter, "./") {
-		datacenter = "./" + datacenter
-	}
-
 	cfg := &config{
 		VSphereURL:        controlPlaneConfig.Workspace.Server,
 		VSphereUsername:   sources.Username,
@@ -69,7 +61,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		NumCPUs:           controlPlaneConfig.NumCPUs,
 		NumCoresPerSocket: controlPlaneConfig.NumCoresPerSocket,
 		Cluster:           sources.Cluster,
-		Datacenter:        datacenter,
+		Datacenter:        controlPlaneConfig.Workspace.Datacenter,
 		Datastore:         controlPlaneConfig.Workspace.Datastore,
 		Folder:            folderRelPath,
 		Network:           controlPlaneConfig.Network.Devices[0].NetworkName,


### PR DESCRIPTION
This reverts commit cbc778f7608f383174605f6299b3b0cd3060f7fa.

This change was insufficient to resolve the issue. Another solution will be needed, and this bit of code will not be used.