### PR TITLE
Bug 2006965: bump RHCOS 4.8 boot images

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,166 +1,169 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-038772fdd54b78a4f"
+            "hvm": "ami-0c879d0aa64259ad0"
         },
         "ap-east-1": {
-            "hvm": "ami-03a6473cd438b2fea"
+            "hvm": "ami-0e6a2dea7bfd862a5"
         },
         "ap-northeast-1": {
-            "hvm": "ami-05977c4081111f3bb"
+            "hvm": "ami-0b9b3588ea302934d"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0a0fcda229d58dec1"
+            "hvm": "ami-012b7f860e994e868"
         },
         "ap-northeast-3": {
-            "hvm": "ami-0467ba9dc70f85538"
+            "hvm": "ami-0e42b5afc5baeea34"
         },
         "ap-south-1": {
-            "hvm": "ami-07c047be0d3ec46ca"
+            "hvm": "ami-0cec0dfd6e955718d"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0b574d30ee267107c"
+            "hvm": "ami-0980a2024cd30b5bf"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0c1b7b6fd42c043c2"
+            "hvm": "ami-032069c0b51483ad1"
+        },
+        "ap-southeast-3": {
+            "hvm": "ami-0f19ad8d973aea0ec"
         },
         "ca-central-1": {
-            "hvm": "ami-05bef6aaeb6a8cc3c"
+            "hvm": "ami-0f131d428f7d39da7"
         },
         "eu-central-1": {
-            "hvm": "ami-0d56b8ae868345407"
+            "hvm": "ami-089e4575a0dcafb0b"
         },
         "eu-north-1": {
-            "hvm": "ami-08dd7be7e8ebe13b6"
+            "hvm": "ami-04a0fcdd1fee18228"
         },
         "eu-south-1": {
-            "hvm": "ami-06f4c9dfde4e75eb1"
+            "hvm": "ami-05b65f41216a7da4b"
         },
         "eu-west-1": {
-            "hvm": "ami-0aef183a3bbfeeaf3"
+            "hvm": "ami-0ff5d97cd0b6cd949"
         },
         "eu-west-2": {
-            "hvm": "ami-07b3715c986152140"
+            "hvm": "ami-06a805d9f546f670a"
         },
         "eu-west-3": {
-            "hvm": "ami-0feee7f927014e9ad"
+            "hvm": "ami-00cca0795cfeead80"
         },
         "me-south-1": {
-            "hvm": "ami-01db7ebc5addfc2f6"
+            "hvm": "ami-0e8ba9d5ba5e65106"
         },
         "sa-east-1": {
-            "hvm": "ami-097223d194bcb71f0"
+            "hvm": "ami-041fbbc302a372a36"
         },
         "us-east-1": {
-            "hvm": "ami-06e6531aef9359b1e"
+            "hvm": "ami-0a0091d01a8bd2947"
         },
         "us-east-2": {
-            "hvm": "ami-09145c219cb4df3e1"
+            "hvm": "ami-0147e13e9b1975251"
         },
         "us-west-1": {
-            "hvm": "ami-0afa3199a442f45cb"
+            "hvm": "ami-05662d869042ffd84"
         },
         "us-west-2": {
-            "hvm": "ami-02a3699138ec7ecf4"
+            "hvm": "ami-074ed14912081db41"
         }
     },
     "azure": {
-        "image": "rhcos-48.84.202109241901-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202109241901-0-azure.x86_64.vhd"
+        "image": "rhcos-48.84.202206140145-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202206140145-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/",
-    "buildid": "48.84.202109241901-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/",
+    "buildid": "48.84.202206140145-0",
     "gcp": {
-        "image": "rhcos-48-84-202109241901-0-gcp-x86-64",
+        "image": "rhcos-48-84-202206140145-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202109241901-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202206140145-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.84.202109241901-0-aws.x86_64.vmdk.gz",
-            "sha256": "c081a65325330379e91707475b8dadf82e0f2d5c1c9f7f056fcd978641bb5114",
-            "size": 1031334820,
-            "uncompressed-sha256": "152a82e870e7e4d30d8204280f61ccfee90d826377bb25c51b2eac04f2fd82db",
-            "uncompressed-size": 1052379136
+            "path": "rhcos-48.84.202206140145-0-aws.x86_64.vmdk.gz",
+            "sha256": "c43356afc304edc5d2656095b6c4dd3052a35b0fe11adbaa4640b4f56bbc2f4c",
+            "size": 1030828645,
+            "uncompressed-sha256": "5580e5ea6d744e4e535b6416beac2c771a7e668ab86e0fe4b8395cf6eb87a343",
+            "uncompressed-size": 1051906048
         },
         "azure": {
-            "path": "rhcos-48.84.202109241901-0-azure.x86_64.vhd.gz",
-            "sha256": "801498fe0ccb754b898bef30e4d226f796874e615d7719b00d64b8054d434481",
-            "size": 1031392167,
-            "uncompressed-sha256": "b433bf7793db745c22c7ca09415a4dc87526ae7727e646d7b157acb323c3ee4f",
+            "path": "rhcos-48.84.202206140145-0-azure.x86_64.vhd.gz",
+            "sha256": "c9e355bb545baf2f34482cfc0a556b90dc89a71cf6058ed1546199fbff8a9c60",
+            "size": 1030940095,
+            "uncompressed-sha256": "333b3560bb635ce5c0f01bfa3784c8cd6ac1fa29ad85c52fbe0a773bf02b28e0",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.84.202109241901-0-gcp.x86_64.tar.gz",
-            "sha256": "5231bdd554841c01fbd1092ea96c39b06dda3187549c0672a5f5c5e4d7eecdad",
-            "size": 1016813602
+            "path": "rhcos-48.84.202206140145-0-gcp.x86_64.tar.gz",
+            "sha256": "7b732b6b3622f5ba00a4b2f3bfd32d6987a814f044daaf3831b0db0b168b81a6",
+            "size": 1016382695
         },
         "ibmcloud": {
-            "path": "rhcos-48.84.202109241901-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "440ce3c4367a10fa66436638cef6ed938848050fd7f0de2d78d1294a4f56995d",
-            "size": 1017169285,
-            "uncompressed-sha256": "d81934aa386286ad35591fd46dc9cd809dc5e88623b563f220abae52665de472",
-            "uncompressed-size": 2535325696
+            "path": "rhcos-48.84.202206140145-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "5113a7c63abe8a89cbce07d70e93eaeb685df1f4f96b7e467736a824889373d3",
+            "size": 1016732179,
+            "uncompressed-sha256": "87e637ebab6eab1ef9c4ae1d76613b5a0701a31c78793ac325596c77bdbede21",
+            "uncompressed-size": 2534473728
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202109241901-0-live-initramfs.x86_64.img",
-            "sha256": "5b6f1b728a5e656ef128a54f9534f7d3d63953ef46e726a808aacf1ce9ad2742"
+            "path": "rhcos-48.84.202206140145-0-live-initramfs.x86_64.img",
+            "sha256": "1641cb2005abf362283ddc328c1ad07c8640900d296e793913b1881faecc8926"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202109241901-0-live.x86_64.iso",
-            "sha256": "dc0c7af647137c9b16210c977896dc756b72b5e568774daf199964ca020935ae"
+            "path": "rhcos-48.84.202206140145-0-live.x86_64.iso",
+            "sha256": "1483da2bb1a64f6f90577036935fd5b47ad6d20758fd241981943c46cf516ff0"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202109241901-0-live-kernel-x86_64",
-            "sha256": "d13269e6c60119397210418781b7057673c4018692d28a868e248a0b550ea247"
+            "path": "rhcos-48.84.202206140145-0-live-kernel-x86_64",
+            "sha256": "2f73cda50fa9cfcd14b9624cce3fa663c91341a8eafae22bb6bbc6357f83e679"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202109241901-0-live-rootfs.x86_64.img",
-            "sha256": "bd005071f295762a613ff42c26ce453be7c19d35594b68c94fab6797b4d834d4"
+            "path": "rhcos-48.84.202206140145-0-live-rootfs.x86_64.img",
+            "sha256": "f0a729b85ace85e158c02a4ea69e53b5663210ffb2cb423f9899239481d9e479"
         },
         "metal": {
-            "path": "rhcos-48.84.202109241901-0-metal.x86_64.raw.gz",
-            "sha256": "6e67556bebee87b6d85d776a8b728ef727fb2e55c77a183f7979e8b89211b4db",
-            "size": 1018907248,
-            "uncompressed-sha256": "1b104a26b338f6aa4ba16a0bb3887e7bdc05c8735902785578208fb793fc504d",
-            "uncompressed-size": 3960471552
+            "path": "rhcos-48.84.202206140145-0-metal.x86_64.raw.gz",
+            "sha256": "c2fb42fe571bc231993889e0790c21b4643d78efaa99eab9035dab506fee2df5",
+            "size": 1018203635,
+            "uncompressed-sha256": "048eef6702941fd566ec67d51426c1fecb469ecdc94d5eae55435593b53f69a6",
+            "uncompressed-size": 3957325824
         },
         "metal4k": {
-            "path": "rhcos-48.84.202109241901-0-metal4k.x86_64.raw.gz",
-            "sha256": "9cf43a94eded275b2fb54bbb164ce63b18d7e696ca6c15f8cea4bb09941a0e57",
-            "size": 1016543064,
-            "uncompressed-sha256": "475d1123a2da31882b445c51ec5d5896c84de417feca5fe0ac1f93d8ea4e2c84",
-            "uncompressed-size": 3960471552
+            "path": "rhcos-48.84.202206140145-0-metal4k.x86_64.raw.gz",
+            "sha256": "8fbf4a1b82a763e3dca32de1c5c9a2bd40382d80c576e9eac6a12c03f92c0d41",
+            "size": 1015886091,
+            "uncompressed-sha256": "3842893bf80c00a2f11b6d591284b60b6bf60bead4c3e67fb148d34843d5c9fc",
+            "uncompressed-size": 3957325824
         },
         "openstack": {
-            "path": "rhcos-48.84.202109241901-0-openstack.x86_64.qcow2.gz",
-            "sha256": "99da4ed945b391d452e55a3a7809c799e4c74f69acbee1ecaec78f368c4e369e",
-            "size": 1017176202,
-            "uncompressed-sha256": "e0a1d8a99c5869150a56b8de475ea7952ca2fa3aacad7ca48533d1176df503ab",
-            "uncompressed-size": 2535325696
+            "path": "rhcos-48.84.202206140145-0-openstack.x86_64.qcow2.gz",
+            "sha256": "137c3b236d2bcaa9681c968ad333b112762539c6df196a704f1cd8ba78d49f11",
+            "size": 1016727289,
+            "uncompressed-sha256": "0a147f49f35030fd8153266bb186357043fbc044c77dbaa5b46922984db0d750",
+            "uncompressed-size": 2534473728
         },
         "ostree": {
-            "path": "rhcos-48.84.202109241901-0-ostree.x86_64.tar",
-            "sha256": "4e1c0dc1bcebcedf861256474db12822830e004e823e8a7968c6bed59002e924",
-            "size": 941015040
+            "path": "rhcos-48.84.202206140145-0-ostree.x86_64.tar",
+            "sha256": "3438b2c53b1078b4e288ad2869fb7ce839f466ae564f0c807ba22ad74d246048",
+            "size": 940503040
         },
         "qemu": {
-            "path": "rhcos-48.84.202109241901-0-qemu.x86_64.qcow2.gz",
-            "sha256": "0105a1de918e94e9c456f32dac63e3cf296efa0b59f543fc23c1ef00ebb15a5f",
-            "size": 1018340613,
-            "uncompressed-sha256": "50377ba9c5cb92c649c7d9e31b508185241a3c204b34dd991fcb3cf0adc53983",
-            "uncompressed-size": 2572288000
+            "path": "rhcos-48.84.202206140145-0-qemu.x86_64.qcow2.gz",
+            "sha256": "0120dfdcbfa70eeb804c1cd2368f140c577b12d85391d3553d189fb9b42938a1",
+            "size": 1017896853,
+            "uncompressed-sha256": "158e32571ca4934b05da0fe425eab453e6ceda3245cfc1a6cba45cbb53bf648a",
+            "uncompressed-size": 2571108352
         },
         "vmware": {
-            "path": "rhcos-48.84.202109241901-0-vmware.x86_64.ova",
-            "sha256": "28eabddd539b3e0bd3d39c08a63f96cfd674817e25e4a84b67f9ca29baafd88a",
-            "size": 1052395520
+            "path": "rhcos-48.84.202206140145-0-vmware.x86_64.ova",
+            "sha256": "7fa00b31d7f28c1318c23fe466a66cced0cbacd32b8833d8af05e874d1195332",
+            "size": 1051914240
         }
     },
     "oscontainer": {
-        "digest": "sha256:57f6acfd48e833ef07a505b25a296849b74631a2b058814d618a347c9304308d",
+        "digest": "sha256:648258313a495364dcd7663fa36e2d371fe4c78349d14b883fb5f4a301c824a5",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "13c18da5e6fee09fade484c3903209730cbb73e9ebcab806b9e9000cf97fd719",
-    "ostree-version": "48.84.202109241901-0"
+    "ostree-commit": "8fd19b78118cf1ba87bbb38adad80a5f8e74630c969d8c7d908e412ce4fb0e47",
+    "ostree-version": "48.84.202206140145-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/",
-    "buildid": "48.84.202109242319-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/",
+    "buildid": "48.84.202206132151-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-48.84.202109242319-0-live-initramfs.ppc64le.img",
-            "sha256": "284329c5530e92f4d99ae47a3dd91338ec437ab28663959769fafbc80459f58a"
+            "path": "rhcos-48.84.202206132151-0-live-initramfs.ppc64le.img",
+            "sha256": "8a1d182869d65eeb5e9a9245ebeec6f278c9936bf341ef202278fa9d8eed2039"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202109242319-0-live.ppc64le.iso",
-            "sha256": "efc9c5ac6479c610c5ea32fbf99c480dcee42d839b597a3cdef1e2884ec98ab4"
+            "path": "rhcos-48.84.202206132151-0-live.ppc64le.iso",
+            "sha256": "a1a80feb7ed74179fa5058efc6ddac17ce07630fc1d1903bf6d862dee0c6cb8e"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202109242319-0-live-kernel-ppc64le",
-            "sha256": "d2f8f29ef59b87de2cbd7df8be60c06620bc90e88f4a722bb8278333d76ca3f8"
+            "path": "rhcos-48.84.202206132151-0-live-kernel-ppc64le",
+            "sha256": "44e70f6abe2bf6e828ce8f833323cdf44035de6f9cc041219a2ddc16036fa210"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202109242319-0-live-rootfs.ppc64le.img",
-            "sha256": "898a23a6c936718855b5ec886e2aaa7bacede1cfcb3f1d24979adc35d6b9da70"
+            "path": "rhcos-48.84.202206132151-0-live-rootfs.ppc64le.img",
+            "sha256": "209ffd30459bec61c9cea34abf3869845f7c3343bbe40c276af8c044cc339f12"
         },
         "metal": {
-            "path": "rhcos-48.84.202109242319-0-metal.ppc64le.raw.gz",
-            "sha256": "fc0d83dde1e9c7b235fe33493594fa80b4ea78eacea386725cc2c7e5979ff96e",
-            "size": 984725024,
-            "uncompressed-sha256": "e0bb7614dd7f13ffd6823af0b974886d931197db3d048e0302a229d89c4d76f6",
-            "uncompressed-size": 4104126464
+            "path": "rhcos-48.84.202206132151-0-metal.ppc64le.raw.gz",
+            "sha256": "a78c0d8dce939b8bd27020e5950e3e160f255886cbb21a86ae9f3535fac9209c",
+            "size": 984654794,
+            "uncompressed-sha256": "c5ec1cb253791c79b412b1777b4e95e7dae72ebc2338226234d9343211b883cd",
+            "uncompressed-size": 4103077888
         },
         "metal4k": {
-            "path": "rhcos-48.84.202109242319-0-metal4k.ppc64le.raw.gz",
-            "sha256": "cce8fe6a661aa6d88da2365c1a93917cdd6750d261cf63c4f4f25416e111c213",
-            "size": 985109674,
-            "uncompressed-sha256": "1ff9baff8b141c8a055400fc536a5900721946d248d35cc75b7e8e92a048c639",
-            "uncompressed-size": 4104126464
+            "path": "rhcos-48.84.202206132151-0-metal4k.ppc64le.raw.gz",
+            "sha256": "9289afcdd91b1209c8c3201727281d2992559bd7f2d3b1177aaef759cddfcf73",
+            "size": 984771184,
+            "uncompressed-sha256": "434a1e6dbdc2ffec338df9328fc16e555c78989b3059ed8068a1a2e2360ff255",
+            "uncompressed-size": 4103077888
         },
         "openstack": {
-            "path": "rhcos-48.84.202109242319-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "fe1493a49b3332e0e462b8984d98b02eade0dbf864968d114e9403a9c62053cf",
-            "size": 983063322,
-            "uncompressed-sha256": "045aec0c7c562e832a0340d82143846c4596ca0638e7ad3f68136a0620fd04b7",
-            "uncompressed-size": 2649817088
+            "path": "rhcos-48.84.202206132151-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "8f674bef48429a8d8e42ee8ec03dc2ad4137417883388c64f40b1b876bfcbcc7",
+            "size": 982859226,
+            "uncompressed-sha256": "9fdc89ac3bdf7e9539b1bef1e59b5805ea9fd2388c9305678898245bba586a89",
+            "uncompressed-size": 2649292800
         },
         "ostree": {
-            "path": "rhcos-48.84.202109242319-0-ostree.ppc64le.tar",
-            "sha256": "08f9262a4963781935b9ef08e8858f437032d62f0810eae83803dec5b9cb250a",
-            "size": 905707520
+            "path": "rhcos-48.84.202206132151-0-ostree.ppc64le.tar",
+            "sha256": "f3fc03dabc34a7e5662125c3c89ae169345a5ed77efeed31eaab591257e83cec",
+            "size": 905461760
         },
         "qemu": {
-            "path": "rhcos-48.84.202109242319-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "7cbe2d49b089e3b0402ee8d305264c6f55e427ab8454e8510e832c9afc5d5d52",
-            "size": 984210968,
-            "uncompressed-sha256": "0cd8e500f4b507e595fc4bf07e03350cdc165e44a5154adccd50c6e8cd9f597b",
-            "uncompressed-size": 2687303680
+            "path": "rhcos-48.84.202206132151-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "c262bb5a71b8b53dfeda1e2f0d88c8b6609d9790d486a4c603268f82b61fd323",
+            "size": 983932188,
+            "uncompressed-sha256": "04c54cde0bcdfea17ee74d09e3afdee3bedae29df15d04fd2848ba20b2000dbf",
+            "uncompressed-size": 2686976000
         }
     },
     "oscontainer": {
-        "digest": "sha256:9379fc0a9936523568fd9fcc04fdbe11c09b58b257fb48de62b475e183e1a996",
+        "digest": "sha256:57f7af528f3d866924411735c4a64ea7b9b3763f9f1dbd45afeda9df3d020ecc",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "60a547930f87ad1ed1d97f49aa12493e9db855bd84e876f0d1a2874b46ceebc3",
-    "ostree-version": "48.84.202109242319-0"
+    "ostree-commit": "27ccb7f5641f6f842b82889a268f9101a953d63a91b2b2a361dcabd991cd5880",
+    "ostree-version": "48.84.202206132151-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/",
-    "buildid": "48.84.202109242104-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/",
+    "buildid": "48.84.202206132149-0",
     "images": {
         "dasd": {
-            "path": "rhcos-48.84.202109242104-0-dasd.s390x.raw.gz",
-            "sha256": "572072ecb782fd9e9ea1faf9abc935ded986fac05ae9a2c809d9c68981bcd46e",
-            "size": 893328718,
-            "uncompressed-sha256": "c0a8ced21b0fdb26affb64670f05add27262e8316faeaabfee9e96b55ccb4ba3",
-            "uncompressed-size": 3696230400
+            "path": "rhcos-48.84.202206132149-0-dasd.s390x.raw.gz",
+            "sha256": "f4a6017cfb77db9973f8333783b941229a3592f699b8a90f80fb8ce881452e54",
+            "size": 891244845,
+            "uncompressed-sha256": "61ea55957d4a26b4cc61cc6e8d2a6599529f009e6afd061b493a2d5ba089c228",
+            "uncompressed-size": 3688890368
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202109242104-0-live-initramfs.s390x.img",
-            "sha256": "09d05a1d1592da1e3799bded203b00874f7024f85ee8dcf8933cb0dba3a5da94"
+            "path": "rhcos-48.84.202206132149-0-live-initramfs.s390x.img",
+            "sha256": "630ce92d10f4636533cc2340a2e0c72442e0629dd7d097b314661065ba5bd580"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202109242104-0-live.s390x.iso",
-            "sha256": "168d17811b73a7da45ada38751a28db247381115021f8f2eb4e9d4083d29b719"
+            "path": "rhcos-48.84.202206132149-0-live.s390x.iso",
+            "sha256": "4665d304f3757aeef8f15cde37935c1ee1473d384c23101c993d4c72e99adf94"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202109242104-0-live-kernel-s390x",
-            "sha256": "81d8f6040cf3913ed01379e6af950d0c8168a4f6e0adeecaf63ae527c759ade9"
+            "path": "rhcos-48.84.202206132149-0-live-kernel-s390x",
+            "sha256": "de91cc8ffbd3b35c1e1f33deed6c8393ffe95b558d60b79bd34792e595397f7c"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202109242104-0-live-rootfs.s390x.img",
-            "sha256": "42d7b8caaafc9f911bef265cfeeef3a9369ceb984bfe6ea001649adb641e1fc6"
+            "path": "rhcos-48.84.202206132149-0-live-rootfs.s390x.img",
+            "sha256": "6d4b51ed83d7273a7110aeccd9f848769912dc9b99b7efe07859027ad9150d84"
         },
         "metal": {
-            "path": "rhcos-48.84.202109242104-0-metal.s390x.raw.gz",
-            "sha256": "12194de81db10b9d1cc51cd639a8cdd2c83c3793bd1e80c37da06d388d1e6929",
-            "size": 893348003,
-            "uncompressed-sha256": "f9d30d701ffaff5b241b55663edc84bad1158c42f4db60feb9bd0901b35f4aea",
-            "uncompressed-size": 3696230400
+            "path": "rhcos-48.84.202206132149-0-metal.s390x.raw.gz",
+            "sha256": "302d8d724b65a68d642fefb40109e410e635f4cd2414bf7325d4e3810ff9e8c6",
+            "size": 891259390,
+            "uncompressed-sha256": "1dd9ab5dc127f9d0d22565b25b94d0e8603fb642d67f70fa6754d50ef587d6aa",
+            "uncompressed-size": 3688890368
         },
         "metal4k": {
-            "path": "rhcos-48.84.202109242104-0-metal4k.s390x.raw.gz",
-            "sha256": "b73bdd631daa7a4f36f5af93ebdfae3b23e5f5cd351b4c69078e97cb09edd941",
-            "size": 893351283,
-            "uncompressed-sha256": "838ded2c00bd62b4f4cc45c529edc4e90c693ed25435300923a587bfb3de7b2b",
-            "uncompressed-size": 3696230400
+            "path": "rhcos-48.84.202206132149-0-metal4k.s390x.raw.gz",
+            "sha256": "6f3306b9b8ebeccdcb2e59d80d21ad20bdfe2d9fc9a338ba2714ed48bde03d66",
+            "size": 891519818,
+            "uncompressed-sha256": "228ba0b9fd1b0625d698d6ad7202ffb760e43b37d824d19a86b7447d3ecd94e6",
+            "uncompressed-size": 3688890368
         },
         "openstack": {
-            "path": "rhcos-48.84.202109242104-0-openstack.s390x.qcow2.gz",
-            "sha256": "8b617aa20707dcaa1841faa3a4ff197391f55ae7d9bd60c86294668904d8925d",
-            "size": 891648879,
-            "uncompressed-sha256": "8b1182a4b7f00d29bb5d36ad3689412328c48b8c4b914d2c8f84883126151673",
-            "uncompressed-size": 2306670592
+            "path": "rhcos-48.84.202206132149-0-openstack.s390x.qcow2.gz",
+            "sha256": "b327ed36c1d42277a0cb1f75da420dcbb5c768aa76ed3df6f488bc08c4879c8d",
+            "size": 889679936,
+            "uncompressed-sha256": "92238a282bb9adeee4600880a2d7388ae46c99551929ce6e7756ece7b7ace5cc",
+            "uncompressed-size": 2303000576
         },
         "ostree": {
-            "path": "rhcos-48.84.202109242104-0-ostree.s390x.tar",
-            "sha256": "3425a33c4244ec42007a0db6b5433bb7e2db22178f7f7ec1f61da066cb25dd16",
-            "size": 840007680
+            "path": "rhcos-48.84.202206132149-0-ostree.s390x.tar",
+            "sha256": "f0bf24961d1426a8232ebe5f4f06417a19b89178e9a4fcfb2116efc6323ee66f",
+            "size": 837990400
         },
         "qemu": {
-            "path": "rhcos-48.84.202109242104-0-qemu.s390x.qcow2.gz",
-            "sha256": "6cb9ca9d8f099720b7874650692df88c5c5d54762d614b7dc456fdd7c5d16674",
-            "size": 892710211,
-            "uncompressed-sha256": "b1a18112ab5455e8217edaef0304a9ec9d117931135618883cc7097d97eaab81",
-            "uncompressed-size": 2343043072
+            "path": "rhcos-48.84.202206132149-0-qemu.s390x.qcow2.gz",
+            "sha256": "8c5b9d24682834c285f0c9145cbc5247d39c5455cf163e0a815f6e4c6f1825a9",
+            "size": 890797115,
+            "uncompressed-sha256": "68169b0017a651adff9ba662f2b501dc51681efcde7ac65ca1952fe8ec79b5f1",
+            "uncompressed-size": 2338848768
         }
     },
     "oscontainer": {
-        "digest": "sha256:2db38ed16177ce76e581234b4d71b7a0f6627719325b6e8e093288a01c41a140",
+        "digest": "sha256:c746b90e659da4b445423d6627a3e1a3a2306f25a45c8b660a7a216f31cc9cbd",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "71f9571a1fe8e623c5b2a60b0ba94b014487ec5aba02f477b14028d7f58a9956",
-    "ostree-version": "48.84.202109242104-0"
+    "ostree-commit": "fc31cb78f858f5e7cdac5dd8693bebd4ef40bce5755a4d6e3405be853772aadd",
+    "ostree-version": "48.84.202206132149-0"
 }

--- a/data/data/rhcos-stream.json
+++ b/data/data/rhcos-stream.json
@@ -1,7 +1,8 @@
 {
   "stream": "rhcos-4.8",
   "metadata": {
-    "last-modified": "2021-09-27T13:12:20Z"
+    "last-modified": "2022-06-15T16:36:48Z",
+    "generator": "plume cosa2stream 0.14.0+14-g5f11e7652-dirty"
   },
   "architectures": {
     "aarch64": {
@@ -11,8 +12,8 @@
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-aws.aarch64.vmdk.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-aws.aarch64.vmdk.gz.sig",
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-aws.aarch64.vmdk.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-aws.aarch64.vmdk.gz.sig",
                 "sha256": "9f21ce65bf800866037104b9a5bb90a81364e60fb609539bbd5b41d3ffdf60a7",
                 "uncompressed-sha256": "f62dc06e5ebe91ba204cda2537b11ac6793c98702529cd06f23b1b5a2497bec8"
               }
@@ -24,40 +25,40 @@
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-metal4k.aarch64.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-metal4k.aarch64.raw.gz.sig",
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-metal4k.aarch64.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-metal4k.aarch64.raw.gz.sig",
                 "sha256": "59d8460416a07c5b048c9b7ee0d8c4716931365b692ac77690e675a80786e472",
                 "uncompressed-sha256": "7e2cc9b45bca6bb0ea7d55c99268f66095413f96605adfdf892bd73dbe20db84"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live.aarch64.iso",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live.aarch64.iso.sig",
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live.aarch64.iso",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live.aarch64.iso.sig",
                 "sha256": "312820bf6df5e9ac10afd7ec766590a0778a89c25692fe6ed252e72d5b06f4a0"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-kernel-aarch64",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-kernel-aarch64.sig",
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-kernel-aarch64",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-kernel-aarch64.sig",
                 "sha256": "a4bea38efeb692d6f7724b9b10793e7d9d12272467cfb9c407acd2e5c80fa0f0"
               },
               "initramfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-initramfs.aarch64.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-initramfs.aarch64.img.sig",
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-initramfs.aarch64.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-initramfs.aarch64.img.sig",
                 "sha256": "3f401c85863c0e52d8c6b836bb56f883e9d8710043c76dc250ff41a885f048ef"
               },
               "rootfs": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-rootfs.aarch64.img",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-rootfs.aarch64.img.sig",
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-rootfs.aarch64.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-live-rootfs.aarch64.img.sig",
                 "sha256": "71717fb7b01d4723f0c1822906747db23875e84a51b66036eb6767ccfba77891"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-metal.aarch64.raw.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-metal.aarch64.raw.gz.sig",
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-metal.aarch64.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-metal.aarch64.raw.gz.sig",
                 "sha256": "d68746c7829714982f44a4d2defe0ab08c912ecf53c89665bef3957762ffe8ae",
                 "uncompressed-sha256": "36fbff46e6285386d57e692882a850d366272facac0737ef39864b1add8fb75b"
               }
