### PR TITLE
.yamllint: ignore cluster-networkconfig-crd.yaml

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -15,3 +15,4 @@ rules:
 ignore: |
   vendor/
   data/data/install.openshift.io_installconfigs.yaml
+  data/data/manifests/openshift/cluster-networkconfig-crd.yaml


### PR DESCRIPTION
data/data/manifests/openshift/cluster-networkconfig-crd.yaml is a
symlink to a vendored file. yamllint should ignored vendored files. I
don't see a generic way to ignore symlinks based on their targets, so
I'm adding this explicit path.