### PR TITLE
Managing the defaults for the Vsphere platform and add descriptions for it

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2141,8 +2141,13 @@ spec:
                         type: object
                     type: object
                   diskType:
-                    description: Disk Type Thin specifies if thin disks should be
-                      use instead of thick
+                    description: DiskType is the name of the disk provisioning type for vsphere,
+                      it can be defined as thin, thick or eagerZeroedThick, by default it will be undefined.
+                    enum:
+                    - ""
+                    - thin
+                    - thick
+                    - eagerZeroedThick
                     type: string
                   folder:
                     description: Folder is the absolute path of the folder that will

--- a/data/data/vsphere/variables-vsphere.tf
+++ b/data/data/vsphere/variables-vsphere.tf
@@ -83,5 +83,4 @@ variable "vsphere_control_plane_cores_per_socket" {
 }
 variable "vsphere_disk_type" {
   type    = string
-  default = "thick"
 }

--- a/docs/user/vsphere/customization.md
+++ b/docs/user/vsphere/customization.md
@@ -19,7 +19,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `cpus` (optional integer): The total number of virtual processor cores to assign a vm.
 * `coresPerSocket` (optional integer): The number of cores per socket in a vm. The number of vCPUs on the vm will be cpus/coresPerSocket (default is 1).
 * `memoryMB` (optional integer): The size of a VM's memory in megabytes.
-* `disk_type` (optional string): DiskType is the name of the disk provisioning type for vsphere, for e.g thick or thin, by default it will be eagerZeroedThick.
+* `disk_type` (optional string): DiskType is the name of the disk provisioning type for vsphere,it can be defined as thin, thick or eagerZeroedThick, by default it will be undefined.
 
 ## Examples
 

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -1,16 +1,17 @@
 package vsphere
 
 // DiskType is a disk provisioning type for vsphere.
+// +kubebuilder:validation:Enum="";Thin;Thick;EagerZeroedThick
 type DiskType string
 
 const (
-	// DiskTypeThin uses Thin disk type for vsphere in the cluster.
+	// DiskTypeThin uses Thin disk provisioning type for vsphere in the cluster.
 	DiskTypeThin DiskType = "thin"
 
-	// DiskTypeThick uses Thick disk type for vsphere in the cluster.
+	// DiskTypeThick uses Thick disk provisioning type for vsphere in the cluster.
 	DiskTypeThick DiskType = "thick"
 
-	// DiskTypeEagerZeroedThick uses EagerZeroedThick disk type for vsphere in the cluster.
+	// DiskTypeEagerZeroedThick uses EagerZeroedThick disk provisioning type for vsphere in the cluster.
 	DiskTypeEagerZeroedThick DiskType = "eagerZeroedThick"
 )
 


### PR DESCRIPTION
- Add a kubebuilder:validation:Enum annotation to the DiskType type.
- Add documentation to the DiskType field making it explicit what the default value is.
- Add code to the SetPlatformDefaults to set the default value when the user omits it.