### PR TITLE
Bug 2025464: aws: get ips for all control plane instances for bootstrap gather

### DIFF
--- a/data/data/aws/cluster/master/outputs.tf
+++ b/data/data/aws/cluster/master/outputs.tf
@@ -1,3 +1,3 @@
 output "ip_addresses" {
-  value = aws_network_interface.master.*.private_ips[0]
+  value = [for m in aws_network_interface.master : tolist(m.private_ips)[0]]
 }


### PR DESCRIPTION
The tf code for aws outputs only the IP address of the first control plane instance rather than the IPs of all of the control plane instances. The issue is that all of the IPs for all of the instances are collected into a single list and only then the first IP is taken from the list. Instead, we want to take the first IP from each instance and then collect those IPs into a list.