### PR TITLE
Power VS config.json changes

### DIFF
--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -72,11 +72,7 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 			return errors.Wrap(err, "creating IBM Cloud session")
 		}
 	case powervs.Name:
-		bxCli, err := powervsconfig.NewBxClient()
-		if err != nil {
-			return err
-		}
-		err = bxCli.NewPISession()
+		_, err = powervsconfig.NewClient()
 		if err != nil {
 			return errors.Wrap(err, "creating IBM Cloud session")
 		}

--- a/pkg/asset/installconfig/platformpermscheck.go
+++ b/pkg/asset/installconfig/platformpermscheck.go
@@ -92,7 +92,7 @@ func (a *PlatformPermsCheck) Generate(dependencies asset.Parents) error {
 	case ibmcloud.Name:
 		// TODO: IBM[#90]: platformpermscheck
 	case powervs.Name:
-		bxCli, err := powervsconfig.NewBxClient()
+		bxCli, err := powervsconfig.NewBxClient(false)
 		if err != nil {
 			return err
 		}

--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -59,7 +59,7 @@ type DNSZoneResponse struct {
 
 // NewClient initializes a client with a session.
 func NewClient() (*Client, error) {
-	bxCli, err := NewBxClient()
+	bxCli, err := NewBxClient(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/installconfig/powervs/platform.go
+++ b/pkg/asset/installconfig/powervs/platform.go
@@ -9,12 +9,7 @@ import (
 // Platform collects powervs-specific configuration.
 func Platform() (*powervs.Platform, error) {
 
-	bxCli, err := NewBxClient()
-	if err != nil {
-		return nil, err
-	}
-
-	err = bxCli.NewPISession()
+	bxCli, err := NewBxClient(true)
 	if err != nil {
 		return nil, err
 	}
@@ -28,9 +23,9 @@ func Platform() (*powervs.Platform, error) {
 		p.ClusterOSImage = osOverride
 	}
 
-	p.Region = bxCli.PISession.Options.Region
-	p.Zone = bxCli.PISession.Options.Zone
-	p.UserID = bxCli.PISession.Options.UserAccount
+	p.Region = bxCli.Region
+	p.Zone = bxCli.Zone
+	p.UserID = bxCli.User.ID
 
 	return &p, nil
 }

--- a/pkg/asset/installconfig/powervs/regions.go
+++ b/pkg/asset/installconfig/powervs/regions.go
@@ -48,7 +48,7 @@ func IsKnownZone(region string, zone string) bool {
 }
 
 // GetRegion prompts the user to select a region and returns that region.
-func GetRegion() (string, error) {
+func GetRegion(defaultRegion string) (string, error) {
 	regions := knownRegions()
 
 	longRegions := make([]string, 0, len(regions))
@@ -71,12 +71,19 @@ func GetRegion() (string, error) {
 	}
 
 	var region string
+	li := sort.SearchStrings(shortRegions, defaultRegion)
+	if li == len(shortRegions) || shortRegions[li] != defaultRegion {
+		defaultRegion = ""
+	} else {
+		defaultRegion = longRegions[li]
+	}
 
 	err := survey.Ask([]*survey.Question{
 		{
 			Prompt: &survey.Select{
 				Message: "Region",
 				Help:    "The Power VS region to be used for installation.",
+				Default: fmt.Sprintf("%s", defaultRegion),
 				Options: longRegions,
 			},
 			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
@@ -98,9 +105,11 @@ func GetRegion() (string, error) {
 }
 
 // GetZone prompts the user for a zone given a zone.
-func GetZone(region string) (string, error) {
+func GetZone(region string, defaultZone string) (string, error) {
 	zones := knownZones(region)
-	defaultZone := zones[0]
+	if len(defaultZone) == 0 {
+		defaultZone = zones[0]
+	}
 
 	var zoneTransform survey.Transformer = func(ans interface{}) interface{} {
 		switch v := ans.(type) {

--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -146,15 +146,11 @@ func (a *PlatformQuotaCheck) Generate(dependencies asset.Parents) error {
 		}
 		summarizeReport(reports)
 	case powervs.Name:
-		bxCli, err := configpowervs.NewBxClient()
+		bxCli, err := configpowervs.NewBxClient(false)
 		if err != nil {
 			return errors.Wrap(err, "failed to create bluemix client")
 		}
 
-		err = bxCli.NewPISession()
-		if err != nil {
-			return errors.Wrap(err, "failed to get PowerVS connection details")
-		}
 		err = bxCli.ValidateCloudConnectionInPowerVSRegion(context.TODO(), ic.Config.Platform.PowerVS.ServiceInstanceID)
 		if err != nil {
 			return errors.Wrap(err, "failed to meet the prerequisite for Cloud Connections")

--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -165,7 +165,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 		err      error
 	)
 
-	bxClient, err = powervs.NewBxClient()
+	bxClient, err = powervs.NewBxClient(false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Removing zone and region from config.json, and updating calls to NewBxClient that only require the apikey to call GetSessionCredsFromAuthFIle directly.  This was done to bypass the additional survey prompts for region and zone that are no longer pulled from config.json.