### PR TITLE
libvirt: use el8 repo for Google Cloud SDK

### DIFF
--- a/images/libvirt/google-cloud-sdk.repo
+++ b/images/libvirt/google-cloud-sdk.repo
@@ -1,6 +1,6 @@
 [google-cloud-sdk]
 name=Google Cloud SDK
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1


### PR DESCRIPTION
The following error has been observed on the CI jobs using the
`libvirt-installer` image:

`ERROR: gcloud crashed (SystemError): ffi_prep_closure(): bad user_data (it seems that the version of the libffi library seen at runtime is different from the 'ffi.h' file seen at compile-time)`

See an example failed job - https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_installer/5452/pull-ci-openshift-installer-master-e2e-crc/1468627926126694400

This seems to coincide with version 366.0 of the Google Cloud SDK
which was released on Dec 7.

https://cloud.google.com/sdk/docs/release-notes#36600_2021-12-07

This changes the use of the el7 version of the SDK repo to use the el8
version.

I'm kind of surprised that things have been working as long as they
have because the `builder` image has been using UBI8 as the base image
for some time.