### PR TITLE
AGENT-194: Fixes to start cluster installation script and service

### DIFF
--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -7,10 +7,19 @@ wait_for_assisted_service
 
 BASE_URL="{{.ServiceBaseURL}}api/assisted-install/v2"
 
-# Get cluster id
-cluster_id=$(curl -s -S "${BASE_URL}/clusters" | jq -r .[].id)
-# Get infra_env_id
-infra_env_id=$(curl -s -S "${BASE_URL}/infra-envs"| jq -r .[].id)
+cluster_id=""
+infra_env_id=""
+while [[ "${infra_env_id}" = "" || "${cluster_id}" = "" ]]
+do
+    # Get cluster id
+    cluster_id=$(curl -s -S "${BASE_URL}/clusters" | jq -r .[].id)
+    # Get infra_env_id
+    infra_env_id=$(curl -s -S "${BASE_URL}/infra-envs"| jq -r .[].id)
+    if [[ "${infra_env_id}" = "" || "${cluster_id}" = "" ]]; then
+        sleep 2
+    fi
+done
+echo -e "\nInfra env id is $infra_env_id"`
 
 required_master_nodes={{.ControlPlaneAgents}}
 required_worker_nodes={{.WorkerAgents}}

--- a/data/data/agent/systemd/units/start-cluster-installation.service
+++ b/data/data/agent/systemd/units/start-cluster-installation.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Service that starts cluster installation
-Wants=network-online.target create-cluster-and-infra-env.service
-After=network-online.target create-cluster-and-infra-env.service
+Wants=network-online.target create-cluster-and-infra-env.service assisted-service.service
+PartOf=assisted-service-pod.service
+After=network-online.target create-cluster-and-infra-env.service assisted-service.service
 ConditionPathExists=/etc/assisted-service/node0
 
 [Service]
@@ -9,7 +10,7 @@ ExecStart=/usr/local/bin/start-cluster-installation.sh
 
 KillMode=none
 Type=oneshot
-
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add dependencies to start-cluster-installation service so it starts after assisted-service, and also to ensure it will be rerun if assisted service fails (see https://github.com/openshift/installer/commit/0dbbef3667ab64753819c483fffcaeea0e6a4fde).

Fix script to ensure that the infra_env_id can be retrieved before it is used.