### PR TITLE
Bug 2057582: Remove all occurances of packet_device from upi/metal

### DIFF
--- a/upi/metal/bootstrap/outputs.tf
+++ b/upi/metal/bootstrap/outputs.tf
@@ -1,11 +1,11 @@
 output "device_ip" {
-  value = packet_device.bootstrap.network[0].address
+  value = metal_device.bootstrap.network[0].address
 }
 
 output "device_hostname" {
-  value = packet_device.bootstrap.hostname
+  value = metal_device.bootstrap.hostname
 }
 
 output "device_id" {
-  value = packet_device.bootstrap.id
+  value = metal_device.bootstrap.id
 }


### PR DESCRIPTION
With the move to equinix/metal terraform provider , resource names
have to be migrated to metal_device.

Is a remnant from the work done in https://github.com/openshift/installer/pull/5941