### PR TITLE
Bug 2099401: IBMCloud: Set regional URL for ibmcloud client

### DIFF
--- a/pkg/asset/installconfig/ibmcloud/client.go
+++ b/pkg/asset/installconfig/ibmcloud/client.go
@@ -35,6 +35,7 @@ type API interface {
 	GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, error)
 	GetVPC(ctx context.Context, vpcID string) (*vpcv1.VPC, error)
 	GetVPCZonesForRegion(ctx context.Context, region string) ([]string, error)
+	SetVPCServiceURLForRegion(ctx context.Context, region string) error
 }
 
 // Client makes calls to the IBM Cloud API.
@@ -151,7 +152,7 @@ func (c *Client) GetCISInstance(ctx context.Context, crnstr string) (*resourceco
 
 // GetDedicatedHostByName gets dedicated host by name.
 func (c *Client) GetDedicatedHostByName(ctx context.Context, name string, region string) (*vpcv1.DedicatedHost, error) {
-	err := c.setVPCServiceURLForRegion(ctx, region)
+	err := c.SetVPCServiceURLForRegion(ctx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +174,7 @@ func (c *Client) GetDedicatedHostByName(ctx context.Context, name string, region
 
 // GetDedicatedHostProfiles gets a list of profiles supported in a region.
 func (c *Client) GetDedicatedHostProfiles(ctx context.Context, region string) ([]vpcv1.DedicatedHostProfile, error) {
-	err := c.setVPCServiceURLForRegion(ctx, region)
+	err := c.SetVPCServiceURLForRegion(ctx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -452,7 +453,8 @@ func (c *Client) loadVPCV1API() error {
 	return nil
 }
 
-func (c *Client) setVPCServiceURLForRegion(ctx context.Context, region string) error {
+// SetVPCServiceURLForRegion will set the VPC Service URL to a specific IBM Cloud Region, in order to access Region scoped resources
+func (c *Client) SetVPCServiceURLForRegion(ctx context.Context, region string) error {
 	regionOptions := c.vpcAPI.NewGetRegionOptions(region)
 	vpcRegion, _, err := c.vpcAPI.GetRegionWithContext(ctx, regionOptions)
 	if err != nil {

--- a/pkg/asset/installconfig/ibmcloud/metadata.go
+++ b/pkg/asset/installconfig/ibmcloud/metadata.go
@@ -13,6 +13,7 @@ import (
 // from external APIs).
 type Metadata struct {
 	BaseDomain string
+	Region     string
 
 	accountID      string
 	cisInstanceCRN string
@@ -22,8 +23,11 @@ type Metadata struct {
 }
 
 // NewMetadata initializes a new Metadata object.
-func NewMetadata(baseDomain string) *Metadata {
-	return &Metadata{BaseDomain: baseDomain}
+func NewMetadata(baseDomain string, region string) *Metadata {
+	return &Metadata{
+		BaseDomain: baseDomain,
+		Region:     region,
+	}
 }
 
 // AccountID returns the IBM Cloud account ID associated with the authentication
@@ -85,6 +89,7 @@ func (m *Metadata) SetCISInstanceCRN(crn string) {
 func (m *Metadata) Client() (*Client, error) {
 	if m.client == nil {
 		client, err := NewClient()
+		client.SetVPCServiceURLForRegion(context.TODO(), m.Region)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/asset/installconfig/ibmcloud/validation_test.go
+++ b/pkg/asset/installconfig/ibmcloud/validation_test.go
@@ -172,7 +172,7 @@ func TestValidatePreExitingPublicDNS(t *testing.T) {
 
 	dnsRecordName := fmt.Sprintf("api.%s.%s", validClusterName, validBaseDomain)
 
-	metadata := ibmcloud.NewMetadata(validBaseDomain)
+	metadata := ibmcloud.NewMetadata(validBaseDomain, "us-south")
 	metadata.SetCISInstanceCRN(validCISInstanceCRN)
 
 	// Mocks: no pre-existing DNS records

--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -164,7 +164,7 @@ func (a *InstallConfig) finish(filename string) error {
 		a.Azure = icazure.NewMetadata(a.Config.Azure.CloudName, a.Config.Azure.ARMEndpoint)
 	}
 	if a.Config.IBMCloud != nil {
-		a.IBMCloud = icibmcloud.NewMetadata(a.Config.BaseDomain)
+		a.IBMCloud = icibmcloud.NewMetadata(a.Config.BaseDomain, a.Config.IBMCloud.Region)
 	}
 	if a.Config.PowerVS != nil {
 		a.PowerVS = icpowervs.NewMetadata(a.Config.BaseDomain)


### PR DESCRIPTION
Certain resources for IBM Cloud require that the region is set in
the Client. Adding support to set the regional URL for the IBM
Cloud client.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2099401