### PR TITLE
[SPLAT-211] vSphere: Switch from sockets to cores by default

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -342,6 +342,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	case vspheretypes.Name:
 		mpool := defaultVSphereMachinePoolPlatform()
 		mpool.NumCPUs = 4
+		mpool.NumCoresPerSocket = 4
 		mpool.MemoryMiB = 16384
 		mpool.Set(ic.Platform.VSphere.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.VSphere)

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -136,7 +136,7 @@ func defaultOvirtMachinePoolPlatform() ovirttypes.MachinePool {
 func defaultVSphereMachinePoolPlatform() vspheretypes.MachinePool {
 	return vspheretypes.MachinePool{
 		NumCPUs:           2,
-		NumCoresPerSocket: 1,
+		NumCoresPerSocket: 2,
 		MemoryMiB:         8192,
 		OSDisk: vspheretypes.OSDisk{
 			DiskSizeGB: 120,


### PR DESCRIPTION
Based on VMware vSphere performance best practices and
a resulting blog post from VMware in relation to vNUMA.
Cores should be used instead of sockets.

https://blogs.vmware.com/performance/2017/03/virtual-machine-vcpu-and-vnuma-rightsizing-rules-of-thumb.html