### PR TITLE
Bug 1958154: Restrict number of AWS user tags

### DIFF
--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -48,6 +48,9 @@ func validateUserTags(tags map[string]string, propagatingTags bool, fldPath *fie
 	if len(tags) == 0 {
 		return allErrs
 	}
+	if len(tags) > 8 {
+		allErrs = append(allErrs, field.Invalid(fldPath, len(tags), "number of user tags cannot be more than 8"))
+	}
 	for key, value := range tags {
 		if strings.EqualFold(key, "Name") {
 			allErrs = append(allErrs, field.Invalid(fldPath.Key(key), tags[key], "Name key is not allowed for user defined tags"))


### PR DESCRIPTION
AWS S3 bucket does not allow more than 10 user tags to be applied
to them. Since the installer adds two tags, the "Name" and the
"kubernetes.io" tags, the user specified tags should only be a maximum
of 8.

Adding this restriction to the validation of user tags to prevent
error from terraform during cluster creation.