### PR TITLE
[CFE-465] As a developer I want to support wildcard character for noProxy

### DIFF
--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -775,7 +775,38 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Proxy.NoProxy = ""
 				return c
 			}(),
-			expectedError: `^proxy: Required value: must include httpProxy or httpsProxy$`,
+			expectedError: `^proxy: Required value: must include httpProxy or httpsProxy or noProxy with only wildcard$`,
+		},
+		{
+			name: "wildcard proxy settings",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Proxy.HTTPProxy = ""
+				c.Proxy.HTTPSProxy = ""
+				c.Proxy.NoProxy = "*"
+				return c
+			}(),
+			expectedError: "",
+		},
+		{
+			name: "wildcard proxy settings",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Proxy.NoProxy = "*"
+				return c
+			}(),
+			expectedError: "",
+		},
+		{
+			name: "wildcard proxy settings",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Proxy.HTTPProxy = ""
+				c.Proxy.HTTPSProxy = ""
+				c.Proxy.NoProxy = "validproxy.com"
+				return c
+			}(),
+			expectedError: `^proxy: Required value: must include httpProxy or httpsProxy or noProxy with only wildcard$`,
 		},
 		{
 			name: "invalid HTTPProxy",


### PR DESCRIPTION
Added wildcard '*' validation support to signify transparent proxy when there is no proxy set for http/https config.
