### PR TITLE
baremetal: refresh owners list

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -53,14 +53,18 @@ aliases:
     - jstuever
   baremetal-approvers:
     - andfasano
-    - ardaguclu
+    - dtantsur
+    - elfosardo
     - hardys
+    - iurygregory
     - sadasu
   baremetal-reviewers:
     - andfasano
-    - ardaguclu
     - celebdor
+    - dtantsur
+    - elfosardo
     - hardys
+    - iurygregory
     - sadasu
   aws-approvers:
     - jstuever


### PR DESCRIPTION
Refresh the baremetal owners list to reflect latest organizational changes