### PR TITLE
open cluster-policy-controller ports for metrics

### DIFF
--- a/data/data/aws/cluster/vpc/sg-master.tf
+++ b/data/data/aws/cluster/vpc/sg-master.tf
@@ -289,6 +289,28 @@ resource "aws_security_group_rule" "master_ingress_kube_controller_manager_from_
   to_port   = 10257
 }
 
+resource "aws_security_group_rule" "master_ingress_cluster_policy_controller" {
+  type              = "ingress"
+  security_group_id = aws_security_group.master.id
+  description       = local.description
+
+  protocol  = "tcp"
+  from_port = 10357
+  to_port   = 10357
+  self      = true
+}
+
+resource "aws_security_group_rule" "master_ingress_cluster_policy_controller_from_worker" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.master.id
+  source_security_group_id = aws_security_group.worker.id
+  description              = local.description
+
+  protocol  = "tcp"
+  from_port = 10357
+  to_port   = 10357
+}
+
 resource "aws_security_group_rule" "master_ingress_kubelet_secure" {
   type              = "ingress"
   security_group_id = aws_security_group.master.id

--- a/data/data/gcp/cluster/network/firewall.tf
+++ b/data/data/gcp/cluster/network/firewall.tf
@@ -54,6 +54,12 @@ resource "google_compute_firewall" "control_plane" {
     ports    = ["10257"]
   }
 
+  # cluster policy controller
+  allow {
+    protocol = "tcp"
+    ports    = ["10357"]
+  }
+
   # kube scheduler
   allow {
     protocol = "tcp"

--- a/data/data/ibmcloud/network/vpc/security-groups.tf
+++ b/data/data/ibmcloud/network/vpc/security-groups.tf
@@ -231,6 +231,17 @@ resource "ibm_is_security_group_rule" "control_plane_kube_default_ports_inbound"
   }
 }
 
+# Cluster policy controller port
+resource "ibm_is_security_group_rule" "control_plane_cluster_policy_controller_ports_inbound" {
+  group     = ibm_is_security_group.control_plane.id
+  direction = "inbound"
+  remote    = ibm_is_security_group.control_plane.id
+  tcp {
+    port_min = 10357
+    port_max = 10357
+  }
+}
+
 # Kubernetes API - inbound
 resource "ibm_is_security_group_rule" "control_plane_kubernetes_api_inbound" {
   group     = ibm_is_security_group.control_plane.id

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -182,6 +182,17 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_controller
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_cluster_policy_controller" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10357
+  port_range_max    = 10357
+  remote_ip_prefix  = var.cidr_block
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure" {
   direction         = "ingress"
   ethertype         = "IPv4"

--- a/upi/aws/cloudformation/03_cluster_security.yaml
+++ b/upi/aws/cloudformation/03_cluster_security.yaml
@@ -250,6 +250,26 @@ Resources:
       ToPort: 10259
       IpProtocol: tcp
 
+  MasterIngressCPC:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt MasterSecurityGroup.GroupId
+      Description: Cluster policy controller
+      FromPort: 10357
+      ToPort: 10357
+      IpProtocol: tcp
+
+  MasterIngressWorkerCPC:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !GetAtt MasterSecurityGroup.GroupId
+      SourceSecurityGroupId: !GetAtt WorkerSecurityGroup.GroupId
+      Description: Cluster policy controller
+      FromPort: 10357
+      ToPort: 10357
+      IpProtocol: tcp
+
   MasterIngressIngressServices:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:

--- a/upi/gcp/03_firewall.py
+++ b/upi/gcp/03_firewall.py
@@ -62,6 +62,9 @@ def GenerateConfig(context):
             },{
                 'IPProtocol': 'tcp',
                 'ports': ['22623']
+            },{
+                'IPProtocol': 'tcp',
+                'ports': ['10357']
             }],
             'sourceTags': [
                 context.properties['infra_id'] + '-master',

--- a/upi/openstack/security-groups.yaml
+++ b/upi/openstack/security-groups.yaml
@@ -142,6 +142,14 @@
       port_range_min: 10257
       port_range_max: 10257
 
+  - name: 'Create master-sg rule "cluster policy controller"'
+    os_security_group_rule:
+      security_group: "{{ os_sg_master }}"
+      protocol: tcp
+      remote_ip_prefix: "{{ os_subnet_range }}"
+      port_range_min: 10357
+      port_range_max: 10357
+
   - name: 'Create master-sg rule "master ingress kubelet secure"'
     os_security_group_rule:
       security_group: "{{ os_sg_master }}"


### PR DESCRIPTION
This opens ports for gathering cluster-policy-controller metrics. The container itself is running on the same pod as kube-controller-manager.

I updated the configs in similar manner as kube-controller-manager. Please let me know if there are other steps needed.