### PR TITLE
Change the default machine pool config for Nutanix

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -451,9 +451,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	case nonetypes.Name:
 	case nutanixtypes.Name:
 		mpool := defaultNutanixMachinePoolPlatform()
-		mpool.NumCPUs = 4
-		mpool.NumCoresPerSocket = 4
-		mpool.MemoryMiB = 16384
+		mpool.NumCPUs = 8
 		mpool.Set(ic.Platform.Nutanix.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Nutanix)
 		pool.Platform.Nutanix = &mpool

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -174,9 +174,9 @@ func defaultPowerVSMachinePoolPlatform() powervstypes.MachinePool {
 
 func defaultNutanixMachinePoolPlatform() nutanixtypes.MachinePool {
 	return nutanixtypes.MachinePool{
-		NumCPUs:           2,
-		NumCoresPerSocket: 2,
-		MemoryMiB:         8192,
+		NumCPUs:           4,
+		NumCoresPerSocket: 1,
+		MemoryMiB:         16384,
 		OSDisk: nutanixtypes.OSDisk{
 			DiskSizeMiB: decimalRootVolumeSize * 1024,
 		},


### PR DESCRIPTION
Adjust the default machine pool configuration for Nutanix machines
  - Reduce the number of cores per socket:
    - Control plane nodes: From 4 cores per socket to 1
    - Worker nodes: From 2 cores per socket to 1
  - Increase the number of CPUs:
    - Control plane nodes: From 4 CPUs to 8
    - Worker nodes: From 2 CPUs to 4
  - Increased the RAM to 16GB.

Note: The AHV scheduler treats socket and core allocation exactly the same.