### PR TITLE
Enforce IBM Cloud cluster name limitations

### DIFF
--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -87,6 +87,13 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 		// FIX-ME: As soon bz#1915122 get resolved remove the limitation of 14 chars for the clustername
 		nameErr = validate.ClusterNameMaxLength(c.ObjectMeta.Name, 14)
 	}
+	if c.Platform.IBMCloud != nil {
+		ibmNameErr := validate.ClusterNameIBMMaxLength(c.ObjectMeta.Name)
+		// Override cluster name error if name does not meet IBM Cloud restrictions
+		if ibmNameErr != nil {
+			nameErr = ibmNameErr
+		}
+	}
 	if nameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, nameErr.Error()))
 	}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/pborman/uuid"
@@ -258,6 +259,20 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 			expectedError: `^metadata.name: Invalid value: "bad-name-": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '\.', and must start and end with an alphanumeric character \(e\.g\. 'example\.com', regex used for validation is '\[a-z0-9]\(\[-a-z0-9]\*\[a-z0-9]\)\?\(\\\.\[a-z0-9]\(\[-a-z0-9]\*\[a-z0-9]\)\?\)\*'\)$`,
+		},
+		{
+			name: "invalid ibmcloud name",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.ObjectMeta.Name = strings.Repeat("abc", 11)
+				c.Platform = types.Platform{
+					IBMCloud: &ibmcloud.Platform{
+						Region: "us-south",
+					},
+				}
+				return c
+			}(),
+			expectedError: `^metadata.name: Invalid value: "` + strings.Repeat("abc", 11) + `": must be no more than 32 characters$`,
 		},
 		{
 			name: "invalid ssh key",

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -18,6 +18,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
+// IBMCloudClusterNameMaxLength is the maximum allowed length for a cluster name on IBM Cloud
+const IBMCloudClusterNameMaxLength = 32
+
 var (
 	// DockerBridgeCIDR is the network range that is used by default network for docker.
 	DockerBridgeCIDR = func() *net.IPNet {
@@ -145,6 +148,11 @@ func ClusterName(v string) error {
 		return err
 	}
 	return validateSubdomain(v)
+}
+
+// ClusterNameIBMMaxLength checks if the given string meets the length restrictions for IBM Cloud
+func ClusterNameIBMMaxLength(v string) error {
+	return ClusterNameMaxLength(v, IBMCloudClusterNameMaxLength)
 }
 
 // SubnetCIDR checks if the given IP net is a valid CIDR.

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -90,6 +90,27 @@ func TestClusterName1035(t *testing.T) {
 	}
 }
 
+func TestClusterNameIBMMaxLength(t *testing.T) {
+	cases := []struct {
+		name        string
+		clusterName string
+		valid       bool
+	}{
+		{"max size", "abcdefghijklmnopqrstuvwxyz012345", true},
+		{"too long", "abcdefghijklmnopqrstuvwxyz0123456", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ClusterNameIBMMaxLength(tc.clusterName)
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestVCenter(t *testing.T) {
 	cases := []struct {
 		name        string


### PR DESCRIPTION
Validate the cluster name provided meets the restrictions on IBM
Cloud. Compress the SecurityGroup names for IBM Cloud to make sure
those names can meet the IBM Cloud restricitions (character limits).

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2027498