### PR TITLE
feat(ibmcloud): Support VPC dedicated hosts

### DIFF
--- a/data/data/ibmcloud/bootstrap/main.tf
+++ b/data/data/ibmcloud/bootstrap/main.tf
@@ -21,6 +21,8 @@ resource "ibm_is_instance" "bootstrap_node" {
     security_groups = concat(var.control_plane_security_group_id_list, [ibm_is_security_group.bootstrap.id])
   }
 
+  dedicated_host = length(var.control_plane_dedicated_host_id_list) > 0 ? var.control_plane_dedicated_host_id_list[0] : null
+
   vpc  = var.vpc_id
   zone = var.control_plane_subnet_zone_list[0]
   keys = []

--- a/data/data/ibmcloud/bootstrap/variables.tf
+++ b/data/data/ibmcloud/bootstrap/variables.tf
@@ -2,6 +2,11 @@
 # Bootstrap module variables
 #######################################
 
+variable "control_plane_dedicated_host_id_list" {
+  type    = list(string)
+  default = []
+}
+
 variable "control_plane_security_group_id_list" {
   type = list(string)
 }

--- a/data/data/ibmcloud/master/main.tf
+++ b/data/data/ibmcloud/master/main.tf
@@ -25,6 +25,8 @@ resource "ibm_is_instance" "master_node" {
     security_groups = var.control_plane_security_group_id_list
   }
 
+  dedicated_host = length(var.control_plane_dedicated_host_id_list) > 0 ? var.control_plane_dedicated_host_id_list[count.index % local.zone_count] : null
+
   vpc  = var.vpc_id
   zone = var.control_plane_subnet_zone_list[count.index % local.zone_count]
   keys = []

--- a/data/data/ibmcloud/master/variables.tf
+++ b/data/data/ibmcloud/master/variables.tf
@@ -2,6 +2,11 @@
 # Master module variables
 #######################################
 
+variable "control_plane_dedicated_host_id_list" {
+  type    = list(string)
+  default = []
+}
+
 variable "control_plane_security_group_id_list" {
   type = list(string)
 }

--- a/data/data/ibmcloud/network/dhost/main.tf
+++ b/data/data/ibmcloud/network/dhost/main.tf
@@ -1,0 +1,73 @@
+locals {
+  prefix               = var.cluster_id
+  dhosts_master_create = [for dhost in var.dedicated_hosts_master : dhost if lookup(dhost, "id", "") == ""]
+  dhosts_master_zones  = [for i, dhost in var.dedicated_hosts_master : var.zones_master[i] if lookup(dhost, "id", "") == ""]
+  dhosts_worker_create = [for dhost in var.dedicated_hosts_worker : dhost if lookup(dhost, "id", "") == ""]
+  dhosts_worker_zones  = [for i, dhost in var.dedicated_hosts_worker : var.zones_worker[i] if lookup(dhost, "id", "") == ""]
+  dhosts_master_merged = [
+    for i, dhost in var.dedicated_hosts_master :
+    lookup(dhost, "id", "") == ""
+    ? ibm_is_dedicated_host.control_plane[index(ibm_is_dedicated_host.control_plane.*.zone, var.zones_master[i])].id
+    : dhost.id
+  ]
+}
+
+############################################
+# Dedicated hosts (Control Plane)
+############################################
+
+data "ibm_is_dedicated_host_profile" "control_plane" {
+  count = length(local.dhosts_master_create)
+  name  = local.dhosts_master_create[count.index].profile
+}
+
+resource "ibm_is_dedicated_host_group" "control_plane" {
+  count = length(local.dhosts_master_create)
+
+  name           = "${local.prefix}-dgroup-control-plane-${local.dhosts_master_zones[count.index]}"
+  class          = data.ibm_is_dedicated_host_profile.control_plane[count.index].class
+  family         = data.ibm_is_dedicated_host_profile.control_plane[count.index].family
+  resource_group = var.resource_group_id
+  zone           = local.dhosts_master_zones[count.index]
+}
+
+resource "ibm_is_dedicated_host" "control_plane" {
+  count = length(local.dhosts_master_create)
+
+  name           = "${local.prefix}-dhost-control-plane-${local.dhosts_master_zones[count.index]}"
+  host_group     = ibm_is_dedicated_host_group.control_plane[count.index].id
+  profile        = local.dhosts_master_create[count.index].profile
+  resource_group = var.resource_group_id
+
+  instance_placement_enabled = true
+}
+
+############################################
+# Dedicated hosts (Compute)
+############################################
+
+data "ibm_is_dedicated_host_profile" "compute" {
+  count = length(local.dhosts_worker_create)
+  name  = local.dhosts_worker_create[count.index].profile
+}
+
+resource "ibm_is_dedicated_host_group" "compute" {
+  count = length(local.dhosts_worker_create)
+
+  name           = "${local.prefix}-dgroup-compute-${local.dhosts_worker_zones[count.index]}"
+  class          = data.ibm_is_dedicated_host_profile.compute[count.index].class
+  family         = data.ibm_is_dedicated_host_profile.compute[count.index].family
+  resource_group = var.resource_group_id
+  zone           = local.dhosts_worker_zones[count.index]
+}
+
+resource "ibm_is_dedicated_host" "compute" {
+  count = length(local.dhosts_worker_create)
+
+  name           = "${local.prefix}-dhost-compute-${local.dhosts_worker_zones[count.index]}"
+  host_group     = ibm_is_dedicated_host_group.compute[count.index].id
+  profile        = local.dhosts_worker_create[count.index].profile
+  resource_group = var.resource_group_id
+
+  instance_placement_enabled = true
+}

--- a/data/data/ibmcloud/network/dhost/outputs.tf
+++ b/data/data/ibmcloud/network/dhost/outputs.tf
@@ -1,0 +1,7 @@
+#######################################
+# Dedicated Host module outputs
+#######################################
+
+output "control_plane_dedicated_host_id_list" {
+  value = local.dhosts_master_merged
+}

--- a/data/data/ibmcloud/network/dhost/variables.tf
+++ b/data/data/ibmcloud/network/dhost/variables.tf
@@ -1,0 +1,29 @@
+#######################################
+# Dedicated Host module variables
+#######################################
+
+variable "cluster_id" {
+  type = string
+}
+
+variable "dedicated_hosts_master" {
+  type    = list(map(string))
+  default = []
+}
+
+variable "dedicated_hosts_worker" {
+  type    = list(map(string))
+  default = []
+}
+
+variable "resource_group_id" {
+  type = string
+}
+
+variable "zones_master" {
+  type = list(string)
+}
+
+variable "zones_worker" {
+  type = list(string)
+}

--- a/data/data/ibmcloud/network/image/main.tf
+++ b/data/data/ibmcloud/network/image/main.tf
@@ -21,7 +21,7 @@ resource "ibm_iam_authorization_policy" "policy" {
   source_service_name         = "is"
   source_resource_type        = "image"
   target_service_name         = "cloud-object-storage"
-  target_resource_instance_id = "${element(split(":", var.cos_resource_instance_crn), 7)}"
+  target_resource_instance_id = element(split(":", var.cos_resource_instance_crn), 7)
   roles                       = ["Reader"]
 }
 

--- a/data/data/ibmcloud/network/main.tf
+++ b/data/data/ibmcloud/network/main.tf
@@ -60,6 +60,21 @@ module "cis" {
 }
 
 ############################################
+# Dedicated Host module
+############################################
+
+module "dhost" {
+  source = "./dhost"
+
+  cluster_id             = var.cluster_id
+  dedicated_hosts_master = var.ibmcloud_master_dedicated_hosts
+  dedicated_hosts_worker = var.ibmcloud_worker_dedicated_hosts
+  resource_group_id      = local.resource_group_id
+  zones_master           = distinct(var.ibmcloud_master_availability_zones)
+  zones_worker           = distinct(var.ibmcloud_worker_availability_zones)
+}
+
+############################################
 # VPC module
 ############################################
 
@@ -69,7 +84,7 @@ module "vpc" {
   cluster_id        = var.cluster_id
   public_endpoints  = local.public_endpoints
   resource_group_id = local.resource_group_id
-  region            = var.ibmcloud_region
   tags              = local.tags
-  zone_list         = distinct(var.ibmcloud_master_availability_zones)
+  zones_master      = distinct(var.ibmcloud_master_availability_zones)
+  zones_worker      = distinct(var.ibmcloud_worker_availability_zones)
 }

