### PR TITLE
Revert "GCP: Revert Instance Type from N2 to N1"

### DIFF
--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -112,7 +112,7 @@ func defaultAzureMachinePoolPlatform() azuretypes.MachinePool {
 
 func defaultGCPMachinePoolPlatform() gcptypes.MachinePool {
 	return gcptypes.MachinePool{
-		InstanceType: "n1-standard-4",
+		InstanceType: "n2-standard-4",
 		OSDisk: gcptypes.OSDisk{
 			DiskSizeGB: powerOfTwoRootVolumeSize,
 			DiskType:   "pd-ssd",


### PR DESCRIPTION
This reverts commit e6bbf3e1dab9928c0caf35036fe1451adc8168fb.

This reintroduces using N2 as the default instance type for GCP. CI
quota has been bumped. This should allow installs in regions that
don't have N1 instances.