### PR TITLE
Bug 1928761: Validation of platform.openstack.machineSubnet

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -38,7 +38,7 @@ func validateMachinesSubnet(p *openstack.Platform, n *types.Networking, ci *Clou
 		if len(p.ExternalDNS) > 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("externalDNS"), p.ExternalDNS, "externalDNS is set, externalDNS is not supported when machinesSubnet is set"))
 		}
-		if !validUUIDv4(p.MachinesSubnet) {
+		if !validUUIDv4(p.MachinesSubnet) || ci.MachinesSubnet == nil {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("machinesSubnet"), errors.New("invalid subnet ID")))
 		} else {
 			if n.MachineNetwork[0].CIDR.String() != ci.MachinesSubnet.CIDR {

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -38,7 +38,9 @@ func validateMachinesSubnet(p *openstack.Platform, n *types.Networking, ci *Clou
 		if len(p.ExternalDNS) > 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("externalDNS"), p.ExternalDNS, "externalDNS is set, externalDNS is not supported when machinesSubnet is set"))
 		}
-		if !validUUIDv4(p.MachinesSubnet) || ci.MachinesSubnet == nil {
+		if ci.MachinesSubnet == nil {
+			allErrs = append(allErrs, field.NotFound(fldPath.Child("machinesSubnet"), p.MachinesSubnet))
+		} else if !validUUIDv4(p.MachinesSubnet) {
 			allErrs = append(allErrs, field.InternalError(fldPath.Child("machinesSubnet"), errors.New("invalid subnet ID")))
 		} else {
 			if n.MachineNetwork[0].CIDR.String() != ci.MachinesSubnet.CIDR {


### PR DESCRIPTION
This is a combined backport of 2 commits:
- Bug 1957809: Validation of platform.openstack.machineSubnet
- Update pkg/asset/installconfig/openstack/validation/platform.go

This will help to fix user experience when a subnet doesn't exist, the error will be shown as the following:
```
FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.openstack.machinesSubnet: Not found: "27178ac7-a4d8-41c3-938a-0605707657e9"
```

Instead of a huge Go trace.