@@ -69,8 +70,8 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-qemu.aarch64.qcow2.gz",
-                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-qemu.aarch64.qcow2.gz.sig",
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-qemu.aarch64.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-aarch64/48.84.202106171757-0/aarch64/rhcos-48.84.202106171757-0-qemu.aarch64.qcow2.gz.sig",
                 "sha256": "2b1ec36be75a29c03b96f6d0cad8b543e6c813a7d2b788c56df7ad470ded872d",
                 "uncompressed-sha256": "78995cb9c2586c9b7a9d3c8fe312fb63415ac483052e81975dc62eee471608d5"
               }
@@ -152,72 +153,72 @@
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "48.84.202109242319-0",
+          "release": "48.84.202206132151-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-metal4k.ppc64le.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-metal4k.ppc64le.raw.gz.sig",
-                "sha256": "cce8fe6a661aa6d88da2365c1a93917cdd6750d261cf63c4f4f25416e111c213",
-                "uncompressed-sha256": "1ff9baff8b141c8a055400fc536a5900721946d248d35cc75b7e8e92a048c639"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-metal4k.ppc64le.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-metal4k.ppc64le.raw.gz.sig",
+                "sha256": "9289afcdd91b1209c8c3201727281d2992559bd7f2d3b1177aaef759cddfcf73",
+                "uncompressed-sha256": "434a1e6dbdc2ffec338df9328fc16e555c78989b3059ed8068a1a2e2360ff255"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-live.ppc64le.iso",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-live.ppc64le.iso.sig",
-                "sha256": "efc9c5ac6479c610c5ea32fbf99c480dcee42d839b597a3cdef1e2884ec98ab4"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live.ppc64le.iso",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live.ppc64le.iso.sig",
+                "sha256": "a1a80feb7ed74179fa5058efc6ddac17ce07630fc1d1903bf6d862dee0c6cb8e"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-live-kernel-ppc64le",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-live-kernel-ppc64le.sig",
-                "sha256": "d2f8f29ef59b87de2cbd7df8be60c06620bc90e88f4a722bb8278333d76ca3f8"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-kernel-ppc64le",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-kernel-ppc64le.sig",
+                "sha256": "44e70f6abe2bf6e828ce8f833323cdf44035de6f9cc041219a2ddc16036fa210"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-live-initramfs.ppc64le.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-live-initramfs.ppc64le.img.sig",
-                "sha256": "284329c5530e92f4d99ae47a3dd91338ec437ab28663959769fafbc80459f58a"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-initramfs.ppc64le.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-initramfs.ppc64le.img.sig",
+                "sha256": "8a1d182869d65eeb5e9a9245ebeec6f278c9936bf341ef202278fa9d8eed2039"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-live-rootfs.ppc64le.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-live-rootfs.ppc64le.img.sig",
-                "sha256": "898a23a6c936718855b5ec886e2aaa7bacede1cfcb3f1d24979adc35d6b9da70"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-rootfs.ppc64le.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-rootfs.ppc64le.img.sig",
+                "sha256": "209ffd30459bec61c9cea34abf3869845f7c3343bbe40c276af8c044cc339f12"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-metal.ppc64le.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-metal.ppc64le.raw.gz.sig",
-                "sha256": "fc0d83dde1e9c7b235fe33493594fa80b4ea78eacea386725cc2c7e5979ff96e",
-                "uncompressed-sha256": "e0bb7614dd7f13ffd6823af0b974886d931197db3d048e0302a229d89c4d76f6"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-metal.ppc64le.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-metal.ppc64le.raw.gz.sig",
+                "sha256": "a78c0d8dce939b8bd27020e5950e3e160f255886cbb21a86ae9f3535fac9209c",
+                "uncompressed-sha256": "c5ec1cb253791c79b412b1777b4e95e7dae72ebc2338226234d9343211b883cd"
               }
             }
           }
         },
         "openstack": {
-          "release": "48.84.202109242319-0",
+          "release": "48.84.202206132151-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-openstack.ppc64le.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-openstack.ppc64le.qcow2.gz.sig",
-                "sha256": "fe1493a49b3332e0e462b8984d98b02eade0dbf864968d114e9403a9c62053cf",
-                "uncompressed-sha256": "045aec0c7c562e832a0340d82143846c4596ca0638e7ad3f68136a0620fd04b7"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-openstack.ppc64le.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-openstack.ppc64le.qcow2.gz.sig",
+                "sha256": "8f674bef48429a8d8e42ee8ec03dc2ad4137417883388c64f40b1b876bfcbcc7",
+                "uncompressed-sha256": "9fdc89ac3bdf7e9539b1bef1e59b5805ea9fd2388c9305678898245bba586a89"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202109242319-0",
+          "release": "48.84.202206132151-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-qemu.ppc64le.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202109242319-0/ppc64le/rhcos-48.84.202109242319-0-qemu.ppc64le.qcow2.gz.sig",
-                "sha256": "7cbe2d49b089e3b0402ee8d305264c6f55e427ab8454e8510e832c9afc5d5d52",
-                "uncompressed-sha256": "0cd8e500f4b507e595fc4bf07e03350cdc165e44a5154adccd50c6e8cd9f597b"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-qemu.ppc64le.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-qemu.ppc64le.qcow2.gz.sig",
+                "sha256": "c262bb5a71b8b53dfeda1e2f0d88c8b6609d9790d486a4c603268f82b61fd323",
+                "uncompressed-sha256": "04c54cde0bcdfea17ee74d09e3afdee3bedae29df15d04fd2848ba20b2000dbf"
               }
             }
           }
