### PR TITLE
AGENT-193: Do not set api_vip for SNO cluster

### DIFF
--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -39,7 +39,7 @@ done
 
 echo "All ${total_required_nodes} hosts are ready."
 
-if [[ "$total_required_nodes" > "1" ]]; then
+if [[ "${APIVIP}" != "" ]]; then
     api_vip=$(curl -s -S "${BASE_URL}/clusters" | jq -r .[].api_vip)
     if [ "${api_vip}" == null ]; then
         echo "Setting api vip"

--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -39,10 +39,12 @@ done
 
 echo "All ${total_required_nodes} hosts are ready."
 
-api_vip=$(curl -s -S "${BASE_URL}/clusters" | jq -r .[].api_vip)
-if [ "${api_vip}" == null ]; then
-    echo "Setting api vip"
-    curl -s -S -X PATCH "${BASE_URL}/clusters/${cluster_id}" -H "Content-Type: application/json" -d '{"api_vip": "{{.APIVIP}}"}'
+if [[ "$total_required_nodes" > "1" ]]; then
+    api_vip=$(curl -s -S "${BASE_URL}/clusters" | jq -r .[].api_vip)
+    if [ "${api_vip}" == null ]; then
+        echo "Setting api vip"
+        curl -s -S -X PATCH "${BASE_URL}/clusters/${cluster_id}" -H "Content-Type: application/json" -d '{"api_vip": "{{.APIVIP}}"}'
+    fi
 fi
 
 while [[ "${cluster_status}" != "ready" ]]


### PR DESCRIPTION
Fix the unwanted API call to set API_VIP in case of SNO cluster in start-cluster-installation.service. 
`{"code":"400","href":"","id":400,"kind":"Error","reason":"API VIP cannot be set with User Managed Networking"}`
Although this HTTP 400 error doesn't impact starting cluster installation in the case of SNO, there is no need to check the API_VIP in the first place.

Ref: https://issues.redhat.com/browse/AGENT-193