### PR TITLE
BUG 2075459: IOPS was not being set even when manually configured

### DIFF
--- a/data/data/aws/cluster/master/main.tf
+++ b/data/data/aws/cluster/master/main.tf
@@ -161,7 +161,7 @@ resource "aws_instance" "master" {
   root_block_device {
     volume_type = var.root_volume_type
     volume_size = var.root_volume_size
-    iops        = var.root_volume_type == "io1" ? var.root_volume_iops : 0
+    iops        = var.root_volume_iops
     encrypted   = var.root_volume_encrypted
     kms_key_id  = var.root_volume_kms_key_id == "" ? data.aws_ebs_default_kms_key.current.key_arn : var.root_volume_kms_key_id
   }

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -178,7 +178,8 @@ spec:
                           properties:
                             iops:
                               description: IOPS defines the amount of provisioned
-                                IOPS. This is only valid for type io1.
+                                IOPS. (KiB/s). IOPS may only be set for io1, io2,
+                                & gp3 volume types.
                               minimum: 0
                               type: integer
                             kmsKeyARN:
@@ -805,7 +806,8 @@ spec:
                         properties:
                           iops:
                             description: IOPS defines the amount of provisioned IOPS.
-                              This is only valid for type io1.
+                              (KiB/s). IOPS may only be set for io1, io2, & gp3 volume
+                              types.
                             minimum: 0
                             type: integer
                           kmsKeyARN:
@@ -1606,7 +1608,8 @@ spec:
                         properties:
                           iops:
                             description: IOPS defines the amount of provisioned IOPS.
-                              This is only valid for type io1.
+                              (KiB/s). IOPS may only be set for io1, io2, & gp3 volume
+                              types.
                             minimum: 0
                             type: integer
                           kmsKeyARN:

--- a/pkg/types/aws/machinepool.go
+++ b/pkg/types/aws/machinepool.go
@@ -78,8 +78,8 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 // EC2RootVolume defines the storage for an ec2 instance.
 type EC2RootVolume struct {
-	// IOPS defines the amount of provisioned IOPS. This is only valid
-	// for type io1.
+	// IOPS defines the amount of provisioned IOPS. (KiB/s). IOPS may only be set for
+	// io1, io2, & gp3 volume types.
 	//
 	// +kubebuilder:validation:Minimum=0
 	// +optional

--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -38,15 +38,49 @@ func ValidateMachinePool(platform *aws.Platform, p *aws.MachinePool, fldPath *fi
 		}
 	}
 
-	if p.IOPS < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("iops"), p.IOPS, "Storage IOPS must be positive"))
-	}
-	if p.Size < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("size"), p.Size, "Storage size must be positive"))
+	if p.EC2RootVolume.Type != "" {
+		allErrs = append(allErrs, validateVolumeSize(p, fldPath)...)
+		allErrs = append(allErrs, validateIOPS(p, fldPath)...)
 	}
 
 	if p.EC2Metadata.Authentication != "" && !validMetadataAuthValues.Has(p.EC2Metadata.Authentication) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("authentication"), p.EC2Metadata.Authentication, "must be either Required or Optional"))
+	}
+
+	return allErrs
+}
+
+func validateVolumeSize(p *aws.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	volumeSize := p.EC2RootVolume.Size
+
+	if volumeSize <= 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("size"), volumeSize, "volume size value must be a positive number"))
+	}
+
+	return allErrs
+}
+
+func validateIOPS(p *aws.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	volumeType := strings.ToLower(p.EC2RootVolume.Type)
+	iops := p.EC2RootVolume.IOPS
+
+	switch volumeType {
+	case "io1", "io2":
+		if iops <= 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("iops"), iops, "iops must be a positive number"))
+		}
+	case "gp3":
+		if iops < 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("iops"), iops, "iops must be a positive number"))
+		}
+	case "gp2", "st1", "sc1", "standard":
+		if iops != 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("iops"), iops, fmt.Sprintf("iops not supported for type %s", volumeType)))
+		}
+	default:
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("type"), volumeType, fmt.Sprintf("failed to find volume type %s", volumeType)))
 	}
 
 	return allErrs

