### PR TITLE
Bug 1989279: openstack: backport quotas/BYON improvements

### DIFF
--- a/pkg/asset/quota/openstack/openstack.go
+++ b/pkg/asset/quota/openstack/openstack.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
+	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/asset/installconfig/openstack/validation"
 	"github.com/openshift/installer/pkg/quota"
 	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
@@ -29,7 +30,7 @@ func buildNetworkConstraint(ports, routers, subnets, networks, securityGroups, s
 }
 
 func getNetworkConstraints(networkType string) []quota.Constraint {
-	if networkType == "kuryr" {
+	if networkType == string(operv1.NetworkTypeKuryr) {
 		return networkConstraintWithKuryr
 	}
 	return networkConstraint

--- a/pkg/asset/quota/openstack/openstack.go
+++ b/pkg/asset/quota/openstack/openstack.go
@@ -16,8 +16,8 @@ import (
 // https://github.com/openshift/installer/blob/master/docs/user/openstack/kuryr.md
 // Number of ports, routers, subnets and routers here don't include the constraints needed
 // for each machine, which are calculated later
-var minNetworkConstraint = buildNetworkConstraint(15, 0, 0, 0, 3, 60)
-var minNetworkConstraintWithKuryr = buildNetworkConstraint(1500, 1, 250, 250, 250, 1000)
+var minNetworkConstraint = buildNetworkConstraint(9, 0, 0, 0, 3, 60)
+var minNetworkConstraintWithKuryr = buildNetworkConstraint(1494, 1, 250, 250, 250, 1000)
 
 func buildNetworkConstraint(ports, routers, subnets, networks, securityGroups, securityGroupRules int64) []quota.Constraint {
 	return []quota.Constraint{

--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -3,6 +3,7 @@ package quota
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -122,6 +123,10 @@ func (a *PlatformQuotaCheck) Generate(dependencies asset.Parents) error {
 		}
 		summarizeReport(reports)
 	case typesopenstack.Name:
+		if skip := os.Getenv("OPENSHIFT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS"); skip == "1" {
+			logrus.Warnf("OVERRIDE: pre-flight validation disabled.")
+			return nil
+		}
 		ci, err := openstackvalidation.GetCloudInfo(ic.Config)
 		if err != nil {
 			return errors.Wrap(err, "failed to get cloud info")


### PR DESCRIPTION
## Run kuryr-specific quota checks for kuryr envs

Due to a missing capitalization we didn't run the kuryr-specific network
quota checks for OpenStack validation which could result in the
installation starting even though the user has not nearly enough quota
for a successful Kuryr deployment.

## openstack: allow to skip quota checks

Allow to skip quota checks by re-using
OPENSHIFT_INSTALL_SKIP_PREFLIGHT_VALIDATIONS variable that has been used
for validations already.
When set to 1, we'll skip quota checks. Note that this is not suggested
and please use it at your own risks.

## openstack: relax quota checks in BYON

When deploying OCP with pre-provisioned networks, we do not need to have
available quotas for routers, networks and subnets for the machines
since they are created already.

This patch does the following:

* On Kuryr based deployment:
- Do not touch the quotas on networks / subnets, since we still need to
  have a bunch of quotas to create what's needed for Kuryr.
- Relax the quota on Routers, since it wouldn't create one in BYON mode.

* For other network types:
Relax routers, subnets, networks to be 0 by default and if we don't
configure OCP in BYON mode, then we add the necessary quotas (1 router,
1 network and 1 subnet).

## openstack - relax value for minNetworkConstraint

We currently document that a tenant should have ports quota set to 15
(or 1500 with Kuryr), but we didn't take in account the ports that are
used for the machines:

3 masters + 3 workers = 6 ports.

With these new numbers, we can deploy clusters with the existing
documentation with enough resources used from available quotas.


This is a combined cherry-pick to make the review easier, and the overall solves a single problem related to quotas.
