### PR TITLE
Bug 1981999: bump RHCOS boot images for 4.9

### DIFF
--- a/data/data/rhcos-aarch64.json
+++ b/data/data/rhcos-aarch64.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/",
-    "buildid": "49.84.202106302247-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/",
+    "buildid": "49.84.202108221747-0",
     "images": {
         "aws": {
-            "path": "rhcos-49.84.202106302247-0-aws.aarch64.vmdk.gz",
-            "sha256": "fef05108ddf8c9c858277ef1d59ea7dc7331f5a71d07e725e425bd861f7f4630",
-            "size": 939747412,
-            "uncompressed-sha256": "95c6bcf55ed710df5f621bceab16e811e0ae912c710c83c1f92d07e872b73f81",
-            "uncompressed-size": 960489472
+            "path": "rhcos-49.84.202108221747-0-aws.aarch64.vmdk.gz",
+            "sha256": "f5dbe7c9aa764e5f1ebb82ef6af994f7b1058127a320d27302df85716b7c6e4d",
+            "size": 944735224,
+            "uncompressed-sha256": "42bb29d755a92959033b417acc9f58058bb2e83c53c19e82535ef5f50c6088db",
+            "uncompressed-size": 966518272
         },
         "live-initramfs": {
-            "path": "rhcos-49.84.202106302247-0-live-initramfs.aarch64.img",
-            "sha256": "bef9a83d2993d695810918eeb2f4c81f77d3b2844e1ea482664ef1c364cd905e"
+            "path": "rhcos-49.84.202108221747-0-live-initramfs.aarch64.img",
+            "sha256": "cb477af2d3f7ca915ec85bfd2a8a337d171a67ef5f2d25bbb1779467321c5067"
         },
         "live-iso": {
-            "path": "rhcos-49.84.202106302247-0-live.aarch64.iso",
-            "sha256": "f2a91f4cb51b6aa4194c0eb375a6db71c43487612242d517fff47fc3e40dee85"
+            "path": "rhcos-49.84.202108221747-0-live.aarch64.iso",
+            "sha256": "955cb5d4a1349f25a10049bc2da41f7fa8fe2f34926cab5fd2f8f6d27bfc0a77"
         },
         "live-kernel": {
-            "path": "rhcos-49.84.202106302247-0-live-kernel-aarch64",
-            "sha256": "83de7667d9f926e42191579e3545c1bd745d0f34b8587b112e0178a30a84a2e6"
+            "path": "rhcos-49.84.202108221747-0-live-kernel-aarch64",
+            "sha256": "0329956a74097f785877fea0f3f7ac19377bb75af0b802f42c8e3b5cb92b07dc"
         },
         "live-rootfs": {
-            "path": "rhcos-49.84.202106302247-0-live-rootfs.aarch64.img",
-            "sha256": "90505fd8f6ec72517a0d036d078e450f611b58d11a7b35cb6904414550ec1d00"
+            "path": "rhcos-49.84.202108221747-0-live-rootfs.aarch64.img",
+            "sha256": "c0bfe659697803640fd4c4669597b319dd37ba139fa1f50f3f0b86f3f17f18c5"
         },
         "metal": {
-            "path": "rhcos-49.84.202106302247-0-metal.aarch64.raw.gz",
-            "sha256": "79dd89bd9079f5b03dccca8f12ce6c2511a80d33dfcdbd3f575a37a4c8acd22e",
-            "size": 930256668,
-            "uncompressed-sha256": "cdfa03b96c408f6fa9a4f7e543ad60edd6a03e347cc6746bbcdccc84ffb02378",
-            "uncompressed-size": 3876585472
+            "path": "rhcos-49.84.202108221747-0-metal.aarch64.raw.gz",
+            "sha256": "ad1a3bea492c97aca55aa7e0a0aad14cd467285b7268c1bb24448dc3730ff611",
+            "size": 935123538,
+            "uncompressed-sha256": "8ce5a7692e22685f2cf73d2c101e37949bbf0157409775d538c855af32f1fc41",
+            "uncompressed-size": 3938451456
         },
         "metal4k": {
-            "path": "rhcos-49.84.202106302247-0-metal4k.aarch64.raw.gz",
-            "sha256": "ee21dd2887c7b354f182cc8000b2f35a1b39f71e0e983f0d46c6ff99c63b2964",
-            "size": 930158918,
-            "uncompressed-sha256": "abbff17f5b9de8eeef31219bf3144f743d6b3d0bfc0ee3dce749e55b4499de3f",
-            "uncompressed-size": 3876585472
+            "path": "rhcos-49.84.202108221747-0-metal4k.aarch64.raw.gz",
+            "sha256": "82a9681e0565b671565fded5a7e689b91bdb5e53bf79df225958dfd886186f2d",
+            "size": 935255167,
+            "uncompressed-sha256": "f73b74c6380ccc461daae47b81a21716c6dcc06eee064477f6613f352882b2d2",
+            "uncompressed-size": 3938451456
         },
         "openstack": {
-            "path": "rhcos-49.84.202106302247-0-openstack.aarch64.qcow2.gz",
-            "sha256": "c4711e847bbc657f37deb79cfc1c5bf359eb18ab34b12afa7c7282281b424542",
-            "size": 928546506,
-            "uncompressed-sha256": "020ccec2e74193e87b0913f3d8792c1edfc99541195d0cd66a20d3b4bb1ae956",
-            "uncompressed-size": 2457010176
+            "path": "rhcos-49.84.202108221747-0-openstack.aarch64.qcow2.gz",
+            "sha256": "7eb11b6a018dbf60fd924970062e0963d921e20c41b6cce96c6889947deff7b2",
+            "size": 933507715,
+            "uncompressed-sha256": "e327e5ed3a80e2cf8b33c75d3a1db01e0f957ae106acd6a0344aef84e932c06d",
+            "uncompressed-size": 2499739648
         },
         "ostree": {
-            "path": "rhcos-49.84.202106302247-0-ostree.aarch64.tar",
-            "sha256": "98021f49b14ae1657afb70c67c40b4ee25c27f34c49bfa894fde45d10055c103",
-            "size": 860702720
+            "path": "rhcos-49.84.202108221747-0-ostree.aarch64.tar",
+            "sha256": "812cdf812a28adb0b9b623b074c4a07c80b4d6e23f3879d451abe3a5ff07183f",
+            "size": 867932160
         },
         "qemu": {
-            "path": "rhcos-49.84.202106302247-0-qemu.aarch64.qcow2.gz",
-            "sha256": "7213f07ba49dadf70321abe84524cb287207f73b02f6ba96f5a418ec42f1dd9a",
-            "size": 929639141,
-            "uncompressed-sha256": "5a3321105f978824892575cda538aa7cd0f4bc62640670180f096ccc73825c32",
-            "uncompressed-size": 2493513728
+            "path": "rhcos-49.84.202108221747-0-qemu.aarch64.qcow2.gz",
+            "sha256": "c186ea2bf81549a50b0ededdc5ef106f3baedc588f7d385cb73f058e62c6749e",
+            "size": 934482657,
+            "uncompressed-sha256": "7864e8321998c5a6e519f9e3fd6f2df45fef01448dcbd544ea576b886694378a",
+            "uncompressed-size": 2535915520
         }
     },
     "oscontainer": {
-        "digest": "sha256:8f50f9e6c91c47c42d8e961470fb22648c301516f9a5cbdf76faac63c030bcc8",
+        "digest": "sha256:275bf235ba6a610cef1a14bc0bf94d9222ee39c72fc19c15a556a12fe3b96ff6",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "a65890e652bfe4ab36a251a650c8601a140ba278eb3f0c5c7496a0429819cefd",
-    "ostree-version": "49.84.202106302247-0"
+    "ostree-commit": "b0499708696af32aa765a28e20fc599636585087af46ca4eae273fb6b2ccd89e",
+    "ostree-version": "49.84.202108221747-0"
 }

