### PR TITLE
azure: Enable HyperVGeneration setting for Azure disks

### DIFF
--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -163,3 +163,10 @@ This determined whether User defined routing will be used for egress to Internet
 When false, Standard LB will be used for egress to the Internet.
 EOF
 }
+
+variable "azure_hypervgeneration_version" {
+  type = string
+  description = <<EOF
+This determines the HyperVGeneration disk type to use for the control plane VMs.
+EOF
+}

--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -102,3 +102,16 @@ resource "azurerm_image" "cluster" {
     blob_uri = azurerm_storage_blob.rhcos_image.url
   }
 }
+
+resource "azurerm_image" "clustergen2" {
+  name                = "${var.cluster_id}-gen2"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.azure_region
+  hyper_v_generation  = "V2"
+
+  os_disk {
+    os_type  = "Linux"
+    os_state = "Generalized"
+    blob_uri = azurerm_storage_blob.rhcos_image.url
+  }
+}

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -51,7 +51,7 @@ output "resource_group_name" {
 }
 
 output "vm_image" {
-  value = azurerm_image.cluster.id
+  value = var.azure_hypervgeneration_version == "V2" ? azurerm_image.clustergen2.id : azurerm_image.cluster.id
 }
 
 output "identity" {

--- a/pkg/asset/installconfig/azure/mock/azureclient_generated.go
+++ b/pkg/asset/installconfig/azure/mock/azureclient_generated.go
@@ -202,3 +202,18 @@ func (mr *MockAPIMockRecorder) GetDiskEncryptionSet(ctx, subscriptionID, groupNa
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskEncryptionSet", reflect.TypeOf((*MockAPI)(nil).GetDiskEncryptionSet), ctx, subscriptionID, groupName, diskEncryptionSetName)
 }
+
+// GetHyperVGenerationVersion mocks base method
+func (m *MockAPI) GetHyperVGenerationVersion(ctx context.Context, instanceType, diskType, region string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHyperVGenerationVersion", ctx, instanceType, diskType, region)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHyperVGenerationVersion indicates an expected call of GetHyperVGenerationVersion
+func (mr *MockAPIMockRecorder) GetHyperVGenerationVersion(ctx, instanceType, diskType, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHyperVGenerationVersion", reflect.TypeOf((*MockAPI)(nil).GetHyperVGenerationVersion), ctx, instanceType, diskType, region)
+}

--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -13,7 +13,6 @@ import (
 	aznetwork "github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/network/mgmt/network"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -112,16 +111,6 @@ func ValidateInstanceType(client API, fieldPath *field.Path, region, instanceTyp
 			if cpus < float64(req.minimumVCpus) {
 				errMsg := fmt.Sprintf("instance type does not meet minimum resource requirements of %d vCPUsAvailable", req.minimumVCpus)
 				allErrs = append(allErrs, field.Invalid(fieldPath.Child("type"), instanceType, errMsg))
-			}
-		} else if strings.EqualFold(*capability.Name, "HyperVGenerations") {
-			generations := sets.NewString()
-			for _, g := range strings.Split(to.String(capability.Value), ",") {
-				g = strings.TrimSpace(g)
-				g = strings.ToUpper(g)
-				generations.Insert(g)
-			}
-			if !generations.Has("V1") {
-				allErrs = append(allErrs, field.Invalid(fieldPath.Child("type"), instanceType, "only disks with HyperVGeneration V1 are supported"))
 			}
 		} else if strings.EqualFold(*capability.Name, "MemoryGB") {
 			memory, err := strconv.ParseFloat(*capability.Value, 0)

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -96,7 +96,6 @@ var (
 	nonpremiumInstanceTypeDiskControlPlane = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.Azure.InstanceType = "Standard_D_v4" }
 	premiumDiskDefault                     = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.OSDisk.DiskType = "Premium_LRS" }
 	nonpremiumInstanceTypeDiskDefault      = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.InstanceType = "Standard_D_v4" }
-	unsupportedHyperVGeneration            = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.InstanceType = "Standard_Dc4_v4" }
 	enabledSSDCapabilityControlPlane       = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.Azure.UltraSSDCapability = "Enabled" }
 	enabledSSDCapabilityCompute            = func(ic *types.InstallConfig) { ic.Compute[0].Platform.Azure.UltraSSDCapability = "Enabled" }
 	enabledSSDCapabilityDefault            = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.UltraSSDCapability = "Enabled" }
