### PR TITLE
asset/tfvars: use generic name for platform tfvars file

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -64,11 +64,11 @@ const (
 	// TfVarsFileName is the filename for Terraform variables.
 	TfVarsFileName = "terraform.tfvars.json"
 
-	// TfPlatformVarsFileName is a template for platform-specific
+	// TfPlatformVarsFileName is the name for platform-specific
 	// Terraform variable files.
 	//
 	// https://www.terraform.io/docs/configuration/variables.html#variable-files
-	TfPlatformVarsFileName = "terraform.%s.auto.tfvars.json"
+	TfPlatformVarsFileName = "terraform.platform.auto.tfvars.json"
 
 	tfvarsAssetName = "Terraform Variables"
 )
@@ -291,7 +291,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	case azure.Name:
@@ -343,7 +343,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	case gcp.Name:
@@ -416,7 +416,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	case ibmcloud.Name:
@@ -519,7 +519,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	case libvirt.Name:
@@ -551,7 +551,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	case openstack.Name:
@@ -567,7 +567,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	case baremetal.Name:
@@ -598,7 +598,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	case ovirt.Name:
@@ -655,7 +655,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	case vsphere.Name:
@@ -686,7 +686,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	case alibabacloud.Name:
@@ -748,7 +748,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}
 		t.FileList = append(t.FileList, &asset.File{
-			Filename: fmt.Sprintf(TfPlatformVarsFileName, platform),
+			Filename: TfPlatformVarsFileName,
 			Data:     data,
 		})
 	default:
@@ -774,11 +774,12 @@ func (t *TerraformVariables) Load(f asset.FileFetcher) (found bool, err error) {
 	}
 	t.FileList = []*asset.File{file}
 
-	fileList, err := f.FetchByPattern(fmt.Sprintf(TfPlatformVarsFileName, "*"))
-	if err != nil {
+	switch file, err := f.FetchByName(TfPlatformVarsFileName); {
+	case err == nil:
+		t.FileList = append(t.FileList, file)
+	case !os.IsNotExist(err):
 		return false, err
 	}
-	t.FileList = append(t.FileList, fileList...)
 
 	return true, nil
 }

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -35,16 +35,12 @@ func Destroy(dir string) (err error) {
 		}
 	}
 
-	tfPlatformVarsFileName := fmt.Sprintf(cluster.TfPlatformVarsFileName, platform)
-
 	// Azure Stack uses the Azure platform but has its own Terraform configuration.
-	// Set platform to azurestack after setting tfPlatformVarsFileName, because the
-	// tfvars file is still terraform.azure.auto.tfvars.json in the case of Azure Stack.
 	if platform == typesazure.Name && metadata.Azure.CloudName == typesazure.StackCloud {
 		platform = typesazure.StackTerraformName
 	}
 
-	varFiles := []string{cluster.TfVarsFileName, tfPlatformVarsFileName}
+	varFiles := []string{cluster.TfVarsFileName, cluster.TfPlatformVarsFileName}
 	tfStages := platformstages.StagesForPlatform(platform)
 	for _, stage := range tfStages {
 		varFiles = append(varFiles, stage.OutputsFilename())
@@ -69,7 +65,7 @@ func Destroy(dir string) (err error) {
 
 		extraArgs := make([]string, len(varFiles))
 		for i, filename := range varFiles {
-			allowMissing := filename == tfPlatformVarsFileName // platform may not need platform-specific Terraform variables
+			allowMissing := filename == cluster.TfPlatformVarsFileName // platform may not need platform-specific Terraform variables
 			if err := copyToTemp(filename, dir, tempDir, allowMissing); err != nil {
 				return err
 			}


### PR DESCRIPTION
Since we are not installing multiple platforms at once, there is no need to include the platform name in the tfvars file containing the platform-specific variables. Removing the platform name from the file makes the code cleaner for Azure Stack.

See https://github.com/openshift/installer/pull/5443#discussion_r766337074.