### PR TITLE
Bug 2103144: openstack: validate apiVIP and ingressVIP to be semantically different

### DIFF
--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -91,8 +92,11 @@ func validateFloatingIPs(p *openstack.Platform, ci *CloudInfo, fldPath *field.Pa
 }
 
 func validateVIPs(p *openstack.Platform, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {
-	if p.APIVIP != "" && p.IngressVIP != "" {
-		if p.APIVIP == p.IngressVIP {
+	apiVIP := net.ParseIP(p.APIVIP)
+	ingressVIP := net.ParseIP(p.IngressVIP)
+
+	if apiVIP != nil && ingressVIP != nil {
+		if apiVIP.Equal(ingressVIP) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("ingressVIP"), p.IngressVIP, "ingressVIP can not be the same as apiVIP"))
 		}
 	}

--- a/pkg/asset/installconfig/openstack/validation/platform_test.go
+++ b/pkg/asset/installconfig/openstack/validation/platform_test.go
@@ -209,6 +209,19 @@ func TestOpenStackPlatformValidation(t *testing.T) {
 			expectedError:  true,
 			expectedErrMsg: "platform.openstack.ingressVIP: Invalid value: \"128.35.27.8\": ingressVIP can not be the same as apiVIP",
 		},
+		{
+			name: "APIVIP and IngressVIP are synonyms",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				p.APIVIP = "2001:db8::5"
+				p.IngressVIP = "2001:db8:0::5"
+				return p
+			}(),
+			cloudInfo:      validPlatformCloudInfo(),
+			networking:     validNetworking(),
+			expectedError:  true,
+			expectedErrMsg: "platform.openstack.ingressVIP: Invalid value: \"2001:db8:0::5\": ingressVIP can not be the same as apiVIP",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Before this patch, apiVIP and ingressVIP are checked to be different
based on a comparison of their string representation.

However, the same IP can have different string representation; this is
especially true with IPv6.

With this patch, IP comparison is delegated to the Go standard library.