### PR TITLE
Bug 2025093: Remove The Default Value For The Disk Provisioning Type of Vsphere

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2141,8 +2141,14 @@ spec:
                         type: object
                     type: object
                   diskType:
-                    description: Disk Type Thin specifies if thin disks should be
-                      use instead of thick
+                    description: DiskType is the name of the disk provisioning type
+                      for vsphere, it can be defined as thin, thick, eagerZeroedThick,
+                      or let it undefined as the value is not required.
+                    enum:
+                    - ""
+                    - thin
+                    - thick
+                    - eagerZeroedThick
                     type: string
                   folder:
                     description: Folder is the absolute path of the folder that will

--- a/data/data/vsphere/variables-vsphere.tf
+++ b/data/data/vsphere/variables-vsphere.tf
@@ -82,6 +82,5 @@ variable "vsphere_control_plane_cores_per_socket" {
   type = number
 }
 variable "vsphere_disk_type" {
-  type    = string
-  default = "thick"
+  type = string
 }

--- a/docs/user/vsphere/customization.md
+++ b/docs/user/vsphere/customization.md
@@ -19,7 +19,7 @@ Beyond the [platform-agnostic `install-config.yaml` properties](../customization
 * `cpus` (optional integer): The total number of virtual processor cores to assign a vm.
 * `coresPerSocket` (optional integer): The number of cores per socket in a vm. The number of vCPUs on the vm will be cpus/coresPerSocket (default is 1).
 * `memoryMB` (optional integer): The size of a VM's memory in megabytes.
-* `disk_type` (optional string): DiskType is the name of the disk provisioning type for vsphere, for e.g thick or thin, by default it will be eagerZeroedThick.
+* `disk_type` (optional string): DiskType is the name of the disk provisioning type for vsphere,it can be defined as thin, thick, eagerZeroedThick, or let it undefined as the value is not required
 
 ## Examples
 

--- a/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
+++ b/pkg/terraform/exec/plugins/vsphereprivate/resource_vsphereprivate_import_ova.go
@@ -102,8 +102,8 @@ func resourceVSpherePrivateImportOva() *schema.Resource {
 			},
 			"disk_type": {
 				Type:        schema.TypeString,
-				Description: "The name of the disk provisioning, for e.g eagerZeroedThick or thin, by default it will be thick.",
-				Required:    true,
+				Description: "The name of the disk provisioning type for vsphere,it can be defined as thin, thick or eagerZeroedThick, or let it undefined as the value is not required",
+				Optional:    true,
 				ForceNew:    true,
 			},
 		},
@@ -365,22 +365,19 @@ func resourceVSpherePrivateImportOvaCreate(d *schema.ResourceData, meta interfac
 		Network: importOvaParams.Network.Reference(),
 	}}
 
-	var diskType types.OvfCreateImportSpecParamsDiskProvisioningType
-
+	cisp := types.OvfCreateImportSpecParams{
+		EntityName:     d.Get("name").(string),
+		NetworkMapping: networkMappings,
+	}
 	if d.Get("disk_type") == "thin" {
-		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThin
+		cisp.DiskProvisioning = string(types.OvfCreateImportSpecParamsDiskProvisioningTypeThin)
+	} else if d.Get("disk_type") == "thick" {
+		cisp.DiskProvisioning = string(types.OvfCreateImportSpecParamsDiskProvisioningTypeThick)
 	} else if d.Get("disk_type") == "eagerZeroedThick" {
-		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeEagerZeroedThick
-	} else {
-		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThick
+		cisp.DiskProvisioning = string(types.OvfCreateImportSpecParamsDiskProvisioningTypeEagerZeroedThick)
 	}
 	// This is a very minimal spec for importing
 	// an OVF.
-	cisp := types.OvfCreateImportSpecParams{
-		DiskProvisioning: string(diskType),
-		EntityName:       d.Get("name").(string),
-		NetworkMapping:   networkMappings,
-	}
 
 	m := ovf.NewManager(client)
 	spec, err := m.CreateImportSpec(ctx,

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -1,16 +1,17 @@
 package vsphere
 
 // DiskType is a disk provisioning type for vsphere.
+// +kubebuilder:validation:Enum="";thin;thick;eagerZeroedThick
 type DiskType string
 
 const (
-	// DiskTypeThin uses Thin disk type for vsphere in the cluster.
+	// DiskTypeThin uses Thin disk provisioning type for vsphere in the cluster.
 	DiskTypeThin DiskType = "thin"
 
-	// DiskTypeThick uses Thick disk type for vsphere in the cluster.
+	// DiskTypeThick uses Thick disk provisioning type for vsphere in the cluster.
 	DiskTypeThick DiskType = "thick"
 
-	// DiskTypeEagerZeroedThick uses EagerZeroedThick disk type for vsphere in the cluster.
+	// DiskTypeEagerZeroedThick uses EagerZeroedThick disk provisioning type for vsphere in the cluster.
 	DiskTypeEagerZeroedThick DiskType = "eagerZeroedThick"
 )
 
@@ -66,6 +67,8 @@ type Platform struct {
 	// Network specifies the name of the network to be used by the cluster.
 	Network string `json:"network,omitempty"`
 
-	// Disk Type Thin specifies if thin disks should be use instead of thick
+	// DiskType is the name of the disk provisioning type
+	// for vsphere, it can be defined as thin, thick, eagerZeroedThick,
+	// or let it undefined as the value is not required.
 	DiskType DiskType `json:"diskType,omitempty"`
 }


### PR DESCRIPTION
Resolved the following bug by removing the default values for the disk provisioning type of Vsphere.
https://bugzilla.redhat.com/show_bug.cgi?id=2025093