### PR TITLE
AGENT-136: Add optional install-config asset for agent installation

### DIFF
--- a/pkg/asset/agent/image/baseiso.go
+++ b/pkg/asset/agent/image/baseiso.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/rhcos"
 )
 
@@ -87,8 +88,7 @@ func getIsoFromReleasePayload() (string, error) {
 // Dependencies returns dependencies used by the asset.
 func (i *BaseIso) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		// TODO - will need to depend on installConfig for disconnected image registry
-		// &installconfig.InstallConfig{},
+		&agent.OptionalInstallConfig{},
 	}
 }
 
@@ -96,7 +96,7 @@ func (i *BaseIso) Dependencies() []asset.Asset {
 func (i *BaseIso) Generate(p asset.Parents) error {
 
 	// TODO - if image registry location is defined in InstallConfig,
-	// ic := &installconfig.InstallConfig{}
+	// ic := &agent.OptionalInstallConfig{}
 	// p.Get(ic)
 	// use the GetIso function to get the BaseIso from the release payload
 	isoGetter := newGetIso(GetIsoPluggable)

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -1,0 +1,37 @@
+package agent
+
+import (
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+)
+
+// OptionalInstallConfig is an InstallConfig where the default is empty, rather
+// than generated from running the survey.
+type OptionalInstallConfig struct {
+	installconfig.InstallConfig
+	Supplied bool
+}
+
+// Dependencies returns all of the dependencies directly needed by an
+// InstallConfig asset.
+func (a *OptionalInstallConfig) Dependencies() []asset.Asset {
+	// Return no dependencies for the Agent install config, because it is
+	// optional. We don't need to run the survey if it doesn't exist, since the
+	// user may have supplied cluster-manifests that fully define the cluster.
+	return []asset.Asset{}
+}
+
+// Generate generates the install-config.yaml file.
+func (a *OptionalInstallConfig) Generate(parents asset.Parents) error {
+	// Just generate an empty install config, since we have no dependencies.
+	return nil
+}
+
+// Load returns the installconfig from disk.
+func (a *OptionalInstallConfig) Load(f asset.FileFetcher) (bool, error) {
+	found, err := a.InstallConfig.Load(f)
+	if found && err == nil {
+		a.Supplied = true
+	}
+	return found, err
+}

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -7,6 +7,7 @@ import (
 
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 )
@@ -32,13 +33,13 @@ func (*AgentClusterInstall) Name() string {
 // the asset.
 func (*AgentClusterInstall) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		// &installconfig.InstallConfig{},
+		&agent.OptionalInstallConfig{},
 	}
 }
 
 // Generate generates the AgentClusterInstall manifest.
 func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
-	// installConfig := &installconfig.InstallConfig{}
+	// installConfig := &agent.OptionalInstallConfig{}
 	// dependencies.Get(installConfig)
 
 	// agentClusterInstall := &hiveext.AgentClusterInstall{

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -31,7 +31,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 		// {
 		// 	name: "default",
 		// 	dependencies: []asset.Asset{
-		// 		&installconfig.InstallConfig{
+		// 		&agent.OptionalInstallConfig{
 		// 			Config: &types.InstallConfig{
 		// 				ObjectMeta: v1.ObjectMeta{
 		// 					Name:      "ocp-edge-cluster-0",
@@ -104,7 +104,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 
 // func TestAgentClusterInstall_Generate(t *testing.T) {
 
-// 	installConfig := &installconfig.InstallConfig{
+// 	installConfig := &agent.OptionalInstallConfig{
 // 		Config: &types.InstallConfig{
 // 			ObjectMeta: v1.ObjectMeta{
 // 				Name:      "cluster0-name",

--- a/pkg/asset/agent/manifests/agentpullsecret.go
+++ b/pkg/asset/agent/manifests/agentpullsecret.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/pkg/errors"
 )
 
@@ -35,14 +36,14 @@ func (*AgentPullSecret) Name() string {
 // the asset.
 func (*AgentPullSecret) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		// &installconfig.InstallConfig{},
+		&agent.OptionalInstallConfig{},
 	}
 }
 
 // Generate generates the AgentPullSecret manifest.
 func (a *AgentPullSecret) Generate(dependencies asset.Parents) error {
 
-	// installConfigAsset := &installconfig.InstallConfig{}
+	// installConfigAsset := &agent.OptionalInstallConfig{}
 	// dependencies.Get(installConfigAsset)
 
 	// secret := &corev1.Secret{

--- a/pkg/asset/agent/manifests/agentpullsecret_test.go
+++ b/pkg/asset/agent/manifests/agentpullsecret_test.go
@@ -29,7 +29,7 @@ func TestAgentPullSecret_Generate(t *testing.T) {
 		// {
 		// 	name: "default",
 		// 	dependencies: []asset.Asset{
-		// 		&installconfig.InstallConfig{
+		// 		&agent.OptionalInstallConfig{
 		// 			Config: &types.InstallConfig{
 		// 				ObjectMeta: v1.ObjectMeta{
 		// 					Namespace: "cluster-0",

--- a/pkg/asset/agent/manifests/clusterdeployment.go
+++ b/pkg/asset/agent/manifests/clusterdeployment.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent"
 )
 
 var (
@@ -33,7 +34,7 @@ func (*ClusterDeployment) Name() string {
 // the asset.
 func (*ClusterDeployment) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		// TODO: add dependency to InstallConfig when generation is implemented
+		&agent.OptionalInstallConfig{},
 	}
 }
 

--- a/pkg/asset/agent/manifests/clusterimageset.go
+++ b/pkg/asset/agent/manifests/clusterimageset.go
@@ -7,6 +7,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -35,7 +36,7 @@ func (*ClusterImageSet) Name() string {
 func (*ClusterImageSet) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		// &releaseimage.Image{},
-		// &installconfig.InstallConfig{},
+		&agent.OptionalInstallConfig{},
 	}
 }
 
