### PR TITLE
aws-ec2: add m6i as preferred instance type

### DIFF
--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -40,7 +40,7 @@ func InstanceClass(region string, arch types.Architecture) string {
 }
 
 // InstanceClasses returns a list of instance "class", in decreasing priority order, which we should use for a given
-// region. Default is m5 then m4 unless a region override is defined in defaultMachineClass.
+// region. Default is m6i then m5 unless a region override is defined in defaultMachineClass.
 func InstanceClasses(region string, arch types.Architecture) []string {
 	if classesForArch, ok := defaultMachineClass[arch]; ok {
 		if classes, ok := classesForArch[region]; ok {
@@ -52,6 +52,6 @@ func InstanceClasses(region string, arch types.Architecture) []string {
 	case types.ArchitectureARM64:
 		return []string{"m6g"}
 	default:
-		return []string{"m5"}
+		return []string{"m6i", "m5"}
 	}
 }


### PR DESCRIPTION
AWS recently launched the m6i instance that is a newer generation of m5 (default AWS IPI). The m6i offers up to 15% improvement in price/performance versus comparable fifth-generation instances. The new instances are powered by the latest generation Intel Xeon Scalable processors (code-named Ice Lake) with an all-core turbo frequency of 3.5 GHz.

Compared to M5 instances using an Intel processor, this new instance type provides:
- Up to 15% improvement in compute price/performance.
- Up to 20% higher memory bandwidth.
- Up to 40 Gbps for Amazon Elastic Block Store (EBS) and 50 Gbps for networking.
- Always-on memory encryption.

The m6i instance is available in 8 of 21 regions, so clusters running on those regions can take advantage of that new instance type.

```
                count(m5.xlarge)  count(m6i.xlarge)  diff(m5_m6i)
region                                                           
af-south-1                     3                  0             3
ap-east-1                      3                  0             3
ap-northeast-1                 3                  2             1
ap-northeast-2                 4                  0             4
ap-northeast-3                 3                  0             3
ap-south-1                     3                  0             3
ap-southeast-1                 3                  3             0
ap-southeast-2                 3                  0             3
ca-central-1                   3                  0             3
eu-central-1                   3                  2             1
eu-north-1                     3                  0             3
eu-south-1                     3                  0             3
eu-west-1                      3                  3             0
eu-west-2                      3                  0             3
eu-west-3                      3                  0             3
me-south-1                     3                  0             3
sa-east-1                      3                  0             3
us-east-1                      5                  5             0
us-east-2                      3                  3             0
us-west-1                      2                  2             0
us-west-2                      6                  4             2
```

The point of attention is the regions that are not deployed that type across all zones: ap-northeast-1, eu-central-1, and us-west-2. But afaik it should not be a problem as the algorithm to choose the better instance should get the instance more available in the region.

Changing the default AWS IPI ec2 to m6i.xlarge and the EBS volume type to gp3 on control planes could be an "easy win" for performance and costs.