### PR TITLE
pkg/destroy/gcp: report cluster footprint in quota

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/go-playground/validator/v10 v10.2.0
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
+	github.com/google/go-cmp v0.5.2
 	github.com/google/martian v2.1.1-0.20190517191504-25dcb96d9e51+incompatible // indirect
 	github.com/google/uuid v1.2.0
 	github.com/gophercloud/gophercloud v0.17.0

--- a/pkg/asset/cluster/quota.go
+++ b/pkg/asset/cluster/quota.go
@@ -1,0 +1,29 @@
+package cluster
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+const (
+	quotaFileName = "quota.json"
+)
+
+// WriteQuota writes the cluster quota footprint into the asset directory.
+func WriteQuota(dir string, quota *types.ClusterQuota) error {
+	path := filepath.Join(dir, quotaFileName)
+
+	raw, err := json.Marshal(quota)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal quota")
+	}
+	if err := ioutil.WriteFile(path, raw, 0777); err != nil {
+		return errors.Wrap(err, "failed to write quota")
+	}
+	return nil
+}

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -109,9 +109,9 @@ func (o *ClusterUninstaller) validate() error {
 }
 
 // Run is the entrypoint to start the uninstall process
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	_, err := o.RunWithContext(context.Background())
-	return err
+	return nil, err
 }
 
 // RunWithContext runs the uninstall process with a context.

--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -106,7 +106,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	var errs []error
 	var err error
 
@@ -205,7 +205,7 @@ func (o *ClusterUninstaller) Run() error {
 		o.Logger.Debug(err)
 	}
 
-	return utilerrors.NewAggregate(errs)
+	return nil, utilerrors.NewAggregate(errs)
 }
 
 func deleteAzureStackPublicRecords(ctx context.Context, o *ClusterUninstaller) error {

--- a/pkg/destroy/baremetal/baremetal.go
+++ b/pkg/destroy/baremetal/baremetal.go
@@ -20,22 +20,22 @@ type ClusterUninstaller struct {
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	o.Logger.Debug("Deleting bare metal resources")
 
 	// FIXME: close the connection
 	conn, err := libvirt.NewConnect(o.LibvirtURI)
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to Libvirt daemon")
+		return nil, errors.Wrap(err, "failed to connect to Libvirt daemon")
 	}
 	err = o.deleteStoragePool(conn)
 	if err != nil {
-		return errors.Wrap(err, "failed to clean baremetal bootstrap storage pool")
+		return nil, errors.Wrap(err, "failed to clean baremetal bootstrap storage pool")
 	}
 
 	o.Logger.Debug("FIXME: delete resources!")
 
-	return nil
+	return nil, nil
 }
 
 // New returns bare metal Uninstaller from ClusterMetadata.

--- a/pkg/destroy/gcp/backendservice.go
+++ b/pkg/destroy/gcp/backendservice.go
@@ -1,9 +1,10 @@
 package gcp
 
 import (
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -32,6 +33,13 @@ func (o *ClusterUninstaller) listBackendServicesWithFilter(fields string, filter
 					key:      item.Name,
 					name:     item.Name,
 					typeName: "backendservice",
+					quota: []gcp.QuotaUsage{{
+						Metric: &gcp.Metric{
+							Service: gcp.ServiceComputeEngineAPI,
+							Limit:   "backend_services",
+						},
+						Amount: 1,
+					}},
 				})
 			}
 		}

--- a/pkg/destroy/gcp/cloudresource.go
+++ b/pkg/destroy/gcp/cloudresource.go
@@ -1,5 +1,7 @@
 package gcp
 