@@ -306,11 +305,6 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 			name:     "Non-premium instance disk type for control-plane",
 			edits:    editFunctions{premiumDiskControlPlane, nonpremiumInstanceTypeDiskControlPlane},
 			errorMsg: `controlPlane.platform.azure.osDisk.diskType: Invalid value: "Premium_LRS": PremiumIO not supported for instance type Standard_D_v4$`,
-		},
-		{
-			name:     "Unsupported HyperVGeneration",
-			edits:    editFunctions{unsupportedHyperVGeneration},
-			errorMsg: `^\[controlPlane.platform.azure.type: Invalid value: "Standard_Dc4_v4": only disks with HyperVGeneration V1 are supported, compute\[0\].platform.azure.type: Invalid value: "Standard_Dc4_v4": only disks with HyperVGeneration V1 are supported\]$`,
 		},
 		{
 			name:     "Unsupported UltraSSD capability in Control Plane",

--- a/pkg/asset/machines/azure/machinesets.go
+++ b/pkg/asset/machines/azure/machinesets.go
@@ -13,7 +13,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string) ([]*clusterapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, hyperVGen string) ([]*clusterapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != azure.Name {
 		return nil, fmt.Errorf("non-azure configuration: %q", configPlatform)
 	}
@@ -40,7 +40,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		if int64(idx) < total%numOfAZs {
 			replicas++
 		}
-		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx)
+		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx, hyperVGen)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	"github.com/openshift/installer/pkg/asset/machines/alibabacloud"
 	"github.com/openshift/installer/pkg/asset/machines/aws"
 	"github.com/openshift/installer/pkg/asset/machines/azure"
@@ -405,7 +406,13 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			}
 
 			pool.Platform.Azure = &mpool
-			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", workerUserDataSecretName)
+			client := icazure.NewClient(session)
+			hyperVGen, err := client.GetHyperVGenerationVersion(context.TODO(), mpool.InstanceType, mpool.OSDisk.DiskType, installConfig.Config.Platform.Azure.Region)
+			if err != nil {
+				return err
+			}
+
+			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", workerUserDataSecretName, hyperVGen)
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -44,6 +44,7 @@ type config struct {
 	OutboundUDR                     bool              `json:"azure_outbound_user_defined_routing"`
 	BootstrapIgnitionStub           string            `json:"azure_bootstrap_ignition_stub"`
 	BootstrapIgnitionURLPlaceholder string            `json:"azure_bootstrap_ignition_url_placeholder"`
+	HyperVGeneration                string            `json:"azure_hypervgeneration_version"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -61,6 +62,7 @@ type TFVarsSources struct {
 	OutboundType                    azure.OutboundType
 	BootstrapIgnStub                string
 	BootstrapIgnitionURLPlaceholder string
+	HyperVGeneration                string
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
@@ -118,6 +120,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		PreexistingNetwork:              sources.PreexistingNetwork,
 		BootstrapIgnitionStub:           sources.BootstrapIgnStub,
 		BootstrapIgnitionURLPlaceholder: sources.BootstrapIgnitionURLPlaceholder,
+		HyperVGeneration:                sources.HyperVGeneration,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
Currently, azure disks do not support HyperVGeneration version 2
so adding a field in the install config and set it to either V1
or the preferred V2 if the instance type supports it.

This includes adding another OS image for version 2 and picking
the right image depending on the HyperVGeneration version set and
passing the version to terraform to output the right image name
used.