### PR TITLE
Bug 2023839: Bump Fedora CoreOS to 35.20220116.2.0

### DIFF
--- a/data/data/coreos/fcos.json
+++ b/data/data/coreos/fcos.json
@@ -1,194 +1,92 @@
 {
-    "stream": "stable",
+    "stream": "testing",
     "metadata": {
-        "last-modified": "2021-07-14T21:50:43Z"
+        "last-modified": "2022-01-18T15:49:44Z",
+        "generator": "fedora-coreos-stream-generator v0.2.1"
     },
     "architectures": {
-        "x86_64": {
+        "aarch64": {
             "artifacts": {
-                "aliyun": {
-                    "release": "34.20210626.3.1",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-aliyun.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-aliyun.x86_64.qcow2.xz.sig",
-                                "sha256": "579f145159d36d86b769797baf8420d531b0108fe683b53929464e7ba8c4aba5",
-                                "uncompressed-sha256": "51e4d35ea09d453eb4128dfd98365cc722c2244bf5e207ba9df4235022889650"
-                            }
-                        }
-                    }
-                },
                 "aws": {
-                    "release": "34.20210626.3.1",
+                    "release": "35.20220116.2.0",
                     "formats": {
                         "vmdk.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-aws.x86_64.vmdk.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-aws.x86_64.vmdk.xz.sig",
-                                "sha256": "1f5d995f4b2d45eb05d7c3060a52c77cc411412fa2e2d9e0bdeadd98f8ca40b5",
-                                "uncompressed-sha256": "b84880acccfb8e5fb3b7b3343ed7f7b2aaff023960b581fe6229b446b1332664"
-                            }
-                        }
-                    }
-                },
-                "azure": {
-                    "release": "34.20210626.3.1",
-                    "formats": {
-                        "vhd.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-azure.x86_64.vhd.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-azure.x86_64.vhd.xz.sig",
-                                "sha256": "e89e4e43e16ccc60f6ad52ebcd3430d9d1a50d6f2750d6c19788d0d820e07e6d",
-                                "uncompressed-sha256": "62085a62b381964f88a56df976d8305c03c0d73e37510723587d031792ddcc30"
-                            }
-                        }
-                    }
-                },
-                "digitalocean": {
-                    "release": "34.20210626.3.1",
-                    "formats": {
-                        "qcow2.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-digitalocean.x86_64.qcow2.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-digitalocean.x86_64.qcow2.gz.sig",
-                                "sha256": "4a9823aa4d7afe8d547eee2251a89755dd72ffb4e652d52df78b5ea0d4937c34",
-                                "uncompressed-sha256": "43278955c49125b3a777490cc7ccbe6fe880386a325bd4166c7c1a7dc194e0af"
-                            }
-                        }
-                    }
-                },
-                "exoscale": {
-                    "release": "34.20210626.3.1",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-exoscale.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-exoscale.x86_64.qcow2.xz.sig",
-                                "sha256": "3877a91c4887d469264a6908d1d9c1a2eaf3ac5df666b6f8d9399f43d799f35b",
-                                "uncompressed-sha256": "6c7879873dca4ba0fc0af04f6f90ac0c41075d0e9c88ec3f2e90a75e0467e8b6"
-                            }
-                        }
-                    }
-                },
-                "gcp": {
-                    "release": "34.20210626.3.1",
-                    "formats": {
-                        "tar.gz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-gcp.x86_64.tar.gz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-gcp.x86_64.tar.gz.sig",
-                                "sha256": "425b3ddf913151f118852394f5c33ecd2445294c4f9dac81a5a9f0b34c2cb476",
-                                "uncompressed-sha256": "20fe4983e19ee4dc62e17b8710f60259cf2c9e3f739f76482d1412138c292524"
-                            }
-                        }
-                    }
-                },
-                "ibmcloud": {
-                    "release": "34.20210626.3.1",
-                    "formats": {
-                        "qcow2.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-ibmcloud.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-ibmcloud.x86_64.qcow2.xz.sig",
-                                "sha256": "006b96c01d077c62f579c34d7b8158c703c80a8a0ccbfbf6519770dc716f42e9",
-                                "uncompressed-sha256": "f38e75b7e6e3c466ab0d532654ed07683bca8a387435d0f4be2f9801785d4c6a"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-aws.aarch64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-aws.aarch64.vmdk.xz.sig",
+                                "sha256": "55cb1063d7f443dab3d9fdcf4dba18c23854fa77c25f96255137c1c6c8754a44",
+                                "uncompressed-sha256": "bea3b66d5ad6eceb30843950175e3c4a4350bf043d21a03d5f18eafdd2438fb5"
                             }
                         }
                     }
                 },
                 "metal": {
-                    "release": "34.20210626.3.1",
+                    "release": "35.20220116.2.0",
                     "formats": {
                         "4k.raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-metal4k.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-metal4k.x86_64.raw.xz.sig",
-                                "sha256": "38dbe2eec68f18cd998dd659f82f9b1a10b77cef38d1eb231b98afd01662337e",
-                                "uncompressed-sha256": "5609f162c7ba9ceac47c34eabd972e2999869716d79e1fbd3d9cd69211fa3f4f"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-metal4k.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-metal4k.aarch64.raw.xz.sig",
+                                "sha256": "987285577dc908c0b8cec3abdf1bf770a785f7d511771edef3d278348feae58b",
+                                "uncompressed-sha256": "465b4f99b518199a1d49cbcee9f36aed4bad2ba8d1bce6833b474eb79a8857d1"
                             }
                         },
                         "iso": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live.x86_64.iso",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live.x86_64.iso.sig",