+import "github.com/openshift/installer/pkg/types/gcp"
+
 // cloudResource hold various fields for any given cloud resource
 type cloudResource struct {
 	key      string
@@ -8,6 +10,7 @@ type cloudResource struct {
 	typeName string
 	url      string
 	zone     string
+	quota    []gcp.QuotaUsage
 }
 
 type cloudResources map[string]cloudResource

--- a/pkg/destroy/gcp/firewall.go
+++ b/pkg/destroy/gcp/firewall.go
@@ -1,9 +1,10 @@
 package gcp
 
 import (
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -32,6 +33,13 @@ func (o *ClusterUninstaller) listFirewallsWithFilter(fields string, filter strin
 					key:      item.Name,
 					name:     item.Name,
 					typeName: "firewall",
+					quota: []gcp.QuotaUsage{{
+						Metric: &gcp.Metric{
+							Service: gcp.ServiceComputeEngineAPI,
+							Limit:   "firewalls",
+						},
+						Amount: 1,
+					}},
 				})
 			}
 		}

--- a/pkg/destroy/gcp/gcp_test.go
+++ b/pkg/destroy/gcp/gcp_test.go
@@ -1,0 +1,55 @@
+package gcp
+
+import "testing"
+
+func TestGetNameFromURL(t *testing.T) {
+	var testCases = []struct {
+		item, url, expected string
+	}{
+		{
+			item:     "zones",
+			url:      "https://www.googleapis.com/compute/v1/projects/ci-op-lk2ifbjc/zones/us-central1-a",
+			expected: "us-central1-a",
+		},
+		{
+			item:     "networks",
+			url:      "https://www.googleapis.com/compute/v1/projects/ci-op-lk2ifbjc/global/networks/ci-op-lk2ifbjc-15937-q68kj-network",
+			expected: "ci-op-lk2ifbjc-15937-q68kj-network",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.item, func(t *testing.T) {
+			if actual, expected := getNameFromURL(testCase.item, testCase.url), testCase.expected; actual != expected {
+				t.Errorf("got incorrect name %s for item %s from url %s", actual, testCase.item, testCase.url)
+			}
+		})
+	}
+}
+
+func TestGetRegionFromZone(t *testing.T) {
+	if actual, expected := getRegionFromZone("us-central1-a"), "us-central1"; actual != expected {
+		t.Errorf("got %s, not %s", actual, expected)
+	}
+}
+
+func TestGetDiskLimit(t *testing.T) {
+	var testCases = []struct {
+		url, expected string
+	}{
+		{
+			url:      "https://www.googleapis.com/compute/v1/projects/ci-op-lk2ifbjc/zones/us-central1-a/diskTypes/pd-standard",
+			expected: "disks_total_storage",
+		},
+		{
+			url:      "https://www.googleapis.com/compute/v1/projects/ci-op-lk2ifbjc/zones/us-central1-a/diskTypes/pd-ssd",
+			expected: "ssd_total_storage",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.url, func(t *testing.T) {
+			if actual, expected := getDiskLimit(testCase.url), testCase.expected; actual != expected {
+				t.Errorf("got incorrect limit %s for url %s", actual, testCase.url)
+			}
+		})
+	}
+}

--- a/pkg/destroy/gcp/healthcheck.go
+++ b/pkg/destroy/gcp/healthcheck.go
@@ -1,9 +1,10 @@
 package gcp
 
 import (
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -32,6 +33,13 @@ func (o *ClusterUninstaller) listHealthChecksWithFilter(fields string, filter st
 					key:      item.Name,
 					name:     item.Name,
 					typeName: "healthcheck",
+					quota: []gcp.QuotaUsage{{
+						Metric: &gcp.Metric{
+							Service: gcp.ServiceComputeEngineAPI,
+							Limit:   "health_checks",
+						},
+						Amount: 1,
+					}},
 				})
 			}
 		}

--- a/pkg/destroy/gcp/httphealthcheck.go
+++ b/pkg/destroy/gcp/httphealthcheck.go
@@ -1,9 +1,10 @@
 package gcp
 
 import (
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -32,6 +33,13 @@ func (o *ClusterUninstaller) listHTTPHealthChecksWithFilter(fields string, filte
 					key:      item.Name,
 					name:     item.Name,
 					typeName: "httphealthcheck",
+					quota: []gcp.QuotaUsage{{
+						Metric: &gcp.Metric{
+							Service: gcp.ServiceComputeEngineAPI,
+							Limit:   "health_checks",
+						},
+						Amount: 1,
+					}},
 				})
 			}
 		}

