### PR TITLE
Bug 2027387: fix(ibmcloud): Do not compute image file checksum

### DIFF
--- a/data/data/ibmcloud/network/image/main.tf
+++ b/data/data/ibmcloud/network/image/main.tf
@@ -14,7 +14,6 @@ resource "ibm_cos_bucket_object" "file" {
   bucket_location = ibm_cos_bucket.images.region_location
   content_file    = var.image_filepath
   key             = basename(var.image_filepath)
-  etag            = filemd5(var.image_filepath)
 }
 
 resource "ibm_iam_authorization_policy" "policy" {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2027387

Remove the usage of the `etag` TF variable with `filemd()`. This variable is intended for TF to compute the diff of a file to perform an update of an existing object. The installer is not designed to run update operations, so we can just remove.

The `filemd()` TF function is causing high memory consumption according to https://github.com/hashicorp/terraform/issues/23890.