--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,173 +1,175 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0e7bac9d978e79a6e"
+            "hvm": "ami-00d008288d9de1355"
         },
         "ap-east-1": {
-            "hvm": "ami-051d83ebbfb127ea2"
+            "hvm": "ami-03f0ca27f13ffe5ff"
         },
         "ap-northeast-1": {
-            "hvm": "ami-00413a0acfd76de7c"
+            "hvm": "ami-087f590236fd0e919"
         },
         "ap-northeast-2": {
-            "hvm": "ami-08e2db228a5695fb3"
+            "hvm": "ami-0d5624ca864f92ad6"
         },
         "ap-northeast-3": {
-            "hvm": "ami-0d0b87fc092ee2e74"
+            "hvm": "ami-08c0f738caba4cf5e"
         },
         "ap-south-1": {
-            "hvm": "ami-03c83da1b6ce6d151"
+            "hvm": "ami-003e5dbce864a9ad0"
         },
         "ap-southeast-1": {
-            "hvm": "ami-020876d27dc04936a"
+            "hvm": "ami-061e3cf4ecb91de34"
         },
         "ap-southeast-2": {
-            "hvm": "ami-02eecabb2b32443e5"
+            "hvm": "ami-0cf7d25f65a82fa6c"
         },
         "ca-central-1": {
-            "hvm": "ami-070fd5123ab359da8"
+            "hvm": "ami-0f881d6f9f5b90225"
         },
         "eu-central-1": {
-            "hvm": "ami-07ac34b5c836bb738"
+            "hvm": "ami-0f031c6d4461876c1"
         },
         "eu-north-1": {
-            "hvm": "ami-01a85ec5bac734d6b"
+            "hvm": "ami-0e0a0c62a8d357d3f"
         },
         "eu-south-1": {
-            "hvm": "ami-0da7775afdefce9c6"
+            "hvm": "ami-0affd9a20c9104f0c"
         },
         "eu-west-1": {
-            "hvm": "ami-031117dace22be7c5"
+            "hvm": "ami-08a847733e8a15508"
         },
         "eu-west-2": {
-            "hvm": "ami-0c455b12ceed301cd"
+            "hvm": "ami-05dd4b82210ebb603"
         },
         "eu-west-3": {
-            "hvm": "ami-0cc8ddaee632a3086"
+            "hvm": "ami-06055669ac261d783"
         },
         "me-south-1": {
-            "hvm": "ami-034359190c2c7c906"
+            "hvm": "ami-0696eafd323d46079"
         },
         "sa-east-1": {
-            "hvm": "ami-0fc38ad5e19dfd32b"
+            "hvm": "ami-0941aa93b3c9e2700"
         },
         "us-east-1": {
-            "hvm": "ami-01b2bf223fccdb8e3"
+            "hvm": "ami-0f123ebe52c3accc9"
         },
         "us-east-2": {
-            "hvm": "ami-0798e63b24f54c102"
+            "hvm": "ami-045089e3aeb7444db"
         },
         "us-west-1": {
-            "hvm": "ami-004c277e7c9366226"
+            "hvm": "ami-01ba807424ad8ceee"
         },
         "us-west-2": {
-            "hvm": "ami-0acecf5d7224232a8"
+            "hvm": "ami-0228531eacc8ad7e9"
         }
     },
     "azure": {
-        "image": "rhcos-49.84.202107010027-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202107010027-0-azure.x86_64.vhd"
+        "image": "rhcos-49.84.202108221651-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202108221651-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/",
-    "buildid": "49.84.202107010027-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/",
+    "buildid": "49.84.202108221651-0",
     "gcp": {
-        "image": "rhcos-49-84-202107010027-0-gcp-x86-64",
+        "image": "rhcos-49-84-202108221651-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-49-84-202107010027-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-49-84-202108221651-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-49.84.202107010027-0-aws.x86_64.vmdk.gz",
-            "sha256": "932dd626e76f84e8f6d5158abcc753af6e865305169588203dede2bb4c41f28a",
-            "size": 1030950571,
-            "uncompressed-sha256": "3efafda489b5a789725ada0d2ea6c93a8e76775ce4e789b3b5ef5ee235b45ecb",
-            "uncompressed-size": 1051976192
+            "path": "rhcos-49.84.202108221651-0-aws.x86_64.vmdk.gz",
+            "sha256": "482ba61e89effca5d3028cb14cf07d45359146c8fbac4c1b5adcc5692bd1ba98",
+            "size": 1036152582,
+            "uncompressed-sha256": "6fcd8528079edb1e31ee065e9ea15b10045f8995581d61f72e5283c14c2424e9",
+            "uncompressed-size": 1058205696
         },
         "azure": {
-            "path": "rhcos-49.84.202107010027-0-azure.x86_64.vhd.gz",
-            "sha256": "9bbedfb75c1be0f5331882840fff65b194bf9ca87548ce6c764db604056a999f",
-            "size": 1030871708,
-            "uncompressed-sha256": "e79180d7e455fbf1d8db5eb2a3522ae4c12782d35e52acba3ab95f124af73164",
+            "path": "rhcos-49.84.202108221651-0-azure.x86_64.vhd.gz",
+            "sha256": "f7d87820242fc7606c0be9f40d431008ee48bdd6a3a3aaafcc36bddbd4551d42",
+            "size": 1036795995,
+            "uncompressed-sha256": "6dc6e6d82c1c359a950509ef87290a1e261422d4115af9d5300fe9066e4feda3",
             "uncompressed-size": 17179869696
         },
         "azurestack": {
-            "path": "rhcos-49.84.202107010027-0-azurestack.x86_64.vhd.gz",
-            "sha256": "3c6d3dbc75deb47aaaef62e76628ef4f37143ef8d5f00435a89c03266fecac29",
-            "size": 1030872938,
-            "uncompressed-sha256": "951db0b6585976034fd6cc23de834bc7fd0cad102115bb6efd509ef1c8a38e53",
+            "path": "rhcos-49.84.202108221651-0-azurestack.x86_64.vhd.gz",
+            "sha256": "16e32b6f03f1d4f07395a0874bc93c2c75c355a29b6954ae1bc56fdeab174d04",
+            "size": 1036797561,
+            "uncompressed-sha256": "ef25419462c5d3e8fbe2851d086784f7f1648277d730c841a2f293b798f0fb5e",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-49.84.202107010027-0-gcp.x86_64.tar.gz",
-            "sha256": "28c816bfe2df8570472607f5ae3cd5adb455932e68412370785c78617c50e7ab",
-            "size": 1016304764
+            "path": "rhcos-49.84.202108221651-0-gcp.x86_64.tar.gz",
+            "sha256": "95863e050f6beeb9a78de7805380b0dcbafe2f0a4c3b79ea4ca9346d4e126b7b",
+            "size": 1017048530,
+            "uncompressed-sha256": "17f13516c56ea6735aee18bec8e92d5c3da49fbb94e6eaa2597605e1f7bb3dee",
+            "uncompressed-size": 2529259520
         },
         "ibmcloud": {
-            "path": "rhcos-49.84.202107010027-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "0ffb7e3583faf05bb0d5bceda73f048bca5ab19d5fed6091ffd791c19167dd72",
-            "size": 1016679625,
-            "uncompressed-sha256": "eeee1e663f25bec15af029cd6fcb13079f661da80444271a7db944c7484c8a72",
-            "uncompressed-size": 2534342656
+            "path": "rhcos-49.84.202108221651-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "ea8d9ba650ccd8020cfb7f3c25b1ae0624eeb7d472a7f9284950dfa293ea2748",
+            "size": 1022594999,
+            "uncompressed-sha256": "587c0b088009d8dd4a68ee581668b76574ba7fb02bbd35be95205deb9e640516",
+            "uncompressed-size": 2579103744
         },
         "live-initramfs": {
-            "path": "rhcos-49.84.202107010027-0-live-initramfs.x86_64.img",
-            "sha256": "cb8a23fa2ddf1c427135fb6aa016e9765c25aca9d1e863f9d0b3a18e1c4c41f8"
+            "path": "rhcos-49.84.202108221651-0-live-initramfs.x86_64.img",
+            "sha256": "de573cfae77a342da18d26f2a4b6c57fc3d665dabe3205bd9e176b882d05e105"
         },
         "live-iso": {
-            "path": "rhcos-49.84.202107010027-0-live.x86_64.iso",
-            "sha256": "244a2148ba6bc0e8e2355e6bdd90c8a2b81bdedc51c0bd323b00c8f797d2bd50"
+            "path": "rhcos-49.84.202108221651-0-live.x86_64.iso",
+            "sha256": "816156977d0ae0d04306baf1a0934f39a8808c85cc967ae74cd851c7a9a55aa3"
         },
         "live-kernel": {
-            "path": "rhcos-49.84.202107010027-0-live-kernel-x86_64",
-            "sha256": "9b900e88ca71b067d8f9971dc4454f454a12666b53d3ca2d80919729060a198d"
+            "path": "rhcos-49.84.202108221651-0-live-kernel-x86_64",
+            "sha256": "dd63e3832b277a16671832cd1464b7a338ef906f139ed8292daf228e1586d81c"
         },
         "live-rootfs": {
-            "path": "rhcos-49.84.202107010027-0-live-rootfs.x86_64.img",
-            "sha256": "383993d4ff10d620f9e4bc452eb8f24473b271b04ed1c0d97fac3bd0d987f747"
+            "path": "rhcos-49.84.202108221651-0-live-rootfs.x86_64.img",
+            "sha256": "985bcadcb4ce3fd512ac0703727a85b3b8ba5bc3d00865143e35e8014622ba6a"
         },
         "metal": {
-            "path": "rhcos-49.84.202107010027-0-metal.x86_64.raw.gz",
-            "sha256": "aaf1cdcd5d085e0e8decbb19ab4fbbc8d8278d7638cceaea80b48331b263706f",
-            "size": 1018448313,
-            "uncompressed-sha256": "7080110bc282855f9e91cb86769b53f0fe4136206eac99e47f4608d5a9fecf00",
-            "uncompressed-size": 3959422976
+            "path": "rhcos-49.84.202108221651-0-metal.x86_64.raw.gz",
+            "sha256": "7871a3b53db995d49198523a1ddad888882fa1009aa63a7364051bd0ba508685",
+            "size": 1024417867,
+            "uncompressed-sha256": "3fd044f4351c2a87102aae80f0ec4b8b8cb2d2436831282636f6966db7e0e1d6",
+            "uncompressed-size": 4022337536
         },
         "metal4k": {
-            "path": "rhcos-49.84.202107010027-0-metal4k.x86_64.raw.gz",
-            "sha256": "93c5b9631ea0cac516ea2ff2a8b9949af1d856849a48763299b800ae8f25c4e6",
-            "size": 1016010632,
-            "uncompressed-sha256": "9d95fbbacad73415c6de086ce78ac06a9810db3e7fb3e3693039bd4631fa1553",
-            "uncompressed-size": 3959422976
+            "path": "rhcos-49.84.202108221651-0-metal4k.x86_64.raw.gz",
+            "sha256": "10965655b1f6478e81caa2326aa6e5fa5a34218a6abcb02500ef9c2584027614",
+            "size": 1022026749,
+            "uncompressed-sha256": "6651cc2894aba0bbecb1f98c5e827ed81f1fa13017311363c5e9598d6199051f",
+            "uncompressed-size": 4022337536
         },
         "openstack": {
-            "path": "rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz",
-            "sha256": "c7dde5f96826c33c97b5a4ad34110212281916128ae11100956f400db3d5299e",
-            "size": 1016679212,
-            "uncompressed-sha256": "00cb56c8711686255744646394e22a8ca5f27e059016f6758f14388e5a0a14cb",
-            "uncompressed-size": 2534342656
+            "path": "rhcos-49.84.202108221651-0-openstack.x86_64.qcow2.gz",
+            "sha256": "6e10a09efa967dcbf5c67449e04b22d55ae1d8e46b12eb4e9488b1c28101edfc",
+            "size": 1022598458,
+            "uncompressed-sha256": "4a617207e3e88b4d5eeaf29db8d96006ed038b65651ef828f2b12ce5c625315e",
+            "uncompressed-size": 2579103744
         },
         "ostree": {
-            "path": "rhcos-49.84.202107010027-0-ostree.x86_64.tar",
-            "sha256": "54affb52ee9056d1bf237049f4815c686f317ef8ca135d4b1b72f69e31ee1f81",
-            "size": 940769280
+            "path": "rhcos-49.84.202108221651-0-ostree.x86_64.tar",
+            "sha256": "0a7e73d6d8fcb77a76b9436e607a8d372ae8b1a4891884ea32e06d8140a044d4",
+            "size": 947783680
         },
         "qemu": {
-            "path": "rhcos-49.84.202107010027-0-qemu.x86_64.qcow2.gz",
-            "sha256": "6dc06832d28ed28594902844fb1b205f3aa58c4960f976ae78c9122dc417111d",
-            "size": 1017869225,
-            "uncompressed-sha256": "c645d5eba8cba58fce4571135edb1c7ec03f04e9c5ad6466cef72f7a9717d09c",
-            "uncompressed-size": 2570452992
+            "path": "rhcos-49.84.202108221651-0-qemu.x86_64.qcow2.gz",
+            "sha256": "fa59765813b30b6d36a7474b57244aa9357738c9d643b1fbb0afe53930e3b77a",
+            "size": 1023869619,
+            "uncompressed-sha256": "18ef1488ae31b382b655eddc905c836cbe26fd00a3774829225303fc5fe0281a",
+            "uncompressed-size": 2615541760
         },
         "vmware": {
-            "path": "rhcos-49.84.202107010027-0-vmware.x86_64.ova",
-            "sha256": "f9ee706482c8088d1ce4d9b798d9d9cd229ce8ae011fe5909b4eb79455c08940",
-            "size": 1051985920
+            "path": "rhcos-49.84.202108221651-0-vmware.x86_64.ova",
+            "sha256": "2eee525ba5098cae67390821056df90c5d34c2dfd552db8820ba6d053cb24f7f",
+            "size": 1058222080
         }
     },
     "oscontainer": {
-        "digest": "sha256:cf5f21445e2d6c43ab424f99db7844bfe5463af7e429842bd679deba5926e7e2",
+        "digest": "sha256:f828fcc873e4cf2b6af8329dc218a1e8605e7a3ced259ae3748ad91ecab1aee3",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "abb247c075d0e2d4b7cf41e0fcef3305fbd9efe9dbcde2211a072acd6ddccabb",
-    "ostree-version": "49.84.202107010027-0"
+    "ostree-commit": "95aec436ee83751dea39060f5234a45c8eb389e19f4b535eb34f33c9d42208fb",
+    "ostree-version": "49.84.202108221651-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/",
-    "buildid": "49.84.202107010047-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/",
+    "buildid": "49.84.202108241610-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-49.84.202107010047-0-live-initramfs.ppc64le.img",
-            "sha256": "79e42469694b273fce31a54e6790e4c594619577693e1b34621f1675a33538e8"
+            "path": "rhcos-49.84.202108241610-0-live-initramfs.ppc64le.img",
+            "sha256": "218e29aaeaa78c6ca51acaa26d29cffc99d98129993b4ae35984a9bbe2c531e4"
         },
         "live-iso": {
-            "path": "rhcos-49.84.202107010047-0-live.ppc64le.iso",
-            "sha256": "0f6418dc5eb43b0f12da60cf583ce19cbbf85f421c0d35b0be85c33161ab8e87"
+            "path": "rhcos-49.84.202108241610-0-live.ppc64le.iso",
+            "sha256": "f00fb4b712a4ef1413a9d36a3ca6136e8fd3066a6ecccf74d4cee9268537bfbb"
         },
         "live-kernel": {
-            "path": "rhcos-49.84.202107010047-0-live-kernel-ppc64le",
-            "sha256": "ae1165bb13992f9b6543e2c8baa0f1f10460d84db740d1876c8f4f9226cb9a6d"
+            "path": "rhcos-49.84.202108241610-0-live-kernel-ppc64le",
+            "sha256": "29430ef56340b0d43bcc2c5e45767442b3eaab0120561f034c9bb7cc04897bfd"
         },
         "live-rootfs": {
-            "path": "rhcos-49.84.202107010047-0-live-rootfs.ppc64le.img",
-            "sha256": "6c3a9728fd82b09d11778370b68ae0875502a84d3ccbea5a0e1a9c69d855c08b"
+            "path": "rhcos-49.84.202108241610-0-live-rootfs.ppc64le.img",
+            "sha256": "3bc414e61e31f3db7433bd27d32c7a75d034a57e3891d94260d5d02ad3e43814"
         },
         "metal": {
-            "path": "rhcos-49.84.202107010047-0-metal.ppc64le.raw.gz",
-            "sha256": "f08f36d75aa726dbb6dd1cd5f1c0ef561174c7f5324f3fba2cd8ff52187bc242",
-            "size": 988450954,
-            "uncompressed-sha256": "3d268c733b48b884f4215bb1f4e53883dd460b2a3eedd0e02e5b4e5800dafcc6",
-            "uncompressed-size": 4126146560
+            "path": "rhcos-49.84.202108241610-0-metal.ppc64le.raw.gz",
+            "sha256": "ad68867196a021890c30dd6cf5f106474c6616a9f21b0c6fb0c97a03959db574",
+            "size": 993149567,
+            "uncompressed-sha256": "89e900a2ee5b59b5fc0bd812c2b1214edfa735e2b31318e60c9c99e33a428705",
+            "uncompressed-size": 4189061120
         },
         "metal4k": {
-            "path": "rhcos-49.84.202107010047-0-metal4k.ppc64le.raw.gz",
-            "sha256": "fc64722125fa0db0eb534db6af8a9ebcfff3c1bd6bf34482041ab09191e83f5d",
-            "size": 988748793,
-            "uncompressed-sha256": "662cf671d988c6b7feb48413384630596ebc0b33bfbbbfae8bef5d03ad494d4e",
-            "uncompressed-size": 4126146560
+            "path": "rhcos-49.84.202108241610-0-metal4k.ppc64le.raw.gz",
+            "sha256": "b30f038f162e2b62b86153a3522350112011f985b9f99aacdf4d103d57cd4520",
+            "size": 993481248,
+            "uncompressed-sha256": "ec3fe048b1063ef1138395c40f67819766a0de8beae445dec26d82e3cbf7f242",
+            "uncompressed-size": 4189061120
         },
         "openstack": {
-            "path": "rhcos-49.84.202107010047-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "e30fc32cdf50ff02a72feb71cd3f4e9c92f1b038aef506d6e8396dbbf841d085",
-            "size": 986664044,
-            "uncompressed-sha256": "9d1dc160337cda643805c96109f086015f111d46e7982b9f21cf49276cab3fb5",
-            "uncompressed-size": 2665480192
+            "path": "rhcos-49.84.202108241610-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "e04f81a5b90a3df5b1fa20a4bf627efd3eefd2fdf9c17b8814f777644926e0a2",
+            "size": 991493454,
+            "uncompressed-sha256": "f86738346ad8eed5bc30ac327ef082b5ec59c963792ac5d570e34c83f20abf27",
+            "uncompressed-size": 2709520384
         },
         "ostree": {
-            "path": "rhcos-49.84.202107010047-0-ostree.ppc64le.tar",
-            "sha256": "2387066fe638c276c2ec89e2a4ab66a526bb70cc039fecadd4d9ed563df7e8cf",
-            "size": 909711360
+            "path": "rhcos-49.84.202108241610-0-ostree.ppc64le.tar",
+            "sha256": "80787791994e79515caece67e4b5152ec148767954e2af799fe37401912c2d2e",
+            "size": 915937280
         },
         "qemu": {
-            "path": "rhcos-49.84.202107010047-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "9145e08f39baf2df968ea6803303ccb1fc2941f8eae60d41ba91c9016e13ba33",
-            "size": 987690835,
-            "uncompressed-sha256": "b3822dd7eddcf2faf4028c6a6cfa7fcfaf56153d2da6bd47c462705f90887871",
-            "uncompressed-size": 2702639104
+            "path": "rhcos-49.84.202108241610-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "e4d1dcda57dc2ad576a5288f00141106813098c5b5e770131401242eebe6ca0c",
+            "size": 992542220,
+            "uncompressed-sha256": "dee3731cc5e313a190bc84fd9edb70c96e4bf4ab508e9c68e1f7fe568162f6ff",
+            "uncompressed-size": 2746810368
         }
     },
     "oscontainer": {
-        "digest": "sha256:cbb5ff0ef87cf99ec4873720bc350e09c699e5a533a8bef95a7805042da5254e",
+        "digest": "sha256:4297acb5eb7c615aa66ab175eb235b495b18915dfe3680c2cb63982d0445c689",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "63a0c41848555ff81ef062bfbfbd8c467979c2a3c4889bdf2b61eb83069efb90",
-    "ostree-version": "49.84.202107010047-0"
+    "ostree-commit": "3b626a10ec039f3f788748880e9fca831212bcf20c466b8a76795c45d0fca60b",
+    "ostree-version": "49.84.202108241610-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/",
-    "buildid": "49.84.202106302347-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/",
+    "buildid": "49.84.202108221604-0",
     "images": {
         "dasd": {
-            "path": "rhcos-49.84.202106302347-0-dasd.s390x.raw.gz",
-            "sha256": "6090a52b26b6b38b3c1c31b8db44a6df81ae7a58fa685bcaa3c746494cf826f8",
-            "size": 899371546,
-            "uncompressed-sha256": "12e09dbe0283ccfd4e62c8350ee0b4e3143b99fedafafb3d11f3e614c9e99720",
-            "uncompressed-size": 3714056192
+            "path": "rhcos-49.84.202108221604-0-dasd.s390x.raw.gz",
+            "sha256": "b94533e76cc0d6b2f8e0338ed617d46bc9bbb9071af9b74e3f832e16e8005d09",
+            "size": 905310566,
+            "uncompressed-sha256": "1a5e5f6ca9365cdb9a04517d796f85326c0e6eda9f9479ba95dc1a3a4e783273",
+            "uncompressed-size": 3775922176
         },
         "live-initramfs": {
-            "path": "rhcos-49.84.202106302347-0-live-initramfs.s390x.img",
-            "sha256": "8c0d82cee34d24c14e92b724a44c36227e626debdd4394a4db531330dbb756a1"
+            "path": "rhcos-49.84.202108221604-0-live-initramfs.s390x.img",
+            "sha256": "11b7d1259af05e8c5110d50082d277b72307cce02894315fd915ea257b449161"
         },
         "live-iso": {
-            "path": "rhcos-49.84.202106302347-0-live.s390x.iso",
-            "sha256": "28176925febed1c021e0b10ca2cc30842f05436be8f56782ecb96f240914801a"
+            "path": "rhcos-49.84.202108221604-0-live.s390x.iso",
+            "sha256": "f479cad9dc94cd416a592d5281df70d3355f92e7b4819c36119d8e7d0b69e3f8"
         },
         "live-kernel": {
-            "path": "rhcos-49.84.202106302347-0-live-kernel-s390x",
-            "sha256": "fc1762c98976a3ca46fe5b971f706570b4bcf3f3a8567dfe96c95b4f9e0e94df"
+            "path": "rhcos-49.84.202108221604-0-live-kernel-s390x",
+            "sha256": "9bc2ed1d7f140367755d5434ebffb99a44549100397f3be0cee374e9e145fc62"
         },
         "live-rootfs": {
-            "path": "rhcos-49.84.202106302347-0-live-rootfs.s390x.img",
-            "sha256": "e36127fd8d6dd991a278c070f04aabeb7281864d5a7b9f3439442993b4963ccc"
+            "path": "rhcos-49.84.202108221604-0-live-rootfs.s390x.img",
+            "sha256": "9bfb42b2f95534375fefa0622359a0b8c88fa909de04e6d74cf0decc6ba5c46a"
         },
         "metal": {
-            "path": "rhcos-49.84.202106302347-0-metal.s390x.raw.gz",
-            "sha256": "b108435618b3f4704878f404ffa2101a31887fc1595a422e7c6bfd3fe06ebd2b",
-            "size": 899307689,
-            "uncompressed-sha256": "cd7b648002adced929fef097bf563de6397b63076eff802804f37d7d6ceeecce",
-            "uncompressed-size": 3714056192
+            "path": "rhcos-49.84.202108221604-0-metal.s390x.raw.gz",
+            "sha256": "c1e15dcd7fdb77c81b5ea499d6b5af3ee696a4687e55df9550724db7cc7057fe",
+            "size": 905473741,
+            "uncompressed-sha256": "44d460ffb4c2d0ee96858a1465b282a56ebc1885c144048553ce065bcfc6b65c",
+            "uncompressed-size": 3775922176
         },
         "metal4k": {
-            "path": "rhcos-49.84.202106302347-0-metal4k.s390x.raw.gz",
-            "sha256": "2164753adff4472ce74778ee46d3f3b2e46ebc2bc550f27da8adf73013870bfe",
-            "size": 899317895,
-            "uncompressed-sha256": "ee3245325d61570d908cc06b0e8a4d8ec31adaa848c1cf2b73213ad1d7fa5b2d",
-            "uncompressed-size": 3714056192
+            "path": "rhcos-49.84.202108221604-0-metal4k.s390x.raw.gz",
+            "sha256": "931fd21733a6ad838180cb92ad139fa0997a1132caaaf02048c57abfb1e0d5ba",
+            "size": 905320848,
+            "uncompressed-sha256": "9cecd33fa65a7e65e7ad383499a100e7d229721f26e2d7278ec9ad5a47e33210",
+            "uncompressed-size": 3775922176
         },
         "openstack": {
-            "path": "rhcos-49.84.202106302347-0-openstack.s390x.qcow2.gz",
-            "sha256": "d2811c21276a305d74973a4a999ad4027b959faa21b16ab4aa305d29c982d59f",
-            "size": 897642318,
-            "uncompressed-sha256": "e7531161b61cbaefec434a105a1ad2b6b43476448f702fb584d0955a68845f57",
-            "uncompressed-size": 2320302080
+            "path": "rhcos-49.84.202108221604-0-openstack.s390x.qcow2.gz",
+            "sha256": "c05fa65b4c40addc42afe1c0a4a29d76ca3cbb0ed75d617781e305fa00cdabd9",
+            "size": 903747714,
+            "uncompressed-sha256": "4b6e866f8e2107e3a6334722b34b94b619c748bb96b3a68c9accf054776eed91",
+            "uncompressed-size": 2364211200
         },
         "ostree": {
-            "path": "rhcos-49.84.202106302347-0-ostree.s390x.tar",
-            "sha256": "6491e82fb27501d25890c66c3e175d2b8e1070a8c39be78e733e21c017422cf0",
-            "size": 845158400
+            "path": "rhcos-49.84.202108221604-0-ostree.s390x.tar",
+            "sha256": "a58bc26eaf18ee1681292d38ac809f1ed3a76bc18ed4d555e9fabacd9160cf1f",
+            "size": 852572160
         },
         "qemu": {
-            "path": "rhcos-49.84.202106302347-0-qemu.s390x.qcow2.gz",
-            "sha256": "8847d2e9679d676e4dde33df9e7dca3eefcd7f4bfdcf8d454bf20ca40b05322b",
-            "size": 898841848,
-            "uncompressed-sha256": "165c64704d4780a9ea0f84a7bbb3fab7a37b730c6a0197db5362090cc11d1016",
-            "uncompressed-size": 2356215808
+            "path": "rhcos-49.84.202108221604-0-qemu.s390x.qcow2.gz",
+            "sha256": "706ed1dc886001fa8f5cd231bf75e30dc7a81c9c9fb2e3e779f444b0ef9bb7c6",
+            "size": 904813261,
+            "uncompressed-sha256": "e05731e756f0c329751af4023416b5ea29cdd248b364b3e0c03f3aca02666a0b",
+            "uncompressed-size": 2400059392
         }
     },
     "oscontainer": {
-        "digest": "sha256:23031dcc36fcb5666c17b6f877e910c4f3d4df48d62b813f69b392a536da9f59",
+        "digest": "sha256:4c4caf0ce363106d6d9f765f782d3473db46ea1153dc6081d5bce462ffb14050",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "7aeaa67448301e5acdcd6928f435e197702ef4de09161b49a70ce75942c43875",
-    "ostree-version": "49.84.202106302347-0"
+    "ostree-commit": "006b853bde437149fcd3da7b1615fefeb677faa4f8234b7130f9995c0bfa95f7",
+    "ostree-version": "49.84.202108221604-0"
 }

--- a/data/data/rhcos-stream.json
+++ b/data/data/rhcos-stream.json
@@ -1,91 +1,91 @@
 {
-  "stream": "rhcos-4.8",
+  "stream": "rhcos-4.9",
   "metadata": {
-    "last-modified": "2021-07-21T16:48:51Z"
+    "last-modified": "2021-08-24T18:38:10Z"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "49.84.202106302247-0",
+          "release": "49.84.202108221747-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-aws.aarch64.vmdk.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-aws.aarch64.vmdk.gz.sig",
-                "sha256": "fef05108ddf8c9c858277ef1d59ea7dc7331f5a71d07e725e425bd861f7f4630",
-                "uncompressed-sha256": "95c6bcf55ed710df5f621bceab16e811e0ae912c710c83c1f92d07e872b73f81"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-aws.aarch64.vmdk.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-aws.aarch64.vmdk.gz.sig",
+                "sha256": "f5dbe7c9aa764e5f1ebb82ef6af994f7b1058127a320d27302df85716b7c6e4d",
+                "uncompressed-sha256": "42bb29d755a92959033b417acc9f58058bb2e83c53c19e82535ef5f50c6088db"
               }
             }
           }
         },
         "metal": {
-          "release": "49.84.202106302247-0",
+          "release": "49.84.202108221747-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-metal4k.aarch64.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-metal4k.aarch64.raw.gz.sig",
-                "sha256": "ee21dd2887c7b354f182cc8000b2f35a1b39f71e0e983f0d46c6ff99c63b2964",
-                "uncompressed-sha256": "abbff17f5b9de8eeef31219bf3144f743d6b3d0bfc0ee3dce749e55b4499de3f"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-metal4k.aarch64.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-metal4k.aarch64.raw.gz.sig",
+                "sha256": "82a9681e0565b671565fded5a7e689b91bdb5e53bf79df225958dfd886186f2d",
+                "uncompressed-sha256": "f73b74c6380ccc461daae47b81a21716c6dcc06eee064477f6613f352882b2d2"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live.aarch64.iso",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live.aarch64.iso.sig",
-                "sha256": "f2a91f4cb51b6aa4194c0eb375a6db71c43487612242d517fff47fc3e40dee85"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-live.aarch64.iso",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-live.aarch64.iso.sig",
+                "sha256": "955cb5d4a1349f25a10049bc2da41f7fa8fe2f34926cab5fd2f8f6d27bfc0a77"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-kernel-aarch64",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-kernel-aarch64.sig",
-                "sha256": "83de7667d9f926e42191579e3545c1bd745d0f34b8587b112e0178a30a84a2e6"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-live-kernel-aarch64",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-live-kernel-aarch64.sig",
+                "sha256": "0329956a74097f785877fea0f3f7ac19377bb75af0b802f42c8e3b5cb92b07dc"
               },
               "initramfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-initramfs.aarch64.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-initramfs.aarch64.img.sig",
