### PR TITLE
Bug 1990617: Update fedora-coreos stream to 34.20210725.2.0

### DIFF
--- a/data/data/fcos-stream.json
+++ b/data/data/fcos-stream.json
@@ -1,194 +1,207 @@
 {
     "stream": "testing",
     "metadata": {
-        "last-modified": "2021-06-29T10:21:17Z"
+        "last-modified": "2021-07-28T11:05:01Z"
     },
     "architectures": {
         "x86_64": {
             "artifacts": {
                 "aliyun": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "8a5ac227de31c2b7cdccc7b546e3e165a915e7d5c5535ac7022ad8148ae7bc5b",
-                                "uncompressed-sha256": "12b6fc9de963fd9318e50532dcae3efa706bfb1b2a02e532f230b796cd6f2570"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "d0616160da27cdd8814a5d05609678643423d9e4f76e11e8d76f706ca4bb314d",
+                                "uncompressed-sha256": "3dbbeaac58489eb4e4c2c6075548bb4cff0e403953ba9404c0c3d39cdfd44760"
                             }
                         }
                     }
                 },
                 "aws": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "39ed71217a276e6bcbdeccd3cbbfd67a34d09101bfb9e7a2b6cc048c03fb23d7",
-                                "uncompressed-sha256": "4fbfde923d7b0e243f20ab81124bee20ef4e21b9842421b18926c4db1d8857a3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "25f03b8b86723651409c44b5e5a98e9fbc1827ababc3b51e00539a5980ba504c",
+                                "uncompressed-sha256": "780d60ec839eb0364cecfdac1b5d122512cb8c3c5ad1248f2e592e7bb10ac718"
                             }
                         }
                     }
                 },
                 "azure": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "vhd.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-azure.x86_64.vhd.xz.sig",
-                                "sha256": "eb9ef79c36d99d22656c3308992524304fe4959807af374c962fbd162f19f046",
-                                "uncompressed-sha256": "1669e2f28260762278571569e5465fad07dff7d8391e19dbd1364ef0a90d3719"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "e8bd73f9a0203c1c5beedc7cffd49ee358a39ad1be93c16e2c87b7f2913b5bcc",
+                                "uncompressed-sha256": "a67a9427f05ce0400b45003b1c5697f4699435955bf318afc4660a934d6b10a2"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "34.20210725.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "bbe002f09822234e662ead24bf905de8c9c38636987410887ea851d1e5628aa8",
+                                "uncompressed-sha256": "0222d9fe6ba75035c80e3b61ee2d8cc2aeda085d4f85fe6b79bcd2e8b6ae2e70"
                             }
                         }
                     }
                 },
                 "digitalocean": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "00ca38e6fe69738a22ad58dce6b023d043f51db8198a056cc87c553d04f5fbb5",
-                                "uncompressed-sha256": "fdad83ec1519c9ee6ec6056c6962f8e7652c5789d6b18463dedd32aaaae302b4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "36a2a606d517f47e37590d6186e749790214bc7ff759ddf9aec2c5332149bbb0",
+                                "uncompressed-sha256": "5144bb1aa134c9403fdf87c052873f92063166550a070dba877a2a239b3eee40"
                             }
                         }
                     }
                 },
                 "exoscale": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "09c084cc040af5fd1d1012f5ed52f67da5b373d19ada3b5d8ccef7c649e76cde",
-                                "uncompressed-sha256": "7c4ac26830489429e35192ba11379b94873b652424fe9505241fb47074d29521"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "8919a150c5ceae11bbe755bff0292598874f969dcaf0a222817812f5dd1e8976",
+                                "uncompressed-sha256": "1664ad86886a99548b668eb412c4ea3ce675491d9c4337627e8e4e222365bdc0"
                             }
                         }
                     }
                 },
                 "gcp": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "tar.gz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-gcp.x86_64.tar.gz.sig",
