### PR TITLE
Make Nutanix image pull behaviour contingent on clusterOSImage

### DIFF
--- a/data/data/nutanix/cluster/main.tf
+++ b/data/data/nutanix/cluster/main.tf
@@ -30,6 +30,7 @@ resource "nutanix_category_value" "ocp_category_value_shared" {
 resource "nutanix_image" "rhcos" {
   name        = var.nutanix_image
   source_uri  = var.nutanix_image_uri
+  source_path = var.nutanix_image_filepath
   description = local.description
 
   categories {

--- a/data/data/nutanix/variables-nutanix.tf
+++ b/data/data/nutanix/variables-nutanix.tf
@@ -27,9 +27,16 @@ variable "nutanix_prism_element_uuid" {
   description = "This is the uuid of the Prism Element cluster."
 }
 
+variable "nutanix_image_filepath" {
+  type        = string
+  description = "This is the filepath to the image file that will be imported into Prism Central."
+  default     = null
+}
+
 variable "nutanix_image_uri" {
   type        = string
   description = "This is the uri to the image file that will be imported into Prism Central."
+  default     = null
 }
 
 variable "nutanix_image" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -867,21 +867,23 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 
 		imgURI := string(*rhcosImage)
+		var useImagePullOnPrism bool
 		if installConfig.Config.Nutanix.ClusterOSImage != "" {
 			imgURI = installConfig.Config.Nutanix.ClusterOSImage
+			useImagePullOnPrism = true
 		}
-		data, err = nutanixtfvars.TFVars(
-			nutanixtfvars.TFVarsSources{
-				PrismCentralAddress:   installConfig.Config.Nutanix.PrismCentral.Endpoint.Address,
-				Port:                  strconv.Itoa(int(installConfig.Config.Nutanix.PrismCentral.Endpoint.Port)),
-				Username:              installConfig.Config.Nutanix.PrismCentral.Username,
-				Password:              installConfig.Config.Nutanix.PrismCentral.Password,
-				ImageURI:              imgURI,
-				BootstrapIgnitionData: bootstrapIgn,
-				ClusterID:             clusterID.InfraID,
-				ControlPlaneConfigs:   controlPlaneConfigs,
-			},
-		)
+		nutanixTfVars := nutanixtfvars.TFVarsSources{
+			PrismCentralAddress:   installConfig.Config.Nutanix.PrismCentral.Endpoint.Address,
+			Port:                  strconv.Itoa(int(installConfig.Config.Nutanix.PrismCentral.Endpoint.Port)),
+			Username:              installConfig.Config.Nutanix.PrismCentral.Username,
+			Password:              installConfig.Config.Nutanix.PrismCentral.Password,
+			ImageURI:              imgURI,
+			BootstrapIgnitionData: bootstrapIgn,
+			ClusterID:             clusterID.InfraID,
+			ControlPlaneConfigs:   controlPlaneConfigs,
+			UseImagePullOnPrism:   useImagePullOnPrism,
+		}
+		data, err = nutanixtfvars.TFVars(nutanixTfVars)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)
 		}


### PR DESCRIPTION
New behaviour: By default installer will default to downloading, unpacking
the gzipped image, and uploading the unzipped qcow2 image from image cache.
If the clusterOSImage property has been explicitly set on the nutanix
platform in install-config, installer will pass on the URI in clusterOSImage
to terraform for prism central to pull image directly.