### PR TITLE
Bug 2003113: Improve host role management during assets creation

### DIFF
--- a/data/data/baremetal/main.tf
+++ b/data/data/baremetal/main.tf
@@ -28,7 +28,7 @@ module "masters" {
 
   master_count   = var.master_count
   ignition       = var.ignition_master
-  hosts          = var.hosts
+  masters        = var.masters
   properties     = var.properties
   root_devices   = var.root_devices
   driver_infos   = var.driver_infos

--- a/data/data/baremetal/masters/main.tf
+++ b/data/data/baremetal/masters/main.tf
@@ -1,6 +1,6 @@
 resource "ironic_node_v1" "openshift-master-host" {
   count          = var.master_count
-  name           = var.hosts[count.index]["name"]
+  name           = var.masters[count.index]["name"]
   resource_class = "baremetal"
 
   inspect   = true
@@ -9,7 +9,7 @@ resource "ironic_node_v1" "openshift-master-host" {
 
   ports = [
     {
-      address     = var.hosts[count.index]["port_address"]
+      address     = var.masters[count.index]["port_address"]
       pxe_enabled = "true"
     },
   ]
@@ -17,14 +17,14 @@ resource "ironic_node_v1" "openshift-master-host" {
   properties  = var.properties[count.index]
   root_device = var.root_devices[count.index]
 
-  driver      = var.hosts[count.index]["driver"]
+  driver      = var.masters[count.index]["driver"]
   driver_info = var.driver_infos[count.index]
 
-  boot_interface       = var.hosts[count.index]["boot_interface"]
-  management_interface = var.hosts[count.index]["management_interface"]
-  power_interface      = var.hosts[count.index]["power_interface"]
-  raid_interface       = var.hosts[count.index]["raid_interface"]
-  vendor_interface     = var.hosts[count.index]["vendor_interface"]
+  boot_interface       = var.masters[count.index]["boot_interface"]
+  management_interface = var.masters[count.index]["management_interface"]
+  power_interface      = var.masters[count.index]["power_interface"]
+  raid_interface       = var.masters[count.index]["raid_interface"]
+  vendor_interface     = var.masters[count.index]["vendor_interface"]
 }
 
 resource "ironic_deployment" "openshift-master-deployment" {

--- a/data/data/baremetal/masters/variables.tf
+++ b/data/data/baremetal/masters/variables.tf
@@ -9,27 +9,27 @@ variable "ignition" {
   description = "The content of the master ignition file"
 }
 
-variable "hosts" {
+variable "masters" {
   type        = list(map(string))
-  description = "Hardware details for hosts"
+  description = "Hardware details for masters"
 }
 
 variable "properties" {
   type        = list(map(string))
-  description = "Properties for hosts"
+  description = "Properties for masters"
 }
 
 variable "root_devices" {
   type        = list(map(string))
-  description = "Root devices for hosts"
+  description = "Root devices for masters"
 }
 
 variable "driver_infos" {
   type        = list(map(string))
-  description = "BMC information for hosts"
+  description = "BMC information for masters"
 }
 
 variable "instance_infos" {
   type        = list(map(string))
-  description = "Instance information for hosts"
+  description = "Instance information for masters"
 }

--- a/data/data/baremetal/variables-baremetal.tf
+++ b/data/data/baremetal/variables-baremetal.tf
@@ -28,9 +28,9 @@ variable "ironic_password" {
   description = "Password for authentication to Ironic"
 }
 
-variable "hosts" {
+variable "masters" {
   type        = list(map(string))
-  description = "Hardware details for hosts"
+  description = "Hardware details for masters"
 }
 
 variable "bridges" {
@@ -40,20 +40,20 @@ variable "bridges" {
 
 variable "properties" {
   type        = list(map(string))
-  description = "Properties for hosts"
+  description = "Properties for masters"
 }
 
 variable "root_devices" {
   type        = list(map(string))
-  description = "Root devices for hosts"
+  description = "Root devices for masters"
 }
 
 variable "driver_infos" {
   type        = list(map(string))
-  description = "BMC information for hosts"
+  description = "BMC information for masters"
 }
 
 variable "instance_infos" {
   type        = list(map(string))
-  description = "Instance information for hosts"
+  description = "Instance information for masters"
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -525,6 +525,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 
 		data, err = baremetaltfvars.TFVars(
+			*installConfig.Config.ControlPlane.Replicas,
 			installConfig.Config.Platform.BareMetal.LibvirtURI,
 			installConfig.Config.Platform.BareMetal.APIVIP,
 			imageCacheIP,

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -74,7 +74,7 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 
 		var dhcpAllowList []string
 		for _, host := range config.Hosts {
-			if host.Role == "master" {
+			if host.IsMaster() {
 				dhcpAllowList = append(dhcpAllowList, host.BootMACAddress)
 			}
 		}

--- a/pkg/asset/machines/baremetal/hosts.go
+++ b/pkg/asset/machines/baremetal/hosts.go
@@ -12,6 +12,7 @@ import (
 	baremetalhost "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/baremetal"
 )
 
 // HostSettings hold the information needed to build the manifests to
@@ -25,6 +26,64 @@ type HostSettings struct {
 	Secrets []corev1.Secret
 }
 
+func createSecret(host *baremetal.Host) (*corev1.Secret, baremetalhost.BMCDetails) {
+	bmc := baremetalhost.BMCDetails{}
+	if host.BMC.Username != "" && host.BMC.Password != "" {
+		// Each host needs a secret to hold the credentials for
+		// communicating with the management controller that drives
+		// that host.
+		secret := &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-bmc-secret", host.Name),
+				Namespace: "openshift-machine-api",
+			},
+			Data: map[string][]byte{
+				"username": []byte(host.BMC.Username),
+				"password": []byte(host.BMC.Password),
+			},
+		}
+		bmc.Address = host.BMC.Address
+		bmc.CredentialsName = secret.Name
+		bmc.DisableCertificateVerification = host.BMC.DisableCertificateVerification
+
+		return secret, bmc
+	}
+	return nil, bmc
+}
+
+func createBaremetalHost(host *baremetal.Host, bmc baremetalhost.BMCDetails) baremetalhost.BareMetalHost {
+
+	// Map string 'default' to hardware.DefaultProfileName
+	if host.HardwareProfile == "default" {
+		host.HardwareProfile = hardware.DefaultProfileName
+	}
+
+	newHost := baremetalhost.BareMetalHost{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: baremetalhost.GroupVersion.String(),
+			Kind:       "BareMetalHost",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      host.Name,
+			Namespace: "openshift-machine-api",
+		},
+		Spec: baremetalhost.BareMetalHostSpec{
+			Online:          true,
+			BMC:             bmc,
+			BootMACAddress:  host.BootMACAddress,
+			HardwareProfile: host.HardwareProfile,
+			BootMode:        baremetalhost.BootMode(host.BootMode),
+			RootDeviceHints: host.RootDeviceHints.MakeCRDHints(),
+		},
+	}
+
+	return newHost
+}
+
 // Hosts returns the HostSettings with details of the hardware being
 // used to construct the cluster.
 func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSettings, error) {
@@ -34,68 +93,27 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 		return nil, fmt.Errorf("no baremetal platform in configuration")
 	}
 
-	for i, host := range config.Platform.BareMetal.Hosts {
-		bmc := baremetalhost.BMCDetails{}
-		if host.BMC.Username != "" && host.BMC.Password != "" {
-			// Each host needs a secret to hold the credentials for
-			// communicating with the management controller that drives
-			// that host.
-			secret := corev1.Secret{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Secret",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("%s-bmc-secret", host.Name),
-					Namespace: "openshift-machine-api",
-				},
-				Data: map[string][]byte{
-					"username": []byte(host.BMC.Username),
-					"password": []byte(host.BMC.Password),
-				},
-			}
-			bmc.Address = host.BMC.Address
-			bmc.CredentialsName = secret.Name
-			bmc.DisableCertificateVerification = host.BMC.DisableCertificateVerification
-			settings.Secrets = append(settings.Secrets, secret)
-		}
+	numRequiredMasters := len(machines)
+	numMasters := 0
+	for _, host := range config.Platform.BareMetal.Hosts {
 
-		// Map string 'default' to hardware.DefaultProfileName
-		if host.HardwareProfile == "default" {
-			host.HardwareProfile = hardware.DefaultProfileName
+		secret, bmc := createSecret(host)
+		if secret != nil {
+			settings.Secrets = append(settings.Secrets, *secret)
 		}
+		newHost := createBaremetalHost(host, bmc)
 
-		newHost := baremetalhost.BareMetalHost{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: baremetalhost.GroupVersion.String(),
-				Kind:       "BareMetalHost",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      host.Name,
-				Namespace: "openshift-machine-api",
-			},
-			Spec: baremetalhost.BareMetalHostSpec{
-				Online:          true,
-				BMC:             bmc,
-				BootMACAddress:  host.BootMACAddress,
-				HardwareProfile: host.HardwareProfile,
-				BootMode:        baremetalhost.BootMode(host.BootMode),
-				RootDeviceHints: host.RootDeviceHints.MakeCRDHints(),
-			},
-		}
-		if i < len(machines) {
+		if !host.IsWorker() && numMasters < numRequiredMasters {
 			// Setting ExternallyProvisioned to true and adding a
 			// ConsumerRef without setting Image associates the host
 			// with a machine without triggering provisioning. We only
-			// want to do that for control plane hosts. We assume the
-			// first known hosts are the control plane and that the
-			// hosts are in the same order as the control plane
-			// machines.
+			// want to do that for control plane hosts.
 			newHost.Spec.ExternallyProvisioned = true
 			// Pause reconciliation until we can annotate with the initial
 			// status containing the HardwareDetails
 			newHost.ObjectMeta.Annotations = map[string]string{"baremetalhost.metal3.io/paused": ""}
-			machine := machines[i]
+			// Link the new host to the currently available machine
+			machine := machines[numMasters]
 			newHost.Spec.ConsumerRef = &corev1.ObjectReference{
 				APIVersion: machine.TypeMeta.APIVersion,
 				Kind:       machine.TypeMeta.Kind,
@@ -103,7 +121,9 @@ func Hosts(config *types.InstallConfig, machines []machineapi.Machine) (*HostSet
 				Name:       machine.ObjectMeta.Name,
 			}
 			newHost.Spec.Online = true
+			numMasters++
 		}
+
 		settings.Hosts = append(settings.Hosts, newHost)
 	}
 

--- a/pkg/asset/machines/baremetal/hosts_test.go
+++ b/pkg/asset/machines/baremetal/hosts_test.go
@@ -1,6 +1,7 @@
 package baremetal
 
 import (
+	"fmt"
 	"testing"
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
@@ -59,7 +60,7 @@ func TestHosts(t *testing.T) {
 				hosts(host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
 		},
 		{
-			Scenario: "3-hosts-3-machines",
+			Scenario: "3-hosts-3-machines-norole-all",
 			Machines: machines(
 				machine("machine-0"),
 				machine("machine-1"),
@@ -113,19 +114,46 @@ func TestHosts(t *testing.T) {
 				hostType("master-0").bmc("usr0", "pwd0"),
 				hostType("master-1").bmc("usr1", "pwd1"),
 				hostType("master-2").bmc("usr2", "pwd2"),
-				hostType("master-3").bmc("usr3", "pwd3")),
+				hostType("worker-0").bmc("wrk0", "pwd0")),
 
 			ExpectedSetting: settings().
 				secrets(
 					secret("master-0-bmc-secret").data("usr0", "pwd0"),
 					secret("master-1-bmc-secret").data("usr1", "pwd1"),
 					secret("master-2-bmc-secret").data("usr2", "pwd2"),
-					secret("master-3-bmc-secret").data("usr3", "pwd3")).
+					secret("worker-0-bmc-secret").data("wrk0", "pwd0")).
 				hosts(
 					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
 					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
 					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("master-3")).build(),
+					host("worker-0")).build(),
+		},
+		{
+			Scenario: "5-hosts-3-machines",
+			Machines: machines(
+				machine("machine-0"),
+				machine("machine-1"),
+				machine("machine-2")),
+			Config: configHosts(
+				hostType("master-0").bmc("usr0", "pwd0").role("master"),
+				hostType("master-1").bmc("usr1", "pwd1").role("master"),
+				hostType("master-2").bmc("usr2", "pwd2").role("master"),
+				hostType("worker-0").bmc("wrk0", "pwd0").role("worker"),
+				hostType("worker-1").bmc("wrk1", "pwd1").role("worker")),
+
+			ExpectedSetting: settings().
+				secrets(
+					secret("master-0-bmc-secret").data("usr0", "pwd0"),
+					secret("master-1-bmc-secret").data("usr1", "pwd1"),
+					secret("master-2-bmc-secret").data("usr2", "pwd2"),
+					secret("worker-0-bmc-secret").data("wrk0", "pwd0"),
+					secret("worker-1-bmc-secret").data("wrk1", "pwd1")).
+				hosts(
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("worker-0"),
+					host("worker-1")).build(),
 		},
 		{
 			Scenario: "5-hosts-3-machines-mixed",
@@ -134,71 +162,73 @@ func TestHosts(t *testing.T) {
 				machine("machine-1"),
 				machine("machine-2")),
 			Config: configHosts(
-				hostType("master-0").bmc("usr0", "pwd0").role("master"),
-				hostType("worker-0").bmc("wrk0", "pwd0").role("worker"),
 				hostType("master-1").bmc("usr1", "pwd1").role("master"),
+				hostType("worker-0").bmc("wrk0", "pwd0").role("worker"),
 				hostType("worker-1").bmc("wrk1", "pwd1").role("worker"),
-				hostType("master-2").bmc("usr2", "pwd2").role("master")),
+				hostType("master-0").bmc("usr0", "pwd0"),
+				hostType("master-2").bmc("usr2", "pwd2")),
 
 			ExpectedSetting: settings().
 				secrets(
-					secret("master-0-bmc-secret").data("usr0", "pwd0"),
-					secret("worker-0-bmc-secret").data("wrk0", "pwd0"),
 					secret("master-1-bmc-secret").data("usr1", "pwd1"),
+					secret("worker-0-bmc-secret").data("wrk0", "pwd0"),
 					secret("worker-1-bmc-secret").data("wrk1", "pwd1"),
+					secret("master-0-bmc-secret").data("usr0", "pwd0"),
 					secret("master-2-bmc-secret").data("usr2", "pwd2")).
 				hosts(
-					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-1").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
 					host("worker-0"),
-					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
 					host("worker-1"),
+					host("master-0").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
 					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
 		},
 		{
-			Scenario: "5-hosts-3-machines-mixed-norole",
+			Scenario: "4-hosts-3-machines-norole-master",
 			Machines: machines(
 				machine("machine-0"),
 				machine("machine-1"),
 				machine("machine-2")),
 			Config: configHosts(
-				hostType("master-0").bmc("usr0", "pwd0"),
 				hostType("worker-0").bmc("wrk0", "pwd0").role("worker"),
-				hostType("master-1").bmc("usr1", "pwd1").role("master"),
-				hostType("worker-1").bmc("wrk1", "pwd1").role("worker"),
+				hostType("master-0").bmc("usr0", "pwd0"),
+				hostType("master-1").bmc("usr1", "pwd1"),
 				hostType("master-2").bmc("usr2", "pwd2")),
 
 			ExpectedSetting: settings().
 				secrets(
-					secret("master-0-bmc-secret").data("usr0", "pwd0"),
 					secret("worker-0-bmc-secret").data("wrk0", "pwd0"),
+					secret("master-0-bmc-secret").data("usr0", "pwd0"),
 					secret("master-1-bmc-secret").data("usr1", "pwd1"),
-					secret("worker-1-bmc-secret").data("wrk1", "pwd1"),
 					secret("master-2-bmc-secret").data("usr2", "pwd2")).
 				hosts(
-					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
 					host("worker-0"),
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
 					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("worker-1"),
 					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
 		},
 		{
-			Scenario: "3-hosts-mixed",
+			Scenario: "4-hosts-3-machines-norole-worker",
 			Machines: machines(
-				machine("machine-0")),
+				machine("machine-0"),
+				machine("machine-1"),
+				machine("machine-2")),
 			Config: configHosts(
-				hostType("server-0").bmc("usr0", "pwd0"),
-				hostType("server-1").bmc("usr1", "pwd1"),
-				hostType("server-2").bmc("usr2", "pwd2").role("master")),
+				hostType("master-0").bmc("usr0", "pwd0").role("master"),
+				hostType("master-1").bmc("usr1", "pwd1").role("master"),
+				hostType("master-2").bmc("usr2", "pwd2").role("master"),
+				hostType("worker-0").bmc("wrk0", "pwd0")),
 
 			ExpectedSetting: settings().
 				secrets(
-					secret("server-0-bmc-secret").data("usr0", "pwd0"),
-					secret("server-1-bmc-secret").data("usr1", "pwd1"),
-					secret("server-2-bmc-secret").data("usr2", "pwd2")).
+					secret("master-0-bmc-secret").data("usr0", "pwd0"),
+					secret("master-1-bmc-secret").data("usr1", "pwd1"),
+					secret("master-2-bmc-secret").data("usr2", "pwd2"),
+					secret("worker-0-bmc-secret").data("wrk0", "pwd0")).
 				hosts(
-					host("server-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
-					host("server-1"),
-					host("server-2")).build(),
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("worker-0")).build(),
 		},
 	}
 
@@ -211,7 +241,13 @@ func TestHosts(t *testing.T) {
 			}
 
 			if tc.ExpectedSetting != nil {
-				assert.Equal(t, tc.ExpectedSetting, settings)
+				for i, h := range tc.ExpectedSetting.Hosts {
+					assert.Equal(t, h, settings.Hosts[i], fmt.Sprintf("%s and %s are not equal", h.Name, settings.Hosts[i].Name))
+				}
+
+				for i, s := range tc.ExpectedSetting.Secrets {
+					assert.Equal(t, s, settings.Secrets[i], s.Name, fmt.Sprintf("%s and %s are not equal", s.Name, settings.Secrets[i].Name))
+				}
 			}
 		})
 	}

--- a/pkg/asset/machines/baremetal/hosts_test.go
+++ b/pkg/asset/machines/baremetal/hosts_test.go
@@ -1,10 +1,10 @@
 package baremetal
 
 import (
-	"fmt"
 	"testing"
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -14,240 +14,422 @@ import (
 	baremetalhost "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 )
 
-func makeConfig(nHosts int) *types.InstallConfig {
-	config := &types.InstallConfig{
-		Platform: types.Platform{
-			BareMetal: &baremetaltypes.Platform{},
-		},
-	}
-
-	config.Platform.BareMetal.Hosts = make([]*baremetaltypes.Host, nHosts)
-	for i := 0; i < nHosts; i++ {
-		config.Platform.BareMetal.Hosts[i] = &baremetaltypes.Host{
-			Name: fmt.Sprintf("host%d", i),
-			BMC: baremetaltypes.BMC{
-				Username: fmt.Sprintf("user%d", i),
-				Password: fmt.Sprintf("password%d", i),
-			},
-		}
-	}
-
-	return config
-}
-
-func makeMachines(n int) []machineapi.Machine {
-	results := []machineapi.Machine{}
-
-	for i := 0; i < n; i++ {
-		results = append(results, machineapi.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("machine%d", i),
-			},
-		})
-	}
-
-	return results
-}
-
 func TestHosts(t *testing.T) {
 	testCases := []struct {
-		Scenario    string
-		Machines    []machineapi.Machine
-		Config      *types.InstallConfig
-		Expected    HostSettings
-		ExpectError bool
+		Scenario        string
+		Machines        []machineapi.Machine
+		Config          *types.InstallConfig
+		ExpectedSecrets []corev1.Secret
+		ExpectedHosts   []baremetalhost.BareMetalHost
+		ExpectedError   string
+		ExpectedSetting *HostSettings
 	}{
 		{
-			Scenario:    "no platform",
-			Config:      &types.InstallConfig{},
-			ExpectError: true,
-		},
-
-		{
-			Scenario: "no hosts",
-			Config:   makeConfig(0),
-			Expected: HostSettings{},
-		},
-
-		{
-			Scenario: "3 hosts and machines",
-			Config:   makeConfig(3),
-			Machines: makeMachines(3),
-			Expected: HostSettings{
-				Hosts: []baremetalhost.BareMetalHost{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "host0",
-						},
-						Spec: baremetalhost.BareMetalHostSpec{
-							Online: true,
-							BMC: baremetalhost.BMCDetails{
-								CredentialsName: "host0-bmc-secret",
-							},
-							ConsumerRef: &corev1.ObjectReference{
-								Name: "machine0",
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "host1",
-						},
-						Spec: baremetalhost.BareMetalHostSpec{
-							Online: true,
-							BMC: baremetalhost.BMCDetails{
-								CredentialsName: "host1-bmc-secret",
-							},
-							ConsumerRef: &corev1.ObjectReference{
-								Name: "machine1",
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "host2",
-						},
-						Spec: baremetalhost.BareMetalHostSpec{
-							Online: true,
-							BMC: baremetalhost.BMCDetails{
-								CredentialsName: "host2-bmc-secret",
-							},
-							ConsumerRef: &corev1.ObjectReference{
-								Name: "machine2",
-							},
-						},
-					},
+			Scenario: "no-platform",
+			Config: &types.InstallConfig{
+				Platform: types.Platform{
+					BareMetal: nil,
 				},
 			},
-		},
 
+			ExpectedError: "no baremetal platform in configuration",
+		},
 		{
-			Scenario: "4 hosts and 3 machines",
-			Config:   makeConfig(4),
-			Machines: makeMachines(3),
-			Expected: HostSettings{
-				Hosts: []baremetalhost.BareMetalHost{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "host0",
-						},
-						Spec: baremetalhost.BareMetalHostSpec{
-							Online: true,
-							BMC: baremetalhost.BMCDetails{
-								CredentialsName: "host0-bmc-secret",
-							},
-							ConsumerRef: &corev1.ObjectReference{
-								Name: "machine0",
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "host1",
-						},
-						Spec: baremetalhost.BareMetalHostSpec{
-							Online: true,
-							BMC: baremetalhost.BMCDetails{
-								CredentialsName: "host1-bmc-secret",
-							},
-							ConsumerRef: &corev1.ObjectReference{
-								Name: "machine1",
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "host2",
-						},
-						Spec: baremetalhost.BareMetalHostSpec{
-							Online: true,
-							BMC: baremetalhost.BMCDetails{
-								CredentialsName: "host2-bmc-secret",
-							},
-							ConsumerRef: &corev1.ObjectReference{
-								Name: "machine2",
-							},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "host3",
-						},
-						Spec: baremetalhost.BareMetalHostSpec{
-							Online: true,
-							BMC: baremetalhost.BMCDetails{
-								CredentialsName: "host3-bmc-secret",
-							},
-						},
-					},
-				},
-			},
+			Scenario: "no-hosts",
+			Config:   config().build(),
+
+			ExpectedSetting: settings().build(),
+		},
+		{
+			Scenario: "default",
+			Machines: machines(machine("machine-0")),
+			Config:   configHosts(hostType("master-0").bmc("usr0", "pwd0").role("master")),
+
+			ExpectedSetting: settings().
+				secrets(secret("master-0-bmc-secret").data("usr0", "pwd0")).
+				hosts(host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+		},
+		{
+			Scenario: "default-norole",
+			Machines: machines(machine("machine-0")),
+			Config:   configHosts(hostType("master-0").bmc("usr0", "pwd0")),
+
+			ExpectedSetting: settings().
+				secrets(secret("master-0-bmc-secret").data("usr0", "pwd0")).
+				hosts(host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+		},
+		{
+			Scenario: "3-hosts-3-machines",
+			Machines: machines(
+				machine("machine-0"),
+				machine("machine-1"),
+				machine("machine-2")),
+			Config: configHosts(
+				hostType("master-0").bmc("usr0", "pwd0"),
+				hostType("master-1").bmc("usr1", "pwd1"),
+				hostType("master-2").bmc("usr2", "pwd2")),
+
+			ExpectedSetting: settings().
+				secrets(
+					secret("master-0-bmc-secret").data("usr0", "pwd0"),
+					secret("master-1-bmc-secret").data("usr1", "pwd1"),
+					secret("master-2-bmc-secret").data("usr2", "pwd2")).
+				hosts(
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+		},
+		{
+			Scenario: "4-hosts-3-machines",
+			Machines: machines(
+				machine("machine-0"),
+				machine("machine-1"),
+				machine("machine-2")),
+			Config: configHosts(
+				hostType("master-0").bmc("usr0", "pwd0").role("master"),
+				hostType("master-1").bmc("usr1", "pwd1").role("master"),
+				hostType("master-2").bmc("usr2", "pwd2").role("master"),
+				hostType("master-3").bmc("usr3", "pwd3").role("worker")),
+
+			ExpectedSetting: settings().
+				secrets(
+					secret("master-0-bmc-secret").data("usr0", "pwd0"),
+					secret("master-1-bmc-secret").data("usr1", "pwd1"),
+					secret("master-2-bmc-secret").data("usr2", "pwd2"),
+					secret("master-3-bmc-secret").data("usr3", "pwd3")).
+				hosts(
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-3")).build(),
+		},
+		{
+			Scenario: "4-hosts-3-machines-norole",
+			Machines: machines(
+				machine("machine-0"),
+				machine("machine-1"),
+				machine("machine-2")),
+			Config: configHosts(
+				hostType("master-0").bmc("usr0", "pwd0"),
+				hostType("master-1").bmc("usr1", "pwd1"),
+				hostType("master-2").bmc("usr2", "pwd2"),
+				hostType("master-3").bmc("usr3", "pwd3")),
+
+			ExpectedSetting: settings().
+				secrets(
+					secret("master-0-bmc-secret").data("usr0", "pwd0"),
+					secret("master-1-bmc-secret").data("usr1", "pwd1"),
+					secret("master-2-bmc-secret").data("usr2", "pwd2"),
+					secret("master-3-bmc-secret").data("usr3", "pwd3")).
+				hosts(
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("master-3")).build(),
+		},
+		{
+			Scenario: "5-hosts-3-machines-mixed",
+			Machines: machines(
+				machine("machine-0"),
+				machine("machine-1"),
+				machine("machine-2")),
+			Config: configHosts(
+				hostType("master-0").bmc("usr0", "pwd0").role("master"),
+				hostType("worker-0").bmc("wrk0", "pwd0").role("worker"),
+				hostType("master-1").bmc("usr1", "pwd1").role("master"),
+				hostType("worker-1").bmc("wrk1", "pwd1").role("worker"),
+				hostType("master-2").bmc("usr2", "pwd2").role("master")),
+
+			ExpectedSetting: settings().
+				secrets(
+					secret("master-0-bmc-secret").data("usr0", "pwd0"),
+					secret("worker-0-bmc-secret").data("wrk0", "pwd0"),
+					secret("master-1-bmc-secret").data("usr1", "pwd1"),
+					secret("worker-1-bmc-secret").data("wrk1", "pwd1"),
+					secret("master-2-bmc-secret").data("usr2", "pwd2")).
+				hosts(
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("worker-0"),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("worker-1"),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+		},
+		{
+			Scenario: "5-hosts-3-machines-mixed-norole",
+			Machines: machines(
+				machine("machine-0"),
+				machine("machine-1"),
+				machine("machine-2")),
+			Config: configHosts(
+				hostType("master-0").bmc("usr0", "pwd0"),
+				hostType("worker-0").bmc("wrk0", "pwd0").role("worker"),
+				hostType("master-1").bmc("usr1", "pwd1").role("master"),
+				hostType("worker-1").bmc("wrk1", "pwd1").role("worker"),
+				hostType("master-2").bmc("usr2", "pwd2")),
+
+			ExpectedSetting: settings().
+				secrets(
+					secret("master-0-bmc-secret").data("usr0", "pwd0"),
+					secret("worker-0-bmc-secret").data("wrk0", "pwd0"),
+					secret("master-1-bmc-secret").data("usr1", "pwd1"),
+					secret("worker-1-bmc-secret").data("wrk1", "pwd1"),
+					secret("master-2-bmc-secret").data("usr2", "pwd2")).
+				hosts(
+					host("master-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("worker-0"),
+					host("master-1").consumerRef("machine-1").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("worker-1"),
+					host("master-2").consumerRef("machine-2").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned()).build(),
+		},
+		{
+			Scenario: "3-hosts-mixed",
+			Machines: machines(
+				machine("machine-0")),
+			Config: configHosts(
+				hostType("server-0").bmc("usr0", "pwd0"),
+				hostType("server-1").bmc("usr1", "pwd1"),
+				hostType("server-2").bmc("usr2", "pwd2").role("master")),
+
+			ExpectedSetting: settings().
+				secrets(
+					secret("server-0-bmc-secret").data("usr0", "pwd0"),
+					secret("server-1-bmc-secret").data("usr1", "pwd1"),
+					secret("server-2-bmc-secret").data("usr2", "pwd2")).
+				hosts(
+					host("server-0").consumerRef("machine-0").annotation("baremetalhost.metal3.io/paused", "").externallyProvisioned(),
+					host("server-1"),
+					host("server-2")).build(),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			actual, err := Hosts(tc.Config, tc.Machines)
+			settings, err := Hosts(tc.Config, tc.Machines)
 
-			if tc.ExpectError {
-				if err == nil {
-					t.Error("expected error but did not get one")
-				}
-			} else {
+			if tc.ExpectedError != "" {
+				assert.EqualError(t, err, tc.ExpectedError)
+			}
 
-				if err != nil {
-					t.Error("did not expect error but got one")
-					return
-				}
-
-				if len(tc.Expected.Hosts) != len(actual.Hosts) {
-					t.Errorf("Expected %d hosts but received %d (%v)",
-						len(tc.Expected.Hosts),
-						len(actual.Hosts),
-						actual.Hosts,
-					)
-					return
-				}
-
-				if len(tc.Expected.Hosts) != len(actual.Secrets) {
-					t.Errorf("Expected %d secrets to go with hosts, got %d",
-						len(tc.Expected.Hosts), len(actual.Secrets))
-					return
-				}
-
-				// Make sure the first few hosts that correspond to
-				// machines have their consumer ref set correctly
-				for i := 0; i < len(tc.Machines); i++ {
-					if actual.Hosts[i].Spec.ConsumerRef.Name != tc.Expected.Hosts[i].Spec.ConsumerRef.Name {
-						t.Errorf("Expected host %d to link to %q but got %q",
-							i,
-							tc.Expected.Hosts[i].Spec.ConsumerRef.Name,
-							actual.Hosts[i].Spec.ConsumerRef.Name,
-						)
-					}
-				}
-
-				// Make sure any extra hosts do not have a consumer set.
-				for i := len(actual.Hosts) - 1; i > len(tc.Machines); i-- {
-					if actual.Hosts[i].Spec.ConsumerRef != nil {
-						t.Errorf("Expected host %d to have no consumer but has %v",
-							i, actual.Hosts[i].Spec.ConsumerRef,
-						)
-					}
-				}
-
-				for i, sec := range actual.Secrets {
-					expectedName := fmt.Sprintf("host%d-bmc-secret", i)
-					if sec.Name != expectedName {
-						t.Errorf("Expected secret name %d to be %q but got %q",
-							i,
-							expectedName,
-							sec.Name,
-						)
-					}
-				}
-
+			if tc.ExpectedSetting != nil {
+				assert.Equal(t, tc.ExpectedSetting, settings)
 			}
 		})
+	}
+}
+
+func configHosts(builders ...*hostTypeBuilder) *types.InstallConfig {
+	return config().hosts(builders...).build()
+}
+
+type installConfigBuilder struct {
+	types.InstallConfig
+}
+
+func (ib *installConfigBuilder) build() *types.InstallConfig {
+	return &ib.InstallConfig
+}
+
+func config() *installConfigBuilder {
+	return &installConfigBuilder{
+		types.InstallConfig{
+			Platform: types.Platform{
+				BareMetal: &baremetaltypes.Platform{},
+			},
+		},
+	}
+}
+
+func (ib *installConfigBuilder) hosts(builders ...*hostTypeBuilder) *installConfigBuilder {
+	ib.Platform.BareMetal.Hosts = []*baremetaltypes.Host{}
+
+	for _, hb := range builders {
+		ib.Platform.BareMetal.Hosts = append(ib.Platform.BareMetal.Hosts, hb.build())
+	}
+	return ib
+}
+
+type hostTypeBuilder struct {
+	baremetaltypes.Host
+}
+
+func (htb *hostTypeBuilder) build() *baremetaltypes.Host {
+	return &htb.Host
+}
+
+func hostType(name string) *hostTypeBuilder {
+	return &hostTypeBuilder{
+		Host: baremetaltypes.Host{
+			Name:           name,
+			BootMACAddress: "c0:ff:ee:ca:fe:00",
+			BootMode:       baremetaltypes.UEFI,
+			RootDeviceHints: &baremetaltypes.RootDeviceHints{
+				DeviceName: "userd_devicename",
+			},
+		},
+	}
+}
+
+func (htb *hostTypeBuilder) role(role string) *hostTypeBuilder {
+	htb.Role = role
+	return htb
+}
+
+func (htb *hostTypeBuilder) bmc(user, password string) *hostTypeBuilder {
+	htb.BMC = baremetaltypes.BMC{
+		Username: user,
+		Password: password,
+	}
+	return htb
+}
+
+type machineBuilder struct {
+	machineapi.Machine
+}
+
+func (mb *machineBuilder) build() *machineapi.Machine {
+	return &mb.Machine
+}
+
+func machine(name string) *machineBuilder {
+	return &machineBuilder{
+		machineapi.Machine{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Machine",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "namespace",
+			},
+		},
+	}
+}
+
+func machines(builders ...*machineBuilder) []machineapi.Machine {
+	m := []machineapi.Machine{}
+
+	for _, mb := range builders {
+		m = append(m, *mb.build())
+	}
+	return m
+}
+
+type hostBuilder struct {
+	baremetalhost.BareMetalHost
+}
+
+func host(name string) *hostBuilder {
+	return &hostBuilder{
+		baremetalhost.BareMetalHost{
+
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "metal3.io/v1alpha1",
+				Kind:       "BareMetalHost",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "openshift-machine-api",
+			},
+			Spec: baremetalhost.BareMetalHostSpec{
+				BMC: baremetalhost.BMCDetails{
+					CredentialsName: name + "-bmc-secret",
+				},
+				RootDeviceHints: &baremetalhost.RootDeviceHints{
+					DeviceName: "userd_devicename",
+				},
+				BootMode:       "UEFI",
+				BootMACAddress: "c0:ff:ee:ca:fe:00",
+				Online:         true,
+			},
+		},
+	}
+}
+
+func (hb *hostBuilder) build() *baremetalhost.BareMetalHost {
+	return &hb.BareMetalHost
+}
+
+func (hb *hostBuilder) externallyProvisioned() *hostBuilder {
+	hb.Spec.ExternallyProvisioned = true
+	return hb
+}
+
+func (hb *hostBuilder) annotation(key, value string) *hostBuilder {
+	if hb.Annotations == nil {
+		hb.Annotations = map[string]string{}
+	}
+
+	hb.Annotations[key] = value
+	return hb
+}
+
+func (hb *hostBuilder) consumerRef(name string) *hostBuilder {
+	hb.Spec.ConsumerRef = &corev1.ObjectReference{
+		APIVersion: "v1",
+		Kind:       "Machine",
+		Namespace:  "namespace",
+		Name:       name,
+	}
+	return hb
+}
+
+type secretBuilder struct {
+	corev1.Secret
+}
+
+func secret(name string) *secretBuilder {
+	return &secretBuilder{
+		corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "openshift-machine-api",
+			},
+		},
+	}
+}
+
+func (sb *secretBuilder) data(user, password string) *secretBuilder {
+	sb.Data = map[string][]byte{
+		"username": []byte(user),
+		"password": []byte(password),
+	}
+	return sb
+}
+
+func (sb *secretBuilder) build() *corev1.Secret {
+	return &sb.Secret
+}
+
+type hostSettingsBuilder struct {
+	HostSettings
+}
+
+func (hsb *hostSettingsBuilder) secrets(builders ...*secretBuilder) *hostSettingsBuilder {
+	hsb.Secrets = []corev1.Secret{}
+	for _, sb := range builders {
+		hsb.Secrets = append(hsb.Secrets, *sb.build())
+	}
+	return hsb
+}
+
+func (hsb *hostSettingsBuilder) hosts(builders ...*hostBuilder) *hostSettingsBuilder {
+	hsb.Hosts = []baremetalhost.BareMetalHost{}
+	for _, hb := range builders {
+		hsb.Hosts = append(hsb.Hosts, *hb.build())
+	}
+	return hsb
+}
+
+func (hsb *hostSettingsBuilder) build() *HostSettings {
+	return &hsb.HostSettings
+}
+
+func settings() *hostSettingsBuilder {
+	return &hostSettingsBuilder{
+		HostSettings: HostSettings{},
 	}
 }

--- a/pkg/tfvars/baremetal/baremetal_test.go
+++ b/pkg/tfvars/baremetal/baremetal_test.go
@@ -43,11 +43,11 @@ func TestMastersSelectionByRole(t *testing.T) {
 			expectedHosts: []string{"master-0", "master-1"},
 		},
 		{
-			scenario:                "mixed-order",
+			scenario:                "filter-all-workers",
 			numControlPlaneReplicas: 1,
 			platformHosts: platformHosts(
-				host("worker-0", "worker"),
 				host("master-0", "master"),
+				host("worker-0", "worker"),
 				host("worker-1", "worker"),
 			),
 			expectedHosts: []string{"master-0"},
@@ -56,8 +56,8 @@ func TestMastersSelectionByRole(t *testing.T) {
 			scenario:                "hosts-norole",
 			numControlPlaneReplicas: 2,
 			platformHosts: platformHosts(
-				host("master-0", ""),
 				host("worker-0", "worker"),
+				host("master-0", ""),
 				host("master-1", ""),
 			),
 			expectedHosts: []string{"master-0", "master-1"},
@@ -73,7 +73,17 @@ func TestMastersSelectionByRole(t *testing.T) {
 			expectedHosts: []string{"master-0", "master-1", "master-2"},
 		},
 		{
-			scenario:                "more-hosts-than-required",
+			scenario:                "more-masters-than-required",
+			numControlPlaneReplicas: 2,
+			platformHosts: platformHosts(
+				host("master-0", "master"),
+				host("master-1", "master"),
+				host("master-2", "master"),
+			),
+			expectedHosts: []string{"master-0", "master-1"},
+		},
+		{
+			scenario:                "more-hosts-than-required-mixed",
 			numControlPlaneReplicas: 2,
 			platformHosts: platformHosts(
 				host("master-0", "master"),
@@ -93,27 +103,17 @@ func TestMastersSelectionByRole(t *testing.T) {
 			expectedHosts: []string{"master-0", "master-1"},
 		},
 		{
-			scenario:                "more-hosts-than-required-mixed",
+			scenario:                "more-hosts-than-required-mixed-again",
 			numControlPlaneReplicas: 2,
 			platformHosts: platformHosts(
 				host("worker-0", "worker"),
-				host("master-0", ""),
 				host("worker-1", "worker"),
-				host("master-1", ""),
 				host("worker-2", "worker"),
+				host("master-0", ""),
+				host("master-1", ""),
 				host("master-2", ""),
 			),
 			expectedHosts: []string{"master-0", "master-1"},
-		},
-		{
-			scenario:                "more-masters-than-required",
-			numControlPlaneReplicas: 1,
-			platformHosts: platformHosts(
-				host("server-0", ""),
-				host("server-1", ""),
-				host("server-2", "master"),
-			),
-			expectedHosts: []string{"server-0"},
 		},
 	}
 

--- a/pkg/tfvars/baremetal/baremetal_test.go
+++ b/pkg/tfvars/baremetal/baremetal_test.go
@@ -1,0 +1,174 @@
+// Package baremetal contains bare metal specific Terraform-variable logic.
+package baremetal
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMastersSelectionByRole(t *testing.T) {
+
+	cases := []struct {
+		scenario string
+
+		numControlPlaneReplicas int64
+		libvirtURI              string
+		apiVIP                  string
+		imageCacheIP            string
+		bootstrapOSImage        string
+		externalBridge          string
+		externalMAC             string
+		provisioningBridge      string
+		provisioningMAC         string
+		platformHosts           []*baremetal.Host
+		image                   string
+		ironicUsername          string
+		ironicPassword          string
+		ignition                string
+
+		expectedError string
+		expectedHosts []string
+	}{
+		{
+			scenario:                "filter-workers",
+			numControlPlaneReplicas: 2,
+			platformHosts: platformHosts(
+				host("master-0", "master"),
+				host("master-1", "master"),
+				host("worker-0", "worker"),
+			),
+			expectedHosts: []string{"master-0", "master-1"},
+		},
+		{
+			scenario:                "mixed-order",
+			numControlPlaneReplicas: 1,
+			platformHosts: platformHosts(
+				host("worker-0", "worker"),
+				host("master-0", "master"),
+				host("worker-1", "worker"),
+			),
+			expectedHosts: []string{"master-0"},
+		},
+		{
+			scenario:                "hosts-norole",
+			numControlPlaneReplicas: 2,
+			platformHosts: platformHosts(
+				host("master-0", ""),
+				host("worker-0", "worker"),
+				host("master-1", ""),
+			),
+			expectedHosts: []string{"master-0", "master-1"},
+		},
+		{
+			scenario:                "no-role",
+			numControlPlaneReplicas: 3,
+			platformHosts: platformHosts(
+				host("master-0", ""),
+				host("master-1", ""),
+				host("master-2", ""),
+			),
+			expectedHosts: []string{"master-0", "master-1", "master-2"},
+		},
+		{
+			scenario:                "more-hosts-than-required",
+			numControlPlaneReplicas: 2,
+			platformHosts: platformHosts(
+				host("master-0", "master"),
+				host("master-1", "master"),
+				host("master-2", ""),
+			),
+			expectedHosts: []string{"master-0", "master-1"},
+		},
+		{
+			scenario:                "more-hosts-than-required-norole",
+			numControlPlaneReplicas: 2,
+			platformHosts: platformHosts(
+				host("master-0", ""),
+				host("master-1", ""),
+				host("master-2", ""),
+			),
+			expectedHosts: []string{"master-0", "master-1"},
+		},
+		{
+			scenario:                "more-hosts-than-required-mixed",
+			numControlPlaneReplicas: 2,
+			platformHosts: platformHosts(
+				host("worker-0", "worker"),
+				host("master-0", ""),
+				host("worker-1", "worker"),
+				host("master-1", ""),
+				host("worker-2", "worker"),
+				host("master-2", ""),
+			),
+			expectedHosts: []string{"master-0", "master-1"},
+		},
+		{
+			scenario:                "more-masters-than-required",
+			numControlPlaneReplicas: 1,
+			platformHosts: platformHosts(
+				host("server-0", ""),
+				host("server-1", ""),
+				host("server-2", "master"),
+			),
+			expectedHosts: []string{"server-0"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.scenario, func(t *testing.T) {
+
+			imageDownloader = func(baseURL string) (string, error) {
+				return "", nil
+			}
+
+			data, err := TFVars(
+				tc.numControlPlaneReplicas,
+				tc.libvirtURI,
+				tc.apiVIP,
+				tc.imageCacheIP,
+				tc.bootstrapOSImage,
+				tc.externalBridge,
+				tc.externalMAC,
+				tc.provisioningBridge,
+				tc.provisioningMAC,
+				tc.platformHosts,
+				tc.image,
+				tc.ironicUsername,
+				tc.ironicPassword,
+				tc.ignition)
+
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, tc.expectedError, err)
+			}
+
+			var cfg config
+			err = json.Unmarshal(data, &cfg)
+			assert.Nil(t, err)
+
+			assert.Equal(t, len(tc.expectedHosts), len(cfg.Masters))
+			for i, hostName := range tc.expectedHosts {
+				assert.Equal(t, hostName, cfg.Masters[i]["name"])
+			}
+		})
+	}
+}
+
+func host(name, tag string) *baremetal.Host {
+	return &baremetal.Host{
+		Name:            name,
+		Role:            tag,
+		HardwareProfile: "default",
+		BMC: baremetal.BMC{
+			Address: "redfish+http://192.168.111.1:8000/redfish/v1/Systems/e4427260-6250-4df9-9e8a-120f78a46aa6",
+		},
+	}
+}
+
+func platformHosts(hosts ...*baremetal.Host) []*baremetal.Host {
+	return hosts
+}

--- a/pkg/types/baremetal/defaults/platform.go
+++ b/pkg/types/baremetal/defaults/platform.go
@@ -2,8 +2,10 @@ package defaults
 
 import (
 	"fmt"
-	"github.com/openshift/installer/pkg/ipnet"
 	"net"
+	"sort"
+
+	"github.com/openshift/installer/pkg/ipnet"
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/openshift/installer/pkg/types"
@@ -115,5 +117,11 @@ func SetPlatformDefaults(p *baremetal.Platform, c *types.InstallConfig) {
 		} else {
 			p.IngressVIP = vip[0]
 		}
+	}
+
+	if p.Hosts != nil {
+		sort.SliceStable(p.Hosts, func(i, j int) bool {
+			return p.Hosts[i].CompareByRole(p.Hosts[j])
+		})
 	}
 }

--- a/pkg/types/baremetal/defaults/platform_test.go
+++ b/pkg/types/baremetal/defaults/platform_test.go
@@ -189,3 +189,86 @@ func TestSetPlatformDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestBaremetalHostsSortByRole(t *testing.T) {
+	cases := []struct {
+		name          string
+		hosts         []*baremetal.Host
+		expectedHosts []string
+	}{
+		{
+			name: "default",
+			hosts: []*baremetal.Host{
+				{Name: "master-0", Role: "master"},
+				{Name: "master-1", Role: "master"},
+				{Name: "master-2", Role: "master"},
+				{Name: "worker-0", Role: "worker"},
+				{Name: "worker-1", Role: "worker"},
+			},
+			expectedHosts: []string{
+				"master-0", "master-1", "master-2", "worker-0", "worker-1",
+			},
+		},
+		{
+			name: "norole",
+			hosts: []*baremetal.Host{
+				{Name: "master-0"},
+				{Name: "master-1"},
+				{Name: "master-2"},
+				{Name: "worker-0"},
+				{Name: "worker-1"},
+			},
+			expectedHosts: []string{
+				"master-0", "master-1", "master-2", "worker-0", "worker-1",
+			},
+		},
+		{
+			name: "mixed",
+			hosts: []*baremetal.Host{
+				{Name: "worker-0", Role: "worker"},
+				{Name: "master-0", Role: "master"},
+				{Name: "worker-1", Role: "worker"},
+				{Name: "master-1", Role: "master"},
+				{Name: "master-2", Role: "master"},
+			},
+			expectedHosts: []string{
+				"master-0", "master-1", "master-2", "worker-0", "worker-1",
+			},
+		},
+		{
+			name: "mixed-norole",
+			hosts: []*baremetal.Host{
+				{Name: "worker-0", Role: "worker"},
+				{Name: "master-0", Role: "master"},
+				{Name: "worker-1", Role: ""},
+				{Name: "master-1", Role: "master"},
+				{Name: "master-2", Role: "master"},
+			},
+			expectedHosts: []string{
+				"master-0", "master-1", "master-2", "worker-0", "worker-1",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			ic := &types.InstallConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testClusterName,
+				},
+				Platform: types.Platform{
+					BareMetal: &baremetal.Platform{
+						Hosts: tc.hosts,
+					},
+				},
+				BaseDomain: "test",
+			}
+			SetPlatformDefaults(ic.Platform.BareMetal, ic)
+
+			for i, h := range ic.Platform.BareMetal.Hosts {
+				assert.Equal(t, h.Name, tc.expectedHosts[i])
+			}
+		})
+	}
+}

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -36,6 +36,16 @@ type Host struct {
 	BootMode        BootMode         `json:"bootMode,omitempty"`
 }
 
+// IsMaster checks if the current host is a master
+func (h *Host) IsMaster() bool {
+	return h.Role == "master"
+}
+
+// IsWorker checks if the current host is a worker
+func (h *Host) IsWorker() bool {
+	return h.Role == "worker"
+}
+
 // ProvisioningNetwork determines how we will use the provisioning network.
 // +kubebuilder:validation:Enum="";Managed;Unmanaged;Disabled
 type ProvisioningNetwork string

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -25,6 +25,11 @@ const (
 	Legacy         BootMode = "legacy"
 )
 
+const (
+	masterRole string = "master"
+	workerRole string = "worker"
+)
+
 // Host stores all the configuration data for a baremetal host.
 type Host struct {
 	Name            string           `json:"name,omitempty" validate:"required,uniqueField"`
@@ -38,12 +43,19 @@ type Host struct {
 
 // IsMaster checks if the current host is a master
 func (h *Host) IsMaster() bool {
-	return h.Role == "master"
+	return h.Role == masterRole
 }
 
 // IsWorker checks if the current host is a worker
 func (h *Host) IsWorker() bool {
-	return h.Role == "worker"
+	return h.Role == workerRole
+}
+
+var sortIndex = map[string]int{masterRole: -1, workerRole: 0, "": 1}
+
+// CompareByRole allows to compare two hosts by the Role
+func (h *Host) CompareByRole(k *Host) bool {
+	return sortIndex[h.Role] < sortIndex[k.Role]
 }
 
 // ProvisioningNetwork determines how we will use the provisioning network.

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/metal3-io/baremetal-operator/pkg/bmc"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -278,21 +279,56 @@ func validateOSImages(p *baremetal.Platform, fldPath *field.Path) field.ErrorLis
 	return platformErrs
 }
 
+// ensure that the number of hosts is enough to cover the ControlPlane
+// and Compute replicas. Hosts without role will be considered eligible
+// for the ControlPlane or Compute requirements.
 func validateHostsCount(hosts []*baremetal.Host, installConfig *types.InstallConfig) error {
 
-	hostsNum := int64(len(hosts))
-	counter := int64(0)
+	numRequiredMasters := int64(0)
+	if installConfig.ControlPlane != nil && installConfig.ControlPlane.Replicas != nil {
+		numRequiredMasters += *installConfig.ControlPlane.Replicas
+	}
 
+	numRequiredWorkers := int64(0)
 	for _, worker := range installConfig.Compute {
 		if worker.Replicas != nil {
-			counter += *worker.Replicas
+			numRequiredWorkers += *worker.Replicas
 		}
 	}
-	if installConfig.ControlPlane != nil && installConfig.ControlPlane.Replicas != nil {
-		counter += *installConfig.ControlPlane.Replicas
+
+	numMasters := int64(0)
+	numWorkers := int64(0)
+
+	for _, h := range hosts {
+		// The first N hosts, not explicitly tagged with the worker role,
+		// are considered eligible as master
+		if numMasters < numRequiredMasters {
+			if !h.IsWorker() {
+				numMasters++
+			} else {
+				numWorkers++
+			}
+		} else {
+			// The remaining hosts, not explicitly tagged with the master role,
+			// are considered eligible as worker
+			if !h.IsMaster() {
+				numWorkers++
+			} else {
+				numMasters++
+			}
+		}
 	}
-	if hostsNum < counter {
-		return fmt.Errorf("not enough hosts found (%v) to support all the configured ControlPlane and Compute replicas (%v)", hostsNum, counter)
+
+	if numMasters < numRequiredMasters {
+		return fmt.Errorf("not enough hosts found (%v) to support all the configured ControlPlane replicas (%v)", numMasters, numRequiredMasters)
+	}
+
+	if numMasters > numRequiredMasters {
+		logrus.Warn("Found more hosts configured as master than required")
+	}
+
+	if numWorkers < numRequiredWorkers {
+		return fmt.Errorf("not enough hosts found (%v) to support all the configured Compute replicas (%v)", numWorkers, numRequiredWorkers)
 	}
 
 	return nil

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -67,32 +67,135 @@ func TestValidatePlatform(t *testing.T) {
 			expected: "bare metal hosts are missing",
 		},
 		{
-			name: "toofew_hosts",
+			name: "toofew_masters_norole",
 			config: installConfig().
 				BareMetalPlatform(
 					platform().Hosts(
-						host1())).
+						host1(),
+						host2().Role("worker"))).
 				ControlPlane(
 					machinePool().Replicas(3)).
 				Compute(
-					machinePool().Replicas(2),
+					machinePool().Replicas(1)).build(),
+			expected: "baremetal.Hosts: Required value: not enough hosts found \\(1\\) to support all the configured ControlPlane replicas \\(3\\)",
+		},
+		{
+			name: "toofew_masters",
+			config: installConfig().
+				BareMetalPlatform(
+					platform().Hosts(
+						host1().Role("master"),
+						host2().Role("worker"))).
+				ControlPlane(
+					machinePool().Replicas(3)).
+				Compute(
+					machinePool().Replicas(1)).build(),
+			expected: "baremetal.Hosts: Required value: not enough hosts found \\(1\\) to support all the configured ControlPlane replicas \\(3\\)",
+		},
+		{
+			name: "toofew_workers",
+			config: installConfig().
+				BareMetalPlatform(
+					platform().Hosts(
+						host1().Role("master"),
+						host2().Role("worker"))).
+				ControlPlane(
+					machinePool().Replicas(1)).
+				Compute(
 					machinePool().Replicas(3)).build(),
-			expected: "baremetal.Hosts: Required value: not enough hosts found \\(1\\) to support all the configured ControlPlane and Compute replicas \\(8\\)",
+			expected: "baremetal.Hosts: Required value: not enough hosts found \\(1\\) to support all the configured Compute replicas \\(3\\)",
 		},
 		{
 			name: "enough_hosts",
 			config: installConfig().
 				BareMetalPlatform(
 					platform().Hosts(
-						host1(),
-						host2())).
+						host1().Role("master"),
+						host2().Role("worker"))).
 				ControlPlane(
+					machinePool().Replicas(1)).
+				Compute(
+					machinePool().Replicas(1)).build(),
+		},
+		{
+			name: "enough_hosts_norole",
+			config: installConfig().
+				BareMetalPlatform(
+					platform().Hosts(
+						host1(),
+						host2(),
+						host3())).
+				ControlPlane(
+					machinePool().Replicas(1)).
+				Compute(
 					machinePool().Replicas(2)).build(),
 		},
 		{
+			name: "enough_hosts_mixed",
+			config: installConfig().
+				BareMetalPlatform(
+					platform().Hosts(
+						host1().Role("master"),
+						host2(),
+						host3(),
+						host4().Role("worker"))).
+				ControlPlane(
+					machinePool().Replicas(2)).
+				Compute(
+					machinePool().Replicas(2)).build(),
+		},
+		{
+			name: "not_enough_hosts_norole",
+			config: installConfig().
+				BareMetalPlatform(
+					platform().Hosts(
+						host1(),
+						host2(),
+						host3())).
+				ControlPlane(
+					machinePool().Replicas(2)).
+				Compute(
+					machinePool().Replicas(2)).build(),
+			expected: "baremetal.Hosts: Required value: not enough hosts found \\(1\\) to support all the configured Compute replicas \\(2\\)",
+		},
+		{
+			name: "more_than_enough_hosts",
+			config: installConfig().
+				BareMetalPlatform(
+					platform().Hosts(
+						host1().Role("master"),
+						host2().Role("master"),
+						host3(),
+						host4().Role("worker"),
+						host5().Role("worker"))).
+				ControlPlane(
+					machinePool().Replicas(1)).
+				Compute(
+					machinePool().Replicas(1)).build(),
+		},
+		{
+			name: "not_enough_workers_norole",
+			config: installConfig().
+				BareMetalPlatform(
+					platform().Hosts(
+						host1(),
+						host2(),
+						host3().Role("master"),
+						host4().Role("master"),
+						host5().Role("master"))).
+				ControlPlane(
+					machinePool().Replicas(3)).
+				Compute(
+					machinePool().Replicas(2)).build(),
+			expected: "baremetal.Hosts: Required value: not enough hosts found \\(0\\) to support all the configured Compute replicas \\(2\\)",
+		},
+		{
 			name: "missing_name",
-			platform: platform().
-				Hosts(host1().Name("")).build(),
+			config: installConfig().
+				BareMetalPlatform(
+					platform().Hosts(
+						host1().Name(""))).
+				ControlPlane(machinePool().Replicas(1)).build(),
 			expected: "baremetal.hosts\\[0\\].Name: Required value: missing Name",
 		},
 		{
@@ -548,6 +651,48 @@ func host2() *hostBuilder {
 	}
 }
 
+func host3() *hostBuilder {
+	return &hostBuilder{
+		baremetal.Host{
+			Name:           "host3",
+			BootMACAddress: "CA:FE:CA:FE:00:02",
+			BMC: baremetal.BMC{
+				Username: "root",
+				Password: "password",
+				Address:  "ipmi://192.168.111.3",
+			},
+		},
+	}
+}
+
+func host4() *hostBuilder {
+	return &hostBuilder{
+		baremetal.Host{
+			Name:           "host4",
+			BootMACAddress: "CA:FE:CA:FE:00:03",
+			BMC: baremetal.BMC{
+				Username: "root",
+				Password: "password",
+				Address:  "ipmi://192.168.111.4",
+			},
+		},
+	}
+}
+
+func host5() *hostBuilder {
+	return &hostBuilder{
+		baremetal.Host{
+			Name:           "host5",
+			BootMACAddress: "CA:FE:CA:FE:00:04",
+			BMC: baremetal.BMC{
+				Username: "root",
+				Password: "password",
+				Address:  "ipmi://192.168.111.5",
+			},
+		},
+	}
+}
+
 func (hb *hostBuilder) build() *baremetal.Host {
 	return &hb.Host
 }
@@ -579,6 +724,11 @@ func (hb *hostBuilder) BMCUsername(value string) *hostBuilder {
 
 func (hb *hostBuilder) BMCPassword(value string) *hostBuilder {
 	hb.Host.BMC.Password = value
+	return hb
+}
+
+func (hb *hostBuilder) Role(value string) *hostBuilder {
+	hb.Host.Role = value
 	return hb
 }
 

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -71,8 +71,8 @@ func TestValidatePlatform(t *testing.T) {
 			config: installConfig().
 				BareMetalPlatform(
 					platform().Hosts(
-						host1(),
-						host2().Role("worker"))).
+						host1().Role("worker"),
+						host2())).
 				ControlPlane(
 					machinePool().Replicas(3)).
 				Compute(
@@ -136,9 +136,9 @@ func TestValidatePlatform(t *testing.T) {
 				BareMetalPlatform(
 					platform().Hosts(
 						host1().Role("master"),
-						host2(),
+						host2().Role("worker"),
 						host3(),
-						host4().Role("worker"))).
+						host4())).
 				ControlPlane(
 					machinePool().Replicas(2)).
 				Compute(
@@ -165,29 +165,28 @@ func TestValidatePlatform(t *testing.T) {
 					platform().Hosts(
 						host1().Role("master"),
 						host2().Role("master"),
-						host3(),
+						host3().Role("worker"),
 						host4().Role("worker"),
-						host5().Role("worker"))).
+						host5())).
 				ControlPlane(
 					machinePool().Replicas(1)).
 				Compute(
 					machinePool().Replicas(1)).build(),
 		},
 		{
-			name: "not_enough_workers_norole",
+			name: "norole_for_workers",
 			config: installConfig().
 				BareMetalPlatform(
 					platform().Hosts(
-						host1(),
-						host2(),
+						host1().Role("master"),
+						host2().Role("master"),
 						host3().Role("master"),
-						host4().Role("master"),
-						host5().Role("master"))).
+						host4(),
+						host5())).
 				ControlPlane(
 					machinePool().Replicas(3)).
 				Compute(
 					machinePool().Replicas(2)).build(),
-			expected: "baremetal.Hosts: Required value: not enough hosts found \\(0\\) to support all the configured Compute replicas \\(2\\)",
 		},
 		{
 			name: "missing_name",

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -109,6 +109,7 @@ func validBareMetalPlatform() *baremetal.Platform {
 		Hosts: []*baremetal.Host{
 			{
 				Name:           "host1",
+				Role:           "master",
 				BootMACAddress: "CA:FE:CA:FE:00:00",
 				BMC: baremetal.BMC{
 					Username: "root",
@@ -118,6 +119,7 @@ func validBareMetalPlatform() *baremetal.Platform {
 			},
 			{
 				Name:           "host2",
+				Role:           "worker",
 				BootMACAddress: "CA:FE:CA:FE:00:01",
 				BMC: baremetal.BMC{
 					Username: "root",


### PR DESCRIPTION
The current patch provides a fix for the issue BZ 2003113.
The logic for generating baremetal manifests and Terraform variables now takes into account the host `role` tag properly, if defined.
To remain backward compatible, if an host doesn not have any role defined (or supported value), it's considered eligible for the ControlPlane or Compute respectively, based on the configured requirements.
For that, the validation rule has been enhanced to verify that the correct number of hosts have been configured.
