### PR TITLE
IBMCloud: Update RHCOS image for VSI

### DIFF
--- a/data/data/ibmcloud/network/image/main.tf
+++ b/data/data/ibmcloud/network/image/main.tf
@@ -31,7 +31,7 @@ resource "ibm_is_image" "image" {
 
   name             = var.name
   href             = "cos://${ibm_cos_bucket.images.region_location}/${ibm_cos_bucket.images.bucket_name}/${ibm_cos_bucket_object.file.key}"
-  operating_system = "fedora-coreos-stable-amd64"
+  operating_system = "rhel-coreos-stable-amd64"
   resource_group   = var.resource_group_id
   tags             = var.tags
 }


### PR DESCRIPTION
Update the image tag for the VSI's in IBM Cloud to be RHCOS rather
than Fedora CoreOS, now that IBM Cloud provides proper support for
the RHCOS image tag.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2082604
Related: https://github.com/openshift/installer/pull/5869
Related: https://github.com/openshift/installer/pull/5860