### PR TITLE
AGENT-286: Use default image built by podman for pause container

### DIFF
--- a/data/data/agent/files/etc/containers/containers.conf
+++ b/data/data/agent/files/etc/containers/containers.conf
@@ -1,0 +1,3 @@
+[engine]
+# By default use the infra image build by podman
+infra_image = ""


### PR DESCRIPTION
The 'podman create pod' requires a pause container which is fetched from registry.access.redhat.com/ubi8/pause:latest. This won't work in a disconnected environment. This change overwrite the default infra image defined in /usr/share/containers/containers.conf:
`infra_image = "registry.access.redhat.com/ubi8/pause"`

By supplying this field in /etc/containers/containers.conf set to an empty string. 
When this image is not defined, podman will build the image by default and not attempt to retrieve it.  The image which is build and used is:
localhost/podman-pause


