### PR TITLE
Bug 1975475: aws: block creation of bootstrap instance until ignition config is uploaded

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -170,6 +170,8 @@ resource "aws_instance" "bootstrap" {
     },
     local.tags,
   )
+
+  depends_on = [aws_s3_bucket_object.ignition]
 }
 
 resource "aws_lb_target_group_attachment" "bootstrap" {


### PR DESCRIPTION
Give the bootstrap instance a dependency on the creation of the s3 bucket object holding the bootstrap's ignition config. The bootstrap instance requires the ignition config in order to complete its creation. It takes around 2 minutes to create the bucket object, and the instance creation has a 2-minute timeout. Consequently, there are times when the bootstrap fails to complete in time because the creation of the bucket object took too long.