### PR TITLE
Bug 2102228: rhcos: Move to rhcos.mirror.openshift.com

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -12,7 +12,7 @@
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-aws.aarch64.vmdk.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-aws.aarch64.vmdk.gz",
                 "sha256": "5fb260c73933d093c094ff92390cc8b21e200a4b125f2797cd52cedf2656d488",
                 "uncompressed-sha256": "a2a4c3b666650b3520a1cf60a79b63fc078d631750aa97f4c392a3bf77d4de75"
               }
@@ -24,7 +24,7 @@
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-azure.aarch64.vhd.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-azure.aarch64.vhd.gz",
                 "sha256": "2bffd71472f24be9ea4d0e19418f06bdb06fb93bee10c107e6c59276ef461484",
                 "uncompressed-sha256": "d7fbc29f5d85f436928de65c3c665e093d59641d73a80b47f03d8d326d943305"
               }
@@ -36,34 +36,34 @@
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-metal4k.aarch64.raw.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-metal4k.aarch64.raw.gz",
                 "sha256": "c9c79647229c6bb09c1852ce53d2e98912d2f6a50cd76284e371e9aa1c728438",
                 "uncompressed-sha256": "c7cb6987b3286e7d70514df7d4b763143ed233fd6423057e7100150ad5ce9557"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live.aarch64.iso",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live.aarch64.iso",
                 "sha256": "5558d4f4625a95b267ee2096f108c8be7eb5e5c27fa95d5cbad31af040c53674"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-kernel-aarch64",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-kernel-aarch64",
                 "sha256": "5d044dfb1bcebc86effbef794b94a424e3d2e5d2a217cf968cc2a73a1efbe320"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-initramfs.aarch64.img",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-initramfs.aarch64.img",
                 "sha256": "980121a55b682c4388f525bb5ac7882ca9d4dec27dfc6f261c376c64944ac894"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-rootfs.aarch64.img",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-rootfs.aarch64.img",
                 "sha256": "30393784dd1612d9eedbda0d8d3e4a2e4f2452b4de4bb13ca509345c88de4c97"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-metal.aarch64.raw.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-metal.aarch64.raw.gz",
                 "sha256": "b779180a783fa80478618b310efe4691d90211b283752b868edba70058f09050",
                 "uncompressed-sha256": "5f90d700758123fcf861fa4df8b2216cf8caec588602a37d746f2d8b485c9301"
               }
@@ -75,7 +75,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-openstack.aarch64.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-openstack.aarch64.qcow2.gz",
                 "sha256": "075f26218a9087604abc91618370bf59cf8e7f6496f14f8ea8d60be8dd339a82",
                 "uncompressed-sha256": "23cd254f1ff554db761ca44df281d0396a14c5d54d10c1f773c2e7757a2ec6cc"
               }
@@ -87,7 +87,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-qemu.aarch64.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-qemu.aarch64.qcow2.gz",
                 "sha256": "a02ce9ee1e92341cc37af58a055c514fa62cd0e2ae7cf8a1be1011f79ab19d51",
                 "uncompressed-sha256": "a719d911ef875dfbbdb2d826b6fa91ce5f85a703ec88ea6ff2cf1d4141333830"
               }
@@ -191,34 +191,34 @@
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-metal4k.ppc64le.raw.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-metal4k.ppc64le.raw.gz",
                 "sha256": "334e469ea525a83225a9d978f96e37ed2c1c6e1468d71a7c63dba70013c08aa7",
                 "uncompressed-sha256": "ee76292fa895144c09c65564d96911732f6df53d74cefa24f6aec0240c21e76b"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live.ppc64le.iso",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live.ppc64le.iso",
                 "sha256": "6b76622f864f7f4ac56b4cd432ccfe2cb09dbfe7a7d5c3c36685e2c4faeb7324"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-kernel-ppc64le",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-kernel-ppc64le",
                 "sha256": "1087567be28bbe7e247c08986e2e46d6daa8b7a8d5c627e518a39cd3723c0bab"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-initramfs.ppc64le.img",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-initramfs.ppc64le.img",
                 "sha256": "f35074fd3a3720502446cfd265134bec61b3b98256a403afb0e22b90593ef8b1"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-rootfs.ppc64le.img",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-rootfs.ppc64le.img",
                 "sha256": "3254f11117fee0ab6d8155c98ca21615878f54f4af2c7e23046936c8ecf724f8"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-metal.ppc64le.raw.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-metal.ppc64le.raw.gz",
                 "sha256": "83b7fdfbbece9be07a7a6cd299f608db37f4a7dc707cbd874fe9ca9271d2d2ee",
                 "uncompressed-sha256": "0a383533eabc1644a52edd968f7ee5d6510a2eba01ab83d8fb5914084d0ee9b0"
               }
