### PR TITLE
Changing the machine-config service name

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -25,7 +25,7 @@ done
 
 echo "Gathering master journals ..."
 mkdir -p "${ARTIFACTS}/journals"
-for service in crio kubelet machine-config-daemon-host machine-config-master-firstboot openshift-azure-routes openshift-gcp-routes pivot sssd
+for service in crio kubelet machine-config-daemon-host machine-config-daemon-firstboot openshift-azure-routes openshift-gcp-routes pivot sssd
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
 done


### PR DESCRIPTION
Fixes #5706. 

This should now fetch the machine-config-daemon-firstboot logs from the control plane nodes if OpenShift 4 installation fails.