### PR TITLE
AGENT-228: Systemd service to set hostname defined in agent-config

### DIFF
--- a/data/data/agent/files/usr/local/bin/set-hostname.sh
+++ b/data/data/agent/files/usr/local/bin/set-hostname.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 #
 # The hostnames defined in agent-config.yaml are written out
-# to files at /etc/agent-installer/hostnames/<MAC-address>.
+# to files at /etc/assisted/hostnames/<MAC-address>.
 # 
 # If a host has multiple interfaces, the host's first network 
 # interface's MAC address is used.
 #
 # This script compares the MAC addresses on the current host
-# with the addresses in /etc/agent-installer/hostnames/.
+# with the addresses in /etc/assisted/hostnames/.
 #
 # If a match is found, then the hostname in the file is set
 # as this host's hostname.
 #
 
-HOSTNAMES_PATH=/etc/agent-installer/hostnames
+HOSTNAMES_PATH=/etc/assisted/hostnames
 FILES=$(ls $HOSTNAMES_PATH)
 for filename in $FILES
 do

--- a/data/data/agent/files/usr/local/bin/set-hostname.sh
+++ b/data/data/agent/files/usr/local/bin/set-hostname.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# The hostnames defined in agent-config.yaml are written out
+# to files at /etc/agent-installer/hostnames/<MAC-address>.
+# 
+# If a host has multiple interfaces, the host's first network 
+# interface's MAC address is used.
+#
+# This script compares the MAC addresses on the current host
+# with the addresses in /etc/agent-installer/hostnames/.
+#
+# If a match is found, then the hostname in the file is set
+# as this host's hostname.
+#
+
+HOSTNAMES_PATH=/etc/agent-installer/hostnames
+FILES=$(ls $HOSTNAMES_PATH)
+for filename in $FILES
+do
+    MATCHED_MAC_ADDRESS_WITH_HOST=$(ip address | grep $filename)
+    if [ "$MATCHED_MAC_ADDRESS_WITH_HOST" != "" ]; then
+        HOSTNAME=$(cat ${HOSTNAMES_PATH}/${filename})
+        echo "Host has matching MAC address: $filename" 1>&2
+        echo "Setting hostname to $HOSTNAME" 1>&2
+        hostnamectl set-hostname $HOSTNAME
+    else
+        echo "MAC address, $filename, does not exist on this host" 1>&2
+    fi
+done

--- a/data/data/agent/systemd/units/agent.service.template
+++ b/data/data/agent/systemd/units/agent.service.template
@@ -16,8 +16,8 @@ TimeoutStartSec=3000
 ExecStartPre=podman run --privileged --rm -v /usr/local/bin:/hostbin quay.io/edge-infrastructure/assisted-installer-agent:latest cp /usr/bin/agent /hostbin
 ExecStart=/usr/local/bin/start-agent.sh
 [Unit]
-Wants=network-online.target
-After=network-online.target
+Wants=network-online.target set-hostname.service
+After=network-online.target set-hostname.service
 
 [Install]
 WantedBy=multi-user.target

--- a/data/data/agent/systemd/units/set-hostname.service
+++ b/data/data/agent/systemd/units/set-hostname.service
@@ -6,7 +6,10 @@ After=network-online.target
 [Service]
 ExecStart=/usr/local/bin/set-hostname.sh
 ExecStartPost=/bin/sleep 5
-Restart=on-failure
+
+KillMode=none
+Type=oneshot
+RemainAfterExit=true
 
 [Install]
 WantedBy=multi-user.target

--- a/data/data/agent/systemd/units/set-hostname.service
+++ b/data/data/agent/systemd/units/set-hostname.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Agent-based installer hostname update service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/set-hostname.sh
+ExecStartPost=/bin/sleep 5
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/data/data/agent/systemd/units/set-hostname.service
+++ b/data/data/agent/systemd/units/set-hostname.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Agent-based installer hostname update service
 Wants=network-online.target
-After=network-online.target
+After=local-fs.target
 
 [Service]
 ExecStart=/usr/local/bin/set-hostname.sh

--- a/data/data/agent/systemd/units/set-hostname.service
+++ b/data/data/agent/systemd/units/set-hostname.service
@@ -5,7 +5,6 @@ After=network-online.target
 
 [Service]
 ExecStart=/usr/local/bin/set-hostname.sh
-ExecStartPost=/bin/sleep 5
 
 KillMode=none
 Type=oneshot

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -22,7 +22,7 @@ import (
 )
 
 const manifestPath = "/etc/assisted/manifests"
-const hostnamesPath = "/etc/agent-installer/hostnames"
+const hostnamesPath = "/etc/assisted/hostnames"
 const nmConnectionsPath = "/etc/assisted/network"
 const mirrorPath = "/etc/assisted/mirror"
 

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -22,6 +22,7 @@ import (
 )
 
 const manifestPath = "/etc/assisted/manifests"
+const hostnamesPath = "/etc/agent-installer/hostnames"
 const nmConnectionsPath = "/etc/assisted/network"
 const mirrorPath = "/etc/assisted/mirror"
 
@@ -62,6 +63,7 @@ var (
 		"multipathd.service",
 		"pre-network-manager-config.service",
 		"selinux.service",
+		"set-hostname.service",
 		"start-cluster-installation.service",
 	}
 )
@@ -173,6 +175,8 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		config.Storage.Files = append(config.Storage.Files, agentConfigFile)
 	}
 
+	addMacAddressToHostnameMappings(&config, agentConfigAsset)
+
 	err = addStaticNetworkConfig(&config, agentManifests.StaticNetworkConfigs)
 	if err != nil {
 		return err
@@ -273,7 +277,25 @@ func addMirrorData(config *igntypes.Config, agentMirror *mirror.AgentMirror) {
 			mirrorFile := ignition.FileFromBytes("/etc/pki/ca-trust/source/anchors/domain.crt",
 				"root", 0600, file.Data)
 			config.Storage.Files = append(config.Storage.Files, mirrorFile)
+		}
+	}
+}
 
+// Creates a file named with a host's MAC address. The desired hostname
+// is the file's content. The files are read by a systemd service that
+// sets the hostname using "hostnamectl set-hostname" when the ISO boots.
+func addMacAddressToHostnameMappings(
+	config *igntypes.Config,
+	agentConfigAsset *agentconfig.Asset) {
+	if agentConfigAsset.Config == nil || len(agentConfigAsset.Config.Spec.Hosts) == 0 {
+		return
+	}
+	for _, host := range agentConfigAsset.Config.Spec.Hosts {
+		if host.Hostname != "" {
+			file := ignition.FileFromBytes(filepath.Join(hostnamesPath,
+				filepath.Base(host.Interfaces[0].MacAddress)),
+				"root", 0600, []byte(host.Hostname))
+			config.Storage.Files = append(config.Storage.Files, file)
 		}
 	}
 }


### PR DESCRIPTION
[AGENT-228](https://issues.redhat.com//browse/AGENT-228): Systemd service to set hostname defined in agent-config
    
Users may specify a hostname for a host by defining the hostname
and the host's macAddress in agent-config.yaml.
    
The agent Ignition then writes each macAddress to hostname mapping
to a file at /etc/assisted/hostnames/.
    
The file names in that path are MAC addresses. The desired hostname
is the file's content.
    
 A new set-hostname.service runs during boot and reads the macAddress
 to hostname mappings and if it finds one of the host's macAddress
 is in the mapping, it then updates the host's hostname using the
 mapped value.

~~Depends on: #6022~~
