### PR TITLE
Bug 1990206: Fix invalid UPI AWS instance type

### DIFF
--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -67,7 +67,7 @@ Parameters:
     - "m5a.2xlarge"
     - "m5a.4xlarge"
     - "m5a.8xlarge"
-    - "m5a.10xlarge"
+    - "m5a.12xlarge"
     - "m5a.16xlarge"
     - "c4.2xlarge"
     - "c4.4xlarge"

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -51,7 +51,7 @@ Parameters:
     - "m5a.2xlarge"
     - "m5a.4xlarge"
     - "m5a.8xlarge"
-    - "m5a.10xlarge"
+    - "m5a.12xlarge"
     - "m5a.16xlarge"
     - "c4.large"
     - "c4.xlarge"


### PR DESCRIPTION
On AWS, m5a.10xlarge is not a valid instance type anymore. Replaced with m5a.12xlarge
per https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceTypes.html

generated with `find . -type f -print0 | xargs -0 sed -i 's|m5a.10xlarge|m5a.12xlarge|'`

https://bugzilla.redhat.com/show_bug.cgi?id=1990206