### PR TITLE
Remove defaultStorageContainer from nutanix platform installconfig

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2173,10 +2173,6 @@ spec:
                             type: integer
                         type: object
                     type: object
-                  defaultStorageContainer:
-                    description: DefaultStorageContainer is the default datastore
-                      to use for provisioning volumes.
-                    type: string
                   ingressVIP:
                     description: IngressVIP is the virtual IP address for ingress
                     type: string
@@ -2204,7 +2200,6 @@ spec:
                       to the Prism Central.
                     type: string
                 required:
-                - defaultStorageContainer
                 - password
                 - port
                 - prismCentral

--- a/pkg/asset/installconfig/nutanix/nutanix.go
+++ b/pkg/asset/installconfig/nutanix/nutanix.go
@@ -50,21 +50,15 @@ func Platform() (*nutanix.Platform, error) {
 		return nil, errors.Wrap(err, "failed to get VIPs")
 	}
 
-	defaultStorageContainer, err := getDefaultStorageContainer()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get default storage container")
-	}
-
 	platform := &nutanix.Platform{
-		PrismCentral:            nutanixClient.PrismCentral,
-		Port:                    nutanixClient.Port,
-		Username:                nutanixClient.Username,
-		Password:                nutanixClient.Password,
-		PrismElementUUID:        peUUID,
-		SubnetUUID:              subnetUUID,
-		DefaultStorageContainer: defaultStorageContainer,
-		APIVIP:                  apiVIP,
-		IngressVIP:              ingressVIP,
+		PrismCentral:     nutanixClient.PrismCentral,
+		Port:             nutanixClient.Port,
+		Username:         nutanixClient.Username,
+		Password:         nutanixClient.Password,
+		PrismElementUUID: peUUID,
+		SubnetUUID:       subnetUUID,
+		APIVIP:           apiVIP,
+		IngressVIP:       ingressVIP,
 	}
 	return platform, nil
 
@@ -280,21 +274,4 @@ func getVIPs() (string, string, error) {
 	}
 
 	return apiVIP, ingressVIP, nil
-}
-
-func getDefaultStorageContainer() (string, error) {
-	var defaultStorageContainer string
-	if err := survey.Ask([]*survey.Question{
-		{
-			Prompt: &survey.Password{
-				Message: "Default Storage Container",
-				Help:    "The name of the default storage container for the cluster.",
-			},
-			Validate: survey.Required,
-		},
-	}, &defaultStorageContainer); err != nil {
-		return "", errors.Wrap(err, "failed UserInput")
-	}
-
-	return defaultStorageContainer, nil
 }

--- a/pkg/types/nutanix/platform.go
+++ b/pkg/types/nutanix/platform.go
@@ -17,9 +17,6 @@ type Platform struct {
 	// PrismElementUUID is the UUID of the Prism Element cluster to use in the Prism Central.
 	PrismElementUUID string `json:"prismElementUUID"`
 
-	// DefaultStorageContainer is the default datastore to use for provisioning volumes.
-	DefaultStorageContainer string `json:"defaultStorageContainer"`
-
 	// ClusterOSImage overrides the url provided in rhcos.json to download the RHCOS Image
 	//
 	// +optional

--- a/pkg/types/nutanix/validation/platform.go
+++ b/pkg/types/nutanix/validation/platform.go
@@ -26,9 +26,6 @@ func ValidatePlatform(p *nutanix.Platform, fldPath *field.Path) field.ErrorList 
 	if len(p.Port) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("port"), "must specify the port"))
 	}
-	if len(p.DefaultStorageContainer) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("defaultStorageContainer"), "must specify the default storage container"))
-	}
 	if len(p.SubnetUUID) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("subnet"), "must specify the subnet"))
 	}

--- a/pkg/types/nutanix/validation/platform_test.go
+++ b/pkg/types/nutanix/validation/platform_test.go
@@ -11,13 +11,12 @@ import (
 
 func validPlatform() *nutanix.Platform {
 	return &nutanix.Platform{
-		PrismCentral:            "test-pc",
-		PrismElementUUID:        "12992bc3-e919-454b-980e-8b51e217c9bd",
-		DefaultStorageContainer: "test-storage-container",
-		Username:                "test-username",
-		Password:                "test-password",
-		SubnetUUID:              "b06179c8-dea3-4f8e-818a-b2e88fbc2201",
-		Port:                    "8080",
+		PrismCentral:     "test-pc",
+		PrismElementUUID: "12992bc3-e919-454b-980e-8b51e217c9bd",
+		Username:         "test-username",
+		Password:         "test-password",
+		SubnetUUID:       "b06179c8-dea3-4f8e-818a-b2e88fbc2201",
+		Port:             "8080",
 	}
 }
 
@@ -66,15 +65,6 @@ func TestValidatePlatform(t *testing.T) {
 				return p
 			}(),
 			expectedError: `^test-path\.prismElement: Required value: must specify the Prism Element$`,
-		},
-		{
-			name: "missing default storage container",
-			platform: func() *nutanix.Platform {
-				p := validPlatform()
-				p.DefaultStorageContainer = ""
-				return p
-			}(),
-			expectedError: `^test-path\.defaultStorageContainer: Required value: must specify the default storage container$`,
 		},
 		{
 			name: "valid VIPs",

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -165,13 +165,12 @@ func validOpenStackPlatform() *openstack.Platform {
 
 func validNutanixPlatform() *nutanix.Platform {
 	return &nutanix.Platform{
-		PrismCentral:            "test-pc",
-		PrismElementUUID:        "test-pe",
-		DefaultStorageContainer: "test-storage-container",
-		Username:                "test-username",
-		Password:                "test-password",
-		SubnetUUID:              "test-subnet",
-		Port:                    "8080",
+		PrismCentral:     "test-pc",
+		PrismElementUUID: "test-pe",
+		Username:         "test-username",
+		Password:         "test-password",
+		SubnetUUID:       "test-subnet",
+		Port:             "8080",
 	}
 }
 


### PR DESCRIPTION
Remove defaultStorageContainer from the platform, installconfig, and survey.
This was added earlier with the intention to provide a default storage class
for the cluster. However, with the Nutanix CSI driver provisioning being a day-2
operation for Nutanix, a defaultStorageContainer is no longer required.