### PR TITLE
Bug 2065893: bump RHCOS 4.11 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,83 +1,95 @@
 {
   "stream": "rhcos-4.11",
   "metadata": {
-    "last-modified": "2022-03-19T00:15:57Z",
-    "generator": "plume cosa2stream 0.13.0+21-g434af80e2-dirty"
+    "last-modified": "2022-05-10T19:25:06Z",
+    "generator": "plume cosa2stream 0.13.0+135-gc29b6f7d5-dirty"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "410.84.202201251203-0",
+          "release": "411.85.202205040359-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-aws.aarch64.vmdk.gz",
-                "sha256": "5002dcdfdca3e7e80e01866d8470218a585272e7251db0cc9c04aef39fd6fc02",
-                "uncompressed-sha256": "03d27b9f4a5ec04fb0829a7da39bd5666009b08eb6d8265a528c35713ecb2e90"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-aws.aarch64.vmdk.gz",
+                "sha256": "5fb260c73933d093c094ff92390cc8b21e200a4b125f2797cd52cedf2656d488",
+                "uncompressed-sha256": "a2a4c3b666650b3520a1cf60a79b63fc078d631750aa97f4c392a3bf77d4de75"
+              }
+            }
+          }
+        },
+        "azure": {
+          "release": "411.85.202205040359-0",
+          "formats": {
+            "vhd.gz": {
+              "disk": {
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-azure.aarch64.vhd.gz",
+                "sha256": "2bffd71472f24be9ea4d0e19418f06bdb06fb93bee10c107e6c59276ef461484",
+                "uncompressed-sha256": "d7fbc29f5d85f436928de65c3c665e093d59641d73a80b47f03d8d326d943305"
               }
             }
           }
         },
         "metal": {
-          "release": "410.84.202201251203-0",
+          "release": "411.85.202205040359-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-metal4k.aarch64.raw.gz",
-                "sha256": "3e3e33afb27c54cad5d243a8d42ac9b498c1cd32b1366ca2d86b076937063b89",
-                "uncompressed-sha256": "976315a9e8c5d57055390de55f907ddfb24152601909ab3aba561d38dd0f6eda"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-metal4k.aarch64.raw.gz",
+                "sha256": "c9c79647229c6bb09c1852ce53d2e98912d2f6a50cd76284e371e9aa1c728438",
+                "uncompressed-sha256": "c7cb6987b3286e7d70514df7d4b763143ed233fd6423057e7100150ad5ce9557"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-live.aarch64.iso",
-                "sha256": "66e4ea2d58090761a8da4ee9816d5ea9a0bfc99eb6874119b2c677cc7dff4953"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live.aarch64.iso",
+                "sha256": "5558d4f4625a95b267ee2096f108c8be7eb5e5c27fa95d5cbad31af040c53674"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-live-kernel-aarch64",
-                "sha256": "3467e8bfffedf402fe82156e9710d6684f273a77e1dd3017ae134ff3a6d3dc52"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-kernel-aarch64",
+                "sha256": "5d044dfb1bcebc86effbef794b94a424e3d2e5d2a217cf968cc2a73a1efbe320"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-live-initramfs.aarch64.img",
-                "sha256": "d24d5cca403f20e3b20b77d607ee9775609c8c0a8390ed44f405d6f110d9f176"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-initramfs.aarch64.img",
+                "sha256": "980121a55b682c4388f525bb5ac7882ca9d4dec27dfc6f261c376c64944ac894"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-live-rootfs.aarch64.img",
-                "sha256": "183ed2219c9be0e2b1887d060663e0a0279ff7a6866dc598d865f79c094fd38d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-rootfs.aarch64.img",
+                "sha256": "30393784dd1612d9eedbda0d8d3e4a2e4f2452b4de4bb13ca509345c88de4c97"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-metal.aarch64.raw.gz",
-                "sha256": "4c60214ccb8e4315b797b1d2a68be9b4c7345e48414625a573057a477773b6b1",
-                "uncompressed-sha256": "a8509ee5f97a04fc32dcd2057c75a05517e7619f75000c45e1f9b32b3300f19c"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-metal.aarch64.raw.gz",
+                "sha256": "b779180a783fa80478618b310efe4691d90211b283752b868edba70058f09050",
+                "uncompressed-sha256": "5f90d700758123fcf861fa4df8b2216cf8caec588602a37d746f2d8b485c9301"
               }
             }
           }
         },
         "openstack": {
-          "release": "410.84.202201251203-0",
+          "release": "411.85.202205040359-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-openstack.aarch64.qcow2.gz",
-                "sha256": "43d705930aa55be857d08586660554f44a6fea48859dde0638ca23bf33f22f9f",
-                "uncompressed-sha256": "14903b14d58bd9991e0c6dfad723a59f33c04a7b092f01db45de48a0d910ca4d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-openstack.aarch64.qcow2.gz",
+                "sha256": "075f26218a9087604abc91618370bf59cf8e7f6496f14f8ea8d60be8dd339a82",
+                "uncompressed-sha256": "23cd254f1ff554db761ca44df281d0396a14c5d54d10c1f773c2e7757a2ec6cc"
               }
             }
           }
         },
         "qemu": {
-          "release": "410.84.202201251203-0",
+          "release": "411.85.202205040359-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-qemu.aarch64.qcow2.gz",
-                "sha256": "b44ed28acd79c3971a71be971a7604407dbe69fcc0af9240209797bea7464223",
-                "uncompressed-sha256": "1f1c76d0815345e2b394fa8ae88aaa87e5804041ca0de8cf05e8b18d744e2a90"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-qemu.aarch64.qcow2.gz",
+                "sha256": "a02ce9ee1e92341cc37af58a055c514fa62cd0e2ae7cf8a1be1011f79ab19d51",
+                "uncompressed-sha256": "a719d911ef875dfbbdb2d826b6fa91ce5f85a703ec88ea6ff2cf1d4141333830"
               }
             }
           }
