### PR TITLE
Bug 2098243: Adding error handling to powervs platform

### DIFF
--- a/pkg/asset/installconfig/platform.go
+++ b/pkg/asset/installconfig/platform.go
@@ -112,6 +112,9 @@ func (a *platform) Generate(asset.Parents) error {
 		}
 	case powervs.Name:
 		a.PowerVS, err = powervsconfig.Platform()
+		if err != nil {
+			return err
+		}
 	case nutanix.Name:
 		a.Nutanix, err = nutanixconfig.Platform()
 		if err != nil {


### PR DESCRIPTION
This solves a bug where platform errors out, and subsequently have issues later in the install.