### PR TITLE
Bug 1972776: improve dual-stack install-config validation

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -303,7 +303,7 @@ func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorLis
 	}
 
 	for i, sn := range n.ServiceNetwork {
-		if err := validate.SubnetCIDR(&sn.IPNet); err != nil {
+		if err := validate.ServiceSubnetCIDR(&sn.IPNet); err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceNetwork").Index(i), sn.String(), err.Error()))
 		}
 		for _, network := range n.MachineNetwork {

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -136,8 +137,15 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 	return allErrs
 }
 
-// ipAddressTypeByField is a map of field path to whether they request IPv4 or IPv6.
-type ipAddressTypeByField map[string]struct{ IPv4, IPv6 bool }
+// ipAddressType indicates the address types provided for a given field
+type ipAddressType struct {
+	IPv4    bool
+	IPv6    bool
+	Primary corev1.IPFamily
+}
+
+// ipAddressTypeByField is a map of field path to ipAddressType
+type ipAddressTypeByField map[string]ipAddressType
 
 // ipByField is a map of field path to the net.IPs in sorted order.
 type ipByField map[string][]net.IP
@@ -161,15 +169,21 @@ func inferIPVersionFromInstallConfig(n *types.Networking) (hasIPv4, hasIPv6 bool
 	}
 	presence = make(ipAddressTypeByField)
 	for k, ips := range addresses {
-		for _, ip := range ips {
+		for i, ip := range ips {
 			has := presence[k]
 			if ip.To4() != nil {
 				has.IPv4 = true
+				if i == 0 {
+					has.Primary = corev1.IPv4Protocol
+				}
 				if k == "serviceNetwork" {
 					hasIPv4 = true
 				}
 			} else {
 				has.IPv6 = true
+				if i == 0 {
+					has.Primary = corev1.IPv6Protocol
+				}
 				if k == "serviceNetwork" {
 					hasIPv6 = true
 				}
@@ -231,6 +245,13 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipSliceToStrings(addresses[k]), ", "), "dual-stack IPv4/IPv6 requires an IPv6 address in this list"))
 			case !v.IPv4 && v.IPv6:
 				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipSliceToStrings(addresses[k]), ", "), "dual-stack IPv4/IPv6 requires an IPv4 address in this list"))
+			}
+
+			// FIXME: we should allow either all-networks-IPv4Primary or
+			// all-networks-IPv6Primary, but the latter currently causes
+			// confusing install failures, so block it.
+			if v.IPv4 && v.IPv6 && v.Primary != corev1.IPv4Protocol {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipSliceToStrings(addresses[k]), ", "), "IPv4 addresses must be listed before IPv6 addresses"))
 			}
 		}
 

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -230,8 +230,6 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 		}
 		for k, v := range presence {
 			switch {
-			case k == "machineNetwork" && p.AWS != nil:
-				// AWS can default an ipv6 subnet
 			case v.IPv4 && !v.IPv6:
 				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipnetworksToStrings(addresses[k]), ", "), "dual-stack IPv4/IPv6 requires an IPv6 network in this list"))
 			case !v.IPv4 && v.IPv6:

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -147,31 +147,31 @@ type ipAddressType struct {
 // ipAddressTypeByField is a map of field path to ipAddressType
 type ipAddressTypeByField map[string]ipAddressType
 
-// ipByField is a map of field path to the net.IPs in sorted order.
-type ipByField map[string][]net.IP
+// ipNetByField is a map of field path to the IPNets
+type ipNetByField map[string][]ipnet.IPNet
 
 // inferIPVersionFromInstallConfig infers the user's desired ip version from the networking config.
 // Presence field names match the field path of the struct within the Networking type. This function
 // assumes a valid install config.
-func inferIPVersionFromInstallConfig(n *types.Networking) (hasIPv4, hasIPv6 bool, presence ipAddressTypeByField, addresses ipByField) {
+func inferIPVersionFromInstallConfig(n *types.Networking) (hasIPv4, hasIPv6 bool, presence ipAddressTypeByField, addresses ipNetByField) {
 	if n == nil {
 		return
 	}
-	addresses = make(ipByField)
+	addresses = make(ipNetByField)
 	for _, network := range n.MachineNetwork {
-		addresses["machineNetwork"] = append(addresses["machineNetwork"], network.CIDR.IP)
+		addresses["machineNetwork"] = append(addresses["machineNetwork"], network.CIDR)
 	}
 	for _, network := range n.ServiceNetwork {
-		addresses["serviceNetwork"] = append(addresses["serviceNetwork"], network.IP)
+		addresses["serviceNetwork"] = append(addresses["serviceNetwork"], network)
 	}
 	for _, network := range n.ClusterNetwork {
-		addresses["clusterNetwork"] = append(addresses["clusterNetwork"], network.CIDR.IP)
+		addresses["clusterNetwork"] = append(addresses["clusterNetwork"], network.CIDR)
 	}
 	presence = make(ipAddressTypeByField)
-	for k, ips := range addresses {
-		for i, ip := range ips {
+	for k, ipnets := range addresses {
+		for i, ipnet := range ipnets {
 			has := presence[k]
-			if ip.To4() != nil {
+			if ipnet.IP.To4() != nil {
 				has.IPv4 = true
 				if i == 0 {
 					has.Primary = corev1.IPv4Protocol
@@ -194,20 +194,11 @@ func inferIPVersionFromInstallConfig(n *types.Networking) (hasIPv4, hasIPv6 bool
 	return
 }
 
-func ipSliceToStrings(ips []net.IP) []string {
-	var s []string
-	for _, ip := range ips {
-		s = append(s, ip.String())
-	}
-	return s
-}
-
 func ipnetworksToStrings(networks []ipnet.IPNet) []string {
 	var diag []string
 	for _, sn := range networks {
 		diag = append(diag, sn.String())
 	}
-	sort.Strings(diag)
 	return diag
 }
 
@@ -242,16 +233,16 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 			case k == "machineNetwork" && p.AWS != nil:
 				// AWS can default an ipv6 subnet
 			case v.IPv4 && !v.IPv6:
-				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipSliceToStrings(addresses[k]), ", "), "dual-stack IPv4/IPv6 requires an IPv6 address in this list"))
+				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipnetworksToStrings(addresses[k]), ", "), "dual-stack IPv4/IPv6 requires an IPv6 network in this list"))
 			case !v.IPv4 && v.IPv6:
-				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipSliceToStrings(addresses[k]), ", "), "dual-stack IPv4/IPv6 requires an IPv4 address in this list"))
+				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipnetworksToStrings(addresses[k]), ", "), "dual-stack IPv4/IPv6 requires an IPv4 network in this list"))
 			}
 
 			// FIXME: we should allow either all-networks-IPv4Primary or
 			// all-networks-IPv6Primary, but the latter currently causes
 			// confusing install failures, so block it.
 			if v.IPv4 && v.IPv6 && v.Primary != corev1.IPv4Protocol {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipSliceToStrings(addresses[k]), ", "), "IPv4 addresses must be listed before IPv6 addresses"))
