### PR TITLE
data/manifests/bootkube/cvo-overrides: Default to stable-4.11

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -8,6 +8,6 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-4
 {{- else }}
-  channel: stable-4.10
+  channel: stable-4.11
 {{- end }}
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
Like d1bf677d62 (#5312) and earlier, now that 4.10 has forked off from the development branch.
