### PR TITLE
libvirt bootstrap - vcpu count to 4 

### DIFF
--- a/data/data/libvirt/bootstrap/main.tf
+++ b/data/data/libvirt/bootstrap/main.tf
@@ -21,7 +21,7 @@ resource "libvirt_domain" "bootstrap" {
 
   memory = var.libvirt_bootstrap_memory
 
-  vcpu = "2"
+  vcpu = "4"
 
   coreos_ignition = libvirt_ignition.bootstrap.id
 


### PR DESCRIPTION
changing the vcpu count as per described minimum resource requirements.