### PR TITLE
Bug 2041598: Azure Stack remove CA bundle from CPC

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -164,10 +164,6 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 				return errors.Wrap(err, "could not serialize Azure Stack endpoints")
 			}
 			cm.Data[cloudProviderEndpointsKey] = string(b)
-
-			if trustBundle := installConfig.Config.AdditionalTrustBundle; trustBundle != "" {
-				cm.Data[cloudProviderConfigCABundleDataKey] = trustBundle
-			}
 		}
 	case gcptypes.Name:
 		subnet := fmt.Sprintf("%s-worker-subnet", clusterID.InfraID)


### PR DESCRIPTION
Remove the CA bundle from the clooud provider config, because the MCO does not expect it. This leads to a discrepency between the bootstrap generated and cluster generated master configs.

Considering there is a discrepency, we could add support in the MCO for the trust bundle in the Azure cloud provider config. But we have decided that the long-term plan should be a unified approach to internal CAs. Until then, operators on Azure Stack should use the CA from the proxy object.

So there is no need for the CA bundle in the Azure configmap so let's just remove it.