### PR TITLE
Replaced the m5a.10xlarge instance type with the m5a.12xlarge instance type

### DIFF
--- a/upi/aws/cloudformation/05_cluster_master_nodes.yaml
+++ b/upi/aws/cloudformation/05_cluster_master_nodes.yaml
@@ -67,7 +67,7 @@ Parameters:
     - "m5a.2xlarge"
     - "m5a.4xlarge"
     - "m5a.8xlarge"
-    - "m5a.10xlarge"
+    - "m5a.12xlarge"
     - "m5a.16xlarge"
     - "c4.2xlarge"
     - "c4.4xlarge"

--- a/upi/aws/cloudformation/06_cluster_worker_node.yaml
+++ b/upi/aws/cloudformation/06_cluster_worker_node.yaml
@@ -51,7 +51,7 @@ Parameters:
     - "m5a.2xlarge"
     - "m5a.4xlarge"
     - "m5a.8xlarge"
-    - "m5a.10xlarge"
+    - "m5a.12xlarge"
     - "m5a.16xlarge"
     - "c4.large"
     - "c4.xlarge"


### PR DESCRIPTION
This pull request changes the template files so that the documentation reflects the currently supported AWS instance types correctly. AWS no longer supports `m5a.10xlarge` instance type, which has been replaced with the `m5a.12xlarge` instance type. The documentation PR is https://github.com/openshift/openshift-docs/pull/35359.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1990206, https://bugzilla.redhat.com/show_bug.cgi?id=1977897