### PR TITLE
Bug 2039241: [baremetal] use podman secret for image-customization server

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -180,6 +180,10 @@ else
     IRONIC_HOST="${IRONIC_IP}"
 fi
 
+# Create a podman secret for the image-customization-server 
+podman secret rm pull-secret || true
+base64 -w 0 /root/.docker/config.json | podman secret create pull-secret -
+
 # Embed agent ignition into the rhcos live iso
 podman run -d --net host --privileged --name image-customization \
     --env DEPLOY_ISO="/shared/html/images/ironic-python-agent.iso" \
@@ -187,13 +191,13 @@ podman run -d --net host --privileged --name image-customization \
     --env IRONIC_BASE_URL="http://${IRONIC_HOST}" \
     --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
     --env IRONIC_AGENT_IMAGE="$IRONIC_AGENT_IMAGE" \
-    --env IRONIC_AGENT_PULL_SECRET="{{.PlatformData.BareMetal.PullSecretBase64}}" \
     --env IP_OPTIONS=$EXTERNAL_IP_OPTIONS \
     --env REGISTRIES_CONF_PATH=/tmp/containers/registries.conf \
     --entrypoint '["/image-customization-server", "--nmstate-dir=/tmp/nmstate/", "--images-publish-addr=http://0.0.0.0:8084"]' \
     -v /tmp/nmstate/:/tmp/nmstate/ \
     -v $IRONIC_SHARED_VOLUME:/shared:z \
     -v /etc/containers:/tmp/containers:z \
+    --secret pull-secret,mode=400 \
     ${CUSTOMIZATION_IMAGE}
 
 podman run -d --net host --privileged --name ironic-conductor \

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -1,7 +1,6 @@
 package baremetal
 
 import (
-	"encoding/base64"
 	"fmt"
 	"net"
 	"strings"
@@ -56,13 +55,10 @@ type TemplateData struct {
 
 	// Hosts is the information needed to create the objects in Ironic.
 	Hosts []*baremetal.Host
-
-	// Pull secret for Ironic agent.
-	PullSecretBase64 string
 }
 
 // GetTemplateData returns platform-specific data for bootstrap templates.
-func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetworkEntry, ironicUsername, ironicPassword string, pullSecret string) *TemplateData {
+func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetworkEntry, ironicUsername, ironicPassword string) *TemplateData {
 	var templateData TemplateData
 
 	templateData.Hosts = config.Hosts
@@ -114,7 +110,6 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 	templateData.IronicPassword = ironicPassword
 	templateData.ClusterOSImage = config.ClusterOSImage
 	templateData.APIVIP = config.APIVIP
-	templateData.PullSecretBase64 = base64.StdEncoding.EncodeToString([]byte(pullSecret))
 
 	return &templateData
 }

--- a/pkg/asset/ignition/bootstrap/baremetal/template_test.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template_test.go
@@ -1,11 +1,11 @@
 package baremetal
 
 import (
-	"encoding/base64"
+	"testing"
+
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestTemplatingIPv4(t *testing.T) {
@@ -34,7 +34,7 @@ func TestTemplatingIPv4(t *testing.T) {
 		},
 	}
 
-	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd", "pullsecret")
+	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd")
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "172.22.0.10,172.22.0.100,24")
 	assert.Equal(t, result.ProvisioningCIDR, 24)
@@ -43,7 +43,6 @@ func TestTemplatingIPv4(t *testing.T) {
 	assert.Equal(t, result.ProvisioningDHCPAllowList, "c0:ff:ee:ca:fe:00 c0:ff:ee:ca:fe:01 c0:ff:ee:ca:fe:02")
 	assert.Equal(t, result.IronicUsername, "bootstrap-ironic-user")
 	assert.Equal(t, result.IronicPassword, "passw0rd")
-	assert.Equal(t, result.PullSecretBase64, base64.StdEncoding.EncodeToString([]byte("pullsecret")))
 }
 
 func TestTemplatingManagedIPv6(t *testing.T) {
@@ -54,7 +53,7 @@ func TestTemplatingManagedIPv6(t *testing.T) {
 		ProvisioningNetwork:     baremetal.ManagedProvisioningNetwork,
 	}
 
-	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd", "pullsecret")
+	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd")
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "fd2e:6f44:5dd8:b856::1,fd2e:6f44:5dd8::ff,80")
 	assert.Equal(t, result.ProvisioningCIDR, 80)
@@ -71,7 +70,7 @@ func TestTemplatingUnmanagedIPv6(t *testing.T) {
 		ProvisioningNetwork:     baremetal.UnmanagedProvisioningNetwork,
 	}
 
-	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd", "pullsecret")
+	result := GetTemplateData(&bareMetalConfig, nil, "bootstrap-ironic-user", "passw0rd")
 
 	assert.Equal(t, result.ProvisioningDHCPRange, "")
 	assert.Equal(t, result.ProvisioningCIDR, 64)

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -259,7 +259,7 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 
 	switch installConfig.Config.Platform.Name() {
 	case baremetaltypes.Name:
-		platformData.BareMetal = baremetal.GetTemplateData(installConfig.Config.Platform.BareMetal, installConfig.Config.MachineNetwork, ironicCreds.Username, ironicCreds.Password, installConfig.Config.PullSecret)
+		platformData.BareMetal = baremetal.GetTemplateData(installConfig.Config.Platform.BareMetal, installConfig.Config.MachineNetwork, ironicCreds.Username, ironicCreds.Password)
 	case vspheretypes.Name:
 		platformData.VSphere = vsphere.GetTemplateData(installConfig.Config.Platform.VSphere)
 	}


### PR DESCRIPTION
Use a podman secret to inject the pull secret into the image-customization container, instead of a plain env var. Related template code also removed.

Requires https://github.com/openshift/image-customization-controller/pull/30