### PR TITLE
AGENT-133: Export addStorageFiles and addSystemdUnits as functions

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap_in_place.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap_in_place.go
@@ -41,10 +41,10 @@ func (a *SingleNodeBootstrapInPlace) Generate(dependencies asset.Parents) error 
 	if err := a.generateConfig(dependencies, templateData); err != nil {
 		return err
 	}
-	if err := a.addStorageFiles("/", "bootstrap/bootstrap-in-place/files", templateData); err != nil {
+	if err := AddStorageFiles(a.Config, "/", "bootstrap/bootstrap-in-place/files", templateData); err != nil {
 		return err
 	}
-	if err := a.addSystemdUnits("bootstrap/bootstrap-in-place/systemd/units", templateData, bootstrapInPlaceEnabledServices); err != nil {
+	if err := AddSystemdUnits(a.Config, "bootstrap/bootstrap-in-place/systemd/units", templateData, bootstrapInPlaceEnabledServices); err != nil {
 		return err
 	}
 	if err := a.Common.generateFile(singleNodeBootstrapInPlaceIgnFilename); err != nil {


### PR DESCRIPTION
These methods have been exported as functions so that they can be
used by code outside of bootstrap package that are also building
Ignition configs.

The functions have been modified to take in the Ignition config
that is being modified as its first parameter.