### PR TITLE
Bug 2013877: Validate OpenStack supports resource tagging

### DIFF
--- a/pkg/asset/installconfig/openstack/validate.go
+++ b/pkg/asset/installconfig/openstack/validate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/openstack"
 	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
+	"github.com/openshift/installer/pkg/types/openstack/validation/networkextensions"
 	"github.com/sirupsen/logrus"
 )
 
@@ -28,9 +29,13 @@ func Validate(ic *types.InstallConfig) error {
 		return nil
 	}
 
+	if err := ValidateCloud(ci); err != nil {
+		return err
+	}
+
 	allErrs := field.ErrorList{}
 
-	// Validate platform platform
+	// Validate platform
 	allErrs = append(allErrs, validation.ValidatePlatform(ic.Platform.OpenStack, ic.Networking, ci)...)
 
 	// Validate control plane
@@ -69,4 +74,9 @@ func defaultOpenStackMachinePoolPlatform() openstack.MachinePool {
 	return openstack.MachinePool{
 		Zones: []string{""},
 	}
+}
+
+// ValidateCloud checks OpenStack requirements, regardless of the InstallConfig.
+func ValidateCloud(ci *validation.CloudInfo) error {
+	return networkextensions.Validate(ci.NetworkExtensions)
 }

--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/availabilityzones"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumetypes"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
 	computequotasets "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	tokensv2 "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens"
@@ -26,20 +27,22 @@ import (
 	"github.com/openshift/installer/pkg/quota"
 	"github.com/openshift/installer/pkg/types"
 	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
+	"github.com/openshift/installer/pkg/types/openstack/validation/networkextensions"
 )
 
 // CloudInfo caches data fetched from the user's openstack cloud
 type CloudInfo struct {
-	APIFIP          *floatingips.FloatingIP
-	ExternalNetwork *networks.Network
-	Flavors         map[string]Flavor
-	IngressFIP      *floatingips.FloatingIP
-	MachinesSubnet  *subnets.Subnet
-	OSImage         *images.Image
-	ComputeZones    []string
-	VolumeZones     []string
-	VolumeTypes     []string
-	Quotas          []quota.Quota
+	APIFIP            *floatingips.FloatingIP
+	ExternalNetwork   *networks.Network
+	Flavors           map[string]Flavor
+	IngressFIP        *floatingips.FloatingIP
+	MachinesSubnet    *subnets.Subnet
+	OSImage           *images.Image
+	ComputeZones      []string
+	VolumeZones       []string
+	VolumeTypes       []string
+	NetworkExtensions []extensions.Extension
+	Quotas            []quota.Quota
 
 	clients *clients
 }
@@ -215,6 +218,11 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig, opts *clientconfig.Cli
 			return nil
 		}
 		return errors.Wrap(err, "failed to load Quota")
+	}
+
+	ci.NetworkExtensions, err = networkextensions.Get(ci.clients.networkClient)
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch network extensions")
 	}
 
 	return nil

--- a/pkg/types/openstack/validation/networkextensions/error.go
+++ b/pkg/types/openstack/validation/networkextensions/error.go
@@ -1,0 +1,10 @@
+package networkextensions
+
+// Error is the error type for this package, ready to be unwrapped with
+// `errors.As`.
+type Error string
+
+// Error implements the error interface
+func (err Error) Error() string {
+	return string(err)
+}

--- a/pkg/types/openstack/validation/networkextensions/networkextensions.go
+++ b/pkg/types/openstack/validation/networkextensions/networkextensions.go
@@ -1,0 +1,84 @@
+package networkextensions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
+)
+
+const (
+	// ErrMissingStandardAttrTag is returned when standard-attr-tag is not found in the cloud
+	ErrMissingStandardAttrTag Error = "openstack platform does not have the required standard-attr-tag network extension"
+
+	// ErrInvalidStandardAttrTag is returned when standard-attr-tag is too old and missing the required tag and tag-ext extensions
+	ErrInvalidStandardAttrTag Error = "openstack platform's neutron extension standard-attr-tag is too old and missing the required tag and tag-ext extensions"
+)
+
+// Get returns a slice of the extensions available in the Neutron instance
+// targeted by networkClient, or a non-nil error.
+func Get(networkClient *gophercloud.ServiceClient) ([]extensions.Extension, error) {
+	allPages, err := extensions.List(networkClient).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list network extensions: %w", err)
+	}
+	allExtensions, err := extensions.ExtractExtensions(allPages)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response with network extensions list: %w", err)
+	}
+
+	return allExtensions, nil
+}
+
+// Validate returns a non-nil error if the available extensions do not match
+// the Installer requirements.
+//
+// Network resource tagging is a bit complex with OpenStack:
+// - up until OpenStack Ocata / OSP 11, there were two extensions for
+//   tagging neutron resources, `tag` for network only and `tag-ext`
+//   for subnet, subnetpool, port, and router.
+// - OpenStack Pike / OSP 12 introduced the `standard-attr-tag`
+//   extension for trunk, policy, security_group, and floatingip.
+// - with OpenStack Rocky / OSP 14, everything went under the
+//   `standard-attr-tag` extension.
+//
+// We need to check that:
+// 1. `standard-attr-tag` extension is enabled
+// 2. `standard-attr-tag` covers all the necessary resources (from the
+//           extension description) or that the `tag` and `tag-ext`
+//           extensions are enabled as well
+func Validate(availableExtensions []extensions.Extension) error {
+	var (
+		standardAttrTagEnabled      = false
+		standardAttrTagAllResources = false
+		tagEnabled                  = false
+		tagExtEnabled               = false
+	)
+
+	for _, extension := range availableExtensions {
+		if extension.Alias == "standard-attr-tag" {
+			standardAttrTagEnabled = true
+			// this should be good enough to ensure OpenStack version is >= Rocky
+			if strings.Contains(extension.Name, "subnet") {
+				standardAttrTagAllResources = true
+			}
+		}
+		if extension.Alias == "tag" {
+			tagEnabled = true
+		}
+		if extension.Alias == "tag-ext" {
+			tagExtEnabled = true
+		}
+	}
+
+	if !standardAttrTagEnabled {
+		return ErrMissingStandardAttrTag
+	}
+
+	if !(standardAttrTagAllResources || (tagEnabled && tagExtEnabled)) {
+		return ErrInvalidStandardAttrTag
+	}
+
+	return nil
+}

