### PR TITLE
Bug 2060617: fix(ibmcloud): Properly match regex for DNS destroy

### DIFF
--- a/pkg/destroy/ibmcloud/dns.go
+++ b/pkg/destroy/ibmcloud/dns.go
@@ -28,7 +28,7 @@ func (o *ClusterUninstaller) listDNSRecords() (cloudResources, error) {
 
 		for _, record := range resources.Result {
 			// Match all of the cluster's DNS records
-			exp := fmt.Sprintf(`.*\Q%s.%s\E$`, o.ClusterName, o.BaseDomain)
+			exp := fmt.Sprintf(`.*\Q.%s.%s\E$`, o.ClusterName, o.BaseDomain)
 			nameMatches, _ := regexp.Match(exp, []byte(*record.Name))
 			contentMatches, _ := regexp.Match(exp, []byte(*record.Content))
 			if nameMatches || contentMatches {


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2060617

Update regex for IBM Cloud DNS destroy to explicitly match the cluster subdomain.