### PR TITLE
Bug 1980866: [4.7] Prefer IPv6 hostIP on bootstrap IPv6 deployments

### DIFF
--- a/data/data/bootstrap/systemd/units/kubelet.service.template
+++ b/data/data/bootstrap/systemd/units/kubelet.service.template
@@ -18,6 +18,9 @@ ExecStart=/usr/bin/hyperkube \
     --container-runtime=remote \
     --container-runtime-endpoint=/var/run/crio/crio.sock \
     --runtime-request-timeout=${KUBELET_RUNTIME_REQUEST_TIMEOUT} \
+{{- if .UseIPv6ForNodeIP }}
+    --node-ip=:: \
+{{- end}}
     --pod-manifest-path=/etc/kubernetes/manifests \
     --minimum-container-ttl-duration=6m0s \
     --cluster-domain=cluster.local \


### PR DESCRIPTION
Prefer IPv6 hostIP on bootstrap IPv6 deployments 

Kubelet can end up choosing IPv4 addresses as its hostIP, which after:

https://github.com/openshift/cluster-kube-apiserver-operator/pull/1042/files

mean that the kubernetes API service ends up with an endpoint being an
IPv4 address.  This breaks the kubernetes API loadbalancer in the
service network and prevent the deployment from succeeding.

Backport of https://github.com/openshift/installer/pull/4756