### PR TITLE
Bug 2083327: [release-4.10] Add 'ARG TAGS=""' line for each build step

### DIFF
--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -9,12 +9,14 @@ RUN go generate ./data && \
     SKIP_GENERATION=y GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS macarmbuilder
+ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN go generate ./data && \
     SKIP_GENERATION=y GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS linuxbuilder
+ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN go generate ./data && \


### PR DESCRIPTION
For OKD builds TAGS are not propagated to all three builds.  Adding
'ARG TAGS=""' to each build stanza fixes this

Cherry-pick of https://github.com/openshift/installer/pull/5794 on release-4.10