### PR TITLE
gather: collect sssd journal logs

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -34,7 +34,7 @@ done
 
 echo "Gathering bootstrap journals ..."
 mkdir -p "${ARTIFACTS}/bootstrap/journals"
-for service in release-image release-image-download crio-configure bootkube kubelet crio approve-csr ironic master-bmh-update
+for service in approve-csr bootkube crio crio-configure ironic kubelet master-bmh-update release-image release-image-download sssd
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"
 done

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -25,7 +25,7 @@ done
 
 echo "Gathering master journals ..."
 mkdir -p "${ARTIFACTS}/journals"
-for service in kubelet crio machine-config-master-firstboot machine-config-daemon-host pivot openshift-azure-routes openshift-gcp-routes
+for service in crio kubelet machine-config-daemon-host machine-config-master-firstboot openshift-azure-routes openshift-gcp-routes pivot sssd
 do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
 done


### PR DESCRIPTION
This adds sssd to the list of services we collect logs from. Currently,
vsphere and metal are failing to bootstrap and there's some evidence
collected from manual runs that we're hitting an issue in sssd[1].

Note, this also alphabetizes the list of services we collect logs from.

[1] https://github.com/SSSD/sssd/issues/5753