### PR TITLE
libvirt: bump memory of machines to 16G in the provider config

### DIFF
--- a/pkg/asset/machines/libvirt/machines.go
+++ b/pkg/asset/machines/libvirt/machines.go
@@ -63,7 +63,7 @@ func provider(clusterID string, networkInterfaceAddress string, platform *libvir
 			APIVersion: "libvirtproviderconfig.openshift.io/v1beta1",
 			Kind:       "LibvirtMachineProviderConfig",
 		},
-		DomainMemory: 8192,
+		DomainMemory: 16384,
 		DomainVcpu:   4,
 		Ignition: &libvirtprovider.Ignition{
 			UserDataSecret: userDataSecret,


### PR DESCRIPTION
While the terraform defaults for the libvirt master memory size was set to 16G through this PR:https://github.com/openshift/installer/pull/5069, the sizes were still fixed to 8G because they were being overwritten by the value set in the provider. Change the provider value to 16G to address this issue.

Note: This will also set the worker memory size to 16G which should be fine, but can also be overriden by changing the machineset manifest.