### PR TITLE
Bug 2106061: bump RHCOS 4.12 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.11",
   "metadata": {
-    "last-modified": "2022-05-10T19:25:06Z",
-    "generator": "plume cosa2stream 0.13.0+135-gc29b6f7d5-dirty"
+    "last-modified": "2022-07-17T01:52:17Z",
+    "generator": "plume cosa2stream 0.14.0+129-g80da54553-dirty"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "411.85.202205040359-0",
+          "release": "412.86.202207160442-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-aws.aarch64.vmdk.gz",
-                "sha256": "5fb260c73933d093c094ff92390cc8b21e200a4b125f2797cd52cedf2656d488",
-                "uncompressed-sha256": "a2a4c3b666650b3520a1cf60a79b63fc078d631750aa97f4c392a3bf77d4de75"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-aws.aarch64.vmdk.gz",
+                "sha256": "504992b8fefc2d756ffb0efa4c2f2d77ce2981b6eebf0a77099766249cc8d7fa",
+                "uncompressed-sha256": "10b51f7da9673d7aa4ede28cb9b37ab5a144c0ffeb383ec6f1a499fc822f5565"
               }
             }
           }
         },
         "azure": {
-          "release": "411.85.202205040359-0",
+          "release": "412.86.202207160442-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-azure.aarch64.vhd.gz",
-                "sha256": "2bffd71472f24be9ea4d0e19418f06bdb06fb93bee10c107e6c59276ef461484",
-                "uncompressed-sha256": "d7fbc29f5d85f436928de65c3c665e093d59641d73a80b47f03d8d326d943305"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-azure.aarch64.vhd.gz",
+                "sha256": "9bc00cbda48bdf464bd559f046f497a785d2ff1d0d50df15ac9930e69b5d967e",
+                "uncompressed-sha256": "b741facc26fed2a2e71dcabf46ced199f2e6cd44502f75465d370aeaf1a74f01"
               }
             }
           }
         },
         "metal": {
-          "release": "411.85.202205040359-0",
+          "release": "412.86.202207160442-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-metal4k.aarch64.raw.gz",
-                "sha256": "c9c79647229c6bb09c1852ce53d2e98912d2f6a50cd76284e371e9aa1c728438",
-                "uncompressed-sha256": "c7cb6987b3286e7d70514df7d4b763143ed233fd6423057e7100150ad5ce9557"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-metal4k.aarch64.raw.gz",
+                "sha256": "738221ee2e34c004e902ec54a1646b41074f6b02cc7bacfebccf5e935c4c20c4",
+                "uncompressed-sha256": "b5d604e8b6e811c5317a9f60c3eb66ede77fdab4ea1dfab52516c54348cf2fc0"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live.aarch64.iso",
-                "sha256": "5558d4f4625a95b267ee2096f108c8be7eb5e5c27fa95d5cbad31af040c53674"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-live.aarch64.iso",
+                "sha256": "82257aeb0af837e20fa5c125c62e69486cc8947719c412b5fcbdf377eb2aa68c"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-kernel-aarch64",
-                "sha256": "5d044dfb1bcebc86effbef794b94a424e3d2e5d2a217cf968cc2a73a1efbe320"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-live-kernel-aarch64",
+                "sha256": "eaf770aec132b748c0a5a9e1363949e85f71b796a12bf082a086120c6b1d3a5e"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-initramfs.aarch64.img",
-                "sha256": "980121a55b682c4388f525bb5ac7882ca9d4dec27dfc6f261c376c64944ac894"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-live-initramfs.aarch64.img",
+                "sha256": "7d64edc973a43a7df7e415f8fd357b6bacb076c4aea555bcee395fbb335041e9"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-live-rootfs.aarch64.img",
-                "sha256": "30393784dd1612d9eedbda0d8d3e4a2e4f2452b4de4bb13ca509345c88de4c97"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-live-rootfs.aarch64.img",
+                "sha256": "4a62658769c3d6026443469beb1b64c67af1ff6c926064942b275216f8a09229"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-metal.aarch64.raw.gz",
-                "sha256": "b779180a783fa80478618b310efe4691d90211b283752b868edba70058f09050",
-                "uncompressed-sha256": "5f90d700758123fcf861fa4df8b2216cf8caec588602a37d746f2d8b485c9301"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-metal.aarch64.raw.gz",
+                "sha256": "e06c00602fe4c8f61121f6b83505589a3ca8869af0310e440be8411f46d7424f",
+                "uncompressed-sha256": "062cca494138863f13820cab27919249efa381519aedd57ff1131ac2db1ef303"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.85.202205040359-0",
+          "release": "412.86.202207160442-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-openstack.aarch64.qcow2.gz",
-                "sha256": "075f26218a9087604abc91618370bf59cf8e7f6496f14f8ea8d60be8dd339a82",
-                "uncompressed-sha256": "23cd254f1ff554db761ca44df281d0396a14c5d54d10c1f773c2e7757a2ec6cc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-openstack.aarch64.qcow2.gz",
+                "sha256": "7c03b8662b9ce03343dc16dc3c4d0829d71753bf958e281f9c3e3f98f2dffbdb",
+                "uncompressed-sha256": "262e88bb80aed165317872a691ca77c47ac3ccb5e01e89099b144e460cc1a1e7"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.85.202205040359-0",
+          "release": "412.86.202207160442-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.85.202205040359-0/aarch64/rhcos-411.85.202205040359-0-qemu.aarch64.qcow2.gz",
-                "sha256": "a02ce9ee1e92341cc37af58a055c514fa62cd0e2ae7cf8a1be1011f79ab19d51",
-                "uncompressed-sha256": "a719d911ef875dfbbdb2d826b6fa91ce5f85a703ec88ea6ff2cf1d4141333830"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-qemu.aarch64.qcow2.gz",
+                "sha256": "26cb1bb9263cdcb136dc3a9bbbc7ea1a93121fe6ba4ac9b5a802474c4c8c878f",
+                "uncompressed-sha256": "cee2815ba075fe39f7859044b34e644a0f031f4d49fc3d353c930ac42ea633e0"
               }
             }
           }
