### PR TITLE
Bug 2028695: Delete bootstrap profiles during cluster destroy

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -452,7 +452,7 @@ func (o *ClusterUninstaller) findIAMUsers(ctx context.Context, search *iamUserSe
 func (o *ClusterUninstaller) findUntaggableResources(ctx context.Context, iamClient *iam.IAM, deleted sets.String) (sets.String, error) {
 	resources := sets.NewString()
 	o.Logger.Debug("search for IAM instance profiles")
-	for _, profileType := range []string{"master", "worker"} {
+	for _, profileType := range []string{"master", "worker", "bootstrap"} {
 		profile := fmt.Sprintf("%s-%s-profile", o.ClusterID, profileType)
 		response, err := iamClient.GetInstanceProfileWithContext(ctx, &iam.GetInstanceProfileInput{InstanceProfileName: &profile})
 		if err != nil {


### PR DESCRIPTION
The installer has been ignoring the bootstrap profiles during
cluster destroy and needs to be cleaned up along with the
cluster. Added bootstrap-profiles to the list of profiles to
check during destroy.