-                                "sha256": "3ab9eee817051825ff7963de24dcd31a807f620f27cb6eb23ad71c598b60d0d4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-live.aarch64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-live.aarch64.iso.sig",
+                                "sha256": "2dd5107e3b0ef4c0d0989283ce112c372adc7c5bbe3a4af8a1ee5fa887094d4e"
                             }
                         },
                         "pxe": {
                             "kernel": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-kernel-x86_64",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-kernel-x86_64.sig",
-                                "sha256": "e4b5cac76b9f5991a488f2f8d178d82f70cce3457f62986c0136ba19a0463aa5"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-live-kernel-aarch64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-live-kernel-aarch64.sig",
+                                "sha256": "36e8be4fc36c3b92859e9bdf959fafe725d37483b8dec65e1cb42cf96f469fb4"
                             },
                             "initramfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-initramfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-initramfs.x86_64.img.sig",
-                                "sha256": "6bd515d56bb32d169d241a8b667a18ea87093e704996abc59ae0786912935578"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-live-initramfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-live-initramfs.aarch64.img.sig",
+                                "sha256": "494910925fe224d9b79b7f838715475e6127ac5a1816f55a62c621551d6f85a9"
                             },
                             "rootfs": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-rootfs.x86_64.img",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-live-rootfs.x86_64.img.sig",
-                                "sha256": "7d370e7cb0190d8d1c4871021d181d637b891a7ff76b478069ed9b1f4715fade"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-live-rootfs.aarch64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-live-rootfs.aarch64.img.sig",
+                                "sha256": "e82035c2913981320f2bd6e26cf37cb48cdeeb905b19debe1bc443295e08191c"
                             }
                         },
                         "raw.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-metal.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-metal.x86_64.raw.xz.sig",