@@ -87,158 +99,164 @@
         "aws": {
           "regions": {
             "ap-east-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0f8195c36da4edbd7"
+              "release": "411.85.202205040359-0",
+              "image": "ami-036d1208cdf3de159"
             },
             "ap-northeast-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-000a86fa0a0b76144"
+              "release": "411.85.202205040359-0",
+              "image": "ami-06e557068aa9d9f7a"
             },
             "ap-northeast-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0f772f5dc2347a954"
+              "release": "411.85.202205040359-0",
+              "image": "ami-043ccba70c960763b"
             },
             "ap-south-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-02ab23e25b8e8af97"
+              "release": "411.85.202205040359-0",
+              "image": "ami-045e7baccaa83c111"
             },
             "ap-southeast-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-085ae5a7dcbfb056d"
+              "release": "411.85.202205040359-0",
+              "image": "ami-096f943d29ecc3e4a"
             },
             "ap-southeast-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-085ff9f4e8d4d66e0"
+              "release": "411.85.202205040359-0",
+              "image": "ami-0a64b24b072b16484"
             },
             "ca-central-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0050cdf32f76ba82c"
+              "release": "411.85.202205040359-0",
+              "image": "ami-02c3de67904625e15"
             },
             "eu-central-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-092527fcf7c21fe42"
+              "release": "411.85.202205040359-0",
+              "image": "ami-0e7953667e665f239"
             },
             "eu-north-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-07d673450675ea033"
+              "release": "411.85.202205040359-0",
+              "image": "ami-05738cfc2497f5129"
             },
             "eu-south-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0f165ac29cc9d27bf"
+              "release": "411.85.202205040359-0",
+              "image": "ami-0439daa940eb1f030"
             },
             "eu-west-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0e0cd7d2eb949538d"
+              "release": "411.85.202205040359-0",
+              "image": "ami-0c34be73e1f1f0712"
             },
             "eu-west-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0790ba70a444fe74d"
+              "release": "411.85.202205040359-0",
+              "image": "ami-0ece7d7e0c1b854ee"
             },
             "eu-west-3": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0d16af5bd22cc5227"
+              "release": "411.85.202205040359-0",
+              "image": "ami-092015f22728917bc"
             },
             "me-south-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-05e1ba911ce321052"
+              "release": "411.85.202205040359-0",
+              "image": "ami-0099e38b399d32641"
             },
             "sa-east-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-04b124534c7f05cd2"
+              "release": "411.85.202205040359-0",
+              "image": "ami-05449f30e4b409025"
             },
             "us-east-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-09bbec91849ca85bc"
+              "release": "411.85.202205040359-0",
+              "image": "ami-062d88886dbd84123"
             },
             "us-east-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-048ac599f7315a0bc"
+              "release": "411.85.202205040359-0",
+              "image": "ami-043ee03f44ace71b6"
             },
             "us-west-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0af1d3b7fa5be2131"
+              "release": "411.85.202205040359-0",
+              "image": "ami-024ef8a05563af10d"
             },
             "us-west-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0bd3bf54ee678e2a6"
+              "release": "411.85.202205040359-0",
+              "image": "ami-0cc3dc567c31ea4db"
             }
           }
