### PR TITLE
Azure Stack Bootstrap Destroy Bug

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -72,6 +72,11 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	}
 
 	platform := installConfig.Config.Platform.Name()
+
+	if azure := installConfig.Config.Platform.Azure; azure != nil && azure.CloudName == typesazure.StackCloud {
+		platform = typesazure.StackTerraformName
+	}
+
 	stages := platformstages.StagesForPlatform(platform)
 
 	logrus.Infof("Creating infrastructure resources...")
@@ -80,12 +85,9 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		if err := aws.PreTerraform(context.TODO(), clusterID.InfraID, installConfig); err != nil {
 			return err
 		}
-	case typesazure.Name:
+	case typesazure.Name, typesazure.StackTerraformName:
 		if err := azure.PreTerraform(context.TODO(), clusterID.InfraID, installConfig); err != nil {
 			return err
-		}
-		if installConfig.Config.Platform.Azure.CloudName == typesazure.StackCloud {
-			platform = "azurestack"
 		}
 	}
 

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -41,7 +41,7 @@ func Destroy(dir string) (err error) {
 	// Set platform to azurestack after setting tfPlatformVarsFileName, because the
 	// tfvars file is still terraform.azure.auto.tfvars.json in the case of Azure Stack.
 	if platform == typesazure.Name && metadata.Azure.CloudName == typesazure.StackCloud {
-		platform = "azurestack"
+		platform = typesazure.StackTerraformName
 	}
 
 	varFiles := []string{cluster.TfVarsFileName, tfPlatformVarsFileName}

--- a/pkg/terraform/stages/azure/stages.go
+++ b/pkg/terraform/stages/azure/stages.go
@@ -3,21 +3,19 @@ package azure
 import (
 	"github.com/openshift/installer/pkg/terraform"
 	"github.com/openshift/installer/pkg/terraform/stages"
+	typesazure "github.com/openshift/installer/pkg/types/azure"
 )
-
-const azure string = "azure"
-const azurestack string = "azurestack"
 
 // PlatformStages are the stages to run to provision the infrastructure in Azure.
 var PlatformStages = []terraform.Stage{
-	stages.NewStage(azure, "vnet"),
-	stages.NewStage(azure, "bootstrap", stages.WithNormalDestroy()),
-	stages.NewStage(azure, "cluster"),
+	stages.NewStage(typesazure.Name, "vnet"),
+	stages.NewStage(typesazure.Name, "bootstrap", stages.WithNormalDestroy()),
+	stages.NewStage(typesazure.Name, "cluster"),
 }
 
 // StackPlatformStages are the stages to run to provision the infrastructure in Azure Stack.
 var StackPlatformStages = []terraform.Stage{
-	stages.NewStage(azurestack, "vnet"),
-	stages.NewStage(azurestack, "bootstrap", stages.WithNormalDestroy()),
-	stages.NewStage(azurestack, "cluster"),
+	stages.NewStage(typesazure.StackTerraformName, "vnet"),
+	stages.NewStage(typesazure.StackTerraformName, "bootstrap", stages.WithNormalDestroy()),
+	stages.NewStage(typesazure.StackTerraformName, "cluster"),
 }

--- a/pkg/terraform/stages/platform/stages.go
+++ b/pkg/terraform/stages/platform/stages.go
@@ -28,7 +28,7 @@ func StagesForPlatform(platform string) []terraform.Stage {
 		return aws.PlatformStages
 	case azuretypes.Name:
 		return azure.PlatformStages
-	case azuretypes.StackCloud.Name():
+	case azuretypes.StackTerraformName:
 		return azure.StackPlatformStages
 	case gcptypes.Name:
 		return gcp.PlatformStages

--- a/pkg/types/azure/doc.go
+++ b/pkg/types/azure/doc.go
@@ -2,5 +2,8 @@
 // configuration and management.
 package azure
 
-// Name is name for the Azure platform.
+// Name is the name for the Azure platform.
 const Name string = "azure"
+
+// StackTerraformName is the name used for Terraform code when installing to the Azure Stack platform.
+const StackTerraformName string = "azurestack"


### PR DESCRIPTION
There was a bug where the wrong platform name was being set for Azure Stack Hub bootstrap destroy.
