### PR TITLE
Azure Provider: fix vmNetworkType defaults by checking vm capabilities

### DIFF
--- a/pkg/asset/installconfig/azure/mock/azureclient_generated.go
+++ b/pkg/asset/installconfig/azure/mock/azureclient_generated.go
@@ -189,6 +189,21 @@ func (mr *MockAPIMockRecorder) GetStorageEndpointSuffix(ctx interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorageEndpointSuffix", reflect.TypeOf((*MockAPI)(nil).GetStorageEndpointSuffix), ctx)
 }
 
+// GetVMCapabilities mocks base method.
+func (m *MockAPI) GetVMCapabilities(ctx context.Context, instanceType, region string) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVMCapabilities", ctx, instanceType, region)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVMCapabilities indicates an expected call of GetVMCapabilities.
+func (mr *MockAPIMockRecorder) GetVMCapabilities(ctx, instanceType, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMCapabilities", reflect.TypeOf((*MockAPI)(nil).GetVMCapabilities), ctx, instanceType, region)
+}
+
 // GetVirtualMachineSku mocks base method.
 func (m *MockAPI) GetVirtualMachineSku(ctx context.Context, name, region string) (*compute.ResourceSku, error) {
 	m.ctrl.T.Helper()

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -44,14 +44,23 @@ var (
 		{Name: to.StringPtr("Standard_D4_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}}},
 		{Name: to.StringPtr("Standard_D2s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}}},
 		{Name: to.StringPtr("Standard_D8s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("UltraSSDAvailable"), Value: to.StringPtr("True")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}}},
-		{Name: to.StringPtr("Standard_D_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("False")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}}},
 		{Name: to.StringPtr("Standard_Dc4_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V2")}}},
+	}
+	vmCapabilities = map[string]map[string]string{
+		"Standard_D8s_v3": {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True", "UltraSSDAvailable": "True"},
+		"Standard_D4s_v3": {"vCPUsAvailable": "4", "MemoryGB": "32", "PremiumIO": "True", "HyperVGenerations": "V1", "AcceleratedNetworkingEnabled": "True", "UltraSSDAvailable": "True"},
+		"Standard_A1_v2":  {"vCPUsAvailable": "1", "MemoryGB": "2", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "False"},
+		"Standard_D2_v4":  {"vCPUsAvailable": "2", "MemoryGB": "8", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True"},
+		"Standard_D4_v4":  {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "False", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True"},
+		"Standard_D2s_v3": {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True"},
+		"Standard_Dc4_v4": {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V2"},
+		"Standard_B4ms":   {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "False", "UltraSSDAvailable": "True"},
 	}
 
 	validInstanceTypes = func(ic *types.InstallConfig) {
-		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_D2_v4"
-		ic.ControlPlane.Platform.Azure.InstanceType = "Standard_D4_v4"
-		ic.Compute[0].Platform.Azure.InstanceType = "Standard_D2_v4"
+		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_D4s_v3"
+		ic.ControlPlane.Platform.Azure.InstanceType = "Standard_D8s_v3"
+		ic.Compute[0].Platform.Azure.InstanceType = "Standard_D4s_v3"
 	}
 
 	invalidateDefaultInstanceTypes = func(ic *types.InstallConfig) {
@@ -79,7 +88,7 @@ var (
 	}
 
 	invalidVMNetworkingIstanceTypes = func(ic *types.InstallConfig) {
-		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_A1_v2"
+		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_B4ms"
 	}
 
 	invalidateMachineCIDR = func(ic *types.InstallConfig) {
@@ -90,20 +99,20 @@ var (
 	}
 	invalidResourceSkuRegion = "centralus"
 
-	invalidateVirtualNetwork                = func(ic *types.InstallConfig) { ic.Azure.VirtualNetwork = "invalid-virtual-network" }
-	invalidateComputeSubnet                 = func(ic *types.InstallConfig) { ic.Azure.ComputeSubnet = "invalid-compute-subnet" }
-	invalidateControlPlaneSubnet            = func(ic *types.InstallConfig) { ic.Azure.ControlPlaneSubnet = "invalid-controlplane-subnet" }
-	invalidateRegion                        = func(ic *types.InstallConfig) { ic.Azure.Region = "neverland" }
-	invalidateRegionCapabilities            = func(ic *types.InstallConfig) { ic.Azure.Region = "australiacentral2" }
-	invalidateRegionLetterCase              = func(ic *types.InstallConfig) { ic.Azure.Region = "Central US" }
-	removeVirtualNetwork                    = func(ic *types.InstallConfig) { ic.Azure.VirtualNetwork = "" }
-	removeSubnets                           = func(ic *types.InstallConfig) { ic.Azure.ComputeSubnet, ic.Azure.ControlPlaneSubnet = "", "" }
-	premiumDiskCompute                      = func(ic *types.InstallConfig) { ic.Compute[0].Platform.Azure.OSDisk.DiskType = "Premium_LRS" }
-	nonpremiumInstanceTypeDiskCompute       = func(ic *types.InstallConfig) { ic.Compute[0].Platform.Azure.InstanceType = "Standard_D_v4" }
-	premiumDiskControlPlane                 = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.Azure.OSDisk.DiskType = "Premium_LRS" }
-	nonpremiumInstanceTypeDiskControlPlane  = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.Azure.InstanceType = "Standard_D_v4" }
-	premiumDiskDefault                      = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.OSDisk.DiskType = "Premium_LRS" }
-	nonpremiumInstanceTypeDiskDefault       = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.InstanceType = "Standard_D_v4" }
+	invalidateVirtualNetwork               = func(ic *types.InstallConfig) { ic.Azure.VirtualNetwork = "invalid-virtual-network" }
+	invalidateComputeSubnet                = func(ic *types.InstallConfig) { ic.Azure.ComputeSubnet = "invalid-compute-subnet" }
+	invalidateControlPlaneSubnet           = func(ic *types.InstallConfig) { ic.Azure.ControlPlaneSubnet = "invalid-controlplane-subnet" }
+	invalidateRegion                       = func(ic *types.InstallConfig) { ic.Azure.Region = "neverland" }
+	invalidateRegionCapabilities           = func(ic *types.InstallConfig) { ic.Azure.Region = "australiacentral2" }
+	invalidateRegionLetterCase             = func(ic *types.InstallConfig) { ic.Azure.Region = "Central US" }
+	removeVirtualNetwork                   = func(ic *types.InstallConfig) { ic.Azure.VirtualNetwork = "" }
+	removeSubnets                          = func(ic *types.InstallConfig) { ic.Azure.ComputeSubnet, ic.Azure.ControlPlaneSubnet = "", "" }
+	premiumDiskCompute                     = func(ic *types.InstallConfig) { ic.Compute[0].Platform.Azure.OSDisk.DiskType = "Premium_LRS" }
+	nonpremiumInstanceTypeDiskCompute      = func(ic *types.InstallConfig) { ic.Compute[0].Platform.Azure.InstanceType = "Standard_D4_v4" }
+	premiumDiskControlPlane                = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.Azure.OSDisk.DiskType = "Premium_LRS" }
+	nonpremiumInstanceTypeDiskControlPlane = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.Azure.InstanceType = "Standard_D4_v4" }
+	// premiumDiskDefault                      = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.OSDisk.DiskType = "Premium_LRS" }
+	nonpremiumInstanceTypeDiskDefault       = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.InstanceType = "Standard_D4_v4" }
 	enabledSSDCapabilityControlPlane        = func(ic *types.InstallConfig) { ic.ControlPlane.Platform.Azure.UltraSSDCapability = "Enabled" }
 	enabledSSDCapabilityCompute             = func(ic *types.InstallConfig) { ic.Compute[0].Platform.Azure.UltraSSDCapability = "Enabled" }
 	enabledSSDCapabilityDefault             = func(ic *types.InstallConfig) { ic.Azure.DefaultMachinePlatform.UltraSSDCapability = "Enabled" }
@@ -303,9 +312,8 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 			errorMsg: "",
 		},
 		{
-			name:  "Invalid default machine type",
-			edits: editFunctions{invalidateDefaultInstanceTypes},
-			// errorMsg: `\[controlPlane.platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 4 vCPUsAvailable, controlPlane.platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 16 GB Memory, controlPlane.platform.azure.vmNetworkingType: Invalid value: "Accelerated": vm networking type is not supported for instance type Standard_A1_v2, compute\[0\].platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 2 vCPUsAvailable, compute\[0\].platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 8 GB Memory\, compute\[0\].platform.azure.vmNetworkingType: Invalid value: "Accelerated": vm networking type is not supported for instance type Standard_A1_v2\]`,
+			name:     "Invalid default machine type",
+			edits:    editFunctions{invalidateDefaultInstanceTypes},
 			errorMsg: `\[controlPlane.platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 4 vCPUsAvailable, controlPlane.platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 16 GB Memory, compute\[0\].platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 2 vCPUsAvailable, compute\[0\].platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 8 GB Memory\]`,
 		},
 		{
@@ -341,27 +349,27 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 		{
 			name:     "Non-premium instance disk type for compute",
 			edits:    editFunctions{premiumDiskCompute, nonpremiumInstanceTypeDiskCompute},
-			errorMsg: `compute\[0\].platform.azure.osDisk.diskType: Invalid value: "Premium_LRS": PremiumIO not supported for instance type Standard_D_v4$`,
+			errorMsg: `compute\[0\].platform.azure.osDisk.diskType: Invalid value: "Premium_LRS": PremiumIO not supported for instance type Standard_D4_v4`,
 		},
 		{
 			name:     "Non-premium instance disk type for control-plane",
 			edits:    editFunctions{premiumDiskControlPlane, nonpremiumInstanceTypeDiskControlPlane},
-			errorMsg: `controlPlane.platform.azure.osDisk.diskType: Invalid value: "Premium_LRS": PremiumIO not supported for instance type Standard_D_v4$`,
+			errorMsg: `controlPlane.platform.azure.osDisk.diskType: Invalid value: "Premium_LRS": PremiumIO not supported for instance type Standard_D4_v4$`,
 		},
 		{
 			name:     "Unsupported UltraSSD capability in Control Plane",
-			edits:    editFunctions{enabledSSDCapabilityControlPlane, validInstanceTypes},
-			errorMsg: `controlPlane.platform.azure.type: Invalid value: "Standard_D4_v4": UltraSSD capability not supported for this instance type in the centralus region$`,
+			edits:    editFunctions{enabledSSDCapabilityControlPlane, nonpremiumInstanceTypeDiskDefault},
+			errorMsg: `\[controlPlane.platform.azure.osDisk.diskType: Invalid value: "Premium_LRS": PremiumIO not supported for instance type Standard_D4_v4`,
 		},
 		{
 			name:     "Unsupported UltraSSD capability in Compute",
-			edits:    editFunctions{enabledSSDCapabilityCompute, validInstanceTypes},
-			errorMsg: `compute\[0\].platform.azure.type: Invalid value: "Standard_D2_v4": UltraSSD capability not supported for this instance type in the centralus region$`,
+			edits:    editFunctions{enabledSSDCapabilityCompute, nonpremiumInstanceTypeDiskDefault},
+			errorMsg: `compute\[0\].platform.azure.osDisk.diskType: Invalid value: "Premium_LRS": PremiumIO not supported for instance type Standard_D4_v4\]`,
 		},
 		{
 			name:     "Unsupported UltraSSD capability as default",
-			edits:    editFunctions{enabledSSDCapabilityDefault, validInstanceTypes},
-			errorMsg: `^\[controlPlane.platform.azure.type: Invalid value: "Standard_D4_v4": UltraSSD capability not supported for this instance type in the centralus region, compute\[0\].platform.azure.type: Invalid value: "Standard_D2_v4": UltraSSD capability not supported for this instance type in the centralus region\]$`,
+			edits:    editFunctions{enabledSSDCapabilityDefault, nonpremiumInstanceTypeDiskDefault},
+			errorMsg: `\[controlPlane.platform.azure.osDisk.diskType: Invalid value: "Premium_LRS": PremiumIO not supported for instance type Standard_D4_v4, compute\[0\].platform.azure.osDisk.diskType: Invalid value: "Premium_LRS": PremiumIO not supported for instance type Standard_D4_v4\]$`,
 		},
 		{
 			name:     "Supported UltraSSD capability in Control Plane",
@@ -391,12 +399,12 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 		{
 			name:     "Unsupported VMNetworkingType in Control Plane",
 			edits:    editFunctions{invalidVMNetworkingIstanceTypes, vmNetworkingTypeAcceleratedControlPlane},
-			errorMsg: `\[controlPlane.platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 4 vCPUsAvailable, controlPlane.platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 16 GB Memory, compute\[0\].platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 2 vCPUsAvailable, compute\[0\].platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 8 GB Memory\]`,
+			errorMsg: `controlPlane.platform.azure.vmNetworkingType: Invalid value: "Accelerated": vm networking type is not supported for instance type Standard_B4ms`,
 		},
 		{
 			name:     "Unsupported VMNetworkingType in Compute",
 			edits:    editFunctions{invalidVMNetworkingIstanceTypes, vmNetworkingTypeAcceleratedCompute},
-			errorMsg: `\[controlPlane.platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 4 vCPUsAvailable, controlPlane.platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 16 GB Memory, compute\[0\].platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 2 vCPUsAvailable, compute\[0\].platform.azure.type: Invalid value: "Standard_A1_v2": instance type does not meet minimum resource requirements of 8 GB Memory\]`,
+			errorMsg: `compute\[0\].platform.azure.vmNetworkingType: Invalid value: "Accelerated": vm networking type is not supported for instance type Standard_B4ms`,
 		},
 		{
 			name:  "Valid OS Image",
@@ -429,6 +437,15 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 		azureClient.EXPECT().GetVirtualMachineSku(gomock.Any(), to.String(value.Name), gomock.Any()).Return(value, nil).AnyTimes()
 	}
 	azureClient.EXPECT().GetVirtualMachineSku(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	for key, value := range vmCapabilities {
+		azureClient.EXPECT().GetVMCapabilities(gomock.Any(), key, validRegion).Return(value, nil).AnyTimes()
+	}
+	azureClient.EXPECT().GetVMCapabilities(gomock.Any(), "Dne_D2_v4", validRegion).Return(nil, fmt.Errorf("not found in region centralus")).AnyTimes()
+	azureClient.EXPECT().GetVMCapabilities(gomock.Any(), gomock.Any(), "neverland").Return(nil, nil).AnyTimes()
+	azureClient.EXPECT().GetVMCapabilities(gomock.Any(), gomock.Any(), "australiacentral2").Return(vmCapabilities["Standard_D8s_v3"], nil).AnyTimes()
+	azureClient.EXPECT().GetVMCapabilities(gomock.Any(), gomock.Any(), "centralus").Return(vmCapabilities["Standard_D8s_v3"], nil).AnyTimes()
+	azureClient.EXPECT().GetVMCapabilities(gomock.Any(), gomock.Any(), "Central US").Return(nil, nil).AnyTimes()
 
 	// VirtualNetwork
 	azureClient.EXPECT().GetVirtualNetwork(gomock.Any(), validNetworkResourceGroup, validVirtualNetwork).Return(virtualNetworkAPIResult, nil).AnyTimes()

--- a/pkg/asset/machines/azure/capabilities.go
+++ b/pkg/asset/machines/azure/capabilities.go
@@ -1,0 +1,41 @@
+package azure
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/installer/pkg/types/azure"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func getHyperVGenerationVersion(capabilities map[string]string) (string, error) {
+	if val, ok := capabilities["HyperVGenerations"]; ok {
+		generations := sets.NewString()
+		for _, g := range strings.Split(val, ",") {
+			g = strings.TrimSpace(g)
+			g = strings.ToUpper(g)
+			generations.Insert(g)
+		}
+		if generations.Has("V2") {
+			return "V2", nil
+		}
+		return "V1", nil
+	}
+	return "", fmt.Errorf("unable to determine HyperVGeneration version")
+}
+
+func getVMNetworkingCapability(capabilities map[string]string) bool {
+	val, ok := capabilities[string(azure.AcceleratedNetworkingEnabled)]
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(val, "True")
+}
+
+func getUltraSSDCapability(capabilities map[string]string) (bool, error) {
+	val, ok := capabilities["UltraSSDAvailable"]
+	if !ok {
+		return false, fmt.Errorf("unable to determine ultra ssd capability")
+	}
+	return strings.EqualFold(val, "True"), nil
+}

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -20,7 +21,7 @@ const (
 )
 
 // Machines returns a list of machines for a machinepool.
-func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, hyperVGen string) ([]machineapi.Machine, error) {
+func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string) ([]machineapi.Machine, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != azure.Name {
 		return nil, fmt.Errorf("non-Azure configuration: %q", configPlatform)
 	}
@@ -29,6 +30,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	}
 	platform := config.Platform.Azure
 	mpool := pool.Platform.Azure
+
 	if len(mpool.Zones) == 0 {
 		// if no azs are given we set to []string{""} for convenience over later operations.
 		// It means no-zoned for the machine API
@@ -46,7 +48,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		if len(azs) > 0 {
 			azIndex = int(idx) % len(azs)
 		}
-		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &azIndex, hyperVGen)
+		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &azIndex, capabilities)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
@@ -78,12 +80,25 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	return machines, nil
 }
 
-func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string, userDataSecret string, clusterID string, role string, azIdx *int, hyperVGen string) (*machineapi.AzureMachineProviderSpec, error) {
+func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string, userDataSecret string, clusterID string, role string, azIdx *int, capabilities map[string]string) (*machineapi.AzureMachineProviderSpec, error) {
 	var az *string
 	if len(mpool.Zones) > 0 && azIdx != nil {
 		az = &mpool.Zones[*azIdx]
 	}
 
+	hyperVGen, err := getHyperVGenerationVersion(capabilities)
+	if err != nil {
+		return nil, err
+	}
+
+	if mpool.VMNetworkingType == "" {
+		acceleratedNetworking := getVMNetworkingCapability(capabilities)
+		if acceleratedNetworking {
+			mpool.VMNetworkingType = string(azure.VMnetworkingTypeAccelerated)
+		} else {
+			logrus.Infof("Instance type %s does not support Accelerated Networking. Using Basic Networking instead.", mpool.InstanceType)
+		}
+	}
 	rg := platform.ClusterResourceGroupName(clusterID)
 
 	var image machineapi.Image
@@ -193,6 +208,7 @@ func getNetworkInfo(platform *azure.Platform, clusterID, role string) (string, s
 	}
 }
 
+// getVMNetworkingType should set the correct capability for instance type
 func getVMNetworkingType(value string) bool {
 	return value == string(azure.VMnetworkingTypeAccelerated)
 }

--- a/pkg/asset/machines/azure/machinesets.go
+++ b/pkg/asset/machines/azure/machinesets.go
@@ -13,7 +13,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, hyperVGen string) ([]*clusterapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string) ([]*clusterapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != azure.Name {
 		return nil, fmt.Errorf("non-azure configuration: %q", configPlatform)
 	}
@@ -22,6 +22,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	}
 	platform := config.Platform.Azure
 	mpool := pool.Platform.Azure
+
 	if len(mpool.Zones) == 0 {
 		// if no azs are given we set to []string{""} for convenience over later operations.
 		// It means no-zoned for the machine API
@@ -40,7 +41,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		if int64(idx) < total%numOfAZs {
 			replicas++
 		}
-		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx, hyperVGen)
+		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx, capabilities)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -362,12 +362,12 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		pool.Platform.Azure = &mpool
 
 		client := icazure.NewClient(session)
-		hyperVGeneration, err := client.GetHyperVGenerationVersion(context.TODO(), mpool.InstanceType, mpool.OSDisk.DiskType, installConfig.Config.Platform.Azure.Region)
+		capabilities, err := client.GetVMCapabilities(context.TODO(), mpool.InstanceType, installConfig.Config.Platform.Azure.Region)
 		if err != nil {
 			return err
 		}
 
-		machines, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, hyperVGeneration)
+		machines, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, capabilities)
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -405,12 +405,13 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 
 			pool.Platform.Azure = &mpool
 			client := icazure.NewClient(session)
-			hyperVGen, err := client.GetHyperVGenerationVersion(context.TODO(), mpool.InstanceType, mpool.OSDisk.DiskType, installConfig.Config.Platform.Azure.Region)
+
+			capabilities, err := client.GetVMCapabilities(context.TODO(), mpool.InstanceType, installConfig.Config.Platform.Azure.Region)
 			if err != nil {
 				return err
 			}
 
-			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", workerUserDataSecretName, hyperVGen)
+			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", workerUserDataSecretName, capabilities)
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}


### PR DESCRIPTION
Summary:
With the recent changes introduced to vmNetworkingType #5309, the default setting for was set to true (enable accelerated networking). This has broken a QE test for instance type  `Standard_B4ms`.

The idea behind this PR is to fetch the vm capabilities and then set the default to `vmNetworkingType` to whether or not the VM has the capability. This introduces a new azure client call `GetVMCapabilities`.