### PR TITLE
Bug 2046181: baremetal: reduce API timeout to 15 minutes

### DIFF
--- a/data/data/baremetal/bootstrap/main.tf
+++ b/data/data/baremetal/bootstrap/main.tf
@@ -6,7 +6,7 @@ provider "ironic" {
   url                = var.ironic_uri
   inspector          = var.inspector_uri
   microversion       = "1.56"
-  timeout            = 3600
+  timeout            = 900
   auth_strategy      = "http_basic"
   ironic_username    = var.ironic_username
   ironic_password    = var.ironic_password


### PR DESCRIPTION
There is no point in waiting 1 hours for Ironic API to start: even given
the bootstrap VM start-up, it takes much less. Currently, users have to
wait 1 hour to learn that API failed to start for some reason (e.g.
because the network config has an error).
