### PR TITLE
Bug 2062998: Update region check for coreos AMIs

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -16,7 +16,7 @@ locals {
 provider "aws" {
   region = var.aws_region
 
-  skip_region_validation = var.aws_skip_region_validation
+  skip_region_validation = true
 
   endpoints {
     ec2     = lookup(var.custom_endpoints, "ec2", null)

--- a/data/data/aws/cluster/main.tf
+++ b/data/data/aws/cluster/main.tf
@@ -11,7 +11,7 @@ locals {
 provider "aws" {
   region = var.aws_region
 
-  skip_region_validation = var.aws_skip_region_validation
+  skip_region_validation = true
 
   endpoints {
     ec2     = lookup(var.custom_endpoints, "ec2", null)

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -137,11 +137,6 @@ variable "aws_publish_strategy" {
   description = "The cluster publishing strategy, either Internal or External"
 }
 
-variable "aws_skip_region_validation" {
-  type        = bool
-  description = "This decides if the AWS provider should validate if the region is known."
-}
-
 variable "aws_ignition_bucket" {
   type        = string
   description = "The S3 bucket where the ignition configuration is stored"

--- a/pkg/asset/installconfig/aws/platform.go
+++ b/pkg/asset/installconfig/aws/platform.go
@@ -17,7 +17,7 @@ import (
 // Platform collects AWS-specific configuration.
 func Platform() (*aws.Platform, error) {
 	architecture := version.DefaultArch()
-	regions := knownRegions(architecture)
+	regions := knownPublicRegions(architecture)
 	longRegions := make([]string, 0, len(regions))
 	shortRegions := make([]string, 0, len(regions))
 	for id, location := range regions {
@@ -35,7 +35,7 @@ func Platform() (*aws.Platform, error) {
 	}
 
 	defaultRegion := "us-east-1"
-	if !IsKnownRegion(defaultRegion, architecture) {
+	if !IsKnownPublicRegion(defaultRegion, architecture) {
 		panic(fmt.Sprintf("installer bug: invalid default AWS region %q", defaultRegion))
 	}
 
@@ -46,7 +46,7 @@ func Platform() (*aws.Platform, error) {
 
 	defaultRegionPointer := ssn.Config.Region
 	if defaultRegionPointer != nil && *defaultRegionPointer != "" {
-		if IsKnownRegion(*defaultRegionPointer, architecture) {
+		if IsKnownPublicRegion(*defaultRegionPointer, architecture) {
 			defaultRegion = *defaultRegionPointer
 		} else {
 			logrus.Warnf("Unrecognized AWS region %q, defaulting to %s", *defaultRegionPointer, defaultRegion)

--- a/pkg/asset/installconfig/aws/regions.go
+++ b/pkg/asset/installconfig/aws/regions.go
@@ -7,10 +7,10 @@ import (
 	"github.com/openshift/installer/pkg/types"
 )
 
-// knownRegions is a list of AWS regions that the installer recognizes.
-// This is subset of AWS regions and the regions where RHEL CoreOS images are published.
-// The result is a map of region identifier to region description
-func knownRegions(architecture types.Architecture) map[string]string {
+// knownPublicRegions is the subset of public AWS regions where RHEL CoreOS images are published.
+// This subset does not include supported regions which are found in other partitions, such as us-gov-east-1.
+// Returns: a map of region identifier to region description.
+func knownPublicRegions(architecture types.Architecture) map[string]string {
 	required := rhcos.AMIRegions(architecture)
 
 	regions := make(map[string]string)
@@ -22,10 +22,10 @@ func knownRegions(architecture types.Architecture) map[string]string {
 	return regions
 }
 
-// IsKnownRegion return true is a specified region is Known to the installer.
-// A known region is subset of AWS regions and the regions where RHEL CoreOS images are published.
-func IsKnownRegion(region string, architecture types.Architecture) bool {
-	if _, ok := knownRegions(architecture)[region]; ok {
+// IsKnownPublicRegion returns true if a specified region is Known to the installer.
+// A known region is the subset of public AWS regions where RHEL CoreOS images are published.
+func IsKnownPublicRegion(region string, architecture types.Architecture) bool {
+	if _, ok := knownPublicRegions(architecture)[region]; ok {
 		return true
 	}
 	return false

--- a/pkg/asset/rhcos/image.go
+++ b/pkg/asset/rhcos/image.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	configaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/rhcos"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/alibabacloud"
@@ -86,8 +85,10 @@ func osImage(config *types.InstallConfig) (string, error) {
 			return config.Platform.AWS.AMIID, nil
 		}
 		region := config.Platform.AWS.Region
-		if !configaws.IsKnownRegion(config.Platform.AWS.Region, config.ControlPlane.Architecture) {
-			region = "us-east-1"
+		if !rhcos.AMIRegions(config.ControlPlane.Architecture).Has(region) {
+			const globalResourceRegion = "us-east-1"
+			logrus.Debugf("No AMI found in %s. Using AMI from %s.", region, globalResourceRegion)
+			region = globalResourceRegion
 		}
 		osimage, err := st.GetAMI(archName, region)
 		if err != nil {

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1"
 
-	configaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/types"
 	typesaws "github.com/openshift/installer/pkg/types/aws"
 )
@@ -34,7 +33,6 @@ type config struct {
 	PublicSubnets           *[]string         `json:"aws_public_subnets,omitempty"`
 	InternalZone            string            `json:"aws_internal_zone,omitempty"`
 	PublishStrategy         string            `json:"aws_publish_strategy,omitempty"`
-	SkipRegionCheck         bool              `json:"aws_skip_region_validation"`
 	IgnitionBucket          string            `json:"aws_ignition_bucket"`
 	BootstrapIgnitionStub   string            `json:"aws_bootstrap_stub_ignition"`
 	MasterIAMRoleName       string            `json:"aws_master_iam_role_name,omitempty"`
@@ -128,7 +126,6 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		PrivateSubnets:          sources.PrivateSubnets,
 		InternalZone:            sources.InternalZone,
 		PublishStrategy:         string(sources.Publish),
-		SkipRegionCheck:         !configaws.IsKnownRegion(masterConfig.Placement.Region, sources.Architecture),
 		IgnitionBucket:          sources.IgnitionBucket,
 		MasterIAMRoleName:       sources.MasterIAMRoleName,
 		WorkerIAMRoleName:       sources.WorkerIAMRoleName,


### PR DESCRIPTION
When determining whether an AMI is available in a region, we should use the coreos stream directly. The installer function for determining known regions has been changed to only list public regions.