### PR TITLE
Bug 1970179: update boot images for RHCOS 4.9

### DIFF
--- a/data/data/rhcos-aarch64.json
+++ b/data/data/rhcos-aarch64.json
@@ -1,61 +1,68 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/",
-    "buildid": "48.84.202105182319-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/",
+    "buildid": "49.84.202106302247-0",
     "images": {
         "aws": {
-            "path": "rhcos-48.84.202105182319-0-aws.aarch64.vmdk.gz",
-            "sha256": "9301797efefa3eead792e5012ead5248ef70a010cfc6f0a86872174757bb8e0d",
-            "size": 937162462,
-            "uncompressed-sha256": "072a81bd43917eb2f1b00782a247acee470d42b9e8b11fa68f6886eab21b7135",
-            "uncompressed-size": 957807104
+            "path": "rhcos-49.84.202106302247-0-aws.aarch64.vmdk.gz",
+            "sha256": "fef05108ddf8c9c858277ef1d59ea7dc7331f5a71d07e725e425bd861f7f4630",
+            "size": 939747412,
+            "uncompressed-sha256": "95c6bcf55ed710df5f621bceab16e811e0ae912c710c83c1f92d07e872b73f81",
+            "uncompressed-size": 960489472
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202105182319-0-live-initramfs.aarch64.img",
-            "sha256": "5db0ae2d19c2a3a0043f8bc34e6d655688a8a565b82e8bfa1d9a903283734ca7"
+            "path": "rhcos-49.84.202106302247-0-live-initramfs.aarch64.img",
+            "sha256": "bef9a83d2993d695810918eeb2f4c81f77d3b2844e1ea482664ef1c364cd905e"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202105182319-0-live.aarch64.iso",
-            "sha256": "7fe8198c190d71c2072b98dee908c19e2128cf7968d24417f605a4f6b5a0c1e4"
+            "path": "rhcos-49.84.202106302247-0-live.aarch64.iso",
+            "sha256": "f2a91f4cb51b6aa4194c0eb375a6db71c43487612242d517fff47fc3e40dee85"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202105182319-0-live-kernel-aarch64",
-            "sha256": "7b2df22d96362cc9f0e365c8dd75996adb20753bbec62f7b2e5e9d0a391b9313"
+            "path": "rhcos-49.84.202106302247-0-live-kernel-aarch64",
+            "sha256": "83de7667d9f926e42191579e3545c1bd745d0f34b8587b112e0178a30a84a2e6"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202105182319-0-live-rootfs.aarch64.img",
-            "sha256": "ff581e615fa32b33e83f34e6bdcfca9d12f5cb678e92c568bb92f6e0b3eec524"
+            "path": "rhcos-49.84.202106302247-0-live-rootfs.aarch64.img",
+            "sha256": "90505fd8f6ec72517a0d036d078e450f611b58d11a7b35cb6904414550ec1d00"
         },
         "metal": {
-            "path": "rhcos-48.84.202105182319-0-metal.aarch64.raw.gz",
-            "sha256": "025889151222c56d1255a06631e0be087d65b636f54f50c342e0a0d39f597156",
-            "size": 927704266,
-            "uncompressed-sha256": "0dc21b5570ec108e82a19e7633b65780d4f996e85b84ce1617439f33b85fae9c",
-            "uncompressed-size": 3865051136
+            "path": "rhcos-49.84.202106302247-0-metal.aarch64.raw.gz",
+            "sha256": "79dd89bd9079f5b03dccca8f12ce6c2511a80d33dfcdbd3f575a37a4c8acd22e",
+            "size": 930256668,
+            "uncompressed-sha256": "cdfa03b96c408f6fa9a4f7e543ad60edd6a03e347cc6746bbcdccc84ffb02378",
+            "uncompressed-size": 3876585472
         },
         "metal4k": {
-            "path": "rhcos-48.84.202105182319-0-metal4k.aarch64.raw.gz",
-            "sha256": "6a2f8a33910e1170b95b90b85c32564747d48f37102cfa03d14d541c0975b3e1",
-            "size": 927642050,
-            "uncompressed-sha256": "72637bbf9649ec7c0a5aab89a0859320b0681bffc26562d45246955903027b75",
-            "uncompressed-size": 3865051136
+            "path": "rhcos-49.84.202106302247-0-metal4k.aarch64.raw.gz",
+            "sha256": "ee21dd2887c7b354f182cc8000b2f35a1b39f71e0e983f0d46c6ff99c63b2964",
+            "size": 930158918,
+            "uncompressed-sha256": "abbff17f5b9de8eeef31219bf3144f743d6b3d0bfc0ee3dce749e55b4499de3f",
+            "uncompressed-size": 3876585472
+        },
+        "openstack": {
+            "path": "rhcos-49.84.202106302247-0-openstack.aarch64.qcow2.gz",
+            "sha256": "c4711e847bbc657f37deb79cfc1c5bf359eb18ab34b12afa7c7282281b424542",
+            "size": 928546506,
+            "uncompressed-sha256": "020ccec2e74193e87b0913f3d8792c1edfc99541195d0cd66a20d3b4bb1ae956",
+            "uncompressed-size": 2457010176
         },
         "ostree": {
-            "path": "rhcos-48.84.202105182319-0-ostree.aarch64.tar",
-            "sha256": "9fc07c3913cc131b45706c5e1968d85e3a7ea1fd3f7a1c1f026c09afca9f3a75",
-            "size": 858439680
+            "path": "rhcos-49.84.202106302247-0-ostree.aarch64.tar",
+            "sha256": "98021f49b14ae1657afb70c67c40b4ee25c27f34c49bfa894fde45d10055c103",
+            "size": 860702720
         },
         "qemu": {
-            "path": "rhcos-48.84.202105182319-0-qemu.aarch64.qcow2.gz",
-            "sha256": "f7efbf124a831ede1e488dd7308c52fc0ab44b051fe8e4828d5097685a9711d2",
-            "size": 927096675,
-            "uncompressed-sha256": "2de808a6d9087a3ed3c259a5c63774f7986a1193a45a38935c36f8a03023bb66",
-            "uncompressed-size": 2484076544
+            "path": "rhcos-49.84.202106302247-0-qemu.aarch64.qcow2.gz",
+            "sha256": "7213f07ba49dadf70321abe84524cb287207f73b02f6ba96f5a418ec42f1dd9a",
+            "size": 929639141,
+            "uncompressed-sha256": "5a3321105f978824892575cda538aa7cd0f4bc62640670180f096ccc73825c32",
+            "uncompressed-size": 2493513728
         }
     },
     "oscontainer": {
-        "digest": "sha256:6525144d718316953fe052889d646e54a7ccf5c591bfded0665bd155d59b8be5",
+        "digest": "sha256:8f50f9e6c91c47c42d8e961470fb22648c301516f9a5cbdf76faac63c030bcc8",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "0631afa968dada234dbf8c45a3ffd1929152e801367014423672095e69612bde",
-    "ostree-version": "48.84.202105182319-0"
+    "ostree-commit": "a65890e652bfe4ab36a251a650c8601a140ba278eb3f0c5c7496a0429819cefd",
+    "ostree-version": "49.84.202106302247-0"
 }

