### PR TITLE
Bug 2047257: openstack: Migration script should --force drain

### DIFF
--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -725,7 +725,7 @@ readonly server_id
 
 # Drain the node
 oc adm cordon "$node_name"
-oc adm drain "$node_name" --delete-emptydir-data --ignore-daemonsets
+oc adm drain "$node_name" --delete-emptydir-data --ignore-daemonsets --force
 
 # Power off the server
 oc debug "node/${node_name}" -- chroot /host shutdown -h 1


### PR DESCRIPTION
Before this patch, the migration would sometimes fail with the following
error:

```
cannot delete Pods not managed by ReplicationController, ReplicaSet,
Job, DaemonSet or StatefulSet (use --force to override)
```