### PR TITLE
Bug 2049108: Fix network interface not found error

### DIFF
--- a/data/data/aws/cluster/master/main.tf
+++ b/data/data/aws/cluster/master/main.tf
@@ -172,6 +172,10 @@ resource "aws_instance" "master" {
     },
     var.tags,
   )
+
+  depends_on = [
+    aws_network_interface.master
+  ]
 }
 
 resource "aws_lb_target_group_attachment" "master" {


### PR DESCRIPTION
Right now, the control-plane nodes and their network interfaces
are being created in parallel and sometimes the control plane nodes
try to find their network interface before it's created, causing
an error in the creation of the nodes. Adding a depends on block
to instruct terraform to create the network interfaces before
trying to create the control plane nodes.