### PR TITLE
IBMCloud: BYON Enablement - InstallConfig

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2220,6 +2220,18 @@ spec:
                 description: IBMCloud is the configuration used when installing on
                   IBM Cloud.
                 properties:
+                  computeSubnets:
+                    description: ComputeSubnets are the names of already existing
+                      subnets where the cluster compute nodes should be created.
+                    items:
+                      type: string
+                    type: array
+                  controlPlaneSubnets:
+                    description: ControlPlaneSubnets are the names of already existing
+                      subnets where the cluster control plane nodes should be created.
+                    items:
+                      type: string
+                    type: array
                   defaultMachinePlatform:
                     description: DefaultMachinePlatform is the default configuration
                       used when installing on IBM Cloud for machine pools which do
@@ -2270,15 +2282,13 @@ spec:
                       will be created.
                     type: string
                   resourceGroupName:
-                    description: "ResourceGroupName is the name of an already existing
-                      resource group where the cluster should be installed. This resource
-                      group should only be used for this specific cluster and the
-                      cluster components will assume ownership of all resources in
-                      the resource group. Destroying the cluster using installer will
-                      delete this resource group. \n This resource group must be empty
-                      with no other resources when trying to use it for creating a
-                      cluster. If empty, a new resource group will be created for
-                      the cluster."
+                    description: ResourceGroupName is the name of an already existing
+                      resource group where the cluster should be installed. If empty,
+                      a new resource group will be created for the cluster.
+                    type: string
+                  vpcName:
+                    description: VPCName is the name of an already existing VPC where
+                      the cluster should be installed.
                     type: string
                 required:
                 - region

--- a/pkg/asset/cluster/ibmcloud/ibmcloud.go
+++ b/pkg/asset/cluster/ibmcloud/ibmcloud.go
@@ -20,5 +20,6 @@ func Metadata(infraID string, config *types.InstallConfig, meta *icibmcloud.Meta
 		CISInstanceCRN:    cisCrn,
 		Region:            config.Platform.IBMCloud.Region,
 		ResourceGroupName: config.Platform.IBMCloud.ClusterResourceGroupName(infraID),
+		VPC:               config.Platform.IBMCloud.GetVPCName(),
 	}
 }

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -471,6 +471,9 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			workerConfigs[i] = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*ibmcloudprovider.IBMCloudMachineProviderSpec)
 		}
 
+		// Set existing network (boolean of whether one is being used)
+		preexistingVPC := installConfig.Config.Platform.IBMCloud.GetVPCName() != ""
+
 		// Set machine pool info
 		var masterMachinePool ibmcloud.MachinePool
 		var workerMachinePool ibmcloud.MachinePool
@@ -534,6 +537,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				ImageURL:             string(*rhcosImage),
 				MasterConfigs:        masterConfigs,
 				MasterDedicatedHosts: masterDedicatedHosts,
+				PreexistingVPC:       preexistingVPC,
 				PublishStrategy:      installConfig.Config.Publish,
 				ResourceGroupName:    installConfig.Config.Platform.IBMCloud.ResourceGroupName,
 				WorkerConfigs:        workerConfigs,

--- a/pkg/asset/installconfig/ibmcloud/client.go
+++ b/pkg/asset/installconfig/ibmcloud/client.go
@@ -32,8 +32,10 @@ type API interface {
 	GetResourceGroups(ctx context.Context) ([]resourcemanagerv2.ResourceGroup, error)
 	GetResourceGroup(ctx context.Context, nameOrID string) (*resourcemanagerv2.ResourceGroup, error)
 	GetSubnet(ctx context.Context, subnetID string) (*vpcv1.Subnet, error)
+	GetSubnetByName(ctx context.Context, subnetName string, region string) (*vpcv1.Subnet, error)
 	GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, error)
 	GetVPC(ctx context.Context, vpcID string) (*vpcv1.VPC, error)
+	GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error)
 	GetVPCZonesForRegion(ctx context.Context, region string) ([]string, error)
 	SetVPCServiceURLForRegion(ctx context.Context, region string) error
 }
@@ -340,6 +342,25 @@ func (c *Client) GetSubnet(ctx context.Context, subnetID string) (*vpcv1.Subnet,
 	return subnet, err
 }
 
