### PR TITLE
install yq in upi installer image

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -44,6 +44,7 @@ RUN python -m pip install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python
 
 RUN python3 -m pip install yq
+RUN curl -L https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64 -o /bin/yq-3.3.0 && chmod +x /bin/yq-3.3.0
 
 ENV TERRAFORM_VERSION=1.0.11
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \

--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -38,6 +38,8 @@ RUN yum update -y && \
     rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 
+RUN curl -L https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64 -o /bin/yq-3.3.0 && chmod +x /bin/yq-3.3.0
+
 # Not packaged for Python 2, but required by gcloud.  See https://cloud.google.com/sdk/crypto
 RUN pip-2 install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python


### PR DESCRIPTION
In https://github.com/openshift/release, there are many places downloading https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64, move it to upi installer image, will save bandwidth and reduce network race condition. 