### PR TITLE
Bug 2027329: Handle unset default machine pool

### DIFF
--- a/pkg/types/openstack/validation/machinepool.go
+++ b/pkg/types/openstack/validation/machinepool.go
@@ -39,6 +39,9 @@ func validateWorkerMachinePool(pool *openstack.MachinePool, fldPath *field.Path)
 }
 
 func validateDefaultMachinePool(pool *openstack.MachinePool, fldPath *field.Path) field.ErrorList {
+	if pool == nil {
+		return nil
+	}
 	var errs field.ErrorList
 	if pool.ServerGroupPolicy != openstack.SGPolicyUnset {
 		errs = append(errs, field.Invalid(fldPath.Child("serverGroupPolicy"), pool.ServerGroupPolicy, "server group policy cannot be set as default because compute machines do not support it"))

--- a/pkg/types/openstack/validation/machinepool_test.go
+++ b/pkg/types/openstack/validation/machinepool_test.go
@@ -54,6 +54,11 @@ func TestValidateDefaultMachinePool(t *testing.T) {
 		checks      []checkFunc
 	}{
 		{
+			"absent",
+			nil,
+			check(noError),
+		},
+		{
 			"empty",
 			testMachinePool(),
 			check(noError),


### PR DESCRIPTION
If the user has explicitly provided `controlPlane` and `compute` configuration, then there won't be a default to consider.

This was hit in CI once `platform.openstack.computeFlavor` was no longer defined in a generated `install-config.yaml` file. This had been masking the bug since setting that attribute resulted in us initializing `config.Platform.OpenStack.DefaultMachinePlatform` with an `openstack.MachinePool` instance and populating the `FlavorName` attribute of this struct (see `pkg/types/conversion/installconfig.go` for more info).

/label platform/openstack