### PR TITLE
Bug 2061544: azurestack: stop pinning to Standard_LRS for disk type

### DIFF
--- a/data/data/azurestack/bootstrap/main.tf
+++ b/data/data/azurestack/bootstrap/main.tf
@@ -137,7 +137,7 @@ resource "azurestack_virtual_machine" "bootstrap" {
     name              = "${var.cluster_id}-bootstrap_OSDisk" # os disk name needs to match cluster-api convention
     create_option     = "FromImage"
     disk_size_gb      = 100
-    managed_disk_type = "Standard_LRS"
+    managed_disk_type = var.azure_master_root_volume_type
   }
 
   boot_diagnostics {

--- a/data/data/azurestack/cluster/main.tf
+++ b/data/data/azurestack/cluster/main.tf
@@ -30,6 +30,7 @@ module "master" {
   subnet_id              = var.master_subnet_id
   instance_count         = var.master_count
   storage_account        = var.storage_account
+  os_volume_type         = var.azure_master_root_volume_type
   os_volume_size         = var.azure_master_root_volume_size
   private                = var.azure_private
   availability_set_id    = var.availability_set_id

--- a/data/data/azurestack/cluster/master/master.tf
+++ b/data/data/azurestack/cluster/master/master.tf
@@ -55,7 +55,7 @@ resource "azurestack_virtual_machine" "master" {
     name              = "${var.cluster_id}-master-${count.index}_OSDisk" # os disk name needs to match cluster-api convention
     create_option     = "FromImage"
     disk_size_gb      = min(var.os_volume_size, 1023)
-    managed_disk_type = "Standard_LRS"
+    managed_disk_type = var.os_volume_type
   }
 
   boot_diagnostics {

--- a/data/data/azurestack/cluster/master/variables.tf
+++ b/data/data/azurestack/cluster/master/variables.tf
@@ -38,6 +38,11 @@ variable "subnet_id" {
   description = "The subnet to attach the masters to."
 }
 
+variable "os_volume_type" {
+  type        = string
+  description = "The type of the volume for the root block device."
+}
+
 variable "os_volume_size" {
   type        = string
   description = "The size of the volume in gigabytes for the root block device."


### PR DESCRIPTION
Azure Stack supports disks types other than Standard_LRS. The installer should not overriding the disk type choice made by the user and silently restricting the disk type for the control plane to Standard_LRS.