### PR TITLE
Bug 1992463: libvirt: bump default memory and cpus

### DIFF
--- a/data/data/libvirt/variables-libvirt.tf
+++ b/data/data/libvirt/variables-libvirt.tf
@@ -32,7 +32,7 @@ variable "libvirt_master_ips" {
 variable "libvirt_master_memory" {
   type        = string
   description = "RAM in MiB allocated to masters"
-  default     = "6144"
+  default     = "16384"
 }
 
 # At some point this one is likely to default to the number
@@ -41,13 +41,13 @@ variable "libvirt_master_memory" {
 variable "libvirt_master_vcpu" {
   type        = string
   description = "CPUs allocated to masters"
-  default     = "4"
+  default     = "2"
 }
 
 variable "libvirt_bootstrap_memory" {
   type        = number
   description = "RAM in MiB allocated to the bootstrap node"
-  default     = 4096
+  default     = 8192
 }
 
 # Currently RHCOS maintain its default 16G size if that


### PR DESCRIPTION
This commit bumps memory to 8gb for bootstrap vm and 16gb for masters, which seem minimal defaults for a successful install.
User can still override those values when building but this provide an alternative workflow when using public binaries (the openshift-baremetal one containing libvirt bindings)