### PR TITLE
AGENT-230: Enable multipathd in agent ISO

### DIFF
--- a/data/data/agent/files/etc/multipath.conf
+++ b/data/data/agent/files/etc/multipath.conf
@@ -1,0 +1,10 @@
+defaults {
+    user_friendly_names yes
+    find_multipaths yes
+    enable_foreign "^$"
+}
+blacklist_exceptions {
+    property "(SCSI_IDENT_|ID_WWN)"
+}
+blacklist {
+}

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -51,6 +51,7 @@ var (
 		"assisted-service.service",
 		"create-cluster-and-infraenv.service",
 		"node-zero.service",
+		"multipathd.service",
 		"pre-network-manager-config.service",
 		"selinux.service",
 		"start-cluster-installation.service",


### PR DESCRIPTION
Enable the multipathd service with a default config file in the agent
ISO. This is equivalent to specifying the `rd.multipath=default` flag on
the kernel command line, but without the need to mess with the kernel
command line. Since the ISO itself will be attached as virtual or actual
media, there is no need for anything to run during the initramfs.

This allows us the agent to discover multipath Fibre Channel volumes if
they exist.