@@ -228,72 +229,72 @@
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "48.84.202109242104-0",
+          "release": "48.84.202206132149-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-metal4k.s390x.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-metal4k.s390x.raw.gz.sig",
-                "sha256": "b73bdd631daa7a4f36f5af93ebdfae3b23e5f5cd351b4c69078e97cb09edd941",
-                "uncompressed-sha256": "838ded2c00bd62b4f4cc45c529edc4e90c693ed25435300923a587bfb3de7b2b"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-metal4k.s390x.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-metal4k.s390x.raw.gz.sig",
+                "sha256": "6f3306b9b8ebeccdcb2e59d80d21ad20bdfe2d9fc9a338ba2714ed48bde03d66",
+                "uncompressed-sha256": "228ba0b9fd1b0625d698d6ad7202ffb760e43b37d824d19a86b7447d3ecd94e6"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-live.s390x.iso",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-live.s390x.iso.sig",
-                "sha256": "168d17811b73a7da45ada38751a28db247381115021f8f2eb4e9d4083d29b719"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live.s390x.iso",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live.s390x.iso.sig",
+                "sha256": "4665d304f3757aeef8f15cde37935c1ee1473d384c23101c993d4c72e99adf94"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-live-kernel-s390x",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-live-kernel-s390x.sig",
-                "sha256": "81d8f6040cf3913ed01379e6af950d0c8168a4f6e0adeecaf63ae527c759ade9"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-kernel-s390x",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-kernel-s390x.sig",
+                "sha256": "de91cc8ffbd3b35c1e1f33deed6c8393ffe95b558d60b79bd34792e595397f7c"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-live-initramfs.s390x.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-live-initramfs.s390x.img.sig",
-                "sha256": "09d05a1d1592da1e3799bded203b00874f7024f85ee8dcf8933cb0dba3a5da94"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-initramfs.s390x.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-initramfs.s390x.img.sig",
+                "sha256": "630ce92d10f4636533cc2340a2e0c72442e0629dd7d097b314661065ba5bd580"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-live-rootfs.s390x.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-live-rootfs.s390x.img.sig",
-                "sha256": "42d7b8caaafc9f911bef265cfeeef3a9369ceb984bfe6ea001649adb641e1fc6"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-rootfs.s390x.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-rootfs.s390x.img.sig",
+                "sha256": "6d4b51ed83d7273a7110aeccd9f848769912dc9b99b7efe07859027ad9150d84"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-metal.s390x.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-metal.s390x.raw.gz.sig",
-                "sha256": "12194de81db10b9d1cc51cd639a8cdd2c83c3793bd1e80c37da06d388d1e6929",
-                "uncompressed-sha256": "f9d30d701ffaff5b241b55663edc84bad1158c42f4db60feb9bd0901b35f4aea"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-metal.s390x.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-metal.s390x.raw.gz.sig",
+                "sha256": "302d8d724b65a68d642fefb40109e410e635f4cd2414bf7325d4e3810ff9e8c6",
+                "uncompressed-sha256": "1dd9ab5dc127f9d0d22565b25b94d0e8603fb642d67f70fa6754d50ef587d6aa"
               }
             }
           }
         },
         "openstack": {
-          "release": "48.84.202109242104-0",
+          "release": "48.84.202206132149-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-openstack.s390x.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-openstack.s390x.qcow2.gz.sig",
-                "sha256": "8b617aa20707dcaa1841faa3a4ff197391f55ae7d9bd60c86294668904d8925d",
-                "uncompressed-sha256": "8b1182a4b7f00d29bb5d36ad3689412328c48b8c4b914d2c8f84883126151673"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-openstack.s390x.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-openstack.s390x.qcow2.gz.sig",
+                "sha256": "b327ed36c1d42277a0cb1f75da420dcbb5c768aa76ed3df6f488bc08c4879c8d",
+                "uncompressed-sha256": "92238a282bb9adeee4600880a2d7388ae46c99551929ce6e7756ece7b7ace5cc"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202109242104-0",
+          "release": "48.84.202206132149-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-qemu.s390x.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202109242104-0/s390x/rhcos-48.84.202109242104-0-qemu.s390x.qcow2.gz.sig",
-                "sha256": "6cb9ca9d8f099720b7874650692df88c5c5d54762d614b7dc456fdd7c5d16674",
-                "uncompressed-sha256": "b1a18112ab5455e8217edaef0304a9ec9d117931135618883cc7097d97eaab81"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-qemu.s390x.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-qemu.s390x.qcow2.gz.sig",
+                "sha256": "8c5b9d24682834c285f0c9145cbc5247d39c5455cf163e0a815f6e4c6f1825a9",
+                "uncompressed-sha256": "68169b0017a651adff9ba662f2b501dc51681efcde7ac65ca1952fe8ec79b5f1"
               }
             }
           }
