### PR TITLE
baremetal: static IP for bootstrap node

### DIFF
--- a/data/data/bootstrap/baremetal/files/etc/NetworkManager/system-connections/nmconnection.template
+++ b/data/data/bootstrap/baremetal/files/etc/NetworkManager/system-connections/nmconnection.template
@@ -1,0 +1,15 @@
+{{if .PlatformData.BareMetal.ExternalStaticIP}}
+[connection]
+type=ethernet
+[ethernet]
+mac-address={{.PlatformData.BareMetal.ExternalMACAddress}}
+{{ if .UseIPv6ForNodeIP }}
+[ipv6]
+{{ else }}
+[ipv4]
+{{ end }}
+method=manual
+addresses={{.PlatformData.BareMetal.ExternalStaticIP}}/{{.PlatformData.BareMetal.ExternalSubnetCIDR}}
+gateway={{.PlatformData.BareMetal.ExternalStaticGateway}}
+dns={{.PlatformData.BareMetal.ExternalStaticGateway}}
+{{end}}

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1871,6 +1871,18 @@ spec:
                     description: APIVIP is the VIP to use for internal API communication
                     format: ip
                     type: string
+                  bootstrapExternalStaticGateway:
+                    description: BootstrapExternalStaticGateway is the static network
+                      gateway of the bootstrap node. This can be useful in environments
+                      without a DHCP server.
+                    format: ip
+                    type: string
+                  bootstrapExternalStaticIP:
+                    description: BootstrapExternalStaticIP is the static IP address
+                      of the bootstrap node. This can be useful in environments without
+                      a DHCP server.
+                    format: ip
+                    type: string
                   bootstrapOSImage:
                     description: BootstrapOSImage is a URL to override the default
                       OS image for the bootstrap node. The URL must contain a sha256

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -58,6 +58,16 @@ type TemplateData struct {
 
 	// ProvisioningNetwork displays the type of provisioning network being used
 	ProvisioningNetwork string
+
+	// ExternalStaticIP is the static IP of the bootstrap node
+	ExternalStaticIP string
+
+	// ExternalStaticIP is the static gateway of the bootstrap node
+	ExternalStaticGateway string
+
+	ExternalSubnetCIDR int
+
+	ExternalMACAddress string
 }
 
 // GetTemplateData returns platform-specific data for bootstrap templates.
@@ -70,6 +80,17 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 	templateData.ProvisioningNetwork = string(config.ProvisioningNetwork)
 	templateData.BaremetalEndpointOverride = fmt.Sprintf("http://%s/v1", net.JoinHostPort(config.APIVIP, "6385"))
 	templateData.BaremetalIntrospectionEndpointOverride = fmt.Sprintf("http://%s/v1", net.JoinHostPort(config.APIVIP, "5050"))
+	templateData.ExternalStaticIP = config.BootstrapExternalStaticIP
+	templateData.ExternalStaticGateway = config.BootstrapExternalStaticGateway
+	templateData.ExternalMACAddress = config.ExternalMACAddress
+
+	if config.BootstrapExternalStaticIP != "" {
+		for _, network := range networks {
+			cidr, _ := network.CIDR.Mask.Size()
+			templateData.ExternalSubnetCIDR = cidr
+			break
+		}
+	}
 
 	if config.ProvisioningNetwork != baremetal.DisabledProvisioningNetwork {
 		cidr, _ := config.ProvisioningNetworkCIDR.Mask.Size()

--- a/pkg/asset/installconfig/baremetal/validation.go
+++ b/pkg/asset/installconfig/baremetal/validation.go
@@ -20,3 +20,20 @@ func ValidateProvisioning(ic *types.InstallConfig) error {
 
 	return allErrs.ToAggregate()
 }
+
+// ValidateStaticBootstrapNetworking ensures that both or neither of  BootstrapExternalStaticIP and BootstrapExternalStaticGateway are set
+func ValidateStaticBootstrapNetworking(ic *types.InstallConfig) error {
+	if ic.Platform.BareMetal == nil {
+		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "Baremetal validation requires a baremetal platform configuration").Error())
+	}
+
+	if ic.Platform.BareMetal.BootstrapExternalStaticIP != "" && ic.Platform.BareMetal.BootstrapExternalStaticGateway == "" {
+		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "You must specify a value for BootstrapExternalStaticGateway when BootstrapExternalStaticIP is set.").Error())
+	}
+
+	if ic.Platform.BareMetal.BootstrapExternalStaticGateway != "" && ic.Platform.BareMetal.BootstrapExternalStaticIP == "" {
+		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "You must specify a value for BootstrapExternalStaticIP when BootstrapExternalStaticGateway is set.").Error())
+	}
+
+	return nil
+}

