### PR TITLE
collect machine state in bootstrap gather

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-cluster-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-cluster-gather.sh
@@ -50,6 +50,7 @@ function cluster_bootstrap_gather() {
     queue resources/events.json oc --request-timeout=5s get events --all-namespaces -o json
     queue resources/kubeapiserver.json oc --request-timeout=5s get kubeapiserver -o json
     queue resources/kubecontrollermanager.json oc --request-timeout=5s get kubecontrollermanager -o json
+    queue resources/machines.json oc --request-timeout=5s get machines --all-namespaces -o json
     queue resources/machineconfigpools.json oc --request-timeout=5s get machineconfigpools -o json
     queue resources/machineconfigs.json oc --request-timeout=5s get machineconfigs -o json
     queue resources/namespaces.json oc --request-timeout=5s get namespaces -o json


### PR DESCRIPTION
While debugging https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere/1511046135223947264, we lacked the summarization of the machines present.  Somehow a list of master IPs was retrieved, so machines exist at some level, try gathering them.