### PR TITLE
Bug 2034147: Validate num cores with vcpus

### DIFF
--- a/pkg/types/vsphere/validation/machinepool_test.go
+++ b/pkg/types/vsphere/validation/machinepool_test.go
@@ -53,6 +53,21 @@ func TestValidateMachinePool(t *testing.T) {
 			},
 			expectedErrMsg: `^test-path\.coresPerSocket: Invalid value: 8: cores per socket must be less than number of CPUs$`,
 		},
+		{
+			name: "numCPUs not a multiple of cores per socket",
+			pool: &vsphere.MachinePool{
+				NumCPUs:           7,
+				NumCoresPerSocket: 4,
+			},
+			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket$`,
+		},
+		{
+			name: "numCPUs not a multiple of default cores per socket",
+			pool: &vsphere.MachinePool{
+				NumCPUs: 7,
+			},
+			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket which is by default 4$`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
An error occurs if the vcpus specified is not a multiple of the
number of cores specified. A validation check is added to check
if it is indeed a multiple. The check also accounts for default
values of both the vcpus and number of cores (4 by default) in
case only one of the two is set.