### PR TITLE
Bug 2106667: OpenStack UPI: Allow setting external DNS

### DIFF
--- a/upi/openstack/inventory.yaml
+++ b/upi/openstack/inventory.yaml
@@ -28,6 +28,17 @@ all:
       # 3 is the minimum number for a fully-functional cluster.
       os_compute_nodes_number: 3
 
+      # The IP addresses of DNS servers to be used for the DNS resolution of
+      # all instances in the cluster. The total number of dns servers supported
+      # by an instance is three. That total includes any dns server provided by
+      # the underlying OpenStack infrastructure.
+      #
+      # Note that the values below are example IPs and do not point to actual
+      # resolvers. To use the OpenStack defaults, remove the values below.
+      os_external_dns:
+      - 192.0.2.53
+      - 192.0.2.153
+
       # The public network providing connectivity to the cluster. If not
       # provided, the cluster external connectivity must be provided in another
       # way.

--- a/upi/openstack/network.yaml
+++ b/upi/openstack/network.yaml
@@ -26,6 +26,7 @@
       cidr: "{{ os_subnet_range }}"
       allocation_pool_start: "{{ os_subnet_range | next_nth_usable(10) }}"
       allocation_pool_end: "{{ os_subnet_range | ipaddr('last_usable') }}"
+      dns_nameservers: "{{ os_external_dns }}"
 
   - name: 'Set tags on  primary cluster subnet'
     command:


### PR DESCRIPTION
Akin to `install-config.yaml`'s `platform.openstack.externalDNS`, add a
new `os_external_dns` property of the UPI inventory to allow setting up
external DNS resolvers to the machines' subnet.