### PR TITLE
openstack: Fix install config for openstack manifests

### DIFF
--- a/scripts/openstack/manifest-tests/additional-security-group/install-config.yaml
+++ b/scripts/openstack/manifest-tests/additional-security-group/install-config.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 baseDomain: shiftstack.example.com
-clusterID: manifests1
 controlPlane:
   hyperthreading: Enabled
   architecture: amd64

--- a/scripts/openstack/manifest-tests/cinder-availability-zones/install-config.yaml
+++ b/scripts/openstack/manifest-tests/cinder-availability-zones/install-config.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 baseDomain: shiftstack.example.com
-clusterID: manifests1
 controlPlane:
   hyperthreading: Enabled
   architecture: amd64

--- a/scripts/openstack/manifest-tests/nova-availability-zones/install-config.yaml
+++ b/scripts/openstack/manifest-tests/nova-availability-zones/install-config.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 baseDomain: shiftstack.example.com
-clusterID: manifests1
 controlPlane:
   hyperthreading: Enabled
   architecture: amd64

--- a/scripts/openstack/manifest-tests/server-groups/install-config.yaml
+++ b/scripts/openstack/manifest-tests/server-groups/install-config.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 baseDomain: shiftstack.example.com
-clusterID: manifests1
 controlPlane:
   hyperthreading: Enabled
   architecture: amd64


### PR DESCRIPTION
The openstack manifests tests use an install config with the
clusterID field that is no longer supported by the installer.
Changes to the installer to enforce strict unmarshalling of the
install config is in place but is being hindered by the openstack
manifests tests in this PR.

https://github.com/openshift/installer/pull/5307