### PR TITLE
pkg/asset/installconfig/aws: public DNS validation

### DIFF
--- a/data/data/aws/cluster/route53/base.tf
+++ b/data/data/aws/cluster/route53/base.tf
@@ -13,6 +13,8 @@ data "aws_route53_zone" "public" {
   count = local.public_endpoints ? 1 : 0
 
   name = var.base_domain
+
+  depends_on = [aws_route53_record.api_external_internal_zone_alias, aws_route53_record.api_external_internal_zone_cname]
 }
 
 data "aws_route53_zone" "int" {
@@ -35,8 +37,6 @@ resource "aws_route53_zone" "new_int" {
     },
     var.tags,
   )
-
-  depends_on = [aws_route53_record.api_external_alias, aws_route53_record.api_external_cname]
 }
 
 resource "aws_route53_record" "api_external_alias" {


### PR DESCRIPTION
Verify no DNS records exist in the public DNS zone. This helps to prevent
installing into an existing cluster. The goal here is to not leak public DNS
records. This should help make the race condition less likely.

https://issues.redhat.com/browse/CORS-1195