### PR TITLE
OpenStack: explicitly disable octavia when using kuryr

### DIFF
--- a/pkg/asset/manifests/openstack/cloudproviderconfig.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig.go
@@ -91,8 +91,11 @@ secret-namespace = kube-system
 		cloudProviderConfigCABundleData = string(caFile)
 	}
 
+	cloudProviderConfigData += "[LoadBalancer]\n"
 	if installConfig.NetworkType == string(operv1.NetworkTypeKuryr) {
-		cloudProviderConfigData += "[LoadBalancer]\nuse-octavia = False\n"
+		cloudProviderConfigData += "use-octavia = False\n"
+	} else {
+		cloudProviderConfigData += "use-octavia = True\n"
 	}
 
 	return cloudProviderConfigData, cloudProviderConfigCABundleData, nil

--- a/pkg/asset/manifests/openstack/cloudproviderconfig.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	"github.com/openshift/installer/pkg/types"
 )
@@ -72,7 +73,7 @@ func CloudProviderConfigSecret(cloud *clientconfig.Cloud) ([]byte, error) {
 	return []byte(res.String()), nil
 }
 
-func generateCloudProviderConfig(cloudConfig *clientconfig.Cloud) (cloudProviderConfigData, cloudProviderConfigCABundleData string, err error) {
+func generateCloudProviderConfig(cloudConfig *clientconfig.Cloud, installConfig types.InstallConfig) (cloudProviderConfigData, cloudProviderConfigCABundleData string, err error) {
 	cloudProviderConfigData = `[Global]
 secret-name = openstack-credentials
 secret-namespace = kube-system
@@ -90,6 +91,10 @@ secret-namespace = kube-system
 		cloudProviderConfigCABundleData = string(caFile)
 	}
 
+	if installConfig.NetworkType == string(operv1.NetworkTypeKuryr) {
+		cloudProviderConfigData += "[LoadBalancer]\nuse-octavia = False\n"
+	}
+
 	return cloudProviderConfigData, cloudProviderConfigCABundleData, nil
 }
 
@@ -101,5 +106,5 @@ func GenerateCloudProviderConfig(installConfig types.InstallConfig) (cloudProvid
 		return "", "", Error{err, "failed to get cloud config for openstack"}
 	}
 
-	return generateCloudProviderConfig(cloud.CloudConfig)
+	return generateCloudProviderConfig(cloud.CloudConfig, installConfig)
 }

--- a/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
@@ -106,6 +106,8 @@ func TestCloudProviderConfig(t *testing.T) {
 secret-name = openstack-credentials
 secret-namespace = kube-system
 region = my_region
+[LoadBalancer]
+use-octavia = True
 `,
 		}, {
 			name: "installation with kuryr",

--- a/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -91,6 +92,38 @@ password = "` + v + `"
 }
 
 func TestCloudProviderConfig(t *testing.T) {
+	cases := []struct {
+		name           string
+		installConfig  *types.InstallConfig
+		expectedConfig string
+	}{
+		{
+			name: "default install config",
+			installConfig: &types.InstallConfig{
+				Networking: &types.Networking{},
+			},
+			expectedConfig: `[Global]
+secret-name = openstack-credentials
+secret-namespace = kube-system
+region = my_region
+`,
+		}, {
+			name: "installation with kuryr",
+			installConfig: &types.InstallConfig{
+				Networking: &types.Networking{
+					NetworkType: "Kuryr",
+				},
+			},
+			expectedConfig: `[Global]
+secret-name = openstack-credentials
+secret-namespace = kube-system
+region = my_region
+[LoadBalancer]
+use-octavia = False
+`,
+		},
+	}
+
 	cloud := clientconfig.Cloud{
 		AuthInfo: &clientconfig.AuthInfo{
 			Username:   "my_user",
@@ -103,11 +136,10 @@ func TestCloudProviderConfig(t *testing.T) {
 		RegionName: "my_region",
 	}
 
-	expectedConfig := `[Global]
-secret-name = openstack-credentials
-secret-namespace = kube-system
-region = my_region
-`
-	actualConfig, _, _ := generateCloudProviderConfig(&cloud)
-	assert.Equal(t, expectedConfig, string(actualConfig), "unexpected cloud provider config")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualConfig, _, _ := generateCloudProviderConfig(&cloud, *tc.installConfig)
+			assert.Equal(t, tc.expectedConfig, string(actualConfig), "unexpected cloud provider config")
+		})
+	}
 }


### PR DESCRIPTION
Kuryr already handles the service type Load Balancer and we need to
explicitly disable the use of octavia in the cloud provider
configuration otherwise we'll run into issues once the default for
`use-octavia` changes from false to true with the out-of-tree openstack
cloud provider.

Implements [OSASINFRA-2510](https://issues.redhat.com/browse/OSASINFRA-2510)