### PR TITLE
Bug 2084280: Remove optional services from permissions check

### DIFF
--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -360,11 +360,10 @@ func TestGCPEnabledServicesList(t *testing.T) {
 			" serviceusage.googleapis.com, cloudresourcemanager.googleapis.com",
 	}, {
 		name: "All pre-existing",
-		services: []string{"compute.googleapis.com", "cloudapis.googleapis.com",
+		services: []string{"compute.googleapis.com",
 			"cloudresourcemanager.googleapis.com", "dns.googleapis.com",
-			"iam.googleapis.com", "iamcredentials.googleapis.com",
-			"servicemanagement.googleapis.com", "serviceusage.googleapis.com",
-			"storage-api.googleapis.com", "storage-component.googleapis.com"},
+			"iam.googleapis.com", "iamcredentials.googleapis.com", "serviceusage.googleapis.com",
+			"deploymentmanager.googleapis.com"},
 	}, {
 		name:     "Some services present",
 		services: []string{"compute.googleapis.com"},


### PR DESCRIPTION
There are a few services that are not required for the installer
to run but are now causing the installer to fail if the permission
is not provided. Adding an optional set of permissions and warn
the user if these permissions are not provided.

List of required services:
compute - used for creating VMs
cloudresourcemanager - used for updating metadata for resources
iam, iamcredentials - used for creating iam accounts
dns - used for dns creation