### PR TITLE
Ensure Nutanix API VIP is populated in the SAN for the MCS Cert

### DIFF
--- a/pkg/asset/tls/mcscertkey.go
+++ b/pkg/asset/tls/mcscertkey.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	baremetaltypes "github.com/openshift/installer/pkg/types/baremetal"
+	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
 	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
 	ovirttypes "github.com/openshift/installer/pkg/types/ovirt"
 	vspheretypes "github.com/openshift/installer/pkg/types/vsphere"
@@ -48,6 +49,12 @@ func (a *MCSCertKey) Generate(dependencies asset.Parents) error {
 	case baremetaltypes.Name:
 		cfg.IPAddresses = []net.IP{net.ParseIP(installConfig.Config.BareMetal.APIVIP)}
 		cfg.DNSNames = []string{hostname, installConfig.Config.BareMetal.APIVIP}
+	case nutanixtypes.Name:
+		cfg.DNSNames = []string{hostname}
+		if installConfig.Config.Nutanix.APIVIP != "" {
+			cfg.IPAddresses = []net.IP{net.ParseIP(installConfig.Config.Nutanix.APIVIP)}
+			cfg.DNSNames = append(cfg.DNSNames, installConfig.Config.Nutanix.APIVIP)
+		}
 	case openstacktypes.Name:
 		cfg.IPAddresses = []net.IP{net.ParseIP(installConfig.Config.OpenStack.APIVIP)}
 		cfg.DNSNames = []string{hostname, installConfig.Config.OpenStack.APIVIP}


### PR DESCRIPTION
Without the API VIP populated in the SAN for the MCS Cert, the
nodes created by the installer will fail to ignite due to a x509
verification error.