### PR TITLE
close a verify-codegen ci failure loophole

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
 if [ "$IS_CONTAINER" != "" ]; then
-  set -x
+  set -xe
   go generate ./pkg/types/installconfig.go
-  go generate ./pkg/rhcos/ami.go
-  set +x
+  # See https://github.com/openshift/installer/pull/5447#discussion_r762340594
+  # go generate ./pkg/rhcos/ami.go
+  set +ex
   git diff --exit-code
 else
   podman run --rm \


### PR DESCRIPTION
if the `go codegen` commands failed, the the `hack/verify-codegen.sh` script continued and the CI check passed. see https://github.com/openshift/installer/pull/5406 for an example. the script was not set to fail on a non-zero return code. this pr adds the bash `e` option to the `set` builtin to catch errors and exit on failure.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>