-                                "sha256": "1c73752a3686f580fa86dd1a1f1a4bc12c616e431f8d01d2ccc2fe9c7d048935",
-                                "uncompressed-sha256": "c32629174d753571351d632af3c4ed7bd48f536733cb8f4902f583753338d3e3"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "f56fffcb62ce6effba5075fe6633ff5f1334250a769d870e0dc5be6f0bd013fe",
+                                "uncompressed-sha256": "fb23cc64310835be53d8d0caeaa652ce69b4676e40c115a02d5438234a2903b9"
                             }
                         }
                     }
                 },
                 "ibmcloud": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "da7abcc7666187851a62636e98d56d519417ce8ba56e6dd14b6e17c3200dd119",
-                                "uncompressed-sha256": "3e3f59e6b8ab3493e1ed7f2dfb046fe5a5bc91a16f40df5fd55a7021903e1be8"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "b9a192cbf62587fe1afedba0e816f315c56889dda71fcde36c249db3f1715034",
+                                "uncompressed-sha256": "0dbd198fa167066723ef28c39e0081c185573c36d50703dcbefe7827ee787ab9"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "de374a7234ff93117cd44c2c580cd621f74f08ff13af25cfe0e45ceb774fb35e",
-                                "uncompressed-sha256": "a2d8d87fc46e0ab0ba778684afb041fa795847d59c3ab56e58de58d5597df871"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "c3112558c29d9904e48d26e0a892c9bfb7ecd97265f945f8a272121a90162552",
+                                "uncompressed-sha256": "f4c45ee4496c3a7283bbc352e894864a658cefb256dd4b3d132c45ee4f6670be"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live.x86_64.iso.sig",
-                                "sha256": "598587080f2a96770d660e3d42dbdb1059aabca9d8eaaeb5222b68b92e26d225"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live.x86_64.iso.sig",
+                                "sha256": "01045f9e5312bd29905237e989a5be1cd76db7e756f89e97243471fc1e264439"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-kernel-x86_64.sig",
-                                "sha256": "e4b5cac76b9f5991a488f2f8d178d82f70cce3457f62986c0136ba19a0463aa5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-kernel-x86_64.sig",
+                                "sha256": "3166c98d325ff3b06e092683060b512bc6f72dc354e424c1634186492b032db5"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-initramfs.x86_64.img.sig",
-                                "sha256": "e17f6082861fefced56d908af54a3a43832823fa9447dfac5327e9ff250dbc83"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "746cf3208658e6331682fdff8de15d1772825bbbf27a8de9daed15a58efd25ef"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-live-rootfs.x86_64.img.sig",
-                                "sha256": "043472e6e1b8bbb7f3907b5df5ae890dedb765424b763dff6e8bf8657b9739c2"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "cc93eef97457efc351b95f8f5b853809065e6d35671455684860d276edab8c10"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-metal.x86_64.raw.xz.sig",
-                                "sha256": "156cfd20264af88b1efe41ea41f8eb929a0fc98704293ec7f5a1f1524658ade6",
-                                "uncompressed-sha256": "0502afe6689566ec5661cd39435f82e864a1d057eacb50fa4889925c2b552571"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "e2f6b5f16f78056438d3e409cedbaed19e1becce33b34e0e23a6a7cf44583848",
+                                "uncompressed-sha256": "46dab51f454eb18c03bdb5affc22015b51717f34827efd4461278da33c030c33"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "a83fc15db3e2274fc3e9f3909c08d2784e1e3a9352276fa30954f62a49e2ded7",
-                                "uncompressed-sha256": "24cc37d752028c8f78dd4aed66e13eb294e9a07c0e1c506ccabc33459faccff1"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "cfbfbb0f8a6e7558c73322a7304878737f76bb4ae27b4ff81237a7e169a29bf3",
+                                "uncompressed-sha256": "5fb778e1a494dc79b65e862f01e91465dad985a7d27765981e694161167c7c2c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "6f1e5e38eb9dac07466433665cda204bfee2cad144acba0aba9af75e76b27919",
-                                "uncompressed-sha256": "490ab7341a4a7fffda5fbf56bf022ddc71161af492d0eb9cbce2239318d1d064"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "7d8fab929f6e1ae83cc247065098eff632e40a7b5bc0af34c294798e30235a9a",
+                                "uncompressed-sha256": "1c21719ac6dbab16f65399c4950612c456152d629cab425537cde286bfdc1fca"
                             }
                         }
                     }
                 },
                 "vmware": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "ova": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vmware.x86_64.ova.sig",
