### PR TITLE
Bug 2077662: Fix AWS Platform Provisioning Check

### DIFF
--- a/pkg/asset/installconfig/aws/validation.go
+++ b/pkg/asset/installconfig/aws/validation.go
@@ -460,7 +460,7 @@ func getSubDomainDNSRecords(client *route53.Route53, hostedZone *route53.HostedZ
 				name := aws.StringValue(recordSet.Name)
 				// skip record sets that are not sub-domains of the cluster domain. Such record sets may exist for
 				// hosted zones that are used for other clusters or other purposes.
-				if !strings.HasSuffix(name, dottedClusterDomain) {
+				if !strings.HasSuffix(name, "."+dottedClusterDomain) {
 					continue
 				}
 				// skip record sets that are the cluster domain. Record sets for the cluster domain are fine. If the


### PR DESCRIPTION
This fixes a bug in the AWS Platform Provisioning Check where it
identifies a record that merely matches the DNS suffix domain without
checking for a "." in the record.

For example, if cluster name is "abcd" with baseDomain "example.com"
then a record "foo-abcd.example.com" is misidentified as part of the
domain of the cluster ("abcd.example.com").