-                "sha256": "bef9a83d2993d695810918eeb2f4c81f77d3b2844e1ea482664ef1c364cd905e"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-live-initramfs.aarch64.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-live-initramfs.aarch64.img.sig",
+                "sha256": "cb477af2d3f7ca915ec85bfd2a8a337d171a67ef5f2d25bbb1779467321c5067"
               },
               "rootfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-rootfs.aarch64.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-live-rootfs.aarch64.img.sig",
-                "sha256": "90505fd8f6ec72517a0d036d078e450f611b58d11a7b35cb6904414550ec1d00"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-live-rootfs.aarch64.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-live-rootfs.aarch64.img.sig",
+                "sha256": "c0bfe659697803640fd4c4669597b319dd37ba139fa1f50f3f0b86f3f17f18c5"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-metal.aarch64.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-metal.aarch64.raw.gz.sig",
-                "sha256": "79dd89bd9079f5b03dccca8f12ce6c2511a80d33dfcdbd3f575a37a4c8acd22e",
-                "uncompressed-sha256": "cdfa03b96c408f6fa9a4f7e543ad60edd6a03e347cc6746bbcdccc84ffb02378"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-metal.aarch64.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-metal.aarch64.raw.gz.sig",
+                "sha256": "ad1a3bea492c97aca55aa7e0a0aad14cd467285b7268c1bb24448dc3730ff611",
+                "uncompressed-sha256": "8ce5a7692e22685f2cf73d2c101e37949bbf0157409775d538c855af32f1fc41"
               }
             }
           }
         },
         "openstack": {
-          "release": "49.84.202106302247-0",
+          "release": "49.84.202108221747-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-openstack.aarch64.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-openstack.aarch64.qcow2.gz.sig",
-                "sha256": "c4711e847bbc657f37deb79cfc1c5bf359eb18ab34b12afa7c7282281b424542",
-                "uncompressed-sha256": "020ccec2e74193e87b0913f3d8792c1edfc99541195d0cd66a20d3b4bb1ae956"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-openstack.aarch64.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-openstack.aarch64.qcow2.gz.sig",
+                "sha256": "7eb11b6a018dbf60fd924970062e0963d921e20c41b6cce96c6889947deff7b2",
+                "uncompressed-sha256": "e327e5ed3a80e2cf8b33c75d3a1db01e0f957ae106acd6a0344aef84e932c06d"
               }
             }
           }
         },
         "qemu": {
-          "release": "49.84.202106302247-0",
+          "release": "49.84.202108221747-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-qemu.aarch64.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-aarch64/49.84.202106302247-0/aarch64/rhcos-49.84.202106302247-0-qemu.aarch64.qcow2.gz.sig",
-                "sha256": "7213f07ba49dadf70321abe84524cb287207f73b02f6ba96f5a418ec42f1dd9a",
-                "uncompressed-sha256": "5a3321105f978824892575cda538aa7cd0f4bc62640670180f096ccc73825c32"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-qemu.aarch64.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/rhcos-49.84.202108221747-0-qemu.aarch64.qcow2.gz.sig",
+                "sha256": "c186ea2bf81549a50b0ededdc5ef106f3baedc588f7d385cb73f058e62c6749e",
+                "uncompressed-sha256": "7864e8321998c5a6e519f9e3fd6f2df45fef01448dcbd544ea576b886694378a"
               }
             }
           }
