### PR TITLE
Use powervs NewClient in GetDNSZone

### DIFF
--- a/pkg/asset/installconfig/basedomain.go
+++ b/pkg/asset/installconfig/basedomain.go
@@ -11,6 +11,7 @@ import (
 	azureconfig "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	ibmcloudconfig "github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
+	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
 	"github.com/openshift/installer/pkg/types/alibabacloud"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -72,8 +73,15 @@ func (a *baseDomain) Generate(parents asset.Parents) error {
 		if !(gcpconfig.IsForbidden(err) || gcpconfig.IsThrottled(err)) {
 			return err
 		}
-	case ibmcloud.Name, powervs.Name:
+	case ibmcloud.Name:
 		zone, err := ibmcloudconfig.GetDNSZone()
+		if err != nil {
+			return err
+		}
+		a.BaseDomain = zone.Name
+		return nil
+	case powervs.Name:
+		zone, err := powervsconfig.GetDNSZone()
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/installconfig/powervs/dns.go
+++ b/pkg/asset/installconfig/powervs/dns.go
@@ -1,0 +1,71 @@
+package powervs
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	survey "github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/core"
+	"github.com/pkg/errors"
+)
+
+// Zone represents a DNS Zone
+type Zone struct {
+	Name            string
+	CISInstanceCRN  string
+	ResourceGroupID string
+}
+
+// GetDNSZone returns a DNS Zone chosen by survey.
+func GetDNSZone() (*Zone, error) {
+	client, err := NewClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	publicZones, err := client.GetDNSZones(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not retrieve base domains")
+	}
+	if len(publicZones) == 0 {
+		return nil, errors.New("no domain names found in project")
+	}
+
+	var options []string
+	var optionToZoneMap = make(map[string]*Zone, len(publicZones))
+	for _, zone := range publicZones {
+		option := fmt.Sprintf("%s (%s)", zone.Name, zone.CISInstanceName)
+		optionToZoneMap[option] = &Zone{
+			Name:            zone.Name,
+			CISInstanceCRN:  zone.CISInstanceCRN,
+			ResourceGroupID: zone.ResourceGroupID,
+		}
+		options = append(options, option)
+	}
+	sort.Strings(options)
+
+	var zoneChoice string
+	if err := survey.AskOne(&survey.Select{
+		Message: "Base Domain",
+		Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base and will also include the cluster name.\n\nIf you don't see your intended base-domain listed, create a new public hosted zone and rerun the installer.",
+		Options: options,
+	},
+		&zoneChoice,
+		survey.WithValidator(func(ans interface{}) error {
+			choice := ans.(core.OptionAnswer).Value
+			i := sort.SearchStrings(options, choice)
+			if i == len(publicZones) || options[i] != choice {
+				return errors.Errorf("invalid base domain %q", choice)
+			}
+			return nil
+		}),
+	); err != nil {
+		return nil, errors.Wrap(err, "failed UserInput")
+	}
+
+	return optionToZoneMap[zoneChoice], nil
+}


### PR DESCRIPTION
The powervs code uses a new version of the power-go-client which requires
not reusing the Authenticator structure as input.  We are using our own
code instead of ibmcloud's code since ibmcloud may diverge in the future.
Also, their timetables on fixes and testing are different than ours.