### PR TITLE
Bug 2069259: Set ironic httpd port to 6180

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -6,6 +6,7 @@ set -ex
 # Must match ironic.service
 EXIT_CODE_NO_RESTART=42
 
+DEFAULT_HTTP_PORT="6180"
 IRONIC_IMAGE=$(image_for ironic)
 IRONIC_AGENT_IMAGE=$(image_for ironic-agent)
 CUSTOMIZATION_IMAGE=$(image_for image-customization-controller)
@@ -72,10 +73,11 @@ done
 {{ if .PlatformData.BareMetal.ProvisioningDNSMasq }}
 dnsmasq_container_name="dnsmasq"
 podman run -d --net host --privileged --name $dnsmasq_container_name \
-     --restart on-failure \
-     --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
-     --env DHCP_RANGE=$DHCP_RANGE \
-     -v $IRONIC_SHARED_VOLUME:/shared:z --entrypoint /bin/rundnsmasq ${IRONIC_IMAGE}
+    --restart on-failure \
+    --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
+    --env DHCP_RANGE=$DHCP_RANGE \
+    --env HTTP_PORT=$DEFAULT_HTTP_PORT \
+    -v $IRONIC_SHARED_VOLUME:/shared:z --entrypoint /bin/rundnsmasq ${IRONIC_IMAGE}
 {{ else }}
 dnsmasq_container_name=""
 {{ end }}
@@ -114,13 +116,14 @@ podman run -d --name coreos-downloader \
 podman wait -i 1000ms coreos-downloader
 
 podman run -d --net host --privileged --name httpd \
-     --restart on-failure \
-     --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
-     --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
-     -v $IRONIC_SHARED_VOLUME:/shared:z --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
+    --restart on-failure \
+    --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
+    --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
+    --env HTTP_PORT=$DEFAULT_HTTP_PORT \
+    -v $IRONIC_SHARED_VOLUME:/shared:z --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
 
 # Add firewall rules to ensure the IPA ramdisk can reach httpd, Ironic and the Inspector API on the host
-for port in 80 5050 6385 ; do
+for port in 6180 5050 6385 ; do
     if ! $IPTABLES -C INPUT -i $PROVISIONING_NIC -p tcp -m tcp --dport $port -j ACCEPT > /dev/null 2>&1; then
         $IPTABLES -I INPUT -i $PROVISIONING_NIC -p tcp -m tcp --dport $port -j ACCEPT
     fi
@@ -215,26 +218,28 @@ podman run -d --net host --privileged --name image-customization \
     ${CUSTOMIZATION_IMAGE}
 
 podman run -d --net host --privileged --name ironic \
-     --restart on-failure \
-     --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
-     --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
-     --env OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120 \
-     --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env INSPECTOR_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
-     --entrypoint /bin/runironic \
-     -v $AUTH_DIR:/auth:ro \
-     -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
+    --restart on-failure \
+    --env IRONIC_RAMDISK_SSH_KEY="$IRONIC_RAMDISK_SSH_KEY" \
+    --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
+    --env OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120 \
+    --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD} \
+    --env INSPECTOR_HTPASSWD=${IRONIC_HTPASSWD} \
+    --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
+    --env HTTP_PORT=$DEFAULT_HTTP_PORT \
+    --entrypoint /bin/runironic \
+    -v $AUTH_DIR:/auth:ro \
+    -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
 
 podman run -d --net host --privileged --name ironic-inspector \
-     --restart on-failure \
-     --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
-     --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env INSPECTOR_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
-     --entrypoint /bin/runironic-inspector \
-     -v $AUTH_DIR:/auth:ro \
-     -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_IMAGE}"
+    --restart on-failure \
+    --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
+    --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD} \
+    --env INSPECTOR_HTPASSWD=${IRONIC_HTPASSWD} \
+    --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
+    --env HTTP_PORT=$DEFAULT_HTTP_PORT \
+    --entrypoint /bin/runironic-inspector \
+    -v $AUTH_DIR:/auth:ro \
+    -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_IMAGE}"
 
 podman run -d --name ironic-ramdisk-logs \
      --restart on-failure \


### PR DESCRIPTION
We should not use default port 80 as it may cause conflicts and
it's potentially unsecure in production environments.
Also we may want to comply with the docs at
https://docs.openshift.com/container-platform/4.10/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-out-of-band_ipi-install-prerequisites