### PR TITLE
Bug 2045771: bump RHCOS 4.10 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,83 +1,83 @@
 {
   "stream": "rhcos-4.10",
   "metadata": {
-    "last-modified": "2022-01-25T15:22:46Z",
-    "generator": "plume cosa2stream 0.12.0+91-g38082aacc"
+    "last-modified": "2022-05-19T20:30:04Z",
+    "generator": "plume cosa2stream 0.12.0+128-ge7e5dfbeb-dirty"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "410.84.202201251203-0",
+          "release": "410.84.202205191023-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-aws.aarch64.vmdk.gz",
-                "sha256": "5002dcdfdca3e7e80e01866d8470218a585272e7251db0cc9c04aef39fd6fc02",
-                "uncompressed-sha256": "03d27b9f4a5ec04fb0829a7da39bd5666009b08eb6d8265a528c35713ecb2e90"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202205191023-0/aarch64/rhcos-410.84.202205191023-0-aws.aarch64.vmdk.gz",
+                "sha256": "04a4346605f1756d46275cac42d6041bd29d4d475f502eb7ea6923af6c86cfaa",
+                "uncompressed-sha256": "f0318beaaa32c15305bf0d2ddd0d9bf53539c452b5da64e2917cc2455de3432a"
               }
             }
           }
         },
         "metal": {
-          "release": "410.84.202201251203-0",
+          "release": "410.84.202205191023-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-metal4k.aarch64.raw.gz",
-                "sha256": "3e3e33afb27c54cad5d243a8d42ac9b498c1cd32b1366ca2d86b076937063b89",
-                "uncompressed-sha256": "976315a9e8c5d57055390de55f907ddfb24152601909ab3aba561d38dd0f6eda"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202205191023-0/aarch64/rhcos-410.84.202205191023-0-metal4k.aarch64.raw.gz",
+                "sha256": "d751e29e9f718d9e218cb7f1efe1d6641a7b552c96827a91638c4edbff29fa7d",
+                "uncompressed-sha256": "22cb2fec3c7eb8ed89832abaa4fd3cc3d855df488848300078ffadfc44752a5c"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-live.aarch64.iso",
-                "sha256": "66e4ea2d58090761a8da4ee9816d5ea9a0bfc99eb6874119b2c677cc7dff4953"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202205191023-0/aarch64/rhcos-410.84.202205191023-0-live.aarch64.iso",
+                "sha256": "671ca9ee7a722be8b246c4e17f16540539f4025e27a213ccf764fc8cd920d21a"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-live-kernel-aarch64",
-                "sha256": "3467e8bfffedf402fe82156e9710d6684f273a77e1dd3017ae134ff3a6d3dc52"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202205191023-0/aarch64/rhcos-410.84.202205191023-0-live-kernel-aarch64",
+                "sha256": "351479f71e1c0934cf0608863f8ea6c1b2e2cb94623032ec9513d54f8f6de26d"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-live-initramfs.aarch64.img",
-                "sha256": "d24d5cca403f20e3b20b77d607ee9775609c8c0a8390ed44f405d6f110d9f176"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202205191023-0/aarch64/rhcos-410.84.202205191023-0-live-initramfs.aarch64.img",
+                "sha256": "37716ad923d0eb9caf78bede7b6df8cc1b240cfc55dee1fca785fc0ddb9881b0"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-live-rootfs.aarch64.img",
-                "sha256": "183ed2219c9be0e2b1887d060663e0a0279ff7a6866dc598d865f79c094fd38d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202205191023-0/aarch64/rhcos-410.84.202205191023-0-live-rootfs.aarch64.img",
+                "sha256": "d074c37650bc7a6a3e24c65854a13c2cb14fac1aa795c9f6d601d225129d0926"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-metal.aarch64.raw.gz",
-                "sha256": "4c60214ccb8e4315b797b1d2a68be9b4c7345e48414625a573057a477773b6b1",
-                "uncompressed-sha256": "a8509ee5f97a04fc32dcd2057c75a05517e7619f75000c45e1f9b32b3300f19c"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202205191023-0/aarch64/rhcos-410.84.202205191023-0-metal.aarch64.raw.gz",
+                "sha256": "565cdb17ec89aec45c95910206ef0875f0beec3b7224dc32c43a2db1f3b511e2",
+                "uncompressed-sha256": "4b751a1034940aacb86619178c6f3d8550857f68185a49ca3fe9abfdfc558ff9"
               }
             }
           }
         },
         "openstack": {
-          "release": "410.84.202201251203-0",
+          "release": "410.84.202205191023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-openstack.aarch64.qcow2.gz",
-                "sha256": "43d705930aa55be857d08586660554f44a6fea48859dde0638ca23bf33f22f9f",
-                "uncompressed-sha256": "14903b14d58bd9991e0c6dfad723a59f33c04a7b092f01db45de48a0d910ca4d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202205191023-0/aarch64/rhcos-410.84.202205191023-0-openstack.aarch64.qcow2.gz",
+                "sha256": "c053853eb19041ba9a371cd4f43e0496b970c3b3c9c3412beee8663d90408cf8",
+                "uncompressed-sha256": "6f15c2c1a7ef9f02ba46b1034601c7ca35efe5c669a0e29d868319b0e3385b3f"
               }
             }
           }
         },
         "qemu": {
-          "release": "410.84.202201251203-0",
+          "release": "410.84.202205191023-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202201251203-0/aarch64/rhcos-410.84.202201251203-0-qemu.aarch64.qcow2.gz",
-                "sha256": "b44ed28acd79c3971a71be971a7604407dbe69fcc0af9240209797bea7464223",
-                "uncompressed-sha256": "1f1c76d0815345e2b394fa8ae88aaa87e5804041ca0de8cf05e8b18d744e2a90"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-aarch64/410.84.202205191023-0/aarch64/rhcos-410.84.202205191023-0-qemu.aarch64.qcow2.gz",
+                "sha256": "b6f7f8cb43f8c1fc74fa5e49782a9b5536402708d4b198ffeaf190257c58cc5b",
+                "uncompressed-sha256": "f2e2e5cc885bbaa51ee22fc4c46427ff9d44fe37e2d0e92318ed75ed04b07613"
               }
             }
           }
