### PR TITLE
Alibaba: support to create a resource group

### DIFF
--- a/data/data/alibabacloud/bootstrap/main.tf
+++ b/data/data/alibabacloud/bootstrap/main.tf
@@ -95,7 +95,7 @@ resource "alicloud_ram_role_policy_attachment" "attach" {
 }
 
 resource "alicloud_security_group" "sg_bootstrap" {
-  resource_group_id = var.ali_resource_group_id
+  resource_group_id = var.resource_group_id
   name              = "${local.prefix}_sg_bootstrap"
   description       = local.description
   vpc_id            = var.vpc_id
@@ -130,7 +130,7 @@ resource "alicloud_security_group_rule" "sg_rule_journald_gateway" {
 }
 
 resource "alicloud_instance" "bootstrap" {
-  resource_group_id = var.ali_resource_group_id
+  resource_group_id = var.resource_group_id
 
   host_name                  = "${local.prefix}-bootstrap"
   instance_name              = "${local.prefix}-bootstrap"

--- a/data/data/alibabacloud/bootstrap/variables.tf
+++ b/data/data/alibabacloud/bootstrap/variables.tf
@@ -1,3 +1,8 @@
+variable "resource_group_id" {
+  type        = string
+  description = "The resource group ID of the bootstrap ECS and security group."
+}
+
 variable "vpc_id" {
   type        = string
   description = "The VPC id of the bootstrap ECS."

--- a/data/data/alibabacloud/cluster/main.tf
+++ b/data/data/alibabacloud/cluster/main.tf
@@ -15,13 +15,19 @@ provider "alicloud" {
   region     = var.ali_region_id
 }
 
+module "resource_group" {
+  source            = "./resourcegroup"
+  cluster_id        = var.cluster_id
+  resource_group_id = var.ali_resource_group_id
+}
+
 module "vpc" {
   source              = "./vpc"
   cluster_id          = var.cluster_id
   region_id           = var.ali_region_id
   zone_ids            = var.ali_zone_ids
   nat_gateway_zone_id = var.ali_nat_gateway_zone_id
-  resource_group_id   = var.ali_resource_group_id
+  resource_group_id   = module.resource_group.resource_group_id
   vpc_cidr_block      = var.machine_v4_cidrs[0]
   tags                = local.tags
 }
@@ -29,7 +35,7 @@ module "vpc" {
 module "dns" {
   source            = "./dns"
   cluster_id        = var.cluster_id
-  resource_group_id = var.ali_resource_group_id
+  resource_group_id = module.resource_group.resource_group_id
   vpc_id            = module.vpc.vpc_id
   cluster_domain    = var.cluster_domain
   base_domain       = var.base_domain
@@ -49,7 +55,7 @@ module "ram" {
 module "master" {
   source               = "./master"
   cluster_id           = var.cluster_id
-  resource_group_id    = var.ali_resource_group_id
+  resource_group_id    = module.resource_group.resource_group_id
   vpc_id               = module.vpc.vpc_id
   vswitch_ids          = module.vpc.vswitch_ids
   sg_id                = module.vpc.sg_master_id

--- a/data/data/alibabacloud/cluster/outputs.tf
+++ b/data/data/alibabacloud/cluster/outputs.tf
@@ -1,3 +1,7 @@
+output "resource_group_id" {
+  value = module.resource_group.resource_group_id
+}
+
 output "vpc_id" {
   value = module.vpc.vpc_id
 }

--- a/data/data/alibabacloud/cluster/resourcegroup/main.tf
+++ b/data/data/alibabacloud/cluster/resourcegroup/main.tf
@@ -1,0 +1,10 @@
+locals {
+  resource_group_id = var.resource_group_id == "" ? alicloud_resource_manager_resource_group.resource_group.0.id : var.resource_group_id
+}
+
+resource "alicloud_resource_manager_resource_group" "resource_group" {
+  count = var.resource_group_id == "" ? 1 : 0
+
+  resource_group_name = "${var.cluster_id}-rg"
+  display_name        = "${var.cluster_id}-rg"
+}

--- a/data/data/alibabacloud/cluster/resourcegroup/outputs.tf
+++ b/data/data/alibabacloud/cluster/resourcegroup/outputs.tf
@@ -1,0 +1,3 @@
+output "resource_group_id" {
+  value = local.resource_group_id
+}

--- a/data/data/alibabacloud/cluster/resourcegroup/variables.tf
+++ b/data/data/alibabacloud/cluster/resourcegroup/variables.tf
@@ -1,0 +1,7 @@
+variable "cluster_id" {
+  type = string
+}
+
+variable "resource_group_id" {
+  type = string
+}

--- a/data/data/alibabacloud/cluster/vpc/sg-master.tf
+++ b/data/data/alibabacloud/cluster/vpc/sg-master.tf
@@ -1,7 +1,8 @@
 resource "alicloud_security_group" "sg_master" {
-  name        = "${local.prefix}-sg-master"
-  description = local.description
-  vpc_id      = alicloud_vpc.vpc.id
+  name              = "${local.prefix}-sg-master"
+  description       = local.description
+  resource_group_id = var.resource_group_id
+  vpc_id            = alicloud_vpc.vpc.id
   tags = merge(
     {
       "Name" = "${local.prefix}-sg-master"

--- a/data/data/alibabacloud/cluster/vpc/sg-worker.tf
+++ b/data/data/alibabacloud/cluster/vpc/sg-worker.tf
@@ -1,7 +1,8 @@
 resource "alicloud_security_group" "sg_worker" {
-  name        = "${local.prefix}-sg-worker"
-  description = local.description
-  vpc_id      = alicloud_vpc.vpc.id
+  name              = "${local.prefix}-sg-worker"
+  description       = local.description
+  resource_group_id = var.resource_group_id
+  vpc_id            = alicloud_vpc.vpc.id
   tags = merge(
     {
       "Name" = "${local.prefix}-sg-worker"

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1128,7 +1128,11 @@ spec:
                     type: string
                   resourceGroupID:
                     description: ResourceGroupID is the ID of an already existing
-                      resource group where the cluster should be installed.
+                      resource group where the cluster should be installed. This resource
+                      group must be empty with no other resources when trying to use
+                      it for creating a cluster. If empty, a new resource group will
+                      created for the cluster. Destroying the cluster using installer
+                      will delete this resource group.
                     type: string
                   tags:
                     additionalProperties:
@@ -1139,7 +1143,6 @@ spec:
                     type: object
                 required:
                 - region
-                - resourceGroupID
                 type: object
               aws:
                 description: AWS is the configuration used when installing on AWS.

--- a/pkg/asset/installconfig/alibabacloud/alibabacloud.go
+++ b/pkg/asset/installconfig/alibabacloud/alibabacloud.go
@@ -29,19 +29,8 @@ func Platform() (*alibabacloud.Platform, error) {
 		return nil, err
 	}
 
-	client, err = NewClient(region)
-	if err != nil {
-		return nil, err
-	}
-
-	resourceGroup, err := selectResourceGroup(client)
-	if err != nil {
-		return nil, err
-	}
-
 	return &alibabacloud.Platform{
-		Region:          region,
-		ResourceGroupID: resourceGroup,
+		Region: region,
 	}, nil
 }
 
@@ -95,39 +84,4 @@ func selectRegion(client *Client) (string, error) {
 		return "", err
 	}
 	return selectedRegion, nil
-}
-
-func selectResourceGroup(client *Client) (string, error) {
-	groupsResponse, err := client.ListResourceGroups()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to list resource groups")
-	}
-
-	groups := groupsResponse.ResourceGroups.ResourceGroup
-
-	if len(groups) == 0 {
-		return "", errors.Wrap(err, "resource group not found")
-	}
-
-	var options []string
-	names := make(map[string]string)
-
-	for _, group := range groups {
-		option := fmt.Sprintf("%s (%s)", group.Name, group.Id)
-		names[option] = group.Id
-		options = append(options, option)
-	}
-	sort.Strings(options)
-
-	var selectedResourceGroup string
-	err = survey.Ask([]*survey.Question{
-		{
-			Prompt: &survey.Select{
-				Message: "Resource Group",
-				Help:    "The resource group where the cluster will be provisioned.",
-				Options: options,
-			},
-		},
-	}, &selectedResourceGroup)
-	return names[selectedResourceGroup], err
 }

--- a/pkg/asset/installconfig/alibabacloud/validation.go
+++ b/pkg/asset/installconfig/alibabacloud/validation.go
@@ -33,7 +33,10 @@ func Validate(client *Client, ic *types.InstallConfig) error {
 func validatePlatform(client *Client, ic *types.InstallConfig, path *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, validateResourceGroup(client, ic, path)...)
+	if ic.AlibabaCloud.ResourceGroupID != "" {
+		allErrs = append(allErrs, validateResourceGroup(client, ic, path)...)
+	}
+
 	if ic.Platform.AlibabaCloud.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, validateMachinePool(client, ic, path.Child("defaultMachinePlatform"), ic.Platform.AlibabaCloud.DefaultMachinePlatform, nil)...)
 	}

--- a/pkg/types/alibabacloud/metadata.go
+++ b/pkg/types/alibabacloud/metadata.go
@@ -2,12 +2,7 @@ package alibabacloud
 
 // Metadata contains Alibaba Cloud metadata (e.g. for uninstalling the cluster).
 type Metadata struct {
-	Region string `json:"region"`
-	// The system checks whether the resource group contains resources after deleted,
-	// This process takes 7 days. The resource group remains in the 'Deleting' state
-	// and couldn't create resource group with the same name during this period.
-	// Before deploying the cluster, the user must manually create a resource group.
-	// The parameter ResourceGroupID is required.
+	Region          string `json:"region"`
 	ResourceGroupID string `json:"resourceGroupID"`
 	ClusterDomain   string `json:"clusterDomain"`
 }

--- a/pkg/types/alibabacloud/platform.go
+++ b/pkg/types/alibabacloud/platform.go
@@ -5,9 +5,12 @@ type Platform struct {
 	// Region specifies the Alibaba Cloud region where the cluster will be created.
 	Region string `json:"region"`
 
-	// ResourceGroupID is the ID of an already existing resource group where the
-	// cluster should be installed.
-	ResourceGroupID string `json:"resourceGroupID"`
+	// ResourceGroupID is the ID of an already existing resource group where the cluster should be installed.
+	// This resource group must be empty with no other resources when trying to use it for creating a cluster.
+	// If empty, a new resource group will created for the cluster.
+	// Destroying the cluster using installer will delete this resource group.
+	// +optional
+	ResourceGroupID string `json:"resourceGroupID,omitempty"`
 
 	// Tags additional keys and values that the installer will add
 	// as tags to all resources that it creates. Resources created by the


### PR DESCRIPTION
Support the creation of a new resource group to manage the resources in the cluster.
Users do not need to manually create a resource group before creating a cluster. The `resourceGroupID` parameter is no longer a required parameter

