### PR TITLE
Bug 2026853: Add a nil check after Delete

### DIFF
--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -469,7 +469,7 @@ func deleteResourceGroup(ctx context.Context, client resources.GroupsClient, log
 
 	delFuture, err := client.Delete(ctx, name)
 	if err != nil {
-		if wasNotFound(delFuture.Response()) {
+		if delFuture.FutureAPI != nil && wasNotFound(delFuture.FutureAPI.Response()) {
 			logger.Debug("already deleted")
 			return nil
 		}


### PR DESCRIPTION
A code path was dereferencing the return value from a Delete() call on
error without first checking whether the return value was nil. Fix.

Closes: 2026853