### PR TITLE
Bug 2007087: bump RHCOS 4.7 boot images

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,166 +1,169 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0d2dc1d021677ce2a"
+            "hvm": "ami-0449356b3f5bf07cf"
         },
         "ap-east-1": {
-            "hvm": "ami-0f55993dd2f556c04"
+            "hvm": "ami-0d1a71281b1657919"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0ca47d6344e5f20e1"
+            "hvm": "ami-0ecbb338388aece3d"
         },
         "ap-northeast-2": {
-            "hvm": "ami-045aad00900706629"
+            "hvm": "ami-04e91a7100a72d730"
         },
         "ap-northeast-3": {
-            "hvm": "ami-071199e1cf8c6c217"
+            "hvm": "ami-0d51d33c57d85a282"
         },
         "ap-south-1": {
-            "hvm": "ami-0863576151906a9cd"
+            "hvm": "ami-03ab8bea1ceb5d685"
         },
         "ap-southeast-1": {
-            "hvm": "ami-04e2280104f031ece"
+            "hvm": "ami-0050f3e4828207f92"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0c0a4abd2fb06aaec"
+            "hvm": "ami-0e614097099cda6fd"
+        },
+        "ap-southeast-3": {
+            "hvm": "ami-05a1827e5adf8c5e3"
         },
         "ca-central-1": {
-            "hvm": "ami-022db1580095cfa87"
+            "hvm": "ami-0f6d2c2eca690930e"
         },
         "eu-central-1": {
-            "hvm": "ami-039650b38f8ad01e9"
+            "hvm": "ami-0ec75793074bc2eb2"
         },
         "eu-north-1": {
-            "hvm": "ami-028bbd02e2077b8b9"
+            "hvm": "ami-047fc9c4636940c82"
         },
         "eu-south-1": {
-            "hvm": "ami-0e906eb19f26e785c"
+            "hvm": "ami-0db740ca2d93e18da"
         },
         "eu-west-1": {
-            "hvm": "ami-0ba9baee1056795ea"
+            "hvm": "ami-036742c74b1bf9a5b"
         },
         "eu-west-2": {
-            "hvm": "ami-0dbf443b171145ce4"
+            "hvm": "ami-0a9ffee6aa024f9af"
         },
         "eu-west-3": {
-            "hvm": "ami-073d36aa242e8e68f"
+            "hvm": "ami-011267735f0a85fcb"
         },
         "me-south-1": {
-            "hvm": "ami-0b87c37294c892f18"
+            "hvm": "ami-0b3d774e68570a9f6"
         },
         "sa-east-1": {
-            "hvm": "ami-0a69a3d8f5d5b8c5b"
+            "hvm": "ami-03d2aecd25fe6fa82"
         },
         "us-east-1": {
-            "hvm": "ami-0625e52375a07b058"
+            "hvm": "ami-055d4184de959659e"
         },
         "us-east-2": {
-            "hvm": "ami-0f0650094e7a74b2b"
+            "hvm": "ami-05e7303da6cb77bb7"
         },
         "us-west-1": {
-            "hvm": "ami-0aea82dddfa9c6c4f"
+            "hvm": "ami-0cb0d95c5f95c25a9"
         },
         "us-west-2": {
-            "hvm": "ami-032288ad75a92d7ec"
+            "hvm": "ami-0ea55f36c5e166eb0"
         }
     },
     "azure": {
-        "image": "rhcos-47.84.202109241831-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.84.202109241831-0-azure.x86_64.vhd"
+        "image": "rhcos-47.84.202206131038-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.84.202206131038-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202109241831-0/x86_64/",
-    "buildid": "47.84.202109241831-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202206131038-0/x86_64/",
+    "buildid": "47.84.202206131038-0",
     "gcp": {
-        "image": "rhcos-47-84-202109241831-0-gcp-x86-64",
+        "image": "rhcos-47-84-202206131038-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-84-202109241831-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-84-202206131038-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.84.202109241831-0-aws.x86_64.vmdk.gz",
-            "sha256": "9e01fd5a7c1636785a3ffc8a0ba3b0636112f31fa0d1e9ca7efad03b172df0f7",
-            "size": 1001398897,
-            "uncompressed-sha256": "41e96725ec27adcda83ea0742df4753b4691c7d08db1647cfbf3c5701da5d15e",
-            "uncompressed-size": 1021609984
+            "path": "rhcos-47.84.202206131038-0-aws.x86_64.vmdk.gz",
+            "sha256": "eac96e68859767ba8654951f142702e7925215616929e06df6a3734bc91fb837",
+            "size": 1001537303,
+            "uncompressed-sha256": "3337a2384ca0d21e659eafbfa0bb017e7962c5b94f1bfa7f508bb94fc34735a4",
+            "uncompressed-size": 1021786624
         },
         "azure": {
-            "path": "rhcos-47.84.202109241831-0-azure.x86_64.vhd.gz",
-            "sha256": "b95992c971fc58e076695bf09261b4e54d83837031b643e37f200edfb31e13b2",
-            "size": 1001539581,
-            "uncompressed-sha256": "f241c7b5401aec7d69076b448dfc55b1f0afcd8cc4fbedf77f6ea02d6ed378ee",
+            "path": "rhcos-47.84.202206131038-0-azure.x86_64.vhd.gz",
+            "sha256": "f84eae13cbf2df71fe15547b9400722060d6cdb6087c4b079ce61e35860e538f",
+            "size": 1001636486,
+            "uncompressed-sha256": "a4e1b29e47444321cb8554970324246aaead8179016e3d2fee6a5cf5e4f92ba7",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.84.202109241831-0-gcp.x86_64.tar.gz",
-            "sha256": "49f4f882300f900c1c23951711d70eb4bb00b2d63409692ac70f19d48dde2763",
-            "size": 986893356
+            "path": "rhcos-47.84.202206131038-0-gcp.x86_64.tar.gz",
+            "sha256": "4a317b9661ef1082f33f6e83597ff9fcde7545ce2cab0fc139d0b738378c4db6",
+            "size": 987002457
         },
         "ibmcloud": {
-            "path": "rhcos-47.84.202109241831-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "d501e686e2b72ed9f24d89d04522361ddc68c3675f4f5016931ad4fd6302cb37",
-            "size": 987246741,
-            "uncompressed-sha256": "69effc14d9f6d72acb56bc0e53e94035ce69668c07a6018b910d6111eddf910d",
-            "uncompressed-size": 2449408000
+            "path": "rhcos-47.84.202206131038-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "0ec0a336f257bf815982c6a292dcb55e0f183d5de9f439e9b75ae9c0f4e23a53",
+            "size": 987325971,
+            "uncompressed-sha256": "0e5ed8d6263808d32e46b5e5b5f5722a5ea30490610f24e33b9f1b7613bfabfc",
+            "uncompressed-size": 2449604608
         },
         "live-initramfs": {
-            "path": "rhcos-47.84.202109241831-0-live-initramfs.x86_64.img",
-            "sha256": "bf4a35f3cf2b441829fad59b4a198aa9e40577e6d48a3353a4a4d8e75fdab0c4"
+            "path": "rhcos-47.84.202206131038-0-live-initramfs.x86_64.img",
+            "sha256": "1b10fcad119d2c3f12f819483035398297d17475315bc1e8a662ca2c55a3da9c"
         },
         "live-iso": {
-            "path": "rhcos-47.84.202109241831-0-live.x86_64.iso",
-            "sha256": "621d3621fb4aa6e0d5d31c05fc79447481bdeeca7009a26ac7b56f7e385f5065"
+            "path": "rhcos-47.84.202206131038-0-live.x86_64.iso",
+            "sha256": "8053f7cb5ef906ce0e2aae426a7f72e944a9a4fa7783c6ed775d29f00cf073ed"
         },
         "live-kernel": {
-            "path": "rhcos-47.84.202109241831-0-live-kernel-x86_64",
-            "sha256": "d13269e6c60119397210418781b7057673c4018692d28a868e248a0b550ea247"
+            "path": "rhcos-47.84.202206131038-0-live-kernel-x86_64",
+            "sha256": "2f73cda50fa9cfcd14b9624cce3fa663c91341a8eafae22bb6bbc6357f83e679"
         },
         "live-rootfs": {
-            "path": "rhcos-47.84.202109241831-0-live-rootfs.x86_64.img",
-            "sha256": "71b0aa577b4ba4732ecc355843efd069f53b7d790b402959175754746f00f488"
+            "path": "rhcos-47.84.202206131038-0-live-rootfs.x86_64.img",
+            "sha256": "e0b27e42b568314ea2c4f5d981f3b29d2ddf25fa11bae9b4b9045d703c5d0a0b"
         },
         "metal": {
-            "path": "rhcos-47.84.202109241831-0-metal.x86_64.raw.gz",
-            "sha256": "ad4df2dfbde1da260a7f31f946f875e24285923317e79177b36f1aaab19b45d6",
-            "size": 988863082,
-            "uncompressed-sha256": "691a279a7803eb833f97f6c29a5eb5238d4cee2976d54748f3362e14b763fbeb",
+            "path": "rhcos-47.84.202206131038-0-metal.x86_64.raw.gz",
+            "sha256": "e431768afd7a151c51398f5efdf1a5c2f029d6288b0dadb2d9263d687ccc1282",
+            "size": 989016785,
+            "uncompressed-sha256": "0f4124ae89cd88260ece3f58a328ece5a95df6fc9392d6e620bb361619cf1cc0",
             "uncompressed-size": 3838836736
         },
         "metal4k": {
-            "path": "rhcos-47.84.202109241831-0-metal4k.x86_64.raw.gz",
-            "sha256": "2cc0cfeb0035e7dd23392bd306a3b8ce9626a93ea7b003ff07352bcd8be824e1",
-            "size": 986471700,
-            "uncompressed-sha256": "aada7e7fee4936bb45a754b64cd7c62b63afe7d4c09b4d8406c9e33a46e77d0a",
+            "path": "rhcos-47.84.202206131038-0-metal4k.x86_64.raw.gz",
+            "sha256": "5a55250726cdc344180b2059f63341b03a8cf75d77e8190324f5dcddfb2bbd01",
+            "size": 986564139,
+            "uncompressed-sha256": "21a97f48e3e1fe0caced5d043d93fca4928d1f40de580c1698b940ef21a720c4",
             "uncompressed-size": 3838836736
         },
         "openstack": {
-            "path": "rhcos-47.84.202109241831-0-openstack.x86_64.qcow2.gz",
-            "sha256": "859add6f751baf7070cb485394cb2777a253f07ea3ecd336cf9f5c98d25a3552",
-            "size": 987245565,
-            "uncompressed-sha256": "49f107e6106abaa178e657bbb0da9910b22cebd68cc15975ff7280734483faa8",
-            "uncompressed-size": 2449408000
+            "path": "rhcos-47.84.202206131038-0-openstack.x86_64.qcow2.gz",
+            "sha256": "827318ca49d465fe0888cb66199c7bf24bcbce3968437ecd41bcb5b4b8acf584",
+            "size": 987324987,
+            "uncompressed-sha256": "b20c9a9b525e3f399d4846fd468e7ecba415963da549cfd1ba2e237d301ed412",
+            "uncompressed-size": 2449604608
         },
         "ostree": {
-            "path": "rhcos-47.84.202109241831-0-ostree.x86_64.tar",
-            "sha256": "42be543418f3998de03bf586a545f78a1f19c6c1ec199a7b1fe6d77c383fc878",
-            "size": 910929920
+            "path": "rhcos-47.84.202206131038-0-ostree.x86_64.tar",
+            "sha256": "81a95d23a968f4f8508580ece85bc9327bcc86deba97e57b50d441f7c5ace950",
+            "size": 911073280
         },
         "qemu": {
-            "path": "rhcos-47.84.202109241831-0-qemu.x86_64.qcow2.gz",
-            "sha256": "222d030b23cb9753573c83e141cf226d948e31a6891596128c490c9fa9e3d14a",
-            "size": 988507503,
-            "uncompressed-sha256": "2203a9ac29c0065cfbef0f0ad3ce20fcd0ba18f46b2a0d5544365382a1d76e1f",
+            "path": "rhcos-47.84.202206131038-0-qemu.x86_64.qcow2.gz",
+            "sha256": "cd37801bfb4955110a309c5c32da8f5fd46fe140f91658af2b84ad8e6c25533a",
+            "size": 988551162,
+            "uncompressed-sha256": "07ba5a7c96acac1869a3f84381ef76d8ee31afe23a92dcce7f6da52d8a2283da",
             "uncompressed-size": 2485977088
         },
         "vmware": {
-            "path": "rhcos-47.84.202109241831-0-vmware.x86_64.ova",
-            "sha256": "f489fe5ff3b35dce00c4a9ca88d5e0ce1f831bcf6fcd8756365dadbc4de82665",
-            "size": 1021624320
+            "path": "rhcos-47.84.202206131038-0-vmware.x86_64.ova",
+            "sha256": "8deccb3360d28e1e39174523cd8a894e5ec00538af543680b6c239ebe69b9e5e",
+            "size": 1021798400
         }
     },
     "oscontainer": {
-        "digest": "sha256:532b4aee9644ec3f689d0648bf889f66e130c3d047ba4cb1de2e772f1eaf34ac",
+        "digest": "sha256:e5792c45d0292832e897e69357cb7e7600fcb9ef39160a0ce3f1c836ba06d387",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "855dbb83e02cb2f2b627082f678936ee5c9a3b21e0eb3ac7667787102d13e316",
-    "ostree-version": "47.84.202109241831-0"
+    "ostree-commit": "d1d016103377968db034641fd7430ac23c56779c78448932bbddd2ce738f66a6",
+    "ostree-version": "47.84.202206131038-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-ppc64le/47.84.202109242011-0/ppc64le/",
-    "buildid": "47.84.202109242011-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-ppc64le/47.84.202206131039-0/ppc64le/",
+    "buildid": "47.84.202206131039-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-47.84.202109242011-0-live-initramfs.ppc64le.img",
-            "sha256": "0580c03bfae4728aa8ac69fc8494f913e0b174b6693a9373aac5778a31b46271"
+            "path": "rhcos-47.84.202206131039-0-live-initramfs.ppc64le.img",
+            "sha256": "be3f7d796f647c2c7cf3dc4d5aba17b08b461a164d55181e28ecbb0b52cd1b53"
         },
         "live-iso": {
-            "path": "rhcos-47.84.202109242011-0-live.ppc64le.iso",
-            "sha256": "a07743846e404ac8480dff39c0a9d90616aa3dd13ea4196a1478759e24d88fab"
+            "path": "rhcos-47.84.202206131039-0-live.ppc64le.iso",
+            "sha256": "8de396d41bb0dd99dc988c411768bc47f7a5586ba448e248cfcc9b2135ccac76"
         },
         "live-kernel": {
-            "path": "rhcos-47.84.202109242011-0-live-kernel-ppc64le",
-            "sha256": "d2f8f29ef59b87de2cbd7df8be60c06620bc90e88f4a722bb8278333d76ca3f8"
+            "path": "rhcos-47.84.202206131039-0-live-kernel-ppc64le",
+            "sha256": "44e70f6abe2bf6e828ce8f833323cdf44035de6f9cc041219a2ddc16036fa210"
         },
         "live-rootfs": {
-            "path": "rhcos-47.84.202109242011-0-live-rootfs.ppc64le.img",
-            "sha256": "8f72670c628c27df365a79b84053bf2f61753d89492521bda688da2bcf4c4c70"
+            "path": "rhcos-47.84.202206131039-0-live-rootfs.ppc64le.img",
+            "sha256": "f3ae3724c4d040c266bff3362c1c30f979b69d2c66b0a2d3583b9073e419ba86"
         },
         "metal": {
-            "path": "rhcos-47.84.202109242011-0-metal.ppc64le.raw.gz",
-            "sha256": "0021a883bb3bde083b077ba961e5f1aae1a9e934a58c5a327306088b8efbaa2b",
-            "size": 957912234,
-            "uncompressed-sha256": "2179dfddcaacfce9cd8cc3fe0ba4eed656b194990b519f39444c2f2a47f177fa",
-            "uncompressed-size": 3990880256
+            "path": "rhcos-47.84.202206131039-0-metal.ppc64le.raw.gz",
+            "sha256": "b5af4d2dc6c34f9028433cf8fa75daa8b4d38f3334a5b9988236fe268aa54a05",
+            "size": 958506482,
+            "uncompressed-sha256": "309059b232f397ebd3a647b0a36b02cc65be8df0fd02ba8f56700ec1547232a3",
+            "uncompressed-size": 3992977408
         },
         "metal4k": {
-            "path": "rhcos-47.84.202109242011-0-metal4k.ppc64le.raw.gz",
-            "sha256": "591522153864dffb6646814d3bf26bf827386487618163c2b265297285e81349",
-            "size": 958257005,
-            "uncompressed-sha256": "2a6e8ed057002e83c6a4337e005e519edaba0a27bc511a6d8df70cbd8e0f13c2",
-            "uncompressed-size": 3990880256
+            "path": "rhcos-47.84.202206131039-0-metal4k.ppc64le.raw.gz",
+            "sha256": "59b9d7f3b9226de4f7d83674f0f87959147040df98a23bc77caa4d4b75c6f3a2",
+            "size": 958904503,
+            "uncompressed-sha256": "004fdb636695aa8c3d5e2dc5c6886fe3ae29387e645875ab8433a212273f07c2",
+            "uncompressed-size": 3992977408
         },
         "openstack": {
-            "path": "rhcos-47.84.202109242011-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "21a522617e5476b651bb3ba55700fb9f0f3d0ea02657afebb94a5a269a45c85d",
-            "size": 956243504,
-            "uncompressed-sha256": "772132ecfeb05ed3b8f9252f758f354855cc11fa41bd0abef6ba624c6645cdfe",
-            "uncompressed-size": 2569273344
+            "path": "rhcos-47.84.202206131039-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "d87557eeab01e07436bbe6a45b065d155cbf2abca9c6e1e4ea8a5ca5cd5e92e3",
+            "size": 956902316,
+            "uncompressed-sha256": "55b9598780a60979ff6be10f6c2c714dd6cdcb4a6c08e0744bece585f1511d5f",
+            "uncompressed-size": 2569994240
         },
         "ostree": {
-            "path": "rhcos-47.84.202109242011-0-ostree.ppc64le.tar",
-            "sha256": "dee9456e38c73ce9b476b315265b2c236c9bfa058d41bb6c0ef41ab3d0f25789",
-            "size": 879001600
+            "path": "rhcos-47.84.202206131039-0-ostree.ppc64le.tar",
+            "sha256": "0c80e7936cabedbb65099b0f0cf6ce9617dd450573cae9485ea52f3e8782608e",
+            "size": 879523840
         },
         "qemu": {
-            "path": "rhcos-47.84.202109242011-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "63ba6dfe2766fddfcb19ec45c49308944fe8ac34b7a286824577c9541cdd5af4",
-            "size": 957286620,
-            "uncompressed-sha256": "ffd3f3c75af16d475f8c230a8bf2f37224d356adacbf97c55a9130e6e8627efd",
-            "uncompressed-size": 2606825472
+            "path": "rhcos-47.84.202206131039-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "7c5aec8e731734b93f5d2efc4c3b04dcad466f03f0d161cb1d6e6bc3a09bcd60",
+            "size": 957900229,
+            "uncompressed-sha256": "99d4d51d3878a5281ec1f828bfdb7afe07fe4d2c45f26f69a158db8b5c24623e",
+            "uncompressed-size": 2607874048
         }
     },
     "oscontainer": {
-        "digest": "sha256:8ee9920afef10cf84ab2f4f92924e9baddc97e25053dd3d60b214a18b320f55a",
+        "digest": "sha256:adfbe30fe4d49c9d978affc107ceec2d49899d16b1d7254c80160df5d83ecd77",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "ea8ab06592e01907ae8ec799a4001ae9ea4f8a1278b50e88fbed0340e9222351",
-    "ostree-version": "47.84.202109242011-0"
+    "ostree-commit": "4e8af1890c494412d2e81295bce5493bf74bb4bde931f49688e5740bcb32b99b",
+    "ostree-version": "47.84.202206131039-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-s390x/47.84.202109242305-0/s390x/",
-    "buildid": "47.84.202109242305-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-s390x/47.84.202206131037-0/s390x/",
+    "buildid": "47.84.202206131037-0",
     "images": {
         "dasd": {
-            "path": "rhcos-47.84.202109242305-0-dasd.s390x.raw.gz",
-            "sha256": "4dd5e4170ca2bc2399d93baaeee2adcc3cd2be03e3123c7a07dd8790cf57612a",
-            "size": 865020381,
-            "uncompressed-sha256": "f6c4b202a0a107d9556267b522905e17e33a44d8cbd22709490049d5ee0340d1",
-            "uncompressed-size": 3589275648
+            "path": "rhcos-47.84.202206131037-0-dasd.s390x.raw.gz",
+            "sha256": "f12624f2c5a3c4b838422b923cd203c7bb219eb9716c76e4dfc6202a5352f650",
+            "size": 863844530,
+            "uncompressed-sha256": "206c8e52d2fd63ee0b696feae3ff3d047328692e429ce4ab0cd2be6065204f7d",
+            "uncompressed-size": 3585081344
         },
         "live-initramfs": {
-            "path": "rhcos-47.84.202109242305-0-live-initramfs.s390x.img",
-            "sha256": "eb755014d8d03dc83ba4e125f4903aa221ecea26283275c8e264d2e5770e7062"
+            "path": "rhcos-47.84.202206131037-0-live-initramfs.s390x.img",
+            "sha256": "4189e26ad76798817e8cba30d81e14fde23274166c01727a9f4df6b691766b76"
         },
         "live-iso": {
-            "path": "rhcos-47.84.202109242305-0-live.s390x.iso",
-            "sha256": "41554a319c9ac1e9fb7a4b4399e06e0114f059934e15ef15ff34b51a5747858c"
+            "path": "rhcos-47.84.202206131037-0-live.s390x.iso",
+            "sha256": "84fd70fbcf27260d0ad5c05e4721042b318e3103c16f5613bac6b51b241bb3ba"
         },
         "live-kernel": {
-            "path": "rhcos-47.84.202109242305-0-live-kernel-s390x",
-            "sha256": "81d8f6040cf3913ed01379e6af950d0c8168a4f6e0adeecaf63ae527c759ade9"
+            "path": "rhcos-47.84.202206131037-0-live-kernel-s390x",
+            "sha256": "de91cc8ffbd3b35c1e1f33deed6c8393ffe95b558d60b79bd34792e595397f7c"
         },
         "live-rootfs": {
-            "path": "rhcos-47.84.202109242305-0-live-rootfs.s390x.img",
-            "sha256": "20dbdfed003083cf3a26b0b489f2cee48bce886dfe274487107128c503cf3ec6"
+            "path": "rhcos-47.84.202206131037-0-live-rootfs.s390x.img",
+            "sha256": "e4acddf51faed63c566875efae739f1bbc26f9d493b28f0b0306f8ca8c5b85c8"
         },
         "metal": {
-            "path": "rhcos-47.84.202109242305-0-metal.s390x.raw.gz",
-            "sha256": "581b60df2de4451f90b58b9e06ec4e36240f8db9a5d60c88a4aae92058253419",
-            "size": 865037513,
-            "uncompressed-sha256": "4220bfb6b4d6fe85fef137d7d0f61a879e9c1967349c9f36a26b07bcd8ebb113",
-            "uncompressed-size": 3589275648
+            "path": "rhcos-47.84.202206131037-0-metal.s390x.raw.gz",
+            "sha256": "7705ccbb07e2874be42538574ba36463eb7630895c3673637c7f651ba6fb8586",
+            "size": 863878047,
+            "uncompressed-sha256": "7863c4840b0057d55c6999b138e749cbed9674e3113ca9b0c9a054dfcd08eb38",
+            "uncompressed-size": 3585081344
         },
         "metal4k": {
-            "path": "rhcos-47.84.202109242305-0-metal4k.s390x.raw.gz",
-            "sha256": "f75427d26aeb297b986af152ef4558eed1a5661b0104034498d4d493efd4912a",
-            "size": 865083760,
-            "uncompressed-sha256": "b2c7fd8d07288589c4b995efc0d9bc8c0092b163d1b43a89758440f5af097b35",
-            "uncompressed-size": 3589275648
+            "path": "rhcos-47.84.202206131037-0-metal4k.s390x.raw.gz",
+            "sha256": "a4bb31831c4c3338ba444fd7522efc32b050a30da62050fd042ac8078060daeb",
+            "size": 863923392,
+            "uncompressed-sha256": "fa5901eb163e663a5eae4c823cbeaa7f5473525e75e89f0269176c09b967d8d1",
+            "uncompressed-size": 3585081344
         },
         "openstack": {
-            "path": "rhcos-47.84.202109242305-0-openstack.s390x.qcow2.gz",
-            "sha256": "2437049e9d66baa906aa64a772d5954404740513f7fe1b70862119cd36022912",
-            "size": 863400562,
-            "uncompressed-sha256": "9f5ea290315f30b79dbf45b030e8f6c242a1b47c0735da58642643d9da9f4369",
-            "uncompressed-size": 2231173120
+            "path": "rhcos-47.84.202206131037-0-openstack.s390x.qcow2.gz",
+            "sha256": "628202845b3074511b8346fc6fc66a486126b1f1eae7ef06dac59761c4efcc63",
+            "size": 862241352,
+            "uncompressed-sha256": "a64b6c92c24176db8fa83d881a17e781863363fea23edb68e869f7c67dce073b",
+            "uncompressed-size": 2228092928
         },
         "ostree": {
-            "path": "rhcos-47.84.202109242305-0-ostree.s390x.tar",
-            "sha256": "651e99ee4ee5ced7c4abf32e7487325b18004eeaf7ef644b0925bfdc79f2fdd2",
-            "size": 811816960
+            "path": "rhcos-47.84.202206131037-0-ostree.s390x.tar",
+            "sha256": "dba4bc571c51d9559d83149d2666459799c9ea7393856506dcb33b3ed0991bbd",
+            "size": 810516480
         },
         "qemu": {
-            "path": "rhcos-47.84.202109242305-0-qemu.s390x.qcow2.gz",
-            "sha256": "da5927cc7ecc72e9d6ef781d2032dd65e3c3ee8a825c8b78c96575567adcf328",
-            "size": 864402427,
-            "uncompressed-sha256": "76714236d4827882c19c2dfdaa48de5872b5b7704b1e43b2436564dbcc2acad9",
-            "uncompressed-size": 2267348992
+            "path": "rhcos-47.84.202206131037-0-qemu.s390x.qcow2.gz",
+            "sha256": "c1403cf49bfba2bba3753a2c7050c77c09099ac415400429a0bb034df88eeba8",
+            "size": 863201637,
+            "uncompressed-sha256": "cf9f76e5dd98850ad523734317bb62165fe3e920712de23c15ca31eec85a910a",
+            "uncompressed-size": 2264203264
         }
     },
     "oscontainer": {
-        "digest": "sha256:31beef6c052e1e7f76c1959ed386ba4831014511b4e15e32d67054d7ee2e7c26",
+        "digest": "sha256:ae482143e8872f49adb7548d900f494d93526c46345d326a96b06ce9f1c42e15",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "b9c1b79d2afac33f3d4b18b58f5bf0e3566ba8f6bd4e3bad0b0be350dc1fa00c",
-    "ostree-version": "47.84.202109242305-0"
+    "ostree-commit": "5862c745055acc1cf6b639d0a5dd595617f574ab65967afc1c54d381623cc992",
+    "ostree-version": "47.84.202206131037-0"
 }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,166 +1,169 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0d2dc1d021677ce2a"
+            "hvm": "ami-0449356b3f5bf07cf"
         },
         "ap-east-1": {
-            "hvm": "ami-0f55993dd2f556c04"
+            "hvm": "ami-0d1a71281b1657919"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0ca47d6344e5f20e1"
+            "hvm": "ami-0ecbb338388aece3d"
         },
         "ap-northeast-2": {
-            "hvm": "ami-045aad00900706629"
+            "hvm": "ami-04e91a7100a72d730"
         },
         "ap-northeast-3": {
-            "hvm": "ami-071199e1cf8c6c217"
+            "hvm": "ami-0d51d33c57d85a282"
         },
         "ap-south-1": {
-            "hvm": "ami-0863576151906a9cd"
+            "hvm": "ami-03ab8bea1ceb5d685"
         },
         "ap-southeast-1": {
-            "hvm": "ami-04e2280104f031ece"
+            "hvm": "ami-0050f3e4828207f92"
         },
         "ap-southeast-2": {
-            "hvm": "ami-0c0a4abd2fb06aaec"
+            "hvm": "ami-0e614097099cda6fd"
+        },
+        "ap-southeast-3": {
+            "hvm": "ami-05a1827e5adf8c5e3"
         },
         "ca-central-1": {
-            "hvm": "ami-022db1580095cfa87"
+            "hvm": "ami-0f6d2c2eca690930e"
         },
         "eu-central-1": {
-            "hvm": "ami-039650b38f8ad01e9"
+            "hvm": "ami-0ec75793074bc2eb2"
         },
         "eu-north-1": {
-            "hvm": "ami-028bbd02e2077b8b9"
+            "hvm": "ami-047fc9c4636940c82"
         },
         "eu-south-1": {
-            "hvm": "ami-0e906eb19f26e785c"
+            "hvm": "ami-0db740ca2d93e18da"
         },
         "eu-west-1": {
-            "hvm": "ami-0ba9baee1056795ea"
+            "hvm": "ami-036742c74b1bf9a5b"
         },
         "eu-west-2": {
-            "hvm": "ami-0dbf443b171145ce4"
+            "hvm": "ami-0a9ffee6aa024f9af"
         },
         "eu-west-3": {
-            "hvm": "ami-073d36aa242e8e68f"
+            "hvm": "ami-011267735f0a85fcb"
         },
         "me-south-1": {
-            "hvm": "ami-0b87c37294c892f18"
+            "hvm": "ami-0b3d774e68570a9f6"
         },
         "sa-east-1": {
-            "hvm": "ami-0a69a3d8f5d5b8c5b"
+            "hvm": "ami-03d2aecd25fe6fa82"
         },
         "us-east-1": {
-            "hvm": "ami-0625e52375a07b058"
+            "hvm": "ami-055d4184de959659e"
         },
         "us-east-2": {
-            "hvm": "ami-0f0650094e7a74b2b"
+            "hvm": "ami-05e7303da6cb77bb7"
         },
         "us-west-1": {
-            "hvm": "ami-0aea82dddfa9c6c4f"
+            "hvm": "ami-0cb0d95c5f95c25a9"
         },
         "us-west-2": {
-            "hvm": "ami-032288ad75a92d7ec"
+            "hvm": "ami-0ea55f36c5e166eb0"
         }
     },
     "azure": {
-        "image": "rhcos-47.84.202109241831-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.84.202109241831-0-azure.x86_64.vhd"
+        "image": "rhcos-47.84.202206131038-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.84.202206131038-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202109241831-0/x86_64/",
-    "buildid": "47.84.202109241831-0",
+    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202206131038-0/x86_64/",
+    "buildid": "47.84.202206131038-0",
     "gcp": {
-        "image": "rhcos-47-84-202109241831-0-gcp-x86-64",
+        "image": "rhcos-47-84-202206131038-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-84-202109241831-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-47-84-202206131038-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-47.84.202109241831-0-aws.x86_64.vmdk.gz",
-            "sha256": "9e01fd5a7c1636785a3ffc8a0ba3b0636112f31fa0d1e9ca7efad03b172df0f7",
-            "size": 1001398897,
-            "uncompressed-sha256": "41e96725ec27adcda83ea0742df4753b4691c7d08db1647cfbf3c5701da5d15e",
-            "uncompressed-size": 1021609984
+            "path": "rhcos-47.84.202206131038-0-aws.x86_64.vmdk.gz",
+            "sha256": "eac96e68859767ba8654951f142702e7925215616929e06df6a3734bc91fb837",
+            "size": 1001537303,
+            "uncompressed-sha256": "3337a2384ca0d21e659eafbfa0bb017e7962c5b94f1bfa7f508bb94fc34735a4",
+            "uncompressed-size": 1021786624
         },
         "azure": {
-            "path": "rhcos-47.84.202109241831-0-azure.x86_64.vhd.gz",
-            "sha256": "b95992c971fc58e076695bf09261b4e54d83837031b643e37f200edfb31e13b2",
-            "size": 1001539581,
-            "uncompressed-sha256": "f241c7b5401aec7d69076b448dfc55b1f0afcd8cc4fbedf77f6ea02d6ed378ee",
+            "path": "rhcos-47.84.202206131038-0-azure.x86_64.vhd.gz",
+            "sha256": "f84eae13cbf2df71fe15547b9400722060d6cdb6087c4b079ce61e35860e538f",
+            "size": 1001636486,
+            "uncompressed-sha256": "a4e1b29e47444321cb8554970324246aaead8179016e3d2fee6a5cf5e4f92ba7",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-47.84.202109241831-0-gcp.x86_64.tar.gz",
-            "sha256": "49f4f882300f900c1c23951711d70eb4bb00b2d63409692ac70f19d48dde2763",
-            "size": 986893356
+            "path": "rhcos-47.84.202206131038-0-gcp.x86_64.tar.gz",
+            "sha256": "4a317b9661ef1082f33f6e83597ff9fcde7545ce2cab0fc139d0b738378c4db6",
+            "size": 987002457
         },
         "ibmcloud": {
-            "path": "rhcos-47.84.202109241831-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "d501e686e2b72ed9f24d89d04522361ddc68c3675f4f5016931ad4fd6302cb37",
-            "size": 987246741,
-            "uncompressed-sha256": "69effc14d9f6d72acb56bc0e53e94035ce69668c07a6018b910d6111eddf910d",
-            "uncompressed-size": 2449408000
+            "path": "rhcos-47.84.202206131038-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "0ec0a336f257bf815982c6a292dcb55e0f183d5de9f439e9b75ae9c0f4e23a53",
+            "size": 987325971,
+            "uncompressed-sha256": "0e5ed8d6263808d32e46b5e5b5f5722a5ea30490610f24e33b9f1b7613bfabfc",
+            "uncompressed-size": 2449604608
         },
         "live-initramfs": {
-            "path": "rhcos-47.84.202109241831-0-live-initramfs.x86_64.img",
-            "sha256": "bf4a35f3cf2b441829fad59b4a198aa9e40577e6d48a3353a4a4d8e75fdab0c4"
+            "path": "rhcos-47.84.202206131038-0-live-initramfs.x86_64.img",
+            "sha256": "1b10fcad119d2c3f12f819483035398297d17475315bc1e8a662ca2c55a3da9c"
         },
         "live-iso": {
-            "path": "rhcos-47.84.202109241831-0-live.x86_64.iso",
-            "sha256": "621d3621fb4aa6e0d5d31c05fc79447481bdeeca7009a26ac7b56f7e385f5065"
+            "path": "rhcos-47.84.202206131038-0-live.x86_64.iso",
+            "sha256": "8053f7cb5ef906ce0e2aae426a7f72e944a9a4fa7783c6ed775d29f00cf073ed"
         },
         "live-kernel": {
-            "path": "rhcos-47.84.202109241831-0-live-kernel-x86_64",
-            "sha256": "d13269e6c60119397210418781b7057673c4018692d28a868e248a0b550ea247"
+            "path": "rhcos-47.84.202206131038-0-live-kernel-x86_64",
+            "sha256": "2f73cda50fa9cfcd14b9624cce3fa663c91341a8eafae22bb6bbc6357f83e679"
         },
         "live-rootfs": {
-            "path": "rhcos-47.84.202109241831-0-live-rootfs.x86_64.img",
-            "sha256": "71b0aa577b4ba4732ecc355843efd069f53b7d790b402959175754746f00f488"
+            "path": "rhcos-47.84.202206131038-0-live-rootfs.x86_64.img",
+            "sha256": "e0b27e42b568314ea2c4f5d981f3b29d2ddf25fa11bae9b4b9045d703c5d0a0b"
         },
         "metal": {
-            "path": "rhcos-47.84.202109241831-0-metal.x86_64.raw.gz",
-            "sha256": "ad4df2dfbde1da260a7f31f946f875e24285923317e79177b36f1aaab19b45d6",
-            "size": 988863082,
-            "uncompressed-sha256": "691a279a7803eb833f97f6c29a5eb5238d4cee2976d54748f3362e14b763fbeb",
+            "path": "rhcos-47.84.202206131038-0-metal.x86_64.raw.gz",
+            "sha256": "e431768afd7a151c51398f5efdf1a5c2f029d6288b0dadb2d9263d687ccc1282",
+            "size": 989016785,
+            "uncompressed-sha256": "0f4124ae89cd88260ece3f58a328ece5a95df6fc9392d6e620bb361619cf1cc0",
             "uncompressed-size": 3838836736
         },
         "metal4k": {
-            "path": "rhcos-47.84.202109241831-0-metal4k.x86_64.raw.gz",
-            "sha256": "2cc0cfeb0035e7dd23392bd306a3b8ce9626a93ea7b003ff07352bcd8be824e1",
-            "size": 986471700,
-            "uncompressed-sha256": "aada7e7fee4936bb45a754b64cd7c62b63afe7d4c09b4d8406c9e33a46e77d0a",
+            "path": "rhcos-47.84.202206131038-0-metal4k.x86_64.raw.gz",
+            "sha256": "5a55250726cdc344180b2059f63341b03a8cf75d77e8190324f5dcddfb2bbd01",
+            "size": 986564139,
+            "uncompressed-sha256": "21a97f48e3e1fe0caced5d043d93fca4928d1f40de580c1698b940ef21a720c4",
             "uncompressed-size": 3838836736
         },
         "openstack": {
-            "path": "rhcos-47.84.202109241831-0-openstack.x86_64.qcow2.gz",
-            "sha256": "859add6f751baf7070cb485394cb2777a253f07ea3ecd336cf9f5c98d25a3552",
-            "size": 987245565,
-            "uncompressed-sha256": "49f107e6106abaa178e657bbb0da9910b22cebd68cc15975ff7280734483faa8",
-            "uncompressed-size": 2449408000
+            "path": "rhcos-47.84.202206131038-0-openstack.x86_64.qcow2.gz",
+            "sha256": "827318ca49d465fe0888cb66199c7bf24bcbce3968437ecd41bcb5b4b8acf584",
+            "size": 987324987,
+            "uncompressed-sha256": "b20c9a9b525e3f399d4846fd468e7ecba415963da549cfd1ba2e237d301ed412",
+            "uncompressed-size": 2449604608
         },
         "ostree": {
-            "path": "rhcos-47.84.202109241831-0-ostree.x86_64.tar",
-            "sha256": "42be543418f3998de03bf586a545f78a1f19c6c1ec199a7b1fe6d77c383fc878",
-            "size": 910929920
+            "path": "rhcos-47.84.202206131038-0-ostree.x86_64.tar",
+            "sha256": "81a95d23a968f4f8508580ece85bc9327bcc86deba97e57b50d441f7c5ace950",
+            "size": 911073280
         },
         "qemu": {
-            "path": "rhcos-47.84.202109241831-0-qemu.x86_64.qcow2.gz",
-            "sha256": "222d030b23cb9753573c83e141cf226d948e31a6891596128c490c9fa9e3d14a",
-            "size": 988507503,
-            "uncompressed-sha256": "2203a9ac29c0065cfbef0f0ad3ce20fcd0ba18f46b2a0d5544365382a1d76e1f",
+            "path": "rhcos-47.84.202206131038-0-qemu.x86_64.qcow2.gz",
+            "sha256": "cd37801bfb4955110a309c5c32da8f5fd46fe140f91658af2b84ad8e6c25533a",
+            "size": 988551162,
+            "uncompressed-sha256": "07ba5a7c96acac1869a3f84381ef76d8ee31afe23a92dcce7f6da52d8a2283da",
             "uncompressed-size": 2485977088
         },
         "vmware": {
-            "path": "rhcos-47.84.202109241831-0-vmware.x86_64.ova",
-            "sha256": "f489fe5ff3b35dce00c4a9ca88d5e0ce1f831bcf6fcd8756365dadbc4de82665",
-            "size": 1021624320
+            "path": "rhcos-47.84.202206131038-0-vmware.x86_64.ova",
+            "sha256": "8deccb3360d28e1e39174523cd8a894e5ec00538af543680b6c239ebe69b9e5e",
+            "size": 1021798400
         }
     },
     "oscontainer": {
-        "digest": "sha256:532b4aee9644ec3f689d0648bf889f66e130c3d047ba4cb1de2e772f1eaf34ac",
+        "digest": "sha256:e5792c45d0292832e897e69357cb7e7600fcb9ef39160a0ce3f1c836ba06d387",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "855dbb83e02cb2f2b627082f678936ee5c9a3b21e0eb3ac7667787102d13e316",
-    "ostree-version": "47.84.202109241831-0"
+    "ostree-commit": "d1d016103377968db034641fd7430ac23c56779c78448932bbddd2ce738f66a6",
+    "ostree-version": "47.84.202206131038-0"
 }

--- a/pkg/rhcos/ami_regions.go
+++ b/pkg/rhcos/ami_regions.go
@@ -12,6 +12,7 @@ var AMIRegions = []string{
 	"ap-south-1",
 	"ap-southeast-1",
 	"ap-southeast-2",
+	"ap-southeast-3",
 	"ca-central-1",
 	"eu-central-1",
 	"eu-north-1",


### PR DESCRIPTION
This brings in fixes for the following issues:
BZ 2078001 - Publish RHEL CoreOS AMIs in AWS ap-southeast-3 region

These changes were generated with:

```
    $ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202206131038-0/x86_64/meta.json amd64
    $ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-ppc64le/47.84.202206131039-0/ppc64le/meta.json ppc64le
    $ hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-s390x/47.84.202206131037-0/s390x/meta.json s390x
```