### PR TITLE
BUG 2109388: Add AWS S3 Bucket Permissions

### DIFF
--- a/pkg/asset/installconfig/aws/permissions.go
+++ b/pkg/asset/installconfig/aws/permissions.go
@@ -150,6 +150,7 @@ var permissions = map[PermissionGroup][]string{
 		"s3:GetBucketLocation",
 		"s3:GetBucketLogging",
 		"s3:GetBucketObjectLockConfiguration",
+		"s3:GetBucketPolicy",
 		"s3:GetBucketRequestPayment",
 		"s3:GetBucketTagging",
 		"s3:GetBucketVersioning",


### PR DESCRIPTION
** Added the s3::GetBucketPolicy. This is require the user to have permissions to
return the policy of the specified bucket.