### PR TITLE
baremetal: Always use image cache

### DIFF
--- a/pkg/asset/machines/baremetal/machines.go
+++ b/pkg/asset/machines/baremetal/machines.go
@@ -89,12 +89,10 @@ func provider(platform *baremetal.Platform, osImage string, userDataSecret strin
 	cachedImageFilename := "cached-" + imageFilename
 
 	cacheImageIP := platform.ClusterProvisioningIP
-	cacheImagePort := "6180"
 	if platform.ProvisioningNetwork == baremetal.DisabledProvisioningNetwork && platform.ClusterProvisioningIP == "" {
 		cacheImageIP = platform.APIVIP
-		cacheImagePort = "6181"
 	}
-	cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(cacheImageIP, cacheImagePort), imageFilename, cachedImageFilename)
+	cacheImageURL := fmt.Sprintf("http://%s/images/%s/%s", net.JoinHostPort(cacheImageIP, "6181"), imageFilename, cachedImageFilename)
 	cacheChecksumURL := fmt.Sprintf("%s.md5sum", cacheImageURL)
 	config := &baremetalprovider.BareMetalMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
The metal3-image-cache daemonset is started unconditionally by the
cluster-baremetal-operator, serving on port 6181. However, we were only
pointing at this service in the MachineConfig if the provisioning
network was not present.

Given that the MachineConfig is fixed at install time while the
provisioning network can be added or removed by changing the
Provisioning resource, we should always use the cache.

This also means the cache will get exercised in CI, where previously it
was not.