@@ -95,68 +95,68 @@
         "aws": {
           "regions": {
             "ap-east-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-00d99b5617266ee2f"
+              "release": "49.84.202108221747-0",
+              "image": "ami-01c57578e3911ad91"
             },
             "ap-northeast-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-06a0cc06c13f4f3e7"
+              "release": "49.84.202108221747-0",
+              "image": "ami-081b9bb40be878be6"
             },
             "ap-northeast-2": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-0410a347146b76e80"
+              "release": "49.84.202108221747-0",
+              "image": "ami-0c2e9d698a857ad93"
             },
             "ap-south-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-0a363f72ed7ed0882"
+              "release": "49.84.202108221747-0",
+              "image": "ami-0fb1394cff338785e"
             },
             "ap-southeast-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-0e562d6c0df5be076"
+              "release": "49.84.202108221747-0",
+              "image": "ami-095182d22174b584f"
             },
             "ap-southeast-2": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-060ecd2ec871a5688"
+              "release": "49.84.202108221747-0",
+              "image": "ami-03ff3abf382f93487"
             },
             "ca-central-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-002ee032a667716ee"
+              "release": "49.84.202108221747-0",
+              "image": "ami-025a23701ab8b3e71"
             },
             "eu-central-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-0e1d50cc2e93524c2"
