### PR TITLE
Record rpm-ostree status and history in log-bundle

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -59,6 +59,11 @@ do
     sudo podman inspect "${container_id}" >& "${ARTIFACTS}/bootstrap/pods/${container_name}-${container_id}.inspect"
 done
 
+echo "Gathering bootstrap rpm-ostree info ..."
+mkdir -p "${ARTIFACTS}/bootstrap/rpm-ostree"
+sudo rpm-ostree status >& "${ARTIFACTS}/bootstrap/rpm-ostree/status"
+sudo rpm-ostree ex history >& "${ARTIFACTS}/bootstrap/rpm-ostree/history"
+
 echo "Gathering rendered assets..."
 mkdir -p "${ARTIFACTS}/rendered-assets"
 sudo cp -r /var/opt/openshift/ "${ARTIFACTS}/rendered-assets"

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -49,5 +49,10 @@ do
     podman inspect "${container_id}" >& "${ARTIFACTS}/containers/${container_name}-${container_id}.inspect"
 done
 
+echo "Gathering master rpm-ostree info ..."
+mkdir -p "${ARTIFACTS}/rpm-ostree"
+sudo rpm-ostree status >& "${ARTIFACTS}/rpm-ostree/status"
+sudo rpm-ostree ex history >& "${ARTIFACTS}/rpm-ostree/history"
+
 echo "Waiting for logs ..."
 while wait -n; do jobs; done


### PR DESCRIPTION
During log-bundle analysis it should be trivial to find out which FCOS/RHCOS os image was used during installation.  

Fixes https://github.com/openshift/okd/issues/652