### PR TITLE
terraform/openstack: remove unused extra_tags

### DIFF
--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -51,7 +51,7 @@ resource "openstack_compute_instance_v2" "bootstrap" {
 
   user_data = var.bootstrap_shim_ignition
 
-  dynamic block_device {
+  dynamic "block_device" {
     for_each = var.root_volume_size == null ? [] : [openstack_blockstorage_volume_v3.bootstrap_volume[0].id]
     content {
       uuid                  = block_device.value
@@ -66,7 +66,7 @@ resource "openstack_compute_instance_v2" "bootstrap" {
     port = openstack_networking_port_v2.bootstrap_port.id
   }
 
-  dynamic network {
+  dynamic "network" {
     for_each = var.additional_network_ids
 
     content {

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -3,18 +3,6 @@ variable "base_image_id" {
   description = "The identifier of the Glance image for the bootstrap node."
 }
 
-variable "extra_tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOF
-(optional) Extra tags to be applied to created resources.
-
-Example: `{ "key" = "value", "foo" = "bar" }`
-EOF
-
-}
-
 variable "cluster_id" {
   type = string
   description = "The identifier for the cluster."

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -4,22 +4,22 @@ variable "base_image_id" {
 }
 
 variable "cluster_id" {
-  type = string
+  type        = string
   description = "The identifier for the cluster."
 }
 
 variable "ignition" {
-  type = string
+  type        = string
   description = "The content of the bootstrap ignition file."
 }
 
 variable "bootstrap_shim_ignition" {
-  type = string
+  type        = string
   description = "The content of the ignition file with user ca bundle."
 }
 
 variable "flavor_name" {
-  type = string
+  type        = string
   description = "The Nova flavor for the bootstrap node."
 }
 
@@ -28,7 +28,7 @@ variable "api_int_ip" {
 }
 
 variable "external_network" {
-  type = string
+  type    = string
   default = ""
 }
 
@@ -53,26 +53,26 @@ variable "master_port_ids" {
 }
 
 variable "root_volume_size" {
-  type = number
+  type        = number
   description = "The size of the volume in gigabytes for the root block device."
 }
 
 variable "root_volume_type" {
-  type = string
+  type        = string
   description = "The type of volume for the root block device."
 }
 
 variable "zone" {
-  type = string
+  type        = string
   description = "Availability Zone to schedule the bootstrap node onto."
 }
 
 variable "root_volume_zone" {
-  type = string
+  type        = string
   description = "Availability Zone to schedule the bootstrap root volume onto."
 }
 
 variable "additional_network_ids" {
-  type = list(string)
+  type        = list(string)
   description = "IDs of additional networks for the bootstrap node."
 }

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -30,7 +30,6 @@ module "bootstrap" {
   source = "./bootstrap"
 
   cluster_id         = var.cluster_id
-  extra_tags         = var.openstack_extra_tags
   base_image_id      = data.openstack_images_image_v2.base_image.id
   flavor_name        = var.openstack_master_flavor_name
   ignition           = var.ignition_bootstrap

--- a/data/data/openstack/masters/main.tf
+++ b/data/data/openstack/masters/main.tf
@@ -77,7 +77,7 @@ resource "openstack_compute_instance_v2" "master_conf_0" {
     0,
   )
 
-  dynamic block_device {
+  dynamic "block_device" {
     for_each = var.root_volume_size == null ? [] : [openstack_blockstorage_volume_v3.master_volume[0].id]
     content {
       uuid = block_device.value
@@ -96,7 +96,7 @@ resource "openstack_compute_instance_v2" "master_conf_0" {
     group = openstack_compute_servergroup_v2.master_group.id
   }
 
-  dynamic network {
+  dynamic "network" {
     for_each = var.additional_network_ids
 
     content {
@@ -125,7 +125,7 @@ resource "openstack_compute_instance_v2" "master_conf_1" {
     1,
   )
 
-  dynamic block_device {
+  dynamic "block_device" {
     for_each = var.root_volume_size == null ? [] : [openstack_blockstorage_volume_v3.master_volume[1].id]
     content {
       uuid = block_device.value
@@ -144,7 +144,7 @@ resource "openstack_compute_instance_v2" "master_conf_1" {
     group = openstack_compute_servergroup_v2.master_group.id
   }
 
-  dynamic network {
+  dynamic "network" {
     for_each = var.additional_network_ids
 
     content {
@@ -175,7 +175,7 @@ resource "openstack_compute_instance_v2" "master_conf_2" {
     2,
   )
 
-  dynamic block_device {
+  dynamic "block_device" {
     for_each = var.root_volume_size == null ? [] : [openstack_blockstorage_volume_v3.master_volume[2].id]
     content {
       uuid = block_device.value
@@ -194,7 +194,7 @@ resource "openstack_compute_instance_v2" "master_conf_2" {
     group = openstack_compute_servergroup_v2.master_group.id
   }
 
-  dynamic network {
+  dynamic "network" {
     for_each = var.additional_network_ids
 
     content {

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -252,18 +252,6 @@ EOF
 
 }
 
-variable "openstack_extra_tags" {
-  type = map(string)
-  default = {}
-
-  description = <<EOF
-(optional) Extra tags to be applied to created resources.
-
-Example: `{ "key" = "value", "foo" = "bar" }`
-EOF
-
-}
-
 variable "openstack_master_extra_sg_ids" {
   type    = list(string)
   default = []

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -253,7 +253,7 @@ EOF
 }
 
 variable "openstack_master_extra_sg_ids" {
-  type    = list(string)
+  type = list(string)
   default = []
 
   description = <<EOF
@@ -265,7 +265,7 @@ EOF
 }
 
 variable "openstack_api_floating_ip" {
-  type = string
+  type    = string
   default = ""
 
   description = <<EOF
@@ -275,7 +275,7 @@ EOF
 }
 
 variable "openstack_ingress_floating_ip" {
-  type    = string
+  type = string
   default = ""
 
   description = <<EOF
@@ -285,34 +285,34 @@ EOF
 }
 
 variable "openstack_api_int_ip" {
-  type = string
+  type        = string
   description = "IP on the node subnet reserved for api-int VIP."
 }
 
 variable "openstack_ingress_ip" {
-  type = string
+  type        = string
   description = "IP on the nodes subnet reserved for the ingress VIP."
 }
 
 variable "openstack_external_dns" {
-  type = list(string)
+  type        = list(string)
   description = "IP addresses of exernal dns servers to add to networks."
-  default = []
+  default     = []
 }
 
 variable "openstack_additional_network_ids" {
-  type = list(string)
+  type        = list(string)
   description = "IDs of additional networks for master nodes."
-  default = []
+  default     = []
 }
 
 variable "openstack_master_flavor_name" {
-  type = string
+  type        = string
   description = "Instance size for the master node(s). Example: `m1.medium`."
 }
 
 variable "openstack_trunk_support" {
-  type = bool
+  type    = bool
   default = false
 
   description = <<EOF
@@ -322,7 +322,7 @@ EOF
 }
 
 variable "openstack_octavia_support" {
-  type    = bool
+  type = bool
   default = false
 
   description = <<EOF
@@ -332,35 +332,35 @@ EOF
 }
 
 variable "openstack_master_server_group_name" {
-  type = string
+  type        = string
   description = "Name of the server group for the master nodes."
 }
 
 variable "openstack_master_server_group_policy" {
-  type = string
+  type        = string
   description = "Policy of the server group for the master nodes."
 }
 
 variable "openstack_machines_subnet_id" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "ID of the subnet to use for cluster machines. If empty, the installer will create a subnet to use as machinesSubnet."
 }
 
 variable "openstack_machines_network_id" {
-  type = string
-  default = ""
+  type        = string
+  default     = ""
   description = "ID of the network the machines subnet is on. If empty, the installer will create a network to use as machinesNetwork."
 }
 
 variable "openstack_master_availability_zones" {
-  type = list(string)
-  default = [""]
+  type        = list(string)
+  default     = [""]
   description = "List of availability Zones to Schedule the masters on."
 }
 
 variable "openstack_master_root_volume_availability_zones" {
-  type = list(string)
-  default = [""]
+  type        = list(string)
+  default     = [""]
   description = "List of availability Zones to Schedule the masters root volumes on."
 }


### PR DESCRIPTION
Since commit 63f7a03d8967d754a9e2110ccd6a1d5cf321515d the
extra_tags seem to go unused