### PR TITLE
Bug 2107151: use regional STS endpoints

### DIFF
--- a/pkg/asset/installconfig/aws/session.go
+++ b/pkg/asset/installconfig/aws/session.go
@@ -59,7 +59,10 @@ func GetSession() (*session.Session, error) { return GetSessionWithOptions() }
 // and, if no creds are found, asks for them and stores them on disk in a config file
 func GetSessionWithOptions(optFuncs ...SessionOptions) (*session.Session, error) {
 	options := session.Options{
-		Config:            aws.Config{MaxRetries: aws.Int(0)},
+		Config: aws.Config{
+			MaxRetries:          aws.Int(0),
+			STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
+		},
 		SharedConfigState: session.SharedConfigEnable,
 	}
 	for _, optFunc := range optFuncs {


### PR DESCRIPTION
By default the AWS SDK for Go V1 SDK uses the global STS access point.
Let's tell it to use the regional one instead.

https://github.com/aws/aws-sdk-go/issues/4112#issuecomment-941292922