### PR TITLE
Bug 2102324: Fix panic when unknown region is provided.

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -79,7 +79,7 @@ func validateInstanceTypes(client API, ic *types.InstallConfig) field.ErrorList 
 
 	// Get list of zones in region
 	zones, err := client.GetZones(context.TODO(), ic.GCP.ProjectID, fmt.Sprintf("region eq .*%s", ic.GCP.Region))
-	if err != nil {
+	if err != nil || len(zones) == 0 {
 		return append(allErrs, field.InternalError(nil, err))
 	}
 


### PR DESCRIPTION
If an unknown region is provided, installer queries GCP for zones
which returns empty. The installer assumes if there are no errors,
the array is populated and uses the first entry that does not
get populated. Adding another safe check to see if the zone length
is not zero and then proceed.