### PR TITLE
OpenStack: fix SR-IOV documentation TOC

### DIFF
--- a/docs/user/openstack/deploy_sriov_workers.md
+++ b/docs/user/openstack/deploy_sriov_workers.md
@@ -3,9 +3,10 @@
 ## Table of Contents
 
 - [Prerequisites](#prerequisites)
-- [Preparing your OpenShift Cluster to use SR-IOV Networks](#preparing-your-openshift-cluster-to-use-sr-iov-networks)
 - [Creating SR-IOV Networks for Worker Nodes](#creating-sr-iov-networks-for-worker-nodes)
 - [Creating SR-IOV Worker Nodes in IPI](#creating-sr-iov-worker-nodes-in-ipi)
+- [Install the SRIOV Network Operator and configure a network device](#install-the-sriov-network-operator-and-configure-a-network-device)
+- [Deploy a testpmd pod](#deploy-a-testpmd-pod)
 - [Creating SR-IOV Worker Nodes in UPI](#creating-sr-iov-worker-nodes-in-upi)
 
 ## Prerequisites


### PR DESCRIPTION
While refreshing the SR-IOV documentation in #5712 we forgot to update the Table of Contents at the top of the document. This PR fixes it.