### PR TITLE
vsphere upi: missing etc resolv

### DIFF
--- a/data/data/bootstrap/vsphere/files/etc/NetworkManager/conf.d/99-vsphere.conf
+++ b/data/data/bootstrap/vsphere/files/etc/NetworkManager/conf.d/99-vsphere.conf
@@ -1,2 +1,0 @@
-[main]
-rc-manager=unmanaged

--- a/data/data/bootstrap/vsphere/files/etc/NetworkManager/conf.d/99-vsphere.conf.template
+++ b/data/data/bootstrap/vsphere/files/etc/NetworkManager/conf.d/99-vsphere.conf.template
@@ -1,0 +1,4 @@
+{{if .PlatformData.VSphere.UserProvidedVIPs}}
+[main]
+rc-manager=unmanaged
+{{end}}


### PR DESCRIPTION
Using rc-manager=unmanaged
for vsphere upi breaks the bootstrap
process since the RHCOS instance has
no `/etc/resolv.conf`