+// GetSubnetByName gets a subnet by its Name.
+func (c *Client) GetSubnetByName(ctx context.Context, subnetName string, region string) (*vpcv1.Subnet, error) {
+	_, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	c.SetVPCServiceURLForRegion(ctx, region)
+	listSubnetsOptions := c.vpcAPI.NewListSubnetsOptions()
+	subnetCollection, detailedResponse, err := c.vpcAPI.ListSubnetsWithContext(ctx, listSubnetsOptions)
+	if detailedResponse.GetStatusCode() == http.StatusNotFound {
+		return nil, err
+	}
+	for _, subnet := range subnetCollection.Subnets {
+		if subnetName == *subnet.Name {
+			return &subnet, nil
+		}
+	}
+	return nil, &VPCResourceNotFoundError{}
+}
+
 // GetVSIProfiles gets a list of all VSI profiles.
 func (c *Client) GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, error) {
 	listInstanceProfilesOptions := c.vpcAPI.NewListInstanceProfilesOptions()
@@ -376,6 +397,27 @@ func (c *Client) GetVPC(ctx context.Context, vpcID string) (*vpcv1.VPC, error) {
 	}
 
 	return nil, &VPCResourceNotFoundError{}
+}
+
+// GetVPCs gets all VPCs in a region
+func (c *Client) GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error) {
+	_, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	err := c.SetVPCServiceURLForRegion(ctx, region)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to set vpc api service url")
+	}
+
+	allVPCs := []vpcv1.VPC{}
+	if vpcs, detailedResponse, err := c.vpcAPI.ListVpcs(c.vpcAPI.NewListVpcsOptions()); err != nil {
+		if detailedResponse.GetStatusCode() != http.StatusNotFound {
+			return nil, err
+		}
+	} else if vpcs != nil {
+		allVPCs = append(allVPCs, vpcs.Vpcs...)
+	}
+	return allVPCs, nil
 }
 
 // GetVPCZonesForRegion gets the supported zones for a VPC region.

--- a/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
+++ b/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
@@ -205,6 +205,21 @@ func (mr *MockAPIMockRecorder) GetSubnet(ctx, subnetID interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockAPI)(nil).GetSubnet), ctx, subnetID)
 }
 
