### PR TITLE
Bug 2021607: Relax vcenter hostname check

### DIFF
--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -277,9 +277,5 @@ func Host(v string) error {
 	if proxyIP != nil {
 		return nil
 	}
-	re := regexp.MustCompile("^[a-z]")
-	if !re.MatchString(v) {
-		return errors.New("domain name must begin with a lower-case letter")
-	}
 	return validateSubdomain(v)
 }

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -101,7 +101,7 @@ func TestVCenter(t *testing.T) {
 		{"single lowercase", "a", true},
 		{"single uppercase", "A", false},
 		{"contains whitespace", "abc D", false},
-		{"single number", "1", false},
+		{"single number", "1", true},
 		{"single dot", ".", false},
 		{"ends with dot", "a.", false},
 		{"starts with dot", ".a", false},
@@ -115,7 +115,6 @@ func TestVCenter(t *testing.T) {
 		{"contains non-ascii", "a日本語a", false},
 		{"URLs", "https://hello.openshift.org", false},
 		{"IP", "192.168.1.1", true},
-		{"invalid IP", "192.168.1", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The vsphere vcenter validation in the installer right now is
to check if the first character starts with a lowercase alphabet
but we should allow digits as well so removing the first
character check in validation.