+        }
+      },
+      "rhel-coreos-extensions": {
+        "azure-disk": {
+          "release": "411.85.202205040359-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-411.85.202205040359-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "411.85.202203181612-0",
+          "release": "411.85.202203250810-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203181612-0/ppc64le/rhcos-411.85.202203181612-0-metal4k.ppc64le.raw.gz",
-                "sha256": "83e4cc2fad8bc949ddfa33d6d6704898966c009285f34ec4051b43efca28e38e",
-                "uncompressed-sha256": "2156130c9f3e0b8c7ccaa9a06d5d04da5921e5275b39f090bd6ac9df01963982"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-metal4k.ppc64le.raw.gz",
+                "sha256": "334e469ea525a83225a9d978f96e37ed2c1c6e1468d71a7c63dba70013c08aa7",
+                "uncompressed-sha256": "ee76292fa895144c09c65564d96911732f6df53d74cefa24f6aec0240c21e76b"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203181612-0/ppc64le/rhcos-411.85.202203181612-0-live.ppc64le.iso",
-                "sha256": "26f22fec5e2ef8d39ba77faa95972f94caba977c9e2813eb05fdaef733daf041"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live.ppc64le.iso",
+                "sha256": "6b76622f864f7f4ac56b4cd432ccfe2cb09dbfe7a7d5c3c36685e2c4faeb7324"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203181612-0/ppc64le/rhcos-411.85.202203181612-0-live-kernel-ppc64le",
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-kernel-ppc64le",
                 "sha256": "1087567be28bbe7e247c08986e2e46d6daa8b7a8d5c627e518a39cd3723c0bab"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203181612-0/ppc64le/rhcos-411.85.202203181612-0-live-initramfs.ppc64le.img",
-                "sha256": "7e7da40f9b2794bca4c158570beea9a6d67bf88c1e742d01fd3653064d0cf3b3"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-initramfs.ppc64le.img",
+                "sha256": "f35074fd3a3720502446cfd265134bec61b3b98256a403afb0e22b90593ef8b1"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203181612-0/ppc64le/rhcos-411.85.202203181612-0-live-rootfs.ppc64le.img",
-                "sha256": "3d7554f1bbbac0532746dae224525dae674023526fd7c721e9753ee26c760cf5"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-rootfs.ppc64le.img",
+                "sha256": "3254f11117fee0ab6d8155c98ca21615878f54f4af2c7e23046936c8ecf724f8"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203181612-0/ppc64le/rhcos-411.85.202203181612-0-metal.ppc64le.raw.gz",
-                "sha256": "10ac9315a3d250bff98e2ec84ee2d996c50a4e2adeee9459a6e5adeddadd15d4",
-                "uncompressed-sha256": "084e78ead58b8269554b1189a94987b35a3e42ef0ec10fedd35fb5d948b470f3"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-metal.ppc64le.raw.gz",
+                "sha256": "83b7fdfbbece9be07a7a6cd299f608db37f4a7dc707cbd874fe9ca9271d2d2ee",
+                "uncompressed-sha256": "0a383533eabc1644a52edd968f7ee5d6510a2eba01ab83d8fb5914084d0ee9b0"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.85.202203181612-0",
+          "release": "411.85.202203250810-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203181612-0/ppc64le/rhcos-411.85.202203181612-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "d4c93261b4e36f9dd800d2cb53cfdb2e0a556077e1ff045826446caa938e6d18",
-                "uncompressed-sha256": "303dc6d93a5768fdefa9566da7a0c5f9e8b132e6358963dadbf62dfd6f955914"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "e648e8e8271e35aac15da4aebfaf2145fd41dbd0c6c70c6f836aac86446b783d",
+                "uncompressed-sha256": "65e55e6a0d2dfa9415ed3fac9951a645d87f257e34b4ae57dda9d006504c5048"
               }
             }
           }
         },
         "powervs": {
-          "release": "411.85.202203181612-0",
+          "release": "411.85.202203250810-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203181612-0/ppc64le/rhcos-411.85.202203181612-0-powervs.ppc64le.ova.gz",
-                "sha256": "4bb0b7a22e92ac02992e6bc96f45cb2e527340b4fd86a6e25652c2ac88f3cdd9",
-                "uncompressed-sha256": "574de6dd5f6cdbcccb05be645e83aa0c08dc7617785251f61a07986c90dc8c3f"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-powervs.ppc64le.ova.gz",
+                "sha256": "fd14f78e2b2d30fd925ddee219845e2d558b2de86756efd43a4b18bc1a954465",
+                "uncompressed-sha256": "d783c3713ff2d2029476c1ae0ee0ab358b68808800d26b015757cd8de886b957"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.85.202203181612-0",
+          "release": "411.85.202203250810-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203181612-0/ppc64le/rhcos-411.85.202203181612-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "d864f568cd8cd680a1656e76bd6bbc82aa586da6378d85ca0928070aba312952",
-                "uncompressed-sha256": "430f4df4e6ee2ba27874d8159026a4f127faf45e94418a6d4c6d3d944d73f019"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "af84b0af643981e3a047d5f7f6d3ba7eb1b40a25ff6eee8f4fc54d9c88567e46",
+                "uncompressed-sha256": "4da192bc1f1288e1e02effcedd1701ac97d47cbd344b7a590455a460a38875a4"
               }
             }
           }
