### PR TITLE
Bug 1992876: gather: Add OKD specific journal logs

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -31,7 +31,7 @@ done
 
 echo "Gathering bootstrap journals ..."
 mkdir -p "${ARTIFACTS}/bootstrap/journals"
-for service in release-image crio-configure bootkube kubelet crio approve-csr ironic master-bmh-update
+for service in release-image release-image-download crio-configure bootkube kubelet crio approve-csr ironic master-bmh-update
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"
 done

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -22,7 +22,7 @@ done
 
 echo "Gathering master journals ..."
 mkdir -p "${ARTIFACTS}/journals"
-for service in kubelet crio machine-config-daemon-host pivot openshift-azure-routes openshift-gcp-routes
+for service in kubelet crio machine-config-master-firstboot machine-config-daemon-host pivot openshift-azure-routes openshift-gcp-routes
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
 done


### PR DESCRIPTION
OKD runs on FCOS, which requires services release-image-download on bootstrap and machine-config-master-firstboot on nodes. Gathering a log bundle should include them too.

Fixes https://github.com/openshift/okd/issues/651