### PR TITLE
vendor: update terraform-provider-google for rate limit fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -386,6 +386,7 @@ replace (
 	github.com/terraform-providers/terraform-provider-aws => github.com/openshift/terraform-provider-aws v1.60.1-0.20210622193531-7d13cfbb1a8c // Pin to openshift fork with tag v2.67.0-openshift-1
 	github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.44.1-0.20210224232508-7509319df0f4 // Pin to 2.48.0-openshift
 	github.com/terraform-providers/terraform-provider-azurestack => github.com/openshift/terraform-provider-azurestack v0.10.0-openshift // Use OpenShift fork
+	github.com/terraform-providers/terraform-provider-google v1.20.1-0.20200623174414-27107f2ee160 => github.com/openshift/terraform-providers-terraform-provider-google v1.20.1-0.20211201190933-7b79c6d1afc8 // Pin to 3.27.0-openshift
 	github.com/terraform-providers/terraform-provider-ignition/v2 => github.com/community-terraform-providers/terraform-provider-ignition/v2 v2.1.0
 	k8s.io/client-go => k8s.io/client-go v0.22.0
 	k8s.io/kubectl => k8s.io/kubectl v0.21.0-rc.0

--- a/go.sum
+++ b/go.sum
@@ -1602,6 +1602,8 @@ github.com/openshift/terraform-provider-ibm v1.26.2-openshift-2 h1:HxvKVrzgLpfuz
 github.com/openshift/terraform-provider-ibm v1.26.2-openshift-2/go.mod h1:LnGKkV2HJUeJrIMMPK+/Ka6F+5JIy45mbEj9VpoHHqc=
 github.com/openshift/terraform-provider-vsphere v1.24.3-openshift h1:tG83XgfFwH4OLONUeEsxh8JPG9QRrqKLoPzkPmLye/Y=
 github.com/openshift/terraform-provider-vsphere v1.24.3-openshift/go.mod h1:FgcsrcPpnjLUO4XWpudYiBho9ETIXYRxVXWV7R3Iz6k=
+github.com/openshift/terraform-providers-terraform-provider-google v1.20.1-0.20211201190933-7b79c6d1afc8 h1:0cPSCz8rgQKLRIQDdKxpWTQ19nMlzXphqxuMw2j4nz0=
+github.com/openshift/terraform-providers-terraform-provider-google v1.20.1-0.20211201190933-7b79c6d1afc8/go.mod h1:QxehqxV8Swl+O2JXJUdS6orHYJXWUEr4HFfYH5JV9ew=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -1880,8 +1882,6 @@ github.com/terraform-provider-openstack/terraform-provider-openstack v1.37.0 h1:
 github.com/terraform-provider-openstack/terraform-provider-openstack v1.37.0/go.mod h1:tPCEc/DdR9fVX9rmcJiqa85oTG7BUb5Xc0bSY/aOTf8=
 github.com/terraform-providers/terraform-provider-azuread v0.9.0 h1:XLzFgVHakq6qjJ2L0o/tN2yHu/hT4vIW9sKtejr7gPs=
 github.com/terraform-providers/terraform-provider-azuread v0.9.0/go.mod h1:sSDzB/8CD639+yWo5lZf+NJvGSYQBSS6z+GoET9IrzE=
-github.com/terraform-providers/terraform-provider-google v1.20.1-0.20200623174414-27107f2ee160 h1:Ghc1PD9TckxsdyP1BG+dM8q84cNNyL93qRmYq/PVNow=
-github.com/terraform-providers/terraform-provider-google v1.20.1-0.20200623174414-27107f2ee160/go.mod h1:QxehqxV8Swl+O2JXJUdS6orHYJXWUEr4HFfYH5JV9ew=
 github.com/terraform-providers/terraform-provider-ignition v1.2.1 h1:dlRZGcokysc9Z2gTVm+neSghAMv9/2WA/pYiGZ6JHCg=
 github.com/terraform-providers/terraform-provider-ignition v1.2.1/go.mod h1:tUlGVBhkz+z79iffnt7vKISS199MdPd85+l6SNpoS/s=
 github.com/terraform-providers/terraform-provider-local v1.4.0 h1:n0CNTMjBfCC5R6LMyuqxJRlgWPUqx0mvSU+ZIhg8EN0=

--- a/vendor/github.com/terraform-providers/terraform-provider-google/google/common_operation.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-google/google/common_operation.go
@@ -111,7 +111,7 @@ func CommonRefreshFunc(w Waiter) resource.StateRefreshFunc {
 		op, err := w.QueryOp()
 		if err != nil {
 			// Retry 404 when getting operation (not resource state)
-			if isRetryableError(err, isNotFoundRetryableError("GET operation")) {
+			if isRetryableError(err, isNotFoundRetryableError("GET operation"), isOperationReadQuotaError) {
 				log.Printf("[DEBUG] Dismissed retryable error on GET operation %q: %s", w.OpName(), err)
 				return nil, "done: false", nil
 			}

--- a/vendor/github.com/terraform-providers/terraform-provider-google/google/error_retry_predicates.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-google/google/error_retry_predicates.go
@@ -190,6 +190,17 @@ func isSqlOperationInProgressError(err error) (bool, string) {
 	return false, ""
 }
 
+// Retry if operation returns a 403 with the message for
+// exceeding the quota limit for 'OperationReadGroup'
+func isOperationReadQuotaError(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 403 && strings.Contains(gerr.Body, "Quota exceeded for quota group") {
+			return true, "Waiting for quota to refresh"
+		}
+	}
+	return false, ""
+}
+
 // Retry if Monitoring operation returns a 429 with a specific message for
 // concurrent operations.
 func isMonitoringConcurrentEditError(err error) (bool, string) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2258,7 +2258,7 @@ github.com/terraform-providers/terraform-provider-azurerm/version
 ## explicit; go 1.16
 github.com/terraform-providers/terraform-provider-azurestack/azurestack
 github.com/terraform-providers/terraform-provider-azurestack/azurestack/helpers/azure
-# github.com/terraform-providers/terraform-provider-google v1.20.1-0.20200623174414-27107f2ee160
+# github.com/terraform-providers/terraform-provider-google v1.20.1-0.20200623174414-27107f2ee160 => github.com/openshift/terraform-providers-terraform-provider-google v1.20.1-0.20211201190933-7b79c6d1afc8
 ## explicit; go 1.14
 github.com/terraform-providers/terraform-provider-google/google
 github.com/terraform-providers/terraform-provider-google/version


### PR DESCRIPTION
In CI, we're hitting errors like this:

```
level=error msg=Error: Error when reading or editing Target Pool
"ci-op-x5j99sbj-82914-2f74l-api": googleapi: Error 403: Quota exceeded
for quota group 'ReadGroup' and limit 'Read requests per 100 seconds' of
service 'compute.googleapis.com' for consumer
'project_number:711936183532'., rateLimitExceeded
```

This was fixed in v3.62.0, however v3.62.0 uses v2 of the terraform sdk. This
changes the installer to use the openshift fork which contains the
existing version in the repo (3.27.0), with these two fixes
applied.[1][2]

[1] hashicorp/terraform-provider-google#8746
[2] hashicorp/terraform-provider-google#8997