### PR TITLE
Alibaba: support existing VPC, VSwitchs and PrivateZone

### DIFF
--- a/data/data/alibabacloud/cluster/dns/outputs.tf
+++ b/data/data/alibabacloud/cluster/dns/outputs.tf
@@ -1,3 +1,3 @@
 output "privatezone_id" {
-  value = alicloud_pvtz_zone.pvtz.id
+  value = local.private_zone_id
 }

--- a/data/data/alibabacloud/cluster/dns/privatezone.tf
+++ b/data/data/alibabacloud/cluster/dns/privatezone.tf
@@ -1,7 +1,8 @@
 locals {
-  description  = "Created By OpenShift Installer"
-  prefix       = var.cluster_id
-  cluster_name = split(".", var.cluster_domain)[0]
+  description     = "Created By OpenShift Installer"
+  prefix          = var.cluster_id
+  cluster_name    = split(".", var.cluster_domain)[0]
+  private_zone_id = var.private_zone_id == "" ? alicloud_pvtz_zone.pvtz.0.id : var.private_zone_id
 }
 
 // Using this data source can open Private Zone service automatically.
@@ -24,17 +25,20 @@ resource "alicloud_alidns_record" "dns_public_record" {
 }
 
 resource "alicloud_pvtz_zone" "pvtz" {
+  count = var.private_zone_id == "" ? 1 : 0
+
   resource_group_id = var.resource_group_id
   zone_name         = var.cluster_domain
 }
 
 resource "alicloud_pvtz_zone_attachment" "pvtz_attachment" {
-  zone_id = alicloud_pvtz_zone.pvtz.id
+  count   = var.private_zone_id == "" ? 1 : 0
+  zone_id = local.private_zone_id
   vpc_ids = [var.vpc_id]
 }
 
 resource "alicloud_pvtz_zone_record" "pvtz_record_api_int" {
-  zone_id = alicloud_pvtz_zone.pvtz.id
+  zone_id = local.private_zone_id
   type    = "A"
   rr      = "api-int"
   value   = var.slb_internal_ip
@@ -42,7 +46,7 @@ resource "alicloud_pvtz_zone_record" "pvtz_record_api_int" {
 }
 
 resource "alicloud_pvtz_zone_record" "pvtz_record_api" {
-  zone_id = alicloud_pvtz_zone.pvtz.id
+  zone_id = local.private_zone_id
   type    = "A"
   rr      = "api"
   value   = var.slb_internal_ip

--- a/data/data/alibabacloud/cluster/dns/variables.tf
+++ b/data/data/alibabacloud/cluster/dns/variables.tf
@@ -2,6 +2,10 @@ variable "cluster_id" {
   type = string
 }
 
+variable "private_zone_id" {
+  type = string
+}
+
 variable "resource_group_id" {
   type = string
 }

--- a/data/data/alibabacloud/cluster/main.tf
+++ b/data/data/alibabacloud/cluster/main.tf
@@ -24,9 +24,11 @@ module "resource_group" {
 
 module "vpc" {
   source              = "./vpc"
+  vpc_id              = var.ali_vpc_id
+  vswitch_ids         = var.ali_vswitch_ids
   cluster_id          = var.cluster_id
   region_id           = var.ali_region_id
-  zone_ids            = var.ali_zone_ids
+  zone_ids            = distinct(var.ali_zone_ids)
   nat_gateway_zone_id = var.ali_nat_gateway_zone_id
   resource_group_id   = module.resource_group.resource_group_id
   vpc_cidr_block      = var.machine_v4_cidrs[0]
@@ -36,6 +38,7 @@ module "vpc" {
 module "dns" {
   source            = "./dns"
   cluster_id        = var.cluster_id
+  private_zone_id   = var.ali_private_zone_id
   resource_group_id = module.resource_group.resource_group_id
   vpc_id            = module.vpc.vpc_id
   cluster_domain    = var.cluster_domain
@@ -56,10 +59,12 @@ module "master" {
   cluster_id           = var.cluster_id
   resource_group_id    = module.resource_group.resource_group_id
   vpc_id               = module.vpc.vpc_id
-  vswitch_ids          = module.vpc.vswitch_ids
+  zone_ids             = var.ali_zone_ids
+  az_to_vswitch_id     = module.vpc.az_to_vswitch_id
   sg_id                = module.vpc.sg_master_id
   slb_ids              = module.vpc.slb_ids
   instance_type        = var.ali_master_instance_type
+  instance_count       = var.master_count
   image_id             = var.ali_image_id
   system_disk_size     = var.ali_system_disk_size
   system_disk_category = var.ali_system_disk_category

--- a/data/data/alibabacloud/cluster/master/main.tf
+++ b/data/data/alibabacloud/cluster/master/main.tf
@@ -8,7 +8,7 @@ data "alicloud_instances" "master_data" {
 }
 
 resource "alicloud_instance" "master" {
-  count             = length(var.vswitch_ids)
+  count             = var.instance_count
   resource_group_id = var.resource_group_id
 
   host_name                  = "${local.prefix}-master-${count.index}"
@@ -17,7 +17,7 @@ resource "alicloud_instance" "master" {
   image_id                   = var.image_id
   internet_max_bandwidth_out = 0
 
-  vswitch_id      = var.vswitch_ids[count.index]
+  vswitch_id      = var.az_to_vswitch_id[var.zone_ids[count.index]]
   security_groups = [var.sg_id]
   role_name       = var.role_name
 

--- a/data/data/alibabacloud/cluster/master/variables.tf
+++ b/data/data/alibabacloud/cluster/master/variables.tf
@@ -11,9 +11,14 @@ variable "vpc_id" {
   description = "The VPC ID of the master ECS."
 }
 
-variable "vswitch_ids" {
+variable "zone_ids" {
   type        = list(string)
-  description = "The VSwitch IDs of the master ECS. Example: [vsw-xxx1, vsw-xxx2, vsw-xxx3]"
+  description = "The availability zones in which to create the masters. The length of this list must match instance_count."
+}
+
+variable "az_to_vswitch_id" {
+  type        = map(string)
+  description = "Map from availability zone ID to the ID of the VSwitch in that availability zone"
 }
 
 variable "sg_id" {
@@ -23,6 +28,10 @@ variable "sg_id" {
 
 variable "slb_ids" {
   type = list(string)
+}
+
+variable "instance_count" {
+  type = string
 }
 
 variable "instance_type" {

--- a/data/data/alibabacloud/cluster/vpc/nat_gateway.tf
+++ b/data/data/alibabacloud/cluster/vpc/nat_gateway.tf
@@ -1,6 +1,6 @@
 
 resource "alicloud_nat_gateway" "nat_gateway" {
-  vpc_id           = alicloud_vpc.vpc.id
+  vpc_id           = local.vpc_id
   specification    = "Small"
   nat_gateway_name = "${local.prefix}-ngw"
   vswitch_id       = alicloud_vswitch.vswitch_nat_gateway.id
@@ -15,10 +15,10 @@ resource "alicloud_nat_gateway" "nat_gateway" {
 }
 
 resource "alicloud_snat_entry" "snat_entrys" {
-  count = length(var.zone_ids)
+  count = length(local.vswitch_ids)
 
   depends_on        = [alicloud_eip_association.eip_association]
   snat_table_id     = alicloud_nat_gateway.nat_gateway.snat_table_ids
-  source_vswitch_id = alicloud_vswitch.vswitchs[count.index].id
+  source_vswitch_id = local.vswitch_ids[count.index]
   snat_ip           = alicloud_eip_address.eip.ip_address
 }

--- a/data/data/alibabacloud/cluster/vpc/outputs.tf
+++ b/data/data/alibabacloud/cluster/vpc/outputs.tf
@@ -1,9 +1,13 @@
 output "vpc_id" {
-  value = alicloud_vpc.vpc.id
+  value = local.vpc_id
 }
 
 output "vswitch_ids" {
-  value = alicloud_vswitch.vswitchs.*.id
+  value = local.vswitch_ids
+}
+
+output "az_to_vswitch_id" {
+  value = zipmap(data.alicloud_vswitches.vswitches.vswitches.*.zone_id, data.alicloud_vswitches.vswitches.vswitches.*.id)
 }
 
 output "gw_id" {

--- a/data/data/alibabacloud/cluster/vpc/sg-master.tf
+++ b/data/data/alibabacloud/cluster/vpc/sg-master.tf
@@ -2,7 +2,7 @@ resource "alicloud_security_group" "sg_master" {
   name              = "${local.prefix}-sg-master"
   description       = local.description
   resource_group_id = var.resource_group_id
-  vpc_id            = alicloud_vpc.vpc.id
+  vpc_id            = local.vpc_id
   tags = merge(
     {
       "Name" = "${local.prefix}-sg-master"

--- a/data/data/alibabacloud/cluster/vpc/sg-worker.tf
+++ b/data/data/alibabacloud/cluster/vpc/sg-worker.tf
@@ -2,7 +2,7 @@ resource "alicloud_security_group" "sg_worker" {
   name              = "${local.prefix}-sg-worker"
   description       = local.description
   resource_group_id = var.resource_group_id
-  vpc_id            = alicloud_vpc.vpc.id
+  vpc_id            = local.vpc_id
   tags = merge(
     {
       "Name" = "${local.prefix}-sg-worker"

--- a/data/data/alibabacloud/cluster/vpc/slb.tf
+++ b/data/data/alibabacloud/cluster/vpc/slb.tf
@@ -42,7 +42,7 @@ resource "alicloud_slb_load_balancer" "slb_internal" {
   resource_group_id  = var.resource_group_id
   load_balancer_name = "${local.prefix}-slb-internal"
   address_type       = "intranet"
-  vswitch_id         = alicloud_vswitch.vswitchs[0].id
+  vswitch_id         = local.vswitch_ids[0]
   load_balancer_spec = "slb.s2.small"
   tags = merge(
     {

--- a/data/data/alibabacloud/cluster/vpc/variables.tf
+++ b/data/data/alibabacloud/cluster/vpc/variables.tf
@@ -6,6 +6,14 @@ variable "region_id" {
   type = string
 }
 
+variable "vpc_id" {
+  type = string
+}
+
+variable "vswitch_ids" {
+  type = list(string)
+}
+
 variable "zone_ids" {
   type        = list(string)
   description = "The availability zones in which to create the masters."

--- a/data/data/alibabacloud/variables-alibabacloud.tf
+++ b/data/data/alibabacloud/variables-alibabacloud.tf
@@ -11,9 +11,21 @@ variable "ali_region_id" {
   description = "The target Alibaba Cloud region for the cluster."
 }
 
+variable "ali_vpc_id" {
+  type = string
+}
+
+variable "ali_vswitch_ids" {
+  type = list(string)
+}
+
+variable "ali_private_zone_id" {
+  type = string
+}
+
 variable "ali_zone_ids" {
   type        = list(string)
-  description = "The availability zones in which to create the masters."
+  description = "The availability zones in which to create the masters. The length of this list must match master_count."
 }
 
 variable "ali_nat_gateway_zone_id" {

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1161,6 +1161,14 @@ spec:
                           type: string
                         type: array
                     type: object
+                  privateZoneID:
+                    description: PrivateZoneID is the ID of an existing private zone
+                      into which to add DNS records for the cluster's internal API.
+                      An existing private zone can only be used when also using existing
+                      VPC. The private zone must be associated with the VPC containing
+                      the subnets. Leave the private zone unset to have the installer
+                      create the private zone on your behalf.
+                    type: string
                   region:
                     description: Region specifies the Alibaba Cloud region where the
                       cluster will be created.
@@ -1177,6 +1185,19 @@ spec:
                       will add as tags to all resources that it creates. Resources
                       created by the cluster itself may not include these tags.
                     type: object
+                  vpcID:
+                    description: VpcID is the ID of an already existing VPC where
+                      the cluster should be installed. If empty, the installer will
+                      create a new VPC for the cluster.
+                    type: string
+                  vswitchIDs:
+                    description: VSwitchIDs is the ID list of already existing VSwitches
+                      where cluster resources will be created. The existing VSwitches
+                      can only be used when also using existing VPC. If empty, the
+                      installer will create new VSwitches for the cluster.
+                    items:
+                      type: string
+                    type: array
                 required:
                 - region
                 type: object

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -729,9 +729,16 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		natGatewayZoneID := natGatewayZones.Zones[0].ZoneId
 
+		vswitchIDs := []string{}
+		if len(installConfig.Config.AlibabaCloud.VSwitchIDs) > 0 {
+			vswitchIDs = installConfig.Config.AlibabaCloud.VSwitchIDs
+		}
 		data, err := alibabacloudtfvars.TFVars(
 			alibabacloudtfvars.TFVarsSources{
 				Auth:                  auth,
+				VpcID:                 installConfig.Config.AlibabaCloud.VpcID,
+				VSwitchIDs:            vswitchIDs,
+				PrivateZoneID:         installConfig.Config.AlibabaCloud.PrivateZoneID,
 				ResourceGroupID:       installConfig.Config.AlibabaCloud.ResourceGroupID,
 				BaseDomain:            installConfig.Config.BaseDomain,
 				NatGatewayZoneID:      natGatewayZoneID,

--- a/pkg/asset/installconfig/alibabacloud/client.go
+++ b/pkg/asset/installconfig/alibabacloud/client.go
@@ -246,13 +246,51 @@ func (client *Client) ListDNSDomain(baseDomain string) (response *alidns.Describ
 	return
 }
 
+// ListPrivateZonesByName gets the list of privatezones with the specified name.
+func (client *Client) ListPrivateZonesByName(zoneName string) (response *pvtz.DescribeZonesResponse, err error) {
+	return client.ListPrivateZones(zoneName, "")
+}
+
+// ListPrivateZonesByVPC gets the list of privatezones attached to the specified VPC.
+func (client *Client) ListPrivateZonesByVPC(queryVpcID string) (response *pvtz.DescribeZonesResponse, err error) {
+	return client.ListPrivateZones("", queryVpcID)
+}
+
 // ListPrivateZones gets the list of privatzones.
-func (client *Client) ListPrivateZones(zoneName string) (response *pvtz.DescribeZonesResponse, err error) {
+func (client *Client) ListPrivateZones(zoneName string, queryVpcID string) (response *pvtz.DescribeZonesResponse, err error) {
 	request := pvtz.CreateDescribeZonesRequest()
 	request.Lang = "en"
-	request.Keyword = zoneName
 	request.SearchMode = "EXACT"
+	request.Keyword = zoneName
+	request.QueryVpcId = queryVpcID
+
 	response = &pvtz.DescribeZonesResponse{
+		BaseResponse: &responses.BaseResponse{},
+	}
+	err = client.doActionWithSetDomain(request, response)
+	return
+}
+
+// ListVpcs gets the list of VPCs.
+func (client *Client) ListVpcs(vpcID string) (response *vpc.DescribeVpcsResponse, err error) {
+	request := vpc.CreateDescribeVpcsRequest()
+	request.RegionId = client.RegionID
+	request.VpcId = vpcID
+
+	response = &vpc.DescribeVpcsResponse{
+		BaseResponse: &responses.BaseResponse{},
+	}
+	err = client.doActionWithSetDomain(request, response)
+	return
+}
+
+// ListVSwitches gets the list of VSwitches.
+func (client *Client) ListVSwitches(vswitchID string) (response *vpc.DescribeVSwitchesResponse, err error) {
+	request := vpc.CreateDescribeVSwitchesRequest()
+	request.RegionId = client.RegionID
+	request.VSwitchId = vswitchID
+
+	response = &vpc.DescribeVSwitchesResponse{
 		BaseResponse: &responses.BaseResponse{},
 	}
 	err = client.doActionWithSetDomain(request, response)

--- a/pkg/asset/installconfig/alibabacloud/metadata.go
+++ b/pkg/asset/installconfig/alibabacloud/metadata.go
@@ -4,13 +4,19 @@ package alibabacloud
 // does not need to be user-supplied (e.g. because it can be retrieved
 // from external APIs).
 type Metadata struct {
-	client *Client
-	Region string `json:"region,omitempty"`
+	client      *Client
+	vswitchMaps map[string]string
+
+	VSwitchIDs []string
+	Region     string `json:"region,omitempty"`
 }
 
 // NewMetadata initializes a new Metadata object.
-func NewMetadata(region string) *Metadata {
-	return &Metadata{Region: region}
+func NewMetadata(region string, vswitchIDs []string) *Metadata {
+	return &Metadata{
+		Region:     region,
+		VSwitchIDs: vswitchIDs,
+	}
 }
 
 // Client returns a client used for making API calls to Alibaba Cloud services.
@@ -23,4 +29,24 @@ func (m *Metadata) Client() (*Client, error) {
 		m.client = client
 	}
 	return m.client, nil
+}
+
+// VSwitchMaps retrieves VSwitch and availability zone metadata indexed by VSwitch ID
+func (m *Metadata) VSwitchMaps() (vswitchMaps map[string]string, err error) {
+	vswitchMaps = map[string]string{}
+	if len(m.vswitchMaps) == 0 {
+		client, err := m.Client()
+		if err != nil {
+			return nil, err
+		}
+		for _, vswitchID := range m.VSwitchIDs {
+			response, err := client.ListVSwitches(vswitchID)
+			if err != nil {
+				return nil, err
+			}
+			vswitchMaps[response.VSwitches.VSwitch[0].ZoneId] = vswitchID
+		}
+		m.vswitchMaps = vswitchMaps
+	}
+	return m.vswitchMaps, nil
 }

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -153,7 +153,7 @@ func (a *InstallConfig) finish(filename string) error {
 		a.AWS = aws.NewMetadata(a.Config.Platform.AWS.Region, a.Config.Platform.AWS.Subnets, a.Config.AWS.ServiceEndpoints)
 	}
 	if a.Config.AlibabaCloud != nil {
-		a.AlibabaCloud = alibabacloud.NewMetadata(a.Config.AlibabaCloud.Region)
+		a.AlibabaCloud = alibabacloud.NewMetadata(a.Config.AlibabaCloud.Region, a.Config.AlibabaCloud.VSwitchIDs)
 	}
 	if a.Config.Azure != nil {
 		a.Azure = icazure.NewMetadata(a.Config.Azure.CloudName, a.Config.Azure.ARMEndpoint)

--- a/pkg/tfvars/alibabacloud/alibabacloud.go
+++ b/pkg/tfvars/alibabacloud/alibabacloud.go
@@ -19,7 +19,10 @@ type Auth struct {
 type config struct {
 	Auth                  `json:",inline"`
 	Region                string            `json:"ali_region_id"`
+	VpcID                 string            `json:"ali_vpc_id"`
+	VSwitchIDs            []string          `json:"ali_vswitch_ids"`
 	ZoneIDs               []string          `json:"ali_zone_ids"`
+	PrivateZoneID         string            `json:"ali_private_zone_id"`
 	NatGatewayZoneID      string            `json:"ali_nat_gateway_zone_id"`
 	ResourceGroupID       string            `json:"ali_resource_group_id"`
 	BootstrapInstanceType string            `json:"ali_bootstrap_instance_type"`
@@ -35,6 +38,9 @@ type config struct {
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
 	Auth                  Auth
+	VpcID                 string
+	VSwitchIDs            []string
+	PrivateZoneID         string
 	ResourceGroupID       string
 	BaseDomain            string
 	NatGatewayZoneID      string
@@ -65,6 +71,9 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Auth:                  sources.Auth,
 		Region:                masterConfig.RegionID,
 		ZoneIDs:               zoneIDs,
+		VpcID:                 sources.VpcID,
+		VSwitchIDs:            sources.VSwitchIDs,
+		PrivateZoneID:         sources.PrivateZoneID,
 		NatGatewayZoneID:      sources.NatGatewayZoneID,
 		ResourceGroupID:       sources.ResourceGroupID,
 		BootstrapInstanceType: masterConfig.InstanceType,

--- a/pkg/types/alibabacloud/platform.go
+++ b/pkg/types/alibabacloud/platform.go
@@ -10,6 +10,26 @@ type Platform struct {
 	// +optional
 	ResourceGroupID string `json:"resourceGroupID,omitempty"`
 
+	// VpcID is the ID of an already existing VPC where the cluster should be installed.
+	// If empty, the installer will create a new VPC for the cluster.
+	// +optional
+	VpcID string `json:"vpcID,omitempty"`
+
+	// VSwitchIDs is the ID list of already existing VSwitches where cluster resources will be created.
+	// The existing VSwitches can only be used when also using existing VPC.
+	// If empty, the installer will create new VSwitches for the cluster.
+	// +optional
+	VSwitchIDs []string `json:"vswitchIDs,omitempty"`
+
+	// PrivateZoneID is the ID of an existing private zone into which to add DNS
+	// records for the cluster's internal API. An existing private zone can
+	// only be used when also using existing VPC. The private zone must be
+	// associated with the VPC containing the subnets.
+	// Leave the private zone unset to have the installer create the private zone
+	// on your behalf.
+	// +optional
+	PrivateZoneID string `json:"privateZoneID,omitempty"`
+
 	// Tags additional keys and values that the installer will add
 	// as tags to all resources that it creates. Resources created by the
 	// cluster itself may not include these tags.

--- a/pkg/types/alibabacloud/validation/platform_test.go
+++ b/pkg/types/alibabacloud/validation/platform_test.go
@@ -14,8 +14,7 @@ import (
 
 func validPlatform() *alibabacloud.Platform {
 	return &alibabacloud.Platform{
-		Region:          "cn-hangzhou",
-		ResourceGroupID: "test-resource-group",
+		Region: "cn-hangzhou",
 	}
 }
 
@@ -82,6 +81,36 @@ func TestValidatePlatform(t *testing.T) {
 				ResourceGroupID: "test-resource-group",
 			},
 			expected:   `^test-path\.region: Required value: region must be specified$`,
+			networking: validNetworking(),
+		},
+		{
+			name: "invalid vpc ID for existing VSwitches",
+			platform: &alibabacloud.Platform{
+				Region:     "cn-hangzhou",
+				VpcID:      "",
+				VSwitchIDs: []string{"vsw-test"},
+			},
+			expected:   `^test-path\.vpcID: Required value: when using existing VSwitches, an existing VPC must be used$`,
+			networking: validNetworking(),
+		},
+		{
+			name: "duplicate VSwitch ID",
+			platform: &alibabacloud.Platform{
+				Region:     "cn-hangzhou",
+				VpcID:      "vpc-test",
+				VSwitchIDs: []string{"vsw-test", "vsw-test"},
+			},
+			expected:   `^test-path\.vswitchIDs\[1\]: Duplicate value: \"vsw-test\"$`,
+			networking: validNetworking(),
+		},
+		{
+			name: "invalid vpc ID for existing private zones",
+			platform: &alibabacloud.Platform{
+				Region:        "cn-hangzhou",
+				VpcID:         "",
+				PrivateZoneID: "pvtz-test",
+			},
+			expected:   `^test-path\.vpcID: Required value: when using existing privatezones, an existing VPC must be used$`,
 			networking: validNetworking(),
 		},
 		{


### PR DESCRIPTION
This PR is based on #5378
If the user wants the Installer to install the cluster in an existing network, it is now supported.