@@ -248,58 +266,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "411.85.202203181612-0",
-              "object": "rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz",
+              "release": "411.85.202203250810-0",
+              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "411.85.202203181612-0",
-              "object": "rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz",
+              "release": "411.85.202203250810-0",
+              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "411.85.202203181612-0",
-              "object": "rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz",
+              "release": "411.85.202203250810-0",
+              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "411.85.202203181612-0",
-              "object": "rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz",
+              "release": "411.85.202203250810-0",
+              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "411.85.202203181612-0",
-              "object": "rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz",
+              "release": "411.85.202203250810-0",
+              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "411.85.202203181612-0",
-              "object": "rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz",
+              "release": "411.85.202203250810-0",
+              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "411.85.202203181612-0",
-              "object": "rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz",
+              "release": "411.85.202203250810-0",
+              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "411.85.202203181612-0",
-              "object": "rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz",
+              "release": "411.85.202203250810-0",
+              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "411.85.202203181612-0",
-              "object": "rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz",
+              "release": "411.85.202203250810-0",
+              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-411-85-202203181612-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -308,64 +326,64 @@
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "411.85.202203181515-0",
+          "release": "411.86.202205030351-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.85.202203181515-0/s390x/rhcos-411.85.202203181515-0-metal4k.s390x.raw.gz",
-                "sha256": "d933908261f4b2f248a93438a17c3948882fab12fbb604ee39848ca98732df45",
-                "uncompressed-sha256": "50ef9275403b14111b9ae5ecc04c101926bf090cfe09f7669463213f171d3c67"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-metal4k.s390x.raw.gz",
+                "sha256": "d24808f010de1a70842430dc20018afb2901847577c4bed24f8021c5f7315a05",
+                "uncompressed-sha256": "e29f62460f7fdf250e106a02b5b787cf0fd19d12dfd8336f6a205f0471c2eefc"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.85.202203181515-0/s390x/rhcos-411.85.202203181515-0-live.s390x.iso",
-                "sha256": "368249e2c40dbfa9801cf2e2d5bc47d7003d9c585679aed8635f67c67b1e4159"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live.s390x.iso",
+                "sha256": "8e64fca95fd0c9b31115de5dbab16f0086455664a4468b2d0b0fe43712d0d471"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.85.202203181515-0/s390x/rhcos-411.85.202203181515-0-live-kernel-s390x",
-                "sha256": "cc61227d6a0c9d05487b9b3f348dbff3e13e9854cfc16b5bdee012c34c8bbb19"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-kernel-s390x",
+                "sha256": "f3bab30ea08f5155b3c67ae08764004349e68042a4aee8482a027f55144282d2"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.85.202203181515-0/s390x/rhcos-411.85.202203181515-0-live-initramfs.s390x.img",
-                "sha256": "91f5729ef35a3069a4c00741e13a161032fdbdab9fed71889f5dcadeb983dc28"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-initramfs.s390x.img",
+                "sha256": "355bdfa8ce4defe5bf0ffac7856ec4ddf8396317b31075aa329d67aea2d1945a"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.85.202203181515-0/s390x/rhcos-411.85.202203181515-0-live-rootfs.s390x.img",
-                "sha256": "30b344ff0d7d6fbb7b7c8f0c41a2ffee684dc4f8adacd0e36a3b518f11894884"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-rootfs.s390x.img",
+                "sha256": "7a3048a92f6999c125ffaab735fccceef5f0e1e706de803734f59f37d0bdc78f"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.85.202203181515-0/s390x/rhcos-411.85.202203181515-0-metal.s390x.raw.gz",
-                "sha256": "ecb1a5ef825a9c7db2ea3919b1570f66bef0af5c4b698c86ef2fd7248be71309",
-                "uncompressed-sha256": "ba9c9f6f957ad1ddb2d67149d50cc8e9c3797b2b602e5442aabe3e1de906d946"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-metal.s390x.raw.gz",
+                "sha256": "d9cb0eb0970fa57b00d9e572a364ab7211c91f53bf4499d15cf3512b86e4db81",
+                "uncompressed-sha256": "73106e2261caa89e0e1ff25bed4f7cfe72d8bafe19d25063b89ad07a90365b8e"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.85.202203181515-0",
+          "release": "411.86.202205030351-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.85.202203181515-0/s390x/rhcos-411.85.202203181515-0-openstack.s390x.qcow2.gz",
-                "sha256": "5462f68b702fde25bd22e523c8d9536a8da77f52aa4ceb5d0447eded4635b291",
-                "uncompressed-sha256": "f85bc0d7db0b260c3da78ba907a3ef56dc82291fbd4830906bea31a9909c6473"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-openstack.s390x.qcow2.gz",
+                "sha256": "9d814822d367a081032fbb48c07e5532279e2d61da33b09fdc3dba059c4c3bd8",
+                "uncompressed-sha256": "073be4b8a15dfcec6b51557d967dfad96ffc97908a8aeec919471de5ac42ce5b"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.85.202203181515-0",
+          "release": "411.86.202205030351-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.85.202203181515-0/s390x/rhcos-411.85.202203181515-0-qemu.s390x.qcow2.gz",
-                "sha256": "579867555adb1f3c17040ac8d5ed017006b9d342adf085c5d59cdc02172a4cb0",
-                "uncompressed-sha256": "10d4cbb6134e69c2806fbb39a5bb6f42b3f31a1315a0ca6f488e7d287e6e4ac8"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-qemu.s390x.qcow2.gz",
+                "sha256": "4b690a17fb685b495df776a93a4d6da0e92c7aff07f5036269f28273df02ea92",
+                "uncompressed-sha256": "b0828d8ea6d3949343419cc26b794888897494a21fb5c4a8881a9b428d3fb57f"
               }
             }
           }
