### PR TITLE
Fix broken data/unpack_test.go

### DIFF
--- a/data/unpack_test.go
+++ b/data/unpack_test.go
@@ -21,7 +21,7 @@ func TestUnpack(t *testing.T) {
 	}
 
 	expected := "# Bootstrap Module"
-	content, err := ioutil.ReadFile(filepath.Join(path, "aws", "bootstrap", "README.md"))
+	content, err := ioutil.ReadFile(filepath.Join(path, "baremetal", "bootstrap", "README.md"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Commit https://github.com/openshift/installer/commit/5c9e55ca3 broke `data/unpack_test.go` by removing the file `data/data/aws/bootstrap/README.md`.

Pick a different file to check for so the test passes again.

cc: @m1kola 