### PR TITLE
bootstrap: remove support for certs lacking SAN

### DIFF
--- a/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env-godebug.conf.template
+++ b/data/data/bootstrap/files/etc/systemd/system.conf.d/10-default-env-godebug.conf.template
@@ -1,2 +1,0 @@
-[Manager]
-DefaultEnvironment=GODEBUG=x509ignoreCN=0


### PR DESCRIPTION
This removes the deprecated support for certs which lack a SAN.

See https://github.com/openshift/installer/pull/4248