### PR TITLE
Bug 2061947: IBMCloud: Skip DNS Record delete

### DIFF
--- a/pkg/destroy/ibmcloud/dns.go
+++ b/pkg/destroy/ibmcloud/dns.go
@@ -74,6 +74,12 @@ func (o *ClusterUninstaller) deleteDNSRecord(item cloudResource) error {
 // destroyDNSRecords removes all DNS record resources that have a name containing
 // the cluster's infra ID.
 func (o *ClusterUninstaller) destroyDNSRecords() error {
+	// If CIS CRN is not set, skip DNS records cleanup
+	if len(o.CISInstanceCRN) == 0 {
+		o.Logger.Info("Skipping deletion of DNS Records, no CIS CRN found")
+		return nil
+	}
+
 	found, err := o.listDNSRecords()
 	if err != nil {
 		return err


### PR DESCRIPTION
During uninstall/destroy, if no CIS CRN is available, the installer
errors trying to collect DNS Records for deletion. If no CIS CRN
is supplied in metadata, skip attempting to delete the DNS Records.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2061947