### PR TITLE
pkg/asset/installconfig: fix dropped errors

### DIFF
--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -112,6 +112,9 @@ func (a *platform) Generate(asset.Parents) error {
 		}
 	case powervs.Name:
 		a.PowerVS, err = powervsconfig.Platform()
+		if err != nil {
+			return err
+		}
 	case nutanix.Name:
 		a.Nutanix, err = nutanixconfig.Platform()
 		if err != nil {

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -111,13 +111,15 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 	case alibabacloud.Name:
-		client, err := ic.AlibabaCloud.Client()
+		var client *alibabacloudconfig.Client
+		client, err = ic.AlibabaCloud.Client()
 		if err != nil {
 			return err
 		}
 		err = alibabacloudconfig.ValidateForProvisioning(client, ic.Config, ic.AlibabaCloud)
 	case powervs.Name:
-		client, err := powervsconfig.NewClient()
+		var client *powervsconfig.Client
+		client, err = powervsconfig.NewClient()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This fixes two `err` variables that were being lost in a `select` due to use of `:=`. It also picks up an error that was being dropped outright.