### PR TITLE
cmd/openshift-install/create: Do not attempt analysis when we fail to gather logs

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -66,11 +66,14 @@ func newGatherBootstrapCmd() *cobra.Command {
 			if err != nil {
 				logrus.Fatal(err)
 			}
+
 			if !gatherBootstrapOpts.skipAnalysis {
 				if err := service.AnalyzeGatherBundle(bundlePath); err != nil {
 					logrus.Fatal(err)
 				}
 			}
+
+			logrus.Infof("Bootstrap gather logs captured here %q", bundlePath)
 		},
 	}
 	cmd.PersistentFlags().StringVar(&gatherBootstrapOpts.bootstrap, "bootstrap", "", "Hostname or IP of the bootstrap host")
@@ -135,10 +138,10 @@ func runGatherBootstrapCmd(directory string) (string, error) {
 		return "", errors.New("must provide both bootstrap host address and at least one control plane host address when providing one")
 	}
 
-	return logGatherBootstrap(bootstrap, port, masters, directory)
+	return gatherBootstrap(bootstrap, port, masters, directory)
 }
 
-func logGatherBootstrap(bootstrap string, port int, masters []string, directory string) (string, error) {
+func gatherBootstrap(bootstrap string, port int, masters []string, directory string) (string, error) {
 	logrus.Info("Pulling debug logs from the bootstrap machine")
 	client, err := ssh.NewClient("core", net.JoinHostPort(bootstrap, strconv.Itoa(port)), gatherBootstrapOpts.sshKeys)
 	if err != nil {
@@ -160,7 +163,6 @@ func logGatherBootstrap(bootstrap string, port int, masters []string, directory 
 	if err != nil {
 		return "", errors.Wrap(err, "failed to stat log file")
 	}
-	logrus.Infof("Bootstrap gather logs captured here %q", path)
 	return path, nil
 }
 


### PR DESCRIPTION
Adding a conditional that we overlooked in fdb04a76e50d (#4751).  This will avoid distractions [like][1]:

```
level=error msg=Attempted to gather debug logs after installation failure: bootstrap host address and at least one control plane host address must be provided
...
level=error msg=Attempted to analyze the debug logs after installation failure: could not open the gather bundle: open : no such file or directory
```

where the first line usefully explains that we failed to gather the log bundle, while the second line uselessly adds that without a log bundle, there can be no log bundle analysis.

In a separate commit, I'm shifting #4800's:

```go
logrus.Error("Bootstrap failed to complete: ", err.Unwrap())
logrus.Error(err.Error())
```

to move them out from between the gather and gather-analysis commands.  There are a few options for where to move them too, and I explain my motivation for my choice in f6db6b84d030, but I have no problem with folks telling me they disagree and where I should put them instead, as long as it's not "right between the two gather steps" ;)

[1]: https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-ovirt-ovn/1486127081728249856#1:build-log.txt%3A50