--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,166 +1,173 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-08c63bb1b8b661ab9"
+            "hvm": "ami-0e7bac9d978e79a6e"
         },
         "ap-east-1": {
-            "hvm": "ami-01f2a0e8aee56e1f4"
+            "hvm": "ami-051d83ebbfb127ea2"
         },
         "ap-northeast-1": {
-            "hvm": "ami-012420354c0b2bf59"
+            "hvm": "ami-00413a0acfd76de7c"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0d8c0ce731da9faaf"
+            "hvm": "ami-08e2db228a5695fb3"
         },
         "ap-northeast-3": {
-            "hvm": "ami-00cac27e65ae02107"
+            "hvm": "ami-0d0b87fc092ee2e74"
         },
         "ap-south-1": {
-            "hvm": "ami-05b69d7e80f1178c6"
+            "hvm": "ami-03c83da1b6ce6d151"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0bd576d6deb6094c8"
+            "hvm": "ami-020876d27dc04936a"
         },
         "ap-southeast-2": {
-            "hvm": "ami-06e7e674d4b8cdc59"
+            "hvm": "ami-02eecabb2b32443e5"
         },
         "ca-central-1": {
-            "hvm": "ami-04990181ab3872dc9"
+            "hvm": "ami-070fd5123ab359da8"
         },
         "eu-central-1": {
-            "hvm": "ami-0ed56edc094183f18"
+            "hvm": "ami-07ac34b5c836bb738"
         },
         "eu-north-1": {
-            "hvm": "ami-0e63e7e6de6dac812"
+            "hvm": "ami-01a85ec5bac734d6b"
         },
         "eu-south-1": {
-            "hvm": "ami-01c63dbdcd28938c0"
+            "hvm": "ami-0da7775afdefce9c6"
         },
         "eu-west-1": {
-            "hvm": "ami-04885ff040bf8e8d0"
+            "hvm": "ami-031117dace22be7c5"
         },
         "eu-west-2": {
-            "hvm": "ami-04b31bbfe532cbb45"
+            "hvm": "ami-0c455b12ceed301cd"
         },
         "eu-west-3": {
-            "hvm": "ami-0e188558a41f87d82"
+            "hvm": "ami-0cc8ddaee632a3086"
         },
         "me-south-1": {
-            "hvm": "ami-006b4ea9d3e62fdc2"
+            "hvm": "ami-034359190c2c7c906"
         },
         "sa-east-1": {
-            "hvm": "ami-094888ec0f3125ad7"
+            "hvm": "ami-0fc38ad5e19dfd32b"
         },
         "us-east-1": {
-            "hvm": "ami-0b08ba24af2f005c9"
+            "hvm": "ami-01b2bf223fccdb8e3"
         },
         "us-east-2": {
-            "hvm": "ami-0cd5c6a0f8bb3c33d"
+            "hvm": "ami-0798e63b24f54c102"
         },
         "us-west-1": {
-            "hvm": "ami-0d3e625f84626bbda"
+            "hvm": "ami-004c277e7c9366226"
         },
         "us-west-2": {
-            "hvm": "ami-040e8d23c125e7a75"
+            "hvm": "ami-0acecf5d7224232a8"
         }
     },
     "azure": {
-        "image": "rhcos-48.84.202105190318-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202105190318-0-azure.x86_64.vhd"
+        "image": "rhcos-49.84.202107010027-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202107010027-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/",
-    "buildid": "48.84.202105190318-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/",
+    "buildid": "49.84.202107010027-0",
     "gcp": {
-        "image": "rhcos-48-84-202105190318-0-gcp-x86-64",
+        "image": "rhcos-49-84-202107010027-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202105190318-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-49-84-202107010027-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.84.202105190318-0-aws.x86_64.vmdk.gz",
-            "sha256": "3a07b55dd91391472d2f8d2723ed2e78cfcab0188590a67342981f71ec566cb4",
-            "size": 1023936424,
-            "uncompressed-sha256": "848cb5a00405e5b2da0070ead2b612ed7f4add48eab1639ba85fa912ad9a5c47",
-            "uncompressed-size": 1044896256
+            "path": "rhcos-49.84.202107010027-0-aws.x86_64.vmdk.gz",
+            "sha256": "932dd626e76f84e8f6d5158abcc753af6e865305169588203dede2bb4c41f28a",
+            "size": 1030950571,
+            "uncompressed-sha256": "3efafda489b5a789725ada0d2ea6c93a8e76775ce4e789b3b5ef5ee235b45ecb",
+            "uncompressed-size": 1051976192
         },
         "azure": {
-            "path": "rhcos-48.84.202105190318-0-azure.x86_64.vhd.gz",
-            "sha256": "0c2ad96789c50cd37e72054053309c3d9c66ac27d62a45f1eed4281a98a527b8",
-            "size": 1024000773,
-            "uncompressed-sha256": "587ffdf54f242bfc50f2a413222783112a4128f125bde6cc8231f449575395ea",
+            "path": "rhcos-49.84.202107010027-0-azure.x86_64.vhd.gz",
+            "sha256": "9bbedfb75c1be0f5331882840fff65b194bf9ca87548ce6c764db604056a999f",
+            "size": 1030871708,
+            "uncompressed-sha256": "e79180d7e455fbf1d8db5eb2a3522ae4c12782d35e52acba3ab95f124af73164",
+            "uncompressed-size": 17179869696
+        },
+        "azurestack": {
+            "path": "rhcos-49.84.202107010027-0-azurestack.x86_64.vhd.gz",
+            "sha256": "3c6d3dbc75deb47aaaef62e76628ef4f37143ef8d5f00435a89c03266fecac29",
+            "size": 1030872938,
+            "uncompressed-sha256": "951db0b6585976034fd6cc23de834bc7fd0cad102115bb6efd509ef1c8a38e53",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.84.202105190318-0-gcp.x86_64.tar.gz",
-            "sha256": "6f2074939a561985bf065e0af742248e4fc5d2ec950094987a72c6e72c3d8a94",
-            "size": 1009471820
+            "path": "rhcos-49.84.202107010027-0-gcp.x86_64.tar.gz",
+            "sha256": "28c816bfe2df8570472607f5ae3cd5adb455932e68412370785c78617c50e7ab",
+            "size": 1016304764
         },
         "ibmcloud": {
-            "path": "rhcos-48.84.202105190318-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "11a3e6c7893c7c8b6fde6c99a816e62ae1c76accaeea79aced286984f339cecb",
-            "size": 1009816890,
-            "uncompressed-sha256": "698a3b800ae4c070278aa759fc7a498b0406c7a1714567b8f059d8466c2e180d",
-            "uncompressed-size": 2518024192
+            "path": "rhcos-49.84.202107010027-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "0ffb7e3583faf05bb0d5bceda73f048bca5ab19d5fed6091ffd791c19167dd72",
+            "size": 1016679625,
+            "uncompressed-sha256": "eeee1e663f25bec15af029cd6fcb13079f661da80444271a7db944c7484c8a72",
+            "uncompressed-size": 2534342656
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202105190318-0-live-initramfs.x86_64.img",
-            "sha256": "e7c22b2003ef3fce887d09fa9600d2f36bd4be0fcc85833c864dad65333a5689"
+            "path": "rhcos-49.84.202107010027-0-live-initramfs.x86_64.img",
+            "sha256": "cb8a23fa2ddf1c427135fb6aa016e9765c25aca9d1e863f9d0b3a18e1c4c41f8"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202105190318-0-live.x86_64.iso",
-            "sha256": "9f59d8320f456d1e27ebd33a76db6311df61b1ff6e9f5ebaa5d663e426461bc2"
+            "path": "rhcos-49.84.202107010027-0-live.x86_64.iso",
+            "sha256": "244a2148ba6bc0e8e2355e6bdd90c8a2b81bdedc51c0bd323b00c8f797d2bd50"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202105190318-0-live-kernel-x86_64",
-            "sha256": "0fd7b56183cbac5e6c114b363b8c69340732cfc9f958edf6d1b273441d78dd8f"
+            "path": "rhcos-49.84.202107010027-0-live-kernel-x86_64",
+            "sha256": "9b900e88ca71b067d8f9971dc4454f454a12666b53d3ca2d80919729060a198d"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202105190318-0-live-rootfs.x86_64.img",
-            "sha256": "ef434d53914cdd7c38bd1328ccd7d579378393f5b2e8e03e3ebb80326175002c"
+            "path": "rhcos-49.84.202107010027-0-live-rootfs.x86_64.img",
+            "sha256": "383993d4ff10d620f9e4bc452eb8f24473b271b04ed1c0d97fac3bd0d987f747"
         },
         "metal": {
-            "path": "rhcos-48.84.202105190318-0-metal.x86_64.raw.gz",
-            "sha256": "b00854a91c9d5fbf6ba07c2da5dec2c5b10252c66056973f244c9f4344f4245c",
-            "size": 1011514392,
-            "uncompressed-sha256": "2e2310a800911dda55ba9fd596d6e21952ae99bfda6e7a77c39900d27022c21d",
-            "uncompressed-size": 3938451456
+            "path": "rhcos-49.84.202107010027-0-metal.x86_64.raw.gz",
+            "sha256": "aaf1cdcd5d085e0e8decbb19ab4fbbc8d8278d7638cceaea80b48331b263706f",
+            "size": 1018448313,
+            "uncompressed-sha256": "7080110bc282855f9e91cb86769b53f0fe4136206eac99e47f4608d5a9fecf00",
+            "uncompressed-size": 3959422976
         },
         "metal4k": {
-            "path": "rhcos-48.84.202105190318-0-metal4k.x86_64.raw.gz",
-            "sha256": "02fe9775efc5863965bc3924b33c89eebdfc515e0a49d3a699cba8e09b79d598",
-            "size": 1009019314,
-            "uncompressed-sha256": "23ec0e1e7a37e1a0a0a7a78c980976df92a62ebde00465567deaa0d298cd04b9",
-            "uncompressed-size": 3938451456
+            "path": "rhcos-49.84.202107010027-0-metal4k.x86_64.raw.gz",
+            "sha256": "93c5b9631ea0cac516ea2ff2a8b9949af1d856849a48763299b800ae8f25c4e6",
+            "size": 1016010632,
+            "uncompressed-sha256": "9d95fbbacad73415c6de086ce78ac06a9810db3e7fb3e3693039bd4631fa1553",
+            "uncompressed-size": 3959422976
         },
         "openstack": {
-            "path": "rhcos-48.84.202105190318-0-openstack.x86_64.qcow2.gz",
-            "sha256": "37a156f9f2b0efded45cb3cd5688aa2d42c26873a534951484e96f546a6b2c84",
-            "size": 1009815265,
-            "uncompressed-sha256": "82d4540048f887c33c635397ce772867e192c72a349ff73d9b5ce66e08ab3274",
-            "uncompressed-size": 2518024192
+            "path": "rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz",
+            "sha256": "c7dde5f96826c33c97b5a4ad34110212281916128ae11100956f400db3d5299e",
+            "size": 1016679212,
+            "uncompressed-sha256": "00cb56c8711686255744646394e22a8ca5f27e059016f6758f14388e5a0a14cb",
+            "uncompressed-size": 2534342656
         },
         "ostree": {
-            "path": "rhcos-48.84.202105190318-0-ostree.x86_64.tar",
-            "sha256": "7728d538f4537ca9ab516697ace9dc787430912937909ad1409d53137d1a934a",
-            "size": 935157760
+            "path": "rhcos-49.84.202107010027-0-ostree.x86_64.tar",
+            "sha256": "54affb52ee9056d1bf237049f4815c686f317ef8ca135d4b1b72f69e31ee1f81",
+            "size": 940769280
         },
         "qemu": {
-            "path": "rhcos-48.84.202105190318-0-qemu.x86_64.qcow2.gz",
-            "sha256": "154fa07c4194898b493d5c25a4be6b48e11ba019b1352dd585f33198f560a11d",
-            "size": 1011011783,
-            "uncompressed-sha256": "84683a75c0e3d164c1d4a95448e142490a0bf91ff07076bff2b3bbc209c6c368",
-            "uncompressed-size": 2554527744
+            "path": "rhcos-49.84.202107010027-0-qemu.x86_64.qcow2.gz",
+            "sha256": "6dc06832d28ed28594902844fb1b205f3aa58c4960f976ae78c9122dc417111d",
+            "size": 1017869225,
+            "uncompressed-sha256": "c645d5eba8cba58fce4571135edb1c7ec03f04e9c5ad6466cef72f7a9717d09c",
+            "uncompressed-size": 2570452992
         },
         "vmware": {
-            "path": "rhcos-48.84.202105190318-0-vmware.x86_64.ova",
-            "sha256": "35beaa2b8ac6d8c87f3eee77541e7d08562fdfb6ceb481647d1c663947312412",
-            "size": 1044910080
+            "path": "rhcos-49.84.202107010027-0-vmware.x86_64.ova",
+            "sha256": "f9ee706482c8088d1ce4d9b798d9d9cd229ce8ae011fe5909b4eb79455c08940",
+            "size": 1051985920
         }
     },
     "oscontainer": {
-        "digest": "sha256:4d74181e0e7bff9739fab7cae6f946f186dd8af0848d9cded0f64db93e22e816",
+        "digest": "sha256:cf5f21445e2d6c43ab424f99db7844bfe5463af7e429842bd679deba5926e7e2",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "92ede04b462bc884de5562062fb45e06d803754cbaa466e3a2d34b4ee5e9634b",
-    "ostree-version": "48.84.202105190318-0"
+    "ostree-commit": "abb247c075d0e2d4b7cf41e0fcef3305fbd9efe9dbcde2211a072acd6ddccabb",
+    "ostree-version": "49.84.202107010027-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/",
-    "buildid": "48.84.202105182221-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/",
+    "buildid": "49.84.202107010047-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-48.84.202105182221-0-live-initramfs.ppc64le.img",
-            "sha256": "b0c9276c3c62d337ee0f042c8ec3c845a6065822c0ac4e62b4b4feb2d0807b57"
+            "path": "rhcos-49.84.202107010047-0-live-initramfs.ppc64le.img",
+            "sha256": "79e42469694b273fce31a54e6790e4c594619577693e1b34621f1675a33538e8"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202105182221-0-live.ppc64le.iso",
-            "sha256": "91e0505a95041f8f4e74eddc138f7298d92a7ff99e45e57feed8f0c74f8a2e51"
+            "path": "rhcos-49.84.202107010047-0-live.ppc64le.iso",
+            "sha256": "0f6418dc5eb43b0f12da60cf583ce19cbbf85f421c0d35b0be85c33161ab8e87"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202105182221-0-live-kernel-ppc64le",
-            "sha256": "7a34a35fe7bd6c89d99232d6c728fa01832b3e918e20aef9cbad53926fb0be8f"
+            "path": "rhcos-49.84.202107010047-0-live-kernel-ppc64le",
+            "sha256": "ae1165bb13992f9b6543e2c8baa0f1f10460d84db740d1876c8f4f9226cb9a6d"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202105182221-0-live-rootfs.ppc64le.img",
-            "sha256": "11ce4269e8403c73aa6ef2b207e25d2876901a7c1bdee32e4b3d7ffe2ebba0f7"
+            "path": "rhcos-49.84.202107010047-0-live-rootfs.ppc64le.img",
+            "sha256": "6c3a9728fd82b09d11778370b68ae0875502a84d3ccbea5a0e1a9c69d855c08b"
         },
         "metal": {
-            "path": "rhcos-48.84.202105182221-0-metal.ppc64le.raw.gz",
-            "sha256": "20a8487327533da03d9e6509c66118010ab86e3dda9d04182e9ec2aa33efc88d",
-            "size": 981365154,
-            "uncompressed-sha256": "0800250b789e61e917b2aa32b4b40a31746c0a7d9d8504d6eeeba671ff120879",
-            "uncompressed-size": 4086300672
+            "path": "rhcos-49.84.202107010047-0-metal.ppc64le.raw.gz",
+            "sha256": "f08f36d75aa726dbb6dd1cd5f1c0ef561174c7f5324f3fba2cd8ff52187bc242",
+            "size": 988450954,
+            "uncompressed-sha256": "3d268c733b48b884f4215bb1f4e53883dd460b2a3eedd0e02e5b4e5800dafcc6",
+            "uncompressed-size": 4126146560
         },
         "metal4k": {
-            "path": "rhcos-48.84.202105182221-0-metal4k.ppc64le.raw.gz",
-            "sha256": "b457e9af68fb0e1378fdd03d341d59de51ae97519ba2ee30be31e771e42ad3f5",
-            "size": 981720139,
-            "uncompressed-sha256": "e990d20cdb5a70f1317ec47e9ada318c545e6144d2cd1481f88bbf8f58c0e289",
-            "uncompressed-size": 4086300672
+            "path": "rhcos-49.84.202107010047-0-metal4k.ppc64le.raw.gz",
+            "sha256": "fc64722125fa0db0eb534db6af8a9ebcfff3c1bd6bf34482041ab09191e83f5d",
+            "size": 988748793,
+            "uncompressed-sha256": "662cf671d988c6b7feb48413384630596ebc0b33bfbbbfae8bef5d03ad494d4e",
+            "uncompressed-size": 4126146560
         },
         "openstack": {
-            "path": "rhcos-48.84.202105182221-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "f6afa3c2918136887f174169c62a2eb4e314444e379ec9bee3f71bcd4cc77b75",
-            "size": 979706091,
-            "uncompressed-sha256": "4da3714b72968b19109f00c3af5a5411a455636f9ef1462eb4a0489c6763ce44",
-            "uncompressed-size": 2636578816
+            "path": "rhcos-49.84.202107010047-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "e30fc32cdf50ff02a72feb71cd3f4e9c92f1b038aef506d6e8396dbbf841d085",
+            "size": 986664044,
+            "uncompressed-sha256": "9d1dc160337cda643805c96109f086015f111d46e7982b9f21cf49276cab3fb5",
+            "uncompressed-size": 2665480192
         },
         "ostree": {
-            "path": "rhcos-48.84.202105182221-0-ostree.ppc64le.tar",
-            "sha256": "f29256fed1804d33b98d0178f17ae4fc54ea9473ec182efdd449f78782245591",
-            "size": 902328320
+            "path": "rhcos-49.84.202107010047-0-ostree.ppc64le.tar",
+            "sha256": "2387066fe638c276c2ec89e2a4ab66a526bb70cc039fecadd4d9ed563df7e8cf",
+            "size": 909711360
         },
         "qemu": {
-            "path": "rhcos-48.84.202105182221-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "6be7e4e037c21907195d73f3a8f0cab1b7edd891c452b8539d3f778f6bab981d",
-            "size": 980800360,
-            "uncompressed-sha256": "466221f4455c3363bb2503421f92907a29e7b89c48685740a8e1b728d41a8ff2",
-            "uncompressed-size": 2673934336
+            "path": "rhcos-49.84.202107010047-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "9145e08f39baf2df968ea6803303ccb1fc2941f8eae60d41ba91c9016e13ba33",
+            "size": 987690835,
+            "uncompressed-sha256": "b3822dd7eddcf2faf4028c6a6cfa7fcfaf56153d2da6bd47c462705f90887871",
+            "uncompressed-size": 2702639104
         }
     },
     "oscontainer": {
-        "digest": "sha256:09514cc6edd53efa1ba01594c42bfd366d13cb7d045a65b847750e75b2b08aa8",
+        "digest": "sha256:cbb5ff0ef87cf99ec4873720bc350e09c699e5a533a8bef95a7805042da5254e",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "be4bcbb4ae3cfd25c4e12d567c790e606295e86b1fe528837d0eed83e58a315e",
-    "ostree-version": "48.84.202105182221-0"
+    "ostree-commit": "63a0c41848555ff81ef062bfbfbd8c467979c2a3c4889bdf2b61eb83069efb90",
+    "ostree-version": "49.84.202107010047-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/",
-    "buildid": "48.84.202105190719-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/",
+    "buildid": "49.84.202106302347-0",
     "images": {
         "dasd": {
-            "path": "rhcos-48.84.202105190719-0-dasd.s390x.raw.gz",
-            "sha256": "71338f934ebad1e5300c8467bdf1c2aebf0f100bea299837d74da9f623f766cf",
-            "size": 889980527,
-            "uncompressed-sha256": "01d659943869f5b4e40e098b748da45d9d4743ade6169c9801d52e03425a7789",
-            "uncompressed-size": 3680501760
+            "path": "rhcos-49.84.202106302347-0-dasd.s390x.raw.gz",
+            "sha256": "6090a52b26b6b38b3c1c31b8db44a6df81ae7a58fa685bcaa3c746494cf826f8",
+            "size": 899371546,
+            "uncompressed-sha256": "12e09dbe0283ccfd4e62c8350ee0b4e3143b99fedafafb3d11f3e614c9e99720",
+            "uncompressed-size": 3714056192
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202105190719-0-live-initramfs.s390x.img",
-            "sha256": "6cf4d58813f862b492f1a248133fc8c27d49ba60a6cddd8f2b9311990f69f2b1"
+            "path": "rhcos-49.84.202106302347-0-live-initramfs.s390x.img",
+            "sha256": "8c0d82cee34d24c14e92b724a44c36227e626debdd4394a4db531330dbb756a1"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202105190719-0-live.s390x.iso",
-            "sha256": "4f1814296f6e1897adc55026daeeaebf07158c17079024f33b4edbba2b32e270"
+            "path": "rhcos-49.84.202106302347-0-live.s390x.iso",
+            "sha256": "28176925febed1c021e0b10ca2cc30842f05436be8f56782ecb96f240914801a"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202105190719-0-live-kernel-s390x",
-            "sha256": "d960ad108a5d3db362aa97e2d782110746590984b3bf36af8b9641c4d7890e4a"
+            "path": "rhcos-49.84.202106302347-0-live-kernel-s390x",
+            "sha256": "fc1762c98976a3ca46fe5b971f706570b4bcf3f3a8567dfe96c95b4f9e0e94df"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202105190719-0-live-rootfs.s390x.img",
-            "sha256": "29c3921841629e1f60c371c284c88dd272bfe4bd0ae3c5bd6dbf151db8cf6b2b"
+            "path": "rhcos-49.84.202106302347-0-live-rootfs.s390x.img",
+            "sha256": "e36127fd8d6dd991a278c070f04aabeb7281864d5a7b9f3439442993b4963ccc"
         },
         "metal": {
-            "path": "rhcos-48.84.202105190719-0-metal.s390x.raw.gz",
-            "sha256": "69e28e6bf1fc5cf0ad978f8f4cb83357efad7c963276e32f196992f115a82d25",
-            "size": 889962033,
-            "uncompressed-sha256": "8f22fe0fc6d8e08d0ee5192c7773e9b8f57f3a6ef1f4a36a1364878512aa8310",
-            "uncompressed-size": 3680501760
+            "path": "rhcos-49.84.202106302347-0-metal.s390x.raw.gz",
+            "sha256": "b108435618b3f4704878f404ffa2101a31887fc1595a422e7c6bfd3fe06ebd2b",
+            "size": 899307689,
+            "uncompressed-sha256": "cd7b648002adced929fef097bf563de6397b63076eff802804f37d7d6ceeecce",
+            "uncompressed-size": 3714056192
         },
         "metal4k": {
-            "path": "rhcos-48.84.202105190719-0-metal4k.s390x.raw.gz",
-            "sha256": "14f8265cd33f9fe8bc972e8b1a9a72ab9fd6910c27eb08aa1746606c0869793a",
-            "size": 889944387,
-            "uncompressed-sha256": "b53b2178c295b1a265c13634f1a9e4208ec44c692dc22c87e0a2ec1bdea905ce",
-            "uncompressed-size": 3680501760
+            "path": "rhcos-49.84.202106302347-0-metal4k.s390x.raw.gz",
+            "sha256": "2164753adff4472ce74778ee46d3f3b2e46ebc2bc550f27da8adf73013870bfe",
+            "size": 899317895,
+            "uncompressed-sha256": "ee3245325d61570d908cc06b0e8a4d8ec31adaa848c1cf2b73213ad1d7fa5b2d",
+            "uncompressed-size": 3714056192
         },
         "openstack": {
-            "path": "rhcos-48.84.202105190719-0-openstack.s390x.qcow2.gz",
-            "sha256": "3e20ba2e5b91ebb39a3dbcc119546ef3ff19f0818a33d8dd8dd75b9652574775",
-            "size": 888279616,
-            "uncompressed-sha256": "1e902b881c97340194611bc09e4846d30630f39f60604a58c1ba8364b1bec6d5",
-            "uncompressed-size": 2295529472
+            "path": "rhcos-49.84.202106302347-0-openstack.s390x.qcow2.gz",
+            "sha256": "d2811c21276a305d74973a4a999ad4027b959faa21b16ab4aa305d29c982d59f",
+            "size": 897642318,
+            "uncompressed-sha256": "e7531161b61cbaefec434a105a1ad2b6b43476448f702fb584d0955a68845f57",
+            "uncompressed-size": 2320302080
         },
         "ostree": {
-            "path": "rhcos-48.84.202105190719-0-ostree.s390x.tar",
-            "sha256": "218bf0a6d3c16843b695fe623e77517fbfc3d1908317fb02d2077819a4dd16b4",
-            "size": 836874240
+            "path": "rhcos-49.84.202106302347-0-ostree.s390x.tar",
+            "sha256": "6491e82fb27501d25890c66c3e175d2b8e1070a8c39be78e733e21c017422cf0",
+            "size": 845158400
         },
         "qemu": {
-            "path": "rhcos-48.84.202105190719-0-qemu.s390x.qcow2.gz",
-            "sha256": "e1a38224bf08ac794278857baec771047c01282d0841956ed2c8b8f741b18c96",
-            "size": 889450959,
-            "uncompressed-sha256": "2fb6e0f3091ad63707e86e4f8743902968f0e3e7b29f09e4f4bd76108c9a576b",
-            "uncompressed-size": 2331246592
+            "path": "rhcos-49.84.202106302347-0-qemu.s390x.qcow2.gz",
+            "sha256": "8847d2e9679d676e4dde33df9e7dca3eefcd7f4bfdcf8d454bf20ca40b05322b",
+            "size": 898841848,
+            "uncompressed-sha256": "165c64704d4780a9ea0f84a7bbb3fab7a37b730c6a0197db5362090cc11d1016",
+            "uncompressed-size": 2356215808
         }
     },
     "oscontainer": {
-        "digest": "sha256:9f6aab7c60706e2d193f08164e57b4ab0b4e59699edecc2ebf80ad5eb1dd108f",
+        "digest": "sha256:23031dcc36fcb5666c17b6f877e910c4f3d4df48d62b813f69b392a536da9f59",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "748bd9aa1251405f0d9c9c43d4f47a7521fcf25e02b130db071572e2e2cd2107",
-    "ostree-version": "48.84.202105190719-0"
+    "ostree-commit": "7aeaa67448301e5acdcd6928f435e197702ef4de09161b49a70ce75942c43875",
+    "ostree-version": "49.84.202106302347-0"
 }

--- a/data/data/rhcos-stream.json
+++ b/data/data/rhcos-stream.json
@@ -1,78 +1,91 @@
 {
   "stream": "rhcos-4.8",
   "metadata": {
-    "last-modified": "2021-05-19T08:48:09Z"
+    "last-modified": "2021-07-21T16:48:51Z"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "48.84.202105182319-0",
+          "release": "49.84.202106302247-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-aws.aarch64.vmdk.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-aws.aarch64.vmdk.gz.sig",
-                "sha256": "9301797efefa3eead792e5012ead5248ef70a010cfc6f0a86872174757bb8e0d",
-                "uncompressed-sha256": "072a81bd43917eb2f1b00782a247acee470d42b9e8b11fa68f6886eab21b7135"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-aws.aarch64.vmdk.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-aws.aarch64.vmdk.gz.sig",
+                "sha256": "fef05108ddf8c9c858277ef1d59ea7dc7331f5a71d07e725e425bd861f7f4630",
+                "uncompressed-sha256": "95c6bcf55ed710df5f621bceab16e811e0ae912c710c83c1f92d07e872b73f81"
               }
             }
           }
         },
         "metal": {
-          "release": "48.84.202105182319-0",
+          "release": "49.84.202106302247-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-metal4k.aarch64.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-metal4k.aarch64.raw.gz.sig",
-                "sha256": "6a2f8a33910e1170b95b90b85c32564747d48f37102cfa03d14d541c0975b3e1",
-                "uncompressed-sha256": "72637bbf9649ec7c0a5aab89a0859320b0681bffc26562d45246955903027b75"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-metal4k.aarch64.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-metal4k.aarch64.raw.gz.sig",
+                "sha256": "ee21dd2887c7b354f182cc8000b2f35a1b39f71e0e983f0d46c6ff99c63b2964",
+                "uncompressed-sha256": "abbff17f5b9de8eeef31219bf3144f743d6b3d0bfc0ee3dce749e55b4499de3f"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-live.aarch64.iso",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-live.aarch64.iso.sig",
-                "sha256": "7fe8198c190d71c2072b98dee908c19e2128cf7968d24417f605a4f6b5a0c1e4"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live.aarch64.iso",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live.aarch64.iso.sig",
+                "sha256": "f2a91f4cb51b6aa4194c0eb375a6db71c43487612242d517fff47fc3e40dee85"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-live-kernel-aarch64",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-live-kernel-aarch64.sig",
-                "sha256": "7b2df22d96362cc9f0e365c8dd75996adb20753bbec62f7b2e5e9d0a391b9313"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-kernel-aarch64",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-kernel-aarch64.sig",
+                "sha256": "83de7667d9f926e42191579e3545c1bd745d0f34b8587b112e0178a30a84a2e6"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-live-initramfs.aarch64.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-live-initramfs.aarch64.img.sig",
-                "sha256": "5db0ae2d19c2a3a0043f8bc34e6d655688a8a565b82e8bfa1d9a903283734ca7"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-initramfs.aarch64.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-initramfs.aarch64.img.sig",
+                "sha256": "bef9a83d2993d695810918eeb2f4c81f77d3b2844e1ea482664ef1c364cd905e"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-live-rootfs.aarch64.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-live-rootfs.aarch64.img.sig",
-                "sha256": "ff581e615fa32b33e83f34e6bdcfca9d12f5cb678e92c568bb92f6e0b3eec524"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-rootfs.aarch64.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-rootfs.aarch64.img.sig",
+                "sha256": "90505fd8f6ec72517a0d036d078e450f611b58d11a7b35cb6904414550ec1d00"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-metal.aarch64.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-metal.aarch64.raw.gz.sig",
-                "sha256": "025889151222c56d1255a06631e0be087d65b636f54f50c342e0a0d39f597156",
-                "uncompressed-sha256": "0dc21b5570ec108e82a19e7633b65780d4f996e85b84ce1617439f33b85fae9c"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-metal.aarch64.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-metal.aarch64.raw.gz.sig",
+                "sha256": "79dd89bd9079f5b03dccca8f12ce6c2511a80d33dfcdbd3f575a37a4c8acd22e",
+                "uncompressed-sha256": "cdfa03b96c408f6fa9a4f7e543ad60edd6a03e347cc6746bbcdccc84ffb02378"
+              }
+            }
+          }
+        },
+        "openstack": {
+          "release": "49.84.202106302247-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-openstack.aarch64.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-openstack.aarch64.qcow2.gz.sig",
+                "sha256": "c4711e847bbc657f37deb79cfc1c5bf359eb18ab34b12afa7c7282281b424542",
+                "uncompressed-sha256": "020ccec2e74193e87b0913f3d8792c1edfc99541195d0cd66a20d3b4bb1ae956"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202105182319-0",
+          "release": "49.84.202106302247-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-qemu.aarch64.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202105182319-0/aarch64/rhcos-48.84.202105182319-0-qemu.aarch64.qcow2.gz.sig",
-                "sha256": "f7efbf124a831ede1e488dd7308c52fc0ab44b051fe8e4828d5097685a9711d2",
-                "uncompressed-sha256": "2de808a6d9087a3ed3c259a5c63774f7986a1193a45a38935c36f8a03023bb66"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-qemu.aarch64.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-qemu.aarch64.qcow2.gz.sig",
+                "sha256": "7213f07ba49dadf70321abe84524cb287207f73b02f6ba96f5a418ec42f1dd9a",
+                "uncompressed-sha256": "5a3321105f978824892575cda538aa7cd0f4bc62640670180f096ccc73825c32"
               }
             }
           }
