### PR TITLE
[OCPCLOUD-1385] Ensure removal of placement-groups during cluster destroy on AWS

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -760,6 +760,8 @@ func deleteEC2(ctx context.Context, session *session.Session, arn arn.ARN, logge
 		return deleteEC2InternetGateway(ctx, client, id, logger)
 	case "natgateway":
 		return deleteEC2NATGateway(ctx, client, id, logger)
+	case "placement-group":
+		return deleteEC2PlacementGroup(ctx, client, id, logger)
 	case "route-table":
 		return deleteEC2RouteTable(ctx, client, id, logger)
 	case "security-group":
@@ -994,6 +996,29 @@ func deleteEC2NATGatewaysByVPC(ctx context.Context, client *ec2.EC2, vpc string,
 		return lastError
 	}
 	return err
+}
+
+func deleteEC2PlacementGroup(ctx context.Context, client *ec2.EC2, id string, logger logrus.FieldLogger) error {
+	response, err := client.DescribePlacementGroupsWithContext(ctx, &ec2.DescribePlacementGroupsInput{
+		GroupIds: []*string{aws.String(id)},
+	})
+	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidPlacementGroup.Unknown" {
+			return nil
+		}
+		return err
+	}
+
+	for _, placementGroup := range response.PlacementGroups {
+		if _, err := client.DeletePlacementGroupWithContext(ctx, &ec2.DeletePlacementGroupInput{
+			GroupName: placementGroup.GroupName,
+		}); err != nil {
+			return err
+		}
+	}
+
+	logger.Info("Deleted")
+	return nil
 }
 
 func deleteEC2RouteTable(ctx context.Context, client *ec2.EC2, id string, logger logrus.FieldLogger) error {


### PR DESCRIPTION
As a part of the effort to introduce AWS EFA into openshift, we need to also include placement groups (https://github.com/openshift/enhancements/pull/995). 

As part of this, Machine API will create placement groups for users if they do not exist. During cluster teardown, these currently block the destroy operation as the installer does not know how to handle the placement groups.

This PR teaches the destroy logic how to handle placement groups, with an implementation based on other resources.

I have manually tested this by creating a cluster, adding two placement groups (created by MAPI) and then destroying the cluster. It no longer blocks indefinitely and successfully removes the placement groups and completes the cluster destroy operation.