### PR TITLE
Bug 2035705: Azure: Only attempt to destroy resourcegroups if present

### DIFF
--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -489,14 +489,21 @@ func isNotFoundError(err error) bool {
 	}
 
 	var dErr autorest.DetailedError
-	if errors.As(err, &dErr) {
-		switch statusCode := dErr.StatusCode.(type) {
-		case int:
-			if statusCode == http.StatusNotFound {
+	errors.As(err, &dErr)
+
+	if dErr.StatusCode == http.StatusNotFound {
+		return true
+	}
+
+	if dErr.StatusCode == 0 {
+		serviceErr, ok := dErr.Original.(*azureenv.ServiceError)
+		if ok {
+			if strings.HasSuffix(serviceErr.Code, "NotFound") {
 				return true
 			}
 		}
 	}
+
 	return false
 }
 


### PR DESCRIPTION
This is a follow up PR to https://github.com/openshift/installer/pull/5314 which didn't correctly check whether the resourcegroups were already deleted before attempting deletion.

This PR fixes the bug and has been locally tested by attempting to delete a missing resourcegroup.