### PR TITLE
WIP - Disable metal bootstrap networkmanager rDNS hostname

### DIFF
--- a/data/data/bootstrap/baremetal/files/etc/NetworkManager/conf.d/99-baremetal.conf
+++ b/data/data/bootstrap/baremetal/files/etc/NetworkManager/conf.d/99-baremetal.conf
@@ -1,5 +1,24 @@
 [main]
 rc-manager=unmanaged
+# This config effectively prevents NetworkManager from trying to set the
+# transient hostname based on rDNS lookups. We disable this functionality
+# because when the bootstrap node holds the API VIP and DHCP is disabled,
+# NetworkManager could see the VIP on one of the bootstrap host network
+# interfaces and attempt to rDNS lookup the VIP in order to determine a
+# transient hostname for the bootstrap machine. The OCP documentation
+# recommends users set up DNS PTR records for their API domains. If the user
+# correctly did that in advance, it could lead to that rDNS lookup being
+# successful and as a result NM will set the bootstrap node's hostname to be
+# the cluster's API domain name. This is bad because Podman --net=host
+# containers get a /etc/hosts entry with the host's hostname pointing at
+# 127.0.1.1. That means that when bootkube creates Podman containers after NM
+# set the transient hostname according to the rDNS lookup, that container will
+# forever consider the API domain (which is also the host's transient hostname
+# during the container's creation) to be 127.0.1.1. When the bootstrap node is
+# no longer running any API servers, this results in the software running
+# inside that container to not be able to contact the API via this domain, as
+# it's being resolved to 127.0.1.1.
+hostname-mode=dhcp
 [connection]
 ipv6.dhcp-duid=ll
 ipv6.dhcp-iaid=mac


### PR DESCRIPTION
(WIP for now because we're still testing whether this fix is sufficient)

This config effectively prevents NetworkManager from trying to set the
transient hostname based on rDNS lookups. We disable this functionality
because when the bootstrap node holds the API VIP and DHCP is disabled,
NetworkManager could see the VIP on one of the bootstrap host network
interfaces and attempt to rDNS lookup the VIP in order to determine a
transient hostname for the bootstrap machine. The OCP documentation
recommends users set up DNS PTR records for their API domains. If the user
correctly did that in advance, it could lead to that rDNS lookup being
successful and as a result NM will set the bootstrap node's hostname to be
the cluster's API domain name. This is bad because Podman --net=host
containers get a /etc/hosts entry with the host's hostname pointing at
127.0.1.1. That means that when bootkube creates Podman containers after NM
set the transient hostname according to the rDNS lookup, that container will
forever consider the API domain (which is also the host's transient hostname
during the container's creation) to be 127.0.1.1. When the bootstrap node is
no longer running any API servers, this results in the software running
inside that container to not be able to contact the API via this domain, as
it's being resolved to 127.0.1.1.