@@ -82,68 +95,68 @@
         "aws": {
           "regions": {
             "ap-east-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-006f831c882d67705"
+              "release": "49.84.202106302247-0",
+              "image": "ami-00d99b5617266ee2f"
             },
             "ap-northeast-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-06b0224748013de32"
+              "release": "49.84.202106302247-0",
+              "image": "ami-06a0cc06c13f4f3e7"
             },
             "ap-northeast-2": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-0aeff4caaa4ed70c1"
+              "release": "49.84.202106302247-0",
+              "image": "ami-0410a347146b76e80"
             },
             "ap-south-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-0be723883eecb006c"
+              "release": "49.84.202106302247-0",
+              "image": "ami-0a363f72ed7ed0882"
             },
             "ap-southeast-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-0e82497717095c0bc"
+              "release": "49.84.202106302247-0",
+              "image": "ami-0e562d6c0df5be076"
             },
             "ap-southeast-2": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-0082f399576698359"
+              "release": "49.84.202106302247-0",
+              "image": "ami-060ecd2ec871a5688"
             },
             "ca-central-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-04e909f3639d7d5a5"
+              "release": "49.84.202106302247-0",
+              "image": "ami-002ee032a667716ee"
             },
             "eu-central-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-0d3e197842f5e73df"
+              "release": "49.84.202106302247-0",
+              "image": "ami-0e1d50cc2e93524c2"
             },
             "eu-south-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-0419dd808b12336ea"