+              "release": "49.84.202108221747-0",
+              "image": "ami-0ab50a14e0fdffe09"
             },
             "eu-south-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-08330d3946e5c95a8"
+              "release": "49.84.202108221747-0",
+              "image": "ami-0bd2328f64df9bae5"
             },
             "eu-west-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-0b6a511fd43d60348"
+              "release": "49.84.202108221747-0",
+              "image": "ami-04d5a950d69b29aaf"
             },
             "eu-west-2": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-0bc312877c4f2df9a"
+              "release": "49.84.202108221747-0",
+              "image": "ami-00748632e2c8b9123"
             },
             "sa-east-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-07718907d7e11e6d4"
+              "release": "49.84.202108221747-0",
+              "image": "ami-06d61a87c3fa04424"
             },
             "us-east-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-079edafacdc552483"
+              "release": "49.84.202108221747-0",
+              "image": "ami-0251190247a2b41aa"
             },
             "us-east-2": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-0c43c31a4d82928b1"
+              "release": "49.84.202108221747-0",
+              "image": "ami-00033b241162023da"
             },
             "us-west-1": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-0de590635ab688456"
+              "release": "49.84.202108221747-0",
+              "image": "ami-0a5d30eae426f9d19"
             },
             "us-west-2": {
-              "release": "49.84.202106302247-0",
-              "image": "ami-0b265680574faa8c0"
+              "release": "49.84.202108221747-0",
+              "image": "ami-04f5b1b85074980e8"
             }
           }
         }
@@ -165,72 +165,72 @@
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "49.84.202107010047-0",
+          "release": "49.84.202108241610-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-metal4k.ppc64le.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-metal4k.ppc64le.raw.gz.sig",
-                "sha256": "fc64722125fa0db0eb534db6af8a9ebcfff3c1bd6bf34482041ab09191e83f5d",
-                "uncompressed-sha256": "662cf671d988c6b7feb48413384630596ebc0b33bfbbbfae8bef5d03ad494d4e"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-metal4k.ppc64le.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-metal4k.ppc64le.raw.gz.sig",
+                "sha256": "b30f038f162e2b62b86153a3522350112011f985b9f99aacdf4d103d57cd4520",
+                "uncompressed-sha256": "ec3fe048b1063ef1138395c40f67819766a0de8beae445dec26d82e3cbf7f242"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live.ppc64le.iso",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live.ppc64le.iso.sig",
-                "sha256": "0f6418dc5eb43b0f12da60cf583ce19cbbf85f421c0d35b0be85c33161ab8e87"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-live.ppc64le.iso",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-live.ppc64le.iso.sig",
+                "sha256": "f00fb4b712a4ef1413a9d36a3ca6136e8fd3066a6ecccf74d4cee9268537bfbb"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-kernel-ppc64le",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-kernel-ppc64le.sig",
-                "sha256": "ae1165bb13992f9b6543e2c8baa0f1f10460d84db740d1876c8f4f9226cb9a6d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-live-kernel-ppc64le",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-live-kernel-ppc64le.sig",
+                "sha256": "29430ef56340b0d43bcc2c5e45767442b3eaab0120561f034c9bb7cc04897bfd"
               },
               "initramfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-initramfs.ppc64le.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-initramfs.ppc64le.img.sig",
-                "sha256": "79e42469694b273fce31a54e6790e4c594619577693e1b34621f1675a33538e8"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-live-initramfs.ppc64le.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-live-initramfs.ppc64le.img.sig",
+                "sha256": "218e29aaeaa78c6ca51acaa26d29cffc99d98129993b4ae35984a9bbe2c531e4"
               },
               "rootfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-rootfs.ppc64le.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-live-rootfs.ppc64le.img.sig",
-                "sha256": "6c3a9728fd82b09d11778370b68ae0875502a84d3ccbea5a0e1a9c69d855c08b"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-live-rootfs.ppc64le.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-live-rootfs.ppc64le.img.sig",
+                "sha256": "3bc414e61e31f3db7433bd27d32c7a75d034a57e3891d94260d5d02ad3e43814"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-metal.ppc64le.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-metal.ppc64le.raw.gz.sig",
-                "sha256": "f08f36d75aa726dbb6dd1cd5f1c0ef561174c7f5324f3fba2cd8ff52187bc242",
-                "uncompressed-sha256": "3d268c733b48b884f4215bb1f4e53883dd460b2a3eedd0e02e5b4e5800dafcc6"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-metal.ppc64le.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-metal.ppc64le.raw.gz.sig",
+                "sha256": "ad68867196a021890c30dd6cf5f106474c6616a9f21b0c6fb0c97a03959db574",
+                "uncompressed-sha256": "89e900a2ee5b59b5fc0bd812c2b1214edfa735e2b31318e60c9c99e33a428705"
               }
             }
           }
         },
         "openstack": {
-          "release": "49.84.202107010047-0",
+          "release": "49.84.202108241610-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-openstack.ppc64le.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-openstack.ppc64le.qcow2.gz.sig",
-                "sha256": "e30fc32cdf50ff02a72feb71cd3f4e9c92f1b038aef506d6e8396dbbf841d085",
-                "uncompressed-sha256": "9d1dc160337cda643805c96109f086015f111d46e7982b9f21cf49276cab3fb5"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-openstack.ppc64le.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-openstack.ppc64le.qcow2.gz.sig",
+                "sha256": "e04f81a5b90a3df5b1fa20a4bf627efd3eefd2fdf9c17b8814f777644926e0a2",
+                "uncompressed-sha256": "f86738346ad8eed5bc30ac327ef082b5ec59c963792ac5d570e34c83f20abf27"
               }
             }
           }
         },
         "qemu": {
-          "release": "49.84.202107010047-0",
+          "release": "49.84.202108241610-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-qemu.ppc64le.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-ppc64le/49.84.202107010047-0/ppc64le/rhcos-49.84.202107010047-0-qemu.ppc64le.qcow2.gz.sig",
-                "sha256": "9145e08f39baf2df968ea6803303ccb1fc2941f8eae60d41ba91c9016e13ba33",
-                "uncompressed-sha256": "b3822dd7eddcf2faf4028c6a6cfa7fcfaf56153d2da6bd47c462705f90887871"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-qemu.ppc64le.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-ppc64le/49.84.202108241610-0/ppc64le/rhcos-49.84.202108241610-0-qemu.ppc64le.qcow2.gz.sig",
+                "sha256": "e4d1dcda57dc2ad576a5288f00141106813098c5b5e770131401242eebe6ca0c",
+                "uncompressed-sha256": "dee3731cc5e313a190bc84fd9edb70c96e4bf4ab508e9c68e1f7fe568162f6ff"
               }
             }
           }
@@ -241,72 +241,72 @@
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "49.84.202106302347-0",
+          "release": "49.84.202108221604-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-metal4k.s390x.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-metal4k.s390x.raw.gz.sig",
-                "sha256": "2164753adff4472ce74778ee46d3f3b2e46ebc2bc550f27da8adf73013870bfe",
-                "uncompressed-sha256": "ee3245325d61570d908cc06b0e8a4d8ec31adaa848c1cf2b73213ad1d7fa5b2d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-metal4k.s390x.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-metal4k.s390x.raw.gz.sig",
+                "sha256": "931fd21733a6ad838180cb92ad139fa0997a1132caaaf02048c57abfb1e0d5ba",
+                "uncompressed-sha256": "9cecd33fa65a7e65e7ad383499a100e7d229721f26e2d7278ec9ad5a47e33210"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live.s390x.iso",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live.s390x.iso.sig",
-                "sha256": "28176925febed1c021e0b10ca2cc30842f05436be8f56782ecb96f240914801a"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-live.s390x.iso",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-live.s390x.iso.sig",
+                "sha256": "f479cad9dc94cd416a592d5281df70d3355f92e7b4819c36119d8e7d0b69e3f8"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-kernel-s390x",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-kernel-s390x.sig",
-                "sha256": "fc1762c98976a3ca46fe5b971f706570b4bcf3f3a8567dfe96c95b4f9e0e94df"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-live-kernel-s390x",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-live-kernel-s390x.sig",
+                "sha256": "9bc2ed1d7f140367755d5434ebffb99a44549100397f3be0cee374e9e145fc62"
               },
               "initramfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-initramfs.s390x.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-initramfs.s390x.img.sig",
-                "sha256": "8c0d82cee34d24c14e92b724a44c36227e626debdd4394a4db531330dbb756a1"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-live-initramfs.s390x.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-live-initramfs.s390x.img.sig",
+                "sha256": "11b7d1259af05e8c5110d50082d277b72307cce02894315fd915ea257b449161"
               },
               "rootfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-rootfs.s390x.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-live-rootfs.s390x.img.sig",
