### PR TITLE
fix(ibmcloud): Delete COS in recursive mode

### DIFF
--- a/pkg/destroy/ibmcloud/cloudobjectstorage.go
+++ b/pkg/destroy/ibmcloud/cloudobjectstorage.go
@@ -55,6 +55,7 @@ func (o *ClusterUninstaller) deleteCOSInstance(item cloudResource) error {
 	defer cancel()
 
 	options := o.controllerSvc.NewDeleteResourceInstanceOptions(item.id)
+	options.SetRecursive(true)
 	details, err := o.controllerSvc.DeleteResourceInstanceWithContext(ctx, options)
 
 	if err != nil && details != nil && details.StatusCode == http.StatusNotFound {


### PR DESCRIPTION
Delete COS instances recursively to delete any associated resource keys that will be created by image-registry operator. Without this option set, destroy is blocked by failure to delete these COS instances.

```
time="2021-08-18T17:19:12Z" level=debug msg="Failed to delete COS instance ipi-ci-test-12-glldh-image-registry: Cannot delete instance or alias, resource keys must first be deleted."
time="2021-08-18T17:19:12Z" level=debug msg="Cloud Object Storage Instances: 1 items pending"
```