### PR TITLE
Bug 2085336: based on 4.11 CORS-1916 add the vm family

### DIFF
--- a/docs/user/azure/tested_instance_types.md
+++ b/docs/user/azure/tested_instance_types.md
@@ -2,6 +2,8 @@
 * `standardDADSv5Family`
 * `standardDASv4Family`
 * `standardDASv5Family`
+* `standardDCSv3Family`
+* `standardDDCSv3Family`
 * `standardDDSv4Family`
 * `standardDDSv5Family`
 * `standardDSFamily`
@@ -25,3 +27,4 @@
 * `standardLSv2Family`
 * `standardMSFamily`
 * `standardNCSv3Family`
+* `standardNPSFamily`


### PR DESCRIPTION
Azure: add tested VM family
<BLANK LINE>
add the VM family tested on 4.11 for [CORS-1916 Enable HyperVGeneration version 2 for Azure disks](https://issues.redhat.com/browse/CORS-1916)
[Bug 2085336 [IPI-Azure] Fail to create the worker node which HyperVGenerations is V2 or V1 and vmNetworkingType is Accelerated](https://bugzilla.redhat.com/show_bug.cgi?id=2085336) 
<BLANK LINE>
<footer>
