### PR TITLE
Bug 1956776: Fix network validation for UPI

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -41,7 +41,9 @@ func Validate(ic *types.InstallConfig) error {
 func validateResources(finder Finder, ic *types.InstallConfig) error {
 	allErrs := field.ErrorList{}
 	p := ic.Platform.VSphere
-	allErrs = append(allErrs, validateNetwork(finder, p, field.NewPath("platform").Child("vsphere").Child("network"))...)
+	if p.Network != "" {
+		allErrs = append(allErrs, validateNetwork(finder, p, field.NewPath("platform").Child("vsphere").Child("network"))...)
+	}
 	return allErrs.ToAggregate()
 }
 


### PR DESCRIPTION
Adding a check to see if vsphere network is set before validating
it for UPI installations where network is optional.