### PR TITLE
Bug 2012233: IBMCloud: Handle 5 rule SG limit

### DIFF
--- a/data/data/ibmcloud/network/vpc/outputs.tf
+++ b/data/data/ibmcloud/network/vpc/outputs.tf
@@ -7,6 +7,7 @@ output "control_plane_security_group_id_list" {
     ibm_is_security_group.cluster_wide.id,
     ibm_is_security_group.openshift_network.id,
     ibm_is_security_group.control_plane.id,
+    ibm_is_security_group.control_plane_internal.id,
   ]
 }
 

--- a/data/data/ibmcloud/network/vpc/security-groups.tf
+++ b/data/data/ibmcloud/network/vpc/security-groups.tf
@@ -209,11 +209,18 @@ resource "ibm_is_security_group" "control_plane" {
   vpc            = ibm_is_vpc.vpc.id
 }
 
+resource "ibm_is_security_group" "control_plane_internal" {
+  name           = "${local.prefix}-security-group-control-plane-internal"
+  resource_group = var.resource_group_id
+  tags           = var.tags
+  vpc            = ibm_is_vpc.vpc.id
+}
+
 # etcd
-resource "ibm_is_security_group_rule" "control_plane_etcd_inbound" {
-  group     = ibm_is_security_group.control_plane.id
+resource "ibm_is_security_group_rule" "control_plane_internal_etcd_inbound" {
+  group     = ibm_is_security_group.control_plane_internal.id
   direction = "inbound"
-  remote    = ibm_is_security_group.control_plane.id
+  remote    = ibm_is_security_group.control_plane_internal.id
   tcp {
     port_min = 2379
     port_max = 2380
@@ -221,10 +228,10 @@ resource "ibm_is_security_group_rule" "control_plane_etcd_inbound" {
 }
 
 # Kubernetes default ports
-resource "ibm_is_security_group_rule" "control_plane_kube_default_ports_inbound" {
-  group     = ibm_is_security_group.control_plane.id
+resource "ibm_is_security_group_rule" "control_plane_internal_kube_default_ports_inbound" {
+  group     = ibm_is_security_group.control_plane_internal.id
   direction = "inbound"
-  remote    = ibm_is_security_group.control_plane.id
+  remote    = ibm_is_security_group.control_plane_internal.id
   tcp {
     port_min = 10257
     port_max = 10259
@@ -232,10 +239,10 @@ resource "ibm_is_security_group_rule" "control_plane_kube_default_ports_inbound"
 }
 
 # Cluster policy controller port
-resource "ibm_is_security_group_rule" "control_plane_cluster_policy_controller_ports_inbound" {
-  group     = ibm_is_security_group.control_plane.id
+resource "ibm_is_security_group_rule" "control_plane_internal_cluster_policy_controller_ports_inbound" {
+  group     = ibm_is_security_group.control_plane_internal.id
   direction = "inbound"
-  remote    = ibm_is_security_group.control_plane.id
+  remote    = ibm_is_security_group.control_plane_internal.id
   tcp {
     port_min = 10357
     port_max = 10357

--- a/pkg/asset/machines/ibmcloud/machines.go
+++ b/pkg/asset/machines/ibmcloud/machines.go
@@ -138,6 +138,7 @@ func getSecurityGroupNames(clusterID string, role string) ([]string, error) {
 			fmt.Sprintf("%s-security-group-cluster-wide", clusterID),
 			fmt.Sprintf("%s-security-group-openshift-network", clusterID),
 			fmt.Sprintf("%s-security-group-control-plane", clusterID),
+			fmt.Sprintf("%s-security-group-control-plane-internal", clusterID),
 		}, nil
 	case "worker":
 		return []string{


### PR DESCRIPTION
IBM Cloud has a 5 (remote) rule limit on each SecurityGroup. A
recent change placed the rules over that limit on the ControlPlane
SG. Split rules on that SG into 2 SG for the ControlPlane traffic.