### PR TITLE
tf/stages: add resolution to stages for openstack and ovirt

### DIFF
--- a/pkg/terraform/stages/platform/stages.go
+++ b/pkg/terraform/stages/platform/stages.go
@@ -10,6 +10,8 @@ import (
 	"github.com/openshift/installer/pkg/terraform/stages/gcp"
 	"github.com/openshift/installer/pkg/terraform/stages/ibmcloud"
 	"github.com/openshift/installer/pkg/terraform/stages/libvirt"
+	"github.com/openshift/installer/pkg/terraform/stages/openstack"
+	"github.com/openshift/installer/pkg/terraform/stages/ovirt"
 	"github.com/openshift/installer/pkg/terraform/stages/vsphere"
 	alibabacloudtypes "github.com/openshift/installer/pkg/types/alibabacloud"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
@@ -18,6 +20,8 @@ import (
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
+	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
+	ovirttypes "github.com/openshift/installer/pkg/types/ovirt"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 )
 
@@ -40,6 +44,10 @@ func StagesForPlatform(platform string) []terraform.Stage {
 		return ibmcloud.PlatformStages
 	case libvirttypes.Name:
 		return libvirt.PlatformStages
+	case openstacktypes.Name:
+		return openstack.PlatformStages
+	case ovirttypes.Name:
+		return ovirt.PlatformStages
 	case vspheretypes.Name:
 		return vsphere.PlatformStages
 	default:


### PR DESCRIPTION
The resolution from the platform name to the tf stages to use for openstack and ovirt were accidentally removed in a poor rebase.