### PR TITLE
vSphere: Add datastore and storagepod to category

### DIFF
--- a/data/data/vsphere/main.tf
+++ b/data/data/vsphere/main.tf
@@ -60,7 +60,9 @@ resource "vsphere_tag_category" "category" {
   associable_types = [
     "VirtualMachine",
     "ResourcePool",
-    "Folder"
+    "Folder",
+    "Datastore",
+    "StoragePod"
   ]
 }
 


### PR DESCRIPTION
Allow the tag that is created by the installer to be attached
to a datastore for storage policy based management.