### PR TITLE
Bug 1964751: Bump boot images for RHCOS fixes

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,159 +1,159 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0cb7096c55762208e"
+            "hvm": "ami-0073e7acee623c143"
         },
         "ap-east-1": {
-            "hvm": "ami-021682e27bec1ee87"
+            "hvm": "ami-053195bb945fac54c"
         },
         "ap-northeast-1": {
-            "hvm": "ami-038d6133bf9ddee00"
+            "hvm": "ami-0da3db5b319d70d36"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0a485021689fe2eb9"
+            "hvm": "ami-09f67be00e3d15211"
         },
         "ap-northeast-3": {
-            "hvm": "ami-020e0d8666f0d3170"
+            "hvm": "ami-0d448b4051ed03169"
         },
         "ap-south-1": {
-            "hvm": "ami-02fd44354bcde25a3"
+            "hvm": "ami-0cb23d9294973b84e"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0557e6167fe242389"
+            "hvm": "ami-06d834dcbdc0155f0"
         },
         "ap-southeast-2": {
-            "hvm": "ami-008f040a1fc38209d"
+            "hvm": "ami-08a1e52d5b4b9c008"
         },
         "ca-central-1": {
-            "hvm": "ami-082f532e52293d463"
+            "hvm": "ami-0b3a9c3aba022cf20"
         },
         "eu-central-1": {
-            "hvm": "ami-0b623fd02ca4775a5"
+            "hvm": "ami-0cfea57628f92c93f"
         },
         "eu-north-1": {
-            "hvm": "ami-0af74b0d36637f646"
+            "hvm": "ami-07f5a295d9471918f"
         },
         "eu-south-1": {
-            "hvm": "ami-0e19c0d9263db9ff5"
+            "hvm": "ami-06f3bd79fcdd842b5"
         },
         "eu-west-1": {
-            "hvm": "ami-0b97f7bd61c1ecd0b"
+            "hvm": "ami-0080f1a074bb3a432"
         },
         "eu-west-2": {
-            "hvm": "ami-01b6f3e8f0ad9054d"
+            "hvm": "ami-0e087b0428a7eba34"
         },
         "eu-west-3": {
-            "hvm": "ami-07dea9de166255375"
+            "hvm": "ami-0715c1d69c8f02d96"
         },
         "me-south-1": {
-            "hvm": "ami-014f667835c573656"
+            "hvm": "ami-0ae890cb263ec62bb"
         },
         "sa-east-1": {
-            "hvm": "ami-0577fc850f1ebce4c"
+            "hvm": "ami-0f2bb2b823f67966d"
         },
         "us-east-1": {
-            "hvm": "ami-0475651470951812f"
+            "hvm": "ami-06a4426aa2dc7ff77"
         },
         "us-east-2": {
-            "hvm": "ami-03696639de42a5d18"
+            "hvm": "ami-05ec663bd5cba73ae"
         },
         "us-west-1": {
-            "hvm": "ami-0694c5c7d6b0bb63d"
+            "hvm": "ami-03569b4ba28880ff7"
         },
         "us-west-2": {
-            "hvm": "ami-06246178752716deb"
+            "hvm": "ami-022d9b18676e83a8f"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202106161040-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202106161040-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202109242004-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202109242004-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202106161040-0/x86_64/",
-    "buildid": "46.82.202106161040-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6/46.82.202109242004-0/x86_64/",
+    "buildid": "46.82.202109242004-0",
     "gcp": {
-        "image": "rhcos-46-82-202106161040-0-gcp-x86-64",
+        "image": "rhcos-46-82-202109242004-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202106161040-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202109242004-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202106161040-0-aws.x86_64.vmdk.gz",
-            "sha256": "943f4302a685a4fad8867660893ee777e91b386d4d335ec560bbadcf6a8c6ee0",
-            "size": 905821025,
-            "uncompressed-sha256": "02294545395fa1c5d5507ce6255ef3272df4841628741a1e7114f04630cfc928",
-            "uncompressed-size": 924866048
+            "path": "rhcos-46.82.202109242004-0-aws.x86_64.vmdk.gz",
+            "sha256": "09c10bc7bb5c415932d2222e6df82ea09e8318bdac430d37cad97aa9ad4e24fd",
+            "size": 903076703,
+            "uncompressed-sha256": "789689162ad8e78705bfd6a8a63de3b1b48690c97a175fc248e0afe473e9bc9b",
+            "uncompressed-size": 921948160
         },
         "azure": {
-            "path": "rhcos-46.82.202106161040-0-azure.x86_64.vhd.gz",
-            "sha256": "b055fa9617ce10c8a5091f248927e62bfb1f050449078d80ecbc85f27a4c9c53",
-            "size": 907035912,
-            "uncompressed-sha256": "fa58c5bc8f796d8ff900cc731a0e0fa4c568bc7088d4ceb70eaf42549cffa7ec",
+            "path": "rhcos-46.82.202109242004-0-azure.x86_64.vhd.gz",
+            "sha256": "d3f5c021facc83f3ba3a1a95601f5da5f63ed044dec2c127a99611461e84e4b3",
+            "size": 904318692,
+            "uncompressed-sha256": "eaf5f4be31121fd14ff4109265fa103a24bf4bf4550e6ae91ff92391360d1db4",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202106161040-0-gcp.x86_64.tar.gz",
-            "sha256": "aa91df7de250d007dd42e70f3270647a509592b78b29dd0f993ac8c911fd3dfb",
-            "size": 892218739
+            "path": "rhcos-46.82.202109242004-0-gcp.x86_64.tar.gz",
+            "sha256": "63dc4105f79c976a831c74de537cbecd3c17ad24835969a3eaf495ab12e5bd3b",
+            "size": 889516716
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202106161040-0-live-initramfs.x86_64.img",
-            "sha256": "652d93ed9d0d7ec2033d3a78f790c81241d80e7203bfcb882190df7e2925780e"
+            "path": "rhcos-46.82.202109242004-0-live-initramfs.x86_64.img",
+            "sha256": "a2a402e34cf02b1eca9d845879b1189ac8ea7a29eb3b8fd6e9d4f14188fc036c"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202106161040-0-live.x86_64.iso",
-            "sha256": "5b41a7d5df9e986731fef49df8d197a8e6add79d1bf8c11f8457a98f676c6daa"
+            "path": "rhcos-46.82.202109242004-0-live.x86_64.iso",
+            "sha256": "147d5cb6e96fcb52ea07bfa5d359a443d4f29a8df752c3457789d2f4ce85ab99"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202106161040-0-live-kernel-x86_64",
-            "sha256": "0c70a2d1d0b1a7be3b06e38a667c8589918105f0294bc4a032f04d0ce9a23d2a"
+            "path": "rhcos-46.82.202109242004-0-live-kernel-x86_64",
+            "sha256": "8604a15ce7f6d513fb1bb825f3e83ed2a87017f77aefae02eb9630da3c9ff54a"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202106161040-0-live-rootfs.x86_64.img",
-            "sha256": "659972e40eaeec853011350c4ffa56aeb8c7591838a9bd19cd7c52307e09baf2"
+            "path": "rhcos-46.82.202109242004-0-live-rootfs.x86_64.img",
+            "sha256": "59c71204ae37032394dee7ef93d22600900affafb3e53dc732977cacda533c94"
         },
         "metal": {
-            "path": "rhcos-46.82.202106161040-0-metal.x86_64.raw.gz",
-            "sha256": "3b9d00f121231dc8ea666f6d1270382c67d71cf04862be354857609df1735335",
-            "size": 893757414,
-            "uncompressed-sha256": "2f32209aa2520df0a42d18f0868ca48acace7e6e343897166d7b024654c3721d",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202109242004-0-metal.x86_64.raw.gz",
+            "sha256": "1091e1f54872ae171511dbfd8b49c5e441363beea3c7c8e6e5b9f12bebba4570",
+            "size": 891123404,
+            "uncompressed-sha256": "3a0278bf68812d663b3dbe4920afc61a679c3c39ae6b74ccb0ad5d33b3f3afc7",
+            "uncompressed-size": 3533701120
         },
         "metal4k": {
-            "path": "rhcos-46.82.202106161040-0-metal4k.x86_64.raw.gz",
-            "sha256": "77cfadac32c4e14bff08b283184b6d228a638c71a6d2ec97e6a345cacb69b5e5",
-            "size": 891501461,
-            "uncompressed-sha256": "f9cd709aafa6a07e1ca767986aa2d988db3bf4bcc881ce860bec083551ceba32",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202109242004-0-metal4k.x86_64.raw.gz",
+            "sha256": "a4dbb138c5c868ff60f83819d3029256487ba5f57c162de048b14348d1f4365c",
+            "size": 888844131,
+            "uncompressed-sha256": "3423a710e0702f19ec8c3ce5c8a83b945747dbb26823955b80264ea6729dd188",
+            "uncompressed-size": 3533701120
         },
         "openstack": {
-            "path": "rhcos-46.82.202106161040-0-openstack.x86_64.qcow2.gz",
-            "sha256": "f4fcfc72f9e460bfbe5749145c54ab94322761aa21c964db8102854ad6a8536e",
-            "size": 892526355,
-            "uncompressed-sha256": "50fc0be318647c009f4e568674ce9f889d18cccbb31b1b725657dc88381d031c",
-            "uncompressed-size": 2253324288
+            "path": "rhcos-46.82.202109242004-0-openstack.x86_64.qcow2.gz",
+            "sha256": "fd840c052b80ff8cb3fd31837c43dedfaf8fe405410deb767eebdaa53f118d23",
+            "size": 889845203,
+            "uncompressed-sha256": "9a700b2bdc265e55a9e16d0f1fac4ca4bdcdce459c7b0124232d18acfc0c8092",
+            "uncompressed-size": 2240610304
         },
         "ostree": {
-            "path": "rhcos-46.82.202106161040-0-ostree.x86_64.tar",
-            "sha256": "e2700ec18b6174ab0bdf31ea8bfa8fc09cab5479c369379bea3c6fec97cf213e",
-            "size": 805836800
+            "path": "rhcos-46.82.202109242004-0-ostree.x86_64.tar",
+            "sha256": "d47ea65dbc1e7f6e33d48dfaf65d4c4f9419d7ef036935fcf9a3bba3192a6ab6",
+            "size": 803164160
         },
         "qemu": {
-            "path": "rhcos-46.82.202106161040-0-qemu.x86_64.qcow2.gz",
-            "sha256": "063d40a27e5128f4131db25ecb53da47b2f72e1becb1df6278af23cecf821bc9",
-            "size": 893409738,
-            "uncompressed-sha256": "384d2258441e1287874fa8e6899bcd943311568055961db8960ea47980e970f1",
-            "uncompressed-size": 2289631232
+            "path": "rhcos-46.82.202109242004-0-qemu.x86_64.qcow2.gz",
+            "sha256": "679b446005ae75ec8ce564d487f2848dd7d6e4fa10e46319e171bf6aef18f6db",
+            "size": 890698427,
+            "uncompressed-sha256": "6b467ad2a88795eec33c8cf8b24b5b3c5d9de24f6ad342283528752da3511d73",
+            "uncompressed-size": 2274164736
         },
         "vmware": {
-            "path": "rhcos-46.82.202106161040-0-vmware.x86_64.ova",
-            "sha256": "688ff47de3e31295d57331a729620bf1856abb6a45677edc596c3d3c0a9988b9",
-            "size": 924876800
+            "path": "rhcos-46.82.202109242004-0-vmware.x86_64.ova",
+            "sha256": "0a003f5fa48553af0590093f88229be4f2fa48bdd9b9c9d2a002d04d57ab9315",
+            "size": 921958400
         }
     },
     "oscontainer": {
-        "digest": "sha256:1be33942e6a8ecc0af87d846fa0148681368cce0021c9c73b56317e1742b1fd0",
+        "digest": "sha256:9b2d6c7b8a810c73ad2a098114d145be460d81ed18ce38b14276d9dc98f0f383",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "5afdb909b7bdfcadc4261cc428bd466c982ef195430443c51465e5198f8a6f72",
-    "ostree-version": "46.82.202106161040-0"
+    "ostree-commit": "f85d8febca4775c5a0a59defdac14b06e80dcdb2e5bfe03d30b4d1f2bd35805e",
+    "ostree-version": "46.82.202109242004-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-ppc64le/46.82.202106162140-0/ppc64le/",
-    "buildid": "46.82.202106162140-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6-ppc64le/46.82.202109180809-0/ppc64le/",
+    "buildid": "46.82.202109180809-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-46.82.202106162140-0-live-initramfs.ppc64le.img",
-            "sha256": "254d63283b2d8a15fea0855da7f85189107e19d02fc616f37965d7c37fd65acf"
+            "path": "rhcos-46.82.202109180809-0-live-initramfs.ppc64le.img",
+            "sha256": "8ed531b854b61c856a608ecd6ed86410649b11b7680c3354cf1bd60e175c0f4e"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202106162140-0-live.ppc64le.iso",
-            "sha256": "44a5394fcd4bedb9f1c7865e6bdd35019738df729b86e22bd9c4b04556ed6399"
+            "path": "rhcos-46.82.202109180809-0-live.ppc64le.iso",
+            "sha256": "3631d3719d29c07e617783c93803a5271e3d5bd9dfc1976177b6b2f8e2d6a5ba"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202106162140-0-live-kernel-ppc64le",
-            "sha256": "7ec5ad9a7acc2cf00da926ffe79bbd8db27d65bef0bde87bde2aa30129a59215"
+            "path": "rhcos-46.82.202109180809-0-live-kernel-ppc64le",
+            "sha256": "436852b552eab40db4bab6a94207d3575ec7af3ceb98d7868759a2de5b603b4b"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202106162140-0-live-rootfs.ppc64le.img",
-            "sha256": "4b5a813501a3387018c88e38ed8dd2df4b0dfc38ad31c395bd6246e4505c345b"
+            "path": "rhcos-46.82.202109180809-0-live-rootfs.ppc64le.img",
+            "sha256": "bdd80a23ce79e8067ba031a819fca9704701ebd601e087105b5e079f17fe422f"
         },
         "metal": {
-            "path": "rhcos-46.82.202106162140-0-metal.ppc64le.raw.gz",
-            "sha256": "048915ace8ad696e2b3a938dfa8ce85513cd477fb54483b47ff64ce0b44e639b",
-            "size": 874719384,
-            "uncompressed-sha256": "5d8473480cb70877b4b786b194dfc66f985827020799f90b4da030d74751f07c",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-46.82.202109180809-0-metal.ppc64le.raw.gz",
+            "sha256": "a9916c46abdca1912bed1aa772c97a76b345868e60c7ff6c3a208c82f3e8bb45",
+            "size": 871031357,
+            "uncompressed-sha256": "ba31b1183e1d78fa60c2ab94770a0e1a5ca84f3f3bb6fed50c2f638746ae1ff5",
+            "uncompressed-size": 3696230400
         },
         "metal4k": {
-            "path": "rhcos-46.82.202106162140-0-metal4k.ppc64le.raw.gz",
-            "sha256": "8fdd7adbd477f66d1ee4fdc4c742c4e938140e379fb219ed629d1db8cd9070f1",
-            "size": 874326345,
-            "uncompressed-sha256": "c04fe81748d0eef77b6cc56c53834e45f3690904b57859cef95dada0c7b1d5c6",
-            "uncompressed-size": 3717201920
+            "path": "rhcos-46.82.202109180809-0-metal4k.ppc64le.raw.gz",
+            "sha256": "c00bd670e2d8d4ce49999ad911e3ea0db098ce3f90e23ec3d372c7c5526e4635",
+            "size": 871692550,
+            "uncompressed-sha256": "d18de7465969f2e2723354e58d03c12b855631ad1ab1175e115e50e216268b8a",
+            "uncompressed-size": 3696230400
         },
         "openstack": {
-            "path": "rhcos-46.82.202106162140-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "1bfd371b8e560cbab2319506abd4a20ed5ae63195676d530bfe11df49186ae56",
-            "size": 872726330,
-            "uncompressed-sha256": "0e58c05631c4dd252e0e8474821e197449b7d7a47aadabb0af8a9e93d42dbc29",
-            "uncompressed-size": 2380464128
+            "path": "rhcos-46.82.202109180809-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "0c6f61fd4ade3d86f8fdcc005eaa681b53ae1cf4e1586b91cc5cdf82e99cc028",
+            "size": 869649974,
+            "uncompressed-sha256": "379f811986e51693cc2d69064e4ef1a2cd41cf759045a2f95d72a5daeef5426f",
+            "uncompressed-size": 2368602112
         },
         "ostree": {
-            "path": "rhcos-46.82.202106162140-0-ostree.ppc64le.tar",
-            "sha256": "d1651368778cca42549b027aa473cce653f7bc0ae8bf86ce2b292e559297963e",
-            "size": 783933440
+            "path": "rhcos-46.82.202109180809-0-ostree.ppc64le.tar",
+            "sha256": "4f6a6aea536d0698fc1a4c723b7872263ad927a612cabdce97694cfbae3285ce",
+            "size": 781025280
         },
         "qemu": {
-            "path": "rhcos-46.82.202106162140-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "9fd5ca7c72a766d703f5c3604f1f8f1be4480a97dbc9dd9b0e83d4ca8ea82cde",
-            "size": 873312356,
-            "uncompressed-sha256": "ecce897a7f6234de29d8c04cf0b4208f739c2193d16e5080fd73af9bc46cd9cf",
-            "uncompressed-size": 2417950720
+            "path": "rhcos-46.82.202109180809-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "7959bc864ccd244afb06df3e66995cbd373daaa031b1577e9e1321d436e8deac",
+            "size": 870248526,
+            "uncompressed-sha256": "39fa0a6cbc08d049c256a7f2319552b38867accb971ce8eb7ea5284ab84aa3a5",
+            "uncompressed-size": 2402942976
         }
     },
     "oscontainer": {
-        "digest": "sha256:e8405ec7fbf7cd46a9dabdfc50da0b91032112152bb4d250cb1d24dcf13af62b",
+        "digest": "sha256:2703b19c386af43e7b0a9df953bf53d913558aa76bc26c519e6f5d08d492a048",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ca345325c80c10aa31c18e274bada4a9b9fb6f097be2eea00baac930fb26129c",
-    "ostree-version": "46.82.202106162140-0"
+    "ostree-commit": "73c2e880d1a2af918afca300cc6f8d87ea0ac4b11c40775fc4f6f809ec65826f",
+    "ostree-version": "46.82.202109180809-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6-s390x/46.82.202106161139-0/s390x/",
-    "buildid": "46.82.202106161139-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6-s390x/46.82.202109180304-0/s390x/",
+    "buildid": "46.82.202109180304-0",
     "images": {
         "dasd": {
-            "path": "rhcos-46.82.202106161139-0-dasd.s390x.raw.gz",
-            "sha256": "a56b117c0915de7dd29f9e976db7f8d0b1457e5a38011468f1be5cb5015c4b59",
-            "size": 789078630,
-            "uncompressed-sha256": "d7874c77e6a10f69eb89dcfad5c0fc581a03f3718655b6f3693cd3c6b596d600",
-            "uncompressed-size": 3362783232
+            "path": "rhcos-46.82.202109180304-0-dasd.s390x.raw.gz",
+            "sha256": "22943905a9d4561969717eff611a3183e7e94339d14ba0581f6819cf421c145f",
+            "size": 785726366,
+            "uncompressed-sha256": "8c1e609be6b6cae78a9a3943661cddfb2ce8848efa5dd9eab41e1ef4b2d1f7c6",
+            "uncompressed-size": 3339714560
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202106161139-0-live-initramfs.s390x.img",
-            "sha256": "1b27f8d6f8235c7f5d6109773b00a3e9d3694f782278f1cbd5788c77928ce48e"
+            "path": "rhcos-46.82.202109180304-0-live-initramfs.s390x.img",
+            "sha256": "35781e6c96c9b599c6a6927cb9c856ce2755ff2bdc18a796f291d0e8bc462418"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202106161139-0-live.s390x.iso",
-            "sha256": "f3942d6e10483afc69d5931c41e613cc0069c87be5987ae2feeed8d42fb8074a"
+            "path": "rhcos-46.82.202109180304-0-live.s390x.iso",
+            "sha256": "7291a741cd8a7e14dea917937a294ec00dd1d1872ed2bf556197c48699b646ae"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202106161139-0-live-kernel-s390x",
-            "sha256": "c7b6e51a50f66519f937e4837f8403d23dcb4b815bfadf5d24194e7858cc0ece"
+            "path": "rhcos-46.82.202109180304-0-live-kernel-s390x",
+            "sha256": "b66b6e1d8e54ef3a09b628655cc134c96d4160058372e3e5a77d8287efbf82a9"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202106161139-0-live-rootfs.s390x.img",
-            "sha256": "cc2966ac4758eb4d97d4d48ffa63c0fd9d65cea633abd375145ca6ccfe43ae29"
+            "path": "rhcos-46.82.202109180304-0-live-rootfs.s390x.img",
+            "sha256": "2a48364ce81038dfec924500a9a348354102f7cad86e16fa6938f5b3ffceceed"
         },
         "metal": {
-            "path": "rhcos-46.82.202106161139-0-metal.s390x.raw.gz",
-            "sha256": "5c3959001f6e1f279f0bfb3458236b64f02ad60048a4b8c9aa6f79d133ee8196",
-            "size": 789054386,
-            "uncompressed-sha256": "6598f460340eb13f934007fe945d85b2f1ed0e7a321ccecbcfee24c632a21f41",
-            "uncompressed-size": 3362783232
+            "path": "rhcos-46.82.202109180304-0-metal.s390x.raw.gz",
+            "sha256": "41167352037204daca7ebe5643ff40c2adc15976a9b2849c53ca926f1a9a610b",
+            "size": 785868463,
+            "uncompressed-sha256": "8e946f970a8aaf2f95884eb58943665f85f4036c14512214ffe3fa6c0fbe05b8",
+            "uncompressed-size": 3339714560
         },
         "metal4k": {
-            "path": "rhcos-46.82.202106161139-0-metal4k.s390x.raw.gz",
-            "sha256": "ec4cf4c1a6866945776dd4f7cf017488e636113385ff894026307a592ca45299",
-            "size": 789271175,
-            "uncompressed-sha256": "c15631952dc8ea1d1e7d5db425275e81e5dfe3f3e277c9c70c32ced623737d73",
-            "uncompressed-size": 3362783232
+            "path": "rhcos-46.82.202109180304-0-metal4k.s390x.raw.gz",
+            "sha256": "e9766e472268f6a5760c266cbc8c3fe8451673a58972c55e7a251692ef880246",
+            "size": 785830478,
+            "uncompressed-sha256": "ccea90c468f76ec6c52c3f636f53496537475cb3c11ef1483547e65be18ff6d7",
+            "uncompressed-size": 3339714560
         },
         "openstack": {
-            "path": "rhcos-46.82.202106161139-0-openstack.s390x.qcow2.gz",
-            "sha256": "ef03660e939b560445ead1187e909412b886cc4c06260e14c621bc6cf771bb3a",
-            "size": 787999387,
-            "uncompressed-sha256": "396295041573b0f8c0314106bf65e6c14eebd21458ec9403e246a399d28312d3",
-            "uncompressed-size": 2079391744
+            "path": "rhcos-46.82.202109180304-0-openstack.s390x.qcow2.gz",
+            "sha256": "d9a6225566e813ca5c2586b6060bc53ba6d194b5091d569135692632b646c906",
+            "size": 784563877,
+            "uncompressed-sha256": "b16fdd52315cf7674b14ae13fd4e6a1cccc871e952e20d308c73cbc9d8d241dd",
+            "uncompressed-size": 2066022400
         },
         "ostree": {
-            "path": "rhcos-46.82.202106161139-0-ostree.s390x.tar",
-            "sha256": "f8e8eb9af95de532d4843ee3bb5e646275ff56a7b51405da835ffca2707138fc",
-            "size": 724736000
+            "path": "rhcos-46.82.202109180304-0-ostree.s390x.tar",
+            "sha256": "167ab7c1dc240ca6fd54ac9a6520c182d3dbc991a1ed28e555df4c6bb2efc464",
+            "size": 721367040
         },
         "qemu": {
-            "path": "rhcos-46.82.202106161139-0-qemu.s390x.qcow2.gz",
-            "sha256": "c0ea1650b7a15c52c1cd1f4f50e0ed48aa75f7491244b2ac50e56fe3831be236",
-            "size": 788704580,
-            "uncompressed-sha256": "0f722f27e7b8691b2fc061442433f79a7e4b2a8739ac525bc816374327d14b5c",
-            "uncompressed-size": 2115567616
+            "path": "rhcos-46.82.202109180304-0-qemu.s390x.qcow2.gz",
+            "sha256": "478a30a002a8a253a42d823f5c2fc19fb1b675a736fc68ed6a7621bd2816edcd",
+            "size": 785106513,
+            "uncompressed-sha256": "3b37f6e1d1b8aec83b572d29103d2d1628206befcc45e3c80576cdedd9e03a97",
+            "uncompressed-size": 2099380224
         }
     },
     "oscontainer": {
-        "digest": "sha256:d363b059dd212bcb8b9728cfaf1dca1ea6a77a774719b9d05e94bb8b2eec0a51",
+        "digest": "sha256:3851d36de68cf134c7b28c97fa993ba2705dff065be139dd570c2dfaee8bba43",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "9be96131d492b59660842356b70034acc5197fd68ce0f93f1694fdf8641a425d",
-    "ostree-version": "46.82.202106161139-0"
+    "ostree-commit": "a7ba2de20c714eb9debc1b1d450c09f76f176e9e24cdd9ab513e749da792dfd1",
+    "ostree-version": "46.82.202109180304-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,159 +1,159 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0cb7096c55762208e"
+            "hvm": "ami-0073e7acee623c143"
         },
         "ap-east-1": {
-            "hvm": "ami-021682e27bec1ee87"
+            "hvm": "ami-053195bb945fac54c"
         },
         "ap-northeast-1": {
-            "hvm": "ami-038d6133bf9ddee00"
+            "hvm": "ami-0da3db5b319d70d36"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0a485021689fe2eb9"
+            "hvm": "ami-09f67be00e3d15211"
         },
         "ap-northeast-3": {
-            "hvm": "ami-020e0d8666f0d3170"
+            "hvm": "ami-0d448b4051ed03169"
         },
         "ap-south-1": {
-            "hvm": "ami-02fd44354bcde25a3"
+            "hvm": "ami-0cb23d9294973b84e"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0557e6167fe242389"
+            "hvm": "ami-06d834dcbdc0155f0"
         },
         "ap-southeast-2": {
-            "hvm": "ami-008f040a1fc38209d"
+            "hvm": "ami-08a1e52d5b4b9c008"
         },
         "ca-central-1": {
-            "hvm": "ami-082f532e52293d463"
+            "hvm": "ami-0b3a9c3aba022cf20"
         },
         "eu-central-1": {
-            "hvm": "ami-0b623fd02ca4775a5"
+            "hvm": "ami-0cfea57628f92c93f"
         },
         "eu-north-1": {
-            "hvm": "ami-0af74b0d36637f646"
+            "hvm": "ami-07f5a295d9471918f"
         },
         "eu-south-1": {
-            "hvm": "ami-0e19c0d9263db9ff5"
+            "hvm": "ami-06f3bd79fcdd842b5"
         },
         "eu-west-1": {
-            "hvm": "ami-0b97f7bd61c1ecd0b"
+            "hvm": "ami-0080f1a074bb3a432"
         },
         "eu-west-2": {
-            "hvm": "ami-01b6f3e8f0ad9054d"
+            "hvm": "ami-0e087b0428a7eba34"
         },
         "eu-west-3": {
-            "hvm": "ami-07dea9de166255375"
+            "hvm": "ami-0715c1d69c8f02d96"
         },
         "me-south-1": {
-            "hvm": "ami-014f667835c573656"
+            "hvm": "ami-0ae890cb263ec62bb"
         },
         "sa-east-1": {
-            "hvm": "ami-0577fc850f1ebce4c"
+            "hvm": "ami-0f2bb2b823f67966d"
         },
         "us-east-1": {
-            "hvm": "ami-0475651470951812f"
+            "hvm": "ami-06a4426aa2dc7ff77"
         },
         "us-east-2": {
-            "hvm": "ami-03696639de42a5d18"
+            "hvm": "ami-05ec663bd5cba73ae"
         },
         "us-west-1": {
-            "hvm": "ami-0694c5c7d6b0bb63d"
+            "hvm": "ami-03569b4ba28880ff7"
         },
         "us-west-2": {
-            "hvm": "ami-06246178752716deb"
+            "hvm": "ami-022d9b18676e83a8f"
         }
     },
     "azure": {
-        "image": "rhcos-46.82.202106161040-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202106161040-0-azure.x86_64.vhd"
+        "image": "rhcos-46.82.202109242004-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-46.82.202109242004-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202106161040-0/x86_64/",
-    "buildid": "46.82.202106161040-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6/46.82.202109242004-0/x86_64/",
+    "buildid": "46.82.202109242004-0",
     "gcp": {
-        "image": "rhcos-46-82-202106161040-0-gcp-x86-64",
+        "image": "rhcos-46-82-202109242004-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202106161040-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-46-82-202109242004-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-46.82.202106161040-0-aws.x86_64.vmdk.gz",
-            "sha256": "943f4302a685a4fad8867660893ee777e91b386d4d335ec560bbadcf6a8c6ee0",
-            "size": 905821025,
-            "uncompressed-sha256": "02294545395fa1c5d5507ce6255ef3272df4841628741a1e7114f04630cfc928",
-            "uncompressed-size": 924866048
+            "path": "rhcos-46.82.202109242004-0-aws.x86_64.vmdk.gz",
+            "sha256": "09c10bc7bb5c415932d2222e6df82ea09e8318bdac430d37cad97aa9ad4e24fd",
+            "size": 903076703,
+            "uncompressed-sha256": "789689162ad8e78705bfd6a8a63de3b1b48690c97a175fc248e0afe473e9bc9b",
+            "uncompressed-size": 921948160
         },
         "azure": {
-            "path": "rhcos-46.82.202106161040-0-azure.x86_64.vhd.gz",
-            "sha256": "b055fa9617ce10c8a5091f248927e62bfb1f050449078d80ecbc85f27a4c9c53",
-            "size": 907035912,
-            "uncompressed-sha256": "fa58c5bc8f796d8ff900cc731a0e0fa4c568bc7088d4ceb70eaf42549cffa7ec",
+            "path": "rhcos-46.82.202109242004-0-azure.x86_64.vhd.gz",
+            "sha256": "d3f5c021facc83f3ba3a1a95601f5da5f63ed044dec2c127a99611461e84e4b3",
+            "size": 904318692,
+            "uncompressed-sha256": "eaf5f4be31121fd14ff4109265fa103a24bf4bf4550e6ae91ff92391360d1db4",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-46.82.202106161040-0-gcp.x86_64.tar.gz",
-            "sha256": "aa91df7de250d007dd42e70f3270647a509592b78b29dd0f993ac8c911fd3dfb",
-            "size": 892218739
+            "path": "rhcos-46.82.202109242004-0-gcp.x86_64.tar.gz",
+            "sha256": "63dc4105f79c976a831c74de537cbecd3c17ad24835969a3eaf495ab12e5bd3b",
+            "size": 889516716
         },
         "live-initramfs": {
-            "path": "rhcos-46.82.202106161040-0-live-initramfs.x86_64.img",
-            "sha256": "652d93ed9d0d7ec2033d3a78f790c81241d80e7203bfcb882190df7e2925780e"
+            "path": "rhcos-46.82.202109242004-0-live-initramfs.x86_64.img",
+            "sha256": "a2a402e34cf02b1eca9d845879b1189ac8ea7a29eb3b8fd6e9d4f14188fc036c"
         },
         "live-iso": {
-            "path": "rhcos-46.82.202106161040-0-live.x86_64.iso",
-            "sha256": "5b41a7d5df9e986731fef49df8d197a8e6add79d1bf8c11f8457a98f676c6daa"
+            "path": "rhcos-46.82.202109242004-0-live.x86_64.iso",
+            "sha256": "147d5cb6e96fcb52ea07bfa5d359a443d4f29a8df752c3457789d2f4ce85ab99"
         },
         "live-kernel": {
-            "path": "rhcos-46.82.202106161040-0-live-kernel-x86_64",
-            "sha256": "0c70a2d1d0b1a7be3b06e38a667c8589918105f0294bc4a032f04d0ce9a23d2a"
+            "path": "rhcos-46.82.202109242004-0-live-kernel-x86_64",
+            "sha256": "8604a15ce7f6d513fb1bb825f3e83ed2a87017f77aefae02eb9630da3c9ff54a"
         },
         "live-rootfs": {
-            "path": "rhcos-46.82.202106161040-0-live-rootfs.x86_64.img",
-            "sha256": "659972e40eaeec853011350c4ffa56aeb8c7591838a9bd19cd7c52307e09baf2"
+            "path": "rhcos-46.82.202109242004-0-live-rootfs.x86_64.img",
+            "sha256": "59c71204ae37032394dee7ef93d22600900affafb3e53dc732977cacda533c94"
         },
         "metal": {
-            "path": "rhcos-46.82.202106161040-0-metal.x86_64.raw.gz",
-            "sha256": "3b9d00f121231dc8ea666f6d1270382c67d71cf04862be354857609df1735335",
-            "size": 893757414,
-            "uncompressed-sha256": "2f32209aa2520df0a42d18f0868ca48acace7e6e343897166d7b024654c3721d",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202109242004-0-metal.x86_64.raw.gz",
+            "sha256": "1091e1f54872ae171511dbfd8b49c5e441363beea3c7c8e6e5b9f12bebba4570",
+            "size": 891123404,
+            "uncompressed-sha256": "3a0278bf68812d663b3dbe4920afc61a679c3c39ae6b74ccb0ad5d33b3f3afc7",
+            "uncompressed-size": 3533701120
         },
         "metal4k": {
-            "path": "rhcos-46.82.202106161040-0-metal4k.x86_64.raw.gz",
-            "sha256": "77cfadac32c4e14bff08b283184b6d228a638c71a6d2ec97e6a345cacb69b5e5",
-            "size": 891501461,
-            "uncompressed-sha256": "f9cd709aafa6a07e1ca767986aa2d988db3bf4bcc881ce860bec083551ceba32",
-            "uncompressed-size": 3553624064
+            "path": "rhcos-46.82.202109242004-0-metal4k.x86_64.raw.gz",
+            "sha256": "a4dbb138c5c868ff60f83819d3029256487ba5f57c162de048b14348d1f4365c",
+            "size": 888844131,
+            "uncompressed-sha256": "3423a710e0702f19ec8c3ce5c8a83b945747dbb26823955b80264ea6729dd188",
+            "uncompressed-size": 3533701120
         },
         "openstack": {
-            "path": "rhcos-46.82.202106161040-0-openstack.x86_64.qcow2.gz",
-            "sha256": "f4fcfc72f9e460bfbe5749145c54ab94322761aa21c964db8102854ad6a8536e",
-            "size": 892526355,
-            "uncompressed-sha256": "50fc0be318647c009f4e568674ce9f889d18cccbb31b1b725657dc88381d031c",
-            "uncompressed-size": 2253324288
+            "path": "rhcos-46.82.202109242004-0-openstack.x86_64.qcow2.gz",
+            "sha256": "fd840c052b80ff8cb3fd31837c43dedfaf8fe405410deb767eebdaa53f118d23",
+            "size": 889845203,
+            "uncompressed-sha256": "9a700b2bdc265e55a9e16d0f1fac4ca4bdcdce459c7b0124232d18acfc0c8092",
+            "uncompressed-size": 2240610304
         },
         "ostree": {
-            "path": "rhcos-46.82.202106161040-0-ostree.x86_64.tar",
-            "sha256": "e2700ec18b6174ab0bdf31ea8bfa8fc09cab5479c369379bea3c6fec97cf213e",
-            "size": 805836800
+            "path": "rhcos-46.82.202109242004-0-ostree.x86_64.tar",
+            "sha256": "d47ea65dbc1e7f6e33d48dfaf65d4c4f9419d7ef036935fcf9a3bba3192a6ab6",
+            "size": 803164160
         },
         "qemu": {
-            "path": "rhcos-46.82.202106161040-0-qemu.x86_64.qcow2.gz",
-            "sha256": "063d40a27e5128f4131db25ecb53da47b2f72e1becb1df6278af23cecf821bc9",
-            "size": 893409738,
-            "uncompressed-sha256": "384d2258441e1287874fa8e6899bcd943311568055961db8960ea47980e970f1",
-            "uncompressed-size": 2289631232
+            "path": "rhcos-46.82.202109242004-0-qemu.x86_64.qcow2.gz",
+            "sha256": "679b446005ae75ec8ce564d487f2848dd7d6e4fa10e46319e171bf6aef18f6db",
+            "size": 890698427,
+            "uncompressed-sha256": "6b467ad2a88795eec33c8cf8b24b5b3c5d9de24f6ad342283528752da3511d73",
+            "uncompressed-size": 2274164736
         },
         "vmware": {
-            "path": "rhcos-46.82.202106161040-0-vmware.x86_64.ova",
-            "sha256": "688ff47de3e31295d57331a729620bf1856abb6a45677edc596c3d3c0a9988b9",
-            "size": 924876800
+            "path": "rhcos-46.82.202109242004-0-vmware.x86_64.ova",
+            "sha256": "0a003f5fa48553af0590093f88229be4f2fa48bdd9b9c9d2a002d04d57ab9315",
+            "size": 921958400
         }
     },
     "oscontainer": {
-        "digest": "sha256:1be33942e6a8ecc0af87d846fa0148681368cce0021c9c73b56317e1742b1fd0",
+        "digest": "sha256:9b2d6c7b8a810c73ad2a098114d145be460d81ed18ce38b14276d9dc98f0f383",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "5afdb909b7bdfcadc4261cc428bd466c982ef195430443c51465e5198f8a6f72",
-    "ostree-version": "46.82.202106161040-0"
+    "ostree-commit": "f85d8febca4775c5a0a59defdac14b06e80dcdb2e5bfe03d30b4d1f2bd35805e",
+    "ostree-version": "46.82.202109242004-0"
 }

--- a/hack/update-rhcos-bootimage.py
+++ b/hack/update-rhcos-bootimage.py
@@ -6,7 +6,7 @@ import urllib.request
 
 # An app running in the CI cluster exposes this public endpoint about ART RHCOS
 # builds.  Do not try to e.g. point to RHT-internal endpoints.
-RHCOS_RELEASES_APP = 'https://releases-art-rhcos.svc.ci.openshift.org'
+RHCOS_RELEASES_APP = 'https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com'
 
 parser = argparse.ArgumentParser()
 parser.add_argument("meta", action='store')


### PR DESCRIPTION
Changes generated with:
```
python update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6-ppc64le/46.82.202109161439-0/ppc64le/meta.json ppc64le
python update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6-s390x/46.82.202109171905-0/s390x/meta.json s390x
python update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.6/46.82.202109171856-0/x86_64/meta.json amd64
```
Signed-off-by: Renata Ravanelli <rravanel@redhat.com>