### PR TITLE
Bug 2027501: bump RHCOS 4.10 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,83 +1,83 @@
 {
   "stream": "rhcos-4.10",
   "metadata": {
-    "last-modified": "2021-11-11T19:40:38Z",
-    "generator": "plume cosa2stream 0.11.0+454-g226dbc8e9"
+    "last-modified": "2021-12-06T23:26:01Z",
+    "generator": "plume cosa2stream 0.12.0+47-g052fabbb7"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "410.84.202111111403-0",
+          "release": "410.84.202112060851-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-aws.aarch64.vmdk.gz",
-                "sha256": "b355cb94d0e5e640f729419eea34f0a5fbd2dcb181bb00b229fcef2892bef660",
-                "uncompressed-sha256": "cd33b106831eec1dbb2914bec9df6b84b5e821ef639a35195e2681512530ddca"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202112060851-0/aarch64/rhcos-410.84.202112060851-0-aws.aarch64.vmdk.gz",
+                "sha256": "e64f9770e50d8991b867880ff24a487925d8a5f66c8878e209dad78dd248c831",
+                "uncompressed-sha256": "fe9ef13cc6c7d39d6560270fd059c89c2a4d497cff789530c72a080ecff0c597"
               }
             }
           }
         },
         "metal": {
-          "release": "410.84.202111111403-0",
+          "release": "410.84.202112060851-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-metal4k.aarch64.raw.gz",
-                "sha256": "19379c5e3796c30923c61bebefed3e286835d4d7d16fa4793f732700ade1d5cd",
-                "uncompressed-sha256": "c2b3bfe292f1fdd15068e0a24a757eca7d2069b4077488aa32a687bd3fbc47b3"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202112060851-0/aarch64/rhcos-410.84.202112060851-0-metal4k.aarch64.raw.gz",
+                "sha256": "847925bbcdefef78582102e3b674e7061e14f061d15437b3bed9777d1ec8c044",
+                "uncompressed-sha256": "60f94f7f5cac264d17db31b56778bec013de15853c7514e27eeb27eb791085cd"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-live.aarch64.iso",
-                "sha256": "0c7797b5325ab0f71e0786e1249ad62c9319799145721bedf99e1ff8622cd138"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202112060851-0/aarch64/rhcos-410.84.202112060851-0-live.aarch64.iso",
+                "sha256": "3a1973d5e2206eeb1a23f30435c9617b9a4584906dfe3264903cf2f8db4657f3"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-live-kernel-aarch64",
-                "sha256": "210ad7e3cf24d0a5388600bad437cd3a0ac211605decf869498dd9ffb32d7ccb"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202112060851-0/aarch64/rhcos-410.84.202112060851-0-live-kernel-aarch64",
+                "sha256": "19b001194a5c79ac426925398e230223afd0f5c7d222b52b4f3de10adb820b31"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-live-initramfs.aarch64.img",
-                "sha256": "9e9e5ffcac9b3c6968d48dae9e0793626f7bf43e80ce77a58bab574206b7335c"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202112060851-0/aarch64/rhcos-410.84.202112060851-0-live-initramfs.aarch64.img",
+                "sha256": "077fef11108c4aa83828634a1e2c4952b5c291344ca52e0ce50eb5b04d36ee2a"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-live-rootfs.aarch64.img",
-                "sha256": "9bcf2a82d8aa7ebcadbdeb56d408f43fe6729cbc141a0e37e4e4218c47b59e81"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202112060851-0/aarch64/rhcos-410.84.202112060851-0-live-rootfs.aarch64.img",
+                "sha256": "2f595533a2eb1ce6c108c51576e2e210fe1e6ab183e5898cab9b7e7a75a2f046"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-metal.aarch64.raw.gz",
-                "sha256": "4e901e4024631b211244bcc92a97e6e911c07bc677c7e6e777aecdf05cb4b2af",
-                "uncompressed-sha256": "b721f664926ce85906dc289a17189485f80fc6f0c62a8bd46aeaba17c9df1da8"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202112060851-0/aarch64/rhcos-410.84.202112060851-0-metal.aarch64.raw.gz",
+                "sha256": "324b4b30034a75b15ab45bb2fa3cd42e04e97ab0a829ff697158756d49468cdf",
+                "uncompressed-sha256": "1473a42c5fa0434bbbe010c43be407bf0bb4ec8ab66d3bbbaec8af3796831f62"
               }
             }
           }
         },
         "openstack": {
-          "release": "410.84.202111111403-0",
+          "release": "410.84.202112060851-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-openstack.aarch64.qcow2.gz",
-                "sha256": "2f1aaeff835adcdb63af923c852b903686c9c0496f4fe8fbf0699de076f7f63d",
-                "uncompressed-sha256": "636760c3a974faa1ce8698ab4ab7fab72d0cfeca21f3c40081993159382e3608"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202112060851-0/aarch64/rhcos-410.84.202112060851-0-openstack.aarch64.qcow2.gz",
+                "sha256": "5230eb5b540244264d1604b9a1c956b8a4fdc9d9fd316a4e43b9499174af2772",
+                "uncompressed-sha256": "94a16d371af42372a677f353e94b9990fc61fdc0487f70aca523c54e11e6992a"
               }
             }
           }
         },
         "qemu": {
-          "release": "410.84.202111111403-0",
+          "release": "410.84.202112060851-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202111111403-0/aarch64/rhcos-410.84.202111111403-0-qemu.aarch64.qcow2.gz",
-                "sha256": "291b806387b630d020f1158984eff9e764e292ace3abfc31bd854ffcaab3d5b2",
-                "uncompressed-sha256": "0e463b9bd462dcac8270d9dc5ae0c4910630032a8878ae92e4a58d34504e1e0f"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202112060851-0/aarch64/rhcos-410.84.202112060851-0-qemu.aarch64.qcow2.gz",
+                "sha256": "b6e03b55d914c837852c7c3cc0b1a7fdaf41854e11da7013828015a6b05eb0b8",
+                "uncompressed-sha256": "5d85e6682f8bc376cbdb8619a20b0a8f25c8327a6f871a1693cb86e8a3d152a5"
               }
             }
           }
