### PR TITLE
Bug 1969371: Fix AWS destroy to not check us-east-1

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -140,6 +140,8 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) ([]string, erro
 	}
 
 	switch o.Region {
+	case endpoints.CnNorth1RegionID, endpoints.CnNorthwest1RegionID:
+		break
 	case endpoints.UsGovEast1RegionID, endpoints.UsGovWest1RegionID:
 		if o.Region != endpoints.UsGovWest1RegionID {
 			tagClients = append(tagClients,


### PR DESCRIPTION
Fixes the AWS China destroyer to not add us-east-1 region to
the destroyer.