### PR TITLE
Alibaba: fix: remove the default value

### DIFF
--- a/data/data/alibabacloud/cluster/dns/variables.tf
+++ b/data/data/alibabacloud/cluster/dns/variables.tf
@@ -40,6 +40,5 @@ variable "master_ips" {
 
 variable "tags" {
   type        = map(string)
-  default     = {}
   description = "Tags to be applied to created resources."
 }

--- a/data/data/alibabacloud/cluster/master/variables.tf
+++ b/data/data/alibabacloud/cluster/master/variables.tf
@@ -42,8 +42,7 @@ variable "system_disk_size" {
 
 variable "system_disk_category" {
   type        = string
-  description = "The system disk category of the master ECS.Valid values are cloud_efficiency, cloud_ssd, cloud_essd. Default value is cloud_essd."
-  default     = "cloud_essd"
+  description = "The system disk category of the master ECS. Valid values are cloud_efficiency, cloud_ssd, cloud_essd."
 }
 
 variable "role_name" {
@@ -57,6 +56,5 @@ variable "user_data_ign" {
 
 variable "tags" {
   type        = map(string)
-  default     = {}
   description = "Tags to be applied to created resources."
 }

--- a/data/data/alibabacloud/cluster/ram/variables.tf
+++ b/data/data/alibabacloud/cluster/ram/variables.tf
@@ -4,6 +4,5 @@ variable "cluster_id" {
 
 variable "tags" {
   type        = map(string)
-  default     = {}
   description = "Tags to be applied to created resources."
 }

--- a/data/data/alibabacloud/cluster/vpc/variables.tf
+++ b/data/data/alibabacloud/cluster/vpc/variables.tf
@@ -26,6 +26,5 @@ variable "resource_group_id" {
 
 variable "tags" {
   type        = map(string)
-  default     = {}
   description = "Tags to be applied to created resources."
 }

--- a/data/data/alibabacloud/variables-alibabacloud.tf
+++ b/data/data/alibabacloud/variables-alibabacloud.tf
@@ -47,8 +47,7 @@ variable "ali_system_disk_size" {
 
 variable "ali_system_disk_category" {
   type        = string
-  description = "The system disk category of the master ECS.Valid values are cloud_efficiency, cloud_ssd, cloud_essd. Default value is cloud_essd."
-  default     = "cloud_essd"
+  description = "The system disk category of the master ECS. Valid values are cloud_efficiency, cloud_ssd, cloud_essd."
 }
 
 variable "ali_extra_tags" {
@@ -59,7 +58,6 @@ variable "ali_extra_tags" {
 
 Example: `{ "key" = "value", "foo" = "bar" }`
 EOF
-  default = {}
 }
 
 variable "ali_ignition_bucket" {

--- a/pkg/tfvars/alibabacloud/alibabacloud.go
+++ b/pkg/tfvars/alibabacloud/alibabacloud.go
@@ -27,7 +27,7 @@ type config struct {
 	ImageID               string            `json:"ali_image_id"`
 	SystemDiskSize        int               `json:"ali_system_disk_size"`
 	SystemDiskCategory    string            `json:"ali_system_disk_category"`
-	ExtraTags             map[string]string `json:"ali_extra_tags,omitempty"`
+	ExtraTags             map[string]string `json:"ali_extra_tags"`
 	IgnitionBucket        string            `json:"ali_ignition_bucket"`
 	BootstrapIgnitionStub string            `json:"ali_bootstrap_stub_ignition"`
 }


### PR DESCRIPTION
Remove the default value in terraform variables, because the root module
and tfvars file should always be  explicitly supplying a value.
