### PR TITLE
azure: Fix terraform cluster IP output

### DIFF
--- a/data/data/azure/cluster/master/outputs.tf
+++ b/data/data/azure/cluster/master/outputs.tf
@@ -1,3 +1,3 @@
 output "ip_addresses" {
-  value = azurerm_network_interface.master.*.private_ip_addresses
+  value = azurerm_network_interface.master.*.private_ip_address
 }


### PR DESCRIPTION
Fixing an output produced by the cluster stage of create command
in Azure where the stage provided a list of lists as output for
the IP addresses. This could be made as simple as a list hence
making the change to pick only the first IP address of each
control plane node.