### PR TITLE
openstack: Expose master server group policy

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -308,6 +308,17 @@ spec:
                           - size
                           - type
                           type: object
+                        serverGroupPolicy:
+                          description: ServerGroupPolicy will be used to create the
+                            Server Group that will contain all the machines of this
+                            MachinePool. Defaults to "soft-anti-affinity".
+                          enum:
+                          - ""
+                          - affinity
+                          - soft-affinity
+                          - anti-affinity
+                          - soft-anti-affinity
+                          type: string
                         type:
                           description: FlavorName defines the OpenStack Nova flavor.
                             eg. m1.large
@@ -680,6 +691,17 @@ spec:
                         - size
                         - type
                         type: object
+                      serverGroupPolicy:
+                        description: ServerGroupPolicy will be used to create the
+                          Server Group that will contain all the machines of this
+                          MachinePool. Defaults to "soft-anti-affinity".
+                        enum:
+                        - ""
+                        - affinity
+                        - soft-affinity
+                        - anti-affinity
+                        - soft-anti-affinity
+                        type: string
                       type:
                         description: FlavorName defines the OpenStack Nova flavor.
                           eg. m1.large
@@ -1661,6 +1683,17 @@ spec:
                         - size
                         - type
                         type: object
+                      serverGroupPolicy:
+                        description: ServerGroupPolicy will be used to create the
+                          Server Group that will contain all the machines of this
+                          MachinePool. Defaults to "soft-anti-affinity".
+                        enum:
+                        - ""
+                        - affinity
+                        - soft-affinity
+                        - anti-affinity
+                        - soft-anti-affinity
+                        type: string
                       type:
                         description: FlavorName defines the OpenStack Nova flavor.
                           eg. m1.large

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -68,6 +68,7 @@ module "masters" {
   root_volume_size       = var.openstack_master_root_volume_size
   root_volume_type       = var.openstack_master_root_volume_type
   server_group_name      = var.openstack_master_server_group_name
+  server_group_policy    = var.openstack_master_server_group_policy
   additional_network_ids = var.openstack_additional_network_ids
   zones                  = var.openstack_master_availability_zones
   root_volume_zones      = var.openstack_master_root_volume_availability_zones

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -44,7 +44,7 @@ resource "openstack_blockstorage_volume_v3" "master_volume" {
 
 resource "openstack_compute_servergroup_v2" "master_group" {
   name = var.server_group_name
-  policies = ["soft-anti-affinity"]
+  policies = [var.server_group_policy]
 }
 
 # The master servers are created in three separate resource definition blocks,

--- a/data/data/openstack/masters/variables.tf
+++ b/data/data/openstack/masters/variables.tf
@@ -46,6 +46,11 @@ variable "server_group_name" {
   description = "Name of the server group for the master nodes."
 }
 
+variable "server_group_policy" {
+  type        = string
+  description = "Policy of the server group for the master nodes."
+}
+
 variable "additional_network_ids" {
   type        = list(string)
   description = "IDs of additional networks for master nodes."

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -348,6 +348,11 @@ variable "openstack_master_server_group_name" {
   description = "Name of the server group for the master nodes."
 }
 
+variable "openstack_master_server_group_policy" {
+  type = string
+  description = "Policy of the server group for the master nodes."
+}
+
 variable "openstack_machines_subnet_id" {
   type = string
   default = ""

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -39,6 +39,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 * `additionalNetworkIDs` (optional list of strings): IDs of additional networks for machines.
 * `additionalSecurityGroupIDs` (optional list of strings): IDs of additional security groups for machines.
+* `serverGroupPolicy` (optional string): Server group policy to apply to the group that will contain the machines in the pool. Defaults to "soft-anti-affinity". Only applicable to the Control plane MachinePool.
 * `type` (optional string): The OpenStack flavor name for machines in the pool.
 * `rootVolume` (optional object): Defines the root volume for instances in the machine pool. The instances use ephemeral disks if not set.
   * `size` (required integer): Size of the root volume in GB. Must be set to at least 25.

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -23,27 +23,28 @@ import (
 )
 
 type config struct {
-	BaseImageName                    string   `json:"openstack_base_image_name,omitempty"`
-	ExternalNetwork                  string   `json:"openstack_external_network,omitempty"`
-	Cloud                            string   `json:"openstack_credentials_cloud,omitempty"`
-	FlavorName                       string   `json:"openstack_master_flavor_name,omitempty"`
-	APIFloatingIP                    string   `json:"openstack_api_floating_ip,omitempty"`
-	IngressFloatingIP                string   `json:"openstack_ingress_floating_ip,omitempty"`
-	APIVIP                           string   `json:"openstack_api_int_ip,omitempty"`
-	IngressVIP                       string   `json:"openstack_ingress_ip,omitempty"`
-	TrunkSupport                     bool     `json:"openstack_trunk_support,omitempty"`
-	OctaviaSupport                   bool     `json:"openstack_octavia_support,omitempty"`
-	RootVolumeSize                   int      `json:"openstack_master_root_volume_size,omitempty"`
-	RootVolumeType                   string   `json:"openstack_master_root_volume_type,omitempty"`
-	BootstrapShim                    string   `json:"openstack_bootstrap_shim_ignition,omitempty"`
-	ExternalDNS                      []string `json:"openstack_external_dns,omitempty"`
-	MasterServerGroupName            string   `json:"openstack_master_server_group_name,omitempty"`
-	AdditionalNetworkIDs             []string `json:"openstack_additional_network_ids,omitempty"`
-	AdditionalSecurityGroupIDs       []string `json:"openstack_master_extra_sg_ids,omitempty"`
-	MachinesSubnet                   string   `json:"openstack_machines_subnet_id,omitempty"`
-	MachinesNetwork                  string   `json:"openstack_machines_network_id,omitempty"`
-	MasterAvailabilityZones          []string `json:"openstack_master_availability_zones,omitempty"`
-	MasterRootVolumeAvalabilityZones []string `json:"openstack_master_root_volume_availability_zones,omitempty"`
+	BaseImageName                    string                            `json:"openstack_base_image_name,omitempty"`
+	ExternalNetwork                  string                            `json:"openstack_external_network,omitempty"`
+	Cloud                            string                            `json:"openstack_credentials_cloud,omitempty"`
+	FlavorName                       string                            `json:"openstack_master_flavor_name,omitempty"`
+	APIFloatingIP                    string                            `json:"openstack_api_floating_ip,omitempty"`
+	IngressFloatingIP                string                            `json:"openstack_ingress_floating_ip,omitempty"`
+	APIVIP                           string                            `json:"openstack_api_int_ip,omitempty"`
+	IngressVIP                       string                            `json:"openstack_ingress_ip,omitempty"`
+	TrunkSupport                     bool                              `json:"openstack_trunk_support,omitempty"`
+	OctaviaSupport                   bool                              `json:"openstack_octavia_support,omitempty"`
+	RootVolumeSize                   int                               `json:"openstack_master_root_volume_size,omitempty"`
+	RootVolumeType                   string                            `json:"openstack_master_root_volume_type,omitempty"`
+	BootstrapShim                    string                            `json:"openstack_bootstrap_shim_ignition,omitempty"`
+	ExternalDNS                      []string                          `json:"openstack_external_dns,omitempty"`
+	MasterServerGroupName            string                            `json:"openstack_master_server_group_name,omitempty"`
+	MasterServerGroupPolicy          types_openstack.ServerGroupPolicy `json:"openstack_master_server_group_policy"`
+	AdditionalNetworkIDs             []string                          `json:"openstack_additional_network_ids,omitempty"`
+	AdditionalSecurityGroupIDs       []string                          `json:"openstack_master_extra_sg_ids,omitempty"`
+	MachinesSubnet                   string                            `json:"openstack_machines_subnet_id,omitempty"`
+	MachinesNetwork                  string                            `json:"openstack_machines_network_id,omitempty"`
+	MasterAvailabilityZones          []string                          `json:"openstack_master_availability_zones,omitempty"`
+	MasterRootVolumeAvalabilityZones []string                          `json:"openstack_master_root_volume_availability_zones,omitempty"`
 }
 
 // TFVars generates OpenStack-specific Terraform variables.
@@ -160,6 +161,14 @@ func TFVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, exter
 	}
 
 	cfg.MasterServerGroupName = masterConfig.ServerGroupName
+
+	if mpool != nil && mpool.ServerGroupPolicy != types_openstack.SGPolicyUnset {
+		cfg.MasterServerGroupPolicy = mpool.ServerGroupPolicy
+	} else if defaultmpool != nil && defaultmpool.ServerGroupPolicy != types_openstack.SGPolicyUnset {
+		cfg.MasterServerGroupPolicy = defaultmpool.ServerGroupPolicy
+	} else {
+		cfg.MasterServerGroupPolicy = types_openstack.SGPolicySoftAntiAffinity
+	}
 
 	if masterConfig.ServerGroupID != "" {
 		return nil, errors.Errorf("ServerGroupID is not implemented in the Installer. Please use ServerGroupName for automatic creation of the Control Plane server group.")

--- a/pkg/types/openstack/machinepool.go
+++ b/pkg/types/openstack/machinepool.go
@@ -23,6 +23,10 @@ type MachinePool struct {
 	// +optional
 	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
 
+	// ServerGroupPolicy will be used to create the Server Group that will contain all the machines of this MachinePool.
+	// Defaults to "soft-anti-affinity".
+	ServerGroupPolicy ServerGroupPolicy `json:"serverGroupPolicy,omitempty"`
+
 	// Zones is the list of availability zones where the instances should be deployed.
 	// If no zones are provided, all instances will be deployed on OpenStack Nova default availability zone
 	// +optional
@@ -56,6 +60,10 @@ func (o *MachinePool) Set(required *MachinePool) {
 
 	if required.AdditionalSecurityGroupIDs != nil {
 		o.AdditionalSecurityGroupIDs = append(required.AdditionalSecurityGroupIDs[:0:0], required.AdditionalSecurityGroupIDs...)
+	}
+
+	if required.ServerGroupPolicy != "" {
+		o.ServerGroupPolicy = required.ServerGroupPolicy
 	}
 
 	if len(required.Zones) > 0 {

--- a/pkg/types/openstack/servergrouppolicy.go
+++ b/pkg/types/openstack/servergrouppolicy.go
@@ -1,0 +1,24 @@
+package openstack
+
+const (
+	// SGPolicyUnset represents the default empty string for the ServerGroupPolicy field of the MachinePool.
+	SGPolicyUnset ServerGroupPolicy = ""
+
+	// SGPolicyAffinity represents the "affinity" ServerGroupPolicy field of the MachinePool.
+	SGPolicyAffinity ServerGroupPolicy = "affinity"
+
+	// SGPolicySoftAffinity represents the "soft-affinity" ServerGroupPolicy field of the MachinePool.
+	SGPolicySoftAffinity ServerGroupPolicy = "soft-affinity"
+
+	// SGPolicyAntiAffinity represents the "anti-affinity" ServerGroupPolicy field of the MachinePool.
+	SGPolicyAntiAffinity ServerGroupPolicy = "anti-affinity"
+
+	// SGPolicySoftAntiAffinity represents the "soft-anti-affinity" ServerGroupPolicy field of the MachinePool.
+	SGPolicySoftAntiAffinity ServerGroupPolicy = "soft-anti-affinity"
+)
+
+// ServerGroupPolicy is the policy to be applied to an OpenStack Server Group.
+//
+// +kubebuilder:validation:Enum="";affinity;soft-affinity;anti-affinity;soft-anti-affinity
+// +optional
+type ServerGroupPolicy string

--- a/pkg/types/openstack/validation/machinepool.go
+++ b/pkg/types/openstack/validation/machinepool.go
@@ -1,0 +1,47 @@
+package validation
+
+import (
+	"github.com/openshift/installer/pkg/types/openstack"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var validServerGroupPolicies = []string{
+	string(openstack.SGPolicyAffinity),
+	string(openstack.SGPolicyAntiAffinity),
+	string(openstack.SGPolicySoftAffinity),
+	string(openstack.SGPolicySoftAntiAffinity),
+}
+
+// ValidateMachinePool validates Control plane and Compute MachinePools
+func ValidateMachinePool(platform *openstack.Platform, machinePool *openstack.MachinePool, poolName string, fldPath *field.Path) field.ErrorList {
+	if poolName == "master" {
+		return validateMasterMachinePool(machinePool, fldPath)
+	}
+	return validateWorkerMachinePool(machinePool, fldPath)
+}
+
+func validateMasterMachinePool(pool *openstack.MachinePool, fldPath *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	switch pool.ServerGroupPolicy {
+	case openstack.SGPolicyUnset, openstack.SGPolicyAffinity, openstack.SGPolicyAntiAffinity, openstack.SGPolicySoftAffinity, openstack.SGPolicySoftAntiAffinity:
+	default:
+		errs = append(errs, field.NotSupported(fldPath.Child("serverGroupPolicy"), pool.ServerGroupPolicy, validServerGroupPolicies))
+	}
+	return errs
+}
+
+func validateWorkerMachinePool(pool *openstack.MachinePool, fldPath *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if pool.ServerGroupPolicy != openstack.SGPolicyUnset {
+		errs = append(errs, field.Invalid(fldPath.Child("serverGroupPolicy"), pool.ServerGroupPolicy, "server group policy cannot be set for compute machines"))
+	}
+	return errs
+}
+
+func validateDefaultMachinePool(pool *openstack.MachinePool, fldPath *field.Path) field.ErrorList {
+	var errs field.ErrorList
+	if pool.ServerGroupPolicy != openstack.SGPolicyUnset {
+		errs = append(errs, field.Invalid(fldPath.Child("serverGroupPolicy"), pool.ServerGroupPolicy, "server group policy cannot be set as default because compute machines do not support it"))
+	}
+	return errs
+}

--- a/pkg/types/openstack/validation/machinepool_test.go
+++ b/pkg/types/openstack/validation/machinepool_test.go
@@ -1,0 +1,210 @@
+package validation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/openshift/installer/pkg/types/openstack"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func withServerGroupPolicy(serverGroupPolicy string) func(*openstack.MachinePool) {
+	return func(mp *openstack.MachinePool) { mp.ServerGroupPolicy = openstack.ServerGroupPolicy(serverGroupPolicy) }
+}
+
+func testMachinePool(options ...func(*openstack.MachinePool)) *openstack.MachinePool {
+	var mp openstack.MachinePool
+	for _, apply := range options {
+		apply(&mp)
+	}
+	return &mp
+}
+
+func TestValidateDefaultMachinePool(t *testing.T) {
+	type checkFunc func(field.ErrorList) error
+	check := func(fns ...checkFunc) []checkFunc { return fns }
+	noError := func(errs field.ErrorList) error {
+		if errs != nil && len(errs) > 0 {
+			return fmt.Errorf("expected zero errors, found %v", errs)
+		}
+		return nil
+	}
+	someErrorType := func(wantType field.ErrorType) checkFunc {
+		return func(errs field.ErrorList) error {
+			for _, err := range errs {
+				if wantType == err.Type {
+					return nil
+				}
+			}
+			return fmt.Errorf("expected error type %q, not found", wantType)
+		}
+	}
+	exactlyNErrors := func(want int) checkFunc {
+		return func(errs field.ErrorList) error {
+			if have := len(errs); want != have {
+				return fmt.Errorf("expected %d errors, got %d", want, have)
+			}
+			return nil
+		}
+	}
+
+	for _, tc := range [...]struct {
+		name        string
+		machinePool *openstack.MachinePool
+		checks      []checkFunc
+	}{
+		{
+			"empty",
+			testMachinePool(),
+			check(noError),
+		},
+		{
+			"with valid server group policy",
+			testMachinePool(withServerGroupPolicy("anti-affinity")),
+			check(someErrorType(field.ErrorTypeInvalid)),
+		},
+		{
+			"with invalid server group policy",
+			testMachinePool(withServerGroupPolicy("anti-gravity")),
+			check(
+				someErrorType(field.ErrorTypeInvalid),
+				exactlyNErrors(1),
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateDefaultMachinePool(tc.machinePool, nil)
+			for _, check := range tc.checks {
+				if e := check(errs); e != nil {
+					t.Error(e)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateMasterMachinePool(t *testing.T) {
+	type checkFunc func(field.ErrorList) error
+	check := func(fns ...checkFunc) []checkFunc { return fns }
+	noError := func(errs field.ErrorList) error {
+		if errs != nil && len(errs) > 0 {
+			return fmt.Errorf("expected zero errors, found %v", errs)
+		}
+		return nil
+	}
+	someErrorType := func(wantType field.ErrorType) checkFunc {
+		return func(errs field.ErrorList) error {
+			for _, err := range errs {
+				if wantType == err.Type {
+					return nil
+				}
+			}
+			return fmt.Errorf("expected error type %q, not found", wantType)
+		}
+	}
+	exactlyNErrors := func(want int) checkFunc {
+		return func(errs field.ErrorList) error {
+			if have := len(errs); want != have {
+				return fmt.Errorf("expected %d errors, got %d", want, have)
+			}
+			return nil
+		}
+	}
+
+	for _, tc := range [...]struct {
+		name        string
+		machinePool *openstack.MachinePool
+		checks      []checkFunc
+	}{
+		{
+			"empty",
+			testMachinePool(),
+			check(noError),
+		},
+		{
+			"with valid server group policy",
+			testMachinePool(withServerGroupPolicy("anti-affinity")),
+			check(noError),
+		},
+		{
+			"with invalid server group policy",
+			testMachinePool(withServerGroupPolicy("anti-gravity")),
+			check(
+				someErrorType(field.ErrorTypeNotSupported),
+				exactlyNErrors(1),
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateMasterMachinePool(tc.machinePool, nil)
+			for _, check := range tc.checks {
+				if e := check(errs); e != nil {
+					t.Error(e)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateWorkerMachinePool(t *testing.T) {
+	type checkFunc func(field.ErrorList) error
+	check := func(fns ...checkFunc) []checkFunc { return fns }
+	noError := func(errs field.ErrorList) error {
+		if errs != nil && len(errs) > 0 {
+			return fmt.Errorf("expected zero errors, found %v", errs)
+		}
+		return nil
+	}
+	someErrorType := func(wantType field.ErrorType) checkFunc {
+		return func(errs field.ErrorList) error {
+			for _, err := range errs {
+				if wantType == err.Type {
+					return nil
+				}
+			}
+			return fmt.Errorf("expected error type %q, not found", wantType)
+		}
+	}
+	exactlyNErrors := func(want int) checkFunc {
+		return func(errs field.ErrorList) error {
+			if have := len(errs); want != have {
+				return fmt.Errorf("expected %d errors, got %d", want, have)
+			}
+			return nil
+		}
+	}
+
+	for _, tc := range [...]struct {
+		name        string
+		machinePool *openstack.MachinePool
+		checks      []checkFunc
+	}{
+		{
+			"empty",
+			testMachinePool(),
+			check(noError),
+		},
+		{
+			"with valid server group policy",
+			testMachinePool(withServerGroupPolicy("anti-affinity")),
+			check(someErrorType(field.ErrorTypeInvalid)),
+		},
+		{
+			"with invalid server group policy",
+			testMachinePool(withServerGroupPolicy("anti-gravity")),
+			check(
+				someErrorType(field.ErrorTypeInvalid),
+				exactlyNErrors(1),
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validateWorkerMachinePool(tc.machinePool, nil)
+			for _, check := range tc.checks {
+				if e := check(errs); e != nil {
+					t.Error(e)
+				}
+			}
+		})
+	}
+}

--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -34,6 +34,8 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressVIP"), p.IngressVIP, err.Error()))
 	}
 
+	allErrs = append(allErrs, validateDefaultMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
+
 	return allErrs
 }
 

--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -18,6 +18,8 @@ import (
 	kubevirtvalidation "github.com/openshift/installer/pkg/types/kubevirt/validation"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	libvirtvalidation "github.com/openshift/installer/pkg/types/libvirt/validation"
+	"github.com/openshift/installer/pkg/types/openstack"
+	openstackvalidation "github.com/openshift/installer/pkg/types/openstack/validation"
 	"github.com/openshift/installer/pkg/types/ovirt"
 	ovirtvalidation "github.com/openshift/installer/pkg/types/ovirt/validation"
 	"github.com/openshift/installer/pkg/types/vsphere"
@@ -110,6 +112,11 @@ func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolP
 	}
 	if p.Kubevirt != nil {
 		validate(kubevirt.Name, p.Kubevirt, func(f *field.Path) field.ErrorList { return kubevirtvalidation.ValidateMachinePool(p.Kubevirt, f) })
+	}
+	if p.OpenStack != nil {
+		validate(openstack.Name, p.OpenStack, func(f *field.Path) field.ErrorList {
+			return openstackvalidation.ValidateMachinePool(platform.OpenStack, p.OpenStack, pool.Name, f)
+		})
 	}
 	return allErrs
 }


### PR DESCRIPTION
Prior to this change, the Control plane nodes are created in a server
group with the hardcoded policy "soft-anti-affinity".

This change adds a new configuration knob in the OpenStack-specific
MachinePool configuration of `install-config.yaml`.

The new property `controlPlane.platform.openstack.serverGroupPolicy`
defines the policy that will be applied to the Control Plane server
group.

Acceptable values are:

* `affinity`
* `anti-affinity`
* `soft-affinity`
* `soft-anti-affinity`

Defaults to `soft-anti-affinity`, to match the previous hardcoded
behaviour.

Validation will fail if the property is set on the Compute MachinePool.

Implements [OSASINFRA-2507](https://issues.redhat.com/browse/OSASINFRA-2507)

/hold for gathering team consensus on the API.