@@ -99,164 +99,164 @@
         "aws": {
           "regions": {
             "ap-east-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-036d1208cdf3de159"
+              "release": "412.86.202207160442-0",
+              "image": "ami-01fc78d8f1de3b321"
             },
             "ap-northeast-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-06e557068aa9d9f7a"
+              "release": "412.86.202207160442-0",
+              "image": "ami-068b6ece9d007d962"
             },
             "ap-northeast-2": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-043ccba70c960763b"
+              "release": "412.86.202207160442-0",
+              "image": "ami-069571d4a0af48e32"
             },
             "ap-south-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-045e7baccaa83c111"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0bb47e06d5cb73553"
             },
             "ap-southeast-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-096f943d29ecc3e4a"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0936434cf20500c4f"
             },
             "ap-southeast-2": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-0a64b24b072b16484"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0f3473d8d4edc7414"
             },
             "ca-central-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-02c3de67904625e15"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0725162edbfe7d9a5"
             },
             "eu-central-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-0e7953667e665f239"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0add2891c7356e1f2"
             },
             "eu-north-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-05738cfc2497f5129"
+              "release": "412.86.202207160442-0",
+              "image": "ami-012a6e91a6ffb7d6d"
             },
             "eu-south-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-0439daa940eb1f030"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0669e33bff8b26bc7"
             },
             "eu-west-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-0c34be73e1f1f0712"
+              "release": "412.86.202207160442-0",
+              "image": "ami-09ba5e60d1ded4aa8"
             },
             "eu-west-2": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-0ece7d7e0c1b854ee"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0f4dc5b0e63dfa612"
             },
             "eu-west-3": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-092015f22728917bc"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0452139490c73b5a2"
             },
             "me-south-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-0099e38b399d32641"
+              "release": "412.86.202207160442-0",
+              "image": "ami-082870ad6537d64e7"
             },
             "sa-east-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-05449f30e4b409025"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0f31e0b14b49826db"
             },
             "us-east-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-062d88886dbd84123"
+              "release": "412.86.202207160442-0",
+              "image": "ami-066d84c996a02f4f9"
             },
             "us-east-2": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-043ee03f44ace71b6"
+              "release": "412.86.202207160442-0",
+              "image": "ami-02277def1155a7154"
             },
             "us-west-1": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-024ef8a05563af10d"
