### PR TITLE
Bug 2095917: Nutanix set osDisk with diskSizeGB rather than diskSizeMiB

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -459,9 +459,9 @@ spec:
                         osDisk:
                           description: OSDisk defines the storage for instance.
                           properties:
-                            diskSizeMiB:
-                              description: DiskSizeMiB defines the size of disk in
-                                MiB.
+                            diskSizeGiB:
+                              description: DiskSizeGiB defines the size of disk in
+                                GiB.
                               format: int64
                               type: integer
                           type: object
@@ -1089,8 +1089,8 @@ spec:
                       osDisk:
                         description: OSDisk defines the storage for instance.
                         properties:
-                          diskSizeMiB:
-                            description: DiskSizeMiB defines the size of disk in MiB.
+                          diskSizeGiB:
+                            description: DiskSizeGiB defines the size of disk in GiB.
                             format: int64
                             type: integer
                         type: object
@@ -2347,8 +2347,8 @@ spec:
                       osDisk:
                         description: OSDisk defines the storage for instance.
                         properties:
-                          diskSizeMiB:
-                            description: DiskSizeMiB defines the size of disk in MiB.
+                          diskSizeGiB:
+                            description: DiskSizeGiB defines the size of disk in GiB.
                             format: int64
                             type: integer
                         type: object

--- a/pkg/asset/machines/nutanix/machines.go
+++ b/pkg/asset/machines/nutanix/machines.go
@@ -93,7 +93,7 @@ func provider(clusterID string, platform *nutanix.Platform, mpool *nutanix.Machi
 			Type: machinev1.NutanixIdentifierUUID,
 			UUID: &platform.PrismElements[0].UUID,
 		},
-		SystemDiskSize: resource.MustParse(fmt.Sprintf("%dMi", mpool.OSDisk.DiskSizeMiB)),
+		SystemDiskSize: resource.MustParse(fmt.Sprintf("%dGi", mpool.OSDisk.DiskSizeGiB)),
 	}, nil
 }
 

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -177,7 +177,7 @@ func defaultNutanixMachinePoolPlatform() nutanixtypes.MachinePool {
 		NumCoresPerSocket: 1,
 		MemoryMiB:         16384,
 		OSDisk: nutanixtypes.OSDisk{
-			DiskSizeMiB: decimalRootVolumeSize * 1024,
+			DiskSizeGiB: decimalRootVolumeSize,
 		},
 	}
 }

--- a/pkg/types/nutanix/machinepool.go
+++ b/pkg/types/nutanix/machinepool.go
@@ -30,10 +30,10 @@ type MachinePool struct {
 
 // OSDisk defines the disk for a virtual machine.
 type OSDisk struct {
-	// DiskSizeMiB defines the size of disk in MiB.
+	// DiskSizeGiB defines the size of disk in GiB.
 	//
 	// +optional
-	DiskSizeMiB int64 `json:"diskSizeMiB,omitempty"`
+	DiskSizeGiB int64 `json:"diskSizeGiB,omitempty"`
 }
 
 // Set sets the values from `required` to `p`.
@@ -54,7 +54,7 @@ func (p *MachinePool) Set(required *MachinePool) {
 		p.MemoryMiB = required.MemoryMiB
 	}
 
-	if required.OSDisk.DiskSizeMiB != 0 {
-		p.OSDisk.DiskSizeMiB = required.OSDisk.DiskSizeMiB
+	if required.OSDisk.DiskSizeGiB != 0 {
+		p.OSDisk.DiskSizeGiB = required.OSDisk.DiskSizeGiB
 	}
 }

--- a/pkg/types/nutanix/validation/machinepool.go
+++ b/pkg/types/nutanix/validation/machinepool.go
@@ -9,8 +9,8 @@ import (
 // ValidateMachinePool checks that the specified machine pool is valid.
 func ValidateMachinePool(p *nutanix.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if p.DiskSizeMiB < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeMiB"), p.DiskSizeMiB, "storage disk size must be positive"))
+	if p.DiskSizeGiB < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("diskSizeGiB"), p.DiskSizeGiB, "storage disk size must be positive"))
 	}
 	if p.MemoryMiB < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("memoryMiB"), p.MemoryMiB, "memory size must be positive"))

--- a/pkg/types/nutanix/validation/machinepool_test.go
+++ b/pkg/types/nutanix/validation/machinepool_test.go
@@ -23,10 +23,10 @@ func TestValidateMachinePool(t *testing.T) {
 			name: "negative disk size",
 			pool: &nutanix.MachinePool{
 				OSDisk: nutanix.OSDisk{
-					DiskSizeMiB: -1,
+					DiskSizeGiB: -1,
 				},
 			},
-			expectedErrMsg: `^test-path\.diskSizeMiB: Invalid value: -1: storage disk size must be positive$`,
+			expectedErrMsg: `^test-path\.diskSizeGiB: Invalid value: -1: storage disk size must be positive$`,
 		}, {
 			name: "negative CPUs",
 			pool: &nutanix.MachinePool{


### PR DESCRIPTION
Use GiB instead of MiB for the osDisk size format to make it more readable and convenient for users.