### PR TITLE
AGENT-133: Remove double embedding of agent data

### DIFF
--- a/data/data/agent/embed.go
+++ b/data/data/agent/embed.go
@@ -1,7 +1,0 @@
-package agent
-
-import "embed"
-
-// IgnitionData contains the source data for building the ignition file
-//go:embed *
-var IgnitionData embed.FS


### PR DESCRIPTION
The code in from the fleeting prototype relied on the embed module to
embed the data in data/data/agent. Since that code has now been removed,
and replaced with native installer code, in #5945 the agent data is now
accessed through data.Assets. This second copy of it is no longer
needed.