### PR TITLE
openstack: Move TFVars logic to own package

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1"
 	azureprovider "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
-	openstackprovider "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition"
@@ -30,7 +28,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
-	openstackconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	ovirtconfig "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/openshiftinstall"
@@ -497,47 +494,13 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			Data:     data,
 		})
 	case openstack.Name:
-		cloud, err := openstackconfig.GetSession(installConfig.Config.Platform.OpenStack.Cloud)
-		if err != nil {
-			return errors.Wrap(err, "failed to get cloud config for openstack")
-		}
-		var caCert string
-		// Get the ca-cert-bundle key if there is a value for cacert in clouds.yaml
-		if caPath := cloud.CloudConfig.CACertFile; caPath != "" {
-			caFile, err := ioutil.ReadFile(caPath)
-			if err != nil {
-				return errors.Wrap(err, "failed to read clouds.yaml ca-cert from disk")
-			}
-			caCert = string(caFile)
-		}
-
-		masters, err := mastersAsset.Machines()
-		if err != nil {
-			return err
-		}
-
-		var masterSpecs []*openstackprovider.OpenstackProviderSpec
-		for _, master := range masters {
-			masterSpecs = append(masterSpecs, master.Spec.ProviderSpec.Value.Object.(*openstackprovider.OpenstackProviderSpec))
-		}
 		data, err = openstacktfvars.TFVars(
-			masterSpecs,
-			installConfig.Config.Platform.OpenStack.Cloud,
-			installConfig.Config.Platform.OpenStack.ExternalNetwork,
-			installConfig.Config.Platform.OpenStack.ExternalDNS,
-			installConfig.Config.Platform.OpenStack.APIFloatingIP,
-			installConfig.Config.Platform.OpenStack.IngressFloatingIP,
-			installConfig.Config.Platform.OpenStack.APIVIP,
-			installConfig.Config.Platform.OpenStack.IngressVIP,
+			installConfig,
+			mastersAsset,
+			workersAsset,
 			string(*rhcosImage),
-			installConfig.Config.Platform.OpenStack.ClusterOSImageProperties,
-			clusterID.InfraID,
-			caCert,
+			clusterID,
 			bootstrapIgn,
-			installConfig.Config.ControlPlane.Platform.OpenStack,
-			installConfig.Config.OpenStack.DefaultMachinePlatform,
-			installConfig.Config.Platform.OpenStack.MachinesSubnet,
-			installConfig.Config.Proxy,
 		)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)


### PR DESCRIPTION
This refactoring moves code from the shared `tfvars` asset directory to
the OpenStack-specific package.

The behaviour is left completely unchanged.

Implements [OSASINFRA-2695](https://issues.redhat.com/browse/OSASINFRA-2695)