### PR TITLE
Bug 2098299: Switch to perform normal marshalling with unknown fields

### DIFF
--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -131,11 +132,17 @@ func (a *InstallConfig) Load(f asset.FileFetcher) (found bool, err error) {
 
 	config := &types.InstallConfig{}
 	if err := yaml.UnmarshalStrict(file.Data, config, yaml.DisallowUnknownFields); err != nil {
-		if strings.Contains(err.Error(), "unknown field") {
-			err = errors.Wrapf(err, "failed to parse first occurence of unknown field")
-		}
 		err = errors.Wrapf(err, "failed to unmarshal %s", installConfigFilename)
-		return false, errors.Wrap(err, asset.InstallConfigError)
+		if !strings.Contains(err.Error(), "unknown field") {
+			return false, errors.Wrap(err, asset.InstallConfigError)
+		}
+		err = errors.Wrapf(err, "failed to parse first occurence of unknown field")
+		logrus.Warnf(err.Error())
+		logrus.Info("Attempting to unmarshal while ignoring unknown keys because strict unmarshaling failed")
+		if err = yaml.UnmarshalStrict(file.Data, config); err != nil {
+			err = errors.Wrapf(err, "failed to unmarshal %s", installConfigFilename)
+			return false, errors.Wrap(err, asset.InstallConfigError)
+		}
 	}
 	a.Config = config
 

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -190,7 +190,50 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 wrong_key: wrong_value 
 `,
-			expectedError: true,
+			expectedFound: true,
+			expectedConfig: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				BaseDomain: "test-domain",
+				Networking: &types.Networking{
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+					},
+					NetworkType:    "OpenShiftSDN",
+					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
+					ClusterNetwork: []types.ClusterNetworkEntry{
+						{
+							CIDR:       *ipnet.MustParseCIDR("10.128.0.0/14"),
+							HostPrefix: 23,
+						},
+					},
+				},
+				ControlPlane: &types.MachinePool{
+					Name:           "master",
+					Replicas:       pointer.Int64Ptr(3),
+					Hyperthreading: types.HyperthreadingEnabled,
+					Architecture:   types.ArchitectureAMD64,
+				},
+				Compute: []types.MachinePool{
+					{
+						Name:           "worker",
+						Replicas:       pointer.Int64Ptr(3),
+						Hyperthreading: types.HyperthreadingEnabled,
+						Architecture:   types.ArchitectureAMD64,
+					},
+				},
+				Platform: types.Platform{
+					AWS: &aws.Platform{
+						Region: "us-east-1",
+					},
+				},
+				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				Publish:    types.ExternalPublishingStrategy,
+			},
 		},
 		{
 			name: "old valid InstallConfig",


### PR DESCRIPTION
The hive team uses a lot of fields in the install config that might
not exist due to older versions of the installer missing a few fields
that may have been added in the newer versions, which causes the
installer to reject them all but is needed for proper functioning.

Changing the code a little to now provide a warning message to the
user in case of any unknown fields and then try to unmarshal it
normally instead of strict.