### PR TITLE
Download `yq` in upi installer containers

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -38,12 +38,17 @@ RUN yum update -y && \
     rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 
+ARG YQ_URI=https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
+ARG YQ_HASH=e70e482e7ddb9cf83b52f5e83b694a19e3aaf36acf6b82512cbe66e41d569201
+RUN echo "${YQ_HASH} -" > /tmp/sum.txt && \
+  curl -L --fail "${YQ_URI}" | tee /bin/yq | sha256sum -c /tmp/sum.txt >/dev/null && \
+  chmod +x /bin/yq && \
+  rm /tmp/sum.txt
+
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
 RUN python get-pip.py 'pip<21.0'
 RUN python -m pip install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python
-
-RUN python3 -m pip install yq
 
 ENV TERRAFORM_VERSION=1.0.11
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \

--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -41,14 +41,16 @@ RUN yum update -y && \
 ARG YQ_URI=https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
 ARG YQ_HASH=e70e482e7ddb9cf83b52f5e83b694a19e3aaf36acf6b82512cbe66e41d569201
 RUN echo "${YQ_HASH} -" > /tmp/sum.txt && \
-  curl -L --fail "${YQ_URI}" | tee /bin/yq | sha256sum -c /tmp/sum.txt >/dev/null && \
-  chmod +x /bin/yq && \
+  curl -L --fail "${YQ_URI}" | tee /bin/yq-go | sha256sum -c /tmp/sum.txt >/dev/null && \
+  chmod +x /bin/yq-go && \
   rm /tmp/sum.txt
 
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
 RUN python get-pip.py 'pip<21.0'
 RUN python -m pip install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python
+
+RUN python3 -m pip install yq
 
 ENV TERRAFORM_VERSION=1.0.11
 RUN curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \

--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -38,6 +38,13 @@ RUN yum update -y && \
     rm -rf /var/cache/yum/* && \
     chmod g+w /etc/passwd
 
+ARG YQ_URI=https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
+ARG YQ_HASH=e70e482e7ddb9cf83b52f5e83b694a19e3aaf36acf6b82512cbe66e41d569201
+RUN echo "${YQ_HASH} -" > /tmp/sum.txt && \
+  curl -L --fail "${YQ_URI}" | tee /bin/yq | sha256sum -c /tmp/sum.txt >/dev/null && \
+  chmod +x /bin/yq && \
+  rm /tmp/sum.txt
+
 # Not packaged for Python 2, but required by gcloud.  See https://cloud.google.com/sdk/crypto
 RUN pip-2 install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python

--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -41,8 +41,8 @@ RUN yum update -y && \
 ARG YQ_URI=https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
 ARG YQ_HASH=e70e482e7ddb9cf83b52f5e83b694a19e3aaf36acf6b82512cbe66e41d569201
 RUN echo "${YQ_HASH} -" > /tmp/sum.txt && \
-  curl -L --fail "${YQ_URI}" | tee /bin/yq | sha256sum -c /tmp/sum.txt >/dev/null && \
-  chmod +x /bin/yq && \
+  curl -L --fail "${YQ_URI}" | tee /bin/yq-go | sha256sum -c /tmp/sum.txt >/dev/null && \
+  chmod +x /bin/yq-go && \
   rm /tmp/sum.txt
 
 # Not packaged for Python 2, but required by gcloud.  See https://cloud.google.com/sdk/crypto


### PR DESCRIPTION
[TRT-319](https://issues.redhat.com//browse/TRT-319)

Various CI steps use the upi-installer container for it's access to the
aws cli tools among other things.  However, most of those steps also
curl `yq` directly from GitHub.  We can save ourselves some headaches
when GitHub is down by just embedding the binary in the image already.