--- a/pkg/destroy/gcp/image.go
+++ b/pkg/destroy/gcp/image.go
@@ -1,9 +1,10 @@
 package gcp
 
 import (
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -32,6 +33,13 @@ func (o *ClusterUninstaller) listImagesWithFilter(fields string, filter string, 
 					key:      item.Name,
 					name:     item.Name,
 					typeName: "image",
+					quota: []gcp.QuotaUsage{{
+						Metric: &gcp.Metric{
+							Service: gcp.ServiceComputeEngineAPI,
+							Limit:   "images",
+						},
+						Amount: 1,
+					}},
 				})
 			}
 		}

--- a/pkg/destroy/gcp/instancegroup.go
+++ b/pkg/destroy/gcp/instancegroup.go
@@ -3,9 +3,10 @@ package gcp
 import (
 	"fmt"
 
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -38,6 +39,16 @@ func (o *ClusterUninstaller) listInstanceGroupsWithFilter(fields string, filter 
 						typeName: "instancegroup",
 						zone:     zoneName,
 						url:      item.SelfLink,
+						quota: []gcp.QuotaUsage{{
+							Metric: &gcp.Metric{
+								Service: gcp.ServiceComputeEngineAPI,
+								Limit:   "instance_groups",
+								Dimensions: map[string]string{
+									"region": getRegionFromZone(zoneName),
+								},
+							},
+							Amount: 1,
+						}},
 					})
 				}
 			}

--- a/pkg/destroy/gcp/quota.go
+++ b/pkg/destroy/gcp/quota.go
@@ -1,0 +1,20 @@
+package gcp
+
+import "github.com/openshift/installer/pkg/types/gcp"
+
+// mergeAllUsage merges the update into the usage we know about, matching on metrics
+func mergeAllUsage(into []gcp.QuotaUsage, update []gcp.QuotaUsage) []gcp.QuotaUsage {
+	for _, item := range update {
+		updated := false
+		for i := range into {
+			if into[i].Metric.Matches(item.Metric) {
+				into[i].Amount += item.Amount
+				updated = true
+			}
+		}
+		if !updated {
+			into = append(into, item)
+		}
+	}
+	return into
+}

