### PR TITLE
Bug 2011893: baremetal: check that driver supports secure boot

### DIFF
--- a/docs/user/metal/install_ipi.md
+++ b/docs/user/metal/install_ipi.md
@@ -232,7 +232,7 @@ should be used to build the cluster. The number of assets must be at least great
 | `bmc` | | Connection details for the baseboard management controller. See below for details. |
 | `bootMACAddress` | | The MAC address of the NIC the host will use to boot on the provisioning network. It must be unique. |
 | `rootDeviceHints` | | How to choose the target disk for the OS during provisioning - for more details see [upstream docs](https://github.com/metal3-io/baremetal-operator/blob/master/docs/api.md). |
-| `bootMode` | `UEFI` | Choose `legacy` (BIOS) or `UEFI` mode for booting. Use `UEFISecureBoot` to enable UEFI and secure boot on the server. |
+| `bootMode` | `UEFI` | Choose `legacy` (BIOS) or `UEFI` mode for booting. Use `UEFISecureBoot` to enable UEFI and secure boot on the server. Only some drivers support UEFI secure boot (notably, IPMI does not). |
 
 The `bmc` parameter for each host is a set of values for accessing the
 baseboard management controller in the host.

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -125,8 +125,14 @@ func TestValidatePlatform(t *testing.T) {
 		{
 			name: "uefi_secure_boot_mode",
 			platform: platform().
-				Hosts(host1().BootMode("UEFISecureBoot")).build(),
+				Hosts(host1().BMCAddress("redfish://example.com/redfish/v1").BootMode("UEFISecureBoot")).build(),
 			expected: "",
+		},
+		{
+			name: "unsupported_uefi_secure_boot_mode",
+			platform: platform().
+				Hosts(host1().BootMode("UEFISecureBoot")).build(),
+			expected: "baremetal.Hosts\\[0\\].bootMode: Invalid value: \"UEFISecureBoot\": driver ipmi does not support UEFI secure boot",
 		},
 		{
 			name: "legacy_boot_mode",


### PR DESCRIPTION
Notably, the IPMI driver does not support managing secure boot.
