### PR TITLE
aws: Update our local zone filtering code

### DIFF
--- a/pkg/asset/installconfig/aws/availabilityzones.go
+++ b/pkg/asset/installconfig/aws/availabilityzones.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -29,19 +28,9 @@ func availabilityZones(ctx context.Context, session *session.Session, region str
 		return nil, errors.Wrap(err, "fetching availability zones")
 	}
 
-	// This finds local zones and allows us to filter them out. It does so by
-	// using the fact that local zones have a predictable format based on the
-	// region, for example a local zone in us-west-2 will look like
-	// "us-west-2-las-1a". This is calculated relative to the region name as not
-	// all regions follow the same format with 2 hyphens.
-	// This is a temporary fix until we update our aws-sdk-go package to a
-	// version that adds the ZoneType field to the AvailabilityZone struct
-	numberOfHyphensInRegion := strings.Count(region, "-")
-
 	zones := []string{}
 	for _, zone := range resp.AvailabilityZones {
-		numberOfHyphensInZone := strings.Count(*zone.ZoneName, "-")
-		if numberOfHyphensInZone != numberOfHyphensInRegion+2 {
+		if *zone.ZoneType == "availability-zone" {
 			zones = append(zones, *zone.ZoneName)
 		}
 	}


### PR DESCRIPTION
We have updated our aws-sdk-go dependency to a version that exposes the
ZoneType field on AvailabilityZone objects, we can use this field to
filter out local zones instead of our temporary fix that used the format
of the zone name.