### PR TITLE
AGENT-194: Fix service name in dependencies

### DIFF
--- a/data/data/agent/systemd/units/start-cluster-installation.service
+++ b/data/data/agent/systemd/units/start-cluster-installation.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Service that starts cluster installation
-Wants=network-online.target create-cluster-and-infra-env.service assisted-service.service
+Wants=network-online.target create-cluster-and-infraenv.service
 PartOf=assisted-service-pod.service
-After=network-online.target create-cluster-and-infra-env.service assisted-service.service
+After=network-online.target create-cluster-and-infraenv.service
 ConditionPathExists=/etc/assisted-service/node0
 
 [Service]


### PR DESCRIPTION
The create-cluster-and-infra-env service was renamed in
d87d402510aaa96553f46a415483a67d023b3dc2, but the dependencies on it
were not.