### PR TITLE
Bug 2043731: Add IP outputs for IBM terraform instances

### DIFF
--- a/data/data/ibmcloud/bootstrap/outputs.tf
+++ b/data/data/ibmcloud/bootstrap/outputs.tf
@@ -1,0 +1,3 @@
+output "bootstrap_ip" {
+  value = local.public_endpoints ? ibm_is_floating_ip.bootstrap_floatingip[0].address : ibm_is_instance.bootstrap_node.primary_network_interface[0].primary_ipv4_address
+}

--- a/data/data/ibmcloud/master/outputs.tf
+++ b/data/data/ibmcloud/master/outputs.tf
@@ -1,0 +1,3 @@
+output "control_plane_ips" {
+  value = ibm_is_instance.master_node[*].primary_network_interface[0].primary_ipv4_address
+}


### PR DESCRIPTION
Add the IP addresses for IBM bootstrap and master nodes to allow
collecting of logs from those nodes.