### PR TITLE
Bug 2084441: Remove capabilities check for internal clusters

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -205,8 +205,10 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 		if vmNetworkingType == "" {
 			vmNetworkingType = defaultVMNetworkingType
 		}
-		ultraSSDEnabled := strings.EqualFold(ultraSSDCapability, "Enabled")
-		allErrs = append(allErrs, ValidateInstanceType(client, fieldPath, ic.Azure.Region, instanceType, diskType, controlPlaneReq, ultraSSDEnabled, vmNetworkingType)...)
+		if ic.Publish != types.InternalPublishingStrategy {
+			ultraSSDEnabled := strings.EqualFold(ultraSSDCapability, "Enabled")
+			allErrs = append(allErrs, ValidateInstanceType(client, fieldPath, ic.Azure.Region, instanceType, diskType, controlPlaneReq, ultraSSDEnabled, vmNetworkingType)...)
+		}
 	}
 
 	for idx, compute := range ic.Compute {
@@ -232,9 +234,11 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 			if vmNetworkingType == "" {
 				vmNetworkingType = defaultVMNetworkingType
 			}
-			ultraSSDEnabled := strings.EqualFold(ultraSSDCapability, "Enabled")
-			allErrs = append(allErrs, ValidateInstanceType(client, fieldPath.Child("platform", "azure"),
-				ic.Azure.Region, instanceType, diskType, computeReq, ultraSSDEnabled, vmNetworkingType)...)
+			if ic.Publish != types.InternalPublishingStrategy {
+				ultraSSDEnabled := strings.EqualFold(ultraSSDCapability, "Enabled")
+				allErrs = append(allErrs, ValidateInstanceType(client, fieldPath.Child("platform", "azure"),
+					ic.Azure.Region, instanceType, diskType, computeReq, ultraSSDEnabled, vmNetworkingType)...)
+			}
 		}
 	}
 


### PR DESCRIPTION
Internal clusters are restricted and cannot check the Azure API
for capabilities and hence will error out if a check is made.
Adding an if block to not perform the check for internal clusters.