### PR TITLE
Bug 2084580: Add check to validate cluster name for dots

### DIFF
--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -48,6 +48,11 @@ func (a *clusterName) Generate(parents asset.Parents) error {
 			return validate.ClusterNameMaxLength(ans.(string), 14)
 		})
 	}
+	if platform.VSphere != nil || platform.BareMetal != nil {
+		validator = survey.ComposeValidators(validator, func(ans interface{}) error {
+			return validate.OnPremClusterName(ans.(string))
+		})
+	}
 	validator = survey.ComposeValidators(validator, func(ans interface{}) error {
 		installConfig := &types.InstallConfig{BaseDomain: bd.BaseDomain}
 		installConfig.ObjectMeta.Name = ans.(string)

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -92,6 +92,9 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 		// FIX-ME: As soon bz#1915122 get resolved remove the limitation of 14 chars for the clustername
 		nameErr = validate.ClusterNameMaxLength(c.ObjectMeta.Name, 14)
 	}
+	if c.Platform.VSphere != nil || c.Platform.BareMetal != nil {
+		nameErr = validate.OnPremClusterName(c.ObjectMeta.Name)
+	}
 	if nameErr != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), c.ObjectMeta.Name, nameErr.Error()))
 	}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -279,3 +279,11 @@ func Host(v string) error {
 	}
 	return validateSubdomain(v)
 }
+
+// OnPremClusterName verifies if the cluster name contains a '.' and returns an error if it does.
+func OnPremClusterName(v string) error {
+	if strings.Contains(v, ".") {
+		return errors.New("cluster name must not contain '.'")
+	}
+	return ClusterName(v)
+}

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -49,6 +49,28 @@ func TestClusterName(t *testing.T) {
 	}
 }
 
+func TestOnPremClusterName(t *testing.T) {
+	cases := []struct {
+		name        string
+		clusterName string
+		valid       bool
+	}{
+		{"single lowercase", "a", true},
+		{"has a dot", "a.a", false},
+		{"valid name", "abcde", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := OnPremClusterName(tc.clusterName)
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestClusterName1035(t *testing.T) {
 	maxSizeName := "a" + strings.Repeat("123456789.", 5) + "123"
 


### PR DESCRIPTION
On prem clusters with a dot in the cluster name causes issues
in keepalived and should be validated to prevent this. Adding
an extra check to make sure there are no dots in the cluster
name.