### PR TITLE
Bug 1995655: bump default channel to stable-4.9

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -8,6 +8,6 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-4
 {{- else }}
-  channel: stable-4.8
+  channel: stable-4.9
 {{- end }}
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
```
# ./oc get clusterversion
NAME      VERSION                             AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.9.0-0.nightly-2021-08-18-144658   True        False         157m    Cluster version is 4.9.0-0.nightly-2021-08-18-144658

# ./oc get clusterversion -ojson|jq .items[].spec
{
  "channel": "stable-4.8",
  "clusterID": "a26e6104-d182-488e-b261-d785e5caf424"
}
```
The default channel should be stable-4.9.