### PR TITLE
Bug 2042315: Fallback to External IP_OPTIONS when ProvisioningNetwork is Disabled

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -104,10 +104,14 @@ EXTERNAL_IP_OPTIONS="ip=dhcp"
 {{ end }}
 
 
-{{ if .PlatformData.BareMetal.ProvisioningIPv6 }}
-PROVISIONING_IP_OPTIONS="ip=dhcp6"
+{{ if eq .PlatformData.BareMetal.ProvisioningNetwork "Disabled" }}
+PROVISIONING_IP_OPTIONS=$EXTERNAL_IP_OPTIONS
 {{ else }}
+  {{ if .PlatformData.BareMetal.ProvisioningIPv6 }}
+PROVISIONING_IP_OPTIONS="ip=dhcp6"
+  {{ else }}
 PROVISIONING_IP_OPTIONS="ip=dhcp"
+  {{ end }}
 {{ end }}
 
 

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -55,6 +55,9 @@ type TemplateData struct {
 
 	// Hosts is the information needed to create the objects in Ironic.
 	Hosts []*baremetal.Host
+
+	// ProvisioningNetwork displays the type of provisioning network being used
+	ProvisioningNetwork string
 }
 
 // GetTemplateData returns platform-specific data for bootstrap templates.
@@ -64,6 +67,7 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 	templateData.Hosts = config.Hosts
 
 	templateData.ProvisioningIP = config.BootstrapProvisioningIP
+	templateData.ProvisioningNetwork = string(config.ProvisioningNetwork)
 	templateData.BaremetalEndpointOverride = fmt.Sprintf("http://%s/v1", net.JoinHostPort(config.APIVIP, "6385"))
 	templateData.BaremetalIntrospectionEndpointOverride = fmt.Sprintf("http://%s/v1", net.JoinHostPort(config.APIVIP, "5050"))
 


### PR DESCRIPTION
If ProvisioningNetwork is Disabled the PROVISIONING_IP_OPTIONS should be
based on the IP version on the external network.