@@ -376,159 +394,159 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "7bdcac320bc3bea289e7978f79be43370cd3e4b290d241dcac24192e23e0b0c6",
-                "uncompressed-sha256": "fa2c6e563acbcf87c59cb85e1638bdac38d82113678b426562f1d430f5a63641"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "b716728ea93b7e28006b1cbc95b286e37bb04d6cbfc14f23b06beb97a87fccb7",
+                "uncompressed-sha256": "d88c56177e898769ea9382d7a51b055ab4dd1b4f699a7c329ea30c18867a7ed1"
               }
             }
           }
         },
         "aws": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-aws.x86_64.vmdk.gz",
-                "sha256": "79d462c508714842595cb0041fdc06fd44881316884e317f656405fba626f646",
-                "uncompressed-sha256": "fb0b8eda40547f363a5be8a9f365162a412dd51a1a33499dbf647e9cb5a1bdc4"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-aws.x86_64.vmdk.gz",
+                "sha256": "37918a20b67e3b3445acfc8e8b2611565b2a8db9a55299a4e85d5e99c5da8748",
+                "uncompressed-sha256": "2a76b77118e5911fd1780bd5b8f77d58b252e1200936173c77104eaa836989b9"
               }
             }
           }
         },
         "azure": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-azure.x86_64.vhd.gz",
-                "sha256": "c505a91dd6947162f73def0838167ed96c296fe989349447b21d6ecb0002751e",
-                "uncompressed-sha256": "4c04a4e57743b8fb438ced62abc2e2276c6b389814c7a6f6b12508e77409ab74"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-azure.x86_64.vhd.gz",
+                "sha256": "ccdf7414f6f432a1dd8a9711ba16ccec87ab643ec87b5cac2bf33eeea7fd5cb0",
+                "uncompressed-sha256": "d5d687fcc5a84889eebcf414357636b7fa93a28ce8186ae4f592d761a501c282"
               }
             }
           }
         },
         "azurestack": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-azurestack.x86_64.vhd.gz",
-                "sha256": "417e5d87a2a948a0de069374032184c6ae0586f04b8e06329745867422c739ad",
-                "uncompressed-sha256": "618eea4625aac8bbc853fc1559945f4b6879d0bc737d62ac86e2fe088f817e05"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-azurestack.x86_64.vhd.gz",
+                "sha256": "aab8bd1b2d0e932da7c41e22d51a49e673f3dd77bfafc69b87834b6b84b132b3",
+                "uncompressed-sha256": "d150e113c726662b1493f5d73211d829191214f4d124793380c6696203315fa5"
               }
             }
           }
         },
         "gcp": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-gcp.x86_64.tar.gz",
-                "sha256": "006ffeefdd116676ca68ba141b12d2db2dc00b9392f7c47b5c856d06975e1902",
-                "uncompressed-sha256": "a83d25bcc84ef70cf784bd68dcc90de24e1232e4251c15dd6b988ef7d7c596b1"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-gcp.x86_64.tar.gz",
+                "sha256": "93b3e416a09b94dbd7c8660d20e89817b348c80c15c3d8319589d0c2806b22fd",
+                "uncompressed-sha256": "c041a28a5f1b5147d2cd420beeb1fe993ac861ead037401f49bbbc8a445685ea"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "8def1301c8014e8791168c62de4df0efa6a5c3321c0d2596bc7e5556e529f778",
-                "uncompressed-sha256": "ecf66e68d35331c326e9164e577f74737bb86201b7e3628d314c4159683df1da"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "6d9b2b366e6b9eeac3d1a8d5942b01cc1a33345f5c93da0e6788df51b02e2ace",
+                "uncompressed-sha256": "a32925bf6d99a0237c724ab0a006cf5a5c7d5f7ff1e01187f955845b4a9e7933"
               }
             }
           }
         },
         "metal": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-metal4k.x86_64.raw.gz",