+				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipnetworksToStrings(addresses[k]), ", "), "IPv4 addresses must be listed before IPv6 addresses"))
 			}
 		}
 

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1141,16 +1141,6 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `Invalid value: "10.0.0.0/16": dual-stack IPv4/IPv6 requires an IPv6 network in this list`,
 		},
 		{
-			name: "valid dual-stack configuration, machine has no IPv6 but is on AWS",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Networking = validDualStackNetworkingConfig()
-				c.Networking.MachineNetwork = c.Networking.MachineNetwork[1:]
-				return c
-			}(),
-			expectedError: `Invalid value: "DualStack": dual-stack IPv4/IPv6 is not supported for this platform, specify only one type of address`,
-		},
-		{
 			name: "invalid dual-stack configuration, IPv6-primary",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -162,7 +162,7 @@ func validIPv6NetworkingConfig() *types.Networking {
 			},
 		},
 		ServiceNetwork: []ipnet.IPNet{
-			*ipnet.MustParseCIDR("ffd1::/48"),
+			*ipnet.MustParseCIDR("ffd1::/112"),
 		},
 		ClusterNetwork: []types.ClusterNetworkEntry{
 			{
@@ -186,7 +186,7 @@ func validDualStackNetworkingConfig() *types.Networking {
 		},
 		ServiceNetwork: []ipnet.IPNet{
 			*ipnet.MustParseCIDR("172.30.0.0/16"),
-			*ipnet.MustParseCIDR("ffd1::/48"),
+			*ipnet.MustParseCIDR("ffd1::/112"),
 		},
 		ClusterNetwork: []types.ClusterNetworkEntry{
 			{
@@ -1190,6 +1190,17 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: `Invalid value: 72: cluster network host subnetwork prefix must be 64 for IPv6 networks`,
+		},
+		{
+			name: "invalid IPv6 service network size",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validIPv6NetworkingConfig()
+				c.Networking.ServiceNetwork[0] = *ipnet.MustParseCIDR("ffd1::/48")
+				return c
+			}(),
+			expectedError: `Invalid value: "ffd1::/48": subnet size for IPv6 service network should be /112`,
 		},
 
 		{

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1138,7 +1138,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Networking.MachineNetwork = c.Networking.MachineNetwork[:1]
 				return c
 			}(),
-			expectedError: `Invalid value: "10.0.0.0": dual-stack IPv4/IPv6 requires an IPv6 address in this list`,
+			expectedError: `Invalid value: "10.0.0.0/16": dual-stack IPv4/IPv6 requires an IPv6 network in this list`,
 		},
 		{
 			name: "valid dual-stack configuration, machine has no IPv6 but is on AWS",
@@ -1162,7 +1162,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: `Invalid value: "ffd1::, 172.30.0.0": IPv4 addresses must be listed before IPv6 addresses`,
+			expectedError: `Invalid value: "ffd1::/112, 172.30.0.0/16": IPv4 addresses must be listed before IPv6 addresses`,
 		},
 		{
 			name: "valid dual-stack configuration with mixed-order clusterNetworks",

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -178,24 +178,24 @@ func validDualStackNetworkingConfig() *types.Networking {
 		NetworkType: "OVNKubernetes",
 		MachineNetwork: []types.MachineNetworkEntry{
 			{
-				CIDR: *ipnet.MustParseCIDR("ffd0::/48"),
+				CIDR: *ipnet.MustParseCIDR("10.0.0.0/16"),
 			},
 			{
-				CIDR: *ipnet.MustParseCIDR("10.0.0.0/16"),
+				CIDR: *ipnet.MustParseCIDR("ffd0::/48"),
 			},
 		},
 		ServiceNetwork: []ipnet.IPNet{
-			*ipnet.MustParseCIDR("ffd1::/48"),
 			*ipnet.MustParseCIDR("172.30.0.0/16"),
+			*ipnet.MustParseCIDR("ffd1::/48"),
 		},
 		ClusterNetwork: []types.ClusterNetworkEntry{
 			{
-				CIDR:       *ipnet.MustParseCIDR("ffd2::/48"),
-				HostPrefix: 64,
-			},
-			{
 				CIDR:       *ipnet.MustParseCIDR("192.168.1.0/24"),
 				HostPrefix: 28,
+			},
+			{
+				CIDR:       *ipnet.MustParseCIDR("ffd2::/48"),
+				HostPrefix: 64,
 			},
 		},
 	}
@@ -1135,7 +1135,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				c := validInstallConfig()
 				c.Platform = types.Platform{None: &none.Platform{}}
 				c.Networking = validDualStackNetworkingConfig()
-				c.Networking.MachineNetwork = c.Networking.MachineNetwork[1:]
+				c.Networking.MachineNetwork = c.Networking.MachineNetwork[:1]
 				return c
 			}(),
 			expectedError: `Invalid value: "10.0.0.0": dual-stack IPv4/IPv6 requires an IPv6 address in this list`,
@@ -1149,6 +1149,36 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: `Invalid value: "DualStack": dual-stack IPv4/IPv6 is not supported for this platform, specify only one type of address`,
+		},
+		{
+			name: "invalid dual-stack configuration, IPv6-primary",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validDualStackNetworkingConfig()
+				c.Networking.ServiceNetwork = []ipnet.IPNet{
+					c.Networking.ServiceNetwork[1],
+					c.Networking.ServiceNetwork[0],
+				}
+				return c
+			}(),
+			expectedError: `Invalid value: "ffd1::, 172.30.0.0": IPv4 addresses must be listed before IPv6 addresses`,
+		},
+		{
+			name: "valid dual-stack configuration with mixed-order clusterNetworks",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{None: &none.Platform{}}
+				c.Networking = validDualStackNetworkingConfig()
+				c.Networking.ClusterNetwork = append(c.Networking.ClusterNetwork,
+					types.ClusterNetworkEntry{
+						CIDR:       *ipnet.MustParseCIDR("192.168.2.0/24"),
+						HostPrefix: 28,
+					},
+				)
+				// ClusterNetwork is now "IPv4, IPv6, IPv4", which is allowed
+				return c
+			}(),
 		},
 		{
 			name: "invalid IPv6 hostprefix",


### PR DESCRIPTION
tl;dr: require dual-stack install-configs to be "IPv4-primary". To be backported to 4.8.

At some point in early 4.7 we noticed that "IPv6-primary" dual-stack configurations (eg, where the first value for clusterNetworks/serviceNetworks is IPv6 rather than IPv4) didn't work right due to cluster-etcd-operator issues. I think that specific bug was fixed, but other problems have popped up, and more importantly, we aren't testing IPv6-primary installation anywhere, and dev-scripts actually _can't_ bring up an IPv6-primary cluster currently. Someone just pointed out that a customer had tried this with a 4.8 fc release and was running into weird problems, so let's just block it.

(eg, see https://coreos.slack.com/archives/CQQ7P8UTT/p1623765189017300, https://coreos.slack.com/archives/CQQ7P8UTT/p1624015997022800)

The second commit is another fail-early-on-bad-config fix; it makes us reject values for serviceNetwork that will later be rejected by kube-apiserver.

The third and fourth commits are drive-by fixes, and don't necessarily have to be backported to 4.8.