### PR TITLE
openstack: Expose worker server group policy

### DIFF
--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -73,6 +73,13 @@ module "masters" {
   root_volume_zones      = var.openstack_master_root_volume_availability_zones
 }
 
+module "workers" {
+  source = "./workers"
+
+  server_group_names  = var.openstack_worker_server_group_names
+  server_group_policy = var.openstack_worker_server_group_policy
+}
+
 module "topology" {
   source = "./topology"
 

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -364,3 +364,13 @@ variable "openstack_master_root_volume_availability_zones" {
   default     = [""]
   description = "List of availability Zones to Schedule the masters root volumes on."
 }
+
+variable "openstack_worker_server_group_names" {
+  type        = set(string)
+  description = "Names of the server groups for the worker nodes."
+}
+
+variable "openstack_worker_server_group_policy" {
+  type        = string
+  description = "Policy of the server groups for the worker nodes."
+}

--- a/data/data/openstack/workers/main.tf
+++ b/data/data/openstack/workers/main.tf
@@ -1,0 +1,6 @@
+# Pre-create server groups for the Compute MachineSets, with the given policy.
+resource "openstack_compute_servergroup_v2" "server_groups" {
+  for_each = var.server_group_names
+  name     = each.key
+  policies = [var.server_group_policy]
+}

--- a/data/data/openstack/workers/variables.tf
+++ b/data/data/openstack/workers/variables.tf
@@ -1,0 +1,9 @@
+variable "server_group_names" {
+  type        = set(string)
+  description = "Names of the server groups for the worker nodes."
+}
+
+variable "server_group_policy" {
+  type        = string
+  description = "Policy of the server groups for the worker nodes."
+}

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -69,7 +69,7 @@ For a successful installation it is required:
 - Security Group Rules: 60
 - Routers: 1
 - Subnets: 1
-- Server Groups: 1
+- Server Groups: 2, plus one per additional Availability zone in each machine-pool
 - RAM: 112 GB
 - vCPUs: 28
 - Volume Storage: 175 GB
@@ -91,11 +91,13 @@ Once you configure the quota for your project, please ensure that the user for t
 
 The default deployment stands up 3 master nodes, which is the minimum amount required for a cluster. For each master node you stand up, you will need 1 instance, and 1 port available in your quota. They should be assigned a flavor with at least 16 GB RAM, 4 vCPUs, and 25 GB Disk (or Root Volume). It is theoretically possible to run with a smaller flavor, but be aware that if it takes too long to stand up services, or certain essential services crash, the installer could time out, leading to a failed install.
 
-The Master Nodes are placed in a single Server Group with "soft anti-affinity" policy; the machines will therefore be creted on separate hosts when possible.
+The master nodes are placed in a single Server group with "soft anti-affinity" policy by default; the machines will therefore be created on separate hosts when possible.
 
 ### Worker Nodes
 
 The default deployment stands up 3 worker nodes. Worker nodes host the applications you run on OpenShift. The flavor assigned to the worker nodes should have at least 2 vCPUs, 8 GB RAM and 25 GB Disk (or Root Volume). However, if you are experiencing `Out Of Memory` issues, or your installs are timing out, try increasing the size of your flavor to match the master nodes: 4 vCPUs and 16 GB RAM.
+
+The worker nodes are placed in a single Server group with "soft anti-affinity" policy by default; the machines will therefore be created on separate hosts when possible.
 
 See the [OpenShift documentation](https://docs.openshift.com/container-platform/4.4/architecture/control-plane.html#defining-workers_control-plane) for more information on the worker nodes.
 

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -40,7 +40,10 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 
 * `additionalNetworkIDs` (optional list of strings): IDs of additional networks for machines.
 * `additionalSecurityGroupIDs` (optional list of strings): IDs of additional security groups for machines.
-* `serverGroupPolicy` (optional string): Server group policy to apply to the group that will contain the machines in the pool. Defaults to "soft-anti-affinity". Only applicable to the Control plane MachinePool.
+* `serverGroupPolicy` (optional string): Server group policy to apply to the group that will contain the machines in the pool. Defaults to "soft-anti-affinity". Allowed values are "affinity", "soft-affinity", "anti-affinity", "soft-anti-affinity".
+  * It is not possible to change a server group policy or a server's affiliation to a group after creation
+  * A strict "affinity" policy prevents migrations, and therefore affects OpenStack upgrades
+  * An additional OpenStack host is needed when migrating instances with a strict "anti-affinity" policy
 * `type` (optional string): The OpenStack flavor name for machines in the pool.
 * `rootVolume` (optional object): Defines the root volume for instances in the machine pool. The instances use ephemeral disks if not set.
   * `size` (required integer): Size of the root volume in GB. Must be set to at least 25.

--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -80,9 +80,6 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		}
 
 		provider = providerConfigs[zone]
-		if role == "master" {
-			provider.ServerGroupName = clusterID + "-master"
-		}
 
 		machine := machineapi.Machine{
 			TypeMeta: metav1.TypeMeta{
@@ -147,6 +144,10 @@ func generateProvider(clusterID string, platform *openstack.Platform, mpool *ope
 		})
 	}
 
+	serverGroupName := clusterID + "-" + role
+	if az != "" {
+		serverGroupName += "-" + az
+	}
 	spec := openstackprovider.OpenstackProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: openstackprovider.SchemeGroupVersion.String(),
@@ -160,6 +161,7 @@ func generateProvider(clusterID string, platform *openstack.Platform, mpool *ope
 		PrimarySubnet:    platform.MachinesSubnet,
 		AvailabilityZone: az,
 		SecurityGroups:   securityGroups,
+		ServerGroupName:  serverGroupName,
 		Trunk:            trunkSupport,
 		Tags: []string{
 			fmt.Sprintf("openshiftClusterID=%s", clusterID),

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -44,6 +44,8 @@ type config struct {
 	ExternalDNS                      []string                          `json:"openstack_external_dns,omitempty"`
 	MasterServerGroupName            string                            `json:"openstack_master_server_group_name,omitempty"`
 	MasterServerGroupPolicy          types_openstack.ServerGroupPolicy `json:"openstack_master_server_group_policy"`
+	WorkerServerGroupNames           []string                          `json:"openstack_worker_server_group_names,omitempty"`
+	WorkerServerGroupPolicy          types_openstack.ServerGroupPolicy `json:"openstack_worker_server_group_policy"`
 	AdditionalNetworkIDs             []string                          `json:"openstack_additional_network_ids,omitempty"`
 	AdditionalSecurityGroupIDs       []string                          `json:"openstack_master_extra_sg_ids,omitempty"`
 	MachinesSubnet                   string                            `json:"openstack_machines_subnet_id,omitempty"`
@@ -56,7 +58,7 @@ type config struct {
 func TFVars(
 	installConfig *installconfig.InstallConfig,
 	mastersAsset *machines.Master,
-	_ *machines.Worker,
+	workersAsset *machines.Worker,
 	rhcosImage string,
 	clusterID *installconfig.ClusterID,
 	bootstrapIgn string,
@@ -75,17 +77,50 @@ func TFVars(
 		caCert = string(caFile)
 	}
 
-	masters, err := mastersAsset.Machines()
-	if err != nil {
-		return nil, err
+	var masterSpecs []*openstackprovider.OpenstackProviderSpec
+	{
+		masters, err := mastersAsset.Machines()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, master := range masters {
+			masterSpecs = append(masterSpecs, master.Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec))
+		}
 	}
 
-	var masterSpecs []*openstackprovider.OpenstackProviderSpec
-	for _, master := range masters {
-		masterSpecs = append(masterSpecs, master.Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec))
+	var workerSpecs []*openstackprovider.OpenstackProviderSpec
+	{
+		workers, err := workersAsset.MachineSets()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, worker := range workers {
+			workerSpecs = append(workerSpecs, worker.Spec.Template.Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec))
+		}
 	}
+	// Only considering the first Compute machinepool here, because
+	// the current Installer implementation allows for one only.
+	//
+	// This validation code[1] errors if the pool is not named
+	// "worker", and also errors in case of duplicate names,
+	// factually rendering impossible to have two machinepools in
+	// the install-config YAML array.
+	//
+	// [1]: https://github.com/openshift/installer/blob/252facf5e6e1238ee60b5f78607214e8691a3eab/pkg/types/validation/installconfig.go#L404-L410
+	if len(installConfig.Config.Compute) > 1 {
+		panic("Multiple machine-pools are currently not supported by the OpenShift installer on OpenStack platform")
+	}
+
+	var workermpool *types_openstack.MachinePool
+	if len(installConfig.Config.Compute) > 0 {
+		workermpool = installConfig.Config.Compute[0].Platform.OpenStack
+	}
+
 	return tfVars(
 		masterSpecs,
+		workerSpecs,
 		installConfig.Config.Platform.OpenStack.Cloud,
 		installConfig.Config.Platform.OpenStack.ExternalNetwork,
 		installConfig.Config.Platform.OpenStack.ExternalDNS,
@@ -99,13 +134,14 @@ func TFVars(
 		caCert,
 		bootstrapIgn,
 		installConfig.Config.ControlPlane.Platform.OpenStack,
+		workermpool,
 		installConfig.Config.OpenStack.DefaultMachinePlatform,
 		installConfig.Config.Platform.OpenStack.MachinesSubnet,
 		installConfig.Config.Proxy,
 	)
 }
 
-func tfVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, apiFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, baseImageProperties map[string]string, infraID string, userCA string, bootstrapIgn string, mpool, defaultmpool *types_openstack.MachinePool, machinesSubnet string, proxy *types.Proxy) ([]byte, error) {
+func tfVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, workerConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, externalNetwork string, externalDNS []string, apiFloatingIP string, ingressFloatingIP string, apiVIP string, ingressVIP string, baseImage string, baseImageProperties map[string]string, infraID string, userCA string, bootstrapIgn string, mastermpool, workermpool, defaultmpool *types_openstack.MachinePool, machinesSubnet string, proxy *types.Proxy) ([]byte, error) {
 	zones := []string{}
 	seen := map[string]bool{}
 	for _, config := range masterConfigs {
@@ -131,8 +167,8 @@ func tfVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, exter
 	if defaultmpool != nil && defaultmpool.RootVolume != nil {
 		cfg.MasterRootVolumeAvalabilityZones = defaultmpool.RootVolume.Zones
 	}
-	if mpool != nil && mpool.RootVolume != nil && mpool.RootVolume.Zones != nil {
-		cfg.MasterRootVolumeAvalabilityZones = mpool.RootVolume.Zones
+	if mastermpool != nil && mastermpool.RootVolume != nil && mastermpool.RootVolume.Zones != nil {
+		cfg.MasterRootVolumeAvalabilityZones = mastermpool.RootVolume.Zones
 	}
 
 	serviceCatalog, err := getServiceCatalog(cloud)
@@ -219,9 +255,9 @@ func tfVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, exter
 
 	cfg.MasterServerGroupName = masterConfig.ServerGroupName
 
-	if mpool != nil && mpool.ServerGroupPolicy != types_openstack.SGPolicyUnset {
-		cfg.MasterServerGroupPolicy = mpool.ServerGroupPolicy
-	} else if defaultmpool != nil && defaultmpool.ServerGroupPolicy != types_openstack.SGPolicyUnset {
+	if mastermpool != nil && mastermpool.ServerGroupPolicy.IsSet() {
+		cfg.MasterServerGroupPolicy = mastermpool.ServerGroupPolicy
+	} else if defaultmpool != nil && defaultmpool.ServerGroupPolicy.IsSet() {
 		cfg.MasterServerGroupPolicy = defaultmpool.ServerGroupPolicy
 	} else {
 		cfg.MasterServerGroupPolicy = types_openstack.SGPolicySoftAntiAffinity
@@ -231,14 +267,29 @@ func tfVars(masterConfigs []*v1alpha1.OpenstackProviderSpec, cloud string, exter
 		return nil, errors.Errorf("ServerGroupID is not implemented in the Installer. Please use ServerGroupName for automatic creation of the Control Plane server group.")
 	}
 
+	for _, workerConfig := range workerConfigs {
+		cfg.WorkerServerGroupNames = append(cfg.WorkerServerGroupNames, workerConfig.ServerGroupName)
+		if workerConfig.ServerGroupID != "" {
+			return nil, errors.Errorf("ServerGroupID is not implemented in the Installer. Please use ServerGroupName for automatic creation of the Compute server group.")
+		}
+	}
+
+	if workermpool != nil && workermpool.ServerGroupPolicy.IsSet() {
+		cfg.WorkerServerGroupPolicy = workermpool.ServerGroupPolicy
+	} else if defaultmpool != nil && defaultmpool.ServerGroupPolicy.IsSet() {
+		cfg.WorkerServerGroupPolicy = defaultmpool.ServerGroupPolicy
+	} else {
+		cfg.WorkerServerGroupPolicy = types_openstack.SGPolicySoftAntiAffinity
+	}
+
 	cfg.AdditionalNetworkIDs = []string{}
-	if mpool != nil {
-		cfg.AdditionalNetworkIDs = append(cfg.AdditionalNetworkIDs, mpool.AdditionalNetworkIDs...)
+	if mastermpool != nil {
+		cfg.AdditionalNetworkIDs = append(cfg.AdditionalNetworkIDs, mastermpool.AdditionalNetworkIDs...)
 	}
 
 	cfg.AdditionalSecurityGroupIDs = []string{}
-	if mpool != nil {
-		cfg.AdditionalSecurityGroupIDs = append(cfg.AdditionalSecurityGroupIDs, mpool.AdditionalSecurityGroupIDs...)
+	if mastermpool != nil {
+		cfg.AdditionalSecurityGroupIDs = append(cfg.AdditionalSecurityGroupIDs, mastermpool.AdditionalSecurityGroupIDs...)
 	}
 
 	if machinesSubnet != "" {

--- a/pkg/types/openstack/servergrouppolicy.go
+++ b/pkg/types/openstack/servergrouppolicy.go
@@ -22,3 +22,8 @@ const (
 // +kubebuilder:validation:Enum="";affinity;soft-affinity;anti-affinity;soft-anti-affinity
 // +optional
 type ServerGroupPolicy string
+
+// IsSet returns true when p is not the empty string.
+func (p ServerGroupPolicy) IsSet() bool {
+	return p != SGPolicyUnset
+}

--- a/pkg/types/openstack/validation/machinepool.go
+++ b/pkg/types/openstack/validation/machinepool.go
@@ -13,35 +13,15 @@ var validServerGroupPolicies = []string{
 }
 
 // ValidateMachinePool validates Control plane and Compute MachinePools
-func ValidateMachinePool(platform *openstack.Platform, machinePool *openstack.MachinePool, poolName string, fldPath *field.Path) field.ErrorList {
-	if poolName == "master" {
-		return validateMasterMachinePool(machinePool, fldPath)
+func ValidateMachinePool(_ *openstack.Platform, machinePool *openstack.MachinePool, _ string, fldPath *field.Path) field.ErrorList {
+	if machinePool == nil {
+		return nil
 	}
-	return validateWorkerMachinePool(machinePool, fldPath)
-}
-
-func validateMasterMachinePool(pool *openstack.MachinePool, fldPath *field.Path) field.ErrorList {
 	var errs field.ErrorList
-	switch pool.ServerGroupPolicy {
+	switch machinePool.ServerGroupPolicy {
 	case openstack.SGPolicyUnset, openstack.SGPolicyAffinity, openstack.SGPolicyAntiAffinity, openstack.SGPolicySoftAffinity, openstack.SGPolicySoftAntiAffinity:
 	default:
-		errs = append(errs, field.NotSupported(fldPath.Child("serverGroupPolicy"), pool.ServerGroupPolicy, validServerGroupPolicies))
-	}
-	return errs
-}
-
-func validateWorkerMachinePool(pool *openstack.MachinePool, fldPath *field.Path) field.ErrorList {
-	var errs field.ErrorList
-	if pool.ServerGroupPolicy != openstack.SGPolicyUnset {
-		errs = append(errs, field.Invalid(fldPath.Child("serverGroupPolicy"), pool.ServerGroupPolicy, "server group policy cannot be set for compute machines"))
-	}
-	return errs
-}
-
-func validateDefaultMachinePool(pool *openstack.MachinePool, fldPath *field.Path) field.ErrorList {
-	var errs field.ErrorList
-	if pool.ServerGroupPolicy != openstack.SGPolicyUnset {
-		errs = append(errs, field.Invalid(fldPath.Child("serverGroupPolicy"), pool.ServerGroupPolicy, "server group policy cannot be set as default because compute machines do not support it"))
+		errs = append(errs, field.NotSupported(fldPath.Child("serverGroupPolicy"), machinePool.ServerGroupPolicy, validServerGroupPolicies))
 	}
 	return errs
 }

--- a/pkg/types/openstack/validation/machinepool_test.go
+++ b/pkg/types/openstack/validation/machinepool_test.go
@@ -20,15 +20,9 @@ func testMachinePool(options ...func(*openstack.MachinePool)) *openstack.Machine
 	return &mp
 }
 
-func TestValidateDefaultMachinePool(t *testing.T) {
+func TestValidateMachinePool(t *testing.T) {
 	type checkFunc func(field.ErrorList) error
 	check := func(fns ...checkFunc) []checkFunc { return fns }
-	noError := func(errs field.ErrorList) error {
-		if errs != nil && len(errs) > 0 {
-			return fmt.Errorf("expected zero errors, found %v", errs)
-		}
-		return nil
-	}
 	someErrorType := func(wantType field.ErrorType) checkFunc {
 		return func(errs field.ErrorList) error {
 			for _, err := range errs {
@@ -47,69 +41,7 @@ func TestValidateDefaultMachinePool(t *testing.T) {
 			return nil
 		}
 	}
-
-	for _, tc := range [...]struct {
-		name        string
-		machinePool *openstack.MachinePool
-		checks      []checkFunc
-	}{
-		{
-			"empty",
-			testMachinePool(),
-			check(noError),
-		},
-		{
-			"with valid server group policy",
-			testMachinePool(withServerGroupPolicy("anti-affinity")),
-			check(someErrorType(field.ErrorTypeInvalid)),
-		},
-		{
-			"with invalid server group policy",
-			testMachinePool(withServerGroupPolicy("anti-gravity")),
-			check(
-				someErrorType(field.ErrorTypeInvalid),
-				exactlyNErrors(1),
-			),
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			errs := validateDefaultMachinePool(tc.machinePool, nil)
-			for _, check := range tc.checks {
-				if e := check(errs); e != nil {
-					t.Error(e)
-				}
-			}
-		})
-	}
-}
-
-func TestValidateMasterMachinePool(t *testing.T) {
-	type checkFunc func(field.ErrorList) error
-	check := func(fns ...checkFunc) []checkFunc { return fns }
-	noError := func(errs field.ErrorList) error {
-		if errs != nil && len(errs) > 0 {
-			return fmt.Errorf("expected zero errors, found %v", errs)
-		}
-		return nil
-	}
-	someErrorType := func(wantType field.ErrorType) checkFunc {
-		return func(errs field.ErrorList) error {
-			for _, err := range errs {
-				if wantType == err.Type {
-					return nil
-				}
-			}
-			return fmt.Errorf("expected error type %q, not found", wantType)
-		}
-	}
-	exactlyNErrors := func(want int) checkFunc {
-		return func(errs field.ErrorList) error {
-			if have := len(errs); want != have {
-				return fmt.Errorf("expected %d errors, got %d", want, have)
-			}
-			return nil
-		}
-	}
+	noError := exactlyNErrors(0)
 
 	for _, tc := range [...]struct {
 		name        string
@@ -136,70 +68,7 @@ func TestValidateMasterMachinePool(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := validateMasterMachinePool(tc.machinePool, nil)
-			for _, check := range tc.checks {
-				if e := check(errs); e != nil {
-					t.Error(e)
-				}
-			}
-		})
-	}
-}
-
-func TestValidateWorkerMachinePool(t *testing.T) {
-	type checkFunc func(field.ErrorList) error
-	check := func(fns ...checkFunc) []checkFunc { return fns }
-	noError := func(errs field.ErrorList) error {
-		if errs != nil && len(errs) > 0 {
-			return fmt.Errorf("expected zero errors, found %v", errs)
-		}
-		return nil
-	}
-	someErrorType := func(wantType field.ErrorType) checkFunc {
-		return func(errs field.ErrorList) error {
-			for _, err := range errs {
-				if wantType == err.Type {
-					return nil
-				}
-			}
-			return fmt.Errorf("expected error type %q, not found", wantType)
-		}
-	}
-	exactlyNErrors := func(want int) checkFunc {
-		return func(errs field.ErrorList) error {
-			if have := len(errs); want != have {
-				return fmt.Errorf("expected %d errors, got %d", want, have)
-			}
-			return nil
-		}
-	}
-
-	for _, tc := range [...]struct {
-		name        string
-		machinePool *openstack.MachinePool
-		checks      []checkFunc
-	}{
-		{
-			"empty",
-			testMachinePool(),
-			check(noError),
-		},
-		{
-			"with valid server group policy",
-			testMachinePool(withServerGroupPolicy("anti-affinity")),
-			check(someErrorType(field.ErrorTypeInvalid)),
-		},
-		{
-			"with invalid server group policy",
-			testMachinePool(withServerGroupPolicy("anti-gravity")),
-			check(
-				someErrorType(field.ErrorTypeInvalid),
-				exactlyNErrors(1),
-			),
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			errs := validateWorkerMachinePool(tc.machinePool, nil)
+			errs := ValidateMachinePool(nil, tc.machinePool, "", nil)
 			for _, check := range tc.checks {
 				if e := check(errs); e != nil {
 					t.Error(e)

--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -34,7 +34,7 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressVIP"), p.IngressVIP, err.Error()))
 	}
 
-	allErrs = append(allErrs, validateDefaultMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
+	allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, "default", fldPath.Child("defaultMachinePlatform"))...)
 
 	return allErrs
 }

--- a/scripts/openstack/manifest-tests/server-groups/install-config.yaml
+++ b/scripts/openstack/manifest-tests/server-groups/install-config.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+baseDomain: shiftstack.example.com
+clusterID: manifests1
+controlPlane:
+  hyperthreading: Enabled
+  architecture: amd64
+  name: master
+  platform:
+    openstack:
+      type: ${COMPUTE_FLAVOR}
+      serverGroupPolicy: anti-affinity
+      zones:
+      - zoneone
+  replicas: 3
+compute:
+- name: worker
+  platform:
+    openstack:
+      type: ${COMPUTE_FLAVOR}
+      serverGroupPolicy: affinity
+      zones:
+      - zonetwo
+      - zonethree
+  replicas: 3
+metadata:
+  name: manifests1
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.128.0/17
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  openstack:
+    cloud: ${OS_CLOUD}
+    externalNetwork: ${EXTERNAL_NETWORK}
+    apiFloatingIP: ${API_FIP}
+pullSecret: ${PULL_SECRET}

--- a/scripts/openstack/manifest-tests/server-groups/test_machines.py
+++ b/scripts/openstack/manifest-tests/server-groups/test_machines.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import sys
+import glob
+import yaml
+
+ASSETS_DIR = ""
+
+
+class TestMachinesServerGroup(unittest.TestCase):
+    def setUp(self):
+        """Parse the Machines into a Python data structure."""
+        self.machines = []
+        for machine_path in glob.glob(
+                f'{ASSETS_DIR}/openshift/99_openshift-cluster-api_master-machines-*.yaml'
+        ):
+            with open(machine_path) as f:
+                self.machines.append(yaml.load(f, Loader=yaml.FullLoader))
+
+    def test_consistent_group_name(self):
+        """Assert that all machines bear the same server group name."""
+        group_name = None
+        for machine in self.machines:
+            name = machine["spec"]["providerSpec"]["value"]["serverGroupName"]
+            if group_name is None:
+                group_name = name
+
+            self.assertEqual(name, group_name)
+
+
+if __name__ == '__main__':
+    ASSETS_DIR = sys.argv.pop()
+    unittest.main(verbosity=2)

--- a/scripts/openstack/manifest-tests/server-groups/test_machinesets.py
+++ b/scripts/openstack/manifest-tests/server-groups/test_machinesets.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import sys
+import glob
+import yaml
+
+ASSETS_DIR = ""
+
+
+class TestMachinesetsServerGroup(unittest.TestCase):
+    def setUp(self):
+        """Parse the MachineSets into a Python data structure."""
+        self.machinesets = []
+        for machineset_path in glob.glob(
+                f'{ASSETS_DIR}/openshift/99_openshift-cluster-api_worker-machineset-*.yaml'
+        ):
+            with open(machineset_path) as f:
+                self.machinesets.append(yaml.load(f, Loader=yaml.FullLoader))
+
+    def test_consistent_group_names(self):
+        """Assert that server group names are unique across machinesets."""
+        found = []
+        for machineset in self.machinesets:
+            name = machineset["spec"]["template"]["spec"]["providerSpec"][
+                "value"]["serverGroupName"]
+            self.assertNotIn(name, found)
+            found.append(name)
+
+
+if __name__ == '__main__':
+    ASSETS_DIR = sys.argv.pop()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
With this change, Compute nodes within each MachineSet are automatically
created in a Server group, with a default policy of
"soft-anti-affinity".

With this change, a "serverGroupPolicy" can be set in install-config, on
the worker MachinePool and/or in the platform default.

Implements [OSASINFRA-2570](https://issues.redhat.com/browse/OSASINFRA-2570)

Co-Authored-By: Matthew Booth <mbooth@redhat.com>