### PR TITLE
Adding public&private zones to DNS config on PowerVS

### DIFF
--- a/pkg/asset/manifests/dns.go
+++ b/pkg/asset/manifests/dns.go
@@ -17,6 +17,7 @@ import (
 	icaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	icgcp "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	icibmcloud "github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
+	icpowervs "github.com/openshift/installer/pkg/asset/installconfig/powervs"
 	"github.com/openshift/installer/pkg/types"
 	alibabacloudtypes "github.com/openshift/installer/pkg/types/alibabacloud"
 	awstypes "github.com/openshift/installer/pkg/types/aws"
@@ -141,7 +142,7 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 			config.Spec.PublicZone = &configv1.DNSZone{ID: zone.Name}
 		}
 		config.Spec.PrivateZone = &configv1.DNSZone{ID: fmt.Sprintf("%s-private-zone", clusterID.InfraID)}
-	case ibmcloudtypes.Name, powervstypes.Name:
+	case ibmcloudtypes.Name:
 		client, err := icibmcloud.NewClient()
 		if err != nil {
 			return errors.Wrap(err, "failed to get IBM Cloud client")
@@ -149,7 +150,26 @@ func (d *DNS) Generate(dependencies asset.Parents) error {
 
 		zoneID, err := client.GetDNSZoneIDByName(context.TODO(), installConfig.Config.BaseDomain)
 		if err != nil {
-			return errors.Wrap(err, "failed ot get DNS zone ID")
+			return errors.Wrap(err, "failed to get DNS zone ID")
+		}
+
+		if installConfig.Config.Publish == types.ExternalPublishingStrategy {
+			config.Spec.PublicZone = &configv1.DNSZone{
+				ID: zoneID,
+			}
+		}
+		config.Spec.PrivateZone = &configv1.DNSZone{
+			ID: zoneID,
+		}
+	case powervstypes.Name:
+		client, err := icpowervs.NewClient()
+		if err != nil {
+			return errors.Wrap(err, "failed to get IBM PowerVS client")
+		}
+
+		zoneID, err := client.GetDNSZoneIDByName(context.TODO(), installConfig.Config.BaseDomain)
+		if err != nil {
+			return errors.Wrap(err, "failed to get DNS zone ID")
 		}
 
 		if installConfig.Config.Publish == types.ExternalPublishingStrategy {


### PR DESCRIPTION
Zones are checked and used by `ingress` operator, at: https://github.com/openshift/cluster-ingress-operator/blob/3fdb8608f385a94a2c75e129edbac1dcd8760c32/pkg/operator/controller/dns/controller.go#L463

This proposed change adds just that for PowerVS, as can be seen in `oc describe dns/cluster` below;
![image](https://user-images.githubusercontent.com/1767126/160168678-9ea2946f-ef4b-47c5-84ba-33f2affd47cd.png)


Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>