### PR TITLE
images/libvirt: provide specific version of google cloud sdk

### DIFF
--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -18,7 +18,7 @@ RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y \
     genisoimage \
     gettext \
-    google-cloud-sdk \
+    google-cloud-sdk-365.0.1 \
     libvirt-client \
     libvirt-libs \
     nss_wrapper \


### PR DESCRIPTION
Proposed fix based on the changes to CRC https://github.com/code-ready/crc/commit/b85050b66be6b0923e73db5d7de1c3fabe1f4633

Currently, google-cloud-sdk is broken and issuing the following error when launching and running jobs.  

err
```gcloud crashed (SystemError): ffi_prep_closure(): bad user_data (it seems that the version of the libffi library seen at runtime is different from the 'ffi.h' file seen at compile-time```

Providing a specific version should allow jobs to no longer fail