### PR TITLE
Bug 2008599: Azure Stack: Add Internal Load Balancer

### DIFF
--- a/docs/user/azure/install_upi_azurestack.md
+++ b/docs/user/azure/install_upi_azurestack.md
@@ -378,8 +378,9 @@ Create an `api` and `api-int` DNS record in the *public* zone for the API public
 
 ```sh
 export PUBLIC_IP=$(az network public-ip list -g "$RESOURCE_GROUP" --query "[?name=='${INFRA_ID}-master-pip'] | [0].ipAddress" -o tsv)
+export PRIVATE_IP=$(az network lb frontend-ip show -g "$RESOURCE_GROUP" --lb-name "${INFRA_ID}-internal-lb" -n internal-lb-ip --query "privateIpAddress" -o tsv)
 az network dns record-set a add-record -g "$RESOURCE_GROUP" -z "${CLUSTER_NAME}.${BASE_DOMAIN}" -n api -a "$PUBLIC_IP" --ttl 60
-az network dns record-set a add-record -g "$RESOURCE_GROUP" -z "${CLUSTER_NAME}.${BASE_DOMAIN}" -n api-int -a "$PUBLIC_IP" --ttl 60
+az network dns record-set a add-record -g "$RESOURCE_GROUP" -z "${CLUSTER_NAME}.${BASE_DOMAIN}" -n api-int -a "$PRIVATE_IP" --ttl 60
 ```
 
 ## Launch the temporary cluster bootstrap

--- a/docs/user/azure/install_upi_azurestack.md
+++ b/docs/user/azure/install_upi_azurestack.md
@@ -378,7 +378,7 @@ Create an `api` and `api-int` DNS record in the *public* zone for the API public
 
 ```sh
 export PUBLIC_IP=$(az network public-ip list -g "$RESOURCE_GROUP" --query "[?name=='${INFRA_ID}-master-pip'] | [0].ipAddress" -o tsv)
-export PRIVATE_IP=$(az network lb frontend-ip show -g "$RESOURCE_GROUP" --lb-name "${INFRA_ID}-internal-lb" -n internal-lb-ip --query "privateIpAddress" -o tsv)
+export PRIVATE_IP=$(az network lb frontend-ip show -g "$RESOURCE_GROUP" --lb-name "${INFRA_ID}-internal" -n internal-lb-ip --query "privateIpAddress" -o tsv)
 az network dns record-set a add-record -g "$RESOURCE_GROUP" -z "${CLUSTER_NAME}.${BASE_DOMAIN}" -n api -a "$PUBLIC_IP" --ttl 60
 az network dns record-set a add-record -g "$RESOURCE_GROUP" -z "${CLUSTER_NAME}.${BASE_DOMAIN}" -n api-int -a "$PRIVATE_IP" --ttl 60
 ```

