### PR TITLE
Bug 2050146: Don't shortcut OpenStack scraping if quota is unavailable

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/cloudinfo.go
+++ b/pkg/asset/installconfig/openstack/validation/cloudinfo.go
@@ -211,13 +211,11 @@ func (ci *CloudInfo) collectInfo(ic *types.InstallConfig, opts *clientconfig.Cli
 	if err != nil {
 		if isUnauthorized(err) {
 			logrus.Warnf("Missing permissions to fetch Quotas and therefore will skip checking them: %v", err)
-			return nil
-		}
-		if isNotFoundError(err) {
+		} else if isNotFoundError(err) {
 			logrus.Warnf("Quota API is not available and therefore will skip checking them: %v", err)
-			return nil
+		} else {
+			return errors.Wrap(err, "failed to load Quota")
 		}
-		return errors.Wrap(err, "failed to load Quota")
 	}
 
 	ci.NetworkExtensions, err = networkextensions.Get(ci.clients.networkClient)


### PR DESCRIPTION
This results in an incorrect failure to validate network capabilities
because network extensions weren't loaded.