@@ -87,80 +87,80 @@
         "aws": {
           "regions": {
             "ap-east-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-0a5d702a40d99411c"
+              "release": "410.84.202112060851-0",
+              "image": "ami-078c88bb08b375995"
             },
             "ap-northeast-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-0874b6143e5a90dd8"
+              "release": "410.84.202112060851-0",
+              "image": "ami-001877619f58e20b4"
             },
             "ap-northeast-2": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-09aef6d4c011743f5"
+              "release": "410.84.202112060851-0",
+              "image": "ami-06b845eec5b22f61a"
             },
             "ap-south-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-078e98cd05e71e714"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0c4dea1016d2bad52"
             },
             "ap-southeast-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-07e5fc52189352c74"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0f43d7ff0996520a8"
             },
             "ap-southeast-2": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-0d5d934b9f6516fa2"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0b5dcbc5b7449be2d"
             },
             "ca-central-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-0a03806dd3fc25850"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0e7ef9359f79ccf69"
             },
             "eu-central-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-048cc5892569bef7f"
+              "release": "410.84.202112060851-0",
+              "image": "ami-07b21264c3cefa239"
             },
             "eu-north-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-0945a4f116ee187ac"
+              "release": "410.84.202112060851-0",
+              "image": "ami-03db9375fc409785a"
             },
             "eu-south-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-011f6f9ef172db09c"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0682aab61da1c344c"
             },
             "eu-west-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-0131e0ac452aba369"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0f70b8968464d6655"
             },
             "eu-west-2": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-01e3e0bc9d26c320f"
+              "release": "410.84.202112060851-0",
+              "image": "ami-021dc77b913976af8"
             },
             "eu-west-3": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-0d224e2702a94b211"
+              "release": "410.84.202112060851-0",
+              "image": "ami-005a817cb4ebad67c"
             },
             "me-south-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-041b0da04cdbb81e2"
+              "release": "410.84.202112060851-0",
+              "image": "ami-09199d7b0c2e815c5"
             },
             "sa-east-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-036851f96b8898f44"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0755794c5df6068af"
             },
             "us-east-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-0022ae02b40256546"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0ab731d0da73f2668"
             },
             "us-east-2": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-0b511d5d32d354b67"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0bd29f242d1faa66c"
             },
             "us-west-1": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-06135896c507a0fb5"
+              "release": "410.84.202112060851-0",
+              "image": "ami-04629199d5dd7756f"
             },
             "us-west-2": {
-              "release": "410.84.202111111403-0",
-              "image": "ami-02ae1fa58542aeb5d"
+              "release": "410.84.202112060851-0",
+              "image": "ami-0fe5691f99b240e73"
             }
           }
         }
