### PR TITLE
Bug 2042438: openstack/Dockerfile: add make and gettext

### DIFF
--- a/images/openstack/Dockerfile.ci
+++ b/images/openstack/Dockerfile.ci
@@ -18,7 +18,7 @@ COPY --from=builder /go/src/github.com/openshift/installer/hack/openstack/test-m
 
 # Install Dependendencies for tests
 # https://github.com/openshift/origin/blob/6114cbc507bf18890f009f16ee424a62007bc390/images/tests/Dockerfile.rhel
-RUN yum install --setopt=tsflags=nodocs -y git gzip util-linux glibc-locale-source && \
+RUN yum install --setopt=tsflags=nodocs -y gettext make git gzip util-linux glibc-locale-source && \
     yum clean all && rm -rf /var/cache/yum/* && \
     localedef -c -f UTF-8 -i en_US en_US.UTF-8 && \
     git config --system user.name test && \


### PR DESCRIPTION
These rpms would be helpful for some of our CI jobs that we run for
OpenStack; where we'll need to use `envsubst` and `make` commands.
