### PR TITLE
Bug 2042655: revert delay of bootstrap control plane teardown for alibaba

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -402,11 +402,7 @@ run_cluster_bootstrap() {
         --volume "$PWD:/assets:z" \
         --volume /etc/kubernetes:/etc/kubernetes:z \
         "${CLUSTER_BOOTSTRAP_IMAGE}" \
-        start \
-          --tear-down-early=false \
-          --tear-down-delay="{{.TearDownDelay}}" \
-          --asset-dir=/assets \
-          --required-pods="${REQUIRED_PODS}"
+        start --tear-down-early=false --asset-dir=/assets --required-pods="${REQUIRED_PODS}"
 }
     
 if [ ! -f cb-bootstrap.done ]

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -38,7 +38,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/rhcos"
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/alibabacloud"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
 )
@@ -79,7 +78,6 @@ type bootstrapTemplateData struct {
 	BootstrapInPlace      *types.BootstrapInPlace
 	UseIPv6ForNodeIP      bool
 	IsOKD                 bool
-	TearDownDelay         string
 }
 
 // platformTemplateData is the data to use to replace values in bootstrap
@@ -280,14 +278,6 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		logrus.Warnf("Found override for Cluster Profile: %q", cp)
 		clusterProfile = cp
 	}
-
-	tearDownDelay := "0"
-	if installConfig.Config.Platform.Name() == alibabacloud.Name {
-		// tear-down set to let kube-apiserver rolls out and avoid loopback CLB limitation
-		// BZ https://bugzilla.redhat.com/show_bug.cgi?id=2035757
-		tearDownDelay = "10m"
-	}
-
 	var bootstrapInPlaceConfig *types.BootstrapInPlace
 	if bootstrapInPlace {
 		bootstrapInPlaceConfig = installConfig.Config.BootstrapInPlace
@@ -307,7 +297,6 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		BootstrapInPlace:      bootstrapInPlaceConfig,
 		UseIPv6ForNodeIP:      APIIntVIPonIPv6,
 		IsOKD:                 installConfig.Config.IsOKD(),
-		TearDownDelay:         tearDownDelay,
 	}
 }
 


### PR DESCRIPTION
This reverts commit 6e2d76b61c98ce6b3289a2bbee2c25778a1a1d4a.

With https://github.com/openshift/machine-config-operator/pull/2919, it is no longer necessary to delay the teardown
of the bootstrap control plane. The cluster will no longer get into an unusable state when there is only a single
kube-apiserver pod running.

/hold for https://github.com/openshift/machine-config-operator/pull/2919