### PR TITLE
Bug 1882490: data/azure/master: Add dash to nic name

### DIFF
--- a/data/data/azure/cluster/master/master.tf
+++ b/data/data/azure/cluster/master/master.tf
@@ -9,7 +9,7 @@ locals {
 resource "azurerm_network_interface" "master" {
   count = var.instance_count
 
-  name                = "${var.cluster_id}-master${count.index}-nic"
+  name                = "${var.cluster_id}-master-${count.index}-nic"
   location            = var.region
   resource_group_name = var.resource_group_name
 


### PR DESCRIPTION
Fix code consistency issue of missing dash in nic name.

```
> $ git grep '${var.cluster_id}-master-${count.index}' | wc -l
21

> $ git grep '${var.cluster_id}-master${count.index}' | wc -l 
1
```