### PR TITLE
remove platform.azure.osDisk

### DIFF
--- a/docs/user/azure/customization.md
+++ b/docs/user/azure/customization.md
@@ -102,9 +102,6 @@ platform:
   azure:
     region: centralus
     baseDomainResourceGroupName: os4-common
-    osDisk:
-        diskSizeGB: 512
-        diskType: Premium_LRS
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ```


### PR DESCRIPTION
tested on 4.10.9 
platform.azure.osDisk will caused the following error
FATAL failed to fetch Metadata: failed to load asset "Install Config": failed to unmarshal install-config.yaml: failed to parse first occurence of unknown field: error unmarshaling JSON: while decoding JSON: json: unknown field "osDisk"