### PR TITLE
Pull the OS Image for Nutanix via URL

### DIFF
--- a/data/data/nutanix/cluster/main.tf
+++ b/data/data/nutanix/cluster/main.tf
@@ -29,7 +29,7 @@ resource "nutanix_category_value" "ocp_category_value_shared" {
 
 resource "nutanix_image" "rhcos" {
   name        = var.nutanix_image
-  source_path = var.nutanix_image_filepath
+  source_uri  = var.nutanix_image_uri
   description = local.description
 
   categories {

--- a/data/data/nutanix/variables-nutanix.tf
+++ b/data/data/nutanix/variables-nutanix.tf
@@ -27,9 +27,9 @@ variable "nutanix_prism_element_uuid" {
   description = "This is the uuid of the Prism Element cluster."
 }
 
-variable "nutanix_image_filepath" {
+variable "nutanix_image_uri" {
   type        = string
-  description = "This is the filepath to the image file that will be imported into Prism Central."
+  description = "This is the uri to the image file that will be imported into Prism Central."
 }
 
 variable "nutanix_image" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -866,13 +866,17 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			controlPlaneConfigs[i] = c.Spec.ProviderSpec.Value.Object.(*machinev1.NutanixMachineProviderConfig)
 		}
 
+		imgURI := string(*rhcosImage)
+		if installConfig.Config.Nutanix.ClusterOSImage != "" {
+			imgURI = installConfig.Config.Nutanix.ClusterOSImage
+		}
 		data, err = nutanixtfvars.TFVars(
 			nutanixtfvars.TFVarsSources{
 				PrismCentralAddress:   installConfig.Config.Nutanix.PrismCentral.Endpoint.Address,
 				Port:                  strconv.Itoa(int(installConfig.Config.Nutanix.PrismCentral.Endpoint.Port)),
 				Username:              installConfig.Config.Nutanix.PrismCentral.Username,
 				Password:              installConfig.Config.Nutanix.PrismCentral.Password,
-				ImageURL:              string(*rhcosImage),
+				ImageURI:              imgURI,
 				BootstrapIgnitionData: bootstrapIgn,
 				ClusterID:             clusterID.InfraID,
 				ControlPlaneConfigs:   controlPlaneConfigs,


### PR DESCRIPTION
Instead of uploading the rhcos image from the installer machine
to Prism Central, ask Prism Central to download the image through
a URL. This is a lot less error prone.