--- a/pkg/types/aws/validation/machinepool_test.go
+++ b/pkg/types/aws/validation/machinepool_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,59 +22,102 @@ func TestValidateMachinePool(t *testing.T) {
 			pool: &aws.MachinePool{},
 		},
 		{
-			name: "valid zone",
+			name: "valid zone io instance",
 			pool: &aws.MachinePool{
 				Zones: []string{"us-east-1a", "us-east-1b"},
+				EC2RootVolume: aws.EC2RootVolume{
+					Type: "io2",
+					Size: 128,
+					IOPS: 10000,
+				},
 			},
+		},
+		{
+			name: "valid zone gp3 instance no iops",
+			pool: &aws.MachinePool{
+				Zones: []string{"us-east-1a", "us-east-1b"},
+				EC2RootVolume: aws.EC2RootVolume{
+					Type: "gp3",
+					Size: 128,
+				},
+			},
+		},
+		{
+			name: "valid zone gp3 instance with iops",
+			pool: &aws.MachinePool{
+				Zones: []string{"us-east-1a", "us-east-1b"},
+				EC2RootVolume: aws.EC2RootVolume{
+					Type: "gp3",
+					Size: 128,
+					IOPS: 10000,
+				},
+			},
+		},
+		{
+			name: "valid zone gp2 instance no iops",
+			pool: &aws.MachinePool{
+				Zones: []string{"us-east-1a", "us-east-1b"},
+				EC2RootVolume: aws.EC2RootVolume{
+					Type: "gp2",
+					Size: 128,
+				},
+			},
+		},
+		{
+			name: "invalid zone gp2 instance with iops",
+			pool: &aws.MachinePool{
+				Zones: []string{"us-east-1a", "us-east-1b"},
+				EC2RootVolume: aws.EC2RootVolume{
+					Type: "gp2",
+					Size: 128,
+					IOPS: 10000,
+				},
+			},
+			expected: fmt.Sprintf("test-path.iops: Invalid value: 10000: iops not supported for type gp2"),
 		},
 		{
 			name: "invalid zone",
 			pool: &aws.MachinePool{
 				Zones: []string{"us-east-1a", "us-west-1a"},
+				EC2RootVolume: aws.EC2RootVolume{
+					Type: "io2",
+					Size: 128,
+					IOPS: 10000,
+				},
 			},
 			expected: `^test-path\.zones\[1]: Invalid value: "us-west-1a": Zone not in configured region \(us-east-1\)$`,
 		},
 		{
-			name: "valid iops",
+			name: "invalid volume type",
 			pool: &aws.MachinePool{
 				EC2RootVolume: aws.EC2RootVolume{
-					IOPS: 10,
+					Type: "bad-volume-type",
+					Size: 128,
 				},
 			},
+			expected: fmt.Sprintf("test-path.type: Invalid value: \"bad-volume-type\": failed to find volume type bad-volume-type"),
 		},
 		{
-			name: "invalid iops",
+			name: "invalid volume size using zero",
 			pool: &aws.MachinePool{
 				EC2RootVolume: aws.EC2RootVolume{
-					IOPS: -10,
+					Type: "io2",
+					Size: 0,
+					IOPS: 10000,
 				},
 			},
-			expected: `^test-path\.iops: Invalid value: -10: Storage IOPS must be positive$`,
+			expected: fmt.Sprintf("test-path.size: Invalid value: 0: volume size value must be a positive number"),
 		},
 		{
-			name: "valid size",
+			name: "invalid volume size using negative",
 			pool: &aws.MachinePool{
 				EC2RootVolume: aws.EC2RootVolume{
-					Size: 10,
+					Type: "gp3",
+					Size: -1,
+					IOPS: 10000,
 				},
 			},
-		},
-		{
-			name: "invalid size",
-			pool: &aws.MachinePool{
-				EC2RootVolume: aws.EC2RootVolume{
-					Size: -10,
-				},
-			},
-			expected: `^test-path\.size: Invalid value: -10: Storage size must be positive$`,
-		},
-		{
-			name: "valid metadata auth option",
-			pool: &aws.MachinePool{
-				EC2Metadata: aws.EC2Metadata{
-					Authentication: "Optional",
-				},
-			},
+			expected: fmt.Sprintf("test-path.size: Invalid value: -1: volume size value must be a positive number"),
 		},
 		{
 			name: "invalid metadata auth option",

--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -128,11 +128,13 @@ func TestValidatePlatform(t *testing.T) {
 				Region: "us-east-1",
 				DefaultMachinePlatform: &aws.MachinePool{
 					EC2RootVolume: aws.EC2RootVolume{
+						Type: "io1",
 						IOPS: -10,
+						Size: 128,
 					},
 				},
 			},
-			expected: `^test-path\.defaultMachinePlatform\.iops: Invalid value: -10: Storage IOPS must be positive$`,
+			expected: `^test-path.*iops: Invalid value: -10: iops must be a positive number$`,
 		},
 		{
 			name: "invalid userTags, Name key",

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -77,6 +77,8 @@ func TestValidateMachinePool(t *testing.T) {
 				p.Platform = types.MachinePoolPlatform{
 					AWS: &aws.MachinePool{
 						EC2RootVolume: aws.EC2RootVolume{
+							Type: "io1",
+							Size: 128,
 							IOPS: -10,
 						},
 					},


### PR DESCRIPTION
aws: IOPS was not being set even when manually configured

** Removed the terraform parameter that was constantly set to 0 unless this
was an io1 instance.

** Left the bootstrap terraform value remain as it isn't causing any issues, but
we should be aware if we want to change the boostrap aws instance to anything
other than gp3 then we will change that too.

** Added static value tests for the volume type, volume size and iops
for AWS.