@@ -230,7 +230,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-openstack.ppc64le.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-openstack.ppc64le.qcow2.gz",
                 "sha256": "e648e8e8271e35aac15da4aebfaf2145fd41dbd0c6c70c6f836aac86446b783d",
                 "uncompressed-sha256": "65e55e6a0d2dfa9415ed3fac9951a645d87f257e34b4ae57dda9d006504c5048"
               }
@@ -242,7 +242,7 @@
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-powervs.ppc64le.ova.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-powervs.ppc64le.ova.gz",
                 "sha256": "fd14f78e2b2d30fd925ddee219845e2d558b2de86756efd43a4b18bc1a954465",
                 "uncompressed-sha256": "d783c3713ff2d2029476c1ae0ee0ab358b68808800d26b015757cd8de886b957"
               }
@@ -254,7 +254,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-qemu.ppc64le.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-qemu.ppc64le.qcow2.gz",
                 "sha256": "af84b0af643981e3a047d5f7f6d3ba7eb1b40a25ff6eee8f4fc54d9c88567e46",
                 "uncompressed-sha256": "4da192bc1f1288e1e02effcedd1701ac97d47cbd344b7a590455a460a38875a4"
               }
@@ -330,34 +330,34 @@
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-metal4k.s390x.raw.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-metal4k.s390x.raw.gz",
                 "sha256": "d24808f010de1a70842430dc20018afb2901847577c4bed24f8021c5f7315a05",
                 "uncompressed-sha256": "e29f62460f7fdf250e106a02b5b787cf0fd19d12dfd8336f6a205f0471c2eefc"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live.s390x.iso",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live.s390x.iso",
                 "sha256": "8e64fca95fd0c9b31115de5dbab16f0086455664a4468b2d0b0fe43712d0d471"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-kernel-s390x",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-kernel-s390x",
                 "sha256": "f3bab30ea08f5155b3c67ae08764004349e68042a4aee8482a027f55144282d2"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-initramfs.s390x.img",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-initramfs.s390x.img",
                 "sha256": "355bdfa8ce4defe5bf0ffac7856ec4ddf8396317b31075aa329d67aea2d1945a"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-rootfs.s390x.img",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-rootfs.s390x.img",
                 "sha256": "7a3048a92f6999c125ffaab735fccceef5f0e1e706de803734f59f37d0bdc78f"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-metal.s390x.raw.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-metal.s390x.raw.gz",
                 "sha256": "d9cb0eb0970fa57b00d9e572a364ab7211c91f53bf4499d15cf3512b86e4db81",
                 "uncompressed-sha256": "73106e2261caa89e0e1ff25bed4f7cfe72d8bafe19d25063b89ad07a90365b8e"
               }
@@ -369,7 +369,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-openstack.s390x.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-openstack.s390x.qcow2.gz",
                 "sha256": "9d814822d367a081032fbb48c07e5532279e2d61da33b09fdc3dba059c4c3bd8",
                 "uncompressed-sha256": "073be4b8a15dfcec6b51557d967dfad96ffc97908a8aeec919471de5ac42ce5b"
               }
@@ -381,7 +381,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-qemu.s390x.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-qemu.s390x.qcow2.gz",
                 "sha256": "4b690a17fb685b495df776a93a4d6da0e92c7aff07f5036269f28273df02ea92",
                 "uncompressed-sha256": "b0828d8ea6d3949343419cc26b794888897494a21fb5c4a8881a9b428d3fb57f"
               }
@@ -398,7 +398,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-aliyun.x86_64.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-aliyun.x86_64.qcow2.gz",
                 "sha256": "b716728ea93b7e28006b1cbc95b286e37bb04d6cbfc14f23b06beb97a87fccb7",
                 "uncompressed-sha256": "d88c56177e898769ea9382d7a51b055ab4dd1b4f699a7c329ea30c18867a7ed1"
               }
@@ -410,7 +410,7 @@
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-aws.x86_64.vmdk.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-aws.x86_64.vmdk.gz",
                 "sha256": "37918a20b67e3b3445acfc8e8b2611565b2a8db9a55299a4e85d5e99c5da8748",
                 "uncompressed-sha256": "2a76b77118e5911fd1780bd5b8f77d58b252e1200936173c77104eaa836989b9"
               }
@@ -422,7 +422,7 @@
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-azure.x86_64.vhd.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-azure.x86_64.vhd.gz",
                 "sha256": "ccdf7414f6f432a1dd8a9711ba16ccec87ab643ec87b5cac2bf33eeea7fd5cb0",
                 "uncompressed-sha256": "d5d687fcc5a84889eebcf414357636b7fa93a28ce8186ae4f592d761a501c282"
               }
