### PR TITLE
Bug 2042826: Set 1 ingresscontroller replica for private SNO

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -75,32 +75,13 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 			PlatformSpec: configv1.PlatformSpec{},
 		},
 		Status: configv1.InfrastructureStatus{
-			InfrastructureName:   clusterID.InfraID,
-			APIServerURL:         getAPIServerURL(installConfig.Config),
-			APIServerInternalURL: getInternalAPIServerURL(installConfig.Config),
-			PlatformStatus:       &configv1.PlatformStatus{},
+			InfrastructureName:     clusterID.InfraID,
+			APIServerURL:           getAPIServerURL(installConfig.Config),
+			APIServerInternalURL:   getInternalAPIServerURL(installConfig.Config),
+			PlatformStatus:         &configv1.PlatformStatus{},
+			ControlPlaneTopology:   getControlPlaneTopology(installConfig.Config),
+			InfrastructureTopology: getInfrastructureTopology(installConfig.Config),
 		},
-	}
-
-	if installConfig.Config.ControlPlane.Replicas != nil && *installConfig.Config.ControlPlane.Replicas < 3 {
-		config.Status.ControlPlaneTopology = configv1.SingleReplicaTopologyMode
-	} else {
-		config.Status.ControlPlaneTopology = configv1.HighlyAvailableTopologyMode
-	}
-
-	numOfWorkers := int64(0)
-	for _, mp := range installConfig.Config.Compute {
-		if mp.Replicas != nil {
-			numOfWorkers += *mp.Replicas
-		}
-	}
-	switch numOfWorkers {
-	case 0:
-		config.Status.InfrastructureTopology = config.Status.ControlPlaneTopology
-	case 1:
-		config.Status.InfrastructureTopology = configv1.SingleReplicaTopologyMode
-	default:
-		config.Status.InfrastructureTopology = configv1.HighlyAvailableTopologyMode
 	}
 
 	switch installConfig.Config.Platform.Name() {

--- a/pkg/asset/manifests/ingress.go
+++ b/pkg/asset/manifests/ingress.go
@@ -97,6 +97,11 @@ func (ing *Ingress) generateClusterConfig(config *types.InstallConfig) ([]byte, 
 func (ing *Ingress) generateDefaultIngressController(config *types.InstallConfig) ([]byte, error) {
 	switch config.Publish {
 	case types.InternalPublishingStrategy:
+		var replicas *int32
+		if getInfrastructureTopology(config) == configv1.SingleReplicaTopologyMode {
+			one := int32(1)
+			replicas = &one
+		}
 		obj := &operatorv1.IngressController{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: operatorv1.GroupVersion.String(),
@@ -113,6 +118,7 @@ func (ing *Ingress) generateDefaultIngressController(config *types.InstallConfig
 						Scope: operatorv1.InternalLoadBalancer,
 					},
 				},
+				Replicas: replicas,
 			},
 		}
 		return yaml.Marshal(obj)

--- a/pkg/asset/manifests/ingress_test.go
+++ b/pkg/asset/manifests/ingress_test.go
@@ -1,0 +1,135 @@
+package manifests
+
+import (
+	"testing"
+
+	"github.com/ghodss/yaml"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/types"
+)
+
+func TestGenerateDefaultIngressController(t *testing.T) {
+	cases := []struct {
+		name                      string
+		installConfig             *types.InstallConfig
+		expectedIngressController *operatorv1.IngressController
+	}{{
+		name: "public",
+		installConfig: icBuild.build(
+			icBuild.withPublish(types.ExternalPublishingStrategy),
+		),
+		expectedIngressController: nil,
+	}, {
+		name: "private highly available cluster",
+		installConfig: icBuild.build(
+			icBuild.withPublish(types.InternalPublishingStrategy),
+		),
+		expectedIngressController: ingresscontrollerBuild.build(
+			ingresscontrollerBuild.withLoadBalancer(),
+			ingresscontrollerBuild.withScope(operatorv1.InternalLoadBalancer),
+		),
+	}, {
+		name: "private single-node cluster",
+		installConfig: icBuild.build(
+			icBuild.withPublish(types.InternalPublishingStrategy),
+			icBuild.withControlPlaneReplicas(1),
+		),
+		expectedIngressController: ingresscontrollerBuild.build(
+			ingresscontrollerBuild.withLoadBalancer(),
+			ingresscontrollerBuild.withScope(operatorv1.InternalLoadBalancer),
+			ingresscontrollerBuild.withReplicas(1),
+		),
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parents := asset.Parents{}
+			parents.Add(
+				&installconfig.ClusterID{
+					UUID:    "test-uuid",
+					InfraID: "test-infra-id",
+				},
+				&installconfig.InstallConfig{Config: tc.installConfig},
+				&CloudProviderConfig{},
+				&AdditionalTrustBundleConfig{},
+			)
+			ingressAsset := &Ingress{}
+			err := ingressAsset.Generate(parents)
+			if !assert.NoError(t, err, "failed to generate asset") {
+				return
+			}
+			if tc.expectedIngressController == nil {
+				assert.Len(t, ingressAsset.FileList, 1, "expected only one file to be generated")
+				return
+			}
+			if !assert.Len(t, ingressAsset.FileList, 2, "expected two files to be generated") {
+				return
+			}
+			assert.Equal(t, ingressAsset.FileList[1].Filename, "manifests/cluster-ingress-default-ingresscontroller.yaml")
+			var actualIngressController operatorv1.IngressController
+			err = yaml.Unmarshal(ingressAsset.FileList[1].Data, &actualIngressController)
+			if !assert.NoError(t, err, "failed to unmarshal ingress manifest") {
+				return
+			}
+			assert.Equal(t, tc.expectedIngressController, &actualIngressController)
+		})
+	}
+}
+
+func (b icBuildNamespace) withPublish(publish types.PublishingStrategy) icOption {
+	return func(ic *types.InstallConfig) {
+		ic.Publish = publish
+	}
+}
+
+type ingresscontrollerOption func(*operatorv1.IngressController)
+
+type ingresscontrollerBuildNamespace struct{}
+
+var ingresscontrollerBuild ingresscontrollerBuildNamespace
+
+func (ingresscontrollerBuildNamespace) build(opts ...ingresscontrollerOption) *operatorv1.IngressController {
+	ingresscontroller := &operatorv1.IngressController{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: operatorv1.GroupVersion.String(),
+			Kind:       "IngressController",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-ingress-operator",
+			Name:      "default",
+		},
+	}
+	for _, opt := range opts {
+		opt(ingresscontroller)
+	}
+	return ingresscontroller
+}
+
+func (b ingresscontrollerBuildNamespace) withLoadBalancer() ingresscontrollerOption {
+	return func(ingresscontroller *operatorv1.IngressController) {
+		if ingresscontroller.Spec.EndpointPublishingStrategy != nil && ingresscontroller.Spec.EndpointPublishingStrategy.LoadBalancer != nil {
+			return
+		}
+		ingresscontroller.Spec.EndpointPublishingStrategy = &operatorv1.EndpointPublishingStrategy{
+			Type:         operatorv1.LoadBalancerServiceStrategyType,
+			LoadBalancer: &operatorv1.LoadBalancerStrategy{},
+		}
+	}
+}
+
+func (b ingresscontrollerBuildNamespace) withReplicas(replicas int) ingresscontrollerOption {
+	return func(ingresscontroller *operatorv1.IngressController) {
+		i := int32(replicas)
+		ingresscontroller.Spec.Replicas = &i
+	}
+}
+
+func (b ingresscontrollerBuildNamespace) withScope(scope operatorv1.LoadBalancerScope) ingresscontrollerOption {
+	return func(ingresscontroller *operatorv1.IngressController) {
+		ingresscontroller.Spec.EndpointPublishingStrategy.LoadBalancer.Scope = scope
+	}
+}

