### PR TITLE
[vsphere] installation failure sometimes with error: the object 'vim.Folder:group-v******' has already been deleted or has not been completely created 

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -49,9 +49,7 @@ ENV IGNITION_PROVIDER_VERSION=v2.1.0
 RUN curl -L -O https://github.com/community-terraform-providers/terraform-provider-ignition/releases/download/${IGNITION_PROVIDER_VERSION}/terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \
     tar xzf terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \
     mv terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64/terraform-provider-ignition /bin/terraform-provider-ignition
-RUN curl -L -O https://github.com/vmware/govmomi/releases/download/v0.20.0/govc_linux_amd64.gz && \
-    gzip -d govc_linux_amd64.gz && \
-    chmod +x govc_linux_amd64 && mv govc_linux_amd64 /bin/govc
+RUN curl -L -o - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | tar -C /bin -xvzf - govc
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
     unzip awscliv2.zip && \
     ./aws/install -b /bin && \


### PR DESCRIPTION
Updating the version of govc for the upi container to fix the bugs we are experiencing in terms of failing tests for the CI jobs.

Attaching some useful links below:

https://github.com/openshift/release/blob/master/ci-operator/step-registry/upi/conf/vsphere/ova/upi-conf-vsphere-ova-commands.sh#L38-L44

https://github.com/openshift/installer/blob/master/images/installer/Dockerfile.upi.ci#L59-L61

https://github.com/vmware/govmomi/pull/1916/files

PR for the latest release:  https://github.com/openshift/installer/pull/5495