### PR TITLE
Bug 2047258: Read GovCloud from RHCOS stream

### DIFF
--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -54,7 +54,7 @@ func ValidateAMIID(platform *aws.Platform, p *aws.MachinePool, fldPath *field.Pa
 
 	// regions is a list of regions for which the user should set AMI ID as copying the AMI to these regions
 	// is known to not be supported.
-	regions := sets.NewString("us-gov-west-1", "us-gov-east-1", "us-iso-east-1", "cn-north-1", "cn-northwest-1")
+	regions := sets.NewString("us-iso-east-1", "cn-north-1", "cn-northwest-1")
 	if pool.AMIID == "" && regions.Has(platform.Region) {
 		allErrs = append(allErrs, field.Required(fldPath, fmt.Sprintf("AMI ID must be provided for regions %s", strings.Join(regions.List(), ", "))))
 	}

--- a/pkg/types/aws/validation/machinepool_test.go
+++ b/pkg/types/aws/validation/machinepool_test.go
@@ -89,9 +89,6 @@ func Test_validateAMIID(t *testing.T) {
 	}{{
 		platform: &aws.Platform{Region: "us-east-1"},
 	}, {
-		platform: &aws.Platform{Region: "us-gov-east-1"},
-		err:      `^test-path: Required value: AMI ID must be provided for regions .*$`,
-	}, {
 		platform: &aws.Platform{Region: "cn-north-1"},
 		err:      `^test-path: Required value: AMI ID must be provided for regions .*$`,
 	}, {


### PR DESCRIPTION
AMIs for GovCloud regions have been added to the RHCOS stream. Remove
validation requiring users to provide an AMI.