### PR TITLE
Bug 2047455: Update custom image os type

### DIFF
--- a/data/data/ibmcloud/network/image/main.tf
+++ b/data/data/ibmcloud/network/image/main.tf
@@ -31,7 +31,7 @@ resource "ibm_is_image" "image" {
 
   name             = var.name
   href             = "cos://${ibm_cos_bucket.images.region_location}/${ibm_cos_bucket.images.bucket_name}/${ibm_cos_bucket_object.file.key}"
-  operating_system = "centos-8-amd64"
+  operating_system = "fedora-coreos-stable-amd64"
   resource_group   = var.resource_group_id
   tags             = var.tags
 }


### PR DESCRIPTION
Changing custom image os type to `fedora-coreos-stable-amd64` (a better choice that `centos-8-amd64`).

A correct `rchos` os type will be set once support is added. The support being the ability to set os type to `rhcos` on a custom image. That support should be coming soon (likely in time for 4.11).

Note: the actual image being used IS a RHCOS image. This is an os type labelling issue due to having to import it as a custom image for usage on IBM Cloud VPC.