### PR TITLE
pkg/types: Correct docs for deprecated options

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1078,8 +1078,8 @@ spec:
                   type: object
                 type: array
               machineCIDR:
-                description: Deprecated name for MachineCIDRs. If set, MachineCIDRs
-                  must be empty or the first index must match.
+                description: Deprecated way to configure an IP address pool for machines.
+                  Replaced by MachineNetwork which allows for multiple pools.
                 type: Any
               machineNetwork:
                 description: MachineNetwork is the list of IP address pools for machines.
@@ -1105,7 +1105,8 @@ spec:
                   is OpenShiftSDN
                 type: string
               serviceCIDR:
-                description: Deprecated name for ServiceNetwork
+                description: Deprecated way to configure an IP address pool for services.
+                  Replaced by ServiceNetwork which allows for multiple pools.
                 type: Any
               serviceNetwork:
                 description: 'ServiceNetwork is the list of IP address pools for services.

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -281,8 +281,8 @@ type Networking struct {
 
 	// Deprecated types, scheduled to be removed
 
-	// Deprecated name for MachineCIDRs. If set, MachineCIDRs must
-	// be empty or the first index must match.
+	// Deprecated way to configure an IP address pool for machines.
+	// Replaced by MachineNetwork which allows for multiple pools.
 	// +optional
 	DeprecatedMachineCIDR *ipnet.IPNet `json:"machineCIDR,omitempty"`
 
@@ -290,7 +290,8 @@ type Networking struct {
 	// +optional
 	DeprecatedType string `json:"type,omitempty"`
 
-	// Deprecated name for ServiceNetwork
+	// Deprecated way to configure an IP address pool for services.
+	// Replaced by ServiceNetwork which allows for multiple pools.
 	// +optional
 	DeprecatedServiceCIDR *ipnet.IPNet `json:"serviceCIDR,omitempty"`
 


### PR DESCRIPTION
The `machineCIDR` config option wasn't replaced by `machineCIDRs` - it was replaced by `machineNetwork[*].cidr`. Similarly, `serviceNetwork` isn't a like-for-like replacement for `serviceCIDR`: the latter took a single value while the former takes a list. Update docs to reflect this, fixing an unrelated bug in the process.