### PR TITLE
AGENT-265: Agent asset interface with traits

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -239,6 +239,15 @@ func newCreateCmd() *cobra.Command {
 	return cmd
 }
 
+func asFileWriter(a asset.WritableAsset) asset.FileWriter {
+	switch v := a.(type) {
+	case asset.FileWriter:
+		return v
+	default:
+		return asset.NewDefaultFileWriter(a)
+	}
+}
+
 func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args []string) {
 	runner := func(directory string) error {
 		assetStore, err := assetstore.NewStore(directory)
@@ -252,7 +261,8 @@ func runTargetCmd(targets ...asset.WritableAsset) func(cmd *cobra.Command, args 
 				err = errors.Wrapf(err, "failed to fetch %s", a.Name())
 			}
 
-			if err2 := asset.PersistToFile(a, directory); err2 != nil {
+			err2 := asFileWriter(a).PersistToFile(directory)
+			if err2 != nil {
 				err2 = errors.Wrapf(err2, "failed to write asset (%s) to disk", a.Name())
 				if err != nil {
 					logrus.Error(err2)

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -55,6 +55,7 @@ func (a *AgentImage) Generate(dependencies asset.Parents) error {
 	return nil
 }
 
+// PersistToFile writes the iso image in the assets folder
 func (a *AgentImage) PersistToFile(directory string) error {
 	if a.imageReader == nil {
 		return errors.New("image reader not available")

--- a/pkg/asset/filewriter.go
+++ b/pkg/asset/filewriter.go
@@ -1,0 +1,19 @@
+package asset
+
+// Asset interface used to write all the files in the specified location
+type FileWriter interface {
+	PersistToFile(directory string) error
+}
+
+// Create a new adapter to expose the default implementation as a FileWriter
+func NewDefaultFileWriter(a WritableAsset) FileWriter {
+	return &fileWriterAdapter{a: a}
+}
+
+type fileWriterAdapter struct {
+	a WritableAsset
+}
+
+func (fwa *fileWriterAdapter) PersistToFile(directory string) error {
+	return PersistToFile(fwa.a, directory)
+}

--- a/pkg/asset/filewriter.go
+++ b/pkg/asset/filewriter.go
@@ -1,11 +1,11 @@
 package asset
 
-// Asset interface used to write all the files in the specified location
+// FileWriter interface is used to write all the files in the specified location
 type FileWriter interface {
 	PersistToFile(directory string) error
 }
 
-// Create a new adapter to expose the default implementation as a FileWriter
+// NewDefaultFileWriter create a new adapter to expose the default implementation as a FileWriter
 func NewDefaultFileWriter(a WritableAsset) FileWriter {
 	return &fileWriterAdapter{a: a}
 }
@@ -14,6 +14,7 @@ type fileWriterAdapter struct {
 	a WritableAsset
 }
 
+// PersistToFile wraps the default implementation
 func (fwa *fileWriterAdapter) PersistToFile(directory string) error {
 	return PersistToFile(fwa.a, directory)
 }


### PR DESCRIPTION
Inspired by the initial work developed by @patrickdillon in PR #5990, also this patch offers the possibility for a writable asset to customize the way its content is persisted into the currently configured assets folder.
This approach it's a tentative to limit the refactoring impact required on the existing codebase by adopting a traits-like pattern, in conjuction with the an adapter to wrap the current default behavior.
In addition, an example of how it could be used to persist the current agent ISO image is provided.