### PR TITLE
Bug 2109538: nutanix: allow creating manifests without Prism Central connection

### DIFF
--- a/pkg/asset/installconfig/nutanix/validation.go
+++ b/pkg/asset/installconfig/nutanix/validation.go
@@ -17,21 +17,6 @@ func Validate(ic *types.InstallConfig) error {
 		return field.Required(field.NewPath("platform", "nutanix"), "nutanix validation requires a nutanix platform configuration")
 	}
 
-	p := ic.Platform.Nutanix
-	nc, err := nutanixtypes.CreateNutanixClient(context.TODO(),
-		p.PrismCentral.Endpoint.Address,
-		strconv.Itoa(int(p.PrismCentral.Endpoint.Port)),
-		p.PrismCentral.Username,
-		p.PrismCentral.Password)
-
-	// validate whether a prism element with the UUID actually exists
-	for _, pe := range p.PrismElements {
-		_, err = nc.V3.GetCluster(pe.UUID)
-		if err != nil {
-			return field.InternalError(field.NewPath("platform", "nutanix", "prismElements"), errors.Wrapf(err, "prism element UUID %s does not correspond to a valid prism element in Prism", pe.UUID))
-		}
-	}
-
 	return nil
 }
 
@@ -51,6 +36,14 @@ func ValidateForProvisioning(ic *types.InstallConfig) error {
 		p.PrismCentral.Password)
 	if err != nil {
 		return field.InternalError(field.NewPath("platform", "nutanix"), errors.Wrapf(err, "unable to connect to Prism Central %q", p.PrismCentral.Endpoint.Address))
+	}
+
+	// validate whether a prism element with the UUID actually exists
+	for _, pe := range p.PrismElements {
+		_, err = nc.V3.GetCluster(pe.UUID)
+		if err != nil {
+			return field.InternalError(field.NewPath("platform", "nutanix", "prismElements"), errors.Wrapf(err, "prism element UUID %s does not correspond to a valid prism element in Prism", pe.UUID))
+		}
 	}
 
 	// validate whether a subnet with the UUID actually exists


### PR DESCRIPTION
In Assisted Installer we create manifests and generate Ignition in the cloud and pass ignition files to the agents. For platform integration we can't request credentials from users, instead we fill these in with fake credentials and let them change these later.

This commit moves validations to ValidateForProvisioning, so that `openshift-install create manifests` phase would pass with fake credentials