### PR TITLE
Bootstrap-in-place ignition creation should also create a `worker.ign` file

### DIFF
--- a/pkg/asset/targets/targets.go
+++ b/pkg/asset/targets/targets.go
@@ -56,6 +56,7 @@ var (
 	SingleNodeIgnitionConfig = []asset.WritableAsset{
 		&kubeconfig.AdminClient{},
 		&password.KubeadminPassword{},
+		&machine.Worker{},
 		&bootstrap.SingleNodeBootstrapInPlace{},
 		&cluster.Metadata{},
 	}


### PR DESCRIPTION
This is an implementation of the second other part of the single node + workers
enhancement:

https://github.com/openshift/enhancements/blob/master/enhancements/single-node/single-node-openshift-with-workers.md

The first part is implemented in this PR: https://github.com/openshift/installer/pull/5746

________________________________

Today, performing bootstrap-in-place installation of a "none"-platform
single control-plane node cluster using the OpenShift Installer does not
provide the user with a worker node ignition file. As a result, the user
is not able to manually add worker nodes to the resulting cluster. This
was historically done intentionally to prevent users from adding worker
nodes to a single-node cluster, which would be an unsupported operation.

All current official OCP documentation points the user to use "the
worker ignition file that get generated during installation", but as
mentioned, that file is not currently generated in such
bootstrap-in-place installation, so users would not be able to find this
file.

Now that adding worker nodes to single control-plane node clusters is
going to be supported, this commit makes it so that this worker node
ignition file does get generated alongside the bootstrap-in-place
ignition file, so users will be able to use it and follow the existing
documentation.