### PR TITLE
Bug 2009253: Add validation to check APIVIP is IPv4 in dual-stack for Bare Metal

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -232,6 +232,15 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 			if apiVIPIPFamily != presence["machineNetwork"].Primary {
 				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", "baremetal", "apiVIP"), p.BareMetal.APIVIP, "VIP for the API must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6"))
 			}
+
+			ingressVIPIPFamily := corev1.IPv6Protocol
+			if net.ParseIP(p.BareMetal.IngressVIP).To4() != nil {
+				ingressVIPIPFamily = corev1.IPv4Protocol
+			}
+
+			if ingressVIPIPFamily != presence["machineNetwork"].Primary {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", "baremetal", "ingressVIP"), p.BareMetal.IngressVIP, "VIP for the Ingress must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6"))
+			}
 		case p.None != nil:
 		default:
 			allErrs = append(allErrs, field.Invalid(field.NewPath("networking"), "DualStack", "dual-stack IPv4/IPv6 is not supported for this platform, specify only one type of address"))

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -663,6 +663,19 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^\[platform\.baremetal\.ingressVIP: Invalid value: "test": "test" is not a valid IP, platform\.baremetal\.ingressVIP: Invalid value: "test": IP expected to be in one of the machine networks: 10.0.0.0/16]$`,
 		},
 		{
+			name: "baremetal Ingress VIP set to an incorrect IP Family",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking = validDualStackNetworkingConfig()
+				c.Platform = types.Platform{
+					BareMetal: validBareMetalPlatform(),
+				}
+				c.Platform.BareMetal.IngressVIP = "ffd0::"
+				return c
+			}(),
+			expectedError: `networking.baremetal.ingressVIP: Invalid value: "ffd0::": VIP for the Ingress must be of the same IP family with machine network's primary IP Family for dual-stack IPv4/IPv6`,
+		},
+		{
 			name: "baremetal Ingress VIP set to an incorrect value",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
This PR adds validation to check VIP for API belongs to IPv4 family
for bare metal dual-stack. Because in dual-stack, primary network
must be in IPv4. Hence, APIVIP must also be in IPv4.