+              "release": "412.86.202207160442-0",
+              "image": "ami-0e69cdc42d63d27b2"
             },
             "us-west-2": {
-              "release": "411.85.202205040359-0",
-              "image": "ami-0cc3dc567c31ea4db"
+              "release": "412.86.202207160442-0",
+              "image": "ami-02e7f79bf863c81fa"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "411.85.202205040359-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-411.85.202205040359-0-azure.aarch64.vhd"
+          "release": "412.86.202207160442-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202207160442-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "411.85.202203250810-0",
+          "release": "412.86.202207151711-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-metal4k.ppc64le.raw.gz",
-                "sha256": "334e469ea525a83225a9d978f96e37ed2c1c6e1468d71a7c63dba70013c08aa7",
-                "uncompressed-sha256": "ee76292fa895144c09c65564d96911732f6df53d74cefa24f6aec0240c21e76b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-metal4k.ppc64le.raw.gz",
+                "sha256": "359ce1f2e721eaaed3c5ab205c0ca112cc939561d821b49df144083235c444d9",
+                "uncompressed-sha256": "f9330eb545c584a6af9ef6c67c85368fe32fa8643c89ceff6f9f625b7d026e58"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live.ppc64le.iso",
-                "sha256": "6b76622f864f7f4ac56b4cd432ccfe2cb09dbfe7a7d5c3c36685e2c4faeb7324"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-live.ppc64le.iso",
+                "sha256": "65ff867f818ae80e3523abae9bb688fea3aaad5f307d516f899c9d2407aefbeb"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-kernel-ppc64le",
-                "sha256": "1087567be28bbe7e247c08986e2e46d6daa8b7a8d5c627e518a39cd3723c0bab"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-live-kernel-ppc64le",
+                "sha256": "7f3c269bd78edbf69d38a71fccc15235a319904edfe57e702ad63a54142a77d7"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-initramfs.ppc64le.img",
-                "sha256": "f35074fd3a3720502446cfd265134bec61b3b98256a403afb0e22b90593ef8b1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-live-initramfs.ppc64le.img",
+                "sha256": "6d0b8ddecd327171ac780dc048ce3c19ec5175b297d9e846c646849164c751d0"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-live-rootfs.ppc64le.img",
-                "sha256": "3254f11117fee0ab6d8155c98ca21615878f54f4af2c7e23046936c8ecf724f8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-live-rootfs.ppc64le.img",
+                "sha256": "5d022414dab538fcb024b19b7ff333e8c476e4c6bca2e6197d63546492c9d4ec"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-metal.ppc64le.raw.gz",
-                "sha256": "83b7fdfbbece9be07a7a6cd299f608db37f4a7dc707cbd874fe9ca9271d2d2ee",
-                "uncompressed-sha256": "0a383533eabc1644a52edd968f7ee5d6510a2eba01ab83d8fb5914084d0ee9b0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-metal.ppc64le.raw.gz",
+                "sha256": "f7de8ebedb4104c8ebbdab6845d12194354f53c3cdcff5336349440d6977c609",
+                "uncompressed-sha256": "4f7d92fcd32d65d3ad24f311d0bc9eff39068fd80f90c3d54d918d23ea42061e"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.85.202203250810-0",
+          "release": "412.86.202207151711-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "e648e8e8271e35aac15da4aebfaf2145fd41dbd0c6c70c6f836aac86446b783d",
-                "uncompressed-sha256": "65e55e6a0d2dfa9415ed3fac9951a645d87f257e34b4ae57dda9d006504c5048"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "1fb02c8c40772dcc36b1538ede0f653af3817d8a63ee09c928fd3af4441745f4",
+                "uncompressed-sha256": "9dfef585f1b6a319a5c67fc9a90560f88fb9503ce0f28d0f570732ee5c907897"
               }
             }
           }
         },
         "powervs": {
-          "release": "411.85.202203250810-0",
+          "release": "412.86.202207151711-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-powervs.ppc64le.ova.gz",
-                "sha256": "fd14f78e2b2d30fd925ddee219845e2d558b2de86756efd43a4b18bc1a954465",
-                "uncompressed-sha256": "d783c3713ff2d2029476c1ae0ee0ab358b68808800d26b015757cd8de886b957"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-powervs.ppc64le.ova.gz",
+                "sha256": "6c5200febfda986beff2776adb30dbefafb5d60494df3ddf0cdc019655190f10",
+                "uncompressed-sha256": "3a1a5e1414c5202a6cf2fa69860db4bed0e4d30a5d54ec941db0b8755f3246e7"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.85.202203250810-0",
+          "release": "412.86.202207151711-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.85.202203250810-0/ppc64le/rhcos-411.85.202203250810-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "af84b0af643981e3a047d5f7f6d3ba7eb1b40a25ff6eee8f4fc54d9c88567e46",
-                "uncompressed-sha256": "4da192bc1f1288e1e02effcedd1701ac97d47cbd344b7a590455a460a38875a4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "cbdde8834a9cca226f620dec889dfadac4e37a403b476a6014a32be770ecc59a",
+                "uncompressed-sha256": "b2901174fd809ca9d8c47f68697d74184520c24bf45d9a32fc7da33b18a1dd65"
               }
             }
           }
