### PR TITLE
Updated owners to current OCP on RHV members

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -74,15 +74,15 @@ aliases:
     - jhixson74
     - m1kola
   ovirt-approvers:
-    - rgolangh
-    - Gal-Zaidman
-    - eslutsky
     - janosdebugs
+    - eslutsky
+    - mmartinv
+    - bkhizgiy
   ovirt-reviewers:
-    - rgolangh
-    - Gal-Zaidman
-    - eslutsky
     - janosdebugs
+    - eslutsky
+    - mmartinv
+    - bkhizgiy
   ibmcloud-approvers:
     - bobbyradford
     - hasueki


### PR DESCRIPTION
This PR updates the ovirt-reviewers and ovirt-approvers groups to match the current OCP on RHV team structure.