### PR TITLE
Rename "fleeting" to "agent-installer"

### DIFF
--- a/data/data/agent/files/etc/issue
+++ b/data/data/agent/files/etc/issue
@@ -1,2 +1,2 @@
 \S
-This image built by fleeting.
+This image built by agent installer.

--- a/pkg/agent/imagebuilder/embed_ignition.go
+++ b/pkg/agent/imagebuilder/embed_ignition.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	outputImage = "output/fleeting.iso"
+	outputImage = "output/agent.iso"
 )
 
 // BuildImage builds an ISO with ignition content from a base image, and writes


### PR DESCRIPTION
`fleeting` was the temp name for agent-installer.