### PR TITLE
cmd/openshift-install/gather: Errorf for Available=False

### DIFF
--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -213,7 +213,7 @@ func logClusterOperatorConditions(ctx context.Context, config *rest.Config) erro
 			} else if (condition.Type == configv1.OperatorDegraded || condition.Type == configv1.OperatorProgressing) && condition.Status == configv1.ConditionFalse {
 				continue
 			}
-			if condition.Type == configv1.OperatorDegraded {
+			if condition.Type == configv1.OperatorAvailable || condition.Type == configv1.OperatorDegraded {
 				logrus.Errorf("Cluster operator %s %s is %s with %s: %s", operator.ObjectMeta.Name, condition.Type, condition.Status, condition.Reason, condition.Message)
 			} else {
 				logrus.Infof("Cluster operator %s %s is %s with %s: %s", operator.ObjectMeta.Name, condition.Type, condition.Status, condition.Reason, condition.Message)


### PR DESCRIPTION
Errors [like][1]:

    level=error msg=Cluster operator monitoring Degraded is True with UpdatingPrometheusK8SFailed: Failed to rollout the stack. Error: updating prometheus-k8s: waiting for Prometheus object changes failed: waiting for Prometheus openshift-monitoring/k8s: expected 2 replicas, got 0 updated replicas
    level=info msg=Cluster operator monitoring Available is False with MultipleTasksFailed: Rollout of the monitoring stack failed and is degraded. Please investigate the degraded status error.

should give equal level=error weight to `Available=False` and `Degraded=True`.  The logic I'm improving hasn't been touched since de5a26aa42 (#2450).

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/kubevirt_kubevirt-tekton-tasks/149/pull-ci-kubevirt-kubevirt-tekton-tasks-main-e2e-tests-namespace-scope/1534819052839505920#1:build-log.txt%3A101