### PR TITLE
include conn timed out err for bootstrap collection

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -145,7 +145,7 @@ func gatherBootstrap(bootstrap string, port int, masters []string, directory str
 	logrus.Info("Pulling debug logs from the bootstrap machine")
 	client, err := ssh.NewClient("core", net.JoinHostPort(bootstrap, strconv.Itoa(port)), gatherBootstrapOpts.sshKeys)
 	if err != nil {
-		if errors.Is(err, syscall.ECONNREFUSED) {
+		if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ETIMEDOUT) {
 			return "", errors.Wrap(err, "failed to connect to the bootstrap machine")
 		}
 		return "", errors.Wrap(err, "failed to create SSH client")


### PR DESCRIPTION
When debugging a failed installation, its important to understand the constraints in which the installer failed to connect to the bootstrap node. Currently when `connection timed out` occurs, its accompanied by a logging message that indicates the ssh client failed. 

```
time="2022-03-04T00:05:49Z" level=fatal msg="failed to create SSH client: dial tcp 172.16.19.161:22: connect: connection timed out"
```

In this situation the SSH client was successful and some kind of networking condition or service ACL is causing the connection timed out, thus it should follow https://github.com/openshift/installer/blob/master/cmd/openshift-install/gather.go#L149.  This small peice of information assists SREs in hypothesising the conditions in which the installation and/or boostrap logs collection has failed. 


The below indicates to OPERATOR that SSH client failed to create but connection timed out. 
```
time="2022-03-04T00:03:37Z" level=debug msg="Using Install Config loaded from state file"
time="2022-03-04T00:03:37Z" level=debug msg="Reusing previously-fetched Install Config"
time="2022-03-04T00:03:37Z" level=info msg="Pulling debug logs from the bootstrap machine"
time="2022-03-04T00:03:37Z" level=debug msg="Using SSH_AUTH_SOCK /tmp/ssh-AgIRS5ES03o0/agent.14 to connect to an existing agent"
time="2022-03-04T00:05:49Z" level=fatal msg="failed to create SSH client: dial tcp 172.16.19.161:22: connect: connection timed out"
time="2022-03-04T00:05:50Z" level=error msg="error after waiting for command completion" error="exit status 1" installID=x292j64g
time="2022-03-04T00:05:50Z" level=error msg="failed to gather logs from bootstrap node" error="exit status 1" installID=x292j64g
time="2022-03-04T00:05:50Z" level=warning msg="error fetching logs from bootstrap node" error="exit status 1" installID=x292j64g
```