### PR TITLE
azure/validation: Skip "resource group empty" check for ARO

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -329,15 +329,18 @@ func validateResourceGroup(client API, fieldPath *field.Path, platform *aztypes.
 		allErrs = append(allErrs, field.Invalid(fieldPath.Child("resourceGroupName"), platform.ResourceGroupName, fmt.Sprintf("resource group has conflicting tags %s", strings.Join(conflictingTagKeys, ", "))))
 	}
 
-	ids, err := client.ListResourceIDsByGroup(context.TODO(), platform.ResourceGroupName)
-	if err != nil {
-		return append(allErrs, field.InternalError(fieldPath.Child("resourceGroupName"), errors.Wrap(err, "failed to list resources in the resource group")))
-	}
-	if l := len(ids); l > 0 {
-		if len(ids) > 2 {
-			ids = ids[:2]
+	// ARO provisions Azure resources before resolving the asset graph.
+	if !platform.IsARO() {
+		ids, err := client.ListResourceIDsByGroup(context.TODO(), platform.ResourceGroupName)
+		if err != nil {
+			return append(allErrs, field.InternalError(fieldPath.Child("resourceGroupName"), errors.Wrap(err, "failed to list resources in the resource group")))
 		}
-		allErrs = append(allErrs, field.Invalid(fieldPath.Child("resourceGroupName"), platform.ResourceGroupName, fmt.Sprintf("resource group must be empty but it has %d resources like %s ...", l, strings.Join(ids, ", "))))
+		if l := len(ids); l > 0 {
+			if len(ids) > 2 {
+				ids = ids[:2]
+			}
+			allErrs = append(allErrs, field.Invalid(fieldPath.Child("resourceGroupName"), platform.ResourceGroupName, fmt.Sprintf("resource group must be empty but it has %d resources like %s ...", l, strings.Join(ids, ", "))))
+		}
 	}
 	return allErrs
 }


### PR DESCRIPTION
As of release 4.9, the `Cluster` target now inherits the `PlatformProvisionCheck` dependency by way of [this commit for baremetal](https://github.com/openshift/installer/commit/e6ea0c6364837204428a08abfc9a2cdae2076960).

In the context of [Azure Red Hat OpenShift (ARO)](https://azure.microsoft.com/en-us/services/openshift/), all provisioning checks are passing except for one, which we need to disable.  Since the [ARO Resource Provider](https://github.com/Azure/ARO-RP) provisions Azure resources _before_ resolving the installer asset graph, it's normal for the Azure resource group to be populated.

cc: @m1kola 