-                                "sha256": "33e57b0df4001d86fd7e186d20e07bf951f6f6a053177ef3c7a31b1484d5bc8b",
-                                "uncompressed-sha256": "9ada6809945fc972757aa8c16ed55c2c2e137c557cb4e7d580dde6f2b3748e5c"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-metal.aarch64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-metal.aarch64.raw.xz.sig",
+                                "sha256": "7240e187c73fb001e6f12569d81c6269068efffb270c8a2f1136932041d53918",
+                                "uncompressed-sha256": "1e2d94481ca29a0660097cc6c1498e47a853750a68339b5b8993f848264580cb"
                             }
                         }
                     }
                 },
                 "openstack": {
-                    "release": "34.20210626.3.1",
+                    "release": "35.20220116.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-openstack.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-openstack.x86_64.qcow2.xz.sig",
-                                "sha256": "65706172925a57dbd3fd9dc63b846ce41c83aa0ae34159701d2050faba4921ca",
-                                "uncompressed-sha256": "c2364a4ddb747d23263dec398d956799d2362983fb8fc257a5ab1d87b604683d"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-openstack.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-openstack.aarch64.qcow2.xz.sig",
+                                "sha256": "9d4071afdc199b92b800e40f9565720091e7af8fc4d84aa421b98594293111d6",
+                                "uncompressed-sha256": "e278cf92bff5262e4ec87defebbaebdd75fa9180e08c6403c8c8041c2498df7c"
                             }
                         }
                     }
                 },
                 "qemu": {
-                    "release": "34.20210626.3.1",
+                    "release": "35.20220116.2.0",
                     "formats": {
                         "qcow2.xz": {
                             "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-qemu.x86_64.qcow2.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-qemu.x86_64.qcow2.xz.sig",
-                                "sha256": "f1e6984e356822f419c217c95a58fb059c8629e3fa1989278d3e7c1a68cf32d2",
-                                "uncompressed-sha256": "acecea6dd7b6d99a554cd381c15390a41affbde46ee16c8eb9a66e7aa7653f7f"
-                            }
-                        }
-                    }
-                },
-                "vmware": {
-                    "release": "34.20210626.3.1",
-                    "formats": {
-                        "ova": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-vmware.x86_64.ova",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-vmware.x86_64.ova.sig",
-                                "sha256": "39847867bd44d26529a9927cb654ecfe110e765dd03ef24320c8d357091e8664"
-                            }
-                        }
-                    }
-                },
-                "vultr": {
-                    "release": "34.20210626.3.1",
-                    "formats": {
-                        "raw.xz": {
-                            "disk": {
-                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-vultr.x86_64.raw.xz",
-                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210626.3.1/x86_64/fedora-coreos-34.20210626.3.1-vultr.x86_64.raw.xz.sig",
-                                "sha256": "b8c88e6262fd08ad1e23808b8aea3c7934c6d71cf0281244d398b047f9258240",
-                                "uncompressed-sha256": "b0e7cfee0d4653821973d6a6af41729a0bb04c7783fb80a950a84ccf76fb5cb4"
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-qemu.aarch64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/aarch64/fedora-coreos-35.20220116.2.0-qemu.aarch64.qcow2.xz.sig",
+                                "sha256": "56b51d472024d89c7fd3741c6e341d192a6912ae7c727f418e9dac534e5c2c55",
+                                "uncompressed-sha256": "54637c25aa5daf4390a3ebea3a3ed87b43101e204b52ba163f1ac5cc38b4b0c0"
                             }
                         }
                     }
@@ -198,95 +96,411 @@
                 "aws": {
                     "regions": {
                         "af-south-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-0e78e6cb9666e4866"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0d207cbf58dd6a5db"
                         },
                         "ap-east-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-09585374e960d19e7"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-081ee86f45ea8e7bf"
                         },
                         "ap-northeast-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-07d0591c7f35e1c50"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0a221eb5ec2f676a0"
                         },
                         "ap-northeast-2": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-06b9ade598c46aad5"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-05296b9d217d10bf9"
                         },
                         "ap-northeast-3": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-0e660991a6256edf8"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-08376314b636b5af2"
                         },
                         "ap-south-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-0de887f898b8b9edf"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0c5093606b7feb850"
                         },
                         "ap-southeast-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-03c5b518d836e0f10"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0c654d63926ed10cb"
                         },
                         "ap-southeast-2": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-02126f543e5642165"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-07fd2ea727805d1df"
