### PR TITLE
Repin libvirt-version

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -1,9 +1,12 @@
 # This Dockerfile is a used by CI to publish an installer image
 # It builds an image containing openshift-install.
 
+ARG libvirt_version="8.0.0"
+
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
+ARG libvirt_version
 ARG TAGS="libvirt baremetal"
-RUN dnf install -y libvirt-devel-6.0.0 && \
+RUN dnf install -y libvirt-devel-$libvirt_version && \
     dnf clean all && rm -rf /var/cache/yum/*
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
@@ -11,11 +14,12 @@ RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 
 FROM registry.ci.openshift.org/ocp/4.11:base
+ARG libvirt_version
 COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install /bin/openshift-install
 
 RUN dnf upgrade -y && \
     dnf install --setopt=tsflags=nodocs -y \
-    libvirt-libs-6.0.0 openssl unzip jq openssh-clients && \
+    libvirt-libs-$libvirt_version openssl unzip jq openssh-clients && \
     dnf clean all && rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 


### PR DESCRIPTION
Also use a shared ARG to keep it consistent between stages

This should fix the downstream build pipeline