### PR TITLE
Bug 2046181: baremetal: wait for image-customization to come up

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -3,6 +3,9 @@ set -ex
 
 . /usr/local/bin/release-image.sh
 
+# Must match ironic.service
+EXIT_CODE_NO_RESTART=42
+
 IRONIC_IMAGE=$(image_for ironic)
 IRONIC_AGENT_IMAGE=$(image_for ironic-agent)
 CUSTOMIZATION_IMAGE=$(image_for image-customization-controller)
@@ -241,6 +244,13 @@ podman run -d --name ironic-ramdisk-logs \
      --restart on-failure \
      --entrypoint /bin/runlogwatch.sh \
      -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
+
+# Failure to start image-customization results in a very confusing error
+icc_id=$(podman ps --filter name=image-customization --filter status=running --format '{{`{{.ID}}`}}')
+if [ -z "$icc_id" ]; then
+    echo The image-customization service crashed after start, check its logs
+    exit $EXIT_CODE_NO_RESTART
+fi
 
 set +x
 AUTH_DIR=/opt/metal3/auth

--- a/data/data/bootstrap/baremetal/systemd/units/ironic.service
+++ b/data/data/bootstrap/baremetal/systemd/units/ironic.service
@@ -11,6 +11,8 @@ RemainAfterExit=yes
 
 Restart=on-failure
 RestartSec=10
+# Used in startironic.sh to indicate a fatal failure
+RestartPreventExitStatus=42
 TimeoutStartSec=600
 
 [Install]


### PR DESCRIPTION
It crashes if the provided network configuration is invalid. In this
case inspection currently fails with a generic message.