@@ -87,80 +87,80 @@
         "aws": {
           "regions": {
             "ap-east-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0f8195c36da4edbd7"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0a1941353bf3c3275"
             },
             "ap-northeast-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-000a86fa0a0b76144"
+              "release": "410.84.202205191023-0",
+              "image": "ami-08fa3f1102260dd6a"
             },
             "ap-northeast-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0f772f5dc2347a954"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0b4fe48061ac8fc45"
             },
             "ap-south-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-02ab23e25b8e8af97"
+              "release": "410.84.202205191023-0",
+              "image": "ami-04ee51f336e8b3a47"
             },
             "ap-southeast-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-085ae5a7dcbfb056d"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0b25c0c614f5fa4b9"
             },
             "ap-southeast-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-085ff9f4e8d4d66e0"
+              "release": "410.84.202205191023-0",
+              "image": "ami-077820ead6e8b048d"
             },
             "ca-central-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0050cdf32f76ba82c"
+              "release": "410.84.202205191023-0",
+              "image": "ami-04a2f761890fd596b"
             },
             "eu-central-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-092527fcf7c21fe42"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0686ff3d76b03aac5"
             },
             "eu-north-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-07d673450675ea033"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0d13ea638620af9ac"
             },
             "eu-south-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0f165ac29cc9d27bf"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0f6dfad3968dbd7eb"
             },
             "eu-west-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0e0cd7d2eb949538d"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0ae44672131825d33"
             },
             "eu-west-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0790ba70a444fe74d"
+              "release": "410.84.202205191023-0",
+              "image": "ami-07b13b005a3ec1047"
             },
             "eu-west-3": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0d16af5bd22cc5227"
+              "release": "410.84.202205191023-0",
+              "image": "ami-01d1a405ed2d06259"
             },
             "me-south-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-05e1ba911ce321052"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0a14f8c2b3cdef8f5"
             },
             "sa-east-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-04b124534c7f05cd2"
+              "release": "410.84.202205191023-0",
+              "image": "ami-07c2ca22a1657e43b"
             },
             "us-east-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-09bbec91849ca85bc"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0b61c73be33b512d9"
             },
             "us-east-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-048ac599f7315a0bc"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0dbed7dd0c09f4708"
             },
             "us-west-1": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0af1d3b7fa5be2131"
+              "release": "410.84.202205191023-0",
+              "image": "ami-0e4139af5fea5b532"
             },
             "us-west-2": {
-              "release": "410.84.202201251203-0",
-              "image": "ami-0bd3bf54ee678e2a6"
+              "release": "410.84.202205191023-0",
+              "image": "ami-08f1d10c8940d343a"
             }
           }
         }
