### PR TITLE
Improve user interface of agent installer

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -285,7 +285,9 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 			}
 			logrus.Fatal(err)
 		}
-		if cmd.Name() != "cluster" {
+		switch cmd.Name() {
+		case "cluster", "image":
+		default:
 			logrus.Infof(logging.LogCreatedFiles(cmd.Name(), rootOpts.dir, targets))
 		}
 

--- a/pkg/asset/agent/image/cache.go
+++ b/pkg/asset/agent/image/cache.go
@@ -201,7 +201,7 @@ func (u *urlWithIntegrity) download(dataType string) (string, error) {
 	// If the file has already been cached, return its path
 	_, err = os.Stat(filePath)
 	if err == nil {
-		logrus.Infof("The file was found in cache: %v. Reusing...", filePath)
+		logrus.Debugf("The file was found in cache: %v. Reusing...", filePath)
 		return filePath, nil
 	}
 	if !os.IsNotExist(err) {
@@ -232,7 +232,7 @@ func (u *urlWithIntegrity) download(dataType string) (string, error) {
 // puts it in the cache and returns the local file path.  If the file is compressed
 // by a known compressor, the file is uncompressed prior to being returned.
 func DownloadImageFile(baseURL string) (string, error) {
-	logrus.Infof("Obtaining RHCOS image file from '%v'", baseURL)
+	logrus.Debugf("Obtaining RHCOS image file from '%v'", baseURL)
 
 	var u urlWithIntegrity
 	parsedURL, err := url.ParseRequestURI(baseURL)

--- a/pkg/asset/agent/manifests/agent.go
+++ b/pkg/asset/agent/manifests/agent.go
@@ -17,7 +17,7 @@ import (
 const (
 	// This could be change to "cluster-manifests" once all the agent code will be migrated to using
 	// assets (and will stop reading from the hard-code "manifests" relative path)
-	clusterManifestDir = "manifests"
+	clusterManifestDir = "cluster-manifests"
 )
 
 var (

--- a/pkg/asset/agent/manifests/agentpullsecret_test.go
+++ b/pkg/asset/agent/manifests/agentpullsecret_test.go
@@ -84,7 +84,7 @@ stringData:
 		{
 			name:          "not-yaml",
 			data:          `This is not a yaml file`,
-			expectedError: "failed to unmarshal manifests/pull-secret.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1.Secret",
+			expectedError: "failed to unmarshal cluster-manifests/pull-secret.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1.Secret",
 		},
 		{
 			name:          "empty",
@@ -120,7 +120,7 @@ stringData:
 		{
 			name:          "error-fetching-file",
 			fetchError:    errors.New("fetch failed"),
-			expectedError: "failed to load manifests/pull-secret.yaml file: fetch failed",
+			expectedError: "failed to load cluster-manifests/pull-secret.yaml file: fetch failed",
 		},
 		{
 			name: "unknown-field",
@@ -130,7 +130,7 @@ stringData:
 		  namespace: cluster0
 		spec:
 		  wrongField: wrongValue`,
-			expectedError: "failed to unmarshal manifests/pull-secret.yaml: error converting YAML to JSON: yaml: line 2: found character that cannot start any token",
+			expectedError: "failed to unmarshal cluster-manifests/pull-secret.yaml: error converting YAML to JSON: yaml: line 2: found character that cannot start any token",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/asset/agent/manifests/infraenv_test.go
+++ b/pkg/asset/agent/manifests/infraenv_test.go
@@ -107,7 +107,7 @@ spec:
 		{
 			name:          "not-yaml",
 			data:          `This is not a yaml file`,
-			expectedError: "failed to unmarshal manifests/infraenv.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1beta1.InfraEnv",
+			expectedError: "failed to unmarshal cluster-manifests/infraenv.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1beta1.InfraEnv",
 		},
 		{
 			name:       "file-not-found",
@@ -116,7 +116,7 @@ spec:
 		{
 			name:          "error-fetching-file",
 			fetchError:    errors.New("fetch failed"),
-			expectedError: "failed to load manifests/infraenv.yaml file: fetch failed",
+			expectedError: "failed to load cluster-manifests/infraenv.yaml file: fetch failed",
 		},
 		{
 			name: "unknown-field",
@@ -126,7 +126,7 @@ spec:
 		  namespace: cluster0
 		spec:
 		  wrongField: wrongValue`,
-			expectedError: "failed to unmarshal manifests/infraenv.yaml: error converting YAML to JSON: yaml: line 2: found character that cannot start any token",
+			expectedError: "failed to unmarshal cluster-manifests/infraenv.yaml: error converting YAML to JSON: yaml: line 2: found character that cannot start any token",
 		},
 		{
 			name: "empty-NMStateLabelSelector",

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -243,7 +243,7 @@ func buildMacInterfaceMap(nmStateConfig aiv1beta1.NMStateConfig) models.MacInter
 	// TODO - this eventually will move to another asset so the interface definition can be shared with Butane
 	macInterfaceMap := make(models.MacInterfaceMap, 0, len(nmStateConfig.Spec.Interfaces))
 	for _, cfg := range nmStateConfig.Spec.Interfaces {
-		logrus.Println("adding MAC interface map to host static network config - Name: ", cfg.Name, " MacAddress:", cfg.MacAddress)
+		logrus.Debug("adding MAC interface map to host static network config - Name: ", cfg.Name, " MacAddress:", cfg.MacAddress)
 		macInterfaceMap = append(macInterfaceMap, &models.MacInterfaceMapItems0{
 			MacAddress:     cfg.MacAddress,
 			LogicalNicName: cfg.Name,

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -108,6 +108,7 @@ func (n *NMStateConfig) Load(f asset.FileFetcher) (bool, error) {
 	}
 
 	log := logrus.New()
+	log.Level = logrus.WarnLevel
 	staticNetworkConfigGenerator := staticnetworkconfig.New(log.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
 
 	// Validate the network config using nmstatectl

--- a/pkg/asset/agent/manifests/nmstateconfig_test.go
+++ b/pkg/asset/agent/manifests/nmstateconfig_test.go
@@ -214,7 +214,7 @@ spec:
 		{
 			name:          "not-yaml",
 			data:          `This is not a yaml file`,
-			expectedError: "could not decode YAML for manifests/nmstateconfig.yaml: Error reading multiple YAMLs: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1beta1.NMStateConfig",
+			expectedError: "could not decode YAML for cluster-manifests/nmstateconfig.yaml: Error reading multiple YAMLs: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1beta1.NMStateConfig",
 		},
 		{
 			name:          "empty",
@@ -228,7 +228,7 @@ spec:
 		{
 			name:          "error-fetching-file",
 			fetchError:    errors.New("fetch failed"),
-			expectedError: "failed to load file manifests/nmstateconfig.yaml: fetch failed",
+			expectedError: "failed to load file cluster-manifests/nmstateconfig.yaml: fetch failed",
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
* ZTP manifests go in `cluster-manifests`
* Output ISO goes in work directory directly (i.e. same dir as install-config.yaml)
* Suppress debug logs by default