### PR TITLE
Bug 2078895: ovirt: fixing incorrect 'format' value validation

### DIFF
--- a/pkg/types/ovirt/validation/machinepool.go
+++ b/pkg/types/ovirt/validation/machinepool.go
@@ -63,12 +63,12 @@ func ValidateMachinePool(p *ovirt.MachinePool, fldPath *field.Path) field.ErrorL
 	switch p.Format {
 	case "":
 	case "raw":
-	case "format":
+	case "cow":
 	default:
 		allErrs = append(allErrs, field.NotSupported(
 			fldPath.Child("format"),
 			p.Format,
-			[]string{"", "raw", "format"},
+			[]string{"", "raw", "cow"},
 		))
 	}
 


### PR DESCRIPTION
This change fixes a bug where the 'format' parameter on the oVirt platform would be validated incorrectly and only accept empty, raw, or format. Instead, it should accept empty, raw, or cow.