--- a/pkg/destroy/gcp/quota_test.go
+++ b/pkg/destroy/gcp/quota_test.go
@@ -1,0 +1,119 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/installer/pkg/types/gcp"
+)
+
+func TestMergeAllUsage(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		into     []gcp.QuotaUsage
+		update   []gcp.QuotaUsage
+		expected []gcp.QuotaUsage
+	}{
+		{
+			name:     "no previous data, one new",
+			into:     nil,
+			update:   []gcp.QuotaUsage{{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1}},
+			expected: []gcp.QuotaUsage{{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1}},
+		},
+		{
+			name: "no previous data, many new",
+			into: nil,
+			update: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1},
+				{Metric: &gcp.Metric{Service: "S", Limit: "L"}, Amount: 1},
+			},
+			expected: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1},
+				{Metric: &gcp.Metric{Service: "S", Limit: "L"}, Amount: 1},
+			},
+		},
+		{
+			name: "merge adds new entry",
+			into: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1},
+			},
+			update: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "S", Limit: "L"}, Amount: 1},
+			},
+			expected: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1},
+				{Metric: &gcp.Metric{Service: "S", Limit: "L"}, Amount: 1},
+			},
+		},
+		{
+			name: "merge updates current entry",
+			into: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1},
+			},
+			update: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1},
+			},
+			expected: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 2},
+			},
+		},
+		{
+			name: "merge updates current entry only with full match",
+			into: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l", Dimensions: map[string]string{"a": "b"}}, Amount: 1},
+			},
+			update: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1},                                          // no dimensions
+				{Metric: &gcp.Metric{Service: "s", Limit: "L", Dimensions: map[string]string{"a": "b"}}, Amount: 1}, // different limit
+				{Metric: &gcp.Metric{Service: "S", Limit: "l", Dimensions: map[string]string{"a": "b"}}, Amount: 1}, // different service
+				{Metric: &gcp.Metric{Service: "s", Limit: "l", Dimensions: map[string]string{"a": "B"}}, Amount: 1}, // different dimensions
+				{Metric: &gcp.Metric{Service: "s", Limit: "l", Dimensions: map[string]string{"a": "b"}}, Amount: 1}, // match
+			},
+			expected: []gcp.QuotaUsage{
+				{Metric: &gcp.Metric{Service: "s", Limit: "l", Dimensions: map[string]string{"a": "b"}}, Amount: 2},
+				{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1},
+				{Metric: &gcp.Metric{Service: "s", Limit: "L", Dimensions: map[string]string{"a": "b"}}, Amount: 1},
+				{Metric: &gcp.Metric{Service: "S", Limit: "l", Dimensions: map[string]string{"a": "b"}}, Amount: 1},
+				{Metric: &gcp.Metric{Service: "s", Limit: "l", Dimensions: map[string]string{"a": "B"}}, Amount: 1},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if diff := cmp.Diff(mergeAllUsage(testCase.into, testCase.update), testCase.expected, cmp.AllowUnexported(gcp.QuotaUsage{}, gcp.Metric{})); diff != "" {
+				t.Errorf("%s: got incorrect usage after merge: %v", testCase.name, diff)
+			}
+		})
+	}
+}
+
+func TestQuotaIntegration(t *testing.T) {
+	uninstaller := &ClusterUninstaller{
+		pendingItemTracker: newPendingItemTracker(),
+	}
+	uninstaller.insertPendingItems("fake", []cloudResource{{
+		key:   "first",
+		quota: nil,
+	}, {
+		key: "second",
+		quota: []gcp.QuotaUsage{
+			{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 1},
+			{Metric: &gcp.Metric{Service: "S", Limit: "L"}, Amount: 1},
+		},
+	}, {
+		key: "third",
+		quota: []gcp.QuotaUsage{
+			{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 123},
+			{Metric: &gcp.Metric{Service: "S", Limit: "L"}, Amount: 111},
+		},
+	}})
+	for _, item := range uninstaller.getPendingItems("fake") {
+		uninstaller.deletePendingItems("fake", []cloudResource{item})
+	}
+	if diff := cmp.Diff(uninstaller.pendingItemTracker.removedQuota, []gcp.QuotaUsage{
+		{Metric: &gcp.Metric{Service: "s", Limit: "l"}, Amount: 124},
+		{Metric: &gcp.Metric{Service: "S", Limit: "L"}, Amount: 112},
+	}, cmp.AllowUnexported(gcp.QuotaUsage{}, gcp.Metric{})); diff != "" {
+		t.Errorf("didn't get correct removed quota: %v", diff)
+	}
+}

--- a/pkg/destroy/gcp/route.go
+++ b/pkg/destroy/gcp/route.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -42,6 +43,13 @@ func (o *ClusterUninstaller) listRoutesWithFilter(fields string, filter string, 
 					key:      item.Name,
 					name:     item.Name,
 					typeName: "route",
+					quota: []gcp.QuotaUsage{{
+						Metric: &gcp.Metric{
+							Service: gcp.ServiceComputeEngineAPI,
+							Limit:   "routes",
+						},
+						Amount: 1,
+					}},
 				})
 			}
 		}