@@ -266,58 +266,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "411.85.202203250810-0",
-              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202207151711-0",
+              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "411.85.202203250810-0",
-              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202207151711-0",
+              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "411.85.202203250810-0",
-              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202207151711-0",
+              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "411.85.202203250810-0",
-              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202207151711-0",
+              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "411.85.202203250810-0",
-              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202207151711-0",
+              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "411.85.202203250810-0",
-              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202207151711-0",
+              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "411.85.202203250810-0",
-              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202207151711-0",
+              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "411.85.202203250810-0",
-              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202207151711-0",
+              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "411.85.202203250810-0",
-              "object": "rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202207151711-0",
+              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-411-85-202203250810-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -326,64 +326,64 @@
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "411.86.202205030351-0",
+          "release": "412.86.202207142236-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-metal4k.s390x.raw.gz",
-                "sha256": "d24808f010de1a70842430dc20018afb2901847577c4bed24f8021c5f7315a05",
-                "uncompressed-sha256": "e29f62460f7fdf250e106a02b5b787cf0fd19d12dfd8336f6a205f0471c2eefc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-metal4k.s390x.raw.gz",
+                "sha256": "0f7e51de04c00f8494ea886a4564ee77bab2a9b7067449371a0122070ea4a08f",
+                "uncompressed-sha256": "60e24d250331ec121329533cec8669e4efff9f4d9e8440118e93b5f5ed608766"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live.s390x.iso",
-                "sha256": "8e64fca95fd0c9b31115de5dbab16f0086455664a4468b2d0b0fe43712d0d471"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-live.s390x.iso",
+                "sha256": "4641e5fbff87e86b323f5f80be307fc3ecab3a053a34910ce39994198f1242f5"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-kernel-s390x",
-                "sha256": "f3bab30ea08f5155b3c67ae08764004349e68042a4aee8482a027f55144282d2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-live-kernel-s390x",
+                "sha256": "f563e0135192798520a869aac81482d11f17fbb8ca91a9515d3c749a7f5a31f3"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-initramfs.s390x.img",
-                "sha256": "355bdfa8ce4defe5bf0ffac7856ec4ddf8396317b31075aa329d67aea2d1945a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-live-initramfs.s390x.img",
+                "sha256": "9445b763fe55552858c93da71e32efcea053f0603c21e4478e8ac317906b5af9"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-live-rootfs.s390x.img",
-                "sha256": "7a3048a92f6999c125ffaab735fccceef5f0e1e706de803734f59f37d0bdc78f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-live-rootfs.s390x.img",
+                "sha256": "69a11e815c4bbc0493d1466ae97ebcf5359cc54bc6b2deacbae57e88fc347deb"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-metal.s390x.raw.gz",
-                "sha256": "d9cb0eb0970fa57b00d9e572a364ab7211c91f53bf4499d15cf3512b86e4db81",
-                "uncompressed-sha256": "73106e2261caa89e0e1ff25bed4f7cfe72d8bafe19d25063b89ad07a90365b8e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-metal.s390x.raw.gz",
+                "sha256": "da4178181044451c1a3125801160e58fea69a9f1d0d61486fe88e8bdd2b8619c",
+                "uncompressed-sha256": "0dfe122fc5a11ecb5898c82f313f92b150db3cb16ff49394b0bd406f3202f78f"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.86.202205030351-0",
+          "release": "412.86.202207142236-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-openstack.s390x.qcow2.gz",
-                "sha256": "9d814822d367a081032fbb48c07e5532279e2d61da33b09fdc3dba059c4c3bd8",
-                "uncompressed-sha256": "073be4b8a15dfcec6b51557d967dfad96ffc97908a8aeec919471de5ac42ce5b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-openstack.s390x.qcow2.gz",
+                "sha256": "a02659cc28aa97615c6d8ae70e6435efe45958a9f0c328f952932309ade1e288",
+                "uncompressed-sha256": "b6931da9d839f172736e362fe2e53009dd194380c4bab620e6e58f612d3e9a7a"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.86.202205030351-0",
+          "release": "412.86.202207142236-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202205030351-0/s390x/rhcos-411.86.202205030351-0-qemu.s390x.qcow2.gz",
-                "sha256": "4b690a17fb685b495df776a93a4d6da0e92c7aff07f5036269f28273df02ea92",
-                "uncompressed-sha256": "b0828d8ea6d3949343419cc26b794888897494a21fb5c4a8881a9b428d3fb57f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-qemu.s390x.qcow2.gz",
+                "sha256": "4b17a4b545d539b40c43cff56a07446973aecd9a686d2acb2f0a6fcc010a7731",
+                "uncompressed-sha256": "8def26944144535fc6aa3bcd800f5c9c31edf2b603749bb68e1251936f748b0d"
               }
             }
           }
@@ -394,159 +394,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "b716728ea93b7e28006b1cbc95b286e37bb04d6cbfc14f23b06beb97a87fccb7",
-                "uncompressed-sha256": "d88c56177e898769ea9382d7a51b055ab4dd1b4f699a7c329ea30c18867a7ed1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "9be779ec3d96c65a8b6cf477219b6fc781da8f315060192051a1b7480c7e32a9",
+                "uncompressed-sha256": "109f8c2817d3f98e5514ce2730509654adfbdb8c554e16056116fbb1f209631b"
               }
             }
           }
         },
         "aws": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-aws.x86_64.vmdk.gz",