--- a/pkg/asset/installconfig/baremetal/validation.go
+++ b/pkg/asset/installconfig/baremetal/validation.go
@@ -8,25 +8,23 @@ import (
 	"github.com/openshift/installer/pkg/types/baremetal/validation"
 )
 
-// ValidateProvisioning performs platform validation specifically for any optional requirement
-// to be called when the cluster creation takes place
-func ValidateProvisioning(ic *types.InstallConfig) error {
-	allErrs := field.ErrorList{}
+// ValidateBaremetalPlatformSet ensures that the BareMetal platform data is populated
+func ValidateBaremetalPlatformSet(ic *types.InstallConfig) error {
 	if ic.Platform.BareMetal == nil {
 		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "Baremetal validation requires a baremetal platform configuration").Error())
 	}
 
-	allErrs = append(allErrs, validation.ValidateProvisioning(ic.Platform.BareMetal, ic.Networking, field.NewPath("platform").Child("baremetal"))...)
+	return nil
+}
 
-	return allErrs.ToAggregate()
+// ValidateProvisioning performs platform validation specifically for any optional requirement
+// to be called when the cluster creation takes place
+func ValidateProvisioning(ic *types.InstallConfig) error {
+	return validation.ValidateProvisioning(ic.Platform.BareMetal, ic.Networking, field.NewPath("platform").Child("baremetal")).ToAggregate()
 }
 
 // ValidateStaticBootstrapNetworking ensures that both or neither of  BootstrapExternalStaticIP and BootstrapExternalStaticGateway are set
 func ValidateStaticBootstrapNetworking(ic *types.InstallConfig) error {
-	if ic.Platform.BareMetal == nil {
-		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "Baremetal validation requires a baremetal platform configuration").Error())
-	}
-
 	if ic.Platform.BareMetal.BootstrapExternalStaticIP != "" && ic.Platform.BareMetal.BootstrapExternalStaticGateway == "" {
 		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "You must specify a value for BootstrapExternalStaticGateway when BootstrapExternalStaticIP is set.").Error())
 	}

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -77,6 +77,10 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+		err = bmconfig.ValidateStaticBootstrapNetworking(ic.Config)
+		if err != nil {
+			return err
+		}
 	case gcp.Name:
 		client, err := gcpconfig.NewClient(context.TODO())
 		if err != nil {

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -73,6 +73,10 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		}
 		return azconfig.ValidateForProvisioning(client, ic.Config)
 	case baremetal.Name:
+		err = bmconfig.ValidateBaremetalPlatformSet(ic.Config)
+		if err != nil {
+			return err
+		}
 		err = bmconfig.ValidateProvisioning(ic.Config)
 		if err != nil {
 			return err

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -190,4 +190,16 @@ type Platform struct {
 	//
 	// +optional
 	ClusterOSImage string `json:"clusterOSImage,omitempty" validate:"omitempty,osimageuri,urlexist"`
+
+	// BootstrapExternalStaticIP is the static IP address of the bootstrap node.
+	// This can be useful in environments without a DHCP server.
+	// +kubebuilder:validation:Format=ip
+	// +optional
+	BootstrapExternalStaticIP string `json:"bootstrapExternalStaticIP,omitempty"`
+
+	// BootstrapExternalStaticGateway is the static network gateway of the bootstrap node.
+	// This can be useful in environments without a DHCP server.
+	// +kubebuilder:validation:Format=ip
+	// +optional
+	BootstrapExternalStaticGateway string `json:"bootstrapExternalStaticGateway,omitempty"`
 }


### PR DESCRIPTION
Add new configuration fields to `install-config.yaml` that will enable the cluster operator to set up static networking for the bootstrap node

This is the implementation of the [Bootstrap external IP OpenShift enhancement](https://github.com/openshift/enhancements/blob/master/enhancements/baremetal/bootstrap-external-ip.md).