### PR TITLE
UPI: Add yq to images for ASH CI

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -43,6 +43,8 @@ RUN python get-pip.py 'pip<21.0'
 RUN python -m pip install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python
 
+RUN python3 -m pip install yq
+
 ENV TERRAFORM_VERSION=0.12.24
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin/


### PR DESCRIPTION
Adding yq for ASH CI to pick up information from yaml file to
login to the ASH environment which is needed for cluster
installation.