### PR TITLE
Update user provided tags in infra PlatformSpec

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -106,7 +106,6 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 	switch installConfig.Config.Platform.Name() {
 	case aws.Name:
 		config.Spec.PlatformSpec.Type = configv1.AWSPlatformType
-		config.Spec.PlatformSpec.AWS = &configv1.AWSPlatformSpec{}
 
 		var resourceTags []configv1.AWSResourceTag
 		if installConfig.Config.AWS.ExperimentalPropagateUserTag {
@@ -117,6 +116,9 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 		}
 		config.Status.PlatformStatus.AWS = &configv1.AWSPlatformStatus{
 			Region:       installConfig.Config.Platform.AWS.Region,
+			ResourceTags: resourceTags,
+		}
+		config.Spec.PlatformSpec.AWS = &configv1.AWSPlatformSpec{
 			ResourceTags: resourceTags,
 		}
 

--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -107,16 +107,15 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 	case aws.Name:
 		config.Spec.PlatformSpec.Type = configv1.AWSPlatformType
 
-		var resourceTags []configv1.AWSResourceTag
-		if installConfig.Config.AWS.ExperimentalPropagateUserTag {
-			resourceTags = make([]configv1.AWSResourceTag, 0, len(installConfig.Config.AWS.UserTags))
-			for k, v := range installConfig.Config.AWS.UserTags {
-				resourceTags = append(resourceTags, configv1.AWSResourceTag{Key: k, Value: v})
-			}
+		resourceTags := make([]configv1.AWSResourceTag, 0, len(installConfig.Config.AWS.UserTags))
+		for k, v := range installConfig.Config.AWS.UserTags {
+			resourceTags = append(resourceTags, configv1.AWSResourceTag{Key: k, Value: v})
 		}
 		config.Status.PlatformStatus.AWS = &configv1.AWSPlatformStatus{
 			Region:       installConfig.Config.Platform.AWS.Region,
-			ResourceTags: resourceTags,
+		}
+		if installConfig.Config.AWS.ExperimentalPropagateUserTag {
+			config.Status.PlatformStatus.AWS.ResourceTags = resourceTags
 		}
 		config.Spec.PlatformSpec.AWS = &configv1.AWSPlatformSpec{
 			ResourceTags: resourceTags,

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -56,6 +56,29 @@ spec:
                       description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
                       type: object
                       properties:
+                        resourceTags:
+                          description: ResourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user. While ResourceTags field is mutable, items can not be removed.
+                          type: array
+                          maxItems: 25
+                          items:
+                            description: AWSResourceTag is a tag to apply to AWS resources created for the cluster.
+                            type: object
+                            required:
+                              - key
+                              - value
+                            properties:
+                              key:
+                                description: key is the key of the tag
+                                type: string
+                                maxLength: 128
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              value:
+                                description: value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.
+                                type: string
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
                         serviceEndpoints:
                           description: serviceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
                           type: array

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -343,6 +343,15 @@ type AWSPlatformSpec struct {
 	// There must be only one ServiceEndpoint for a service.
 	// +optional
 	ServiceEndpoints []AWSServiceEndpoint `json:"serviceEndpoints,omitempty"`
+
+	// ResourceTags is a list of additional tags to apply to AWS resources created for the cluster.
+	// See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources.
+	// AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags
+	// available for the user.
+	// While ResourceTags field is mutable, items can not be removed.
+	// +kubebuilder:validation:MaxItems=25
+	// +optional
+	ResourceTags []AWSResourceTag `json:"resourceTags,omitempty"`
 }
 
 // AWSPlatformStatus holds the current status of the Amazon Web Services infrastructure provider.

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.deepcopy.go
@@ -187,6 +187,11 @@ func (in *AWSPlatformSpec) DeepCopyInto(out *AWSPlatformSpec) {
 		*out = make([]AWSServiceEndpoint, len(*in))
 		copy(*out, *in)
 	}
+	if in.ResourceTags != nil {
+		in, out := &in.ResourceTags, &out.ResourceTags
+		*out = make([]AWSResourceTag, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -885,6 +885,7 @@ func (RepositoryDigestMirrors) SwaggerDoc() map[string]string {
 var map_AWSPlatformSpec = map[string]string{
 	"":                 "AWSPlatformSpec holds the desired state of the Amazon Web Services infrastructure provider. This only includes fields that can be modified in the cluster.",
 	"serviceEndpoints": "serviceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.",
+	"resourceTags":     "ResourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user. While ResourceTags field is mutable, items can not be removed.",
 }
 
 func (AWSPlatformSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Populate resourceTags in PlatformSpec of Infrastructure CR with the userTags from the install_config when platform type is AWS.
This change is required for the [RFE-2012](https://issues.redhat.com/browse/RFE-2012) to support updating of userTags.