### PR TITLE
Bug 1968364: azure: fix upi bug preventing using ed25519 keys

### DIFF
--- a/upi/azure/04_bootstrap.json
+++ b/upi/azure/04_bootstrap.json
@@ -18,8 +18,9 @@
     },
     "sshKeyData" : {
       "type" : "securestring",
+      "defaultValue" : "Unused",
       "metadata" : {
-        "description" : "SSH RSA public key file as a string."
+        "description" : "Unused"
       }
     },
     "bootstrapVMSize" : {
@@ -184,17 +185,10 @@
         "osProfile" : {
           "computerName" : "[variables('vmName')]",
           "adminUsername" : "core",
+          "adminPassword" : "NotActuallyApplied!",
           "customData" : "[parameters('bootstrapIgnition')]",
           "linuxConfiguration" : {
-            "disablePasswordAuthentication" : true,
-            "ssh" : {
-              "publicKeys" : [
-                {
-                  "path" : "[variables('sshKeyPath')]",
-                  "keyData" : "[parameters('sshKeyData')]"
-                }
-              ]
-            }
+            "disablePasswordAuthentication" : false
           }
         },
         "storageProfile" : {

--- a/upi/azure/05_masters.json
+++ b/upi/azure/05_masters.json
@@ -26,8 +26,9 @@
     },
     "sshKeyData" : {
       "type" : "securestring",
+      "defaultValue" : "Unused",
       "metadata" : {
-        "description" : "SSH RSA public key file as a string"
+        "description" : "Unused"
       }
     },
     "privateDNSZoneName" : {
@@ -237,17 +238,10 @@
         "osProfile" : {
           "computerName" : "[variables('vmNames')[copyIndex()]]",
           "adminUsername" : "core",
+          "adminPassword" : "NotActuallyApplied!",
           "customData" : "[parameters('masterIgnition')]",
           "linuxConfiguration" : {
-            "disablePasswordAuthentication" : true,
-            "ssh" : {
-              "publicKeys" : [
-                {
-                  "path" : "[variables('sshKeyPath')]",
-                  "keyData" : "[parameters('sshKeyData')]"
-                }
-              ]
-            }
+            "disablePasswordAuthentication" : false
           }
         },
         "storageProfile" : {

--- a/upi/azure/06_workers.json
+++ b/upi/azure/06_workers.json
@@ -26,8 +26,9 @@
     },
     "sshKeyData" : {
       "type" : "securestring",
+      "defaultValue" : "Unused",
       "metadata" : {
-        "description" : "SSH RSA public key file as a string"
+        "description" : "Unused"
       }
     },
     "nodeVMSize" : {
@@ -182,17 +183,10 @@
                 "osProfile" : {
                   "computerName" : "[variables('vmNames')[copyIndex()]]",
                   "adminUsername" : "capi",
+                  "adminPassword" : "NotActuallyApplied!",
                   "customData" : "[parameters('workerIgnition')]",
                   "linuxConfiguration" : {
-                    "disablePasswordAuthentication" : true,
-                    "ssh" : {
-                      "publicKeys" : [
-                        {
-                          "path" : "[variables('sshKeyPath')]",
-                          "keyData" : "[parameters('sshKeyData')]"
-                        }
-                      ]
-                    }
+                    "disablePasswordAuthentication" : false
                   }
                 },
                 "storageProfile" : {


### PR DESCRIPTION
This updates the azure UPI arm templates to not add the ssh keys.
The azure API does not support using ed25519 ssh keys which
caused the deployment to fail when using ed25519 keys, we are already
providing ssh keys in the ignition so we can bypass this limitation.


fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1968364