### PR TITLE
Add documentation on setting cloud provider opts

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -39,7 +39,9 @@ In addition, it covers the installation with the default CNI (OpenShiftSDN), as 
       - [Using a Server Group](#using-a-server-group)
       - [Setting Nova Availability Zones](#setting-nova-availability-zones)
     - [Using a Custom External Load Balancer](#using-a-custom-external-load-balancer)
-    - [Refreshing a CA Certificate](#refreshing-a-ca-certificate)
+    - [Reconfiguring cloud provider](#reconfiguring-cloud-provider)
+      - [Modifying cloud provider options](#modifying-cloud-provider-options)
+      - [Refreshing a CA Certificate](#refreshing-a-ca-certificate)
   - [Reporting Issues](#reporting-issues)
 
 ## Reference Documents
@@ -646,13 +648,26 @@ set-cookie: 1e2670d92730b515ce3a1bb65da45062=9b714eb87e93cf34853e87a92d6894be; p
 cache-control: private
 ```
 
-### Refreshing a CA Certificate
+### Reconfiguring cloud provider
 
-If you ran the installer with a [custom CA certificate](#self-signed-openstack-ca-certificates), then this certificate can be changed while the cluster is running. To change your certificate, edit the value of the `ca-cert.pem` key in the `cloud-provider-config` configmap with a valid PEM certificate.
+If you need to update the OpenStack cloud provider configuration you can edit the ConfigMap containing it:
 
 ```sh
 oc edit configmap -n openshift-config cloud-provider-config
 ```
+
+**NOTE:** It can take a while to reconfigure the cluster depending on the size of it. The reconfiguration is completed once no node is getting `SchedulingDisabled` taint anymore.
+
+There are several things you can change:
+
+#### Modifying cloud provider options
+
+If you need to modify the direct cloud provider options, then edit the `config` key in the ConfigMap. A brief list of possible options is shown in [Cloud Provider configuration](./customization.md#cloud-provider-configuration) section.
+
+
+#### Refreshing a CA Certificate
+
+If you ran the installer with a [custom CA certificate](#self-signed-openstack-ca-certificates), then this certificate can be changed while the cluster is running. To change your certificate, edit the value of the `ca-cert.pem` key in the `cloud-provider-config` configmap with a valid PEM certificate.
 
 ## Reporting Issues
 

--- a/docs/user/openstack/customization.md
+++ b/docs/user/openstack/customization.md
@@ -15,6 +15,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
   - [Custom Subnets](#custom-subnets)
   - [Additional Networks](#additional-networks)
   - [Additional Security Groups](#additional-security-groups)
+  - [Cloud Provider configuration](#cloud-provider-configuration)
   - [Further customization](#further-customization)
 
 ## Cluster-scoped properties
@@ -233,6 +234,32 @@ controlPlane:
 ```
 
 **NOTE:** The additional security groups attached to the Control Plane machine will also be attached to the bootstrap node.
+
+## Cloud Provider configuration
+
+You may want to modify cloud provider configuration in order to make it work with your OpenStack cloud. This is possible if you'll let the installer generate the manifests before running the installation:
+
+```sh
+openshift-install --dir <directory> create manifests
+```
+
+Then modify the manifest containing the [cloud provider configuration](https://v1-18.docs.kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#cloud-conf):
+
+```sh
+vi <directory>/manifests/cloud-provider-config.yaml
+```
+
+As an example in order to tweak support for LoadBalancer Services you can modify options regarding Octavia configuration in the `[LoadBalancer]` section of `config` key. In particular:
+
+* `use-octavia = true` enables the Octavia integration.
+* `lb-provider = <"amphora" or "ovn">` lets you choose the Octavia provider to use when creating load balancers. Please note that setting "ovn" requires setting `lb-method = SOURCE_IP_PORT` as this is the only method supported by OVN.
+* `floating-network-id = <uuid>` is required to be set if your OpenStack cluster has multiple external networks. The network set here will be used by cloud provider to create floating IPs on.
+
+After saving the file you can continue the installation normally:
+
+```sh
+openshift-install --dir <directory> create cluster
+```
 
 ## Further customization
 


### PR DESCRIPTION
In 4.9 we introduce support for LoadBalancer services. This means that
user might need to tweak the cloud provider options to match their
OpenStack cluster configuration. This commit adds documentation on how
to do it before and after the installation.