### PR TITLE
Bug 2026356: Fix bootstrap disk instance type

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -188,7 +188,7 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
   location              = var.azure_region
   resource_group_name   = var.resource_group_name
   network_interface_ids = [azurerm_network_interface.bootstrap.id]
-  size                  = var.azure_bootstrap_vm_type
+  size                  = var.azure_master_vm_type
   admin_username        = "core"
   # The password is normally applied by WALA (the Azure agent), but this
   # isn't installed in RHCOS. As a result, this password is never set. It is
@@ -204,7 +204,7 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
   os_disk {
     name                 = "${var.cluster_id}-bootstrap_OSDisk" # os disk name needs to match cluster-api convention
     caching              = "ReadWrite"
-    storage_account_type = "Premium_LRS"
+    storage_account_type = var.azure_master_root_volume_type
     disk_size_gb         = 100
   }
 

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -18,11 +18,6 @@ variable "azure_region" {
   description = "The target Azure region for the cluster."
 }
 
-variable "azure_bootstrap_vm_type" {
-  type = string
-  description = "Instance type for the bootstrap node. Example: `Standard_DS4_v3`."
-}
-
 variable "azure_master_vm_type" {
   type = string
   description = "Instance type for the master node(s). Example: `Standard_D8s_v3`."

--- a/data/data/azurestack/bootstrap/main.tf
+++ b/data/data/azurestack/bootstrap/main.tf
@@ -109,7 +109,7 @@ resource "azurestack_virtual_machine" "bootstrap" {
   location              = var.azure_region
   resource_group_name   = var.resource_group_name
   network_interface_ids = [azurestack_network_interface.bootstrap.id]
-  vm_size               = var.azure_bootstrap_vm_type
+  vm_size               = var.azure_master_vm_type
   availability_set_id   = var.availability_set_id
 
   os_profile {

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -9,7 +9,6 @@ import (
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
-	"github.com/openshift/installer/pkg/types/azure/defaults"
 )
 
 // Auth is the collection of credentials that will be used by terrform.
@@ -25,7 +24,6 @@ type config struct {
 	Environment                     string            `json:"azure_environment"`
 	ARMEndpoint                     string            `json:"azure_arm_endpoint"`
 	ExtraTags                       map[string]string `json:"azure_extra_tags,omitempty"`
-	BootstrapInstanceType           string            `json:"azure_bootstrap_vm_type,omitempty"`
 	MasterInstanceType              string            `json:"azure_master_vm_type,omitempty"`
 	MasterAvailabilityZones         []string          `json:"azure_master_availability_zones"`
 	VolumeType                      string            `json:"azure_master_root_volume_type"`
@@ -84,7 +82,6 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Environment:                     environment,
 		ARMEndpoint:                     sources.ARMEndpoint,
 		Region:                          region,
-		BootstrapInstanceType:           defaults.BootstrapInstanceType(sources.CloudName, region),
 		MasterInstanceType:              masterConfig.VMSize,
 		MasterAvailabilityZones:         masterAvailabilityZones,
 		VolumeType:                      masterConfig.OSDisk.ManagedDisk.StorageAccountType,

--- a/pkg/types/azure/defaults/machines.go
+++ b/pkg/types/azure/defaults/machines.go
@@ -6,19 +6,6 @@ import (
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
-// BootstrapInstanceType sets the defaults for bootstrap instances.
-// Minimum requirements are 4 CPU's, 16GiB of ram, and 120GiB storage.
-// D4s v3 gives us 4 CPU's, 16GiB ram and 32GiB of temporary storage.
-// DS4_v2 gives us 8 CPUs, 28GiB ram, and 56GiB of temporary storage.
-func BootstrapInstanceType(cloud azure.CloudEnvironment, region string) string {
-	instanceClass := getInstanceClass(region)
-	size := "D4s_v3"
-	if cloud == azure.StackCloud {
-		size = "DS4_v2"
-	}
-	return instanceType(instanceClass, size)
-}
-
 // ControlPlaneInstanceType sets the defaults for control plane instances.
 // Minimum requirements are 4 CPU's, 16GiB of ram, and 120GiB storage.
 // D8s v3 gives us 8 CPU's, 32GiB ram and 64GiB of temporary storage


### PR DESCRIPTION
The bootstrap VM type is set to the default value for the given
region but must be instead set to the value given for the master
VM type. Making the changes to use the master VM type.