### PR TITLE
images: Add az cli for CI ash testing

### DIFF
--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -8,6 +8,9 @@ COPY . .
 RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 RUN go run -mod=vendor hack/build-coreos-manifest.go
 
+RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc
+RUN sh -c 'echo -e "[azure-cli]\nname=Azure CLI\nbaseurl=https://packages.microsoft.com/yumrepos/azure-cli\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc" >/etc/yum.repos.d/azure-cli.repo'
+RUN yum update -y && yum install -y azure-cli
 
 FROM registry.ci.openshift.org/ocp/4.9:base
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install


### PR DESCRIPTION
In order to do IPI testing, login to the Azure Stack Hub is necessary
as it is private and not accessible ordinarily. Installing az cli
in the IPI image to allow for login to the Azure Stack Hub.
