### PR TITLE
Bug 1984576: baremetal: reinstate provisioningInterface for provisioning CR

### DIFF
--- a/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
+++ b/data/data/manifests/openshift/baremetal-provisioning-config.yaml.template
@@ -3,6 +3,7 @@ kind: Provisioning
 metadata:
   name: provisioning-configuration
 spec:
+  provisioningInterface: "{{.Baremetal.ProvisioningNetworkInterface}}"
   provisioningIP: "{{.Baremetal.ClusterProvisioningIP}}"
   provisioningNetworkCIDR: "{{.Baremetal.ProvisioningNetworkCIDR}}"
   provisioningNetwork: "{{.Baremetal.ProvisioningNetwork}}"


### PR DESCRIPTION
This was removed in #5015 but we should still include it if a user
provides a value - since it's now optional we'll pass an empty
string if no value is provided, which will trigger the new logic
that detects the interface name by MAC.