### PR TITLE
vSphere: ignore bootstrap eagerly scrub changes

### DIFF
--- a/data/data/vsphere/bootstrap/main.tf
+++ b/data/data/vsphere/bootstrap/main.tf
@@ -33,6 +33,12 @@ resource "vsphere_virtual_machine" "vm_bootstrap" {
     eagerly_scrub    = var.scrub_disk
     thin_provisioned = var.thin_disk
   }
+  lifecycle {
+    ignore_changes = [
+      disk[0].eagerly_scrub,
+    ]
+  }
+
 
   clone {
     template_uuid = var.template


### PR DESCRIPTION
The vsphere terraform provider has a long standing
bug if a disk parameter is changed underneath
terraform by vSphere the apply will fail.

This resolves reported issue:
https://github.com/openshift/installer/issues/5830