### PR TITLE
pkg/asset/manifests/operators: Set kubernetes.io/description for cluster-config-v1

### DIFF
--- a/pkg/asset/manifests/operators.go
+++ b/pkg/asset/manifests/operators.go
@@ -92,6 +92,11 @@ func (m *Manifests) Generate(dependencies asset.Parents) error {
 	m.KubeSysConfig = configMap("kube-system", "cluster-config-v1", genericData{
 		"install-config": string(redactedConfig),
 	})
+	if m.KubeSysConfig.Metadata.Annotations == nil {
+		m.KubeSysConfig.Metadata.Annotations = make(map[string]string, 1)
+	}
+	m.KubeSysConfig.Metadata.Annotations["kubernetes.io/description"] = "The install-config content used to create the cluster.  The cluster configuration may have evolved since installation, so check cluster configuration resources directly if you are interested in the current cluster state."
+
 	kubeSysConfigData, err := yaml.Marshal(m.KubeSysConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to create kube-system/cluster-config-v1 configmap")

--- a/pkg/asset/manifests/utils.go
+++ b/pkg/asset/manifests/utils.go
@@ -15,8 +15,9 @@ type configurationObject struct {
 }
 
 type metadata struct {
-	Name      string `json:"name,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
 }
 
 func configMap(namespace, name string, data genericData) *configurationObject {


### PR DESCRIPTION
The ConfigMap is install-time archival, and may no longer express the current cluster state.  Having it in-cluster was intended to be a temporary hack until we got Infrastructure and such, and we just failed to remove the ConfigMap quickly enough, and now removing it would be a breaking change.  But with this commit, we get a warning about this into the cluster, so folks looking at the resource are more likely to understand its limitations.

The kubernetes.io/description annotation has been documented since kubernetes/website#31621.