### PR TITLE
Alibaba: fix: update comment on ResourceGroupID

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1128,11 +1128,8 @@ spec:
                     type: string
                   resourceGroupID:
                     description: ResourceGroupID is the ID of an already existing
-                      resource group where the cluster should be installed. This resource
-                      group must be empty with no other resources when trying to use
-                      it for creating a cluster. If empty, a new resource group will
-                      created for the cluster. Destroying the cluster using installer
-                      will delete this resource group.
+                      resource group where the cluster should be installed. If empty,
+                      the installer will create a new resource group for the cluster.
                     type: string
                   tags:
                     additionalProperties:

--- a/pkg/types/alibabacloud/platform.go
+++ b/pkg/types/alibabacloud/platform.go
@@ -6,9 +6,7 @@ type Platform struct {
 	Region string `json:"region"`
 
 	// ResourceGroupID is the ID of an already existing resource group where the cluster should be installed.
-	// This resource group must be empty with no other resources when trying to use it for creating a cluster.
-	// If empty, a new resource group will created for the cluster.
-	// Destroying the cluster using installer will delete this resource group.
+	// If empty, the installer will create a new resource group for the cluster.
 	// +optional
 	ResourceGroupID string `json:"resourceGroupID,omitempty"`
 


### PR DESCRIPTION
In fact, it has no effect if it is not empty. we do not query and destroy resources through resource group. So this description is incorrect
