### PR TITLE
Bug 2045916: IBMCloud: Stop defaulting to dedicated storage profile

### DIFF
--- a/data/data/ibmcloud/variables-ibmcloud.tf
+++ b/data/data/ibmcloud/variables-ibmcloud.tf
@@ -11,7 +11,7 @@ variable "ibmcloud_api_key" {
 
 variable "ibmcloud_bootstrap_instance_type" {
   type        = string
-  description = "Instance type for the bootstrap node. Example: `bx2d-4x16`"
+  description = "Instance type for the bootstrap node. Example: `bx2-4x16`"
 }
 
 variable "ibmcloud_cis_crn" {
@@ -26,7 +26,7 @@ variable "ibmcloud_region" {
 
 variable "ibmcloud_master_instance_type" {
   type        = string
-  description = "Instance type for the master node(s). Example: `bx2d-4x16`"
+  description = "Instance type for the master node(s). Example: `bx2-4x16`"
 }
 
 variable "ibmcloud_master_availability_zones" {

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -118,7 +118,7 @@ func defaultGCPMachinePoolPlatform() gcptypes.MachinePool {
 
 func defaultIBMCloudMachinePoolPlatform() ibmcloudtypes.MachinePool {
 	return ibmcloudtypes.MachinePool{
-		InstanceType: "bx2d-4x16",
+		InstanceType: "bx2-4x16",
 	}
 }
 


### PR DESCRIPTION
Move off the dedicated storage machine profile, as it has shown to
be less reliable for provisioning on IBM Cloud.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2045916