### PR TITLE
Update to Golang v1.17

### DIFF
--- a/docs/dev/dependencies.md
+++ b/docs/dev/dependencies.md
@@ -18,7 +18,7 @@ We follow a hard flattening approach; i.e. direct and inherited dependencies are
 
 Dependencies are managed with [Go Modules](https://github.com/golang/go/wiki/Modules) but committed directly to the repository.
 
-We require at least Go 1.16.
+We require at least Go 1.17.
 
 - Add or update a dependency with `go get <dependency>@<version>`.
 - If you want to use a fork of a project or ensure that a dependency is not updated even when another dependency requires a newer version of it, manually add a [replace directive in the go.mod file](https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive). 

--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -9,6 +9,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.16 \
+    docker.io/golang:1.17 \
     ./hack/go-fmt.sh "${@}"
 fi

--- a/hack/go-genmock.sh
+++ b/hack/go-genmock.sh
@@ -9,6 +9,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.16 \
+    docker.io/golang:1.17 \
     ./hack/go-genmock.sh "${@}"
 fi

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -8,6 +8,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.16 \
+    docker.io/golang:1.17 \
     ./hack/go-lint.sh "${@}"
 fi

--- a/hack/go-sec.sh
+++ b/hack/go-sec.sh
@@ -12,6 +12,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.16 \
+    docker.io/golang:1.17 \
     ./hack/go-sec.sh "${@}"
 fi

--- a/hack/go-test.sh
+++ b/hack/go-test.sh
@@ -8,6 +8,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.16 \
+    docker.io/golang:1.17 \
     ./hack/go-test.sh "${@}"
 fi

--- a/hack/go-vet.sh
+++ b/hack/go-vet.sh
@@ -6,6 +6,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/openshift/origin-release:golang-1.16 \
+    docker.io/golang:1.17 \
     ./hack/go-vet.sh "${@}"
 fi;

--- a/images/installer/Dockerfile.ci.rhel7
+++ b/images/installer/Dockerfile.ci.rhel7
@@ -1,7 +1,7 @@
 # This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.16-openshift-4.10 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-7-golang-1.17-openshift-4.10 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .


### PR DESCRIPTION
When I run the `hack/go-test.sh` locally, I get the following errors:

```
$ ./hack/go-test.sh
# sigs.k8s.io/json/internal/golang/encoding/json
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1249:12: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
vendor/sigs.k8s.io/json/internal/golang/encoding/json/encode.go:1255:18: sf.IsExported undefined (type reflect.StructField has no field or method IsExported)
...
```
This is because of an older golang version (CI is running already on Golang 1.17: https://github.com/openshift/installer/blob/21cd5218bb58288cd7b03018b9a2513aca3a13a5/.ci-operator.yaml#L4)

This PR addresses it and updates the Golang version to 1.17.