### PR TITLE
Bug 1989917: openstack: relax Security Group quotas

### DIFF
--- a/pkg/asset/quota/openstack/openstack.go
+++ b/pkg/asset/quota/openstack/openstack.go
@@ -16,8 +16,8 @@ import (
 // https://github.com/openshift/installer/blob/master/docs/user/openstack/kuryr.md
 // Number of ports, routers, subnets and routers here don't include the constraints needed
 // for each machine, which are calculated later
-var minNetworkConstraint = buildNetworkConstraint(9, 0, 0, 0, 3, 60)
-var minNetworkConstraintWithKuryr = buildNetworkConstraint(1494, 0, 249, 249, 250, 1000)
+var minNetworkConstraint = buildNetworkConstraint(9, 0, 0, 0, 2, 56)
+var minNetworkConstraintWithKuryr = buildNetworkConstraint(1494, 0, 249, 249, 249, 996)
 
 func buildNetworkConstraint(ports, routers, subnets, networks, securityGroups, securityGroupRules int64) []quota.Constraint {
 	return []quota.Constraint{


### PR DESCRIPTION
OpenStack clouds deployed by Red Hat have a `default` security group
which contains 4 rules.

This patch will relax the number of security groups and rules so it
takes in account that a number of these resources could already be there
before installing OpenShift.

This is fine because the installer will create 2 security groups (one
for masters and one for workers, when using OpenShiftSDN, etc) and less
than 45 rules, so 56 rules is enough.
Same with Kuryr, new numbers will be enough as well.

This will allow our users following the documentation and the quotas, to
deploy on Red Hat OpenStack without modifying the quota numbers.