--- a/pkg/asset/manifests/utils_test.go
+++ b/pkg/asset/manifests/utils_test.go
@@ -1,0 +1,69 @@
+package manifests
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+func TestGetInfrastructureTopology(t *testing.T) {
+	cases := []struct {
+		name                 string
+		installConfig        *types.InstallConfig
+		expectedTopologyMode configv1.TopologyMode
+	}{{
+		name:                 "no workers, no control-plane replicas",
+		installConfig:        icBuild.build(),
+		expectedTopologyMode: configv1.HighlyAvailableTopologyMode,
+	}, {
+		name: "no workers, 1 control-plane replica",
+		installConfig: icBuild.build(
+			icBuild.withControlPlaneReplicas(1),
+		),
+		expectedTopologyMode: configv1.SingleReplicaTopologyMode,
+	}, {
+		name: "no workers, 3 control-plane replicas",
+		installConfig: icBuild.build(
+			icBuild.withControlPlaneReplicas(3),
+		),
+		expectedTopologyMode: configv1.HighlyAvailableTopologyMode,
+	}, {
+		name: "1 worker",
+		installConfig: icBuild.build(
+			icBuild.withWorkerReplicas(1),
+		),
+		expectedTopologyMode: configv1.SingleReplicaTopologyMode,
+	}, {
+		name: "2 workers",
+		installConfig: icBuild.build(
+			icBuild.withWorkerReplicas(2),
+		),
+		expectedTopologyMode: configv1.HighlyAvailableTopologyMode,
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedTopologyMode, getInfrastructureTopology(tc.installConfig))
+		})
+	}
+}
+
+func (b icBuildNamespace) withControlPlaneReplicas(replicas int) icOption {
+	return func(ic *types.InstallConfig) {
+		i := int64(replicas)
+		ic.ControlPlane = &types.MachinePool{
+			Replicas: &i,
+		}
+	}
+}
+
+func (b icBuildNamespace) withWorkerReplicas(replicas int) icOption {
+	return func(ic *types.InstallConfig) {
+		i := int64(replicas)
+		ic.Compute = []types.MachinePool{{
+			Replicas: &i,
+		}}
+	}
+}