-                "sha256": "37918a20b67e3b3445acfc8e8b2611565b2a8db9a55299a4e85d5e99c5da8748",
-                "uncompressed-sha256": "2a76b77118e5911fd1780bd5b8f77d58b252e1200936173c77104eaa836989b9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-aws.x86_64.vmdk.gz",
+                "sha256": "6bfbdd7f3a4a53fcc4d567f372fc06d416bc7428244deb8409237dad1a99199e",
+                "uncompressed-sha256": "dda2165dc6ef8cc31112b37e57d9f9b6b82a9c539f642a25972496ccca7bffe2"
               }
             }
           }
         },
         "azure": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-azure.x86_64.vhd.gz",
-                "sha256": "ccdf7414f6f432a1dd8a9711ba16ccec87ab643ec87b5cac2bf33eeea7fd5cb0",
-                "uncompressed-sha256": "d5d687fcc5a84889eebcf414357636b7fa93a28ce8186ae4f592d761a501c282"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-azure.x86_64.vhd.gz",
+                "sha256": "4dd848b6d5d4c1199c3405fa5706f6773ff1503557b8caab70f2a74aed9d4d49",
+                "uncompressed-sha256": "31405e604dc24689c802e1910bef1380cb02e8ae0ff7d78b735c5d528f6da207"
               }
             }
           }
         },
         "azurestack": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-azurestack.x86_64.vhd.gz",
-                "sha256": "aab8bd1b2d0e932da7c41e22d51a49e673f3dd77bfafc69b87834b6b84b132b3",
-                "uncompressed-sha256": "d150e113c726662b1493f5d73211d829191214f4d124793380c6696203315fa5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-azurestack.x86_64.vhd.gz",
+                "sha256": "1514e29bbc4695ed52af04fe7e21231d2c93e5c0d812bd5decadd01f30a32a4c",
+                "uncompressed-sha256": "a831d88b5e64eef701e8ff460dc5ae2b87dbcf05301203e0b01bb77d2c29715b"
               }
             }
           }
         },
         "gcp": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-gcp.x86_64.tar.gz",
-                "sha256": "93b3e416a09b94dbd7c8660d20e89817b348c80c15c3d8319589d0c2806b22fd",
-                "uncompressed-sha256": "c041a28a5f1b5147d2cd420beeb1fe993ac861ead037401f49bbbc8a445685ea"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-gcp.x86_64.tar.gz",
+                "sha256": "e8bd88269c98b7929d42adf7f44a284a0cb043288fd8ac938d4002016c1a87f2",
+                "uncompressed-sha256": "ad323860ddfc2edbe232723b89398e6eca35eb3a78507f174526c63fae8deb08"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "6d9b2b366e6b9eeac3d1a8d5942b01cc1a33345f5c93da0e6788df51b02e2ace",
-                "uncompressed-sha256": "a32925bf6d99a0237c724ab0a006cf5a5c7d5f7ff1e01187f955845b4a9e7933"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "b64d7fe413c22c99d4733cba8190cb30bcd318bf4f5728e27be9ac3cfcfd2fba",
+                "uncompressed-sha256": "f78414f3d898deb94b3e198102db29880d32ad436592985bfcf72f9b48ff977f"
               }
             }
           }
         },
         "metal": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-metal4k.x86_64.raw.gz",
-                "sha256": "12ad39b79e7993beb0c25bff5e99553725aac88ba89eb0c8214bc5e7cf50635a",
-                "uncompressed-sha256": "f77c2b36e97fb2de6d3b6e603a68e2dd720cb9df9ef320a7c09ea572e75aeb8f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-metal4k.x86_64.raw.gz",
+                "sha256": "9dcea5933d813111e696f2dd88efbbefc552c060cd862c96186a83af307b282b",
+                "uncompressed-sha256": "0257f69ba8e0e8080a4abb6d8254b1fa4367a23ae7a072916b08a169fe7715ff"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live.x86_64.iso",
-                "sha256": "6fb6fb45fbd9279d62c9abeaeec3d7cd98a9a1bb31e963b17c026e72a95b587a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-live.x86_64.iso",
+                "sha256": "151b1aeb322d02c1ca60026244895ff45128d70f6d3e05934d55e4b8d98407fb"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-kernel-x86_64",
-                "sha256": "6208caa9642c9d17971747d078e1e52b62a9a35f3067544ceaa3346e5e1fb285"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-live-kernel-x86_64",
+                "sha256": "90bf526e7e31f42ae5b5804a2b47479f5512b6dc2d33cf7c1d5cc6b6eebb34d3"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-initramfs.x86_64.img",
-                "sha256": "43cd07465de241e605ce3cc83c68fd282bdfcb5993e5df4d4b94cd4366f7df49"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-live-initramfs.x86_64.img",
+                "sha256": "e82fcdb46860a51757de26b521aada0e5e851904034e02c276ef22a1fad982ab"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-live-rootfs.x86_64.img",
-                "sha256": "56ddc8693ad3ded29aa815e38749c0d9b74660dc5fbe69683433709401a985a6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-live-rootfs.x86_64.img",
+                "sha256": "e493380e2b17d25f4b722d4adae3e31a6fa27f4e125e9a664ddba19cc649c3e4"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-metal.x86_64.raw.gz",
-                "sha256": "f3a7bffaf036d2671fa3009798cb88960a28a5235a5a77f11b6bf3e34b659f6e",
-                "uncompressed-sha256": "8db32bc9cd090fa02d791351527da598e91041b2a0ccc46d74fa4b92a68f31c5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-metal.x86_64.raw.gz",
+                "sha256": "a5738ab1573dda2732dbb7d52b3706d30e985367681d23a9160901b020090dc1",
+                "uncompressed-sha256": "641292012941c180fc02a0a3d8da66030106bc58daa6a222c2a8c2c542b1b7f7"
               }
             }
           }
         },
         "nutanix": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
