### PR TITLE
Server-Side Encryption and Encryption At Host support

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -195,6 +195,7 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
   # included here because it is required by the Azure ARM API.
   admin_password                  = "NotActuallyApplied!"
   disable_password_authentication = false
+  encryption_at_host_enabled      = var.azure_master_encryption_at_host_enabled
 
   identity {
     type         = "UserAssigned"

--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -202,10 +202,11 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
   }
 
   os_disk {
-    name                 = "${var.cluster_id}-bootstrap_OSDisk" # os disk name needs to match cluster-api convention
-    caching              = "ReadWrite"
-    storage_account_type = "Premium_LRS"
-    disk_size_gb         = 100
+    name                   = "${var.cluster_id}-bootstrap_OSDisk" # os disk name needs to match cluster-api convention
+    caching                = "ReadWrite"
+    storage_account_type   = "Premium_LRS"
+    disk_size_gb           = 100
+    disk_encryption_set_id = var.azure_master_disk_encryption_set_id
   }
 
   source_image_id = var.vm_image

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -29,26 +29,27 @@ provider "azureprivatedns" {
 }
 
 module "master" {
-  source                 = "./master"
-  resource_group_name    = var.resource_group_name
-  cluster_id             = var.cluster_id
-  region                 = var.azure_region
-  availability_zones     = var.azure_master_availability_zones
-  vm_size                = var.azure_master_vm_type
-  vm_image               = var.vm_image
-  identity               = var.identity
-  ignition               = var.ignition_master
-  elb_backend_pool_v4_id = var.elb_backend_pool_v4_id
-  elb_backend_pool_v6_id = var.elb_backend_pool_v6_id
-  ilb_backend_pool_v4_id = var.ilb_backend_pool_v4_id
-  ilb_backend_pool_v6_id = var.ilb_backend_pool_v6_id
-  subnet_id              = var.master_subnet_id
-  instance_count         = var.master_count
-  storage_account        = var.storage_account
-  os_volume_type         = var.azure_master_root_volume_type
-  os_volume_size         = var.azure_master_root_volume_size
-  private                = var.azure_private
-  outbound_udr           = var.azure_outbound_user_defined_routing
+  source                     = "./master"
+  resource_group_name        = var.resource_group_name
+  cluster_id                 = var.cluster_id
+  region                     = var.azure_region
+  availability_zones         = var.azure_master_availability_zones
+  vm_size                    = var.azure_master_vm_type
+  disk_encryption_set_id     = var.azure_master_disk_encryption_set_id
+  vm_image                   = var.vm_image
+  identity                   = var.identity
+  ignition                   = var.ignition_master
+  elb_backend_pool_v4_id     = var.elb_backend_pool_v4_id
+  elb_backend_pool_v6_id     = var.elb_backend_pool_v6_id
+  ilb_backend_pool_v4_id     = var.ilb_backend_pool_v4_id
+  ilb_backend_pool_v6_id     = var.ilb_backend_pool_v6_id
+  subnet_id                  = var.master_subnet_id
+  instance_count             = var.master_count
+  storage_account            = var.storage_account
+  os_volume_type             = var.azure_master_root_volume_type
+  os_volume_size             = var.azure_master_root_volume_size
+  private                    = var.azure_private
+  outbound_udr               = var.azure_outbound_user_defined_routing
 
   use_ipv4 = var.use_ipv4
   use_ipv6 = var.use_ipv6

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -36,6 +36,7 @@ module "master" {
   availability_zones         = var.azure_master_availability_zones
   vm_size                    = var.azure_master_vm_type
   disk_encryption_set_id     = var.azure_master_disk_encryption_set_id
+  encryption_at_host_enabled = var.azure_master_encryption_at_host_enabled
   vm_image                   = var.vm_image
   identity                   = var.identity
   ignition                   = var.ignition_master

--- a/data/data/azure/cluster/master/master.tf
+++ b/data/data/azure/cluster/master/master.tf
@@ -103,10 +103,11 @@ resource "azurerm_linux_virtual_machine" "master" {
   }
 
   os_disk {
-    name                 = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
-    caching              = "ReadOnly"
-    storage_account_type = var.os_volume_type
-    disk_size_gb         = var.os_volume_size
+    name                   = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
+    caching                = "ReadOnly"
+    storage_account_type   = var.os_volume_type
+    disk_size_gb           = var.os_volume_size
+    disk_encryption_set_id = var.disk_encryption_set_id
   }
 
   source_image_id = var.vm_image

--- a/data/data/azure/cluster/master/master.tf
+++ b/data/data/azure/cluster/master/master.tf
@@ -96,6 +96,7 @@ resource "azurerm_linux_virtual_machine" "master" {
   # included here because it is required by the Azure ARM API.
   admin_password                  = "NotActuallyApplied!"
   disable_password_authentication = false
+  encryption_at_host_enabled      = var.encryption_at_host_enabled
 
   identity {
     type         = "UserAssigned"
@@ -112,7 +113,7 @@ resource "azurerm_linux_virtual_machine" "master" {
 
   source_image_id = var.vm_image
 
-  //we don't provide a ssh key, because it is set with ignition. 
+  //we don't provide a ssh key, because it is set with ignition.
   //it is required to provide at least 1 auth method to deploy a linux vm
   computer_name = "${var.cluster_id}-master-${count.index}"
   custom_data   = base64encode(var.ignition)
@@ -121,4 +122,3 @@ resource "azurerm_linux_virtual_machine" "master" {
     storage_account_uri = var.storage_account.primary_blob_endpoint
   }
 }
-

--- a/data/data/azure/cluster/master/variables.tf
+++ b/data/data/azure/cluster/master/variables.tf
@@ -22,6 +22,12 @@ variable "disk_encryption_set_id" {
   description = "The ID of the Disk Encryption Set which should be used to encrypt OS disk."
 }
 
+variable "encryption_at_host_enabled" {
+  default     = false
+  type        = bool
+  description = "Enables encryption at the VM host."
+}
+
 variable "vm_image" {
   type        = string
   description = "The resource id of the vm image used for masters."

--- a/data/data/azure/cluster/master/variables.tf
+++ b/data/data/azure/cluster/master/variables.tf
@@ -16,6 +16,12 @@ variable "vm_size" {
   type = string
 }
 
+variable "disk_encryption_set_id" {
+  default     = null
+  type        = string
+  description = "The ID of the Disk Encryption Set which should be used to encrypt OS disk."
+}
+
 variable "vm_image" {
   type        = string
   description = "The resource id of the vm image used for masters."

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -28,6 +28,12 @@ variable "azure_master_vm_type" {
   description = "Instance type for the master node(s). Example: `Standard_D8s_v3`."
 }
 
+variable "azure_master_disk_encryption_set_id" {
+  default = null
+  type = string
+  description = "The ID of the Disk Encryption Set which should be used to encrypt OS disk for the master node(s)."
+}
+
 variable "azure_extra_tags" {
   type = map(string)
 

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -34,6 +34,12 @@ variable "azure_master_disk_encryption_set_id" {
   description = "The ID of the Disk Encryption Set which should be used to encrypt OS disk for the master node(s)."
 }
 
+variable "azure_master_encryption_at_host_enabled" {
+  default = false
+  type = bool
+  description = "Enables encryption at the VM host for the master node(s)."
+}
+
 variable "azure_extra_tags" {
   type = map(string)
 

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -168,6 +168,10 @@ spec:
                         osDisk:
                           description: OSDisk defines the storage for instance.
                           properties:
+                            diskEncryptionSetId:
+                              description: DiskEncryptionSetID is a resource ID of
+                                disk encryption set
+                              type: string
                             diskSizeGB:
                               description: DiskSizeGB defines the size of disk in
                                 GB.
@@ -630,6 +634,10 @@ spec:
                       osDisk:
                         description: OSDisk defines the storage for instance.
                         properties:
+                          diskEncryptionSetId:
+                            description: DiskEncryptionSetID is a resource ID of disk
+                              encryption set
+                            type: string
                           diskSizeGB:
                             description: DiskSizeGB defines the size of disk in GB.
                             format: int32
@@ -1363,6 +1371,10 @@ spec:
                       osDisk:
                         description: OSDisk defines the storage for instance.
                         properties:
+                          diskEncryptionSetId:
+                            description: DiskEncryptionSetID is a resource ID of disk
+                              encryption set
+                            type: string
                           diskSizeGB:
                             description: DiskSizeGB defines the size of disk in GB.
                             format: int32

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -165,6 +165,10 @@ spec:
                       description: Azure is the configuration used when installing
                         on Azure.
                       properties:
+                        encryptionAtHost:
+                          description: EncryptionAtHost enables encryption at the
+                            VM host.
+                          type: boolean
                         osDisk:
                           description: OSDisk defines the storage for instance.
                           properties:
@@ -631,6 +635,10 @@ spec:
                     description: Azure is the configuration used when installing on
                       Azure.
                     properties:
+                      encryptionAtHost:
+                        description: EncryptionAtHost enables encryption at the VM
+                          host.
+                        type: boolean
                       osDisk:
                         description: OSDisk defines the storage for instance.
                         properties:
@@ -1368,6 +1376,10 @@ spec:
                       used when installing on Azure for machine pools which do not
                       define their own platform configuration.
                     properties:
+                      encryptionAtHost:
+                        description: EncryptionAtHost enables encryption at the VM
+                          host.
+                        type: boolean
                       osDisk:
                         description: OSDisk defines the storage for instance.
                         properties:

--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -23,6 +23,7 @@ The following options are available when using Azure:
 * `osDisk` (optional object):
     * `diskSizeGB` (optional integer): The size of the disk in gigabytes (GB).
     * `diskType` (optional string): The type of disk (allowed values are: `Premium_LRS`, `Standard_LRS`, and `StandardSSD_LRS`).
+    * `diskEncryptionSetId` (optional string): resource ID of disk encryption set
 * `type` (optional string): The Azure instance type.
 * `zones` (optional string slice): List of Azure availability zones that can be used (for example, `["1", "2", "3"]`).
 

--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -24,6 +24,7 @@ The following options are available when using Azure:
     * `diskSizeGB` (optional integer): The size of the disk in gigabytes (GB).
     * `diskType` (optional string): The type of disk (allowed values are: `Premium_LRS`, `Standard_LRS`, and `StandardSSD_LRS`).
     * `diskEncryptionSetId` (optional string): resource ID of disk encryption set
+* `encryptionAtHost` (optional bool): enables encryption at host
 * `type` (optional string): The Azure instance type.
 * `zones` (optional string slice): List of Azure availability zones that can be used (for example, `["1", "2", "3"]`).
 

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -112,6 +112,13 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		}
 	}
 
+	var securityProfile *machineapi.SecurityProfile
+	if mpool.EncryptionAtHost {
+		securityProfile = &machineapi.SecurityProfile{
+			EncryptionAtHost: &mpool.EncryptionAtHost,
+		}
+	}
+
 	spec := &machineapi.AzureMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machine.openshift.io/v1beta1",
@@ -132,6 +139,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 				DiskEncryptionSet:  diskEncryptionSet,
 			},
 		},
+		SecurityProfile:      securityProfile,
 		Zone:                 az,
 		Subnet:               subnet,
 		ManagedIdentity:      managedIdentity,

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -105,6 +105,13 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		managedIdentity = ""
 	}
 
+	var diskEncryptionSet *machineapi.DiskEncryptionSetParameters
+	if mpool.OSDisk.DiskEncryptionSetID != "" {
+		diskEncryptionSet = &machineapi.DiskEncryptionSetParameters{
+			ID: mpool.OSDisk.DiskEncryptionSetID,
+		}
+	}
+
 	spec := &machineapi.AzureMachineProviderSpec{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "machine.openshift.io/v1beta1",
@@ -122,6 +129,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 			DiskSizeGB: mpool.OSDisk.DiskSizeGB,
 			ManagedDisk: machineapi.ManagedDiskParameters{
 				StorageAccountType: mpool.OSDisk.DiskType,
+				DiskEncryptionSet:  diskEncryptionSet,
 			},
 		},
 		Zone:                 az,

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -28,6 +28,7 @@ type config struct {
 	BootstrapInstanceType           string            `json:"azure_bootstrap_vm_type,omitempty"`
 	MasterInstanceType              string            `json:"azure_master_vm_type,omitempty"`
 	MasterAvailabilityZones         []string          `json:"azure_master_availability_zones"`
+	MasterDiskEncryptionSetID       string            `json:"azure_master_disk_encryption_set_id,omitempty"`
 	VolumeType                      string            `json:"azure_master_root_volume_type"`
 	VolumeSize                      int32             `json:"azure_master_root_volume_size"`
 	ImageURL                        string            `json:"azure_image_url,omitempty"`
@@ -79,6 +80,11 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		return nil, errors.Wrap(err, "could not determine Azure environment to use for Terraform")
 	}
 
+	var masterDiskEncryptionSetID string
+	if masterConfig.OSDisk.ManagedDisk.DiskEncryptionSet != nil {
+		masterDiskEncryptionSetID = masterConfig.OSDisk.ManagedDisk.DiskEncryptionSet.ID
+	}
+
 	cfg := &config{
 		Auth:                            sources.Auth,
 		Environment:                     environment,
@@ -87,6 +93,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		BootstrapInstanceType:           defaults.BootstrapInstanceType(sources.CloudName, region),
 		MasterInstanceType:              masterConfig.VMSize,
 		MasterAvailabilityZones:         masterAvailabilityZones,
+		MasterDiskEncryptionSetID:       masterDiskEncryptionSetID,
 		VolumeType:                      masterConfig.OSDisk.ManagedDisk.StorageAccountType,
 		VolumeSize:                      masterConfig.OSDisk.DiskSizeGB,
 		ImageURL:                        sources.ImageURL,

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -28,6 +28,7 @@ type config struct {
 	BootstrapInstanceType           string            `json:"azure_bootstrap_vm_type,omitempty"`
 	MasterInstanceType              string            `json:"azure_master_vm_type,omitempty"`
 	MasterAvailabilityZones         []string          `json:"azure_master_availability_zones"`
+	MasterEncryptionAtHostEnabled   bool              `json:"azure_master_encryption_at_host_enabled,omitempty"`
 	MasterDiskEncryptionSetID       string            `json:"azure_master_disk_encryption_set_id,omitempty"`
 	VolumeType                      string            `json:"azure_master_root_volume_type"`
 	VolumeSize                      int32             `json:"azure_master_root_volume_size"`
@@ -80,6 +81,10 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		return nil, errors.Wrap(err, "could not determine Azure environment to use for Terraform")
 	}
 
+	masterEncryptionAtHostEnabled := masterConfig.SecurityProfile != nil &&
+		(*masterConfig.SecurityProfile).EncryptionAtHost != nil &&
+		*masterConfig.SecurityProfile.EncryptionAtHost
+
 	var masterDiskEncryptionSetID string
 	if masterConfig.OSDisk.ManagedDisk.DiskEncryptionSet != nil {
 		masterDiskEncryptionSetID = masterConfig.OSDisk.ManagedDisk.DiskEncryptionSet.ID
@@ -93,6 +98,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		BootstrapInstanceType:           defaults.BootstrapInstanceType(sources.CloudName, region),
 		MasterInstanceType:              masterConfig.VMSize,
 		MasterAvailabilityZones:         masterAvailabilityZones,
+		MasterEncryptionAtHostEnabled:   masterEncryptionAtHostEnabled,
 		MasterDiskEncryptionSetID:       masterDiskEncryptionSetID,
 		VolumeType:                      masterConfig.OSDisk.ManagedDisk.StorageAccountType,
 		VolumeSize:                      masterConfig.OSDisk.DiskSizeGB,

--- a/pkg/types/azure/machinepool.go
+++ b/pkg/types/azure/machinepool.go
@@ -34,6 +34,10 @@ type OSDisk struct {
 	// +optional
 	// +kubebuilder:validation:Enum=Standard_LRS;Premium_LRS;StandardSSD_LRS
 	DiskType string `json:"diskType"`
+
+	// DiskEncryptionSetID is a resource ID of disk encryption set
+	// +optional
+	DiskEncryptionSetID string `json:"diskEncryptionSetId,omitempty"`
 }
 
 // DefaultDiskType holds the default Azure disk type used by the VMs.
@@ -59,5 +63,9 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.OSDisk.DiskType != "" {
 		a.OSDisk.DiskType = required.OSDisk.DiskType
+	}
+
+	if required.OSDisk.DiskEncryptionSetID != "" {
+		a.OSDisk.DiskEncryptionSetID = required.OSDisk.DiskEncryptionSetID
 	}
 }

--- a/pkg/types/azure/machinepool.go
+++ b/pkg/types/azure/machinepool.go
@@ -15,6 +15,11 @@ type MachinePool struct {
 	// +optional
 	InstanceType string `json:"type"`
 
+	// EncryptionAtHost enables encryption at the VM host.
+	//
+	// +optional
+	EncryptionAtHost bool `json:"encryptionAtHost,omitempty"`
+
 	// OSDisk defines the storage for instance.
 	//
 	// +optional
@@ -55,6 +60,10 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.InstanceType != "" {
 		a.InstanceType = required.InstanceType
+	}
+
+	if required.EncryptionAtHost {
+		a.EncryptionAtHost = required.EncryptionAtHost
 	}
 
 	if required.OSDisk.DiskSizeGB != 0 {


### PR DESCRIPTION
## What this PR does

Adds support for:

* [Server-Side Encryption](https://docs.microsoft.com/en-us/azure/virtual-machines/disk-encryption) with customer managed keys
* [Encryption At Host](https://docs.microsoft.com/en-us/azure/virtual-machines/disk-encryption#encryption-at-host---end-to-end-encryption-for-your-vm-data) support

This PR is based on the work done for Azure Red Hat OpenShift and hopefully gives the installer team a good starting point for [CORS-1494](https://issues.redhat.com/browse/CORS-1494).

In the current form the PR allows to create clusters with server side encryption (customer managed keys) and encryption at host, but it requires a user to provision key vault and disk encryption set manually, set required permissions, etc (see the steps below). Basically It works similar to bringing own vnet.

UX for IPI can be improved by giving an option to provision key vault and disk encryption set for the user.

Also cluster's default storage class is not going to use customer managed keys which might be confusing/missleading as mentioned [here](https://issues.redhat.com/browse/CORS-1494?focusedCommentId=16497490&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16497490). The installer team might need to work together with the storage team to allow the default storage class to use disk encryption set straight after the installation (**OR** at least big warning is required somewhere in the documentation).

## Manual testing

### Prerequisite: Enable EncryptionAtHost feature

```
az feature register --namespace "Microsoft.Compute" --name "EncryptionAtHost"
```

To check the status run

```
az feature show --namespace Microsoft.Compute --name EncryptionAtHost
```

Once the feature 'EncryptionAtHost' is registered, invoking 'az provider register -n Microsoft.Compute' is required to get the change propagated.

```
az provider register -n Microsoft.Compute
```

### Set basic variables

```
OUTPUT_DIR=<some-dir>   # Output dir for the installer assets directory (install config will be here)
RESOURCEGROUP=$USER-test-encryption
LOCATION=eastus

KEYVAULT_NAME=$USER-kv  # Needs to be globally unique
KEYVAULT_KEY_NAME=$USER-disk-encryption-key
DISK_ENCRYPTION_SET_NAME=$USER-disk-encryption-set

CLUSTER_SP_ID=<appId>   # Service principal ID which is going to be used to create a cluster
```



### Create resource group for key vault and disk encryption set


Resource group creation:

```
az group create --name $RESOURCEGROUP --location $LOCATION
```

### Create Key Vault

```
az keyvault create -n $KEYVAULT_NAME -g $RESOURCEGROUP -l $LOCATION --enable-purge-protection true --enable-soft-delete true

az keyvault key create --vault-name $KEYVAULT_NAME -n $KEYVAULT_KEY_NAME --protection software
```

### Create an instance of a DiskEncryptionSet

```
KEYVAULT_ID=$(az keyvault show --name $KEYVAULT_NAME --query "[id]" -o tsv)

KEYVAULT_KEY_URL=$(az keyvault key show --vault-name $KEYVAULT_NAME --name $KEYVAULT_KEY_NAME --query "[key.kid]" -o tsv)

az disk-encryption-set create -n $DISK_ENCRYPTION_SET_NAME -l $LOCATION -g $RESOURCEGROUP --source-vault $KEYVAULT_ID --key-url $KEYVAULT_KEY_URL
```

### Grant the DiskEncryptionSet resource access to the key vault:

```
DES_IDENTITY=$(az disk-encryption-set show -n $DISK_ENCRYPTION_SET_NAME -g $RESOURCEGROUP --query "[identity.principalId]" -o tsv)

az keyvault set-policy -n $KEYVAULT_NAME -g $RESOURCEGROUP --object-id $DES_IDENTITY --key-permissions wrapkey unwrapkey get
```

### Grant service principal Reader permissions to DiskEncryptionSet

```
DES_RESOURCE_ID=$(az disk-encryption-set show -n $DISK_ENCRYPTION_SET_NAME -g $RESOURCEGROUP --query "[id]" -o tsv)

az role assignment create --assignee $CLUSTER_SP_ID --role Reader --scope $DES_RESOURCE_ID -o jsonc
```

### Get disk encryption set ID

```
echo $DES_RESOURCE_ID
```

You will need to later so you can put it into the install config yaml.

### Generate and modify an install config

```
openshift-install create install-config --dir $OUTPUT_DIR
```

In the editor of choice open `$OUTPUT_DIR/install-config.yaml` and modify both `compute` and `controlPlane` sections:
replace `platform` with the following:

```yaml
  platform:
    azure:
      encryptionAtHost: true
      osDisk:
        diskEncryptionSetId: "<output of echo $DES_RESOURCE_ID from the previous step>"
```

### Create a cluster

```
openshift-install create cluster --dir $OUTPUT_DIR
```


### Validate that all VMs have correct properties:

```
CLUSTER_RESOURCEGROUP=<cluster-resource-group-provisioned-by-installer>
az vm list -g $CLUSTER_RESOURCEGROUP --query "[].{Name:name, diskEncryptionSet: storageProfile.osDisk.managedDisk.diskEncryptionSet.id, encryptionAtHost: securityProfile.encryptionAtHost}"
```

Note: you can run this command while bootstrap nodes still exist: they should have the same properties as set in `masterProfile`.

You should expect something like:

```
[
  {
    "Name": "foo-bar-master-0",
    "diskEncryptionSet": "<disk encryption set ID provided earlier>",
    "encryptionAtHost": true
  },
  # ...
]
```