-                "sha256": "8fc079f48655ae2a4f53af5bbe04f3b93603f777fd86c85bda0455f81f7d345a",
-                "uncompressed-sha256": "7992d71855ff27928635620d8b5f2ed3dc6411091f5cd88325cc0b1241f4e543"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-metal4k.x86_64.raw.gz",
+                "sha256": "12ad39b79e7993beb0c25bff5e99553725aac88ba89eb0c8214bc5e7cf50635a",
+                "uncompressed-sha256": "f77c2b36e97fb2de6d3b6e603a68e2dd720cb9df9ef320a7c09ea572e75aeb8f"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-live.x86_64.iso",
-                "sha256": "c874e1c79defb02b33952d16111fca9674dd07b585b2c2dcfd17c147fb0aba9f"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live.x86_64.iso",
+                "sha256": "6fb6fb45fbd9279d62c9abeaeec3d7cd98a9a1bb31e963b17c026e72a95b587a"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-live-kernel-x86_64",
-                "sha256": "20967413fa3e03cf49eb1ce77438897985673533336833a39fb8a284d4239b4e"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-kernel-x86_64",
+                "sha256": "6208caa9642c9d17971747d078e1e52b62a9a35f3067544ceaa3346e5e1fb285"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-live-initramfs.x86_64.img",
-                "sha256": "7f01fb7f06827cd1cc0fe3720df18b718dcc0a38ac99bc2cbc612235de454f73"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-initramfs.x86_64.img",
+                "sha256": "43cd07465de241e605ce3cc83c68fd282bdfcb5993e5df4d4b94cd4366f7df49"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-live-rootfs.x86_64.img",
-                "sha256": "181a36292bf0654ec8a101b8f05049621ed0e0048f173c4aa444826b76eaa109"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-rootfs.x86_64.img",
+                "sha256": "56ddc8693ad3ded29aa815e38749c0d9b74660dc5fbe69683433709401a985a6"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-metal.x86_64.raw.gz",
-                "sha256": "1e85dcd8fa58f6c6f03b8173e412d83815d1febacdff936fd91eb8be4678cff4",
-                "uncompressed-sha256": "d5b019cadd639cc3fb7f8843f8a092cd29e853ce460d92af45d539a4e799fad1"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-metal.x86_64.raw.gz",
+                "sha256": "f3a7bffaf036d2671fa3009798cb88960a28a5235a5a77f11b6bf3e34b659f6e",
+                "uncompressed-sha256": "8db32bc9cd090fa02d791351527da598e91041b2a0ccc46d74fa4b92a68f31c5"
               }
             }
           }
         },
         "nutanix": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-nutanix.x86_64.qcow2.gz",
-                "sha256": "ec0411fc35c707cea03804408fbc636783e0a18af894f268a7b8c50d5e61d436",
-                "uncompressed-sha256": "d96c4215c22c8cebd01540fd3f69e017ba2fdd8ff8fa87d54515dbb4aa069bc4"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-nutanix.x86_64.qcow2.gz",
+                "sha256": "40b253ece9471afaa3c7566dd3d4fec86d5daa5d9fadc33174ebcc6aa262966f",
+                "uncompressed-sha256": "2d81134c2bde2ae131640da201036721c63bf28a71cbfd8d3114b48d522ba163"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-openstack.x86_64.qcow2.gz",
-                "sha256": "67f16b765b18b92a7a79a74304de718a2ebf0a802906df42114d01a325f4de5c",
-                "uncompressed-sha256": "c31e876b6302ac915613df78771d411766b08633bda6f4f3da1919a24a0e511d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-openstack.x86_64.qcow2.gz",
+                "sha256": "b1ef44b77ae3b1e731d57eea7c73813f28668e4d0a663442a0076b614eb543ee",
+                "uncompressed-sha256": "46278e035367c88349d50cbefb01a9ca73db26808b6dcee8ce58ebf4b52deaf4"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-qemu.x86_64.qcow2.gz",
-                "sha256": "2b496f6b90d85af1540c36d07780d398ae2ccfb1f040a9e2e60768183af0d76c",
-                "uncompressed-sha256": "6708d5d95a7ad6e0b1d10335ac3ffe5c2780b6e880f6fb2407ac95a97cbffed9"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-qemu.x86_64.qcow2.gz",
+                "sha256": "5e713be5b575bc2ae9600518fcd72d64c3a51e21b719444c1c0172f92066280f",
+                "uncompressed-sha256": "75ca83efc8c40669631d7367664fd48372c067da5fa448551bc2ab28026b94c4"
               }
             }
           }
         },
         "vmware": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202203181601-0/x86_64/rhcos-411.85.202203181601-0-vmware.x86_64.ova",
-                "sha256": "a39054725aea870a929046abcdfd897e61763e2556844e47bb87492c4367cb74"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-vmware.x86_64.ova",
+                "sha256": "a6d7b1bafc5b28fa3941e4c70049dd0d55804ce460ebc5f9c9769389f8986bad"
               }
             }
           }
