### PR TITLE
Bug 2033749: Azure Stack: Terraform Local Provider

### DIFF
--- a/data/data/azurestack/bootstrap/versions.tf
+++ b/data/data/azurestack/bootstrap/versions.tf
@@ -7,6 +7,9 @@ terraform {
     ignition = {
       source = "openshift/local/ignition"
     }
+    local = {
+      source = "openshift/local/local"
+    }
   }
 }
 


### PR DESCRIPTION
Specify local provider to fix this failure:

```
ERROR Could not retrieve the list of available versions for provider
ERROR hashicorp/local: provider registry.terraform.io/hashicorp/local was not found
ERROR in any of the search locations
```