### PR TITLE
Fix sanity check image metadata arches match error

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
@@ -28,6 +28,7 @@ do
 done
 
 # Sanity check the image metadata to see if the arches match
+record_service_stage_start "image-metadata-arches-match"
 image_arch=$(podman inspect $RELEASE_IMAGE --format {{ "{{.Architecture}}" }})
 host_arch=$(uname -m)
 case $host_arch in
@@ -39,4 +40,6 @@ if [[ "$image_arch" != "$host_arch" ]]; then
     record_service_stage_failure
     echo "ERROR: release image arch $image_arch does not match host arch $host_arch"
     exit 1
+else
+    record_service_stage_success
 fi


### PR DESCRIPTION
If the wrong image is specified for a different architecture, then the following is observed:
```
systemd[1]: Starting Download the OpenShift Release Image...
release-image-download.sh[1392]: Pulling registry.ci.openshift.org/origin/release:4.8...
release-image-download.sh[1392]: d4d56de3fdd878f8c61032e6cb8fcc1fef03a28073b574ff7f1a6dbfb02f7359
release-image-download.sh[1392]: attempt to record the end of a stage without starting one
systemd[1]: release-image.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: release-image.service: Failed with result 'exit-code'.
systemd[1]: Failed to start Download the OpenShift Release Image.
systemd[1]: Dependency failed for Bootstrap a Kubernetes cluster.
systemd[1]: bootkube.service: Job bootkube.service/start failed with result 'dependency'.
```

Which is very misleading when the underlying error is

```
++ podman inspect registry.ci.openshift.org/origin/release:4.8 --format '{{.Architecture}}'
+ image_arch=amd64
++ uname -m
+ host_arch=ppc64le
+ case $host_arch in
+ [[ amd64 != \p\p\c\6\4\l\e ]]
+ record_service_stage_failure
```