### PR TITLE
AWS: Remove unused Instance Class Function

### DIFF
--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -3,7 +3,6 @@ package aws
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1"
@@ -11,7 +10,6 @@ import (
 	configaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/types"
 	typesaws "github.com/openshift/installer/pkg/types/aws"
-	"github.com/openshift/installer/pkg/types/aws/defaults"
 )
 
 type config struct {
@@ -114,15 +112,13 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		return nil, errors.New("EBS IOPS must be configured for the io1 root volume")
 	}
 
-	instanceClass := defaults.InstanceClass(masterConfig.Placement.Region, sources.Architecture)
-
 	cfg := &config{
 		CustomEndpoints:         endpoints,
 		Region:                  masterConfig.Placement.Region,
 		ExtraTags:               tags,
 		MasterAvailabilityZones: masterAvailabilityZones,
 		WorkerAvailabilityZones: workerAvailabilityZones,
-		BootstrapInstanceType:   fmt.Sprintf("%s.large", instanceClass),
+		BootstrapInstanceType:   masterConfig.InstanceType,
 		MasterInstanceType:      masterConfig.InstanceType,
 		Size:                    *rootVolume.EBS.VolumeSize,
 		Type:                    *rootVolume.EBS.VolumeType,

--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -22,23 +22,6 @@ var (
 func SetPlatformDefaults(p *aws.Platform) {
 }
 
-// InstanceClass returns the instance "class" we should use for a given
-// region. Default is m5 unless a region override is defined in defaultMachineClass.
-func InstanceClass(region string, arch types.Architecture) string {
-	if classesForArch, ok := defaultMachineClass[arch]; ok {
-		if classes, ok := classesForArch[region]; ok {
-			return classes[0]
-		}
-	}
-
-	switch arch {
-	case types.ArchitectureARM64:
-		return "m6g"
-	default:
-		return "m5"
-	}
-}
-
 // InstanceClasses returns a list of instance "class", in decreasing priority order, which we should use for a given
 // region. Default is m6i then m5 unless a region override is defined in defaultMachineClass.
 func InstanceClasses(region string, arch types.Architecture) []string {


### PR DESCRIPTION
After switching the bootstrap to use the same instance type as masters, the defaults.InstanceClass is no longer used so this
commit removes it.

/hold
Depends on #5334