### PR TITLE
[splat-330] vSphere: Modify the platform spec

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2492,6 +2492,99 @@ spec:
                   vCenter:
                     description: VCenter is the domain name or IP address of the vCenter.
                     type: string
+                  vcenters:
+                    description: VCenters slice is the configuration for the use of
+                      Regions and Zones. Also deploying openshift cluster virtual
+                      machines in multiple datacenters and clusters.
+                    items:
+                      description: VCenter stores the vCenter connection fields and
+                        the Region slice that is used to create virtual machines in
+                        various datacenters and clusters
+                      properties:
+                        password:
+                          description: Password is the password for the user to use
+                            to connect to the vCenter.
+                          type: string
+                        port:
+                          description: Port is the vCenter API TCP port that the vCenter
+                            SDK clients connect to.
+                          type: integer
+                        regions:
+                          description: Regions slice is the configuration of the vCenter
+                            datacenter and Zones that will be used in deployment of
+                            virtual machines, cloud provider and tags.
+                          items:
+                            description: Region stores the name of the region, the
+                              datacenter that defines the region and the Zones that
+                              are a part of a particular region.
+                            properties:
+                              datacenter:
+                                description: Datacenter is the name of the datacenter
+                                  to use in the vCenter.
+                                type: string
+                              name:
+                                description: Name is the region name that will be
+                                  used for cloud provider and tag
+                                type: string
+                              zones:
+                                description: Zones slice is the configuration of the
+                                  vCenter Resource Pool (optionally), Cluster, Network
+                                  and Datastore to deploy virtual machines.
+                                items:
+                                  description: Zone stores the name of the zone, the
+                                    cluster associated with the zone. ResourcePool,
+                                    Network and Datastore is provided for virtual
+                                    machine deployment.
+                                  properties:
+                                    cluster:
+                                      description: Cluster is the name of the cluster
+                                        virtual machines will be cloned into.
+                                      type: string
+                                    datastore:
+                                      description: Datastore is the default datastore
+                                        to use for provisioning volumes.
+                                      type: string
+                                    name:
+                                      description: Name is the zone name that will
+                                        be used for the cloud provider and tag
+                                      type: string
+                                    network:
+                                      description: Network specifies the name of the
+                                        network to be used by the cluster.
+                                      type: string
+                                    resourcePool:
+                                      description: ResourcePool is the name of the
+                                        already configured Resource Pool to use when
+                                        deploying virtual machines.
+                                      type: string
+                                  required:
+                                  - cluster
+                                  - datastore
+                                  - name
+                                  - network
+                                  type: object
+                                type: array
+                            required:
+                            - datacenter
+                            - name
+                            - zones
+                            type: object
+                          type: array
+                        server:
+                          description: Server is the domain name or IP address of
+                            the vCenter.
+                          type: string
+                        user:
+                          description: User is the name of the user to use to connect
+                            to the vCenter.
+                          type: string
+                      required:
+                      - password
+                      - regions
+                      - server
+                      - user
+                      type: object
+                    type: array
                 required:
                 - datacenter
                 - defaultDatastore

--- a/pkg/asset/installconfig/vsphere/validation_test.go
+++ b/pkg/asset/installconfig/vsphere/validation_test.go
@@ -18,6 +18,46 @@ var (
 	validCIDR = "10.0.0.0/16"
 )
 
