### PR TITLE
Bug 2034527: Pass different IP options to installed CoreOS image and IPA

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -188,6 +188,7 @@ sudo podman run -d --net host --privileged --name image-customization \
     --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
     --env IRONIC_AGENT_IMAGE="$IRONIC_AGENT_IMAGE" \
     --env IRONIC_AGENT_PULL_SECRET="{{.PlatformData.BareMetal.PullSecretBase64}}" \
+    --env IP_OPTIONS=$EXTERNAL_IP_OPTIONS \
     --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
     --env REGISTRIES_CONF_PATH=/tmp/containers/registries.conf \
     --entrypoint '["/image-customization-server", "--nmstate-dir=/tmp/nmstate/", "--images-publish-addr=http://0.0.0.0:8084"]' \

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -189,7 +189,6 @@ sudo podman run -d --net host --privileged --name image-customization \
     --env IRONIC_AGENT_IMAGE="$IRONIC_AGENT_IMAGE" \
     --env IRONIC_AGENT_PULL_SECRET="{{.PlatformData.BareMetal.PullSecretBase64}}" \
     --env IP_OPTIONS=$EXTERNAL_IP_OPTIONS \
-    --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
     --env REGISTRIES_CONF_PATH=/tmp/containers/registries.conf \
     --entrypoint '["/image-customization-server", "--nmstate-dir=/tmp/nmstate/", "--images-publish-addr=http://0.0.0.0:8084"]' \
     -v /tmp/nmstate/:/tmp/nmstate/ \

--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -98,14 +98,22 @@ IPTABLES=iptables
 {{ end }}
 
 {{ if .UseIPv6ForNodeIP }}
-IP_OPTIONS="ip=dhcp6"
+EXTERNAL_IP_OPTIONS="ip=dhcp6"
 {{ else }}
-IP_OPTIONS="ip=dhcp"
+EXTERNAL_IP_OPTIONS="ip=dhcp"
 {{ end }}
+
+
+{{ if .PlatformData.BareMetal.ProvisioningIPv6 }}
+PROVISIONING_IP_OPTIONS="ip=dhcp6"
+{{ else }}
+PROVISIONING_IP_OPTIONS="ip=dhcp"
+{{ end }}
+
 
 podman run -d --name coreos-downloader \
      --restart on-failure \
-     --env IP_OPTIONS=${IP_OPTIONS} \
+     --env IP_OPTIONS=${PROVISIONING_IP_OPTIONS} \
      -v $IRONIC_SHARED_VOLUME:/shared:z \
      ${MACHINE_OS_IMAGES_IMAGE} /bin/copy-metal --all /shared/html/images/
 
@@ -195,7 +203,7 @@ sudo podman run -d --net host --privileged --name ironic-conductor \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120 \
      --env HTTP_BASIC_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env IRONIC_KERNEL_PARAMS=${IP_OPTIONS} \
+     --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
      --entrypoint /bin/runironic-conductor \
      -v $AUTH_DIR:/auth:ro \
      -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
@@ -207,7 +215,7 @@ podman run -d --net host --privileged --name ironic-inspector \
      --restart on-failure \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env HTTP_BASIC_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env IRONIC_KERNEL_PARAMS=${IP_OPTIONS} \
+     --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
      --entrypoint /bin/runironic-inspector \
      -v $AUTH_DIR:/auth:ro \
      -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_IMAGE}"


### PR DESCRIPTION
The installed CoreOS that is written to disk needs IP options set such that it can contact the MCO over the external network to obtain the Ignition file for the Machine.
These options may be different from the ones needed for pre-provisioning, when IPA has to contact ironic, usually over the provisioning network.

Pass the option to the image-customization-controller, so it can build it into the IPA ignition (in openshift/image-customization-controller#31)