### PR TITLE
AGENT-267: Add host role to /etc/assisted/hostconfig

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -269,6 +269,66 @@ spec:
 				},
 			},
 		},
+		{
+			name: "host-roles-have-correct-values",
+			data: `
+metadata:
+  name: agent-config-cluster0
+spec:
+  rendezvousIP: 192.168.111.80
+  hosts:
+    - role: master
+      interfaces:
+        - name: enp3s1
+          macAddress: 28:d2:44:d2:b2:1a
+    - role: worker
+      interfaces:
+        - name: enp3s1
+          macAddress: 28:d2:44:d2:b2:1b`,
+			expectedFound: true,
+			expectedConfig: &agent.Config{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "agent-config-cluster0",
+				},
+				Spec: agent.Spec{
+					RendezvousIP: "192.168.111.80",
+					Hosts: []agent.Host{
+						{
+							Role: "master",
+							Interfaces: []*aiv1beta1.Interface{
+								{
+									Name:       "enp3s1",
+									MacAddress: "28:d2:44:d2:b2:1a",
+								},
+							},
+						},
+						{
+							Role: "worker",
+							Interfaces: []*aiv1beta1.Interface{
+								{
+									Name:       "enp3s1",
+									MacAddress: "28:d2:44:d2:b2:1b",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "host-roles-have-incorrect-values",
+			data: `
+metadata:
+  name: agent-config-cluster0
+spec:
+  rendezvousIP: 192.168.111.80
+  hosts:
+    - role: invalid-role
+      interfaces:
+        - name: enp3s1
+          macAddress: 28:d2:44:d2:b2:1a`,
+			expectedError: "invalid Agent Config configuration: Spec.Hosts[0].Host: Forbidden: host role has incorrect value. Role must either be 'master' or 'worker'",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"strings"
 	"testing"
 
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
@@ -9,6 +10,7 @@ import (
 	"github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/models"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/installer/pkg/asset/agent/agentconfig"
 	"github.com/openshift/installer/pkg/types/agent"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -174,6 +176,74 @@ func TestRetrieveRendezvousIP(t *testing.T) {
 			rendezvousIP, err := retrieveRendezvousIP(tc.agentConfig, tc.nmStateConfigs)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedRendezvousIP, rendezvousIP)
+		})
+	}
+
+}
+
+func TestAddHostConfig_Roles(t *testing.T) {
+	cases := []struct {
+		Name                            string
+		agentConfig                     *agentconfig.Asset
+		expectedNumberOfHostConfigFiles int
+	}{
+		{
+			Name: "one-host-role-defined",
+			agentConfig: &agentconfig.Asset{
+				Config: &agent.Config{
+					Spec: agent.Spec{
+						Hosts: []agent.Host{
+							{
+								Role: "master",
+							},
+						},
+					},
+				},
+			},
+			expectedNumberOfHostConfigFiles: 1,
+		},
+		{
+			Name: "multiple-host-roles-defined",
+			agentConfig: &agentconfig.Asset{
+				Config: &agent.Config{
+					Spec: agent.Spec{
+						Hosts: []agent.Host{
+							{
+								Role: "master",
+							},
+							{
+								Role: "master",
+							},
+							{
+								Role: "master",
+							},
+							{
+								Role: "worker",
+							},
+							{
+								Role: "worker",
+							},
+						},
+					},
+				},
+			},
+			expectedNumberOfHostConfigFiles: 5,
+		},
+		{
+			Name:                            "zero-host-roles-defined",
+			expectedNumberOfHostConfigFiles: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			config := &igntypes.Config{}
+			err := addHostConfig(config, tc.agentConfig)
+			assert.NoError(t, err)
+			assert.Equal(t, len(config.Storage.Files), tc.expectedNumberOfHostConfigFiles)
+			for _, file := range config.Storage.Files {
+				assert.Equal(t, true, strings.HasPrefix(file.Path, "/etc/assisted/hostconfig"))
+				assert.Equal(t, true, strings.HasSuffix(file.Path, "role"))
+			}
 		})
 	}
 


### PR DESCRIPTION
Validate role value can either be "master" or "worker"
More complex validations will require install-config manifest to
be available.