### PR TITLE
Bug 2064693: Restore ability to use local clouds.yaml

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/cluster/aws"
 	"github.com/openshift/installer/pkg/asset/cluster/azure"
+	"github.com/openshift/installer/pkg/asset/cluster/openstack"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/quota"
@@ -22,6 +23,7 @@ import (
 	platformstages "github.com/openshift/installer/pkg/terraform/stages/platform"
 	typesaws "github.com/openshift/installer/pkg/types/aws"
 	typesazure "github.com/openshift/installer/pkg/types/azure"
+	typesopenstack "github.com/openshift/installer/pkg/types/openstack"
 )
 
 var (
@@ -109,6 +111,10 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 		}
 	case typesazure.Name, typesazure.StackTerraformName:
 		if err := azure.PreTerraform(context.TODO(), clusterID.InfraID, installConfig); err != nil {
+			return err
+		}
+	case typesopenstack.Name:
+		if err := openstack.PreTerraform(context.TODO(), clusterID.InfraID, installConfig); err != nil {
 			return err
 		}
 	}

--- a/pkg/asset/cluster/openstack/openstack.go
+++ b/pkg/asset/cluster/openstack/openstack.go
@@ -3,9 +3,43 @@
 package openstack
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
+
+// PreTerraform performs any infrastructure initialization which must
+// happen before Terraform creates the remaining infrastructure.
+func PreTerraform(ctx context.Context, clusterID string, installConfig *installconfig.InstallConfig) error {
+	// Terraform runs in a different directory but we want to allow people to
+	// use clouds.yaml files in their local directory. Emulate this by setting
+	// the necessary environment variable to point to this file if (a) the user
+	// hasn't already set this environment variable and (b) there is actually
+	// a local file
+	if path := os.Getenv("OS_CLIENT_CONFIG_FILE"); path != "" {
+		return nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return errors.Wrapf(err, "unable to determine working directory")
+	}
+
+	cloudsYAML := filepath.Join(cwd, "clouds.yaml")
+	if _, err = os.Stat(cloudsYAML); err == nil {
+		os.Setenv("OS_CLIENT_CONFIG_FILE", cloudsYAML)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return errors.Wrapf(err, "unable to determine if clouds.yaml exists")
+	}
+
+	return nil
+}
 
 // Metadata converts an install configuration to OpenStack metadata.
 func Metadata(infraID string, config *types.InstallConfig) *openstack.Metadata {


### PR DESCRIPTION
We recently switched from using Terraform as a library to using it as a binary. As part of this switch, we have changed the definition of `$PWD` for the providers - it is now a temporary working directory we create rather than the user's current working directory. This breaks the ability to use a `clouds.yaml` file in the local directory when provisioning on OpenStack clouds.

Restore this by checking for the presence of such a file early in the provisioning process and setting an environment variable to point to this file if found. This isn't the nicest solution - it would probably be better to load the file as an asset and copy it to the Terraform working directory - but it should be effective.