@@ -43,7 +44,7 @@ func (*ClusterImageSet) Dependencies() []asset.Asset {
 func (a *ClusterImageSet) Generate(dependencies asset.Parents) error {
 
 	// releaseImage := &releaseimage.Image{}
-	// installConfig := &installconfig.InstallConfig{}
+	// installConfig := &agent.OptionalInstallConfig{}
 	// dependencies.Get(releaseImage, installConfig)
 
 	// currentVersion, err := version.Version()

--- a/pkg/asset/agent/manifests/infraenv.go
+++ b/pkg/asset/agent/manifests/infraenv.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent"
 )
 
 var (
@@ -34,7 +35,7 @@ func (*InfraEnv) Name() string {
 // the asset.
 func (*InfraEnv) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		// &installconfig.InstallConfig{},
+		&agent.OptionalInstallConfig{},
 		// &AgentPullSecret{},
 	}
 }
@@ -42,7 +43,7 @@ func (*InfraEnv) Dependencies() []asset.Asset {
 // Generate generates the InfraEnv manifest.
 func (i *InfraEnv) Generate(dependencies asset.Parents) error {
 
-	// installConfig := &installconfig.InstallConfig{}
+	// installConfig := &agent.OptionalInstallConfig{}
 	// agentPullSecret := &AgentPullSecret{}
 	// dependencies.Get(installConfig, agentPullSecret)
 

--- a/pkg/asset/agent/manifests/infraenv_test.go
+++ b/pkg/asset/agent/manifests/infraenv_test.go
@@ -31,7 +31,7 @@ func TestInfraEnv_Generate(t *testing.T) {
 		// {
 		// 	name: "default",
 		// 	dependencies: []asset.Asset{
-		// 		&installconfig.InstallConfig{
+		// 		&agent.OptionalInstallConfig{
 		// 			Config: &types.InstallConfig{
 		// 				ObjectMeta: v1.ObjectMeta{
 		// 					Name:      "ocp-edge-cluster-0",

--- a/pkg/asset/agent/mirror/cabundle.go
+++ b/pkg/asset/agent/mirror/cabundle.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/pkg/errors"
 )
 
@@ -30,14 +31,14 @@ func (*CaBundle) Name() string {
 // the asset.
 func (*CaBundle) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		// &installconfig.InstallConfig{},
+		&agent.OptionalInstallConfig{},
 	}
 }
 
 // Generate generates the Mirror Registries certificate file from install-config.
 func (i *CaBundle) Generate(dependencies asset.Parents) error {
 
-	// installConfig := &installconfig.InstallConfig{}
+	// installConfig := &agent.OptionalInstallConfig{}
 	// dependencies.Get(installConfig)
 
 	// if installConfig.Config.AdditionalTrustBundle == "" {

--- a/pkg/asset/agent/mirror/registriesconf.go
+++ b/pkg/asset/agent/mirror/registriesconf.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 )
@@ -38,14 +39,14 @@ func (*RegistriesConf) Name() string {
 // the asset.
 func (*RegistriesConf) Dependencies() []asset.Asset {
 	return []asset.Asset{
-		// &installconfig.InstallConfig{},
+		&agent.OptionalInstallConfig{},
 	}
 }
 
 // Generate generates the registries.conf file from install-config.
 func (i *RegistriesConf) Generate(dependencies asset.Parents) error {
 
-	// installConfig := &installconfig.InstallConfig{}
+	// installConfig := &agent.OptionalInstallConfig{}
 
 	// registries := []sysregistriesv2.Registry{}
 	// for _, group := range bootstrap.MergedMirrorSets(installConfig.Config.ImageContentSources) {


### PR DESCRIPTION
With agent-based installation, we allow users to start directly from ZTP
CRs in cluster-manifests without first generating them from an
install-config. However, the latter will be an option, so resources will
need to depend on the InstallConfig without causing the survey to run if
it is not present.