### PR TITLE
Fix tf format failure on ibmcloud/network/image

### DIFF
--- a/data/data/ibmcloud/network/image/main.tf
+++ b/data/data/ibmcloud/network/image/main.tf
@@ -21,7 +21,7 @@ resource "ibm_iam_authorization_policy" "policy" {
   source_service_name         = "is"
   source_resource_type        = "image"
   target_service_name         = "cloud-object-storage"
-  target_resource_instance_id = "${element(split(":", var.cos_resource_instance_crn),7)}"
+  target_resource_instance_id = "${element(split(":", var.cos_resource_instance_crn), 7)}"
   roles                       = ["Reader"]
 }
 


### PR DESCRIPTION
Fix a terraform formatting failure from linting in the
ibmcloud/network/image/main.tf file.