### PR TITLE
Add Power VS-specific fields to cloud-provider config

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -236,7 +236,11 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			installConfig.Config.PowerVS.VPC,
 			vpcRegion,
 			installConfig.Config.Platform.PowerVS.PowerVSResourceGroup,
-			installConfig.Config.PowerVS.Subnets)
+			installConfig.Config.PowerVS.Subnets,
+			installConfig.Config.PowerVS.ServiceInstanceID,
+			installConfig.Config.PowerVS.Region,
+			installConfig.Config.PowerVS.Zone,
+		)
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")
 		}

--- a/pkg/asset/manifests/powervs/cloudproviderconfig.go
+++ b/pkg/asset/manifests/powervs/cloudproviderconfig.go
@@ -31,10 +31,13 @@ type provider struct {
 	G2VPCName                string `gcfg:"g2VpcName"`
 	G2WorkerServiceAccountID string `gcfg:"g2workerServiceAccountID"`
 	G2VPCSubnetNames         string `gcfg:"g2VpcSubnetNames"`
+	PowerVSCloudInstanceID   string `gcfg:"powerVSCloudInstanceID"`
+	PowerVSRegion            string `gcfg:"powerVSRegion"`
+	PowerVSZone              string `gcfg:"powerVSZone"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the IBM Power VS platform.
-func CloudProviderConfig(infraID string, accountID string, vpcName string, region string, resourceGroupName string, subnets []string) (string, error) {
+func CloudProviderConfig(infraID string, accountID string, vpcName string, region string, resourceGroupName string, subnets []string, cloudInstID string, pvsRegion string, pvsZone string) (string, error) {
 	config := &config{
 		Global: global{
 			Version: "1.1.0",
@@ -52,6 +55,9 @@ func CloudProviderConfig(infraID string, accountID string, vpcName string, regio
 			G2VPCName:                vpcName,
 			G2WorkerServiceAccountID: accountID,
 			G2VPCSubnetNames:         strings.Join(subnets, ","),
+			PowerVSCloudInstanceID:   cloudInstID,
+			PowerVSRegion:            pvsRegion,
+			PowerVSZone:              pvsZone,
 		},
 	}
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
adding new fields to align with changes in cloud-provider-powervs

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>