### PR TITLE
Bug 1978213: openstack - relax value for minNetworkConstraint

### DIFF
--- a/pkg/asset/quota/openstack/openstack.go
+++ b/pkg/asset/quota/openstack/openstack.go
@@ -16,8 +16,8 @@ import (
 // https://github.com/openshift/installer/blob/master/docs/user/openstack/kuryr.md
 // Number of ports, routers, subnets and routers here don't include the constraints needed
 // for each machine, which are calculated later
-var minNetworkConstraint = buildNetworkConstraint(15, 0, 0, 0, 3, 60)
-var minNetworkConstraintWithKuryr = buildNetworkConstraint(1500, 1, 250, 250, 250, 1000)
+var minNetworkConstraint = buildNetworkConstraint(9, 0, 0, 0, 3, 60)
+var minNetworkConstraintWithKuryr = buildNetworkConstraint(1494, 1, 250, 250, 250, 1000)
 
 func buildNetworkConstraint(ports, routers, subnets, networks, securityGroups, securityGroupRules int64) []quota.Constraint {
 	return []quota.Constraint{


### PR DESCRIPTION
We currently document that a tenant should have ports quota set to 15
(or 1500 with Kuryr), but we didn't take in account the ports that are
used for the machines:

3 masters + 3 workers = 6 ports.

With these new numbers, we can deploy clusters with the existing
documentation with enough resources used from available quotas.
