### PR TITLE
Bug 2033271: [Alibaba] fix deletion of resource group

### DIFF
--- a/pkg/destroy/alibabacloud/alibabacloud.go
+++ b/pkg/destroy/alibabacloud/alibabacloud.go
@@ -323,7 +323,7 @@ func (o *ClusterUninstaller) deleteResourceGroup(logger logrus.FieldLogger) (err
 	logger = logger.WithField("name", resourceGroupName)
 	logger.Debug("Searching resource groups")
 
-	response, err := o.listResourceGroups()
+	response, err := o.listResourceGroups(resourceGroupName)
 	if err != nil {
 		return err
 	}
@@ -347,7 +347,7 @@ func (o *ClusterUninstaller) deleteResourceGroup(logger logrus.FieldLogger) (err
 		2*time.Second,
 		1*time.Minute,
 		func() (bool, error) {
-			response, err := o.listResourceGroups()
+			response, err := o.listResourceGroups(resourceGroupName)
 			if err != nil {
 				return false, err
 			}
@@ -373,9 +373,10 @@ func (o *ClusterUninstaller) deleteResourceGroupByID(resourceGroupID string, log
 	return
 }
 
-func (o *ClusterUninstaller) listResourceGroups() (response *resourcemanager.ListResourceGroupsResponse, err error) {
+func (o *ClusterUninstaller) listResourceGroups(resourceGroupName string) (response *resourcemanager.ListResourceGroupsResponse, err error) {
 	request := resourcemanager.CreateListResourceGroupsRequest()
 	request.Scheme = "https"
+	request.QueryParams["Name"] = resourceGroupName
 	response, err = o.rmanagerClient.ListResourceGroups(request)
 	return
 }


### PR DESCRIPTION
Since there is no automatic paging function, the resource group may not
be queried and not deleted.
Search the resource group created by the installer by the resource group name.
