### PR TITLE
baremetal: Specify entrypoint when starting inspector

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -4,7 +4,6 @@ set -ex
 . /usr/local/bin/release-image.sh
 
 IRONIC_IMAGE=$(image_for ironic)
-IRONIC_INSPECTOR_IMAGE=$(image_for ironic-inspector)
 IPA_DOWNLOADER_IMAGE=$(image_for ironic-ipa-downloader)
 COREOS_DOWNLOADER_IMAGE=$(image_for ironic-machine-os-downloader || image_for ironic-rhcos-downloader)
 
@@ -177,8 +176,9 @@ podman run -d --net host --privileged --name ironic-inspector \
      --restart on-failure \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env HTTP_BASIC_HTPASSWD=${IRONIC_HTPASSWD} \
+     --entrypoint /bin/runironic-inspector \
      -v $AUTH_DIR:/auth:ro \
-     -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_INSPECTOR_IMAGE}"
+     -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_IMAGE}"
 
 sudo podman run -d --net host --privileged --name ironic-api \
      --restart on-failure \
@@ -197,7 +197,7 @@ sudo podman run -d --name ironic-deploy-ramdisk-logs \
 podman run -d --name ironic-inspector-ramdisk-logs \
      --restart on-failure \
      --entrypoint /bin/runlogwatch.sh \
-     -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_INSPECTOR_IMAGE}"
+     -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_IMAGE}"
 
 set +x
 AUTH_DIR=/opt/metal3/auth


### PR DESCRIPTION
Since https://github.com/openshift/ironic-image/pull/190 the inspector components and entrypoint moved to the ironic-image, so we need to update the image and entrypoint to match, also aligning with https://github.com/openshift/cluster-baremetal-operator/pull/132