### PR TITLE
ipi/vsphere: improve permission error messages

### DIFF
--- a/terraform/providers/vsphere/vendor/github.com/hashicorp/terraform-provider-vsphere/vsphere/resource_vsphere_tag.go
+++ b/terraform/providers/vsphere/vendor/github.com/hashicorp/terraform-provider-vsphere/vsphere/resource_vsphere_tag.go
@@ -57,6 +57,13 @@ func resourceVSphereTagCreate(d *schema.ResourceData, meta interface{}) error {
 	defer cancel()
 	id, err := tm.CreateTag(ctx, spec)
 	if err != nil {
+		if strings.Contains(err.Error(), "403 Forbidden") {
+			permissionMessage := `[permission denied] could not create category! Check if the user has the required privileges on:
+			vSphere Tagging
+			*  Create vSphere Tag
+	    `
+			return fmt.Errorf("%s %s", permissionMessage, err)
+		}
 		return fmt.Errorf("could not create tag: %s", err)
 	}
 	if id == "" {

--- a/terraform/providers/vsphere/vendor/github.com/hashicorp/terraform-provider-vsphere/vsphere/resource_vsphere_tag_category.go
+++ b/terraform/providers/vsphere/vendor/github.com/hashicorp/terraform-provider-vsphere/vsphere/resource_vsphere_tag_category.go
@@ -89,6 +89,13 @@ func resourceVSphereTagCategoryCreate(d *schema.ResourceData, meta interface{}) 
 	defer cancel()
 	id, err := tm.CreateCategory(ctx, spec)
 	if err != nil {
+		if strings.Contains(err.Error(), "403 Forbidden") {
+			permissionMessage := `[permission denied] could not create category! Check if the user has the required privileges on:
+			vSphere Tagging
+			*  Create vSphere Tag Category
+	    `
+			return fmt.Errorf("%s %s", permissionMessage, err)
+		}
 		return fmt.Errorf("could not create category: %s", err)
 	}
 	if id == "" {


### PR DESCRIPTION
Make it easier to find the missing privileges in case of an error on vSphere installations.
Maybe not the best way to implement it, as it is parsing the error messages (string)
to provide better output, but this is the only way that I could find considering
that the VMware vSphere API is not public, so we cannot make any changes to it.


Proposal implementation for https://issues.redhat.com/browse/RFE-1965
