### PR TITLE
Add SRIOV Support for Kubevirt Provider

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1684,6 +1684,10 @@ spec:
                       ingress controller.
                     format: ip
                     type: string
+                  interfaceBindingMethod:
+                    description: InterfaceBindingMethod is the the interface binding
+                      method of the nodes of the tenantcluster (Bridge | SRIOV).
+                    type: string
                   namespace:
                     description: Namespace is the namespace in the infra cluster,
                       which the control plane (master vms) and the compute (worker

--- a/data/data/kubevirt/bootstrap/main.tf
+++ b/data/data/kubevirt/bootstrap/main.tf
@@ -117,7 +117,7 @@ resource "kubevirt_virtual_machine" "bootstrap_vm" {
             }
             interface {
               name = "main"
-              interface_binding_method = "InterfaceBridge"
+              interface_binding_method = var.interface_binding_method
             }
           }
         }

--- a/data/data/kubevirt/bootstrap/variables.tf
+++ b/data/data/kubevirt/bootstrap/variables.tf
@@ -40,14 +40,19 @@ variable "network_name" {
   description = "The name of the sub network created in the infracluster which should be used by the tenant cluster resources"
 }
 
+variable "interface_binding_method" {
+  type        = string
+  description = "The interface binding method of the nodes of the tenantcluster"
+}
+
 variable "pv_access_mode" {
   type        = string
-  description = "The access mode which all the persistant volumes should be created with [ReadWriteOnce,ReadOnlyMany,ReadWriteMany]"
+  description = "The access mode which all the persistent volumes should be created with [ReadWriteOnce,ReadOnlyMany,ReadWriteMany]"
 }
 
 variable "pvc_name" {
   type        = string
-  description = "The Persistant data volume which bootstrap VM should be cloned from"
+  description = "The Persistent data volume which bootstrap VM should be cloned from"
 }
 
 variable "labels" {

--- a/data/data/kubevirt/datavolume/variables.tf
+++ b/data/data/kubevirt/datavolume/variables.tf
@@ -1,6 +1,6 @@
 variable "pvc_name" {
   type        = string
-  description = "The Persistant data volume name"
+  description = "The Persistent data volume name"
 }
 
 variable "namespace" {
@@ -10,13 +10,13 @@ variable "namespace" {
 
 variable "storage" {
   type        = string
-  description = "persistant data volume disk size, of type Quantity (see: https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go)"
+  description = "persistent data volume disk size, of type Quantity (see: https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go)"
   default     = "20Gi"
 }
 
 variable "pv_access_mode" {
   type        = string
-  description = "The access mode which all the persistant volumes should be created with [ReadWriteOnce,ReadOnlyMany,ReadWriteMany]"
+  description = "The access mode which all the persistent volumes should be created with [ReadWriteOnce,ReadOnlyMany,ReadWriteMany]"
 }
 
 variable "storage_class" {
@@ -26,7 +26,7 @@ variable "storage_class" {
 
 variable "image_url" {
   type        = string
-  description = "The source image URL to be used to create the source persistant data volume (all the VMs are cloned from)"
+  description = "The source image URL to be used to create the source persistent data volume (all the VMs are cloned from)"
 }
 
 variable "labels" {

--- a/data/data/kubevirt/main.tf
+++ b/data/data/kubevirt/main.tf
@@ -15,29 +15,33 @@ module "datavolume" {
 }
 
 module "masters" {
-  source         = "./masters"
-  master_count   = var.master_count
-  cluster_id     = var.cluster_id
-  ignition_data  = var.ignition_master
-  namespace      = var.kubevirt_namespace
-  storage        = var.kubevirt_master_storage
-  memory         = var.kubevirt_master_memory
-  cpu            = var.kubevirt_master_cpu
-  storage_class  = var.kubevirt_storage_class
-  network_name   = var.kubevirt_network_name
-  pv_access_mode = var.kubevirt_pv_access_mode
-  labels         = var.kubevirt_labels
-  pvc_name       = module.datavolume.pvc_name
+  source                   = "./masters"
+  master_count             = var.master_count
+  cluster_id               = var.cluster_id
+  ignition_data            = var.ignition_master
+  namespace                = var.kubevirt_namespace
+  storage                  = var.kubevirt_master_storage
+  memory                   = var.kubevirt_master_memory
+  cpu                      = var.kubevirt_master_cpu
+  storage_class            = var.kubevirt_storage_class
+  network_name             = var.kubevirt_network_name
+  interface_binding_method = var.kubevirt_interface_binding_method
+  pv_access_mode           = var.kubevirt_pv_access_mode
+  labels                   = var.kubevirt_labels
+  pvc_name                 = module.datavolume.pvc_name
+
 }
 
 module "bootstrap" {
-  source         = "./bootstrap"
-  cluster_id     = var.cluster_id
-  ignition_data  = var.ignition_bootstrap
-  namespace      = var.kubevirt_namespace
-  storage_class  = var.kubevirt_storage_class
-  network_name   = var.kubevirt_network_name
-  pv_access_mode = var.kubevirt_pv_access_mode
-  labels         = var.kubevirt_labels
-  pvc_name       = module.datavolume.pvc_name
+  source                   = "./bootstrap"
+  cluster_id               = var.cluster_id
+  ignition_data            = var.ignition_bootstrap
+  namespace                = var.kubevirt_namespace
+  storage_class            = var.kubevirt_storage_class
+  network_name             = var.kubevirt_network_name
+  interface_binding_method = var.kubevirt_interface_binding_method
+  pv_access_mode           = var.kubevirt_pv_access_mode
+  labels                   = var.kubevirt_labels
+  pvc_name                 = module.datavolume.pvc_name
+
 }

--- a/data/data/kubevirt/masters/main.tf
+++ b/data/data/kubevirt/masters/main.tf
@@ -127,7 +127,7 @@ resource "kubevirt_virtual_machine" "master_vm" {
             }
             interface {
               name                     = "main"
-              interface_binding_method = "InterfaceBridge"
+              interface_binding_method = var.interface_binding_method
             }
           }
         }

--- a/data/data/kubevirt/masters/variables.tf
+++ b/data/data/kubevirt/masters/variables.tf
@@ -41,14 +41,19 @@ variable "network_name" {
   description = "The name of the sub network created in the infracluster which should be used by the tenantcluster resources"
 }
 
+variable "interface_binding_method" {
+  type        = string
+  description = "The interface binding method of the nodes of the tenantcluster"
+}
+
 variable "pv_access_mode" {
   type        = string
-  description = "The access mode which all the persistant volumes should be created with [ReadWriteOnce,ReadWriteMany]"
+  description = "The access mode which all the persistent volumes should be created with [ReadWriteOnce,ReadWriteMany]"
 }
 
 variable "pvc_name" {
   type        = string
-  description = "The Persistant data volume which all the vms (workers/masters) should be cloned from"
+  description = "The Persistent data volume which all the vms (workers/masters) should be cloned from"
 }
 
 variable "labels" {

--- a/data/data/kubevirt/variables-kubevirt.tf
+++ b/data/data/kubevirt/variables-kubevirt.tf
@@ -41,6 +41,7 @@ variable "kubevirt_network_name" {
 variable "kubevirt_interface_binding_method" {
   type        = string
   description = "The interface binding method of the nodes of the tenantcluster"
+  default     = "Bridge"
 }
 
 variable "kubevirt_pv_access_mode" {

--- a/data/data/kubevirt/variables-kubevirt.tf
+++ b/data/data/kubevirt/variables-kubevirt.tf
@@ -5,7 +5,7 @@ variable "kubevirt_namespace" {
 
 variable "kubevirt_source_pvc_name" {
   type        = string
-  description = "The Persistant data volume which all the vms (workers/masters) should be cloned from"
+  description = "The Persistent data volume which all the vms (workers/masters) should be cloned from"
 }
 
 variable "kubevirt_master_storage" {
@@ -15,7 +15,7 @@ variable "kubevirt_master_storage" {
 
 variable "kubevirt_image_url" {
   type        = string
-  description = "The source image URL to be used to create the source persistant data volume (all the VMs are cloned from)"
+  description = "The source image URL to be used to create the source persistent data volume (all the VMs are cloned from)"
 }
 
 variable "kubevirt_master_memory" {
@@ -38,9 +38,14 @@ variable "kubevirt_network_name" {
   description = "The name of the sub network created in the infracluster which should be used by the tenantcluster resources"
 }
 
+variable "kubevirt_interface_binding_method" {
+  type        = string
+  description = "The interface binding method of the nodes of the tenantcluster"
+}
+
 variable "kubevirt_pv_access_mode" {
   type        = string
-  description = "The access mode which all the persistant volumes should be created with [ReadWriteOnce,ReadOnlyMany,ReadWriteMany]"
+  description = "The access mode which all the persistent volumes should be created with [ReadWriteOnce,ReadOnlyMany,ReadWriteMany]"
 }
 
 variable "kubevirt_labels" {

--- a/docs/user/kubevirt/install-config.yaml
+++ b/docs/user/kubevirt/install-config.yaml
@@ -30,6 +30,7 @@ platform:
     ingressVIP: Enter here the Ingress virtual IP
     namespace: Enter here the namespace to create the tenant cluster resources in
     networkName: Enter here the network (NAD name) to be used by the tenant cluster
+    interfaceBindingMethod: Enter here the interface binding method of the NAD to be used by the tenant cluster's nodes [Bridge|SRIOV]
     storageClass: Enter here the storage class used in the infra cluster
 publish: External
 pullSecret: Enter pullSecret here, You can get this secret from https://cloud.redhat.com/openshift/install/pull-secret

--- a/docs/user/kubevirt/install_ipi.md
+++ b/docs/user/kubevirt/install_ipi.md
@@ -130,6 +130,7 @@ At this stage, as the Kubevirt provider defined a dev preview, the installer can
 >>> |namespace                   |string                        |Yes     |The namespace in the infra cluster, where the control plane (master vms) and the compute (worker vms) will be created in   |
 >>> |storageClass                |string                        |No      |The Storage Class used in the infra cluster   |
 >>> |networkName                 |string                        |Yes     |The target network of all the network interfaces of the nodes   |
+>>> |networkType                 |string                        |No      |The type of the network interfaces of the nodes of the tenantcluster ("Bridge" or "SRIOV"). Default: "Bridge".
 >>> |apiVIP                      |IPV4                          |Yes     |The virtual IP address for the api endpoint   |
 >>> |ingressVIP                  |IPV4                          |Yes     |An external IP which routes to the default ingress controller   |
 >>> |persistentVolumeAccessMode  |[ReadWriteMany,ReadWriteOnce] |No      |The access mode should be use with the persistent volumes   |

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e
 	github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201203141909-4dc702fd57a5
 	github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20210702173623-676faba9895d
-	github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20201214114543-e5aed9c73f1f
+	github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20210719100556-9b8bc3666720
 	github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603
 	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210622084102-c4f9f269bcb7
 	github.com/openshift/library-go v0.0.0-20210408164723-7a65fdb398e2

--- a/go.sum
+++ b/go.sum
@@ -575,7 +575,6 @@ github.com/go-logr/logr v0.2.1/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTg
 github.com/go-logr/logr v0.3.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/zapr v0.2.0/go.mod h1:qhKdvif7YF5GI9NWEpyxTSSBdGmzkNguibrdCNVPunU=
 github.com/go-logr/zapr v0.4.0 h1:uc1uML3hRYL9/ZZPdgHS/n8Nzo+eaYL/Efxkkamf7OM=
 github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
@@ -1459,14 +1458,13 @@ github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200701112720-3a7d727c9a
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200713133651-5c8a640669ac/go.mod h1:XVYX9JE339nKbDDa/W481XD+1GTeqeaBm8bDPr7WE7I=
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200901173901-9056dbc8c9b9/go.mod h1:rcwAydGZX+z4l91wtOdbq+fqDwuo6iu0YuFik3UUc+8=
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201002065957-9854f7420570/go.mod h1:7NRECVE26rvP1/fs1CbhfY5gsgnnFQNhb9txTFzWmUw=
-github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201027164920-70f2f92e64ab/go.mod h1:S38HjVtBmaX6PHq99updVereupkHcwcOEM5jq6rTILI=
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201201000827-1117a4fc438c/go.mod h1:21N0wWjiTQypZ7WosEYhcGJHr9JoDR1RBFztE0NvdYM=
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201203141909-4dc702fd57a5 h1:75U75i/GfStAartlsP/F9v3Gv3MwzuLwqdLTjP1vPeE=
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201203141909-4dc702fd57a5/go.mod h1:/XjFaKnqBc8K/jcRXHO7tau39CmzNinqmpxYaQGRvnE=
 github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20210702173623-676faba9895d h1:FD/0xn/h8Do//QkPGhsf1pgXkH8nUkfIUmQ16bRU6TQ=
 github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20210702173623-676faba9895d/go.mod h1:hIEdP3ZudO/l2J8+gm8IFW0KMHn0YURvMSTZy9luK7w=
-github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20201214114543-e5aed9c73f1f h1:GLvV9l0Qtk8NfqrfDuanHPUyZB413vxp9nUUX1+oyfg=
-github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20201214114543-e5aed9c73f1f/go.mod h1:Moiq8vUJ4IdTaJBxIA756FFJ4GgVXZAiOds7lTpZ1kQ=
+github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20210719100556-9b8bc3666720 h1:+7K3weJLiXzIlUfdKbJ34QaAROrQMxXuEMi0ozmMyZY=
+github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20210719100556-9b8bc3666720/go.mod h1:jiZXnZ50S7oYVnLIKp9K2RExM2zTtPpoCVSGtsmotqc=
 github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603 h1:MC6BSZYxFPoqqKj9PdlGjHGVKcMsvn6Kv1NiVzQErZ8=
 github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603/go.mod h1:7pQ9Bzha+ug/5zd+0ufbDEcnn2OnNlPwRwYrzhXk4NM=
 github.com/openshift/cluster-api-provider-openstack v0.0.0-20210302164104-8498241fa4bd h1:5mq9/JftiO9u/RknQ5iR9Nkd09R1XFfUPS1nO11Wth0=
@@ -1492,7 +1490,6 @@ github.com/openshift/machine-api-operator v0.2.1-0.20200701225707-950912b03628/g
 github.com/openshift/machine-api-operator v0.2.1-0.20200722104429-f4f9b84df9b7/go.mod h1:XDsNRAVEJtkI00e51SAZ/PnqNJl1zv0rHXSdl9L1oOY=
 github.com/openshift/machine-api-operator v0.2.1-0.20200926044412-b7d860f8074c/go.mod h1:cp/wPVzxHZeLUjOLkNPNqrk4wyyW6HuHd3Kz9+hl5xw=
 github.com/openshift/machine-api-operator v0.2.1-0.20201002104344-6abfb5440597/go.mod h1:+oAfoCl+TUd2TM79/6NdqLpFUHIJpmqkKdmiHe2O7mw=
-github.com/openshift/machine-api-operator v0.2.1-0.20201111151924-77300d0c997a/go.mod h1:XQN83eD5YoXEkla3di+exKIpLYx/ApLAOe0EE66Q+hw=
 github.com/openshift/machine-api-operator v0.2.1-0.20201203125141-79567cb3368e/go.mod h1:Vxdx8K+8sbdcGozW86hSvcVl5JgJOqNFYhLRRhEM9HY=
 github.com/openshift/machine-api-operator v0.2.1-0.20210104142355-8e6ae0acdfcf/go.mod h1:U5eAHChde1XvtQy3s1Zcr7ll4X7heb0SzYpaiAwxmQc=
 github.com/openshift/machine-api-operator v0.2.1-0.20210504014029-a132ec00f7dd/go.mod h1:DFZBMPtC2TYZH5NE9+2JQIpbZAnruqc9F26QmbOm9pw=
@@ -1939,7 +1936,6 @@ go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKY
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
-go.uber.org/zap v1.8.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.13.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -674,17 +674,12 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 
 		labels := kubevirtutils.BuildLabels(clusterID.InfraID)
-		interfaceBindingMethod := "InterfaceBridge"
-		if installConfig.Config.Kubevirt.InterfaceBindingMethod != "" {
-			interfaceBindingMethod = "Interface" + installConfig.Config.Kubevirt.InterfaceBindingMethod
-		}
 		data, err := kubevirttfvars.TFVars(
 			kubevirttfvars.TFVarsSources{
-				MasterSpecs:            masterSpecs,
-				ImageURL:               string(*rhcosImage),
-				Namespace:              installConfig.Config.Kubevirt.Namespace,
-				InterfaceBindingMethod: interfaceBindingMethod,
-				ResourcesLabels:        labels,
+				MasterSpecs:     masterSpecs,
+				ImageURL:        string(*rhcosImage),
+				Namespace:       installConfig.Config.Kubevirt.Namespace,
+				ResourcesLabels: labels,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -674,7 +674,10 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 
 		labels := kubevirtutils.BuildLabels(clusterID.InfraID)
-		interfaceBindingMethod := "Interface" + installConfig.Config.Kubevirt.InterfaceBindingMethod
+		interfaceBindingMethod := "InterfaceBridge"
+		if installConfig.Config.Kubevirt.InterfaceBindingMethod != "" {
+			interfaceBindingMethod = "Interface" + installConfig.Config.Kubevirt.InterfaceBindingMethod
+		}
 		data, err := kubevirttfvars.TFVars(
 			kubevirttfvars.TFVarsSources{
 				MasterSpecs:            masterSpecs,

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -674,12 +674,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 
 		labels := kubevirtutils.BuildLabels(clusterID.InfraID)
+		interfaceBindingMethod := "Interface" + installConfig.Config.Kubevirt.InterfaceBindingMethod
 		data, err := kubevirttfvars.TFVars(
 			kubevirttfvars.TFVarsSources{
-				MasterSpecs:     masterSpecs,
-				ImageURL:        string(*rhcosImage),
-				Namespace:       installConfig.Config.Kubevirt.Namespace,
-				ResourcesLabels: labels,
+				MasterSpecs:            masterSpecs,
+				ImageURL:               string(*rhcosImage),
+				Namespace:              installConfig.Config.Kubevirt.Namespace,
+				InterfaceBindingMethod: interfaceBindingMethod,
+				ResourcesLabels:        labels,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
+++ b/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
@@ -6,8 +6,6 @@ package mock
 
 import (
 	context "context"
-	reflect "reflect"
-
 	dnsrecordsv1 "github.com/IBM/networking-go-sdk/dnsrecordsv1"
 	iamidentityv1 "github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	resourcecontrollerv2 "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
@@ -15,32 +13,33 @@ import (
 	vpcv1 "github.com/IBM/vpc-go-sdk/vpcv1"
 	gomock "github.com/golang/mock/gomock"
 	ibmcloud "github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
+	reflect "reflect"
 )
 
-// MockAPI is a mock of API interface.
+// MockAPI is a mock of API interface
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI.
+// MockAPIMockRecorder is the mock recorder for MockAPI
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance.
+// NewMockAPI creates a new mock instance
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// GetAuthenticatorAPIKeyDetails mocks base method.
+// GetAuthenticatorAPIKeyDetails mocks base method
 func (m *MockAPI) GetAuthenticatorAPIKeyDetails(ctx context.Context) (*iamidentityv1.APIKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthenticatorAPIKeyDetails", ctx)
@@ -49,13 +48,13 @@ func (m *MockAPI) GetAuthenticatorAPIKeyDetails(ctx context.Context) (*iamidenti
 	return ret0, ret1
 }
 
-// GetAuthenticatorAPIKeyDetails indicates an expected call of GetAuthenticatorAPIKeyDetails.
+// GetAuthenticatorAPIKeyDetails indicates an expected call of GetAuthenticatorAPIKeyDetails
 func (mr *MockAPIMockRecorder) GetAuthenticatorAPIKeyDetails(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthenticatorAPIKeyDetails", reflect.TypeOf((*MockAPI)(nil).GetAuthenticatorAPIKeyDetails), ctx)
 }
 
-// GetCISInstance mocks base method.
+// GetCISInstance mocks base method
 func (m *MockAPI) GetCISInstance(ctx context.Context, crnstr string) (*resourcecontrollerv2.ResourceInstance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCISInstance", ctx, crnstr)
@@ -64,13 +63,13 @@ func (m *MockAPI) GetCISInstance(ctx context.Context, crnstr string) (*resourcec
 	return ret0, ret1
 }
 
-// GetCISInstance indicates an expected call of GetCISInstance.
+// GetCISInstance indicates an expected call of GetCISInstance
 func (mr *MockAPIMockRecorder) GetCISInstance(ctx, crnstr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCISInstance", reflect.TypeOf((*MockAPI)(nil).GetCISInstance), ctx, crnstr)
 }
 
-// GetDNSRecordsByName mocks base method.
+// GetDNSRecordsByName mocks base method
 func (m *MockAPI) GetDNSRecordsByName(ctx context.Context, crnstr, zoneID, recordName string) ([]dnsrecordsv1.DnsrecordDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDNSRecordsByName", ctx, crnstr, zoneID, recordName)
@@ -79,13 +78,13 @@ func (m *MockAPI) GetDNSRecordsByName(ctx context.Context, crnstr, zoneID, recor
 	return ret0, ret1
 }
 
-// GetDNSRecordsByName indicates an expected call of GetDNSRecordsByName.
+// GetDNSRecordsByName indicates an expected call of GetDNSRecordsByName
 func (mr *MockAPIMockRecorder) GetDNSRecordsByName(ctx, crnstr, zoneID, recordName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSRecordsByName", reflect.TypeOf((*MockAPI)(nil).GetDNSRecordsByName), ctx, crnstr, zoneID, recordName)
 }
 
-// GetDNSZoneIDByName mocks base method.
+// GetDNSZoneIDByName mocks base method
 func (m *MockAPI) GetDNSZoneIDByName(ctx context.Context, name string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDNSZoneIDByName", ctx, name)
@@ -94,13 +93,13 @@ func (m *MockAPI) GetDNSZoneIDByName(ctx context.Context, name string) (string, 
 	return ret0, ret1
 }
 
-// GetDNSZoneIDByName indicates an expected call of GetDNSZoneIDByName.
+// GetDNSZoneIDByName indicates an expected call of GetDNSZoneIDByName
 func (mr *MockAPIMockRecorder) GetDNSZoneIDByName(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSZoneIDByName", reflect.TypeOf((*MockAPI)(nil).GetDNSZoneIDByName), ctx, name)
 }
 
-// GetDNSZones mocks base method.
+// GetDNSZones mocks base method
 func (m *MockAPI) GetDNSZones(ctx context.Context) ([]ibmcloud.DNSZoneResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDNSZones", ctx)
@@ -109,13 +108,13 @@ func (m *MockAPI) GetDNSZones(ctx context.Context) ([]ibmcloud.DNSZoneResponse, 
 	return ret0, ret1
 }
 
-// GetDNSZones indicates an expected call of GetDNSZones.
+// GetDNSZones indicates an expected call of GetDNSZones
 func (mr *MockAPIMockRecorder) GetDNSZones(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSZones", reflect.TypeOf((*MockAPI)(nil).GetDNSZones), ctx)
 }
 
-// GetEncryptionKey mocks base method.
+// GetEncryptionKey mocks base method
 func (m *MockAPI) GetEncryptionKey(ctx context.Context, keyCRN string) (*ibmcloud.EncryptionKeyResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEncryptionKey", ctx, keyCRN)
@@ -124,28 +123,13 @@ func (m *MockAPI) GetEncryptionKey(ctx context.Context, keyCRN string) (*ibmclou
 	return ret0, ret1
 }
 
-// GetEncryptionKey indicates an expected call of GetEncryptionKey.
+// GetEncryptionKey indicates an expected call of GetEncryptionKey
 func (mr *MockAPIMockRecorder) GetEncryptionKey(ctx, keyCRN interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncryptionKey", reflect.TypeOf((*MockAPI)(nil).GetEncryptionKey), ctx, keyCRN)
 }
 
-// GetResourceGroup mocks base method.
-func (m *MockAPI) GetResourceGroup(ctx context.Context, nameOrID string) (*resourcemanagerv2.ResourceGroup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResourceGroup", ctx, nameOrID)
-	ret0, _ := ret[0].(*resourcemanagerv2.ResourceGroup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetResourceGroup indicates an expected call of GetResourceGroup.
-func (mr *MockAPIMockRecorder) GetResourceGroup(ctx, nameOrID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceGroup", reflect.TypeOf((*MockAPI)(nil).GetResourceGroup), ctx, nameOrID)
-}
-
-// GetResourceGroups mocks base method.
+// GetResourceGroups mocks base method
 func (m *MockAPI) GetResourceGroups(ctx context.Context) ([]resourcemanagerv2.ResourceGroup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourceGroups", ctx)
@@ -154,13 +138,28 @@ func (m *MockAPI) GetResourceGroups(ctx context.Context) ([]resourcemanagerv2.Re
 	return ret0, ret1
 }
 
-// GetResourceGroups indicates an expected call of GetResourceGroups.
+// GetResourceGroups indicates an expected call of GetResourceGroups
 func (mr *MockAPIMockRecorder) GetResourceGroups(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceGroups", reflect.TypeOf((*MockAPI)(nil).GetResourceGroups), ctx)
 }
 
-// GetSubnet mocks base method.
+// GetResourceGroup mocks base method
+func (m *MockAPI) GetResourceGroup(ctx context.Context, nameOrID string) (*resourcemanagerv2.ResourceGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResourceGroup", ctx, nameOrID)
+	ret0, _ := ret[0].(*resourcemanagerv2.ResourceGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResourceGroup indicates an expected call of GetResourceGroup
+func (mr *MockAPIMockRecorder) GetResourceGroup(ctx, nameOrID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceGroup", reflect.TypeOf((*MockAPI)(nil).GetResourceGroup), ctx, nameOrID)
+}
+
+// GetSubnet mocks base method
 func (m *MockAPI) GetSubnet(ctx context.Context, subnetID string) (*vpcv1.Subnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubnet", ctx, subnetID)
@@ -169,43 +168,13 @@ func (m *MockAPI) GetSubnet(ctx context.Context, subnetID string) (*vpcv1.Subnet
 	return ret0, ret1
 }
 
-// GetSubnet indicates an expected call of GetSubnet.
+// GetSubnet indicates an expected call of GetSubnet
 func (mr *MockAPIMockRecorder) GetSubnet(ctx, subnetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockAPI)(nil).GetSubnet), ctx, subnetID)
 }
 
-// GetVPC mocks base method.
-func (m *MockAPI) GetVPC(ctx context.Context, vpcID string) (*vpcv1.VPC, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVPC", ctx, vpcID)
-	ret0, _ := ret[0].(*vpcv1.VPC)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVPC indicates an expected call of GetVPC.
-func (mr *MockAPIMockRecorder) GetVPC(ctx, vpcID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPC", reflect.TypeOf((*MockAPI)(nil).GetVPC), ctx, vpcID)
-}
-
-// GetVPCZonesForRegion mocks base method.
-func (m *MockAPI) GetVPCZonesForRegion(ctx context.Context, region string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVPCZonesForRegion", ctx, region)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVPCZonesForRegion indicates an expected call of GetVPCZonesForRegion.
-func (mr *MockAPIMockRecorder) GetVPCZonesForRegion(ctx, region interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCZonesForRegion", reflect.TypeOf((*MockAPI)(nil).GetVPCZonesForRegion), ctx, region)
-}
-
-// GetVSIProfiles mocks base method.
+// GetVSIProfiles mocks base method
 func (m *MockAPI) GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVSIProfiles", ctx)
@@ -214,8 +183,38 @@ func (m *MockAPI) GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, 
 	return ret0, ret1
 }
 
-// GetVSIProfiles indicates an expected call of GetVSIProfiles.
+// GetVSIProfiles indicates an expected call of GetVSIProfiles
 func (mr *MockAPIMockRecorder) GetVSIProfiles(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVSIProfiles", reflect.TypeOf((*MockAPI)(nil).GetVSIProfiles), ctx)
+}
+
+// GetVPC mocks base method
+func (m *MockAPI) GetVPC(ctx context.Context, vpcID string) (*vpcv1.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPC", ctx, vpcID)
+	ret0, _ := ret[0].(*vpcv1.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPC indicates an expected call of GetVPC
+func (mr *MockAPIMockRecorder) GetVPC(ctx, vpcID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPC", reflect.TypeOf((*MockAPI)(nil).GetVPC), ctx, vpcID)
+}
+
+// GetVPCZonesForRegion mocks base method
+func (m *MockAPI) GetVPCZonesForRegion(ctx context.Context, region string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPCZonesForRegion", ctx, region)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPCZonesForRegion indicates an expected call of GetVPCZonesForRegion
+func (mr *MockAPIMockRecorder) GetVPCZonesForRegion(ctx, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCZonesForRegion", reflect.TypeOf((*MockAPI)(nil).GetVPCZonesForRegion), ctx, region)
 }

--- a/pkg/asset/installconfig/kubevirt/client.go
+++ b/pkg/asset/installconfig/kubevirt/client.go
@@ -39,7 +39,6 @@ type Client interface {
 	GetStorageClass(ctx context.Context, name string) (*storagev1.StorageClass, error)
 	GetNetworkAttachmentDefinition(ctx context.Context, name string, namespace string) (*unstructured.Unstructured, error)
 	CreateSelfSubjectAccessReview(ctx context.Context, reviewObj *authv1.SelfSubjectAccessReview) (*authv1.SelfSubjectAccessReview, error)
-	GetHyperConverged(ctx context.Context, name string, namespace string) (*unstructured.Unstructured, error)
 	GetKubeVirt(ctx context.Context, name string, namespace string) (*unstructured.Unstructured, error)
 }
 
@@ -210,19 +209,10 @@ func (c *client) CreateSelfSubjectAccessReview(ctx context.Context, reviewObj *a
 	return c.kubernetesClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, reviewObj, metav1.CreateOptions{})
 }
 
-func (c *client) GetHyperConverged(ctx context.Context, name string, namespace string) (*unstructured.Unstructured, error) {
-	resource := schema.GroupVersionResource{
-		Group:    "hco.kubevirt.io",
-		Version:  "v1beta1",
-		Resource: "hyperconvergeds",
-	}
-	return c.getResource(ctx, namespace, name, resource)
-}
-
 func (c *client) GetKubeVirt(ctx context.Context, name string, namespace string) (*unstructured.Unstructured, error) {
 	resource := schema.GroupVersionResource{
 		Group:    "kubevirt.io",
-		Version:  "v1",
+		Version:  "v1alpha3",
 		Resource: "kubevirts",
 	}
 	return c.getResource(ctx, namespace, name, resource)

--- a/pkg/asset/installconfig/kubevirt/client.go
+++ b/pkg/asset/installconfig/kubevirt/client.go
@@ -40,6 +40,7 @@ type Client interface {
 	GetNetworkAttachmentDefinition(ctx context.Context, name string, namespace string) (*unstructured.Unstructured, error)
 	CreateSelfSubjectAccessReview(ctx context.Context, reviewObj *authv1.SelfSubjectAccessReview) (*authv1.SelfSubjectAccessReview, error)
 	GetHyperConverged(ctx context.Context, name string, namespace string) (*unstructured.Unstructured, error)
+	GetKubeVirt(ctx context.Context, name string, namespace string) (*unstructured.Unstructured, error)
 }
 
 type client struct {
@@ -214,6 +215,15 @@ func (c *client) GetHyperConverged(ctx context.Context, name string, namespace s
 		Group:    "hco.kubevirt.io",
 		Version:  "v1beta1",
 		Resource: "hyperconvergeds",
+	}
+	return c.getResource(ctx, namespace, name, resource)
+}
+
+func (c *client) GetKubeVirt(ctx context.Context, name string, namespace string) (*unstructured.Unstructured, error) {
+	resource := schema.GroupVersionResource{
+		Group:    "kubevirt.io",
+		Version:  "v1",
+		Resource: "kubevirts",
 	}
 	return c.getResource(ctx, namespace, name, resource)
 }

--- a/pkg/asset/installconfig/kubevirt/mock/client_generated.go
+++ b/pkg/asset/installconfig/kubevirt/mock/client_generated.go
@@ -241,8 +241,23 @@ func (m *MockClient) GetHyperConverged(ctx context.Context, name, namespace stri
 	return ret0, ret1
 }
 
+// GetKubeVirt mocks base method
+func (m *MockClient) GetKubeVirt(ctx context.Context, name, namespace string) (*unstructured.Unstructured, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKubeVirt", ctx, name, namespace)
+	ret0, _ := ret[0].(*unstructured.Unstructured)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // GetHyperConverged indicates an expected call of GetHyperConverged
 func (mr *MockClientMockRecorder) GetHyperConverged(ctx, name, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHyperConverged", reflect.TypeOf((*MockClient)(nil).GetHyperConverged), ctx, name, namespace)
+}
+
+// GetKubeVirt indicates an expected call of GetKubeVirt
+func (mr *MockClientMockRecorder) GetKubeVirt(ctx, name, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKubeVirt", reflect.TypeOf((*MockClient)(nil).GetKubeVirt), ctx, name, namespace)
 }

--- a/pkg/asset/installconfig/kubevirt/mock/client_generated.go
+++ b/pkg/asset/installconfig/kubevirt/mock/client_generated.go
@@ -232,15 +232,6 @@ func (mr *MockClientMockRecorder) CreateSelfSubjectAccessReview(ctx, reviewObj i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSelfSubjectAccessReview", reflect.TypeOf((*MockClient)(nil).CreateSelfSubjectAccessReview), ctx, reviewObj)
 }
 
-// GetHyperConverged mocks base method
-func (m *MockClient) GetHyperConverged(ctx context.Context, name, namespace string) (*unstructured.Unstructured, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHyperConverged", ctx, name, namespace)
-	ret0, _ := ret[0].(*unstructured.Unstructured)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
 // GetKubeVirt mocks base method
 func (m *MockClient) GetKubeVirt(ctx context.Context, name, namespace string) (*unstructured.Unstructured, error) {
 	m.ctrl.T.Helper()
@@ -248,12 +239,6 @@ func (m *MockClient) GetKubeVirt(ctx context.Context, name, namespace string) (*
 	ret0, _ := ret[0].(*unstructured.Unstructured)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
-}
-
-// GetHyperConverged indicates an expected call of GetHyperConverged
-func (mr *MockClientMockRecorder) GetHyperConverged(ctx, name, namespace interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHyperConverged", reflect.TypeOf((*MockClient)(nil).GetHyperConverged), ctx, name, namespace)
 }
 
 // GetKubeVirt indicates an expected call of GetKubeVirt

--- a/pkg/asset/installconfig/kubevirt/validation_test.go
+++ b/pkg/asset/installconfig/kubevirt/validation_test.go
@@ -35,12 +35,10 @@ var (
 	invalidMachineCIDR    = "10.0.0.0/16"
 	namespaceStruct       = &corev1.Namespace{}
 	kubeMacPoolLabels     = map[string]string{"mutatevirtualmachines.kubemacpool.io": "allocate"}
-	hcoNamespace          = "openshift-cnv"
-	hcoCrName             = "kubevirt-hyperconverged"
+	kvNamespace           = "openshift-cnv"
 	kvCrName              = "kubevirt-kubevirt-hyperconverged"
-	hcoValidCr            = unstructured.Unstructured{}
 	kvValidCr             = unstructured.Unstructured{}
-	hcoInvalidCr          = unstructured.Unstructured{}
+	kvInvalidCr           = unstructured.Unstructured{}
 )
 
 func validInstallConfig() *types.InstallConfig {
@@ -236,69 +234,104 @@ func TestValidatePermissions(t *testing.T) {
 }
 
 func TestValidationForProvisioning(t *testing.T) {
-	createHcoObjects()
+	createKvObjects()
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	t.Run("Missing HyperConverged CR", func(t *testing.T) {
+	// HotplugVolumes feature is always enabled by HCO in version 4.8.0.
+	// For backward compitability, we are now checking that kubevirt CR is configured
+	// with hotPlugVolumes feature gate.
+	t.Run("Missing Kubevirt CR", func(t *testing.T) {
 		client := mock.NewMockClient(mockCtrl)
-		client.EXPECT().GetHyperConverged(gomock.Any(), hcoCrName, hcoNamespace).Return(nil, fmt.Errorf("test")).AnyTimes()
+		client.EXPECT().GetKubeVirt(gomock.Any(), kvCrName, kvNamespace).Return(nil, fmt.Errorf("test")).AnyTimes()
 		err := ValidateForProvisioning(client)
 		assert.NotNil(t, err)
 	})
 
-	t.Run("Feature gate not set", func(t *testing.T) {
+	t.Run("HotplugVolumes feature gate is NOT set on KubeVirt CR", func(t *testing.T) {
 		client := mock.NewMockClient(mockCtrl)
-		client.EXPECT().GetHyperConverged(gomock.Any(), hcoCrName, hcoNamespace).Return(&hcoInvalidCr, nil).AnyTimes()
+		client.EXPECT().GetKubeVirt(gomock.Any(), kvCrName, kvNamespace).Return(&kvInvalidCr, nil).AnyTimes()
 		err := ValidateForProvisioning(client)
 		assert.NotNil(t, err)
 	})
 
-	t.Run("Feature gate is set", func(t *testing.T) {
+	t.Run("HotplugVolumes feature gate is set on KubeVirt CR", func(t *testing.T) {
 		client := mock.NewMockClient(mockCtrl)
-		client.EXPECT().GetHyperConverged(gomock.Any(), hcoCrName, hcoNamespace).Return(&hcoValidCr, nil).AnyTimes()
-		err := ValidateForProvisioning(client)
-		assert.Nil(t, err)
-	})
-
-	t.Run("HotplugVolumes is set", func(t *testing.T) {
-		client := mock.NewMockClient(mockCtrl)
-		client.EXPECT().GetKubeVirt(gomock.Any(), kvCrName, hcoNamespace).Return(&kvValidCr, nil).AnyTimes()
+		client.EXPECT().GetKubeVirt(gomock.Any(), kvCrName, kvNamespace).Return(&kvValidCr, nil).AnyTimes()
 		err := ValidateForProvisioning(client)
 		assert.Nil(t, err)
 	})
 }
 
-func createHcoObjects() {
-	hcoValidCrJSON := `{
-							"apiVersion": "hco.kubevirt.io/v1beta1",
-							"kind": "HyperConverged",
-							"metadata": {
-								"name": "kubevirt-hyperconverged",
-								"namespace": "openshift-cnv"
+func createKvObjects() {
+	kvValidCrJSON := `{
+						  "apiVersion": "kubevirt.io/v1",
+						  "kind": "KubeVirt",
+						  "metadata": {
+							"name": "kubevirt-kubevirt-hyperconverged",
+							"namespace": "openshift-cnv"
+						  },
+						  "spec": {
+							"configuration": {
+							  "developerConfiguration": {
+								"featureGates": [
+								  "DataVolumes",
+								  "SRIOV",
+								  "LiveMigration",
+								  "CPUManager",
+								  "CPUNodeDiscovery",
+								  "Snapshot",
+								  "HotplugVolumes",
+								  "GPU",
+								  "HostDevices",
+								  "WithHostModelCPU",
+								  "HypervStrictCheck"
+								]
+							  }
 							},
-							"spec": {
-								"featureGates": {
-									"hotplugVolumes": true
-								}
-							}
-						}`
-	hcoInvalidCrJSON := `{
-							"apiVersion": "hco.kubevirt.io/v1beta1",
-							"kind": "HyperConverged",
-							"metadata": {
-								"name": "kubevirt-hyperconverged",
-								"namespace": "openshift-cnv"
-							},
-							"spec": {}
+							"customizeComponents": {},
+							"infra": {},
+							"uninstallStrategy": "BlockUninstallIfWorkloadsExist",
+							"workloadUpdateStrategy": {}
+						  }
 						}`
 
-	err := hcoValidCr.UnmarshalJSON([]byte(hcoValidCrJSON))
+	kvInvalidCrJSON := `{
+						  "apiVersion": "kubevirt.io/v1",
+						  "kind": "KubeVirt",
+						  "metadata": {
+							"name": "kubevirt-kubevirt-hyperconverged",
+							"namespace": "openshift-cnv"
+						  },
+						  "spec": {
+							"configuration": {
+							  "developerConfiguration": {
+								"featureGates": [
+								  "DataVolumes",
+								  "SRIOV",
+								  "LiveMigration",
+								  "CPUManager",
+								  "CPUNodeDiscovery",
+								  "Snapshot",
+								  "GPU",
+								  "HostDevices",
+								  "WithHostModelCPU",
+								  "HypervStrictCheck"
+								]
+							  }
+							},
+							"customizeComponents": {},
+							"infra": {},
+							"uninstallStrategy": "BlockUninstallIfWorkloadsExist",
+							"workloadUpdateStrategy": {}
+						  }
+						}`
+	err := kvValidCr.UnmarshalJSON([]byte(kvValidCrJSON))
 	if err != nil {
 		panic(err)
 	}
-	err = hcoInvalidCr.UnmarshalJSON([]byte(hcoInvalidCrJSON))
+	err = kvInvalidCr.UnmarshalJSON([]byte(kvInvalidCrJSON))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/asset/installconfig/kubevirt/validation_test.go
+++ b/pkg/asset/installconfig/kubevirt/validation_test.go
@@ -37,7 +37,9 @@ var (
 	kubeMacPoolLabels     = map[string]string{"mutatevirtualmachines.kubemacpool.io": "allocate"}
 	hcoNamespace          = "openshift-cnv"
 	hcoCrName             = "kubevirt-hyperconverged"
+	kvCrName              = "kubevirt-kubevirt-hyperconverged"
 	hcoValidCr            = unstructured.Unstructured{}
+	kvValidCr             = unstructured.Unstructured{}
 	hcoInvalidCr          = unstructured.Unstructured{}
 )
 
@@ -256,6 +258,13 @@ func TestValidationForProvisioning(t *testing.T) {
 	t.Run("Feature gate is set", func(t *testing.T) {
 		client := mock.NewMockClient(mockCtrl)
 		client.EXPECT().GetHyperConverged(gomock.Any(), hcoCrName, hcoNamespace).Return(&hcoValidCr, nil).AnyTimes()
+		err := ValidateForProvisioning(client)
+		assert.Nil(t, err)
+	})
+
+	t.Run("HotplugVolumes is set", func(t *testing.T) {
+		client := mock.NewMockClient(mockCtrl)
+		client.EXPECT().GetKubeVirt(gomock.Any(), kvCrName, hcoNamespace).Return(&kvValidCr, nil).AnyTimes()
 		err := ValidateForProvisioning(client)
 		assert.Nil(t, err)
 	})

--- a/pkg/asset/machines/kubevirt/machines.go
+++ b/pkg/asset/machines/kubevirt/machines.go
@@ -71,6 +71,7 @@ func provider(clusterID string, platform *kubevirt.Platform, pool *types.Machine
 		StorageClassName:           platform.StorageClass,
 		IgnitionSecretName:         userDataSecret,
 		NetworkName:                platform.NetworkName,
+		InterfaceBindingMethod:     platform.InterfaceBindingMethod,
 		PersistentVolumeAccessMode: platform.PersistentVolumeAccessMode,
 	}
 	return &spec

--- a/pkg/asset/machines/kubevirt/machines.go
+++ b/pkg/asset/machines/kubevirt/machines.go
@@ -28,7 +28,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	if pool.Replicas != nil {
 		total = *pool.Replicas
 	}
-	provider := provider(clusterID, platform, pool, userDataSecret, osImage)
+	provider := provider(clusterID, platform, pool, userDataSecret, config)
 	var machines []machineapi.Machine
 	for idx := int64(0); idx < total; idx++ {
 		machine := machineapi.Machine{
@@ -58,7 +58,11 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	return machines, nil
 }
 
-func provider(clusterID string, platform *kubevirt.Platform, pool *types.MachinePool, userDataSecret string, osImage string) *kubevirtprovider.KubevirtMachineProviderSpec {
+func provider(clusterID string, platform *kubevirt.Platform, pool *types.MachinePool, userDataSecret string, config *types.InstallConfig) *kubevirtprovider.KubevirtMachineProviderSpec {
+	interfaceBindingMethod := "InterfaceBridge"
+	if config.Kubevirt.InterfaceBindingMethod != "" {
+		interfaceBindingMethod = "Interface" + config.Kubevirt.InterfaceBindingMethod
+	}
 	spec := kubevirtprovider.KubevirtMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "kubevirtproviderconfig.openshift.io/v1alpha1",
@@ -71,7 +75,7 @@ func provider(clusterID string, platform *kubevirt.Platform, pool *types.Machine
 		StorageClassName:           platform.StorageClass,
 		IgnitionSecretName:         userDataSecret,
 		NetworkName:                platform.NetworkName,
-		InterfaceBindingMethod:     platform.InterfaceBindingMethod,
+		InterfaceBindingMethod:     interfaceBindingMethod,
 		PersistentVolumeAccessMode: platform.PersistentVolumeAccessMode,
 	}
 	return &spec

--- a/pkg/asset/machines/kubevirt/machinesets.go
+++ b/pkg/asset/machines/kubevirt/machinesets.go
@@ -30,7 +30,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		total = *pool.Replicas
 	}
 
-	provider := provider(clusterID, platform, pool, userDataSecret, osImage)
+	provider := provider(clusterID, platform, pool, userDataSecret, config)
 	name := fmt.Sprintf("%s-%s", clusterID, pool.Name)
 	mset := &machineapi.MachineSet{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/tfvars/kubevirt/kubevirt.go
+++ b/pkg/tfvars/kubevirt/kubevirt.go
@@ -3,7 +3,6 @@ package kubevirt
 
 import (
 	"encoding/json"
-
 	v1 "github.com/openshift/cluster-api-provider-kubevirt/pkg/apis/kubevirtprovider/v1alpha1"
 )
 
@@ -16,23 +15,25 @@ type config struct {
 	Storage                    string            `json:"kubevirt_master_storage"`
 	StorageClass               string            `json:"kubevirt_storage_class"`
 	NetworkName                string            `json:"kubevirt_network_name"`
+	InterfaceBindingMethod     string            `json:"kubevirt_interface_binding_method"`
 	PersistentVolumeAccessMode string            `json:"kubevirt_pv_access_mode"`
 	ResourcesLabels            map[string]string `json:"kubevirt_labels"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
-	MasterSpecs     []*v1.KubevirtMachineProviderSpec
-	ImageURL        string
-	Namespace       string
-	ResourcesLabels map[string]string
+	MasterSpecs            []*v1.KubevirtMachineProviderSpec
+	ImageURL               string
+	Namespace              string
+	InterfaceBindingMethod string
+	ResourcesLabels        map[string]string
 }
 
 // TFVars generates kubevirt-specific Terraform variables.
 func TFVars(sources TFVarsSources) ([]byte, error) {
 	masterSpec := sources.MasterSpecs[0]
 
-	// For optional parametes, set only if not nil
+	// For optional parameters, set only if not nil
 	cfg := config{
 		Namespace:                  sources.Namespace,
 		ImageURL:                   sources.ImageURL,
@@ -42,6 +43,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Storage:                    masterSpec.RequestedStorage,
 		StorageClass:               masterSpec.StorageClassName,
 		NetworkName:                masterSpec.NetworkName,
+		InterfaceBindingMethod:     sources.InterfaceBindingMethod,
 		PersistentVolumeAccessMode: masterSpec.PersistentVolumeAccessMode,
 		ResourcesLabels:            sources.ResourcesLabels,
 	}

--- a/pkg/tfvars/kubevirt/kubevirt.go
+++ b/pkg/tfvars/kubevirt/kubevirt.go
@@ -3,6 +3,7 @@ package kubevirt
 
 import (
 	"encoding/json"
+
 	v1 "github.com/openshift/cluster-api-provider-kubevirt/pkg/apis/kubevirtprovider/v1alpha1"
 )
 

--- a/pkg/tfvars/kubevirt/kubevirt.go
+++ b/pkg/tfvars/kubevirt/kubevirt.go
@@ -22,11 +22,10 @@ type config struct {
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
-	MasterSpecs            []*v1.KubevirtMachineProviderSpec
-	ImageURL               string
-	Namespace              string
-	InterfaceBindingMethod string
-	ResourcesLabels        map[string]string
+	MasterSpecs     []*v1.KubevirtMachineProviderSpec
+	ImageURL        string
+	Namespace       string
+	ResourcesLabels map[string]string
 }
 
 // TFVars generates kubevirt-specific Terraform variables.
@@ -43,7 +42,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Storage:                    masterSpec.RequestedStorage,
 		StorageClass:               masterSpec.StorageClassName,
 		NetworkName:                masterSpec.NetworkName,
-		InterfaceBindingMethod:     sources.InterfaceBindingMethod,
+		InterfaceBindingMethod:     masterSpec.InterfaceBindingMethod,
 		PersistentVolumeAccessMode: masterSpec.PersistentVolumeAccessMode,
 		ResourcesLabels:            sources.ResourcesLabels,
 	}

--- a/pkg/types/kubevirt/platform.go
+++ b/pkg/types/kubevirt/platform.go
@@ -13,6 +13,10 @@ type Platform struct {
 	// NetworkName is the target network of all the network interfaces of the nodes.
 	NetworkName string `json:"networkName"`
 
+	// InterfaceBindingMethod is the the interface binding method of the nodes of the tenantcluster (Bridge | SRIOV).
+	// +optional
+	InterfaceBindingMethod string `json:"interfaceBindingMethod"`
+
 	// APIVIP is the virtual IP address for the api endpoint.
 	// +kubebuilder:validation:Format=ip
 	APIVIP string `json:"apiVIP"`

--- a/pkg/types/kubevirt/validation/platform.go
+++ b/pkg/types/kubevirt/validation/platform.go
@@ -23,6 +23,11 @@ func ValidatePlatform(p *kubevirt.Platform, fldPath *field.Path, c *types.Instal
 		allErrs = append(allErrs, field.Required(fldPath.Child("networkName"), "networkName is required"))
 	}
 
+	if p.InterfaceBindingMethod != "" && p.InterfaceBindingMethod != "Bridge" && p.InterfaceBindingMethod != "SRIOV" {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("interfaceBindingMethod"), p.InterfaceBindingMethod,
+			"interfaceBindingMethod must be either 'Bridge' or 'SRIOV'"))
+	}
+
 	if err := validate.IP(p.APIVIP); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("apiVIP"), p.APIVIP, err.Error()))
 	} else if err := validateIPInMachineNetworkEntryList(c.MachineNetwork, p.APIVIP); err != nil {

--- a/vendor/github.com/openshift/cluster-api-provider-kubevirt/pkg/apis/kubevirtprovider/v1alpha1/types.go
+++ b/vendor/github.com/openshift/cluster-api-provider-kubevirt/pkg/apis/kubevirtprovider/v1alpha1/types.go
@@ -35,6 +35,7 @@ type KubevirtMachineProviderSpec struct {
 	StorageClassName           string `json:"storageClassName,omitempty"`
 	IgnitionSecretName         string `json:"ignitionSecretName,omitempty"`
 	NetworkName                string `json:"networkName,omitempty"`
+	InterfaceBindingMethod     string `json:"interfaceBindingMethod,omitempty"`
 	PersistentVolumeAccessMode string `json:"persistentVolumeAccessMode,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1422,7 +1422,7 @@ github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1
 ## explicit
 github.com/openshift/cluster-api-provider-ibmcloud/pkg/apis
 github.com/openshift/cluster-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1beta1
-# github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20201214114543-e5aed9c73f1f
+# github.com/openshift/cluster-api-provider-kubevirt v0.0.0-20210719100556-9b8bc3666720
 ## explicit
 github.com/openshift/cluster-api-provider-kubevirt/pkg/apis
 github.com/openshift/cluster-api-provider-kubevirt/pkg/apis/kubevirtprovider/v1alpha1


### PR DESCRIPTION
Currently, the kubevirt VirtualMachines that are created during the cluster provisioning, are hard-coded with Bridge interface binding, despite the actual type of the network that was configured in `install-config.yaml`.
This PR adds an optional new field to install-config.yaml, specifying the interface binding method to be used when creating the kubevirt VirtualMachines.
Example:
```
platform:
  kubevirt:
    apiVIP: <api_vip>
    ingressVIP: <ingress_vip>
    namespace: kubevirt-nested-cluster
    networkName: <NAD name>
    InterfaceBindingMethod: SRIOV          # <------- New Field
    storageClass: <storage class used>
```

This PR is strictly related to PR in openshift/cluster-api-provider-kubevirt - https://github.com/openshift/cluster-api-provider-kubevirt/pull/38, as it's changing the API for `KubevirtMachineProviderSpec` which is consumed in this PR.

Signed-off-by: orenc1 <ocohen@redhat.com>