### PR TITLE
Bug 1969794: Correct typo

### DIFF
--- a/docs/user/openstack/image_registry_with_custom_pvc_backends.md
+++ b/docs/user/openstack/image_registry_with_custom_pvc_backends.md
@@ -36,7 +36,7 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  volumeMode: Block
+  volumeMode: Filesystem
   resources:
     requests:
       storage: 100Gi


### PR DESCRIPTION
The created pvc needs to use a volumeMode of 'Filesystem', not 'Block'. Using the latter will result in the image-registry pod failing to mount the volume because it can't handle raw block devices without a filesystem [1].

[1] https://docs.openshift.com/container-platform/4.10/virt/virtual_machines/virtual_disks/virt-creating-data-volumes.html
