### PR TITLE
Bug 1949672: Update UPI ignition version to 3.2.0

### DIFF
--- a/upi/gcp/04_bootstrap.py
+++ b/upi/gcp/04_bootstrap.py
@@ -22,7 +22,7 @@ def GenerateConfig(context):
             'metadata': {
                 'items': [{
                     'key': 'user-data',
-                    'value': '{"ignition":{"config":{"replace":{"source":"' + context.properties['bootstrap_ign'] + '"}},"version":"3.1.0"}}',
+                    'value': '{"ignition":{"config":{"replace":{"source":"' + context.properties['bootstrap_ign'] + '"}},"version":"3.2.0"}}',
                 }]
             },
             'networkInterfaces': [{


### PR DESCRIPTION
Updating ignition version from 3.1.0 to 3.2.0 for GCP UPI
templates.