### PR TITLE
validation: Enforce strict unmarshalling of config

### DIFF
--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -178,6 +178,21 @@ metadata:
 			expectedError: true,
 		},
 		{
+			name: "unknown field",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+platform:
+  aws:
+    region: us-east-1
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+wrong_key: wrong_value 
+`,
+			expectedError: true,
+		},
+		{
 			name: "old valid InstallConfig",
 			data: `
 apiVersion: v1beta3
@@ -188,8 +203,6 @@ platform:
   aws:
     region: us-east-1
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
-network:
-  type: OpenShiftSDN
 `,
 			expectedFound: true,
 			expectedConfig: &types.InstallConfig{


### PR DESCRIPTION
In order to stop the user from adding unrecognized properties
in the install config, a validation check is added to force the
user to remove them. This is done by enforcing a strict
unmarshalling of the install config yaml file that will raise an
error when an unknown property is added.

This will force the installer to return an error for the first
occurence of an unknown property since the current library
returns only the first unknown field.