### PR TITLE
GCP: Add networkProjectID parameter to install-config.

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2229,6 +2229,11 @@ spec:
                     description: Network specifies an existing VPC where the cluster
                       should be created rather than provisioning a new one.
                     type: string
+                  networkProjectID:
+                    description: NetworkProjectID is currently unsupported. NetworkProjectID
+                      specifies which project the network and subnets exist in when
+                      they are not in the main ProjectID.
+                    type: string
                   projectID:
                     description: ProjectID is the the project that will be used for
                       the cluster.

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -60,14 +60,15 @@ var (
 		ic.Platform.GCP.DefaultMachinePlatform.InstanceType = "n1-dne-1"
 	}
 
-	invalidateNetwork       = func(ic *types.InstallConfig) { ic.GCP.Network = "invalid-vpc" }
-	invalidateComputeSubnet = func(ic *types.InstallConfig) { ic.GCP.ComputeSubnet = "invalid-compute-subnet" }
-	invalidateCPSubnet      = func(ic *types.InstallConfig) { ic.GCP.ControlPlaneSubnet = "invalid-cp-subnet" }
-	invalidateRegion        = func(ic *types.InstallConfig) { ic.GCP.Region = invalidRegion }
-	invalidateProject       = func(ic *types.InstallConfig) { ic.GCP.ProjectID = invalidProjectName }
-	removeVPC               = func(ic *types.InstallConfig) { ic.GCP.Network = "" }
-	removeSubnets           = func(ic *types.InstallConfig) { ic.GCP.ComputeSubnet, ic.GCP.ControlPlaneSubnet = "", "" }
-	invalidClusterName      = func(ic *types.InstallConfig) { ic.ObjectMeta.Name = "testgoogletest" }
+	invalidateNetwork        = func(ic *types.InstallConfig) { ic.GCP.Network = "invalid-vpc" }
+	invalidateComputeSubnet  = func(ic *types.InstallConfig) { ic.GCP.ComputeSubnet = "invalid-compute-subnet" }
+	invalidateCPSubnet       = func(ic *types.InstallConfig) { ic.GCP.ControlPlaneSubnet = "invalid-cp-subnet" }
+	invalidateRegion         = func(ic *types.InstallConfig) { ic.GCP.Region = invalidRegion }
+	invalidateProject        = func(ic *types.InstallConfig) { ic.GCP.ProjectID = invalidProjectName }
+	invalidateNetworkProject = func(ic *types.InstallConfig) { ic.GCP.NetworkProjectID = invalidProjectName }
+	removeVPC                = func(ic *types.InstallConfig) { ic.GCP.Network = "" }
+	removeSubnets            = func(ic *types.InstallConfig) { ic.GCP.ComputeSubnet, ic.GCP.ControlPlaneSubnet = "", "" }
+	invalidClusterName       = func(ic *types.InstallConfig) { ic.ObjectMeta.Name = "testgoogletest" }
 
 	machineTypeAPIResult = map[string]*compute.MachineType{
 		"n1-standard-1": {GuestCpus: 1, MemoryMb: 3840},
@@ -228,6 +229,12 @@ func TestGCPInstallConfigValidation(t *testing.T) {
 			edits:          editFunctions{invalidateProject, removeSubnets, removeVPC},
 			expectedError:  true,
 			expectedErrMsg: "platform.gcp.project: Invalid value: \"invalid-project\": invalid project ID",
+		},
+		{
+			name:           "Invalid network project ID",
+			edits:          editFunctions{invalidateNetworkProject},
+			expectedError:  true,
+			expectedErrMsg: "platform.gcp.networkProjectID: Invalid value: \"invalid-project\": invalid project ID",
 		},
 		{
 			name:           "Valid Region",

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -20,6 +20,12 @@ type Platform struct {
 	// +optional
 	Network string `json:"network,omitempty"`
 
+	// NetworkProjectID is currently unsupported.
+	// NetworkProjectID specifies which project the network and subnets exist in when
+	// they are not in the main ProjectID.
+	// +optional
+	NetworkProjectID string `json:"networkProjectID,omitempty"`
+
 	// ControlPlaneSubnet is an existing subnet where the control plane will be deployed.
 	// The value should be the name of the subnet.
 	// +optional


### PR DESCRIPTION
This change adds the networkProjecID parameter to the GCP platform in
the install-config. When set, it also validates the project exists and
that the network and subnetworks belong to this project.

https://issues.redhat.com/browse/CORS-2036