### PR TITLE
agent: default openshift version when pullspec it's a digest

### DIFF
--- a/pkg/agent/imagebuilder/content.go
+++ b/pkg/agent/imagebuilder/content.go
@@ -262,17 +262,6 @@ func (c ConfigBuilder) getManifests(manifestPath string) ([]igntypes.File, error
 			if err != nil {
 				return files, fmt.Errorf("failed to read file %s: %w", localPath, err)
 			}
-			// TODO: remove hard-coded ClusterImageSet manifest
-			if e.Name() == "cluster-image-set.yaml" {
-				contents = []byte(`
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  name: openshift-4.11
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64
-`)
-			}
 			mode := 0600
 			file := ignitionFileEmbed(ignitionPath, mode, true, contents)
 			files = append(files, file)

--- a/pkg/agent/imagebuilder/releaseimage.go
+++ b/pkg/agent/imagebuilder/releaseimage.go
@@ -3,7 +3,10 @@ package imagebuilder
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
+
+	"github.com/openshift/installer/pkg/version"
 )
 
 type releaseImage struct {
@@ -13,7 +16,28 @@ type releaseImage struct {
 	Tag            string `json:"version"`
 }
 
+func isDigest(pullspec string) bool {
+	return regexp.MustCompile(`.*sha256:[a-fA-F0-9]{64}$`).MatchString(pullspec)
+}
+
 func releaseImageFromPullSpec(pullSpec, arch string) (releaseImage, error) {
+
+	// When the pullspec it's a digest let's use the current version
+	// stored in the installer
+	if isDigest(pullSpec) {
+		versionString, err := version.Version()
+		if err != nil {
+			return releaseImage{}, err
+		}
+
+		return releaseImage{
+			ReleaseVersion: versionString,
+			Arch:           arch,
+			PullSpec:       pullSpec,
+			Tag:            versionString,
+		}, nil
+	}
+
 	components := strings.SplitN(pullSpec, ":", 2)
 	if len(components) < 2 {
 		return releaseImage{}, fmt.Errorf("invalid release image \"%s\"", pullSpec)

--- a/pkg/agent/imagebuilder/releaseimage.go
+++ b/pkg/agent/imagebuilder/releaseimage.go
@@ -35,18 +35,10 @@ func releaseImageFromPullSpec(pullSpec, arch string) (releaseImage, error) {
 }
 
 func releaseImageList(pullSpec, arch string) (string, error) {
-	// TODO: re-enable this code instead of hard-coding
-	/*
-		relImage, err := releaseImageFromPullSpec(pullSpec, arch)
-		if err != nil {
-			return "", err
-		}
-	*/
-	relImage := releaseImage{
-		ReleaseVersion: "4.10",
-		Arch:           arch,
-		PullSpec:       "quay.io/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64",
-		Tag:            "4.10.0-rc.1",
+
+	relImage, err := releaseImageFromPullSpec(pullSpec, arch)
+	if err != nil {
+		return "", err
 	}
 
 	imageList := []interface{}{relImage}

--- a/pkg/agent/imagebuilder/releaseimage_test.go
+++ b/pkg/agent/imagebuilder/releaseimage_test.go
@@ -31,13 +31,21 @@ func TestReleaseImageList(t *testing.T) {
 			arch:     "x86_64",
 			result:   "[{\"openshift_version\":\"4.11\",\"cpu_architecture\":\"x86_64\",\"url\":\"registry.ci.openshift.org/ocp/release:4.11.0-0.ci-2022-05-16-202609\",\"version\":\"4.11.0-0.ci-2022-05-16-202609\"}]",
 		},
+		{
+			name:     "CI-ephemeral",
+			pullSpec: "registry.build04.ci.openshift.org/ci-op-m7rfgytz/release@sha256:ebb203f24ee060d61bdb466696a9c20b3841f9929badf9b81fc99cbedc2a679e",
+			arch:     "x86_64",
+			result:   "[{\"openshift_version\":\"was not built correctly\",\"cpu_architecture\":\"x86_64\",\"url\":\"registry.build04.ci.openshift.org/ci-op-m7rfgytz/release@sha256:ebb203f24ee060d61bdb466696a9c20b3841f9929badf9b81fc99cbedc2a679e\",\"version\":\"was not built correctly\"}]",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			output, err := releaseImageList(tc.pullSpec, tc.arch)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.result, output)
+			if err == nil {
+				assert.Equal(t, tc.result, output)
+			}
 		})
 	}
 }

--- a/pkg/agent/imagebuilder/releaseimage_test.go
+++ b/pkg/agent/imagebuilder/releaseimage_test.go
@@ -7,8 +7,6 @@ import (
 )
 
 func TestReleaseImageList(t *testing.T) {
-	t.Skip("Release is hard-coded")
-
 	cases := []struct {
 		name     string
 		pullSpec string
@@ -45,8 +43,6 @@ func TestReleaseImageList(t *testing.T) {
 }
 
 func TestReleaseImageListErrors(t *testing.T) {
-	t.Skip("Release is hard-coded")
-
 	cases := []string{
 		"",
 		"quay.io/openshift-release-dev/ocp-release-4.10",


### PR DESCRIPTION
Since currently we don't have a way to extract the openshift version when the pullspec it's a digest, let's default the version to some hard-coded values. The current approach will not work properly in the general case but it will support the CI environment, where the pullspec it's referencing the current ephemeral release payload