### PR TITLE
azurestack: Fix gather bootstrap for azurestack

### DIFF
--- a/data/data/azurestack/cluster/master/outputs.tf
+++ b/data/data/azurestack/cluster/master/outputs.tf
@@ -1,3 +1,3 @@
 output "ip_addresses" {
-  value = azurestack_network_interface.master.*.private_ip_addresses
+  value = azurestack_network_interface.master.*.private_ip_address
 }


### PR DESCRIPTION
The terraform stages needs just a list of control plane ips to
gather bootstrap logs but the azurestack terraform output is
a list of lists causing the gather command to fail. Fixing the
output of the terraform stage to flatten the ips to a single
list. This will enable azurestack gather command.