### PR TITLE
Bug 2104578: Remove unnecessary SG rule

### DIFF
--- a/data/data/openstack/masters/sg-master.tf
+++ b/data/data/openstack/masters/sg-master.tf
@@ -182,17 +182,6 @@ resource "openstack_networking_secgroup_rule_v2" "master_ingress_kube_controller
   description       = local.description
 }
 
-resource "openstack_networking_secgroup_rule_v2" "master_ingress_cluster_policy_controller" {
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 10357
-  port_range_max    = 10357
-  remote_ip_prefix  = var.machine_v4_cidrs[0]
-  security_group_id = openstack_networking_secgroup_v2.master.id
-  description       = local.description
-}
-
 resource "openstack_networking_secgroup_rule_v2" "master_ingress_kubelet_secure" {
   direction         = "ingress"
   ethertype         = "IPv4"


### PR DESCRIPTION
The master_ingress_cluster_policy_controller security group rule was
initially introduced with 2636aef but later reverted with a7040d4. It
was then re-introduced by mistake with 40febcf.