### PR TITLE
[release-4.11.0] Bug 2092296: Changed DefaultMachineCIDR of PowerVS to 192.168.0.0/16

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1440,8 +1440,8 @@ spec:
                 description: MachineNetwork is the list of IP address pools for machines.
                   This field replaces MachineCIDR, and if set MachineCIDR must be
                   empty or match the first entry in the list. Default is 10.0.0.0/16
-                  for all platforms other than libvirt. For libvirt, the default is
-                  192.168.126.0/24.
+                  for all platforms other than libvirt and Power VS. For libvirt,
+                  the default is 192.168.126.0/24. For Power VS, the default is 192.168.0.0/16.
                 items:
                   description: MachineNetworkEntry is a single IP address block for
                     node IP blocks.

--- a/pkg/asset/installconfig/powervs/validation_test.go
+++ b/pkg/asset/installconfig/powervs/validation_test.go
@@ -19,7 +19,7 @@ type editFunctions []func(ic *types.InstallConfig)
 
 var (
 	validRegion                  = "lon"
-	validCIDR                    = "10.0.0.0/16"
+	validCIDR                    = "192.168.0.0/16"
 	validCISInstanceCRN          = "crn:v1:bluemix:public:internet-svcs:global:a/valid-account-id:valid-instance-id::"
 	validClusterName             = "valid-cluster-name"
 	validDNSZoneID               = "valid-zone-id"

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -42,6 +42,11 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 				{CIDR: *libvirtdefaults.DefaultMachineCIDR},
 			}
 		}
+		if c.Platform.PowerVS != nil {
+			c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+				{CIDR: *powervsdefaults.DefaultMachineCIDR},
+			}
+		}
 	}
 	if c.Networking.NetworkType == "" {
 		if c.IsOKD() {
@@ -82,6 +87,8 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		if c.Platform.Azure != nil && c.Platform.Azure.CloudName == azure.StackCloud {
 			c.CredentialsMode = types.ManualCredentialsMode
 		} else if c.Platform.Nutanix != nil {
+			c.CredentialsMode = types.ManualCredentialsMode
+		} else if c.Platform.PowerVS != nil {
 			c.CredentialsMode = types.ManualCredentialsMode
 		}
 	}

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -283,8 +283,9 @@ type Networking struct {
 	// MachineNetwork is the list of IP address pools for machines.
 	// This field replaces MachineCIDR, and if set MachineCIDR must
 	// be empty or match the first entry in the list.
-	// Default is 10.0.0.0/16 for all platforms other than libvirt.
+	// Default is 10.0.0.0/16 for all platforms other than libvirt and Power VS.
 	// For libvirt, the default is 192.168.126.0/24.
+	// For Power VS, the default is 192.168.0.0/16.
 	//
 	// +optional
 	MachineNetwork []MachineNetworkEntry `json:"machineNetwork,omitempty"`

--- a/pkg/types/powervs/defaults/platform.go
+++ b/pkg/types/powervs/defaults/platform.go
@@ -1,7 +1,15 @@
 package defaults
 
 import (
+	"github.com/openshift/installer/pkg/ipnet"
+
 	"github.com/openshift/installer/pkg/types/powervs"
+)
+
+var (
+	// DefaultMachineCIDR is the PowerVS default IP address space from
+	// which to assign machine IPs.
+	DefaultMachineCIDR = ipnet.MustParseCIDR("192.168.0.0/16")
 )
 
 // SetPlatformDefaults sets the defaults for the platform.


### PR DESCRIPTION
1.Changed PowerVS MachineCIDR from `10.x.x.x/16 to192.168.0.0/16`
2.Added changes to set Default credentialMode for Powervs to `ManualCredentialsMode`