@@ -169,203 +169,132 @@
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "410.84.202201251004-0",
+          "release": "410.84.202205191722-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202201251004-0/ppc64le/rhcos-410.84.202201251004-0-metal4k.ppc64le.raw.gz",
-                "sha256": "651b927a4912730616a7e379f7a2ff336ec5d5fb3e2d4af1b633d63b03fc46f3",
-                "uncompressed-sha256": "2a1a721069500ca05e85f2ef9963bae6fe7fdea3411dbc41ee11e055897b95bf"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202205191722-0/ppc64le/rhcos-410.84.202205191722-0-metal4k.ppc64le.raw.gz",
+                "sha256": "107ed0b2663462cbb6b4af97d94e1ae61a10f22b03ae6865ac87a760289e7345",
+                "uncompressed-sha256": "a1bee3ca0d06eaa5647a8db3aaedcc12511809327f21c9d680934a72d4cd4e79"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202201251004-0/ppc64le/rhcos-410.84.202201251004-0-live.ppc64le.iso",
-                "sha256": "e9b209c9c9dbd69725631c7bd94ad072f4a23045566e4ca86e0cc298098b5d06"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202205191722-0/ppc64le/rhcos-410.84.202205191722-0-live.ppc64le.iso",
+                "sha256": "e2702a9de90cb96790d65760c0fd35a25567cf23611ee8513d9640d27c9158f3"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202201251004-0/ppc64le/rhcos-410.84.202201251004-0-live-kernel-ppc64le",
-                "sha256": "7793c250197f07a05b030561d62fbb15125630df9ffd54e343d7efa73b15b7db"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202205191722-0/ppc64le/rhcos-410.84.202205191722-0-live-kernel-ppc64le",
+                "sha256": "f55a27cb75ebaa56ece0a75d01f24090a958e28e79e9d411f5a159bb3fb178b5"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202201251004-0/ppc64le/rhcos-410.84.202201251004-0-live-initramfs.ppc64le.img",
-                "sha256": "73bf86cea0cc6992251980e9a9934f1b9fe29c06147d9c1339f01ded2b1adb46"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202205191722-0/ppc64le/rhcos-410.84.202205191722-0-live-initramfs.ppc64le.img",
+                "sha256": "9f55487a06468dfdddaf964af17ccd4a3b85cd9e0167373a42ff9b609f920af5"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202201251004-0/ppc64le/rhcos-410.84.202201251004-0-live-rootfs.ppc64le.img",
-                "sha256": "39f444616847d2767a5d087b8b720ec9c1a26cf307fbbf410b24a2dcfbebe152"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202205191722-0/ppc64le/rhcos-410.84.202205191722-0-live-rootfs.ppc64le.img",
+                "sha256": "a2c8407311c17551fddd3f3ee5ddbe0910e0fdf729897083b3c7980cf4204ffe"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202201251004-0/ppc64le/rhcos-410.84.202201251004-0-metal.ppc64le.raw.gz",
-                "sha256": "54140c0918f9bee508d69e8ce3fd72f07184c979c3b63d245ad301c11474adfb",
-                "uncompressed-sha256": "9a4bb4f4423ddd932ab4acd38f4fa46500d1e4e4905203afe76be6a6900d31cb"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202205191722-0/ppc64le/rhcos-410.84.202205191722-0-metal.ppc64le.raw.gz",
+                "sha256": "91f0f83d5fd55f2456b57bef9ecc348df1a62c71f9687486b768ff523d154d6c",
+                "uncompressed-sha256": "e22733524a17f678205a5de6a8f608bd07142c0f8a83235fa3c6ae75c88be8c7"
               }
             }
           }
         },
         "openstack": {
-          "release": "410.84.202201251004-0",
+          "release": "410.84.202205191722-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202201251004-0/ppc64le/rhcos-410.84.202201251004-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "59c080ec8b5c1f826d8a8cefab489d3917b166a02552f84d3d1627672222e149",
-                "uncompressed-sha256": "2c1f4005b49c54db34bad2951752d997551cccc3f93205c9dfd9f0187dd64c6f"
-              }
-            }
-          }
-        },
-        "powervs": {
-          "release": "410.84.202201251004-0",
-          "formats": {
-            "ova.gz": {
-              "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202201251004-0/ppc64le/rhcos-410.84.202201251004-0-powervs.ppc64le.ova.gz",
-                "sha256": "6ef2a5ba8a82a669e590ef38918f73b0924a9dd01d88fae1d18c71e611c52ee2",
-                "uncompressed-sha256": "114b265a4d9e9f3f8db8a79f6cd07955f09d918ee7d17b0ad7ecb04d16e31a70"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202205191722-0/ppc64le/rhcos-410.84.202205191722-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "2f0f9c287b1c684854ef01172585306743791d53d43afe5da230c796864091b1",
+                "uncompressed-sha256": "baa10bf0d36334b69572697443338361679835608c9ebf7d75b7a97a13b50879"
               }
             }
           }
         },
         "qemu": {
-          "release": "410.84.202201251004-0",
+          "release": "410.84.202205191722-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202201251004-0/ppc64le/rhcos-410.84.202201251004-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "4f20e72de17dc0e22f14c76aa03f03b88a7feef6ab3b88461da29a5af0892dfe",
-                "uncompressed-sha256": "b34eb732c7ee03434ed645d7b058d75f8f0a0c9bda96bac1da62459ce1d2d511"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-ppc64le/410.84.202205191722-0/ppc64le/rhcos-410.84.202205191722-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "7db030d846d52468f69ed6e951990ba78e5cdb87951cd240c5566af739d0efbc",
+                "uncompressed-sha256": "3c3cec54435c572bfbb77203c8c8d868ece8a466abdfc07b032683b007455460"
               }
             }
           }
         }
       },