@@ -169,76 +169,76 @@
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "410.84.202111111404-0",
+          "release": "410.84.202112041603-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-metal4k.ppc64le.raw.gz",
-                "sha256": "4cb13dcc7f90cccd84be9b7410477abd446d18d85b444dd93c2b250a65b54917",
-                "uncompressed-sha256": "a87af1c769936ad66cc4a9ef3959f9d85232898208b24464716d65e5293e5af1"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202112041603-0/ppc64le/rhcos-410.84.202112041603-0-metal4k.ppc64le.raw.gz",
+                "sha256": "d76dfa5399ced96d03e6e45fe2793cbf999b19c2e84def517123a80d5cc1db03",
+                "uncompressed-sha256": "763ae7b5807ecefd65b204536c23a0403c3e0b6997f6c47f403ef8831869c335"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-live.ppc64le.iso",
-                "sha256": "a72b48a9595c9d8ab13b84724ea8ab2ba96dd05b4a80b299743667c1eccd7d22"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202112041603-0/ppc64le/rhcos-410.84.202112041603-0-live.ppc64le.iso",
+                "sha256": "e1ecf9cd3d8fd4706f5ea01c71284596dae7f3692e11453c0a9db73ccadca99e"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-live-kernel-ppc64le",
-                "sha256": "d14366b7f5ffdbe7360ba40a0060356268947976bf09201792f3fd3ea014dd90"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202112041603-0/ppc64le/rhcos-410.84.202112041603-0-live-kernel-ppc64le",
+                "sha256": "339e66efd39bb66300a2b8e012fbcf8b1089bdfb362c1045325f0bc88e6eacf3"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-live-initramfs.ppc64le.img",
-                "sha256": "5e3147c81ebe2b421a9985e61d3bac89d2bda3bdbc1ea362bb4103eeeab6847c"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202112041603-0/ppc64le/rhcos-410.84.202112041603-0-live-initramfs.ppc64le.img",
+                "sha256": "30544da2a35ff7c81db981216ca78ab7b6f857d00fd8ebfd1f65651c8138ad1e"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-live-rootfs.ppc64le.img",
-                "sha256": "ae2e3c7df2c981a1f249ee1741cb295a806878182769fa2d80e676b2d7af11cd"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202112041603-0/ppc64le/rhcos-410.84.202112041603-0-live-rootfs.ppc64le.img",
+                "sha256": "ce7327e5a9bf17022082883b71d8ff581ef1223bc15afe37ca3a14e35ec6d79b"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-metal.ppc64le.raw.gz",
-                "sha256": "987878dc024c97782287416141986751a3c29f2f471df4fecc96f6c998e28e4a",
-                "uncompressed-sha256": "8feadeb935e2d0da33fe3dd6052efcc5b95e59d58d96049c5bdd139258c9912c"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202112041603-0/ppc64le/rhcos-410.84.202112041603-0-metal.ppc64le.raw.gz",
+                "sha256": "4bc75295c24182d016b6a861a93aaea9e1b58c53cd8b725eecdfae096ea87c3d",
+                "uncompressed-sha256": "ec84a0a89d8fc19c4c20285d1171161821f1ab58c3959a06836bc6f30ca0e0e6"
               }
             }
           }
         },
         "openstack": {
-          "release": "410.84.202111111404-0",
+          "release": "410.84.202112041603-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "0b8c19a30f4ca6b5a20a43a46f6dcc2c80fd9597e6c4f740688954566454f5f3",
-                "uncompressed-sha256": "6aff5a372dbefd422e18d6241fc942e27bd80e616c00a689df081a266c68e0a5"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202112041603-0/ppc64le/rhcos-410.84.202112041603-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "7e9eda65ebf8ecdfdc1adb6de06aa2da758ed855f5f4fe95ecfd3b23d71de951",
+                "uncompressed-sha256": "b39363b820f66deb5477d235de1d272d65a70594d8428cc0d52a421e294b30ce"
               }
             }
           }
         },
         "powervs": {
-          "release": "410.84.202111111404-0",
+          "release": "410.84.202112041603-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-powervs.ppc64le.ova.gz",
-                "sha256": "b339aa8e2b8d91b5f86c8c863d12143c7dd62f3d70802093f05abb8949a59baf",
-                "uncompressed-sha256": "f3d5e18f48a413de582f60cde755e0d0dbbc9f5d83ee6b06f0d2145baea89c13"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202112041603-0/ppc64le/rhcos-410.84.202112041603-0-powervs.ppc64le.ova.gz",
+                "sha256": "761ea151f56f342d879fb14d245e28dedb0a58bce795240f8703ca282d6f5fbf",
+                "uncompressed-sha256": "95ff2da4ed1aeaed6f9b13ec74a80bd07a85ba18aec2e72a4d9f2af38866207a"
               }
             }
           }
         },
         "qemu": {
-          "release": "410.84.202111111404-0",
+          "release": "410.84.202112041603-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202111111404-0/ppc64le/rhcos-410.84.202111111404-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "055f5e8a39f72ead4fb157e09e49909d6477e1aa3badb9c836cc26f5af165a56",
-                "uncompressed-sha256": "9903f017ba80bdb4141a3edbfc42a46f09ac04d7cd73ebd0194382b9a3c42565"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202112041603-0/ppc64le/rhcos-410.84.202112041603-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "086b631091015546ede2f57698cee19df5f1d4020f04e25d47d348f148ecdd2e",
+                "uncompressed-sha256": "6aba42ffbb43704836fbbabfe8eb7a523d66b9152b59ee85016c29ec4a8787ea"
               }
             }
           }
