### PR TITLE
Alibaba: fix: Use master ip list to replace map

### DIFF
--- a/data/data/alibabacloud/cluster/dns/privatezone.tf
+++ b/data/data/alibabacloud/cluster/dns/privatezone.tf
@@ -54,7 +54,7 @@ resource "alicloud_pvtz_zone_record" "pvtz_record_masters" {
 
   zone_id = alicloud_pvtz_zone.pvtz.id
   type    = "A"
-  rr      = "master${reverse(split("-", keys(var.master_ips)[count.index]))[0]}"
-  value   = var.master_ips[keys(var.master_ips)[count.index]]
+  rr      = "master${count.index}"
+  value   = var.master_ips[count.index]
   ttl     = 60
 }

--- a/data/data/alibabacloud/cluster/dns/variables.tf
+++ b/data/data/alibabacloud/cluster/dns/variables.tf
@@ -35,7 +35,7 @@ variable "master_count" {
 }
 
 variable "master_ips" {
-  type = map(string)
+  type = list(string)
 }
 
 variable "tags" {

--- a/data/data/alibabacloud/cluster/master/outputs.tf
+++ b/data/data/alibabacloud/cluster/master/outputs.tf
@@ -3,5 +3,5 @@ output "master_ecs_ids" {
 }
 
 output "master_ecs_private_ips" {
-  value = { for ecs in data.alicloud_instances.master_data.instances : ecs.name => ecs.private_ip }
+  value = data.alicloud_instances.master_data.instances.*.private_ip
 }

--- a/data/data/alibabacloud/cluster/outputs.tf
+++ b/data/data/alibabacloud/cluster/outputs.tf
@@ -19,5 +19,5 @@ output "sg_master_id" {
 }
 
 output "control_plane_ips" {
-  value = values(module.master.master_ecs_private_ips)
+  value = module.master.master_ecs_private_ips
 }


### PR DESCRIPTION
Using `{<master name>: <ip>}` map is a redundant operation, using IP list is simpler
