### PR TITLE
Bug 2108582: [release-4.7] RHCOS: move to rhcos.mirror.openshift.com

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -71,7 +71,7 @@
         "image": "rhcos-47.84.202206131038-0-azure.x86_64.vhd",
         "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.84.202206131038-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202206131038-0/x86_64/",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.7/47.84.202206131038-0/x86_64/",
     "buildid": "47.84.202206131038-0",
     "gcp": {
         "image": "rhcos-47-84-202206131038-0-gcp-x86-64",

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,5 +1,5 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-ppc64le/47.84.202206131039-0/ppc64le/",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.7-ppc64le/47.84.202206131039-0/ppc64le/",
     "buildid": "47.84.202206131039-0",
     "images": {
         "live-initramfs": {

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,5 +1,5 @@
 {
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7-s390x/47.84.202206131037-0/s390x/",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.7-s390x/47.84.202206131037-0/s390x/",
     "buildid": "47.84.202206131037-0",
     "images": {
         "dasd": {

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -71,7 +71,7 @@
         "image": "rhcos-47.84.202206131038-0-azure.x86_64.vhd",
         "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-47.84.202206131038-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202206131038-0/x86_64/",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.7/47.84.202206131038-0/x86_64/",
     "buildid": "47.84.202206131038-0",
     "gcp": {
         "image": "rhcos-47-84-202206131038-0-gcp-x86-64",

--- a/hack/update-rhcos-bootimage.py
+++ b/hack/update-rhcos-bootimage.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-# Usage: ./hack/update-rhcos-bootimage.py https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/rhcos-4.7/47.84.202109171532-0/x86_64/meta.json amd64
+# Usage: ./hack/update-rhcos-bootimage.py https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.7/47.84.202109171532-0/x86_64/meta.json amd64
 import codecs,os,sys,json,argparse
 import urllib.parse
 import urllib.request
 
 # An app running in the CI cluster exposes this public endpoint about ART RHCOS
 # builds.  Do not try to e.g. point to RHT-internal endpoints.
-RHCOS_RELEASES_APP = 'https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com'
+RHCOS_RELEASES_APP = 'https://rhcos.mirror.openshift.com'
 
 parser = argparse.ArgumentParser()
 parser.add_argument("meta", action='store')


### PR DESCRIPTION
Similar to https://github.com/openshift/installer/pull/6109.

rhcos.mirror.openshift.com is the new formal location to download
RHCOS boot images. It is backed by CloudFront CDN, which should be
more reliable and faster than the rhcos-redirector.