### PR TITLE
DO NOT MERGE: Turn log config debugging on in GCP internal API

### DIFF
--- a/data/data/gcp/network/lb-private.tf
+++ b/data/data/gcp/network/lb-private.tf
@@ -19,6 +19,9 @@ resource "google_compute_health_check" "api_internal" {
     port         = 6443
     request_path = "/readyz"
   }
+  log_config {
+    enable = true
+  }
 }
 
 resource "google_compute_region_backend_service" "api_internal" {


### PR DESCRIPTION
The log_config setting shows info about when GCP LBs decide to
take an apiserver out of rotation.