### PR TITLE
Bug 1987845: openstack: relax port constrain by one

### DIFF
--- a/pkg/asset/quota/openstack/openstack.go
+++ b/pkg/asset/quota/openstack/openstack.go
@@ -16,8 +16,8 @@ import (
 // https://github.com/openshift/installer/blob/master/docs/user/openstack/kuryr.md
 // Number of ports, routers, subnets and routers here don't include the constraints needed
 // for each machine, which are calculated later
-var minNetworkConstraint = buildNetworkConstraint(9, 0, 0, 0, 2, 56)
-var minNetworkConstraintWithKuryr = buildNetworkConstraint(1494, 0, 249, 249, 249, 996)
+var minNetworkConstraint = buildNetworkConstraint(8, 0, 0, 0, 2, 56)
+var minNetworkConstraintWithKuryr = buildNetworkConstraint(1493, 0, 249, 249, 249, 996)
 
 func buildNetworkConstraint(ports, routers, subnets, networks, securityGroups, securityGroupRules int64) []quota.Constraint {
 	return []quota.Constraint{


### PR DESCRIPTION
When using a machine network, it's very likely that a port will already
be used by Neutron for OVN metadata, so we need to take that in account
when checking available resources.
