### PR TITLE
GCP: Revert Instance Type from N2 to N1

### DIFF
--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -113,7 +113,7 @@ func defaultAzureMachinePoolPlatform() azuretypes.MachinePool {
 
 func defaultGCPMachinePoolPlatform() gcptypes.MachinePool {
 	return gcptypes.MachinePool{
-		InstanceType: "n2-standard-4",
+		InstanceType: "n1-standard-4",
 		OSDisk: gcptypes.OSDisk{
 			DiskSizeGB: powerOfTwoRootVolumeSize,
 			DiskType:   "pd-ssd",


### PR DESCRIPTION
GCP has separate quotas for N2 CPUs: https://cloud.google.com/compute/quotas#cpu_quota
We should revert this change until we're not breaking CI.

These changes were introduced in: https://github.com/openshift/installer/pull/5841/commits/16f2827aafa325d9ca5c7e525d5c1abb400d5dd9