### PR TITLE
Bug 2021364: aws: remove invalid s3 permission

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -150,7 +150,6 @@ var permissions = map[PermissionGroup][]string{
 		"s3:GetBucketLocation",
 		"s3:GetBucketLogging",
 		"s3:GetBucketObjectLockConfiguration",
-		"s3:GetBucketReplication",
 		"s3:GetBucketRequestPayment",
 		"s3:GetBucketTagging",
 		"s3:GetBucketVersioning",


### PR DESCRIPTION
s3:GetBucketReplication is not a valid IAM action. The correct action is s3:GetReplicationConfiguration which is also included.

https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazons3.html

Since the installer attempts to verify that it has all of the permissions that it thinks it needs, it fails when it checks for this permission and aborts the install. This means that we must include the invalid permission in our IAM policy and ignore the warnings that this generates in order to run the cluster install.