-                                "sha256": "7a178acb5a43b26c31631cbbf928f471e639641d179c779197e7d763b9110414"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "a208f6970909a0faa0b8d2154e65f28bae441481f7d1516843a527dacad82e1e"
                             }
                         }
                     }
                 },
                 "vultr": {
-                    "release": "34.20210626.2.0",
+                    "release": "34.20210725.2.0",
                     "formats": {
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210626.2.0/x86_64/fedora-coreos-34.20210626.2.0-vultr.x86_64.raw.xz.sig",
-                                "sha256": "4e42cc1fb80329646969da90fca7153ffae26952b663012e1b90b351d5715693",
-                                "uncompressed-sha256": "3c601db2b2a9a1231d91b53bbda4fa765661de8a81a2abc6fa1f69180c42202b"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/34.20210725.2.0/x86_64/fedora-coreos-34.20210725.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "072168bad4fda4670f96434155d92ddbdb031f02145d3f06aae9185da489c0d5",
+                                "uncompressed-sha256": "78ae3508f7585b59de2e9b6f8d0a12933c3b0d485758438a1028cf5f7c97b9fd"
                             }
                         }
                     }
@@ -198,95 +211,95 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-06ce6cd7ae14d4e36"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0d1c7c28bc45e9b7d"
                         },
                         "ap-east-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0c523b93e7931c390"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-00f0180441a078114"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0b1bc3f2c1bc08b69"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0a57f5c23b68e2ec0"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-03345d33cb26bc661"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0961c0e317349f150"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-01e001d8864b4f29d"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-016dcfcbe3ff7ea8f"
                         },
                         "ap-south-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0fce67cf8e9812a76"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0b39c0eb9657b9291"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0674b758a90e82f9d"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-011a9e8c425fb0239"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-02234d79a973a5f53"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-07b0fbdd315c6a4de"
                         },
                         "ca-central-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-08c1b1b41febd498c"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-09d522db754b9ef98"
                         },
                         "eu-central-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-05d1ebfc450ec9f1e"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0a435e2284f8f3f76"
                         },
                         "eu-north-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0c304efcf489e8a4f"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0ae343dbb2436d194"
                         },
                         "eu-south-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-049e141bcf79024c5"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0690eeccf397de8f8"
                         },
                         "eu-west-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-07a6835aaad9cc5ca"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-07cdf93198cf4b1b0"
                         },
                         "eu-west-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-06c4d4769614a43e0"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-00079da9fcf80f993"
                         },
                         "eu-west-3": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-06e938ee9a84c2d3e"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0d1705af46305bb53"
                         },
                         "me-south-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-00e6941c14327860a"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0bb9ddf97db6b7e9f"
                         },
                         "sa-east-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0fed26dc669439cdd"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-048249320b62238ce"
                         },
                         "us-east-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0dcce6fefedc4780c"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-03007921612b483cd"
                         },
                         "us-east-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-0227bf3374a60ff8b"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-09c95dbdf2b784ef2"
                         },
                         "us-west-1": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-081afa57703a058b9"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0b6bf028db67ec144"
                         },
                         "us-west-2": {
-                            "release": "34.20210626.2.0",
-                            "image": "ami-07597603ac267ab05"
+                            "release": "34.20210725.2.0",
+                            "image": "ami-0362b8d89f7f61971"
                         }
                     }
                 },
                 "gcp": {
                     "project": "fedora-coreos-cloud",
                     "family": "fedora-coreos-testing",
-                    "name": "fedora-coreos-34-20210626-2-0-gcp-x86-64"
+                    "name": "fedora-coreos-34-20210725-2-0-gcp-x86-64"
                 }
             }
         }


### PR DESCRIPTION
Use latest FCOS images as of https://github.com/coreos/fedora-coreos-streams/commit/2e15ba504e8e8fe9cd22962146c9181241c1653d

Requires https://github.com/openshift/release/pull/14082 to add OKD tests