### PR TITLE
azurestack: Add a custom rhcos image field for ASH

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1342,6 +1342,11 @@ spec:
                     - AzureGermanCloud
                     - AzureStackCloud
                     type: string
+                  clusterOSImage:
+                    description: ClusterOSImage is the url of a storage blob in the
+                      Azure Stack environment containing an RHCOS VHD. This field
+                      is required for Azure Stack and not applicable to Azure.
+                    type: string
                   computeSubnet:
                     description: ComputeSubnet specifies an existing subnet for use
                       by compute nodes

--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -26,6 +26,7 @@ type API interface {
 	GetDiskSkus(ctx context.Context, region string) ([]azsku.ResourceSku, error)
 	GetGroup(ctx context.Context, groupName string) (*azres.Group, error)
 	ListResourceIDsByGroup(ctx context.Context, groupName string) ([]string, error)
+	GetStorageEndpointSuffix(ctx context.Context) (string, error)
 }
 
 // Client makes calls to the Azure API.
@@ -92,6 +93,12 @@ func (c *Client) getVirtualNetworksClient(ctx context.Context) (*aznetwork.Virtu
 	vnetsClient := aznetwork.NewVirtualNetworksClientWithBaseURI(c.ssn.Environment.ResourceManagerEndpoint, c.ssn.Credentials.SubscriptionID)
 	vnetsClient.Authorizer = c.ssn.Authorizer
 	return &vnetsClient, nil
+}
+
+// GetStorageEndpointSuffix retrieves the StorageEndpointSuffix from the
+// session environment
+func (c *Client) GetStorageEndpointSuffix(ctx context.Context) (string, error) {
+	return c.ssn.Environment.StorageEndpointSuffix, nil
 }
 
 // getSubnetsClient sets up a new client to retrieve a subnet

