### PR TITLE
Bug 1926975: Add cloudProviderConfigDataKey to cloud-provider-config map in AWS C2S

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -99,7 +99,10 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			return nil
 		}
 		cm.Data[cloudProviderConfigCABundleDataKey] = trustBundle
-                // Add DataKey to address BZ 1926975. The newline is required or the yaml is invalid
+                // Include a non-empty kube config to appease components--such as the kube-apiserver--that
+                // expect there to be a kube config if the cloud-provider-config ConfigMap exists. See
+                // https://bugzilla.redhat.com/show_bug.cgi?id=1926975.
+                // Note that the newline is required in order to be valid yaml.
                 cm.Data[cloudProviderConfigDataKey] = `[Global]
 `
 	case alibabacloudtypes.Name:

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -99,6 +99,9 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			return nil
 		}
 		cm.Data[cloudProviderConfigCABundleDataKey] = trustBundle
+                // Add DataKey to address BZ 1926975. The newline is required or the yaml is invalid
+                cm.Data[cloudProviderConfigDataKey] = `[Global]
+`
 	case alibabacloudtypes.Name:
 		alibabacloudConfig, err := alibabacloudmanifests.CloudConfig{
 			Global: alibabacloudmanifests.GlobalConfig{

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -99,11 +99,11 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			return nil
 		}
 		cm.Data[cloudProviderConfigCABundleDataKey] = trustBundle
-                // Include a non-empty kube config to appease components--such as the kube-apiserver--that
-                // expect there to be a kube config if the cloud-provider-config ConfigMap exists. See
-                // https://bugzilla.redhat.com/show_bug.cgi?id=1926975.
-                // Note that the newline is required in order to be valid yaml.
-                cm.Data[cloudProviderConfigDataKey] = `[Global]
+		// Include a non-empty kube config to appease components--such as the kube-apiserver--that
+		// expect there to be a kube config if the cloud-provider-config ConfigMap exists. See
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1926975.
+		// Note that the newline is required in order to be valid yaml.
+		cm.Data[cloudProviderConfigDataKey] = `[Global]
 `
 	case alibabacloudtypes.Name:
 		alibabacloudConfig, err := alibabacloudmanifests.CloudConfig{


### PR DESCRIPTION
resolve BZ 1926975

I have tested this fix in C2S and it resolves the issue. The newline looks strange but is needed to generate properly formatted yaml. It is similar to the newlines here: pkg/asset/manifests/openstack/cloudproviderconfig.go