### PR TITLE
terraform: compress provider binaries faster

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -23,7 +23,7 @@ $(TERRAFORM_PROVIDER_TARGETS): bin/terraform-provider-%.zip: providers/%/go.mod
 	cd providers/$*; \
 	if [ -f main.go ]; then path="."; else path=./vendor/`grep _ tools.go|awk '{ print $$2 }'|sed 's|"||g'`; fi; \
 	go build -ldflags $(LDFLAGS) -o ../../bin/terraform-provider-$* "$$path"; \
-	zip -9j ../../bin/terraform-provider-$*.zip ../../bin/terraform-provider-$*;
+	zip -1j ../../bin/terraform-provider-$*.zip ../../bin/terraform-provider-$*;
 
 .PHONY: go-build-terraform
 go-build-terraform: bin/terraform


### PR DESCRIPTION
The amount of time that it takes to compress the terraform binaries is burdensome on development and is causing the brew builds to fail due to timeouts. Changing the compression speed from 9 to 1 increases the resultant size of the installer binary by roughly 10% but reduces the time spent compressing to roughly 20% of the original time.

On my local machine, building and compressing the aws provider is reduced from about 22 seconds to about 4 seconds. The size of the aws provider zip is increased from 99M to 108M. The size of the installer binary is increased from 413M to 450M.