### PR TITLE
Bug 1987279: Delete AWS EFS AccessPoints with owner tags

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -2041,6 +2041,8 @@ func deleteElasticFileSystem(ctx context.Context, session *session.Session, arn 
 	switch resourceType {
 	case "file-system":
 		return deleteFileSystem(ctx, client, id, logger)
+	case "access-point":
+		return deleteAccessPoint(ctx, client, id, logger)
 	default:
 		return errors.Errorf("unrecognized elastic file system resource type %s", resourceType)
 	}


### PR DESCRIPTION
AWS EFS CSI driver creates AccessPoint with the "owner" tag.
Delete these AccessPoints on cluster destruction.

The access points would be cascade-deleted during EFS volume destruction, however, before reaching the code, the destruction would fail with:
> WARNING unrecognized elastic file system resource type access-point