### PR TITLE
Alibaba: fix: rename the bootstrap output variable

### DIFF
--- a/data/data/alibabacloud/bootstrap/outputs.tf
+++ b/data/data/alibabacloud/bootstrap/outputs.tf
@@ -1,3 +1,3 @@
-output "bootstrap_public_ip" {
+output "bootstrap_ip" {
   value = data.alicloud_instances.bootstrap_data.instances.0.public_ip
 }


### PR DESCRIPTION

Rename the variable name of the output bootstrap node's IP to `bootstrap_ip `