-            "qcow2.gz": {
+            "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-nutanix.x86_64.qcow2.gz",
-                "sha256": "40b253ece9471afaa3c7566dd3d4fec86d5daa5d9fadc33174ebcc6aa262966f",
-                "uncompressed-sha256": "2d81134c2bde2ae131640da201036721c63bf28a71cbfd8d3114b48d522ba163"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-nutanix.x86_64.qcow2",
+                "sha256": "0c32012d340993bbb3b4e6d604882dfd68bbf038ae0e1181e4e32b1be6c8dcf8"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-openstack.x86_64.qcow2.gz",
-                "sha256": "b1ef44b77ae3b1e731d57eea7c73813f28668e4d0a663442a0076b614eb543ee",
-                "uncompressed-sha256": "46278e035367c88349d50cbefb01a9ca73db26808b6dcee8ce58ebf4b52deaf4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-openstack.x86_64.qcow2.gz",
+                "sha256": "81731680ae10e189da57e64103bdfacd5df1a6d876c23f15fbaf3de049dabc14",
+                "uncompressed-sha256": "5af1125de5dc3884bb570c69a54b6bbe8599cab5c5e704c73b22d29b4e0d8516"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-qemu.x86_64.qcow2.gz",
-                "sha256": "5e713be5b575bc2ae9600518fcd72d64c3a51e21b719444c1c0172f92066280f",
-                "uncompressed-sha256": "75ca83efc8c40669631d7367664fd48372c067da5fa448551bc2ab28026b94c4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-qemu.x86_64.qcow2.gz",
+                "sha256": "51b4423d9d195b30b416adfec47b446e8b650363cba99bd8c9b0b34be747a47d",
+                "uncompressed-sha256": "e6e78eb6b7358d1bbf7374512216a6b28523256a61bc9891aeb897883499ef04"
               }
             }
           }
         },
         "vmware": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.85.202205101201-0/x86_64/rhcos-411.85.202205101201-0-vmware.x86_64.ova",
-                "sha256": "a6d7b1bafc5b28fa3941e4c70049dd0d55804ce460ebc5f9c9769389f8986bad"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-vmware.x86_64.ova",
+                "sha256": "8bb22350cf61ac431120f99c58e175132c12d9fc7696ffbc567f87bdb963c0a5"
               }
             }
           }
