### PR TITLE
Bug 2041926: [Alibaba] fix creating public record being skipped

### DIFF
--- a/data/data/alibabacloud/cluster/dns/privatezone.tf
+++ b/data/data/alibabacloud/cluster/dns/privatezone.tf
@@ -10,13 +10,7 @@ data "alicloud_pvtz_service" "open" {
   enable = "On"
 }
 
-data "alicloud_alidns_domains" "dns_public" {
-  domain_name_regex = "^${var.base_domain}$"
-}
-
 resource "alicloud_alidns_record" "dns_public_record" {
-  count = length(data.alicloud_alidns_domains.dns_public.domains) == 0 ? 0 : 1
-
   domain_name = var.base_domain
   rr          = "api.${local.cluster_name}"
   type        = "A"


### PR DESCRIPTION
If the user chooses a base domain for which there is no zone, creating the A record in the zone is simply skipped rather than raising an error.