@@ -304,135 +305,135 @@
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "48.84.202109241901-0",
+          "release": "48.84.202206140145-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-aws.x86_64.vmdk.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-aws.x86_64.vmdk.gz.sig",
-                "sha256": "c081a65325330379e91707475b8dadf82e0f2d5c1c9f7f056fcd978641bb5114",
-                "uncompressed-sha256": "152a82e870e7e4d30d8204280f61ccfee90d826377bb25c51b2eac04f2fd82db"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-aws.x86_64.vmdk.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-aws.x86_64.vmdk.gz.sig",
+                "sha256": "c43356afc304edc5d2656095b6c4dd3052a35b0fe11adbaa4640b4f56bbc2f4c",
+                "uncompressed-sha256": "5580e5ea6d744e4e535b6416beac2c771a7e668ab86e0fe4b8395cf6eb87a343"
               }
             }
           }
         },
         "azure": {
-          "release": "48.84.202109241901-0",
+          "release": "48.84.202206140145-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-azure.x86_64.vhd.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-azure.x86_64.vhd.gz.sig",
-                "sha256": "801498fe0ccb754b898bef30e4d226f796874e615d7719b00d64b8054d434481",
-                "uncompressed-sha256": "b433bf7793db745c22c7ca09415a4dc87526ae7727e646d7b157acb323c3ee4f"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-azure.x86_64.vhd.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-azure.x86_64.vhd.gz.sig",
+                "sha256": "c9e355bb545baf2f34482cfc0a556b90dc89a71cf6058ed1546199fbff8a9c60",
+                "uncompressed-sha256": "333b3560bb635ce5c0f01bfa3784c8cd6ac1fa29ad85c52fbe0a773bf02b28e0"
               }
             }
           }
         },
         "gcp": {
-          "release": "48.84.202109241901-0",
+          "release": "48.84.202206140145-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-gcp.x86_64.tar.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-gcp.x86_64.tar.gz.sig",
-                "sha256": "5231bdd554841c01fbd1092ea96c39b06dda3187549c0672a5f5c5e4d7eecdad"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-gcp.x86_64.tar.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-gcp.x86_64.tar.gz.sig",
+                "sha256": "7b732b6b3622f5ba00a4b2f3bfd32d6987a814f044daaf3831b0db0b168b81a6"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "48.84.202109241901-0",
+          "release": "48.84.202206140145-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-ibmcloud.x86_64.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-ibmcloud.x86_64.qcow2.gz.sig",
-                "sha256": "440ce3c4367a10fa66436638cef6ed938848050fd7f0de2d78d1294a4f56995d",
-                "uncompressed-sha256": "d81934aa386286ad35591fd46dc9cd809dc5e88623b563f220abae52665de472"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-ibmcloud.x86_64.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-ibmcloud.x86_64.qcow2.gz.sig",
+                "sha256": "5113a7c63abe8a89cbce07d70e93eaeb685df1f4f96b7e467736a824889373d3",
+                "uncompressed-sha256": "87e637ebab6eab1ef9c4ae1d76613b5a0701a31c78793ac325596c77bdbede21"
               }
             }
           }
         },
         "metal": {
-          "release": "48.84.202109241901-0",
+          "release": "48.84.202206140145-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-metal4k.x86_64.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-metal4k.x86_64.raw.gz.sig",
-                "sha256": "9cf43a94eded275b2fb54bbb164ce63b18d7e696ca6c15f8cea4bb09941a0e57",
-                "uncompressed-sha256": "475d1123a2da31882b445c51ec5d5896c84de417feca5fe0ac1f93d8ea4e2c84"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-metal4k.x86_64.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-metal4k.x86_64.raw.gz.sig",
+                "sha256": "8fbf4a1b82a763e3dca32de1c5c9a2bd40382d80c576e9eac6a12c03f92c0d41",
+                "uncompressed-sha256": "3842893bf80c00a2f11b6d591284b60b6bf60bead4c3e67fb148d34843d5c9fc"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live.x86_64.iso",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live.x86_64.iso.sig",
-                "sha256": "dc0c7af647137c9b16210c977896dc756b72b5e568774daf199964ca020935ae"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live.x86_64.iso",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live.x86_64.iso.sig",
+                "sha256": "1483da2bb1a64f6f90577036935fd5b47ad6d20758fd241981943c46cf516ff0"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live-kernel-x86_64",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live-kernel-x86_64.sig",
-                "sha256": "d13269e6c60119397210418781b7057673c4018692d28a868e248a0b550ea247"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-kernel-x86_64",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-kernel-x86_64.sig",
+                "sha256": "2f73cda50fa9cfcd14b9624cce3fa663c91341a8eafae22bb6bbc6357f83e679"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live-initramfs.x86_64.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live-initramfs.x86_64.img.sig",
-                "sha256": "5b6f1b728a5e656ef128a54f9534f7d3d63953ef46e726a808aacf1ce9ad2742"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-initramfs.x86_64.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-initramfs.x86_64.img.sig",
+                "sha256": "1641cb2005abf362283ddc328c1ad07c8640900d296e793913b1881faecc8926"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live-rootfs.x86_64.img",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-live-rootfs.x86_64.img.sig",
-                "sha256": "bd005071f295762a613ff42c26ce453be7c19d35594b68c94fab6797b4d834d4"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-rootfs.x86_64.img",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-rootfs.x86_64.img.sig",
+                "sha256": "f0a729b85ace85e158c02a4ea69e53b5663210ffb2cb423f9899239481d9e479"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-metal.x86_64.raw.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-metal.x86_64.raw.gz.sig",
-                "sha256": "6e67556bebee87b6d85d776a8b728ef727fb2e55c77a183f7979e8b89211b4db",
-                "uncompressed-sha256": "1b104a26b338f6aa4ba16a0bb3887e7bdc05c8735902785578208fb793fc504d"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-metal.x86_64.raw.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-metal.x86_64.raw.gz.sig",
+                "sha256": "c2fb42fe571bc231993889e0790c21b4643d78efaa99eab9035dab506fee2df5",
+                "uncompressed-sha256": "048eef6702941fd566ec67d51426c1fecb469ecdc94d5eae55435593b53f69a6"
               }
             }
           }
         },
         "openstack": {
-          "release": "48.84.202109241901-0",
+          "release": "48.84.202206140145-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-openstack.x86_64.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-openstack.x86_64.qcow2.gz.sig",
-                "sha256": "99da4ed945b391d452e55a3a7809c799e4c74f69acbee1ecaec78f368c4e369e",
-                "uncompressed-sha256": "e0a1d8a99c5869150a56b8de475ea7952ca2fa3aacad7ca48533d1176df503ab"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-openstack.x86_64.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-openstack.x86_64.qcow2.gz.sig",
+                "sha256": "137c3b236d2bcaa9681c968ad333b112762539c6df196a704f1cd8ba78d49f11",
+                "uncompressed-sha256": "0a147f49f35030fd8153266bb186357043fbc044c77dbaa5b46922984db0d750"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202109241901-0",
+          "release": "48.84.202206140145-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-qemu.x86_64.qcow2.gz",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-qemu.x86_64.qcow2.gz.sig",
-                "sha256": "0105a1de918e94e9c456f32dac63e3cf296efa0b59f543fc23c1ef00ebb15a5f",
-                "uncompressed-sha256": "50377ba9c5cb92c649c7d9e31b508185241a3c204b34dd991fcb3cf0adc53983"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-qemu.x86_64.qcow2.gz",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-qemu.x86_64.qcow2.gz.sig",
+                "sha256": "0120dfdcbfa70eeb804c1cd2368f140c577b12d85391d3553d189fb9b42938a1",
+                "uncompressed-sha256": "158e32571ca4934b05da0fe425eab453e6ceda3245cfc1a6cba45cbb53bf648a"
               }
             }
           }
         },
         "vmware": {
-          "release": "48.84.202109241901-0",
+          "release": "48.84.202206140145-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-vmware.x86_64.ova",
-                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/rhcos-48.84.202109241901-0-vmware.x86_64.ova.sig",
-                "sha256": "28eabddd539b3e0bd3d39c08a63f96cfd674817e25e4a84b67f9ca29baafd88a"
+                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-vmware.x86_64.ova",
+                "signature": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-vmware.x86_64.ova.sig",
+                "sha256": "7fa00b31d7f28c1318c23fe466a66cced0cbacd32b8833d8af05e874d1195332"
               }
             }
           }