--- a/pkg/types/openstack/validation/networkextensions/networkextensions_test.go
+++ b/pkg/types/openstack/validation/networkextensions/networkextensions_test.go
@@ -1,0 +1,106 @@
+package networkextensions_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/openstack/common/extensions"
+	"github.com/openshift/installer/pkg/types/openstack/validation/networkextensions"
+)
+
+func TestValidate(t *testing.T) {
+	type checkFunc func(e error) error
+	check := func(fns ...checkFunc) []checkFunc { return fns }
+
+	ext := func(alias, name string) (ext extensions.Extension) {
+		return extensions.Extension{Alias: alias, Name: name}
+	}
+
+	noError := func(have error) error {
+		if have != nil {
+			return fmt.Errorf("expected nil error, got: %q", have)
+		}
+		return nil
+	}
+
+	networkextensionsError := func(have error) error {
+		if have == nil {
+			return fmt.Errorf("expected networkextensions.Error error, got nil")
+		}
+		var want networkextensions.Error
+		if !errors.As(have, &want) {
+			return fmt.Errorf("expected error to be of networkextensions.Error type")
+		}
+		return nil
+	}
+
+	for _, tc := range [...]struct {
+		name       string
+		extensions []extensions.Extension
+		checks     []checkFunc
+	}{
+		{
+			"compliant OSP 14+",
+			[]extensions.Extension{
+				ext("standard-attr-tag", "Tag support for resources with standard attribute: port, subnet, subnetpool, network, router, floatingip, policy, security_group, trunk, network_segment_range"),
+			},
+			check(noError),
+		},
+		{
+			"compliant OSP 12",
+			[]extensions.Extension{
+				ext("standard-attr-tag", "Tag support for resources with standard attribute: trunk, policy, security_group, floatingip"),
+				ext("tag", "Tag support"),
+				ext("tag-ext", "Tag support for resources: subnet, subnetpool, port, router"),
+			},
+			check(noError),
+		},
+		{
+			"OSP 11",
+			[]extensions.Extension{
+				ext("tag", "Tag support"),
+				ext("tag-ext", "Tag support for resources: subnet, subnetpool, port, router"),
+			},
+			check(networkextensionsError),
+		},
+		{
+			"no tag extension",
+			[]extensions.Extension{},
+			check(networkextensionsError),
+		},
+		{
+			"OSP 12, no standard-attr-tag",
+			[]extensions.Extension{
+				ext("tag", "Tag support"),
+				ext("tag-ext", "Tag support for resources: subnet, subnetpool, port, router"),
+			},
+			check(networkextensionsError),
+		},
+		{
+			"OSP 12, no tag",
+			[]extensions.Extension{
+				ext("standard-attr-tag", "Tag support for resources with standard attribute: trunk, policy, security_group, floatingip"),
+				ext("tag-ext", "Tag support for resources: subnet, subnetpool, port, router"),
+			},
+			check(networkextensionsError),
+		},
+		{
+			"OSP 12, no tag-ext",
+			[]extensions.Extension{
+				ext("standard-attr-tag", "Tag support for resources with standard attribute: trunk, policy, security_group, floatingip"),
+				ext("tag", "Tag support"),
+			},
+			check(networkextensionsError),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := networkextensions.Validate(tc.extensions)
+			for _, check := range tc.checks {
+				if e := check(err); e != nil {
+					t.Error(e)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Networking resources tagging is a hard requirement for OpenShift on
OpenStack and we should refuse from running the installer when the
underlying OpenStack platform does not support it.