### PR TITLE
Add -n argument to copy network config from install environment to install-to-disk.sh.template

### DIFF
--- a/data/data/bootstrap/bootstrap-in-place/files/usr/local/bin/install-to-disk.sh.template
+++ b/data/data/bootstrap/bootstrap-in-place/files/usr/local/bin/install-to-disk.sh.template
@@ -16,7 +16,7 @@ if [ ! -f coreos-installer.done ]; then
   record_service_stage_start "coreos-installer"
   # Write image + ignition to disk
   echo "Executing coreos-installer with the following options: install -i /opt/openshift/master.ign {{.BootstrapInPlace.InstallationDisk}}"
-  coreos-installer install -i /opt/openshift/master.ign {{.BootstrapInPlace.InstallationDisk}}
+  coreos-installer install -n -i /opt/openshift/master.ign {{.BootstrapInPlace.InstallationDisk}}
 
   touch coreos-installer.done
   record_service_stage_success


### PR DESCRIPTION
If a customer creates a custom RHCOS ISO to install Single Node OpenShift and also embeds the Networking Config via Network Manager Keyfile the installer will not copy over the install environment's network configuration.

Adding the `-n` option to the install-to-disk.sh.template file ensures that the embedded network configuration is copied.

If the Customer does not embed a Network Manager keyfile the DHCP configuration is still used without an issue.