+              "release": "49.84.202106302247-0",
+              "image": "ami-08330d3946e5c95a8"
             },
             "eu-west-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-04e072e74075ea7d0"
+              "release": "49.84.202106302247-0",
+              "image": "ami-0b6a511fd43d60348"
             },
             "eu-west-2": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-07d4f52632fbe442f"
+              "release": "49.84.202106302247-0",
+              "image": "ami-0bc312877c4f2df9a"
             },
             "sa-east-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-038e3868a239f226a"
+              "release": "49.84.202106302247-0",
+              "image": "ami-07718907d7e11e6d4"
             },
             "us-east-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-03b88fbbc7569901d"
+              "release": "49.84.202106302247-0",
+              "image": "ami-079edafacdc552483"
             },
             "us-east-2": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-085104482308e8c6f"
+              "release": "49.84.202106302247-0",
+              "image": "ami-0c43c31a4d82928b1"
             },
             "us-west-1": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-01ef9070c1a9ce10c"
+              "release": "49.84.202106302247-0",
+              "image": "ami-0de590635ab688456"
             },
             "us-west-2": {
-              "release": "48.84.202105182319-0",
-              "image": "ami-0d21c200fc178a914"
+              "release": "49.84.202106302247-0",
+              "image": "ami-0b265680574faa8c0"
             }
           }
         }