@@ -538,213 +556,217 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "411.85.202203181601-0",
-              "image": "m-6weev9pf64cymu161jhc"
+              "release": "411.85.202205101201-0",
+              "image": "m-6wedcb2rfmhkcl2bsbz5"
             },
             "ap-south-1": {
-              "release": "411.85.202203181601-0",
-              "image": "m-a2d9i7idzzzd3rag1lf0"
+              "release": "411.85.202205101201-0",
+              "image": "m-a2d35ef3e19laftwxz5p"
             },
             "ap-southeast-1": {
-              "release": "411.85.202203181601-0",
-              "image": "m-t4n168vzz5f16ms5kqbr"
+              "release": "411.85.202205101201-0",
+              "image": "m-t4n2ccy2xj8jqoymb9w1"
             },
             "ap-southeast-2": {
-              "release": "411.85.202203181601-0",
-              "image": "m-p0wexfrw72q08v5j6e4e"
+              "release": "411.85.202205101201-0",
+              "image": "m-p0w34jnw2a5ehgj8pdo7"
             },
             "ap-southeast-3": {
-              "release": "411.85.202203181601-0",
-              "image": "m-8ps3qahwrxdh7x702osl"
+              "release": "411.85.202205101201-0",
+              "image": "m-8ps5b41bwkxlhl4jwfgu"
             },
             "ap-southeast-5": {
-              "release": "411.85.202203181601-0",
-              "image": "m-k1ae6rawoqtkxvuz7myd"
+              "release": "411.85.202205101201-0",
+              "image": "m-k1afh4e2sag56x9yfezc"
             },
             "ap-southeast-6": {
-              "release": "411.85.202203181601-0",
-              "image": "m-5tsim6n7d4xot9i74avt"
+              "release": "411.85.202205101201-0",
+              "image": "m-5ts0rboex0qgxgrsqhve"
             },
             "cn-beijing": {
-              "release": "411.85.202203181601-0",
-              "image": "m-2zedvnyg9y0p30tilebt"
+              "release": "411.85.202205101201-0",
+              "image": "m-2ze5q562bmxri0qvroyg"
             },
             "cn-chengdu": {
-              "release": "411.85.202203181601-0",
-              "image": "m-2vc97qcawcm72ejwevwx"
+              "release": "411.85.202205101201-0",
+              "image": "m-2vcfd486hn2pl4mgiw5r"
             },
             "cn-guangzhou": {
-              "release": "411.85.202203181601-0",
-              "image": "m-7xv787bto66ikaqeqgi8"
+              "release": "411.85.202205101201-0",
+              "image": "m-7xvd7ha404hejciwfdol"
             },
             "cn-hangzhou": {
-              "release": "411.85.202203181601-0",
-              "image": "m-bp1243k7dew81hcws7ge"
+              "release": "411.85.202205101201-0",
+              "image": "m-bp106l9gw0cb6iz4brct"
             },
             "cn-heyuan": {
-              "release": "411.85.202203181601-0",
-              "image": "m-f8zin3xo0wr0378mnkxu"
+              "release": "411.85.202205101201-0",
+              "image": "m-f8zg6xijwkbly7vecrgs"
             },
             "cn-hongkong": {
-              "release": "411.85.202203181601-0",
-              "image": "m-j6c9a603yxnmrcr0k0xe"
+              "release": "411.85.202205101201-0",
+              "image": "m-j6cj44anqpmd7ldg9j7a"
             },
             "cn-huhehaote": {
-              "release": "411.85.202203181601-0",
-              "image": "m-hp3csos7jfan9rc2umgv"
+              "release": "411.85.202205101201-0",
+              "image": "m-hp3hjx2axrxa27ux0fdc"
             },
             "cn-nanjing": {
-              "release": "411.85.202203181601-0",
-              "image": "m-gc7dk6o21jwbxh8t0iol"
+              "release": "411.85.202205101201-0",
+              "image": "m-gc7jb0v7addz77rwcb5q"
             },
             "cn-qingdao": {
-              "release": "411.85.202203181601-0",
-              "image": "m-m5eb8cxeiib19sa1u3a0"
+              "release": "411.85.202205101201-0",
+              "image": "m-m5edoavzt9t9noncxj7x"
             },
             "cn-shanghai": {
-              "release": "411.85.202203181601-0",
-              "image": "m-uf66cz852fh3y7rx0iph"
+              "release": "411.85.202205101201-0",
+              "image": "m-uf65ogf13g9vdvxk56hk"
             },
             "cn-shenzhen": {
-              "release": "411.85.202203181601-0",
-              "image": "m-wz98ej4pmj4hbmjvoomk"
+              "release": "411.85.202205101201-0",
+              "image": "m-wz92sqeyqtgxpwzkwlla"
             },
             "cn-wulanchabu": {
-              "release": "411.85.202203181601-0",
-              "image": "m-0jl1j22cbl19aktv0tjw"
+              "release": "411.85.202205101201-0",
+              "image": "m-0jlh1lst294pxy1fqtio"
             },
             "cn-zhangjiakou": {
-              "release": "411.85.202203181601-0",
-              "image": "m-8vbiwk22jkjualnxlpp7"
+              "release": "411.85.202205101201-0",
+              "image": "m-8vbgb4gpuv4i9c95vzwz"
             },
             "eu-central-1": {
-              "release": "411.85.202203181601-0",
-              "image": "m-gw8ie7hjr9b6ljzylkvk"
+              "release": "411.85.202205101201-0",
+              "image": "m-gw884wape1mxpp46qunu"
             },
             "eu-west-1": {
-              "release": "411.85.202203181601-0",
-              "image": "m-d7o7ousvo8ekohx5rfxw"
+              "release": "411.85.202205101201-0",
+              "image": "m-d7o53gqu9axjqgsa2j6b"
             },
             "me-east-1": {
-              "release": "411.85.202203181601-0",
-              "image": "m-eb3bs50k4hihjjjeoj04"
+              "release": "411.85.202205101201-0",
+              "image": "m-eb390gvibujq9i2zpv27"
             },
             "us-east-1": {
-              "release": "411.85.202203181601-0",
-              "image": "m-0xi29kf08acv9dps47zs"
+              "release": "411.85.202205101201-0",
+              "image": "m-0xi54j6hfhaswm8nxj4o"
             },
             "us-west-1": {
-              "release": "411.85.202203181601-0",
-              "image": "m-rj92cd5lh2mbft6v6bfv"
+              "release": "411.85.202205101201-0",
+              "image": "m-rj9hkuw1uxvgqdpmvico"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-094120dc4868552f6"
+              "release": "411.85.202205101201-0",
+              "image": "ami-054fbac6cfb17f672"
             },
             "ap-east-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0f685ba51ec03dc39"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0d05b0ac3d9b0a7af"
             },
             "ap-northeast-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-085c138166099a799"
