### PR TITLE
support V2 vm size

### DIFF
--- a/upi/azure/02_storage.json
+++ b/upi/azure/02_storage.json
@@ -22,11 +22,12 @@
   },
   "resources" : [
     {
-      "apiVersion" : "2018-06-01",
+      "apiVersion" : "2021-07-01",
       "type": "Microsoft.Compute/images",
       "name": "[variables('imageName')]",
       "location" : "[variables('location')]",
       "properties": {
+        "hyperVGeneration": "V2",
         "storageProfile": {
           "osDisk": {
             "osType": "Linux",


### PR DESCRIPTION
in order to support the vm size which capabilities[?name=='HyperVGenerations'].value==['V2']
such as Standard_DC4ds_v3 Standard_DC4s_v3 in eastus2 region
ref doc [Microsoft.Compute images](https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/images?tabs=json)