### PR TITLE
[vsphere] add zones to machinepool specification

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -522,6 +522,11 @@ spec:
                               format: int32
                               type: integer
                           type: object
+                        zones:
+                          description: Zones defines available zones
+                          items:
+                            type: string
+                          type: array
                       type: object
                   type: object
                 replicas:
@@ -980,6 +985,11 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      zones:
+                        description: Zones defines available zones
+                        items:
+                          type: string
+                        type: array
                     type: object
                 type: object
               replicas:
@@ -2234,6 +2244,11 @@ spec:
                             format: int32
                             type: integer
                         type: object
+                      zones:
+                        description: Zones defines available zones
+                        items:
+                          type: string
+                        type: array
                     type: object
                   diskType:
                     description: DiskType is the name of the disk provisioning type,

--- a/pkg/types/vsphere/machinepool.go
+++ b/pkg/types/vsphere/machinepool.go
@@ -23,6 +23,11 @@ type MachinePool struct {
 	//
 	// +optional
 	OSDisk `json:"osDisk"`
+
+	// Zones defines available zones
+	//
+	// +omitempty
+	Zones []string `json:"zones,omitempty"`
 }
 
 // OSDisk defines the disk for a virtual machine.

--- a/pkg/types/vsphere/validation/machinepool.go
+++ b/pkg/types/vsphere/validation/machinepool.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"github.com/openshift/installer/pkg/validate"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/vsphere"
@@ -23,6 +24,14 @@ func ValidateMachinePool(p *vsphere.MachinePool, fldPath *field.Path) field.Erro
 	}
 	if p.NumCoresPerSocket >= 0 && p.NumCPUs >= 0 && p.NumCoresPerSocket > p.NumCPUs {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("coresPerSocket"), p.NumCoresPerSocket, "cores per socket must be less than number of CPUs"))
+	}
+	if len(p.Zones) > 0 {
+		for _, zone := range p.Zones {
+			err := validate.ClusterName1035(zone)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("zones"), p.Zones, err.Error()))
+			}
+		}
 	}
 	return allErrs
 }

--- a/pkg/types/vsphere/validation/machinepool_test.go
+++ b/pkg/types/vsphere/validation/machinepool_test.go
@@ -52,6 +52,14 @@ func TestValidateMachinePool(t *testing.T) {
 				NumCoresPerSocket: 8,
 			},
 			expectedErrMsg: `^test-path\.coresPerSocket: Invalid value: 8: cores per socket must be less than number of CPUs$`,
+		}, {
+			name: "invalid zone name",
+			pool: &vsphere.MachinePool{
+				Zones: []string{
+					"Zone%^@112233",
+				},
+			},
+			expectedErrMsg: `^test-path.zones: Invalid value: \[\]string{"Zone%\^@112233"}: cluster name must begin with a lower-case letter$`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
The intent of this PR is to allow the definition of zones in the machinepool such that `Machines` can be created in multiple specific vSphere locations. This PR is related to openshift/enhancements#918