### PR TITLE
Azure: Fine-tune wording around ADAL auth

### DIFF
--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -232,7 +232,7 @@ func newSessionFromCredentials(cloudEnv azureenv.Environment, credentials *Crede
 	var authorizer autorest.Authorizer
 	switch cloudName {
 	case azure.StackCloud:
-		logrus.Debug("Falling back to deprecated ADAL authentication")
+		logrus.Debug("Falling back to ADAL authentication")
 		// The new authorization method is not yet supported for private clouds
 		// See https://github.com/Azure/azure-sdk-for-go/pull/16942
 		var err error


### PR DESCRIPTION
ADAL authentication will be deprecated soon, but is not quite deprecated yet. Make the wording a little more politic.