### PR TITLE
[release-4.8] Bug 2023363: Add ingress rules to master SG for compact clusters

### DIFF
--- a/data/data/config.tf
+++ b/data/data/config.tf
@@ -32,6 +32,17 @@ EOF
 
 }
 
+variable "masters_schedulable" {
+  type = bool
+
+  default = false
+
+  description = <<EOF
+Whether master nodes are schedulables.
+EOF
+
+}
+
 variable "base_domain" {
   type = string
 

--- a/data/data/openstack/main.tf
+++ b/data/data/openstack/main.tf
@@ -82,6 +82,7 @@ module "topology" {
   external_network    = var.openstack_external_network
   external_network_id = var.openstack_external_network_id
   masters_count       = var.master_count
+  masters_schedulable = var.masters_schedulable
   api_floating_ip     = var.openstack_api_floating_ip
   ingress_floating_ip = var.openstack_ingress_floating_ip
   api_int_ip          = var.openstack_api_int_ip

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -238,6 +238,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_http" {
+  count             = var.masters_schedulable ? 1 : 0
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
@@ -249,6 +250,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_http" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
+  count             = var.masters_schedulable ? 1 : 0
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
@@ -260,6 +262,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
 }
 
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_router" {
+  count             = var.masters_schedulable ? 1 : 0
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"

--- a/data/data/openstack/topology/sg-master.tf
+++ b/data/data/openstack/topology/sg-master.tf
@@ -62,7 +62,7 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_dns_udp" {
   description       = local.description
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_api" {
   direction      = "ingress"
   ethertype      = "IPv4"
   protocol       = "tcp"
@@ -237,3 +237,35 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_vrrp" {
   description       = local.description
 }
 
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_http" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_https" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_ingress_router" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 1936
+  port_range_max    = 1936
+  remote_ip_prefix  = var.cidr_block
+  security_group_id = openstack_networking_secgroup_v2.master.id
+  description       = local.description
+}

--- a/data/data/openstack/topology/variables.tf
+++ b/data/data/openstack/topology/variables.tf
@@ -39,6 +39,10 @@ variable "masters_count" {
   type = string
 }
 
