### PR TITLE
cluster: unpack terraform binaries into install directory

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -27,6 +27,7 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/cluster"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/logging"
 	assetstore "github.com/openshift/installer/pkg/asset/store"
@@ -264,6 +265,8 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 
 		cleanup := setupFileHook(rootOpts.dir)
 		defer cleanup()
+
+		cluster.InstallDir = rootOpts.dir
 
 		err := runner(rootOpts.dir)
 		if err != nil {

--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -24,6 +24,11 @@ import (
 	typesazure "github.com/openshift/installer/pkg/types/azure"
 )
 
+var (
+	// InstallDir is the directory containing install assets.
+	InstallDir string
+)
+
 // Cluster uses the terraform executable to launch a cluster
 // with the given terraform tfvar and generated templates.
 type Cluster struct {
@@ -58,6 +63,10 @@ func (c *Cluster) Dependencies() []asset.Asset {
 
 // Generate launches the cluster and generates the terraform state file on disk.
 func (c *Cluster) Generate(parents asset.Parents) (err error) {
+	if InstallDir == "" {
+		logrus.Fatalf("InstallDir has not been set for the %q asset", c.Name())
+	}
+
 	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
 	terraformVariables := &TerraformVariables{}
@@ -79,6 +88,13 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 
 	stages := platformstages.StagesForPlatform(platform)
 
+	terraformDir := filepath.Join(InstallDir, "terraform")
+	if err := os.Mkdir(terraformDir, 0777); err != nil {
+		return errors.Wrap(err, "could not create the terraform directory")
+	}
+	defer os.RemoveAll(terraformDir)
+	terraform.UnpackTerraform(terraformDir, stages)
+
 	logrus.Infof("Creating infrastructure resources...")
 	switch platform {
 	case typesaws.Name:
@@ -97,30 +113,12 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 	}
 
 	for _, stage := range stages {
-
-		// Copy the terraform.tfvars to a temp directory where the terraform
-		// will be invoked within.
-		tmpDir, err := ioutil.TempDir("", fmt.Sprintf("openshift-install-%s-", stage.Name()))
+		outputs, err := c.applyStage(platform, stage, terraformDir, tfvarsFiles)
 		if err != nil {
-			return errors.Wrap(err, "failed to create temp dir for terraform execution")
+			return errors.Wrapf(err, "failure applying terraform for %q stage", stage.Name())
 		}
-		defer os.RemoveAll(tmpDir)
-
-		var extraOpts []tfexec.ApplyOption
-		for _, file := range tfvarsFiles {
-			if err := ioutil.WriteFile(filepath.Join(tmpDir, file.Filename), file.Data, 0600); err != nil {
-				return err
-			}
-			extraOpts = append(extraOpts, tfexec.VarFile(filepath.Join(tmpDir, file.Filename)))
-
-		}
-
-		outputs, err := c.applyTerraform(tmpDir, platform, stage, extraOpts...)
-		if err != nil {
-			return err
-		}
-
 		tfvarsFiles = append(tfvarsFiles, outputs)
+		c.FileList = append(c.FileList, outputs)
 	}
 
 	return nil
@@ -145,11 +143,30 @@ func (c *Cluster) Load(f asset.FileFetcher) (found bool, err error) {
 	return false, nil
 }
 
-func (c *Cluster) applyTerraform(tmpDir string, platform string, stage terraform.Stage, opts ...tfexec.ApplyOption) (*asset.File, error) {
+func (c *Cluster) applyStage(platform string, stage terraform.Stage, terraformDir string, tfvarsFiles []*asset.File) (*asset.File, error) {
+	// Copy the terraform.tfvars to a temp directory which will contain the terraform plan.
+	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("openshift-install-%s-", stage.Name()))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create temp dir for terraform execution")
+	}
+	defer os.RemoveAll(tmpDir)
+
+	var extraOpts []tfexec.ApplyOption
+	for _, file := range tfvarsFiles {
+		if err := ioutil.WriteFile(filepath.Join(tmpDir, file.Filename), file.Data, 0600); err != nil {
+			return nil, err
+		}
+		extraOpts = append(extraOpts, tfexec.VarFile(filepath.Join(tmpDir, file.Filename)))
+	}
+
+	return c.applyTerraform(tmpDir, platform, stage, terraformDir, extraOpts...)
+}
+
+func (c *Cluster) applyTerraform(tmpDir string, platform string, stage terraform.Stage, terraformDir string, opts ...tfexec.ApplyOption) (*asset.File, error) {
 	timer.StartTimer(stage.Name())
 	defer timer.StopTimer(stage.Name())
 
-	applyErr := terraform.Apply(tmpDir, platform, stage, opts...)
+	applyErr := terraform.Apply(tmpDir, platform, stage, terraformDir, opts...)
 
 	// Write the state file to the install directory even if the apply failed.
 	if data, err := ioutil.ReadFile(filepath.Join(tmpDir, terraform.StateFilename)); err == nil {
@@ -166,7 +183,7 @@ func (c *Cluster) applyTerraform(tmpDir string, platform string, stage terraform
 		return nil, errors.Wrap(applyErr, "failed to create cluster")
 	}
 
-	outputs, err := terraform.Outputs(tmpDir)
+	outputs, err := terraform.Outputs(tmpDir, terraformDir)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get outputs from stage %q", stage.Name())
 	}
@@ -175,6 +192,5 @@ func (c *Cluster) applyTerraform(tmpDir string, platform string, stage terraform
 		Filename: stage.OutputsFilename(),
 		Data:     outputs,
 	}
-	c.FileList = append(c.FileList, outputsFile)
 	return outputsFile, nil
 }

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -47,6 +47,13 @@ func Destroy(dir string) (err error) {
 		varFiles = append(varFiles, stage.OutputsFilename())
 	}
 
+	terraformDir := filepath.Join(dir, "terraform")
+	if err := os.Mkdir(terraformDir, 0777); err != nil {
+		return errors.Wrap(err, "could not create the terraform directory")
+	}
+	defer os.RemoveAll(terraformDir)
+	terraform.UnpackTerraform(terraformDir, tfStages)
+
 	for i := len(tfStages) - 1; i >= 0; i-- {
 		stage := tfStages[i]
 
@@ -82,7 +89,7 @@ func Destroy(dir string) (err error) {
 			targetVarFiles = append(targetVarFiles, targetPath)
 		}
 
-		if err := stage.Destroy(tempDir, targetVarFiles); err != nil {
+		if err := stage.Destroy(tempDir, terraformDir, targetVarFiles); err != nil {
 			return err
 		}
 

--- a/pkg/terraform/stage.go
+++ b/pkg/terraform/stage.go
@@ -24,7 +24,7 @@ type Stage interface {
 
 	// Destroy destroys the resources created in the stage. This should only be called if the stage should be destroyed
 	// when destroying the bootstrap resources.
-	Destroy(directory string, varFiles []string) error
+	Destroy(directory string, terraformDir string, varFiles []string) error
 
 	// ExtractHostAddresses extracts the IPs of the bootstrap and control plane machines.
 	ExtractHostAddresses(directory string, config *types.InstallConfig) (bootstrap string, port int, masters []string, err error)

--- a/pkg/terraform/stages/alibabacloud/stages.go
+++ b/pkg/terraform/stages/alibabacloud/stages.go
@@ -36,14 +36,14 @@ var PlatformStages = []terraform.Stage{
 	),
 }
 
-func removeFromLoadBalancers(s stages.SplitStage, directory string, varFiles []string) error {
+func removeFromLoadBalancers(s stages.SplitStage, directory string, terraformDir string, varFiles []string) error {
 	opts := make([]tfexec.ApplyOption, 0, len(varFiles)+1)
 	for _, varFile := range varFiles {
 		opts = append(opts, tfexec.VarFile(varFile))
 	}
 	opts = append(opts, tfexec.Var("ali_bootstrap_lb=false"))
 	return errors.Wrap(
-		terraform.Apply(directory, alitypes.Name, s, opts...),
+		terraform.Apply(directory, alitypes.Name, s, terraformDir, opts...),
 		"failed disabling bootstrap load balancing",
 	)
 }

--- a/pkg/terraform/stages/gcp/stages.go
+++ b/pkg/terraform/stages/gcp/stages.go
@@ -31,14 +31,14 @@ var PlatformStages = []terraform.Stage{
 	),
 }
 
-func removeFromLoadBalancers(s stages.SplitStage, directory string, varFiles []string) error {
+func removeFromLoadBalancers(s stages.SplitStage, directory string, terraformDir string, varFiles []string) error {
 	opts := make([]tfexec.ApplyOption, 0, len(varFiles)+1)
 	for _, varFile := range varFiles {
 		opts = append(opts, tfexec.VarFile(varFile))
 	}
 	opts = append(opts, tfexec.Var("gcp_bootstrap_lb=false"))
 	return errors.Wrap(
-		terraform.Apply(directory, gcptypes.Name, s, opts...),
+		terraform.Apply(directory, gcptypes.Name, s, terraformDir, opts...),
 		"failed disabling bootstrap load balancing",
 	)
 }

--- a/pkg/terraform/stages/split.go
+++ b/pkg/terraform/stages/split.go
@@ -69,7 +69,7 @@ type SplitStage struct {
 }
 
 // DestroyFunc is a function for destroying the stage.
-type DestroyFunc func(s SplitStage, directory string, varFiles []string) error
+type DestroyFunc func(s SplitStage, directory string, terraformDir string, varFiles []string) error
 
 // ExtractFunc is a function for extracting host addresses.
 type ExtractFunc func(s SplitStage, directory string, ic *types.InstallConfig) (string, int, []string, error)
@@ -100,8 +100,8 @@ func (s SplitStage) DestroyWithBootstrap() bool {
 }
 
 // Destroy implements pkg/terraform/Stage.Destroy
-func (s SplitStage) Destroy(directory string, varFiles []string) error {
-	return s.destroy(s, directory, varFiles)
+func (s SplitStage) Destroy(directory string, terraformDir string, varFiles []string) error {
+	return s.destroy(s, directory, terraformDir, varFiles)
 }
 
 // ExtractHostAddresses implements pkg/terraform/Stage.ExtractHostAddresses
@@ -165,10 +165,10 @@ func normalExtractHostAddresses(s SplitStage, directory string, _ *types.Install
 	return bootstrap, 0, masters, nil
 }
 
-func normalDestroy(s SplitStage, directory string, varFiles []string) error {
+func normalDestroy(s SplitStage, directory string, terraformDir string, varFiles []string) error {
 	opts := make([]tfexec.DestroyOption, len(varFiles))
 	for i, varFile := range varFiles {
 		opts[i] = tfexec.VarFile(varFile)
 	}
-	return errors.Wrap(terraform.Destroy(directory, s.platform, s, opts...), "terraform destroy")
+	return errors.Wrap(terraform.Destroy(directory, s.platform, s, terraformDir, opts...), "terraform destroy")
 }

--- a/pkg/terraform/state.go
+++ b/pkg/terraform/state.go
@@ -11,8 +11,8 @@ import (
 const StateFilename = "terraform.tfstate"
 
 // Outputs reads the terraform state file and returns the outputs of the stage as json.
-func Outputs(dir string) ([]byte, error) {
-	tf, err := newTFExec(dir)
+func Outputs(dir string, terraformDir string) ([]byte, error) {
+	tf, err := newTFExec(dir, terraformDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -13,11 +13,12 @@ import (
 )
 
 // newTFExec creates a tfexec.Terraform for executing Terraform CLI commands.
-// The `datadir` is the location where the terraform parts (binaries, tf files, etc) have been unpacked to.
+// The `datadir` is the location to which the terraform plan (tf files, etc) has been unpacked.
+// The `terraformDir` is the location to which the terraform and provider binaries have been unpacked.
 // The stdout and stderr will be sent to the logger at the debug and error levels,
 // respectively.
-func newTFExec(datadir string) (*tfexec.Terraform, error) {
-	tfPath := filepath.Join(datadir, "bin", "terraform")
+func newTFExec(datadir string, terraformDir string) (*tfexec.Terraform, error) {
+	tfPath := filepath.Join(terraformDir, "bin", "terraform")
 	tf, err := tfexec.NewTerraform(datadir, tfPath)
 	if err != nil {
 		return nil, err
@@ -43,12 +44,12 @@ func newTFExec(datadir string) (*tfexec.Terraform, error) {
 // Apply unpacks the platform-specific Terraform modules into the
 // given directory and then runs 'terraform init' and 'terraform
 // apply'.
-func Apply(dir string, platform string, stage Stage, extraOpts ...tfexec.ApplyOption) error {
-	if err := unpackAndInit(dir, platform, stage.Name(), stage.Providers()); err != nil {
+func Apply(dir string, platform string, stage Stage, terraformDir string, extraOpts ...tfexec.ApplyOption) error {
+	if err := unpackAndInit(dir, platform, stage.Name(), terraformDir, stage.Providers()); err != nil {
 		return err
 	}
 
-	tf, err := newTFExec(dir)
+	tf, err := newTFExec(dir, terraformDir)
 	if err != nil {
 		return errors.Wrap(err, "failed to create a new tfexec")
 	}
@@ -59,12 +60,12 @@ func Apply(dir string, platform string, stage Stage, extraOpts ...tfexec.ApplyOp
 // Destroy unpacks the platform-specific Terraform modules into the
 // given directory and then runs 'terraform init' and 'terraform
 // destroy'.
-func Destroy(dir string, platform string, stage Stage, extraOpts ...tfexec.DestroyOption) error {
-	if err := unpackAndInit(dir, platform, stage.Name(), stage.Providers()); err != nil {
+func Destroy(dir string, platform string, stage Stage, terraformDir string, extraOpts ...tfexec.DestroyOption) error {
+	if err := unpackAndInit(dir, platform, stage.Name(), terraformDir, stage.Providers()); err != nil {
 		return err
 	}
 
-	tf, err := newTFExec(dir)
+	tf, err := newTFExec(dir, terraformDir)
 	if err != nil {
 		return errors.Wrap(err, "failed to create a new tfexec")
 	}


### PR DESCRIPTION
Currently, the installer unpacks the terraform and terraform providers binaries to the same temporary directory under /tmp that is used for the plan files for a stage. Some users, however, are not able to execute files under /tmp.

A workaround for this would be for the user to set the TMPDIR environment variable to a directory where they do have the ability to execute files. That is not a great experience for a user when there is already a command-line argument that the user can use to specify the install directory.

So, let's use the install directory as the location under which to unpack the terraform binaries instead. At the same time, let's unpack once for all of the stages rather than unpacking once per stage.

One downside of this approach is that either (1) it makes the Cluster asset dependent upon the install directory or (2) it requires that the binaries be added as assets. The second option is not appropriate as it would significantly increase the size of .openshift_install_state.json. The first option is accomplished, for the time being, by having a package-scoped variable set by the create command that the Cluster asset can reference. This ensures that the asset graph itself is not polluted with the install directory and the install directory can be moved without affecting the state. However, it is an ugly encapsulation smell.

https://issues.redhat.com/browse/CORS-1952