+              "release": "411.85.202205101201-0",
+              "image": "ami-06b60b6ff884766bd"
             },
             "ap-northeast-2": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0937cc6e046b3c29f"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0f5a01a738d063548"
             },
             "ap-northeast-3": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0272a54506b14db57"
+              "release": "411.85.202205101201-0",
+              "image": "ami-02d02fac3b388604d"
             },
             "ap-south-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0903ac509714e3fe6"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0a2e625d30249aa61"
             },
             "ap-southeast-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0622071f43f4ff5c8"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0fcc879dc0836be56"
             },
             "ap-southeast-2": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-05365ee3a1ce45e28"
+              "release": "411.85.202205101201-0",
+              "image": "ami-016575b468202d04c"
+            },
+            "ap-southeast-3": {
+              "release": "411.85.202205101201-0",
+              "image": "ami-0b41fb9457145f312"
             },
             "ca-central-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-028199708bf9a4177"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0ff2269e2d5d9c5e3"
             },
             "eu-central-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-033069cf277fddf19"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0dc2e2937e2480b03"
             },
             "eu-north-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0aecf775d5b910232"
+              "release": "411.85.202205101201-0",
+              "image": "ami-08cd809f2008ea27c"
             },
             "eu-south-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-01425be537f78a462"
+              "release": "411.85.202205101201-0",
+              "image": "ami-07b85281ed77e350d"
             },
             "eu-west-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0ef451e586637a7cd"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0728450682fcf240d"
             },
             "eu-west-2": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0639bf0c18fb522e0"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0276bc0ebb9541668"
             },
             "eu-west-3": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0b258397b6d6130f5"
+              "release": "411.85.202205101201-0",
+              "image": "ami-048e76c11b25b3576"
             },
             "me-south-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0ed55a57164ffabcc"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0522c3ab770b23611"
             },
             "sa-east-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0850acee27f06ba81"
+              "release": "411.85.202205101201-0",
+              "image": "ami-04eb1a069c3b3ff2c"
             },
             "us-east-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0149b34a1c0684d59"
+              "release": "411.85.202205101201-0",
+              "image": "ami-045edc1017eeccec7"
             },
             "us-east-2": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0acdb852b0fbcc887"
+              "release": "411.85.202205101201-0",
+              "image": "ami-01990fc3bdf30bc13"
             },
             "us-gov-east-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-082d9990e7f6d8456"
+              "release": "411.85.202205101201-0",
+              "image": "ami-059f105d12b430e77"
             },
             "us-gov-west-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-005f607dd7cf0d5d5"
+              "release": "411.85.202205101201-0",
+              "image": "ami-04d54d7b7e3730f6a"
             },
             "us-west-1": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0742a518beae8328d"
+              "release": "411.85.202205101201-0",
+              "image": "ami-0ac12a3d703710ce4"
             },
             "us-west-2": {
-              "release": "411.85.202203181601-0",
-              "image": "ami-0c4a4f700d9a1739b"
+              "release": "411.85.202205101201-0",
+              "image": "ami-091214206ecd087a7"
             }
           }
         },
         "gcp": {
-          "release": "411.85.202203181601-0",
+          "release": "411.85.202205101201-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-411-85-202203181601-0-gcp-x86-64"
+          "name": "rhcos-411-85-202205101201-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "411.85.202203181601-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-411.85.202203181601-0-azure.x86_64.vhd"
+          "release": "411.85.202205101201-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-411.85.202205101201-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.11 bootimage metadata in the installer.
This change includes fixes for the following BZs:

Bug 2050452 - Update osType and hardware version used by RHCOS OVA to indicate it is a RHEL 8 guest*
Bug 2074483 - coreos-installer doesnt work on Dell machines*
Bug 2079944 - Publish RHEL CoreOS AMIs in AWS ap-southeast-3 region*

Changes generated with:
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos x86_64=411.85.202205101201-0 s390x=411.86.202205030351-0 ppc64le=411.85.202203250810-0 aarch64=411.85.202205040359-0 --url https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases --no-signatures

* May not be fixed in this commit for ppc64le, s390x, and aarch64