### PR TITLE
Alibaba: fix kubebuilder validation

### DIFF
--- a/pkg/types/alibabacloud/machinepool.go
+++ b/pkg/types/alibabacloud/machinepool.go
@@ -31,7 +31,6 @@ type MachinePool struct {
 
 	// SystemDiskCategory defines the category of the system disk.
 	//
-	// +kubebuilder:validation:Type=DiskCategory
 	// +optional
 	SystemDiskCategory DiskCategory `json:"systemDiskCategory,omitempty"`
 


### PR DESCRIPTION
DiskCategory validation had string type instead of enum.

On master without this change:
```
$ go generate ./pkg/types/installconfig.go
github.com/openshift/installer/pkg/types:-: conflicting types in allOf branches in schema: string vs DiskCategory
github.com/openshift/installer/pkg/types:-: conflicting types in allOf branches in schema: string vs DiskCategory
github.com/openshift/installer/pkg/types:-: conflicting types in allOf branches in schema: string vs DiskCategory
Error: not all generators ran successfully
run `controller-gen crd:crdVersions=v1 paths=. output:dir=../../data/data/ -w` to see all available markers, or `controller-gen crd:crdVersions=v1 paths=. output:dir=../../data/data/ -h` for usage
exit status 1
pkg/types/installconfig.go:67: running "go": exit status 1

```