### PR TITLE
[wip] vSphere: Enable change block tracking

### DIFF
--- a/data/data/vsphere/master/main.tf
+++ b/data/data/vsphere/master/main.tf
@@ -45,6 +45,7 @@ resource "vsphere_virtual_machine" "vm_master" {
     "guestinfo.ignition.config.data"          = base64encode(var.ignition_master)
     "guestinfo.ignition.config.data.encoding" = "base64"
     "guestinfo.hostname"                      = "${var.cluster_id}-master-${count.index}"
+    "ctkEnable"                               = "TRUE"
   }
 
   tags = var.tags


### PR DESCRIPTION
Based on upstream CSI issue:
https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/1416

It looks like changed block tracking needs to be enabled.