### PR TITLE
Azure Stack cloud provider config

### DIFF
--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -102,7 +102,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 	}
 
 	managedIdentity := fmt.Sprintf("%s-identity", clusterID)
-	if platform.IsARO() {
+	if platform.IsARO() || platform.CloudName == azure.StackCloud {
 		managedIdentity = ""
 	}
 

--- a/pkg/asset/manifests/azure/cloudproviderconfig.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig.go
@@ -21,6 +21,7 @@ type CloudProviderConfig struct {
 	NetworkSecurityGroupName string
 	VirtualNetworkName       string
 	SubnetName               string
+	ResourceManagerEndpoint  string
 	ARO                      bool
 }
 
@@ -68,6 +69,7 @@ func (params CloudProviderConfig) JSON() (string, error) {
 	if params.CloudName == azure.StackCloud {
 		config.authConfig.AADClientID = params.AADClientID
 		config.authConfig.AADClientSecret = params.AADClientSecret
+		config.authConfig.ResourceManagerEndpoint = params.ResourceManagerEndpoint
 		config.authConfig.UseManagedIdentityExtension = false
 		config.LoadBalancerSku = "basic"
 		config.UseInstanceMetadata = false

--- a/pkg/asset/manifests/azure/cloudproviderconfig.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig.go
@@ -12,6 +12,8 @@ type CloudProviderConfig struct {
 	CloudName                azure.CloudEnvironment
 	TenantID                 string
 	SubscriptionID           string
+	AADClientID              string
+	AADClientSecret          string
 	ResourceGroupName        string
 	GroupLocation            string
 	ResourcePrefix           string
@@ -64,6 +66,8 @@ func (params CloudProviderConfig) JSON() (string, error) {
 	}
 
 	if params.CloudName == azure.StackCloud {
+		config.authConfig.AADClientID = params.AADClientID
+		config.authConfig.AADClientSecret = params.AADClientSecret
 		config.authConfig.UseManagedIdentityExtension = false
 		config.LoadBalancerSku = "basic"
 		config.UseInstanceMetadata = false

--- a/pkg/asset/manifests/azure/types.go
+++ b/pkg/asset/manifests/azure/types.go
@@ -1,6 +1,7 @@
 package azure
 
 //authConfig is part of the CloudProviderConfig as defined in https://github.com/kubernetes/kubernetes/blob/v1.13.5/pkg/cloudprovider/providers/azure/auth/azure_auth.go#L32
+//resourceManagerEndpoint has been added based on https://github.com/kubernetes-sigs/cloud-provider-azure/blob/v1.0.3/pkg/auth/azure_auth.go
 type authConfig struct {
 	// The cloud environment identifier. Takes values from https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13
 	Cloud string `json:"cloud" yaml:"cloud"`
@@ -22,6 +23,9 @@ type authConfig struct {
 	UserAssignedIdentityID string `json:"userAssignedIdentityID" yaml:"userAssignedIdentityID"`
 	// The ID of the Azure Subscription that the cluster is deployed in
 	SubscriptionID string `json:"subscriptionId" yaml:"subscriptionId"`
+	// ResourceManagerEndpoint is the cloud's resource manager endpoint. If set, cloud provider queries this endpoint
+	// in order to generate an autorest.Environment instance instead of using one of the pre-defined Environments.
+	ResourceManagerEndpoint string `json:"resourceManagerEndpoint,omitempty" yaml:"resourceManagerEndpoint,omitempty"`
 }
 
 //config is the cloud provider config as defined in https://github.com/kubernetes/kubernetes/blob/v1.13.5/pkg/cloudprovider/providers/azure/azure.go#L81

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -135,6 +135,8 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			ResourcePrefix:           clusterID.InfraID,
 			SubscriptionID:           session.Credentials.SubscriptionID,
 			TenantID:                 session.Credentials.TenantID,
+			AADClientID:              session.Credentials.ClientID,
+			AADClientSecret:          session.Credentials.ClientSecret,
 			NetworkResourceGroupName: nrg,
 			NetworkSecurityGroupName: nsg,
 			VirtualNetworkName:       vnet,

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -2,6 +2,7 @@ package manifests
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 
@@ -39,6 +40,7 @@ var (
 const (
 	cloudProviderConfigDataKey         = "config"
 	cloudProviderConfigCABundleDataKey = "ca-bundle.pem"
+	cloudProviderEndpointsKey          = "endpoints"
 )
 
 // CloudProviderConfig generates the cloud-provider-config.yaml files.
@@ -143,6 +145,14 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			return errors.Wrap(err, "could not create cloud provider config")
 		}
 		cm.Data[cloudProviderConfigDataKey] = azureConfig
+
+		if installConfig.Azure.CloudName == azuretypes.StackCloud {
+			b, err := json.Marshal(session.Environment)
+			if err != nil {
+				return errors.Wrap(err, "could not serialize Azure Stack endpoints")
+			}
+			cm.Data[cloudProviderEndpointsKey] = string(b)
+		}
 	case gcptypes.Name:
 		subnet := fmt.Sprintf("%s-worker-subnet", clusterID.InfraID)
 		if installConfig.Config.GCP.ComputeSubnet != "" {

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -141,6 +141,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			NetworkSecurityGroupName: nsg,
 			VirtualNetworkName:       vnet,
 			SubnetName:               subnet,
+			ResourceManagerEndpoint:  installConfig.Config.Azure.ARMEndpoint,
 			ARO:                      installConfig.Config.Azure.IsARO(),
 		}.JSON()
 		if err != nil {


### PR DESCRIPTION
These commits add specific cloud provider configuration for Azure Stack Hub. 

be4635c - Adds generic support, separating configuration that differs from public Azure. 

d210770 - Is a temporary commit to add credentials to the cloud provider config. Once bootstrap support for the cloud controller manager is added we should revert this commit and keep credentials in a secret, which is not presently supported as explained in the commit message.

Merging d210770 would allow us to make progress with fully automated IPI install and reverting later would be simple enough. I can create a revert PR now with a basic PoC of how to use the merge config based on ARO.