### PR TITLE
WIP: Add network name to GCP cloud config

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -175,11 +175,17 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			cm.Data[cloudProviderEndpointsKey] = string(b)
 		}
 	case gcptypes.Name:
+		network := fmt.Sprintf("%s-network", clusterID.InfraID)
+		if installConfig.Config.GCP.Network != "" {
+			network = installConfig.Config.GCP.Network
+		}
+
 		subnet := fmt.Sprintf("%s-worker-subnet", clusterID.InfraID)
 		if installConfig.Config.GCP.ComputeSubnet != "" {
 			subnet = installConfig.Config.GCP.ComputeSubnet
 		}
-		gcpConfig, err := gcpmanifests.CloudProviderConfig(clusterID.InfraID, installConfig.Config.GCP.ProjectID, subnet)
+
+		gcpConfig, err := gcpmanifests.CloudProviderConfig(clusterID.InfraID, installConfig.Config.GCP.ProjectID, network, subnet)
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")
 		}

--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -21,11 +21,12 @@ type global struct {
 	NodeInstancePrefix           string   `gcfg:"node-instance-prefix"`
 	ExternalInstanceGroupsPrefix string   `gcfg:"external-instance-groups-prefix"`
 
+	NetworkName    string `gcfg:"network-name"`
 	SubnetworkName string `gcfg:"subnetwork-name"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the GCP platform.
-func CloudProviderConfig(infraID, projectID, subnet string) (string, error) {
+func CloudProviderConfig(infraID, projectID, network, subnet string) (string, error) {
 	config := &config{
 		Global: global{
 			ProjectID: projectID,
@@ -38,6 +39,9 @@ func CloudProviderConfig(infraID, projectID, subnet string) (string, error) {
 			NodeTags:                     []string{fmt.Sprintf("%s-master", infraID), fmt.Sprintf("%s-worker", infraID)},
 			NodeInstancePrefix:           infraID,
 			ExternalInstanceGroupsPrefix: infraID,
+
+			// Used by storage (Filestore CSI Driver)
+			NetworkName: network,
 
 			// Used for internal load balancers
 			SubnetworkName: subnet,
@@ -60,6 +64,7 @@ node-tags       = {{$tag}}
 {{end -}}
 node-instance-prefix = {{.Global.NodeInstancePrefix}}
 external-instance-groups-prefix = {{.Global.ExternalInstanceGroupsPrefix}}
+network-name = {{.Global.NetworkName}}
 subnetwork-name = {{.Global.SubnetworkName}}
 
 `

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -15,10 +15,11 @@ node-tags       = uid-master
 node-tags       = uid-worker
 node-instance-prefix = uid
 external-instance-groups-prefix = uid
+network-name = uid-network
 subnetwork-name = uid-worker-subnet
 
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet")
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-network", "uid-worker-subnet")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }


### PR DESCRIPTION
This will be mostly used by the Filestore CSI Driver, who needs this information in order to provision shares.

Note: this is not ready for review as I need to figure out how we can get the network name in upgraded clusters.

CC @openshift/storage