+// GetSubnetByName mocks base method.
+func (m *MockAPI) GetSubnetByName(ctx context.Context, subnetName, region string) (*vpcv1.Subnet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubnetByName", ctx, subnetName, region)
+	ret0, _ := ret[0].(*vpcv1.Subnet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubnetByName indicates an expected call of GetSubnetByName.
+func (mr *MockAPIMockRecorder) GetSubnetByName(ctx, subnetName, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetByName", reflect.TypeOf((*MockAPI)(nil).GetSubnetByName), ctx, subnetName, region)
+}
+
 // GetVPC mocks base method.
 func (m *MockAPI) GetVPC(ctx context.Context, vpcID string) (*vpcv1.VPC, error) {
 	m.ctrl.T.Helper()
@@ -233,6 +248,21 @@ func (m *MockAPI) GetVPCZonesForRegion(ctx context.Context, region string) ([]st
 func (mr *MockAPIMockRecorder) GetVPCZonesForRegion(ctx, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCZonesForRegion", reflect.TypeOf((*MockAPI)(nil).GetVPCZonesForRegion), ctx, region)
+}
+
+// GetVPCs mocks base method.
+func (m *MockAPI) GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPCs", ctx, region)
+	ret0, _ := ret[0].([]vpcv1.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPCs indicates an expected call of GetVPCs.
+func (mr *MockAPIMockRecorder) GetVPCs(ctx, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCs", reflect.TypeOf((*MockAPI)(nil).GetVPCs), ctx, region)
 }
 
 // GetVSIProfiles mocks base method.

--- a/pkg/asset/installconfig/ibmcloud/validation_test.go
+++ b/pkg/asset/installconfig/ibmcloud/validation_test.go
@@ -1,11 +1,13 @@
 package ibmcloud_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/networking-go-sdk/dnsrecordsv1"
+	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/golang/mock/gomock"
 	"github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
@@ -37,7 +39,77 @@ var (
 		validPrivateSubnetUSSouth1ID,
 		validPrivateSubnetUSSouth2ID,
 	}
+	validSubnetName   = "valid-subnet"
+	validVPCID        = "valid-id"
+	validVPC          = "valid-vpc"
+	validRG           = "valid-resource-group"
 	validZoneUSSouth1 = "us-south-1"
+	wrongRG           = "wrong-resource-group"
+	wrongVPCID        = "wrong-id"
+	wrongVPC          = "wrong-vpc"
+	anotherValidVPCID = "another-valid-id"
+	anotherValidVPC   = "another-valid-vpc"
+	anotherValidRG    = "another-valid-resource-group"
+
+	validResourceGroups = []resourcemanagerv2.ResourceGroup{
+		{
+			Name: &validRG,
+			ID:   &validRG,
+		},
+		{
+			Name: &anotherValidRG,
+			ID:   &anotherValidRG,
+		},
+	}
+	validVPCs = []vpcv1.VPC{
+		{
+			Name: &validVPC,
+			ID:   &validVPCID,
+			ResourceGroup: &vpcv1.ResourceGroupReference{
+				Name: &validRG,
+				ID:   &validRG,
+			},
+		},
+		{
+			Name: &anotherValidVPC,
+			ID:   &anotherValidVPCID,
+			ResourceGroup: &vpcv1.ResourceGroupReference{
+				Name: &anotherValidRG,
+				ID:   &anotherValidRG,
+			},
+		},
+	}
+	invalidVPC = []vpcv1.VPC{
+		{
+			Name: &wrongVPC,
+			ID:   &wrongVPCID,
+			ResourceGroup: &vpcv1.ResourceGroupReference{
+				Name: &validRG,
+				ID:   &validRG,
+			},
+		},
+	}
+	validVPCInvalidRG = []vpcv1.VPC{
+		{
+			Name: &validVPC,
+			ID:   &validVPCID,
+			ResourceGroup: &vpcv1.ResourceGroupReference{
+				Name: &wrongRG,
+				ID:   &wrongRG,
+			},
+		},
+	}
+	validSubnet = &vpcv1.Subnet{
+		Name: &validRG,
+		VPC: &vpcv1.VPCReference{
+			Name: &validVPC,
+			ID:   &validVPCID,
+		},
+		ResourceGroup: &vpcv1.ResourceGroupReference{
+			Name: &validRG,
+			ID:   &validRG,
+		},
+	}
 
 	validInstanceProfies = []vpcv1.InstanceProfile{{Name: &[]string{"type-a"}[0]}, {Name: &[]string{"type-b"}[0]}}
 
@@ -96,6 +168,14 @@ func validMachinePool() *ibmcloudtypes.MachinePool {
 	return &ibmcloudtypes.MachinePool{}
 }
 
+func validResourceGroupName(ic *types.InstallConfig) {
+	ic.Platform.IBMCloud.ResourceGroupName = "valid-resource-group"
+}
+
+func validVPCName(ic *types.InstallConfig) {
+	ic.Platform.IBMCloud.VPCName = "valid-vpc"
+}
+
 func TestValidate(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -107,6 +187,145 @@ func TestValidate(t *testing.T) {
 			edits:    editFunctions{},
 			errorMsg: "",
 		},
+		{
+			name: "VPC with no ResourceGroup supplied",
+			edits: editFunctions{
+				validVPCName,
+			},
+			errorMsg: `resourceGroupName: Not found: ""$`,
+		},
+		{
+			name: "VPC not found",
+			edits: editFunctions{
+				validResourceGroupName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.VPCName = "missing-vpc"
+				},
+			},
+			errorMsg: `vpcName: Not found: "missing-vpc"$`,
+		},
+		{
+			name: "VPC not in ResourceGroup",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ResourceGroupName = "wrong-resource-group"
+				},
+				validVPCName,
+			},
+			errorMsg: `platform.ibmcloud.vpcName: Invalid value: "valid-vpc": vpc is not in provided ResourceGroup: wrong-resource-group`,
+		},
+		{
+			name: "VPC with no control plane subnets",
+			edits: editFunctions{
+				validResourceGroupName,
+				validVPCName,
+			},
+			errorMsg: `platform.ibmcloud.controlPlaneSubnets: Invalid value: \[\]string\(nil\): controlPlaneSubnets cannot be empty when providing a vpcName: valid-vpc`,
+		},
+		{
+			name: "control plane subnet not found",
+			edits: editFunctions{
+				validResourceGroupName,
+				validVPCName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ControlPlaneSubnets = []string{"missing-cp-subnet"}
+				},
+			},
+			errorMsg: `platform.ibmcloud.controlPlaneSubnets: Not found: "missing-cp-subnet"`,
+		},
+		{
+			name: "control plane subnet IBM error",
+			edits: editFunctions{
+				validResourceGroupName,
+				validVPCName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ControlPlaneSubnets = []string{"ibm-error-cp-subnet"}
+				},
+			},
+			errorMsg: `platform.ibmcloud.controlPlaneSubnets: Internal error: ibmcloud error`,
+		},
+		{
+			name: "control plane subnet invalid VPC",
+			edits: editFunctions{
+				validResourceGroupName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.VPCName = "wrong-vpc"
+				},
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ControlPlaneSubnets = []string{"valid-subnet"}
+				},
+			},
+			errorMsg: `platform.ibmcloud.controlPlaneSubnets: Invalid value: "valid-subnet": controlPlaneSubnets contains subnet: valid-subnet, not found in expected vpcID: wrong-id`,
+		},
+		{
+			name: "control plane subnet invalid ResourceGroup",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ResourceGroupName = "wrong-resource-group"
+				},
+				validVPCName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ControlPlaneSubnets = []string{"valid-subnet"}
+				},
+			},
+			errorMsg: `platform.ibmcloud.controlPlaneSubnets: Invalid value: "valid-subnet": controlPlaneSubnets contains subnet: valid-subnet, not found in expected resourceGroupName: wrong-resource-group`,
+		},
+		{
+			name: "VPC with no compute subnets",
+			edits: editFunctions{
+				validResourceGroupName,
+				validVPCName,
+			},
+			errorMsg: `platform.ibmcloud.computeSubnets: Invalid value: \[\]string\(nil\): computeSubnets cannot be empty when providing a vpcName: valid-vpc`,
+		},
+		{
+			name: "compute subnet not found",
+			edits: editFunctions{
+				validResourceGroupName,
+				validVPCName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ComputeSubnets = []string{"missing-compute-subnet"}
+				},
+			},
+			errorMsg: `platform.ibmcloud.computeSubnets: Not found: "missing-compute-subnet"`,
+		},
+		{
+			name: "compute subnet IBM error",
+			edits: editFunctions{
+				validResourceGroupName,
+				validVPCName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ComputeSubnets = []string{"ibm-error-compute-subnet"}
+				},
+			},
+			errorMsg: `platform.ibmcloud.computeSubnets: Internal error: ibmcloud error`,
+		},
+		{
+			name: "compute subnet invalid VPC",
+			edits: editFunctions{
+				validResourceGroupName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.VPCName = "wrong-vpc"
+				},
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ComputeSubnets = []string{"valid-subnet"}
+				},
+			},
+			errorMsg: `platform.ibmcloud.computeSubnets: Invalid value: "valid-subnet": computeSubnets contains subnet: valid-subnet, not found in expected vpcID: wrong-id`,
+		},
+		{
+			name: "compute subnet invalid ResourceGroup",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ResourceGroupName = "wrong-resource-group"
+				},
+				validVPCName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.IBMCloud.ComputeSubnets = []string{"valid-subnet"}
+				},
+			},
+			errorMsg: `platform.ibmcloud.computeSubnets: Invalid value: "valid-subnet": computeSubnets contains subnet: valid-subnet, not found in expected resourceGroupName: wrong-resource-group`,
+		},
 	}
 
 	mockCtrl := gomock.NewController(t)
