### PR TITLE
Bug 2035642: Report bootstrap is complete only when the bootstrap static pod is no longer used

### DIFF
--- a/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
+++ b/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
@@ -50,6 +50,13 @@ function wait_for_cvo {
   done
 }
 
+function report_bootstrap_complete {
+  while ! oc create cm -n kube-system  bootstrap --from-literal=status=complete --dry-run=client -o yaml | kubectl apply -f -
+  do
+    sleep 5
+  done
+}
+
 function clean {
   if [ -d "/etc/kubernetes/bootstrap-secrets" ]; then
      rm -rf /etc/kubernetes/bootstrap-*
@@ -65,5 +72,6 @@ function clean {
 wait_for_api
 approve_csr
 restart_kubelet
+report_bootstrap_complete
 wait_for_cvo
 clean

--- a/data/data/bootstrap/files/usr/local/bin/report-progress.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/report-progress.sh.template
@@ -26,7 +26,11 @@ while ! oc --kubeconfig="$KUBECONFIG" create -f - <<-EOF
 	  name: bootstrap
 	  namespace: kube-system
 	data:
+{{- if .BootstrapInPlace }}
+	  status: bootstrap-in-place
+{{ else }}
 	  status: complete
+{{ end -}}
 EOF
 do
 	sleep 5


### PR DESCRIPTION
From time to time Single node installation with bootstrap in place fails.
When the installation fails after the bootstrap phase is complete and prior of having a running kube-apiserver we fail to get the logs.

This change updates the progress-report script to not report that the bootstrap is complete, instead it will set the status to `bootstrap-in-place`.
The status will get updated to complete in a later phase once the OCP kube-apiserver is running.
This will prolong the time the installer waits for bootstrap to complete, and in case the installation fails while the bootstrap before we have a running OCP kube-apiserver the installer will fall back to execute installer-gather and get the relevant logs.

