### PR TITLE
Ensure that the /bin/terraform-provider-matchbox binary is present

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -50,7 +50,8 @@ RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraf
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin/
 ENV MATCHBOX_PROVIDER_VERSION=0.5.0
 RUN curl -L -O https://github.com/poseidon/terraform-provider-matchbox/releases/download/v${MATCHBOX_PROVIDER_VERSION}/terraform-provider-matchbox_${MATCHBOX_PROVIDER_VERSION}_linux_amd64.zip && \
-    unzip terraform-provider-matchbox_${MATCHBOX_PROVIDER_VERSION}_linux_amd64.zip -d /bin/
+    unzip terraform-provider-matchbox_${MATCHBOX_PROVIDER_VERSION}_linux_amd64.zip -d /bin/ && \
+    mv /bin/terraform-provider-matchbox_v${MATCHBOX_PROVIDER_VERSION} /bin/terraform-provider-matchbox
 ENV IGNITION_PROVIDER_VERSION=v2.1.0
 RUN curl -L -O https://github.com/community-terraform-providers/terraform-provider-ignition/releases/download/${IGNITION_PROVIDER_VERSION}/terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \
     tar xzf terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \

--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -42,13 +42,13 @@ RUN yum update -y && \
 RUN pip-2 install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python
 
-ENV TERRAFORM_VERSION=0.12.24
+ENV TERRAFORM_VERSION=1.0.11
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
     unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin/
-ENV MATCHBOX_PROVIDER_VERSION=v0.3.0
-RUN curl -L -O https://github.com/poseidon/terraform-provider-matchbox/releases/download/${MATCHBOX_PROVIDER_VERSION}/terraform-provider-matchbox-${MATCHBOX_PROVIDER_VERSION}-linux-amd64.tar.gz && \
-    tar xzf terraform-provider-matchbox-${MATCHBOX_PROVIDER_VERSION}-linux-amd64.tar.gz && \
-    mv terraform-provider-matchbox-${MATCHBOX_PROVIDER_VERSION}-linux-amd64/terraform-provider-matchbox /bin/terraform-provider-matchbox
+ENV MATCHBOX_PROVIDER_VERSION=0.5.0
+RUN curl -L -O https://github.com/poseidon/terraform-provider-matchbox/releases/download/v${MATCHBOX_PROVIDER_VERSION}/terraform-provider-matchbox_${MATCHBOX_PROVIDER_VERSION}_linux_amd64.zip && \
+    unzip terraform-provider-matchbox_${MATCHBOX_PROVIDER_VERSION}_linux_amd64.zip -d /bin/ && \
+    mv /bin/terraform-provider-matchbox_v${MATCHBOX_PROVIDER_VERSION} /bin/terraform-provider-matchbox
 ENV IGNITION_PROVIDER_VERSION=v2.1.0
 RUN curl -L -O https://github.com/community-terraform-providers/terraform-provider-ignition/releases/download/${IGNITION_PROVIDER_VERSION}/terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \
     tar xzf terraform-provider-ignition-${IGNITION_PROVIDER_VERSION}-linux-amd64.tar.gz && \


### PR DESCRIPTION
The terraform-provider-matchbox binary was not being correctly extracted into the /bin directory. This PR ensures that the binary is moved to /bin correctly.

This PR also ensures the changes made in this PR and #5762 are reconciled between the two UPI images.

Fixes issues see here: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/27383/rehearse-27383-pull-ci-openshift-installer-master-e2e-metal-upi/1516093307896205312/build-log.txt