### PR TITLE
Bug 2048686: Add mac address validation for hosts bootMACAddress

### DIFF
--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -36,7 +36,7 @@ type Host struct {
 	Name            string           `json:"name,omitempty" validate:"required,uniqueField"`
 	BMC             BMC              `json:"bmc"`
 	Role            string           `json:"role"`
-	BootMACAddress  string           `json:"bootMACAddress" validate:"required,uniqueField"`
+	BootMACAddress  string           `json:"bootMACAddress" validate:"required,uniqueField,mac"`
 	HardwareProfile string           `json:"hardwareProfile"`
 	RootDeviceHints *RootDeviceHints `json:"rootDeviceHints,omitempty"`
 	BootMode        BootMode         `json:"bootMode,omitempty"`

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -218,6 +218,8 @@ func validateHostsBase(hosts []*baremetal.Host, fldPath *field.Path, filter vali
 					hostErrs = append(hostErrs, field.Required(childName, "missing "+err.Field()))
 				case "uniqueField":
 					hostErrs = append(hostErrs, field.Duplicate(childName, err.Value()))
+				case "mac":
+					hostErrs = append(hostErrs, field.Invalid(childName, err.Value(), "invalid "+err.Field()))
 				}
 			}
 		}

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -206,6 +206,12 @@ func TestValidatePlatform(t *testing.T) {
 			expected: "baremetal.hosts\\[0\\].BootMACAddress: Required value: missing BootMACAddress",
 		},
 		{
+			name: "invalid_mac",
+			platform: platform().
+				Hosts(host1().BootMACAddress("00:00:00")).build(),
+			expected: "baremetal.hosts\\[0\\].BootMACAddress: Invalid value: \"00:00:00\": invalid BootMACAddress",
+		},
+		{
 			name: "duplicate_host_name",
 			platform: platform().
 				Hosts(


### PR DESCRIPTION
This PR adds mac address validation for all hosts bootMACAddress
field. If bootMACAddress is not empty, it should be in standard
mac address format.