### PR TITLE
[ibmcloud] Update os name to correct value 

### DIFF
--- a/data/data/ibmcloud/network/image/main.tf
+++ b/data/data/ibmcloud/network/image/main.tf
@@ -31,7 +31,7 @@ resource "ibm_is_image" "image" {
 
   name             = var.name
   href             = "cos://${ibm_cos_bucket.images.region_location}/${ibm_cos_bucket.images.bucket_name}/${ibm_cos_bucket_object.file.key}"
-  operating_system = "fedora-coreos-stable-amd64"
+  operating_system = "red-coreos-stable-amd64"
   resource_group   = var.resource_group_id
   tags             = var.tags
 }


### PR DESCRIPTION
A custom image is used for VSI provisioning. We were unable to to set the operating system name correctly until additional support was added to VPC IaaS.

That support has been added and is available in all supported regions.

This PR will set the os name value to: `red-coreos-stable-amd64` (previously set to: `fedora-coreos-stable-amd64"`).