### PR TITLE
Bug 2106820: Convert all MAC addresses to lowercase

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -160,7 +160,7 @@ func (a *Asset) HostConfigFiles() (HostConfigFileMap, error) {
 
 		macs := []string{}
 		for _, iface := range host.Interfaces {
-			macs = append(macs, iface.MacAddress+"\n")
+			macs = append(macs, strings.ToLower(iface.MacAddress)+"\n")
 		}
 
 		if len(macs) > 0 {

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -322,7 +322,7 @@ func addMacAddressToHostnameMappings(
 	for _, host := range agentConfigAsset.Config.Spec.Hosts {
 		if host.Hostname != "" {
 			file := ignition.FileFromBytes(filepath.Join(hostnamesPath,
-				filepath.Base(host.Interfaces[0].MacAddress)),
+				strings.ToLower(filepath.Base(host.Interfaces[0].MacAddress))),
 				"root", 0600, []byte(host.Hostname))
 			config.Storage.Files = append(config.Storage.Files, file)
 		}


### PR DESCRIPTION
If MAC addresses are provided with uppercase hex digits in the
agent-config, convert them to lowercase before storing in the image. The
client program that searches for hosts just does a direct
(case-sensitive) comparison with the values obtained from inventory.