### PR TITLE
data/bootstrap/files/usr/local/bin/bootkube: Drop config render

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -48,7 +48,6 @@ MACHINE_CONFIG_ETCD_IMAGE=$(image_for etcd)
 MACHINE_CONFIG_INFRA_IMAGE=$(image_for pod)
 
 CLUSTER_ETCD_OPERATOR_IMAGE=$(image_for cluster-etcd-operator)
-CONFIG_OPERATOR_IMAGE=$(image_for cluster-config-operator)
 KUBE_APISERVER_OPERATOR_IMAGE=$(image_for cluster-kube-apiserver-operator)
 KUBE_CONTROLLER_MANAGER_OPERATOR_IMAGE=$(image_for cluster-kube-controller-manager-operator)
 KUBE_SCHEDULER_OPERATOR_IMAGE=$(image_for cluster-kube-scheduler-operator)
@@ -85,38 +84,6 @@ elif [ -f $IDMS_MANIFEST_FILE ]; then
 fi
 
 VERSION="$(oc adm release info -o 'jsonpath={.metadata.version}' "${MIRROR_FLAG}" "${RELEASE_IMAGE_DIGEST}")"
-
-if [ ! -f config-bootstrap.done ]
-then
-    record_service_stage_start "config-bootstrap"
-	echo "Rendering cluster config manifests..."
-
-	rm --recursive --force config-bootstrap
-
-	ADDITIONAL_FLAGS=()
-	if [ -f "$PWD/manifests/cloud-provider-config.yaml" ]; then
-		ADDITIONAL_FLAGS+=("--cloud-provider-config-input-file=/assets/manifests/cloud-provider-config.yaml")
-	fi
-
-	bootkube_podman_run \
-		--name config-render \
-		--volume "$PWD:/assets:z" \
-		"${CONFIG_OPERATOR_IMAGE}" \
-		/usr/bin/cluster-config-operator render \
-		--cluster-infrastructure-input-file=/assets/manifests/cluster-infrastructure-02-config.yml \
-		--cloud-provider-config-output-file=/assets/config-bootstrap/cloud-provider-config-generated.yaml \
-		--config-output-file=/assets/config-bootstrap/config \
-		--asset-input-dir=/assets/tls \
-		--asset-output-dir=/assets/config-bootstrap \
-		--rendered-manifest-files=/assets/manifests \
-		--payload-version=$VERSION \
-		"${ADDITIONAL_FLAGS[@]}"
-
-	cp config-bootstrap/manifests/* manifests/
-
-	touch config-bootstrap.done
-    record_service_stage_success
-fi
 
 if [ ! -f cvo-bootstrap.done ]
 then


### PR DESCRIPTION
We've had config-operator rendering on the bootstrap node since 9994d371df (#1187).  Motivation for that commit isn't clear to me; [this comment][1] suggests maybe keeping CRDs out of the installer repository.  But we run a rendered cluster-version operator on the bootstrap machine since 63e27509dd (#330), so config manifests should have been getting pushed at bootstrap time via the CVO.  Drop the config rendering, so we can see if things work without the config-rendered cluster-bootstrap pushes racing the bootstrap CVO pushes.

[1]: https://github.com/openshift/installer/pull/1187#issuecomment-463634025