### PR TITLE
data/bootstrap/files/usr/local/bin/bootkube: --rm all Podman containers

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -19,12 +19,11 @@ ETCD_ENDPOINTS=
 bootkube_podman_run() {
     # we run all commands in the host-network to prevent IP conflicts with
     # end-user infrastructure.
-    podman run --quiet --net=host "${@}"
+    podman run --quiet --net=host --rm "${@}"
 }
 
 wait_for_etcd_cluster() {
     until bootkube_podman_run \
-        --rm \
         --name etcdctl \
         --env ETCDCTL_API=3 \
         --volume /opt/openshift/tls:/opt/openshift/tls:ro,z \
@@ -109,6 +108,9 @@ if [ ! -f etcd-bootstrap.done ]
 then
     record_service_stage_start "etcd-bootstrap"
 	echo "Rendering CEO Manifests..."
+
+	rm --recursive --force etcd-bootstrap
+
 	bootkube_podman_run \
 		--name etcd-render \
 		--volume "$PWD:/assets:z" \
@@ -399,7 +401,6 @@ run_cluster_bootstrap() {
 	record_service_stage_start "cb-bootstrap"
 	bootkube_podman_run \
         --name cluster-bootstrap \
-        --rm \
         --volume "$PWD:/assets:z" \
         --volume /etc/kubernetes:/etc/kubernetes:z \
         "${CLUSTER_BOOTSTRAP_IMAGE}" \


### PR DESCRIPTION
[Avoid][1]:

```
Error: error creating container storage: the container name "mco-render" is already in use by "877829c1add4c25f797255405478c4b8f75da308bc5cb3037e171487eec0ff37". You have to remove that container to be able to reuse that name.: that name is already in use
```

and similar for other containers by removing inconsistent `--rm` options and baking that in at the `bootkube_podman_run` level.

Also add an `etcd-bootstrap` `rm` call, to clear out any cruft from a previous bootkube round before calling Podman for a fresh etcd render.

Spun out of #5800 as a hopefully straightforward, small robustness improvement.

[1]: https://github.com/openshift/installer/pull/5800#issuecomment-1097141511