### PR TITLE
Bug 2061549: azurestack: create the api DNS record when publishing internally

### DIFF
--- a/data/data/azurestack/cluster/dns/dns.tf
+++ b/data/data/azurestack/cluster/dns/dns.tf
@@ -4,8 +4,6 @@ locals {
 }
 
 resource "azurestack_dns_a_record" "api_external_v4" {
-  count = ! var.private ? 1 : 0
-
   name                = "api.${local.cluster_name}"
   zone_name           = var.base_domain
   resource_group_name = var.base_domain_resource_group_name


### PR DESCRIPTION
When using internal publishing on Azure Stack Hub, the DNS record for the api should be created and point to the internal load balancer.