### PR TITLE
Switch libvirt VM's to vnc graphic mode

### DIFF
--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -70,4 +70,9 @@ resource "libvirt_domain" "bootstrap" {
       mac    = network_interface.value["mac"]
     }
   }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
 }

--- a/data/data/libvirt/bootstrap/main.tf
+++ b/data/data/libvirt/bootstrap/main.tf
@@ -43,5 +43,10 @@ resource "libvirt_domain" "bootstrap" {
     hostname   = "${var.cluster_id}-bootstrap.${var.cluster_domain}"
     addresses  = [var.libvirt_bootstrap_ip]
   }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
 }
 

--- a/data/data/libvirt/cluster/main.tf
+++ b/data/data/libvirt/cluster/main.tf
@@ -99,6 +99,11 @@ resource "libvirt_domain" "master" {
     hostname   = "${var.cluster_id}-master-${count.index}.${var.cluster_domain}"
     addresses  = [var.libvirt_master_ips[count.index]]
   }
+
+  graphics {
+    type        = "vnc"
+    listen_type = "address"
+  }
 }
 
 data "libvirt_network_dns_host_template" "bootstrap" {


### PR DESCRIPTION
terraform-provider-libvirt defaults to using spice, spice is
now discontinued in RHEL and Centos 9. Switch to vnc which
is commonly supported.


Error when using CentOS Stream 9 as a virt host
level=debug msg=2022/02/08 06:32:10 

> [DEBUG] libvirt_domain.bootstrap: apply errored, but we're indicating that via the Error pointer rather than returning it: Error defining libvirt domain: virError(Code=67, Domain=10, Message='unsupported configuration: spice graphics are not supported with this QEMU')

See https://access.redhat.com/solutions/5414901