### PR TITLE
baremetal: add PlatformProvisionCheck dependency for TerraformVariables asset

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -97,6 +97,7 @@ func (t *TerraformVariables) Dependencies() []asset.Asset {
 		&machines.Master{},
 		&machines.Worker{},
 		&baremetalbootstrap.IronicCreds{},
+		&installconfig.PlatformProvisionCheck{},
 	}
 }
 


### PR DESCRIPTION
The TerraformVariables.Generate(), in case of baremetal, uses some configuration vars which require to be validated before their usage (for example, it tries to download the image file). This commit reuses the same validation rules already
defined in the Platform Provision Check asset.

Fixes #5040