### PR TITLE
Bug 1993364: Consider all Networks on Router clean up

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -590,6 +590,9 @@ func getRouterInterfaces(conn *gophercloud.ServiceClient, allNetworks []networks
 			logger.Debug(err)
 			return routerPorts, nil
 		}
+		if subnet.GatewayIP == "" {
+			continue
+		}
 		portListOpts := ports.ListOpts{
 			FixedIPs: []ports.FixedIPOpts{
 				{
@@ -630,14 +633,9 @@ func clearRouterInterfaces(opts *clientconfig.ClientOpts, filter Filter, logger 
 		return false, nil
 	}
 
-	// Find the machines Network by the master machines Ports.
-	// Any worker nodes ports, including the ones used for additionalNetworks,
-	// are tagged with cluster-api-provider-openstack and should be excluded
-	// to ensure only the primary Network ports are filtered.
 	tags := filterTags(filter)
 	networkListOpts := networks.ListOpts{
-		Tags:    strings.Join(tags, ","),
-		NotTags: "cluster-api-provider-openstack",
+		Tags: strings.Join(tags, ","),
 	}
 
 	allNetworksPages, err := networks.List(conn, networkListOpts).AllPages()


### PR DESCRIPTION
When performing a cluster destroy we should
look for all cluster tagged Networks that might be
connected to the router, regardless if it was created
by CAPO. This commit updates the filtering for the
look up of Networks and ensure to skip the Subnet
when no Gateway is set.