### PR TITLE
Bug 2055612: Adding the report message when quotes are available but low

### DIFF
--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -194,7 +195,7 @@ func summarizeFailingReport(reports []quota.ConstraintReport) error {
 // summarizeReport summarizes a report when there are availble.
 func summarizeReport(reports []quota.ConstraintReport) {
 	var low []string
-	var regionMessage string
+	var regionMessage, countMessage string
 	for _, report := range reports {
 		switch report.Result {
 		case quota.AvailableButLow:
@@ -203,7 +204,8 @@ func summarizeReport(reports []quota.ConstraintReport) {
 			} else {
 				regionMessage = ""
 			}
-			low = append(low, fmt.Sprintf("%s%s", report.For.Name, regionMessage))
+			countMessage = " resource required: " + strconv.FormatInt(report.For.Count, 10)
+			low = append(low, fmt.Sprintf("%s%s%s", report.For.Name, regionMessage, countMessage))
 		default:
 			continue
 		}


### PR DESCRIPTION
If, in the unlikely case, a cluster runs out of quotas after checking if there are enough then the install will fail. In this case there is only a warring about which quotas are low. For more information we can add the number of the resource that is required to the output.