### PR TITLE
fix/alibaba-slb: remove unused listeners, and set kube-apiserver to HTTP/6080

### DIFF
--- a/data/data/alibabacloud/cluster/vpc/slb.tf
+++ b/data/data/alibabacloud/cluster/vpc/slb.tf
@@ -13,53 +13,6 @@ resource "alicloud_slb_load_balancer" "slb_external" {
   )
 }
 
-resource "alicloud_slb_listener" "listener_external_80" {
-  load_balancer_id          = alicloud_slb_load_balancer.slb_external.id
-  backend_port              = 80
-  frontend_port             = 80
-  protocol                  = "tcp"
-  bandwidth                 = 10
-  sticky_session            = "on"
-  sticky_session_type       = "insert"
-  cookie_timeout            = 86400
-  health_check              = "on"
-  health_check_connect_port = 80
-  healthy_threshold         = 2
-  unhealthy_threshold       = 2
-  health_check_timeout      = 10
-  health_check_interval     = 10
-  x_forwarded_for {
-    retrive_slb_ip = true
-    retrive_slb_id = true
-  }
-  request_timeout = 80
-  idle_timeout    = 30
-}
-
-
-resource "alicloud_slb_listener" "listener_external_443" {
-  load_balancer_id          = alicloud_slb_load_balancer.slb_external.id
-  backend_port              = 443
-  frontend_port             = 443
-  protocol                  = "tcp"
-  bandwidth                 = 10
-  sticky_session            = "on"
-  sticky_session_type       = "insert"
-  cookie_timeout            = 86400
-  health_check              = "on"
-  health_check_connect_port = 443
-  healthy_threshold         = 2
-  unhealthy_threshold       = 2
-  health_check_timeout      = 10
-  health_check_interval     = 10
-  x_forwarded_for {
-    retrive_slb_ip = true
-    retrive_slb_id = true
-  }
-  request_timeout = 80
-  idle_timeout    = 30
-}
-
 resource "alicloud_slb_listener" "listener_external_6443" {
   load_balancer_id          = alicloud_slb_load_balancer.slb_external.id
   backend_port              = 6443
@@ -70,8 +23,9 @@ resource "alicloud_slb_listener" "listener_external_6443" {
   sticky_session_type       = "insert"
   cookie_timeout            = 86400
   health_check              = "on"
+  health_check_type         = "http"
   health_check_uri          = "/readyz"
-  health_check_connect_port = 6443
+  health_check_connect_port = 6080
   healthy_threshold         = 2
   unhealthy_threshold       = 2
   health_check_timeout      = 10
@@ -108,8 +62,9 @@ resource "alicloud_slb_listener" "listener_internal_6443" {
   sticky_session_type       = "insert"
   cookie_timeout            = 86400
   health_check              = "on"
+  health_check_type         = "http"
   health_check_uri          = "/readyz"
-  health_check_connect_port = 6443
+  health_check_connect_port = 6080
   healthy_threshold         = 2
   unhealthy_threshold       = 2
   health_check_timeout      = 10
@@ -132,54 +87,8 @@ resource "alicloud_slb_listener" "listener_internal_22623" {
   sticky_session_type       = "insert"
   cookie_timeout            = 86400
   health_check              = "on"
-  health_check_uri          = "/healthz"
+  health_check_type         = "tcp"
   health_check_connect_port = 22623
-  healthy_threshold         = 2
-  unhealthy_threshold       = 2
-  health_check_timeout      = 10
-  health_check_interval     = 10
-  x_forwarded_for {
-    retrive_slb_ip = true
-    retrive_slb_id = true
-  }
-  request_timeout = 80
-  idle_timeout    = 30
-}
-
-resource "alicloud_slb_listener" "listener_internal_80" {
-  load_balancer_id          = alicloud_slb_load_balancer.slb_internal.id
-  backend_port              = 80
-  frontend_port             = 80
-  protocol                  = "tcp"
-  bandwidth                 = 10
-  sticky_session            = "on"
-  sticky_session_type       = "insert"
-  cookie_timeout            = 86400
-  health_check              = "on"
-  health_check_connect_port = 80
-  healthy_threshold         = 2
-  unhealthy_threshold       = 2
-  health_check_timeout      = 10
-  health_check_interval     = 10
-  x_forwarded_for {
-    retrive_slb_ip = true
-    retrive_slb_id = true
-  }
-  request_timeout = 80
-  idle_timeout    = 30
-}
-
-resource "alicloud_slb_listener" "listener_internal_443" {
-  load_balancer_id          = alicloud_slb_load_balancer.slb_internal.id
-  backend_port              = 443
-  frontend_port             = 443
-  protocol                  = "tcp"
-  bandwidth                 = 10
-  sticky_session            = "on"
-  sticky_session_type       = "insert"
-  cookie_timeout            = 86400
-  health_check              = "on"
-  health_check_connect_port = 443
   healthy_threshold         = 2
   unhealthy_threshold       = 2
   health_check_timeout      = 10

--- a/data/data/alibabacloud/cluster/vpc/slb.tf
+++ b/data/data/alibabacloud/cluster/vpc/slb.tf
@@ -87,8 +87,9 @@ resource "alicloud_slb_listener" "listener_internal_22623" {
   sticky_session_type       = "insert"
   cookie_timeout            = 86400
   health_check              = "on"
-  health_check_type         = "tcp"
-  health_check_connect_port = 22623
+  health_check_type         = "http"
+  health_check_uri          = "/healthz"
+  health_check_connect_port = 22624
   healthy_threshold         = 2
   unhealthy_threshold       = 2
   health_check_timeout      = 10


### PR DESCRIPTION
- Remove listeners 80 and 443 for public and private SLB[1]
- Fix Health check protocol to HTTP port 6080 (kube-apiserver sidecar for "insecure" health checks): SLB does
not support health check protocol HTTPS[2][3]
  - when `health_check_type`  is not defined, the default will be set which is `TCP`[4]. Keeping explicitly the value of each listener.
- Change the port of machine-config-server health check, listener port 22623, to HTTP that binds on port 22624
- More details on the [internal thread](https://coreos.slack.com/archives/C01PES793LL/p1637846770449300)

References:
1. Other Cloud implementation ([AWS](https://github.com/openshift/installer/blob/master/data/data/aws/cluster/vpc/master-elb.tf#L124-L157) and [Azure](https://github.com/openshift/installer/blob/master/data/data/azure/vnet/internal-lb.tf#L119-L139))
2. [AlibabaCloud Doc: Health check overview](https://www.alibabacloud.com/help/en/doc-detail/85958.html)
3. [AlibabaCloud Doc: Configure health checks](https://www.alibabacloud.com/help/en/doc-detail/85959.html)
4. [Terraform variable `health_check_type`](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/slb_listener#health_check_type)


/cc @kwoodson @staebler 