@@ -442,100 +443,105 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-038772fdd54b78a4f"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0c879d0aa64259ad0"
             },
             "ap-east-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-03a6473cd438b2fea"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0e6a2dea7bfd862a5"
             },
             "ap-northeast-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-05977c4081111f3bb"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0b9b3588ea302934d"
             },
             "ap-northeast-2": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-0a0fcda229d58dec1"
+              "release": "48.84.202206140145-0",
+              "image": "ami-012b7f860e994e868"
             },
             "ap-northeast-3": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-0467ba9dc70f85538"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0e42b5afc5baeea34"
             },
             "ap-south-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-07c047be0d3ec46ca"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0cec0dfd6e955718d"
             },
             "ap-southeast-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-0b574d30ee267107c"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0980a2024cd30b5bf"
             },
             "ap-southeast-2": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-0c1b7b6fd42c043c2"
+              "release": "48.84.202206140145-0",
+              "image": "ami-032069c0b51483ad1"
+            },
+            "ap-southeast-3": {
+              "release": "48.84.202206140145-0",
+              "image": "ami-0f19ad8d973aea0ec"
             },
             "ca-central-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-05bef6aaeb6a8cc3c"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0f131d428f7d39da7"
             },
             "eu-central-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-0d56b8ae868345407"
+              "release": "48.84.202206140145-0",
+              "image": "ami-089e4575a0dcafb0b"
             },
             "eu-north-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-08dd7be7e8ebe13b6"
