### PR TITLE
Bug 2060508: azurestack: fix backend address pools for internal publishing

### DIFF
--- a/data/data/azurestack/bootstrap/main.tf
+++ b/data/data/azurestack/bootstrap/main.tf
@@ -99,7 +99,7 @@ resource "azurestack_network_interface" "bootstrap" {
     public_ip_address_id          = var.azure_private ? null : azurestack_public_ip.bootstrap_public_ip_v4[0].id
     load_balancer_backend_address_pools_ids = concat(
       [var.ilb_backend_pool_v4_id],
-      ! var.azure_private ? [var.elb_backend_pool_v4_id] : null
+      ! var.azure_private ? [var.elb_backend_pool_v4_id] : []
     )
   }
 }

--- a/data/data/azurestack/bootstrap/variables.tf
+++ b/data/data/azurestack/bootstrap/variables.tf
@@ -1,5 +1,6 @@
 variable "elb_backend_pool_v4_id" {
   type        = string
+  default     = null
   description = "The external load balancer backend pool id. used to attach the bootstrap NIC"
 }
 

--- a/data/data/azurestack/cluster/master/master.tf
+++ b/data/data/azurestack/cluster/master/master.tf
@@ -18,7 +18,7 @@ resource "azurestack_network_interface" "master" {
     private_ip_address_allocation = "Dynamic"
     load_balancer_backend_address_pools_ids = concat(
       [var.ilb_backend_pool_v4_id],
-      ! var.private ? [var.elb_backend_pool_v4_id] : null
+      ! var.private ? [var.elb_backend_pool_v4_id] : []
     )
   }
 }


### PR DESCRIPTION
When using internal publishing, the backend address pools of the load balancers incorrectly used a null list for the external load balancer's ID. Terraform requires that the list supplied to the concat function be an empty list rather than a null list.

Also, the elb_backend_pool_v4_id variable used as input to the bootstrap stage did not have a default. For internal publishing, the elb_backend_pool_v4_id output from the vnet stage is null, which is omitted from the outputs rather than explicitly set to null. Consequently, terraform would complain that the required elb_backend_pool_v4_id value was not set.