### PR TITLE
Bug 1969371: Stop searching other China regions for resources

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -140,11 +140,6 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) ([]string, erro
 	}
 
 	switch o.Region {
-	case endpoints.CnNorth1RegionID, endpoints.CnNorthwest1RegionID:
-		if o.Region != endpoints.CnNorthwest1RegionID {
-			tagClients = append(tagClients,
-				resourcegroupstaggingapi.New(awsSession, aws.NewConfig().WithRegion(endpoints.CnNorthwest1RegionID)))
-		}
 	case endpoints.UsGovEast1RegionID, endpoints.UsGovWest1RegionID:
 		if o.Region != endpoints.UsGovWest1RegionID {
 			tagClients = append(tagClients,


### PR DESCRIPTION
For cluster destroy on AWS china regions, the cn-northwest-1
region is always searched for resources even if the cn-north-1
region is used for installation. This might be true for the
public regions where there are a few resources in the us-east-1
location but the china regions are separate partitions and are
not involved in the other region installation.

Removing the northwest region client from the destroy so it
will not be used to search if it is not used for installation.