@@ -248,58 +248,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "410.84.202111111404-0",
-              "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+              "release": "410.84.202112041603-0",
+              "object": "rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "410.84.202111111404-0",
-              "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+              "release": "410.84.202112041603-0",
+              "object": "rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "410.84.202111111404-0",
-              "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+              "release": "410.84.202112041603-0",
+              "object": "rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "410.84.202111111404-0",
-              "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+              "release": "410.84.202112041603-0",
+              "object": "rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "410.84.202111111404-0",
-              "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+              "release": "410.84.202112041603-0",
+              "object": "rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "410.84.202111111404-0",
-              "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+              "release": "410.84.202112041603-0",
+              "object": "rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "410.84.202111111404-0",
-              "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+              "release": "410.84.202112041603-0",
+              "object": "rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "410.84.202111111404-0",
-              "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+              "release": "410.84.202112041603-0",
+              "object": "rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "410.84.202111111404-0",
-              "object": "rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz",
+              "release": "410.84.202112041603-0",
+              "object": "rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-410-84-202111111404-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-410-84-202112041603-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -308,64 +308,64 @@
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "410.84.202111111403-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-metal4k.s390x.raw.gz",
-                "sha256": "0b15622504531b9fb9f6228b3fdb089c1588fba1fb34913019a9be607ffaf9de",
-                "uncompressed-sha256": "33cb5d74cecfa61d3228bcd68d4f09f48f96c523f2be130603ac1557fdbba6d4"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202112040202-0/s390x/rhcos-410.84.202112040202-0-metal4k.s390x.raw.gz",
+                "sha256": "8bbf7571700f446e05916ecb0f383502e2480242890cddc0be5a6173f125d221",
+                "uncompressed-sha256": "9d8842598bc40153085ff92c294bebfb510770c107b19f6f89c5a2c2c1910f23"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-live.s390x.iso",
-                "sha256": "595b1131a243698c9eb6f499c617e13f85e271041eef5c9424c6a10660c59d6b"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202112040202-0/s390x/rhcos-410.84.202112040202-0-live.s390x.iso",
+                "sha256": "24ec38577a8e58797de096bb298555deef78cbaf81ef8e2a723e8a1df57a3afe"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-live-kernel-s390x",
-                "sha256": "56568da41178d4ace5f3f7ff3ffda4ca6c4f3ae156ff4e2769457ef64078c475"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202112040202-0/s390x/rhcos-410.84.202112040202-0-live-kernel-s390x",
+                "sha256": "2114083b70a74c1134ab38f679e561dcda4c89121f888766d38f78ab6a22370d"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-live-initramfs.s390x.img",
-                "sha256": "0f76f39026d0b767b9c58ed2d6baf09d842467679095e6b654f7fccc77338320"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202112040202-0/s390x/rhcos-410.84.202112040202-0-live-initramfs.s390x.img",
+                "sha256": "789584c145b155718825e69942a2ad4d7b972619de8a0af6580d1282a2690c36"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-live-rootfs.s390x.img",
-                "sha256": "c717d8d0f7fe79bcc2dfd6206705254e59e5551336bd3873604849980215d313"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202112040202-0/s390x/rhcos-410.84.202112040202-0-live-rootfs.s390x.img",
+                "sha256": "c675780a98b5ae0a282aefdad46371abef1d829e14b1fea5f25d2c67428c3ae1"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-metal.s390x.raw.gz",
-                "sha256": "7e370a6d5c35138e6c84843e6ecaf0fb2bdbcb4965f3350c1c43e0cf1f1703a8",
-                "uncompressed-sha256": "811e9392e7ff370975dc6cffa4815700416ee94b9799ec007b67d936fbde9fc0"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202112040202-0/s390x/rhcos-410.84.202112040202-0-metal.s390x.raw.gz",
+                "sha256": "22e81b6e39cb357fde835ac297c0b709ae049f71a02ef9aef56c7c8a48a0120c",
+                "uncompressed-sha256": "9156de7523a4559abe3a4e4253de1589d70a07322bb1947a6a80d6ef07c80a48"
               }
             }
           }
         },
         "openstack": {
-          "release": "410.84.202111111403-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-openstack.s390x.qcow2.gz",
-                "sha256": "19d7d557a0f9777d8d1a6b876ac4d18120e27c8b43e10dc3f416020963c5d248",
-                "uncompressed-sha256": "8c968b3e079c02a2a1a51336117cd7e23ad6dc9311642a6b36d166fe3dd14fc5"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202112040202-0/s390x/rhcos-410.84.202112040202-0-openstack.s390x.qcow2.gz",
+                "sha256": "1a166a20deaa0a36aa49d304e202344ff5e6e02d77094c0a583f980e3ead7fbb",
+                "uncompressed-sha256": "8bde4cdf81795f9c8620b5c16a4a066edf50ea395cc3455a58c1a99a6bdfbd52"
               }
             }
           }
         },
         "qemu": {
-          "release": "410.84.202111111403-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202111111403-0/s390x/rhcos-410.84.202111111403-0-qemu.s390x.qcow2.gz",
-                "sha256": "e24346ff4d8c229d500476eaeb4573394ed5a36be3f28c65d40b775ff06244d9",
-                "uncompressed-sha256": "a7c422c1032f609020007771ee7cdc40f30979294c3962d20792762498b613e8"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202112040202-0/s390x/rhcos-410.84.202112040202-0-qemu.s390x.qcow2.gz",
+                "sha256": "b226bb71af9c9fbc11174739a793af1f95f956bb2e3f25971561b345cfb2f749",
+                "uncompressed-sha256": "f1810c3e4afa2f8ed844ebaddecc10f712aa9906f8d4e6772e83112e1b3df7b5"
               }
             }
           }
