### PR TITLE
logging: Decorate logs with fields

### DIFF
--- a/cmd/openshift-install/log-config.go
+++ b/cmd/openshift-install/log-config.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"path"
+
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+type logConfig struct {
+	// Fields contains user-provided fields to be added to all log entries.
+	// +optional
+	Fields *logrus.Fields `json:"fields,omitempty"`
+
+	// Level sets the level of logging to standard out.
+	// Valid values: panic, fatal, error, warning, info, debug, trace
+	// +optional
+	Level *string `json:"level,omitempty"`
+}
+
+func readLogConfigFile(directory string) (logConfig logConfig, err error) {
+	file, err := os.ReadFile(path.Join(directory, "log-config.yaml"))
+	if err != nil {
+		return
+	}
+	err = yaml.Unmarshal(file, &logConfig)
+	return
+}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -85,7 +85,7 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 		level = logrus.InfoLevel
 	}
 
-	logrus.AddHook(newFileHookWithNewlineTruncate(os.Stderr, level, &logrus.TextFormatter{
+	fileHook := newFileHookWithNewlineTruncate(os.Stderr, level, &logrus.TextFormatter{
 		// Setting ForceColors is necessary because logrus.TextFormatter determines
 		// whether or not to enable colors by looking at the output of the logger.
 		// In this case, the output is ioutil.Discard, which is not a terminal.
@@ -95,7 +95,13 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 		DisableTimestamp:       true,
 		DisableLevelTruncation: true,
 		DisableQuote:           true,
-	}))
+	})
+
+	config, err := readLogConfigFile(rootOpts.dir)
+	if err == nil {
+		fileHook.config = config
+	}
+	logrus.AddHook(fileHook)
 
 	if err != nil {
 		logrus.Fatal(errors.Wrap(err, "invalid log-level"))


### PR DESCRIPTION
The requirement is to add extra fields to every log field for ARO
to identify the cluster using these tags. Adding an option to
provide a file "log-config.yaml" file in the install directory
which would have the fields and a log level value.

Every log that has the level below or equal to the log level
provided in the file will be decorated with the key-value field tags
in the file.