-      "images": {
-        "powervs": {
-          "regions": {
-            "au-syd": {
-              "release": "410.84.202201251004-0",
-              "object": "rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz"
-            },
-            "br-sao": {
-              "release": "410.84.202201251004-0",
-              "object": "rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz"
-            },
-            "ca-tor": {
-              "release": "410.84.202201251004-0",
-              "object": "rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz"
-            },
-            "eu-de": {
-              "release": "410.84.202201251004-0",
-              "object": "rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz"
-            },
-            "eu-gb": {
-              "release": "410.84.202201251004-0",
-              "object": "rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz"
-            },
-            "jp-osa": {
-              "release": "410.84.202201251004-0",
-              "object": "rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz"
-            },
-            "jp-tok": {
-              "release": "410.84.202201251004-0",
-              "object": "rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz"
-            },
-            "us-east": {
-              "release": "410.84.202201251004-0",
-              "object": "rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz"
-            },
-            "us-south": {
-              "release": "410.84.202201251004-0",
-              "object": "rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz",
-              "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-410-84-202201251004-0-ppc64le-powervs.ova.gz"
-            }
-          }
-        }
-      }
+      "images": {}
     },
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "410.84.202201251002-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202201251002-0/s390x/rhcos-410.84.202201251002-0-metal4k.s390x.raw.gz",
-                "sha256": "fb88354f8cb3dbad3285840a1667dffab1a17658b4014b58c196dd9b721fc290",
-                "uncompressed-sha256": "b26f40284c15b4983348d6106968be44a2af42621eb7b71ec778a6f8aeb0d973"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202205191234-0/s390x/rhcos-410.84.202205191234-0-metal4k.s390x.raw.gz",
+                "sha256": "b3f3f57419ee47f21cdc51e55550addd7260209132e2d13803c9fe96271a49fb",
+                "uncompressed-sha256": "9fcf33dc97872a8241b42fb3f4e16e62a2dfba0d4cc5e63b903b8ef64d070f04"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202201251002-0/s390x/rhcos-410.84.202201251002-0-live.s390x.iso",
-                "sha256": "8684316965d2e226c3829fc40f7aba9442df59af5902b2987847bd66849835c2"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202205191234-0/s390x/rhcos-410.84.202205191234-0-live.s390x.iso",
+                "sha256": "d54f22d6dc3c4ea9c90873dbe5e34c9efd0871e7f696d04375bd92e712bf6395"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202201251002-0/s390x/rhcos-410.84.202201251002-0-live-kernel-s390x",
-                "sha256": "c6758a5b387d52430c19d808e694e1b8064053286e602449b099f8234a024df9"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202205191234-0/s390x/rhcos-410.84.202205191234-0-live-kernel-s390x",
+                "sha256": "f1e62a5bdb0dbe0753c25e44e818a68536c1fdb50e15b9f98b186ca10c7ed3ed"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202201251002-0/s390x/rhcos-410.84.202201251002-0-live-initramfs.s390x.img",
-                "sha256": "4a7bc840af168f9332d0f36b881cbeff228085fe5c99787a47922e64ff50f463"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202205191234-0/s390x/rhcos-410.84.202205191234-0-live-initramfs.s390x.img",
+                "sha256": "4f1738f8bc797764bf3e5b87653878ed149011925ec3a2cf459f482009bac328"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202201251002-0/s390x/rhcos-410.84.202201251002-0-live-rootfs.s390x.img",
-                "sha256": "f96d2301607b359aedd62dad4dc815e54afb40130373531f54252df3ea9d469f"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202205191234-0/s390x/rhcos-410.84.202205191234-0-live-rootfs.s390x.img",
+                "sha256": "bab247ebfb053264d2a18e65ba71874b26ec92c897020c195431fc91f846a6bd"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202201251002-0/s390x/rhcos-410.84.202201251002-0-metal.s390x.raw.gz",
-                "sha256": "32290a46615ff894677a3827fb7125649a8c3ea37b140813fce28fd4adc222e0",
-                "uncompressed-sha256": "2f620f175783f5737120079cc162fdc6ffd3d8cebd61507e4f8e3c9e79eb72e7"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202205191234-0/s390x/rhcos-410.84.202205191234-0-metal.s390x.raw.gz",
+                "sha256": "463e6cffdbdf4984cf10b1a89a467bd5567010e2f41433e06dbf76561fc04205",
+                "uncompressed-sha256": "2ae92cbf505334079a40f7874f0a51d2f84036a550b2ee4e0d98cf4c68552f3c"
               }
             }
           }
         },
         "openstack": {
-          "release": "410.84.202201251002-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202201251002-0/s390x/rhcos-410.84.202201251002-0-openstack.s390x.qcow2.gz",
-                "sha256": "292ca4a3d102ef1bc6dccd6e3fe6d2c7c19ad765a56ec253368a4fd7158508d4",
-                "uncompressed-sha256": "2cee23f0fd209d74b50d2aac5ce034fb55cb9a66417782948cfaaf4563d5aa4c"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202205191234-0/s390x/rhcos-410.84.202205191234-0-openstack.s390x.qcow2.gz",
+                "sha256": "56e49de8853dbe8c5b28dfe35ae9c92db35fc83883bd76dcd33757466a6a9583",
+                "uncompressed-sha256": "9fbe6a5b2635cec5aae68576b5beafe42617ea4e1347600a075fbc8025a86d27"
               }
             }
           }
         },
         "qemu": {
-          "release": "410.84.202201251002-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202201251002-0/s390x/rhcos-410.84.202201251002-0-qemu.s390x.qcow2.gz",
-                "sha256": "7a17a5e46aa208cbcab962bc5af9007a35fa516c8d3371d75831e6a490723d52",
-                "uncompressed-sha256": "3fce5981a162354bc7a4f7d858efb4c878a4d859fc224bcd2490e659c61f80c3"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10-s390x/410.84.202205191234-0/s390x/rhcos-410.84.202205191234-0-qemu.s390x.qcow2.gz",
+                "sha256": "ef7cd6fc01be451956e610b020f1dcd6fc5db0ed01dd130fd8c94843ebd92734",
+                "uncompressed-sha256": "cfd340fec90ac76dbbd6e9a306a4b7f0a994e40f36ccf5854b3c096fc7d665f8"
               }
             }
           }
