### PR TITLE
NO-ISSUE: Wait for InfraEnv to be created before running agent

### DIFF
--- a/data/data/agent/files/usr/local/bin/start-agent.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-agent.sh.template
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+source common.sh
+
+>&2 echo "Waiting for infra-env-id to be available"
+INFRA_ENV_ID=""
+until [[ $INFRA_ENV_ID != "" && $INFRA_ENV_ID != "null" ]]; do
+    sleep 5
+    >&2 echo "Querying assisted-service for infra-env-id..."
+    INFRA_ENV_ID=$(curl -s -S '{{.ServiceBaseURL}}/api/assisted-install/v2/infra-envs' | jq -r .[0].id)
+done
+echo "Fetched infra-env-id and found: $INFRA_ENV_ID"
+
+# use infra-env-id to have agent register this host with assisted-service
+exec /usr/local/bin/agent --url '{{.ServiceBaseURL}}' --infra-env-id '{{.InfraEnvID}}' --agent-version quay.io/edge-infrastructure/assisted-installer-agent:latest --insecure=true

--- a/data/data/agent/systemd/units/agent.service.template
+++ b/data/data/agent/systemd/units/agent.service.template
@@ -14,7 +14,8 @@ Environment=no_proxy=
 Environment=PULL_SECRET_TOKEN={{.PullSecretToken}}
 TimeoutStartSec=3000
 ExecStartPre=podman run --privileged --rm -v /usr/local/bin:/hostbin quay.io/edge-infrastructure/assisted-installer-agent:latest cp /usr/bin/agent /hostbin
-ExecStart=/usr/local/bin/agent --url '{{.ServiceBaseURL}}' --infra-env-id '{{.InfraEnvID}}' --agent-version quay.io/edge-infrastructure/assisted-installer-agent:latest --insecure=true
+ExecStart=/usr/local/bin/start-agent.sh
+
 [Unit]
 Wants=network-online.target set-hostname.service
 After=network-online.target set-hostname.service


### PR DESCRIPTION
PR#6045 removed the wait. The wait needs to be put back in
because host registration will fail if the InfraEnv has not been
registered with assisted-service.