### PR TITLE
Check for DeletePlacementGroup permission before destroying cluster

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -176,6 +176,7 @@ var permissions = map[PermissionGroup][]string{
 	PermissionDeleteBase: {
 		"autoscaling:DescribeAutoScalingGroups",
 		"ec2:DeleteNetworkInterface",
+		"ec2:DeletePlacementGroup",
 		"ec2:DeleteTags",
 		"ec2:DeleteVolume",
 		"elasticloadbalancing:DeleteTargetGroup",


### PR DESCRIPTION
This is a follow up to #5528 so that we ensure that the credentials provided to the installer have permission to delete the placement groups before we attempt to delete them.

This was highlighted as required by @staebler during a review of the enhancement