### PR TITLE
ovirt: remove dougsland from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -82,13 +82,11 @@ aliases:
     - rgolangh
     - Gal-Zaidman
     - eslutsky
-    - dougsland
     - janosdebugs
   ovirt-reviewers:
     - rgolangh
     - Gal-Zaidman
     - eslutsky
-    - dougsland
     - janosdebugs
   kubevirt-approvers:
     - nirarg


### PR DESCRIPTION
I am not part of the oVirt Installer team anymore.

Signed-off-by: Douglas Schilling Landgraf <dlandgra@redhat.com>