@@ -375,240 +375,372 @@
     },
     "x86_64": {
       "artifacts": {
+        "aliyun": {
+          "release": "410.84.202112040202-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "a60e461de14768cf9804cb066676c11d89f0a7f171fdf91938f2fbde59d24d94",
+                "uncompressed-sha256": "960fb1b4358428f83c9d68230d894a3d6a8cd5d3941235f9467f9cf9c6573e2a"
+              }
+            }
+          }
+        },
         "aws": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-aws.x86_64.vmdk.gz",
-                "sha256": "94e4e6f17e1dd2ee32a03420267691b2c2f1e382ea0a113cc61cc52ebf42e803",
-                "uncompressed-sha256": "a9090e48e2607f5e1103198735f5182f4b89a102ec754e45d4b949b2aa70bb54"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-aws.x86_64.vmdk.gz",
+                "sha256": "28a3ee32100e4944f4ebce262576b4e6b73c994822781c843e9ea30774a761f3",
+                "uncompressed-sha256": "52b7c98057e8960cc811bcc01e646ff4610f1c75c477fc2c2749369e74785a0e"
               }
             }
           }
         },
         "azure": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-azure.x86_64.vhd.gz",
-                "sha256": "49ff633f3488c9e033845891e167209b8f9734d2709274b6f59325c895131ab7",
-                "uncompressed-sha256": "12d28c89287da8d2b86700435edd386f3a21b62415b9c0958b548b9c26c4e7cb"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-azure.x86_64.vhd.gz",
+                "sha256": "7d5dbcd56e6807ea8cd7f216817f1337f595be786ac9230a099c5a54f511aeca",
+                "uncompressed-sha256": "44b99ee96d3776cd9b2c34607e561275d790596b9836ce52e46b84d14ee3ec6c"
               }
             }
           }
         },
         "azurestack": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-azurestack.x86_64.vhd.gz",
-                "sha256": "6ecf18746d9404f237323971cb7d5b3565a033024a7a0c810f6d131b8a546575",
-                "uncompressed-sha256": "17b85a4eba773acec16bb05f61f1d4b2bc8f79ef59acc1804de9f58e2322b964"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-azurestack.x86_64.vhd.gz",
+                "sha256": "c526dce49faf913ae9be0daa9fcf91139b92ab42dd3b695895fff44674bdccf8",
+                "uncompressed-sha256": "827d146ad7c2bdc2c805b540ccaf5cd016a1d038e30b8eec157316e344eac0e3"
               }
             }
           }
         },
         "gcp": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-gcp.x86_64.tar.gz",
-                "sha256": "9df28d47e414e6c5de2e5ccbe4a05d6e9e0cd6d1986589708fe2403fde6ed872",
-                "uncompressed-sha256": "ec9794015b977d53ee319119479d47c1f5d27f2044cd6206d457dff333dd8227"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-gcp.x86_64.tar.gz",
+                "sha256": "fb142cb255bc53c9a16163a3cdf49a76bcce00a4fd503ffaca1e62171c73eb42",
+                "uncompressed-sha256": "8ae37bd4366ca0c3f965945a39a4e208a8c9cef68aaaf5fee695b47d551336de"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "00e11f45277933ffc668248170e2a587fdf1a1ff72a712353002b1f72cc56c57",
-                "uncompressed-sha256": "309051de984fe63f81c5f4996377b2f7c5df8bdf7b903fe832c26fe9a09e7739"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "5c7abfdc0c66fc829fa7b4032226b69c01ae3b9ae6c285e255215ecaf724e44e",
+                "uncompressed-sha256": "d4f1fa855524d1fd34c4886b311c3c52efa7b28f680d3b96fea30fecd3dd87d7"
               }
             }
           }
         },
         "metal": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-metal4k.x86_64.raw.gz",
