### PR TITLE
AGENT-227: Use root device hints from agent-config.yaml

### DIFF
--- a/data/data/agent/systemd/units/apply-host-config.service.template
+++ b/data/data/agent/systemd/units/apply-host-config.service.template
@@ -1,0 +1,24 @@
+[Unit]
+Description=Service that applies host-specific configuration
+Wants=network-online.target
+Requires=create-cluster-and-infraenv.service
+PartOf=assisted-service-pod.service
+After=network-online.target create-cluster-and-infraenv.service
+ConditionPathExists=/etc/assisted-service/node0
+
+[Service]
+Environment=PODMAN_SYSTEMD_UNIT=%n
+Environment=SERVICE_BASE_URL={{.ServiceBaseURL}}
+ExecStartPre=/bin/rm -f %t/%n.ctr-id
+ExecStartPre=/bin/mkdir -p %t/agent-installer /etc/assisted/hostconfig
+ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
+ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL --env-file /etc/assisted/client_config quay.io/edge-infrastructure/assisted-service:latest /usr/local/bin/agent-installer-client configure
+ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
+ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
+
+KillMode=none
+Type=oneshot
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target

--- a/data/data/agent/systemd/units/create-cluster-and-infraenv.service.template
+++ b/data/data/agent/systemd/units/create-cluster-and-infraenv.service.template
@@ -1,6 +1,7 @@
 [Unit]
 Description=Service that creates initial cluster and infraenv
-Wants=network-online.target assisted-service.service
+Wants=network-online.target
+Requires=assisted-service.service
 PartOf=assisted-service-pod.service
 After=network-online.target assisted-service.service
 ConditionPathExists=/etc/assisted-service/node0
@@ -11,7 +12,7 @@ Environment=SERVICE_BASE_URL={{.ServiceBaseURL}}
 Environment=OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR={{.ReleaseImageMirror}}
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=create-cluster-and-infraenv -v /etc/assisted/manifests:/manifests -v /etc/pki/ca-trust:/etc/pki/ca-trust:z --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR quay.io/edge-infrastructure/assisted-service:latest /agent-based-installer-register-cluster-and-infraenv
+ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=create-cluster-and-infraenv -v /etc/assisted/manifests:/manifests -v /etc/assisted:/etc/assisted:z -v /etc/pki/ca-trust:/etc/pki/ca-trust:z --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR quay.io/edge-infrastructure/assisted-service:latest /usr/local/bin/agent-installer-client register
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/data/data/agent/systemd/units/start-cluster-installation.service
+++ b/data/data/agent/systemd/units/start-cluster-installation.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Service that starts cluster installation
-Wants=network-online.target create-cluster-and-infraenv.service
+Wants=network-online.target
+Requires=apply-host-config.service
 PartOf=assisted-service-pod.service
-After=network-online.target create-cluster-and-infraenv.service
+After=network-online.target apply-host-config.service
 ConditionPathExists=/etc/assisted-service/node0
 
 [Service]

--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -166,6 +166,14 @@ func (a *Asset) HostConfigFiles() (HostConfigFileMap, error) {
 		if len(macs) > 0 {
 			files[filepath.Join(name, "mac_addresses")] = []byte(strings.Join(macs, ""))
 		}
+
+		rdh, err := yaml.Marshal(host.RootDeviceHints)
+		if err != nil {
+			return nil, err
+		}
+		if len(rdh) > 0 && string(rdh) != "{}\n" {
+			files[filepath.Join(name, "root-device-hints.yaml")] = rdh
+		}
 	}
 	return files, nil
 }

--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -86,6 +86,10 @@ func (a *Asset) validateAgent() field.ErrorList {
 		allErrs = append(allErrs, err...)
 	}
 
+	if err := a.validateRootDeviceHints(); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
 	return allErrs
 }
 
@@ -112,6 +116,27 @@ func (a *Asset) validateNodesHaveAtLeastOneMacAddressDefined() field.ErrorList {
 			}
 		}
 	}