@@ -114,15 +333,73 @@ func TestValidate(t *testing.T) {
 
 	ibmcloudClient := mock.NewMockAPI(mockCtrl)
 
+	// Mocks: valid install config and all other tests ('AnyTimes()')
 	ibmcloudClient.EXPECT().GetSubnet(gomock.Any(), validPublicSubnetUSSouth1ID).Return(&vpcv1.Subnet{Zone: &vpcv1.ZoneReference{Name: &validZoneUSSouth1}}, nil).AnyTimes()
 	ibmcloudClient.EXPECT().GetSubnet(gomock.Any(), validPublicSubnetUSSouth2ID).Return(&vpcv1.Subnet{Zone: &vpcv1.ZoneReference{Name: &validZoneUSSouth1}}, nil).AnyTimes()
 	ibmcloudClient.EXPECT().GetSubnet(gomock.Any(), validPrivateSubnetUSSouth1ID).Return(&vpcv1.Subnet{Zone: &vpcv1.ZoneReference{Name: &validZoneUSSouth1}}, nil).AnyTimes()
 	ibmcloudClient.EXPECT().GetSubnet(gomock.Any(), validPrivateSubnetUSSouth2ID).Return(&vpcv1.Subnet{Zone: &vpcv1.ZoneReference{Name: &validZoneUSSouth1}}, nil).AnyTimes()
 	ibmcloudClient.EXPECT().GetSubnet(gomock.Any(), "subnet-invalid-zone").Return(&vpcv1.Subnet{Zone: &vpcv1.ZoneReference{Name: &[]string{"invalid"}[0]}}, nil).AnyTimes()
-
 	ibmcloudClient.EXPECT().GetVSIProfiles(gomock.Any()).Return(validInstanceProfies, nil).AnyTimes()
-
 	ibmcloudClient.EXPECT().GetVPCZonesForRegion(gomock.Any(), validRegion).Return([]string{"us-south-1", "us-south-2", "us-south-3"}, nil).AnyTimes()
+
+	// Mocks: VPC with no ResourceGroup supplied
+	// No mocks required
+
+	// Mocks: VPC not found
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
+
+	// Mocks: VPC not in ResourceGroup
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
+
+	// Mocks: VPC with no control plane subnets
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
+
+	// Mocks: control plane subnet not found
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "missing-cp-subnet", validRegion).Return(nil, &ibmcloud.VPCResourceNotFoundError{})
+
+	// Mocks: control plane subnet IBM error
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "ibm-error-cp-subnet", validRegion).Return(nil, errors.New("ibmcloud error"))
+
+	// Mocks: control plane subnet invalid VPC
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(invalidVPC, nil)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "valid-subnet", validRegion).Return(validSubnet, nil)
+
+	// Mocks: control plane subnet invalid ResourceGroup
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCInvalidRG, nil)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "valid-subnet", validRegion).Return(validSubnet, nil)
+
+	// Mocks: VPC with no compute subnets
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
+
+	// Mocks: compute subnet not found
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "missing-compute-subnet", validRegion).Return(nil, &ibmcloud.VPCResourceNotFoundError{})
+
+	// Mocks: compute subnet IBM error
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "ibm-error-compute-subnet", validRegion).Return(nil, errors.New("ibmcloud error"))
+
+	// Mocks: compute subnet invalid VPC
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(invalidVPC, nil)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "valid-subnet", validRegion).Return(validSubnet, nil)
+
+	// Mocks: compute subnet invalid ResourceGroup
+	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
+	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCInvalidRG, nil)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "valid-subnet", validRegion).Return(validSubnet, nil)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/destroy/ibmcloud/instance.go
+++ b/pkg/destroy/ibmcloud/instance.go
@@ -21,7 +21,11 @@ func (o *ClusterUninstaller) listInstances() (cloudResources, error) {
 	defer cancel()
 
 	options := o.vpcSvc.NewListInstancesOptions()
-	options.SetVPCName(fmt.Sprintf("%s-vpc", o.InfraID))
+	if len(o.UserProvidedVPC) > 0 {
+		options.SetVPCName(o.UserProvidedVPC)
+	} else {
+		options.SetVPCName(fmt.Sprintf("%s-vpc", o.InfraID))
+	}
 	resources, _, err := o.vpcSvc.ListInstancesWithContext(ctx, options)
 	if err != nil {
 		return nil, err

--- a/pkg/types/ibmcloud/platform.go
+++ b/pkg/types/ibmcloud/platform.go
@@ -7,16 +7,25 @@ type Platform struct {
 	Region string `json:"region"`
 
 	// ResourceGroupName is the name of an already existing resource group where the
-	// cluster should be installed. This resource group should only be used for
-	// this specific cluster and the cluster components will assume ownership of
-	// all resources in the resource group. Destroying the cluster using installer
-	// will delete this resource group.
-	//
-	// This resource group must be empty with no other resources when trying to
-	// use it for creating a cluster. If empty, a new resource group will be created
+	// cluster should be installed. If empty, a new resource group will be created
 	// for the cluster.
 	// +optional
 	ResourceGroupName string `json:"resourceGroupName,omitempty"`
+
+	// VPCName is the name of an already existing VPC where the cluster should be
+	// installed.
+	// +optional
+	VPCName string `json:"vpcName,omitempty"`
+
+	// ControlPlaneSubnets are the names of already existing subnets where the
+	// cluster control plane nodes should be created.
+	// +optional
+	ControlPlaneSubnets []string `json:"controlPlaneSubnets,omitempty"`
+
+	// ComputeSubnets are the names of already existing subnets where the cluster
+	// compute nodes should be created.
+	// +optional
+	ComputeSubnets []string `json:"computeSubnets,omitempty"`
 
 	// DefaultMachinePlatform is the default configuration used when installing
 	// on IBM Cloud for machine pools which do not define their own platform
@@ -31,4 +40,12 @@ func (p *Platform) ClusterResourceGroupName(infraID string) string {
 		return p.ResourceGroupName
 	}
 	return infraID
+}
+
+// GetVPCName returns the user provided name of the VPC for the cluster.
+func (p *Platform) GetVPCName() string {
+	if len(p.VPCName) > 0 {
+		return p.VPCName
+	}
+	return ""
 }

--- a/pkg/types/ibmcloud/platform_test.go
+++ b/pkg/types/ibmcloud/platform_test.go
@@ -14,3 +14,21 @@ func TestClusterResourceGroupName(t *testing.T) {
 	platform.ResourceGroupName = "test-cluster"
 	assert.Equal(t, "test-cluster", platform.ClusterResourceGroupName(infraID))
 }
+
+func TestGetVPCName(t *testing.T) {
+	platform := Platform{}
+
+	testCases := []struct {
+		name           string
+		vpcName        string
+		expectedResult string
+	}{
+		{"no vpc name", "", ""},
+		{"provided vpc name", "my-vpc", "my-vpc"},
+	}
+
+	for _, tc := range testCases {
+		platform.VPCName = tc.vpcName
+		assert.Equal(t, tc.expectedResult, platform.GetVPCName())
+	}
+}

--- a/pkg/types/ibmcloud/validation/platform.go
+++ b/pkg/types/ibmcloud/validation/platform.go
@@ -43,6 +43,17 @@ func ValidatePlatform(p *ibmcloud.Platform, fldPath *field.Path) field.ErrorList
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("region"), p.Region, regionShortNames))
 	}
 