+              "release": "48.84.202206140145-0",
+              "image": "ami-04a0fcdd1fee18228"
             },
             "eu-south-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-06f4c9dfde4e75eb1"
+              "release": "48.84.202206140145-0",
+              "image": "ami-05b65f41216a7da4b"
             },
             "eu-west-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-0aef183a3bbfeeaf3"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0ff5d97cd0b6cd949"
             },
             "eu-west-2": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-07b3715c986152140"
+              "release": "48.84.202206140145-0",
+              "image": "ami-06a805d9f546f670a"
             },
             "eu-west-3": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-0feee7f927014e9ad"
+              "release": "48.84.202206140145-0",
+              "image": "ami-00cca0795cfeead80"
             },
             "me-south-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-01db7ebc5addfc2f6"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0e8ba9d5ba5e65106"
             },
             "sa-east-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-097223d194bcb71f0"
+              "release": "48.84.202206140145-0",
+              "image": "ami-041fbbc302a372a36"
             },
             "us-east-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-06e6531aef9359b1e"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0a0091d01a8bd2947"
             },
             "us-east-2": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-09145c219cb4df3e1"
+              "release": "48.84.202206140145-0",
+              "image": "ami-0147e13e9b1975251"
             },
             "us-west-1": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-0afa3199a442f45cb"
