### PR TITLE
docs: fix broken link to CVO/operators.md in operators.md

### DIFF
--- a/docs/dev/operators.md
+++ b/docs/dev/operators.md
@@ -18,4 +18,4 @@ Create a new operator asset, and render the Dependencies, Name, Load and Generat
  - Template files
 In the pkg/asset/manifests/content/openshift directory, place the templates golang variables. Then modify pkg/asset/manifests/openshift.go to expand the template. Expand templateData in template.go for filling up the template variables.
 
-[cvo-operators]: https://github.com/openshift/cluster-version-operator/tree/master/docs/dev/operators.md
+[cvo-operators]: https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/operators.md


### PR DESCRIPTION
The link moved from the cluster-version-operator to the enhancements repo.

Unsubscribing because the bot seems to have gone a bit crazy. Please tag me if you want me to be notified. :)

Signed-off-by: Rohan CJ <rohantmp@gmail.com>