+                        },
+                        "ap-southeast-3": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0da7d22c03d0af557"
                         },
                         "ca-central-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-04053e5d27a0fed44"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-021c87903449bdf29"
                         },
                         "eu-central-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-0352f1e0f3e503d23"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0d98a2a3a2eb98741"
                         },
                         "eu-north-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-0f859448095dc6195"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0e35f14c1ce17267b"
                         },
                         "eu-south-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-07990eb903597defa"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-017de3943b84ea01a"
                         },
                         "eu-west-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-052aea8dab8614f0b"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-06ff024c832dcddb8"
                         },
                         "eu-west-2": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-080a4f7c443bbc5a3"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-05c61c924c81f405e"
                         },
                         "eu-west-3": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-03190e74e2b49cb29"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0d5040f05808e004b"
                         },
                         "me-south-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-0f764a1c27bfceed9"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-047a901d47bdc4306"
                         },
                         "sa-east-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-0d92d7edb61886f94"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0014bad46ca05bbff"
                         },
                         "us-east-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-08e8ce95b14176032"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0f626d03dea88a540"
                         },
                         "us-east-2": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-08b1cffdb1cc1e8ea"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0b37b7ce42f36c72a"
                         },
                         "us-west-1": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-0dd2cb185e6859e3b"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0242284590ed54891"
                         },
                         "us-west-2": {
-                            "release": "34.20210626.3.1",
-                            "image": "ami-076e11761838586ea"
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0a24bf7541b38478d"
+                        }
+                    }
+                }
+            }
+        },
+        "x86_64": {
+            "artifacts": {
+                "aliyun": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-aliyun.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-aliyun.x86_64.qcow2.xz.sig",
+                                "sha256": "a9487fd495356c97ce16dc49dfda38cad5d8dffeff5e2bd00b0e7f124e974516",
+                                "uncompressed-sha256": "76b930aa7e6fbc3d858b44a4764f5888a8c7ac2ffaf40290d71c9bbad345bff5"
+                            }
+                        }
+                    }
+                },
+                "aws": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "vmdk.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-aws.x86_64.vmdk.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-aws.x86_64.vmdk.xz.sig",
+                                "sha256": "d9833a009eb140b17302b8240da26ae4ac631c05dbfbe7d4f49cb5c21018ccff",
+                                "uncompressed-sha256": "481535b7b730aecf448a7e8ce19df377192e754c8b22c8d1e64e2291478464ea"
+                            }
+                        }
+                    }
+                },
+                "azure": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-azure.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-azure.x86_64.vhd.xz.sig",
+                                "sha256": "cd464f1dc29b6f253bb5e10d77fde5f1539d15e302316e1d8bc49032b85d21e7",
+                                "uncompressed-sha256": "1a14ef2e96e1eac97d7e32731dabc6d3eb21409237f82955443b504aaac3b682"
+                            }
+                        }
+                    }
+                },
+                "azurestack": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "vhd.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-azurestack.x86_64.vhd.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-azurestack.x86_64.vhd.xz.sig",
+                                "sha256": "3f838691c79cd782e2edfcee6ac9535601f545e7a66fd16dc130a8197acf7463",
+                                "uncompressed-sha256": "d8280cdbe927eea5ac0dba4b3a72554342ca27d77fe4fff706371aa21214d62c"
+                            }
+                        }
+                    }
+                },
+                "digitalocean": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "qcow2.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-digitalocean.x86_64.qcow2.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-digitalocean.x86_64.qcow2.gz.sig",
+                                "sha256": "f125d3bcaba7e007effb668962079ed900a3e9b0d297b4bf8f271eb8bef9d55b",
+                                "uncompressed-sha256": "2385877fa45e049729fe42934c92c9aa87c09fa719068835a985b7b2a68f9da4"
+                            }
+                        }
+                    }
+                },
+                "exoscale": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-exoscale.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-exoscale.x86_64.qcow2.xz.sig",
+                                "sha256": "b06c5d56727f7f4c11514c88bf57d79feeb57d635c295014e4127cd394c5675c",
+                                "uncompressed-sha256": "4552ff6579199b604a5f36ec7f571f96e6b35c77b898abe4740385ce2646510e"
+                            }
                         }
                     }
                 },
                 "gcp": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "tar.gz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-gcp.x86_64.tar.gz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-gcp.x86_64.tar.gz.sig",
