### PR TITLE
Bug 2084471: validate baremetal hosts names are lowercase RFC 1123

### DIFF
--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -214,10 +214,34 @@ func TestValidatePlatform(t *testing.T) {
 			expected: "baremetal.hosts\\[1\\].Name: Duplicate value: \"host1\"",
 		},
 		{
-			name: "invalid_host_name",
+			name: "valid_host_name",
+			platform: platform().
+				Hosts(host1().Name("host1")).build(),
+			expected: "",
+		},
+		{
+			name: "valid_host_name_fqdn",
+			platform: platform().
+				Hosts(host1().Name("test.example.com")).build(),
+			expected: "",
+		},
+		{
+			name: "invalid_host_name_char",
+			platform: platform().
+				Hosts(host1().Name("test,example.com")).build(),
+			expected: "baremetal.Hosts\\[0\\].name: Invalid value: \"test,example.com\"",
+		},
+		{
+			name: "invalid_host_name_uppercase",
 			platform: platform().
 				Hosts(host1().Name("Host1")).build(),
 			expected: "baremetal.Hosts\\[0\\].name: Invalid value: \"Host1\"",
+		},
+		{
+			name: "invalid_host_name_length",
+			platform: platform().
+				Hosts(host1().Name("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")).build(),
+			expected: "baremetal.Hosts\\[0\\].name: Invalid value: \"aaaaaaaaa",
 		},
 		{
 			name: "duplicate_host_mac",

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -240,7 +240,7 @@ func TestValidatePlatform(t *testing.T) {
 		{
 			name: "invalid_host_name_length",
 			platform: platform().
-				Hosts(host1().Name("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")).build(),
+				Hosts(host1().Name(strings.Repeat("a", 300))).build(),
 			expected: "baremetal.Hosts\\[0\\].name: Invalid value: \"aaaaaaaaa",
 		},
 		{

--- a/pkg/types/baremetal/validation/platform_test.go
+++ b/pkg/types/baremetal/validation/platform_test.go
@@ -214,6 +214,12 @@ func TestValidatePlatform(t *testing.T) {
 			expected: "baremetal.hosts\\[1\\].Name: Duplicate value: \"host1\"",
 		},
 		{
+			name: "invalid_host_name",
+			platform: platform().
+				Hosts(host1().Name("Host1")).build(),
+			expected: "baremetal.Hosts\\[0\\].name: Invalid value: \"Host1\"",
+		},
+		{
 			name: "duplicate_host_mac",
 			platform: platform().
 				Hosts(


### PR DESCRIPTION
Capital letters in install-config.yaml .platform.baremetal.hosts[].name caused bootkube to loop forever with errors.
The install gets stuck on openshift-master-host creation.
See: https://bugzilla.redhat.com/show_bug.cgi?id=2084471

This patch uses the same validation function and makes the install fail early with a clear message.

