### PR TITLE
tf/alibaba: fix name of alibaba tf provider

### DIFF
--- a/data/data/alibabacloud/bootstrap/versions.tf
+++ b/data/data/alibabacloud/bootstrap/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    aws = {
-      source = "openshift/local/alibabacloud"
+    alicloud = {
+      source = "openshift/local/alicloud"
     }
   }
 }

--- a/data/data/alibabacloud/cluster/dns/versions.tf
+++ b/data/data/alibabacloud/cluster/dns/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    aws = {
-      source = "openshift/local/alibabacloud"
+    alicloud = {
+      source = "openshift/local/alicloud"
     }
   }
 }

--- a/data/data/alibabacloud/cluster/master/versions.tf
+++ b/data/data/alibabacloud/cluster/master/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    aws = {
-      source = "openshift/local/alibabacloud"
+    alicloud = {
+      source = "openshift/local/alicloud"
     }
   }
 }

--- a/data/data/alibabacloud/cluster/ram/versions.tf
+++ b/data/data/alibabacloud/cluster/ram/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    aws = {
-      source = "openshift/local/alibabacloud"
+    alicloud = {
+      source = "openshift/local/alicloud"
     }
   }
 }

--- a/data/data/alibabacloud/cluster/resourcegroup/versions.tf
+++ b/data/data/alibabacloud/cluster/resourcegroup/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    aws = {
-      source = "openshift/local/alibabacloud"
+    alicloud = {
+      source = "openshift/local/alicloud"
     }
   }
 }

--- a/data/data/alibabacloud/cluster/versions.tf
+++ b/data/data/alibabacloud/cluster/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    aws = {
-      source = "openshift/local/alibabacloud"
+    alicloud = {
+      source = "openshift/local/alicloud"
     }
   }
 }

--- a/data/data/alibabacloud/cluster/vpc/versions.tf
+++ b/data/data/alibabacloud/cluster/vpc/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    aws = {
-      source = "openshift/local/alibabacloud"
+    alicloud = {
+      source = "openshift/local/alicloud"
     }
   }
 }


### PR DESCRIPTION
The name of the alibaba tf provider is terraform-provider-alicloud, so the name of the embedded provider should be openshift/local/alicloud. We had been using openshift/local/alibabacloud.