### PR TITLE
Bug 2050767: vsphere: check that network exist in provisioning validation

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation_test.go
+++ b/pkg/asset/installconfig/vsphere/validation_test.go
@@ -42,27 +42,6 @@ func validIPIInstallConfig() *types.InstallConfig {
 	}
 }
 
-func validUPIInstallConfig() *types.InstallConfig {
-	return &types.InstallConfig{
-		Networking: &types.Networking{
-			MachineNetwork: []types.MachineNetworkEntry{
-				{CIDR: *ipnet.MustParseCIDR(validCIDR)},
-			},
-		},
-		Publish: types.ExternalPublishingStrategy,
-		Platform: types.Platform{
-			VSphere: &vsphere.Platform{
-				Datacenter:       "valid_dc",
-				DefaultDatastore: "valid_ds",
-				Password:         "valid_password",
-				Username:         "valid_username",
-				VCenter:          "valid-vcenter",
-				Network:          "valid_network",
-			},
-		},
-	}
-}
-
 func TestValidate(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -70,10 +49,6 @@ func TestValidate(t *testing.T) {
 		validationMethod func(Finder, *types.InstallConfig) error
 		expectErr        string
 	}{{
-		name:             "valid UPI install config",
-		installConfig:    validUPIInstallConfig(),
-		validationMethod: validateResources,
-	}, {
 		name:             "valid IPI install config",
 		installConfig:    validIPIInstallConfig(),
 		validationMethod: validateProvisioning,
@@ -93,7 +68,7 @@ func TestValidate(t *testing.T) {
 			c.Platform.VSphere.Datacenter = "invalid_dc"
 			return c
 		}(),
-		validationMethod: validateResources,
+		validationMethod: validateProvisioning,
 		expectErr:        `^platform.vsphere.network: Invalid value: "invalid_dc": 404$`,
 	}, {
 		name: "invalid IPI - invalid network",
@@ -102,7 +77,7 @@ func TestValidate(t *testing.T) {
 			c.Platform.VSphere.Network = "invalid_network"
 			return c
 		}(),
-		validationMethod: validateResources,
+		validationMethod: validateProvisioning,
 		expectErr:        `^platform.vsphere.network: Invalid value: "invalid_network": unable to find network provided$`,
 	}, {
 		name: "invalid IPI - no cluster",


### PR DESCRIPTION
Do not check for the existince of the vSphere network until the pre-provision checks. For UPI installs, the network may be created as part of provisioning the infrastructure, and so it may not exist when the manifests are created.