### PR TITLE
Bug 2033482: vsphere: ensure terraform variables are defined

### DIFF
--- a/data/data/vsphere/bootstrap/variables.tf
+++ b/data/data/vsphere/bootstrap/variables.tf
@@ -2,6 +2,21 @@ variable "resource_pool" {
   type = string
 }
 
+variable "bootstrap_moid" {
+  type    = string
+  default = ""
+}
+
+variable "control_plane_ips" {
+  type    = list(string)
+  default = []
+}
+
+variable "control_plane_moids" {
+  type    = list(string)
+  default = []
+}
+
 variable "folder" {
   type = string
 }

--- a/data/data/vsphere/master/variables.tf
+++ b/data/data/vsphere/master/variables.tf
@@ -6,6 +6,11 @@ variable "folder" {
   type = string
 }
 
+variable "bootstrap_moid" {
+  type    = string
+  default = ""
+}
+
 variable "datastore" {
   type = string
 }


### PR DESCRIPTION
This change add missing variables to each vsphere terraform stage in order
to remove the terraform warnings regarding undeclared variables. These
warnings were the result of output variables from some stages not being
declared in the later stages.