### PR TITLE
Bug 1917893: bump oVirt terraform provider version which fix "Disk is locked" bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/openshift/machine-api-operator v0.2.1-0.20210505133115-b7ef098180db
 	github.com/openshift/machine-config-operator v0.0.0
 	github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c
-	github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210628083913-78ce17b16709
+	github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20211019085223-db1ac552ec57
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db // indirect
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1530,8 +1530,8 @@ github.com/ory/dockertest v3.3.4+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnh
 github.com/ostreedev/ostree-go v0.0.0-20190702140239-759a8c1ac913/go.mod h1:J6OG6YJVEWopen4avK3VNQSnALmmjvniMmni/YFYAwc=
 github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c h1:2SbYZedeIawU8sGFnohfrdEcEMBA4V8SDouG6hly+H4=
 github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
-github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210628083913-78ce17b16709 h1:y2MAdgeZ/csROLXpyKQ3Ykw9clPdqj12PQ1mSHmhwtw=
-github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210628083913-78ce17b16709/go.mod h1:wnTGn9+USQJ51TMV5brymzjxUfmYmnOQZuNfYeuqky8=
+github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20211019085223-db1ac552ec57 h1:hBk5iVZY3EXE53s48+hyI03E0gNl7jaxsNxTc35ClGc=
+github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20211019085223-db1ac552ec57/go.mod h1:wnTGn9+USQJ51TMV5brymzjxUfmYmnOQZuNfYeuqky8=
 github.com/oxtoacart/bpool v0.0.0-20150712133111-4e1c5567d7c2/go.mod h1:L3UMQOThbttwfYRNFOWLLVXMhk5Lkio4GGOtw5UrxS0=
 github.com/packer-community/winrmcp v0.0.0-20180102160824-81144009af58/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=
 github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db h1:9uViuKtx1jrlXLBW/pMnhOfzn3iSEdLase/But/IZRU=

--- a/vendor/github.com/ovirt/terraform-provider-ovirt/ovirt/provider.go
+++ b/vendor/github.com/ovirt/terraform-provider-ovirt/ovirt/provider.go
@@ -48,7 +48,7 @@ func (c *providerContext) Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Required:    false,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OVIRT_INSECURE", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OVIRT_INSECURE", false),
 				Description: "Skip certificate verification",
 				Sensitive:   false,
 			},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1452,7 +1452,7 @@ github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.opens
 # github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c
 ## explicit
 github.com/ovirt/go-ovirt
-# github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210628083913-78ce17b16709
+# github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20211019085223-db1ac552ec57
 ## explicit
 github.com/ovirt/terraform-provider-ovirt/ovirt
 # github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db


### PR DESCRIPTION
On RHV 4.4.7 the image upload process changed which lead to a bug that affected many customers.
This change bumps the oVirt terraform version to a version that contains the fix for the Bug.