### PR TITLE
Bug 2096352: Collect whole journal and netstat data

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -39,11 +39,14 @@ do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/bootstrap/journals/${service}.log"
 done
 
+journalctl --no-pager | gzip > "${ARTIFACTS}/bootstrap/journals/journal.log.gz"
+
 echo "Gathering bootstrap networking ..."
 mkdir -p "${ARTIFACTS}/bootstrap/network"
 ip addr >& "${ARTIFACTS}/bootstrap/network/ip-addr.txt"
 ip route >& "${ARTIFACTS}/bootstrap/network/ip-route.txt"
 hostname >& "${ARTIFACTS}/bootstrap/network/hostname.txt"
+netstat -anp >& "${ARTIFACTS}/bootstrap/network/netstat.txt"
 cp -r /etc/resolv.conf "${ARTIFACTS}/bootstrap/network/"
 
 echo "Gathering bootstrap containers ..."

--- a/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-masters-gather.sh
@@ -30,11 +30,14 @@ do
     journalctl --boot --no-pager --output=short --unit="${service}" > "${ARTIFACTS}/journals/${service}.log"
 done
 
+journalctl --no-pager | gzip > "${ARTIFACTS}/journals/journal.log.gz"
+
 echo "Gathering master networking ..."
 mkdir -p "${ARTIFACTS}/network"
 ip addr >& "${ARTIFACTS}/network/ip-addr.txt"
 ip route >& "${ARTIFACTS}/network/ip-route.txt"
 hostname >& "${ARTIFACTS}/network/hostname.txt"
+netstat -anp >& "${ARTIFACTS}/network/netstat.txt"
 cp -r /etc/resolv.conf "${ARTIFACTS}/network/"
 
 echo "Gathering master containers ..."


### PR DESCRIPTION
On multiple occasions, it has been helpful to collect the systemd journal in it's entirety for deep debugging.  We needed this back in April, and again this week for https://bugzilla.redhat.com/show_bug.cgi?id=2096226.

The netstat data turned out to not be as helpful, but I figured it can't hurt.