### PR TITLE
Bug 1960378:  Relax the imageContentSource validation

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -536,6 +536,18 @@ func validateImageContentSources(groups []types.ImageContentSource, fldPath *fie
 func validateNamedRepository(r string) error {
 	ref, err := dockerref.ParseNamed(r)
 	if err != nil {
+		// If a mirror name is provided without the named reference,
+		// then the name is not considered canonical and will cause
+		// an error. e.g. registry.lab.redhat.com:5000 will result
+		// in an error. Instead we will check whether the input is
+		// a valid hostname as a workaround.
+		if err == dockerref.ErrNameNotCanonical {
+			_, err := url.ParseRequestURI(r)
+			if err != nil {
+				return fmt.Errorf("the repository provided is invalid")
+			}
+			return nil
+		}
 		return errors.Wrap(err, "failed to parse")
 	}
 	if !dockerref.IsNameOnly(ref) {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1038,7 +1038,7 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: `^credentialsMode: Unsupported value: "Mint": supported values: "Manual"$`,
 		},
 		{
-			name: "release image source is not canonical",
+			name: "release image source is not valid",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.ImageContentSources = []types.ImageContentSource{{
@@ -1046,10 +1046,10 @@ func TestValidateInstallConfig(t *testing.T) {
 				}}
 				return c
 			}(),
-			expectedError: `^imageContentSources\[0\]\.source: Invalid value: "ocp/release-x\.y": failed to parse: repository name must be canonical$`,
+			expectedError: `^imageContentSources\[0\]\.source: Invalid value: "ocp/release-x\.y": the repository provided is invalid$`,
 		},
 		{
-			name: "release image source's mirror is not canonical",
+			name: "release image source's mirror is not valid",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()
 				c.ImageContentSources = []types.ImageContentSource{{
@@ -1058,7 +1058,18 @@ func TestValidateInstallConfig(t *testing.T) {
 				}}
 				return c
 			}(),
-			expectedError: `^imageContentSources\[0\]\.mirrors\[0\]: Invalid value: "ocp/openshift-x\.y": failed to parse: repository name must be canonical$`,
+			expectedError: `^imageContentSources\[0\]\.mirrors\[0\]: Invalid value: "ocp/openshift-x.y": the repository provided is invalid$`,
+		},
+		{
+			name: "release image source's mirror is valid",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.ImageContentSources = []types.ImageContentSource{{
+					Source:  "q.io/ocp/release-x.y",
+					Mirrors: []string{"mirror.example.com:5000"},
+				}}
+				return c
+			}(),
 		},
 		{
 			name: "release image source is not repository but reference by digest",


### PR DESCRIPTION
Relax the imageContentSource validation to allow for mirroring root registry.

Currently passing a full hostname in the imageContentSource entries will result in an canonical error. This PR relaxes the validation check to allow passing of the registry root.