### PR TITLE
Bug 1989604: ibmcloud: GetVSIProfiles error handling

### DIFF
--- a/pkg/asset/installconfig/ibmcloud/client.go
+++ b/pkg/asset/installconfig/ibmcloud/client.go
@@ -287,7 +287,10 @@ func (c *Client) GetSubnet(ctx context.Context, subnetID string) (*vpcv1.Subnet,
 func (c *Client) GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, error) {
 	listInstanceProfilesOptions := c.vpcAPI.NewListInstanceProfilesOptions()
 	profiles, _, err := c.vpcAPI.ListInstanceProfilesWithContext(ctx, listInstanceProfilesOptions)
-	return profiles.Profiles, err
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list vpc vsi profiles")
+	}
+	return profiles.Profiles, nil
 }
 
 // GetVPC gets a VPC by its ID.


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1989604