### PR TITLE
terraform: fix module name of terraform providers

### DIFF
--- a/terraform/providers/alicloud/go.mod
+++ b/terraform/providers/alicloud/go.mod
@@ -1,4 +1,4 @@
-module alicloud
+module github.com/openshift/installer/terraform/providers/alicloud
 
 go 1.17
 

--- a/terraform/providers/aws/go.mod
+++ b/terraform/providers/aws/go.mod
@@ -1,4 +1,4 @@
-module aws
+module github.com/openshift/installer/terraform/providers/aws
 
 go 1.17
 

--- a/terraform/providers/azureprivatedns/go.mod
+++ b/terraform/providers/azureprivatedns/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/installer/terraform/azureprivatedns
+module github.com/openshift/installer/terraform/providers/azureprivatedns
 
 go 1.17
 

--- a/terraform/providers/azurerm/go.mod
+++ b/terraform/providers/azurerm/go.mod
@@ -1,4 +1,4 @@
-module azurerm
+module github.com/openshift/installer/terraform/providers/azurerm
 
 go 1.17
 

--- a/terraform/providers/azurestack/go.mod
+++ b/terraform/providers/azurestack/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/installer/terraform/azurestack
+module github.com/openshift/installer/terraform/providers/azurestack
 
 go 1.17
 

--- a/terraform/providers/google/go.mod
+++ b/terraform/providers/google/go.mod
@@ -1,4 +1,4 @@
-module google
+module github.com/openshift/installer/terraform/providers/google
 
 go 1.17
 

--- a/terraform/providers/ibm/go.mod
+++ b/terraform/providers/ibm/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/installer/terraform/ibm
+module github.com/openshift/installer/terraform/providers/ibm
 
 go 1.17
 

--- a/terraform/providers/ignition/go.mod
+++ b/terraform/providers/ignition/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/installer/terraform/ignition
+module github.com/openshift/installer/terraform/providers/ignition
 
 go 1.17
 

--- a/terraform/providers/ironic/go.mod
+++ b/terraform/providers/ironic/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/installer/terraform/ironic
+module github.com/openshift/installer/terraform/providers/ironic
 
 go 1.17
 

--- a/terraform/providers/libvirt/go.mod
+++ b/terraform/providers/libvirt/go.mod
@@ -1,4 +1,4 @@
-module libvirt
+module github.com/openshift/installer/terraform/providers/libvirt
 
 go 1.17
 

--- a/terraform/providers/local/go.mod
+++ b/terraform/providers/local/go.mod
@@ -1,4 +1,4 @@
-module local
+module github.com/openshift/installer/terraform/providers/local
 
 go 1.17
 

--- a/terraform/providers/openstack/go.mod
+++ b/terraform/providers/openstack/go.mod
@@ -1,4 +1,4 @@
-module openstack
+module github.com/openshift/installer/terraform/providers/openstack
 
 go 1.17
 

--- a/terraform/providers/ovirt/go.mod
+++ b/terraform/providers/ovirt/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/installer/terraform/ovirt
+module github.com/openshift/installer/terraform/providers/ovirt
 
 go 1.17
 

--- a/terraform/providers/random/go.mod
+++ b/terraform/providers/random/go.mod
@@ -1,4 +1,4 @@
-module random
+module github.com/openshift/installer/terraform/providers/random
 
 go 1.17
 

--- a/terraform/providers/vsphere/go.mod
+++ b/terraform/providers/vsphere/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/installer/terraform/vsphere
+module github.com/openshift/installer/terraform/providers/vsphere
 
 go 1.17
 

--- a/terraform/providers/vsphereprivate/go.mod
+++ b/terraform/providers/vsphereprivate/go.mod
@@ -1,4 +1,4 @@
-module github.com/openshift/installer/terraform/vsphereprivate
+module github.com/openshift/installer/terraform/providers/vsphereprivate
 
 go 1.17
 


### PR DESCRIPTION
The module names used for the terraform providers should have the module as a sub-module of the installer's main module.

```sh
find ./terraform/providers/ -name go.mod -exec sed -E -i 's|^module github.com/openshift/installer/terraform/([^/]+)$|module github.com/openshift/installer/terraform/providers/\1|' {} \;
find ./terraform/providers/ -name go.mod -exec sed -E -i 's|^module ([^/]+)$|module github.com/openshift/installer/terraform/providers/\1|' {} \;
```
    
https://issues.redhat.com/browse/CORS-1978
