### PR TITLE
azure: Log azure request header information along with ids

### DIFF
--- a/pkg/asset/cluster/azure/azure.go
+++ b/pkg/asset/cluster/azure/azure.go
@@ -52,6 +52,10 @@ func PreTerraform(ctx context.Context, clusterID string, installConfig *installc
 	if group.Tags == nil {
 		group.Tags = map[string]*string{}
 	}
+	logrus.Debugf("Resource Group: %s", installConfig.Config.Azure.ResourceGroupName)
+	logrus.Debugf("Subscription ID: %s", session.Credentials.SubscriptionID)
+	logrus.Debugf("Tenant ID: %s", session.Credentials.TenantID)
+	logrus.Debugf("Infra ID: %s", clusterID)
 	group.Tags[fmt.Sprintf("kubernetes.io_cluster.%s", clusterID)] = to.StringPtr("owned")
 	logrus.Debugf("Tagging %s with kubernetes.io/cluster/%s: shared", installConfig.Config.Azure.ResourceGroupName, clusterID)
 	_, err = client.Update(ctx, installConfig.Config.Azure.ResourceGroupName, resources.GroupPatchable{

--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -90,6 +90,10 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 	if len(group) == 0 {
 		group = metadata.InfraID + "-rg"
 	}
+	logger.Debugf("Resource Group: %s", group)
+	logger.Debugf("Subscription ID: %s", session.Credentials.SubscriptionID)
+	logger.Debugf("Tenant ID: %s", session.Credentials.TenantID)
+	logger.Debugf("Infra ID: %s", metadata.InfraID)
 
 	return &ClusterUninstaller{
 		SubscriptionID:              session.Credentials.SubscriptionID,
@@ -224,7 +228,7 @@ func deleteAzureStackPublicRecords(ctx context.Context, o *ClusterUninstaller) e
 	var errs []error
 
 	zonesPage, err := dnsClient.ListByResourceGroup(ctx, rgName, to.Int32Ptr(100))
-	logger.Debug(err)
+	logger.Debugf("%v", zonesPage.Response().Header)
 	if err != nil {
 		if zonesPage.Response().IsHTTPStatus(http.StatusNotFound) {
 			logger.Debug("already deleted the AzureStack zones")
@@ -282,6 +286,7 @@ func deletePublicRecords(ctx context.Context, dnsClient dns.ZonesClient, records
 	var errs []error
 
 	zonesPage, err := dnsClient.ListByResourceGroup(ctx, rgName, to.Int32Ptr(100))
+	logger.Debugf("%v", zonesPage.Response().Header)
 	if err != nil {
 		if zonesPage.Response().IsHTTPStatus(http.StatusNotFound) {
 			logger.Debug("already deleted")
@@ -313,6 +318,7 @@ func deletePublicRecords(ctx context.Context, dnsClient dns.ZonesClient, records
 	}
 
 	privateZonesPage, err := privateDNSClient.ListByResourceGroup(ctx, rgName, to.Int32Ptr(100))
+	logger.Debugf("%v", privateZonesPage.Response().Header)
 	if err != nil {
 		if privateZonesPage.Response().IsHTTPStatus(http.StatusNotFound) {
 			logger.Debug("already deleted")
@@ -465,6 +471,7 @@ func deleteResourceGroup(ctx context.Context, client resources.GroupsClient, log
 	defer cancel()
 
 	delFuture, err := client.Delete(ctx, name)
+	logger.Debugf("%v", delFuture.Response().Header)
 	if err == nil {
 		err = delFuture.WaitForCompletionRef(ctx, client.Client)
 	}


### PR DESCRIPTION
Adding key azure information like correlation_request_id,
client_request_id, request_id etc to the installer logs that
can be used to debug later. Also added information like resource_group
subscription_id, tenant_id and infraID.