-                "sha256": "2972f10c2db39c750c20b50edcd540ea894604aed24826029d706876ce2e5f7c",
-                "uncompressed-sha256": "311bb716f5940a2f847df845f83c864a6a1c332bd5f25120ca509347a5cf6e31"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-metal4k.x86_64.raw.gz",
+                "sha256": "fe3c42c4eeb7c0469496e1b97641beda90dac202464f3e9e8fdff7af0c6a8d26",
+                "uncompressed-sha256": "28bc2c5a4ed999f1dc81bfd61bd154f9fbed91732018c41cbec25965a3757c4e"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-live.x86_64.iso",
-                "sha256": "2349028216f129e914c43a4f83dab902640332122afd0c4f36f8f5acc9320527"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-live.x86_64.iso",
+                "sha256": "906eab3b967e543006d621a61dfd97b02ae483f174a2b26634e190c8d3bca801"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-live-kernel-x86_64",
-                "sha256": "a752fbc6b291520df85a2012c6bfc297a468de67f745b0da3fca734fef709164"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-live-kernel-x86_64",
+                "sha256": "0c3ee4e1fd9bb00c42462963ca070ddbd9c5735a979732107b416cc5860070c7"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-live-initramfs.x86_64.img",
-                "sha256": "cee41269a34fa0f7466ad3d82a3f4f6ae28c3f4601470080185b203d5961e276"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-live-initramfs.x86_64.img",
+                "sha256": "2356b49b4dc62758bfdbd8fcbead60c9c4e03cde9a68b91e99447f0c72243b4b"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-live-rootfs.x86_64.img",
-                "sha256": "b31cca1e9a5098ba360f18214e29799e4ddc336a26a28974ac73b11c1c119207"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-live-rootfs.x86_64.img",
+                "sha256": "f0e242da47f2ef4ff4cef9627ccb97e3dc454e14e6abd70013279e3468ced9fe"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-metal.x86_64.raw.gz",
-                "sha256": "543c4dad51954657727be66e7084c17287864ee2351aa68f2adae8d893b94552",
-                "uncompressed-sha256": "836550fbda2cd51232b22dbde405a727f455bf3dc0f6996c395ce5f72ae46f20"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-metal.x86_64.raw.gz",
+                "sha256": "ec78437e8e367808b4350450c54d211bc6637412c99f54ac288ffd7c0dfb6284",
+                "uncompressed-sha256": "dcbd7f9e46def38a286e8f5e93b75293e3125d1ed6b990cc98e7be3bc0f374d4"
+              }
+            }
+          }
+        },
+        "nutanix": {
+          "release": "410.84.202112040202-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-nutanix.x86_64.qcow2.gz",
+                "sha256": "d2bbba385344fca9a9d58e1c50f6316ec5deed180b410fd9f7169af1823996e8",
+                "uncompressed-sha256": "4eb48912c59a94319961756decc4336aa7742edfdfbdf08dcbc498d5d9cb06fa"
               }
             }
           }
         },
         "openstack": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-openstack.x86_64.qcow2.gz",
-                "sha256": "415f2219b9960829f6c463d1b5f429a09e99d6f7fd458f95cc5b06db1505281b",
-                "uncompressed-sha256": "ee6492e572469c80b940ed38a740e84440c289922382442e365b9eb3b6fda04d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-openstack.x86_64.qcow2.gz",
+                "sha256": "ad395c05f699972a55872d9be83c4265e0c866faae62786da0d806efdd997427",
+                "uncompressed-sha256": "198692bd7f388634736315e73b6fd7647c9971c3803fb8b412e0d4dab33bc527"
               }
             }
           }
         },
         "qemu": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-qemu.x86_64.qcow2.gz",
-                "sha256": "f0d8f502e1107bd282f57ccb7126898f69d177e65a1e8194d31fb4a9c985ad0d",
-                "uncompressed-sha256": "a692ed81c089981a58fdce843136bf6ef2c111585de255a5b874db8a26665706"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-qemu.x86_64.qcow2.gz",
+                "sha256": "425e2c9886781fe8109f8b7a63760753c2327eb132136908892f8e68c244506f",
+                "uncompressed-sha256": "f12e5f09e34266382a5ae2bc89f9c1c6b29430ed60e40412a716442aebd0e20c"
               }
             }
           }
         },
         "vmware": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202111111322-0/x86_64/rhcos-410.84.202111111322-0-vmware.x86_64.ova",
