### PR TITLE
Bug 2035757: cluster-bootstrap/alibaba: set tear-down-delay to wait kube-apiserver rolls out on AlibabaCloud

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -402,7 +402,11 @@ run_cluster_bootstrap() {
         --volume "$PWD:/assets:z" \
         --volume /etc/kubernetes:/etc/kubernetes:z \
         "${CLUSTER_BOOTSTRAP_IMAGE}" \
-        start --tear-down-early=false --asset-dir=/assets --required-pods="${REQUIRED_PODS}"
+        start \
+          --tear-down-early=false \
+          --tear-down-delay="{{.TearDownDelay}}" \
+          --asset-dir=/assets \
+          --required-pods="${REQUIRED_PODS}"
 }
     
 if [ ! -f cb-bootstrap.done ]

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/alibabacloud"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 )
@@ -78,6 +79,7 @@ type bootstrapTemplateData struct {
 	BootstrapInPlace      *types.BootstrapInPlace
 	UseIPv6ForNodeIP      bool
 	IsOKD                 bool
+	TearDownDelay         string
 }
 
 // platformTemplateData is the data to use to replace values in bootstrap
@@ -278,6 +280,18 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		logrus.Warnf("Found override for Cluster Profile: %q", cp)
 		clusterProfile = cp
 	}
+
+	// Set Tear-down delay for platform specific
+	var tearDownDelay string
+	switch installConfig.Config.Platform.Name() {
+	case alibabacloud.Name:
+		// tear-down set to let kube-apiserver rolls out and avoid loopback CLB limitation
+		// BZ https://bugzilla.redhat.com/show_bug.cgi?id=2035757
+		tearDownDelay = "10m"
+	default:
+		tearDownDelay = "0"
+	}
+
 	var bootstrapInPlaceConfig *types.BootstrapInPlace
 	if bootstrapInPlace {
 		bootstrapInPlaceConfig = installConfig.Config.BootstrapInPlace
@@ -297,6 +311,7 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		BootstrapInPlace:      bootstrapInPlaceConfig,
 		UseIPv6ForNodeIP:      APIIntVIPonIPv6,
 		IsOKD:                 installConfig.Config.IsOKD(),
+		TearDownDelay:         tearDownDelay,
 	}
 }
 

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -281,15 +281,11 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		clusterProfile = cp
 	}
 
-	// Set Tear-down delay for platform specific
-	var tearDownDelay string
-	switch installConfig.Config.Platform.Name() {
-	case alibabacloud.Name:
+	tearDownDelay := "0"
+	if installConfig.Config.Platform.Name() == alibabacloud.Name {
 		// tear-down set to let kube-apiserver rolls out and avoid loopback CLB limitation
 		// BZ https://bugzilla.redhat.com/show_bug.cgi?id=2035757
 		tearDownDelay = "10m"
-	default:
-		tearDownDelay = "0"
 	}
 
 	var bootstrapInPlaceConfig *types.BootstrapInPlace


### PR DESCRIPTION
Setting up `--tear-down-delay` flag to `cluster-bootstrap` to wait `10m` until it tear down, to give time to wait for two kube-apiserver pods is available to finish the bootstrap in AlibabaCloud (only). The default value will be set to `0`.

This is caused due to a premature ending of bootkube of `cluster-bootstrap`/`kube-apiserver`  when scheduled the kube-apiserver to only one master, and the "SLB limitation where cannot be accessed by backend servers"[1]. 
[1] https://www.alibabacloud.com/help/en/doc-detail/55206.htm


This is an investigation of the bug https://bugzilla.redhat.com/show_bug.cgi?id=2035757