### PR TITLE
BUG 2102632: destroy/gcp: Use min length for destroying disks

### DIFF
--- a/pkg/destroy/gcp/disk.go
+++ b/pkg/destroy/gcp/disk.go
@@ -17,12 +17,16 @@ const (
 	storageNameLength = maxGCEPDNameLength - estimatedPVNameLength - 1
 )
 
-// formatClusterIDForStorage will format the Cluster ID as it will be used for creating
+// formatClusterIDForStorage will format the Cluster ID as it will be used for destroying
 // GCE PDs. The maximum length is 63 characters, and can end with "-dynamic".
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/util/util.go, GenerateVolumeName()
 func (o *ClusterUninstaller) formatClusterIDForStorage() string {
 	storageName := o.ClusterID + "-dynamic"
-	return storageName[:storageNameLength]
+	slicedLength := storageNameLength
+	if len(storageName) < slicedLength {
+		slicedLength = len(storageName)
+	}
+	return storageName[:slicedLength]
 }
 
 func (o *ClusterUninstaller) storageIDFilter() string {


### PR DESCRIPTION
** The Length of the disks can be less than the 22 char max. In the case that the
cluster name is very small and a minimal name for disks is generated an error
was thrown, this will fix that error.

** Altered comment for uses to destroying from creating.