### PR TITLE
Bug 1974640: Write user credentials to specified env location

### DIFF
--- a/pkg/asset/installconfig/aws/session.go
+++ b/pkg/asset/installconfig/aws/session.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -190,6 +191,9 @@ func getUserCredentials() error {
 	}
 
 	path := defaults.SharedCredentialsFilename()
+	if env := os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); env != "" {
+		path = env
+	}
 	logrus.Infof("Writing AWS credentials to %q (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)", path)
 	err = os.MkdirAll(filepath.Dir(path), 0700)
 	if err != nil {
@@ -198,12 +202,11 @@ func getUserCredentials() error {
 
 	creds, err := ini.Load(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			creds = ini.Empty()
-			creds.Section("").Comment = "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html"
-		} else {
-			return err
+		if !os.IsNotExist(err) {
+			return errors.Wrap(err, fmt.Sprintf("failed to load credentials file %s", path))
 		}
+		creds = ini.Empty()
+		creds.Section("").Comment = "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html"
 	}
 
 	profile := os.Getenv("AWS_PROFILE")


### PR DESCRIPTION
If the user specified the AWS_SHARED_CREDENTIALS_FILE which is
either invalid or empty file, the credentials are collected by
the installer and are written to a default location (~/.aws/credentials)
when it can be written to the location specified in the above location.

Adding a small fix to write to the location specified in the location
specified by AWS_SHARED_CREDENTIALS_FILE if the file is either empty
or is invalid.