### PR TITLE
Determine Nic name in Bootstrap VM for ARM and x86

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -26,8 +26,10 @@ for name in ironic ironic-inspector ironic-ramdisk-logs dnsmasq httpd coreos-dow
 done
 
 # Start the provisioning nic if not already started
-PROVISIONING_NIC={{.PlatformData.BareMetal.ProvisioningInterface}}
 
+#Retrieve the provisioning interface name based on mac address (case insensitive).
+PROVISIONING_NIC=$(ip -j -o link | jq -r '.[] | select(.address != null)| select(.address | match ("{{.PlatformData.BareMetal.ProvisioningInterfaceMAC}}";"i")).ifname')
+echo "Provisioining interface: "$PROVISIONING_NIC
 {{ if .PlatformData.BareMetal.ProvisioningIP }}
 
 if ! nmcli -t device | grep "$PROVISIONING_NIC:ethernet:connected"; then

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -11,9 +11,9 @@ import (
 
 // TemplateData holds data specific to templates used for the baremetal platform.
 type TemplateData struct {
-	// ProvisioningInterface holds the interface the bootstrap node will use to host the ProvisioningIP below.
-	// When the provisioning network is disabled, this is the external baremetal network interface.
-	ProvisioningInterface string
+	// ProvisioningInterfaceMAC holds the interface's MAC address that the bootstrap node will use to host the ProvisioningIP below.
+	// When the provisioning network is disabled, this is the external baremetal network MAC address.
+	ProvisioningInterfaceMAC string
 
 	// ProvisioningIP holds the IP the bootstrap node will use to service Ironic, TFTP, etc.
 	ProvisioningIP string
@@ -75,7 +75,7 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 		cidr, _ := config.ProvisioningNetworkCIDR.Mask.Size()
 		templateData.ProvisioningCIDR = cidr
 		templateData.ProvisioningIPv6 = config.ProvisioningNetworkCIDR.IP.To4() == nil
-		templateData.ProvisioningInterface = "ens4"
+		templateData.ProvisioningInterfaceMAC = config.ProvisioningMACAddress
 		templateData.ProvisioningDNSMasq = true
 	}
 
@@ -95,7 +95,7 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 		}
 		templateData.ProvisioningDHCPAllowList = strings.Join(dhcpAllowList, " ")
 	case baremetal.DisabledProvisioningNetwork:
-		templateData.ProvisioningInterface = "ens3"
+		templateData.ProvisioningInterfaceMAC = config.ExternalMACAddress
 		templateData.ProvisioningDNSMasq = false
 
 		if templateData.ProvisioningIP != "" {

--- a/pkg/types/baremetal/defaults/platform_test.go
+++ b/pkg/types/baremetal/defaults/platform_test.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	"errors"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -180,6 +181,21 @@ func TestSetPlatformDefaults(t *testing.T) {
 			}
 			SetPlatformDefaults(tc.platform, ic)
 			if tc.expected != nil {
+				//Check Generated Provisioning MAC address
+				provisioningmac, err := net.ParseMAC(tc.platform.ProvisioningMACAddress)
+				if err != nil {
+					assert.Fail(t, "Invalid Provisioning MAC %s", string(provisioningmac), err)
+				} else {
+					tc.expected.ProvisioningMACAddress = tc.platform.ProvisioningMACAddress
+				}
+				//Check Generated External MAC address
+				externalmac, err := net.ParseMAC(tc.platform.ExternalMACAddress)
+				if err != nil {
+					assert.Fail(t, "Invalid External MAC %s", string(externalmac), err)
+				} else {
+					tc.expected.ExternalMACAddress = tc.platform.ExternalMACAddress
+				}
+
 				assert.Equal(t, tc.expected, tc.platform, "unexpected platform")
 			}
 


### PR DESCRIPTION

Hey @hardys 

I dug into why arm/x86 were creating nic names:

By default libvirt the bootstrap x86 vm that gets created uses pci:  
```        
<controller type='pci' index='0' model='pci-root'>
<interface type='bridge'>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
 </interface>
<interface type='bridge'>
      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
 </interface>
```
By default libvirt the bootstrap arm64 vm that gets created uses pcie:
 ```     
<controller type='pci' index='0' model='pcie-root'>
<interface type='bridge'>
      <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
</interface>
<interface type='bridge'>
      <address type='pci' domain='0x0000' bus='0x02' slot='0x00' function='0x0'/>
 </interface>
 ```

This causes RHCOS (and RHEL/Fedora) to rename `eth0` and `eth1` differently on startup:
 x86:
 ```
 # dmesg -t | grep eth
virtio_net virtio1 ens4: renamed from eth1
virtio_net virtio0 ens3: renamed from eth0
```
 arm64: 
 ```
 # dmesg -t | grep eth
virtio_net virtio1 enp2s0: renamed from eth1
virtio_net virtio0 enp1s0: renamed from eth0
```
More on RHEL naming [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/consistent-network-interface-device-naming_configuring-and-managing-networking#predictable-network-interface-device-names-on-the-x86_64-platform-explained_consistent-network-interface-device-naming).

According to this [RHEL DOC](https://access.redhat.com/solutions/2435891) using eth0/eth1 should be reliable as long as we continue to use virtio-net, and not mix or use with other nic types (like e1000).

This proposed fix seems to be the least painful way around this issue. I looked at trying to pass in mac address, and adding `net.ifnames=0` as a kernel parameter, but didn't see a straight forward way to do so. 

Let me know your thoughts, we've targeted  IPI Metal support for 4.11. If you agree, I can get this PR cleaned up (the linters  won't run on my arm dev machine).

Multi-Arch Ticket: https://issues.redhat.com/browse/ARMOCP-234
Similar PR: https://github.com/openshift/installer/pull/5554

cc: @bn222 