### PR TITLE
Terraform Stages: ensure inputs match outputs

### DIFF
--- a/data/data/aws/bootstrap/variables.tf
+++ b/data/data/aws/bootstrap/variables.tf
@@ -1,3 +1,8 @@
+variable "control_plane_ips" {
+  type    = list(string)
+  default = null
+}
+
 variable "lb_target_group_arns" {
   type = list(string)
 }
@@ -24,4 +29,9 @@ variable "master_sg_id" {
 
 variable "ami_id" {
   type = string
+}
+
+variable "bootstrap_ip" {
+  type    = string
+  default = null
 }

--- a/data/data/azure/bootstrap/variables.tf
+++ b/data/data/azure/bootstrap/variables.tf
@@ -68,3 +68,29 @@ https://github.com/hashicorp/terraform/issues/12570
 EOF
 }
 
+variable "internal_lb_ip_v4_address" {
+  type = string
+  default = null
+}
+
+variable "virtual_network_id" {
+  description = "The ID for Virtual Network that will be linked to the Private DNS zone."
+  type = string
+  default = null
+}
+
+variable "worker_subnet_id" {
+  type = string
+  default = null
+}
+
+variable "public_lb_pip_v4_fqdn" {
+  type = string
+  default = null
+}
+
+variable "bootstrap_ip" {
+  type = string
+  description = "The ip of the bootstrap node. Used for log gathering but not for infrastructure provisioning."
+  default = null
+}

--- a/data/data/azure/cluster/variables.tf
+++ b/data/data/azure/cluster/variables.tf
@@ -52,6 +52,11 @@ variable "master_subnet_id" {
   description = "The subnet ID for the bootstrap node."
 }
 
+variable "worker_subnet_id" {
+  type    = string
+  default = null
+}
+
 variable "nsg_name" {
   type        = string
   description = "The network security group for the subnet."
@@ -91,4 +96,15 @@ completely and therefore the `vnet/public-lb.tf`
 conditional need to be recreated. See
 https://github.com/hashicorp/terraform/issues/12570
 EOF
+}
+
+variable "bootstrap_ip" {
+  type = string
+  description = "The ip of the bootstrap node. Used for log gathering but not for infrastructure provisioning."
+  default = null
+}
+
+variable "control_plane_ips" {
+  type = list(string)
+  default = []
 }

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -58,10 +58,6 @@ output "identity" {
   value = azurerm_user_assigned_identity.main.id
 }
 
-output "subnet_id" {
-  value = local.master_subnet_id
-}
-
 output "storage_account" {
   value = azurerm_storage_account.cluster
 }

--- a/data/data/gcp/bootstrap/variables.tf
+++ b/data/data/gcp/bootstrap/variables.tf
@@ -1,3 +1,13 @@
+variable "cluster_ip" {
+  type    = string
+  default = null
+}
+
+variable "cluster_public_ip" {
+  type    = string
+  default = null
+}
+
 variable "network" {
   type = string
 }
@@ -6,6 +16,43 @@ variable "master_subnet" {
   type = string
 }
 
+variable "api_health_checks" {
+  type = list
+}
+
+variable "api_internal_health_checks" {
+  type = list
+}
+
+variable "master_instances" {
+  type = list
+}
+
+variable "master_instance_groups" {
+  type = list
+}
+
 variable "compute_image" {
   type = string
+}
+
+variable "control_plane_ips" {
+  type = list
+}
+
+variable "bootstrap_ip" {
+  type    = string
+  default = null
+}
+
+variable "bootstrap_instances" {
+  type        = list
+  default     = []
+  description = "The bootstrap instance."
+}
+
+variable "bootstrap_instance_groups" {
+  type        = list
+  default     = []
+  description = "The bootstrap instance groups."
 }

--- a/data/data/gcp/post-bootstrap/variables.tf
+++ b/data/data/gcp/post-bootstrap/variables.tf
@@ -1,11 +1,27 @@
-variable "bootstrap_instances" {
-  type        = list
-  description = "The bootstrap instance."
+variable "cluster_ip" {
+  type = string
 }
 
-variable "bootstrap_instance_groups" {
-  type        = list
-  description = "The bootstrap instance groups."
+variable "cluster_public_ip" {
+  type        = string
+  default     = null
+  description = "IP of the API load balancer; it is null with the internal publishing strategy."
+}
+
+variable "network" {
+  type = string
+}
+
+variable "master_subnet" {
+  type = string
+}
+
+variable "api_health_checks" {
+  type = list
+}
+
+variable "api_internal_health_checks" {
+  type = list
 }
 
 variable "master_instances" {
@@ -18,28 +34,25 @@ variable "master_instance_groups" {
   description = "The master instance groups."
 }
 
-variable "network" {
+variable "compute_image" {
   type = string
 }
 
-variable "master_subnet" {
-  type = string
-}
-
-variable "cluster_ip" {
-  type = string
-}
-
-variable "cluster_public_ip" {
-  type        = string
-  default     = null
-  description = "IP of the API load balancer; it is null with the internal publishing strategy."
-}
-
-variable "api_health_checks" {
+variable "control_plane_ips" {
   type = list
 }
 
-variable "api_internal_health_checks" {
-  type = list
+variable "bootstrap_ip" {
+  type    = string
+  default = null
+}
+
+variable "bootstrap_instances" {
+  type        = list
+  description = "The bootstrap instance."
+}
+
+variable "bootstrap_instance_groups" {
+  type        = list
+  description = "The bootstrap instance groups."
 }


### PR DESCRIPTION
If a Terraform stage receives input (from tf vars)
which is not declared, it results in a warning:

level=debug msg="Warning: Value for undeclared variable"

This suppresses those warnings for GA platforms by
declaring input for all declared outputs from previous
stages.

This builds on https://github.com/openshift/installer/pull/5187