### PR TITLE
Bug 1972582: Installing with an oVirt network with 2 vnics on the same network causes the installer to not create tfvars and fail with terraform error

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -531,7 +531,9 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				return errors.Wrapf(err, "failed to compute values for Engine platform")
 			}
 			if len(profiles) != 1 {
-				return errors.Wrapf(err, "failed to compute values for Engine platform, there are multiple vNIC profiles.")
+				return fmt.Errorf("failed to compute values for Engine platform, "+
+					"there are multiple vNIC profiles. found %v vNIC profiles for network %s",
+					len(profiles), installConfig.Config.Platform.Ovirt.NetworkName)
 			}
 			installConfig.Config.Platform.Ovirt.VNICProfileID = profiles[0].MustId()
 		}


### PR DESCRIPTION
We need to return a custom error.
We wrapped a nil error which causes errors.Wrapf to return nil and then the installer would move to the next phase and fail due to missing tfvars.json file