### PR TITLE
Ensure ignition host is set to API VIP for Nutanix platform

### DIFF
--- a/pkg/asset/ignition/machine/node.go
+++ b/pkg/asset/ignition/machine/node.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/types"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
 	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
 	ovirttypes "github.com/openshift/installer/pkg/types/ovirt"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
@@ -33,6 +34,10 @@ func pointerIgnitionConfig(installConfig *types.InstallConfig, rootCA []byte, ro
 		// Baremetal needs to point directly at the VIP because we don't have a
 		// way to configure DNS before Ignition runs.
 		ignitionHost = net.JoinHostPort(installConfig.BareMetal.APIVIP, "22623")
+	case nutanixtypes.Name:
+		if installConfig.Nutanix.APIVIP != "" {
+			ignitionHost = net.JoinHostPort(installConfig.Nutanix.APIVIP, "22623")
+		}
 	case openstacktypes.Name:
 		ignitionHost = net.JoinHostPort(installConfig.OpenStack.APIVIP, "22623")
 	case ovirttypes.Name:


### PR DESCRIPTION
This is to make sure the user does not have to manually set A records
for api-int.