### PR TITLE
Bug 2068180: update doc for DNS and disconnected clusters

### DIFF
--- a/docs/user/aws/install_upi.md
+++ b/docs/user/aws/install_upi.md
@@ -114,6 +114,10 @@ open(path, "w").write(yaml.dump(data, default_flow_style=False))'
 
 If you do so, you'll need to [add ingress DNS records manually](#add-the-ingress-dns-records) later on.
 
+#### Disconnected clusters
+
+For disconnected clusters, Openshift has to be configured [not to manage DNS](#remove-dns-zones), otherwise [the ingress operator][ingress-operator] will try to contact the STS endpoint "sts.amazon.com" directly as opposed to the configured VPC endpoint for the cluster.
+
 ## Create Ignition Configs
 
 Now we can create the bootstrap Ignition configs:


### PR DESCRIPTION
For disconnected clusters, OpenShift can be configured not to manage
DNS, and the cluster administrator can configure DNS manually.
Otherwise, the Ingress operator will try to contact sts directly
"sts.amazonaws.com" as opposed to the configured VPC endpoint for the
cluster.