--- a/pkg/destroy/gcp/router.go
+++ b/pkg/destroy/gcp/router.go
@@ -1,9 +1,10 @@
 package gcp
 
 import (
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -32,6 +33,13 @@ func (o *ClusterUninstaller) listRoutersWithFilter(fields string, filter string,
 					key:      item.Name,
 					name:     item.Name,
 					typeName: "router",
+					quota: []gcp.QuotaUsage{{
+						Metric: &gcp.Metric{
+							Service: gcp.ServiceComputeEngineAPI,
+							Limit:   "routers",
+						},
+						Amount: 1,
+					}},
 				})
 			}
 		}

--- a/pkg/destroy/gcp/serviceaccount.go
+++ b/pkg/destroy/gcp/serviceaccount.go
@@ -3,10 +3,11 @@ package gcp
 import (
 	"fmt"
 
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	iam "google.golang.org/api/iam/v1"
+	"google.golang.org/api/iam/v1"
 )
 
 // listServiceAccounts retrieves all service accounts with a display name prefixed with the cluster's
@@ -26,6 +27,13 @@ func (o *ClusterUninstaller) listServiceAccounts() ([]cloudResource, error) {
 			name:     item.Name,
 			url:      item.Email,
 			typeName: "serviceaccount",
+			quota: []gcp.QuotaUsage{{
+				Metric: &gcp.Metric{
+					Service: gcp.ServiceIAMAPI,
+					Limit:   "quota/service-account-count",
+				},
+				Amount: 1,
+			}},
 		})
 	}
 	return result, nil

--- a/pkg/destroy/gcp/targetpool.go
+++ b/pkg/destroy/gcp/targetpool.go
@@ -1,9 +1,10 @@
 package gcp
 
 import (
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/pkg/errors"
 
-	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -32,6 +33,13 @@ func (o *ClusterUninstaller) listTargetPoolsWithFilter(fields string, filter str
 					key:      item.Name,
 					name:     item.Name,
 					typeName: "targetpool",
+					quota: []gcp.QuotaUsage{{
+						Metric: &gcp.Metric{
+							Service: gcp.ServiceComputeEngineAPI,
+							Limit:   "target_pools",
+						},
+						Amount: 1,
+					}},
 				})
 			}
 		}