+func validIPIZoningInstallConfig() *types.InstallConfig {
+	return &types.InstallConfig{
+		Networking: &types.Networking{
+			MachineNetwork: []types.MachineNetworkEntry{
+				{CIDR: *ipnet.MustParseCIDR(validCIDR)},
+			},
+		},
+		Publish: types.ExternalPublishingStrategy,
+		Platform: types.Platform{
+			VSphere: &vsphere.Platform{
+				Cluster:          "valid_cluster",
+				Datacenter:       "valid_dc",
+				DefaultDatastore: "valid_ds",
+				Network:          "valid_network",
+				Password:         "valid_password",
+				Username:         "valid_username",
+				VCenter:          "valid-vcenter",
+				APIVIP:           "192.168.111.0",
+				IngressVIP:       "192.168.111.1",
+				VCenters: []vsphere.VCenter{{
+					Server:   "valid-vcenter",
+					Password: "valid_password",
+					User:     "valid_username",
+					Regions: []vsphere.Region{{
+						Name:       "valid_region_name",
+						Datacenter: "valid_dc",
+						Zones: []vsphere.Zone{{
+							Name:         "valid_zone_name",
+							Cluster:      "valid_cluster",
+							Network:      "valid_network",
+							ResourcePool: "valid_rp",
+							Datastore:    "valid_ds",
+						}},
+					}},
+				}},
+			},
+		},
+	}
+}
+
 func validIPIInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
 		Networking: &types.Networking{
@@ -51,6 +91,10 @@ func TestValidate(t *testing.T) {
 	}{{
 		name:             "valid IPI install config",
 		installConfig:    validIPIInstallConfig(),
+		validationMethod: validateProvisioning,
+	}, {
+		name:             "valid IPI zoning install config",
+		installConfig:    validIPIZoningInstallConfig(),
 		validationMethod: validateProvisioning,
 	}, {
 		name: "invalid IPI - no network",

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -72,4 +72,77 @@ type Platform struct {
 	// specified, it will be set according to the default storage policy
 	// of vsphere.
 	DiskType DiskType `json:"diskType,omitempty"`
+
+	// VCenters slice is the configuration for the use of Regions and Zones. Also
+	// deploying openshift cluster virtual machines in multiple datacenters and clusters.
+	// +optional
+	VCenters []VCenter `json:"vcenters,omitempty"`
+}
+
+// VCenter stores the vCenter connection fields and the Region slice
+// that is used to create virtual machines in various datacenters and clusters
+type VCenter struct {
+	// Server is the domain name or IP address of the vCenter.
+	// +required
+	Server string `json:"server"`
+
+	// User is the name of the user to use to connect to the vCenter.
+	// +required
+	User string `json:"user"`
+
+	// Password is the password for the user to use to connect to the vCenter.
+	// +required
+	Password string `json:"password"`
+
+	// Port is the vCenter API TCP port that the vCenter SDK clients connect to.
+	// +optional
+	Port uint `json:"port,omitempty"`
+
+	// Regions slice is the configuration of the vCenter datacenter and Zones that
+	// will be used in deployment of virtual machines, cloud provider and tags.
+	// +required
+	Regions []Region `json:"regions"`
+}
+
+// Region stores the name of the region, the datacenter that defines the region and the Zones
+// that are a part of a particular region.
+type Region struct {
+
+	// Name is the region name that will be used for cloud provider and tag
+	// +required
+	Name string `json:"name"`
+
+	// Datacenter is the name of the datacenter to use in the vCenter.
+	// +required
+	Datacenter string `json:"datacenter"`
+
+	// Zones slice is the configuration of the vCenter Resource Pool (optionally),
+	// Cluster, Network and Datastore to deploy virtual machines.
+	// +required
+	Zones []Zone `json:"zones"`
+}
+
+// Zone stores the name of the zone, the cluster associated with the zone.
+// ResourcePool, Network and Datastore is provided for virtual machine deployment.
+type Zone struct {
+	// Name is the zone name that will be used for the cloud provider and tag
+	// +required
+	Name string `json:"name"`
+
+	// ResourcePool is the name of the already configured Resource Pool to use
+	// when deploying virtual machines.
+	// +optional
+	ResourcePool string `json:"resourcePool,omitempty"`
+
+	// Cluster is the name of the cluster virtual machines will be cloned into.
+	// +required
+	Cluster string `json:"cluster"`
+
+	// Network specifies the name of the network to be used by the cluster.
+	// +required
+	Network string `json:"network"`
+
+	// Datastore is the default datastore to use for provisioning volumes.
+	// +required
+	Datastore string `json:"datastore"`
 }


### PR DESCRIPTION
Modification of the platform spec to include
`VCenters`, `Regions` and `Zones` that will allow
deployment of a OpenShift cluster in vSphere across
multiple vCenter datacenters and clusters. This will also
enable Regions and Zones as implemented by the cloud-provider.