### PR TITLE
Bug 2090836: Fixes CFE-489 - AWS installer should go through proxy for s3 bootstrap ignition call

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -340,7 +340,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			// Due to the SAS created in Terraform to limit access to bootstrap ignition, we cannot know the URL in advance.
 			// Instead, we will pass a placeholder string in the ignition to be replaced in TF once the value is known.
 			bootstrapIgnURLPlaceholder = "BOOTSTRAP_IGNITION_URL_PLACEHOLDER"
-			shim, err := bootstrap.GenerateIgnitionShimWithCertBundle(bootstrapIgnURLPlaceholder, installConfig.Config.AdditionalTrustBundle)
+			shim, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(bootstrapIgnURLPlaceholder, installConfig.Config.AdditionalTrustBundle, installConfig.Config.Proxy)
 			if err != nil {
 				return errors.Wrap(err, "failed to create stub Ignition config for bootstrap")
 			}
@@ -846,6 +846,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				AdditionalTrustBundle: installConfig.Config.AdditionalTrustBundle,
 				Architecture:          installConfig.Config.ControlPlane.Architecture,
 				Publish:               installConfig.Config.Publish,
+				Proxy:                 installConfig.Config.Proxy,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -291,6 +291,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			MasterIAMRoleName:     masterIAMRoleName,
 			WorkerIAMRoleName:     workerIAMRoleName,
 			Architecture:          installConfig.Config.ControlPlane.Architecture,
+			Proxy:                 installConfig.Config.Proxy,
 		})
 		if err != nil {
 			return errors.Wrapf(err, "failed to get %s Terraform variables", platform)

--- a/pkg/tfvars/alibabacloud/alibabacloud.go
+++ b/pkg/tfvars/alibabacloud/alibabacloud.go
@@ -53,6 +53,7 @@ type TFVarsSources struct {
 	Publish               types.PublishingStrategy
 	AdditionalTrustBundle string
 	Architecture          types.Architecture
+	Proxy                 *types.Proxy
 }
 
 // TFVars generates AlibabaCloud-specific Terraform variables launching the cluster.
@@ -100,7 +101,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		PublishStrategy:           string(sources.Publish),
 	}
 
-	stubIgn, err := bootstrap.GenerateIgnitionShimWithCertBundle(sources.IgnitionPresignedURL, sources.AdditionalTrustBundle)
+	stubIgn, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(sources.IgnitionPresignedURL, sources.AdditionalTrustBundle, sources.Proxy)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create stub Ignition config for bootstrap")
 	}

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -62,6 +62,8 @@ type TFVarsSources struct {
 	MasterMetadataAuthentication string
 
 	Architecture types.Architecture
+
+	Proxy *types.Proxy
 }
 
 // TFVars generates AWS-specific Terraform variables launching the cluster.
@@ -134,7 +136,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		WorkerIAMRoleName:       sources.WorkerIAMRoleName,
 	}
 
-	stubIgn, err := bootstrap.GenerateIgnitionShimWithCertBundle(sources.IgnitionPresignedURL, sources.AdditionalTrustBundle)
+	stubIgn, err := bootstrap.GenerateIgnitionShimWithCertBundleAndProxy(sources.IgnitionPresignedURL, sources.AdditionalTrustBundle, sources.Proxy)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create stub Ignition config for bootstrap")
 	}


### PR DESCRIPTION
BZ-2090836 states:
Given An AWS Openshift Install
When I Configured HTTP Proxy for Openshift installer
Then bootstrap Ignition should grab assets in S3 through the configured HTTP proxy
And Not expect direct internet access to the assets
Unless VPC endpoints are added to the noProxy configuration to bypass those endpoints

This PR passes proxy configuration to the ignition by using `GenerateIgnitionShimWithCertBundleAndProxy` 