### PR TITLE
Bug 2048222: Remove non-public AWS regions from list of regions

### DIFF
--- a/pkg/asset/installconfig/aws/regions.go
+++ b/pkg/asset/installconfig/aws/regions.go
@@ -14,12 +14,9 @@ func knownRegions(architecture types.Architecture) map[string]string {
 	required := rhcos.AMIRegions(architecture)
 
 	regions := make(map[string]string)
-	for _, partition := range endpoints.DefaultPartitions() {
-		for _, partitionRegion := range partition.Regions() {
-			partitionRegion := partitionRegion
-			if required.Has(partitionRegion.ID()) {
-				regions[partitionRegion.ID()] = partitionRegion.Description()
-			}
+	for _, region := range endpoints.AwsPartition().Regions() {
+		if required.Has(region.ID()) {
+			regions[region.ID()] = region.Description()
 		}
 	}
 	return regions


### PR DESCRIPTION
When creating the install-config, the installer displays regions
of all partitions of AWS. Certain regions also need extra information
for the validation to work and should not be taken as input since we
only ask for the bare minimum amount of information to create the
install config.

The best approach here would be to only display all the public regions
of AWS and allow for other regions after the install-config is created
to allow for the user to add the extra information.