### PR TITLE
AGENT-180: Allow create image command to fetch manifests files from cluster-manifests assets folder

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -50,7 +50,7 @@ var (
 
 				timer.StartTimer("Agent Create Image Complete")
 
-				err := agentcmd.BuildImage()
+				err := agentcmd.BuildImage(rootOpts.dir)
 				if err != nil {
 					logrus.Fatal(err)
 				}

--- a/pkg/agent/build_image.go
+++ b/pkg/agent/build_image.go
@@ -8,14 +8,14 @@ import (
 )
 
 // BuildImage builds the image required by the agent installer.
-func BuildImage() error {
+func BuildImage(assetsDir string) error {
 
 	baseImage, err := isosource.EnsureIso()
 	if err != nil {
 		return err
 	}
 
-	err = imagebuilder.BuildImage(baseImage)
+	err = imagebuilder.BuildImage(assetsDir, baseImage)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/imagebuilder/embed_ignition.go
+++ b/pkg/agent/imagebuilder/embed_ignition.go
@@ -13,8 +13,8 @@ const (
 
 // BuildImage builds an ISO with ignition content from a base image, and writes
 // the result to disk.
-func BuildImage(baseImage string) error {
-	configBuilder, err := New()
+func BuildImage(assetsDir, baseImage string) error {
+	configBuilder, err := New(assetsDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/manifests/manifests.go
+++ b/pkg/agent/manifests/manifests.go
@@ -16,9 +16,9 @@ import (
 )
 
 // getFileData reads a YAML file and unmarshals the contents
-func getFileData(fileName string, output interface{}) error {
+func getFileData(assetsDir, fileName string, output interface{}) error {
 
-	path := filepath.Join("./manifests", fileName)
+	path := filepath.Join(assetsDir, "cluster-manifests", fileName)
 
 	contents, err := os.ReadFile(path)
 	if err != nil {
@@ -36,10 +36,10 @@ type decodeFormat interface {
 
 // Read a YAML file containing multiple YAML definitions of the same format
 // Each specific format must be of type decodeFormat
-func getFileMultipleYamls(filename string, decoder decodeFormat) ([]interface{}, error) {
+func getFileMultipleYamls(assetsDir, filename string, decoder decodeFormat) ([]interface{}, error) {
 
 	// TODO - this location must be defined by user input via cobra flags
-	path := filepath.Join("./manifests", filename)
+	path := filepath.Join(assetsDir, "cluster-manifests", filename)
 
 	contents, err := os.ReadFile(path)
 	if err != nil {
@@ -68,9 +68,9 @@ func getFileMultipleYamls(filename string, decoder decodeFormat) ([]interface{},
 }
 
 // GetPullSecret gets the pull secret from the manifest file
-func GetPullSecret() (string, error) {
+func GetPullSecret(assetsDir string) (string, error) {
 	var secret corev1.Secret
-	if err := getFileData("pull-secret.yaml", &secret); err != nil {
+	if err := getFileData(assetsDir, "pull-secret.yaml", &secret); err != nil {
 		return "", err
 	}
 
@@ -80,9 +80,9 @@ func GetPullSecret() (string, error) {
 
 // GetAgentClusterInstall gets the AgentClusterInstall resource from the
 // manifest file
-func GetAgentClusterInstall() (hiveext.AgentClusterInstall, error) {
+func GetAgentClusterInstall(assetsDir string) (hiveext.AgentClusterInstall, error) {
 	var aci hiveext.AgentClusterInstall
-	if err := getFileData("agent-cluster-install.yaml", &aci); err != nil {
+	if err := getFileData(assetsDir, "agent-cluster-install.yaml", &aci); err != nil {
 		return aci, err
 	}
 
@@ -90,9 +90,9 @@ func GetAgentClusterInstall() (hiveext.AgentClusterInstall, error) {
 }
 
 // GetInfraEnv gets the InfraEnv resource from the manifest file
-func GetInfraEnv() (aiv1beta1.InfraEnv, error) {
+func GetInfraEnv(assetsDir string) (aiv1beta1.InfraEnv, error) {
 	var infraEnv aiv1beta1.InfraEnv
-	if err := getFileData("infraenv.yaml", &infraEnv); err != nil {
+	if err := getFileData(assetsDir, "infraenv.yaml", &infraEnv); err != nil {
 		return infraEnv, err
 	}
 

--- a/pkg/agent/manifests/nmstateconfig.go
+++ b/pkg/agent/manifests/nmstateconfig.go
@@ -16,7 +16,7 @@ import (
 
 // NMConfig represents a set of configs from which the Node0 IP can be obtained
 type NMConfig struct {
-	nmConfig func() ([]aiv1beta1.NMStateConfig, error)
+	nmConfig func(assetsDir string) ([]aiv1beta1.NMStateConfig, error)
 }
 
 // NewNMConfig creates a new NMConfig
@@ -49,9 +49,9 @@ func (d *nmStateConfigYamlDecoder) newDecodedYaml(yamlDecoder *yaml.YAMLToJSONDe
 }
 
 // Get a list of nmStateConfig objects from the manifest file
-func getNMStateConfig() ([]aiv1beta1.NMStateConfig, error) {
+func getNMStateConfig(assetsDir string) ([]aiv1beta1.NMStateConfig, error) {
 	var decoder nmStateConfigYamlDecoder
-	yamlList, err := getFileMultipleYamls("nmstateconfig.yaml", &decoder)
+	yamlList, err := getFileMultipleYamls(assetsDir, "nmstateconfig.yaml", &decoder)
 
 	var nmStateConfigList []aiv1beta1.NMStateConfig
 	for i := range yamlList {
@@ -122,9 +122,9 @@ func GetNMIgnitionFiles(staticNetworkConfig []*models.HostStaticNetworkConfig) (
 
 // ProcessNMStateConfig processes the NMStateConfig resources from the manifest
 // file and returns the data.
-func ProcessNMStateConfig(infraEnv aiv1beta1.InfraEnv) ([]*models.HostStaticNetworkConfig, error) {
+func ProcessNMStateConfig(assetsDir string, infraEnv aiv1beta1.InfraEnv) ([]*models.HostStaticNetworkConfig, error) {
 
-	nmStateConfigList, err := getNMStateConfig()
+	nmStateConfigList, err := getNMStateConfig(assetsDir)
 
 	if err != nil {
 		err = fmt.Errorf("error with nmstateconfig file: %w", err)
@@ -148,8 +148,8 @@ func ProcessNMStateConfig(infraEnv aiv1beta1.InfraEnv) ([]*models.HostStaticNetw
 }
 
 // GetNodeZeroIP retrieves the first IP from the user provided nmStateConfig yaml file to set as node0 IP
-func (n NMConfig) GetNodeZeroIP() string {
-	configList, err := n.nmConfig()
+func (n NMConfig) GetNodeZeroIP(assetsDir string) string {
+	configList, err := n.nmConfig(assetsDir)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/agent/manifests/nmstateconfig_test.go
+++ b/pkg/agent/manifests/nmstateconfig_test.go
@@ -77,11 +77,11 @@ interfaces:
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			n := NMConfig{
-				nmConfig: func() ([]aiv1beta1.NMStateConfig, error) {
+				nmConfig: func(assetsDir string) ([]aiv1beta1.NMStateConfig, error) {
 					return test.nmConfig, nil
 				},
 			}
-			nodeZeroIP := n.GetNodeZeroIP()
+			nodeZeroIP := n.GetNodeZeroIP("/tmp")
 			assert.Equal(t, nodeZeroIP, test.expectedIP)
 
 		})


### PR DESCRIPTION
Currently the agent installer tries to fetch the required manifests from the `manifests` folder found in the present working directory. This patch introduces the capability to retrieve them from the `cluster-manifests` folder located in the assets directory configured when running the OpenShift Installer (via the `--dir` option)