@@ -376,159 +305,159 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "12c6cd2edb2ef80a90ee3c038491e35df83c5800b686a41240d1dd33b4ca7463",
-                "uncompressed-sha256": "6ba93ad8a08c5c65a331aed6c784749258a9196622bd868306d0bd193a3da17b"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "1320ca5704cb49cfa992b90bf38616f7ec91e153755a7c700514a14aea7721fc",
+                "uncompressed-sha256": "61dd0ea73d3fbe673584dbd63b52ac5957ee454f9827660551967ea233f30eee"
               }
             }
           }
         },
         "aws": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-aws.x86_64.vmdk.gz",
-                "sha256": "2b4eb22e26f13d7bf9c5696f0484216aeda70dead1b85d7affec7ea9e8b124f6",
-                "uncompressed-sha256": "8f537760e8c0a32981af8e5f564183838f57598dc62fa1b36ca4d1d3f9586815"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-aws.x86_64.vmdk.gz",
+                "sha256": "cb54da31a0a6ed94c2ad27df1e9267ff23411bbe5787879b4f4cc53152cede75",
+                "uncompressed-sha256": "8176bf5ddcaf554c628f14a3a0a2fac4dd99d82d5786b3ba4603086a3912d634"
               }
             }
           }
         },
         "azure": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-azure.x86_64.vhd.gz",
-                "sha256": "620a9368a0f09067f40240aa66bbcea04dce18b9586a7049433872ff2d7452f5",
-                "uncompressed-sha256": "705b0dc3a568c818cb8ca9ea6fbe7cfd14c291bfdd4827672a0889afc826949a"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-azure.x86_64.vhd.gz",
+                "sha256": "a5cdc0fcf5b8fd66ae662e88f516f86999f3a895e03863d44e4618b15b458b2a",
+                "uncompressed-sha256": "39e9f6c4f35e63e1e116496451166a4e32c15ec874243f41aa0acc546f2b69a7"
               }
             }
           }
         },
         "azurestack": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-azurestack.x86_64.vhd.gz",
-                "sha256": "3e67e191b7953022cb6e53a1382855102479ccf2eabf1d41763b86f090fa7d1a",
-                "uncompressed-sha256": "13df1632101eff8fbd67020d418c5647e593ec0010b4e412a38a358415b8c815"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-azurestack.x86_64.vhd.gz",
+                "sha256": "93647da0b65c7f53909c535285459fe55f598cdca34d89261e0970ce49c69789",
+                "uncompressed-sha256": "74d27b368327521d5b5a025e17925c50ccbc6397bb0f9a6b418ccac8490617b4"
               }
             }
           }
         },
         "gcp": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-gcp.x86_64.tar.gz",
-                "sha256": "eaf972601eee2b976c1892e597e93f7574bd0a04b1fe92cfcbebf9f2bf11ef71",
-                "uncompressed-sha256": "df3e11356934f453fcbbe099b8cb93286e0d76f6ebde30347c2d530bb1728b0a"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-gcp.x86_64.tar.gz",
+                "sha256": "1f01a76e6a901895e77b8a6e080d4dd3cda865bf5302332d1c9b0dd3e53b0f2e",
+                "uncompressed-sha256": "d40cbe3b70af24b4eb7ce53f4dffe505db1ca32c9496e0cb16a3edf5b42cead5"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "58b6a3401f0d333cba9fdb0351d54dcf55dcd8dc2df5169d7c2c18e8d69cc511",
-                "uncompressed-sha256": "8fc2f8c99b6fc4766907f0e793bdf6ce7d0e0160f5a8296e4b0c3bb05bb57f1d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "4e97099a3c12894a929da59dd07a1347a7fa94159bb94284ad692f62084cddfc",
+                "uncompressed-sha256": "de517856f9d410309e1cf2fdd0a2a59d5ba34bce3edbdf585af77e5e01a3a5da"
               }
             }
           }
         },
         "metal": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-metal4k.x86_64.raw.gz",
