### PR TITLE
Bug 1859153: IAM instance profile race condition

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -175,7 +175,11 @@ resource "aws_instance" "bootstrap" {
     local.tags,
   )
 
-  depends_on = [aws_s3_bucket_object.ignition]
+  depends_on = [
+    aws_s3_bucket_object.ignition,
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1859153
+    aws_iam_instance_profile.bootstrap,
+  ]
 }
 
 resource "aws_lb_target_group_attachment" "bootstrap" {


### PR DESCRIPTION
When terraform tries to find
aws_iam_instance_profile.bootstrap.name it is already available to it
locally from the config that we provide and it need not wait for the
whole resource to actually appear before if tries to spawn ec2 with that
profile name. This can result in the following error:

level=error msg="Error: Error launching source instance: InvalidParameterValue: Value ($cluster_id-bootstrap-profile) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name"
level=error msg="\tstatus code: 400"

This can be avoided if we explicitly use a computed value of aws_iam_instance_profile.bootstrap like arn. That way terraform needs to fetch it before it can use it and it will only be available to terraform once creation is complete.