### PR TITLE
[MCO-8] machineconfig: Use KernelArguments field instead of kernel-args file

### DIFF
--- a/pkg/asset/machines/machineconfig/hyperthreading.go
+++ b/pkg/asset/machines/machineconfig/hyperthreading.go
@@ -11,16 +11,11 @@ import (
 )
 
 // ForHyperthreadingDisabled creates the MachineConfig to disable hyperthreading.
-// RHCOS ships with pivot.service that uses the `/etc/pivot/kernel-args` to override the kernel arguments for hosts.
+// RHCOS ships with pivot.service to override the kernel arguments for hosts.
 func ForHyperthreadingDisabled(role string) (*mcfgv1.MachineConfig, error) {
 	ignConfig := igntypes.Config{
 		Ignition: igntypes.Ignition{
 			Version: igntypes.MaxVersion.String(),
-		},
-		Storage: igntypes.Storage{
-			Files: []igntypes.File{
-				ignition.FileFromString("/etc/pivot/kernel-args", "root", 0600, "ADD nosmt"),
-			},
 		},
 	}
 
@@ -41,7 +36,8 @@ func ForHyperthreadingDisabled(role string) (*mcfgv1.MachineConfig, error) {
 			},
 		},
 		Spec: mcfgv1.MachineConfigSpec{
-			Config: rawExt,
+			Config:          rawExt,
+			KernelArguments: []string{"nosmt"},
 		},
 	}, nil
 }

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -67,18 +67,10 @@ spec:
   config:
     ignition:
       version: 3.2.0
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-        mode: 384
-        overwrite: true
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
   extensions: null
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   kernelType: ""
   osImageURL: ""
 `},
@@ -98,18 +90,10 @@ spec:
   config:
     ignition:
       version: 3.2.0
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-        mode: 384
-        overwrite: true
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
   extensions: null
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   kernelType: ""
   osImageURL: ""
 `, `apiVersion: machineconfiguration.openshift.io/v1

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -67,18 +67,10 @@ spec:
   config:
     ignition:
       version: 3.2.0
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-        mode: 384
-        overwrite: true
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
   extensions: null
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   kernelType: ""
   osImageURL: ""
 `},
@@ -98,18 +90,10 @@ spec:
   config:
     ignition:
       version: 3.2.0
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,QUREIG5vc210
-        mode: 384
-        overwrite: true
-        path: /etc/pivot/kernel-args
-        user:
-          name: root
   extensions: null
   fips: false
-  kernelArguments: null
+  kernelArguments:
+  - nosmt
   kernelType: ""
   osImageURL: ""
 `, `apiVersion: machineconfiguration.openshift.io/v1


### PR DESCRIPTION
The MC KernelArguments field is the recommended way to set kernel args,
and should be used in new installs as opposed to writing kernel args to
the `/etc/pivot/kernel-args` file, which should be considered
deprecated.

This should be considered a stop-gap solution until in-Ignition kargs support has landed in the MCO.

/cc @sinnykumari @yuqi-zhang @craychee @cgwalters 

/hold
for testing

