### PR TITLE
Set CredentialsMode on Manual-only Platforms

### DIFF
--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -5,7 +5,6 @@ import (
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
-	"github.com/openshift/installer/pkg/types/azure"
 	azuredefaults "github.com/openshift/installer/pkg/types/azure/defaults"
 	baremetaldefaults "github.com/openshift/installer/pkg/types/baremetal/defaults"
 	gcpdefaults "github.com/openshift/installer/pkg/types/gcp/defaults"
@@ -14,6 +13,7 @@ import (
 	nonedefaults "github.com/openshift/installer/pkg/types/none/defaults"
 	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
 	ovirtdefaults "github.com/openshift/installer/pkg/types/ovirt/defaults"
+	"github.com/openshift/installer/pkg/types/validation"
 	vspheredefaults "github.com/openshift/installer/pkg/types/vsphere/defaults"
 )
 
@@ -77,7 +77,11 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 	}
 
 	if c.CredentialsMode == "" {
-		if c.Platform.Azure != nil && c.Platform.Azure.CloudName == azure.StackCloud {
+		validModes := validation.ValidCredentialModesFor(c.Platform)
+
+		// CredentialsMode for ManualCredentialMode-only platforms should be explicitly set
+		// in order to not create cluster credentials and execute other manual-mode logic.
+		if len(validModes) == 1 && validModes[0] == types.ManualCredentialsMode {
 			c.CredentialsMode = types.ManualCredentialsMode
 		}
 	}

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -57,6 +57,16 @@ func defaultAzureInstallConfig() *types.InstallConfig {
 	return c
 }
 
+func defaultAzureStackInstallConfig() *types.InstallConfig {
+	c := defaultInstallConfig()
+	c.Platform.Azure = &azure.Platform{
+		CloudName: azure.StackCloud,
+	}
+	azuredefaults.SetPlatformDefaults(c.Platform.Azure)
+	c.CredentialsMode = types.ManualCredentialsMode
+	return c
+}
+
 func defaultLibvirtInstallConfig() *types.InstallConfig {
 	c := defaultInstallConfig()
 	c.Networking.MachineNetwork[0].CIDR = *libvirtdefaults.DefaultMachineCIDR
@@ -120,6 +130,17 @@ func TestSetInstallConfigDefaults(t *testing.T) {
 				},
 			},
 			expected: defaultAzureInstallConfig(),
+		},
+		{
+			name: "empty Azure Stack",
+			config: &types.InstallConfig{
+				Platform: types.Platform{
+					Azure: &azure.Platform{
+						CloudName: azure.StackCloud,
+					},
+				},
+			},
+			expected: defaultAzureStackInstallConfig(),
 		},
 		{
 			name: "empty Libvirt",


### PR DESCRIPTION
CredentialsMode should be set for platforms that only allow manual mode so that no cloud credentials are uploaded to the cluster by the installer. #4416 created logic in the installer to not create cluster credentials when running in manual mode, but unless `CredentialsMode: Manual` is explicitly set in the install config, that logic would be ignored. 

With Azure Stack Hub, IBM, and Alibaba being manual-only platforms, we should use a default credential mode for these platforms to ensure that manual-mode logic is being observed. We should also consider future work of disabling the CCO when manual mode is set.