### PR TITLE
Bug 2097691: vsphere installconfig: use full dc path in network validation

### DIFF
--- a/pkg/asset/installconfig/vsphere/mock/vsphere_sim.go
+++ b/pkg/asset/installconfig/vsphere/mock/vsphere_sim.go
@@ -19,6 +19,9 @@ import (
 //                to retrieve a vim25.client which will connect to and trust this simulator
 func StartSimulator() *simulator.Server {
 	model := simulator.VPX()
+	model.Folder = 1
+	model.Datacenter = 2
+	model.OpaqueNetwork = 1
 	model.Create()
 	model.Service.TLS = new(tls.Config)
 	model.Service.TLS.ServerName = "127.0.0.1"

--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -93,8 +93,9 @@ func validateNetwork(client *vim25.Client, finder Finder, p *vsphere.Platform, f
 	if err != nil {
 		return field.ErrorList{field.Invalid(fldPath, p.Datacenter, err.Error())}
 	}
-
-	_, err = GetNetworkMoID(ctx, client, finder, dataCenter.Name(), p.Cluster, p.Network)
+	// Remove any trailing backslash before getting networkMoID
+	trimmedPath := strings.TrimPrefix(dataCenter.InventoryPath, "/")
+	_, err = GetNetworkMoID(ctx, client, finder, trimmedPath, p.Cluster, p.Network)
 	if err != nil {
 		return field.ErrorList{field.Invalid(fldPath, p.Network, err.Error())}
 	}


### PR DESCRIPTION
If a vspehre datacenter is created within a folder, the full invetory
path must be used when retrieving the cluster for network validation

This also extends tests for including the case where the datacenter
is created in a folder.

Fixes #5999