### PR TITLE
vsphere: remove unused namer interface

### DIFF
--- a/pkg/asset/installconfig/vsphere/vsphere.go
+++ b/pkg/asset/installconfig/vsphere/vsphere.go
@@ -32,15 +32,6 @@ type vCenterClient struct {
 	RestClient *rest.Client
 }
 
-// networkNamer declares an interface for the object.Common.Name() function.
-// This is needed because find.NetworkList() returns the interface object.NetworkReference.
-// All of the types that implement object.NetworkReference (OpaqueNetwork,
-// DistributedVirtualPortgroup, & DistributedVirtualSwitch) and perhaps all
-// types in general embed object.Common.
-type networkNamer interface {
-	Name() string
-}
-
 // Platform collects vSphere-specific configuration.
 func Platform() (*vsphere.Platform, error) {
 	vCenter, err := getClients()


### PR DESCRIPTION
Removes leftover namer interface. The implementation using the interface was removed in e7dfefa7d51d5d4fbee1a37412ef6f8ab7c16d38 but the interface was left behind. We have no need for the interface so clean it
up.