### PR TITLE
BZ 1975475: aws: move creation of bootstrap instance profile to cluster stage

### DIFF
--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -25,3 +25,7 @@ variable "master_sg_id" {
 variable "ami_id" {
   type = string
 }
+
+variable "bootstrap_instance_profile_name" {
+  type = string
+}

--- a/data/data/aws/cluster/iam/outputs.tf
+++ b/data/data/aws/cluster/iam/outputs.tf
@@ -1,0 +1,3 @@
+output "bootstrap_instance_profile_name" {
+  value = var.include_bootstrap ? aws_iam_instance_profile.bootstrap[0].name : ""
+}

--- a/data/data/aws/cluster/iam/variables.tf
+++ b/data/data/aws/cluster/iam/variables.tf
@@ -12,3 +12,13 @@ variable "worker_iam_role_name" {
   type        = string
   description = "The name of the existing role to use for the instance profile for workers"
 }
+
+variable "master_iam_role_name" {
+  type        = string
+  description = "The name of the existing role to use for the instance profile for masters"
+}
+
+variable "include_bootstrap" {
+  type        = bool
+  description = "True if the bootstrap instance profile should be reified"
+}

--- a/data/data/aws/cluster/main.tf
+++ b/data/data/aws/cluster/main.tf
@@ -52,7 +52,9 @@ module "iam" {
   source = "./iam"
 
   cluster_id           = var.cluster_id
+  master_iam_role_name = var.aws_master_iam_role_name
   worker_iam_role_name = var.aws_worker_iam_role_name
+  include_bootstrap    = !var.destroy_bootstrap
 
   tags = local.tags
 }

--- a/data/data/aws/cluster/outputs.tf
+++ b/data/data/aws/cluster/outputs.tf
@@ -29,3 +29,7 @@ output "master_sg_id" {
 output "ami_id" {
   value = var.aws_region == var.aws_ami_region ? var.aws_ami : aws_ami_copy.imported[0].id
 }
+
+output "bootstrap_instance_profile_name" {
+  value = module.iam.bootstrap_instance_profile_name
+}

--- a/data/data/aws/cluster/variables.tf
+++ b/data/data/aws/cluster/variables.tf
@@ -1,0 +1,5 @@
+variable "destroy_bootstrap" {
+  type        = bool
+  default     = false
+  description = "true if the bootstrap resources should be destroyed"
+}

--- a/pkg/terraform/stages/aws/stages.go
+++ b/pkg/terraform/stages/aws/stages.go
@@ -1,12 +1,20 @@
 package aws
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/stages"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
 )
 
 // PlatformStages are the stages to run to provision the infrastructure in AWS.
 var PlatformStages = []terraform.Stage{
-	stages.NewStage("aws", "cluster"),
+	stages.NewStage("aws", "cluster", stages.WithCustomDestroy(destroyBootstrapInstanceProfile)),
 	stages.NewStage("aws", "bootstrap", stages.WithNormalDestroy()),
+}
+
+func destroyBootstrapInstanceProfile(s stages.SplitStage, directory string, extraArgs []string) error {
+	_, err := terraform.Apply(directory, awstypes.Name, s, append(extraArgs, "-var=destroy_bootstrap=true")...)
+	return errors.Wrap(err, "failed destroying bootstrap instance profile")
 }


### PR DESCRIPTION
When the bootstrap instance profile is created just before the bootstrap instance is created, then the RunInstance call will return an invalid value error for a little while. The terraform provider waits up to 2 minutes for this to resolve, which is does in that time. However, the terraform provider can, and frequently does, lose a response to a subsequent RunInstance. When this happens the terraform provider does not re-attempt the RunInstance request and instead sits idly waiting for the 2-minute timeout to elapse.

To combat this, we move the creation of the bootstrap instance profile to the cluster stage. This will create a delay between when the instance profile is created and when the instance is created. This is due to the instance profile being created early in the stage and there being a long delay while waiting for other resources in the stage to be created.