### PR TITLE
WIP: [RFE-2181] To support transparent proxy configuration 

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2935,8 +2935,7 @@ spec:
               configType:
                 description: Config type is the proxy configuration type. The valid values
                   are transparent or explicit
-                format: int32
-                type: integer
+                type: string
                 enum:
                   - explicit
                   - transparent

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2932,6 +2932,14 @@ spec:
             description: Proxy defines the proxy settings for the cluster. If unset,
               the cluster will not be configured to use a proxy.
             properties:
+              configType:
+                description: Config type is the proxy configuration type. The valid values
+                  are transparent or explicit
+                format: int32
+                type: integer
+                enum:
+                  - explicit
+                  - transparent
               httpProxy:
                 description: HTTPProxy is the URL of the proxy for HTTP requests.
                 type: string

--- a/go.mod
+++ b/go.mod
@@ -210,4 +210,4 @@ replace sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.3.1-0.20
 
 replace github.com/terraform-providers/terraform-provider-nutanix => github.com/nutanix/terraform-provider-nutanix v1.2.2-0.20211029075448-e21f85ac2cf7
 
-replace github.com/openshift/api => github.com/TrilokGeer/api v0.0.2
+replace github.com/openshift/api => github.com/TrilokGeer/api v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -209,3 +209,5 @@ replace k8s.io/client-go => k8s.io/client-go v0.23.0
 replace sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.3.1-0.20200617211605-651903477185
 
 replace github.com/terraform-providers/terraform-provider-nutanix => github.com/nutanix/terraform-provider-nutanix v1.2.2-0.20211029075448-e21f85ac2cf7
+
+replace github.com/openshift/api => github.com/TrilokGeer/api v0.0.2

--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -2,6 +2,7 @@ package manifests
 
 import (
 	"fmt"
+	"github.com/openshift/installer/pkg/types/openstack"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/gcp"
-	"github.com/openshift/installer/pkg/types/openstack"
 )
 
 var proxyCfgFilename = filepath.Join(manifestDir, "cluster-proxy-01-config.yaml")
@@ -64,6 +64,7 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 
 	if installConfig.Config.Proxy != nil {
 		p.Config.Spec = configv1.ProxySpec{
+			ConfigType: installConfig.Config.Proxy.ConfigType,
 			HTTPProxy:  installConfig.Config.Proxy.HTTPProxy,
 			HTTPSProxy: installConfig.Config.Proxy.HTTPSProxy,
 			NoProxy:    installConfig.Config.Proxy.NoProxy,

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -348,9 +348,19 @@ type ClusterNetworkEntry struct {
 	DeprecatedHostSubnetLength int32 `json:"hostSubnetLength,omitempty"`
 }
 
+const (
+	ExplicitProxy    string = "explicit"
+	TransparentProxy        = "transparent"
+)
+
 // Proxy defines the proxy settings for the cluster.
 // At least one of HTTPProxy or HTTPSProxy is required.
 type Proxy struct {
+	// configType identifies the configuration is explicitly mentioned in this spec or
+	// transparent proxy configured so that other parameters are ignored.
+	// This enables add additionalCABundle. If the configType is nil, default explicit type is considered.
+	ConfigType string `json:"configType,omitempty"`
+
 	// HTTPProxy is the URL of the proxy for HTTP requests.
 	// +optional
 	HTTPProxy string `json:"httpProxy,omitempty"`

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -522,8 +522,10 @@ func validatePlatform(platform *types.Platform, fldPath *field.Path, network *ty
 func validateProxy(p *types.Proxy, c *types.InstallConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if p.HTTPProxy == "" && p.HTTPSProxy == "" {
-		allErrs = append(allErrs, field.Required(fldPath, "must include httpProxy or httpsProxy"))
+	if p.ConfigType == types.ExplicitProxy {
+		if p.HTTPProxy == "" && p.HTTPSProxy == "" {
+			allErrs = append(allErrs, field.Required(fldPath, "must include httpProxy or httpsProxy"))
+		}
 	}
 	if p.HTTPProxy != "" {
 		allErrs = append(allErrs, validateURI(p.HTTPProxy, fldPath.Child("httpProxy"), []string{"http"})...)


### PR DESCRIPTION
Added configType support during installation to signify transparent or explicit proxy configuration to enable user-ca-bundle configured with cluster proxy and determine configuration type for cluster-wide proxy.