### PR TITLE
Bug 2009019: update legacy RHCOS boot image metadata

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,166 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0910e9e4347267191"
+            "hvm": "ami-038772fdd54b78a4f"
         },
         "ap-east-1": {
-            "hvm": "ami-003c37759615789ad"
+            "hvm": "ami-03a6473cd438b2fea"
         },
         "ap-northeast-1": {
-            "hvm": "ami-04a04d42202f5dffb"
+            "hvm": "ami-05977c4081111f3bb"
         },
         "ap-northeast-2": {
-            "hvm": "ami-087c3504f536820f8"
+            "hvm": "ami-0a0fcda229d58dec1"
         },
         "ap-northeast-3": {
-            "hvm": "ami-03450c8fc4ff0f7bd"
+            "hvm": "ami-0467ba9dc70f85538"
         },
         "ap-south-1": {
-            "hvm": "ami-02b81ab6d01174430"
+            "hvm": "ami-07c047be0d3ec46ca"
         },
         "ap-southeast-1": {
-            "hvm": "ami-099b3006ba35122c6"
+            "hvm": "ami-0b574d30ee267107c"
         },
         "ap-southeast-2": {
-            "hvm": "ami-04d9e06d3edd4b78c"
+            "hvm": "ami-0c1b7b6fd42c043c2"
         },
         "ca-central-1": {
-            "hvm": "ami-0712dffd5af06d6a0"
+            "hvm": "ami-05bef6aaeb6a8cc3c"
         },
         "eu-central-1": {
-            "hvm": "ami-0b911f8bcf1f05a47"
+            "hvm": "ami-0d56b8ae868345407"
         },
         "eu-north-1": {
-            "hvm": "ami-06c6466f9944aee66"
+            "hvm": "ami-08dd7be7e8ebe13b6"
         },
         "eu-south-1": {
-            "hvm": "ami-011fabc962ea99519"
+            "hvm": "ami-06f4c9dfde4e75eb1"
         },
         "eu-west-1": {
-            "hvm": "ami-0cd860942047eaf85"
+            "hvm": "ami-0aef183a3bbfeeaf3"
         },
         "eu-west-2": {
-            "hvm": "ami-057df328de60ac464"
+            "hvm": "ami-07b3715c986152140"
         },
         "eu-west-3": {
-            "hvm": "ami-0e57008c4a59dbf99"
+            "hvm": "ami-0feee7f927014e9ad"
         },
         "me-south-1": {
-            "hvm": "ami-06934e136e2238997"
+            "hvm": "ami-01db7ebc5addfc2f6"
         },
         "sa-east-1": {
-            "hvm": "ami-01e07e22429c5bdef"
+            "hvm": "ami-097223d194bcb71f0"
         },
         "us-east-1": {
-            "hvm": "ami-0b35795bcab04ee70"
+            "hvm": "ami-06e6531aef9359b1e"
         },
         "us-east-2": {
-            "hvm": "ami-0c17b13bb8b268411"
+            "hvm": "ami-09145c219cb4df3e1"
         },
         "us-west-1": {
-            "hvm": "ami-004de02e4e2bba5f2"
+            "hvm": "ami-0afa3199a442f45cb"
         },
         "us-west-2": {
-            "hvm": "ami-0237df7fc4ba6a5cc"
+            "hvm": "ami-02a3699138ec7ecf4"
         }
     },
     "azure": {
-        "image": "rhcos-48.84.202106301921-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202106301921-0-azure.x86_64.vhd"
+        "image": "rhcos-48.84.202109241901-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202109241901-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202106301921-0/x86_64/",
-    "buildid": "48.84.202106301921-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/",
+    "buildid": "48.84.202109241901-0",
     "gcp": {
-        "image": "rhcos-48-84-202106301921-0-gcp-x86-64",
+        "image": "rhcos-48-84-202109241901-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202106301921-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202109241901-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.84.202106301921-0-aws.x86_64.vmdk.gz",
-            "sha256": "d0d100b3e701396bd03613aff74d224bdf568b46537ece01e9714c5415cebdb1",
-            "size": 1029124266,
-            "uncompressed-sha256": "2acb0f72e5404f2b37939358fe7804d4f434b99273fdc74c874ca505c5772cd4",
-            "uncompressed-size": 1050139136
+            "path": "rhcos-48.84.202109241901-0-aws.x86_64.vmdk.gz",
+            "sha256": "c081a65325330379e91707475b8dadf82e0f2d5c1c9f7f056fcd978641bb5114",
+            "size": 1031334820,
+            "uncompressed-sha256": "152a82e870e7e4d30d8204280f61ccfee90d826377bb25c51b2eac04f2fd82db",
+            "uncompressed-size": 1052379136
         },
         "azure": {
-            "path": "rhcos-48.84.202106301921-0-azure.x86_64.vhd.gz",
-            "sha256": "c1874fb74bb0988e6906fa5050989c16ec75306b67efc729c130545baa46f02b",
-            "size": 1029254110,
-            "uncompressed-sha256": "943789e911bd18c8b20ada9f5c4d67db50da56b67a5e0ce096b5b5b7970ab5cb",
+            "path": "rhcos-48.84.202109241901-0-azure.x86_64.vhd.gz",
+            "sha256": "801498fe0ccb754b898bef30e4d226f796874e615d7719b00d64b8054d434481",
+            "size": 1031392167,
+            "uncompressed-sha256": "b433bf7793db745c22c7ca09415a4dc87526ae7727e646d7b157acb323c3ee4f",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.84.202106301921-0-gcp.x86_64.tar.gz",
-            "sha256": "5575d9d6378b0587e67a037e18beeaf614cf9ae933fe1573ce810476caebd041",
-            "size": 1014689317
+            "path": "rhcos-48.84.202109241901-0-gcp.x86_64.tar.gz",
+            "sha256": "5231bdd554841c01fbd1092ea96c39b06dda3187549c0672a5f5c5e4d7eecdad",
+            "size": 1016813602
         },
         "ibmcloud": {
-            "path": "rhcos-48.84.202106301921-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "647c0987f2837abd16b846c130862798b18b2324f434ecfead4b9331a115361e",
-            "size": 1015047293,
-            "uncompressed-sha256": "78c8bc6b7cfb6bd8c29af81edebad5b1a4e06988ba6e59e909c8e29516d3168e",
-            "uncompressed-size": 2528641024
+            "path": "rhcos-48.84.202109241901-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "440ce3c4367a10fa66436638cef6ed938848050fd7f0de2d78d1294a4f56995d",
+            "size": 1017169285,
+            "uncompressed-sha256": "d81934aa386286ad35591fd46dc9cd809dc5e88623b563f220abae52665de472",
+            "uncompressed-size": 2535325696
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202106301921-0-live-initramfs.x86_64.img",
-            "sha256": "b52ff7b137cf70bf68d47cdfe17fea9e8e478aa7f481d32a88af53ad391b4c65"
+            "path": "rhcos-48.84.202109241901-0-live-initramfs.x86_64.img",
+            "sha256": "5b6f1b728a5e656ef128a54f9534f7d3d63953ef46e726a808aacf1ce9ad2742"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202106301921-0-live.x86_64.iso",
-            "sha256": "fb23569974e0184ee69000e5da5b4e2112f7c2f639696ef78f7664c2152ebd52"
+            "path": "rhcos-48.84.202109241901-0-live.x86_64.iso",
+            "sha256": "dc0c7af647137c9b16210c977896dc756b72b5e568774daf199964ca020935ae"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202106301921-0-live-kernel-x86_64",
-            "sha256": "9b900e88ca71b067d8f9971dc4454f454a12666b53d3ca2d80919729060a198d"
+            "path": "rhcos-48.84.202109241901-0-live-kernel-x86_64",
+            "sha256": "d13269e6c60119397210418781b7057673c4018692d28a868e248a0b550ea247"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202106301921-0-live-rootfs.x86_64.img",
-            "sha256": "dbcf72da9b95de52cd4d24aaf22b01ad209d0cb2e59212381e34c869646bb304"
+            "path": "rhcos-48.84.202109241901-0-live-rootfs.x86_64.img",
+            "sha256": "bd005071f295762a613ff42c26ce453be7c19d35594b68c94fab6797b4d834d4"
         },
         "metal": {
-            "path": "rhcos-48.84.202106301921-0-metal.x86_64.raw.gz",
-            "sha256": "66edefd079dba059f983ffe9d50d168860c24d7dd58c740ac7f8b1c66939ce76",
-            "size": 1016832063,
-            "uncompressed-sha256": "3e3bf27674546708a02ad1ddcb95ca8343c682a286476306820e5c1b7415d1dc",
-            "uncompressed-size": 3952082944
+            "path": "rhcos-48.84.202109241901-0-metal.x86_64.raw.gz",
+            "sha256": "6e67556bebee87b6d85d776a8b728ef727fb2e55c77a183f7979e8b89211b4db",
+            "size": 1018907248,
+            "uncompressed-sha256": "1b104a26b338f6aa4ba16a0bb3887e7bdc05c8735902785578208fb793fc504d",
+            "uncompressed-size": 3960471552
         },
         "metal4k": {
-            "path": "rhcos-48.84.202106301921-0-metal4k.x86_64.raw.gz",
-            "sha256": "04c4a2eae0c8968580049302dc8272d3aad936ef97d53f217e77f82254e6b8c4",
-            "size": 1014289639,
-            "uncompressed-sha256": "5c1cd1abe8ae077f6418055fa42f6c6dbe1d90c69b894e986c74b17e067530af",
-            "uncompressed-size": 3952082944
+            "path": "rhcos-48.84.202109241901-0-metal4k.x86_64.raw.gz",
+            "sha256": "9cf43a94eded275b2fb54bbb164ce63b18d7e696ca6c15f8cea4bb09941a0e57",
+            "size": 1016543064,
+            "uncompressed-sha256": "475d1123a2da31882b445c51ec5d5896c84de417feca5fe0ac1f93d8ea4e2c84",
+            "uncompressed-size": 3960471552
         },
         "openstack": {
-            "path": "rhcos-48.84.202106301921-0-openstack.x86_64.qcow2.gz",
-            "sha256": "713910e81c6b3dc4eabb2ea41fcddfc9d24dceca4bba23f690b467bcd28ce75e",
-            "size": 1015048690,
-            "uncompressed-sha256": "5a75df7b4d4dc1861093e520187a133eda3439019f280dc6e2f57edf70eb089d",
-            "uncompressed-size": 2528641024
+            "path": "rhcos-48.84.202109241901-0-openstack.x86_64.qcow2.gz",
+            "sha256": "99da4ed945b391d452e55a3a7809c799e4c74f69acbee1ecaec78f368c4e369e",
+            "size": 1017176202,
+            "uncompressed-sha256": "e0a1d8a99c5869150a56b8de475ea7952ca2fa3aacad7ca48533d1176df503ab",
+            "uncompressed-size": 2535325696
         },
         "ostree": {
-            "path": "rhcos-48.84.202106301921-0-ostree.x86_64.tar",
-            "sha256": "53b9fbcee43569cbb91c9ba23798ef478aff4683e6c63cfea93136c694afb79c",
-            "size": 939161600
+            "path": "rhcos-48.84.202109241901-0-ostree.x86_64.tar",
+            "sha256": "4e1c0dc1bcebcedf861256474db12822830e004e823e8a7968c6bed59002e924",
+            "size": 941015040
         },
         "qemu": {
-            "path": "rhcos-48.84.202106301921-0-qemu.x86_64.qcow2.gz",
-            "sha256": "9de96bfdde0875cc3595e1271bbd6509d19728b1c08a71be33a728a2597343cb",
-            "size": 1016166274,
-            "uncompressed-sha256": "fe7f5cb0bf0a46d8a7a1b58f658cb759732ada5ed875d9ef0f51574bf426b061",
-            "uncompressed-size": 2565013504
+            "path": "rhcos-48.84.202109241901-0-qemu.x86_64.qcow2.gz",
+            "sha256": "0105a1de918e94e9c456f32dac63e3cf296efa0b59f543fc23c1ef00ebb15a5f",
+            "size": 1018340613,
+            "uncompressed-sha256": "50377ba9c5cb92c649c7d9e31b508185241a3c204b34dd991fcb3cf0adc53983",
+            "uncompressed-size": 2572288000
         },
         "vmware": {
-            "path": "rhcos-48.84.202106301921-0-vmware.x86_64.ova",
-            "sha256": "34336e8716e6282692ee5deab94a9fd1b03f2ae8fcfaff0b018df034ccedafe7",
-            "size": 1050152960
+            "path": "rhcos-48.84.202109241901-0-vmware.x86_64.ova",
+            "sha256": "28eabddd539b3e0bd3d39c08a63f96cfd674817e25e4a84b67f9ca29baafd88a",
+            "size": 1052395520
         }
     },
     "oscontainer": {
-        "digest": "sha256:549075ee410913efc2a222b1c19ad6653123a526fe4a639f851cf9e0cea8a74e",
+        "digest": "sha256:57f6acfd48e833ef07a505b25a296849b74631a2b058814d618a347c9304308d",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "c559be8d64c1b0e7d379cd870cae1eb14830d104dea699593eafcd2b91ada6ad",
-    "ostree-version": "48.84.202106301921-0"
+    "ostree-commit": "13c18da5e6fee09fade484c3903209730cbb73e9ebcab806b9e9000cf97fd719",
+    "ostree-version": "48.84.202109241901-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202106302220-0/ppc64le/",
-    "buildid": "48.84.202106302220-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/",
+    "buildid": "48.84.202109242319-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-48.84.202106302220-0-live-initramfs.ppc64le.img",
-            "sha256": "f867267aba500c5af3e25a870efab686f650641f8b015706455b3c422da63822"
+            "path": "rhcos-48.84.202109242319-0-live-initramfs.ppc64le.img",
+            "sha256": "284329c5530e92f4d99ae47a3dd91338ec437ab28663959769fafbc80459f58a"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202106302220-0-live.ppc64le.iso",
-            "sha256": "addcf251344f27eb15529112ab85ffaaf7933e20e5284568d36cf010549f908f"
+            "path": "rhcos-48.84.202109242319-0-live.ppc64le.iso",
+            "sha256": "efc9c5ac6479c610c5ea32fbf99c480dcee42d839b597a3cdef1e2884ec98ab4"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202106302220-0-live-kernel-ppc64le",
-            "sha256": "ae1165bb13992f9b6543e2c8baa0f1f10460d84db740d1876c8f4f9226cb9a6d"
+            "path": "rhcos-48.84.202109242319-0-live-kernel-ppc64le",
+            "sha256": "d2f8f29ef59b87de2cbd7df8be60c06620bc90e88f4a722bb8278333d76ca3f8"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202106302220-0-live-rootfs.ppc64le.img",
-            "sha256": "c646c5608590dfa6e6280dc7d917d6b61a86a177a2058191a9536c11935f14bf"
+            "path": "rhcos-48.84.202109242319-0-live-rootfs.ppc64le.img",
+            "sha256": "898a23a6c936718855b5ec886e2aaa7bacede1cfcb3f1d24979adc35d6b9da70"
         },
         "metal": {
-            "path": "rhcos-48.84.202106302220-0-metal.ppc64le.raw.gz",
-            "sha256": "a123a053c587d7b59c7d2e662528dcddc2e2d1dd57f4b8b54cb48093fe83b2aa",
-            "size": 983391779,
-            "uncompressed-sha256": "60746809cf0364fc991b14c8623c4b62de9f62aecbd20133643c76c845fabe3c",
-            "uncompressed-size": 4096786432
+            "path": "rhcos-48.84.202109242319-0-metal.ppc64le.raw.gz",
+            "sha256": "fc0d83dde1e9c7b235fe33493594fa80b4ea78eacea386725cc2c7e5979ff96e",
+            "size": 984725024,
+            "uncompressed-sha256": "e0bb7614dd7f13ffd6823af0b974886d931197db3d048e0302a229d89c4d76f6",
+            "uncompressed-size": 4104126464
         },
         "metal4k": {
-            "path": "rhcos-48.84.202106302220-0-metal4k.ppc64le.raw.gz",
-            "sha256": "234bd0f07ef663eea49cf62bdbb32640af5cbc65c0423bf521d7473063769a7f",
-            "size": 983716850,
-            "uncompressed-sha256": "2da371e0a521f380fda6e8da916cea5b56424084a32c0332083c224dfb63e4ac",
-            "uncompressed-size": 4096786432
+            "path": "rhcos-48.84.202109242319-0-metal4k.ppc64le.raw.gz",
+            "sha256": "cce8fe6a661aa6d88da2365c1a93917cdd6750d261cf63c4f4f25416e111c213",
+            "size": 985109674,
+            "uncompressed-sha256": "1ff9baff8b141c8a055400fc536a5900721946d248d35cc75b7e8e92a048c639",
+            "uncompressed-size": 4104126464
         },
         "openstack": {
-            "path": "rhcos-48.84.202106302220-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "2ae115a6bd000e3802fcaf7bf32d725523b01fc6f720e52db1c6a2ed0bfd6102",
-            "size": 981600049,
-            "uncompressed-sha256": "1e6835d9b52a41bd8ba7c4bb7522fb717e19d7ee9998da54831c11e96015c008",
-            "uncompressed-size": 2644180992
+            "path": "rhcos-48.84.202109242319-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "fe1493a49b3332e0e462b8984d98b02eade0dbf864968d114e9403a9c62053cf",
+            "size": 983063322,
+            "uncompressed-sha256": "045aec0c7c562e832a0340d82143846c4596ca0638e7ad3f68136a0620fd04b7",
+            "uncompressed-size": 2649817088
         },
         "ostree": {
-            "path": "rhcos-48.84.202106302220-0-ostree.ppc64le.tar",
-            "sha256": "a8fc2cb6f39ccc8e57eacc132bae7b62d146c05b03f93d933745a16b0b5c76d4",
-            "size": 904355840
+            "path": "rhcos-48.84.202109242319-0-ostree.ppc64le.tar",
+            "sha256": "08f9262a4963781935b9ef08e8858f437032d62f0810eae83803dec5b9cb250a",
+            "size": 905707520
         },
         "qemu": {
-            "path": "rhcos-48.84.202106302220-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "cd0f2480a412f381f903f75f812aa1488d8392b4f08722880c53f00f50902334",
-            "size": 982695131,
-            "uncompressed-sha256": "42751f63a346c9d497322223d7e75f0b5d59b36f5635064603aa460c82be3640",
-            "uncompressed-size": 2681470976
+            "path": "rhcos-48.84.202109242319-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "7cbe2d49b089e3b0402ee8d305264c6f55e427ab8454e8510e832c9afc5d5d52",
+            "size": 984210968,
+            "uncompressed-sha256": "0cd8e500f4b507e595fc4bf07e03350cdc165e44a5154adccd50c6e8cd9f597b",
+            "uncompressed-size": 2687303680
         }
     },
     "oscontainer": {
-        "digest": "sha256:79aa996924bf83201acd455d34fba9aa222cb942fb7caffbdd46ef5109c34427",
+        "digest": "sha256:9379fc0a9936523568fd9fcc04fdbe11c09b58b257fb48de62b475e183e1a996",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "2a5829ce26ac890e776c2816a345fdf6d7a4b654f66c77133230fe2d61f2b572",
-    "ostree-version": "48.84.202106302220-0"
+    "ostree-commit": "60a547930f87ad1ed1d97f49aa12493e9db855bd84e876f0d1a2874b46ceebc3",
+    "ostree-version": "48.84.202109242319-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202106302220-0/s390x/",
-    "buildid": "48.84.202106302220-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/",
+    "buildid": "48.84.202109242104-0",
     "images": {
         "dasd": {
-            "path": "rhcos-48.84.202106302220-0-dasd.s390x.raw.gz",
-            "sha256": "c1569087c8e442384af18a6f5597b2bff67f335909df12d4b3e0f71e6b8a3fbc",
-            "size": 891497202,
-            "uncompressed-sha256": "5ba85b5d0c242864a25dd8797691b98c63caf3095964819255de46ab19576667",
-            "uncompressed-size": 3687841792
+            "path": "rhcos-48.84.202109242104-0-dasd.s390x.raw.gz",
+            "sha256": "572072ecb782fd9e9ea1faf9abc935ded986fac05ae9a2c809d9c68981bcd46e",
+            "size": 893328718,
+            "uncompressed-sha256": "c0a8ced21b0fdb26affb64670f05add27262e8316faeaabfee9e96b55ccb4ba3",
+            "uncompressed-size": 3696230400
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202106302220-0-live-initramfs.s390x.img",
-            "sha256": "e6880225f4a2f0e02f08dce5bdc3f8bdda079afed56cf5d1af7fefbbd80ea33f"
+            "path": "rhcos-48.84.202109242104-0-live-initramfs.s390x.img",
+            "sha256": "09d05a1d1592da1e3799bded203b00874f7024f85ee8dcf8933cb0dba3a5da94"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202106302220-0-live.s390x.iso",
-            "sha256": "055623f636a9be0c722addc23ea946c7896a8a90e68a44cadc09ae588f5daa1f"
+            "path": "rhcos-48.84.202109242104-0-live.s390x.iso",
+            "sha256": "168d17811b73a7da45ada38751a28db247381115021f8f2eb4e9d4083d29b719"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202106302220-0-live-kernel-s390x",
-            "sha256": "fc1762c98976a3ca46fe5b971f706570b4bcf3f3a8567dfe96c95b4f9e0e94df"
+            "path": "rhcos-48.84.202109242104-0-live-kernel-s390x",
+            "sha256": "81d8f6040cf3913ed01379e6af950d0c8168a4f6e0adeecaf63ae527c759ade9"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202106302220-0-live-rootfs.s390x.img",
-            "sha256": "e2d58694a45c2f94309af8033420a5c09d0be3fe533d844ecb1c07301c707540"
+            "path": "rhcos-48.84.202109242104-0-live-rootfs.s390x.img",
+            "sha256": "42d7b8caaafc9f911bef265cfeeef3a9369ceb984bfe6ea001649adb641e1fc6"
         },
         "metal": {
-            "path": "rhcos-48.84.202106302220-0-metal.s390x.raw.gz",
-            "sha256": "ac52b47da6170d3c361ea98b63749b3623293dc4e227316b19237e02dd9e6481",
-            "size": 891646853,
-            "uncompressed-sha256": "dbb2c5bd8fa43cb9ebf81e32b7f9cf60a88cef2c6b3599e8842140abe43ed2f2",
-            "uncompressed-size": 3687841792
+            "path": "rhcos-48.84.202109242104-0-metal.s390x.raw.gz",
+            "sha256": "12194de81db10b9d1cc51cd639a8cdd2c83c3793bd1e80c37da06d388d1e6929",
+            "size": 893348003,
+            "uncompressed-sha256": "f9d30d701ffaff5b241b55663edc84bad1158c42f4db60feb9bd0901b35f4aea",
+            "uncompressed-size": 3696230400
         },
         "metal4k": {
-            "path": "rhcos-48.84.202106302220-0-metal4k.s390x.raw.gz",
-            "sha256": "35b53059a770de258ec7b06c4b5725c9239abb0f1a32ed47d67eba69dd6f76d5",
-            "size": 891664461,
-            "uncompressed-sha256": "ad5629ade7c70a61859856c504161ce870f5bd0407c834dcd6b02c2a5cf40c13",
-            "uncompressed-size": 3687841792
+            "path": "rhcos-48.84.202109242104-0-metal4k.s390x.raw.gz",
+            "sha256": "b73bdd631daa7a4f36f5af93ebdfae3b23e5f5cd351b4c69078e97cb09edd941",
+            "size": 893351283,
+            "uncompressed-sha256": "838ded2c00bd62b4f4cc45c529edc4e90c693ed25435300923a587bfb3de7b2b",
+            "uncompressed-size": 3696230400
         },
         "openstack": {
-            "path": "rhcos-48.84.202106302220-0-openstack.s390x.qcow2.gz",
-            "sha256": "f161b15dcbb45550d71fe0347ad59ed872b2d2e3bd5627bed4b255f29501ace8",
-            "size": 889872761,
-            "uncompressed-sha256": "77990fca006cd84a6161534d2a23d1a1fe56413a60a38e8184d2fa681ffb9c99",
-            "uncompressed-size": 2300510208
+            "path": "rhcos-48.84.202109242104-0-openstack.s390x.qcow2.gz",
+            "sha256": "8b617aa20707dcaa1841faa3a4ff197391f55ae7d9bd60c86294668904d8925d",
+            "size": 891648879,
+            "uncompressed-sha256": "8b1182a4b7f00d29bb5d36ad3689412328c48b8c4b914d2c8f84883126151673",
+            "uncompressed-size": 2306670592
         },
         "ostree": {
-            "path": "rhcos-48.84.202106302220-0-ostree.s390x.tar",
-            "sha256": "7f85e10d95dc686f414a35bf0e12e772974678ad1b3eb67cddf0418a403bc86d",
-            "size": 838420480
+            "path": "rhcos-48.84.202109242104-0-ostree.s390x.tar",
+            "sha256": "3425a33c4244ec42007a0db6b5433bb7e2db22178f7f7ec1f61da066cb25dd16",
+            "size": 840007680
         },
         "qemu": {
-            "path": "rhcos-48.84.202106302220-0-qemu.s390x.qcow2.gz",
-            "sha256": "a937ac7c26dfbf648f6130b6d7c61ce8dea2c7038726371df689f3be9f7765cc",
-            "size": 890932160,
-            "uncompressed-sha256": "8254b57c074ce8fb34a83c191cd4aafbddab3edfb990d16a17bfe582b30f9ca8",
-            "uncompressed-size": 2336620544
+            "path": "rhcos-48.84.202109242104-0-qemu.s390x.qcow2.gz",
+            "sha256": "6cb9ca9d8f099720b7874650692df88c5c5d54762d614b7dc456fdd7c5d16674",
+            "size": 892710211,
+            "uncompressed-sha256": "b1a18112ab5455e8217edaef0304a9ec9d117931135618883cc7097d97eaab81",
+            "uncompressed-size": 2343043072
         }
     },
     "oscontainer": {
-        "digest": "sha256:ee0b94aaead6631c6c80d5f5f49f5b0c29d8d9ad1f8cd974b5773e51f6a67e5d",
+        "digest": "sha256:2db38ed16177ce76e581234b4d71b7a0f6627719325b6e8e093288a01c41a140",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "24801bcdf6319e951b18785d8e77827117f3cd47bff1f5121c9363a449742d1c",
-    "ostree-version": "48.84.202106302220-0"
+    "ostree-commit": "71f9571a1fe8e623c5b2a60b0ba94b014487ec5aba02f477b14028d7f58a9956",
+    "ostree-version": "48.84.202109242104-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,166 +1,166 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0910e9e4347267191"
+            "hvm": "ami-038772fdd54b78a4f"
         },
         "ap-east-1": {
-            "hvm": "ami-003c37759615789ad"
+            "hvm": "ami-03a6473cd438b2fea"
         },
         "ap-northeast-1": {
-            "hvm": "ami-04a04d42202f5dffb"
+            "hvm": "ami-05977c4081111f3bb"
         },
         "ap-northeast-2": {
-            "hvm": "ami-087c3504f536820f8"
+            "hvm": "ami-0a0fcda229d58dec1"
         },
         "ap-northeast-3": {
-            "hvm": "ami-03450c8fc4ff0f7bd"
+            "hvm": "ami-0467ba9dc70f85538"
         },
         "ap-south-1": {
-            "hvm": "ami-02b81ab6d01174430"
+            "hvm": "ami-07c047be0d3ec46ca"
         },
         "ap-southeast-1": {
-            "hvm": "ami-099b3006ba35122c6"
+            "hvm": "ami-0b574d30ee267107c"
         },
         "ap-southeast-2": {
-            "hvm": "ami-04d9e06d3edd4b78c"
+            "hvm": "ami-0c1b7b6fd42c043c2"
         },
         "ca-central-1": {
-            "hvm": "ami-0712dffd5af06d6a0"
+            "hvm": "ami-05bef6aaeb6a8cc3c"
         },
         "eu-central-1": {
-            "hvm": "ami-0b911f8bcf1f05a47"
+            "hvm": "ami-0d56b8ae868345407"
         },
         "eu-north-1": {
-            "hvm": "ami-06c6466f9944aee66"
+            "hvm": "ami-08dd7be7e8ebe13b6"
         },
         "eu-south-1": {
-            "hvm": "ami-011fabc962ea99519"
+            "hvm": "ami-06f4c9dfde4e75eb1"
         },
         "eu-west-1": {
-            "hvm": "ami-0cd860942047eaf85"
+            "hvm": "ami-0aef183a3bbfeeaf3"
         },
         "eu-west-2": {
-            "hvm": "ami-057df328de60ac464"
+            "hvm": "ami-07b3715c986152140"
         },
         "eu-west-3": {
-            "hvm": "ami-0e57008c4a59dbf99"
+            "hvm": "ami-0feee7f927014e9ad"
         },
         "me-south-1": {
-            "hvm": "ami-06934e136e2238997"
+            "hvm": "ami-01db7ebc5addfc2f6"
         },
         "sa-east-1": {
-            "hvm": "ami-01e07e22429c5bdef"
+            "hvm": "ami-097223d194bcb71f0"
         },
         "us-east-1": {
-            "hvm": "ami-0b35795bcab04ee70"
+            "hvm": "ami-06e6531aef9359b1e"
         },
         "us-east-2": {
-            "hvm": "ami-0c17b13bb8b268411"
+            "hvm": "ami-09145c219cb4df3e1"
         },
         "us-west-1": {
-            "hvm": "ami-004de02e4e2bba5f2"
+            "hvm": "ami-0afa3199a442f45cb"
         },
         "us-west-2": {
-            "hvm": "ami-0237df7fc4ba6a5cc"
+            "hvm": "ami-02a3699138ec7ecf4"
         }
     },
     "azure": {
-        "image": "rhcos-48.84.202106301921-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202106301921-0-azure.x86_64.vhd"
+        "image": "rhcos-48.84.202109241901-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202109241901-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202106301921-0/x86_64/",
-    "buildid": "48.84.202106301921-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/",
+    "buildid": "48.84.202109241901-0",
     "gcp": {
-        "image": "rhcos-48-84-202106301921-0-gcp-x86-64",
+        "image": "rhcos-48-84-202109241901-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202106301921-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202109241901-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.84.202106301921-0-aws.x86_64.vmdk.gz",
-            "sha256": "d0d100b3e701396bd03613aff74d224bdf568b46537ece01e9714c5415cebdb1",
-            "size": 1029124266,
-            "uncompressed-sha256": "2acb0f72e5404f2b37939358fe7804d4f434b99273fdc74c874ca505c5772cd4",
-            "uncompressed-size": 1050139136
+            "path": "rhcos-48.84.202109241901-0-aws.x86_64.vmdk.gz",
+            "sha256": "c081a65325330379e91707475b8dadf82e0f2d5c1c9f7f056fcd978641bb5114",
+            "size": 1031334820,
+            "uncompressed-sha256": "152a82e870e7e4d30d8204280f61ccfee90d826377bb25c51b2eac04f2fd82db",
+            "uncompressed-size": 1052379136
         },
         "azure": {
-            "path": "rhcos-48.84.202106301921-0-azure.x86_64.vhd.gz",
-            "sha256": "c1874fb74bb0988e6906fa5050989c16ec75306b67efc729c130545baa46f02b",
-            "size": 1029254110,
-            "uncompressed-sha256": "943789e911bd18c8b20ada9f5c4d67db50da56b67a5e0ce096b5b5b7970ab5cb",
+            "path": "rhcos-48.84.202109241901-0-azure.x86_64.vhd.gz",
+            "sha256": "801498fe0ccb754b898bef30e4d226f796874e615d7719b00d64b8054d434481",
+            "size": 1031392167,
+            "uncompressed-sha256": "b433bf7793db745c22c7ca09415a4dc87526ae7727e646d7b157acb323c3ee4f",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.84.202106301921-0-gcp.x86_64.tar.gz",
-            "sha256": "5575d9d6378b0587e67a037e18beeaf614cf9ae933fe1573ce810476caebd041",
-            "size": 1014689317
+            "path": "rhcos-48.84.202109241901-0-gcp.x86_64.tar.gz",
+            "sha256": "5231bdd554841c01fbd1092ea96c39b06dda3187549c0672a5f5c5e4d7eecdad",
+            "size": 1016813602
         },
         "ibmcloud": {
-            "path": "rhcos-48.84.202106301921-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "647c0987f2837abd16b846c130862798b18b2324f434ecfead4b9331a115361e",
-            "size": 1015047293,
-            "uncompressed-sha256": "78c8bc6b7cfb6bd8c29af81edebad5b1a4e06988ba6e59e909c8e29516d3168e",
-            "uncompressed-size": 2528641024
+            "path": "rhcos-48.84.202109241901-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "440ce3c4367a10fa66436638cef6ed938848050fd7f0de2d78d1294a4f56995d",
+            "size": 1017169285,
+            "uncompressed-sha256": "d81934aa386286ad35591fd46dc9cd809dc5e88623b563f220abae52665de472",
+            "uncompressed-size": 2535325696
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202106301921-0-live-initramfs.x86_64.img",
-            "sha256": "b52ff7b137cf70bf68d47cdfe17fea9e8e478aa7f481d32a88af53ad391b4c65"
+            "path": "rhcos-48.84.202109241901-0-live-initramfs.x86_64.img",
+            "sha256": "5b6f1b728a5e656ef128a54f9534f7d3d63953ef46e726a808aacf1ce9ad2742"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202106301921-0-live.x86_64.iso",
-            "sha256": "fb23569974e0184ee69000e5da5b4e2112f7c2f639696ef78f7664c2152ebd52"
+            "path": "rhcos-48.84.202109241901-0-live.x86_64.iso",
+            "sha256": "dc0c7af647137c9b16210c977896dc756b72b5e568774daf199964ca020935ae"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202106301921-0-live-kernel-x86_64",
-            "sha256": "9b900e88ca71b067d8f9971dc4454f454a12666b53d3ca2d80919729060a198d"
+            "path": "rhcos-48.84.202109241901-0-live-kernel-x86_64",
+            "sha256": "d13269e6c60119397210418781b7057673c4018692d28a868e248a0b550ea247"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202106301921-0-live-rootfs.x86_64.img",
-            "sha256": "dbcf72da9b95de52cd4d24aaf22b01ad209d0cb2e59212381e34c869646bb304"
+            "path": "rhcos-48.84.202109241901-0-live-rootfs.x86_64.img",
+            "sha256": "bd005071f295762a613ff42c26ce453be7c19d35594b68c94fab6797b4d834d4"
         },
         "metal": {
-            "path": "rhcos-48.84.202106301921-0-metal.x86_64.raw.gz",
-            "sha256": "66edefd079dba059f983ffe9d50d168860c24d7dd58c740ac7f8b1c66939ce76",
-            "size": 1016832063,
-            "uncompressed-sha256": "3e3bf27674546708a02ad1ddcb95ca8343c682a286476306820e5c1b7415d1dc",
-            "uncompressed-size": 3952082944
+            "path": "rhcos-48.84.202109241901-0-metal.x86_64.raw.gz",
+            "sha256": "6e67556bebee87b6d85d776a8b728ef727fb2e55c77a183f7979e8b89211b4db",
+            "size": 1018907248,
+            "uncompressed-sha256": "1b104a26b338f6aa4ba16a0bb3887e7bdc05c8735902785578208fb793fc504d",
+            "uncompressed-size": 3960471552
         },
         "metal4k": {
-            "path": "rhcos-48.84.202106301921-0-metal4k.x86_64.raw.gz",
-            "sha256": "04c4a2eae0c8968580049302dc8272d3aad936ef97d53f217e77f82254e6b8c4",
-            "size": 1014289639,
-            "uncompressed-sha256": "5c1cd1abe8ae077f6418055fa42f6c6dbe1d90c69b894e986c74b17e067530af",
-            "uncompressed-size": 3952082944
+            "path": "rhcos-48.84.202109241901-0-metal4k.x86_64.raw.gz",
+            "sha256": "9cf43a94eded275b2fb54bbb164ce63b18d7e696ca6c15f8cea4bb09941a0e57",
+            "size": 1016543064,
+            "uncompressed-sha256": "475d1123a2da31882b445c51ec5d5896c84de417feca5fe0ac1f93d8ea4e2c84",
+            "uncompressed-size": 3960471552
         },
         "openstack": {
-            "path": "rhcos-48.84.202106301921-0-openstack.x86_64.qcow2.gz",
-            "sha256": "713910e81c6b3dc4eabb2ea41fcddfc9d24dceca4bba23f690b467bcd28ce75e",
-            "size": 1015048690,
-            "uncompressed-sha256": "5a75df7b4d4dc1861093e520187a133eda3439019f280dc6e2f57edf70eb089d",
-            "uncompressed-size": 2528641024
+            "path": "rhcos-48.84.202109241901-0-openstack.x86_64.qcow2.gz",
+            "sha256": "99da4ed945b391d452e55a3a7809c799e4c74f69acbee1ecaec78f368c4e369e",
+            "size": 1017176202,
+            "uncompressed-sha256": "e0a1d8a99c5869150a56b8de475ea7952ca2fa3aacad7ca48533d1176df503ab",
+            "uncompressed-size": 2535325696
         },
         "ostree": {
-            "path": "rhcos-48.84.202106301921-0-ostree.x86_64.tar",
-            "sha256": "53b9fbcee43569cbb91c9ba23798ef478aff4683e6c63cfea93136c694afb79c",
-            "size": 939161600
+            "path": "rhcos-48.84.202109241901-0-ostree.x86_64.tar",
+            "sha256": "4e1c0dc1bcebcedf861256474db12822830e004e823e8a7968c6bed59002e924",
+            "size": 941015040
         },
         "qemu": {
-            "path": "rhcos-48.84.202106301921-0-qemu.x86_64.qcow2.gz",
-            "sha256": "9de96bfdde0875cc3595e1271bbd6509d19728b1c08a71be33a728a2597343cb",
-            "size": 1016166274,
-            "uncompressed-sha256": "fe7f5cb0bf0a46d8a7a1b58f658cb759732ada5ed875d9ef0f51574bf426b061",
-            "uncompressed-size": 2565013504
+            "path": "rhcos-48.84.202109241901-0-qemu.x86_64.qcow2.gz",
+            "sha256": "0105a1de918e94e9c456f32dac63e3cf296efa0b59f543fc23c1ef00ebb15a5f",
+            "size": 1018340613,
+            "uncompressed-sha256": "50377ba9c5cb92c649c7d9e31b508185241a3c204b34dd991fcb3cf0adc53983",
+            "uncompressed-size": 2572288000
         },
         "vmware": {
-            "path": "rhcos-48.84.202106301921-0-vmware.x86_64.ova",
-            "sha256": "34336e8716e6282692ee5deab94a9fd1b03f2ae8fcfaff0b018df034ccedafe7",
-            "size": 1050152960
+            "path": "rhcos-48.84.202109241901-0-vmware.x86_64.ova",
+            "sha256": "28eabddd539b3e0bd3d39c08a63f96cfd674817e25e4a84b67f9ca29baafd88a",
+            "size": 1052395520
         }
     },
     "oscontainer": {
-        "digest": "sha256:549075ee410913efc2a222b1c19ad6653123a526fe4a639f851cf9e0cea8a74e",
+        "digest": "sha256:57f6acfd48e833ef07a505b25a296849b74631a2b058814d618a347c9304308d",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "c559be8d64c1b0e7d379cd870cae1eb14830d104dea699593eafcd2b91ada6ad",
-    "ostree-version": "48.84.202106301921-0"
+    "ostree-commit": "13c18da5e6fee09fade484c3903209730cbb73e9ebcab806b9e9000cf97fd719",
+    "ostree-version": "48.84.202109241901-0"
 }


### PR DESCRIPTION
This updates the "legacy" RHCOS boot image metadata to match what is
contained in the stream metadata in `data/data/rhcos-stream.json`.

Note: this does not touch `data/data/rhcos-aarch64.json` as it already
matches the stream metadata and was not updated as part of #5227