### PR TITLE
AGENT-263: Get images from release payload

### DIFF
--- a/data/data/agent/files/usr/local/bin/extract-agent.sh.template
+++ b/data/data/agent/files/usr/local/bin/extract-agent.sh.template
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. /usr/local/bin/release-image.sh
+
+IMAGE=$(image_for agent-installer-node-agent)
+
+echo "Using agent image: ${IMAGE} to copy bin"
+
+/usr/bin/podman run --privileged --rm -v /usr/local/bin:/hostbin ${IMAGE} cp /usr/bin/agent /hostbin

--- a/data/data/agent/files/usr/local/bin/get-container-images.sh.template
+++ b/data/data/agent/files/usr/local/bin/get-container-images.sh.template
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+. /usr/local/bin/release-image.sh
+
+# Store images in the environment file used by services and passed to assisted-service
+# The agent image will be also retrieved when its script is run
+cat <<EOF >/usr/local/share/assisted-service/agent-images.env
+SERVICE_IMAGE=$(image_for agent-installer-api-server)
+CONTROLLER_IMAGE=$(image_for agent-installer-csr-approver)
+INSTALLER_IMAGE=$(image_for agent-installer-orchestrator)
+AGENT_DOCKER_IMAGE=$(image_for agent-installer-node-agent)
+EOF

--- a/data/data/agent/files/usr/local/bin/start-agent.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-agent.sh.template
@@ -11,5 +11,12 @@ until [[ $INFRA_ENV_ID != "" && $INFRA_ENV_ID != "null" ]]; do
 done
 echo "Fetched infra-env-id and found: $INFRA_ENV_ID"
 
+# shellcheck disable=SC1091
+. /usr/local/bin/release-image.sh
+
+IMAGE=$(image_for agent-installer-node-agent)
+
+echo "Using agent image: ${IMAGE} to start agent"
+
 # use infra-env-id to have agent register this host with assisted-service
-exec /usr/local/bin/agent --url '{{.ServiceBaseURL}}' --infra-env-id '{{.InfraEnvID}}' --agent-version quay.io/edge-infrastructure/assisted-installer-agent:latest --insecure=true
+exec /usr/local/bin/agent --url '{{.ServiceBaseURL}}' --infra-env-id '{{.InfraEnvID}}' --agent-version ${IMAGE} --insecure=true

--- a/data/data/agent/systemd/units/agent.service.template
+++ b/data/data/agent/systemd/units/agent.service.template
@@ -13,7 +13,7 @@ Environment=no_proxy=
 # https://github.com/openshift/assisted-service/blob/master/internal/ignition/ignition.go#L1381
 Environment=PULL_SECRET_TOKEN={{.PullSecretToken}}
 TimeoutStartSec=3000
-ExecStartPre=podman run --privileged --rm -v /usr/local/bin:/hostbin quay.io/edge-infrastructure/assisted-installer-agent:latest cp /usr/bin/agent /hostbin
+ExecStartPre=/usr/local/bin/extract-agent.sh
 ExecStart=/usr/local/bin/start-agent.sh
 
 [Unit]

--- a/data/data/agent/systemd/units/apply-host-config.service.template
+++ b/data/data/agent/systemd/units/apply-host-config.service.template
@@ -10,10 +10,11 @@ ConditionPathExists=/etc/assisted-service/node0
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Environment=SERVICE_BASE_URL={{.ServiceBaseURL}}
 Environment=INFRA_ENV_ID={{.InfraEnvID}}
+EnvironmentFile=/usr/local/share/assisted-service/agent-images.env
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/bin/mkdir -p %t/agent-installer /etc/assisted/hostconfig
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL  --env INFRA_ENV_ID quay.io/edge-infrastructure/assisted-service:latest /usr/local/bin/agent-installer-client configure
+ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --restart=on-failure:10 --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=apply-host-config -v /etc/assisted/hostconfig:/etc/assisted/hostconfig -v %t/agent-installer:/var/run/agent-installer:z --env SERVICE_BASE_URL --env INFRA_ENV_ID $SERVICE_IMAGE /usr/local/bin/agent-installer-client configure
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/data/data/agent/systemd/units/assisted-service-db.service
+++ b/data/data/agent/systemd/units/assisted-service-db.service
@@ -7,10 +7,11 @@ After=network-online.target assisted-service-pod.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=/usr/local/share/assisted-service/agent-images.env
 Restart=on-failure
 TimeoutStopSec=300
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=assisted-db --env-file=/usr/local/share/assisted-service/assisted-db.env quay.io/centos7/postgresql-12-centos7:latest
+ExecStart=/usr/bin/podman run --user=postgres --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=assisted-db --env-file=/usr/local/share/assisted-service/assisted-db.env $SERVICE_IMAGE /bin/bash start_db.sh
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify

--- a/data/data/agent/systemd/units/assisted-service-pod.service
+++ b/data/data/agent/systemd/units/assisted-service-pod.service
@@ -13,6 +13,7 @@ Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/bin/rm -f %t/%n.pid %t/%N.pod-id
 ExecStartPre=/usr/bin/podman pod create --infra-conmon-pidfile %t/%n.pid --pod-id-file %t/%N.pod-id -n assisted-service --publish=8090:8090 --publish=8080:8080 --publish=8888:8888
