### PR TITLE
Bug 1987083: Azure: cloud provider config excludeMastersFromStandardLB -> false

### DIFF
--- a/pkg/asset/manifests/azure/cloudproviderconfig.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig.go
@@ -29,6 +29,9 @@ type CloudProviderConfig struct {
 // managed resource names are matching the convention defined by capz
 func (params CloudProviderConfig) JSON() (string, error) {
 
+	// Config requires type *bool for excludeMasterFromStandardLB, so define a variable here to get an address in the config.
+	excludeMasterFromStandardLB := false
+
 	config := config{
 		authConfig: authConfig{
 			Cloud:                       params.CloudName.Name(),
@@ -59,7 +62,8 @@ func (params CloudProviderConfig) JSON() (string, error) {
 		UseInstanceMetadata: true,
 		// default to standard load balancer, supports tcp resets on idle
 		// https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-tcp-reset
-		LoadBalancerSku: "standard",
+		LoadBalancerSku:             "standard",
+		ExcludeMasterFromStandardLB: &excludeMasterFromStandardLB,
 	}
 
 	if params.ARO {

--- a/pkg/asset/manifests/azure/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/azure/cloudproviderconfig_test.go
@@ -54,7 +54,7 @@ func TestCloudProviderConfig(t *testing.T) {
 	"cloudProviderRateLimitBucketWrite": 0,
 	"useInstanceMetadata": true,
 	"loadBalancerSku": "standard",
-	"excludeMasterFromStandardLB": null,
+	"excludeMasterFromStandardLB": false,
 	"disableOutboundSNAT": null,
 	"maximumLoadBalancerRuleCount": 0
 }


### PR DESCRIPTION
This updates the Azure cloud provider config to set excludeMastersFromStandardLB to false. The default value is true, which
has not been a problem because the functionality was broken. With the move to out-of-tree providers the functionality has been restored, in which case if a master node restarts the service controller will not add it back to the load balancer backend pool.

cc @JoelSpeed @lobziik 