### PR TITLE
Bug 1963132: Fix us-east4 Ashburn description

### DIFF
--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -38,7 +38,7 @@ var (
 		"southamerica-east1":      "São Paulo, Brazil",
 		"us-central1":             "Council Bluffs, Iowa, USA",
 		"us-east1":                "Moncks Corner, South Carolina, USA",
-		"us-east4":                "Ashburn, Northern Virginia, USA",
+		"us-east4":                "Ashburn, Virginia, USA",
 		"us-west1":                "The Dalles, Oregon, USA",
 		"us-west2":                "Los Angeles, California, USA",
 		"us-west3":                "Salt Lake City, Utah, USA",


### PR DESCRIPTION
Remove the "Northern" word from the description of us-east4
to make it similar to the description in GCP.