### PR TITLE
Bug 2080054: Add 'ARG TAGS=""' line for each build step

### DIFF
--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -9,12 +9,14 @@ RUN go generate ./data && \
     SKIP_GENERATION=y GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS macarmbuilder
+ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN go generate ./data && \
     SKIP_GENERATION=y GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS linuxbuilder
+ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN go generate ./data && \


### PR DESCRIPTION
For OKD builds TAGS are not propagated to all three builds.  Adding
'ARG TAGS=""' to each build stanza fixes this

Command:
`podman build --build-arg TAGS=okd -f images/installer-artifacts/Dockerfile.rhel -t installer-artifacts:4.11-jef .`

**Without fix** (Not all three build as shown as I ran out of disk space)

```
[johnf@johnf-dev installer]$ grep -e "go build" -e TAGS build-installer-artifacts-no-okd.log
[1/4] STEP 2/5: ARG TAGS=""
+ TAGS=okd
+ TAGS='okd release'
+ go build -mod=vendor -ldflags ' -X github.com/openshift/installer/pkg/version.Raw=unreleased-master-5311-gcd69a4bda52fe5e4cf4d250717529ba9e8811ba4-dirty -X github.com/openshift/installer/pkg/version.Commit=cd69a4bda52fe5e4cf4d250717529ba9e8811ba4 -X github.com/openshift/installer/pkg/version.defaultArch=amd64 -s -w' -tags 'okd release' -o bin/openshift-install ./cmd/openshift-install
+ TAGS=
+ TAGS=' release'
+ go build -mod=vendor -ldflags ' -X github.com/openshift/installer/pkg/version.Raw=unreleased-master-5311-gcd69a4bda52fe5e4cf4d250717529ba9e8811ba4-dirty -X github.com/openshift/installer/pkg/version.Commit=cd69a4bda52fe5e4cf4d250717529ba9e8811ba4 -X github.com/openshift/installer/pkg/version.defaultArch=amd64 -s -w' -tags ' release' -o bin/openshift-install ./cmd/openshift-install
```

**With Fix**

```
[johnf@johnf-dev installer]$ grep -e "go build" -e TAGS build-installer-artifacts-with-okd.log
[1/4] STEP 2/5: ARG TAGS=""
+ TAGS=okd
+ TAGS='okd release'
+ go build -mod=vendor -ldflags ' -X github.com/openshift/installer/pkg/version.Raw=unreleased-master-5311-gcd69a4bda52fe5e4cf4d250717529ba9e8811ba4-dirty -X github.com/openshift/installer/pkg/version.Commit=cd69a4bda52fe5e4cf4d250717529ba9e8811ba4 -X github.com/openshift/installer/pkg/version.defaultArch=amd64 -s -w' -tags 'okd release' -o bin/openshift-install ./cmd/openshift-install
[2/4] STEP 2/5: ARG TAGS=""
+ TAGS=okd
+ TAGS='okd release'
+ go build -mod=vendor -ldflags ' -X github.com/openshift/installer/pkg/version.Raw=unreleased-master-5311-gcd69a4bda52fe5e4cf4d250717529ba9e8811ba4-dirty -X github.com/openshift/installer/pkg/version.Commit=cd69a4bda52fe5e4cf4d250717529ba9e8811ba4 -X github.com/openshift/installer/pkg/version.defaultArch=amd64 -s -w' -tags 'okd release' -o bin/openshift-install ./cmd/openshift-install
[3/4] STEP 2/5: ARG TAGS=""
+ TAGS=okd
+ TAGS='okd release'
+ go build -mod=vendor -ldflags ' -X github.com/openshift/installer/pkg/version.Raw=unreleased-master-5311-gcd69a4bda52fe5e4cf4d250717529ba9e8811ba4-dirty -X github.com/openshift/installer/pkg/version.Commit=cd69a4bda52fe5e4cf4d250717529ba9e8811ba4 -X github.com/openshift/installer/pkg/version.defaultArch=amd64 -s -w' -tags 'okd release' -o bin/openshift-install ./cmd/openshift-install
```

