### PR TITLE
Bug 2076880: for vsphere ipi add cluster domain to the uploaded vm configs so that 30-local-dns-prepender can use it

### DIFF
--- a/data/data/bootstrap/vsphere/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
+++ b/data/data/bootstrap/vsphere/files/etc/NetworkManager/dispatcher.d/30-local-dns-prepender.template
@@ -20,11 +20,13 @@ EOF
     set +e
     if systemctl -q is-enabled systemd-resolved; then
         >&2 echo "NM resolv-prepender: Setting up systemd-resolved for local DNS"
-        if [[ ! -f /etc/systemd/resolved.conf.d/60-kni.conf ]]; then
+        DOMAIN=$(/bin/vmtoolsd --cmd 'info-get guestinfo.domain');
+        if [[ -n "$DOMAIN" && ! -f /etc/systemd/resolved.conf.d/60-kni.conf ]]; then
             >&2 echo "NM resolv-prepender: Creating /etc/systemd/resolved.conf.d/60-kni.conf"
             mkdir -p /etc/systemd/resolved.conf.d
             echo "[Resolve]" > /etc/systemd/resolved.conf.d/60-kni.conf
             echo "DNS=$DNS_IP" >> /etc/systemd/resolved.conf.d/60-kni.conf
+            echo "Domains=$DOMAIN" >> /etc/systemd/resolved.conf.d/60-kni.conf
             if systemctl -q is-active systemd-resolved; then
                 >&2 echo "NM resolv-prepender: restarting systemd-resolved"
                 systemctl restart systemd-resolved

--- a/data/data/vsphere/bootstrap/main.tf
+++ b/data/data/vsphere/bootstrap/main.tf
@@ -42,6 +42,7 @@ resource "vsphere_virtual_machine" "vm_bootstrap" {
     "guestinfo.ignition.config.data"          = base64encode(var.ignition_bootstrap)
     "guestinfo.ignition.config.data.encoding" = "base64"
     "guestinfo.hostname"                      = "${var.cluster_id}-bootstrap"
+    "guestinfo.domain"                        = "${var.cluster_domain}"
   }
   tags = var.tags
 }


### PR DESCRIPTION
for vsphere ipi add cluster domain to the uploaded vm configs so that 30-local-dns-prepender can use it

Due to changes in FCOS 35 /etc/nsswitch.conf, we need to move the name resolution of api-int.<domain> to
systemd-resolved.  The way we do this is by adding a Domain attribute to /etc/systemd/resolved.conf.d/60-kni.conf.

Since we are using a slightly different prepender than the masters and workers the domain is not being
discovered automatically.  To address this we are adding the domain in data/data/vsphere/bootstrap/main.tf
which gets uploaded to the bootstrap instance on creation.

30-local-dns-prepender then downloads this information and adds it to /etc/systemd/resolved.conf.d/60-kni.conf

Note that we check for a non-empty domain before writing /etc/systemd/resolved.conf.d/60-kni.conf.

Fixes https://github.com/openshift/okd/issues/1182

Signed-off-by: John Fortin <fortinj66@gmail.com>