-                "sha256": "e36127fd8d6dd991a278c070f04aabeb7281864d5a7b9f3439442993b4963ccc"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-live-rootfs.s390x.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-live-rootfs.s390x.img.sig",
+                "sha256": "9bfb42b2f95534375fefa0622359a0b8c88fa909de04e6d74cf0decc6ba5c46a"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-metal.s390x.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-metal.s390x.raw.gz.sig",
-                "sha256": "b108435618b3f4704878f404ffa2101a31887fc1595a422e7c6bfd3fe06ebd2b",
-                "uncompressed-sha256": "cd7b648002adced929fef097bf563de6397b63076eff802804f37d7d6ceeecce"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-metal.s390x.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-metal.s390x.raw.gz.sig",
+                "sha256": "c1e15dcd7fdb77c81b5ea499d6b5af3ee696a4687e55df9550724db7cc7057fe",
+                "uncompressed-sha256": "44d460ffb4c2d0ee96858a1465b282a56ebc1885c144048553ce065bcfc6b65c"
               }
             }
           }
         },
         "openstack": {
-          "release": "49.84.202106302347-0",
+          "release": "49.84.202108221604-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-openstack.s390x.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-openstack.s390x.qcow2.gz.sig",
-                "sha256": "d2811c21276a305d74973a4a999ad4027b959faa21b16ab4aa305d29c982d59f",
-                "uncompressed-sha256": "e7531161b61cbaefec434a105a1ad2b6b43476448f702fb584d0955a68845f57"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-openstack.s390x.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-openstack.s390x.qcow2.gz.sig",
+                "sha256": "c05fa65b4c40addc42afe1c0a4a29d76ca3cbb0ed75d617781e305fa00cdabd9",
+                "uncompressed-sha256": "4b6e866f8e2107e3a6334722b34b94b619c748bb96b3a68c9accf054776eed91"
               }
             }
           }
         },
         "qemu": {
-          "release": "49.84.202106302347-0",
+          "release": "49.84.202108221604-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-qemu.s390x.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9-s390x/49.84.202106302347-0/s390x/rhcos-49.84.202106302347-0-qemu.s390x.qcow2.gz.sig",
-                "sha256": "8847d2e9679d676e4dde33df9e7dca3eefcd7f4bfdcf8d454bf20ca40b05322b",
-                "uncompressed-sha256": "165c64704d4780a9ea0f84a7bbb3fab7a37b730c6a0197db5362090cc11d1016"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-qemu.s390x.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/rhcos-49.84.202108221604-0-qemu.s390x.qcow2.gz.sig",
+                "sha256": "706ed1dc886001fa8f5cd231bf75e30dc7a81c9c9fb2e3e779f444b0ef9bb7c6",
+                "uncompressed-sha256": "e05731e756f0c329751af4023416b5ea29cdd248b364b3e0c03f3aca02666a0b"
               }
             }
           }
@@ -317,148 +317,149 @@
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "49.84.202107010027-0",
+          "release": "49.84.202108221651-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-aws.x86_64.vmdk.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-aws.x86_64.vmdk.gz.sig",
-                "sha256": "932dd626e76f84e8f6d5158abcc753af6e865305169588203dede2bb4c41f28a",
-                "uncompressed-sha256": "3efafda489b5a789725ada0d2ea6c93a8e76775ce4e789b3b5ef5ee235b45ecb"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-aws.x86_64.vmdk.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-aws.x86_64.vmdk.gz.sig",
+                "sha256": "482ba61e89effca5d3028cb14cf07d45359146c8fbac4c1b5adcc5692bd1ba98",
+                "uncompressed-sha256": "6fcd8528079edb1e31ee065e9ea15b10045f8995581d61f72e5283c14c2424e9"
               }
             }
           }
         },
         "azure": {
-          "release": "49.84.202107010027-0",
+          "release": "49.84.202108221651-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-azure.x86_64.vhd.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-azure.x86_64.vhd.gz.sig",
-                "sha256": "9bbedfb75c1be0f5331882840fff65b194bf9ca87548ce6c764db604056a999f",
-                "uncompressed-sha256": "e79180d7e455fbf1d8db5eb2a3522ae4c12782d35e52acba3ab95f124af73164"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-azure.x86_64.vhd.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-azure.x86_64.vhd.gz.sig",
+                "sha256": "f7d87820242fc7606c0be9f40d431008ee48bdd6a3a3aaafcc36bddbd4551d42",
+                "uncompressed-sha256": "6dc6e6d82c1c359a950509ef87290a1e261422d4115af9d5300fe9066e4feda3"
               }
             }
           }
         },
         "azurestack": {
-          "release": "49.84.202107010027-0",
+          "release": "49.84.202108221651-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-azurestack.x86_64.vhd.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-azurestack.x86_64.vhd.gz.sig",
-                "sha256": "3c6d3dbc75deb47aaaef62e76628ef4f37143ef8d5f00435a89c03266fecac29",
-                "uncompressed-sha256": "951db0b6585976034fd6cc23de834bc7fd0cad102115bb6efd509ef1c8a38e53"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-azurestack.x86_64.vhd.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-azurestack.x86_64.vhd.gz.sig",
+                "sha256": "16e32b6f03f1d4f07395a0874bc93c2c75c355a29b6954ae1bc56fdeab174d04",
+                "uncompressed-sha256": "ef25419462c5d3e8fbe2851d086784f7f1648277d730c841a2f293b798f0fb5e"
               }
             }
           }
         },
         "gcp": {
-          "release": "49.84.202107010027-0",
+          "release": "49.84.202108221651-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-gcp.x86_64.tar.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-gcp.x86_64.tar.gz.sig",
-                "sha256": "28c816bfe2df8570472607f5ae3cd5adb455932e68412370785c78617c50e7ab"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-gcp.x86_64.tar.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-gcp.x86_64.tar.gz.sig",
+                "sha256": "95863e050f6beeb9a78de7805380b0dcbafe2f0a4c3b79ea4ca9346d4e126b7b",
+                "uncompressed-sha256": "17f13516c56ea6735aee18bec8e92d5c3da49fbb94e6eaa2597605e1f7bb3dee"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "49.84.202107010027-0",
+          "release": "49.84.202108221651-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-ibmcloud.x86_64.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-ibmcloud.x86_64.qcow2.gz.sig",
-                "sha256": "0ffb7e3583faf05bb0d5bceda73f048bca5ab19d5fed6091ffd791c19167dd72",
-                "uncompressed-sha256": "eeee1e663f25bec15af029cd6fcb13079f661da80444271a7db944c7484c8a72"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-ibmcloud.x86_64.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-ibmcloud.x86_64.qcow2.gz.sig",
+                "sha256": "ea8d9ba650ccd8020cfb7f3c25b1ae0624eeb7d472a7f9284950dfa293ea2748",
+                "uncompressed-sha256": "587c0b088009d8dd4a68ee581668b76574ba7fb02bbd35be95205deb9e640516"
               }
             }
           }
         },
         "metal": {
-          "release": "49.84.202107010027-0",
+          "release": "49.84.202108221651-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-metal4k.x86_64.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-metal4k.x86_64.raw.gz.sig",
-                "sha256": "93c5b9631ea0cac516ea2ff2a8b9949af1d856849a48763299b800ae8f25c4e6",
-                "uncompressed-sha256": "9d95fbbacad73415c6de086ce78ac06a9810db3e7fb3e3693039bd4631fa1553"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-metal4k.x86_64.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-metal4k.x86_64.raw.gz.sig",
+                "sha256": "10965655b1f6478e81caa2326aa6e5fa5a34218a6abcb02500ef9c2584027614",
+                "uncompressed-sha256": "6651cc2894aba0bbecb1f98c5e827ed81f1fa13017311363c5e9598d6199051f"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live.x86_64.iso",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live.x86_64.iso.sig",
-                "sha256": "244a2148ba6bc0e8e2355e6bdd90c8a2b81bdedc51c0bd323b00c8f797d2bd50"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-live.x86_64.iso",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-live.x86_64.iso.sig",
+                "sha256": "816156977d0ae0d04306baf1a0934f39a8808c85cc967ae74cd851c7a9a55aa3"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-kernel-x86_64",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-kernel-x86_64.sig",
-                "sha256": "9b900e88ca71b067d8f9971dc4454f454a12666b53d3ca2d80919729060a198d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-live-kernel-x86_64",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-live-kernel-x86_64.sig",
+                "sha256": "dd63e3832b277a16671832cd1464b7a338ef906f139ed8292daf228e1586d81c"
               },
               "initramfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-initramfs.x86_64.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-initramfs.x86_64.img.sig",
-                "sha256": "cb8a23fa2ddf1c427135fb6aa016e9765c25aca9d1e863f9d0b3a18e1c4c41f8"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-live-initramfs.x86_64.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-live-initramfs.x86_64.img.sig",
+                "sha256": "de573cfae77a342da18d26f2a4b6c57fc3d665dabe3205bd9e176b882d05e105"
               },
               "rootfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-rootfs.x86_64.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-live-rootfs.x86_64.img.sig",
