### PR TITLE
Bug 2000352: [CORS-1716] vsphere: set the imported ova hardware version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/h2non/filetype v1.0.12
 	github.com/hashicorp/go-azure-helpers v0.16.5
 	github.com/hashicorp/go-plugin v1.3.0
+	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/terraform v0.13.4
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1012,6 +1012,7 @@ github.com/hashicorp/go-safetemp
 # github.com/hashicorp/go-uuid v1.0.2
 github.com/hashicorp/go-uuid
 # github.com/hashicorp/go-version v1.3.0
+## explicit
 github.com/hashicorp/go-version
 # github.com/hashicorp/golang-lru v0.5.4
 github.com/hashicorp/golang-lru


### PR DESCRIPTION
The out-of-tree csi requires hardware 15, vSphere 6.7U3 and greater

Hardware 15 is only supported on 6.7 U2 and greater.
This PR checks for each ESXi host version, if less than 6.7 U3
sets the hardware version to 13. If greater than or equal to 6.7U3
the hardware version is set to 15.

- [x] See if its possible to simplify the version logic