### PR TITLE
AGENT-40: allow reading cert keys

### DIFF
--- a/pkg/asset/tls/adminkubeconfig.go
+++ b/pkg/asset/tls/adminkubeconfig.go
@@ -31,6 +31,11 @@ func (c *AdminKubeConfigSignerCertKey) Generate(parents asset.Parents) error {
 	return c.SelfSignedCertKey.Generate(cfg, "admin-kubeconfig-signer")
 }
 
+// Load reads the asset files from disk.
+func (c *AdminKubeConfigSignerCertKey) Load(f asset.FileFetcher) (bool, error) {
+	return c.loadCertKey(f, "admin-kubeconfig-signer")
+}
+
 // Name returns the human-friendly name of the asset.
 func (c *AdminKubeConfigSignerCertKey) Name() string {
 	return "Certificate (admin-kubeconfig-signer)"
@@ -95,6 +100,11 @@ func (a *AdminKubeConfigClientCertKey) Generate(dependencies asset.Parents) erro
 	}
 
 	return a.SignedCertKey.Generate(cfg, ca, "admin-kubeconfig-client", DoNotAppendParent)
+}
+
+// Load reads the asset files from disk.
+func (a *AdminKubeConfigClientCertKey) Load(f asset.FileFetcher) (bool, error) {
+	return a.loadCertKey(f, "admin-kubeconfig-client")
 }
 
 // Name returns the human-friendly name of the asset.

--- a/pkg/asset/tls/apiserver.go
+++ b/pkg/asset/tls/apiserver.go
@@ -127,6 +127,11 @@ func (c *KubeAPIServerLocalhostSignerCertKey) Generate(parents asset.Parents) er
 	return c.SelfSignedCertKey.Generate(cfg, "kube-apiserver-localhost-signer")
 }
 
+// Load reads the asset files from disk.
+func (c *KubeAPIServerLocalhostSignerCertKey) Load(f asset.FileFetcher) (bool, error) {
+	return c.loadCertKey(f, "kube-apiserver-localhost-signer")
+}
+
 // Name returns the human-friendly name of the asset.
 func (c *KubeAPIServerLocalhostSignerCertKey) Name() string {
 	return "Certificate (kube-apiserver-localhost-signer)"
@@ -222,6 +227,11 @@ func (c *KubeAPIServerServiceNetworkSignerCertKey) Generate(parents asset.Parent
 	}
 
 	return c.SelfSignedCertKey.Generate(cfg, "kube-apiserver-service-network-signer")
+}
+
+// Load reads the asset files from disk.
+func (c *KubeAPIServerServiceNetworkSignerCertKey) Load(f asset.FileFetcher) (bool, error) {
+	return c.loadCertKey(f, "kube-apiserver-service-network-signer")
 }
 
 // Name returns the human-friendly name of the asset.
@@ -330,6 +340,11 @@ func (c *KubeAPIServerLBSignerCertKey) Generate(parents asset.Parents) error {
 	}
 
 	return c.SelfSignedCertKey.Generate(cfg, "kube-apiserver-lb-signer")
+}
+
+// Load reads the asset files from disk.
+func (c *KubeAPIServerLBSignerCertKey) Load(f asset.FileFetcher) (bool, error) {
+	return c.loadCertKey(f, "kube-apiserver-lb-signer")
 }
 
 // Name returns the human-friendly name of the asset.


### PR DESCRIPTION
Ensure that we can use an admin kubeconfig pre-generated by the agent
installer. This requires adding the ability to read all of the
certificates that it depends on:

![overrides](https://user-images.githubusercontent.com/842470/167218047-82262feb-8145-481c-8529-bea85b6c591a.svg)

Certs and keys will be read from disk only if they exist and the environment variable `OPENSHIFT_INSTALL_LOAD_CLUSTER_CERTS` is set to `true`.