### PR TITLE
fixed formatting of supported ovirt hugepages values on validation error

### DIFF
--- a/pkg/types/ovirt/machinepool.go
+++ b/pkg/types/ovirt/machinepool.go
@@ -1,5 +1,7 @@
 package ovirt
 
+import "fmt"
+
 // MachinePool stores the configuration for a machine pool installed
 // on ovirt.
 type MachinePool struct {
@@ -120,6 +122,10 @@ const (
 // with the specific size.
 // +kubebuilder:validation:Enum=2048;1048576
 type Hugepages int32
+
+func (h Hugepages) String() string {
+	return fmt.Sprintf("%d", h)
+}
 
 const (
 	// Hugepages2MB for using 2MB hugepages.

--- a/pkg/types/ovirt/validation/machinepool.go
+++ b/pkg/types/ovirt/validation/machinepool.go
@@ -56,7 +56,7 @@ func ValidateMachinePool(p *ovirt.MachinePool, fldPath *field.Path) field.ErrorL
 	if p.Hugepages > 0 {
 		if p.Hugepages != 2048 && p.Hugepages != 1048576 {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("hugepages"), p.Hugepages,
-				[]string{string(ovirt.Hugepages2MB), string(ovirt.Hugepages1GB)}))
+				[]string{ovirt.Hugepages2MB.String(), ovirt.Hugepages1GB.String()}))
 		}
 	}
 


### PR DESCRIPTION
Running the installer with an invalid value for the ovirt hugepages setting results, as expected, in an error. However, the error message does not provide the proper supported values: 
```
ERROR failed to fetch Metadata: failed to load asset "Install Config": failed to create install config: invalid "install-config.yaml" file: [controlPlane.platform.ovirt.hugepages: Unsupported value: 11111: supported values: "ࠀ", "\U00100000", compute[0].platform.ovirt.hugepages: Unsupported value: 11111: supported values: "ࠀ", "\U00100000"]
```

This PR attempts to fix this formatting issue. 