### PR TITLE
BUG 1952739: Configurable PowerOn Timeout for vsphere

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2965,6 +2965,12 @@ spec:
                     description: Password is the password for the user to use to connect
                       to the vCenter.
                     type: string
+                  powerOnTimeout:
+                    description: PowerOnTimeout is the number of seconds to allow
+                      the virtual machine to power on. When not specified, it will
+                      be set according to the vsphere terraform provider
+                    format: int64
+                    type: integer
                   resourcePool:
                     description: ResourcePool is the absolute path of the resource
                       pool where virtual machines will be created. The absolute path

--- a/data/data/vsphere/master/main.tf
+++ b/data/data/vsphere/master/main.tf
@@ -22,6 +22,7 @@ resource "vsphere_virtual_machine" "vm_master" {
   folder               = var.folder
   enable_disk_uuid     = "true"
   annotation           = local.description
+  poweron_timeout      = var.vsphere_poweron_timeout
 
   wait_for_guest_net_timeout  = "0"
   wait_for_guest_net_routable = "false"

--- a/data/data/vsphere/variables-vsphere.tf
+++ b/data/data/vsphere/variables-vsphere.tf
@@ -62,6 +62,11 @@ variable "vsphere_preexisting_folder" {
   description = "If false, creates a top-level folder with the name from vsphere_folder_rel_path."
 }
 
+variable "vsphere_poweron_timeout" {
+  type        = number
+  description = "Number of seconds to allow the virtual machine to power on."
+}
+
 ///////////
 // Control Plane machine variables
 ///////////

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -781,6 +781,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				PreexistingFolder:   preexistingFolder,
 				DiskType:            installConfig.Config.Platform.VSphere.DiskType,
 				NetworkID:           networkID,
+				PowerOnTimeout:      installConfig.Config.VSphere.PowerOnTimeout,
 			},
 		)
 		if err != nil {

--- a/pkg/tfvars/vsphere/vsphere.go
+++ b/pkg/tfvars/vsphere/vsphere.go
@@ -30,6 +30,7 @@ type config struct {
 	OvaFilePath       string          `json:"vsphere_ova_filepath"`
 	PreexistingFolder bool            `json:"vsphere_preexisting_folder"`
 	DiskType          vtypes.DiskType `json:"vsphere_disk_type"`
+	PowerOnTimeout    int64           `json:"vsphere_poweron_timeout"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -42,6 +43,7 @@ type TFVarsSources struct {
 	PreexistingFolder   bool
 	DiskType            vtypes.DiskType
 	NetworkID           string
+	PowerOnTimeout      int64
 }
 
 //TFVars generate vSphere-specific Terraform variables
@@ -76,6 +78,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		OvaFilePath:       cachedImage,
 		PreexistingFolder: sources.PreexistingFolder,
 		DiskType:          sources.DiskType,
+		PowerOnTimeout:    sources.PowerOnTimeout,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -72,4 +72,8 @@ type Platform struct {
 	// specified, it will be set according to the default storage policy
 	// of vsphere.
 	DiskType DiskType `json:"diskType,omitempty"`
+
+	// PowerOnTimeout is the number of seconds to allow the virtual machine to power on.
+	// When not specified, it will be set according to the vsphere terraform provider
+	PowerOnTimeout int64 `json:"powerOnTimeout,omitempty"`
 }


### PR DESCRIPTION
** Use the poweron_timeout terrafrom value for vsphere. Currently setting the
value to 600 seconds (10 minutes, default is 5 minutes in the provider).