### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/data/unpack_test.go
+++ b/data/unpack_test.go
@@ -3,19 +3,14 @@ package data
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestUnpack(t *testing.T) {
-	path, err := ioutil.TempDir("", "installer-data-test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	err = Unpack(path, ".")
+	err := Unpack(path, ".")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/asset/asset_test.go
+++ b/pkg/asset/asset_test.go
@@ -3,7 +3,6 @@ package asset
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -61,11 +60,7 @@ func TestPersistToFile(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "TestStatePersistToFile")
-			if err != nil {
-				t.Skipf("could not create temporary directory: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			asset := &writablePersistAsset{
 				FileList: make([]*File, len(tc.filenames)),
@@ -79,7 +74,7 @@ func TestPersistToFile(t *testing.T) {
 				}
 				expectedFiles[filepath.Join(dir, filename)] = data
 			}
-			err = PersistToFile(asset, dir)
+			err := PersistToFile(asset, dir)
 			assert.NoError(t, err, "unexpected error persisting state to file")
 			verifyFilesCreated(t, dir, expectedFiles)
 		})

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -87,11 +86,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", "TestCreatedAssetsAreNotDirty")
-			if err != nil {
-				t.Fatalf("could not create the temp dir: %v", err)
-			}
-			defer os.RemoveAll(tempDir)
+			tempDir := t.TempDir()
 
 			for name, contents := range tc.files {
 				if err := ioutil.WriteFile(filepath.Join(tempDir, name), []byte(contents), 0666); err != nil {

--- a/pkg/asset/store/filefetcher_test.go
+++ b/pkg/asset/store/filefetcher_test.go
@@ -46,14 +46,10 @@ func TestFetchByName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", "openshift-install-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(tempDir)
+			tempDir := t.TempDir()
 
 			for filename, data := range tt.files {
-				err = ioutil.WriteFile(filepath.Join(tempDir, filename), data, 0666)
+				err := ioutil.WriteFile(filepath.Join(tempDir, filename), data, 0666)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -74,11 +70,7 @@ func TestFetchByName(t *testing.T) {
 }
 
 func TestFetchByPattern(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "openshift-install-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	files := map[string][]byte{
 		"master-0.ign":   []byte("some data 0"),
@@ -105,7 +97,7 @@ func TestFetchByPattern(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		err = ioutil.WriteFile(filepath.Join(tempDir, path), data, 0666)
+		err := ioutil.WriteFile(filepath.Join(tempDir, path), data, 0666)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/asset/store/store_test.go
+++ b/pkg/asset/store/store_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -260,13 +259,8 @@ func TestStoreFetch(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			clearAssetBehaviors()
-			dir, err := ioutil.TempDir("", "TestStoreFetch")
-			if err != nil {
-				t.Fatalf("failed to create temporary directory: %v", err)
-			}
-			defer os.RemoveAll(dir)
 			store := &storeImpl{
-				directory: dir,
+				directory: t.TempDir(),
 				assets:    map[reflect.Type]*assetState{},
 			}
 			assets := make(map[string]asset.Asset, len(tc.assets))
@@ -287,7 +281,7 @@ func TestStoreFetch(t *testing.T) {
 					source: generatedSource,
 				}
 			}
-			err = store.Fetch(assets[tc.target])
+			err := store.Fetch(assets[tc.target])
 			assert.NoError(t, err, "error fetching asset")
 			assert.EqualValues(t, tc.expectedGenerationLog, generationLog)
 		})
@@ -392,11 +386,7 @@ func TestStoreFetchOnDiskAssets(t *testing.T) {
 func TestStoreFetchIdempotency(t *testing.T) {
 	clearAssetBehaviors()
 
-	tempDir, err := ioutil.TempDir("", "TestStoreFetchIdempotency")
-	if err != nil {
-		t.Fatalf("could not create the temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for i := 0; i < 2; i++ {
 		store, err := newStore(tempDir)


### PR DESCRIPTION
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir