### PR TITLE
Add a way to override the interface used by bootstrap node

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1435,6 +1435,11 @@ spec:
                     description: APIVIP is the VIP to use for internal API communication
                     format: ip
                     type: string
+                  boostrapProvisioningInterfaceOverride:
+                    description: BootstrapProvisioningInterface override. If set,
+                      it sets the interface that the bootstrap node will use to host
+                      its ProvisioningIP.
+                    type: string
                   bootstrapOSImage:
                     description: BootstrapOSImage is a URL to override the default
                       OS image for the bootstrap node. The URL must contain a sha256

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -75,7 +75,11 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 		cidr, _ := config.ProvisioningNetworkCIDR.Mask.Size()
 		templateData.ProvisioningCIDR = cidr
 		templateData.ProvisioningIPv6 = config.ProvisioningNetworkCIDR.IP.To4() == nil
-		templateData.ProvisioningInterface = "ens4"
+		if config.BootstrapProvisioningInterfaceOverride == "" {
+			templateData.ProvisioningInterface = "ens4"
+		} else {
+			templateData.ProvisioningInterface = config.BootstrapProvisioningInterfaceOverride
+		}
 		templateData.ProvisioningDNSMasq = true
 	}
 
@@ -95,7 +99,11 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 		}
 		templateData.ProvisioningDHCPAllowList = strings.Join(dhcpAllowList, " ")
 	case baremetal.DisabledProvisioningNetwork:
-		templateData.ProvisioningInterface = "ens3"
+		if config.BootstrapProvisioningInterfaceOverride == "" {
+			templateData.ProvisioningInterface = "ens3"
+		} else {
+			templateData.ProvisioningInterface = config.BootstrapProvisioningInterfaceOverride
+		}
 		templateData.ProvisioningDNSMasq = false
 
 		if templateData.ProvisioningIP != "" {

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -143,6 +143,11 @@ type Platform struct {
 	// +optional
 	ProvisioningNetworkInterface string `json:"provisioningNetworkInterface"`
 
+	// BootstrapProvisioningInterface override. If set, it sets the interface that the
+	// bootstrap node will use to host its ProvisioningIP.
+	// +optional
+	BootstrapProvisioningInterfaceOverride string `json:"bootstrapProvisioningInterfaceOverride"`
+
 	// ProvisioningNetworkCIDR defines the network to use for provisioning.
 	// +optional
 	ProvisioningNetworkCIDR *ipnet.IPNet `json:"provisioningNetworkCIDR,omitempty"`


### PR DESCRIPTION
Currently, the provision interface name is hardcoded to ens4. On my setup, this interface has a different name but there is no way to override this.

This patch adds a way to specify a different name.