@@ -152,72 +165,72 @@
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "48.84.202105182221-0",
+          "release": "49.84.202107010047-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-metal4k.ppc64le.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-metal4k.ppc64le.raw.gz.sig",
-                "sha256": "b457e9af68fb0e1378fdd03d341d59de51ae97519ba2ee30be31e771e42ad3f5",
-                "uncompressed-sha256": "e990d20cdb5a70f1317ec47e9ada318c545e6144d2cd1481f88bbf8f58c0e289"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-metal4k.ppc64le.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-metal4k.ppc64le.raw.gz.sig",
+                "sha256": "fc64722125fa0db0eb534db6af8a9ebcfff3c1bd6bf34482041ab09191e83f5d",
+                "uncompressed-sha256": "662cf671d988c6b7feb48413384630596ebc0b33bfbbbfae8bef5d03ad494d4e"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-live.ppc64le.iso",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-live.ppc64le.iso.sig",
-                "sha256": "91e0505a95041f8f4e74eddc138f7298d92a7ff99e45e57feed8f0c74f8a2e51"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live.ppc64le.iso",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live.ppc64le.iso.sig",
+                "sha256": "0f6418dc5eb43b0f12da60cf583ce19cbbf85f421c0d35b0be85c33161ab8e87"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-live-kernel-ppc64le",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-live-kernel-ppc64le.sig",
-                "sha256": "7a34a35fe7bd6c89d99232d6c728fa01832b3e918e20aef9cbad53926fb0be8f"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-kernel-ppc64le",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-kernel-ppc64le.sig",
+                "sha256": "ae1165bb13992f9b6543e2c8baa0f1f10460d84db740d1876c8f4f9226cb9a6d"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-live-initramfs.ppc64le.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-live-initramfs.ppc64le.img.sig",
-                "sha256": "b0c9276c3c62d337ee0f042c8ec3c845a6065822c0ac4e62b4b4feb2d0807b57"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-initramfs.ppc64le.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-initramfs.ppc64le.img.sig",
+                "sha256": "79e42469694b273fce31a54e6790e4c594619577693e1b34621f1675a33538e8"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-live-rootfs.ppc64le.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-live-rootfs.ppc64le.img.sig",
-                "sha256": "11ce4269e8403c73aa6ef2b207e25d2876901a7c1bdee32e4b3d7ffe2ebba0f7"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-rootfs.ppc64le.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-rootfs.ppc64le.img.sig",
+                "sha256": "6c3a9728fd82b09d11778370b68ae0875502a84d3ccbea5a0e1a9c69d855c08b"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-metal.ppc64le.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-metal.ppc64le.raw.gz.sig",
-                "sha256": "20a8487327533da03d9e6509c66118010ab86e3dda9d04182e9ec2aa33efc88d",
-                "uncompressed-sha256": "0800250b789e61e917b2aa32b4b40a31746c0a7d9d8504d6eeeba671ff120879"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-metal.ppc64le.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-metal.ppc64le.raw.gz.sig",
+                "sha256": "f08f36d75aa726dbb6dd1cd5f1c0ef561174c7f5324f3fba2cd8ff52187bc242",
+                "uncompressed-sha256": "3d268c733b48b884f4215bb1f4e53883dd460b2a3eedd0e02e5b4e5800dafcc6"
               }
             }
           }
         },
         "openstack": {
-          "release": "48.84.202105182221-0",
+          "release": "49.84.202107010047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-openstack.ppc64le.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-openstack.ppc64le.qcow2.gz.sig",
-                "sha256": "f6afa3c2918136887f174169c62a2eb4e314444e379ec9bee3f71bcd4cc77b75",
-                "uncompressed-sha256": "4da3714b72968b19109f00c3af5a5411a455636f9ef1462eb4a0489c6763ce44"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-openstack.ppc64le.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-openstack.ppc64le.qcow2.gz.sig",
+                "sha256": "e30fc32cdf50ff02a72feb71cd3f4e9c92f1b038aef506d6e8396dbbf841d085",
+                "uncompressed-sha256": "9d1dc160337cda643805c96109f086015f111d46e7982b9f21cf49276cab3fb5"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202105182221-0",
+          "release": "49.84.202107010047-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-qemu.ppc64le.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202105182221-0/ppc64le/rhcos-48.84.202105182221-0-qemu.ppc64le.qcow2.gz.sig",
-                "sha256": "6be7e4e037c21907195d73f3a8f0cab1b7edd891c452b8539d3f778f6bab981d",
-                "uncompressed-sha256": "466221f4455c3363bb2503421f92907a29e7b89c48685740a8e1b728d41a8ff2"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-qemu.ppc64le.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-qemu.ppc64le.qcow2.gz.sig",
+                "sha256": "9145e08f39baf2df968ea6803303ccb1fc2941f8eae60d41ba91c9016e13ba33",
+                "uncompressed-sha256": "b3822dd7eddcf2faf4028c6a6cfa7fcfaf56153d2da6bd47c462705f90887871"
               }
             }
           }
@@ -228,72 +241,72 @@
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "48.84.202105190719-0",
+          "release": "49.84.202106302347-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-metal4k.s390x.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-metal4k.s390x.raw.gz.sig",
-                "sha256": "14f8265cd33f9fe8bc972e8b1a9a72ab9fd6910c27eb08aa1746606c0869793a",
-                "uncompressed-sha256": "b53b2178c295b1a265c13634f1a9e4208ec44c692dc22c87e0a2ec1bdea905ce"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-metal4k.s390x.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-metal4k.s390x.raw.gz.sig",
+                "sha256": "2164753adff4472ce74778ee46d3f3b2e46ebc2bc550f27da8adf73013870bfe",
+                "uncompressed-sha256": "ee3245325d61570d908cc06b0e8a4d8ec31adaa848c1cf2b73213ad1d7fa5b2d"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-live.s390x.iso",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-live.s390x.iso.sig",
-                "sha256": "4f1814296f6e1897adc55026daeeaebf07158c17079024f33b4edbba2b32e270"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live.s390x.iso",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live.s390x.iso.sig",
+                "sha256": "28176925febed1c021e0b10ca2cc30842f05436be8f56782ecb96f240914801a"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-live-kernel-s390x",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-live-kernel-s390x.sig",
-                "sha256": "d960ad108a5d3db362aa97e2d782110746590984b3bf36af8b9641c4d7890e4a"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-kernel-s390x",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-kernel-s390x.sig",
+                "sha256": "fc1762c98976a3ca46fe5b971f706570b4bcf3f3a8567dfe96c95b4f9e0e94df"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-live-initramfs.s390x.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-live-initramfs.s390x.img.sig",
-                "sha256": "6cf4d58813f862b492f1a248133fc8c27d49ba60a6cddd8f2b9311990f69f2b1"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-initramfs.s390x.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-initramfs.s390x.img.sig",
+                "sha256": "8c0d82cee34d24c14e92b724a44c36227e626debdd4394a4db531330dbb756a1"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-live-rootfs.s390x.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-live-rootfs.s390x.img.sig",
-                "sha256": "29c3921841629e1f60c371c284c88dd272bfe4bd0ae3c5bd6dbf151db8cf6b2b"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-rootfs.s390x.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-rootfs.s390x.img.sig",
+                "sha256": "e36127fd8d6dd991a278c070f04aabeb7281864d5a7b9f3439442993b4963ccc"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-metal.s390x.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-metal.s390x.raw.gz.sig",
-                "sha256": "69e28e6bf1fc5cf0ad978f8f4cb83357efad7c963276e32f196992f115a82d25",
-                "uncompressed-sha256": "8f22fe0fc6d8e08d0ee5192c7773e9b8f57f3a6ef1f4a36a1364878512aa8310"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-metal.s390x.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-metal.s390x.raw.gz.sig",
+                "sha256": "b108435618b3f4704878f404ffa2101a31887fc1595a422e7c6bfd3fe06ebd2b",
+                "uncompressed-sha256": "cd7b648002adced929fef097bf563de6397b63076eff802804f37d7d6ceeecce"
               }
             }
           }
         },
         "openstack": {
-          "release": "48.84.202105190719-0",
+          "release": "49.84.202106302347-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-openstack.s390x.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-openstack.s390x.qcow2.gz.sig",
-                "sha256": "3e20ba2e5b91ebb39a3dbcc119546ef3ff19f0818a33d8dd8dd75b9652574775",
-                "uncompressed-sha256": "1e902b881c97340194611bc09e4846d30630f39f60604a58c1ba8364b1bec6d5"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-openstack.s390x.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-openstack.s390x.qcow2.gz.sig",
+                "sha256": "d2811c21276a305d74973a4a999ad4027b959faa21b16ab4aa305d29c982d59f",
+                "uncompressed-sha256": "e7531161b61cbaefec434a105a1ad2b6b43476448f702fb584d0955a68845f57"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202105190719-0",
+          "release": "49.84.202106302347-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-qemu.s390x.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202105190719-0/s390x/rhcos-48.84.202105190719-0-qemu.s390x.qcow2.gz.sig",
-                "sha256": "e1a38224bf08ac794278857baec771047c01282d0841956ed2c8b8f741b18c96",
-                "uncompressed-sha256": "2fb6e0f3091ad63707e86e4f8743902968f0e3e7b29f09e4f4bd76108c9a576b"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-qemu.s390x.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-qemu.s390x.qcow2.gz.sig",
+                "sha256": "8847d2e9679d676e4dde33df9e7dca3eefcd7f4bfdcf8d454bf20ca40b05322b",
+                "uncompressed-sha256": "165c64704d4780a9ea0f84a7bbb3fab7a37b730c6a0197db5362090cc11d1016"
               }
             }
           }
