### PR TITLE
Bug 2034527: Base IPA kernel params on provisioning network IP version

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -98,14 +98,22 @@ IPTABLES=iptables
 {{ end }}
 
 {{ if .UseIPv6ForNodeIP }}
-IP_OPTIONS="ip=dhcp6"
+EXTERNAL_IP_OPTIONS="ip=dhcp6"
 {{ else }}
-IP_OPTIONS="ip=dhcp"
+EXTERNAL_IP_OPTIONS="ip=dhcp"
 {{ end }}
+
+
+{{ if .PlatformData.BareMetal.ProvisioningIPv6 }}
+PROVISIONING_IP_OPTIONS="ip=dhcp6"
+{{ else }}
+PROVISIONING_IP_OPTIONS="ip=dhcp"
+{{ end }}
+
 
 podman run -d --name coreos-downloader \
      --restart on-failure \
-     --env IP_OPTIONS=${IP_OPTIONS} \
+     --env IP_OPTIONS=${EXTERNAL_IP_OPTIONS} \
      -v $IRONIC_SHARED_VOLUME:/shared:z \
      ${MACHINE_OS_IMAGES_IMAGE} /bin/copy-metal --all /shared/html/images/
 
@@ -195,7 +203,7 @@ sudo podman run -d --net host --privileged --name ironic-conductor \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120 \
      --env HTTP_BASIC_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env IRONIC_KERNEL_PARAMS=${IP_OPTIONS} \
+     --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
      --entrypoint /bin/runironic-conductor \
      -v $AUTH_DIR:/auth:ro \
      -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
@@ -207,7 +215,7 @@ podman run -d --net host --privileged --name ironic-inspector \
      --restart on-failure \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env HTTP_BASIC_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env IRONIC_KERNEL_PARAMS=${IP_OPTIONS} \
+     --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
      --entrypoint /bin/runironic-inspector \
      -v $AUTH_DIR:/auth:ro \
      -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_IMAGE}"


### PR DESCRIPTION
We need the kernel param for dhcp version to be based on the
provisioning network version for IPA and the external network
version for the machine image. These can differ.