### PR TITLE
Bug 2017258: bump oVirt terraform provider version which fix "Disk is locked" bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/openshift/machine-api-operator v0.2.1-0.20210104142355-8e6ae0acdfcf
 	github.com/openshift/machine-config-operator v0.0.0
 	github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c
-	github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210527150815-b3d4424a7da1
+	github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20211019085223-db1ac552ec57
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db // indirect
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1375,6 +1375,8 @@ github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c h1:2SbYZedeIawU8sGF
 github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c/go.mod h1:fLDxPk1Sf64DBYtwIYxrnx3gPZ1q0xPdWdI1y9vxUaw=
 github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210527150815-b3d4424a7da1 h1:0RaJz73jvqRLtctoHjDELqRnZnC74VaS4ws2xh628/w=
 github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210527150815-b3d4424a7da1/go.mod h1:wnTGn9+USQJ51TMV5brymzjxUfmYmnOQZuNfYeuqky8=
+github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20211019085223-db1ac552ec57 h1:hBk5iVZY3EXE53s48+hyI03E0gNl7jaxsNxTc35ClGc=
+github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20211019085223-db1ac552ec57/go.mod h1:wnTGn9+USQJ51TMV5brymzjxUfmYmnOQZuNfYeuqky8=
 github.com/oxtoacart/bpool v0.0.0-20150712133111-4e1c5567d7c2/go.mod h1:L3UMQOThbttwfYRNFOWLLVXMhk5Lkio4GGOtw5UrxS0=
 github.com/packer-community/winrmcp v0.0.0-20180102160824-81144009af58/go.mod h1:f6Izs6JvFTdnRbziASagjZ2vmf55NSIkC/weStxCHqk=
 github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db h1:9uViuKtx1jrlXLBW/pMnhOfzn3iSEdLase/But/IZRU=

--- a/vendor/github.com/ovirt/terraform-provider-ovirt/ovirt/provider.go
+++ b/vendor/github.com/ovirt/terraform-provider-ovirt/ovirt/provider.go
@@ -48,7 +48,7 @@ func (c *providerContext) Provider() terraform.ResourceProvider {
 				Type:        schema.TypeBool,
 				Required:    false,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OVIRT_INSECURE", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OVIRT_INSECURE", false),
 				Description: "Skip certificate verification",
 				Sensitive:   false,
 			},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1178,7 +1178,7 @@ github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.opens
 # github.com/ovirt/go-ovirt v0.0.0-20210308100159-ac0bcbc88d7c
 ## explicit
 github.com/ovirt/go-ovirt
-# github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20210527150815-b3d4424a7da1
+# github.com/ovirt/terraform-provider-ovirt v0.99.1-0.20211019085223-db1ac552ec57
 ## explicit
 github.com/ovirt/terraform-provider-ovirt/ovirt
 # github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db


### PR DESCRIPTION
On RHV 4.4.7 the image upload process changed which lead to a bug that affected many customers.
This change bumps the oVirt terraform version to a version that contains the fix for the Bug.