+variable "masters_schedulable" {
+  type = bool
+}
+
 variable "api_int_ip" {
   type = string
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -10,6 +10,7 @@ import (
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	coreosarch "github.com/coreos/stream-metadata-go/arch"
+	"github.com/ghodss/yaml"
 	gcpprovider "github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1"
 	kubevirtprovider "github.com/openshift/cluster-api-provider-kubevirt/pkg/apis/kubevirtprovider/v1alpha1"
 	kubevirtutils "github.com/openshift/cluster-api-provider-kubevirt/pkg/utils"
@@ -22,6 +23,7 @@ import (
 	azureprovider "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
 	openstackprovider "sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
@@ -33,6 +35,7 @@ import (
 	openstackconfig "github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	ovirtconfig "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
 	"github.com/openshift/installer/pkg/asset/machines"
+	"github.com/openshift/installer/pkg/asset/manifests"
 	"github.com/openshift/installer/pkg/asset/openshiftinstall"
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	rhcospkg "github.com/openshift/installer/pkg/rhcos"
@@ -72,8 +75,8 @@ const (
 	tfvarsAssetName = "Terraform Variables"
 )
 
-// TerraformVariables depends on InstallConfig and
-// Ignition to generate the terrafor.tfvars.
+// TerraformVariables depends on InstallConfig, Manifests,
+// and Ignition to generate the terrafor.tfvars.
 type TerraformVariables struct {
 	FileList []*asset.File
 }
@@ -97,6 +100,7 @@ func (t *TerraformVariables) Dependencies() []asset.Asset {
 		&machines.Master{},
 		&machines.Worker{},
 		&baremetalbootstrap.IronicCreds{},
+		&manifests.Manifests{},
 	}
 }
 
@@ -109,10 +113,11 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 	masterIgnAsset := &machine.Master{}
 	mastersAsset := &machines.Master{}
 	workersAsset := &machines.Worker{}
+	manifestsAsset := &manifests.Manifests{}
 	rhcosImage := new(rhcos.Image)
 	rhcosBootstrapImage := new(rhcos.BootstrapImage)
 	ironicCreds := &baremetalbootstrap.IronicCreds{}
-	parents.Get(clusterID, installConfig, bootstrapIgnAsset, masterIgnAsset, mastersAsset, workersAsset, rhcosImage, rhcosBootstrapImage, ironicCreds)
+	parents.Get(clusterID, installConfig, bootstrapIgnAsset, masterIgnAsset, mastersAsset, workersAsset, manifestsAsset, rhcosImage, rhcosBootstrapImage, ironicCreds)
 
 	platform := installConfig.Config.Platform.Name()
 	switch platform {
@@ -145,6 +150,19 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 	}
 
 	masterCount := len(mastersAsset.MachineFiles)
+	mastersSchedulable := false
+	for _, f := range manifestsAsset.Files() {
+		if f.Filename == manifests.SchedulerCfgFilename {
+			schedulerConfig := configv1.Scheduler{}
+			err = yaml.Unmarshal(f.Data, &schedulerConfig)
+			if err != nil {
+				return errors.Wrapf(err, "failed to unmarshall %s", manifests.SchedulerCfgFilename)
+			}
+			mastersSchedulable = schedulerConfig.Spec.MastersSchedulable
+			break
+		}
+	}
+
 	data, err := tfvars.TFVars(
 		clusterID.InfraID,
 		installConfig.Config.ClusterDomain(),
@@ -156,6 +174,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		bootstrapIgn,
 		masterIgn,
 		masterCount,
+		mastersSchedulable,
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Terraform variables")

--- a/pkg/asset/manifests/scheduler.go
+++ b/pkg/asset/manifests/scheduler.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	schedulerCfgFilename = filepath.Join(manifestDir, "cluster-scheduler-02-config.yml")
+	// SchedulerCfgFilename is the path of the Scheduler Config file
+	SchedulerCfgFilename = filepath.Join(manifestDir, "cluster-scheduler-02-config.yml")
 )
 
 // Scheduler generates the cluster-scheduler-*.yml files.
@@ -80,7 +81,7 @@ func (s *Scheduler) Generate(dependencies asset.Parents) error {
 
 	s.FileList = []*asset.File{
 		{
-			Filename: schedulerCfgFilename,
+			Filename: SchedulerCfgFilename,
 			Data:     configData,
 		},
 	}

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -10,12 +10,13 @@ import (
 )
 
 type config struct {
-	ClusterID      string   `json:"cluster_id,omitempty"`
-	ClusterDomain  string   `json:"cluster_domain,omitempty"`
-	BaseDomain     string   `json:"base_domain,omitempty"`
-	Masters        int      `json:"master_count,omitempty"`
-	MachineV4CIDRs []string `json:"machine_v4_cidrs"`
-	MachineV6CIDRs []string `json:"machine_v6_cidrs"`
+	ClusterID          string   `json:"cluster_id,omitempty"`
+	ClusterDomain      string   `json:"cluster_domain,omitempty"`
+	BaseDomain         string   `json:"base_domain,omitempty"`
+	Masters            int      `json:"master_count,omitempty"`
+	MastersSchedulable bool     `json:"masters_schedulable,omitempty"`
+	MachineV4CIDRs     []string `json:"machine_v4_cidrs"`
+	MachineV6CIDRs     []string `json:"machine_v6_cidrs"`
 
 	UseIPv4 bool `json:"use_ipv4"`
 	UseIPv6 bool `json:"use_ipv6"`
@@ -26,7 +27,7 @@ type config struct {
 }
 
 // TFVars generates terraform.tfvar JSON for launching the cluster.
-func TFVars(clusterID string, clusterDomain string, baseDomain string, machineV4CIDRs []string, machineV6CIDRs []string, useIPv4, useIPv6 bool, bootstrapIgn string, masterIgn string, masterCount int) ([]byte, error) {
+func TFVars(clusterID string, clusterDomain string, baseDomain string, machineV4CIDRs []string, machineV6CIDRs []string, useIPv4, useIPv6 bool, bootstrapIgn string, masterIgn string, masterCount int, mastersSchedulable bool) ([]byte, error) {
 	f, err := ioutil.TempFile("", "openshift-install-bootstrap-*.ign")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create tmp file for bootstrap ignition")
@@ -46,6 +47,7 @@ func TFVars(clusterID string, clusterDomain string, baseDomain string, machineV4
 		UseIPv4:               useIPv4,
 		UseIPv6:               useIPv6,
 		Masters:               masterCount,
+		MastersSchedulable:    mastersSchedulable,
 		IgnitionBootstrap:     bootstrapIgn,
 		IgnitionBootstrapFile: f.Name(),
 		IgnitionMaster:        masterIgn,


### PR DESCRIPTION
In the case of compact clusters, where master nodes are schedulable, we
need to open ports for ingress, same as for workers.

Manual cherry-pick of https://github.com/openshift/installer/pull/5320 onto release-4.8.