### PR TITLE
Bug 2070666: Update the default channel for new 4.6 installs to eus-4.6

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -5,5 +5,5 @@ metadata:
   name: version
 spec:
   upstream: https://api.openshift.com/api/upgrades_info/v1/graph
-  channel: stable-4.6
+  channel: eus-4.6
   clusterID: {{.CVOClusterID}}


### PR DESCRIPTION
OpenShift 4.6 EUS is unique in that it doesn't pick up the lifecycle changes
which made EUS available to all subscribers, nor do we continue adding all
4.6.z to stable-4.6 channel. Therefore, so that new installs don't get abandoned
we'll set the default channel to eus-4.6.