### PR TITLE
Bug 1989973: Fix Azure typo

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1258,11 +1258,11 @@ spec:
                     description: ResourceGroupName is the name of an already existing
                       resource group where the cluster should be installed. This resource
                       group should only be used for this specific cluster and the
-                      cluster components will assume assume ownership of all resources
-                      in the resource group. Destroying the cluster using installer
-                      will delete this resource group. This resource group must be
-                      empty with no other resources when trying to use it for creating
-                      a cluster. If empty, a new resource group will created for the
+                      cluster components will assume ownership of all resources in
+                      the resource group. Destroying the cluster using installer will
+                      delete this resource group. This resource group must be empty
+                      with no other resources when trying to use it for creating a
+                      cluster. If empty, a new resource group will created for the
                       cluster.
                     type: string
                   virtualNetwork:

--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -28,7 +28,7 @@ The following options are available when using Azure:
 
 ## Installing to Existing Resource Group
 
-The installer can use an existing resource group when provisioning an OpenShift cluster. This resource group should only be used for this specific cluster and the cluster components will assume assume ownership of all resources in the resource group. Destroying the cluster using installer will delete this resource group. This resource group must be empty with no other resources when trying to use it for creating a cluster.
+The installer can use an existing resource group when provisioning an OpenShift cluster. This resource group should only be used for this specific cluster and the cluster components will assume ownership of all resources in the resource group. Destroying the cluster using installer will delete this resource group. This resource group must be empty with no other resources when trying to use it for creating a cluster.
 
 If you're limiting the installer's Service Principal scope to the Resource Group defined with `resourceGroupName`, you will also need to ensure proper permissions for any other resource used by the installer in your environment such as Public DNS Zone, VNet, etc.
 

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -177,7 +177,7 @@ func Test_PrintFields(t *testing.T) {
       Region specifies the Azure region where the cluster will be created.
 
     resourceGroupName <string>
-      ResourceGroupName is the name of an already existing resource group where the cluster should be installed. This resource group should only be used for this specific cluster and the cluster components will assume assume ownership of all resources in the resource group. Destroying the cluster using installer will delete this resource group. This resource group must be empty with no other resources when trying to use it for creating a cluster. If empty, a new resource group will created for the cluster.
+      ResourceGroupName is the name of an already existing resource group where the cluster should be installed. This resource group should only be used for this specific cluster and the cluster components will assume ownership of all resources in the resource group. Destroying the cluster using installer will delete this resource group. This resource group must be empty with no other resources when trying to use it for creating a cluster. If empty, a new resource group will created for the cluster.
 
     virtualNetwork <string>
       VirtualNetwork specifies the name of an existing VNet for the installer to use`,

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -73,7 +73,7 @@ type Platform struct {
 	OutboundType OutboundType `json:"outboundType"`
 
 	// ResourceGroupName is the name of an already existing resource group where the cluster should be installed.
-	// This resource group should only be used for this specific cluster and the cluster components will assume assume
+	// This resource group should only be used for this specific cluster and the cluster components will assume
 	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
 	// resource group.
 	// This resource group must be empty with no other resources when trying to use it for creating a cluster.


### PR DESCRIPTION
Replace "assume assume" with "assume" in azure
byo resource group description and docs.

Generated with `find . -type f -print0 | xargs -0 sed -i 's|assume assume|assume|'`
Ran codegen for `install.openshift.io_installconfigs.yaml`

https://bugzilla.redhat.com/show_bug.cgi?id=1989973