### PR TITLE
Remove LoadBalancer settings from cloud provider config

### DIFF
--- a/pkg/asset/manifests/openstack/cloudproviderconfig.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/gophercloud/utils/openstack/clientconfig"
-	operv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/asset/installconfig/openstack"
 	"github.com/openshift/installer/pkg/types"
 )
@@ -89,13 +88,6 @@ secret-namespace = kube-system
 			return "", "", Error{err, "failed to read clouds.yaml ca-cert from disk"}
 		}
 		cloudProviderConfigCABundleData = string(caFile)
-	}
-
-	cloudProviderConfigData += "[LoadBalancer]\n"
-	if installConfig.NetworkType == string(operv1.NetworkTypeKuryr) {
-		cloudProviderConfigData += "use-octavia = False\n"
-	} else {
-		cloudProviderConfigData += "use-octavia = True\n"
 	}
 
 	return cloudProviderConfigData, cloudProviderConfigCABundleData, nil

--- a/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig_test.go
@@ -106,22 +106,6 @@ func TestCloudProviderConfig(t *testing.T) {
 secret-name = openstack-credentials
 secret-namespace = kube-system
 region = my_region
-[LoadBalancer]
-use-octavia = True
-`,
-		}, {
-			name: "installation with kuryr",
-			installConfig: &types.InstallConfig{
-				Networking: &types.Networking{
-					NetworkType: "Kuryr",
-				},
-			},
-			expectedConfig: `[Global]
-secret-name = openstack-credentials
-secret-namespace = kube-system
-region = my_region
-[LoadBalancer]
-use-octavia = False
 `,
 		},
 	}


### PR DESCRIPTION
Since the cluster-cloud-controller-manager-operator is
enforcing all the required configurations, there is no
need to specify those anymore in the installer. This
commit removes all the uneeded configurations.