### PR TITLE
machines: Extract root disk sizes to constants

### DIFF
--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -71,6 +71,16 @@ const (
 
 	// workerUserDataFileName is the filename used for the worker user-data secret.
 	workerUserDataFileName = "99_openshift-cluster-api_worker-user-data-secret.yaml"
+
+	// decimalRootVolumeSize is the size in GB we use for some platforms.
+	// See below.
+	decimalRootVolumeSize = 120
+
+	// powerOfTwoRootVolumeSize is the size in GB we use for other platforms.
+	// The reasons for the specific choices between these two may boil down
+	// to which section of code the person adding a platform was copy-pasting from.
+	// https://github.com/openshift/openshift-docs/blob/main/modules/installation-requirements-user-infra.adoc#minimum-resource-requirements
+	powerOfTwoRootVolumeSize = 128
 )
 
 var (
@@ -83,7 +93,7 @@ func defaultAWSMachinePoolPlatform() awstypes.MachinePool {
 	return awstypes.MachinePool{
 		EC2RootVolume: awstypes.EC2RootVolume{
 			Type: "gp2",
-			Size: 120,
+			Size: decimalRootVolumeSize,
 		},
 	}
 }
@@ -103,7 +113,7 @@ func defaultLibvirtMachinePoolPlatform() libvirttypes.MachinePool {
 func defaultAzureMachinePoolPlatform() azuretypes.MachinePool {
 	return azuretypes.MachinePool{
 		OSDisk: azuretypes.OSDisk{
-			DiskSizeGB: 128,
+			DiskSizeGB: powerOfTwoRootVolumeSize,
 			DiskType:   azuretypes.DefaultDiskType,
 		},
 	}
@@ -113,7 +123,7 @@ func defaultGCPMachinePoolPlatform() gcptypes.MachinePool {
 	return gcptypes.MachinePool{
 		InstanceType: "n1-standard-4",
 		OSDisk: gcptypes.OSDisk{
-			DiskSizeGB: 128,
+			DiskSizeGB: powerOfTwoRootVolumeSize,
 			DiskType:   "pd-ssd",
 		},
 	}
@@ -143,7 +153,7 @@ func defaultOvirtMachinePoolPlatform() ovirttypes.MachinePool {
 		},
 		MemoryMB: 16348,
 		OSDisk: &ovirttypes.Disk{
-			SizeGB: 120,
+			SizeGB: decimalRootVolumeSize,
 		},
 		VMType:            ovirttypes.VMTypeServer,
 		AutoPinningPolicy: ovirttypes.AutoPinningNone,
@@ -156,7 +166,7 @@ func defaultVSphereMachinePoolPlatform() vspheretypes.MachinePool {
 		NumCoresPerSocket: 2,
 		MemoryMiB:         8192,
 		OSDisk: vspheretypes.OSDisk{
-			DiskSizeGB: 120,
+			DiskSizeGB: decimalRootVolumeSize,
 		},
 	}
 }


### PR DESCRIPTION
I was looking at this issue:
https://github.com/openshift/openshift-docs/issues/35793
Which then led me to wonder exactly what the defaults are per
platform for disk sizes.

And then I stumbled into this 120 vs 128 thing that as best
I can tell from the git history is mostly an accident.  If someone
happens to know differently (e.g. can/should we unify on 120 or 128?)
then that'd be good.

In the meantime, an additional benefit here is that if one does
e.g. `git grep -i volume.*size` these constants will turn up.
It took me a little while to figure out how to backtrack from
the Terraform code to this.  (The lines here only contained
`Size` which is too generic to grep)