-                "sha256": "bff9e3793708a14e7c7c7fc3f4cc6bcdac8e76bb48754d94c696be3c753e37e0"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202112040202-0/x86_64/rhcos-410.84.202112040202-0-vmware.x86_64.ova",
+                "sha256": "b538513b16d3e9009d3375d88bfdaab8ea681b96d18c684f55489c94ef0d17cd"
               }
             }
           }
         }
       },
       "images": {
+        "aliyun": {
+          "regions": {
+            "ap-northeast-1": {
+              "release": "410.84.202112040202-0",
+              "image": "m-6we2p8nho4898oh47mk3"
+            },
+            "ap-south-1": {
+              "release": "410.84.202112040202-0",
+              "image": "m-a2dicqfidfltbhtgpyqx"
+            },
+            "ap-southeast-1": {
+              "release": "410.84.202112040202-0",
+              "image": "m-t4n4o8sqe88k6lz7frrj"
+            },
+            "ap-southeast-2": {
+              "release": "410.84.202112040202-0",
+              "image": "m-p0w88yey42ebnz4l2rxw"
+            },
+            "ap-southeast-3": {
+              "release": "410.84.202112040202-0",
+              "image": "m-8ps8o9sdl9dihac0gbav"
+            },
+            "ap-southeast-5": {
+              "release": "410.84.202112040202-0",
+              "image": "m-k1a779wf96tbto5sqjsd"
+            },
+            "cn-beijing": {
+              "release": "410.84.202112040202-0",
+              "image": "m-2zeaf8sfxox1bxl3bt0t"
+            },
+            "cn-chengdu": {
+              "release": "410.84.202112040202-0",
+              "image": "m-2vcdfpr7iebzsmhwvpjf"
+            },
+            "cn-guangzhou": {
+              "release": "410.84.202112040202-0",
+              "image": "m-7xv6wlrgwsz6xd868u8p"
+            },
+            "cn-hangzhou": {
+              "release": "410.84.202112040202-0",
+              "image": "m-bp17mubt5wirmpe9rflq"
+            },
+            "cn-heyuan": {
+              "release": "410.84.202112040202-0",
+              "image": "m-f8z6h89izxrj7ln0q615"
+            },
+            "cn-hongkong": {
+              "release": "410.84.202112040202-0",
+              "image": "m-j6c728ewdg1g8ke4607c"
+            },
+            "cn-huhehaote": {
+              "release": "410.84.202112040202-0",
+              "image": "m-hp3iazde979aa07h7rmy"
+            },
+            "cn-nanjing": {
+              "release": "410.84.202112040202-0",
+              "image": "m-gc70rmc0q71wlnzomzl9"
+            },
+            "cn-qingdao": {
+              "release": "410.84.202112040202-0",
+              "image": "m-m5efep4nea2p8bysmwsg"
+            },
+            "cn-shanghai": {
+              "release": "410.84.202112040202-0",
+              "image": "m-uf69691hcr080t8lw47g"
+            },
+            "cn-shenzhen": {
+              "release": "410.84.202112040202-0",
+              "image": "m-wz98ubq2uhk0zyanbg37"
+            },
+            "cn-wulanchabu": {
+              "release": "410.84.202112040202-0",
+              "image": "m-0jl0ods9qj7gcuxuaf1x"
+            },
+            "cn-zhangjiakou": {
+              "release": "410.84.202112040202-0",
+              "image": "m-8vb6ujy4perml0nxuhdz"
+            },
+            "eu-central-1": {
+              "release": "410.84.202112040202-0",
+              "image": "m-gw86q55rtyf26x2thn20"
+            },
+            "eu-west-1": {
+              "release": "410.84.202112040202-0",
+              "image": "m-d7oa7pcfcjf1tx3k92pr"
+            },
+            "me-east-1": {
+              "release": "410.84.202112040202-0",
+              "image": "m-eb329iawd8nd07lr3imv"
+            },
+            "us-east-1": {
+              "release": "410.84.202112040202-0",
+              "image": "m-0xi5sh1y90lsbo8ayl0a"
+            },
+            "us-west-1": {
+              "release": "410.84.202112040202-0",
+              "image": "m-rj9iaale3bzstvipjcjo"
+            }
+          }
+        },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0aa991762109bd955"
+              "release": "410.84.202112040202-0",
+              "image": "ami-039e4bc8089531aa6"
             },
             "ap-east-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0f279d4784a72d40c"
+              "release": "410.84.202112040202-0",
+              "image": "ami-0eda60ca028c5c174"
             },
             "ap-northeast-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0b9a082a4dc3c89cd"
