### PR TITLE
vSphere: Set default disktype to thick not eager

### DIFF
--- a/data/data/vsphere/variables-vsphere.tf
+++ b/data/data/vsphere/variables-vsphere.tf
@@ -83,5 +83,5 @@ variable "vsphere_control_plane_cores_per_socket" {
 }
 variable "vsphere_disk_type" {
   type    = string
-  default = "eagerZeroedThick"
+  default = "thick"
 }

--- a/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
+++ b/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
@@ -369,10 +369,10 @@ func resourceVSpherePrivateImportOvaCreate(d *schema.ResourceData, meta interfac
 
 	if d.Get("disk_type") == "thin" {
 		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThin
-	} else if d.Get("disk_type") == "thick" {
-		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThick
-	} else {
+	} else if d.Get("disk_type") == "eagerZeroedThick" {
 		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeEagerZeroedThick
+	} else {
+		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThick
 	}
 	// This is a very minimal spec for importing
 	// an OVF.


### PR DESCRIPTION
In #4664 I incorrectly commented to use `eagerZeroedThick`.
The correct disktype to keep the vSphere install the same
as previous versions is `thick`. eagerZeroed as named
will write zeros when creating the vmdk which significantly
extends the time to import and clone virtual machines.