@@ -434,7 +434,7 @@
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-azurestack.x86_64.vhd.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-azurestack.x86_64.vhd.gz",
                 "sha256": "aab8bd1b2d0e932da7c41e22d51a49e673f3dd77bfafc69b87834b6b84b132b3",
                 "uncompressed-sha256": "d150e113c726662b1493f5d73211d829191214f4d124793380c6696203315fa5"
               }
@@ -446,7 +446,7 @@
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-gcp.x86_64.tar.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-gcp.x86_64.tar.gz",
                 "sha256": "93b3e416a09b94dbd7c8660d20e89817b348c80c15c3d8319589d0c2806b22fd",
                 "uncompressed-sha256": "c041a28a5f1b5147d2cd420beeb1fe993ac861ead037401f49bbbc8a445685ea"
               }
@@ -458,7 +458,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-ibmcloud.x86_64.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-ibmcloud.x86_64.qcow2.gz",
                 "sha256": "6d9b2b366e6b9eeac3d1a8d5942b01cc1a33345f5c93da0e6788df51b02e2ace",
                 "uncompressed-sha256": "a32925bf6d99a0237c724ab0a006cf5a5c7d5f7ff1e01187f955845b4a9e7933"
               }
@@ -470,34 +470,34 @@
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-metal4k.x86_64.raw.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-metal4k.x86_64.raw.gz",
                 "sha256": "12ad39b79e7993beb0c25bff5e99553725aac88ba89eb0c8214bc5e7cf50635a",
                 "uncompressed-sha256": "f77c2b36e97fb2de6d3b6e603a68e2dd720cb9df9ef320a7c09ea572e75aeb8f"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live.x86_64.iso",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live.x86_64.iso",
                 "sha256": "6fb6fb45fbd9279d62c9abeaeec3d7cd98a9a1bb31e963b17c026e72a95b587a"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-kernel-x86_64",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-kernel-x86_64",
                 "sha256": "6208caa9642c9d17971747d078e1e52b62a9a35f3067544ceaa3346e5e1fb285"
               },
               "initramfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-initramfs.x86_64.img",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-initramfs.x86_64.img",
                 "sha256": "43cd07465de241e605ce3cc83c68fd282bdfcb5993e5df4d4b94cd4366f7df49"
               },
               "rootfs": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-rootfs.x86_64.img",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-rootfs.x86_64.img",
                 "sha256": "56ddc8693ad3ded29aa815e38749c0d9b74660dc5fbe69683433709401a985a6"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-metal.x86_64.raw.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-metal.x86_64.raw.gz",
                 "sha256": "f3a7bffaf036d2671fa3009798cb88960a28a5235a5a77f11b6bf3e34b659f6e",
                 "uncompressed-sha256": "8db32bc9cd090fa02d791351527da598e91041b2a0ccc46d74fa4b92a68f31c5"
               }
@@ -509,7 +509,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-nutanix.x86_64.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-nutanix.x86_64.qcow2.gz",
                 "sha256": "40b253ece9471afaa3c7566dd3d4fec86d5daa5d9fadc33174ebcc6aa262966f",
                 "uncompressed-sha256": "2d81134c2bde2ae131640da201036721c63bf28a71cbfd8d3114b48d522ba163"
               }
@@ -521,7 +521,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-openstack.x86_64.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-openstack.x86_64.qcow2.gz",
                 "sha256": "b1ef44b77ae3b1e731d57eea7c73813f28668e4d0a663442a0076b614eb543ee",
                 "uncompressed-sha256": "46278e035367c88349d50cbefb01a9ca73db26808b6dcee8ce58ebf4b52deaf4"
               }
@@ -533,7 +533,7 @@
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-qemu.x86_64.qcow2.gz",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-qemu.x86_64.qcow2.gz",
                 "sha256": "5e713be5b575bc2ae9600518fcd72d64c3a51e21b719444c1c0172f92066280f",
                 "uncompressed-sha256": "75ca83efc8c40669631d7367664fd48372c067da5fa448551bc2ab28026b94c4"
               }
@@ -545,7 +545,7 @@
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-vmware.x86_64.ova",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-vmware.x86_64.ova",
                 "sha256": "a6d7b1bafc5b28fa3941e4c70049dd0d55804ce460ebc5f9c9769389f8986bad"
               }
             }


### PR DESCRIPTION
rhcos.mirror.openshift.com is the new formal location to download
RHCOS boot images. It is backed by CloudFront CDN, which should be
more reliable and faster than the rhcos-redirector.