+	return allErrs
+}
+
+func (a *Asset) validateRootDeviceHints() field.ErrorList {
+	var allErrs field.ErrorList
+	rootPath := field.NewPath("Spec", "Hosts")
+
+	for i, host := range a.Config.Spec.Hosts {
+		hostPath := rootPath.Index(i)
+		if host.RootDeviceHints.WWNWithExtension != "" {
+			allErrs = append(allErrs, field.Forbidden(
+				hostPath.Child("RootDeviceHints", "WWNWithExtension"),
+				"WWN extensions are not supported in root device hints"))
+		}
+		if host.RootDeviceHints.WWNVendorExtension != "" {
+			allErrs = append(allErrs, field.Forbidden(
+				hostPath.Child("RootDeviceHints", "WWNVendorExtension"),
+				"WWN vendor extensions are not supported in root device hints"))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -96,16 +96,18 @@ func (a *Asset) validateNodesHaveAtLeastOneMacAddressDefined() field.ErrorList {
 		return allErrs
 	}
 
+	rootPath := field.NewPath("Spec", "Hosts")
+
 	for i := range a.Config.Spec.Hosts {
 		node := a.Config.Spec.Hosts[i]
+		interfacePath := rootPath.Index(i).Child("Interfaces")
 		if len(node.Interfaces) == 0 {
-			interfacePath := field.NewPath("Spec", "Hosts", "Interfaces", "macAddress")
 			allErrs = append(allErrs, field.Required(interfacePath, "at least one interface must be defined for each node"))
 		}
 
 		for j := range node.Interfaces {
 			if node.Interfaces[j].MacAddress == "" {
-				macAddressPath := field.NewPath("Spec", "Hosts", "Interfaces", "macAddress")
+				macAddressPath := interfacePath.Index(j).Child("macAddress")
 				allErrs = append(allErrs, field.Required(macAddressPath, "each interface must have a MAC address defined"))
 			}
 		}

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -212,7 +212,7 @@ spec:
         - name: enp2s0
         - name: enp3s1
           macAddress: 28:d2:44:d2:b2:1a`,
-			expectedError: "invalid Agent Config configuration: Spec.Hosts.Interfaces.macAddress: Required value: each interface must have a MAC address defined",
+			expectedError: "invalid Agent Config configuration: Spec.Hosts[0].Interfaces[0].macAddress: Required value: each interface must have a MAC address defined",
 		},
 		{
 			name: "node-hostname-and-role-are-not-required",

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -45,8 +45,6 @@ spec:
         serialNumber: "serial-number-value"
         minSizeGigabytes: 20
         wwn: "wwn-value"
-        wwnWithExtension: "wwn-with-extension-value"
-        wwnVendorExtension: "wwn-vendor-extension-value"
         rotational: false
       interfaces:
         - name: enp2s0
@@ -65,16 +63,14 @@ spec:
 							Hostname: "control-0.example.org",
 							Role:     "master",
 							RootDeviceHints: baremetal.RootDeviceHints{
-								DeviceName:         "/dev/sda",
-								HCTL:               "hctl-value",
-								Model:              "model-value",
-								Vendor:             "vendor-value",
-								SerialNumber:       "serial-number-value",
-								MinSizeGigabytes:   20,
-								WWN:                "wwn-value",
-								WWNWithExtension:   "wwn-with-extension-value",
-								WWNVendorExtension: "wwn-vendor-extension-value",
-								Rotational:         falsePtr,
+								DeviceName:       "/dev/sda",
+								HCTL:             "hctl-value",
+								Model:            "model-value",
+								Vendor:           "vendor-value",
+								SerialNumber:     "serial-number-value",
+								MinSizeGigabytes: 20,
+								WWN:              "wwn-value",
+								Rotational:       falsePtr,
 							},
 							Interfaces: []*aiv1beta1.Interface{
 								{
@@ -109,8 +105,6 @@ spec:
         serialNumber: "serial-number-value"
         minSizeGigabytes: 20
         wwn: "wwn-value"
-        wwnWithExtension: "wwn-with-extension-value"
-        wwnVendorExtension: "wwn-vendor-extension-value"
         rotational: false
       interfaces:
         - name: enp2s0
@@ -136,16 +130,14 @@ spec:
 							Hostname: "control-0.example.org",
 							Role:     "master",
 							RootDeviceHints: baremetal.RootDeviceHints{
-								DeviceName:         "/dev/sda",
-								HCTL:               "hctl-value",
-								Model:              "model-value",
-								Vendor:             "vendor-value",
-								SerialNumber:       "serial-number-value",
-								MinSizeGigabytes:   20,
-								WWN:                "wwn-value",
-								WWNWithExtension:   "wwn-with-extension-value",
-								WWNVendorExtension: "wwn-vendor-extension-value",
-								Rotational:         falsePtr,
+								DeviceName:       "/dev/sda",
+								HCTL:             "hctl-value",
+								Model:            "model-value",
+								Vendor:           "vendor-value",
+								SerialNumber:     "serial-number-value",
+								MinSizeGigabytes: 20,
+								WWN:              "wwn-value",
+								Rotational:       falsePtr,
 							},
 							Interfaces: []*aiv1beta1.Interface{
 								{
@@ -213,6 +205,38 @@ spec:
         - name: enp3s1
           macAddress: 28:d2:44:d2:b2:1a`,
 			expectedError: "invalid Agent Config configuration: Spec.Hosts[0].Interfaces[0].macAddress: Required value: each interface must have a MAC address defined",
+		},
+		{
+			name: "unsupported wwn extension root device hint",
+			data: `
+metadata:
+  name: agent-config-cluster0
+spec:
+  rendezvousIP: 192.168.111.80
+  hosts:
+    - hostname: control-0.example.org
+      interfaces:
+        - name: enp2s0
+          macAddress: 98:af:65:a5:8d:01
+      rootDeviceHints:
+        wwnWithExtension: "wwn-with-extension-value"`,
+			expectedError: "invalid Agent Config configuration: Spec.Hosts[0].RootDeviceHints.WWNWithExtension: Forbidden: WWN extensions are not supported in root device hints",
+		},
+		{
+			name: "unsupported wwn vendor extension root device hint",
+			data: `
+metadata:
+  name: agent-config-cluster0
+spec:
+  rendezvousIP: 192.168.111.80
+  hosts:
+    - hostname: control-0.example.org
+      interfaces:
+        - name: enp2s0
+          macAddress: 98:af:65:a5:8d:01
+      rootDeviceHints:
+        wwnVendorExtension: "wwn-with-vendor-extension-value"`,
+			expectedError: "invalid Agent Config configuration: Spec.Hosts[0].RootDeviceHints.WWNVendorExtension: Forbidden: WWN vendor extensions are not supported in root device hints",
 		},
 		{
 			name: "node-hostname-and-role-are-not-required",

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -187,6 +187,8 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 
 	addMirrorData(&config, agentMirror)
 
+	addHostConfig(&config, agentConfigAsset)
+
 	a.Config = &config
 	return nil
 }
@@ -276,4 +278,17 @@ func addMirrorData(config *igntypes.Config, agentMirror *mirror.AgentMirror) {
 
 		}
 	}
+}
+
+func addHostConfig(config *igntypes.Config, agentConfig *agentconfig.Asset) error {
+	confs, err := agentConfig.HostConfigFiles()
+	if err != nil {
+		return err
+	}
+
+	for path, content := range confs {
+		hostConfigFile := ignition.FileFromBytes(filepath.Join("/etc/assisted/hostconfig", path), "root", 0644, content)
+		config.Storage.Files = append(config.Storage.Files, hostConfigFile)
+	}
+	return nil
 }


### PR DESCRIPTION
Pass the root device hints into the ISO, and create a service to apply them to the cluster once host inventory is available, but before installation starts.