### PR TITLE
bug 1960378: Relax the imageContentSource validation

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -566,9 +566,14 @@ func validateNamedRepository(r string) error {
 		// in an error. Instead we will check whether the input is
 		// a valid hostname as a workaround.
 		if err == dockerref.ErrNameNotCanonical {
-			_, err := url.ParseRequestURI(r)
+			// If the hostname string contains a port, lets attempt
+			// to split them
+			host, _, err := net.SplitHostPort(r)
 			if err != nil {
-				return fmt.Errorf("the repository provided is invalid")
+				host = r
+			}
+			if err = validate.Host(host); err != nil {
+				return errors.Wrap(err, "the repository provided is invalid")
 			}
 			return nil
 		}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1092,7 +1092,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}}
 				return c
 			}(),
-			expectedError: `^imageContentSources\[0\]\.source: Invalid value: "ocp/release-x\.y": the repository provided is invalid$`,
+			expectedError: `^imageContentSources\[0\]\.source: Invalid value: "ocp/release-x\.y": the repository provided is invalid: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, \'\-\' or \'\.\', and must start and end with an alphanumeric character \(e.g. \'example\.com\', regex used for validation is \'\[a\-z0\-9\]\(\[\-a\-z0\-9\]\*\[a\-z0\-9\]\)\?\(\\\.\[a\-z0\-9\]\(\[\-a\-z0\-9\]\*\[a\-z0\-9\]\)\?\)\*\'\)`,
 		},
 		{
 			name: "release image source's mirror is not valid",
@@ -1104,7 +1104,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}}
 				return c
 			}(),
-			expectedError: `^imageContentSources\[0\]\.mirrors\[0\]: Invalid value: "ocp/openshift-x.y": the repository provided is invalid$`,
+			expectedError: `^imageContentSources\[0\]\.mirrors\[0\]: Invalid value: "ocp/openshift-x\.y": the repository provided is invalid: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, \'\-\' or \'\.\', and must start and end with an alphanumeric character \(e.g. \'example\.com\', regex used for validation is \'\[a\-z0\-9\]\(\[\-a\-z0\-9\]\*\[a\-z0\-9\]\)\?\(\\\.\[a\-z0\-9\]\(\[\-a\-z0\-9\]\*\[a\-z0\-9\]\)\?\)\*\'\)`,
 		},
 		{
 			name: "release image source's mirror is valid",


### PR DESCRIPTION
Relax the imageContentSource validation to allow for mirroring root registry.

This is a follow up to a previous attempt: #5297 which didn't quite fix the issue. The use of url.Parse does not work as expected. This PR utilized validate.Host function to check for a valid host name/IP when the canonical check fails.