### PR TITLE
Bug 1956485: bump RHCOS 4.6 boot images

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,156 +1,159 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-09921c9c1c36e695c"
+            "hvm": "ami-0cb7096c55762208e"
         },
         "ap-east-1": {
-            "hvm": "ami-01ee8446e9af6b197"
+            "hvm": "ami-021682e27bec1ee87"
         },
         "ap-northeast-1": {
-            "hvm": "ami-04e5b5722a55846ea"
+            "hvm": "ami-038d6133bf9ddee00"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0fdc25c8a0273a742"
+            "hvm": "ami-0a485021689fe2eb9"
+        },
+        "ap-northeast-3": {
+            "hvm": "ami-020e0d8666f0d3170"
         },
         "ap-south-1": {
-            "hvm": "ami-09e3deb397cc526a8"
+            "hvm": "ami-02fd44354bcde25a3"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0630e03f75e02eec4"
+            "hvm": "ami-0557e6167fe242389"
         },
         "ap-southeast-2": {
-            "hvm": "ami-069450613262ba03c"
+            "hvm": "ami-008f040a1fc38209d"
         },
         "ca-central-1": {
-            "hvm": "ami-012518cdbd3057dfd"
+            "hvm": "ami-082f532e52293d463"
         },
         "eu-central-1": {
-            "hvm": "ami-0bd7175ff5b1aef0c"
+            "hvm": "ami-0b623fd02ca4775a5"
         },
         "eu-north-1": {
-            "hvm": "ami-06c9ec42d0a839ad2"
+            "hvm": "ami-0af74b0d36637f646"
         },
         "eu-south-1": {
-            "hvm": "ami-0614d7440a0363d71"
+            "hvm": "ami-0e19c0d9263db9ff5"
         },
         "eu-west-1": {
-            "hvm": "ami-01b89df58b5d4d5fa"
+            "hvm": "ami-0b97f7bd61c1ecd0b"
         },
         "eu-west-2": {
-            "hvm": "ami-06f6e31ddd554f89d"
+            "hvm": "ami-01b6f3e8f0ad9054d"
         },
         "eu-west-3": {
-            "hvm": "ami-0dc82e2517ded15a1"
+            "hvm": "ami-07dea9de166255375"
         },
         "me-south-1": {
-            "hvm": "ami-07d181e3aa0f76067"
+            "hvm": "ami-014f667835c573656"
         },
         "sa-east-1": {
-            "hvm": "ami-0cd44e6dd20e6c7fa"
+            "hvm": "ami-0577fc850f1ebce4c"
         },
         "us-east-1": {
-            "hvm": "ami-04a16d506e5b0e246"
+            "hvm": "ami-0475651470951812f"
         },
         "us-east-2": {
-            "hvm": "ami-0a1f868ad58ea59a7"
+            "hvm": "ami-03696639de42a5d18"
         },
         "us-west-1": {
-            "hvm": "ami-0a65d76e3a6f6622f"
+            "hvm": "ami-0694c5c7d6b0bb63d"
         },
         "us-west-2": {
-            "hvm": "ami-0dd9008abadc519f1"
+            "hvm": "ami-06246178752716deb"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202011260640-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202011260640-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202106161040-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202106161040-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202011260640-0/x86_64/",
-    "buildid": "46.82.202011260640-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202106161040-0/x86_64/",
+    "buildid": "46.82.202106161040-0",
     "gcp": {
-        "image": "rhcos-46-82-202011260640-0-gcp-x86-64",
+        "image": "rhcos-46-82-202106161040-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202011260640-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202106161040-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202011260640-0-aws.x86_64.vmdk.gz",
-            "sha256": "6e0f720077ac20fae46c16159d03fd51f66cd318155dcd14f0f5d7dc79bfd8ad",
-            "size": 900764628,
-            "uncompressed-sha256": "b38713b80bbcc41d18efcec93d241da48533225e0ce073c2a26235993ffc4166",
-            "uncompressed-size": 919795200
+            "path": "rhcos-46.82.202106161040-0-aws.x86_64.vmdk.gz",
+            "sha256": "943f4302a685a4fad8867660893ee777e91b386d4d335ec560bbadcf6a8c6ee0",
+            "size": 905821025,
+            "uncompressed-sha256": "02294545395fa1c5d5507ce6255ef3272df4841628741a1e7114f04630cfc928",
+            "uncompressed-size": 924866048
         },
         "azure": {
-            "path": "rhcos-46.82.202011260640-0-azure.x86_64.vhd.gz",
-            "sha256": "5255c675ecff4f8932db24b68a7ef451dfc4e502326128931ccd39acf27c6c77",
-            "size": 901953565,
-            "uncompressed-sha256": "0fd7ab096c7ac4b8d807371d1c4a13b3a665b5d2938ff814bd3e46257193941b",
+            "path": "rhcos-46.82.202106161040-0-azure.x86_64.vhd.gz",
+            "sha256": "b055fa9617ce10c8a5091f248927e62bfb1f050449078d80ecbc85f27a4c9c53",
+            "size": 907035912,
+            "uncompressed-sha256": "fa58c5bc8f796d8ff900cc731a0e0fa4c568bc7088d4ceb70eaf42549cffa7ec",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202011260640-0-gcp.x86_64.tar.gz",
-            "sha256": "f470a98c1fc7a4e0226ed4258fdd0b6edcddbb2356e7992bea4b98843cd94d9a",
-            "size": 887140241
+            "path": "rhcos-46.82.202106161040-0-gcp.x86_64.tar.gz",
+            "sha256": "aa91df7de250d007dd42e70f3270647a509592b78b29dd0f993ac8c911fd3dfb",
+            "size": 892218739
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202011260640-0-live-initramfs.x86_64.img",
-            "sha256": "8ff220c6f4bbca35dd071c5f1802566290b70081faeb06fb07f72c4583f8facf"
+            "path": "rhcos-46.82.202106161040-0-live-initramfs.x86_64.img",
+            "sha256": "652d93ed9d0d7ec2033d3a78f790c81241d80e7203bfcb882190df7e2925780e"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202011260640-0-live.x86_64.iso",
-            "sha256": "161046d6275cda89a3f44582bc2b850cd09b987807d3b20090eeab279b7e0550"
+            "path": "rhcos-46.82.202106161040-0-live.x86_64.iso",
+            "sha256": "5b41a7d5df9e986731fef49df8d197a8e6add79d1bf8c11f8457a98f676c6daa"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202011260640-0-live-kernel-x86_64",
-            "sha256": "9bbb496410c04f54d30eb56f76f769bccec7e81b91271ae72261ecc54db9c63d"
+            "path": "rhcos-46.82.202106161040-0-live-kernel-x86_64",
+            "sha256": "0c70a2d1d0b1a7be3b06e38a667c8589918105f0294bc4a032f04d0ce9a23d2a"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202011260640-0-live-rootfs.x86_64.img",
-            "sha256": "007f9c376e1282b77ed662509a3a81b624dfcf28aa971a9e80b33fc06cf9c4fd"
+            "path": "rhcos-46.82.202106161040-0-live-rootfs.x86_64.img",
+            "sha256": "659972e40eaeec853011350c4ffa56aeb8c7591838a9bd19cd7c52307e09baf2"
         },
         "metal": {
-            "path": "rhcos-46.82.202011260640-0-metal.x86_64.raw.gz",
-            "sha256": "bcd9871c373c02898675ec407e83f9ccd107077ff30008ecb601c9869c4a501a",
-            "size": 888607273,
-            "uncompressed-sha256": "a769991d850064ef078ba4dae9050e34a820bf9eba792a2b7922fb7a15315b57",
-            "uncompressed-size": 3555721216
+            "path": "rhcos-46.82.202106161040-0-metal.x86_64.raw.gz",
+            "sha256": "3b9d00f121231dc8ea666f6d1270382c67d71cf04862be354857609df1735335",
+            "size": 893757414,
+            "uncompressed-sha256": "2f32209aa2520df0a42d18f0868ca48acace7e6e343897166d7b024654c3721d",
+            "uncompressed-size": 3553624064
         },
         "metal4k": {
-            "path": "rhcos-46.82.202011260640-0-metal4k.x86_64.raw.gz",
-            "sha256": "ff4ed9d58a286185abdc4be0faaa4cd621c088121133b9b5952d2da320149fad",
-            "size": 886276538,
-            "uncompressed-sha256": "1e57d643969306e84b945c6355eed2793daa3e7675b0daa63defd6f5f8b5a43d",
-            "uncompressed-size": 3555721216
+            "path": "rhcos-46.82.202106161040-0-metal4k.x86_64.raw.gz",
+            "sha256": "77cfadac32c4e14bff08b283184b6d228a638c71a6d2ec97e6a345cacb69b5e5",
+            "size": 891501461,
+            "uncompressed-sha256": "f9cd709aafa6a07e1ca767986aa2d988db3bf4bcc881ce860bec083551ceba32",
+            "uncompressed-size": 3553624064
         },
         "openstack": {
-            "path": "rhcos-46.82.202011260640-0-openstack.x86_64.qcow2.gz",
-            "sha256": "a8a28cfe5f5e5dadedb3442afcb447f85bddf2e82dcd558813a985a4d495782a",
-            "size": 887473972,
-            "uncompressed-sha256": "2bd648e09f086973accd8ac1e355ce0fcd7dfcc16bc9708c938801fcf10e219e",
-            "uncompressed-size": 2254045184
+            "path": "rhcos-46.82.202106161040-0-openstack.x86_64.qcow2.gz",
+            "sha256": "f4fcfc72f9e460bfbe5749145c54ab94322761aa21c964db8102854ad6a8536e",
+            "size": 892526355,
+            "uncompressed-sha256": "50fc0be318647c009f4e568674ce9f889d18cccbb31b1b725657dc88381d031c",
+            "uncompressed-size": 2253324288
         },
         "ostree": {
-            "path": "rhcos-46.82.202011260640-0-ostree.x86_64.tar",
-            "sha256": "1b15017685292447ebb2dc8bfe8a4f216ea1c42f871f666c65d4b98e9998d549",
-            "size": 802641920
+            "path": "rhcos-46.82.202106161040-0-ostree.x86_64.tar",
+            "sha256": "e2700ec18b6174ab0bdf31ea8bfa8fc09cab5479c369379bea3c6fec97cf213e",
+            "size": 805836800
         },
         "qemu": {
-            "path": "rhcos-46.82.202011260640-0-qemu.x86_64.qcow2.gz",
-            "sha256": "0ea6f0852c3e0f8e4182e705561fdccd998503ef423c441e182241cd6a278730",
-            "size": 888353176,
-            "uncompressed-sha256": "99928ff40c2d8e3aa358d9bd453102e3d1b5e9694fb5d54febc56e275f35da51",
-            "uncompressed-size": 2290221056
+            "path": "rhcos-46.82.202106161040-0-qemu.x86_64.qcow2.gz",
+            "sha256": "063d40a27e5128f4131db25ecb53da47b2f72e1becb1df6278af23cecf821bc9",
+            "size": 893409738,
+            "uncompressed-sha256": "384d2258441e1287874fa8e6899bcd943311568055961db8960ea47980e970f1",
+            "uncompressed-size": 2289631232
         },
         "vmware": {
-            "path": "rhcos-46.82.202011260640-0-vmware.x86_64.ova",
-            "sha256": "d73c7bdfd22e5a1231e23663266744c98c10de6f08f6d1fc718e7f72d0490c4a",
-            "size": 919808000
+            "path": "rhcos-46.82.202106161040-0-vmware.x86_64.ova",
+            "sha256": "688ff47de3e31295d57331a729620bf1856abb6a45677edc596c3d3c0a9988b9",
+            "size": 924876800
         }
     },
     "oscontainer": {
-        "digest": "sha256:54f1ab852c6592d6ca453cabb855b5c9f5ced35b1aadbb5d8161d4ca2d3623cc",
+        "digest": "sha256:1be33942e6a8ecc0af87d846fa0148681368cce0021c9c73b56317e1742b1fd0",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "cb0327325553e6922ff25822ea7eb1a2ec213e70c7cf6880965e7e2bb5ee7dea",
-    "ostree-version": "46.82.202011260640-0"
+    "ostree-commit": "5afdb909b7bdfcadc4261cc428bd466c982ef195430443c51465e5198f8a6f72",
+    "ostree-version": "46.82.202106161040-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202011260639-0/ppc64le/",
-    "buildid": "46.82.202011260639-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202106162140-0/ppc64le/",
+    "buildid": "46.82.202106162140-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-46.82.202011260639-0-live-initramfs.ppc64le.img",
-            "sha256": "a63a99b3183d85d2772031ecb5d472c8f709dd55609a27b3f158938b9d34d798"
+            "path": "rhcos-46.82.202106162140-0-live-initramfs.ppc64le.img",
+            "sha256": "254d63283b2d8a15fea0855da7f85189107e19d02fc616f37965d7c37fd65acf"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202011260639-0-live.ppc64le.iso",
-            "sha256": "a1de1afef9d7d624b8b982c5b940ac05dfd50160ea028d71098a72ce02a95310"
+            "path": "rhcos-46.82.202106162140-0-live.ppc64le.iso",
+            "sha256": "44a5394fcd4bedb9f1c7865e6bdd35019738df729b86e22bd9c4b04556ed6399"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202011260639-0-live-kernel-ppc64le",
-            "sha256": "4f33503357e6847d5ddba97d7f3ee0773cbc1046b4121e15f7233eccade092f7"
+            "path": "rhcos-46.82.202106162140-0-live-kernel-ppc64le",
+            "sha256": "7ec5ad9a7acc2cf00da926ffe79bbd8db27d65bef0bde87bde2aa30129a59215"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202011260639-0-live-rootfs.ppc64le.img",
-            "sha256": "ec0af7540cb6d7266424874bd5aec0ac60183f94b3da9e30ad2911492981efcd"
+            "path": "rhcos-46.82.202106162140-0-live-rootfs.ppc64le.img",
+            "sha256": "4b5a813501a3387018c88e38ed8dd2df4b0dfc38ad31c395bd6246e4505c345b"
         },
         "metal": {
-            "path": "rhcos-46.82.202011260639-0-metal.ppc64le.raw.gz",
-            "sha256": "99fc11c699403ccf26610954b27dbbae94a0831a4c39a5c498f808e43cfbdb70",
-            "size": 873495765,
-            "uncompressed-sha256": "e72a39b888c44bd5b7fc276b7a23ae7e8a9facd53abbf59301419dfc4dcd0d46",
-            "uncompressed-size": 3725590528
+            "path": "rhcos-46.82.202106162140-0-metal.ppc64le.raw.gz",
+            "sha256": "048915ace8ad696e2b3a938dfa8ce85513cd477fb54483b47ff64ce0b44e639b",
+            "size": 874719384,
+            "uncompressed-sha256": "5d8473480cb70877b4b786b194dfc66f985827020799f90b4da030d74751f07c",
+            "uncompressed-size": 3717201920
         },
         "metal4k": {
-            "path": "rhcos-46.82.202011260639-0-metal4k.ppc64le.raw.gz",
-            "sha256": "ce17fd2bc612fee6ea5d99895fc6a3f3aaa2b8a1f7bdc05fddf7e3e1acea3f77",
-            "size": 873975134,
-            "uncompressed-sha256": "a04c711706cc15ee90f5e8143d01e6616e6556e7510d168464e16de7f3f66556",
-            "uncompressed-size": 3725590528
+            "path": "rhcos-46.82.202106162140-0-metal4k.ppc64le.raw.gz",
+            "sha256": "8fdd7adbd477f66d1ee4fdc4c742c4e938140e379fb219ed629d1db8cd9070f1",
+            "size": 874326345,
+            "uncompressed-sha256": "c04fe81748d0eef77b6cc56c53834e45f3690904b57859cef95dada0c7b1d5c6",
+            "uncompressed-size": 3717201920
         },
         "openstack": {
-            "path": "rhcos-46.82.202011260639-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "2a7fea1b87a0878363aefc97d0834d6bdf9b80f9ff5696d33bb22938e1102924",
-            "size": 871975342,
-            "uncompressed-sha256": "d4055dee26ddc5ba04fc9e788807238843754f83bb959e0c6bc3ed173b960394",
-            "uncompressed-size": 2387279872
+            "path": "rhcos-46.82.202106162140-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "1bfd371b8e560cbab2319506abd4a20ed5ae63195676d530bfe11df49186ae56",
+            "size": 872726330,
+            "uncompressed-sha256": "0e58c05631c4dd252e0e8474821e197449b7d7a47aadabb0af8a9e93d42dbc29",
+            "uncompressed-size": 2380464128
         },
         "ostree": {
-            "path": "rhcos-46.82.202011260639-0-ostree.ppc64le.tar",
-            "sha256": "2454454574b96b75d2a8aef8b1cad393c79558aa66cc1cee5093688c8b3224e6",
-            "size": 784117760
+            "path": "rhcos-46.82.202106162140-0-ostree.ppc64le.tar",
+            "sha256": "d1651368778cca42549b027aa473cce653f7bc0ae8bf86ce2b292e559297963e",
+            "size": 783933440
         },
         "qemu": {
-            "path": "rhcos-46.82.202011260639-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "bb9611f2d988088fa6dc1d9082f43b719f16f4c84aad669674ada0a59699c288",
-            "size": 872555277,
-            "uncompressed-sha256": "08879b33ac4d46e04824735e283b549b9f03daae150dffb7fd3265d8c5d2d598",
-            "uncompressed-size": 2424307712
+            "path": "rhcos-46.82.202106162140-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "9fd5ca7c72a766d703f5c3604f1f8f1be4480a97dbc9dd9b0e83d4ca8ea82cde",
+            "size": 873312356,
+            "uncompressed-sha256": "ecce897a7f6234de29d8c04cf0b4208f739c2193d16e5080fd73af9bc46cd9cf",
+            "uncompressed-size": 2417950720
         }
     },
     "oscontainer": {
-        "digest": "sha256:af789c7d73b7de9136cc734f05164c692b0b27c738ecedd0f8bd970a182d2848",
+        "digest": "sha256:e8405ec7fbf7cd46a9dabdfc50da0b91032112152bb4d250cb1d24dcf13af62b",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "e11b8d8ca1ab07c8428158fce6c14b6adcaf819cf7353e7a17ac99451bdd5dbf",
-    "ostree-version": "46.82.202011260639-0"
+    "ostree-commit": "ca345325c80c10aa31c18e274bada4a9b9fb6f097be2eea00baac930fb26129c",
+    "ostree-version": "46.82.202106162140-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202011261339-0/s390x/",
-    "buildid": "46.82.202011261339-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202106161139-0/s390x/",
+    "buildid": "46.82.202106161139-0",
     "images": {
         "dasd": {
-            "path": "rhcos-46.82.202011261339-0-dasd.s390x.raw.gz",
-            "sha256": "6f9b92054667c84dec33dfd724444b74d0e3d241c7e7e2b9583165918114e22d",
-            "size": 788978205,
-            "uncompressed-sha256": "0c6627eb4dbc25cfa16e8ba6ef4975d580e403929a2450b05e69477b97111744",
-            "uncompressed-size": 3370123264
+            "path": "rhcos-46.82.202106161139-0-dasd.s390x.raw.gz",
+            "sha256": "a56b117c0915de7dd29f9e976db7f8d0b1457e5a38011468f1be5cb5015c4b59",
+            "size": 789078630,
+            "uncompressed-sha256": "d7874c77e6a10f69eb89dcfad5c0fc581a03f3718655b6f3693cd3c6b596d600",
+            "uncompressed-size": 3362783232
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202011261339-0-live-initramfs.s390x.img",
-            "sha256": "ca544ccce11a9d43b4478c9e6193faf77c6ed8f9996fb58d110fc3a9ec0db471"
+            "path": "rhcos-46.82.202106161139-0-live-initramfs.s390x.img",
+            "sha256": "1b27f8d6f8235c7f5d6109773b00a3e9d3694f782278f1cbd5788c77928ce48e"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202011261339-0-live.s390x.iso",
-            "sha256": "75c7ab592f4a64c844f1bb2486586f5baabed7a791341d9def5246ab8363f92f"
+            "path": "rhcos-46.82.202106161139-0-live.s390x.iso",
+            "sha256": "f3942d6e10483afc69d5931c41e613cc0069c87be5987ae2feeed8d42fb8074a"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202011261339-0-live-kernel-s390x",
-            "sha256": "54d180071776bb989163897079c2652b0c7106f9c41d7187de4d015204aae8c4"
+            "path": "rhcos-46.82.202106161139-0-live-kernel-s390x",
+            "sha256": "c7b6e51a50f66519f937e4837f8403d23dcb4b815bfadf5d24194e7858cc0ece"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202011261339-0-live-rootfs.s390x.img",
-            "sha256": "7e9bfea2c4f76c51540e49413ff5d79290905c18745561183c736309ede3d6bb"
+            "path": "rhcos-46.82.202106161139-0-live-rootfs.s390x.img",
+            "sha256": "cc2966ac4758eb4d97d4d48ffa63c0fd9d65cea633abd375145ca6ccfe43ae29"
         },
         "metal": {
-            "path": "rhcos-46.82.202011261339-0-metal.s390x.raw.gz",
-            "sha256": "70a7f86de36e25883a92956de73db8dc68b51e5881804984868eebf103fac0c9",
-            "size": 788865133,
-            "uncompressed-sha256": "b66d9b48b8d92df4da71296f2eb5fec9cee25b3c36e3a066ceb685c16c889b8e",
-            "uncompressed-size": 3370123264
+            "path": "rhcos-46.82.202106161139-0-metal.s390x.raw.gz",
+            "sha256": "5c3959001f6e1f279f0bfb3458236b64f02ad60048a4b8c9aa6f79d133ee8196",
+            "size": 789054386,
+            "uncompressed-sha256": "6598f460340eb13f934007fe945d85b2f1ed0e7a321ccecbcfee24c632a21f41",
+            "uncompressed-size": 3362783232
         },
         "metal4k": {
-            "path": "rhcos-46.82.202011261339-0-metal4k.s390x.raw.gz",
-            "sha256": "38dabda95ea6c5ed25edaf7b3daa1e844ab4eeaab94623ca407b0b03eb97e5f8",
-            "size": 788950764,
-            "uncompressed-sha256": "6acc28b0f1c40cb6ee653534def9267a20f2043c8091c3e94478409a424ebe68",
-            "uncompressed-size": 3370123264
+            "path": "rhcos-46.82.202106161139-0-metal4k.s390x.raw.gz",
+            "sha256": "ec4cf4c1a6866945776dd4f7cf017488e636113385ff894026307a592ca45299",
+            "size": 789271175,
+            "uncompressed-sha256": "c15631952dc8ea1d1e7d5db425275e81e5dfe3f3e277c9c70c32ced623737d73",
+            "uncompressed-size": 3362783232
         },
         "openstack": {
-            "path": "rhcos-46.82.202011261339-0-openstack.s390x.qcow2.gz",
-            "sha256": "5877ecaf2fda46399260a6b410dda2493a842c92629666dff0bddd4bba5d4265",
-            "size": 787779116,
-            "uncompressed-sha256": "debc4c4bce89ee388de8ae20ad5f3f6f84a51b60d5341380651c661ee86df597",
-            "uncompressed-size": 2084765696
+            "path": "rhcos-46.82.202106161139-0-openstack.s390x.qcow2.gz",
+            "sha256": "ef03660e939b560445ead1187e909412b886cc4c06260e14c621bc6cf771bb3a",
+            "size": 787999387,
+            "uncompressed-sha256": "396295041573b0f8c0314106bf65e6c14eebd21458ec9403e246a399d28312d3",
+            "uncompressed-size": 2079391744
         },
         "ostree": {
-            "path": "rhcos-46.82.202011261339-0-ostree.s390x.tar",
-            "sha256": "64bdf909a35f8f039a3cb6df9a2c2ef942f36309f701c143031cb111816c332a",
-            "size": 725104640
+            "path": "rhcos-46.82.202106161139-0-ostree.s390x.tar",
+            "sha256": "f8e8eb9af95de532d4843ee3bb5e646275ff56a7b51405da835ffca2707138fc",
+            "size": 724736000
         },
         "qemu": {
-            "path": "rhcos-46.82.202011261339-0-qemu.s390x.qcow2.gz",
-            "sha256": "a487fa710176c5540f94fa145e6dc47c5d554594a84da917d22c35c46d782125",
-            "size": 788427226,
-            "uncompressed-sha256": "4f874dd740fe639c37319d78af6100eaa55023cfab081c1e1db55b65d60a3b0f",
-            "uncompressed-size": 2120679424
+            "path": "rhcos-46.82.202106161139-0-qemu.s390x.qcow2.gz",
+            "sha256": "c0ea1650b7a15c52c1cd1f4f50e0ed48aa75f7491244b2ac50e56fe3831be236",
+            "size": 788704580,
+            "uncompressed-sha256": "0f722f27e7b8691b2fc061442433f79a7e4b2a8739ac525bc816374327d14b5c",
+            "uncompressed-size": 2115567616
         }
     },
     "oscontainer": {
-        "digest": "sha256:8247d9e6ce2ca2d081df2d7dc53304f69d17cd09e313c8af393bed7704f289a9",
+        "digest": "sha256:d363b059dd212bcb8b9728cfaf1dca1ea6a77a774719b9d05e94bb8b2eec0a51",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "6dd3045c4e2fad3cf4d15a43116a522cf7686accbd548839783795b74d6f7cb7",
-    "ostree-version": "46.82.202011261339-0"
+    "ostree-commit": "9be96131d492b59660842356b70034acc5197fd68ce0f93f1694fdf8641a425d",
+    "ostree-version": "46.82.202106161139-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,156 +1,159 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-09921c9c1c36e695c"
+            "hvm": "ami-0cb7096c55762208e"
         },
         "ap-east-1": {
-            "hvm": "ami-01ee8446e9af6b197"
+            "hvm": "ami-021682e27bec1ee87"
         },
         "ap-northeast-1": {
-            "hvm": "ami-04e5b5722a55846ea"
+            "hvm": "ami-038d6133bf9ddee00"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0fdc25c8a0273a742"
+            "hvm": "ami-0a485021689fe2eb9"
+        },
+        "ap-northeast-3": {
+            "hvm": "ami-020e0d8666f0d3170"
         },
         "ap-south-1": {
-            "hvm": "ami-09e3deb397cc526a8"
+            "hvm": "ami-02fd44354bcde25a3"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0630e03f75e02eec4"
+            "hvm": "ami-0557e6167fe242389"
         },
         "ap-southeast-2": {
-            "hvm": "ami-069450613262ba03c"
+            "hvm": "ami-008f040a1fc38209d"
         },
         "ca-central-1": {
-            "hvm": "ami-012518cdbd3057dfd"
+            "hvm": "ami-082f532e52293d463"
         },
         "eu-central-1": {
-            "hvm": "ami-0bd7175ff5b1aef0c"
+            "hvm": "ami-0b623fd02ca4775a5"
         },
         "eu-north-1": {
-            "hvm": "ami-06c9ec42d0a839ad2"
+            "hvm": "ami-0af74b0d36637f646"
         },
         "eu-south-1": {
-            "hvm": "ami-0614d7440a0363d71"
+            "hvm": "ami-0e19c0d9263db9ff5"
         },
         "eu-west-1": {
-            "hvm": "ami-01b89df58b5d4d5fa"
+            "hvm": "ami-0b97f7bd61c1ecd0b"
         },
         "eu-west-2": {
-            "hvm": "ami-06f6e31ddd554f89d"
+            "hvm": "ami-01b6f3e8f0ad9054d"
         },
         "eu-west-3": {
-            "hvm": "ami-0dc82e2517ded15a1"
+            "hvm": "ami-07dea9de166255375"
         },
         "me-south-1": {
-            "hvm": "ami-07d181e3aa0f76067"
+            "hvm": "ami-014f667835c573656"
         },
         "sa-east-1": {
-            "hvm": "ami-0cd44e6dd20e6c7fa"
+            "hvm": "ami-0577fc850f1ebce4c"
         },
         "us-east-1": {
-            "hvm": "ami-04a16d506e5b0e246"
+            "hvm": "ami-0475651470951812f"
         },
         "us-east-2": {
-            "hvm": "ami-0a1f868ad58ea59a7"
+            "hvm": "ami-03696639de42a5d18"
         },
         "us-west-1": {
-            "hvm": "ami-0a65d76e3a6f6622f"
+            "hvm": "ami-0694c5c7d6b0bb63d"
         },
         "us-west-2": {
-            "hvm": "ami-0dd9008abadc519f1"
+            "hvm": "ami-06246178752716deb"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202011260640-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202011260640-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202106161040-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202106161040-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202011260640-0/x86_64/",
-    "buildid": "46.82.202011260640-0",
+    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202106161040-0/x86_64/",
+    "buildid": "46.82.202106161040-0",
     "gcp": {
-        "image": "rhcos-46-82-202011260640-0-gcp-x86-64",
+        "image": "rhcos-46-82-202106161040-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202011260640-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202106161040-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202011260640-0-aws.x86_64.vmdk.gz",
-            "sha256": "6e0f720077ac20fae46c16159d03fd51f66cd318155dcd14f0f5d7dc79bfd8ad",
-            "size": 900764628,
-            "uncompressed-sha256": "b38713b80bbcc41d18efcec93d241da48533225e0ce073c2a26235993ffc4166",
-            "uncompressed-size": 919795200
+            "path": "rhcos-46.82.202106161040-0-aws.x86_64.vmdk.gz",
+            "sha256": "943f4302a685a4fad8867660893ee777e91b386d4d335ec560bbadcf6a8c6ee0",
+            "size": 905821025,
+            "uncompressed-sha256": "02294545395fa1c5d5507ce6255ef3272df4841628741a1e7114f04630cfc928",
+            "uncompressed-size": 924866048
         },
         "azure": {
-            "path": "rhcos-46.82.202011260640-0-azure.x86_64.vhd.gz",
-            "sha256": "5255c675ecff4f8932db24b68a7ef451dfc4e502326128931ccd39acf27c6c77",
-            "size": 901953565,
-            "uncompressed-sha256": "0fd7ab096c7ac4b8d807371d1c4a13b3a665b5d2938ff814bd3e46257193941b",
+            "path": "rhcos-46.82.202106161040-0-azure.x86_64.vhd.gz",
+            "sha256": "b055fa9617ce10c8a5091f248927e62bfb1f050449078d80ecbc85f27a4c9c53",
+            "size": 907035912,
+            "uncompressed-sha256": "fa58c5bc8f796d8ff900cc731a0e0fa4c568bc7088d4ceb70eaf42549cffa7ec",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202011260640-0-gcp.x86_64.tar.gz",
-            "sha256": "f470a98c1fc7a4e0226ed4258fdd0b6edcddbb2356e7992bea4b98843cd94d9a",
-            "size": 887140241
+            "path": "rhcos-46.82.202106161040-0-gcp.x86_64.tar.gz",
+            "sha256": "aa91df7de250d007dd42e70f3270647a509592b78b29dd0f993ac8c911fd3dfb",
+            "size": 892218739
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202011260640-0-live-initramfs.x86_64.img",
-            "sha256": "8ff220c6f4bbca35dd071c5f1802566290b70081faeb06fb07f72c4583f8facf"
+            "path": "rhcos-46.82.202106161040-0-live-initramfs.x86_64.img",
+            "sha256": "652d93ed9d0d7ec2033d3a78f790c81241d80e7203bfcb882190df7e2925780e"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202011260640-0-live.x86_64.iso",
-            "sha256": "161046d6275cda89a3f44582bc2b850cd09b987807d3b20090eeab279b7e0550"
+            "path": "rhcos-46.82.202106161040-0-live.x86_64.iso",
+            "sha256": "5b41a7d5df9e986731fef49df8d197a8e6add79d1bf8c11f8457a98f676c6daa"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202011260640-0-live-kernel-x86_64",
-            "sha256": "9bbb496410c04f54d30eb56f76f769bccec7e81b91271ae72261ecc54db9c63d"
+            "path": "rhcos-46.82.202106161040-0-live-kernel-x86_64",
+            "sha256": "0c70a2d1d0b1a7be3b06e38a667c8589918105f0294bc4a032f04d0ce9a23d2a"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202011260640-0-live-rootfs.x86_64.img",
-            "sha256": "007f9c376e1282b77ed662509a3a81b624dfcf28aa971a9e80b33fc06cf9c4fd"
+            "path": "rhcos-46.82.202106161040-0-live-rootfs.x86_64.img",
+            "sha256": "659972e40eaeec853011350c4ffa56aeb8c7591838a9bd19cd7c52307e09baf2"
         },
         "metal": {
-            "path": "rhcos-46.82.202011260640-0-metal.x86_64.raw.gz",
-            "sha256": "bcd9871c373c02898675ec407e83f9ccd107077ff30008ecb601c9869c4a501a",
-            "size": 888607273,
-            "uncompressed-sha256": "a769991d850064ef078ba4dae9050e34a820bf9eba792a2b7922fb7a15315b57",
-            "uncompressed-size": 3555721216
+            "path": "rhcos-46.82.202106161040-0-metal.x86_64.raw.gz",
+            "sha256": "3b9d00f121231dc8ea666f6d1270382c67d71cf04862be354857609df1735335",
+            "size": 893757414,
+            "uncompressed-sha256": "2f32209aa2520df0a42d18f0868ca48acace7e6e343897166d7b024654c3721d",
+            "uncompressed-size": 3553624064
         },
         "metal4k": {
-            "path": "rhcos-46.82.202011260640-0-metal4k.x86_64.raw.gz",
-            "sha256": "ff4ed9d58a286185abdc4be0faaa4cd621c088121133b9b5952d2da320149fad",
-            "size": 886276538,
-            "uncompressed-sha256": "1e57d643969306e84b945c6355eed2793daa3e7675b0daa63defd6f5f8b5a43d",
-            "uncompressed-size": 3555721216
+            "path": "rhcos-46.82.202106161040-0-metal4k.x86_64.raw.gz",
+            "sha256": "77cfadac32c4e14bff08b283184b6d228a638c71a6d2ec97e6a345cacb69b5e5",
+            "size": 891501461,
+            "uncompressed-sha256": "f9cd709aafa6a07e1ca767986aa2d988db3bf4bcc881ce860bec083551ceba32",
+            "uncompressed-size": 3553624064
         },
         "openstack": {
-            "path": "rhcos-46.82.202011260640-0-openstack.x86_64.qcow2.gz",
-            "sha256": "a8a28cfe5f5e5dadedb3442afcb447f85bddf2e82dcd558813a985a4d495782a",
-            "size": 887473972,
-            "uncompressed-sha256": "2bd648e09f086973accd8ac1e355ce0fcd7dfcc16bc9708c938801fcf10e219e",
-            "uncompressed-size": 2254045184
+            "path": "rhcos-46.82.202106161040-0-openstack.x86_64.qcow2.gz",
+            "sha256": "f4fcfc72f9e460bfbe5749145c54ab94322761aa21c964db8102854ad6a8536e",
+            "size": 892526355,
+            "uncompressed-sha256": "50fc0be318647c009f4e568674ce9f889d18cccbb31b1b725657dc88381d031c",
+            "uncompressed-size": 2253324288
         },
         "ostree": {
-            "path": "rhcos-46.82.202011260640-0-ostree.x86_64.tar",
-            "sha256": "1b15017685292447ebb2dc8bfe8a4f216ea1c42f871f666c65d4b98e9998d549",
-            "size": 802641920
+            "path": "rhcos-46.82.202106161040-0-ostree.x86_64.tar",
+            "sha256": "e2700ec18b6174ab0bdf31ea8bfa8fc09cab5479c369379bea3c6fec97cf213e",
+            "size": 805836800
         },
         "qemu": {
-            "path": "rhcos-46.82.202011260640-0-qemu.x86_64.qcow2.gz",
-            "sha256": "0ea6f0852c3e0f8e4182e705561fdccd998503ef423c441e182241cd6a278730",
-            "size": 888353176,
-            "uncompressed-sha256": "99928ff40c2d8e3aa358d9bd453102e3d1b5e9694fb5d54febc56e275f35da51",
-            "uncompressed-size": 2290221056
+            "path": "rhcos-46.82.202106161040-0-qemu.x86_64.qcow2.gz",
+            "sha256": "063d40a27e5128f4131db25ecb53da47b2f72e1becb1df6278af23cecf821bc9",
+            "size": 893409738,
+            "uncompressed-sha256": "384d2258441e1287874fa8e6899bcd943311568055961db8960ea47980e970f1",
+            "uncompressed-size": 2289631232
         },
         "vmware": {
-            "path": "rhcos-46.82.202011260640-0-vmware.x86_64.ova",
-            "sha256": "d73c7bdfd22e5a1231e23663266744c98c10de6f08f6d1fc718e7f72d0490c4a",
-            "size": 919808000
+            "path": "rhcos-46.82.202106161040-0-vmware.x86_64.ova",
+            "sha256": "688ff47de3e31295d57331a729620bf1856abb6a45677edc596c3d3c0a9988b9",
+            "size": 924876800
         }
     },
     "oscontainer": {
-        "digest": "sha256:54f1ab852c6592d6ca453cabb855b5c9f5ced35b1aadbb5d8161d4ca2d3623cc",
+        "digest": "sha256:1be33942e6a8ecc0af87d846fa0148681368cce0021c9c73b56317e1742b1fd0",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "cb0327325553e6922ff25822ea7eb1a2ec213e70c7cf6880965e7e2bb5ee7dea",
-    "ostree-version": "46.82.202011260640-0"
+    "ostree-commit": "5afdb909b7bdfcadc4261cc428bd466c982ef195430443c51465e5198f8a6f72",
+    "ostree-version": "46.82.202106161040-0"
 }

--- a/pkg/rhcos/ami_regions.go
+++ b/pkg/rhcos/ami_regions.go
@@ -8,6 +8,7 @@ var AMIRegions = []string{
 	"ap-east-1",
 	"ap-northeast-1",
 	"ap-northeast-2",
+	"ap-northeast-3",
 	"ap-south-1",
 	"ap-southeast-1",
 	"ap-southeast-2",


### PR DESCRIPTION
This boot image bump for RHCOS 4.6 fixes the following BZs:

1956491 - CVE-2021-3114 ignition: golang: crypto/elliptic: incorrect operations on the P-224 curve
1960750 - RHCOS PXE deployment script coreos-livepxe-rootfs randomly fails to download and verify the image with bonding LACP active-active

Additionally, this includes the AMI published to the ap-northeast-3
(Osaka) region.

46.82.202106161040-0 amd64
46.82.202106162140-0 ppc64le
46.82.202106161139-0 s390x