+              "release": "410.84.202112040202-0",
+              "image": "ami-024924bb7953f7a2d"
             },
             "ap-northeast-2": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0ce4b303db099f99f"
+              "release": "410.84.202112040202-0",
+              "image": "ami-056eb06f8df9b804d"
             },
             "ap-northeast-3": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0b04fcda674dd372c"
+              "release": "410.84.202112040202-0",
+              "image": "ami-0a94434518b52ff17"
             },
             "ap-south-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-05c6342dd03d27b2b"
+              "release": "410.84.202112040202-0",
+              "image": "ami-04cecdb06292abc26"
             },
             "ap-southeast-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-051a71b23d871b011"
+              "release": "410.84.202112040202-0",
+              "image": "ami-02c3b25da447f351f"
             },
             "ap-southeast-2": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0171e63e24d2880b2"
+              "release": "410.84.202112040202-0",
+              "image": "ami-028c65c9625995ae7"
             },
             "ca-central-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-06631ddbe660842b5"
+              "release": "410.84.202112040202-0",
+              "image": "ami-0e5dbb835008be3ef"
             },
             "eu-central-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-02303ca361d9181bc"
+              "release": "410.84.202112040202-0",
+              "image": "ami-050860e97587e34e4"
             },
             "eu-north-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-08ba59b0ad16e7d3e"
+              "release": "410.84.202112040202-0",
+              "image": "ami-0c6e5ee9d28c64d78"
             },
             "eu-south-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0b76a89747f4c3bdc"
+              "release": "410.84.202112040202-0",
+              "image": "ami-04ccb92f252db9805"
             },
             "eu-west-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-027fc9e8211a23fc8"
+              "release": "410.84.202112040202-0",
+              "image": "ami-0489b2f1e05c7579c"
             },
             "eu-west-2": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0ef9f9dce1b9a3dbd"
+              "release": "410.84.202112040202-0",
+              "image": "ami-03d9a15a95223267c"
             },
             "eu-west-3": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-045e1a370fb01a509"
+              "release": "410.84.202112040202-0",
+              "image": "ami-0ce2f9fb077961efb"
             },
             "me-south-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-018903dd2c601602e"
+              "release": "410.84.202112040202-0",
+              "image": "ami-0e6c43b488deb5740"
             },
             "sa-east-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0d56ea3e1e05062bc"
+              "release": "410.84.202112040202-0",
+              "image": "ami-028ca8ae0f3a17958"
             },
             "us-east-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0713d9bcf78401cd1"
+              "release": "410.84.202112040202-0",
+              "image": "ami-0b4315c1df2c53c15"
             },
             "us-east-2": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0c2dbd95931008b1a"
+              "release": "410.84.202112040202-0",
+              "image": "ami-0c5b210f3fd086930"
+            },
+            "us-gov-east-1": {
+              "release": "410.84.202112040202-0",
+              "image": "ami-0699d59807f6ce767"
+            },
+            "us-gov-west-1": {
+              "release": "410.84.202112040202-0",
+              "image": "ami-008a6e7e98ac496db"
             },
             "us-west-1": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0483451d19cd3f521"
+              "release": "410.84.202112040202-0",
+              "image": "ami-03e98361ec58b03fe"
             },
             "us-west-2": {
-              "release": "410.84.202111111322-0",
-              "image": "ami-0fa07c6be7f16a985"
+              "release": "410.84.202112040202-0",
+              "image": "ami-07bc725dcc0b56446"
             }
           }
         },
         "gcp": {
-          "release": "410.84.202111111322-0",
+          "release": "410.84.202112040202-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-410-84-202111111322-0-gcp-x86-64"
+          "name": "rhcos-410-84-202112040202-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "410.84.202111111322-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-410.84.202111111322-0-azure.x86_64.vhd"
+          "release": "410.84.202112040202-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-410.84.202112040202-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.10 bootimage metadata in the installer.
This change includes fixes for the following BZs:

Bug 1990506 - Missing udev rules in initramfs for /dev/disk/by-id/scsi-* symlinks

This change will also introduce artifacts for for Aliyun, AWS GovCloud regions, and Nutanix.

Changes generated with:
```
$ cosa shell
[coreos-assembler]$ plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --no-signatures \
--url https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases aarch64=410.84.202112060851-0 \
ppc64le=410.84.202112041603-0 s390x=410.84.202112040202-0  x86_64=410.84.202112040202-0
```
Verification Steps:

1. Install a new 4.10 cluster
2. `oc debug node/<node name> -- chroot /host rpm-ostree status`
3. Verify that the deployment version matches the version from this PR
   that matches the architecture you are testing on. (i.e. `aarch64`
   should have version `410.84.202112060851-0`)