### PR TITLE
Ensure cluster proxy object sets TrustedCA if only AdditionalTrustBundle is provided

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -59,20 +59,19 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 			Name: "cluster",
 			// not namespaced
 		},
+		Spec = configv1.ProxySpec{},
+	}
+
+	if installConfig.Config.AdditionalTrustBundle != "" {
+		p.Config.Spec.TrustedCA = configv1.ConfigMapNameReference{
+			Name: additionalTrustBundleConfigMapName,
+		}
 	}
 
 	if installConfig.Config.Proxy != nil {
-		p.Config.Spec = configv1.ProxySpec{
-			HTTPProxy:  installConfig.Config.Proxy.HTTPProxy,
-			HTTPSProxy: installConfig.Config.Proxy.HTTPSProxy,
-			NoProxy:    installConfig.Config.Proxy.NoProxy,
-		}
-
-		if installConfig.Config.AdditionalTrustBundle != "" {
-			p.Config.Spec.TrustedCA = configv1.ConfigMapNameReference{
-				Name: additionalTrustBundleConfigMapName,
-			}
-		}
+		p.Config.Spec.HTTPProxy = installConfig.Config.Proxy.HTTPProxy
+		p.Config.Spec.HTTPSProxy = installConfig.Config.Proxy.HTTPSProxy
+		p.Config.Spec.NoProxy = installConfig.Config.Proxy.NoProxy
 	}
 
 	if p.Config.Spec.HTTPProxy != "" || p.Config.Spec.HTTPSProxy != "" {

--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -59,7 +59,7 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 			Name: "cluster",
 			// not namespaced
 		},
-		Spec = configv1.ProxySpec{},
+		Spec: configv1.ProxySpec{},
 	}
 
 	if installConfig.Config.AdditionalTrustBundle != "" {


### PR DESCRIPTION
Before this change, the installer would generate an empty spec for the cluster proxy object unless `installConfig.Config.Proxy` is defined.

This change implements support for the use cases where there is no proxy configured, but there is a desire to include additional trusted CAs.

Related:
- https://access.redhat.com/solutions/6063031
- Case #03038183