### PR TITLE
vSphere session cleanup

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -690,13 +690,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		// instead of the name since port group names aren't always unique in vSphere.
 		// https://bugzilla.redhat.com/show_bug.cgi?id=1918005
 		controlPlaneConfig := controlPlaneConfigs[0]
-		vim25Client, _, err := vsphereconfig.CreateVSphereClients(context.TODO(),
+		vim25Client, _, cleanup, err := vsphereconfig.CreateVSphereClients(context.TODO(),
 			controlPlaneConfig.Workspace.Server,
 			installConfig.Config.VSphere.Username,
 			installConfig.Config.VSphere.Password)
 		if err != nil {
 			return errors.Wrapf(err, "unable to connect to vCenter %s. Ensure provided information is correct and client certs have been added to system trust.", controlPlaneConfig.Workspace.Server)
 		}
+		defer cleanup()
 
 		finder := vsphereconfig.NewFinder(vim25Client)
 		networkID, err := vsphereconfig.GetNetworkMoID(context.TODO(),

--- a/pkg/asset/installconfig/vsphere/client.go
+++ b/pkg/asset/installconfig/vsphere/client.go
@@ -39,31 +39,38 @@ func NewFinder(client *vim25.Client, all ...bool) Finder {
 	return find.NewFinder(client, all...)
 }
 
+// ClientLogout is empty function that logs out of vSphere clients
+type ClientLogout func()
+
 // CreateVSphereClients creates the SOAP and REST client to access
 // different portions of the vSphere API
 // e.g. tags are only available in REST
-func CreateVSphereClients(ctx context.Context, vcenter, username, password string) (*vim25.Client, *rest.Client, error) {
+func CreateVSphereClients(ctx context.Context, vcenter, username, password string) (*vim25.Client, *rest.Client, ClientLogout, error) {
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
 	u, err := soap.ParseURL(vcenter)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	u.User = url.UserPassword(username, password)
 	c, err := govmomi.NewClient(ctx, u, false)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	restClient := rest.NewClient(c.Client)
 	err = restClient.Login(ctx, u.User)
 	if err != nil {
-		return nil, nil, err
+		c.Logout(context.TODO())
+		return nil, nil, nil, err
 	}
 
-	return c.Client, restClient, nil
+	return c.Client, restClient, func() {
+		c.Logout(context.TODO())
+		restClient.Logout(context.TODO())
+	}, nil
 }
 
 // getNetworks returns a slice of Managed Object references for networks in the given vSphere Cluster.

--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -32,7 +32,7 @@ func ValidateForProvisioning(ic *types.InstallConfig) error {
 	}
 
 	p := ic.Platform.VSphere
-	vim25Client, _, err := CreateVSphereClients(context.TODO(),
+	vim25Client, _, cleanup, err := CreateVSphereClients(context.TODO(),
 		p.VCenter,
 		p.Username,
 		p.Password)
@@ -40,6 +40,7 @@ func ValidateForProvisioning(ic *types.InstallConfig) error {
 	if err != nil {
 		return errors.New(field.InternalError(field.NewPath("platform", "vsphere"), errors.Wrapf(err, "unable to connect to vCenter %s.", p.VCenter)).Error())
 	}
+	defer cleanup()
 
 	finder := NewFinder(vim25Client)
 	return validateProvisioning(vim25Client, finder, ic)

--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -136,7 +136,7 @@ func getClients() (*vCenterClient, error) {
 
 	// There is a noticeable delay when creating the client, so let the user know what's going on.
 	logrus.Infof("Connecting to vCenter %s", vcenter)
-	vim25Client, restClient, err := CreateVSphereClients(context.TODO(),
+	vim25Client, restClient, cleanup, err := CreateVSphereClients(context.TODO(),
 		vcenter,
 		username,
 		password)
@@ -146,6 +146,7 @@ func getClients() (*vCenterClient, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to connect to vCenter %s. Ensure provided information is correct and client certs have been added to system trust.", vcenter)
 	}
+	defer cleanup()
 
 	return &vCenterClient{
 		VCenter:    vcenter,

--- a/pkg/terraform/stages/vsphere/stages.go
+++ b/pkg/terraform/stages/vsphere/stages.go
@@ -88,10 +88,11 @@ func extractOutputHostAddresses(s stages.SplitStage, directory string, config *t
 
 // hostIP returns the ip address for a host
 func hostIP(config *types.InstallConfig, moid string) (string, error) {
-	client, _, err := vsphere.CreateVSphereClients(context.TODO(), config.VSphere.VCenter, config.VSphere.Username, config.VSphere.Password)
+	client, _, cleanup, err := vsphere.CreateVSphereClients(context.TODO(), config.VSphere.VCenter, config.VSphere.Username, config.VSphere.Password)
 	if err != nil {
 		return "", err
 	}
+	defer cleanup()
 
 	var errs []error
 	ip, err := waitForVirtualMachineIP(client, moid)


### PR DESCRIPTION
This PR adds logouts for each location a vSphere client is created (excluding inside `terraform-provider-vsphere`). 

A new `Cleanup` method was added to `Destroyer` interface (this method name is open to suggestions) with the first implementation being for vSphere where logouts occur. 

Terraform provider for vSphere is not addressed in this PR due to https://github.com/hashicorp/terraform-provider-vsphere/issues/618

Relates to [SPLAT-471](https://issues.redhat.com//browse/SPLAT-471)