### PR TITLE
Bug 1964753: Bump RHCOS 4.7 boot image

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,166 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0d543735dc9affc0a"
+            "hvm": "ami-0d2dc1d021677ce2a"
         },
         "ap-east-1": {
-            "hvm": "ami-0ebc3e0e299b8cc6f"
+            "hvm": "ami-0f55993dd2f556c04"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0414b946fab7988d6"
+            "hvm": "ami-0ca47d6344e5f20e1"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0e76f835edab2456a"
+            "hvm": "ami-045aad00900706629"
         },
         "ap-northeast-3": {
-            "hvm": "ami-013efa73b7ab96b3a"
+            "hvm": "ami-071199e1cf8c6c217"
         },
         "ap-south-1": {
-            "hvm": "ami-072abf84ada409d74"
+            "hvm": "ami-0863576151906a9cd"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0d5d683c086fdf8c1"
+            "hvm": "ami-04e2280104f031ece"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0f0cfbf037d999802"
+            "hvm": "ami-0c0a4abd2fb06aaec"
         },
         "ca-central-1": {
-            "hvm": "ami-03dab1b5a66487443"
+            "hvm": "ami-022db1580095cfa87"
         },
         "eu-central-1": {
-            "hvm": "ami-0ce189a55f836b366"
+            "hvm": "ami-039650b38f8ad01e9"
         },
         "eu-north-1": {
-            "hvm": "ami-01c5839bea4fb59bb"
+            "hvm": "ami-028bbd02e2077b8b9"
         },
         "eu-south-1": {
-            "hvm": "ami-0e40f2f7d66f23b6e"
+            "hvm": "ami-0e906eb19f26e785c"
         },
         "eu-west-1": {
-            "hvm": "ami-0141183673ded9f18"
+            "hvm": "ami-0ba9baee1056795ea"
         },
         "eu-west-2": {
-            "hvm": "ami-09a265f0e546fd5bb"
+            "hvm": "ami-0dbf443b171145ce4"
         },
         "eu-west-3": {
-            "hvm": "ami-00481fd3c31538be2"
+            "hvm": "ami-073d36aa242e8e68f"
         },
         "me-south-1": {
-            "hvm": "ami-080484bf2e2d5745e"
+            "hvm": "ami-0b87c37294c892f18"
         },
         "sa-east-1": {
-            "hvm": "ami-082784fa843993f42"
+            "hvm": "ami-0a69a3d8f5d5b8c5b"
         },
         "us-east-1": {
-            "hvm": "ami-093573e55a618974b"
+            "hvm": "ami-0625e52375a07b058"
         },
         "us-east-2": {
-            "hvm": "ami-0ce061fbb35d84fc1"
+            "hvm": "ami-0f0650094e7a74b2b"
         },
         "us-west-1": {
-            "hvm": "ami-078f97d297c64c66e"
+            "hvm": "ami-0aea82dddfa9c6c4f"
         },
         "us-west-2": {
-            "hvm": "ami-064366969d8336325"
+            "hvm": "ami-032288ad75a92d7ec"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202105220305-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202105220305-0-azure.x86_64.vhd"
+        "image": "rhcos-47.84.202109241831-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.84.202109241831-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202105220305-0/x86_64/",
-    "buildid": "47.83.202105220305-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202109241831-0/x86_64/",
+    "buildid": "47.84.202109241831-0",
     "gcp": {
-        "image": "rhcos-47-83-202105220305-0-gcp-x86-64",
+        "image": "rhcos-47-84-202109241831-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202105220305-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-84-202109241831-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202105220305-0-aws.x86_64.vmdk.gz",
-            "sha256": "62e55bf5bc40a62598a4089d6798cf137a0d71b00d849d7c94d26c566349fd11",
-            "size": 954799795,
-            "uncompressed-sha256": "d472fe825249f267b4ac529f82b5baad323e71cbe553c28478ece83765f0cfe2",
-            "uncompressed-size": 974443008
+            "path": "rhcos-47.84.202109241831-0-aws.x86_64.vmdk.gz",
+            "sha256": "9e01fd5a7c1636785a3ffc8a0ba3b0636112f31fa0d1e9ca7efad03b172df0f7",
+            "size": 1001398897,
+            "uncompressed-sha256": "41e96725ec27adcda83ea0742df4753b4691c7d08db1647cfbf3c5701da5d15e",
+            "uncompressed-size": 1021609984
         },
         "azure": {
-            "path": "rhcos-47.83.202105220305-0-azure.x86_64.vhd.gz",
-            "sha256": "da927bd6dcafd567dda92c0089a3104355fc2f94a8ef6fcd08140f0de1fcae9b",
-            "size": 955131805,
-            "uncompressed-sha256": "a176d6c9781f8f3caa406808d8c69e9a30158af4a492db9a597fe877ddb2aebe",
+            "path": "rhcos-47.84.202109241831-0-azure.x86_64.vhd.gz",
+            "sha256": "b95992c971fc58e076695bf09261b4e54d83837031b643e37f200edfb31e13b2",
+            "size": 1001539581,
+            "uncompressed-sha256": "f241c7b5401aec7d69076b448dfc55b1f0afcd8cc4fbedf77f6ea02d6ed378ee",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202105220305-0-gcp.x86_64.tar.gz",
-            "sha256": "70fd680a066f66df897ea69825ef61bb7a9ba3754652f528fa897857d8dcab58",
-            "size": 940425889
+            "path": "rhcos-47.84.202109241831-0-gcp.x86_64.tar.gz",
+            "sha256": "49f4f882300f900c1c23951711d70eb4bb00b2d63409692ac70f19d48dde2763",
+            "size": 986893356
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202105220305-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "69f03b9892a9012e84c53382eea6901063ed3df0dabf02aa72ca2b0850b0f01a",
-            "size": 940770169,
-            "uncompressed-sha256": "b9d8d24dfbb22e38fc15b34ed98abb001544b2ab9895bcb22ffeeaebf41d20cd",
-            "uncompressed-size": 2366046208
+            "path": "rhcos-47.84.202109241831-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "d501e686e2b72ed9f24d89d04522361ddc68c3675f4f5016931ad4fd6302cb37",
+            "size": 987246741,
+            "uncompressed-sha256": "69effc14d9f6d72acb56bc0e53e94035ce69668c07a6018b910d6111eddf910d",
+            "uncompressed-size": 2449408000
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202105220305-0-live-initramfs.x86_64.img",
-            "sha256": "da9620ffb5f9c9025c7b26dddd2364ca60e745165eb650f944aa9163141ff390"
+            "path": "rhcos-47.84.202109241831-0-live-initramfs.x86_64.img",
+            "sha256": "bf4a35f3cf2b441829fad59b4a198aa9e40577e6d48a3353a4a4d8e75fdab0c4"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202105220305-0-live.x86_64.iso",
-            "sha256": "2bf11b6a81b022c02f052f9f600b5d7520a6bfb925ed60f2417a64eac38b2ff8"
+            "path": "rhcos-47.84.202109241831-0-live.x86_64.iso",
+            "sha256": "621d3621fb4aa6e0d5d31c05fc79447481bdeeca7009a26ac7b56f7e385f5065"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202105220305-0-live-kernel-x86_64",
-            "sha256": "9f2a35ee745e32584d9671d0098f523f4264ff41ad0cfc620b254bc2f5b256a4"
+            "path": "rhcos-47.84.202109241831-0-live-kernel-x86_64",
+            "sha256": "d13269e6c60119397210418781b7057673c4018692d28a868e248a0b550ea247"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202105220305-0-live-rootfs.x86_64.img",
-            "sha256": "353fc501690ccf1836383a0f43f815551b099bcb8ba7ca964b6a322e28f5def1"
+            "path": "rhcos-47.84.202109241831-0-live-rootfs.x86_64.img",
+            "sha256": "71b0aa577b4ba4732ecc355843efd069f53b7d790b402959175754746f00f488"
         },
         "metal": {
-            "path": "rhcos-47.83.202105220305-0-metal.x86_64.raw.gz",
-            "sha256": "f830f9dea3be56ee73a084af4e517000bd2f560c1b150c3169417fd802c7b705",
-            "size": 942479567,
-            "uncompressed-sha256": "a5d731e3119b487f05d4660df6678771e5270ee6b8111f1fbb84a0f35c26fdd7",
-            "uncompressed-size": 3724541952
+            "path": "rhcos-47.84.202109241831-0-metal.x86_64.raw.gz",
+            "sha256": "ad4df2dfbde1da260a7f31f946f875e24285923317e79177b36f1aaab19b45d6",
+            "size": 988863082,
+            "uncompressed-sha256": "691a279a7803eb833f97f6c29a5eb5238d4cee2976d54748f3362e14b763fbeb",
+            "uncompressed-size": 3838836736
         },
         "metal4k": {
-            "path": "rhcos-47.83.202105220305-0-metal4k.x86_64.raw.gz",
-            "sha256": "16a0e2c8b894abb39e864fe183f6e732526124b3a7989a4d272b50c8304f9e06",
-            "size": 940027922,
-            "uncompressed-sha256": "9d71fa9b060f9388ccf5b3efa8ef5b5136e556f85174f8cf1934ccec63e23396",
-            "uncompressed-size": 3724541952
+            "path": "rhcos-47.84.202109241831-0-metal4k.x86_64.raw.gz",
+            "sha256": "2cc0cfeb0035e7dd23392bd306a3b8ce9626a93ea7b003ff07352bcd8be824e1",
+            "size": 986471700,
+            "uncompressed-sha256": "aada7e7fee4936bb45a754b64cd7c62b63afe7d4c09b4d8406c9e33a46e77d0a",
+            "uncompressed-size": 3838836736
         },
         "openstack": {
-            "path": "rhcos-47.83.202105220305-0-openstack.x86_64.qcow2.gz",
-            "sha256": "156e695b0a834cc9efe1ef95609cec078c65f8030be8c68b8fe946f82a65dd3a",
-            "size": 940770428,
-            "uncompressed-sha256": "94058cc4cff50e63ebeba8e044215c1591d0a4daea2ffdb778836d013290868e",
-            "uncompressed-size": 2366046208
+            "path": "rhcos-47.84.202109241831-0-openstack.x86_64.qcow2.gz",
+            "sha256": "859add6f751baf7070cb485394cb2777a253f07ea3ecd336cf9f5c98d25a3552",
+            "size": 987245565,
+            "uncompressed-sha256": "49f107e6106abaa178e657bbb0da9910b22cebd68cc15975ff7280734483faa8",
+            "uncompressed-size": 2449408000
         },
         "ostree": {
-            "path": "rhcos-47.83.202105220305-0-ostree.x86_64.tar",
-            "sha256": "36bc6b6b187c803ad6a8c641c9e8051d383761a747296d58450a1b299b96ca08",
-            "size": 866938880
+            "path": "rhcos-47.84.202109241831-0-ostree.x86_64.tar",
+            "sha256": "42be543418f3998de03bf586a545f78a1f19c6c1ec199a7b1fe6d77c383fc878",
+            "size": 910929920
         },
         "qemu": {
-            "path": "rhcos-47.83.202105220305-0-qemu.x86_64.qcow2.gz",
-            "sha256": "4be67c5c1a3ac7ca67154244325f2bbf4d2ca872716e650c79e52eff4c512140",
-            "size": 941849543,
-            "uncompressed-sha256": "d3e6f4e1182789480dcb81fc8cdf37416ec9afa34b4be1056426b21b62272248",
-            "uncompressed-size": 2399993856
+            "path": "rhcos-47.84.202109241831-0-qemu.x86_64.qcow2.gz",
+            "sha256": "222d030b23cb9753573c83e141cf226d948e31a6891596128c490c9fa9e3d14a",
+            "size": 988507503,
+            "uncompressed-sha256": "2203a9ac29c0065cfbef0f0ad3ce20fcd0ba18f46b2a0d5544365382a1d76e1f",
+            "uncompressed-size": 2485977088
         },
         "vmware": {
-            "path": "rhcos-47.83.202105220305-0-vmware.x86_64.ova",
-            "sha256": "bb7d5f4246aa7b2985e1f49a2aafde8df0bf56789814647221a3a374393702e8",
-            "size": 974458880
+            "path": "rhcos-47.84.202109241831-0-vmware.x86_64.ova",
+            "sha256": "f489fe5ff3b35dce00c4a9ca88d5e0ce1f831bcf6fcd8756365dadbc4de82665",
+            "size": 1021624320
         }
     },
     "oscontainer": {
-        "digest": "sha256:5649fe979b5ebe2615344d398ee0a841c9ea49d72be9edaf4048ccea5a729c32",
+        "digest": "sha256:532b4aee9644ec3f689d0648bf889f66e130c3d047ba4cb1de2e772f1eaf34ac",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "59309c0148b29cb5149b72a58de019e0236b8dc3b499e3015887f73aa325a409",
-    "ostree-version": "47.83.202105220305-0"
+    "ostree-commit": "855dbb83e02cb2f2b627082f678936ee5c9a3b21e0eb3ac7667787102d13e316",
+    "ostree-version": "47.84.202109241831-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202105211710-0/ppc64le/",
-    "buildid": "47.83.202105211710-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-ppc64le/47.84.202109242011-0/ppc64le/",
+    "buildid": "47.84.202109242011-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-47.83.202105211710-0-live-initramfs.ppc64le.img",
-            "sha256": "22bc784a5595d9cfb84a0e31935457dd3ebd934fc5dd8a408b2e1bd0bcbfe603"
+            "path": "rhcos-47.84.202109242011-0-live-initramfs.ppc64le.img",
+            "sha256": "0580c03bfae4728aa8ac69fc8494f913e0b174b6693a9373aac5778a31b46271"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202105211710-0-live.ppc64le.iso",
-            "sha256": "d89b985f1aa88c6065509423a2d6db34adfc90ac7f3791136f9340754d346508"
+            "path": "rhcos-47.84.202109242011-0-live.ppc64le.iso",
+            "sha256": "a07743846e404ac8480dff39c0a9d90616aa3dd13ea4196a1478759e24d88fab"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202105211710-0-live-kernel-ppc64le",
-            "sha256": "a462d86726c8b96d6db7c2b76ec0efdfddab7627203abdeb114df6aa4e31802a"
+            "path": "rhcos-47.84.202109242011-0-live-kernel-ppc64le",
+            "sha256": "d2f8f29ef59b87de2cbd7df8be60c06620bc90e88f4a722bb8278333d76ca3f8"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202105211710-0-live-rootfs.ppc64le.img",
-            "sha256": "daae7746be162106f3c0b0b8279df1f9a1dcef142a4da133c2baf18350073b8c"
+            "path": "rhcos-47.84.202109242011-0-live-rootfs.ppc64le.img",
+            "sha256": "8f72670c628c27df365a79b84053bf2f61753d89492521bda688da2bcf4c4c70"
         },
         "metal": {
-            "path": "rhcos-47.83.202105211710-0-metal.ppc64le.raw.gz",
-            "sha256": "0ef28e0bd0ba30461bcdd136ca1afff2c92aff82edeb2fb6a3f972009300ebea",
-            "size": 921458959,
-            "uncompressed-sha256": "a5bcddf178f3f5545bbaf4b146cde1c040abbd9d532de7cd81eda28195ea24cb",
-            "uncompressed-size": 3898605568
+            "path": "rhcos-47.84.202109242011-0-metal.ppc64le.raw.gz",
+            "sha256": "0021a883bb3bde083b077ba961e5f1aae1a9e934a58c5a327306088b8efbaa2b",
+            "size": 957912234,
+            "uncompressed-sha256": "2179dfddcaacfce9cd8cc3fe0ba4eed656b194990b519f39444c2f2a47f177fa",
+            "uncompressed-size": 3990880256
         },
         "metal4k": {
-            "path": "rhcos-47.83.202105211710-0-metal4k.ppc64le.raw.gz",
-            "sha256": "af647ca46c5de1e5164218726d567363eaf748a9f91b835c20c0480fa9caa661",
-            "size": 921786483,
-            "uncompressed-sha256": "ed26695d26e7aca47c5873a74ca9a3310e003b4e9e4f35be70b85c45287519b9",
-            "uncompressed-size": 3898605568
+            "path": "rhcos-47.84.202109242011-0-metal4k.ppc64le.raw.gz",
+            "sha256": "591522153864dffb6646814d3bf26bf827386487618163c2b265297285e81349",
+            "size": 958257005,
+            "uncompressed-sha256": "2a6e8ed057002e83c6a4337e005e519edaba0a27bc511a6d8df70cbd8e0f13c2",
+            "uncompressed-size": 3990880256
         },
         "openstack": {
-            "path": "rhcos-47.83.202105211710-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "4f6f55a39c39787531fb5ded8a3b1549e3bdd4a6cfa0e6ff11a1aef3c3141c26",
-            "size": 919782638,
-            "uncompressed-sha256": "c68b0b1c68e78b06bef30536826b03c96f6988074ed752bf4fce16b1eef9f99a",
-            "uncompressed-size": 2501771264
+            "path": "rhcos-47.84.202109242011-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "21a522617e5476b651bb3ba55700fb9f0f3d0ea02657afebb94a5a269a45c85d",
+            "size": 956243504,
+            "uncompressed-sha256": "772132ecfeb05ed3b8f9252f758f354855cc11fa41bd0abef6ba624c6645cdfe",
+            "uncompressed-size": 2569273344
         },
         "ostree": {
-            "path": "rhcos-47.83.202105211710-0-ostree.ppc64le.tar",
-            "sha256": "e0bf27f331fa07cd213c60b48b2cd5d1cc1f75a122228b0b92016add5f778d02",
-            "size": 844042240
+            "path": "rhcos-47.84.202109242011-0-ostree.ppc64le.tar",
+            "sha256": "dee9456e38c73ce9b476b315265b2c236c9bfa058d41bb6c0ef41ab3d0f25789",
+            "size": 879001600
         },
         "qemu": {
-            "path": "rhcos-47.83.202105211710-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "f8cc5e97632465f28d30416458ef4f714d20ff04ddf155cfa9a3ef393a80b019",
-            "size": 920911987,
-            "uncompressed-sha256": "7af9fa2bf98209a6fc75c0e6261147b070f9a3109b95637727fc8cdcfc3b34f0",
-            "uncompressed-size": 2536767488
+            "path": "rhcos-47.84.202109242011-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "63ba6dfe2766fddfcb19ec45c49308944fe8ac34b7a286824577c9541cdd5af4",
+            "size": 957286620,
+            "uncompressed-sha256": "ffd3f3c75af16d475f8c230a8bf2f37224d356adacbf97c55a9130e6e8627efd",
+            "uncompressed-size": 2606825472
         }
     },
     "oscontainer": {
-        "digest": "sha256:dad6f0afc4df270b8a850ca046ff3746ffdeee41203cca0eedc3652fae397d0b",
+        "digest": "sha256:8ee9920afef10cf84ab2f4f92924e9baddc97e25053dd3d60b214a18b320f55a",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "f906c5718681ab7e3c30804398201fee4f09d8f0942eb69c67dfdabf52db4fa7",
-    "ostree-version": "47.83.202105211710-0"
+    "ostree-commit": "ea8ab06592e01907ae8ec799a4001ae9ea4f8a1278b50e88fbed0340e9222351",
+    "ostree-version": "47.84.202109242011-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202105211211-0/s390x/",
-    "buildid": "47.83.202105211211-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-s390x/47.84.202109242305-0/s390x/",
+    "buildid": "47.84.202109242305-0",
     "images": {
         "dasd": {
-            "path": "rhcos-47.83.202105211211-0-dasd.s390x.raw.gz",
-            "sha256": "3279fc8734ed9afadf0e16fbb9375fa57102cf52b38962cb16ee122370ede554",
-            "size": 834720536,
-            "uncompressed-sha256": "5f36e272c453d68c55ca19f70b0187ccdb9cc92c18e13a43442fe4da1f1124be",
-            "uncompressed-size": 3527409664
+            "path": "rhcos-47.84.202109242305-0-dasd.s390x.raw.gz",
+            "sha256": "4dd5e4170ca2bc2399d93baaeee2adcc3cd2be03e3123c7a07dd8790cf57612a",
+            "size": 865020381,
+            "uncompressed-sha256": "f6c4b202a0a107d9556267b522905e17e33a44d8cbd22709490049d5ee0340d1",
+            "uncompressed-size": 3589275648
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202105211211-0-live-initramfs.s390x.img",
-            "sha256": "df401d091a005020a20c1372ef762e21e1194ccb2eee5935db42a412a57e64ae"
+            "path": "rhcos-47.84.202109242305-0-live-initramfs.s390x.img",
+            "sha256": "eb755014d8d03dc83ba4e125f4903aa221ecea26283275c8e264d2e5770e7062"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202105211211-0-live.s390x.iso",
-            "sha256": "e78282823928a3f748f0b7215eea482a37fb8550f1ab7b3c20595111ea125121"
+            "path": "rhcos-47.84.202109242305-0-live.s390x.iso",
+            "sha256": "41554a319c9ac1e9fb7a4b4399e06e0114f059934e15ef15ff34b51a5747858c"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202105211211-0-live-kernel-s390x",
-            "sha256": "eb158cac93d50122699ffe015b14ae8a93c822d4a02536adfa6bcaec304cc713"
+            "path": "rhcos-47.84.202109242305-0-live-kernel-s390x",
+            "sha256": "81d8f6040cf3913ed01379e6af950d0c8168a4f6e0adeecaf63ae527c759ade9"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202105211211-0-live-rootfs.s390x.img",
-            "sha256": "3ace8333d4f04287d192aff03e6afa0c3941f895fa651eab3e05e0d6b2d30ec3"
+            "path": "rhcos-47.84.202109242305-0-live-rootfs.s390x.img",
+            "sha256": "20dbdfed003083cf3a26b0b489f2cee48bce886dfe274487107128c503cf3ec6"
         },
         "metal": {
-            "path": "rhcos-47.83.202105211211-0-metal.s390x.raw.gz",
-            "sha256": "1114152ecd15599d18ce06aad01ff7dd333b0a382dfb515f5b266ddaf77e2f4e",
-            "size": 834721805,
-            "uncompressed-sha256": "58f53a8b55a4b7362c6331fe026220061de763a407638b2de01aa7e60c042c88",
-            "uncompressed-size": 3527409664
+            "path": "rhcos-47.84.202109242305-0-metal.s390x.raw.gz",
+            "sha256": "581b60df2de4451f90b58b9e06ec4e36240f8db9a5d60c88a4aae92058253419",
+            "size": 865037513,
+            "uncompressed-sha256": "4220bfb6b4d6fe85fef137d7d0f61a879e9c1967349c9f36a26b07bcd8ebb113",
+            "uncompressed-size": 3589275648
         },
         "metal4k": {
-            "path": "rhcos-47.83.202105211211-0-metal4k.s390x.raw.gz",
-            "sha256": "7a87c85221e70db66e7cb994431a6ff1ab170c594616b04339f42515d4eca407",
-            "size": 834640951,
-            "uncompressed-sha256": "78147559f06a76b6c929bec3f1e48864bf04df9e7f663a11a879bf9184dfdb9a",
-            "uncompressed-size": 3527409664
+            "path": "rhcos-47.84.202109242305-0-metal4k.s390x.raw.gz",
+            "sha256": "f75427d26aeb297b986af152ef4558eed1a5661b0104034498d4d493efd4912a",
+            "size": 865083760,
+            "uncompressed-sha256": "b2c7fd8d07288589c4b995efc0d9bc8c0092b163d1b43a89758440f5af097b35",
+            "uncompressed-size": 3589275648
         },
         "openstack": {
-            "path": "rhcos-47.83.202105211211-0-openstack.s390x.qcow2.gz",
-            "sha256": "9bd38f9fc2ef76cec9854b1a322f4fbd787feefd101c31fc89f35e5a20a44f56",
-            "size": 833097217,
-            "uncompressed-sha256": "0d5158a22c957d1ae1dda852a278250b7c853de4893e9b9350faf72eb4d07620",
-            "uncompressed-size": 2187591680
+            "path": "rhcos-47.84.202109242305-0-openstack.s390x.qcow2.gz",
+            "sha256": "2437049e9d66baa906aa64a772d5954404740513f7fe1b70862119cd36022912",
+            "size": 863400562,
+            "uncompressed-sha256": "9f5ea290315f30b79dbf45b030e8f6c242a1b47c0735da58642643d9da9f4369",
+            "uncompressed-size": 2231173120
         },
         "ostree": {
-            "path": "rhcos-47.83.202105211211-0-ostree.s390x.tar",
-            "sha256": "4edf8f68a69308e3e62d70109d93487acbe4bc32000d15abe48a33a77d46d169",
-            "size": 783390720
+            "path": "rhcos-47.84.202109242305-0-ostree.s390x.tar",
+            "sha256": "651e99ee4ee5ced7c4abf32e7487325b18004eeaf7ef644b0925bfdc79f2fdd2",
+            "size": 811816960
         },
         "qemu": {
-            "path": "rhcos-47.83.202105211211-0-qemu.s390x.qcow2.gz",
-            "sha256": "9aa07ca4e7abf220aeaac41ef8366dbdc9e5cca386a396bd922143bc375cd5ee",
-            "size": 834160448,
-            "uncompressed-sha256": "587ffb58d67f68fa0bd2fbc6cc573d15be8651a33d7eb806dcf2caf9e2f80608",
-            "uncompressed-size": 2220752896
+            "path": "rhcos-47.84.202109242305-0-qemu.s390x.qcow2.gz",
+            "sha256": "da5927cc7ecc72e9d6ef781d2032dd65e3c3ee8a825c8b78c96575567adcf328",
+            "size": 864402427,
+            "uncompressed-sha256": "76714236d4827882c19c2dfdaa48de5872b5b7704b1e43b2436564dbcc2acad9",
+            "uncompressed-size": 2267348992
         }
     },
     "oscontainer": {
-        "digest": "sha256:d9e97f78460b287ffb6fcc0d609767fa57f02050b41c9fa7ecffafceb316ebf0",
+        "digest": "sha256:31beef6c052e1e7f76c1959ed386ba4831014511b4e15e32d67054d7ee2e7c26",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "27fb045ec373cd41cec517ff3c1074ad3db22c774e5638208daf7e5dd82ef829",
-    "ostree-version": "47.83.202105211211-0"
+    "ostree-commit": "b9c1b79d2afac33f3d4b18b58f5bf0e3566ba8f6bd4e3bad0b0be350dc1fa00c",
+    "ostree-version": "47.84.202109242305-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,166 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0d543735dc9affc0a"
+            "hvm": "ami-0d2dc1d021677ce2a"
         },
         "ap-east-1": {
-            "hvm": "ami-0ebc3e0e299b8cc6f"
+            "hvm": "ami-0f55993dd2f556c04"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0414b946fab7988d6"
+            "hvm": "ami-0ca47d6344e5f20e1"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0e76f835edab2456a"
+            "hvm": "ami-045aad00900706629"
         },
         "ap-northeast-3": {
-            "hvm": "ami-013efa73b7ab96b3a"
+            "hvm": "ami-071199e1cf8c6c217"
         },
         "ap-south-1": {
-            "hvm": "ami-072abf84ada409d74"
+            "hvm": "ami-0863576151906a9cd"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0d5d683c086fdf8c1"
+            "hvm": "ami-04e2280104f031ece"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0f0cfbf037d999802"
+            "hvm": "ami-0c0a4abd2fb06aaec"
         },
         "ca-central-1": {
-            "hvm": "ami-03dab1b5a66487443"
+            "hvm": "ami-022db1580095cfa87"
         },
         "eu-central-1": {
-            "hvm": "ami-0ce189a55f836b366"
+            "hvm": "ami-039650b38f8ad01e9"
         },
         "eu-north-1": {
-            "hvm": "ami-01c5839bea4fb59bb"
+            "hvm": "ami-028bbd02e2077b8b9"
         },
         "eu-south-1": {
-            "hvm": "ami-0e40f2f7d66f23b6e"
+            "hvm": "ami-0e906eb19f26e785c"
         },
         "eu-west-1": {
-            "hvm": "ami-0141183673ded9f18"
+            "hvm": "ami-0ba9baee1056795ea"
         },
         "eu-west-2": {
-            "hvm": "ami-09a265f0e546fd5bb"
+            "hvm": "ami-0dbf443b171145ce4"
         },
         "eu-west-3": {
-            "hvm": "ami-00481fd3c31538be2"
+            "hvm": "ami-073d36aa242e8e68f"
         },
         "me-south-1": {
-            "hvm": "ami-080484bf2e2d5745e"
+            "hvm": "ami-0b87c37294c892f18"
         },
         "sa-east-1": {
-            "hvm": "ami-082784fa843993f42"
+            "hvm": "ami-0a69a3d8f5d5b8c5b"
         },
         "us-east-1": {
-            "hvm": "ami-093573e55a618974b"
+            "hvm": "ami-0625e52375a07b058"
         },
         "us-east-2": {
-            "hvm": "ami-0ce061fbb35d84fc1"
+            "hvm": "ami-0f0650094e7a74b2b"
         },
         "us-west-1": {
-            "hvm": "ami-078f97d297c64c66e"
+            "hvm": "ami-0aea82dddfa9c6c4f"
         },
         "us-west-2": {
-            "hvm": "ami-064366969d8336325"
+            "hvm": "ami-032288ad75a92d7ec"
         }
     },
     "azure": {
-        "image": "rhcos-47.83.202105220305-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.83.202105220305-0-azure.x86_64.vhd"
+        "image": "rhcos-47.84.202109241831-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.84.202109241831-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202105220305-0/x86_64/",
-    "buildid": "47.83.202105220305-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202109241831-0/x86_64/",
+    "buildid": "47.84.202109241831-0",
     "gcp": {
-        "image": "rhcos-47-83-202105220305-0-gcp-x86-64",
+        "image": "rhcos-47-84-202109241831-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-83-202105220305-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-84-202109241831-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.83.202105220305-0-aws.x86_64.vmdk.gz",
-            "sha256": "62e55bf5bc40a62598a4089d6798cf137a0d71b00d849d7c94d26c566349fd11",
-            "size": 954799795,
-            "uncompressed-sha256": "d472fe825249f267b4ac529f82b5baad323e71cbe553c28478ece83765f0cfe2",
-            "uncompressed-size": 974443008
+            "path": "rhcos-47.84.202109241831-0-aws.x86_64.vmdk.gz",
+            "sha256": "9e01fd5a7c1636785a3ffc8a0ba3b0636112f31fa0d1e9ca7efad03b172df0f7",
+            "size": 1001398897,
+            "uncompressed-sha256": "41e96725ec27adcda83ea0742df4753b4691c7d08db1647cfbf3c5701da5d15e",
+            "uncompressed-size": 1021609984
         },
         "azure": {
-            "path": "rhcos-47.83.202105220305-0-azure.x86_64.vhd.gz",
-            "sha256": "da927bd6dcafd567dda92c0089a3104355fc2f94a8ef6fcd08140f0de1fcae9b",
-            "size": 955131805,
-            "uncompressed-sha256": "a176d6c9781f8f3caa406808d8c69e9a30158af4a492db9a597fe877ddb2aebe",
+            "path": "rhcos-47.84.202109241831-0-azure.x86_64.vhd.gz",
+            "sha256": "b95992c971fc58e076695bf09261b4e54d83837031b643e37f200edfb31e13b2",
+            "size": 1001539581,
+            "uncompressed-sha256": "f241c7b5401aec7d69076b448dfc55b1f0afcd8cc4fbedf77f6ea02d6ed378ee",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.83.202105220305-0-gcp.x86_64.tar.gz",
-            "sha256": "70fd680a066f66df897ea69825ef61bb7a9ba3754652f528fa897857d8dcab58",
-            "size": 940425889
+            "path": "rhcos-47.84.202109241831-0-gcp.x86_64.tar.gz",
+            "sha256": "49f4f882300f900c1c23951711d70eb4bb00b2d63409692ac70f19d48dde2763",
+            "size": 986893356
         },
         "ibmcloud": {
-            "path": "rhcos-47.83.202105220305-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "69f03b9892a9012e84c53382eea6901063ed3df0dabf02aa72ca2b0850b0f01a",
-            "size": 940770169,
-            "uncompressed-sha256": "b9d8d24dfbb22e38fc15b34ed98abb001544b2ab9895bcb22ffeeaebf41d20cd",
-            "uncompressed-size": 2366046208
+            "path": "rhcos-47.84.202109241831-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "d501e686e2b72ed9f24d89d04522361ddc68c3675f4f5016931ad4fd6302cb37",
+            "size": 987246741,
+            "uncompressed-sha256": "69effc14d9f6d72acb56bc0e53e94035ce69668c07a6018b910d6111eddf910d",
+            "uncompressed-size": 2449408000
         },
         "live-initramfs": {
-            "path": "rhcos-47.83.202105220305-0-live-initramfs.x86_64.img",
-            "sha256": "da9620ffb5f9c9025c7b26dddd2364ca60e745165eb650f944aa9163141ff390"
+            "path": "rhcos-47.84.202109241831-0-live-initramfs.x86_64.img",
+            "sha256": "bf4a35f3cf2b441829fad59b4a198aa9e40577e6d48a3353a4a4d8e75fdab0c4"
         },
         "live-iso": {
-            "path": "rhcos-47.83.202105220305-0-live.x86_64.iso",
-            "sha256": "2bf11b6a81b022c02f052f9f600b5d7520a6bfb925ed60f2417a64eac38b2ff8"
+            "path": "rhcos-47.84.202109241831-0-live.x86_64.iso",
+            "sha256": "621d3621fb4aa6e0d5d31c05fc79447481bdeeca7009a26ac7b56f7e385f5065"
         },
         "live-kernel": {
-            "path": "rhcos-47.83.202105220305-0-live-kernel-x86_64",
-            "sha256": "9f2a35ee745e32584d9671d0098f523f4264ff41ad0cfc620b254bc2f5b256a4"
+            "path": "rhcos-47.84.202109241831-0-live-kernel-x86_64",
+            "sha256": "d13269e6c60119397210418781b7057673c4018692d28a868e248a0b550ea247"
         },
         "live-rootfs": {
-            "path": "rhcos-47.83.202105220305-0-live-rootfs.x86_64.img",
-            "sha256": "353fc501690ccf1836383a0f43f815551b099bcb8ba7ca964b6a322e28f5def1"
+            "path": "rhcos-47.84.202109241831-0-live-rootfs.x86_64.img",
+            "sha256": "71b0aa577b4ba4732ecc355843efd069f53b7d790b402959175754746f00f488"
         },
         "metal": {
-            "path": "rhcos-47.83.202105220305-0-metal.x86_64.raw.gz",
-            "sha256": "f830f9dea3be56ee73a084af4e517000bd2f560c1b150c3169417fd802c7b705",
-            "size": 942479567,
-            "uncompressed-sha256": "a5d731e3119b487f05d4660df6678771e5270ee6b8111f1fbb84a0f35c26fdd7",
-            "uncompressed-size": 3724541952
+            "path": "rhcos-47.84.202109241831-0-metal.x86_64.raw.gz",
+            "sha256": "ad4df2dfbde1da260a7f31f946f875e24285923317e79177b36f1aaab19b45d6",
+            "size": 988863082,
+            "uncompressed-sha256": "691a279a7803eb833f97f6c29a5eb5238d4cee2976d54748f3362e14b763fbeb",
+            "uncompressed-size": 3838836736
         },
         "metal4k": {
-            "path": "rhcos-47.83.202105220305-0-metal4k.x86_64.raw.gz",
-            "sha256": "16a0e2c8b894abb39e864fe183f6e732526124b3a7989a4d272b50c8304f9e06",
-            "size": 940027922,
-            "uncompressed-sha256": "9d71fa9b060f9388ccf5b3efa8ef5b5136e556f85174f8cf1934ccec63e23396",
-            "uncompressed-size": 3724541952
+            "path": "rhcos-47.84.202109241831-0-metal4k.x86_64.raw.gz",
+            "sha256": "2cc0cfeb0035e7dd23392bd306a3b8ce9626a93ea7b003ff07352bcd8be824e1",
+            "size": 986471700,
+            "uncompressed-sha256": "aada7e7fee4936bb45a754b64cd7c62b63afe7d4c09b4d8406c9e33a46e77d0a",
+            "uncompressed-size": 3838836736
         },
         "openstack": {
-            "path": "rhcos-47.83.202105220305-0-openstack.x86_64.qcow2.gz",
-            "sha256": "156e695b0a834cc9efe1ef95609cec078c65f8030be8c68b8fe946f82a65dd3a",
-            "size": 940770428,
-            "uncompressed-sha256": "94058cc4cff50e63ebeba8e044215c1591d0a4daea2ffdb778836d013290868e",
-            "uncompressed-size": 2366046208
+            "path": "rhcos-47.84.202109241831-0-openstack.x86_64.qcow2.gz",
+            "sha256": "859add6f751baf7070cb485394cb2777a253f07ea3ecd336cf9f5c98d25a3552",
+            "size": 987245565,
+            "uncompressed-sha256": "49f107e6106abaa178e657bbb0da9910b22cebd68cc15975ff7280734483faa8",
+            "uncompressed-size": 2449408000
         },
         "ostree": {
-            "path": "rhcos-47.83.202105220305-0-ostree.x86_64.tar",
-            "sha256": "36bc6b6b187c803ad6a8c641c9e8051d383761a747296d58450a1b299b96ca08",
-            "size": 866938880
+            "path": "rhcos-47.84.202109241831-0-ostree.x86_64.tar",
+            "sha256": "42be543418f3998de03bf586a545f78a1f19c6c1ec199a7b1fe6d77c383fc878",
+            "size": 910929920
         },
         "qemu": {
-            "path": "rhcos-47.83.202105220305-0-qemu.x86_64.qcow2.gz",
-            "sha256": "4be67c5c1a3ac7ca67154244325f2bbf4d2ca872716e650c79e52eff4c512140",
-            "size": 941849543,
-            "uncompressed-sha256": "d3e6f4e1182789480dcb81fc8cdf37416ec9afa34b4be1056426b21b62272248",
-            "uncompressed-size": 2399993856
+            "path": "rhcos-47.84.202109241831-0-qemu.x86_64.qcow2.gz",
+            "sha256": "222d030b23cb9753573c83e141cf226d948e31a6891596128c490c9fa9e3d14a",
+            "size": 988507503,
+            "uncompressed-sha256": "2203a9ac29c0065cfbef0f0ad3ce20fcd0ba18f46b2a0d5544365382a1d76e1f",
+            "uncompressed-size": 2485977088
         },
         "vmware": {
-            "path": "rhcos-47.83.202105220305-0-vmware.x86_64.ova",
-            "sha256": "bb7d5f4246aa7b2985e1f49a2aafde8df0bf56789814647221a3a374393702e8",
-            "size": 974458880
+            "path": "rhcos-47.84.202109241831-0-vmware.x86_64.ova",
+            "sha256": "f489fe5ff3b35dce00c4a9ca88d5e0ce1f831bcf6fcd8756365dadbc4de82665",
+            "size": 1021624320
         }
     },
     "oscontainer": {
-        "digest": "sha256:5649fe979b5ebe2615344d398ee0a841c9ea49d72be9edaf4048ccea5a729c32",
+        "digest": "sha256:532b4aee9644ec3f689d0648bf889f66e130c3d047ba4cb1de2e772f1eaf34ac",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "59309c0148b29cb5149b72a58de019e0236b8dc3b499e3015887f73aa325a409",
-    "ostree-version": "47.83.202105220305-0"
+    "ostree-commit": "855dbb83e02cb2f2b627082f678936ee5c9a3b21e0eb3ac7667787102d13e316",
+    "ostree-version": "47.84.202109241831-0"
 }

--- a/hack/update-rhcos-bootimage.py
+++ b/hack/update-rhcos-bootimage.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-# Usage: ./hack/update-rhcos-bootimage.py https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202008260918-0/x86_64/meta.json amd64
+# Usage: ./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202109171532-0/x86_64/meta.json amd64
 import codecs,os,sys,json,argparse
 import urllib.parse
 import urllib.request
 
 # An app running in the CI cluster exposes this public endpoint about ART RHCOS
 # builds.  Do not try to e.g. point to RHT-internal endpoints.
-RHCOS_RELEASES_APP = 'https://releases-art-rhcos.svc.ci.openshift.org'
+RHCOS_RELEASES_APP = 'https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com'
 
 parser = argparse.ArgumentParser()
 parser.add_argument("meta", action='store')


### PR DESCRIPTION
Changes generated with:
```
./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-ppc64le/47.84.202109242011-0/ppc64le/meta.json ppc64le
./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-s390x/47.84.202109242305-0/s390x/meta.json s390x
./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202109241831-0/x86_64/meta.json amd64
```