### PR TITLE
azurestack: Fix cluster tag check for A record destroy

### DIFF
--- a/pkg/asset/cluster/azure/azure.go
+++ b/pkg/asset/cluster/azure/azure.go
@@ -24,7 +24,6 @@ func Metadata(config *types.InstallConfig) *azure.Metadata {
 		Region:                      config.Platform.Azure.Region,
 		ResourceGroupName:           config.Azure.ResourceGroupName,
 		BaseDomainResourceGroupName: config.Azure.BaseDomainResourceGroupName,
-		ClusterName:                 config.ClusterName,
 	}
 }
 

--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -39,7 +39,6 @@ type ClusterUninstaller struct {
 
 	InfraID                     string
 	ResourceGroupName           string
-	ClusterName                 string
 	BaseDomainResourceGroupName string
 
 	Logger logrus.FieldLogger
@@ -102,7 +101,6 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 		ResourceGroupName:           group,
 		Logger:                      logger,
 		BaseDomainResourceGroupName: metadata.Azure.BaseDomainResourceGroupName,
-		ClusterName:                 metadata.ClusterName,
 		CloudName:                   cloudName,
 	}, nil
 }
@@ -222,7 +220,6 @@ func deleteAzureStackPublicRecords(ctx context.Context, o *ClusterUninstaller) e
 
 	recordsClient := azurestackdns.NewRecordSetsClientWithBaseURI(o.Environment.ResourceManagerEndpoint, o.SubscriptionID)
 	recordsClient.Authorizer = o.Authorizer
-	clusterName := o.ClusterName
 
 	var errs []error
 
@@ -250,7 +247,7 @@ func deleteAzureStackPublicRecords(ctx context.Context, o *ClusterUninstaller) e
 		}
 	}
 
-	clusterTag := fmt.Sprintf("kubernetes.io_cluster.%s", clusterName)
+	clusterTag := fmt.Sprintf("kubernetes.io_cluster.%s", o.InfraID)
 	for _, zone := range allZones.List() {
 		for recordPages, err := recordsClient.ListByDNSZone(ctx, rgName, zone, to.Int32Ptr(100), ""); recordPages.NotDone(); err = recordPages.NextWithContext(ctx) {
 			if err != nil {

--- a/pkg/types/azure/metadata.go
+++ b/pkg/types/azure/metadata.go
@@ -6,6 +6,5 @@ type Metadata struct {
 	CloudName                   CloudEnvironment `json:"cloudName"`
 	Region                      string           `json:"region"`
 	ResourceGroupName           string           `json:"resourceGroupName"`
-	ClusterName                 string           `json:"clusterName"`
 	BaseDomainResourceGroupName string           `json:"baseDomainResourceGroupName"`
 }


### PR DESCRIPTION
The azurestack A record destroy was checking for cluster tag
with the cluster name and not the Infra ID which is the actual
name used for cluster tag population. Changing the name from
clusterName to InfraID to pick the right A records to destroy.