### PR TITLE
data/manifests/bootkube/cvo-overrides: Default to stable-4.10

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -8,6 +8,6 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-4
 {{- else }}
-  channel: stable-4.9
+  channel: stable-4.10
 {{- end }}
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
Like 2fb69e25c0 (#5159), d148108039 (#4868), and earlier.