### PR TITLE
Bug 2094902: Simplify cross-compiling

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -56,7 +56,8 @@ release)
 	TAGS="${TAGS} release"
 	if test "${SKIP_GENERATION}" != y
 	then
-		go generate ./data
+		# this step has to be run natively, even when cross-compiling
+		GOOS='' GOARCH='' go generate ./data
 	fi
 	;;
 dev)

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,7 +13,7 @@ copy_terraform_to_mirror() {
   rm -rf "${PWD}"/pkg/terraform/providers/mirror/*/
 
   # Copy local terraform providers into data
-  find "${PWD}/terraform/bin/" -maxdepth 1 -name "terraform-provider-*.zip" -exec bash -c '
+  find "${PWD}/terraform/bin/${TARGET_OS_ARCH}/" -maxdepth 1 -name "terraform-provider-*.zip" -exec bash -c '
       providerName="$(basename "$1" | cut -d '-' -f 3 | cut -d '.' -f 1)"
       targetOSArch="$2"
       dstDir="${PWD}/pkg/terraform/providers/mirror/openshift/local/$providerName"
@@ -23,7 +23,7 @@ copy_terraform_to_mirror() {
     ' shell {} "${TARGET_OS_ARCH}" \;
 
   mkdir -p "${PWD}/pkg/terraform/providers/mirror/terraform/"
-  cp "${PWD}/terraform/bin/terraform" "${PWD}/pkg/terraform/providers/mirror/terraform/"
+  cp "${PWD}/terraform/bin/${TARGET_OS_ARCH}/terraform" "${PWD}/pkg/terraform/providers/mirror/terraform/"
 }
 
 minimum_go_version=1.17

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -5,22 +5,19 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS 
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-RUN go generate ./data && \
-    SKIP_GENERATION=y GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
+RUN GOOS=darwin GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS macarmbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-RUN go generate ./data && \
-    SKIP_GENERATION=y GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
+RUN GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS linuxbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
-RUN go generate ./data && \
-    SKIP_GENERATION=y GOOS=linux GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
+RUN GOOS=linux GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
 FROM registry.ci.openshift.org/ocp/4.11:installer
 COPY --from=macbuilder /go/src/github.com/openshift/installer/bin/openshift-install /usr/share/openshift/mac/openshift-install

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,9 +1,11 @@
+TARGET_OS_ARCH:=$(shell go env GOOS)_$(shell go env GOARCH)
+
 TFSUBDIRS:=	$(foreach DIR,$(shell find providers -maxdepth 1 -mindepth 1 -type d),$(subst providers/,,$(DIR)))
 
 GO_MOD_TIDY_TARGETS:=	$(foreach DIR,$(TFSUBDIRS), $(subst $(DIR),go-mod-tidy-vendor.$(DIR),$(DIR)))
 GO_BUILD_TARGETS:=	$(foreach DIR,$(TFSUBDIRS), $(subst $(DIR),go-build.$(DIR),$(DIR)))
 GO_CLEAN_TARGETS:=	$(foreach DIR,$(TFSUBDIRS), $(subst $(DIR),go-clean.$(DIR),$(DIR)))
-TERRAFORM_PROVIDER_TARGETS := $(foreach DIR,$(TFSUBDIRS), bin/terraform-provider-$(DIR).zip)
+TERRAFORM_PROVIDER_TARGETS := $(foreach DIR,$(TFSUBDIRS), bin/$(TARGET_OS_ARCH)/terraform-provider-$(DIR).zip)
 
 LDFLAGS:= "-s -w"
 
@@ -19,33 +21,33 @@ $(GO_MOD_TIDY_TARGETS): go-mod-tidy-vendor.%:
 
 .PHONY: go-build
 go-build: $(GO_BUILD_TARGETS) go-build-terraform
-$(GO_BUILD_TARGETS): go-build.%: bin/terraform-provider-%.zip
+$(GO_BUILD_TARGETS): go-build.%: bin/$(TARGET_OS_ARCH)/terraform-provider-%.zip
 
-$(TERRAFORM_PROVIDER_TARGETS): bin/terraform-provider-%.zip: providers/%/go.mod
+$(TERRAFORM_PROVIDER_TARGETS): bin/$(TARGET_OS_ARCH)/terraform-provider-%.zip: providers/%/go.mod
 	cd providers/$*; \
 	if [ -f main.go ]; then path="."; else path=./vendor/`grep _ tools.go|awk '{ print $$2 }'|sed 's|"||g'`; fi; \
-	go build -ldflags $(LDFLAGS) -o ../../bin/terraform-provider-$* "$$path"; \
-	zip -1j ../../bin/terraform-provider-$*.zip ../../bin/terraform-provider-$*;
+	go build -ldflags $(LDFLAGS) -o ../../bin/$(TARGET_OS_ARCH)/terraform-provider-$* "$$path"; \
+	zip -1j ../../bin/$(TARGET_OS_ARCH)/terraform-provider-$*.zip ../../bin/$(TARGET_OS_ARCH)/terraform-provider-$*;
 
 .PHONY: go-build-terraform
-go-build-terraform: bin/terraform
+go-build-terraform: bin/$(TARGET_OS_ARCH)/terraform
 
-bin/terraform: terraform/go.mod
+bin/$(TARGET_OS_ARCH)/terraform: terraform/go.mod
 	cd terraform; \
-	go build -ldflags $(LDFLAGS) -o ../bin/terraform ./vendor/github.com/hashicorp/terraform
+	go build -ldflags $(LDFLAGS) -o ../bin/$(TARGET_OS_ARCH)/terraform ./vendor/github.com/hashicorp/terraform
 
 .PHONY: go-clean
 go-clean: go-clean-providers go-clean-terraform
 
 $(GO_CLEAN_TARGETS): go-clean.%:
-	rm -f bin/terraform-provider-$*
-	rm -f bin/terraform-provider-$*.zip
+	rm -f bin/*/terraform-provider-$*
+	rm -f bin/*/terraform-provider-$*.zip
 
 go-clean-providers:
-	rm -f bin/terraform-provider-*
+	rm -f bin/*/terraform-provider-*
 	
 go-clean-terraform:
-	rm -f bin/terraform
+	rm -f bin/*/terraform
 
 .PHONY: clean
 clean: go-clean


### PR DESCRIPTION
- Always run go generate natively
- Add GOOS_GOARCH to all terraform build paths