+ExecStartPre=/usr/local/bin/get-container-images.sh
 ExecStart=/usr/bin/podman pod start --pod-id-file=%t/%N.pod-id
 ExecStop=/usr/bin/podman pod stop --ignore --pod-id-file=%t/%N.pod-id -t 10
 ExecStopPost=/usr/bin/podman pod rm --ignore -f --pod-id-file=%t/%N.pod-id

--- a/data/data/agent/systemd/units/assisted-service.service.template
+++ b/data/data/agent/systemd/units/assisted-service.service.template
@@ -8,10 +8,11 @@ After=network-online.target assisted-service-pod.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
+EnvironmentFile=/usr/local/share/assisted-service/agent-images.env
 Restart=on-failure
 TimeoutStopSec=300
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=service -v /opt/agent/tls:/opt/agent/tls:z {{.MirrorRegistriesMount}} {{.CaBundleMount}} --env-file=/usr/local/share/assisted-service/assisted-service.env --env-file=/usr/local/share/assisted-service/images.env --env-file=/etc/assisted-service/node0 quay.io/edge-infrastructure/assisted-service:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --sdnotify=conmon --replace -d --name=service -v /opt/agent/tls:/opt/agent/tls:z {{.MirrorRegistriesMount}} {{.CaBundleMount}} --env-file=/usr/local/share/assisted-service/assisted-service.env --env-file=/usr/local/share/assisted-service/images.env --env-file=/etc/assisted-service/node0 --env-file=/usr/local/share/assisted-service/agent-images.env $SERVICE_IMAGE
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify

--- a/data/data/agent/systemd/units/create-cluster-and-infraenv.service.template
+++ b/data/data/agent/systemd/units/create-cluster-and-infraenv.service.template
@@ -10,9 +10,10 @@ ConditionPathExists=/etc/assisted-service/node0
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Environment=SERVICE_BASE_URL={{.ServiceBaseURL}}
 Environment=OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR={{.ReleaseImageMirror}}
+EnvironmentFile=/usr/local/share/assisted-service/agent-images.env
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
 ExecStartPre=/usr/local/bin/wait-for-assisted-service.sh
-ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=create-cluster-and-infraenv -v /etc/assisted/manifests:/manifests -v /etc/pki/ca-trust:/etc/pki/ca-trust:z --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR quay.io/edge-infrastructure/assisted-service:latest /usr/local/bin/agent-installer-client register
+ExecStart=podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --log-driver=journald --rm --pod-id-file=%t/assisted-service-pod.pod-id --replace --name=create-cluster-and-infraenv -v /etc/assisted/manifests:/manifests -v /etc/pki/ca-trust:/etc/pki/ca-trust:z --env SERVICE_BASE_URL --env OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR $SERVICE_IMAGE /usr/local/bin/agent-installer-client register
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -46,6 +46,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 			},
 		},
 	}
+	releaseImage := "quay.io:443/openshift-release-dev/ocp-release:4.10.0-rc.1-x86_64"
 	releaseImageMirror := "virthost.ostest.test.metalkube.org:5000/localimages/local-release-image"
 	mirrorRegistriesMount := "-v /etc/assisted/mirror/registries.conf:/etc/containers/registries.conf"
 	caBundleMount := "-v /etc/assisted/mirror/ca-bundle.crt:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
@@ -53,7 +54,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 
 	releaseImageList, err := releaseImageList(clusterImageSet.Spec.ReleaseImage, "x86_64")
 	assert.NoError(t, err)
-	templateData := getTemplateData(pullSecret, nodeZeroIP, releaseImageList, releaseImageMirror, mirrorRegistriesMount, caBundleMount, agentClusterInstall, infraEnvID)
+	templateData := getTemplateData(pullSecret, nodeZeroIP, releaseImageList, releaseImage, releaseImageMirror, mirrorRegistriesMount, caBundleMount, agentClusterInstall, infraEnvID)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, "http://"+nodeZeroIP+":8090/", templateData.ServiceBaseURL)
 	assert.Equal(t, pullSecret, templateData.PullSecret)
@@ -64,6 +65,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	assert.Equal(t, agentClusterInstall.Spec.ProvisionRequirements.ControlPlaneAgents, templateData.ControlPlaneAgents)
 	assert.Equal(t, agentClusterInstall.Spec.ProvisionRequirements.WorkerAgents, templateData.WorkerAgents)
 	assert.Equal(t, releaseImageList, templateData.ReleaseImages)
+	assert.Equal(t, releaseImage, templateData.ReleaseImage)
 	assert.Equal(t, releaseImageMirror, templateData.ReleaseImageMirror)
 	assert.Equal(t, mirrorRegistriesMount, templateData.MirrorRegistriesMount)
 	assert.Equal(t, caBundleMount, templateData.CaBundleMount)


### PR DESCRIPTION
Get the images used to start all services from the release payload. 

This works in a connected environment, however in order to fully complete a disconnected install, an assisted-service change to use an icsp file when running 'oc adm release extract' is required as described in https://issues.redhat.com/browse/MGMT-10209.

The disconnected environment can be tested in dev-scripts with https://github.com/openshift-metal3/dev-scripts/pull/1424 using
export MIRROR_IMAGES=true
