### PR TITLE
hack: update go version used in hack/verify-vendor.sh

### DIFF
--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$IS_CONTAINER" != "" ]; then
-  set -euxo pipefail
+  set -eux
   go mod tidy
   go mod vendor
   go mod verify
@@ -11,6 +11,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.16 \
+    docker.io/golang:1.17 \
     ./hack/verify-vendor.sh "${@}"
 fi


### PR DESCRIPTION
Update the go version used for verifying vendoring from 1.16 to 1.17. The CI job uses its own image and does not use the image specified in the script. Therefore, the go version in the script must match the go version in the CI job, particularly when there are breaking changes between go versions (as there are between 1.16 and 1.17 when it comes to modules).