### PR TITLE
aws: Remove shared tags from user specified IAM roles

### DIFF
--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -10,7 +10,6 @@ import (
 	awsconfig "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	kubevirtconfig "github.com/openshift/installer/pkg/asset/installconfig/kubevirt"
-	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/baremetal"
@@ -67,9 +66,6 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 			} else {
 				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteNetworking)
 			}
-			if awsIncludesUserSuppliedInstanceRole(ic.Config) {
-				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteSharedInstanceRole)
-			}
 		}
 
 		ssn, err := ic.AWS.Session(ctx)
@@ -113,22 +109,4 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 // Name returns the human-friendly name of the asset.
 func (a *PlatformPermsCheck) Name() string {
 	return "Platform Permissions Check"
-}
-
-func awsIncludesUserSuppliedInstanceRole(installConfig *types.InstallConfig) bool {
-	mp := &aws.MachinePool{}
-	mp.Set(installConfig.Platform.AWS.DefaultMachinePlatform)
-	mp.Set(installConfig.ControlPlane.Platform.AWS)
-	if mp.IAMRole != "" {
-		return true
-	}
-	for _, c := range installConfig.Compute {
-		mp := &aws.MachinePool{}
-		mp.Set(installConfig.Platform.AWS.DefaultMachinePlatform)
-		mp.Set(c.Platform.AWS)
-		if mp.IAMRole != "" {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
The installer tags the IAM roles that are specified by the user
and deletes it during cluster destroy which is not ideal since
the installer should not be deleting the user created resources.

Removing the code that tags the IAM roes provided by the user and
also removing the permission required to delete the IAM role if
the user provided it.