-                "sha256": "4166c4aa8e3ff588d21c06538a9fbb536d6c1957f8c43f0d3ea49ded83f30cb5",
-                "uncompressed-sha256": "9f1e907ec5576f7a63725ecadc9d4ef8d0b3c04a65a5cae720570d2be01c903d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-metal4k.x86_64.raw.gz",
+                "sha256": "5f0c498788bb0ab45500ae87c09d599039354f0bc53891419dd1e599e1f36cbd",
+                "uncompressed-sha256": "a1415eef24a182227a80e0831f9ea7b84d07e07d40e7a0a60cb4467a9562b346"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-live.x86_64.iso",
-                "sha256": "2905c1f0d85739e8600e8816c0d32711fb4002be4f845e0b20eeab35314e5b58"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-live.x86_64.iso",
+                "sha256": "f637115eb221be47af12fdd766e938b138634710344fcc0874e91691a98b10c7"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-live-kernel-x86_64",
-                "sha256": "0c4d5c1c4b5c230de4b98d921569996ea765eb2b16d3531a4bd98d796833c0e3"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-live-kernel-x86_64",
+                "sha256": "cb554926eaeeeca58b4193173f552c5ca90db5cddefc8f0c73877d291b3baa83"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-live-initramfs.x86_64.img",
-                "sha256": "9d6a562839d2760fc35a6645a9a0e337ed561a5ae2d1242d37fea95bf21b2ac5"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-live-initramfs.x86_64.img",
+                "sha256": "dfb9eb7b26a1998f78897174acd9b0a2af393ef072e99f3d340c93ed2e522f12"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-live-rootfs.x86_64.img",
-                "sha256": "d32f9e6afb4091046ab9a06602169932c963a514014603e504dd0ea7c86a388a"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-live-rootfs.x86_64.img",
+                "sha256": "16864119e8cc560fab4f0dffa37f27533a48fa279f69df76aad0fd7e892fafd5"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-metal.x86_64.raw.gz",
-                "sha256": "abb9f690eeeeb108a625d56b08ea7dc9da3130ddc8d4db97c80e1ac84d91e030",
-                "uncompressed-sha256": "64ab60ac5369a62b150a7e70865cc0301a80c01f0edbccb1d025fc616a010ca3"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-metal.x86_64.raw.gz",
+                "sha256": "e4c8a623a99ded5cc41e7a6da4d915e20f6edbdf850bb422b0eb6c3084bbe2ba",
+                "uncompressed-sha256": "fb593d53ed4f371735e15a86d7730d734193287943c44c9c76844653f7412fb7"
               }
             }
           }
         },
         "nutanix": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-nutanix.x86_64.qcow2.gz",
-                "sha256": "d6eb51223074fa4bb4adca181731cb349772bea5513c227e5bfe789f9f187371",
-                "uncompressed-sha256": "38a2f630e4b5035218d33971211b36370a87705bb467c76f1f67bb2306d09fca"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-nutanix.x86_64.qcow2.gz",
+                "sha256": "b26f2edc0f8a59a2844ea3fc0985a39513688c8aad4effac81bc475982ba84c3",
+                "uncompressed-sha256": "8d455a679cd09ba7bc033d5acb88c49c004501b55eec0e3df49b5ca71f5de071"
               }
             }
           }
         },
         "openstack": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-openstack.x86_64.qcow2.gz",
-                "sha256": "f581896eee37216021bfce9ddd5e1fd8289c366ca0d1db25221c77688de85fd7",
-                "uncompressed-sha256": "6b5731d90fa78eb50c07928811675d7f9c1d3f94eca0a94afef17cfbce706ddf"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-openstack.x86_64.qcow2.gz",
+                "sha256": "cd224d5a5ddff1a71cd6cd2c2ae574d06b2790085f1ba0749b3f394fc67ed4c7",
+                "uncompressed-sha256": "15380a3debd92ccf466d98084938229133078c5634e4f926ed150a0c9f699375"
               }
             }
           }
         },
         "qemu": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-qemu.x86_64.qcow2.gz",
-                "sha256": "66f6333c94ce444b619f9a413ff7b00925a51c6ecbdbadf730622861ce36f95e",
-                "uncompressed-sha256": "3a9268526bfc2aa66d7aeb11c1d0a4fd6de640dc475dd7ad20ceb5c953ea7c8b"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-qemu.x86_64.qcow2.gz",
+                "sha256": "09347747749d507280478257c490b3f8830cefec7ae0616922f47db0cee7373b",
+                "uncompressed-sha256": "b8c16f94141c797a388ce50cff98c7c899b29dff7c3777a617fe5f9991078e5a"
               }
             }
           }
         },
         "vmware": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202201251210-0/x86_64/rhcos-410.84.202201251210-0-vmware.x86_64.ova",
-                "sha256": "3d75bcf4d1245f1d10865072b3a735333f2fbc7262b55fafc0fbead8c8c3517d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.10/410.84.202205191234-0/x86_64/rhcos-410.84.202205191234-0-vmware.x86_64.ova",
+                "sha256": "38bdb055aeb39b271b9e65680a40dea02b7b9372588e73e9146d105fe77bb8c8"
               }
             }
           }
