### PR TITLE
OWNERS: update vSphere-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -44,6 +44,7 @@ aliases:
     - jcpowermac
     - patrickdillon
     - jstuever
+    - rvanderp3
   vsphere-reviewers:
     - mtnbikenc
     - jcpowermac


### PR DESCRIPTION
Adding @rvanderp3  to approvers. Keeping out of reviewers to minimize number of review requests. 

/approve

@rvanderp3 you can put an lgtm on here if this looks good to you and you want to be added.