### PR TITLE
Bug 2061527: IBMCloud: Missing infra providertype

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -186,6 +186,7 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 			Location:          installConfig.Config.Platform.IBMCloud.Region,
 			ResourceGroupName: installConfig.Config.Platform.IBMCloud.ClusterResourceGroupName(clusterID.InfraID),
 			CISInstanceCRN:    cisInstanceCRN,
+			ProviderType:      configv1.IBMCloudProviderTypeVPC,
 		}
 	case libvirt.Name:
 		config.Spec.PlatformSpec.Type = configv1.LibvirtPlatformType


### PR DESCRIPTION
The ProviderType was missing from the PlatformStatus block for the
infrastructure asset on IBM Cloud. Added the missing value for
any configuration usage by other components/operators.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2061527