@@ -556,217 +555,217 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "411.85.202205101201-0",
-              "image": "m-6wedcb2rfmhkcl2bsbz5"
+              "release": "412.86.202207142104-0",
+              "image": "m-6we3we0zoee5j00njbz4"
             },
             "ap-south-1": {
-              "release": "411.85.202205101201-0",
-              "image": "m-a2d35ef3e19laftwxz5p"
+              "release": "412.86.202207142104-0",
+              "image": "m-a2dgqagdl04zn11rjmcw"
             },
             "ap-southeast-1": {
-              "release": "411.85.202205101201-0",
-              "image": "m-t4n2ccy2xj8jqoymb9w1"
+              "release": "412.86.202207142104-0",
+              "image": "m-t4n8gw2lpq6ugxpedu5w"
             },
             "ap-southeast-2": {
-              "release": "411.85.202205101201-0",
-              "image": "m-p0w34jnw2a5ehgj8pdo7"
+              "release": "412.86.202207142104-0",
+              "image": "m-p0w3rjvg02wfcgrdbpqq"
             },
             "ap-southeast-3": {
-              "release": "411.85.202205101201-0",
-              "image": "m-8ps5b41bwkxlhl4jwfgu"
+              "release": "412.86.202207142104-0",
+              "image": "m-8psgsol78o77epx2ouke"
             },
             "ap-southeast-5": {
-              "release": "411.85.202205101201-0",
-              "image": "m-k1afh4e2sag56x9yfezc"
+              "release": "412.86.202207142104-0",
+              "image": "m-k1a5npc1v5o0bynti0k0"
             },
             "ap-southeast-6": {
-              "release": "411.85.202205101201-0",
-              "image": "m-5ts0rboex0qgxgrsqhve"
+              "release": "412.86.202207142104-0",
+              "image": "m-5tsajwqroggp4se0dpaj"
             },
             "cn-beijing": {
-              "release": "411.85.202205101201-0",
-              "image": "m-2ze5q562bmxri0qvroyg"
+              "release": "412.86.202207142104-0",
+              "image": "m-2zegyq7fyg7esu4w7nl2"
             },
             "cn-chengdu": {
-              "release": "411.85.202205101201-0",
-              "image": "m-2vcfd486hn2pl4mgiw5r"
+              "release": "412.86.202207142104-0",
+              "image": "m-2vcf8h4lifonvg6jftlf"
             },
             "cn-guangzhou": {
-              "release": "411.85.202205101201-0",
-              "image": "m-7xvd7ha404hejciwfdol"
+              "release": "412.86.202207142104-0",
+              "image": "m-7xv08waf9xnx23pypefx"
             },
             "cn-hangzhou": {
-              "release": "411.85.202205101201-0",
-              "image": "m-bp106l9gw0cb6iz4brct"
+              "release": "412.86.202207142104-0",
+              "image": "m-bp13xtmzxoxl25nqz82j"
             },
             "cn-heyuan": {
-              "release": "411.85.202205101201-0",
-              "image": "m-f8zg6xijwkbly7vecrgs"
+              "release": "412.86.202207142104-0",
+              "image": "m-f8zdr8s6479v9795c58f"
             },
             "cn-hongkong": {
-              "release": "411.85.202205101201-0",
-              "image": "m-j6cj44anqpmd7ldg9j7a"
+              "release": "412.86.202207142104-0",
+              "image": "m-j6c4ghaaduaqfukgaa7i"
             },
             "cn-huhehaote": {
-              "release": "411.85.202205101201-0",
-              "image": "m-hp3hjx2axrxa27ux0fdc"
+              "release": "412.86.202207142104-0",
+              "image": "m-hp34f9gdp01biolfqf77"
             },
             "cn-nanjing": {
-              "release": "411.85.202205101201-0",
-              "image": "m-gc7jb0v7addz77rwcb5q"
+              "release": "412.86.202207142104-0",
+              "image": "m-gc7bsz0jw5dj6n758n5b"
             },
             "cn-qingdao": {
-              "release": "411.85.202205101201-0",
-              "image": "m-m5edoavzt9t9noncxj7x"
+              "release": "412.86.202207142104-0",
+              "image": "m-m5e2kjvlpikupe11bign"
             },
             "cn-shanghai": {
-              "release": "411.85.202205101201-0",
-              "image": "m-uf65ogf13g9vdvxk56hk"
+              "release": "412.86.202207142104-0",
+              "image": "m-uf60wv2b5wyem2yw7d36"
             },
             "cn-shenzhen": {
-              "release": "411.85.202205101201-0",
-              "image": "m-wz92sqeyqtgxpwzkwlla"
+              "release": "412.86.202207142104-0",
+              "image": "m-wz987iwe7gk68m1p22z6"
             },
             "cn-wulanchabu": {
-              "release": "411.85.202205101201-0",
-              "image": "m-0jlh1lst294pxy1fqtio"
+              "release": "412.86.202207142104-0",
+              "image": "m-0jlfthtkdgs3rvfpzc9p"
             },
             "cn-zhangjiakou": {
-              "release": "411.85.202205101201-0",
-              "image": "m-8vbgb4gpuv4i9c95vzwz"
+              "release": "412.86.202207142104-0",
+              "image": "m-8vbhr4kqgojn7ych6k0a"
             },
             "eu-central-1": {
-              "release": "411.85.202205101201-0",
-              "image": "m-gw884wape1mxpp46qunu"
+              "release": "412.86.202207142104-0",
+              "image": "m-gw89dpnontdxhanoy470"
             },
             "eu-west-1": {
-              "release": "411.85.202205101201-0",
-              "image": "m-d7o53gqu9axjqgsa2j6b"
+              "release": "412.86.202207142104-0",
+              "image": "m-d7o1ypzayae9e9mr9s5s"
             },
             "me-east-1": {
-              "release": "411.85.202205101201-0",
-              "image": "m-eb390gvibujq9i2zpv27"
+              "release": "412.86.202207142104-0",
+              "image": "m-eb3a7w8v6gd5x6lw9p2m"
             },
             "us-east-1": {
-              "release": "411.85.202205101201-0",
-              "image": "m-0xi54j6hfhaswm8nxj4o"
+              "release": "412.86.202207142104-0",
+              "image": "m-0xi1fbppyleyceav7iw4"
             },
             "us-west-1": {
-              "release": "411.85.202205101201-0",
-              "image": "m-rj9hkuw1uxvgqdpmvico"
+              "release": "412.86.202207142104-0",
+              "image": "m-rj90mi51f4vounwklo4r"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-054fbac6cfb17f672"
+              "release": "412.86.202207142104-0",
+              "image": "ami-09f93f58d5ee0a7fd"
             },
             "ap-east-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0d05b0ac3d9b0a7af"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0935ab0e3708612a2"
             },
             "ap-northeast-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-06b60b6ff884766bd"