--- a/pkg/asset/installconfig/azure/mock/azureclient_generated.go
+++ b/pkg/asset/installconfig/azure/mock/azureclient_generated.go
@@ -6,53 +6,39 @@ package mock
 
 import (
 	context "context"
+	reflect "reflect"
+
 	compute "github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/compute/mgmt/compute"
 	network "github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/network/mgmt/network"
 	resources "github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/resources/mgmt/resources"
 	subscriptions "github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/resources/mgmt/subscriptions"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockAPI is a mock of API interface
+// MockAPI is a mock of API interface.
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI
+// MockAPIMockRecorder is the mock recorder for MockAPI.
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance
+// NewMockAPI creates a new mock instance.
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// GetVirtualNetwork mocks base method
-func (m *MockAPI) GetVirtualNetwork(ctx context.Context, resourceGroupName, virtualNetwork string) (*network.VirtualNetwork, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVirtualNetwork", ctx, resourceGroupName, virtualNetwork)
-	ret0, _ := ret[0].(*network.VirtualNetwork)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVirtualNetwork indicates an expected call of GetVirtualNetwork
-func (mr *MockAPIMockRecorder) GetVirtualNetwork(ctx, resourceGroupName, virtualNetwork interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualNetwork", reflect.TypeOf((*MockAPI)(nil).GetVirtualNetwork), ctx, resourceGroupName, virtualNetwork)
-}
-
-// GetComputeSubnet mocks base method
+// GetComputeSubnet mocks base method.
 func (m *MockAPI) GetComputeSubnet(ctx context.Context, resourceGroupName, virtualNetwork, subnet string) (*network.Subnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetComputeSubnet", ctx, resourceGroupName, virtualNetwork, subnet)
@@ -61,13 +47,13 @@ func (m *MockAPI) GetComputeSubnet(ctx context.Context, resourceGroupName, virtu
 	return ret0, ret1
 }
 
-// GetComputeSubnet indicates an expected call of GetComputeSubnet
+// GetComputeSubnet indicates an expected call of GetComputeSubnet.
 func (mr *MockAPIMockRecorder) GetComputeSubnet(ctx, resourceGroupName, virtualNetwork, subnet interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetComputeSubnet", reflect.TypeOf((*MockAPI)(nil).GetComputeSubnet), ctx, resourceGroupName, virtualNetwork, subnet)
 }
 
-// GetControlPlaneSubnet mocks base method
+// GetControlPlaneSubnet mocks base method.
 func (m *MockAPI) GetControlPlaneSubnet(ctx context.Context, resourceGroupName, virtualNetwork, subnet string) (*network.Subnet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetControlPlaneSubnet", ctx, resourceGroupName, virtualNetwork, subnet)
@@ -76,58 +62,13 @@ func (m *MockAPI) GetControlPlaneSubnet(ctx context.Context, resourceGroupName, 
 	return ret0, ret1
 }
 
-// GetControlPlaneSubnet indicates an expected call of GetControlPlaneSubnet
+// GetControlPlaneSubnet indicates an expected call of GetControlPlaneSubnet.
 func (mr *MockAPIMockRecorder) GetControlPlaneSubnet(ctx, resourceGroupName, virtualNetwork, subnet interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControlPlaneSubnet", reflect.TypeOf((*MockAPI)(nil).GetControlPlaneSubnet), ctx, resourceGroupName, virtualNetwork, subnet)
 }
 
-// ListLocations mocks base method
-func (m *MockAPI) ListLocations(ctx context.Context) (*[]subscriptions.Location, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListLocations", ctx)
-	ret0, _ := ret[0].(*[]subscriptions.Location)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListLocations indicates an expected call of ListLocations
-func (mr *MockAPIMockRecorder) ListLocations(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLocations", reflect.TypeOf((*MockAPI)(nil).ListLocations), ctx)
-}
-
-// GetResourcesProvider mocks base method
-func (m *MockAPI) GetResourcesProvider(ctx context.Context, resourceProviderNamespace string) (*resources.Provider, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResourcesProvider", ctx, resourceProviderNamespace)
-	ret0, _ := ret[0].(*resources.Provider)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetResourcesProvider indicates an expected call of GetResourcesProvider
-func (mr *MockAPIMockRecorder) GetResourcesProvider(ctx, resourceProviderNamespace interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesProvider", reflect.TypeOf((*MockAPI)(nil).GetResourcesProvider), ctx, resourceProviderNamespace)
-}
-
-// GetVirtualMachineSku mocks base method
-func (m *MockAPI) GetVirtualMachineSku(ctx context.Context, name, region string) (*compute.ResourceSku, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVirtualMachineSku", ctx, name, region)
-	ret0, _ := ret[0].(*compute.ResourceSku)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVirtualMachineSku indicates an expected call of GetVirtualMachineSku
-func (mr *MockAPIMockRecorder) GetVirtualMachineSku(ctx, name, region interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualMachineSku", reflect.TypeOf((*MockAPI)(nil).GetVirtualMachineSku), ctx, name, region)
-}
-
-// GetDiskSkus mocks base method
+// GetDiskSkus mocks base method.
 func (m *MockAPI) GetDiskSkus(ctx context.Context, region string) ([]compute.ResourceSku, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDiskSkus", ctx, region)
@@ -136,13 +77,13 @@ func (m *MockAPI) GetDiskSkus(ctx context.Context, region string) ([]compute.Res
 	return ret0, ret1
 }
 
-// GetDiskSkus indicates an expected call of GetDiskSkus
+// GetDiskSkus indicates an expected call of GetDiskSkus.
 func (mr *MockAPIMockRecorder) GetDiskSkus(ctx, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskSkus", reflect.TypeOf((*MockAPI)(nil).GetDiskSkus), ctx, region)
 }
 
-// GetGroup mocks base method
+// GetGroup mocks base method.
 func (m *MockAPI) GetGroup(ctx context.Context, groupName string) (*resources.Group, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGroup", ctx, groupName)
@@ -151,13 +92,88 @@ func (m *MockAPI) GetGroup(ctx context.Context, groupName string) (*resources.Gr
 	return ret0, ret1
 }
 
-// GetGroup indicates an expected call of GetGroup
+// GetGroup indicates an expected call of GetGroup.
 func (mr *MockAPIMockRecorder) GetGroup(ctx, groupName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroup", reflect.TypeOf((*MockAPI)(nil).GetGroup), ctx, groupName)
 }
 
-// ListResourceIDsByGroup mocks base method
+// GetResourcesProvider mocks base method.
+func (m *MockAPI) GetResourcesProvider(ctx context.Context, resourceProviderNamespace string) (*resources.Provider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResourcesProvider", ctx, resourceProviderNamespace)
+	ret0, _ := ret[0].(*resources.Provider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResourcesProvider indicates an expected call of GetResourcesProvider.
+func (mr *MockAPIMockRecorder) GetResourcesProvider(ctx, resourceProviderNamespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesProvider", reflect.TypeOf((*MockAPI)(nil).GetResourcesProvider), ctx, resourceProviderNamespace)
+}
+
+// GetStorageEndpointSuffix mocks base method.
+func (m *MockAPI) GetStorageEndpointSuffix(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStorageEndpointSuffix", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStorageEndpointSuffix indicates an expected call of GetStorageEndpointSuffix.
+func (mr *MockAPIMockRecorder) GetStorageEndpointSuffix(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageEndpointSuffix", reflect.TypeOf((*MockAPI)(nil).GetStorageEndpointSuffix), ctx)
+}
+
+// GetVirtualMachineSku mocks base method.
+func (m *MockAPI) GetVirtualMachineSku(ctx context.Context, name, region string) (*compute.ResourceSku, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVirtualMachineSku", ctx, name, region)
+	ret0, _ := ret[0].(*compute.ResourceSku)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVirtualMachineSku indicates an expected call of GetVirtualMachineSku.
+func (mr *MockAPIMockRecorder) GetVirtualMachineSku(ctx, name, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualMachineSku", reflect.TypeOf((*MockAPI)(nil).GetVirtualMachineSku), ctx, name, region)
+}
+
+// GetVirtualNetwork mocks base method.
+func (m *MockAPI) GetVirtualNetwork(ctx context.Context, resourceGroupName, virtualNetwork string) (*network.VirtualNetwork, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVirtualNetwork", ctx, resourceGroupName, virtualNetwork)
+	ret0, _ := ret[0].(*network.VirtualNetwork)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVirtualNetwork indicates an expected call of GetVirtualNetwork.
+func (mr *MockAPIMockRecorder) GetVirtualNetwork(ctx, resourceGroupName, virtualNetwork interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualNetwork", reflect.TypeOf((*MockAPI)(nil).GetVirtualNetwork), ctx, resourceGroupName, virtualNetwork)
+}
+
+// ListLocations mocks base method.
+func (m *MockAPI) ListLocations(ctx context.Context) (*[]subscriptions.Location, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListLocations", ctx)
+	ret0, _ := ret[0].(*[]subscriptions.Location)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListLocations indicates an expected call of ListLocations.
+func (mr *MockAPIMockRecorder) ListLocations(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListLocations", reflect.TypeOf((*MockAPI)(nil).ListLocations), ctx)
+}
+
+// ListResourceIDsByGroup mocks base method.
 func (m *MockAPI) ListResourceIDsByGroup(ctx context.Context, groupName string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceIDsByGroup", ctx, groupName)
@@ -166,7 +182,7 @@ func (m *MockAPI) ListResourceIDsByGroup(ctx context.Context, groupName string) 
 	return ret0, ret1
 }
 
-// ListResourceIDsByGroup indicates an expected call of ListResourceIDsByGroup
+// ListResourceIDsByGroup indicates an expected call of ListResourceIDsByGroup.
 func (mr *MockAPIMockRecorder) ListResourceIDsByGroup(ctx, groupName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceIDsByGroup", reflect.TypeOf((*MockAPI)(nil).ListResourceIDsByGroup), ctx, groupName)

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -376,3 +376,52 @@ func Test_validateResourceGroup(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckAzureStackClusterOSImageSet(t *testing.T) {
+	cases := []struct {
+		ClusterOSImage string
+		err            string
+	}{{
+		ClusterOSImage: "https://storage.test-endpoint.com/rhcos-image",
+		err:            "",
+	}, {
+		ClusterOSImage: "",
+		err:            "^platform.azure.clusterOSImage: Required value: clusterOSImage must be set when installing on Azure Stack$",
+	}}
+	for _, test := range cases {
+		t.Run("", func(t *testing.T) {
+			err := checkAzureStackClusterOSImageSet(test.ClusterOSImage, field.NewPath("platform").Child("azure"))
+			if test.err != "" {
+				assert.Regexp(t, test.err, err.ToAggregate())
+			} else {
+				assert.NoError(t, err.ToAggregate())
+			}
+		})
+	}
+}
+
+func TestValidateAzureStackClusterOSImage(t *testing.T) {
+	cases := []struct {
+		StorageEndpointSuffix string
+		ClusterOSImage        string
+		err                   string
+	}{{
+		StorageEndpointSuffix: "storage.test-endpoint.com",
+		ClusterOSImage:        "https://storage.test-endpoint.com/rhcos-image",
+		err:                   "",
+	}, {
+		StorageEndpointSuffix: "storage.test-endpoint.com",
+		ClusterOSImage:        "https://storage.not-in-the-cluster.com/rhcos-image",
+		err:                   `^platform.azure.clusterOSImage: Invalid value: "https://storage.not-in-the-cluster.com/rhcos-image": clusterOSImage must be in the Azure Stack environment$`,
+	}}
+	for _, test := range cases {
+		t.Run("", func(t *testing.T) {
+			err := validateAzureStackClusterOSImage(test.StorageEndpointSuffix, test.ClusterOSImage, field.NewPath("platform").Child("azure"))
+			if test.err != "" {
+				assert.Regexp(t, test.err, err.ToAggregate())
+			} else {
+				assert.NoError(t, err.ToAggregate())
+			}
+		})
+	}
+}

--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -6,156 +6,37 @@ package mock
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	compute "google.golang.org/api/compute/v1"
 	dns "google.golang.org/api/dns/v1"
-	reflect "reflect"
 )
 
-// MockAPI is a mock of API interface
+// MockAPI is a mock of API interface.
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI
+// MockAPIMockRecorder is the mock recorder for MockAPI.
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance
+// NewMockAPI creates a new mock instance.
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// GetNetwork mocks base method
-func (m *MockAPI) GetNetwork(ctx context.Context, network, project string) (*compute.Network, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNetwork", ctx, network, project)
-	ret0, _ := ret[0].(*compute.Network)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNetwork indicates an expected call of GetNetwork
-func (mr *MockAPIMockRecorder) GetNetwork(ctx, network, project interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetwork", reflect.TypeOf((*MockAPI)(nil).GetNetwork), ctx, network, project)
-}
-
-// GetMachineType mocks base method
-func (m *MockAPI) GetMachineType(ctx context.Context, project, zone, machineType string) (*compute.MachineType, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMachineType", ctx, project, zone, machineType)
-	ret0, _ := ret[0].(*compute.MachineType)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMachineType indicates an expected call of GetMachineType
-func (mr *MockAPIMockRecorder) GetMachineType(ctx, project, zone, machineType interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineType", reflect.TypeOf((*MockAPI)(nil).GetMachineType), ctx, project, zone, machineType)
-}
-
-// GetPublicDomains mocks base method
-func (m *MockAPI) GetPublicDomains(ctx context.Context, project string) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPublicDomains", ctx, project)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPublicDomains indicates an expected call of GetPublicDomains
-func (mr *MockAPIMockRecorder) GetPublicDomains(ctx, project interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicDomains", reflect.TypeOf((*MockAPI)(nil).GetPublicDomains), ctx, project)
-}
-
-// GetPublicDNSZone mocks base method
-func (m *MockAPI) GetPublicDNSZone(ctx context.Context, project, baseDomain string) (*dns.ManagedZone, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPublicDNSZone", ctx, project, baseDomain)
-	ret0, _ := ret[0].(*dns.ManagedZone)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPublicDNSZone indicates an expected call of GetPublicDNSZone
-func (mr *MockAPIMockRecorder) GetPublicDNSZone(ctx, project, baseDomain interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicDNSZone", reflect.TypeOf((*MockAPI)(nil).GetPublicDNSZone), ctx, project, baseDomain)
-}
-
-// GetSubnetworks mocks base method
-func (m *MockAPI) GetSubnetworks(ctx context.Context, network, project, region string) ([]*compute.Subnetwork, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubnetworks", ctx, network, project, region)
-	ret0, _ := ret[0].([]*compute.Subnetwork)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSubnetworks indicates an expected call of GetSubnetworks
-func (mr *MockAPIMockRecorder) GetSubnetworks(ctx, network, project, region interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetworks", reflect.TypeOf((*MockAPI)(nil).GetSubnetworks), ctx, network, project, region)
-}
-
-// GetProjects mocks base method
-func (m *MockAPI) GetProjects(ctx context.Context) (map[string]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjects", ctx)
-	ret0, _ := ret[0].(map[string]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetProjects indicates an expected call of GetProjects
-func (mr *MockAPIMockRecorder) GetProjects(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockAPI)(nil).GetProjects), ctx)
-}
-
-// GetRecordSets mocks base method
-func (m *MockAPI) GetRecordSets(ctx context.Context, project, zone string) ([]*dns.ResourceRecordSet, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRecordSets", ctx, project, zone)
-	ret0, _ := ret[0].([]*dns.ResourceRecordSet)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRecordSets indicates an expected call of GetRecordSets
-func (mr *MockAPIMockRecorder) GetRecordSets(ctx, project, zone interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecordSets", reflect.TypeOf((*MockAPI)(nil).GetRecordSets), ctx, project, zone)
-}
-
-// GetZones mocks base method
-func (m *MockAPI) GetZones(ctx context.Context, project, filter string) ([]*compute.Zone, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetZones", ctx, project, filter)
-	ret0, _ := ret[0].([]*compute.Zone)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetZones indicates an expected call of GetZones
-func (mr *MockAPIMockRecorder) GetZones(ctx, project, filter interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetZones", reflect.TypeOf((*MockAPI)(nil).GetZones), ctx, project, filter)
-}
-
-// GetEnabledServices mocks base method
+// GetEnabledServices mocks base method.
 func (m *MockAPI) GetEnabledServices(ctx context.Context, project string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEnabledServices", ctx, project)
@@ -164,8 +45,128 @@ func (m *MockAPI) GetEnabledServices(ctx context.Context, project string) ([]str
 	return ret0, ret1
 }
 
-// GetEnabledServices indicates an expected call of GetEnabledServices
+// GetEnabledServices indicates an expected call of GetEnabledServices.
 func (mr *MockAPIMockRecorder) GetEnabledServices(ctx, project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnabledServices", reflect.TypeOf((*MockAPI)(nil).GetEnabledServices), ctx, project)
+}
+
+// GetMachineType mocks base method.
+func (m *MockAPI) GetMachineType(ctx context.Context, project, zone, machineType string) (*compute.MachineType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineType", ctx, project, zone, machineType)
+	ret0, _ := ret[0].(*compute.MachineType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachineType indicates an expected call of GetMachineType.
+func (mr *MockAPIMockRecorder) GetMachineType(ctx, project, zone, machineType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineType", reflect.TypeOf((*MockAPI)(nil).GetMachineType), ctx, project, zone, machineType)
+}
+
+// GetNetwork mocks base method.
+func (m *MockAPI) GetNetwork(ctx context.Context, network, project string) (*compute.Network, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetwork", ctx, network, project)
+	ret0, _ := ret[0].(*compute.Network)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNetwork indicates an expected call of GetNetwork.
+func (mr *MockAPIMockRecorder) GetNetwork(ctx, network, project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetwork", reflect.TypeOf((*MockAPI)(nil).GetNetwork), ctx, network, project)
+}
+
+// GetProjects mocks base method.
+func (m *MockAPI) GetProjects(ctx context.Context) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProjects", ctx)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProjects indicates an expected call of GetProjects.
+func (mr *MockAPIMockRecorder) GetProjects(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjects", reflect.TypeOf((*MockAPI)(nil).GetProjects), ctx)
+}
+
+// GetPublicDNSZone mocks base method.
+func (m *MockAPI) GetPublicDNSZone(ctx context.Context, project, baseDomain string) (*dns.ManagedZone, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublicDNSZone", ctx, project, baseDomain)
+	ret0, _ := ret[0].(*dns.ManagedZone)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPublicDNSZone indicates an expected call of GetPublicDNSZone.
+func (mr *MockAPIMockRecorder) GetPublicDNSZone(ctx, project, baseDomain interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicDNSZone", reflect.TypeOf((*MockAPI)(nil).GetPublicDNSZone), ctx, project, baseDomain)
+}
+
+// GetPublicDomains mocks base method.
+func (m *MockAPI) GetPublicDomains(ctx context.Context, project string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublicDomains", ctx, project)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPublicDomains indicates an expected call of GetPublicDomains.
+func (mr *MockAPIMockRecorder) GetPublicDomains(ctx, project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicDomains", reflect.TypeOf((*MockAPI)(nil).GetPublicDomains), ctx, project)
+}
+
+// GetRecordSets mocks base method.
+func (m *MockAPI) GetRecordSets(ctx context.Context, project, zone string) ([]*dns.ResourceRecordSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRecordSets", ctx, project, zone)
+	ret0, _ := ret[0].([]*dns.ResourceRecordSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRecordSets indicates an expected call of GetRecordSets.
+func (mr *MockAPIMockRecorder) GetRecordSets(ctx, project, zone interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecordSets", reflect.TypeOf((*MockAPI)(nil).GetRecordSets), ctx, project, zone)
+}
+
+// GetSubnetworks mocks base method.
+func (m *MockAPI) GetSubnetworks(ctx context.Context, network, project, region string) ([]*compute.Subnetwork, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubnetworks", ctx, network, project, region)
+	ret0, _ := ret[0].([]*compute.Subnetwork)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubnetworks indicates an expected call of GetSubnetworks.
+func (mr *MockAPIMockRecorder) GetSubnetworks(ctx, network, project, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetworks", reflect.TypeOf((*MockAPI)(nil).GetSubnetworks), ctx, network, project, region)
+}
+
+// GetZones mocks base method.
+func (m *MockAPI) GetZones(ctx context.Context, project, filter string) ([]*compute.Zone, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetZones", ctx, project, filter)
+	ret0, _ := ret[0].([]*compute.Zone)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetZones indicates an expected call of GetZones.
+func (mr *MockAPIMockRecorder) GetZones(ctx, project, filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetZones", reflect.TypeOf((*MockAPI)(nil).GetZones), ctx, project, filter)
 }

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -127,6 +127,9 @@ func osImage(config *types.InstallConfig) (string, error) {
 		return "", fmt.Errorf("%s: No openstack build found", st.FormatPrefix(archName))
 	case azure.Name:
 		ext := streamArch.RHELCoreOSExtensions
+		if config.Platform.Azure.CloudName == azure.StackCloud {
+			return config.Platform.Azure.ClusterOSImage, nil
+		}
 		if ext == nil {
 			return "", fmt.Errorf("%s: No azure build found", st.FormatPrefix(archName))
 		}

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -156,6 +156,9 @@ func Test_PrintFields(t *testing.T) {
       Valid Values: "","AzurePublicCloud","AzureUSGovernmentCloud","AzureChinaCloud","AzureGermanCloud","AzureStackCloud"
       cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the value is equal to "AzurePublicCloud".
 
+    clusterOSImage <string>
+      ClusterOSImage is the url of a storage blob in the Azure Stack environment containing an RHCOS VHD. This field is required for Azure Stack and not applicable to Azure.
+
     computeSubnet <string>
       ComputeSubnet specifies an existing subnet for use by compute nodes
 

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -31,6 +31,9 @@ type Platform struct {
 	// ARMEndpoint is the endpoint for the Azure API when installing on Azure Stack.
 	ARMEndpoint string `json:"armEndpoint,omitempty"`
 
+	// ClusterOSImage is the url of a storage blob in the Azure Stack environment containing an RHCOS VHD. This field is required for Azure Stack and not applicable to Azure.
+	ClusterOSImage string `json:"clusterOSImage,omitempty"`
+
 	// BaseDomainResourceGroupName specifies the resource group where the Azure DNS zone for the base domain is found.
 	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
 

--- a/pkg/types/azure/validation/platform.go
+++ b/pkg/types/azure/validation/platform.go
@@ -80,6 +80,9 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 		if p.ARMEndpoint != "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("armEndpoint"), fmt.Sprintf("ARM endpoint must not be set when the cloud name is %s", cloud)))
 		}
+		if p.ClusterOSImage != "" {
+			allErrs = append(allErrs, field.Required(fldPath.Child("clusterOSImage"), fmt.Sprintf("clusterOSImage must not be set when the cloud name is %s", cloud)))
+		}
 	}
 
 	return allErrs


### PR DESCRIPTION
Add a new field to the install config so users can specify an RHCOS image
to use in their ASH environment. This field is required for ASH, and not
allowed to be used for azure.