### PR TITLE
Add exit code for infra, bootstrip and install failures

### DIFF
--- a/cmd/openshift-install/waitfor.go
+++ b/cmd/openshift-install/waitfor.go
@@ -55,7 +55,7 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 				logrus.Info("openshift-install gather bootstrap --help")
 				logrus.Error("Bootstrap failed to complete: ", err.Unwrap())
 				logrus.Error(err.Error())
-				logrus.Fatal("Bootstrap failed to complete")
+				logrus.Exit(exitCodeBootstrapFailed)
 			}
 
 			logrus.Info("It is now safe to remove the bootstrap resources")
@@ -89,7 +89,8 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 					logrus.Error("Attempted to gather ClusterOperator status after wait failure: ", err2)
 				}
 				logTroubleshootingLink()
-				logrus.Fatal(err)
+				logrus.Error(err)
+				logrus.Exit(exitCodeInstallFailed)
 			}
 			timer.StopTimer(timer.TotalTimeElapsed)
 			timer.LogSummary()

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -11,6 +11,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// ClusterCreationError is the error when terraform fails, implying infrastructure failures
+	ClusterCreationError = "failed to create cluster"
+	// InstallConfigError wraps all configuration errors in one single error
+	InstallConfigError = "failed to create install config"
+)
+
 // Asset used to install OpenShift.
 type Asset interface {
 	// Dependencies returns the assets upon which this asset directly depends.

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -163,7 +163,7 @@ func (c *Cluster) applyTerraform(tmpDir string, platform string, stage terraform
 	}
 
 	if applyErr != nil {
-		return nil, errors.Wrap(applyErr, "failed to create cluster")
+		return nil, errors.Wrap(applyErr, asset.ClusterCreationError)
 	}
 
 	outputs, err := terraform.Outputs(tmpDir)

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -124,7 +124,7 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
-		return false, err
+		return false, errors.Wrap(err, asset.InstallConfigError)
 	}
 
 	config := &types.InstallConfig{}
@@ -133,18 +133,18 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 			err = errors.Wrapf(err, "failed to parse first occurence of unknown field")
 		}
 		err = errors.Wrapf(err, "failed to unmarshal %s", installConfigFilename)
-		return false, err
+		return false, errors.Wrap(err, asset.InstallConfigError)
 	}
 	a.Config = config
 
 	// Upconvert any deprecated fields
 	if err := conversion.ConvertInstallConfig(a.Config); err != nil {
-		return false, errors.Wrap(err, "failed to upconvert install config")
+		return false, errors.Wrap(errors.Wrap(err, "failed to upconvert install config"), asset.InstallConfigError)
 	}
 
 	err = a.finish(installConfigFilename)
 	if err != nil {
-		return false, err
+		return false, errors.Wrap(err, asset.InstallConfigError)
 	}
 	return true, nil
 }


### PR DESCRIPTION
Attempt to add some additional exit codes to differentiate errors from infrastructure, boothstrap and cluster phases. 

- Exit code for infrastructure phase only applies to "create cluster" command. 
- Exit code for bootstrap catches the result from bootstrap watch phase. 
- Exit code for install catches the final result from cluster installation. Right now the code keeps checking until context is done, or clusterversion is Available. It does not exit because any other reasons. So exitCodeIntallFailed pretty much means the cluster installation did not complete within the specified timeframe. 