### PR TITLE
update-rhcos-bootimage: check that RHCOS metadata has necessary artif…

### DIFF
--- a/hack/update-rhcos-bootimage.py
+++ b/hack/update-rhcos-bootimage.py
@@ -23,6 +23,16 @@ with urllib.request.urlopen(args.meta) as f:
     string_f = codecs.getreader('utf-8')(f)  # support for Python < 3.6
     meta = json.load(string_f)
 newmeta = {}
+
+# x86_64 boot image bumps should contain more than just the ostree tarball and
+# qemu qcow2 image. check the contents of the images dict for well known artifacts.
+if args.arch == 'amd64':
+    for k in ['aws', 'gcp', 'metal', 'metal4k']:
+        if k not in meta['images'].keys():
+            raise SystemExit("You appear to be missing most of the x86_64 boot "
+                             + "image artifacts. Check the meta.json for this "
+                             + "RHCOS version. Also check that boot images were "
+                             + "enabled in the RHCOS build pipeline.")
 for k in ['images', 'buildid', 'oscontainer',
           'ostree-commit', 'ostree-version',
           'azure', 'gcp']:


### PR DESCRIPTION
…acts

It is possible to feed the `update-rhcos-bootimage.py` script a
`meta.json` input that does not contain all the boot image artifacts
required when doing a boot image bump. This changes the script to bail
out if the length of the `images` dict is less than or equal to 2,
which indicates that only the `ostree` tarball and `qemu` qcow2 image
were produced as part of an RHCOS build.