### PR TITLE
Bug 2101879: Use systemd path unit to monitor the node0 file

### DIFF
--- a/data/data/agent/systemd/units/node-zero.service
+++ b/data/data/agent/systemd/units/node-zero.service
@@ -4,9 +4,9 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+Type=oneshot
+RemainAfterExit=True
 ExecStart=/usr/local/bin/set-node-zero.sh
-ExecStartPost=/bin/sleep 5
-Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In some circumnstances the assisted-service-pod.service may fail to start since the node0 is not yet available.  This patch ensures that the `set-node-zero.sh` completes before systemd will activate follow up services.