### PR TITLE
Azure Stack: add trust bundle to cloud config

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -153,6 +153,10 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 				return errors.Wrap(err, "could not serialize Azure Stack endpoints")
 			}
 			cm.Data[cloudProviderEndpointsKey] = string(b)
+
+			if trustBundle := installConfig.Config.AdditionalTrustBundle; trustBundle != "" {
+				cm.Data[cloudProviderConfigCABundleDataKey] = trustBundle
+			}
 		}
 	case gcptypes.Name:
 		subnet := fmt.Sprintf("%s-worker-subnet", clusterID.InfraID)


### PR DESCRIPTION
Adds CA for self-signed certs to the cloud provider config on Azure Stack Hub platform. Some environments, such as our internal dedicated Azure Stack environment, may use self-signed certs for the `armEndpoint`. This PR takes a bundle from `installConfig.additionalTrustBundle` and adds it to the cloud provider config with the key `ca-bundle.pem`.

```shell
$ head ash-ca-bundle/m/manifests/cloud-provider-config.yaml 
apiVersion: v1
data:
  ca-bundle.pem: |
    -----BEGIN CERTIFICATE-----
    MIIDgjCCAmqgAwIBAgIQdrn6bdq60qRPxujNuJEL0DANBgkqhkiG9w0BAQsFADBA
    MRUwEwYKCZImiZPyLGQBGRYFbG9jYWwxFjAUBgoJkiaJk/IsZAEZFgZ3d3RhdGMx
    DzANBgNVBAMTBkFUQy1DQTAeFw0xNTA5MDgxNTM2NThaFw0yNTA5MDgxNTQ2NTda
    MEAxFTATBgoJkiaJk/IsZAEZFgVsb2NhbDEWMBQGCgmSJomT8ixkARkWBnd3dGF0
    YzEPMA0GA1UEAxMGQVRDLUNBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
    AQEAxyGyv2thsIXb5sn3FucF1NnCLMSMPGCpGr8i6QOoCi1Ct22ooFpofLgf05w0
```