@@ -304,135 +317,148 @@
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "48.84.202105190318-0",
+          "release": "49.84.202107010027-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-aws.x86_64.vmdk.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-aws.x86_64.vmdk.gz.sig",
-                "sha256": "3a07b55dd91391472d2f8d2723ed2e78cfcab0188590a67342981f71ec566cb4",
-                "uncompressed-sha256": "848cb5a00405e5b2da0070ead2b612ed7f4add48eab1639ba85fa912ad9a5c47"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-aws.x86_64.vmdk.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-aws.x86_64.vmdk.gz.sig",
+                "sha256": "932dd626e76f84e8f6d5158abcc753af6e865305169588203dede2bb4c41f28a",
+                "uncompressed-sha256": "3efafda489b5a789725ada0d2ea6c93a8e76775ce4e789b3b5ef5ee235b45ecb"
               }
             }
           }
         },
         "azure": {
-          "release": "48.84.202105190318-0",
+          "release": "49.84.202107010027-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-azure.x86_64.vhd.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-azure.x86_64.vhd.gz.sig",
-                "sha256": "0c2ad96789c50cd37e72054053309c3d9c66ac27d62a45f1eed4281a98a527b8",
-                "uncompressed-sha256": "587ffdf54f242bfc50f2a413222783112a4128f125bde6cc8231f449575395ea"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-azure.x86_64.vhd.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-azure.x86_64.vhd.gz.sig",
+                "sha256": "9bbedfb75c1be0f5331882840fff65b194bf9ca87548ce6c764db604056a999f",
+                "uncompressed-sha256": "e79180d7e455fbf1d8db5eb2a3522ae4c12782d35e52acba3ab95f124af73164"
+              }
+            }
+          }
+        },
+        "azurestack": {
+          "release": "49.84.202107010027-0",
+          "formats": {
+            "vhd.gz": {
+              "disk": {
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-azurestack.x86_64.vhd.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-azurestack.x86_64.vhd.gz.sig",
+                "sha256": "3c6d3dbc75deb47aaaef62e76628ef4f37143ef8d5f00435a89c03266fecac29",
+                "uncompressed-sha256": "951db0b6585976034fd6cc23de834bc7fd0cad102115bb6efd509ef1c8a38e53"
               }
             }
           }
         },
         "gcp": {
-          "release": "48.84.202105190318-0",
+          "release": "49.84.202107010027-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-gcp.x86_64.tar.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-gcp.x86_64.tar.gz.sig",
-                "sha256": "6f2074939a561985bf065e0af742248e4fc5d2ec950094987a72c6e72c3d8a94"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-gcp.x86_64.tar.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-gcp.x86_64.tar.gz.sig",
+                "sha256": "28c816bfe2df8570472607f5ae3cd5adb455932e68412370785c78617c50e7ab"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "48.84.202105190318-0",
+          "release": "49.84.202107010027-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-ibmcloud.x86_64.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-ibmcloud.x86_64.qcow2.gz.sig",
-                "sha256": "11a3e6c7893c7c8b6fde6c99a816e62ae1c76accaeea79aced286984f339cecb",
-                "uncompressed-sha256": "698a3b800ae4c070278aa759fc7a498b0406c7a1714567b8f059d8466c2e180d"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-ibmcloud.x86_64.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-ibmcloud.x86_64.qcow2.gz.sig",
+                "sha256": "0ffb7e3583faf05bb0d5bceda73f048bca5ab19d5fed6091ffd791c19167dd72",
+                "uncompressed-sha256": "eeee1e663f25bec15af029cd6fcb13079f661da80444271a7db944c7484c8a72"
               }
             }
           }
         },
         "metal": {
-          "release": "48.84.202105190318-0",
+          "release": "49.84.202107010027-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-metal4k.x86_64.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-metal4k.x86_64.raw.gz.sig",
-                "sha256": "02fe9775efc5863965bc3924b33c89eebdfc515e0a49d3a699cba8e09b79d598",
-                "uncompressed-sha256": "23ec0e1e7a37e1a0a0a7a78c980976df92a62ebde00465567deaa0d298cd04b9"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-metal4k.x86_64.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-metal4k.x86_64.raw.gz.sig",
+                "sha256": "93c5b9631ea0cac516ea2ff2a8b9949af1d856849a48763299b800ae8f25c4e6",
+                "uncompressed-sha256": "9d95fbbacad73415c6de086ce78ac06a9810db3e7fb3e3693039bd4631fa1553"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-live.x86_64.iso",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-live.x86_64.iso.sig",
-                "sha256": "9f59d8320f456d1e27ebd33a76db6311df61b1ff6e9f5ebaa5d663e426461bc2"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live.x86_64.iso",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live.x86_64.iso.sig",
+                "sha256": "244a2148ba6bc0e8e2355e6bdd90c8a2b81bdedc51c0bd323b00c8f797d2bd50"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-live-kernel-x86_64",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-live-kernel-x86_64.sig",
-                "sha256": "0fd7b56183cbac5e6c114b363b8c69340732cfc9f958edf6d1b273441d78dd8f"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-kernel-x86_64",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-kernel-x86_64.sig",
+                "sha256": "9b900e88ca71b067d8f9971dc4454f454a12666b53d3ca2d80919729060a198d"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-live-initramfs.x86_64.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-live-initramfs.x86_64.img.sig",
-                "sha256": "e7c22b2003ef3fce887d09fa9600d2f36bd4be0fcc85833c864dad65333a5689"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-initramfs.x86_64.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-initramfs.x86_64.img.sig",
+                "sha256": "cb8a23fa2ddf1c427135fb6aa016e9765c25aca9d1e863f9d0b3a18e1c4c41f8"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-live-rootfs.x86_64.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-live-rootfs.x86_64.img.sig",
-                "sha256": "ef434d53914cdd7c38bd1328ccd7d579378393f5b2e8e03e3ebb80326175002c"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-rootfs.x86_64.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-rootfs.x86_64.img.sig",
+                "sha256": "383993d4ff10d620f9e4bc452eb8f24473b271b04ed1c0d97fac3bd0d987f747"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-metal.x86_64.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-metal.x86_64.raw.gz.sig",
-                "sha256": "b00854a91c9d5fbf6ba07c2da5dec2c5b10252c66056973f244c9f4344f4245c",
-                "uncompressed-sha256": "2e2310a800911dda55ba9fd596d6e21952ae99bfda6e7a77c39900d27022c21d"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-metal.x86_64.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-metal.x86_64.raw.gz.sig",
+                "sha256": "aaf1cdcd5d085e0e8decbb19ab4fbbc8d8278d7638cceaea80b48331b263706f",
+                "uncompressed-sha256": "7080110bc282855f9e91cb86769b53f0fe4136206eac99e47f4608d5a9fecf00"
               }
             }
           }
         },
         "openstack": {
-          "release": "48.84.202105190318-0",
+          "release": "49.84.202107010027-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-openstack.x86_64.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-openstack.x86_64.qcow2.gz.sig",
-                "sha256": "37a156f9f2b0efded45cb3cd5688aa2d42c26873a534951484e96f546a6b2c84",
-                "uncompressed-sha256": "82d4540048f887c33c635397ce772867e192c72a349ff73d9b5ce66e08ab3274"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz.sig",
+                "sha256": "c7dde5f96826c33c97b5a4ad34110212281916128ae11100956f400db3d5299e",
+                "uncompressed-sha256": "00cb56c8711686255744646394e22a8ca5f27e059016f6758f14388e5a0a14cb"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202105190318-0",
+          "release": "49.84.202107010027-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-qemu.x86_64.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-qemu.x86_64.qcow2.gz.sig",
-                "sha256": "154fa07c4194898b493d5c25a4be6b48e11ba019b1352dd585f33198f560a11d",
-                "uncompressed-sha256": "84683a75c0e3d164c1d4a95448e142490a0bf91ff07076bff2b3bbc209c6c368"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-qemu.x86_64.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-qemu.x86_64.qcow2.gz.sig",
+                "sha256": "6dc06832d28ed28594902844fb1b205f3aa58c4960f976ae78c9122dc417111d",
+                "uncompressed-sha256": "c645d5eba8cba58fce4571135edb1c7ec03f04e9c5ad6466cef72f7a9717d09c"
               }
             }
           }
         },
         "vmware": {
-          "release": "48.84.202105190318-0",
+          "release": "49.84.202107010027-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-vmware.x86_64.ova",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/rhcos-48.84.202105190318-0-vmware.x86_64.ova.sig",
-                "sha256": "35beaa2b8ac6d8c87f3eee77541e7d08562fdfb6ceb481647d1c663947312412"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-vmware.x86_64.ova",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-vmware.x86_64.ova.sig",
+                "sha256": "f9ee706482c8088d1ce4d9b798d9d9cd229ce8ae011fe5909b4eb79455c08940"
               }
             }
           }
