### PR TITLE
Bug 1996124: version: display release architecture

### DIFF
--- a/cmd/openshift-install/version.go
+++ b/cmd/openshift-install/version.go
@@ -33,5 +33,6 @@ func runVersionCmd(cmd *cobra.Command, args []string) error {
 	if image, err := releaseimage.Default(); err == nil {
 		fmt.Printf("release image %s\n", image)
 	}
+	fmt.Printf("release architecture %s\n", version.DefaultArch())
 	return nil
 }


### PR DESCRIPTION
This should make it easier to identify the release/payload architecture
which a particular installer binary will install, since that is often
not clear from the release image name.
