### PR TITLE
Bug 1993207: fix(ibmcloud): Set account ID for resource group look up

### DIFF
--- a/pkg/asset/installconfig/ibmcloud/client.go
+++ b/pkg/asset/installconfig/ibmcloud/client.go
@@ -263,8 +263,14 @@ func (c *Client) GetResourceGroups(ctx context.Context) ([]resourcemanagerv2.Res
 	_, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
 
+	apikey, err := c.GetAuthenticatorAPIKeyDetails(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	options := c.managementAPI.NewListResourceGroupsOptions()
-	listResourceGroupsResponse, _, err := c.managementAPI.ListResourceGroups(options)
+	options.SetAccountID(*apikey.AccountID)
+	listResourceGroupsResponse, _, err := c.managementAPI.ListResourceGroupsWithContext(ctx, options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Make sure the account ID context is set for a resource group look up. This option is required when using a ServiceID-based IBM Cloud API key.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1993207