@@ -538,213 +467,217 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "410.84.202201251210-0",
-              "image": "m-6we3gn9xd4owb6wfn3g5"
+              "release": "410.84.202205191234-0",
+              "image": "m-6wej7n5y21du88ebkqtz"
             },
             "ap-south-1": {
-              "release": "410.84.202201251210-0",
-              "image": "m-a2dafsdgxgyiw905po2k"
+              "release": "410.84.202205191234-0",
+              "image": "m-a2de648dhkg0bv6mkhm8"
             },
             "ap-southeast-1": {
-              "release": "410.84.202201251210-0",
-              "image": "m-t4n9oablw33zshdnkg2m"
+              "release": "410.84.202205191234-0",
+              "image": "m-t4n3ymrqslj50n8ouswm"
             },
             "ap-southeast-2": {
-              "release": "410.84.202201251210-0",
-              "image": "m-p0wb72s792wi8b3t7bei"
+              "release": "410.84.202205191234-0",
+              "image": "m-p0wgcu812qa3wo2fl10a"
             },
             "ap-southeast-3": {
-              "release": "410.84.202201251210-0",
-              "image": "m-8ps6k3jckrivqr6leu14"
+              "release": "410.84.202205191234-0",
+              "image": "m-8psg5m2c23uf074qhnw3"
             },
             "ap-southeast-5": {
-              "release": "410.84.202201251210-0",
-              "image": "m-k1a2lksghh0kc7ylbzyg"
+              "release": "410.84.202205191234-0",
+              "image": "m-k1aj79oxjj27rlt55gbt"
             },
             "ap-southeast-6": {
-              "release": "410.84.202201251210-0",
-              "image": "m-5tsh9hbxcem37dw8kh4q"
+              "release": "410.84.202205191234-0",
+              "image": "m-5ts2fyuzmbhxdvtenr1r"
             },
             "cn-beijing": {
-              "release": "410.84.202201251210-0",
-              "image": "m-2ze0zuq27nwszkhi9z46"
+              "release": "410.84.202205191234-0",
+              "image": "m-2zedigy8c18pwj0aa87a"
             },
             "cn-chengdu": {
-              "release": "410.84.202201251210-0",
-              "image": "m-2vc366vixvwyolwv12rq"
+              "release": "410.84.202205191234-0",
+              "image": "m-2vcck4y8hb06b7jppdi3"
             },
             "cn-guangzhou": {
-              "release": "410.84.202201251210-0",
-              "image": "m-7xv2khdi22412re3illc"
+              "release": "410.84.202205191234-0",
+              "image": "m-7xv8eughmrro30c5bnzw"
             },
             "cn-hangzhou": {
-              "release": "410.84.202201251210-0",
-              "image": "m-bp15w0ph797x2i83tqt3"
+              "release": "410.84.202205191234-0",
+              "image": "m-bp11sgbxml068u1diq47"
             },
             "cn-heyuan": {
-              "release": "410.84.202201251210-0",
-              "image": "m-f8z51sipldsztsk435oc"
+              "release": "410.84.202205191234-0",
+              "image": "m-f8ze4lelnv14vxmtmgox"
             },
             "cn-hongkong": {
-              "release": "410.84.202201251210-0",
-              "image": "m-j6cd6w5lquapdmw8x47m"
+              "release": "410.84.202205191234-0",
+              "image": "m-j6cj3btulzvzptbpdf3b"
             },
             "cn-huhehaote": {
-              "release": "410.84.202201251210-0",
-              "image": "m-hp308d9cobhpyyady888"
+              "release": "410.84.202205191234-0",
+              "image": "m-hp3bbqffnibv72yv0adm"
             },
             "cn-nanjing": {
-              "release": "410.84.202201251210-0",
-              "image": "m-gc7f991g40lj3dtmjbg8"
+              "release": "410.84.202205191234-0",
+              "image": "m-gc74zn3128bo3o95r5xa"
             },
             "cn-qingdao": {
-              "release": "410.84.202201251210-0",
-              "image": "m-m5e8waxa372p18w75pnf"
+              "release": "410.84.202205191234-0",
+              "image": "m-m5e486x19h3xui3ouepk"
             },
             "cn-shanghai": {
-              "release": "410.84.202201251210-0",
-              "image": "m-uf6azfd8576l77g698nj"
+              "release": "410.84.202205191234-0",
+              "image": "m-uf674tcfrngujr9k1kup"
             },
             "cn-shenzhen": {
-              "release": "410.84.202201251210-0",
-              "image": "m-wz90d7tvh6uowypsp2du"
+              "release": "410.84.202205191234-0",
+              "image": "m-wz9h3j8t6soje0bzi9nl"
             },
             "cn-wulanchabu": {
-              "release": "410.84.202201251210-0",
-              "image": "m-0jlerfgv7qqnyrwevnk3"
+              "release": "410.84.202205191234-0",
+              "image": "m-0jl2ulup0gmmvsdahr61"
             },
             "cn-zhangjiakou": {
-              "release": "410.84.202201251210-0",
-              "image": "m-8vb2zqmrxexyz9fgle08"
+              "release": "410.84.202205191234-0",
+              "image": "m-8vbc897ojp4ihpiuz5in"
             },
             "eu-central-1": {
-              "release": "410.84.202201251210-0",
-              "image": "m-gw8ide9k6ctkwc8lt776"
+              "release": "410.84.202205191234-0",
+              "image": "m-gw82qqvsj8ykvcx19vzd"
             },
             "eu-west-1": {
-              "release": "410.84.202201251210-0",
-              "image": "m-d7o3w92dle6won1hg11d"
+              "release": "410.84.202205191234-0",
+              "image": "m-d7objscxcokmsybd49e6"
             },
             "me-east-1": {
-              "release": "410.84.202201251210-0",
-              "image": "m-eb33589hbqpaz1fkpc12"
+              "release": "410.84.202205191234-0",
+              "image": "m-eb3irmf1jf6e2k4gt5u2"
             },
             "us-east-1": {
-              "release": "410.84.202201251210-0",
-              "image": "m-0xibcz15pg2bw5tzz0c3"
+              "release": "410.84.202205191234-0",
+              "image": "m-0xibs0z70uqwi6ovbua8"
             },
             "us-west-1": {
-              "release": "410.84.202201251210-0",
-              "image": "m-rj9ful2e3wjknt7c3c50"
+              "release": "410.84.202205191234-0",
+              "image": "m-rj9bs0z70uqwiamxjy8h"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-030f4cd62ada042ab"
+              "release": "410.84.202205191234-0",
+              "image": "ami-07a3b8a63d985506f"
             },
             "ap-east-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-064a850bc3c8b0f71"
