### PR TITLE
optimizing-destroy-aws-user: filter by prefix clusterName

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -591,7 +591,7 @@ func (search *iamUserSearch) getClusterNameFromTag() (string, error) {
 	var err error
 	k8sTagNamePrefix := "kubernetes.io/cluster/"
 	for _, filter := range search.filters {
-		for filterKey, _ := range filter {
+		for filterKey := range filter {
 			if strings.HasPrefix(filterKey, k8sTagNamePrefix) {
 				return strings.Split(filterKey, "/")[2], nil
 			}


### PR DESCRIPTION
AWS list-user endpoint is so slow and doesn't return the tags, so for each user
we need to make one more API call to list the tags and evaluate if the
tag matches the desired filter. That makes the destroy flow so slow in
the account that has large users (we have ones with 4.8k users that the entire destroy
flow was taking 20+ minutes.). For some reason the first API call takes so long,
about 17 minutes to run, the following are faster.

- Sample01
~~~
--
time="2021-10-28T09:43:00-03:00" level=debug msg="search for IAM users"
time="2021-10-28T10:00:12-03:00" level=debug msg="search for IAM instance profiles"
--
time="2021-10-28T10:00:24-03:00" level=debug msg="search for IAM users"
time="2021-10-28T10:00:37-03:00" level=debug msg="search for IAM instance profiles"
~~~

- Sample02
~~~
--
time="2021-10-28T12:00:30-03:00" level=debug msg="search for IAM users"
time="2021-10-28T12:17:15-03:00" level=debug msg="search for IAM instance profiles"
--
time="2021-10-28T12:19:11-03:00" level=debug msg="search for IAM users"
time="2021-10-28T12:19:26-03:00" level=debug msg="search for IAM instance profiles"
--
~~~

Considering that all the users created by IPI have the prefix name of the clusterName,
we are decreasing the number of API calls doing to list user-tags to N*clusterUser,
instead N*IAM_Users.

Now the time is taking about 15 seconds:

~~~
time="2021-10-29T00:16:40-03:00" level=debug msg="search for IAM users"
time="2021-10-29T00:16:53-03:00" level=debug msg="search for IAM instance profiles"
~~~

Before the fix the complete destroy flow was taking about 20+ minutes, now it can
be decreased to 6-8 minutes.