### PR TITLE
Bug 2082395: Make azure baseDomainResoureGroup optional for private c…

### DIFF
--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -64,6 +64,7 @@ variable "azure_control_plane_ultra_ssd_enabled" {
 
 variable "azure_base_domain_resource_group_name" {
   type        = string
+  default     = ""
   description = "The resource group that contains the dns zone used as base domain for the cluster."
 }
 

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1728,6 +1728,8 @@ spec:
                   baseDomainResourceGroupName:
                     description: BaseDomainResourceGroupName specifies the resource
                       group where the Azure DNS zone for the base domain is found.
+                      This field is optional when creating a private cluster, otherwise
+                      required.
                     type: string
                   cloudName:
                     description: cloudName is the name of the Azure cloud environment

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -159,7 +159,7 @@ func Test_PrintFields(t *testing.T) {
       ARMEndpoint is the endpoint for the Azure API when installing on Azure Stack.
 
     baseDomainResourceGroupName <string>
-      BaseDomainResourceGroupName specifies the resource group where the Azure DNS zone for the base domain is found.
+      BaseDomainResourceGroupName specifies the resource group where the Azure DNS zone for the base domain is found. This field is optional when creating a private cluster, otherwise required.
 
     cloudName <string>
       Valid Values: "","AzurePublicCloud","AzureUSGovernmentCloud","AzureChinaCloud","AzureGermanCloud","AzureStackCloud"

--- a/pkg/types/azure/platform.go
+++ b/pkg/types/azure/platform.go
@@ -34,7 +34,9 @@ type Platform struct {
 	// ClusterOSImage is the url of a storage blob in the Azure Stack environment containing an RHCOS VHD. This field is required for Azure Stack and not applicable to Azure.
 	ClusterOSImage string `json:"clusterOSImage,omitempty"`
 
-	// BaseDomainResourceGroupName specifies the resource group where the Azure DNS zone for the base domain is found.
+	// BaseDomainResourceGroupName specifies the resource group where the Azure DNS zone for the base domain is found. This field is optional when creating a private cluster, otherwise required.
+	//
+	// +optional
 	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
 
 	// DefaultMachinePlatform is the default configuration used when


### PR DESCRIPTION
…lusters

A private azure IPI cluster does not require any public base domain. If a base domain was not provided Terraform would through an error and the installation would fail. By removing omitempty the BaseDomainResourceGroupName becomes optional.