-                "sha256": "383993d4ff10d620f9e4bc452eb8f24473b271b04ed1c0d97fac3bd0d987f747"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-live-rootfs.x86_64.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-live-rootfs.x86_64.img.sig",
+                "sha256": "985bcadcb4ce3fd512ac0703727a85b3b8ba5bc3d00865143e35e8014622ba6a"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-metal.x86_64.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-metal.x86_64.raw.gz.sig",
-                "sha256": "aaf1cdcd5d085e0e8decbb19ab4fbbc8d8278d7638cceaea80b48331b263706f",
-                "uncompressed-sha256": "7080110bc282855f9e91cb86769b53f0fe4136206eac99e47f4608d5a9fecf00"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-metal.x86_64.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-metal.x86_64.raw.gz.sig",
+                "sha256": "7871a3b53db995d49198523a1ddad888882fa1009aa63a7364051bd0ba508685",
+                "uncompressed-sha256": "3fd044f4351c2a87102aae80f0ec4b8b8cb2d2436831282636f6966db7e0e1d6"
               }
             }
           }
         },
         "openstack": {
-          "release": "49.84.202107010027-0",
+          "release": "49.84.202108221651-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz.sig",
-                "sha256": "c7dde5f96826c33c97b5a4ad34110212281916128ae11100956f400db3d5299e",
-                "uncompressed-sha256": "00cb56c8711686255744646394e22a8ca5f27e059016f6758f14388e5a0a14cb"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-openstack.x86_64.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-openstack.x86_64.qcow2.gz.sig",
+                "sha256": "6e10a09efa967dcbf5c67449e04b22d55ae1d8e46b12eb4e9488b1c28101edfc",
+                "uncompressed-sha256": "4a617207e3e88b4d5eeaf29db8d96006ed038b65651ef828f2b12ce5c625315e"
               }
             }
           }
         },
         "qemu": {
-          "release": "49.84.202107010027-0",
+          "release": "49.84.202108221651-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-qemu.x86_64.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-qemu.x86_64.qcow2.gz.sig",
-                "sha256": "6dc06832d28ed28594902844fb1b205f3aa58c4960f976ae78c9122dc417111d",
-                "uncompressed-sha256": "c645d5eba8cba58fce4571135edb1c7ec03f04e9c5ad6466cef72f7a9717d09c"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-qemu.x86_64.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-qemu.x86_64.qcow2.gz.sig",
+                "sha256": "fa59765813b30b6d36a7474b57244aa9357738c9d643b1fbb0afe53930e3b77a",
+                "uncompressed-sha256": "18ef1488ae31b382b655eddc905c836cbe26fd00a3774829225303fc5fe0281a"
               }
             }
           }
         },
         "vmware": {
-          "release": "49.84.202107010027-0",
+          "release": "49.84.202108221651-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-vmware.x86_64.ova",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/rhcos-49.84.202107010027-0-vmware.x86_64.ova.sig",
-                "sha256": "f9ee706482c8088d1ce4d9b798d9d9cd229ce8ae011fe5909b4eb79455c08940"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-vmware.x86_64.ova",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/rhcos-49.84.202108221651-0-vmware.x86_64.ova.sig",
+                "sha256": "2eee525ba5098cae67390821056df90c5d34c2dfd552db8820ba6d053cb24f7f"
               }
             }
           }
@@ -468,100 +469,100 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-0e7bac9d978e79a6e"
+              "release": "49.84.202108221651-0",
+              "image": "ami-00d008288d9de1355"
             },
             "ap-east-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-051d83ebbfb127ea2"
+              "release": "49.84.202108221651-0",
+              "image": "ami-03f0ca27f13ffe5ff"
             },
             "ap-northeast-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-00413a0acfd76de7c"
+              "release": "49.84.202108221651-0",
+              "image": "ami-087f590236fd0e919"
             },
             "ap-northeast-2": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-08e2db228a5695fb3"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0d5624ca864f92ad6"
             },
             "ap-northeast-3": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-0d0b87fc092ee2e74"
+              "release": "49.84.202108221651-0",
+              "image": "ami-08c0f738caba4cf5e"
             },
             "ap-south-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-03c83da1b6ce6d151"
+              "release": "49.84.202108221651-0",
+              "image": "ami-003e5dbce864a9ad0"
             },
             "ap-southeast-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-020876d27dc04936a"
+              "release": "49.84.202108221651-0",
+              "image": "ami-061e3cf4ecb91de34"
             },
             "ap-southeast-2": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-02eecabb2b32443e5"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0cf7d25f65a82fa6c"
             },
             "ca-central-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-070fd5123ab359da8"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0f881d6f9f5b90225"
             },
             "eu-central-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-07ac34b5c836bb738"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0f031c6d4461876c1"
             },
             "eu-north-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-01a85ec5bac734d6b"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0e0a0c62a8d357d3f"
             },
             "eu-south-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-0da7775afdefce9c6"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0affd9a20c9104f0c"
             },
             "eu-west-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-031117dace22be7c5"
+              "release": "49.84.202108221651-0",
+              "image": "ami-08a847733e8a15508"
             },
             "eu-west-2": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-0c455b12ceed301cd"
+              "release": "49.84.202108221651-0",
+              "image": "ami-05dd4b82210ebb603"
             },
             "eu-west-3": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-0cc8ddaee632a3086"
+              "release": "49.84.202108221651-0",
+              "image": "ami-06055669ac261d783"
             },
             "me-south-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-034359190c2c7c906"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0696eafd323d46079"
             },
             "sa-east-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-0fc38ad5e19dfd32b"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0941aa93b3c9e2700"
             },
             "us-east-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-01b2bf223fccdb8e3"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0f123ebe52c3accc9"
             },
             "us-east-2": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-0798e63b24f54c102"
+              "release": "49.84.202108221651-0",
+              "image": "ami-045089e3aeb7444db"
             },
             "us-west-1": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-004c277e7c9366226"
+              "release": "49.84.202108221651-0",
+              "image": "ami-01ba807424ad8ceee"
             },
             "us-west-2": {
-              "release": "49.84.202107010027-0",
-              "image": "ami-0acecf5d7224232a8"
+              "release": "49.84.202108221651-0",
+              "image": "ami-0228531eacc8ad7e9"
             }
           }
         },
         "gcp": {
           "project": "rhcos-cloud",
-          "name": "rhcos-49-84-202107010027-0-gcp-x86-64"
+          "name": "rhcos-49-84-202108221651-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "49.84.202107010027-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202107010027-0-azure.x86_64.vhd"
+          "release": "49.84.202108221651-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202108221651-0-azure.x86_64.vhd"
         }
       }
     }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,173 +1,175 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0e7bac9d978e79a6e"
