### PR TITLE
pkg/asset/manifests/dns: don't create private zone in Azure Stack

### DIFF
--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -113,8 +113,10 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 				ID: dnsConfig.GetDNSZoneID(installConfig.Config.Azure.BaseDomainResourceGroupName, installConfig.Config.BaseDomain),
 			}
 		}
-		config.Spec.PrivateZone = &configv1.DNSZone{
-			ID: dnsConfig.GetPrivateDNSZoneID(installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID), installConfig.Config.ClusterDomain()),
+		if installConfig.Azure.CloudName != azuretypes.StackCloud {
+			config.Spec.PrivateZone = &configv1.DNSZone{
+				ID: dnsConfig.GetPrivateDNSZoneID(installConfig.Config.Azure.ClusterResourceGroupName(clusterID.InfraID), installConfig.Config.ClusterDomain()),
+			}
 		}
 	case gcptypes.Name:
 		if installConfig.Config.Publish == types.ExternalPublishingStrategy {


### PR DESCRIPTION
Skip adding private DNS zones to the DNS manifest for Azure Stack so the ingress controller does not try to create DNS records in private zones, which don't exist in ASH.

Example manifest for Azure Stack:
```
$ cat ash-manifests/m/manifests/cluster-dns-02-config.yml 
apiVersion: config.openshift.io/v1
kind: DNS
metadata:
  creationTimestamp: null
  name: cluster
spec:
  baseDomain: pddimg.ppe.azurestack.devcluster.openshift.com
  publicZone:
    id: /subscriptions/e90a4bc2-2f4e-4d36-874b-9011e4734d74/resourceGroups/openshiftInstallerRG/providers/Microsoft.Network/dnszones/ppe.azurestack.devcluster.openshift.com
status: {}
```

Example manifest for Azure:
```
$ cat azure-man/manifests/cluster-dns-02-config.yml 
apiVersion: config.openshift.io/v1
kind: DNS
metadata:
  creationTimestamp: null
  name: cluster
spec:
  baseDomain: padillon.installer-azure.devcluster.openshift.com
  privateZone:
    id: /subscriptions/433715e6-37fe-4328-af75-3661e13b15fc/resourceGroups/padillon-wbxr7-rg/providers/Microsoft.Network/privateDnsZones/padillon.installer-azure.devcluster.openshift.com
  publicZone:
    id: /subscriptions/433715e6-37fe-4328-af75-3661e13b15fc/resourceGroups/os4-common/providers/Microsoft.Network/dnszones/installer-azure.devcluster.openshift.com
status: {}
```
cc @Miciah 