### PR TITLE
GCP may also return Forbidden status when trying to check quotas

### DIFF
--- a/pkg/quota/gcp/gcp.go
+++ b/pkg/quota/gcp/gcp.go
@@ -118,7 +118,7 @@ func IsUnauthorized(err error) bool {
 	}
 	var gErr *googleapi.Error
 	if errors.As(err, &gErr) {
-		return gErr.Code == http.StatusUnauthorized
+		return gErr.Code == http.StatusUnauthorized || gErr.Code == http.StatusForbidden
 	}
 
 	if grpcCode := status.Code(errors.Cause(err)); grpcCode != codes.OK {


### PR DESCRIPTION
Trying to install OCP on GCP without permission to check quotas resulted in
this error:

```
DEBUG   Generating Platform Quota Check...
FATAL failed to fetch Cluster: failed to fetch dependency of "Cluster": failed to generate asset "Platform Quota Check": failed to load Quota for services: projects/assisted-installer/services/compute.googleapis.com, projects/assisted-installer/services/iam.googleapis.com: failed to load quota limits: googleapi: Error 403: Permission denied to get quota on service [compute.googleapis.com]
FATAL Help Token: <REDACTED>
FATAL Details:
FATAL [
FATAL   {
FATAL     "@type": "type.googleapis.com/google.rpc.PreconditionFailure",
FATAL     "violations": [
FATAL       {
FATAL         "subject": "110002",
FATAL         "type": "googleapis.com"
FATAL       }
FATAL     ]
FATAL   },
FATAL   {
FATAL     "@type": "type.googleapis.com/google.rpc.ErrorInfo",
FATAL     "domain": "serviceusage.googleapis.com",
FATAL     "reason": "AUTH_PERMISSION_DENIED"
FATAL   }
FATAL ]
FATAL , forbidden
```

The code is equipped to handle these kind of errors and skip the quota
check, but it was only checking for `http.StatusUnauthorized` while evidently
Google may also return `http.StatusForbidden` as can be seen in the logs above.