@@ -442,100 +468,100 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-08c63bb1b8b661ab9"
+              "release": "49.84.202107010027-0",
+              "image": "ami-0e7bac9d978e79a6e"
             },
             "ap-east-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-01f2a0e8aee56e1f4"
+              "release": "49.84.202107010027-0",
+              "image": "ami-051d83ebbfb127ea2"
             },
             "ap-northeast-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-012420354c0b2bf59"
+              "release": "49.84.202107010027-0",
+              "image": "ami-00413a0acfd76de7c"
             },
             "ap-northeast-2": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-0d8c0ce731da9faaf"
+              "release": "49.84.202107010027-0",
+              "image": "ami-08e2db228a5695fb3"
             },
             "ap-northeast-3": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-00cac27e65ae02107"
+              "release": "49.84.202107010027-0",
+              "image": "ami-0d0b87fc092ee2e74"
             },
             "ap-south-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-05b69d7e80f1178c6"
+              "release": "49.84.202107010027-0",
+              "image": "ami-03c83da1b6ce6d151"
             },
             "ap-southeast-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-0bd576d6deb6094c8"
+              "release": "49.84.202107010027-0",
+              "image": "ami-020876d27dc04936a"
             },
             "ap-southeast-2": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-06e7e674d4b8cdc59"
+              "release": "49.84.202107010027-0",
+              "image": "ami-02eecabb2b32443e5"
             },
             "ca-central-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-04990181ab3872dc9"
+              "release": "49.84.202107010027-0",
+              "image": "ami-070fd5123ab359da8"
             },
             "eu-central-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-0ed56edc094183f18"
+              "release": "49.84.202107010027-0",
+              "image": "ami-07ac34b5c836bb738"
             },
             "eu-north-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-0e63e7e6de6dac812"
+              "release": "49.84.202107010027-0",
+              "image": "ami-01a85ec5bac734d6b"
             },
             "eu-south-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-01c63dbdcd28938c0"
+              "release": "49.84.202107010027-0",
+              "image": "ami-0da7775afdefce9c6"
             },
             "eu-west-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-04885ff040bf8e8d0"
+              "release": "49.84.202107010027-0",
+              "image": "ami-031117dace22be7c5"
             },
             "eu-west-2": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-04b31bbfe532cbb45"
+              "release": "49.84.202107010027-0",
+              "image": "ami-0c455b12ceed301cd"
             },
             "eu-west-3": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-0e188558a41f87d82"
+              "release": "49.84.202107010027-0",
+              "image": "ami-0cc8ddaee632a3086"
             },
             "me-south-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-006b4ea9d3e62fdc2"
+              "release": "49.84.202107010027-0",
+              "image": "ami-034359190c2c7c906"
             },
             "sa-east-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-094888ec0f3125ad7"
+              "release": "49.84.202107010027-0",
+              "image": "ami-0fc38ad5e19dfd32b"
             },
             "us-east-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-0b08ba24af2f005c9"
+              "release": "49.84.202107010027-0",
+              "image": "ami-01b2bf223fccdb8e3"
             },
             "us-east-2": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-0cd5c6a0f8bb3c33d"
+              "release": "49.84.202107010027-0",
+              "image": "ami-0798e63b24f54c102"
             },
             "us-west-1": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-0d3e625f84626bbda"
+              "release": "49.84.202107010027-0",
+              "image": "ami-004c277e7c9366226"
             },
             "us-west-2": {
-              "release": "48.84.202105190318-0",
-              "image": "ami-040e8d23c125e7a75"
+              "release": "49.84.202107010027-0",
+              "image": "ami-0acecf5d7224232a8"
             }
           }
         },
         "gcp": {
           "project": "rhcos-cloud",
-          "name": "rhcos-48-84-202105190318-0-gcp-x86-64"
+          "name": "rhcos-49-84-202107010027-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "48.84.202105190318-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202105190318-0-azure.x86_64.vhd"
+          "release": "49.84.202107010027-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202107010027-0-azure.x86_64.vhd"
         }
       }
     }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,166 +1,173 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-08c63bb1b8b661ab9"
