### PR TITLE
Azure Stack: fix versions for Terraform Upgrade

### DIFF
--- a/data/data/azurestack/vnet/versions.tf
+++ b/data/data/azurestack/vnet/versions.tf
@@ -1,8 +1,11 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.14"
   required_providers {
     azurestack = {
       source = "openshift/local/azurestack"
+    }
+    random = {
+      source = "openshift/local/random"
     }
   }
 }


### PR DESCRIPTION
Bookkeeping in vnet module for Terraform upgrade. Versions file
was missing random provider and correct terraform version.