+              "release": "412.86.202207142104-0",
+              "image": "ami-07ef07362b6646d19"
             },
             "ap-northeast-2": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0f5a01a738d063548"
+              "release": "412.86.202207142104-0",
+              "image": "ami-08371ad2cebc2d147"
             },
             "ap-northeast-3": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-02d02fac3b388604d"
+              "release": "412.86.202207142104-0",
+              "image": "ami-042af50035f4fd0fd"
             },
             "ap-south-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0a2e625d30249aa61"
+              "release": "412.86.202207142104-0",
+              "image": "ami-07daddde37f6a56b3"
             },
             "ap-southeast-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0fcc879dc0836be56"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0cdbb41c078813e35"
             },
             "ap-southeast-2": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-016575b468202d04c"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0bc6d84fc93ef2e3d"
             },
             "ap-southeast-3": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0b41fb9457145f312"
+              "release": "412.86.202207142104-0",
+              "image": "ami-07a9a840aeb577409"
             },
             "ca-central-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0ff2269e2d5d9c5e3"
+              "release": "412.86.202207142104-0",
+              "image": "ami-04746acad988da069"
             },
             "eu-central-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0dc2e2937e2480b03"
+              "release": "412.86.202207142104-0",
+              "image": "ami-067e348b7982bfab1"
             },
             "eu-north-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-08cd809f2008ea27c"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0e835b635925bdffc"
             },
             "eu-south-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-07b85281ed77e350d"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0aea999da238a1a4b"
             },
             "eu-west-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0728450682fcf240d"
+              "release": "412.86.202207142104-0",
+              "image": "ami-045368cb4885eec18"
             },
             "eu-west-2": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0276bc0ebb9541668"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0532324310ab6d3ab"
             },
             "eu-west-3": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-048e76c11b25b3576"
+              "release": "412.86.202207142104-0",
+              "image": "ami-08a5176fb110a4ab8"
             },
             "me-south-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0522c3ab770b23611"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0deeb2d32037d6e12"
             },
             "sa-east-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-04eb1a069c3b3ff2c"
+              "release": "412.86.202207142104-0",
+              "image": "ami-06ffafd7376921e5b"
             },
             "us-east-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-045edc1017eeccec7"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0b9c602d07818c309"
             },
             "us-east-2": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-01990fc3bdf30bc13"
+              "release": "412.86.202207142104-0",
+              "image": "ami-03c8407be1de91c11"
             },
             "us-gov-east-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-059f105d12b430e77"
+              "release": "412.86.202207142104-0",
+              "image": "ami-08e70a8a41769bfc4"
             },
             "us-gov-west-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-04d54d7b7e3730f6a"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0cc998428b51e5686"
             },
             "us-west-1": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-0ac12a3d703710ce4"
+              "release": "412.86.202207142104-0",
+              "image": "ami-0fbf66888a591222d"
             },
             "us-west-2": {
-              "release": "411.85.202205101201-0",
-              "image": "ami-091214206ecd087a7"
+              "release": "412.86.202207142104-0",
+              "image": "ami-025a4755a86cf05a3"
             }
           }
         },
         "gcp": {
-          "release": "411.85.202205101201-0",
+          "release": "412.86.202207142104-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-411-85-202205101201-0-gcp-x86-64"
+          "name": "rhcos-412-86-202207142104-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "411.85.202205101201-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-411.85.202205101201-0-azure.x86_64.vhd"
+          "release": "412.86.202207142104-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202207142104-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.12 boot image metadata in the
installer which includes the fixes for the following BZs:

BZ 2106055 vSphere defaults to SecureBoot on; breaks installation of out-of-tree drivers

Changes generated with:
```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --url https://rhcos.mirror.openshift.com/art/storage/releases --no-signatures x86_64=412.86.202207142104-0 aarch64=412.86.202207141642-0 s390x=412.86.202207142236-0 ppc64le=412.86.202207151711-0
```