+            "hvm": "ami-00d008288d9de1355"
         },
         "ap-east-1": {
-            "hvm": "ami-051d83ebbfb127ea2"
+            "hvm": "ami-03f0ca27f13ffe5ff"
         },
         "ap-northeast-1": {
-            "hvm": "ami-00413a0acfd76de7c"
+            "hvm": "ami-087f590236fd0e919"
         },
         "ap-northeast-2": {
-            "hvm": "ami-08e2db228a5695fb3"
+            "hvm": "ami-0d5624ca864f92ad6"
         },
         "ap-northeast-3": {
-            "hvm": "ami-0d0b87fc092ee2e74"
+            "hvm": "ami-08c0f738caba4cf5e"
         },
         "ap-south-1": {
-            "hvm": "ami-03c83da1b6ce6d151"
+            "hvm": "ami-003e5dbce864a9ad0"
         },
         "ap-southeast-1": {
-            "hvm": "ami-020876d27dc04936a"
+            "hvm": "ami-061e3cf4ecb91de34"
         },
         "ap-southeast-2": {
-            "hvm": "ami-02eecabb2b32443e5"
+            "hvm": "ami-0cf7d25f65a82fa6c"
         },
         "ca-central-1": {
-            "hvm": "ami-070fd5123ab359da8"
+            "hvm": "ami-0f881d6f9f5b90225"
         },
         "eu-central-1": {
-            "hvm": "ami-07ac34b5c836bb738"
+            "hvm": "ami-0f031c6d4461876c1"
         },
         "eu-north-1": {
-            "hvm": "ami-01a85ec5bac734d6b"
+            "hvm": "ami-0e0a0c62a8d357d3f"
         },
         "eu-south-1": {
-            "hvm": "ami-0da7775afdefce9c6"
+            "hvm": "ami-0affd9a20c9104f0c"
         },
         "eu-west-1": {
-            "hvm": "ami-031117dace22be7c5"
+            "hvm": "ami-08a847733e8a15508"
         },
         "eu-west-2": {
-            "hvm": "ami-0c455b12ceed301cd"
+            "hvm": "ami-05dd4b82210ebb603"
         },
         "eu-west-3": {
-            "hvm": "ami-0cc8ddaee632a3086"
+            "hvm": "ami-06055669ac261d783"
         },
         "me-south-1": {
-            "hvm": "ami-034359190c2c7c906"
+            "hvm": "ami-0696eafd323d46079"
         },
         "sa-east-1": {
-            "hvm": "ami-0fc38ad5e19dfd32b"
+            "hvm": "ami-0941aa93b3c9e2700"
         },
         "us-east-1": {
-            "hvm": "ami-01b2bf223fccdb8e3"
+            "hvm": "ami-0f123ebe52c3accc9"
         },
         "us-east-2": {
-            "hvm": "ami-0798e63b24f54c102"
+            "hvm": "ami-045089e3aeb7444db"
         },
         "us-west-1": {
-            "hvm": "ami-004c277e7c9366226"
+            "hvm": "ami-01ba807424ad8ceee"
         },
         "us-west-2": {
-            "hvm": "ami-0acecf5d7224232a8"
+            "hvm": "ami-0228531eacc8ad7e9"
         }
     },
     "azure": {
-        "image": "rhcos-49.84.202107010027-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202107010027-0-azure.x86_64.vhd"
+        "image": "rhcos-49.84.202108221651-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-49.84.202108221651-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202107010027-0/x86_64/",
-    "buildid": "49.84.202107010027-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/",
+    "buildid": "49.84.202108221651-0",
     "gcp": {
-        "image": "rhcos-49-84-202107010027-0-gcp-x86-64",
+        "image": "rhcos-49-84-202108221651-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-49-84-202107010027-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-49-84-202108221651-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-49.84.202107010027-0-aws.x86_64.vmdk.gz",
-            "sha256": "932dd626e76f84e8f6d5158abcc753af6e865305169588203dede2bb4c41f28a",
-            "size": 1030950571,
-            "uncompressed-sha256": "3efafda489b5a789725ada0d2ea6c93a8e76775ce4e789b3b5ef5ee235b45ecb",
-            "uncompressed-size": 1051976192
+            "path": "rhcos-49.84.202108221651-0-aws.x86_64.vmdk.gz",
+            "sha256": "482ba61e89effca5d3028cb14cf07d45359146c8fbac4c1b5adcc5692bd1ba98",
+            "size": 1036152582,
+            "uncompressed-sha256": "6fcd8528079edb1e31ee065e9ea15b10045f8995581d61f72e5283c14c2424e9",
+            "uncompressed-size": 1058205696
         },
         "azure": {
-            "path": "rhcos-49.84.202107010027-0-azure.x86_64.vhd.gz",
-            "sha256": "9bbedfb75c1be0f5331882840fff65b194bf9ca87548ce6c764db604056a999f",
-            "size": 1030871708,
-            "uncompressed-sha256": "e79180d7e455fbf1d8db5eb2a3522ae4c12782d35e52acba3ab95f124af73164",
+            "path": "rhcos-49.84.202108221651-0-azure.x86_64.vhd.gz",
+            "sha256": "f7d87820242fc7606c0be9f40d431008ee48bdd6a3a3aaafcc36bddbd4551d42",
+            "size": 1036795995,
+            "uncompressed-sha256": "6dc6e6d82c1c359a950509ef87290a1e261422d4115af9d5300fe9066e4feda3",
             "uncompressed-size": 17179869696
         },
         "azurestack": {
-            "path": "rhcos-49.84.202107010027-0-azurestack.x86_64.vhd.gz",
-            "sha256": "3c6d3dbc75deb47aaaef62e76628ef4f37143ef8d5f00435a89c03266fecac29",
-            "size": 1030872938,
-            "uncompressed-sha256": "951db0b6585976034fd6cc23de834bc7fd0cad102115bb6efd509ef1c8a38e53",
+            "path": "rhcos-49.84.202108221651-0-azurestack.x86_64.vhd.gz",
+            "sha256": "16e32b6f03f1d4f07395a0874bc93c2c75c355a29b6954ae1bc56fdeab174d04",
+            "size": 1036797561,
+            "uncompressed-sha256": "ef25419462c5d3e8fbe2851d086784f7f1648277d730c841a2f293b798f0fb5e",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-49.84.202107010027-0-gcp.x86_64.tar.gz",
-            "sha256": "28c816bfe2df8570472607f5ae3cd5adb455932e68412370785c78617c50e7ab",
-            "size": 1016304764
+            "path": "rhcos-49.84.202108221651-0-gcp.x86_64.tar.gz",
+            "sha256": "95863e050f6beeb9a78de7805380b0dcbafe2f0a4c3b79ea4ca9346d4e126b7b",
+            "size": 1017048530,
+            "uncompressed-sha256": "17f13516c56ea6735aee18bec8e92d5c3da49fbb94e6eaa2597605e1f7bb3dee",
+            "uncompressed-size": 2529259520
         },
         "ibmcloud": {
-            "path": "rhcos-49.84.202107010027-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "0ffb7e3583faf05bb0d5bceda73f048bca5ab19d5fed6091ffd791c19167dd72",
-            "size": 1016679625,
-            "uncompressed-sha256": "eeee1e663f25bec15af029cd6fcb13079f661da80444271a7db944c7484c8a72",
-            "uncompressed-size": 2534342656
+            "path": "rhcos-49.84.202108221651-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "ea8d9ba650ccd8020cfb7f3c25b1ae0624eeb7d472a7f9284950dfa293ea2748",
+            "size": 1022594999,
+            "uncompressed-sha256": "587c0b088009d8dd4a68ee581668b76574ba7fb02bbd35be95205deb9e640516",
+            "uncompressed-size": 2579103744
         },
         "live-initramfs": {
-            "path": "rhcos-49.84.202107010027-0-live-initramfs.x86_64.img",
-            "sha256": "cb8a23fa2ddf1c427135fb6aa016e9765c25aca9d1e863f9d0b3a18e1c4c41f8"
+            "path": "rhcos-49.84.202108221651-0-live-initramfs.x86_64.img",
+            "sha256": "de573cfae77a342da18d26f2a4b6c57fc3d665dabe3205bd9e176b882d05e105"
         },
         "live-iso": {
-            "path": "rhcos-49.84.202107010027-0-live.x86_64.iso",
-            "sha256": "244a2148ba6bc0e8e2355e6bdd90c8a2b81bdedc51c0bd323b00c8f797d2bd50"
+            "path": "rhcos-49.84.202108221651-0-live.x86_64.iso",
+            "sha256": "816156977d0ae0d04306baf1a0934f39a8808c85cc967ae74cd851c7a9a55aa3"
         },
         "live-kernel": {
-            "path": "rhcos-49.84.202107010027-0-live-kernel-x86_64",
-            "sha256": "9b900e88ca71b067d8f9971dc4454f454a12666b53d3ca2d80919729060a198d"
+            "path": "rhcos-49.84.202108221651-0-live-kernel-x86_64",
+            "sha256": "dd63e3832b277a16671832cd1464b7a338ef906f139ed8292daf228e1586d81c"
         },
         "live-rootfs": {
-            "path": "rhcos-49.84.202107010027-0-live-rootfs.x86_64.img",
-            "sha256": "383993d4ff10d620f9e4bc452eb8f24473b271b04ed1c0d97fac3bd0d987f747"
+            "path": "rhcos-49.84.202108221651-0-live-rootfs.x86_64.img",
+            "sha256": "985bcadcb4ce3fd512ac0703727a85b3b8ba5bc3d00865143e35e8014622ba6a"
         },
         "metal": {
-            "path": "rhcos-49.84.202107010027-0-metal.x86_64.raw.gz",
-            "sha256": "aaf1cdcd5d085e0e8decbb19ab4fbbc8d8278d7638cceaea80b48331b263706f",
-            "size": 1018448313,
-            "uncompressed-sha256": "7080110bc282855f9e91cb86769b53f0fe4136206eac99e47f4608d5a9fecf00",
-            "uncompressed-size": 3959422976
+            "path": "rhcos-49.84.202108221651-0-metal.x86_64.raw.gz",
+            "sha256": "7871a3b53db995d49198523a1ddad888882fa1009aa63a7364051bd0ba508685",
+            "size": 1024417867,
+            "uncompressed-sha256": "3fd044f4351c2a87102aae80f0ec4b8b8cb2d2436831282636f6966db7e0e1d6",
+            "uncompressed-size": 4022337536
         },
         "metal4k": {
-            "path": "rhcos-49.84.202107010027-0-metal4k.x86_64.raw.gz",
-            "sha256": "93c5b9631ea0cac516ea2ff2a8b9949af1d856849a48763299b800ae8f25c4e6",
-            "size": 1016010632,
-            "uncompressed-sha256": "9d95fbbacad73415c6de086ce78ac06a9810db3e7fb3e3693039bd4631fa1553",
-            "uncompressed-size": 3959422976
+            "path": "rhcos-49.84.202108221651-0-metal4k.x86_64.raw.gz",
+            "sha256": "10965655b1f6478e81caa2326aa6e5fa5a34218a6abcb02500ef9c2584027614",
+            "size": 1022026749,
+            "uncompressed-sha256": "6651cc2894aba0bbecb1f98c5e827ed81f1fa13017311363c5e9598d6199051f",
+            "uncompressed-size": 4022337536
         },
         "openstack": {
-            "path": "rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz",
-            "sha256": "c7dde5f96826c33c97b5a4ad34110212281916128ae11100956f400db3d5299e",
-            "size": 1016679212,
-            "uncompressed-sha256": "00cb56c8711686255744646394e22a8ca5f27e059016f6758f14388e5a0a14cb",
-            "uncompressed-size": 2534342656
+            "path": "rhcos-49.84.202108221651-0-openstack.x86_64.qcow2.gz",
+            "sha256": "6e10a09efa967dcbf5c67449e04b22d55ae1d8e46b12eb4e9488b1c28101edfc",
+            "size": 1022598458,
+            "uncompressed-sha256": "4a617207e3e88b4d5eeaf29db8d96006ed038b65651ef828f2b12ce5c625315e",
+            "uncompressed-size": 2579103744
         },
         "ostree": {
-            "path": "rhcos-49.84.202107010027-0-ostree.x86_64.tar",
-            "sha256": "54affb52ee9056d1bf237049f4815c686f317ef8ca135d4b1b72f69e31ee1f81",
-            "size": 940769280
+            "path": "rhcos-49.84.202108221651-0-ostree.x86_64.tar",
+            "sha256": "0a7e73d6d8fcb77a76b9436e607a8d372ae8b1a4891884ea32e06d8140a044d4",
+            "size": 947783680
         },
         "qemu": {
-            "path": "rhcos-49.84.202107010027-0-qemu.x86_64.qcow2.gz",
-            "sha256": "6dc06832d28ed28594902844fb1b205f3aa58c4960f976ae78c9122dc417111d",
-            "size": 1017869225,
-            "uncompressed-sha256": "c645d5eba8cba58fce4571135edb1c7ec03f04e9c5ad6466cef72f7a9717d09c",
-            "uncompressed-size": 2570452992
+            "path": "rhcos-49.84.202108221651-0-qemu.x86_64.qcow2.gz",
+            "sha256": "fa59765813b30b6d36a7474b57244aa9357738c9d643b1fbb0afe53930e3b77a",
+            "size": 1023869619,
+            "uncompressed-sha256": "18ef1488ae31b382b655eddc905c836cbe26fd00a3774829225303fc5fe0281a",
+            "uncompressed-size": 2615541760
         },
         "vmware": {
-            "path": "rhcos-49.84.202107010027-0-vmware.x86_64.ova",
-            "sha256": "f9ee706482c8088d1ce4d9b798d9d9cd229ce8ae011fe5909b4eb79455c08940",
-            "size": 1051985920
+            "path": "rhcos-49.84.202108221651-0-vmware.x86_64.ova",
+            "sha256": "2eee525ba5098cae67390821056df90c5d34c2dfd552db8820ba6d053cb24f7f",
+            "size": 1058222080
         }
     },
     "oscontainer": {
-        "digest": "sha256:cf5f21445e2d6c43ab424f99db7844bfe5463af7e429842bd679deba5926e7e2",
+        "digest": "sha256:f828fcc873e4cf2b6af8329dc218a1e8605e7a3ced259ae3748ad91ecab1aee3",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "abb247c075d0e2d4b7cf41e0fcef3305fbd9efe9dbcde2211a072acd6ddccabb",
-    "ostree-version": "49.84.202107010027-0"
+    "ostree-commit": "95aec436ee83751dea39060f5234a45c8eb389e19f4b535eb34f33c9d42208fb",
+    "ostree-version": "49.84.202108221651-0"
 }


### PR DESCRIPTION
This updates the RHCOS boot image metadata in the installer with the
most recent version of RHCOS 4.9 artifacts.

This includes fixes for the following BZs:

1967483 - coreos-installer fails to download Ignition (DNS error, failed to lookup address)
1974411 - Installation with multipath parameters in parmfile fails (DNS resolution missing)
1980679 - On a Azure IPI installation MCO fails to create new nodes

Changes generated with the following:

```
$ plume cosa2stream --target data/data/rhcos-stream.json --distro rhcos aarch64=49.84.202108221747-0 ppc64le=49.84.202108241610-0 s390x=49.84.202108221604-0 x86_64=49.84.202108221651-0 --url https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases
$ ./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-aarch64/49.84.202108221747-0/aarch64/meta.json aarch64
$ ./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9-s390x/49.84.202108221604-0/s390x/meta.json s390x
$ ./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/meta.json x86_64
$ ./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.9/49.84.202108221651-0/x86_64/meta.json amd64
```