### PR TITLE
Bug 2072202: Check for api and api-int resolution during cluster install

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -5,6 +5,7 @@ set -euoE pipefail ## -E option will cause functions to inherit trap
 
 . /usr/local/bin/release-image.sh
 . /usr/local/bin/bootstrap-cluster-gather.sh
+. /usr/local/bin/bootstrap-verify-api-server-urls.sh
 
 mkdir --parents /etc/kubernetes/{manifests,bootstrap-configs,bootstrap-manifests}
 
@@ -354,6 +355,19 @@ then
 
 	touch mco-bootstrap.done
     record_service_stage_success
+fi
+
+# Check if the API and API_INT Server URLs can be resolved and reached.
+echo "Check if API and API-Int URLs are resolvable during bootstrap"
+API_SERVER_URL="{{.APIServerURL}}"
+API_INT_SERVER_URL="{{.APIIntServerURL}}" 
+
+if [[ ! -z "${API_SERVER_URL}" ]] ; then
+    check_url "API_URL" "${API_SERVER_URL}"
+fi
+
+if [[ ! -z "${API_INT_SERVER_URL}" ]] ; then
+    check_url "API_INT_URL" "${API_INT_SERVER_URL}"
 fi
 
 if [ ! -f cco-bootstrap.done ]

--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1091
+. /usr/local/bin/bootstrap-service-record.sh
+
+# This functions expects 2 arguments:
+# 1. name of the URL
+# 2. The value of the URL
+function resolve_url() {
+    unset IPS
+    unset IP
+    IPS=$(dig "${2}" +short)
+    if [[ ! -z "${IPS}" ]] ; then
+        echo "Successfully resolved ${1} ${2}"
+        # dig returns multiple IPs. Check if the
+        # first IP is reachable.
+        ip_arr=""
+        readarray ip_arr -t <<<"${IPS}"
+        IP="$(echo "${ip_arr[0]}" | tr -d '\n')"
+        return 0
+    else
+        echo "Unable to resolve ${1} ${2}"
+        return 1
+    fi
+}
+
+# This functions expects 2 arguments:
+# 1. name of the URL
+# 2. URL to validate
+function validate_url() {
+    if [[ $(curl --head -k --silent --fail --write-out "%{http_code}\\n" "${2}" -o /dev/null) == 200 ]]; then
+        echo "Success while trying to reach ${1}'s https endpoint at ${2}"
+        return 0
+    else
+        echo "Unable to reach ${1}'s https endpoint at ${2}"
+        return 1
+    fi
+}
+
+function check_url() {
+    if [[ -z "${1}" ]] || [[ -z "${2}" ]]; then
+        echo "Usage: check_url <API_URL or API_INT URL> <URL that needs to be verified>"
+        return
+    fi
+
+    local URL_TYPE=${1}
+    local SERVER_URL=${2}
+
+    if [[ ${URL_TYPE} != API_URL ]] && [[ ${URL_TYPE} != API_INT_URL ]]; then
+        echo "Usage: check_url <API_URL or API_INT URL> <URL that needs to be verified>"
+        return
+    fi
+
+    echo "Checking validity of ${SERVER_URL} of type ${URL_TYPE}"
+
+    if [[ "${URL_TYPE}" = "API_URL" ]]; then
+        local URL_STAGE_NAME="check-api-url"
+    else 
+        local URL_STAGE_NAME="check-api-int-url"
+    fi
+
+    echo "Starting stage ${URL_STAGE_NAME}"
+    record_service_stage_start ${URL_STAGE_NAME}
+    if resolve_url "$URL_TYPE" "$SERVER_URL"; then
+        record_service_stage_success
+    else
+        record_service_stage_failure
+        # We do not want to stop bootkube service due to this failure.
+        # So not returning failure at this point.
+        return
+    fi
+
+    CURL_URL="https://${IP}:6443/version"
+
+    record_service_stage_start ${URL_STAGE_NAME}
+    if validate_url "$URL_TYPE" "$CURL_URL"; then
+        record_service_stage_success
+    else
+        echo "It might be too early for the ${CURL_URL} to be available."
+        record_service_stage_failure
+    fi
+}

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -80,6 +80,8 @@ type bootstrapTemplateData struct {
 	UseIPv6ForNodeIP      bool
 	IsOKD                 bool
 	BootstrapNodeIP       string
+	APIServerURL          string
+	APIIntServerURL       string
 }
 
 // platformTemplateData is the data to use to replace values in bootstrap
@@ -285,6 +287,9 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 	if bootstrapInPlace {
 		bootstrapInPlaceConfig = installConfig.Config.BootstrapInPlace
 	}
+
+	apiURL := fmt.Sprintf("api.%s", installConfig.Config.ClusterDomain())
+	apiIntURL := fmt.Sprintf("api-int.%s", installConfig.Config.ClusterDomain())
 	return &bootstrapTemplateData{
 		AdditionalTrustBundle: installConfig.Config.AdditionalTrustBundle,
 		FIPS:                  installConfig.Config.FIPS,
@@ -301,6 +306,8 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		UseIPv6ForNodeIP:      APIIntVIPonIPv6,
 		IsOKD:                 installConfig.Config.IsOKD(),
 		BootstrapNodeIP:       bootstrapNodeIP,
+		APIServerURL:          apiURL,
+		APIIntServerURL:       apiIntURL,
 	}
 }
 


### PR DESCRIPTION
During cluster bring up, when nodes are unable to resolve api-int, the cluster fails to come up and the messages in the logs, several times do not hint at any connectivity issues making it difficult to detect and resolve any infrastructure setup issues.

These changes contain:
1. Checks for the API and API-INT URLs to see if they are resolvable from the bootstrap node and logging helpful messages.
2. Records the state of the api-url and api-int-url services
3. Addition of validation of the API and API-INT URLs to the analyze output
 