### PR TITLE
bootstrap: add --infra-config-file to kube-api render

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -181,7 +181,8 @@ then
 		--asset-output-dir=/assets/kube-apiserver-bootstrap \
 		--config-output-file=/assets/kube-apiserver-bootstrap/config \
 		--cluster-config-file=/assets/manifests/cluster-network-02-config.yml \
-		--cluster-auth-file=/assets/manifests/cluster-authentication-02-config.yaml
+		--cluster-auth-file=/assets/manifests/cluster-authentication-02-config.yaml \
+		--infra-config-file=/assets/manifests/cluster-infrastructure-02-config.yml
 
 	cp kube-apiserver-bootstrap/config /etc/kubernetes/bootstrap-configs/kube-apiserver-config.yaml
 	cp kube-apiserver-bootstrap/bootstrap-manifests/* bootstrap-manifests/


### PR DESCRIPTION
Kube-api operator need to render different params in sno and ha modes.
Installer should provide infrastructure file path for kube-api rendering process