+                                "sha256": "a96e86d749cadd0324f2408407953a7191f4903ca774bb49f9cceba4aea1b98b",
+                                "uncompressed-sha256": "2bd549b51ddcf9011f85d7c4b2588c06521ab85d8c6a2eb4fe090c327775c3ae"
+                            }
+                        }
+                    }
+                },
+                "ibmcloud": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-ibmcloud.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-ibmcloud.x86_64.qcow2.xz.sig",
+                                "sha256": "10c4bbbff4fba642ab7624b0a8903ffd20759c0cfec10316cfe013d6289a81df",
+                                "uncompressed-sha256": "ff34dea85b9b33f51d58127b9c3313fff5613bc8e955c5071118c9d1e5864650"
+                            }
+                        }
+                    }
+                },
+                "metal": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "4k.raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-metal4k.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-metal4k.x86_64.raw.xz.sig",
+                                "sha256": "0d32550899a817c7aaa90ff076e7c1039f7e4b7bb75c5fcf96a2f5cf56967fca",
+                                "uncompressed-sha256": "e45f4b8ac7739b4b8fff3cea7957739ba9d7207acb14dc639d4f2cd31a3f994c"
+                            }
+                        },
+                        "iso": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-live.x86_64.iso",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-live.x86_64.iso.sig",
+                                "sha256": "3242cc627e0e5bbfb686082b42922fffee156e1c8e81006ed261662c88d26595"
+                            }
+                        },
+                        "pxe": {
+                            "kernel": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-live-kernel-x86_64",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-live-kernel-x86_64.sig",
+                                "sha256": "0e40e905b6f7ad05d811f35a5a3694749ec82cac0e73001961d396f7cb689b69"
+                            },
+                            "initramfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-live-initramfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-live-initramfs.x86_64.img.sig",
+                                "sha256": "38fa7245812f4b58ca8f086ee4098d06e3810a18433b970ee79b7b05e941151e"
+                            },
+                            "rootfs": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-live-rootfs.x86_64.img",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-live-rootfs.x86_64.img.sig",
+                                "sha256": "b3a8e6eab22b6905a85494ac1d810a03fba3db3cf1e71fde26a2f9dc70afd4dc"
+                            }
+                        },
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-metal.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-metal.x86_64.raw.xz.sig",
+                                "sha256": "04d5ecdce6e8d1900897b4a19eb04637e0d9cb942f85d5ce3269a8f1b134f365",
+                                "uncompressed-sha256": "c3778bf62397e53ce8f0ee2c02216e7438712bb9e87315288397d5283b3cece7"
+                            }
+                        }
+                    }
+                },
+                "nutanix": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-nutanix.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-nutanix.x86_64.qcow2.xz.sig",
+                                "sha256": "bfcbf7c7d1f728c0ebd0b947fe2af30d9b48aaad3f20fe0f9e75e34a10aa06bc",
+                                "uncompressed-sha256": "d2a589580e35dc8cd21ae2f49f489162a713ce01d234252a100862a8394ee042"
+                            }
+                        }
+                    }
+                },
+                "openstack": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-openstack.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-openstack.x86_64.qcow2.xz.sig",
+                                "sha256": "cd2a135355ad4afdfb26c3854c839dc49656c5ec1b2222dfe9a9d4321a676f55",
+                                "uncompressed-sha256": "dc1d6c26e6d2e8d8c3e1e50788590bd8227ca56ecfcaf565a29f98d1ca811970"
+                            }
+                        }
+                    }
+                },
+                "qemu": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "qcow2.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-qemu.x86_64.qcow2.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-qemu.x86_64.qcow2.xz.sig",
+                                "sha256": "163c4af5e4e9068ceda21204b6f81fa245624f6d338ea0693f530904c70680a4",
+                                "uncompressed-sha256": "ddcaf1eedf0e9fb87c5e0a953f7a44fedbce69d92db4ee9a13c2c7bc44cd3b3d"
+                            }
+                        }
+                    }
+                },
+                "vmware": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "ova": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-vmware.x86_64.ova",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-vmware.x86_64.ova.sig",
+                                "sha256": "12b98cabe0a3c28507939b2cde34a5cb7d3578a504b31e70085c310b6e5ab7be"
+                            }
+                        }
+                    }
+                },
+                "vultr": {
+                    "release": "35.20220116.2.0",
+                    "formats": {
+                        "raw.xz": {
+                            "disk": {
+                                "location": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-vultr.x86_64.raw.xz",
+                                "signature": "https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/35.20220116.2.0/x86_64/fedora-coreos-35.20220116.2.0-vultr.x86_64.raw.xz.sig",
+                                "sha256": "e9e88e3bdb6cdf91f09764b8b88e474352cb12b2adb950587672033d1a59f1b3",
+                                "uncompressed-sha256": "2138096786067530288b792a0e6cffbe30dcd5c4bd6a558d4e05c54c2614c0ad"
+                            }
+                        }
+                    }
+                }
+            },
+            "images": {
+                "aws": {
+                    "regions": {
+                        "af-south-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-09f8b95aee5e10f8b"
+                        },
+                        "ap-east-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0640906292345fac5"
+                        },
+                        "ap-northeast-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-000af6e1eecdc7d59"
+                        },
+                        "ap-northeast-2": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-005b08282f7a05476"
+                        },
+                        "ap-northeast-3": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0222ee6667f65610d"
+                        },
+                        "ap-south-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-05e15d8a22a211cfa"
+                        },
+                        "ap-southeast-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0c9db8e9f9fdcb566"
+                        },
+                        "ap-southeast-2": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0af39db22ec94d273"
+                        },
+                        "ap-southeast-3": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0f9e4972d7c69afa4"
+                        },
+                        "ca-central-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-04617ba7aad3fc2e2"
+                        },
+                        "eu-central-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-07419df16ada0d009"
+                        },
+                        "eu-north-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-03acda6598862ab03"
+                        },
+                        "eu-south-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0f84218fe6e8c9713"
+                        },
+                        "eu-west-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-04898ac5d067fec36"
+                        },
+                        "eu-west-2": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-03734e27114a0e1d3"
+                        },
+                        "eu-west-3": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-05f8208e9f85293b1"
+                        },
+                        "me-south-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-018dccf45559727fc"
+                        },
+                        "sa-east-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0f50f95e85aa72bd2"
+                        },
+                        "us-east-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-057b914c6a3f3f487"
+                        },
+                        "us-east-2": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-0096f4d2aa50ff59f"
+                        },
+                        "us-west-1": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-08a9b0f75a2eff517"
+                        },
+                        "us-west-2": {
+                            "release": "35.20220116.2.0",
+                            "image": "ami-05db154fcdc28999a"
+                        }
+                    }
+                },
+                "gcp": {
+                    "release": "35.20220116.2.0",
                     "project": "fedora-coreos-cloud",
-                    "family": "fedora-coreos-stable",
-                    "name": "fedora-coreos-34-20210626-3-1-gcp-x86-64"
+                    "family": "fedora-coreos-testing",
+                    "name": "fedora-coreos-35-20220116-2-0-gcp-x86-64"
                 }
             }
         }


### PR DESCRIPTION
4.10/4.11 OS has moved to F35, this PR updates initial FCOS for master branch to latest testing-devel FCOS