### PR TITLE
OpenStack: Open 0.0.0.0/0 on NodePorts

### DIFF
--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -205,23 +205,25 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_etcd" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_tcp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 30000
-  port_range_max    = 32767
-  remote_ip_prefix  = var.cidr_block
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "tcp"
+  port_range_min = 30000
+  port_range_max = 32767
+  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
+  remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_services_udp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "udp"
-  port_range_min    = 30000
-  port_range_max    = 32767
-  remote_ip_prefix  = var.cidr_block
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "udp"
+  port_range_min = 30000
+  port_range_max = 32767
+  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
+  remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.master.id
   description       = local.description
 }

--- a/data/data/openstack/topology/sg-worker.tf
+++ b/data/data/openstack/topology/sg-worker.tf
@@ -149,23 +149,25 @@ resource "openstack_networking_secgroup_rule_v2" "worker_ingress_kubelet_insecur
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_tcp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 30000
-  port_range_max    = 32767
-  remote_ip_prefix  = var.cidr_block
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "tcp"
+  port_range_min = 30000
+  port_range_max = 32767
+  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
+  remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }
 
 resource "openstack_networking_secgroup_rule_v2" "worker_ingress_services_udp" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "udp"
-  port_range_min    = 30000
-  port_range_max    = 32767
-  remote_ip_prefix  = var.cidr_block
+  direction      = "ingress"
+  ethertype      = "IPv4"
+  protocol       = "udp"
+  port_range_min = 30000
+  port_range_max = 32767
+  # For OVN LBs the traffic will have the *real* origin source-ip, so anything goes.
+  remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.worker.id
   description       = local.description
 }

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -162,7 +162,7 @@
     os_security_group_rule:
       security_group: "{{ os_sg_master }}"
       protocol: tcp
-      remote_ip_prefix: "{{ os_subnet_range }}"
+      remote_ip_prefix: "0.0.0.0/0"
       port_range_min: 30000
       port_range_max: 32767
 
@@ -170,7 +170,7 @@
     os_security_group_rule:
       security_group: "{{ os_sg_master }}"
       protocol: udp
-      remote_ip_prefix: "{{ os_subnet_range }}"
+      remote_ip_prefix: "0.0.0.0/0"
       port_range_min: 30000
       port_range_max: 32767
 
@@ -276,7 +276,7 @@
     os_security_group_rule:
       security_group: "{{ os_sg_worker }}"
       protocol: tcp
-      remote_ip_prefix: "{{ os_subnet_range }}"
+      remote_ip_prefix: "0.0.0.0/0"
       port_range_min: 30000
       port_range_max: 32767
 
@@ -284,7 +284,7 @@
     os_security_group_rule:
       security_group: "{{ os_sg_worker }}"
       protocol: udp
-      remote_ip_prefix: "{{ os_subnet_range }}"
+      remote_ip_prefix: "0.0.0.0/0"
       port_range_min: 30000
       port_range_max: 32767
 


### PR DESCRIPTION
For `LoadBalancer` `Services` OpenStack cloud provider creates an
Octavia loadbalancer and adds all the nodes as members pointing to the
NodePort on the hosts. Previously the SGs opening traffic on those ports
were constrained to CIDR of the nodes subnet. This works fine in case of
Octavia with Amphora driver, as HAProxy will change the source-IP of the
traffic to the IP of the LB:
```
  traffic source-IP: (x.x.x.x)               (y.y.y.y)
  caller (x.x.x.x)      ->     LB (y.y.y.y)     ->     member
```
The LBs are created in nodes subnet, so that worked. Things are
different in case of OVN Octavia driver:
```
  traffic source-IP: (x.x.x.x)               (x.x.x.x)
  caller (x.x.x.x)      ->     LB (y.y.y.y)     ->     member
```
OVN preserves the source-IP of the original caller, meaning that SG
opening just nodes subnet CIDR is not enough as it would only allow
traffic from inside the cluster.

This commit switches those rules opening NodePorts on nodes to allow
0.0.0.0/0.