### PR TITLE
Bug 1987845: openstack: relax quota checks in BYON

### DIFF
--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -3,6 +3,7 @@ package quota
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -123,6 +124,10 @@ func (a *PlatformQuotaCheck) Generate(dependencies asset.Parents) error {
 		}
 		summarizeReport(reports)
 	case typesopenstack.Name:
+		if skip := os.Getenv("OPENSHIFT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS"); skip == "1" {
+			logrus.Warnf("OVERRIDE: pre-flight validation disabled.")
+			return nil
+		}
 		ci, err := openstackvalidation.GetCloudInfo(ic.Config)
 		if err != nil {
 			return errors.Wrap(err, "failed to get cloud info")


### PR DESCRIPTION
## Relax quota checks in BYON
When deploying OCP with pre-provisioned networks, we do not need to have
available quotas for routers, networks and subnets for the machines
since they are created already.

This patch does the following:

* On Kuryr based deployment:
- Do not touch the quotas on networks / subnets, since we still need to
  have a bunch of quotas to create what's needed for Kuryr.
- Relax the quota on Routers, since it wouldn't create one in BYON mode.

* For other network types:
Relax routers, subnets, networks to be 0 by default and if we don't
configure OCP in BYON mode, then we add the necessary quotas (1 router,
1 network and 1 subnet).

## Allow to skip quota checks

Allow to skip quota checks by re-using
`OPENSHIFT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS` variable that has been used
for validations already.