### PR TITLE
Bug 1986420: GCP: make cluster_ip_address optional post-bootstrap

### DIFF
--- a/data/data/gcp/post-bootstrap/variables.tf
+++ b/data/data/gcp/post-bootstrap/variables.tf
@@ -31,7 +31,9 @@ variable "cluster_ip" {
 }
 
 variable "cluster_public_ip" {
-  type = string
+  type        = string
+  default     = null
+  description = "IP of the API load balancer; it is null with the internal publishing strategy."
 }
 
 variable "api_health_checks" {


### PR DESCRIPTION
The cluster_ip_address output variable is null in the cluster stage when the publishing strategy is internal. A null output variable results in no value actually being written to the tfvars. This results in an error when running with publish: internal: "No value for required variable."