### PR TITLE
Update registry.ci.openshift.org/origin image to 4.9

### DIFF
--- a/pkg/asset/releaseimage/default.go
+++ b/pkg/asset/releaseimage/default.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.ci.openshift.org/origin/release:4.8"
+	defaultReleaseImageOriginal = "registry.ci.openshift.org/origin/release:4.9"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
This PR updates the registry.ci.openshift.org/origin image to 4.9.

The quick start guide for libvirt installation relies on source compiled binary. When the installer is built from the master branch it fails to install as the image that is pulled is of v4.8 and some of the command args are not supported anymore.

For example, this is one of the error seen on the bootstrap node, 
```
bootkube.service
Error: unknown flag: --infra-config-file
Usage: Sep 23 12:24:08 ocp-xxxxxxxxxxxx bootkube.sh[2271]: cluster-kube-apiserver-operator render [flags]
```

I could not find an image for version 4.10/master, if there is one I will update the commit to use that.
