### PR TITLE
aws: support the entirety of the secret partitions

### DIFF
--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -58,7 +58,7 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 		}
 
 		// Add delete permissions for non-C2S installs.
-		if !aws.C2SRegions.Has(ic.Config.AWS.Region) {
+		if !aws.IsSecretRegion(ic.Config.AWS.Region) {
 			permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteBase)
 			if usingExistingVPC {
 				permissionGroups = append(permissionGroups, awsconfig.PermissionDeleteSharedNetworking)

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -95,7 +95,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 	case awstypes.Name:
 		// Store the additional trust bundle in the ca-bundle.pem key if the cluster is being installed on a C2S region.
 		trustBundle := installConfig.Config.AdditionalTrustBundle
-		if trustBundle == "" || !awstypes.C2SRegions.Has(installConfig.Config.AWS.Region) {
+		if trustBundle == "" || !awstypes.IsSecretRegion(installConfig.Config.AWS.Region) {
 			return nil
 		}
 		cm.Data[cloudProviderConfigCABundleDataKey] = trustBundle

--- a/pkg/asset/tls/cloudprovidercabundle.go
+++ b/pkg/asset/tls/cloudprovidercabundle.go
@@ -33,7 +33,7 @@ func (a *CloudProviderCABundle) Generate(deps asset.Parents) error {
 	if ic.Config.Platform.Name() != awstypes.Name {
 		return nil
 	}
-	if !awstypes.C2SRegions.Has(ic.Config.Platform.AWS.Region) {
+	if !awstypes.IsSecretRegion(ic.Config.Platform.AWS.Region) {
 		return nil
 	}
 

--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -30,6 +30,7 @@ import (
 	awssession "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/destroy/providers"
 	"github.com/openshift/installer/pkg/types"
+	awstypes "github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/version"
 )
 
@@ -101,8 +102,7 @@ func (o *ClusterUninstaller) validate() error {
 	if len(o.Filters) == 0 {
 		return errors.Errorf("you must specify at least one tag filter")
 	}
-	switch r := o.Region; r {
-	case "us-iso-east-1":
+	if r := o.Region; awstypes.IsSecretRegion(r) {
 		return errors.Errorf("cannot destroy cluster in region %q", r)
 	}
 	return nil

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -1,11 +1,6 @@
 package aws
 
-import "k8s.io/apimachinery/pkg/util/sets"
-
-var (
-	// C2SRegions are the C2S AWS regions.
-	C2SRegions = sets.NewString("us-iso-east-1")
-)
+import "github.com/aws/aws-sdk-go/aws/endpoints"
 
 // Platform stores all the global configuration that all machinesets
 // use.
@@ -73,4 +68,17 @@ type ServiceEndpoint struct {
 	//
 	// +kubebuilder:validation:Pattern=`^https://`
 	URL string `json:"url"`
+}
+
+// IsSecretRegion returns true if the region is part of either the ISO or ISOB partitions.
+func IsSecretRegion(region string) bool {
+	partition, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region)
+	if !ok {
+		return false
+	}
+	switch partition.ID() {
+	case endpoints.AwsIsoPartitionID, endpoints.AwsIsoBPartitionID:
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
When C2S support was added, there was only the one region, us-iso-east-1, in the C2S partition. The us-iso-west-1 region is being added. The installer should be able to support new regions in the partition without requiring code changes going forward, just like it does for the public partition.

Additionally, the installer should be able to support the SC2S partition, as it has all of the same conditional behavior as the C2S partition does.