--- a/data/data/ibmcloud/network/outputs.tf
+++ b/data/data/ibmcloud/network/outputs.tf
@@ -2,6 +2,22 @@
 # Network module outputs
 #######################################
 
+output "control_plane_dedicated_host_id_list" {
+  value = module.dhost.control_plane_dedicated_host_id_list
+}
+
+output "control_plane_security_group_id_list" {
+  value = module.vpc.control_plane_security_group_id_list
+}
+
+output "control_plane_subnet_id_list" {
+  value = module.vpc.control_plane_subnet_id_list
+}
+
+output "control_plane_subnet_zone_list" {
+  value = module.vpc.control_plane_subnet_zone_list
+}
+
 output "cos_resource_instance_crn" {
   value = ibm_resource_instance.cos.crn
 }
@@ -28,18 +44,6 @@ output "lb_pool_machine_config_id" {
 
 output "resource_group_id" {
   value = local.resource_group_id
-}
-
-output "control_plane_security_group_id_list" {
-  value = module.vpc.control_plane_security_group_id_list
-}
-
-output "control_plane_subnet_id_list" {
-  value = module.vpc.control_plane_subnet_id_list
-}
-
-output "control_plane_subnet_zone_list" {
-  value = module.vpc.control_plane_subnet_zone_list
 }
 
 output "vpc_id" {

--- a/data/data/ibmcloud/network/vpc/variables.tf
+++ b/data/data/ibmcloud/network/vpc/variables.tf
@@ -10,10 +10,6 @@ variable "public_endpoints" {
   type = bool
 }
 
-variable "region" {
-  type = string
-}
-
 variable "resource_group_id" {
   type = string
 }
@@ -22,6 +18,10 @@ variable "tags" {
   type = list(string)
 }
 
-variable "zone_list" {
+variable "zones_master" {
+  type = list(string)
+}
+
+variable "zones_worker" {
   type = list(string)
 }

--- a/data/data/ibmcloud/network/vpc/vpc.tf
+++ b/data/data/ibmcloud/network/vpc/vpc.tf
@@ -1,6 +1,6 @@
 locals {
-  prefix     = var.cluster_id
-  zone_count = length(var.zone_list)
+  prefix    = var.cluster_id
+  zones_all = distinct(concat(var.zones_master, var.zones_worker))
 }
 
 ############################################
@@ -18,13 +18,13 @@ resource "ibm_is_vpc" "vpc" {
 ############################################
 
 resource "ibm_is_public_gateway" "public_gateway" {
-  count = local.zone_count
+  count = length(local.zones_all)
 
-  name           = "${local.prefix}-public-gateway-${var.zone_list[count.index]}"
+  name           = "${local.prefix}-public-gateway-${local.zones_all[count.index]}"
   resource_group = var.resource_group_id
   tags           = var.tags
   vpc            = ibm_is_vpc.vpc.id
-  zone           = var.zone_list[count.index]
+  zone           = local.zones_all[count.index]
 }
 
 ############################################
@@ -32,25 +32,25 @@ resource "ibm_is_public_gateway" "public_gateway" {
 ############################################
 
 resource "ibm_is_subnet" "control_plane" {
-  count = local.zone_count
+  count = length(var.zones_master)
 
-  name                     = "${local.prefix}-subnet-control-plane-${var.zone_list[count.index]}"
+  name                     = "${local.prefix}-subnet-control-plane-${var.zones_master[count.index]}"
   resource_group           = var.resource_group_id
   tags                     = var.tags
   vpc                      = ibm_is_vpc.vpc.id
-  zone                     = var.zone_list[count.index]
-  public_gateway           = ibm_is_public_gateway.public_gateway[count.index].id
+  zone                     = var.zones_master[count.index]
+  public_gateway           = ibm_is_public_gateway.public_gateway[index(ibm_is_public_gateway.public_gateway.*.zone, var.zones_master[count.index])].id
   total_ipv4_address_count = "256"
 }
 
 resource "ibm_is_subnet" "compute" {
-  count = local.zone_count
+  count = length(var.zones_worker)
 
-  name                     = "${local.prefix}-subnet-compute-${var.zone_list[count.index]}"
+  name                     = "${local.prefix}-subnet-compute-${var.zones_worker[count.index]}"
   resource_group           = var.resource_group_id
   tags                     = var.tags
   vpc                      = ibm_is_vpc.vpc.id
-  zone                     = var.zone_list[count.index]
-  public_gateway           = ibm_is_public_gateway.public_gateway[count.index].id
+  zone                     = var.zones_worker[count.index]
+  public_gateway           = ibm_is_public_gateway.public_gateway[index(ibm_is_public_gateway.public_gateway.*.zone, var.zones_worker[count.index])].id
   total_ipv4_address_count = "256"
 }

--- a/data/data/ibmcloud/variables-ibmcloud.tf
+++ b/data/data/ibmcloud/variables-ibmcloud.tf
@@ -34,6 +34,11 @@ variable "ibmcloud_master_availability_zones" {
   description = "The availability zones in which to create the masters. The length of this list must match master_count."
 }
 
+variable "ibmcloud_worker_availability_zones" {
+  type        = list(string)
+  description = "The availability zones to provision for workers. Worker instances are created by the machine-API operator, but this variable controls their supporting infrastructure (subnets, routing, dedicated hosts, etc.)."
+}
+
 variable "ibmcloud_image_filepath" {
   type        = string
   description = "The file path to the RHCOS image"
@@ -42,6 +47,18 @@ variable "ibmcloud_image_filepath" {
 #######################################
 # Top-level module variables (optional)
 #######################################
+
+variable "ibmcloud_master_dedicated_hosts" {
+  type        = list(map(string))
+  description = "(optional) The list of dedicated hosts in which to create the control plane nodes."
+  default     = []
+}
+
+variable "ibmcloud_worker_dedicated_hosts" {
+  type        = list(map(string))
+  description = "(optional) The list of dedicated hosts in which to create the compute nodes."
+  default     = []
+}
 
 variable "ibmcloud_extra_tags" {
   type        = list(string)

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -292,6 +292,25 @@ spec:
                                 managed encryption key will be used.
                               type: string
                           type: object
+                        dedicatedHosts:
+                          description: DedicatedHosts is the configuration for the
+                            machine's dedicated host and profile.
+                          items:
+                            description: DedicatedHost stores the configuration for
+                              the machine's dedicated host platform.
+                            properties:
+                              name:
+                                description: Name is the name of the dedicated host
+                                  to provision the machine on. If specified, machines
+                                  will be created on pre-existing dedicated host.
+                                type: string
+                              profile:
+                                description: Profile is the profile ID for the dedicated
+                                  host. If specified, new dedicated host will be created
+                                  for machines.
+                                type: string
+                            type: object
+                          type: array
                         type:
                           description: InstanceType is the VSI machine profile.
                           type: string
@@ -733,6 +752,25 @@ spec:
                               managed encryption key will be used.
                             type: string
                         type: object
+                      dedicatedHosts:
+                        description: DedicatedHosts is the configuration for the machine's
+                          dedicated host and profile.
+                        items:
+                          description: DedicatedHost stores the configuration for
+                            the machine's dedicated host platform.
+                          properties:
+                            name:
+                              description: Name is the name of the dedicated host
+                                to provision the machine on. If specified, machines
+                                will be created on pre-existing dedicated host.
+                              type: string
+                            profile:
+                              description: Profile is the profile ID for the dedicated
+                                host. If specified, new dedicated host will be created
+                                for machines.
+                              type: string
+                          type: object
+                        type: array
                       type:
                         description: InstanceType is the VSI machine profile.
                         type: string
@@ -1699,6 +1737,25 @@ spec:
                               managed encryption key will be used.
                             type: string
                         type: object
+                      dedicatedHosts:
+                        description: DedicatedHosts is the configuration for the machine's
+                          dedicated host and profile.
+                        items:
+                          description: DedicatedHost stores the configuration for
+                            the machine's dedicated host platform.
+                          properties:
+                            name:
+                              description: Name is the name of the dedicated host
+                                to provision the machine on. If specified, machines
+                                will be created on pre-existing dedicated host.
+                              type: string
+                            profile:
+                              description: Profile is the profile ID for the dedicated
+                                host. If specified, new dedicated host will be created
+                                for machines.
+                              type: string
+                          type: object
+                        type: array
                       type:
                         description: InstanceType is the VSI machine profile.
                         type: string

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210409155308-a8e62c60e930
 	github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e
 	github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201203141909-4dc702fd57a5
-	github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20210702173623-676faba9895d
+	github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20211008100740-4d7907adbd6b
 	github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603
 	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20210817084941-2262c7c6cece
 	github.com/openshift/library-go v0.0.0-20210408164723-7a65fdb398e2

--- a/go.sum
+++ b/go.sum
@@ -788,6 +788,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1541,8 +1542,8 @@ github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201002065957-9854f74205
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201201000827-1117a4fc438c/go.mod h1:21N0wWjiTQypZ7WosEYhcGJHr9JoDR1RBFztE0NvdYM=
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201203141909-4dc702fd57a5 h1:75U75i/GfStAartlsP/F9v3Gv3MwzuLwqdLTjP1vPeE=
 github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201203141909-4dc702fd57a5/go.mod h1:/XjFaKnqBc8K/jcRXHO7tau39CmzNinqmpxYaQGRvnE=
-github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20210702173623-676faba9895d h1:FD/0xn/h8Do//QkPGhsf1pgXkH8nUkfIUmQ16bRU6TQ=
-github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20210702173623-676faba9895d/go.mod h1:hIEdP3ZudO/l2J8+gm8IFW0KMHn0YURvMSTZy9luK7w=
+github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20211008100740-4d7907adbd6b h1:atciNID+jTAqvQT0t/hAE+KVFLCxv2asXGih2py2dpg=
+github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20211008100740-4d7907adbd6b/go.mod h1:xkkPB22FMQyrv3G0HLobylRsosJP4Voi8Yojg5WEYrs=
 github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603 h1:MC6BSZYxFPoqqKj9PdlGjHGVKcMsvn6Kv1NiVzQErZ8=
 github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20191219173431-2336783d4603/go.mod h1:7pQ9Bzha+ug/5zd+0ufbDEcnn2OnNlPwRwYrzhXk4NM=
 github.com/openshift/cluster-api-provider-openstack v0.0.0-20210302164104-8498241fa4bd h1:5mq9/JftiO9u/RknQ5iR9Nkd09R1XFfUPS1nO11Wth0=

--- a/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
+++ b/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
@@ -6,6 +6,8 @@ package mock
 
 import (
 	context "context"
+	reflect "reflect"
+
 	dnsrecordsv1 "github.com/IBM/networking-go-sdk/dnsrecordsv1"
 	iamidentityv1 "github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	resourcecontrollerv2 "github.com/IBM/platform-services-go-sdk/resourcecontrollerv2"
@@ -13,33 +15,32 @@ import (
 	vpcv1 "github.com/IBM/vpc-go-sdk/vpcv1"
 	gomock "github.com/golang/mock/gomock"
 	ibmcloud "github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
-	reflect "reflect"
 )
 
-// MockAPI is a mock of API interface
+// MockAPI is a mock of API interface.
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI
+// MockAPIMockRecorder is the mock recorder for MockAPI.
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance
+// NewMockAPI creates a new mock instance.
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// GetAuthenticatorAPIKeyDetails mocks base method
+// GetAuthenticatorAPIKeyDetails mocks base method.
 func (m *MockAPI) GetAuthenticatorAPIKeyDetails(ctx context.Context) (*iamidentityv1.APIKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthenticatorAPIKeyDetails", ctx)
@@ -48,13 +49,13 @@ func (m *MockAPI) GetAuthenticatorAPIKeyDetails(ctx context.Context) (*iamidenti
 	return ret0, ret1
 }
 
-// GetAuthenticatorAPIKeyDetails indicates an expected call of GetAuthenticatorAPIKeyDetails
+// GetAuthenticatorAPIKeyDetails indicates an expected call of GetAuthenticatorAPIKeyDetails.
 func (mr *MockAPIMockRecorder) GetAuthenticatorAPIKeyDetails(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthenticatorAPIKeyDetails", reflect.TypeOf((*MockAPI)(nil).GetAuthenticatorAPIKeyDetails), ctx)
 }
 
-// GetCISInstance mocks base method
+// GetCISInstance mocks base method.
 func (m *MockAPI) GetCISInstance(ctx context.Context, crnstr string) (*resourcecontrollerv2.ResourceInstance, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCISInstance", ctx, crnstr)
@@ -63,13 +64,13 @@ func (m *MockAPI) GetCISInstance(ctx context.Context, crnstr string) (*resourcec
 	return ret0, ret1
 }
 
-// GetCISInstance indicates an expected call of GetCISInstance
+// GetCISInstance indicates an expected call of GetCISInstance.
 func (mr *MockAPIMockRecorder) GetCISInstance(ctx, crnstr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCISInstance", reflect.TypeOf((*MockAPI)(nil).GetCISInstance), ctx, crnstr)
 }
 
-// GetDNSRecordsByName mocks base method
+// GetDNSRecordsByName mocks base method.
 func (m *MockAPI) GetDNSRecordsByName(ctx context.Context, crnstr, zoneID, recordName string) ([]dnsrecordsv1.DnsrecordDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDNSRecordsByName", ctx, crnstr, zoneID, recordName)
@@ -78,13 +79,13 @@ func (m *MockAPI) GetDNSRecordsByName(ctx context.Context, crnstr, zoneID, recor
 	return ret0, ret1
 }
 
-// GetDNSRecordsByName indicates an expected call of GetDNSRecordsByName
+// GetDNSRecordsByName indicates an expected call of GetDNSRecordsByName.
 func (mr *MockAPIMockRecorder) GetDNSRecordsByName(ctx, crnstr, zoneID, recordName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSRecordsByName", reflect.TypeOf((*MockAPI)(nil).GetDNSRecordsByName), ctx, crnstr, zoneID, recordName)
 }
 
-// GetDNSZoneIDByName mocks base method
+// GetDNSZoneIDByName mocks base method.
 func (m *MockAPI) GetDNSZoneIDByName(ctx context.Context, name string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDNSZoneIDByName", ctx, name)
@@ -93,13 +94,13 @@ func (m *MockAPI) GetDNSZoneIDByName(ctx context.Context, name string) (string, 
 	return ret0, ret1
 }
 
-// GetDNSZoneIDByName indicates an expected call of GetDNSZoneIDByName
+// GetDNSZoneIDByName indicates an expected call of GetDNSZoneIDByName.
 func (mr *MockAPIMockRecorder) GetDNSZoneIDByName(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSZoneIDByName", reflect.TypeOf((*MockAPI)(nil).GetDNSZoneIDByName), ctx, name)
 }
 
-// GetDNSZones mocks base method
+// GetDNSZones mocks base method.
 func (m *MockAPI) GetDNSZones(ctx context.Context) ([]ibmcloud.DNSZoneResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDNSZones", ctx)
@@ -108,13 +109,43 @@ func (m *MockAPI) GetDNSZones(ctx context.Context) ([]ibmcloud.DNSZoneResponse, 
 	return ret0, ret1
 }
 
-// GetDNSZones indicates an expected call of GetDNSZones
+// GetDNSZones indicates an expected call of GetDNSZones.
 func (mr *MockAPIMockRecorder) GetDNSZones(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSZones", reflect.TypeOf((*MockAPI)(nil).GetDNSZones), ctx)
 }
 
-// GetEncryptionKey mocks base method
+// GetDedicatedHostByName mocks base method.
+func (m *MockAPI) GetDedicatedHostByName(ctx context.Context, name, region string) (*vpcv1.DedicatedHost, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDedicatedHostByName", ctx, name, region)
+	ret0, _ := ret[0].(*vpcv1.DedicatedHost)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDedicatedHostByName indicates an expected call of GetDedicatedHostByName.
+func (mr *MockAPIMockRecorder) GetDedicatedHostByName(ctx, name, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDedicatedHostByName", reflect.TypeOf((*MockAPI)(nil).GetDedicatedHostByName), ctx, name, region)
+}
+
+// GetDedicatedHostProfiles mocks base method.
+func (m *MockAPI) GetDedicatedHostProfiles(ctx context.Context, region string) ([]vpcv1.DedicatedHostProfile, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDedicatedHostProfiles", ctx, region)
+	ret0, _ := ret[0].([]vpcv1.DedicatedHostProfile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDedicatedHostProfiles indicates an expected call of GetDedicatedHostProfiles.
+func (mr *MockAPIMockRecorder) GetDedicatedHostProfiles(ctx, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDedicatedHostProfiles", reflect.TypeOf((*MockAPI)(nil).GetDedicatedHostProfiles), ctx, region)
+}
+
+// GetEncryptionKey mocks base method.
 func (m *MockAPI) GetEncryptionKey(ctx context.Context, keyCRN string) (*ibmcloud.EncryptionKeyResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEncryptionKey", ctx, keyCRN)
@@ -123,28 +154,13 @@ func (m *MockAPI) GetEncryptionKey(ctx context.Context, keyCRN string) (*ibmclou
 	return ret0, ret1
 }
 
-// GetEncryptionKey indicates an expected call of GetEncryptionKey
+// GetEncryptionKey indicates an expected call of GetEncryptionKey.
 func (mr *MockAPIMockRecorder) GetEncryptionKey(ctx, keyCRN interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncryptionKey", reflect.TypeOf((*MockAPI)(nil).GetEncryptionKey), ctx, keyCRN)
 }
 
-// GetResourceGroups mocks base method
-func (m *MockAPI) GetResourceGroups(ctx context.Context) ([]resourcemanagerv2.ResourceGroup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResourceGroups", ctx)
-	ret0, _ := ret[0].([]resourcemanagerv2.ResourceGroup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetResourceGroups indicates an expected call of GetResourceGroups
-func (mr *MockAPIMockRecorder) GetResourceGroups(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceGroups", reflect.TypeOf((*MockAPI)(nil).GetResourceGroups), ctx)
-}
-
-// GetResourceGroup mocks base method
+// GetResourceGroup mocks base method.
 func (m *MockAPI) GetResourceGroup(ctx context.Context, nameOrID string) (*resourcemanagerv2.ResourceGroup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourceGroup", ctx, nameOrID)
@@ -153,13 +169,28 @@ func (m *MockAPI) GetResourceGroup(ctx context.Context, nameOrID string) (*resou
 	return ret0, ret1
 }
 
-// GetResourceGroup indicates an expected call of GetResourceGroup
+// GetResourceGroup indicates an expected call of GetResourceGroup.
 func (mr *MockAPIMockRecorder) GetResourceGroup(ctx, nameOrID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceGroup", reflect.TypeOf((*MockAPI)(nil).GetResourceGroup), ctx, nameOrID)
 }
 
-// GetSubnet mocks base method
+// GetResourceGroups mocks base method.
+func (m *MockAPI) GetResourceGroups(ctx context.Context) ([]resourcemanagerv2.ResourceGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResourceGroups", ctx)
+	ret0, _ := ret[0].([]resourcemanagerv2.ResourceGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResourceGroups indicates an expected call of GetResourceGroups.
+func (mr *MockAPIMockRecorder) GetResourceGroups(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceGroups", reflect.TypeOf((*MockAPI)(nil).GetResourceGroups), ctx)
+}
+
+// GetSubnet mocks base method.
 func (m *MockAPI) GetSubnet(ctx context.Context, subnetID string) (*vpcv1.Subnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSubnet", ctx, subnetID)
@@ -168,28 +199,13 @@ func (m *MockAPI) GetSubnet(ctx context.Context, subnetID string) (*vpcv1.Subnet
 	return ret0, ret1
 }
 
-// GetSubnet indicates an expected call of GetSubnet
+// GetSubnet indicates an expected call of GetSubnet.
 func (mr *MockAPIMockRecorder) GetSubnet(ctx, subnetID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockAPI)(nil).GetSubnet), ctx, subnetID)
 }
 
-// GetVSIProfiles mocks base method
-func (m *MockAPI) GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVSIProfiles", ctx)
-	ret0, _ := ret[0].([]vpcv1.InstanceProfile)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVSIProfiles indicates an expected call of GetVSIProfiles
-func (mr *MockAPIMockRecorder) GetVSIProfiles(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVSIProfiles", reflect.TypeOf((*MockAPI)(nil).GetVSIProfiles), ctx)
-}
-
-// GetVPC mocks base method
+// GetVPC mocks base method.
 func (m *MockAPI) GetVPC(ctx context.Context, vpcID string) (*vpcv1.VPC, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVPC", ctx, vpcID)
@@ -198,13 +214,13 @@ func (m *MockAPI) GetVPC(ctx context.Context, vpcID string) (*vpcv1.VPC, error) 
 	return ret0, ret1
 }
 
-// GetVPC indicates an expected call of GetVPC
+// GetVPC indicates an expected call of GetVPC.
 func (mr *MockAPIMockRecorder) GetVPC(ctx, vpcID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPC", reflect.TypeOf((*MockAPI)(nil).GetVPC), ctx, vpcID)
 }
 
-// GetVPCZonesForRegion mocks base method
+// GetVPCZonesForRegion mocks base method.
 func (m *MockAPI) GetVPCZonesForRegion(ctx context.Context, region string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVPCZonesForRegion", ctx, region)
@@ -213,8 +229,23 @@ func (m *MockAPI) GetVPCZonesForRegion(ctx context.Context, region string) ([]st
 	return ret0, ret1
 }
 
-// GetVPCZonesForRegion indicates an expected call of GetVPCZonesForRegion
+// GetVPCZonesForRegion indicates an expected call of GetVPCZonesForRegion.
 func (mr *MockAPIMockRecorder) GetVPCZonesForRegion(ctx, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCZonesForRegion", reflect.TypeOf((*MockAPI)(nil).GetVPCZonesForRegion), ctx, region)
+}
+
+// GetVSIProfiles mocks base method.
+func (m *MockAPI) GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVSIProfiles", ctx)
+	ret0, _ := ret[0].([]vpcv1.InstanceProfile)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVSIProfiles indicates an expected call of GetVSIProfiles.
+func (mr *MockAPIMockRecorder) GetVSIProfiles(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVSIProfiles", reflect.TypeOf((*MockAPI)(nil).GetVSIProfiles), ctx)
 }

--- a/pkg/asset/installconfig/ibmcloud/validation.go
+++ b/pkg/asset/installconfig/ibmcloud/validation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -55,24 +56,100 @@ func validateMachinePool(client API, platform *ibmcloud.Platform, machinePool *i
 	allErrs := field.ErrorList{}
 
 	if machinePool.InstanceType != "" {
-		allErrs = append(allErrs, validateMachinePoolType(client, machinePool.InstanceType, path)...)
+		allErrs = append(allErrs, validateMachinePoolType(client, machinePool.InstanceType, path.Child("type"))...)
 	}
 
 	if len(machinePool.Zones) > 0 {
-		allErrs = append(allErrs, validateMachinePoolZones(client, platform.Region, machinePool.Zones, path)...)
+		allErrs = append(allErrs, validateMachinePoolZones(client, platform.Region, machinePool.Zones, path.Child("zones"))...)
 	}
 
 	if machinePool.BootVolume != nil {
-		allErrs = append(allErrs, validateMachinePoolBootVolume(client, *machinePool.BootVolume, path)...)
+		allErrs = append(allErrs, validateMachinePoolBootVolume(client, *machinePool.BootVolume, path.Child("bootVolume"))...)
+	}
+
+	if len(machinePool.DedicatedHosts) > 0 {
+		allErrs = append(allErrs, validateMachinePoolDedicatedHosts(client, machinePool.DedicatedHosts, machinePool.InstanceType, machinePool.Zones, platform.Region, path.Child("dedicatedHosts"))...)
 	}
 
 	return allErrs
 }
 
+func validateMachinePoolDedicatedHosts(client API, dhosts []ibmcloud.DedicatedHost, machineType string, zones []string, region string, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Get list of supported profiles in region
+	dhostProfiles, err := client.GetDedicatedHostProfiles(context.TODO(), region)
+	if err != nil {
+		allErrs = append(allErrs, field.InternalError(path, err))
+	}
+
+	for i, dhost := range dhosts {
+		if dhost.Name != "" {
+			// Check if host with name exists
+			dh, err := client.GetDedicatedHostByName(context.TODO(), dhost.Name, region)
+			if err != nil {
+				allErrs = append(allErrs, field.InternalError(path.Index(i).Child("name"), err))
+			}
+
+			if dh != nil {
+				// Check if instance is provisionable on host
+				if !*dh.InstancePlacementEnabled || !*dh.Provisionable {
+					allErrs = append(allErrs, field.Invalid(path.Index(i).Child("name"), dhost.Name, "dedicated host is unable to provision instances"))
+				}
+
+				// Check if host is in zone
+				if *dh.Zone.Name != zones[i] {
+					allErrs = append(allErrs, field.Invalid(path.Index(i).Child("name"), dhost.Name, fmt.Sprintf("dedicated host not in zone %s", zones[i])))
+				}
+
+				// Check if host profile supports machine type
+				if !isInstanceProfileInList(machineType, dh.SupportedInstanceProfiles) {
+					allErrs = append(allErrs, field.Invalid(path.Index(i).Child("name"), dhost.Name, fmt.Sprintf("dedicated host does not support machine type %s", machineType)))
+				}
+			}
+		} else {
+			// Check if host profile is supported in region
+			if !isDedicatedHostProfileInList(dhost.Profile, dhostProfiles) {
+				allErrs = append(allErrs, field.Invalid(path.Index(i).Child("profile"), dhost.Profile, fmt.Sprintf("dedicated host profile not supported in region %s", region)))
+			}
+
+			// Check if host profile supports machine type
+			for _, profile := range dhostProfiles {
+				if *profile.Name == dhost.Profile {
+					if !isInstanceProfileInList(machineType, profile.SupportedInstanceProfiles) {
+						allErrs = append(allErrs, field.Invalid(path.Index(i).Child("profile"), dhost.Profile, fmt.Sprintf("dedicated host profile does not support machine type %s", machineType)))
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func isInstanceProfileInList(profile string, list []vpcv1.InstanceProfileReference) bool {
+	for _, each := range list {
+		if *each.Name == profile {
+			return true
+		}
+	}
+	return false
+}
+
+func isDedicatedHostProfileInList(profile string, list []vpcv1.DedicatedHostProfile) bool {
+	for _, each := range list {
+		if *each.Name == profile {
+			return true
+		}
+	}
+	return false
+}
+
 func validateMachinePoolType(client API, machineType string, path *field.Path) field.ErrorList {
 	vsiProfiles, err := client.GetVSIProfiles(context.TODO())
 	if err != nil {
-		return field.ErrorList{field.InternalError(path.Child("type"), err)}
+		return field.ErrorList{field.InternalError(path, err)}
 	}
 
 	for _, profile := range vsiProfiles {
@@ -81,19 +158,19 @@ func validateMachinePoolType(client API, machineType string, path *field.Path) f
 		}
 	}
 
-	return field.ErrorList{field.NotFound(path.Child("type"), machineType)}
+	return field.ErrorList{field.NotFound(path, machineType)}
 }
 
 func validateMachinePoolZones(client API, region string, zones []string, path *field.Path) field.ErrorList {
 	regionalZones, err := client.GetVPCZonesForRegion(context.TODO(), region)
 	if err != nil {
-		return field.ErrorList{field.InternalError(path.Child("zones"), err)}
+		return field.ErrorList{field.InternalError(path, err)}
 	}
 
 	for idx, zone := range zones {
 		validZones := sets.NewString(regionalZones...)
 		if !validZones.Has(zone) {
-			return field.ErrorList{field.Invalid(path.Child("zones").Index(idx), zone, fmt.Sprintf("zone must be in region %q", region))}
+			return field.ErrorList{field.Invalid(path.Index(idx), zone, fmt.Sprintf("zone must be in region %q", region))}
 		}
 	}
 	return nil
@@ -109,11 +186,11 @@ func validateMachinePoolBootVolume(client API, bootVolume ibmcloud.BootVolume, p
 	// Make sure the encryptionKey exists
 	key, err := client.GetEncryptionKey(context.TODO(), bootVolume.EncryptionKey)
 	if err != nil {
-		return field.ErrorList{field.InternalError(path.Child("bootVolume").Child("encryptionKey"), err)}
+		return field.ErrorList{field.InternalError(path.Child("encryptionKey"), err)}
 	}
 
 	if key == nil {
-		return field.ErrorList{field.NotFound(path.Child("bootVolume").Child("encryptionKey"), bootVolume.EncryptionKey)}
+		return field.ErrorList{field.NotFound(path.Child("encryptionKey"), bootVolume.EncryptionKey)}
 	}
 
 	return allErrs

--- a/pkg/destroy/ibmcloud/dedicatedhost.go
+++ b/pkg/destroy/ibmcloud/dedicatedhost.go
@@ -1,0 +1,225 @@
+package ibmcloud
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/pkg/errors"
+)
+
+const (
+	dedicatedHostTypeName      = "dedicated host"
+	dedicatedHostGroupTypeName = "dedicated host group"
+)
+
+// listDedicatedHosts searches for dedicated host that have a name that
+// starts with the cluster's infra ID.
+func (o *ClusterUninstaller) listDedicatedHosts() (cloudResources, error) {
+	o.Logger.Debugf("Listing dedicated hosts")
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
+
+	resourceGroupID, err := o.ResourceGroupID()
+	if err != nil {
+		return nil, err
+	}
+
+	options := o.vpcSvc.NewListDedicatedHostsOptions()
+	options.SetResourceGroupID(resourceGroupID)
+	resources, _, err := o.vpcSvc.ListDedicatedHostsWithContext(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []cloudResource{}
+	for _, dhost := range resources.DedicatedHosts {
+		if strings.HasPrefix(*dhost.Name, o.InfraID) {
+			result = append(result, cloudResource{
+				key:      *dhost.ID,
+				name:     *dhost.Name,
+				status:   *dhost.State,
+				typeName: dedicatedHostTypeName,
+				id:       *dhost.ID,
+			})
+		}
+	}
+
+	return cloudResources{}.insert(result...), nil
+}
+
+// listDedicatedHostGroups searches for dedicated host groups that have a name
+// that starts with the cluster's infra ID.
+func (o *ClusterUninstaller) listDedicatedHostGroups() (cloudResources, error) {
+	o.Logger.Debugf("Listing dedicated host groups")
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
+
+	resourceGroupID, err := o.ResourceGroupID()
+	if err != nil {
+		return nil, err
+	}
+
+	options := o.vpcSvc.NewListDedicatedHostGroupsOptions()
+	options.SetResourceGroupID(resourceGroupID)
+	resources, _, err := o.vpcSvc.ListDedicatedHostGroupsWithContext(ctx, options)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []cloudResource{}
+	for _, dgroup := range resources.Groups {
+		if strings.HasPrefix(*dgroup.Name, o.InfraID) {
+			result = append(result, cloudResource{
+				key:      *dgroup.ID,
+				name:     *dgroup.Name,
+				status:   "",
+				typeName: dedicatedHostGroupTypeName,
+				id:       *dgroup.ID,
+			})
+		}
+	}
+
+	return cloudResources{}.insert(result...), nil
+}
+
+// deleteDedicatedHosts disables and deletes a dedicated host
+func (o *ClusterUninstaller) deleteDedicatedHost(item cloudResource) error {
+	if item.status == vpcv1.DedicatedHostLifecycleStateDeletingConst {
+		o.Logger.Debugf("Waiting for dedicated host %q to delete", item.name)
+		return nil
+	}
+
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
+
+	o.Logger.Debugf("Getting dedicated host %q", item.name)
+
+	getOpts := o.vpcSvc.NewGetDedicatedHostOptions(item.id)
+	resource, _, err := o.vpcSvc.GetDedicatedHostWithContext(ctx, getOpts)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to get dedicated host %q", item.name)
+	}
+
+	if *resource.InstancePlacementEnabled {
+		if err := o.disableDedicatedHost(item); err != nil {
+			return err
+		}
+	}
+
+	o.Logger.Debugf("Deleting dedicated host %q", item.name)
+
+	deleteOpts := o.vpcSvc.NewDeleteDedicatedHostOptions(item.id)
+	details, err := o.vpcSvc.DeleteDedicatedHostWithContext(ctx, deleteOpts)
+
+	if err != nil && details != nil && details.StatusCode == http.StatusNotFound {
+		// The resource is gone
+		o.deletePendingItems(item.typeName, []cloudResource{item})
+		o.Logger.Infof("Deleted dedicated host %q", item.name)
+		return nil
+	}
+
+	if err != nil && details != nil && details.StatusCode != http.StatusNotFound {
+		return errors.Wrapf(err, "Failed to delete dedicated host %q", item.name)
+	}
+
+	return nil
+}
+
+// deleteDedicatedHostGroups deletes a dedicated host group
+func (o *ClusterUninstaller) deleteDedicatedHostGroup(item cloudResource) error {
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
+
+	o.Logger.Debugf("Deleting dedicated host group %q", item.name)
+
+	options := o.vpcSvc.NewDeleteDedicatedHostGroupOptions(item.id)
+	details, err := o.vpcSvc.DeleteDedicatedHostGroupWithContext(ctx, options)
+
+	if err != nil && details != nil && details.StatusCode == http.StatusNotFound {
+		// The resource is gone
+		o.deletePendingItems(item.typeName, []cloudResource{item})
+		o.Logger.Infof("Deleted dedicated host group %q", item.name)
+		return nil
+	}
+
+	if err != nil && details != nil && details.StatusCode != http.StatusNotFound {
+		return errors.Wrapf(err, "Failed to delete dedicated host group %q", item.name)
+	}
+
+	return nil
+}
+
+// disableDedicatedHosts disables a dedicated host
+func (o *ClusterUninstaller) disableDedicatedHost(item cloudResource) error {
+	o.Logger.Debugf("Disabling dedicated host %q", item.name)
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
+
+	options := o.vpcSvc.NewUpdateDedicatedHostOptions(item.id, map[string]interface{}{
+		"instance_placement_enabled": core.BoolPtr(false),
+	})
+	_, _, err := o.vpcSvc.UpdateDedicatedHostWithContext(ctx, options)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to disable dedicated host %q", item.name)
+	}
+
+	return nil
+}
+
+// destroyDedicatedHosts searches for dedicated hosts that have a name
+// that starts with the cluster's infra ID.
+func (o *ClusterUninstaller) destroyDedicatedHosts() error {
+	found, err := o.listDedicatedHosts()
+	if err != nil {
+		return err
+	}
+
+	items := o.insertPendingItems(dedicatedHostTypeName, found.list())
+	for _, item := range items {
+		if _, ok := found[item.key]; !ok {
+			// This item has finished deletion.
+			o.deletePendingItems(item.typeName, []cloudResource{item})
+			o.Logger.Infof("Deleted dedicated host %q", item.name)
+			continue
+		}
+		err := o.deleteDedicatedHost(item)
+		if err != nil {
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
+		}
+	}
+
+	if items = o.getPendingItems(dedicatedHostTypeName); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
+}
+
+// destroyDedicatedHostGroups searches for dedicated host groups that have
+// a name that starts with the cluster's infra ID.
+func (o *ClusterUninstaller) destroyDedicatedHostGroups() error {
+	found, err := o.listDedicatedHostGroups()
+	if err != nil {
+		return err
+	}
+
+	items := o.insertPendingItems(dedicatedHostGroupTypeName, found.list())
+	for _, item := range items {
+		if _, ok := found[item.key]; !ok {
+			// This item has finished deletion.
+			o.deletePendingItems(item.typeName, []cloudResource{item})
+			o.Logger.Infof("Deleted dedicated host group %q", item.name)
+			continue
+		}
+		err := o.deleteDedicatedHostGroup(item)
+		if err != nil {
+			o.errorTracker.suppressWarning(item.key, err, o.Logger)
+		}
+	}
+
+	if items = o.getPendingItems(dedicatedHostGroupTypeName); len(items) > 0 {
+		return errors.Errorf("%d items pending", len(items))
+	}
+	return nil
+}

--- a/pkg/destroy/ibmcloud/ibmcloud.go
+++ b/pkg/destroy/ibmcloud/ibmcloud.go
@@ -99,7 +99,6 @@ func (o *ClusterUninstaller) destroyCluster() error {
 		{name: "Stop instances", execute: o.stopInstances},
 	}, {
 		{name: "Instances", execute: o.destroyInstances},
-		{name: "IAM Authorizations", execute: o.destroyIAMAuthorizations},
 	}, {
 		{name: "Load Balancers", execute: o.destroyLoadBalancers},
 	}, {
@@ -111,10 +110,13 @@ func (o *ClusterUninstaller) destroyCluster() error {
 	}, {
 		{name: "Floating IPs", execute: o.destroyFloatingIPs},
 	}, {
+		{name: "Dedicated Hosts", execute: o.destroyDedicatedHosts},
 		{name: "VPCs", execute: o.destroyVPCs},
 	}, {
 		{name: "Cloud Object Storage Instances", execute: o.destroyCOSInstances},
+		{name: "Dedicated Host Groups", execute: o.destroyDedicatedHostGroups},
 		{name: "DNS Records", execute: o.destroyDNSRecords},
+		{name: "IAM Authorizations", execute: o.destroyIAMAuthorizations},
 		{name: "Resource Groups", execute: o.destroyResourceGroups},
 	}}
 

--- a/pkg/tfvars/ibmcloud/ibmcloud.go
+++ b/pkg/tfvars/ibmcloud/ibmcloud.go
@@ -15,28 +15,39 @@ type Auth struct {
 	APIKey string `json:"ibmcloud_api_key,omitempty"`
 }
 
+// DedicatedHost is the format used by terraform.
+type DedicatedHost struct {
+	ID      string `json:"id,omitempty"`
+	Profile string `json:"profile,omitempty"`
+}
+
 type config struct {
 	Auth                    `json:",inline"`
-	Region                  string   `json:"ibmcloud_region,omitempty"`
-	BootstrapInstanceType   string   `json:"ibmcloud_bootstrap_instance_type,omitempty"`
-	CISInstanceCRN          string   `json:"ibmcloud_cis_crn,omitempty"`
-	ExtraTags               []string `json:"ibmcloud_extra_tags,omitempty"`
-	MasterAvailabilityZones []string `json:"ibmcloud_master_availability_zones"`
-	MasterInstanceType      string   `json:"ibmcloud_master_instance_type,omitempty"`
-	PublishStrategy         string   `json:"ibmcloud_publish_strategy,omitempty"`
-	ResourceGroupName       string   `json:"ibmcloud_resource_group_name,omitempty"`
-	ImageFilePath           string   `json:"ibmcloud_image_filepath,omitempty"`
+	Region                  string          `json:"ibmcloud_region,omitempty"`
+	BootstrapInstanceType   string          `json:"ibmcloud_bootstrap_instance_type,omitempty"`
+	CISInstanceCRN          string          `json:"ibmcloud_cis_crn,omitempty"`
+	ExtraTags               []string        `json:"ibmcloud_extra_tags,omitempty"`
+	MasterAvailabilityZones []string        `json:"ibmcloud_master_availability_zones"`
+	WorkerAvailabilityZones []string        `json:"ibmcloud_worker_availability_zones"`
+	MasterInstanceType      string          `json:"ibmcloud_master_instance_type,omitempty"`
+	MasterDedicatedHosts    []DedicatedHost `json:"ibmcloud_master_dedicated_hosts,omitempty"`
+	WorkerDedicatedHosts    []DedicatedHost `json:"ibmcloud_worker_dedicated_hosts,omitempty"`
+	PublishStrategy         string          `json:"ibmcloud_publish_strategy,omitempty"`
+	ResourceGroupName       string          `json:"ibmcloud_resource_group_name,omitempty"`
+	ImageFilePath           string          `json:"ibmcloud_image_filepath,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
-	Auth              Auth
-	CISInstanceCRN    string
-	ImageURL          string
-	MasterConfigs     []*ibmcloudprovider.IBMCloudMachineProviderSpec
-	PublishStrategy   types.PublishingStrategy
-	ResourceGroupName string
-	WorkerConfigs     []*ibmcloudprovider.IBMCloudMachineProviderSpec
+	Auth                 Auth
+	CISInstanceCRN       string
+	ImageURL             string
+	MasterConfigs        []*ibmcloudprovider.IBMCloudMachineProviderSpec
+	MasterDedicatedHosts []DedicatedHost
+	PublishStrategy      types.PublishingStrategy
+	ResourceGroupName    string
+	WorkerConfigs        []*ibmcloudprovider.IBMCloudMachineProviderSpec
+	WorkerDedicatedHosts []DedicatedHost
 }
 
 // TFVars generates ibmcloud-specific Terraform variables launching the cluster.
@@ -47,10 +58,13 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	}
 
 	masterConfig := sources.MasterConfigs[0]
-	// workerConfig := sources.WorkerConfigs[0]
 	masterAvailabilityZones := make([]string, len(sources.MasterConfigs))
 	for i, c := range sources.MasterConfigs {
 		masterAvailabilityZones[i] = c.Zone
+	}
+	workerAvailabilityZones := make([]string, len(sources.WorkerConfigs))
+	for i, c := range sources.WorkerConfigs {
+		workerAvailabilityZones[i] = c.Zone
 	}
 
 	cfg := &config{
@@ -59,10 +73,13 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		CISInstanceCRN:          sources.CISInstanceCRN,
 		ImageFilePath:           cachedImage,
 		MasterAvailabilityZones: masterAvailabilityZones,
+		MasterDedicatedHosts:    sources.MasterDedicatedHosts,
 		MasterInstanceType:      masterConfig.Profile,
 		PublishStrategy:         string(sources.PublishStrategy),
 		Region:                  masterConfig.Region,
 		ResourceGroupName:       sources.ResourceGroupName,
+		WorkerAvailabilityZones: workerAvailabilityZones,
+		WorkerDedicatedHosts:    sources.WorkerDedicatedHosts,
 
 		// TODO: IBM: Future support
 		// ExtraTags:               masterConfig.Tags,

--- a/pkg/types/ibmcloud/machinepool.go
+++ b/pkg/types/ibmcloud/machinepool.go
@@ -12,6 +12,10 @@ type MachinePool struct {
 	// BootVolume is the configuration for the machine's boot volume.
 	// +optional
 	BootVolume *BootVolume `json:"bootVolume,omitempty"`
+
+	// DedicatedHosts is the configuration for the machine's dedicated host and profile.
+	// +optional
+	DedicatedHosts []DedicatedHost `json:"dedicatedHosts,omitempty"`
 }
 
 // BootVolume stores the configuration for an individual machine's boot volume.
@@ -21,6 +25,19 @@ type BootVolume struct {
 	// provider managed encryption key will be used.
 	// +optional
 	EncryptionKey string `json:"encryptionKey,omitempty"`
+}
+
+// DedicatedHost stores the configuration for the machine's dedicated host platform.
+type DedicatedHost struct {
+	// Name is the name of the dedicated host to provision the machine on. If
+	// specified, machines will be created on pre-existing dedicated host.
+	// +optional
+	Name string `json:"name,omitempty"`
+
+	// Profile is the profile ID for the dedicated host. If specified, new
+	// dedicated host will be created for machines.
+	// +optional
+	Profile string `json:"profile,omitempty"`
 }
 
 // Set sets the values from `required` to `a`.
@@ -44,5 +61,9 @@ func (a *MachinePool) Set(required *MachinePool) {
 		if required.BootVolume.EncryptionKey != "" {
 			a.BootVolume.EncryptionKey = required.BootVolume.EncryptionKey
 		}
+	}
+
+	if len(required.DedicatedHosts) > 0 {
+		a.DedicatedHosts = required.DedicatedHosts
 	}
 }

--- a/pkg/types/ibmcloud/validation/machinepool.go
+++ b/pkg/types/ibmcloud/validation/machinepool.go
@@ -1,14 +1,31 @@
 package validation
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/IBM-Cloud/bluemix-go/crn"
 	"github.com/openshift/installer/pkg/types/ibmcloud"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // ValidateMachinePool validates the MachinePool.
-func ValidateMachinePool(mp *ibmcloud.MachinePool, path *field.Path) field.ErrorList {
+func ValidateMachinePool(platform *ibmcloud.Platform, mp *ibmcloud.MachinePool, path *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	for i, zone := range mp.Zones {
+		if !strings.HasPrefix(zone, platform.Region) {
+			allErrs = append(allErrs, field.Invalid(path.Child("zones").Index(i), zone, fmt.Sprintf("zone not in configured region (%s)", platform.Region)))
+		}
+	}
+
+	if mp.DedicatedHosts != nil {
+		allErrs = append(allErrs, validateDedicatedHosts(mp.DedicatedHosts, mp.InstanceType, mp.Zones, path.Child("dedicatedHosts"))...)
+
+		if mp.InstanceType == "" {
+			allErrs = append(allErrs, field.Invalid(path.Child("type"), mp.InstanceType, "type is required, default type not supported for dedicated hosts"))
+		}
+	}
+
 	if mp.BootVolume != nil {
 		allErrs = append(allErrs, validateBootVolume(mp.BootVolume, path.Child("bootVolume"))...)
 	}
@@ -23,5 +40,30 @@ func validateBootVolume(bv *ibmcloud.BootVolume, path *field.Path) field.ErrorLi
 			allErrs = append(allErrs, field.Invalid(path.Child("encryptionKey"), bv.EncryptionKey, "encryptionKey is not a valid IBM CRN"))
 		}
 	}
+	return allErrs
+}
+
+func validateDedicatedHosts(dhosts []ibmcloud.DedicatedHost, itype string, zones []string, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Length of dedicated hosts must match platform zones
+	if len(dhosts) != len(zones) {
+		allErrs = append(allErrs, field.Invalid(path, dhosts, fmt.Sprintf("number of dedicated hosts does not match list of zones (%s)", zones)))
+	}
+
+	for i, dhost := range dhosts {
+		// Dedicated host name or profile is required
+		if dhost.Name == "" && dhost.Profile == "" {
+			allErrs = append(allErrs, field.Invalid(path.Index(i), dhost.Profile, "name or profile must be set"))
+		}
+
+		// Instance type must be in the same profile family as dedicated host
+		if dhost.Profile != "" && itype != "" {
+			if strings.Split(dhost.Profile, "-")[0] != strings.Split(itype, "-")[0] {
+				allErrs = append(allErrs, field.Invalid(path.Index(i).Child("profile"), dhost.Profile, fmt.Sprintf("profile does not support expected instance type (%s)", itype)))
+			}
+		}
+	}
+
 	return allErrs
 }

--- a/pkg/types/ibmcloud/validation/machinepool_test.go
+++ b/pkg/types/ibmcloud/validation/machinepool_test.go
@@ -10,12 +10,13 @@ import (
 
 var (
 	validType            = "valid-type"
-	validZones           = []string{"zone-a", "zone-b"}
+	validZones           = []string{"us-east-1", "us-east-2"}
 	validEncryptionKey   = "crn:v1:bluemix:public:kms:global:a/accountid:service:key:keyid"
 	invalidEncryptionKey = "v1:bluemix:kms:global:a/accountid:service:key:keyid"
 )
 
 func TestValidateMachinePool(t *testing.T) {
+	platform := &ibmcloud.Platform{Region: "us-east"}
 	cases := []struct {
 		name        string
 		machinepool *ibmcloud.MachinePool
@@ -50,7 +51,7 @@ func TestValidateMachinePool(t *testing.T) {
 			valid: true,
 		},
 		{
-			name: "valid bootVolume",
+			name: "invalid bootVolume",
 			machinepool: &ibmcloud.MachinePool{
 				BootVolume: &ibmcloud.BootVolume{
 					EncryptionKey: invalidEncryptionKey,
@@ -58,10 +59,117 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 			valid: false,
 		},
+		{
+			name: "valid dedicatedHosts 1",
+			machinepool: &ibmcloud.MachinePool{
+				Zones: validZones,
+				DedicatedHosts: []ibmcloud.DedicatedHost{
+					{
+						Profile: validType,
+					},
+					{
+						Profile: validType,
+					},
+				},
+				InstanceType: validType,
+			},
+			valid: true,
+		},
+		{
+			name: "valid dedicatedHosts 2",
+			machinepool: &ibmcloud.MachinePool{
+				Zones: validZones,
+				DedicatedHosts: []ibmcloud.DedicatedHost{
+					{
+						Name: "name",
+					},
+					{
+						Name: "name",
+					},
+				},
+				InstanceType: validType,
+			},
+			valid: true,
+		},
+		{
+			name: "valid dedicatedHosts 3",
+			machinepool: &ibmcloud.MachinePool{
+				Zones: validZones,
+				DedicatedHosts: []ibmcloud.DedicatedHost{
+					{
+						Name: "name",
+					},
+					{
+						Profile: validType,
+					},
+				},
+				InstanceType: validType,
+			},
+			valid: true,
+		},
+		{
+			name: "invalid dedicatedHosts 1",
+			machinepool: &ibmcloud.MachinePool{
+				DedicatedHosts: []ibmcloud.DedicatedHost{
+					{
+						Name: "name",
+					},
+					{
+						Profile: validType,
+					},
+				},
+				InstanceType: validType,
+			},
+			valid: false,
+		},
+		{
+			name: "invalid dedicatedHosts 2",
+			machinepool: &ibmcloud.MachinePool{
+				Zones: validZones,
+				DedicatedHosts: []ibmcloud.DedicatedHost{
+					{
+						Name: "name",
+					},
+				},
+				InstanceType: validType,
+			},
+			valid: false,
+		},
+		{
+			name: "invalid dedicatedHosts 3",
+			machinepool: &ibmcloud.MachinePool{
+				Zones: validZones,
+				DedicatedHosts: []ibmcloud.DedicatedHost{
+					{
+						Name: "name",
+					},
+					{
+						Profile: "invalid",
+					},
+				},
+				InstanceType: validType,
+			},
+			valid: false,
+		},
+		{
+			name: "invalid dedicatedHosts 4",
+			machinepool: &ibmcloud.MachinePool{
+				Zones: validZones,
+				DedicatedHosts: []ibmcloud.DedicatedHost{
+					{
+						Name: "name",
+					},
+					{
+						Profile: validType,
+					},
+				},
+			},
+			valid: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateMachinePool(tc.machinepool, field.NewPath("test-path")).ToAggregate()
+			err := ValidateMachinePool(platform, tc.machinepool, field.NewPath("test-path")).ToAggregate()
 			if tc.valid {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/types/ibmcloud/validation/platform.go
+++ b/pkg/types/ibmcloud/validation/platform.go
@@ -45,7 +45,7 @@ func ValidatePlatform(p *ibmcloud.Platform, fldPath *field.Path) field.ErrorList
 	allErrs = append(allErrs, validateVPCConfig(p, fldPath)...)
 
 	if p.DefaultMachinePlatform != nil {
-		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
+		allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}
 	return allErrs
 }

--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -103,7 +103,9 @@ func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolP
 		validate(gcp.Name, p.GCP, func(f *field.Path) field.ErrorList { return validateGCPMachinePool(platform, p, pool, f) })
 	}
 	if p.IBMCloud != nil {
-		validate(ibmcloud.Name, p.IBMCloud, func(f *field.Path) field.ErrorList { return ibmcloudvalidation.ValidateMachinePool(p.IBMCloud, f) })
+		validate(ibmcloud.Name, p.IBMCloud, func(f *field.Path) field.ErrorList {
+			return ibmcloudvalidation.ValidateMachinePool(platform.IBMCloud, p.IBMCloud, f)
+		})
 	}
 	if p.Libvirt != nil {
 		validate(libvirt.Name, p.Libvirt, func(f *field.Path) field.ErrorList { return libvirtvalidation.ValidateMachinePool(p.Libvirt, f) })

--- a/vendor/github.com/openshift/cluster-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1beta1/ibmcloudproviderconfig_types.go
+++ b/vendor/github.com/openshift/cluster-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1beta1/ibmcloudproviderconfig_types.go
@@ -40,9 +40,6 @@ type IBMCloudMachineProviderSpec struct {
 	// to default tags applied by the actuator
 	Tags []TagSpecs `json:"tags,omitempty"`
 
-	// TODO: Add labels to the virtual server
-	// Labels map[string]string `json:"labels,omitempty"`
-
 	// Image is the id of the custom OS image in VPC
 	// Example: rchos-4-4-7 (Image name)
 	Image string `json:"image"`
@@ -50,6 +47,13 @@ type IBMCloudMachineProviderSpec struct {
 	// Profile indicates the flavor of instance.
 	// Example: bx2-8x32 (8 vCPUs, 32 GB RAM)
 	Profile string `json:"profile"`
+
+	// A DedicatedHost is the name of the underlying provisioned host in your VPC on which the instance/s
+	// will be created with the defined Profile.
+	// A dedicated host provides a single tenancy ensuring only your Compute/VSI's are provisioned on it.
+	// Instances provisioned on a dedicated host adds another layer of protection while minimizing latency
+	// and maximizing performance between the instances provisioned on a single host.
+	DedicatedHost string `json:"dedicatedHost,omitempty"`
 
 	// Region of the virtual machine
 	Region string `json:"region"`
@@ -63,7 +67,6 @@ type IBMCloudMachineProviderSpec struct {
 	// PrimaryNetworkInterface is required to specify subnet
 	PrimaryNetworkInterface NetworkInterface `json:"primaryNetworkInterface"`
 
-	// TODO: Probably not needed for the worker machines
 	// SSHKeys is the SSH pub keys that will be used to access virtual service instance
 	// SSHKeys []*string `json:"sshKeys,omitempty"`
 
@@ -96,8 +99,6 @@ type TagSpecs struct {
 // 	Key   string  `json:"key"`
 // 	Value *string `json:"value"`
 // }
-
-// TODO: IBMCloudLoadBalancerReferece - register an instance with the LoadBalancer
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 func init() {

--- a/vendor/github.com/openshift/cluster-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1beta1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/cluster-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1beta1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1540,7 +1540,7 @@ github.com/openshift/cluster-api/pkg/apis/machine/v1beta1
 ## explicit
 github.com/openshift/cluster-api-provider-gcp/pkg/apis
 github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1
-# github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20210702173623-676faba9895d
+# github.com/openshift/cluster-api-provider-ibmcloud v0.0.0-20211008100740-4d7907adbd6b
 ## explicit
 github.com/openshift/cluster-api-provider-ibmcloud/pkg/apis
 github.com/openshift/cluster-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1beta1


### PR DESCRIPTION
New feature: OpenShift IPI on IBM Cloud VPC dedicated hosts (single-tenant hosts)
IBM Cloud docs: https://cloud.ibm.com/docs/vpc?topic=vpc-creating-dedicated-hosts-instances&interface=ui

This change includes the ability to:
- Dynamically create dedicated hosts (control plane and/or compute) based on install-config params
- Import and use existing dedicated hosts based on install-config params
- Provision  instances on dedicated hosts, if specified
- Static validation checks for dedicated host related install-config params (IBM Cloud Machine Pool)
- API validation checks for dedicated host related install-config params
- Machine/MachineSet manifest generation with dedicated host field set
- Destroy installer created dedicated hosts and dedicated host groups

Enabling the use of this dedicated hosts feature will be controlled through the IBM Cloud MachinePool fields in the install-config. Supported for both control plane and compute machine pools.

Examples of valid `install-config.yaml` snippet with dedicated hosts:
```
platform:
  ibmcloud:
    zones:
    - us-east-1
    dedicatedHosts:
    - profile: cx2-host-152x304  # New dedicated host will be created
      zone: us-east-1
    type: cx2-16x32
```
```
platform:
  ibmcloud:
    zones:
    - us-east-1
    dedicatedHosts:
    - id: my-dedicated-host-id  # Use existing dedicated host
      zone: us-east-1
    type: cx2-16x32
```
```
platform:
  ibmcloud:
    zones:
    - us-east-1
    - us-east-2
    - us-east-3
    dedicatedHosts:
    - profile: cx2-host-152x304  # New dedicated host will be created
      zone: us-east-1
    - id: my-dedicated-host-id   # Use existing dedicated host
      zone: us-east-2
    - profile: cx2-host-152x304  # New dedicated host will be created
      zone: us-east-3
    type: cx2-16x32
 ```
 ---
 Updated
 ```
platform:
  ibmcloud:
    zones:
    - us-east-1
    dedicatedHosts:
    - profile: cx2-host-152x304  # New dedicated host will be created
    type: cx2-16x32
```
```
platform:
  ibmcloud:
    zones:
    - us-east-1
    dedicatedHosts:
    - name: my-dedicated-host-name  # Use existing dedicated host
    type: cx2-16x32
```
```
platform:
  ibmcloud:
    zones:
    - us-east-1
    - us-east-2
    - us-east-3
    dedicatedHosts:
    - profile: cx2-host-152x304     # New dedicated host will be created
    - name: my-dedicated-host-name  # Use existing dedicated host
    - profile: cx2-host-152x304     # New dedicated host will be created
    type: cx2-16x32
 ```

