### PR TITLE
AGENT-144: Pass pre-generated InfraEnv ID to apply-host-config

### DIFF
--- a/data/data/agent/systemd/units/apply-host-config.service.template
+++ b/data/data/agent/systemd/units/apply-host-config.service.template
@@ -9,10 +9,11 @@ ConditionPathExists=/etc/assisted-service/node0
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Environment=SERVICE_BASE_URL={{.ServiceBaseURL}}
+Environment=INFRA_ENV_ID={{.InfraEnvID}}
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/bin/mkdir -p %t/agent-installer /etc/assisted/hostconfig
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL --env-file /etc/assisted/client_config quay.io/edge-infrastructure/assisted-service:latest /usr/local/bin/agent-installer-client configure
+ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL  --env INFRA_ENV_ID quay.io/edge-infrastructure/assisted-service:latest /usr/local/bin/agent-installer-client configure
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/data/data/agent/systemd/units/create-cluster-and-infraenv.service.template
+++ b/data/data/agent/systemd/units/create-cluster-and-infraenv.service.template
@@ -12,7 +12,7 @@ Environment=SERVICE_BASE_URL={{.ServiceBaseURL}}
 Environment=OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR={{.ReleaseImageMirror}}
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=create-cluster-and-infraenv -v /etc/assisted/manifests:/manifests -v /etc/assisted:/etc/assisted:z -v /etc/pki/ca-trust:/etc/pki/ca-trust:z --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR quay.io/edge-infrastructure/assisted-service:latest /usr/local/bin/agent-installer-client register
+ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=create-cluster-and-infraenv -v /etc/assisted/manifests:/manifests -v /etc/pki/ca-trust:/etc/pki/ca-trust:z --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR quay.io/edge-infrastructure/assisted-service:latest /usr/local/bin/agent-installer-client register
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 


### PR DESCRIPTION
Since we now know the InfraEnv ID in advance, there's no need to record
it in create-cluster-and-infra-env and then pass it to
apply-host-config from the resulting environment file.