### PR TITLE
Bug 2078875: Delete all the ports from tagged Neutron networks. 

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -103,7 +103,7 @@ func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 		"deleteServerGroups":    deleteServerGroups,
 		"deleteTrunks":          deleteTrunks,
 		"deleteLoadBalancers":   deleteLoadBalancers,
-		"deletePorts":           deletePorts,
+		"deletePorts":           deletePortsByFilter,
 		"deleteSecurityGroups":  deleteSecurityGroups,
 		"clearRouterInterfaces": clearRouterInterfaces,
 		"deleteSubnets":         deleteSubnets,
@@ -320,7 +320,36 @@ func deleteServerGroups(opts *clientconfig.ClientOpts, filter Filter, logger log
 	return numberDeleted == numberToDelete, nil
 }
 
-func deletePorts(opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) (bool, error) {
+func deletePortsByNetwork(opts *clientconfig.ClientOpts, networkID string, logger logrus.FieldLogger) (bool, error) {
+
+	listOpts := ports.ListOpts{
+		NetworkID: networkID,
+	}
+
+	result, err := deletePorts(opts, listOpts, logger)
+	if err != nil {
+		logger.Error(err)
+		return false, nil
+	}
+	return result, err
+}
+
+func deletePortsByFilter(opts *clientconfig.ClientOpts, filter Filter, logger logrus.FieldLogger) (bool, error) {
+
+	tags := filterTags(filter)
+	listOpts := ports.ListOpts{
+		TagsAny: strings.Join(tags, ","),
+	}
+
+	result, err := deletePorts(opts, listOpts, logger)
+	if err != nil {
+		logger.Error(err)
+		return false, nil
+	}
+	return result, err
+}
+
+func deletePorts(opts *clientconfig.ClientOpts, listOpts ports.ListOpts, logger logrus.FieldLogger) (bool, error) {
 	logger.Debug("Deleting openstack ports")
 	defer logger.Debugf("Exiting deleting openstack ports")
 
@@ -328,10 +357,6 @@ func deletePorts(opts *clientconfig.ClientOpts, filter Filter, logger logrus.Fie
 	if err != nil {
 		logger.Error(err)
 		return false, nil
-	}
-	tags := filterTags(filter)
-	listOpts := ports.ListOpts{
-		TagsAny: strings.Join(tags, ","),
 	}
 
 	allPages, err := ports.List(conn, listOpts).AllPages()
@@ -964,6 +989,13 @@ func deleteNetworks(opts *clientconfig.ClientOpts, filter Filter, logger logrus.
 	numberToDelete := len(allNetworks)
 	numberDeleted := 0
 	for _, network := range allNetworks {
+		// Before deleting network, try to remove all the ports it may contain
+		_, err := deletePortsByNetwork(opts, network.ID, logger)
+		if err != nil {
+			logger.Error(err)
+			return false, nil
+		}
+
 		logger.Debugf("Deleting network: %q", network.ID)
 		err = networks.Delete(conn, network.ID).ExtractErr()
 		if err != nil {


### PR DESCRIPTION
Currently, we are trying to remove ports, which are tagged, but
sometimes it happens, that port is created but tagging has failed, or we
didn't get response from Neutron API, resulting with untagged port.

Having network already tagged we can use its id to select all the port
within such network, so that all the ports, not only tagged would be
deleted.