### PR TITLE
agent: create skeleton commands and folders structure for agent-based installer

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -147,3 +147,21 @@ aliases:
     - jmarrero
     - aaradhak
     - ravanelli
+  agent-reviewers:
+    - andfasano
+    - bfournie
+    - celebdor
+    - dhellmann
+    - lranjbar
+    - pawanpinjarkar
+    - rwsu
+    - zaneb
+  agent-approvers:
+    - andfasano
+    - bfournie
+    - celebdor
+    - dhellmann
+    - lranjbar
+    - pawanpinjarkar
+    - rwsu
+    - zaneb

--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/installer/cmd/openshift-install/agent"
+)
+
+func newAgentCmd() *cobra.Command {
+	agentCmd := &cobra.Command{
+		Use:   "agent",
+		Short: "Commands for supporting cluster installation using agent installer",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	agentCmd.AddCommand(agent.NewCreateCmd())
+	agentCmd.AddCommand(agent.NewWaitForCmd())
+	return agentCmd
+}

--- a/cmd/openshift-install/agent/OWNERS
+++ b/cmd/openshift-install/agent/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - agent-approvers
+reviewers:
+  - agent-reviewers

--- a/cmd/openshift-install/agent/create.go
+++ b/cmd/openshift-install/agent/create.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	agentcmd "github.com/openshift/installer/pkg/agent"
+)
+
+// NewCreateCmd create the agent commands for generating the manifests and the bootable image.
+func NewCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Commands for generating agent installer based artifacts",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newCreateManifestsCmd())
+	cmd.AddCommand(newCreateImageCmd())
+	return cmd
+}
+
+func newCreateImageCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "image",
+		Short: "Generates a bootable image containing all the information needed to deploy a cluster",
+		Args:  cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			err := runCreateImageCmd()
+			if err != nil {
+				logrus.Fatal(err)
+			}
+		},
+	}
+}
+
+func runCreateImageCmd() error {
+	return agentcmd.BuildImage()
+}
+
+func newCreateManifestsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "manifests",
+		Short: "Generates intermediate files required by the agent installer",
+		Args:  cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			err := runCreateManifestsCmd()
+			if err != nil {
+				logrus.Fatal(err)
+			}
+		},
+	}
+}
+
+func runCreateManifestsCmd() error {
+	return agentcmd.CreateManifests()
+}

--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -1,0 +1,42 @@
+package agent
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	agentcmd "github.com/openshift/installer/pkg/agent"
+)
+
+// NewWaitForCmd create the commands for waiting the completion of the agent based cluster installation.
+func NewWaitForCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "wait-for",
+		Short: "Wait for install-time events",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newWaitForInstallCompleteCmd())
+	return cmd
+}
+
+func newWaitForInstallCompleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "install-complete",
+		Short: "Wait until the cluster is ready",
+		Args:  cobra.ExactArgs(0),
+		Run: func(_ *cobra.Command, _ []string) {
+			err := runWaitForInstallCompleteCmd()
+			if err != nil {
+				logrus.Fatal(err)
+			}
+		},
+	}
+
+}
+
+func runWaitForInstallCompleteCmd() error {
+	return agentcmd.WaitFor()
+}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -53,6 +53,7 @@ func installerMain() {
 		newCompletionCmd(),
 		newMigrateCmd(),
 		newExplainCmd(),
+		newAgentCmd(),
 	} {
 		rootCmd.AddCommand(subCmd)
 	}

--- a/data/data/agent/OWNERS
+++ b/data/data/agent/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - agent-approvers
+reviewers:
+  - agent-reviewers

--- a/pkg/agent/OWNERS
+++ b/pkg/agent/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - agent-approvers
+reviewers:
+  - agent-reviewers

--- a/pkg/agent/build_image.go
+++ b/pkg/agent/build_image.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// BuildImage builds the image required by the agent installer.
+func BuildImage() error {
+
+	// baseImage, err := isosource.EnsureIso()
+	// if err != nil {
+	// 	return err
+	// }
+
+	// err = imagebuilder.BuildImage(baseImage)
+	// if err != nil {
+	// 	return err
+	// }
+
+	logrus.Info("BuildImage command")
+
+	return nil
+}

--- a/pkg/agent/create_manifests.go
+++ b/pkg/agent/create_manifests.go
@@ -1,0 +1,12 @@
+package agent
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// CreateManifests generates the intermediate files required by the agent installer.
+func CreateManifests() error {
+	logrus.Info("Create manifests command")
+
+	return nil
+}

--- a/pkg/agent/wait_for.go
+++ b/pkg/agent/wait_for.go
@@ -1,0 +1,12 @@
+package agent
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// WaitFor wait for the installation complete triggered by the agent installer.
+func WaitFor() error {
+	logrus.Info("WaitFor command")
+
+	return nil
+}

--- a/pkg/asset/agent/OWNERS
+++ b/pkg/asset/agent/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - agent-approvers
+reviewers:
+  - agent-reviewers


### PR DESCRIPTION
This patch adds the initial project setup for the agent installer, as described in the OpenShift enhancement https://github.com/openshift/enhancements/pull/1067, to be managed by the agent team.

Initially, the developments will be kept in a separate branch, currently named `master-agent-installer`.