### PR TITLE
Bug 2100841: Print the "export KUBECONFIG=..." command on its own line for easier cut-and-paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Example output:
 ```sh
 INFO Waiting 10m0s for the openshift-console route to be created...
 INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/path/to/installer/auth/kubeconfig'
+INFO To access the cluster as the system:admin user when using 'oc', run
+    export KUBECONFIG=/path/to/installer/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.${CLUSTER_NAME}.${BASE_DOMAIN}:6443
 INFO Login to the console with user: kubeadmin, password: 5char-5char-5char-5char
 ```

--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -594,7 +594,7 @@ func logComplete(directory, consoleURL string) error {
 		return err
 	}
 	logrus.Info("Install complete!")
-	logrus.Infof("To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=%s'", kubeconfig)
+	logrus.Infof("To access the cluster as the system:admin user when using 'oc', run\n    export KUBECONFIG=%s", kubeconfig)
 	logrus.Infof("Access the OpenShift web-console here: %s", consoleURL)
 	logrus.Infof("Login to the console with user: %q, and password: %q", "kubeadmin", pw)
 	return nil

--- a/docs/user/aws/install.md
+++ b/docs/user/aws/install.md
@@ -34,7 +34,8 @@ INFO Destroying the bootstrap resources...
 INTO Waiting up to 30m0s for the cluster at https://api.test.example.com:6443 to initialize...
 INFO Waiting up to 10m0s for the openshift-console route to be created...
 INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/user/auth/kubeconfig'
+INFO To access the cluster as the system:admin user when using 'oc', run
+    export KUBECONFIG=/home/user/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.test.example.com
 INFO Login to the console with user: kubeadmin, password: 5char-5char-5char-5char
 ```

--- a/docs/user/azure/install.md
+++ b/docs/user/azure/install.md
@@ -36,7 +36,8 @@ INFO Destroying the bootstrap resources...
 INTO Waiting up to 30m0s for the cluster at https://api.test.example.com:6443 to initialize...
 INFO Waiting up to 10m0s for the openshift-console route to be created...
 INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/user/auth/kubeconfig'
+INFO To access the cluster as the system:admin user when using 'oc', run
+    export KUBECONFIG=/home/user/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.test.example.com
 INFO Login to the console with user: kubeadmin, password: 5char-5char-5char-5char
 ```

--- a/docs/user/azure/install_upi.md
+++ b/docs/user/azure/install_upi.md
@@ -528,7 +528,8 @@ DEBUG Route found in openshift-console namespace: console
 DEBUG Route found in openshift-console namespace: downloads
 DEBUG OpenShift console route is created
 INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=${PWD}/auth/kubeconfig'
+INFO To access the cluster as the system:admin user when using 'oc', run
+    export KUBECONFIG=${PWD}/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.cluster.basedomain.com
 INFO Login to the console with user: kubeadmin, password: REDACTED
 ```

--- a/docs/user/azure/install_upi_azurestack.md
+++ b/docs/user/azure/install_upi_azurestack.md
@@ -630,7 +630,8 @@ DEBUG Route found in openshift-console namespace: console
 DEBUG Route found in openshift-console namespace: downloads
 DEBUG OpenShift console route is created
 INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=${PWD}/auth/kubeconfig'
+INFO To access the cluster as the system:admin user when using 'oc', run
+    export KUBECONFIG=${PWD}/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.cluster.basedomain.com
 INFO Login to the console with user: kubeadmin, password: REDACTED
 ```

--- a/docs/user/gcp/install.md
+++ b/docs/user/gcp/install.md
@@ -38,7 +38,8 @@ INFO Destroying the bootstrap resources...
 INFO Waiting up to 30m0s for the cluster at https://api.mycluster.example.com:6443 to initialize...
 INFO Waiting up to 10m0s for the openshift-console route to be created...
 INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/user/auth/kubeconfig'
+INFO To access the cluster as the system:admin user when using 'oc', run
+    export KUBECONFIG=/home/user/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.mycluster.example.com
 INFO Login to the console with user: kubeadmin, password: 5char-5char-5char-5char
 ```

--- a/docs/user/openstack/README.md
+++ b/docs/user/openstack/README.md
@@ -419,7 +419,8 @@ Look for a message like this to verify that your install succeeded:
 
 ```txt
 INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/stack/ostest/auth/kubeconfig'
+INFO To access the cluster as the system:admin user when using 'oc', run
+    export KUBECONFIG=/home/stack/ostest/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.ostest.shiftstack.com
 INFO Login to the console with user: kubeadmin, password: xxx
 ```

--- a/docs/user/ovirt/install_ipi.md
+++ b/docs/user/ovirt/install_ipi.md
@@ -189,7 +189,8 @@ INFO Destroying the bootstrap resources...
 INFO Waiting up to 30m0s for the cluster at https://api.test.example.org:6443 to initialize...
 INFO Waiting up to 10m0s for the openshift-console route to be created...
 INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/user/install_dir/auth/kubeconfig'
+INFO To access the cluster as the system:admin user when using 'oc', run
+    export KUBECONFIG=/home/user/install_dir/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.test.example.org
 INFO Login to the console with user: kubeadmin, password: xxxxxxxxx
 ```

--- a/docs/user/vsphere/install.md
+++ b/docs/user/vsphere/install.md
@@ -83,7 +83,8 @@ INFO Destroying the bootstrap resources...
 INFO Waiting up to 30m0s for the cluster at https://api.mycluster.example.com:6443 to initialize...
 INFO Waiting up to 10m0s for the openshift-console route to be created...
 INFO Install complete!
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/user/auth/kubeconfig'
+INFO To access the cluster as the system:admin user when using 'oc', run
+    export KUBECONFIG=/home/user/auth/kubeconfig
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.mycluster.example.com
 INFO Login to the console with user: kubeadmin, password: 5char-5char-5char-5char
 ```


### PR DESCRIPTION
instead of saying

```
INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/danw/Desktop/cluster/auth/kubeconfig' 
```

say

```
INFO To access the cluster as the system:admin user when using 'oc', run
    export KUBECONFIG=/home/danw/Desktop/cluster/auth/kubeconfig
```

so you can just triple-click the line to select it rather than having to carefully select between the quote marks