### PR TITLE
Bug 1978213: openstack/quota: relax min ports

### DIFF
--- a/pkg/asset/quota/openstack/openstack.go
+++ b/pkg/asset/quota/openstack/openstack.go
@@ -16,8 +16,8 @@ import (
 // https://github.com/openshift/installer/blob/master/docs/user/openstack/kuryr.md
 // Number of ports, routers, subnets and routers here don't include the constraints needed
 // for each machine, which are calculated later
-var minNetworkConstraint = buildNetworkConstraint(8, 0, 0, 0, 2, 56)
-var minNetworkConstraintWithKuryr = buildNetworkConstraint(1493, 0, 249, 249, 249, 996)
+var minNetworkConstraint = buildNetworkConstraint(4, 0, 0, 0, 2, 56)
+var minNetworkConstraintWithKuryr = buildNetworkConstraint(1490, 0, 249, 249, 249, 996)
 
 func buildNetworkConstraint(ports, routers, subnets, networks, securityGroups, securityGroupRules int64) []quota.Constraint {
 	return []quota.Constraint{


### PR DESCRIPTION
For Kuryr:
Reduce from 1493 to 1490:
* 6 ports taken by machines (and added later in the requirements)
* 2 for floating IPs
* 1 for router gateway
* 1 for bootstrap machine
= 10
1500 - 10 = 1490
So we have now 1490 as a new relaxed number which should satisfy the
documented quotas.

For non-Kuryr:
Reduce from 8 to 4:
* 1 taken by network gateway
* 2 taken by API & Ingress ports or FIPs
* 1 taken by bootstrap
-> this makes 4
Then the installer adds one port per machine, so 6 by default (3 masters
and 3 workers) which makes 10 total. The documented quota is 15 so have
some margin error.
