### PR TITLE
OWNERS_ALIASES: Update current installer team

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,11 +9,16 @@ aliases:
     - sdodson
     - smarterclayton
   installer-reviewers:
+    - AnnaZivkovic
+    - barbacbd
     - jhixson74
     - jstuever
     - kirankt
     - patrickdillon
+    - r4f4
     - rna-afk
+    - sadasu
+    - staebler
   libvirt-approvers:
     - praveenkumar
     - cfergeau


### PR DESCRIPTION
Updating OWNERS_ALIASES to get team up to date.

By being listed here, this means you will be in the review request rotation.

/cc @AnnaZivkovic  @barbacbd  @r4f4 @sadasu 

@staebler you weren't listed in reviewers. I think you get plenty of review requests already based on how the algorithm factors previous contributions. Adding you here, may be a bit of a novelty. Any issues I don't foresee?