+            "hvm": "ami-0e7bac9d978e79a6e"
         },
         "ap-east-1": {
-            "hvm": "ami-01f2a0e8aee56e1f4"
+            "hvm": "ami-051d83ebbfb127ea2"
         },
         "ap-northeast-1": {
-            "hvm": "ami-012420354c0b2bf59"
+            "hvm": "ami-00413a0acfd76de7c"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0d8c0ce731da9faaf"
+            "hvm": "ami-08e2db228a5695fb3"
         },
         "ap-northeast-3": {
-            "hvm": "ami-00cac27e65ae02107"
+            "hvm": "ami-0d0b87fc092ee2e74"
         },
         "ap-south-1": {
-            "hvm": "ami-05b69d7e80f1178c6"
+            "hvm": "ami-03c83da1b6ce6d151"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0bd576d6deb6094c8"
+            "hvm": "ami-020876d27dc04936a"
         },
         "ap-southeast-2": {
-            "hvm": "ami-06e7e674d4b8cdc59"
+            "hvm": "ami-02eecabb2b32443e5"
         },
         "ca-central-1": {
-            "hvm": "ami-04990181ab3872dc9"
+            "hvm": "ami-070fd5123ab359da8"
         },
         "eu-central-1": {
-            "hvm": "ami-0ed56edc094183f18"
+            "hvm": "ami-07ac34b5c836bb738"
         },
         "eu-north-1": {
-            "hvm": "ami-0e63e7e6de6dac812"
+            "hvm": "ami-01a85ec5bac734d6b"
         },
         "eu-south-1": {
-            "hvm": "ami-01c63dbdcd28938c0"
+            "hvm": "ami-0da7775afdefce9c6"
         },
         "eu-west-1": {
-            "hvm": "ami-04885ff040bf8e8d0"
+            "hvm": "ami-031117dace22be7c5"
         },
         "eu-west-2": {
-            "hvm": "ami-04b31bbfe532cbb45"
+            "hvm": "ami-0c455b12ceed301cd"
         },
         "eu-west-3": {
-            "hvm": "ami-0e188558a41f87d82"
+            "hvm": "ami-0cc8ddaee632a3086"
         },
         "me-south-1": {
-            "hvm": "ami-006b4ea9d3e62fdc2"
+            "hvm": "ami-034359190c2c7c906"
         },
         "sa-east-1": {
-            "hvm": "ami-094888ec0f3125ad7"
+            "hvm": "ami-0fc38ad5e19dfd32b"
         },
         "us-east-1": {
-            "hvm": "ami-0b08ba24af2f005c9"
+            "hvm": "ami-01b2bf223fccdb8e3"
         },
         "us-east-2": {
-            "hvm": "ami-0cd5c6a0f8bb3c33d"
+            "hvm": "ami-0798e63b24f54c102"
         },
         "us-west-1": {
-            "hvm": "ami-0d3e625f84626bbda"
+            "hvm": "ami-004c277e7c9366226"
         },
         "us-west-2": {
-            "hvm": "ami-040e8d23c125e7a75"
+            "hvm": "ami-0acecf5d7224232a8"
         }
     },
     "azure": {
-        "image": "rhcos-48.84.202105190318-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202105190318-0-azure.x86_64.vhd"
+        "image": "rhcos-49.84.202107010027-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202107010027-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202105190318-0/x86_64/",
-    "buildid": "48.84.202105190318-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/",
+    "buildid": "49.84.202107010027-0",
     "gcp": {
-        "image": "rhcos-48-84-202105190318-0-gcp-x86-64",
+        "image": "rhcos-49-84-202107010027-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202105190318-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-49-84-202107010027-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.84.202105190318-0-aws.x86_64.vmdk.gz",
-            "sha256": "3a07b55dd91391472d2f8d2723ed2e78cfcab0188590a67342981f71ec566cb4",
-            "size": 1023936424,
-            "uncompressed-sha256": "848cb5a00405e5b2da0070ead2b612ed7f4add48eab1639ba85fa912ad9a5c47",
-            "uncompressed-size": 1044896256
+            "path": "rhcos-49.84.202107010027-0-aws.x86_64.vmdk.gz",
+            "sha256": "932dd626e76f84e8f6d5158abcc753af6e865305169588203dede2bb4c41f28a",
+            "size": 1030950571,
+            "uncompressed-sha256": "3efafda489b5a789725ada0d2ea6c93a8e76775ce4e789b3b5ef5ee235b45ecb",
+            "uncompressed-size": 1051976192
         },
         "azure": {
-            "path": "rhcos-48.84.202105190318-0-azure.x86_64.vhd.gz",
-            "sha256": "0c2ad96789c50cd37e72054053309c3d9c66ac27d62a45f1eed4281a98a527b8",
-            "size": 1024000773,
-            "uncompressed-sha256": "587ffdf54f242bfc50f2a413222783112a4128f125bde6cc8231f449575395ea",
+            "path": "rhcos-49.84.202107010027-0-azure.x86_64.vhd.gz",
+            "sha256": "9bbedfb75c1be0f5331882840fff65b194bf9ca87548ce6c764db604056a999f",
+            "size": 1030871708,
+            "uncompressed-sha256": "e79180d7e455fbf1d8db5eb2a3522ae4c12782d35e52acba3ab95f124af73164",
+            "uncompressed-size": 17179869696
+        },
+        "azurestack": {
+            "path": "rhcos-49.84.202107010027-0-azurestack.x86_64.vhd.gz",
+            "sha256": "3c6d3dbc75deb47aaaef62e76628ef4f37143ef8d5f00435a89c03266fecac29",
+            "size": 1030872938,
+            "uncompressed-sha256": "951db0b6585976034fd6cc23de834bc7fd0cad102115bb6efd509ef1c8a38e53",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.84.202105190318-0-gcp.x86_64.tar.gz",
-            "sha256": "6f2074939a561985bf065e0af742248e4fc5d2ec950094987a72c6e72c3d8a94",
-            "size": 1009471820
+            "path": "rhcos-49.84.202107010027-0-gcp.x86_64.tar.gz",
+            "sha256": "28c816bfe2df8570472607f5ae3cd5adb455932e68412370785c78617c50e7ab",
+            "size": 1016304764
         },
         "ibmcloud": {
-            "path": "rhcos-48.84.202105190318-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "11a3e6c7893c7c8b6fde6c99a816e62ae1c76accaeea79aced286984f339cecb",
-            "size": 1009816890,
-            "uncompressed-sha256": "698a3b800ae4c070278aa759fc7a498b0406c7a1714567b8f059d8466c2e180d",
-            "uncompressed-size": 2518024192
+            "path": "rhcos-49.84.202107010027-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "0ffb7e3583faf05bb0d5bceda73f048bca5ab19d5fed6091ffd791c19167dd72",
+            "size": 1016679625,
+            "uncompressed-sha256": "eeee1e663f25bec15af029cd6fcb13079f661da80444271a7db944c7484c8a72",
+            "uncompressed-size": 2534342656
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202105190318-0-live-initramfs.x86_64.img",
-            "sha256": "e7c22b2003ef3fce887d09fa9600d2f36bd4be0fcc85833c864dad65333a5689"
+            "path": "rhcos-49.84.202107010027-0-live-initramfs.x86_64.img",
+            "sha256": "cb8a23fa2ddf1c427135fb6aa016e9765c25aca9d1e863f9d0b3a18e1c4c41f8"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202105190318-0-live.x86_64.iso",
-            "sha256": "9f59d8320f456d1e27ebd33a76db6311df61b1ff6e9f5ebaa5d663e426461bc2"
+            "path": "rhcos-49.84.202107010027-0-live.x86_64.iso",
+            "sha256": "244a2148ba6bc0e8e2355e6bdd90c8a2b81bdedc51c0bd323b00c8f797d2bd50"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202105190318-0-live-kernel-x86_64",
-            "sha256": "0fd7b56183cbac5e6c114b363b8c69340732cfc9f958edf6d1b273441d78dd8f"
+            "path": "rhcos-49.84.202107010027-0-live-kernel-x86_64",
+            "sha256": "9b900e88ca71b067d8f9971dc4454f454a12666b53d3ca2d80919729060a198d"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202105190318-0-live-rootfs.x86_64.img",
-            "sha256": "ef434d53914cdd7c38bd1328ccd7d579378393f5b2e8e03e3ebb80326175002c"
+            "path": "rhcos-49.84.202107010027-0-live-rootfs.x86_64.img",
+            "sha256": "383993d4ff10d620f9e4bc452eb8f24473b271b04ed1c0d97fac3bd0d987f747"
         },
         "metal": {
-            "path": "rhcos-48.84.202105190318-0-metal.x86_64.raw.gz",
-            "sha256": "b00854a91c9d5fbf6ba07c2da5dec2c5b10252c66056973f244c9f4344f4245c",
-            "size": 1011514392,
-            "uncompressed-sha256": "2e2310a800911dda55ba9fd596d6e21952ae99bfda6e7a77c39900d27022c21d",
-            "uncompressed-size": 3938451456
+            "path": "rhcos-49.84.202107010027-0-metal.x86_64.raw.gz",
+            "sha256": "aaf1cdcd5d085e0e8decbb19ab4fbbc8d8278d7638cceaea80b48331b263706f",
+            "size": 1018448313,
+            "uncompressed-sha256": "7080110bc282855f9e91cb86769b53f0fe4136206eac99e47f4608d5a9fecf00",
+            "uncompressed-size": 3959422976
         },
         "metal4k": {
-            "path": "rhcos-48.84.202105190318-0-metal4k.x86_64.raw.gz",
-            "sha256": "02fe9775efc5863965bc3924b33c89eebdfc515e0a49d3a699cba8e09b79d598",
-            "size": 1009019314,
-            "uncompressed-sha256": "23ec0e1e7a37e1a0a0a7a78c980976df92a62ebde00465567deaa0d298cd04b9",
-            "uncompressed-size": 3938451456
+            "path": "rhcos-49.84.202107010027-0-metal4k.x86_64.raw.gz",
+            "sha256": "93c5b9631ea0cac516ea2ff2a8b9949af1d856849a48763299b800ae8f25c4e6",
+            "size": 1016010632,
+            "uncompressed-sha256": "9d95fbbacad73415c6de086ce78ac06a9810db3e7fb3e3693039bd4631fa1553",
+            "uncompressed-size": 3959422976
         },
         "openstack": {
-            "path": "rhcos-48.84.202105190318-0-openstack.x86_64.qcow2.gz",
-            "sha256": "37a156f9f2b0efded45cb3cd5688aa2d42c26873a534951484e96f546a6b2c84",
-            "size": 1009815265,
-            "uncompressed-sha256": "82d4540048f887c33c635397ce772867e192c72a349ff73d9b5ce66e08ab3274",
-            "uncompressed-size": 2518024192
+            "path": "rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz",
+            "sha256": "c7dde5f96826c33c97b5a4ad34110212281916128ae11100956f400db3d5299e",
+            "size": 1016679212,
+            "uncompressed-sha256": "00cb56c8711686255744646394e22a8ca5f27e059016f6758f14388e5a0a14cb",
+            "uncompressed-size": 2534342656
         },
         "ostree": {
-            "path": "rhcos-48.84.202105190318-0-ostree.x86_64.tar",
-            "sha256": "7728d538f4537ca9ab516697ace9dc787430912937909ad1409d53137d1a934a",
-            "size": 935157760
+            "path": "rhcos-49.84.202107010027-0-ostree.x86_64.tar",
+            "sha256": "54affb52ee9056d1bf237049f4815c686f317ef8ca135d4b1b72f69e31ee1f81",
+            "size": 940769280
         },
         "qemu": {
-            "path": "rhcos-48.84.202105190318-0-qemu.x86_64.qcow2.gz",
-            "sha256": "154fa07c4194898b493d5c25a4be6b48e11ba019b1352dd585f33198f560a11d",
-            "size": 1011011783,
-            "uncompressed-sha256": "84683a75c0e3d164c1d4a95448e142490a0bf91ff07076bff2b3bbc209c6c368",
-            "uncompressed-size": 2554527744
+            "path": "rhcos-49.84.202107010027-0-qemu.x86_64.qcow2.gz",
+            "sha256": "6dc06832d28ed28594902844fb1b205f3aa58c4960f976ae78c9122dc417111d",
+            "size": 1017869225,
+            "uncompressed-sha256": "c645d5eba8cba58fce4571135edb1c7ec03f04e9c5ad6466cef72f7a9717d09c",
+            "uncompressed-size": 2570452992
         },
         "vmware": {
-            "path": "rhcos-48.84.202105190318-0-vmware.x86_64.ova",
-            "sha256": "35beaa2b8ac6d8c87f3eee77541e7d08562fdfb6ceb481647d1c663947312412",
-            "size": 1044910080
+            "path": "rhcos-49.84.202107010027-0-vmware.x86_64.ova",
+            "sha256": "f9ee706482c8088d1ce4d9b798d9d9cd229ce8ae011fe5909b4eb79455c08940",
+            "size": 1051985920
         }
     },
     "oscontainer": {
-        "digest": "sha256:4d74181e0e7bff9739fab7cae6f946f186dd8af0848d9cded0f64db93e22e816",
+        "digest": "sha256:cf5f21445e2d6c43ab424f99db7844bfe5463af7e429842bd679deba5926e7e2",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "92ede04b462bc884de5562062fb45e06d803754cbaa466e3a2d34b4ee5e9634b",
-    "ostree-version": "48.84.202105190318-0"
+    "ostree-commit": "abb247c075d0e2d4b7cf41e0fcef3305fbd9efe9dbcde2211a072acd6ddccabb",
+    "ostree-version": "49.84.202107010027-0"
 }

--- a/docs/dev/pinned-coreos.md
+++ b/docs/dev/pinned-coreos.md
@@ -24,7 +24,7 @@ that data into the cluster as well.
 To update the bootimage for one or more architectures, use e.g.
 
 ```
-$ plume cosa2stream --target data/data/rhcos-stream.json --distro rhcos  x86_64=48.83.202102230316-0 s390x=47.83.202102090311-0 ppc64le=47.83.202102091015-0
+$ plume cosa2stream --target data/data/rhcos-stream.json --distro rhcos  x86_64=48.83.202102230316-0 s390x=47.83.202102090311-0 ppc64le=47.83.202102091015-0 --url https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases
 ```
 
 For more information on this command, see:
@@ -37,7 +37,7 @@ For more information on this command, see:
 To update the legacy metadata, use:
 
 ```
-./hack/update-rhcos-bootimage.py https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202008260918-0/x86_64/meta.json amd64
+./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6/46.82.202008260918-0/x86_64/meta.json amd64
 ```
 
 This will hopefully be removed soon.

--- a/hack/update-rhcos-bootimage.py
+++ b/hack/update-rhcos-bootimage.py
@@ -7,7 +7,7 @@ import urllib.request
 
 # An app running in the CI cluster exposes this public endpoint about ART RHCOS
 # builds.  Do not try to e.g. point to RHT-internal endpoints.
-RHCOS_RELEASES_APP = 'https://releases-art-rhcos.svc.ci.openshift.org'
+RHCOS_RELEASES_APP = 'https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com'
 
 parser = argparse.ArgumentParser()
 parser.add_argument("meta", action='store')


### PR DESCRIPTION
This brings in properly identified RHCOS 4.9 boot images for all
architectures.  In addition, the following BZs are addressed:
    
1959248 - CVE-2021-31525 ignition: golang: net/http: panic in ReadRequest and ReadResponse when reading a very large header
1960485 - Cannot use DASD at virtio block device when installing RHCOS on KVM
    
aarch64=49.84.202106302247-0
ppc64le=49.84.202107010047-0
s390x=49.84.202106302347-0
x86_64=49.84.202107010027-0
    
 ```
$ plume cosa2stream --target=data/data/rhcos-stream.json --distro=rhcos aarch64=49.84.202106302247-0 ppc64le=49.84.202107010047-0 s390x=49.84.202106302347-0 x86_64=49.84.202107010027-0
$ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/meta.json aarch64
$ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/meta.json amd64
$ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/meta.json ppc64le
$ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/meta.json s390x
```

---

hack/update-rhcos-bootimage.py: update RHCOS_RELEASES_APP
    
I think this was supposed to be part of #4928.
    
(cherry picked from commit f9165307f9ed80b99827317b78c420601e7db08a)
