### PR TITLE
Bug 2098299: Make new machinepool fields pointers+omitempty

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -532,6 +532,9 @@ func validateMarketplaceImage(client API, installConfig *types.InstallConfig) fi
 		if platform == nil {
 			continue
 		}
+		if platform.OSImage == nil {
+			continue
+		}
 		if platform.OSImage.Publisher == "" {
 			continue
 		}

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -201,12 +201,6 @@ var (
 	erroringOSImageSKU               = "test-sku-gen1"
 	erroringLicenseTermsOSImageSKU   = "erroring-license-terms"
 	unacceptedLicenseTermsOSImageSKU = "unaccepted-license-terms"
-	validOSImage                     = azure.OSImage{
-		Publisher: validOSImagePublisher,
-		Offer:     validOSImageOffer,
-		SKU:       validOSImageSKU,
-		Version:   validOSImageVersion,
-	}
 
 	validDiskEncryptionSetDefaultMachinePlatform = func(ic *types.InstallConfig) {
 		ic.Azure.DefaultMachinePlatform.OSDisk.DiskEncryptionSet = validDiskEncryptionSetConfig()
@@ -228,7 +222,12 @@ var (
 	}
 
 	validOSImageCompute = func(ic *types.InstallConfig) {
-		ic.Compute[0].Platform.Azure.OSImage = validOSImage
+		ic.Compute[0].Platform.Azure.OSImage = &azure.OSImage{
+			Publisher: validOSImagePublisher,
+			Offer:     validOSImageOffer,
+			SKU:       validOSImageSKU,
+			Version:   validOSImageVersion,
+		}
 	}
 	invalidOSImageCompute = func(ic *types.InstallConfig) {
 		validOSImageCompute(ic)

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -78,7 +78,7 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 	return machines, nil
 }
 
-func provider(clusterID string, region string, subnet string, instanceType string, root *aws.EC2RootVolume, imds aws.EC2Metadata, osImage string, zone, role, userDataSecret string, userTags map[string]string) (*machineapi.AWSMachineProviderConfig, error) {
+func provider(clusterID string, region string, subnet string, instanceType string, root *aws.EC2RootVolume, imds *aws.EC2Metadata, osImage string, zone, role, userDataSecret string, userTags map[string]string) (*machineapi.AWSMachineProviderConfig, error) {
 	tags, err := tagsFromUserTags(clusterID, userTags)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create machineapi.TagSpecifications from UserTags")
@@ -131,7 +131,7 @@ func provider(clusterID string, region string, subnet string, instanceType strin
 		config.AMI.ID = pointer.StringPtr(osImage)
 	}
 
-	if imds.Authentication != "" {
+	if imds != nil && imds.Authentication != "" {
 		config.MetadataServiceOptions.Authentication = machineapi.MetadataServiceAuthentication(imds.Authentication)
 	}
 

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -103,7 +103,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 	rg := platform.ClusterResourceGroupName(clusterID)
 
 	var image machineapi.Image
-	if mpool.OSImage.Publisher != "" {
+	if mpool.OSImage != nil && mpool.OSImage.Publisher != "" {
 		image.Type = machineapi.AzureImageTypeMarketplaceWithPlan
 		image.Publisher = mpool.OSImage.Publisher
 		image.Offer = mpool.OSImage.Offer

--- a/pkg/types/aws/machinepool.go
+++ b/pkg/types/aws/machinepool.go
@@ -28,7 +28,7 @@ type MachinePool struct {
 	// EC2MetadataOptions defines metadata service interaction options for EC2 instances in the machine pool.
 	//
 	// +optional
-	EC2Metadata EC2Metadata `json:"metadataService"`
+	EC2Metadata *EC2Metadata `json:"metadataService,omitempty"`
 
 	// IAMRole is the name of the IAM Role to use for the instance profile of the machine.
 	// Leave unset to have the installer create the IAM Role on your behalf.
@@ -67,7 +67,7 @@ func (a *MachinePool) Set(required *MachinePool) {
 		a.EC2RootVolume.KMSKeyARN = required.EC2RootVolume.KMSKeyARN
 	}
 
-	if required.EC2Metadata.Authentication != "" {
+	if required.EC2Metadata != nil && required.EC2Metadata.Authentication != "" {
 		a.EC2Metadata.Authentication = required.EC2Metadata.Authentication
 	}
 

--- a/pkg/types/aws/validation/machinepool.go
+++ b/pkg/types/aws/validation/machinepool.go
@@ -43,7 +43,7 @@ func ValidateMachinePool(platform *aws.Platform, p *aws.MachinePool, fldPath *fi
 		allErrs = append(allErrs, validateIOPS(p, fldPath)...)
 	}
 
-	if p.EC2Metadata.Authentication != "" && !validMetadataAuthValues.Has(p.EC2Metadata.Authentication) {
+	if p.EC2Metadata != nil && p.EC2Metadata.Authentication != "" && !validMetadataAuthValues.Has(p.EC2Metadata.Authentication) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("authentication"), p.EC2Metadata.Authentication, "must be either Required or Optional"))
 	}
 

--- a/pkg/types/aws/validation/machinepool_test.go
+++ b/pkg/types/aws/validation/machinepool_test.go
@@ -122,7 +122,7 @@ func TestValidateMachinePool(t *testing.T) {
 		{
 			name: "invalid metadata auth option",
 			pool: &aws.MachinePool{
-				EC2Metadata: aws.EC2Metadata{
+				EC2Metadata: &aws.EC2Metadata{
 					Authentication: "foobarbaz",
 				},
 			},

--- a/pkg/types/azure/machinepool.go
+++ b/pkg/types/azure/machinepool.go
@@ -42,7 +42,7 @@ type MachinePool struct {
 
 	// OSImage defines the image to use for the OS.
 	// +optional
-	OSImage OSImage `json:"osImage,omitempty"`
+	OSImage *OSImage `json:"osImage,omitempty"`
 }
 
 // VMNetworkingCapability defines the states for accelerated networking feature
@@ -99,7 +99,7 @@ func (a *MachinePool) Set(required *MachinePool) {
 	}
 
 	var emptyOSImage OSImage
-	if required.OSImage != emptyOSImage {
+	if required.OSImage != nil && *required.OSImage != emptyOSImage {
 		a.OSImage = required.OSImage
 	}
 }

--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -63,7 +63,7 @@ func validateOSImage(p *azure.MachinePool, poolName string, fldPath *field.Path)
 	osImageFldPath := fldPath.Child("osImage")
 
 	emptyOSImage := azure.OSImage{}
-	if p.OSImage != emptyOSImage {
+	if p.OSImage != nil && *p.OSImage != emptyOSImage {
 		// The control plane cannot use the marketplace image. Don't let the default machine pool specify the
 		// marketplace image either.
 		if poolName == "" || poolName == "master" {

--- a/pkg/types/azure/validation/machinepool_test.go
+++ b/pkg/types/azure/validation/machinepool_test.go
@@ -125,7 +125,7 @@ func TestValidateMachinePool(t *testing.T) {
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
 					Azure: &azure.MachinePool{
-						OSImage: azure.OSImage{
+						OSImage: &azure.OSImage{
 							Publisher: "test-publisher",
 							Offer:     "test-offer",
 							SKU:       "test-sku",
@@ -141,7 +141,7 @@ func TestValidateMachinePool(t *testing.T) {
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
 					Azure: &azure.MachinePool{
-						OSImage: azure.OSImage{
+						OSImage: &azure.OSImage{
 							Offer:   "test-offer",
 							SKU:     "test-sku",
 							Version: "test-version",
@@ -157,7 +157,7 @@ func TestValidateMachinePool(t *testing.T) {
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
 					Azure: &azure.MachinePool{
-						OSImage: azure.OSImage{
+						OSImage: &azure.OSImage{
 							Publisher: "test-publisher",
 							SKU:       "test-sku",
 							Version:   "test-version",
@@ -173,7 +173,7 @@ func TestValidateMachinePool(t *testing.T) {
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
 					Azure: &azure.MachinePool{
-						OSImage: azure.OSImage{
+						OSImage: &azure.OSImage{
 							Publisher: "test-publisher",
 							Offer:     "test-offer",
 							Version:   "test-version",
@@ -189,7 +189,7 @@ func TestValidateMachinePool(t *testing.T) {
 				Name: "worker",
 				Platform: types.MachinePoolPlatform{
 					Azure: &azure.MachinePool{
-						OSImage: azure.OSImage{
+						OSImage: &azure.OSImage{
 							Publisher: "test-publisher",
 							Offer:     "test-offer",
 							SKU:       "test-sku",
@@ -205,7 +205,7 @@ func TestValidateMachinePool(t *testing.T) {
 				Name: "master",
 				Platform: types.MachinePoolPlatform{
 					Azure: &azure.MachinePool{
-						OSImage: azure.OSImage{
+						OSImage: &azure.OSImage{
 							Publisher: "test-publisher",
 							Offer:     "test-offer",
 							SKU:       "test-sku",
@@ -222,7 +222,7 @@ func TestValidateMachinePool(t *testing.T) {
 				Name: "",
 				Platform: types.MachinePoolPlatform{
 					Azure: &azure.MachinePool{
-						OSImage: azure.OSImage{
+						OSImage: &azure.OSImage{
 							Publisher: "test-publisher",
 							Offer:     "test-offer",
 							SKU:       "test-sku",


### PR DESCRIPTION
install-configs generated with versions of installer libs since fdb10d991 / #5793 would fail to install on 4.10 due to the addition of optional-but-not-omitempty-pointer fields combined with strict unmarshalling that punts on unrecognized fields. Ensure new fields are a) pointer types, and b) `omitempty` so they are not emitted during marshaling if absent from the go object. cf. https://github.com/golang/go/issues/11939

closes: 2098299