### PR TITLE
Typo: Fixed redundant `

### DIFF
--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -19,7 +19,7 @@ do
         sleep 2
     fi
 done
-echo -e "\nInfra env id is $infra_env_id"`
+echo -e "\nInfra env id is $infra_env_id"
 
 required_master_nodes={{.ControlPlaneAgents}}
 required_worker_nodes={{.WorkerAgents}}


### PR DESCRIPTION
This fixes the failure of `start-cluster-installation.service`

```
[core@master-0 ~]$ sudo journalctl -f -u start-cluster-installation.service 
-- Logs begin at Fri 2022-05-13 14:53:57 UTC. --
May 13 14:55:48 master-0.ostest.test.metalkube.org systemd[1]: Starting Service that starts cluster installation...
May 13 14:55:48 master-0.ostest.test.metalkube.org start-cluster-installation.sh[2961]: Waiting for assisted-service to be ready
May 13 14:55:55 master-0.ostest.test.metalkube.org start-cluster-installation.sh[2961]: ./usr/local/bin/start-cluster-installation.sh: line 22: unexpected EOF while looking for matching ``'
```
