### PR TITLE
Bug 2074659:Fix empty string usage in ValidateForProvisioning

### DIFF
--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -362,8 +362,8 @@ func ValidateForProvisioning(session *session.Session, ic *types.InstallConfig, 
 	client := route53.New(session)
 
 	if ic.AWS.HostedZone != "" {
-		zoneName := ic.AWS.HostedZone
-		zonePath := field.NewPath("aws", "hostedZone")
+		zoneName = ic.AWS.HostedZone
+		zonePath = field.NewPath("aws", "hostedZone")
 		zoneOutput, errors := getHostedZone(client, zonePath, zoneName)
 		if len(errors) > 0 {
 			return field.ErrorList{
@@ -377,8 +377,8 @@ func ValidateForProvisioning(session *session.Session, ic *types.InstallConfig, 
 
 		zone = zoneOutput.HostedZone
 	} else {
-		zoneName := ic.BaseDomain
-		zonePath := field.NewPath("baseDomain")
+		zoneName = ic.BaseDomain
+		zonePath = field.NewPath("baseDomain")
 		zone, errors = getBaseDomain(session, zonePath, zoneName)
 		if len(errors) > 0 {
 			return field.ErrorList{


### PR DESCRIPTION
The zoneName and zonePath were always empty variables. The variables were initialized
outside of the if/else and then reinitialized using := in the if/else causing their
values to go out of scope before the function call to validateZoneRecords.

Fixes: 43224