### PR TITLE
Revert "cluster: unpack terraform binaries into install directory"

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -27,7 +27,6 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/asset/cluster"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/logging"
 	assetstore "github.com/openshift/installer/pkg/asset/store"
@@ -273,8 +272,6 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 
 		cleanup := setupFileHook(rootOpts.dir)
 		defer cleanup()
-
-		cluster.InstallDir = rootOpts.dir
 
 		err := runner(rootOpts.dir)
 		if err != nil {

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -47,13 +47,6 @@ func Destroy(dir string) (err error) {
 		varFiles = append(varFiles, stage.OutputsFilename())
 	}
 
-	terraformDir := filepath.Join(dir, "terraform")
-	if err := os.Mkdir(terraformDir, 0777); err != nil {
-		return errors.Wrap(err, "could not create the terraform directory")
-	}
-	defer os.RemoveAll(terraformDir)
-	terraform.UnpackTerraform(terraformDir, tfStages)
-
 	for i := len(tfStages) - 1; i >= 0; i-- {
 		stage := tfStages[i]
 
@@ -89,7 +82,7 @@ func Destroy(dir string) (err error) {
 			targetVarFiles = append(targetVarFiles, targetPath)
 		}
 
-		if err := stage.Destroy(tempDir, terraformDir, targetVarFiles); err != nil {
+		if err := stage.Destroy(tempDir, targetVarFiles); err != nil {
 			return err
 		}
 

--- a/pkg/terraform/init.go
+++ b/pkg/terraform/init.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/installer/data"
 	prov "github.com/openshift/installer/pkg/terraform/providers"
@@ -46,7 +45,7 @@ func unpack(dir string, platform string, target string) (err error) {
 
 // unpackAndInit unpacks the platform-specific Terraform modules into
 // the given directory and then runs 'terraform init'.
-func unpackAndInit(dir string, platform string, target string, terraformDir string, providers []prov.Provider) (err error) {
+func unpackAndInit(dir string, platform string, target string, providers []prov.Provider) (err error) {
 	err = unpack(dir, platform, target)
 	if err != nil {
 		return errors.Wrap(err, "failed to unpack Terraform modules")
@@ -56,7 +55,11 @@ func unpackAndInit(dir string, platform string, target string, terraformDir stri
 		return errors.Wrap(err, "failed to write versions.tf files")
 	}
 
-	tf, err := newTFExec(dir, terraformDir)
+	if err := setupEmbeddedPlugins(dir, providers); err != nil {
+		return errors.Wrap(err, "failed to setup embedded Terraform plugins")
+	}
+
+	tf, err := newTFExec(dir)
 	if err != nil {
 		return errors.Wrap(err, "failed to create a new tfexec")
 	}
@@ -67,7 +70,7 @@ func unpackAndInit(dir string, platform string, target string, terraformDir stri
 	})
 
 	return errors.Wrap(
-		tf.Init(context.Background(), tfexec.PluginDir(filepath.Join(terraformDir, "plugins"))),
+		tf.Init(context.Background(), tfexec.PluginDir(filepath.Join(dir, "plugins"))),
 		"failed doing terraform init",
 	)
 }
@@ -111,24 +114,16 @@ func addFileToAllDirectories(name string, data []byte, dir string) error {
 	return nil
 }
 
-// UnpackTerraform unpacks the terraform binary and the specified provider binaries into the specified directory.
-func UnpackTerraform(dir string, stages []Stage) error {
+func setupEmbeddedPlugins(dir string, providers []prov.Provider) error {
 	// Unpack the terraform binary.
 	if err := prov.UnpackTerraformBinary(filepath.Join(dir, "bin")); err != nil {
 		return err
 	}
 
 	// Unpack the providers.
-	providers := sets.NewString()
-	for _, stage := range stages {
-		for _, provider := range stage.Providers() {
-			if providers.Has(provider.Name) {
-				continue
-			}
-			if err := provider.Extract(filepath.Join(dir, "plugins")); err != nil {
-				return err
-			}
-			providers.Insert(provider.Name)
+	for _, provider := range providers {
+		if err := provider.Extract(filepath.Join(dir, "plugins")); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/terraform/stage.go
+++ b/pkg/terraform/stage.go
@@ -24,7 +24,7 @@ type Stage interface {
 
 	// Destroy destroys the resources created in the stage. This should only be called if the stage should be destroyed
 	// when destroying the bootstrap resources.
-	Destroy(directory string, terraformDir string, varFiles []string) error
+	Destroy(directory string, varFiles []string) error
 
 	// ExtractHostAddresses extracts the IPs of the bootstrap and control plane machines.
 	ExtractHostAddresses(directory string, config *types.InstallConfig) (bootstrap string, port int, masters []string, err error)

--- a/pkg/terraform/stages/alibabacloud/stages.go
+++ b/pkg/terraform/stages/alibabacloud/stages.go
@@ -36,14 +36,14 @@ var PlatformStages = []terraform.Stage{
 	),
 }
 
-func removeFromLoadBalancers(s stages.SplitStage, directory string, terraformDir string, varFiles []string) error {
+func removeFromLoadBalancers(s stages.SplitStage, directory string, varFiles []string) error {
 	opts := make([]tfexec.ApplyOption, 0, len(varFiles)+1)
 	for _, varFile := range varFiles {
 		opts = append(opts, tfexec.VarFile(varFile))
 	}
 	opts = append(opts, tfexec.Var("ali_bootstrap_lb=false"))
 	return errors.Wrap(
-		terraform.Apply(directory, alitypes.Name, s, terraformDir, opts...),
+		terraform.Apply(directory, alitypes.Name, s, opts...),
 		"failed disabling bootstrap load balancing",
 	)
 }

--- a/pkg/terraform/stages/gcp/stages.go
+++ b/pkg/terraform/stages/gcp/stages.go
@@ -31,14 +31,14 @@ var PlatformStages = []terraform.Stage{
 	),
 }
 
-func removeFromLoadBalancers(s stages.SplitStage, directory string, terraformDir string, varFiles []string) error {
+func removeFromLoadBalancers(s stages.SplitStage, directory string, varFiles []string) error {
 	opts := make([]tfexec.ApplyOption, 0, len(varFiles)+1)
 	for _, varFile := range varFiles {
 		opts = append(opts, tfexec.VarFile(varFile))
 	}
 	opts = append(opts, tfexec.Var("gcp_bootstrap_lb=false"))
 	return errors.Wrap(
-		terraform.Apply(directory, gcptypes.Name, s, terraformDir, opts...),
+		terraform.Apply(directory, gcptypes.Name, s, opts...),
 		"failed disabling bootstrap load balancing",
 	)
 }

--- a/pkg/terraform/stages/split.go
+++ b/pkg/terraform/stages/split.go
@@ -69,7 +69,7 @@ type SplitStage struct {
 }
 
 // DestroyFunc is a function for destroying the stage.
-type DestroyFunc func(s SplitStage, directory string, terraformDir string, varFiles []string) error
+type DestroyFunc func(s SplitStage, directory string, varFiles []string) error
 
 // ExtractFunc is a function for extracting host addresses.
 type ExtractFunc func(s SplitStage, directory string, ic *types.InstallConfig) (string, int, []string, error)
@@ -100,8 +100,8 @@ func (s SplitStage) DestroyWithBootstrap() bool {
 }
 
 // Destroy implements pkg/terraform/Stage.Destroy
-func (s SplitStage) Destroy(directory string, terraformDir string, varFiles []string) error {
-	return s.destroy(s, directory, terraformDir, varFiles)
+func (s SplitStage) Destroy(directory string, varFiles []string) error {
+	return s.destroy(s, directory, varFiles)
 }
 
 // ExtractHostAddresses implements pkg/terraform/Stage.ExtractHostAddresses
@@ -165,10 +165,10 @@ func normalExtractHostAddresses(s SplitStage, directory string, _ *types.Install
 	return bootstrap, 0, masters, nil
 }
 
-func normalDestroy(s SplitStage, directory string, terraformDir string, varFiles []string) error {
+func normalDestroy(s SplitStage, directory string, varFiles []string) error {
 	opts := make([]tfexec.DestroyOption, len(varFiles))
 	for i, varFile := range varFiles {
 		opts[i] = tfexec.VarFile(varFile)
 	}
-	return errors.Wrap(terraform.Destroy(directory, s.platform, s, terraformDir, opts...), "terraform destroy")
+	return errors.Wrap(terraform.Destroy(directory, s.platform, s, opts...), "terraform destroy")
 }

--- a/pkg/terraform/state.go
+++ b/pkg/terraform/state.go
@@ -11,8 +11,8 @@ import (
 const StateFilename = "terraform.tfstate"
 
 // Outputs reads the terraform state file and returns the outputs of the stage as json.
-func Outputs(dir string, terraformDir string) ([]byte, error) {
-	tf, err := newTFExec(dir, terraformDir)
+func Outputs(dir string) ([]byte, error) {
+	tf, err := newTFExec(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -13,12 +13,11 @@ import (
 )
 
 // newTFExec creates a tfexec.Terraform for executing Terraform CLI commands.
-// The `datadir` is the location to which the terraform plan (tf files, etc) has been unpacked.
-// The `terraformDir` is the location to which the terraform and provider binaries have been unpacked.
+// The `datadir` is the location where the terraform parts (binaries, tf files, etc) have been unpacked to.
 // The stdout and stderr will be sent to the logger at the debug and error levels,
 // respectively.
-func newTFExec(datadir string, terraformDir string) (*tfexec.Terraform, error) {
-	tfPath := filepath.Join(terraformDir, "bin", "terraform")
+func newTFExec(datadir string) (*tfexec.Terraform, error) {
+	tfPath := filepath.Join(datadir, "bin", "terraform")
 	tf, err := tfexec.NewTerraform(datadir, tfPath)
 	if err != nil {
 		return nil, err
@@ -44,12 +43,12 @@ func newTFExec(datadir string, terraformDir string) (*tfexec.Terraform, error) {
 // Apply unpacks the platform-specific Terraform modules into the
 // given directory and then runs 'terraform init' and 'terraform
 // apply'.
-func Apply(dir string, platform string, stage Stage, terraformDir string, extraOpts ...tfexec.ApplyOption) error {
-	if err := unpackAndInit(dir, platform, stage.Name(), terraformDir, stage.Providers()); err != nil {
+func Apply(dir string, platform string, stage Stage, extraOpts ...tfexec.ApplyOption) error {
+	if err := unpackAndInit(dir, platform, stage.Name(), stage.Providers()); err != nil {
 		return err
 	}
 
-	tf, err := newTFExec(dir, terraformDir)
+	tf, err := newTFExec(dir)
 	if err != nil {
 		return errors.Wrap(err, "failed to create a new tfexec")
 	}
@@ -60,12 +59,12 @@ func Apply(dir string, platform string, stage Stage, terraformDir string, extraO
 // Destroy unpacks the platform-specific Terraform modules into the
 // given directory and then runs 'terraform init' and 'terraform
 // destroy'.
-func Destroy(dir string, platform string, stage Stage, terraformDir string, extraOpts ...tfexec.DestroyOption) error {
-	if err := unpackAndInit(dir, platform, stage.Name(), terraformDir, stage.Providers()); err != nil {
+func Destroy(dir string, platform string, stage Stage, extraOpts ...tfexec.DestroyOption) error {
+	if err := unpackAndInit(dir, platform, stage.Name(), stage.Providers()); err != nil {
 		return err
 	}
 
-	tf, err := newTFExec(dir, terraformDir)
+	tf, err := newTFExec(dir)
 	if err != nil {
 		return errors.Wrap(err, "failed to create a new tfexec")
 	}


### PR DESCRIPTION
Reverting cluster: unpack terraform binaries into install directory #5715 

I think this may have broken baremetal-ipi like:

"bootstrap" stage: failed to create cluster: failed doing terraform init: fork/exec ocp/ostest/terraform/bin/terraform: no such file or directory

This reverts commit fc75b79aaafb2addb689ae332ae731d6b8c08e82.