### PR TITLE
Bug 1980029: Pin openstacksdk

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -24,9 +24,10 @@ RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux glibc-locale-sour
     git config --system user.email test@example.com && \
     chmod g+w /etc/passwd
 
+# Pin openstacksdk - https://bugzilla.redhat.com/show_bug.cgi?id=1980029
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
-    python3-openstackclient ansible-2.9.14-1.el8ae python3-openstacksdk python3-netaddr unzip jq && \
+    python3-openstackclient ansible-2.9.14-1.el8ae python3-openstacksdk-0.36.* python3-netaddr unzip jq && \
     yum clean all && rm -rf /var/cache/yum/*
 
 RUN python -m pip install yq


### PR DESCRIPTION
Openstacksdk 0.53 introduced an error with older version of Neutron,
where it fails with:

   400: Client Error for url: <cloud>/v2.0/security-group-rules, Unrecognized attribute(s) 'remote_address_group_id'

This was fixed in openstacksdk 0.56 which we do not yet have in the
repositories. Until then, pin to the known working 0.36 version.

Upstream issue: https://storyboard.openstack.org/#!/story/2008577