### PR TITLE
AGENT-218: Agent lock release version

### DIFF
--- a/pkg/asset/agent/manifests/clusterimageset_test.go
+++ b/pkg/asset/agent/manifests/clusterimageset_test.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -8,9 +9,11 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/mock"
+	"github.com/openshift/installer/pkg/asset/releaseimage"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func TestClusterImageSet_Generate(t *testing.T) {
@@ -25,6 +28,23 @@ func TestClusterImageSet_Generate(t *testing.T) {
 			name:          "missing-config",
 			expectedError: "missing configuration or manifest file",
 		},
+		// {
+		// 	name: "default",
+		// 	dependencies: []asset.Asset{
+		// 		&releaseimage.Image{
+		// 			PullSpec: "registry.ci.openshift.org/ocp/release:4.11.0-0.nightly-2022-06-04-014713",
+		// 		},
+		// 	},
+		// 	expectedConfig: &hivev1.ClusterImageSet{
+		// 		ObjectMeta: v1.ObjectMeta{
+		// 			Name:      "openshift-was not built correctly",
+		// 			Namespace: "",
+		// 		},
+		// 		Spec: hivev1.ClusterImageSetSpec{
+		// 			ReleaseImage: "registry.ci.openshift.org/ocp/release:4.11.0-0.nightly-2022-06-04-014713",
+		// 		},
+		// 	},
+		// },
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -39,7 +59,18 @@ func TestClusterImageSet_Generate(t *testing.T) {
 				assert.Equal(t, tc.expectedError, err.Error())
 			} else {
 				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedConfig, asset.Config)
+				assert.NotEmpty(t, asset.Files())
+
+				configFile := asset.Files()[0]
+				assert.Equal(t, "cluster-manifests/cluster-image-set.yaml", configFile.Filename)
+
+				var actualConfig hivev1.ClusterImageSet
+				err = yaml.Unmarshal(configFile.Data, &actualConfig)
+				assert.NoError(t, err)
+				assert.Equal(t, *tc.expectedConfig, actualConfig)
 			}
+
 		})
 	}
 
@@ -47,12 +78,15 @@ func TestClusterImageSet_Generate(t *testing.T) {
 
 func TestClusterImageSet_LoadedFromDisk(t *testing.T) {
 
+	currentRelease, err := releaseimage.Default()
+	assert.NoError(t, err)
+
 	cases := []struct {
 		name           string
 		data           string
 		fetchError     error
 		expectedFound  bool
-		expectedError  bool
+		expectedError  string
 		expectedConfig *hivev1.ClusterImageSet
 	}{
 		{
@@ -61,28 +95,35 @@ func TestClusterImageSet_LoadedFromDisk(t *testing.T) {
 metadata:
   name: openshift-v4.10.0
 spec:
-  releaseImage: quay.io:443/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64`,
+  releaseImage: ` + currentRelease,
 			expectedFound: true,
 			expectedConfig: &hivev1.ClusterImageSet{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "openshift-v4.10.0",
 				},
 				Spec: hivev1.ClusterImageSetSpec{
-					ReleaseImage: "quay.io:443/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64",
+					ReleaseImage: currentRelease,
 				},
 			},
 		},
 		{
-			name:          "not-yaml",
-			data:          `This is not a yaml file`,
-			expectedError: true,
+			name: "different-version-not-supported",
+			data: `
+metadata:
+  name: openshift-v4.10.0
+spec:
+  releaseImage: 99.999`,
+			expectedError: fmt.Sprintf("invalid ClusterImageSet configuration: Spec.ReleaseImage: Forbidden: value must be equal to %s", currentRelease),
 		},
 		{
-			name:           "empty",
-			data:           "",
-			expectedFound:  true,
-			expectedConfig: &hivev1.ClusterImageSet{},
-			expectedError:  false,
+			name:          "not-yaml",
+			data:          `This is not a yaml file`,
+			expectedError: "failed to unmarshal cluster-manifests/cluster-image-set.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1.ClusterImageSet",
+		},
+		{
+			name:          "empty",
+			data:          "",
+			expectedError: fmt.Sprintf("invalid ClusterImageSet configuration: Spec.ReleaseImage: Forbidden: value must be equal to %s", currentRelease),
 		},
 		{
 			name:       "file-not-found",
@@ -91,7 +132,7 @@ spec:
 		{
 			name:          "error-fetching-file",
 			fetchError:    errors.New("fetch failed"),
-			expectedError: true,
+			expectedError: "failed to load cluster-manifests/cluster-image-set.yaml file: fetch failed",
 		},
 		{
 			name: "unknown-field",
@@ -101,7 +142,7 @@ metadata:
   namespace: cluster0
 spec:
   wrongField: wrongValue`,
-			expectedError: true,
+			expectedError: "failed to unmarshal cluster-manifests/cluster-image-set.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"wrongField\"",
 		},
 	}
 	for _, tc := range cases {
@@ -122,10 +163,10 @@ spec:
 			asset := &ClusterImageSet{}
 			found, err := asset.Load(fileFetcher)
 			assert.Equal(t, tc.expectedFound, found, "unexpected found value returned from Load")
-			if tc.expectedError {
-				assert.Error(t, err, "expected error from Load")
+			if tc.expectedError != "" {
+				assert.Equal(t, tc.expectedError, err.Error())
 			} else {
-				assert.NoError(t, err, "unexpected error from Load")
+				assert.NoError(t, err)
 			}
 			if tc.expectedFound {
 				assert.Equal(t, tc.expectedConfig, asset.Config, "unexpected Config in ClusterImageSet")


### PR DESCRIPTION
This patch adds a new validation rule for the ClusterImageSet asset to ensure that the configured version is matching the current one supported by the installer