### PR TITLE
installer-artifacts: add darwin/arm64 binary

### DIFF
--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -8,6 +8,12 @@ COPY . .
 RUN go generate ./data && \
     SKIP_GENERATION=y GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS macarmbuilder
+WORKDIR /go/src/github.com/openshift/installer
+COPY . .
+RUN go generate ./data && \
+    SKIP_GENERATION=y GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS linuxbuilder
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
@@ -16,4 +22,5 @@ RUN go generate ./data && \
 
 FROM registry.ci.openshift.org/ocp/4.10:installer
 COPY --from=macbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac/openshift-install
+COPY --from=macarmbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac_arm64/openshift-install
 COPY --from=linuxbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/linux_amd64/openshift-install


### PR DESCRIPTION
This will require a simultaneous commit to ocp-build-data, so this should not be merged until both are ready.
