### PR TITLE
Interpolation-only expressions are deprecated

### DIFF
--- a/data/data/ibmcloud/network/image/main.tf
+++ b/data/data/ibmcloud/network/image/main.tf
@@ -21,7 +21,7 @@ resource "ibm_iam_authorization_policy" "policy" {
   source_service_name         = "is"
   source_resource_type        = "image"
   target_service_name         = "cloud-object-storage"
-  target_resource_instance_id = "${element(split(":", var.cos_resource_instance_crn), 7)}"
+  target_resource_instance_id = element(split(":", var.cos_resource_instance_crn), 7)
   roles                       = ["Reader"]
 }
 


### PR DESCRIPTION
This is part of closed BZ#1992777, while I was testing it I didn't notice I was using a deprecated interpolation-only expressions because our automation was using terraform-0.12 but when using a more recent version, the warning is present:
~~~
DEBUG Warning: Interpolation-only expressions are deprecated 
DEBUG                                              
DEBUG   on ../../../../tmp/openshift-install-network-409602176/image/main.tf line 24, in resource "ibm_iam_authorization_policy" "policy": 
DEBUG   24:   target_resource_instance_id = "${element(split(":", var.cos_resource_instance_crn), 7)}" 
DEBUG                                              
DEBUG Terraform 0.11 and earlier required all non-constant expressions to be 
DEBUG provided via interpolation syntax, but this pattern is now deprecated. To 
DEBUG silence this warning, remove the "${ sequence from the start and the }" 
DEBUG sequence from the end of this expression, leaving just the inner expression.
~~~
Regards.