### PR TITLE
Bug 2090487: SNO network type update

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1455,9 +1455,9 @@ spec:
                   type: object
                 type: array
               networkType:
-                default: OpenShiftSDN
                 description: NetworkType is the type of network to install. The default
-                  is OpenShiftSDN
+                  value is OVNKubernetes for Single Node OpenShift and OpenShiftSDN
+                  for all other platforms.
                 type: string
               serviceCIDR:
                 description: Deprecated way to configure an IP address pool for services.

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -44,7 +44,7 @@ The following `install-config.yaml` properties are available:
             The default is 10.0.0.0/16 for all platforms other than libvirt.
             For libvirt, the default is 192.168.126.0/24.
     * `networkType` (optional string): The type of network to install.
-        The default is [OpenShiftSDN][openshift-sdn].
+        The default is [OVNKubernetes][ovn-kubernetes] for Single Node OpenShift and [OpenShiftSDN][openshift-sdn] for all other platforms.
     * `serviceNetwork` (optional array of [IP networks](#ip-networks)): The IP address pools for services.
         The default is 172.30.0.0/16.
 * `platform` (required object): The configuration for the specific platform upon which to perform the installation.
@@ -600,6 +600,7 @@ An example `worker.ign` is shown below. It has been modified to increase the HTT
 [machine-config-pool]: https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfigController.md#machinepool
 [machine-config]: https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfiguration.md
 [master-machine-config-pool]: https://github.com/openshift/machine-config-operator/blob/master/manifests/master.machineconfigpool.yaml
+[ovn-kubernetes]: https://github.com/openshift/ovn-kubernetes
 [openshift-sdn]: https://github.com/openshift/sdn
 [proxy]: https://github.com/openshift/api/blob/f2a771e1a90ceb4e65f1ca2c8b11fc1ac6a66da8/config/v1/types_proxy.go#L11
 [proxy-trusted-ca]: https://github.com/openshift/api/blob/f2a771e1a90ceb4e65f1ca2c8b11fc1ac6a66da8/config/v1/types_proxy.go#L44-L69

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -25,7 +25,6 @@ var (
 	defaultClusterNetwork = ipnet.MustParseCIDR("10.128.0.0/14")
 	defaultHostPrefix     = 23
 	defaultNetworkType    = string(operv1.NetworkTypeOpenShiftSDN)
-	defaultOKDNetworkType = string(operv1.NetworkTypeOVNKubernetes)
 )
 
 // SetInstallConfigDefaults sets the defaults for the install config.
@@ -44,8 +43,8 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		}
 	}
 	if c.Networking.NetworkType == "" {
-		if c.IsOKD() {
-			c.Networking.NetworkType = defaultOKDNetworkType
+		if c.IsOKD() || c.IsSingleNodeOpenShift() {
+			c.Networking.NetworkType = string(operv1.NetworkTypeOVNKubernetes)
 		} else {
 			c.Networking.NetworkType = defaultNetworkType
 		}

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -178,6 +178,12 @@ func (c *InstallConfig) IsOKD() bool {
 	return OKD
 }
 
+// IsSingleNodeOpenShift returns true if the install-config has been configured for
+// bootstrapInPlace
+func (c *InstallConfig) IsSingleNodeOpenShift() bool {
+	return c.BootstrapInPlace != nil
+}
+
 // Platform is the configuration for the specific platform upon which to perform
 // the installation. Only one of the platform configuration should be set.
 type Platform struct {
@@ -274,9 +280,9 @@ func (p *Platform) Name() string {
 
 // Networking defines the pod network provider in the cluster.
 type Networking struct {
-	// NetworkType is the type of network to install. The default is OpenShiftSDN
-	//
-	// +kubebuilder:default=OpenShiftSDN
+	// NetworkType is the type of network to install.
+	// The default value is OVNKubernetes for Single Node OpenShift
+	// and OpenShiftSDN for all other platforms.
 	// +optional
 	NetworkType string `json:"networkType,omitempty"`
 

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -106,7 +106,7 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 		}
 	}
 	if c.Networking != nil {
-		allErrs = append(allErrs, validateNetworking(c.Networking, field.NewPath("networking"))...)
+		allErrs = append(allErrs, validateNetworking(c.Networking, c.IsSingleNodeOpenShift(), field.NewPath("networking"))...)
 		allErrs = append(allErrs, validateNetworkingIPVersion(c.Networking, &c.Platform)...)
 		allErrs = append(allErrs, validateNetworkingForPlatform(c.Networking, &c.Platform, field.NewPath("networking"))...)
 	} else {
@@ -295,10 +295,14 @@ func validateNetworkingIPVersion(n *types.Networking, p *types.Platform) field.E
 	return allErrs
 }
 
-func validateNetworking(n *types.Networking, fldPath *field.Path) field.ErrorList {
+func validateNetworking(n *types.Networking, singleNodeOpenShift bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if n.NetworkType == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("networkType"), "network provider type required"))
+	}
+
+	if singleNodeOpenShift && n.NetworkType == string(operv1.NetworkTypeOpenShiftSDN) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("networkType"), n.NetworkType, "networkType OpenShiftSDN is currently not supported on Single Node OpenShift"))
 	}
 
 	if len(n.MachineNetwork) > 0 {


### PR DESCRIPTION
Change the default SNO networking from OpenShiftSDN to OVNKubernetes, which has the features (in particular, IPv6) required for a majority of the deployments.

In addition, also change the default networkType just for SNO deployments to OVNKubernetes.
Details in: https://issues.redhat.com/browse/CORS-2008 