### PR TITLE
Add VolumeID testscases for Power VS machinepool

### DIFF
--- a/pkg/types/powervs/validation/machinepool.go
+++ b/pkg/types/powervs/validation/machinepool.go
@@ -16,11 +16,17 @@ func ValidateMachinePool(p *powervs.MachinePool, fldPath *field.Path) field.Erro
 	allErrs := field.ErrorList{}
 
 	// Validate VolumeIDs
+	volumes := make(map[string]bool)
 	for i, volumeID := range p.VolumeIDs {
 		_, err := uuid.Parse(volumeID)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("volumeIDs").Index(i), volumeID, "volume ID must be a valid UUID"))
 		}
+		if _, ok := volumes[volumeID]; ok {
+			allErrs = append(allErrs, field.Duplicate(fldPath.Child("volumeIDs").Index(i), volumeID))
+			continue
+		}
+		volumes[volumeID] = true
 	}
 
 	// Validate Memory

--- a/pkg/types/powervs/validation/machinepool_test.go
+++ b/pkg/types/powervs/validation/machinepool_test.go
@@ -32,6 +32,19 @@ func TestValidateMachinePool(t *testing.T) {
 			expected: `^test-path\.volumeIDs\[1]: Invalid value: "abc123": volume ID must be a valid UUID$`,
 		},
 		{
+			name: "unique volumeIDs",
+			pool: &powervs.MachinePool{
+				VolumeIDs: []string{"c8b709c4-93f1-499e-915e-0820bcc51406", "c8b709c4-93f1-499e-915e-0820bcc51510"},
+			},
+		},
+		{
+			name: "duplicate volumeIDs",
+			pool: &powervs.MachinePool{
+				VolumeIDs: []string{"c8b709c4-93f1-499e-915e-0820bcc51406", "c8b709c4-93f1-499e-915e-0820bcc51406"},
+			},
+			expected: `^test-path\.volumeIDs\[1]: Duplicate value: "c8b709c4-93f1-499e-915e-0820bcc51406"$`,
+		},
+		{
 			name: "valid memory",
 			pool: &powervs.MachinePool{
 				Memory: "5",


### PR DESCRIPTION
Follow up PR from the below discussion:
https://github.com/openshift/installer/pull/5609#discussion_r812213205

Added testcases to validate unique and duplicate volumeIDs