+              "release": "410.84.202205191234-0",
+              "image": "ami-08ff13e1c533f8e6e"
             },
             "ap-northeast-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-04edc886bdfaa186c"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0c8c387f3a9b3b64d"
             },
             "ap-northeast-2": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-03a84c13e8f8ba99c"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0a17e9bb4f03e5a91"
             },
             "ap-northeast-3": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-08a9ef83721bbc0c9"
+              "release": "410.84.202205191234-0",
+              "image": "ami-024d3ce3e8370aa13"
             },
             "ap-south-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0741239a149d66e1c"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0365d87235a4d8010"
             },
             "ap-southeast-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-002114e49f8e28ccf"
+              "release": "410.84.202205191234-0",
+              "image": "ami-08ba88ab75f3f313d"
             },
             "ap-southeast-2": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0386d15994420ed12"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0d59a29d23d2b1239"
+            },
+            "ap-southeast-3": {
+              "release": "410.84.202205191234-0",
+              "image": "ami-0d4d89e600d4fe37b"
             },
             "ca-central-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0c5bfa07c2280a3b4"
+              "release": "410.84.202205191234-0",
+              "image": "ami-02d0906ddd4ed9ecd"
             },
             "eu-central-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0086b19a2157a6f7f"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0dcb8efb82b8dcb24"
             },
             "eu-north-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0f252bc355d2021f7"
+              "release": "410.84.202205191234-0",
+              "image": "ami-064bcaafa258eb81d"
             },
             "eu-south-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-06e41d2d8bd0cda25"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0acb2341d176048cc"
             },
             "eu-west-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-090230d8af773ae68"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0909b26975626f8d6"
             },
             "eu-west-2": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0af99c32fde2cedf4"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0a9873cca0bc3bedf"
             },
             "eu-west-3": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-07b7248cf3c2b3190"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0ab565313e5261a47"
             },
             "me-south-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0c5053d84d2de947b"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0345117e30d503bfc"
             },
             "sa-east-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-088fd8b154d0796bf"
+              "release": "410.84.202205191234-0",
+              "image": "ami-08489e046a0dbbfc5"
             },
             "us-east-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0efc96a4e17e7b048"
+              "release": "410.84.202205191234-0",
+              "image": "ami-04a508b80321ac196"
             },
             "us-east-2": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-049d248f9e0f4ee7a"
+              "release": "410.84.202205191234-0",
+              "image": "ami-08750efc5bc9eb5ff"
             },
             "us-gov-east-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0c3b11bcccf6ec63c"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0d7970ed8e0273c25"
             },
             "us-gov-west-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-084d95ff443d8bf99"
+              "release": "410.84.202205191234-0",
+              "image": "ami-0e246c1ebbaa3d6d4"
             },
             "us-west-1": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-01faa544d84054192"
+              "release": "410.84.202205191234-0",
+              "image": "ami-03710da2dd807ddd8"
             },
             "us-west-2": {
-              "release": "410.84.202201251210-0",
-              "image": "ami-0643bac9e55077cc2"
+              "release": "410.84.202205191234-0",
+              "image": "ami-09df9f7b30797732c"
             }
           }
         },
         "gcp": {
-          "release": "410.84.202201251210-0",
+          "release": "410.84.202205191234-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-410-84-202201251210-0-gcp-x86-64"
+          "name": "rhcos-410-84-202205191234-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "410.84.202201251210-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-410.84.202201251210-0-azure.x86_64.vhd"
+          "release": "410.84.202205191234-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-410.84.202205191234-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.10 boot image metadata in the
installer which includes the fixes for the following BZs:

Bug 2077998: Publish RHEL CoreOS AMIs in AWS ap-southeast-3 region

Changes generated with:
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --url https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases --no-signatures x86_64=410.84.202205191234-0 aarch64=410.84.202205191023-0 s390x=410.84.202205191234-0 ppc64le=410.84.202205191722-0