### PR TITLE
images: Update terraform version in UPI image

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -45,13 +45,12 @@ ENV CLOUDSDK_PYTHON=/usr/bin/python
 
 RUN python3 -m pip install yq
 
-ENV TERRAFORM_VERSION=0.12.24
+ENV TERRAFORM_VERSION=1.0.11
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin/
-ENV MATCHBOX_PROVIDER_VERSION=v0.3.0
-RUN curl -L -O https://github.com/poseidon/terraform-provider-matchbox/releases/download/${MATCHBOX_PROVIDER_VERSION}/terraform-provider-matchbox-${MATCHBOX_PROVIDER_VERSION}-linux-amd64.tar.gz && \
-    tar xzf terraform-provider-matchbox-${MATCHBOX_PROVIDER_VERSION}-linux-amd64.tar.gz && \
-    mv terraform-provider-matchbox-${MATCHBOX_PROVIDER_VERSION}-linux-amd64/terraform-provider-matchbox /bin/terraform-provider-matchbox
+ENV MATCHBOX_PROVIDER_VERSION=0.5.0
+RUN curl -L -O https://github.com/poseidon/terraform-provider-matchbox/releases/download/v${MATCHBOX_PROVIDER_VERSION}/terraform-provider-matchbox_${MATCHBOX_PROVIDER_VERSION}_linux_amd64.zip && \
+    unzip terraform-provider-matchbox_${MATCHBOX_PROVIDER_VERSION}_linux_amd64.zip -d /bin/
 ENV IGNITION_PROVIDER_VERSION=v2.1.0
 RUN curl -L -O https://github.com/community-terraform-providers/terraform-provider-ignition/releases/download/${IGNITION_PROVIDER_VERSION}/terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \
     tar xzf terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \


### PR DESCRIPTION
Updating terraform version and the matchbox provider version to
latest to help the baremetal UPI CI PR.