### PR DESCRIPTION
When generating a default ingresscontroller manifest, check the infrastructure topology, and set the ingresscontroller's replicas to 1 if the topology is "SingleReplica" (i.e., Single-Node OpenShift).

When the publishing strategy is "Internal", the installer generates a default ingresscontroller manifest.  Before this PR, the installer did not check the cluster topology and always left replicas unspecified in the generated ingresscontroller.  As a result, the ingress operator used the default value of 2 replicas, causing the ingress operator to try to schedule 2 pod replicas for the ingresscontroller, which would fail on single-node clusters because only 1 pod replica can be scheduled per ingresscontroller per node.

This issue does not arise when the publishing strategy is "External" because in this case, the installer does not generate a default ingresscontroller manifest; instead, the ingress operator creates the default ingresscontroller, and the ingress operator does check the topology and set replicas appropriately in the ingresscontroller that it creates.

* `pkg/asset/manifests/infrastructure.go` (`Generate`): Factor out logic for computing the control-plane topology and infrastructure topology.
* `pkg/asset/manifests/ingress.go` (`generateDefaultIngressController`): Check the infrastructure topology and set replicas to 1 if the topology is "SingleReplica".
* `pkg/asset/manifests/ingress_test.go`: New file.
(`TestGenerateDefaultIngressController`): New test.  Verify that `generateDefaultIngressController` behaves correctly.
(`withPublish`): New helper for `icBuildNamespace`.
(`ingresscontrollerOption`, `ingresscontrollerBuildNamespace`): New types for building test inputs.
(`ingresscontrollerBuild`): New variable for building test inputs.
(`build`, `withLoadBalancer`, `withReplicas`, `withScope`): New helpers for `ingresscontrollerBuildNamespace`.
* `pkg/asset/manifests/utils.go` (`getControlPlaneTopology`)
(`getInfrastructureTopology`): New functions.
* `pkg/asset/manifests/utils_test.go`: New file.
(`TestGetInfrastructureTopology`): New test.  Verify that `getInfrastructureTopology` behaves correctly.
(`withControlPlaneReplicas`, `withWorkerReplicas`): New helpers for `TestGetInfrastructureTopology`.