### PR TITLE
AGENT-40: Generate kubeconfig alongside ISO

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent/image"
 	"github.com/openshift/installer/pkg/asset/agent/manifests"
+	"github.com/openshift/installer/pkg/asset/kubeconfig"
 )
 
 func newAgentCmd() *cobra.Command {
@@ -45,6 +46,7 @@ var (
 		},
 		assets: []asset.WritableAsset{
 			&image.AgentImage{},
+			&kubeconfig.AgentAdminClient{},
 		},
 	}
 

--- a/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
+++ b/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
@@ -8,6 +8,7 @@ DEPLOY_TARGET=onprem
 DISK_ENCRYPTION_SUPPORT=true
 DUMMY_IGNITION=false
 ENABLE_SINGLE_NODE_DNSMASQ=true
+EPHEMERAL_INSTALLER_CLUSTER_TLS_CERTS_OVERRIDE_DIR=/opt/agent/tls
 HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]
 IMAGE_SERVICE_BASE_URL=http://{{.NodeZeroIP}}:8888
 IPV6_SUPPORT=true

--- a/data/data/agent/systemd/units/assisted-service.service
+++ b/data/data/agent/systemd/units/assisted-service.service
@@ -11,7 +11,7 @@ Environment=PODMAN_SYSTEMD_UNIT=%n
 Restart=on-failure
 TimeoutStopSec=300
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=service --env-file=/usr/local/share/assisted-service/assisted-service.env --env-file=/usr/local/share/assisted-service/images.env --env-file=/etc/assisted-service/node0 quay.io/edge-infrastructure/assisted-service:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=service -v /opt/agent/tls:/opt/agent/tls:z --env-file=/usr/local/share/assisted-service/assisted-service.env --env-file=/usr/local/share/assisted-service/images.env --env-file=/etc/assisted-service/node0 quay.io/edge-infrastructure/assisted-service:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify

--- a/pkg/asset/kubeconfig/agent.go
+++ b/pkg/asset/kubeconfig/agent.go
@@ -1,0 +1,46 @@
+package kubeconfig
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/installer/pkg/asset"
+	agentmanifests "github.com/openshift/installer/pkg/asset/agent/manifests"
+	"github.com/openshift/installer/pkg/asset/tls"
+)
+
+// AgentAdminClient is the asset for the agent admin kubeconfig.
+type AgentAdminClient struct {
+	AdminClient
+}
+
+// Dependencies returns the dependency of the kubeconfig.
+func (k *AgentAdminClient) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&tls.AdminKubeConfigClientCertKey{},
+		&tls.KubeAPIServerCompleteCABundle{},
+		&agentmanifests.ClusterDeployment{},
+	}
+}
+
+// Generate generates the kubeconfig.
+func (k *AgentAdminClient) Generate(parents asset.Parents) error {
+	ca := &tls.KubeAPIServerCompleteCABundle{}
+	clientCertKey := &tls.AdminKubeConfigClientCertKey{}
+	parents.Get(ca, clientCertKey)
+
+	clusterDeployment := &agentmanifests.ClusterDeployment{}
+	parents.Get(clusterDeployment)
+
+	clusterName := clusterDeployment.Config.Spec.ClusterName
+	extAPIServerURL := fmt.Sprintf("https://api.%s.%s:6443", clusterName, strings.TrimSuffix(clusterDeployment.Config.Spec.BaseDomain, "."))
+
+	return k.kubeconfig.generate(
+		ca,
+		clientCertKey,
+		extAPIServerURL,
+		clusterName,
+		"admin",
+		kubeconfigAdminPath,
+	)
+}


### PR DESCRIPTION
Generate a kubeconfig at the same time as the agent ISO. Pass the certificates used to generate this config into the ISO and to assisted-service to allow it to pass them to the installer, as described in https://github.com/openshift/assisted-service/pull/3836

Note that while this should be safe to merge on its own, the generated kubeconfig will not work until both:

1. https://github.com/openshift/assisted-service/pull/3836 has landed; and
2. we are no longer hard-coding the release image (i.e. openshift/installer#5954 has been reverted), but are instead using a (post-Feature Freeze) 4.11 image.