### PR TITLE
Bug 2059491: [Alibaba] fix the format of Name

### DIFF
--- a/pkg/asset/machines/alibabacloud/machinesets.go
+++ b/pkg/asset/machines/alibabacloud/machinesets.go
@@ -2,7 +2,6 @@ package alibabacloud
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +44,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
-		name := fmt.Sprintf("%s-%s-%s", clusterID, pool.Name, strings.TrimPrefix(az, fmt.Sprintf("%s-", platform.Region)))
+		name := fmt.Sprintf("%s-%s-%s", clusterID, pool.Name, az)
 		mset := &machinev1beta1.MachineSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.openshift.io/v1beta1",


### PR DESCRIPTION
Not all zone IDs are connected using "-", such as the availability zone ID `ap-southeast-6a` mentioned above, and the `ap-southeast-6` is region ID.
