### PR TITLE
update Packet UPI for Equinix Metal rename

### DIFF
--- a/docs/user/metal/install_upi.md
+++ b/docs/user/metal/install_upi.md
@@ -1,5 +1,7 @@
 # Install: BareMetal User Provided Infrastructure
 
+The upstream project that provides management of bare metal hosts is [metal.equinix.com][equinix-metal].
+
 The steps for performing a UPI-based install are outlined here. Several [Terraform][upi-metal-example] templates are provided as an example to help model your own.
 
 ## Table of contents
@@ -224,11 +226,11 @@ INFO Waiting up to 30m0s for the cluster to initialize...
 
 ## Example Bare-Metal UPI deployment
 
-Terraform [templates][upi-metal-example] provides an example of using OpenShift Installer to create an bare-metal UPI OpenShift cluster on Packet.net
+Terraform [templates][upi-metal-example] provides an example of using OpenShift Installer to create an bare-metal UPI OpenShift cluster on [Equinix Metal][equinix-metal].
 
 ### Overview
 
-* Compute: Uses Packet.net to deploy bare-metal machines.
+* Compute: Uses [Equinix Metal][equinix-metal] to deploy bare-metal machines.
     Uses [matchbox] to serve PXE scripts and Ignition configs for bootstrap, control plane and worker machines.
     Uses `public` IPv4 addresses for each machine, so that all the machines are accessible on the internet.
 
@@ -274,7 +276,7 @@ Use the bootstrap [monitoring](#monitor-for-bootstrap-complete) to track when cl
 terraform apply -auto-approve -var=bootstrap_dns="false"
 ```
 
-NOTE: The bootstrap resources like the bootstrap machines currently cannot be removed using terraform. You can use the Packet.net console to remove the bootstrap machine. All the resources will be cleaned up by `terraform destroy`
+NOTE: The bootstrap resources like the bootstrap machines currently cannot be removed using terraform. You can use the [Equinix Metal console][equinix-metal-console] to remove the bootstrap machine. All the resources will be cleaned up by `terraform destroy`
 
 ### Approving server certificates for nodes
 
@@ -312,6 +314,8 @@ terraform destroy -auto-approve
 [coreos-installer-args]: https://github.com/coreos/coreos-installer#kernel-command-line-options-for-coreos-installer-running-in-the-initramfs
 [coreos-installer]: https://github.com/coreos/coreos-installer#coreos-installer
 [csr-requests]: https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/#requesting-a-certificate
+[equinix-metal]: https://metal.equinix.com
+[equinix-metal-console]: https://console.equinix.com
 [etcd-ports]: https://github.com/openshift/origin/pull/21520
 [machine-config-server]: https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfigServer.md
 [matchbox]: https://github.com/coreos/matchbox

--- a/upi/metal/README.md
+++ b/upi/metal/README.md
@@ -1,4 +1,4 @@
-# UPI Bare Metal
+# Equinix Metal UPI
 
 ## Pre-requisites
 
@@ -14,13 +14,19 @@ Create a public route53 zone using this [guide][aws-create-public-route53-zone].
 
 Setup `default` AWS cli profile on the host that will run the example terraform scripts using this [guide][aws-cli-configure-creds]
 
-### Packet
+### Equinix Metal
 
-Setup a Project in Packet.net that will be used to deploy servers, for example using this [guide][packet-deploy-server]
+Some portions of this guide refer to "Packet" variables and tools. [Packet was
+acquired by Equinix][acquisition] and the features became available as [Equinix
+Metal][introducing-equinix-metal] in 2020.
 
-Setup API keys for your Project in Packet.net using this [guide][packet-api-keys]
+Setup a Project in [Equinix Metal][equinix-metal] that will be used to deploy servers, for example using this [guide][metal-deploy-server].
 
-Store the API keys in `PACKET_AUTH_TOKEN` so that `terraform-provide-packet` can use it to deploy servers in the project. For more info see [this][terraform-provider-packet-auth]
+Setup API keys for your project in Equinix Metal using this [guide][metal-api-keys]
+
+Store the API keys in `PACKET_AUTH_TOKEN` so that `terraform-provider-packet`
+can use it to deploy servers in the project. For more info see
+[this][terraform-provider-packet-auth]
 
 #### Terraform
 
@@ -43,8 +49,11 @@ terraform-examples config.tf > terraform.tfvars.example
 [aws-cli-configure-creds]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 [aws-create-public-route53-zone]: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/CreatingHostedZone.html
 [coreos-matchbox-getting-started]: https://matchbox.psdn.io/getting-started/
-[packet-api-keys]: https://www.packet.com/developers/changelog/project-only-api-keys/
-[packet-deploy-server]: https://support.packet.com/kb/articles/deploy-a-server
+[metal-api-keys]: https://metal.equinix.com/developers/docs/accounts/users/#api-keys
+[metal-deploy-server]: https://metal.equinix.com/developers/docs/deploy/on-demand/
 [terraform-examples]: https://github.com/s-urbaniak/terraform-examples#terraform-examples
 [terraform-getting-started]: https://learn.hashicorp.com/terraform/getting-started/install.html
-[terraform-provider-packet-auth]: https://www.terraform.io/docs/providers/packet/index.html#auth_token
+[terraform-provider-packet-auth]: https://registry.terraform.io/providers/packethost/packet/latest/docs#auth_token
+[acquisition]: https://www.equinix.com/newsroom/press-releases/2020/03/equinix-completes-acquisition-of-bare-metal-leader-packet
+[introducing-equinix-metal]: https://blog.equinix.com/blog/2020/10/06/equinix-metal-metal-and-more/
+[equinix-metal]: https://metal.equinix.com


### PR DESCRIPTION
This is a documentation update for the Equinix Metal UPI (based on the Packet terraform provider). This PR only updates the text and links in the relevant README.md and install_upi.md.