+	if p.VPCName != "" {
+		if p.ControlPlaneSubnets == nil {
+			allErrs = append(allErrs, field.Required(fldPath.Child("controlPlaneSubnets"), "must provided at least one control plane subnet when a VPC is specified"))
+		}
+		if p.ComputeSubnets == nil {
+			allErrs = append(allErrs, field.Required(fldPath.Child("computeSubnets"), "must provide at least one compute subnet when a VPC is specified"))
+		}
+	} else if p.ControlPlaneSubnets != nil || p.ComputeSubnets != nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("vpcName"), "must provide a VPC name when supplying subnets"))
+	}
+
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}

--- a/pkg/types/ibmcloud/validation/platform_test.go
+++ b/pkg/types/ibmcloud/validation/platform_test.go
@@ -61,6 +61,47 @@ func TestValidatePlatform(t *testing.T) {
 			}(),
 			valid: true,
 		},
+		{
+			name: "valid vpc and subnets",
+			platform: func() *ibmcloud.Platform {
+				p := validMinimalPlatform()
+				p.VPCName = "valid-vpc-subnets"
+				p.ControlPlaneSubnets = []string{"cp-1", "cp-2", "cp-3"}
+				p.ComputeSubnets = []string{"comp-1", "comp-2"}
+				return p
+			}(),
+			valid: true,
+		},
+		{
+			name: "vpc without control plane subnet",
+			platform: func() *ibmcloud.Platform {
+				p := validMinimalPlatform()
+				p.VPCName = "missing-cp-subnet"
+				p.ComputeSubnets = []string{"comp-1", "comp-2"}
+				return p
+			}(),
+			valid: false,
+		},
+		{
+			name: "vpc without compute subnet",
+			platform: func() *ibmcloud.Platform {
+				p := validMinimalPlatform()
+				p.VPCName = "missing-comp-subnet"
+				p.ControlPlaneSubnets = []string{"cp-1", "cp-2"}
+				return p
+			}(),
+			valid: false,
+		},
+		{
+			name: "subnets without vpc",
+			platform: func() *ibmcloud.Platform {
+				p := validMinimalPlatform()
+				p.ControlPlaneSubnets = []string{"cp-1"}
+				p.ComputeSubnets = []string{"comp-1"}
+				return p
+			}(),
+			valid: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Setup enablement for Bring Your Own Network support on IBM Cloud
using IPI. This portion focuses on adding support for the
required values in the InstallConfig, and performing simple
validation of those resources provided.