--- a/upi/azurestack/03_infra.json
+++ b/upi/azurestack/03_infra.json
@@ -83,7 +83,7 @@
         ],
         "loadBalancingRules" : [
           {
-            "name" : "api-internal",
+            "name" : "api-public",
             "properties" : {
               "frontendIPConfiguration" : {
                 "id" :"[concat(variables('masterLoadBalancerID'), '/frontendIPConfigurations/public-lb-ip')]"
@@ -97,7 +97,69 @@
               "frontendPort" : 6443,
               "backendPort" : 6443,
               "probe" : {
-                "id" : "[concat(variables('masterLoadBalancerID'), '/probes/api-internal-probe')]"
+                "id" : "[concat(variables('masterLoadBalancerID'), '/probes/api-public-probe')]"
+              }
+            }
+          }
+        ],
+        "probes" : [
+          {
+            "name" : "api-public-probe",
+            "properties" : {
+              "protocol" : "Tcp",
+              "port" : 6443,
+              "intervalInSeconds" : 10,
+              "numberOfProbes" : 3
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion" : "2017-10-01",
+      "type" : "Microsoft.Network/loadBalancers",
+      "name" : "[variables('internalLoadBalancerName')]",
+      "location" : "[variables('location')]",
+      "sku": {
+        "name": "[variables('skuName')]"
+      },
+      "properties" : {
+        "frontendIPConfigurations" : [
+          {
+            "name" : "internal-lb-ip",
+            "properties" : {
+              "privateIPAllocationMethod" : "Dynamic",
+              "subnet" : {
+                "id" : "[variables('masterSubnetRef')]"
+              },
+              "privateIPAddressVersion" : "IPv4"
+            }
+          }
+        ],
+        "backendAddressPools" : [
+          {
+            "name" : "internal-lb-backend"
+          }
+        ],
+        "loadBalancingRules" : [
+          {
+            "name" : "api-internal",
+            "properties" : {
+              "frontendIPConfiguration" : {
+                "id" : "[concat(variables('internalLoadBalancerID'), '/frontendIPConfigurations/internal-lb-ip')]"
+              },
+              "frontendPort" : 6443,
+              "backendPort" : 6443,
+              "enableFloatingIP" : false,
+              "idleTimeoutInMinutes" : 30,
+              "protocol" : "Tcp",
+              "enableTcpReset" : false,
+              "loadDistribution" : "Default",
+              "backendAddressPool" : {
+                "id" : "[concat(variables('internalLoadBalancerID'), '/backendAddressPools/internal-lb-backend')]"
+              },
+              "probe" : {
+                "id" : "[concat(variables('internalLoadBalancerID'), '/probes/api-internal-probe')]"
               }
             }
           },
@@ -105,7 +167,7 @@
             "name" : "sint",
             "properties" : {
               "frontendIPConfiguration" : {
-                "id" : "[concat(variables('masterLoadBalancerID'), '/frontendIPConfigurations/public-lb-ip')]"
+                "id" : "[concat(variables('internalLoadBalancerID'), '/frontendIPConfigurations/internal-lb-ip')]"
               },
               "frontendPort" : 22623,
               "backendPort" : 22623,
@@ -115,10 +177,10 @@
               "enableTcpReset" : false,
               "loadDistribution" : "Default",
               "backendAddressPool" : {
-                "id" : "[concat(variables('masterLoadBalancerID'), '/backendAddressPools/', variables('masterLoadBalancerName'))]"
+                "id" : "[concat(variables('internalLoadBalancerID'), '/backendAddressPools/internal-lb-backend')]"
               },
               "probe" : {
-                "id" : "[concat(variables('masterLoadBalancerID'), '/probes/sint-probe')]"
+                "id" : "[concat(variables('internalLoadBalancerID'), '/probes/sint-probe')]"
               }
             }
           }

--- a/upi/azurestack/03_infra.json
+++ b/upi/azurestack/03_infra.json
@@ -21,7 +21,7 @@
     "masterLoadBalancerName" : "[concat(parameters('baseName'))]",
     "masterLoadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('masterLoadBalancerName'))]",
     "masterAvailabilitySetName" : "[concat(parameters('baseName'), '-avset')]",
-    "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
+    "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal')]",
     "internalLoadBalancerID" : "[resourceId('Microsoft.Network/loadBalancers', variables('internalLoadBalancerName'))]",
     "skuName": "Basic"
   },
@@ -138,7 +138,7 @@
         ],
         "backendAddressPools" : [
           {
-            "name" : "internal-lb-backend"
+            "name" : "[variables('internalLoadBalancerName')]"
           }
         ],
         "loadBalancingRules" : [
@@ -156,7 +156,7 @@
               "enableTcpReset" : false,
               "loadDistribution" : "Default",
               "backendAddressPool" : {
-                "id" : "[concat(variables('internalLoadBalancerID'), '/backendAddressPools/internal-lb-backend')]"
+                "id" : "[concat(variables('internalLoadBalancerID'), '/backendAddressPools/', variables('internalLoadBalancerName'))]"
               },
               "probe" : {
                 "id" : "[concat(variables('internalLoadBalancerID'), '/probes/api-internal-probe')]"
@@ -177,7 +177,7 @@
               "enableTcpReset" : false,
               "loadDistribution" : "Default",
               "backendAddressPool" : {
-                "id" : "[concat(variables('internalLoadBalancerID'), '/backendAddressPools/internal-lb-backend')]"
+                "id" : "[concat(variables('internalLoadBalancerID'), '/backendAddressPools/', variables('internalLoadBalancerName'))]"
               },
               "probe" : {
                 "id" : "[concat(variables('internalLoadBalancerID'), '/probes/sint-probe')]"

--- a/upi/azurestack/04_bootstrap.json
+++ b/upi/azurestack/04_bootstrap.json
@@ -96,6 +96,9 @@
               "loadBalancerBackendAddressPools" : [
                 {
                   "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/', variables('masterLoadBalancerName'))]"
+                },
+                {
+                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('internalLoadBalancerName'), '/backendAddressPools/internal-lb-backend')]"
                 }
               ]
             }

--- a/upi/azurestack/04_bootstrap.json
+++ b/upi/azurestack/04_bootstrap.json
@@ -41,7 +41,7 @@
     "masterSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
     "masterLoadBalancerName" : "[concat(parameters('baseName'))]",
     "masterAvailabilitySetName" : "[concat(parameters('baseName'), '-avset')]",
-    "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
+    "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
     "vmName" : "[concat(parameters('baseName'), '-bootstrap')]",
     "nicName" : "[concat(variables('vmName'), '-nic')]",
@@ -98,7 +98,7 @@
                   "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/', variables('masterLoadBalancerName'))]"
                 },
                 {
-                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('internalLoadBalancerName'), '/backendAddressPools/internal-lb-backend')]"
+                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('internalLoadBalancerName'), '/backendAddressPools/', variables('internalLoadBalancerName'))]"
                 }
               ]
             }

--- a/upi/azurestack/05_masters.json
+++ b/upi/azurestack/05_masters.json
@@ -97,6 +97,9 @@
               "loadBalancerBackendAddressPools" : [
                 {
                   "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/', variables('masterLoadBalancerName'))]"
+                },
+                {
+                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('internalLoadBalancerName'), '/backendAddressPools/internal-lb-backend')]"
                 }
               ]
             }

--- a/upi/azurestack/05_masters.json
+++ b/upi/azurestack/05_masters.json
@@ -47,7 +47,7 @@
     "masterSubnetRef" : "[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
     "masterLoadBalancerName" : "[concat(parameters('baseName'))]",
     "masterAvailabilitySetName" : "[concat(parameters('baseName'), '-avset')]",
-    "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
+    "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
     "clusterNsgName" : "[concat(parameters('baseName'), '-nsg')]",
     "imageName" : "[concat(parameters('baseName'), '-image')]",
@@ -99,7 +99,7 @@
                   "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('masterLoadBalancerName'), '/backendAddressPools/', variables('masterLoadBalancerName'))]"
                 },
                 {
-                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('internalLoadBalancerName'), '/backendAddressPools/internal-lb-backend')]"
+                  "id" : "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/loadBalancers/', variables('internalLoadBalancerName'), '/backendAddressPools/', variables('internalLoadBalancerName'))]"
                 }
               ]
             }


### PR DESCRIPTION
In the current solution, ASH only has one public load balancer. Both api DNS records point to the public IP address. This creates an
internal load balancer and updates the docs to point the api-int record to the internal LB.

I have a test in progress. So far it has been successful with masters pulling the ignition from api-int, which points to the private ip address.