+              "release": "48.84.202206140145-0",
+              "image": "ami-05662d869042ffd84"
             },
             "us-west-2": {
-              "release": "48.84.202109241901-0",
-              "image": "ami-02a3699138ec7ecf4"
+              "release": "48.84.202206140145-0",
+              "image": "ami-074ed14912081db41"
             }
           }
         },
         "gcp": {
+          "release": "48.84.202206140145-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-48-84-202109241901-0-gcp-x86-64"
+          "name": "rhcos-48-84-202206140145-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "48.84.202109241901-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202109241901-0-azure.x86_64.vhd"
+          "release": "48.84.202206140145-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202206140145-0-azure.x86_64.vhd"
         }
       }
     }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,166 +1,169 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-038772fdd54b78a4f"
+            "hvm": "ami-0c879d0aa64259ad0"
         },
         "ap-east-1": {
-            "hvm": "ami-03a6473cd438b2fea"
+            "hvm": "ami-0e6a2dea7bfd862a5"
         },
         "ap-northeast-1": {
-            "hvm": "ami-05977c4081111f3bb"
+            "hvm": "ami-0b9b3588ea302934d"
         },
         "ap-northeast-2": {
-            "hvm": "ami-0a0fcda229d58dec1"
+            "hvm": "ami-012b7f860e994e868"
         },
         "ap-northeast-3": {
-            "hvm": "ami-0467ba9dc70f85538"
+            "hvm": "ami-0e42b5afc5baeea34"
         },
         "ap-south-1": {
-            "hvm": "ami-07c047be0d3ec46ca"
+            "hvm": "ami-0cec0dfd6e955718d"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0b574d30ee267107c"
+            "hvm": "ami-0980a2024cd30b5bf"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0c1b7b6fd42c043c2"
+            "hvm": "ami-032069c0b51483ad1"
+        },
+        "ap-southeast-3": {
+            "hvm": "ami-0f19ad8d973aea0ec"
         },
         "ca-central-1": {
-            "hvm": "ami-05bef6aaeb6a8cc3c"
+            "hvm": "ami-0f131d428f7d39da7"
         },
         "eu-central-1": {
-            "hvm": "ami-0d56b8ae868345407"
+            "hvm": "ami-089e4575a0dcafb0b"
         },
         "eu-north-1": {
-            "hvm": "ami-08dd7be7e8ebe13b6"
+            "hvm": "ami-04a0fcdd1fee18228"
         },
         "eu-south-1": {
-            "hvm": "ami-06f4c9dfde4e75eb1"
+            "hvm": "ami-05b65f41216a7da4b"
         },
         "eu-west-1": {
-            "hvm": "ami-0aef183a3bbfeeaf3"
+            "hvm": "ami-0ff5d97cd0b6cd949"
         },
         "eu-west-2": {
-            "hvm": "ami-07b3715c986152140"
+            "hvm": "ami-06a805d9f546f670a"
         },
         "eu-west-3": {
-            "hvm": "ami-0feee7f927014e9ad"
+            "hvm": "ami-00cca0795cfeead80"
         },
         "me-south-1": {
-            "hvm": "ami-01db7ebc5addfc2f6"
+            "hvm": "ami-0e8ba9d5ba5e65106"
         },
         "sa-east-1": {
-            "hvm": "ami-097223d194bcb71f0"
+            "hvm": "ami-041fbbc302a372a36"
         },
         "us-east-1": {
-            "hvm": "ami-06e6531aef9359b1e"
+            "hvm": "ami-0a0091d01a8bd2947"
         },
         "us-east-2": {
-            "hvm": "ami-09145c219cb4df3e1"
+            "hvm": "ami-0147e13e9b1975251"
         },
         "us-west-1": {
-            "hvm": "ami-0afa3199a442f45cb"
+            "hvm": "ami-05662d869042ffd84"
         },
         "us-west-2": {
-            "hvm": "ami-02a3699138ec7ecf4"
+            "hvm": "ami-074ed14912081db41"
         }
     },
     "azure": {
-        "image": "rhcos-48.84.202109241901-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202109241901-0-azure.x86_64.vhd"
+        "image": "rhcos-48.84.202206140145-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202206140145-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202109241901-0/x86_64/",
-    "buildid": "48.84.202109241901-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/",
+    "buildid": "48.84.202206140145-0",
     "gcp": {
-        "image": "rhcos-48-84-202109241901-0-gcp-x86-64",
+        "image": "rhcos-48-84-202206140145-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202109241901-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202206140145-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.84.202109241901-0-aws.x86_64.vmdk.gz",
-            "sha256": "c081a65325330379e91707475b8dadf82e0f2d5c1c9f7f056fcd978641bb5114",
-            "size": 1031334820,
-            "uncompressed-sha256": "152a82e870e7e4d30d8204280f61ccfee90d826377bb25c51b2eac04f2fd82db",
-            "uncompressed-size": 1052379136
+            "path": "rhcos-48.84.202206140145-0-aws.x86_64.vmdk.gz",
+            "sha256": "c43356afc304edc5d2656095b6c4dd3052a35b0fe11adbaa4640b4f56bbc2f4c",
+            "size": 1030828645,
+            "uncompressed-sha256": "5580e5ea6d744e4e535b6416beac2c771a7e668ab86e0fe4b8395cf6eb87a343",
+            "uncompressed-size": 1051906048
         },
         "azure": {
-            "path": "rhcos-48.84.202109241901-0-azure.x86_64.vhd.gz",
-            "sha256": "801498fe0ccb754b898bef30e4d226f796874e615d7719b00d64b8054d434481",
-            "size": 1031392167,
-            "uncompressed-sha256": "b433bf7793db745c22c7ca09415a4dc87526ae7727e646d7b157acb323c3ee4f",
+            "path": "rhcos-48.84.202206140145-0-azure.x86_64.vhd.gz",
+            "sha256": "c9e355bb545baf2f34482cfc0a556b90dc89a71cf6058ed1546199fbff8a9c60",
+            "size": 1030940095,
+            "uncompressed-sha256": "333b3560bb635ce5c0f01bfa3784c8cd6ac1fa29ad85c52fbe0a773bf02b28e0",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.84.202109241901-0-gcp.x86_64.tar.gz",
-            "sha256": "5231bdd554841c01fbd1092ea96c39b06dda3187549c0672a5f5c5e4d7eecdad",
-            "size": 1016813602
+            "path": "rhcos-48.84.202206140145-0-gcp.x86_64.tar.gz",
+            "sha256": "7b732b6b3622f5ba00a4b2f3bfd32d6987a814f044daaf3831b0db0b168b81a6",
+            "size": 1016382695
         },
         "ibmcloud": {
-            "path": "rhcos-48.84.202109241901-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "440ce3c4367a10fa66436638cef6ed938848050fd7f0de2d78d1294a4f56995d",
-            "size": 1017169285,
-            "uncompressed-sha256": "d81934aa386286ad35591fd46dc9cd809dc5e88623b563f220abae52665de472",
-            "uncompressed-size": 2535325696
+            "path": "rhcos-48.84.202206140145-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "5113a7c63abe8a89cbce07d70e93eaeb685df1f4f96b7e467736a824889373d3",
+            "size": 1016732179,
+            "uncompressed-sha256": "87e637ebab6eab1ef9c4ae1d76613b5a0701a31c78793ac325596c77bdbede21",
+            "uncompressed-size": 2534473728
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202109241901-0-live-initramfs.x86_64.img",
-            "sha256": "5b6f1b728a5e656ef128a54f9534f7d3d63953ef46e726a808aacf1ce9ad2742"
+            "path": "rhcos-48.84.202206140145-0-live-initramfs.x86_64.img",
+            "sha256": "1641cb2005abf362283ddc328c1ad07c8640900d296e793913b1881faecc8926"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202109241901-0-live.x86_64.iso",
-            "sha256": "dc0c7af647137c9b16210c977896dc756b72b5e568774daf199964ca020935ae"
+            "path": "rhcos-48.84.202206140145-0-live.x86_64.iso",
+            "sha256": "1483da2bb1a64f6f90577036935fd5b47ad6d20758fd241981943c46cf516ff0"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202109241901-0-live-kernel-x86_64",
-            "sha256": "d13269e6c60119397210418781b7057673c4018692d28a868e248a0b550ea247"
+            "path": "rhcos-48.84.202206140145-0-live-kernel-x86_64",
+            "sha256": "2f73cda50fa9cfcd14b9624cce3fa663c91341a8eafae22bb6bbc6357f83e679"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202109241901-0-live-rootfs.x86_64.img",
-            "sha256": "bd005071f295762a613ff42c26ce453be7c19d35594b68c94fab6797b4d834d4"
+            "path": "rhcos-48.84.202206140145-0-live-rootfs.x86_64.img",
+            "sha256": "f0a729b85ace85e158c02a4ea69e53b5663210ffb2cb423f9899239481d9e479"
         },
         "metal": {
-            "path": "rhcos-48.84.202109241901-0-metal.x86_64.raw.gz",
-            "sha256": "6e67556bebee87b6d85d776a8b728ef727fb2e55c77a183f7979e8b89211b4db",
-            "size": 1018907248,
-            "uncompressed-sha256": "1b104a26b338f6aa4ba16a0bb3887e7bdc05c8735902785578208fb793fc504d",
-            "uncompressed-size": 3960471552
+            "path": "rhcos-48.84.202206140145-0-metal.x86_64.raw.gz",
+            "sha256": "c2fb42fe571bc231993889e0790c21b4643d78efaa99eab9035dab506fee2df5",
+            "size": 1018203635,
+            "uncompressed-sha256": "048eef6702941fd566ec67d51426c1fecb469ecdc94d5eae55435593b53f69a6",
+            "uncompressed-size": 3957325824
         },
         "metal4k": {
-            "path": "rhcos-48.84.202109241901-0-metal4k.x86_64.raw.gz",
-            "sha256": "9cf43a94eded275b2fb54bbb164ce63b18d7e696ca6c15f8cea4bb09941a0e57",
-            "size": 1016543064,
-            "uncompressed-sha256": "475d1123a2da31882b445c51ec5d5896c84de417feca5fe0ac1f93d8ea4e2c84",
-            "uncompressed-size": 3960471552
+            "path": "rhcos-48.84.202206140145-0-metal4k.x86_64.raw.gz",
+            "sha256": "8fbf4a1b82a763e3dca32de1c5c9a2bd40382d80c576e9eac6a12c03f92c0d41",
+            "size": 1015886091,
+            "uncompressed-sha256": "3842893bf80c00a2f11b6d591284b60b6bf60bead4c3e67fb148d34843d5c9fc",
+            "uncompressed-size": 3957325824
         },
         "openstack": {
-            "path": "rhcos-48.84.202109241901-0-openstack.x86_64.qcow2.gz",
-            "sha256": "99da4ed945b391d452e55a3a7809c799e4c74f69acbee1ecaec78f368c4e369e",
-            "size": 1017176202,
-            "uncompressed-sha256": "e0a1d8a99c5869150a56b8de475ea7952ca2fa3aacad7ca48533d1176df503ab",
-            "uncompressed-size": 2535325696
+            "path": "rhcos-48.84.202206140145-0-openstack.x86_64.qcow2.gz",
+            "sha256": "137c3b236d2bcaa9681c968ad333b112762539c6df196a704f1cd8ba78d49f11",
+            "size": 1016727289,
+            "uncompressed-sha256": "0a147f49f35030fd8153266bb186357043fbc044c77dbaa5b46922984db0d750",
+            "uncompressed-size": 2534473728
         },
         "ostree": {
-            "path": "rhcos-48.84.202109241901-0-ostree.x86_64.tar",
-            "sha256": "4e1c0dc1bcebcedf861256474db12822830e004e823e8a7968c6bed59002e924",
-            "size": 941015040
+            "path": "rhcos-48.84.202206140145-0-ostree.x86_64.tar",
+            "sha256": "3438b2c53b1078b4e288ad2869fb7ce839f466ae564f0c807ba22ad74d246048",
+            "size": 940503040
         },
         "qemu": {
-            "path": "rhcos-48.84.202109241901-0-qemu.x86_64.qcow2.gz",
-            "sha256": "0105a1de918e94e9c456f32dac63e3cf296efa0b59f543fc23c1ef00ebb15a5f",
-            "size": 1018340613,
-            "uncompressed-sha256": "50377ba9c5cb92c649c7d9e31b508185241a3c204b34dd991fcb3cf0adc53983",
-            "uncompressed-size": 2572288000
+            "path": "rhcos-48.84.202206140145-0-qemu.x86_64.qcow2.gz",
+            "sha256": "0120dfdcbfa70eeb804c1cd2368f140c577b12d85391d3553d189fb9b42938a1",
+            "size": 1017896853,
+            "uncompressed-sha256": "158e32571ca4934b05da0fe425eab453e6ceda3245cfc1a6cba45cbb53bf648a",
+            "uncompressed-size": 2571108352
         },
         "vmware": {
-            "path": "rhcos-48.84.202109241901-0-vmware.x86_64.ova",
-            "sha256": "28eabddd539b3e0bd3d39c08a63f96cfd674817e25e4a84b67f9ca29baafd88a",
-            "size": 1052395520
+            "path": "rhcos-48.84.202206140145-0-vmware.x86_64.ova",
+            "sha256": "7fa00b31d7f28c1318c23fe466a66cced0cbacd32b8833d8af05e874d1195332",
+            "size": 1051914240
         }
     },
     "oscontainer": {
-        "digest": "sha256:57f6acfd48e833ef07a505b25a296849b74631a2b058814d618a347c9304308d",
+        "digest": "sha256:648258313a495364dcd7663fa36e2d371fe4c78349d14b883fb5f4a301c824a5",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "13c18da5e6fee09fade484c3903209730cbb73e9ebcab806b9e9000cf97fd719",
-    "ostree-version": "48.84.202109241901-0"
+    "ostree-commit": "8fd19b78118cf1ba87bbb38adad80a5f8e74630c969d8c7d908e412ce4fb0e47",
+    "ostree-version": "48.84.202206140145-0"
 }


### PR DESCRIPTION
This brings in fixes for the following issues:
BZ 1983773 - coreos-installer fails to download Ignition (DNS error, failed to lookup address)
BZ 1984086 - Installation with multipath parameters in parmfile fails (DNS resolution missing)
BZ 2078000 - Publish RHEL CoreOS AMIs in AWS ap-southeast-3 region

These changes were generated with:
```
    $ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8/48.84.202206091823-0/x86_64/meta.json amd64
    $ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206072116-0/ppc64le/meta.json ppc64le
    $ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206072009-0/s390x/meta.json s390x
    $ plume cosa2stream --target=data/data/rhcos-stream.json --distro=rhcos x86_64=48.84.202206091823-0 s390x=48.84.202206072009-0 ppc64le=48.84.202206072116-0
```