### PR TITLE
Bug 2061891: IBMCloud: Add br-sao region to static list

### DIFF
--- a/pkg/types/ibmcloud/validation/platform.go
+++ b/pkg/types/ibmcloud/validation/platform.go
@@ -19,6 +19,7 @@ var (
 		"jp-osa":   "Japan (Osaka)",
 		"au-syd":   "Australia (Sydney)",
 		"ca-tor":   "Canada (Toronto)",
+		"br-sao":   "Brazil (Sao Paulo)",
 	}
 
 	regionShortNames = func() []string {


### PR DESCRIPTION
Add the br-sao region to the list of supported regions for IBM
Cloud. We will keep this static list for now and look into generating
the supported regions dynamically in a future patch.


Related: https://bugzilla.redhat.com/show_bug.cgi?id=2061891