### PR TITLE
Bug 2012235: IBM Cloud: Add RG to CP config

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -191,7 +191,8 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			}
 		}
 
-		ibmcloudConfig, err := ibmcloudmanifests.CloudProviderConfig(clusterID.InfraID, accountID, installConfig.Config.IBMCloud.Region, controlPlane.Zones, compute.Zones)
+		resourceGroupName := installConfig.Config.Platform.IBMCloud.ClusterResourceGroupName(clusterID.InfraID)
+		ibmcloudConfig, err := ibmcloudmanifests.CloudProviderConfig(clusterID.InfraID, accountID, installConfig.Config.IBMCloud.Region, resourceGroupName, controlPlane.Zones, compute.Zones)
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")
 		}

--- a/pkg/asset/manifests/ibmcloud/cloudproviderconfig.go
+++ b/pkg/asset/manifests/ibmcloud/cloudproviderconfig.go
@@ -29,13 +29,14 @@ type provider struct {
 	ClusterDefaultProvider   string `gcfg:"cluster-default-provider"`
 	Region                   string `gcfg:"region"`
 	G2CredentialsFilePath    string `gcfg:"g2Credentials"`
+	G2ResourceGroupName      string `gcfg:"g2ResourceGroupName"`
 	G2VPCName                string `gcfg:"g2VpcName"`
 	G2WorkerServiceAccountID string `gcfg:"g2workerServiceAccountID"`
 	G2VPCSubnetNames         string `gcfg:"g2VpcSubnetNames"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the IBMCloud platform.
-func CloudProviderConfig(infraID string, accountID string, region string, controlPlaneZones []string, computeZones []string) (string, error) {
+func CloudProviderConfig(infraID string, accountID string, region string, resourceGroupName string, controlPlaneZones []string, computeZones []string) (string, error) {
 	config := &config{
 		Global: global{
 			Version: "1.1.0",
@@ -49,6 +50,7 @@ func CloudProviderConfig(infraID string, accountID string, region string, contro
 			ClusterDefaultProvider:   "g2",
 			Region:                   region,
 			G2CredentialsFilePath:    "/etc/vpc/ibmcloud_api_key",
+			G2ResourceGroupName:      resourceGroupName,
 			G2VPCName:                fmt.Sprintf("%s-vpc", infraID),
 			G2WorkerServiceAccountID: accountID,
 			G2VPCSubnetNames:         getVpcSubnetNames(infraID, controlPlaneZones, computeZones),
@@ -88,6 +90,7 @@ clusterID = {{.Provider.ClusterID}}
 cluster-default-provider = {{.Provider.ClusterDefaultProvider}}
 region = {{.Provider.Region}}
 g2Credentials = {{.Provider.G2CredentialsFilePath}}
+g2ResourceGroupName = {{.Provider.G2ResourceGroupName}}
 g2VpcName = {{.Provider.G2VPCName}}
 g2workerServiceAccountID = {{.Provider.G2WorkerServiceAccountID}}
 g2VpcSubnetNames = {{.Provider.G2VPCSubnetNames}}

--- a/pkg/asset/manifests/ibmcloud/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/ibmcloud/cloudproviderconfig_test.go
@@ -17,13 +17,14 @@ clusterID = ocp4-8pxks
 cluster-default-provider = g2
 region = us-east
 g2Credentials = /etc/vpc/ibmcloud_api_key
+g2ResourceGroupName = ocp4-8pxks-rg
 g2VpcName = ocp4-8pxks-vpc
 g2workerServiceAccountID = 1e1f75646aef447814a6d907cc83fb3c
 g2VpcSubnetNames = ocp4-8pxks-subnet-compute-us-east-1,ocp4-8pxks-subnet-compute-us-east-2,ocp4-8pxks-subnet-compute-us-east-3,ocp4-8pxks-subnet-control-plane-us-east-1,ocp4-8pxks-subnet-control-plane-us-east-2,ocp4-8pxks-subnet-control-plane-us-east-3
 
 `
 	zones := []string{"us-east-1", "us-east-2", "us-east-3"}
-	actualConfig, err := CloudProviderConfig("ocp4-8pxks", "1e1f75646aef447814a6d907cc83fb3c", "us-east", zones, zones)
+	actualConfig, err := CloudProviderConfig("ocp4-8pxks", "1e1f75646aef447814a6d907cc83fb3c", "us-east", "ocp4-8pxks-rg", zones, zones)
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }


### PR DESCRIPTION
Add the ResourceGroupName into the IBM Cloud provider config as
a required value for the CCM.