### PR TITLE
Bug 2086936: vSphere: change socket back to cores

### DIFF
--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -155,7 +155,7 @@ func defaultOvirtMachinePoolPlatform() ovirttypes.MachinePool {
 func defaultVSphereMachinePoolPlatform() vspheretypes.MachinePool {
 	return vspheretypes.MachinePool{
 		NumCPUs:           4,
-		NumCoresPerSocket: 1,
+		NumCoresPerSocket: 4,
 		MemoryMiB:         16384,
 		OSDisk: vspheretypes.OSDisk{
 			DiskSizeGB: decimalRootVolumeSize,


### PR DESCRIPTION
Virtual machines running on
vSphere should be configured for cores
over sockets for NUMA. The change
in #5841 missed that.

Changing vSphere back to using a single
socket and multiple cores.