### PR TITLE
OWNERS_ALIASES: Drop wking from approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,7 +8,6 @@ aliases:
     - staebler
     - sdodson
     - smarterclayton
-    - wking
   installer-reviewers:
     - jhixson74
     - jstuever


### PR DESCRIPTION
I've been outside the installer for long enough now, that even when I'm pretty confident about a change, I don't think I'd approve anything without someone who's still on the team weighing in.  Dropping myself from the approver set makes that machine-readable ;).