--- a/pkg/destroy/ibmcloud/ibmcloud.go
+++ b/pkg/destroy/ibmcloud/ibmcloud.go
@@ -77,18 +77,18 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 }
 
 // Run is the entrypoint to start the uninstall process
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	err := o.loadSDKServices()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = o.destroyCluster()
 	if err != nil {
-		return errors.Wrap(err, "failed to destroy cluster")
+		return nil, errors.Wrap(err, "failed to destroy cluster")
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (o *ClusterUninstaller) destroyCluster() error {

--- a/pkg/destroy/kubevirt/destroyer.go
+++ b/pkg/destroy/kubevirt/destroyer.go
@@ -34,14 +34,14 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (uninstaller *ClusterUninstaller) Run() error {
+func (uninstaller *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	ctx := context.Background()
 	namespace := uninstaller.Metadata.Kubevirt.Namespace
 
 	listOpts := metav1.ListOptions{LabelSelector: apilabels.FormatLabels(uninstaller.Metadata.Kubevirt.Labels)}
 	kubevirtClient, err := ickubevirt.NewClient()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	deleteFuncs := []deleteFunc{uninstaller.deleteAllVMs, uninstaller.deleteAllDVs, uninstaller.deleteAllSecrets}
@@ -68,9 +68,9 @@ func (uninstaller *ClusterUninstaller) Run() error {
 		}
 	}
 	if resultMsg != "" {
-		return fmt.Errorf("destroy finished with errors: %s", resultMsg)
+		return nil, fmt.Errorf("destroy finished with errors: %s", resultMsg)
 	}
-	return nil
+	return nil, nil
 }
 
 func (uninstaller *ClusterUninstaller) deleteAllVMs(ctx context.Context, namespace string, listOpts metav1.ListOptions, kubevirtClient ickubevirt.Client) error {

--- a/pkg/destroy/libvirt/libvirt.go
+++ b/pkg/destroy/libvirt/libvirt.go
@@ -5,7 +5,7 @@ package libvirt
 import (
 	"strings"
 
-	libvirt "github.com/libvirt/libvirt-go"
+	"github.com/libvirt/libvirt-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -57,10 +57,10 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (o *ClusterUninstaller) Run() error {
+func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	conn, err := libvirt.NewConnect(o.LibvirtURI)
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to Libvirt daemon")
+		return nil, errors.Wrap(err, "failed to connect to Libvirt daemon")
 	}
 
 	for _, del := range []deleteFunc{
@@ -70,11 +70,11 @@ func (o *ClusterUninstaller) Run() error {
 	} {
 		err = del(conn, o.Filter, o.Logger)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 // deleteDomains calls deleteDomainsSinglePass until it finds no

--- a/pkg/destroy/ovirt/destroyer.go
+++ b/pkg/destroy/ovirt/destroyer.go
@@ -21,10 +21,10 @@ type ClusterUninstaller struct {
 }
 
 // Run is the entrypoint to start the uninstall process.
-func (uninstaller *ClusterUninstaller) Run() error {
+func (uninstaller *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	con, err := ovirt.NewConnection()
 	if err != nil {
-		return fmt.Errorf("failed to initialize connection to ovirt-engine's %s", err)
+		return nil, fmt.Errorf("failed to initialize connection to ovirt-engine's %s", err)
 	}
 	defer con.Close()
 
@@ -48,7 +48,7 @@ func (uninstaller *ClusterUninstaller) Run() error {
 		uninstaller.Logger.Errorf("Failed to removing Affinity Groups: %s", err)
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (uninstaller *ClusterUninstaller) removeVMs(con *ovirtsdk.Connection, tag string) error {

--- a/pkg/destroy/providers/types.go
+++ b/pkg/destroy/providers/types.go
@@ -9,7 +9,7 @@ import (
 // Destroyer allows multiple implementations of destroy
 // for different platforms.
 type Destroyer interface {
-	Run() error
+	Run() (*types.ClusterQuota, error)
 }
 
 // NewFunc is an interface for creating platform-specific destroyers.

--- a/pkg/destroy/quota/quota.go
+++ b/pkg/destroy/quota/quota.go
@@ -1,13 +1,12 @@
-package cluster
+package quota
 
 import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"github.com/openshift/installer/pkg/types"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/types/clustermetadata.go
+++ b/pkg/types/clustermetadata.go
@@ -16,11 +16,11 @@ import (
 // ClusterMetadata contains information
 // regarding the cluster that was created by installer.
 type ClusterMetadata struct {
-	// clusterName is the name for the cluster.
+	// ClusterName is the name for the cluster.
 	ClusterName string `json:"clusterName"`
-	// clusterID is a globally unique ID that is used to identify an Openshift cluster.
+	// ClusterID is a globally unique ID that is used to identify an Openshift cluster.
 	ClusterID string `json:"clusterID"`
-	// infraID is an ID that is used to identify cloud resources created by the installer.
+	// InfraID is an ID that is used to identify cloud resources created by the installer.
 	InfraID                 string `json:"infraID"`
 	ClusterPlatformMetadata `json:",inline"`
 }

--- a/pkg/types/clusterquota.go
+++ b/pkg/types/clusterquota.go
@@ -9,16 +9,3 @@ import (
 type ClusterQuota struct {
 	GCP *gcp.Quota `json:"gcp,omitempty"`
 }
-
-// Platform returns a string representation of the platform
-// (e.g. "aws" if AWS is non-nil).  It returns an empty string if no
-// platform is configured.
-func (cpm *ClusterQuota) Platform() string {
-	if cpm == nil {
-		return ""
-	}
-	if cpm.GCP != nil {
-		return gcp.Name
-	}
-	return ""
-}

--- a/pkg/types/clusterquota.go
+++ b/pkg/types/clusterquota.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"github.com/openshift/installer/pkg/types/gcp"
+)
+
+// ClusterQuota contains the size, in cloud quota, of
+// the cluster that was created by installer.
+type ClusterQuota struct {
+	GCP *gcp.Quota `json:"gcp,omitempty"`
+}
+
+// Platform returns a string representation of the platform
+// (e.g. "aws" if AWS is non-nil).  It returns an empty string if no
+// platform is configured.
+func (cpm *ClusterQuota) Platform() string {
+	if cpm == nil {
+		return ""
+	}
+	if cpm.GCP != nil {
+		return gcp.Name
+	}
+	return ""
+}

--- a/pkg/types/gcp/quota.go
+++ b/pkg/types/gcp/quota.go
@@ -1,0 +1,84 @@
+package gcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// ServiceComputeEngineAPI is the GCE service URL
+	ServiceComputeEngineAPI = "compute.googleapis.com"
+	// ServiceIAMAPI is the IAM service URL
+	ServiceIAMAPI = "iam.googleapis.com"
+)
+
+// Quota is a record of the quota in GCP consumed by a cluster
+type Quota []QuotaUsage
+
+// QuotaUsage identifies a quota metric and records the usage
+type QuotaUsage struct {
+	*Metric `json:",inline"`
+	// Amount is the amount of the quota being used
+	Amount int64 `json:"amount,omitempty"`
+}
+
+// String formats the quota usage
+func (q *QuotaUsage) String() string {
+	return fmt.Sprintf("%s:%d", q.Metric.String(), q.Amount)
+}
+
+// Metric identify a quota. Service/Label matches the Google Quota API names for quota metrics
+type Metric struct {
+	// Service is the Google Cloud Service to which this quota belongs (e.g. compute.googleapis.com)
+	Service string `json:"service,omitempty"`
+	// Limit is the name of the item that's limited (e.g. cpus)
+	Limit string `json:"limit,omitempty"`
+	// Dimensions are unique axes on which this Limit is applied (e.g. region: us-central-1)
+	Dimensions map[string]string `json:"dimensions,omitempty"`
+}
+
+// String formats the metric
+func (m *Metric) String() string {
+	var dimensions []string
+	for key, value := range m.Dimensions {
+		dimensions = append(dimensions, fmt.Sprintf("%s=%s", key, value))
+	}
+	var suffix string
+	if len(dimensions) > 0 {
+		suffix = fmt.Sprintf("[%s]", strings.Join(dimensions, ","))
+	}
+	return fmt.Sprintf("%s/%s%s", m.Service, m.Limit, suffix)
+}
+
+// Matches determines if this metric matches the other
+func (m *Metric) Matches(other *Metric) bool {
+	if m.Service != other.Service {
+		return false
+	}
+	if m.Limit != other.Limit {
+		return false
+	}
+
+	if len(m.Dimensions) != len(other.Dimensions) {
+		return false
+	}
+	for key, value := range m.Dimensions {
+		otherValue, recorded := other.Dimensions[key]
+		if !recorded {
+			return false
+		}
+		if value != otherValue {
+			return false
+		}
+	}
+	for key, value := range other.Dimensions {
+		ourValue, recorded := m.Dimensions[key]
+		if !recorded {
+			return false
+		}
+		if value != ourValue {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -797,6 +797,7 @@ github.com/golang/snappy
 # github.com/google/btree v1.0.0
 github.com/google/btree
 # github.com/google/go-cmp v0.5.2
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags


### PR DESCRIPTION
When we destroy an entity in the public cloud relating to a cluster, we
now record the impact that the item had to the quota in the account that
the cluster was provisioned in. This will allow for downstream users of
the installer to reason about the footprint of clusters they run,
allowing for more automated reasoning about how many clusters of a type
can fit into an account.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @jstuever 

I *really* don't know how to test this ... thoughts?