### PR TITLE
Bug 2082604: Revert "image: set os name to red-coreos-stable-amd64"

### DIFF
--- a/data/data/ibmcloud/network/image/main.tf
+++ b/data/data/ibmcloud/network/image/main.tf
@@ -31,7 +31,7 @@ resource "ibm_is_image" "image" {
 
   name             = var.name
   href             = "cos://${ibm_cos_bucket.images.region_location}/${ibm_cos_bucket.images.bucket_name}/${ibm_cos_bucket_object.file.key}"
-  operating_system = "red-coreos-stable-amd64"
+  operating_system = "fedora-coreos-stable-amd64"
   resource_group   = var.resource_group_id
   tags             = var.tags
 }


### PR DESCRIPTION
This reverts commit 9f339a3a6f34c0498bb137693f4941669945b7e9.