### PR TITLE
Bug 1997059: aws: Filter out local zones when generating a default list of zones

### DIFF
--- a/pkg/asset/installconfig/aws/availabilityzones.go
+++ b/pkg/asset/installconfig/aws/availabilityzones.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -28,9 +29,21 @@ func availabilityZones(ctx context.Context, session *session.Session, region str
 		return nil, errors.Wrap(err, "fetching availability zones")
 	}
 
+	// This finds local zones and allows us to filter them out. It does so by
+	// using the fact that local zones have a predictable format based on the
+	// region, for example a local zone in us-west-2 will look like
+	// "us-west-2-las-1a". This is calculated relative to the region name as not
+	// all regions follow the same format with 2 hyphens.
+	// This is a temporary fix until we update our aws-sdk-go package to a
+	// version that adds the ZoneType field to the AvailabilityZone struct
+	numberOfHyphensInRegion := strings.Count(region, "-")
+
 	zones := []string{}
 	for _, zone := range resp.AvailabilityZones {
-		zones = append(zones, *zone.ZoneName)
+		numberOfHyphensInZone := strings.Count(*zone.ZoneName, "-")
+		if numberOfHyphensInZone != numberOfHyphensInRegion+2 {
+			zones = append(zones, *zone.ZoneName)
+		}
 	}
 
 	if len(zones) == 0 {


### PR DESCRIPTION
Certain resources cannot be created in local zones such as load
balancers, this causes an openshift installation to fail, because of
this we need to filter out local zones when generating a default list of
zones to use

https://bugzilla.redhat.com/show_bug.cgi?id=1997059