### PR TITLE
Bug 1977129: Remove runlevel label from openshift-kubevirt-infra

### DIFF
--- a/data/data/manifests/bootkube/openshift-kubevirt-infra-namespace.yaml
+++ b/data/data/manifests/bootkube/openshift-kubevirt-infra-namespace.yaml
@@ -6,4 +6,3 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     name: openshift-kubevirt-infra
-    openshift.io/run-level: "1"


### PR DESCRIPTION
Runlevel was required in installer version <4.6 due to significant
start times of components waiting for the apiserver but it is no
longer necessary. More info is in this bug:
https://bugzilla.redhat.com/show_bug.cgi?id=1977129