### PR TITLE
Bug 2094923: Add the appropriate Tag for aws public subnets for workers

### DIFF
--- a/data/data/aws/cluster/vpc/vpc-public.tf
+++ b/data/data/aws/cluster/vpc/vpc-public.tf
@@ -52,7 +52,8 @@ resource "aws_subnet" "public_subnet" {
 
   tags = merge(
     {
-      "Name" = "${var.cluster_id}-public-${var.availability_zones[count.index]}"
+      "Name"                   = "${var.cluster_id}-public-${var.availability_zones[count.index]}"
+      "kubernetes.io/role/elb" = ""
     },
     var.tags,
   )


### PR DESCRIPTION
1. When creating new subnets, add the "kubernetes.io/role/elb" tag to the worker subnets. See https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L98-L100 for more information
2. When using existing subnets, add the tag with the value "shared". This is based on how the current tag "kubernetes.io/cluster/<cluster-id>" is added
4. Ensure the new tags are destroyed properly for both case 1 & 2. The tags are removed when the public subnets are destroyed because these public subnets could be shared among multiple clusters.

Subnets are auto-discovered using the following criteria:
// ServiceAnnotationLoadBalancerSubnets is the annotation used on the service to specify the
// Availability Zone configuration for the load balancer. The values are comma separated list of
// subnetID or subnetName from different AZs
// By default, the controller will auto-discover the subnets. If there are multiple subnets per AZ, auto-discovery
// will break the tie in the following order -
//   1. prefer the subnet with the correct role tag. kubernetes.io/role/elb for public and kubernetes.io/role/internal-elb for private access
//   2. prefer the subnet with the cluster tag kubernetes.io/cluster/<Cluster Name>
//   3. prefer the subnet that is first in lexicographic order

So, the goal of the fix is to make sure that the usable subnets in the AZ are tagged such that auto-discovery does not fall through to option 3 (and hence picking a subnet that is not owned by OpenShift)