### PR TITLE
Azure: validate UltraSSD instance types

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -54,7 +54,7 @@ func Validate(client API, ic *types.InstallConfig) error {
 }
 
 // ValidateInstanceType ensures the instance type has sufficient Vcpu and Memory.
-func ValidateInstanceType(client API, fieldPath *field.Path, region, instanceType string, diskType string, req resourceRequirements) field.ErrorList {
+func ValidateInstanceType(client API, fieldPath *field.Path, region, instanceType string, diskType string, req resourceRequirements, ultraSSDEnabled bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	typeMeta, err := client.GetVirtualMachineSku(context.TODO(), instanceType, region)
@@ -67,6 +67,7 @@ func ValidateInstanceType(client API, fieldPath *field.Path, region, instanceTyp
 		return append(allErrs, field.Invalid(fieldPath.Child("type"), instanceType, errMsg))
 	}
 
+	ultraSSDAvailable := false
 	for _, capability := range *typeMeta.Capabilities {
 
 		if strings.EqualFold(*capability.Name, "vCPUsAvailable") {
@@ -102,7 +103,15 @@ func ValidateInstanceType(client API, fieldPath *field.Path, region, instanceTyp
 				errMsg := fmt.Sprintf("PremiumIO not supported for instance type %s", instanceType)
 				allErrs = append(allErrs, field.Invalid(fieldPath.Child("osDisk", "diskType"), diskType, errMsg))
 			}
+		} else if strings.EqualFold(*capability.Name, "UltraSSDAvailable") {
+			ultraSSDAvailable = strings.EqualFold(*capability.Value, "True")
 		}
+	}
+
+	// The UltraSSDAvailable capability might not be present at all, in which case it must assumed to be false
+	if ultraSSDEnabled && !ultraSSDAvailable {
+		errMsg := fmt.Sprintf("UltraSSD capability not supported for this instance type in the %s region", region)
+		allErrs = append(allErrs, field.Invalid(fieldPath.Child("type"), instanceType, errMsg))
 	}
 
 	return allErrs
@@ -114,17 +123,24 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 
 	defaultDiskType := aztypes.DefaultDiskType
 	defaultInstanceType := ""
+	defaultUltraSSDCapability := "Disabled"
 
-	if ic.Platform.Azure.DefaultMachinePlatform != nil && ic.Platform.Azure.DefaultMachinePlatform.OSDisk.DiskType != "" {
-		defaultDiskType = ic.Platform.Azure.DefaultMachinePlatform.OSDisk.DiskType
-	}
-	if ic.Platform.Azure.DefaultMachinePlatform != nil && ic.Platform.Azure.DefaultMachinePlatform.InstanceType != "" {
-		defaultInstanceType = ic.Platform.Azure.DefaultMachinePlatform.InstanceType
+	if ic.Platform.Azure.DefaultMachinePlatform != nil {
+		if ic.Platform.Azure.DefaultMachinePlatform.OSDisk.DiskType != "" {
+			defaultDiskType = ic.Platform.Azure.DefaultMachinePlatform.OSDisk.DiskType
+		}
+		if ic.Platform.Azure.DefaultMachinePlatform.InstanceType != "" {
+			defaultInstanceType = ic.Platform.Azure.DefaultMachinePlatform.InstanceType
+		}
+		if ic.Platform.Azure.DefaultMachinePlatform.UltraSSDCapability != "" {
+			defaultUltraSSDCapability = ic.Platform.Azure.DefaultMachinePlatform.UltraSSDCapability
+		}
 	}
 
 	if ic.ControlPlane != nil && ic.ControlPlane.Platform.Azure != nil {
 		diskType := ic.ControlPlane.Platform.Azure.OSDisk.DiskType
 		instanceType := ic.ControlPlane.Platform.Azure.InstanceType
+		ultraSSDCapability := ic.ControlPlane.Platform.Azure.UltraSSDCapability
 
 		if diskType == "" {
 			diskType = defaultDiskType
@@ -135,7 +151,11 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 		if instanceType == "" {
 			instanceType = defaults.ControlPlaneInstanceType(ic.Azure.CloudName, ic.Azure.Region)
 		}
-		allErrs = append(allErrs, ValidateInstanceType(client, field.NewPath("controlPlane", "platform", "azure"), ic.Azure.Region, instanceType, diskType, controlPlaneReq)...)
+		if ultraSSDCapability == "" {
+			ultraSSDCapability = defaultUltraSSDCapability
+		}
+		ultraSSDEnabled := strings.EqualFold(ultraSSDCapability, "Enabled")
+		allErrs = append(allErrs, ValidateInstanceType(client, field.NewPath("controlPlane", "platform", "azure"), ic.Azure.Region, instanceType, diskType, controlPlaneReq, ultraSSDEnabled)...)
 	}
 
 	for idx, compute := range ic.Compute {
@@ -143,6 +163,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 		if compute.Platform.Azure != nil {
 			diskType := compute.Platform.Azure.OSDisk.DiskType
 			instanceType := compute.Platform.Azure.InstanceType
+			ultraSSDCapability := compute.Platform.Azure.UltraSSDCapability
 
 			if diskType == "" {
 				diskType = defaultDiskType
@@ -153,8 +174,12 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 			if instanceType == "" {
 				instanceType = defaults.ComputeInstanceType(ic.Azure.CloudName, ic.Azure.Region)
 			}
+			if ultraSSDCapability == "" {
+				ultraSSDCapability = defaultUltraSSDCapability
+			}
+			ultraSSDEnabled := strings.EqualFold(ultraSSDCapability, "Enabled")
 			allErrs = append(allErrs, ValidateInstanceType(client, fieldPath.Child("platform", "azure"),
-				ic.Azure.Region, instanceType, diskType, computeReq)...)
+				ic.Azure.Region, instanceType, diskType, computeReq, ultraSSDEnabled)...)
 		}
 	}
 

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -42,7 +42,7 @@ var (
 		{Name: to.StringPtr("Standard_D2_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("2")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("8")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}}},
 		{Name: to.StringPtr("Standard_D4_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}}},
 		{Name: to.StringPtr("Standard_D2s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}}},
-		{Name: to.StringPtr("Standard_D8s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}}},
+		{Name: to.StringPtr("Standard_D8s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("UltraSSDAvailable"), Value: to.StringPtr("True")}}},
 		{Name: to.StringPtr("Standard_D_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("False")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}}},
 		{Name: to.StringPtr("Standard_Dc4_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V2")}}},
 	}
@@ -69,6 +69,10 @@ var (
 		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Dne_D2_v4"
 	}
 
+	ultraSSDAvailableInstanceTypes = func(ic *types.InstallConfig) {
+		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_D8s_v3"
+	}
+
 	invalidateMachineCIDR = func(ic *types.InstallConfig) {
 		_, newCidr, _ := net.ParseCIDR("192.168.111.0/24")
 		ic.MachineNetwork = []types.MachineNetworkEntry{
@@ -92,6 +96,9 @@ var (
 	premiumDiskDefault                     = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.OSDisk.DiskType = "Premium_LRS" }
 	nonpremiumInstanceTypeDiskDefault      = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.InstanceType = "Standard_D_v4" }
 	unsupportedHyperVGeneration            = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.InstanceType = "Standard_Dc4_v4" }
+	enabledSSDCapabilityControlPlane       = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.Azure.UltraSSDCapability = "Enabled" }
+	enabledSSDCapabilityCompute            = func(ic *types.InstallConfig) { ic.Compute[0].Platform.Azure.UltraSSDCapability = "Enabled" }
+	enabledSSDCapabilityDefault            = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.UltraSSDCapability = "Enabled" }
 
 	virtualNetworkAPIResult = &aznetwork.VirtualNetwork{
 		Name: &validVirtualNetwork,
@@ -254,6 +261,36 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 			name:     "Unsupported HyperVGeneration",
 			edits:    editFunctions{unsupportedHyperVGeneration},
 			errorMsg: `^\[controlPlane.platform.azure.type: Invalid value: "Standard_Dc4_v4": only disks with HyperVGeneration V1 are supported, compute\[0\].platform.azure.type: Invalid value: "Standard_Dc4_v4": only disks with HyperVGeneration V1 are supported\]$`,
+		},
+		{
+			name:     "Unsupported UltraSSD capability in Control Plane",
+			edits:    editFunctions{enabledSSDCapabilityControlPlane, validInstanceTypes},
+			errorMsg: `controlPlane.platform.azure.type: Invalid value: "Standard_D4_v4": UltraSSD capability not supported for this instance type in the centralus region$`,
+		},
+		{
+			name:     "Unsupported UltraSSD capability in Compute",
+			edits:    editFunctions{enabledSSDCapabilityCompute, validInstanceTypes},
+			errorMsg: `compute\[0\].platform.azure.type: Invalid value: "Standard_D2_v4": UltraSSD capability not supported for this instance type in the centralus region$`,
+		},
+		{
+			name:     "Unsupported UltraSSD capability as default",
+			edits:    editFunctions{enabledSSDCapabilityDefault, validInstanceTypes},
+			errorMsg: `^\[controlPlane.platform.azure.type: Invalid value: "Standard_D4_v4": UltraSSD capability not supported for this instance type in the centralus region, compute\[0\].platform.azure.type: Invalid value: "Standard_D2_v4": UltraSSD capability not supported for this instance type in the centralus region\]$`,
+		},
+		{
+			name:     "Supported UltraSSD capability in Control Plane",
+			edits:    editFunctions{ultraSSDAvailableInstanceTypes, enabledSSDCapabilityControlPlane},
+			errorMsg: "",
+		},
+		{
+			name:     "Supported UltraSSD capability in Compute",
+			edits:    editFunctions{ultraSSDAvailableInstanceTypes, enabledSSDCapabilityCompute},
+			errorMsg: "",
+		},
+		{
+			name:     "Supported UltraSSD capability as default",
+			edits:    editFunctions{ultraSSDAvailableInstanceTypes, enabledSSDCapabilityDefault},
+			errorMsg: "",
 		},
 	}
 


### PR DESCRIPTION
Confirm an instance type is compatible with UltraSSD enabled or fail
early, before provisioning infrastructure, if type is incompatible.