### PR TITLE
aws: move elastic ip permissions to create networking category

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -38,8 +38,6 @@ var permissions = map[PermissionGroup][]string{
 	// Base set of permissions required for cluster creation
 	PermissionCreateBase: {
 		// EC2 related perms
-		"ec2:AllocateAddress",
-		"ec2:AssociateAddress",
 		"ec2:AuthorizeSecurityGroupEgress",
 		"ec2:AuthorizeSecurityGroupIngress",
 		"ec2:CopyImage",
@@ -79,7 +77,6 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:GetEbsDefaultKmsKeyId",
 		"ec2:ModifyInstanceAttribute",
 		"ec2:ModifyNetworkInterfaceAttribute",
-		"ec2:ReleaseAddress",
 		"ec2:RevokeSecurityGroupEgress",
 		"ec2:RevokeSecurityGroupIngress",
 		"ec2:RunInstances",
@@ -196,7 +193,9 @@ var permissions = map[PermissionGroup][]string{
 	},
 	// Permissions required for creating network resources
 	PermissionCreateNetworking: {
+		"ec2:AllocateAddress",
 		"ec2:AssociateDhcpOptions",
+		"ec2:AssociateAddress",
 		"ec2:AssociateRouteTable",
 		"ec2:AttachInternetGateway",
 		"ec2:CreateDhcpOptions",
@@ -222,6 +221,7 @@ var permissions = map[PermissionGroup][]string{
 		"ec2:DeleteVpcEndpoints",
 		"ec2:DetachInternetGateway",
 		"ec2:DisassociateRouteTable",
+		"ec2:ReleaseAddress",
 		"ec2:ReplaceRouteTableAssociation",
 	},
 	// Permissions required for deleting a cluster with shared network resources


### PR DESCRIPTION
Elastic IPs are only created when the installer provisions VPCs and subnets. In the case where users install into an existing VPC, the installer does not need the permissions to create and associate EIPs. Therefore let's move these EIP permissions so that they are only checked when we create networking resources.