### PR TITLE
Update URL from cloud.redhat.com to console.redhat.com

### DIFF
--- a/docs/user/aws/install.md
+++ b/docs/user/aws/install.md
@@ -68,5 +68,5 @@ The OpenShift console is available via the kubeadmin login provided by the insta
 
 ![OpenShift web console](images/install_console.png)
 
-[cloud-install]: https://cloud.redhat.com/openshift/create
+[cloud-install]: https://console.redhat.com/openshift/create
 [encrypted-copy]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIEncryption.html#create-ami-encrypted-root-snapshot

--- a/docs/user/azure/install.md
+++ b/docs/user/azure/install.md
@@ -58,5 +58,5 @@ The OpenShift console is available via the kubeadmin login provided by the insta
 
 ![OpenShift web console](images/install_console.png)
 
-[cloud-install]: https://cloud.redhat.com/openshift/create
+[cloud-install]: https://console.redhat.com/openshift/create
 [rhcos]: https://github.com/openshift/os

--- a/docs/user/gcp/install.md
+++ b/docs/user/gcp/install.md
@@ -57,4 +57,4 @@ The OpenShift console is available via the kubeadmin login provided by the insta
 
 ![OpenShift web console](images/install_console.png)
 
-[cloud-install]: https://cloud.redhat.com/openshift/create
+[cloud-install]: https://console.redhat.com/openshift/create

--- a/docs/user/ovirt/install_upi.md
+++ b/docs/user/ovirt/install_upi.md
@@ -461,7 +461,7 @@ $ openshift-install create install-config --dir $ASSETS_DIR
 used to expose the API interface (`https://api.ocp4.example.org:6443/`)
 and the newly created applications (e.g. `https://console-openshift-console.apps.ocp4.example.org`).
 
-You can obtain a new Pull secret from [here](https://cloud.redhat.com/openshift/install/pull-secret).
+You can obtain a new Pull secret from [here](https://console.redhat.com/openshift/install/pull-secret).
 
 The result of this first step is the creation of a `install-config.yaml` in the specified assets directory:
 

--- a/docs/user/vsphere/install.md
+++ b/docs/user/vsphere/install.md
@@ -100,4 +100,4 @@ The OpenShift console is available via the kubeadmin login provided by the insta
 
 ![OpenShift web console](images/install_console.png)
 
-[cloud-install]: https://cloud.redhat.com/openshift/create
+[cloud-install]: https://console.redhat.com/openshift/create

--- a/pkg/asset/installconfig/pullsecret.go
+++ b/pkg/asset/installconfig/pullsecret.go
@@ -25,7 +25,7 @@ func (a *pullSecret) Generate(asset.Parents) error {
 		{
 			Prompt: &survey.Password{
 				Message: "Pull Secret",
-				Help:    "The container registry pull secret for this cluster, as a single line of JSON (e.g. {\"auths\": {...}}).\n\nYou can get this secret from https://cloud.redhat.com/openshift/install/pull-secret",
+				Help:    "The container registry pull secret for this cluster, as a single line of JSON (e.g. {\"auths\": {...}}).\n\nYou can get this secret from https://console.redhat.com/openshift/install/pull-secret",
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 				return validate.ImagePullSecret(ans.(string))


### PR DESCRIPTION
The console applications currently in cloud.redhat.com have been moved to
to a new URL at console.redhat.com.

https://cloud.redhat.com/blog/check-out-our-new-look

Signed-off-by: Mikel Olasagasti Uranga <mikel@olasagasti.info>