### PR TITLE
Bug 1993207: fix(ibmcloud): Set account ID for rg on destroy

### DIFF
--- a/pkg/destroy/ibmcloud/ibmcloud.go
+++ b/pkg/destroy/ibmcloud/ibmcloud.go
@@ -283,6 +283,7 @@ func (o *ClusterUninstaller) ResourceGroupID() (string, error) {
 	defer cancel()
 
 	options := o.managementSvc.NewListResourceGroupsOptions()
+	options.SetAccountID(o.AccountID)
 	options.SetName(o.ResourceGroupName)
 	resources, _, err := o.managementSvc.ListResourceGroupsWithContext(ctx, options)
 	if err != nil {

--- a/pkg/destroy/ibmcloud/resourcegroup.go
+++ b/pkg/destroy/ibmcloud/resourcegroup.go
@@ -15,6 +15,7 @@ func (o *ClusterUninstaller) listResourceGroups() (cloudResources, error) {
 	defer cancel()
 
 	options := o.managementSvc.NewListResourceGroupsOptions()
+	options.SetAccountID(o.AccountID)
 	resources, _, err := o.managementSvc.ListResourceGroupsWithContext(ctx, options)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to list resource groups")


### PR DESCRIPTION
Make sure the account ID context is set for a resource group look up on destroy operations. This option is required when using a ServiceID-based IBM Cloud API key.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1993207