### PR TITLE
Bug 2039689: Alibaba: fix payment method for NAT gateway

### DIFF
--- a/data/data/alibabacloud/cluster/vpc/nat_gateway.tf
+++ b/data/data/alibabacloud/cluster/vpc/nat_gateway.tf
@@ -1,11 +1,11 @@
 
 resource "alicloud_nat_gateway" "nat_gateway" {
-  vpc_id           = local.vpc_id
-  specification    = "Small"
-  nat_gateway_name = "${local.prefix}-ngw"
-  vswitch_id       = alicloud_vswitch.vswitch_nat_gateway.id
-  nat_type         = "Enhanced"
-  description      = local.description
+  vpc_id               = local.vpc_id
+  nat_gateway_name     = "${local.prefix}-ngw"
+  vswitch_id           = alicloud_vswitch.vswitch_nat_gateway.id
+  internet_charge_type = "PayByLcu"
+  nat_type             = "Enhanced"
+  description          = local.description
   tags = merge(
     {
       "Name" = "${local.prefix}-ngw"


### PR DESCRIPTION
Pay-by-specification NAT is no longer supported. Newly purchased pay-as-you-go NAT gateways only support the pay-by-CU metering method.

The wrong information is as follows:

![image](https://user-images.githubusercontent.com/32291794/148872247-3e2e2873-c157-4e31-8c44-2ad5c5acc401.png)
