### PR TITLE
Alibaba: fix: remove the master node records

### DIFF
--- a/data/data/alibabacloud/cluster/dns/privatezone.tf
+++ b/data/data/alibabacloud/cluster/dns/privatezone.tf
@@ -48,13 +48,3 @@ resource "alicloud_pvtz_zone_record" "pvtz_record_api" {
   value   = var.slb_internal_ip
   ttl     = 60
 }
-
-resource "alicloud_pvtz_zone_record" "pvtz_record_masters" {
-  count = var.master_count
-
-  zone_id = alicloud_pvtz_zone.pvtz.id
-  type    = "A"
-  rr      = "master${reverse(split("-", keys(var.master_ips)[count.index]))[0]}"
-  value   = var.master_ips[keys(var.master_ips)[count.index]]
-  ttl     = 60
-}

--- a/data/data/alibabacloud/cluster/dns/variables.tf
+++ b/data/data/alibabacloud/cluster/dns/variables.tf
@@ -30,14 +30,6 @@ variable "slb_internal_ip" {
   description = "Internal SLB IP address."
 }
 
-variable "master_count" {
-  type = number
-}
-
-variable "master_ips" {
-  type = map(string)
-}
-
 variable "tags" {
   type        = map(string)
   default     = {}

--- a/data/data/alibabacloud/cluster/main.tf
+++ b/data/data/alibabacloud/cluster/main.tf
@@ -41,8 +41,6 @@ module "dns" {
   base_domain       = var.base_domain
   slb_external_ip   = module.vpc.slb_external_ip
   slb_internal_ip   = module.vpc.slb_internal_ip
-  master_count      = length(var.ali_zone_ids)
-  master_ips        = module.master.master_ecs_private_ips
   tags              = local.tags
 }
 

--- a/data/data/alibabacloud/cluster/master/outputs.tf
+++ b/data/data/alibabacloud/cluster/master/outputs.tf
@@ -3,5 +3,5 @@ output "master_ecs_ids" {
 }
 
 output "master_ecs_private_ips" {
-  value = { for ecs in data.alicloud_instances.master_data.instances : ecs.name => ecs.private_ip }
+  value = data.alicloud_instances.master_data.instances.*.private_ip
 }

--- a/data/data/alibabacloud/cluster/outputs.tf
+++ b/data/data/alibabacloud/cluster/outputs.tf
@@ -19,5 +19,5 @@ output "sg_master_id" {
 }
 
 output "control_plane_ips" {
-  value = values(module.master.master_ecs_private_ips)
+  value = module.master.master_ecs_private_ips
 }


### PR DESCRIPTION
The `<master><n>.<cluster name>.<base domain>` records is not needed on
 base domain
