### PR TITLE
updated terraform-provider-ovirt

### DIFF
--- a/terraform/providers/ovirt/go.mod
+++ b/terraform/providers/ovirt/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/installer/terraform/providers/ovirt
 
 go 1.17
 
-require github.com/ovirt/terraform-provider-ovirt/v2 v2.1.0
+require github.com/ovirt/terraform-provider-ovirt/v2 v2.1.4
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -32,7 +32,7 @@ require (
 	github.com/hashicorp/terraform-json v0.14.0 // indirect
 	github.com/hashicorp/terraform-plugin-docs v0.13.0 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.12.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.6.0 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
@@ -50,7 +50,7 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c // indirect
 	github.com/ovirt/go-ovirt-client-log/v3 v3.0.0 // indirect
-	github.com/ovirt/go-ovirt-client/v2 v2.0.0-alpha02 // indirect
+	github.com/ovirt/go-ovirt-client/v2 v2.0.0-alpha03 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/terraform/providers/ovirt/go.sum
+++ b/terraform/providers/ovirt/go.sum
@@ -149,8 +149,9 @@ github.com/hashicorp/terraform-plugin-docs v0.13.0 h1:6e+VIWsVGb6jYJewfzq2ok2smP
 github.com/hashicorp/terraform-plugin-docs v0.13.0/go.mod h1:W0oCmHAjIlTHBbvtppWHe8fLfZ2BznQbuv8+UD8OucQ=
 github.com/hashicorp/terraform-plugin-go v0.12.0 h1:6wW9mT1dSs0Xq4LR6HXj1heQ5ovr5GxXNJwkErZzpJw=
 github.com/hashicorp/terraform-plugin-go v0.12.0/go.mod h1:kwhmaWHNDvT1B3QiSJdAtrB/D4RaKSY/v3r2BuoWK4M=
-github.com/hashicorp/terraform-plugin-log v0.6.0 h1:/Vq78uSIdUSZ3iqDc9PESKtwt8YqNKN6u+khD+lLjuw=
 github.com/hashicorp/terraform-plugin-log v0.6.0/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
+github.com/hashicorp/terraform-plugin-log v0.7.0 h1:SDxJUyT8TwN4l5b5/VkiTIaQgY6R+Y2BQ0sRZftGKQs=
+github.com/hashicorp/terraform-plugin-log v0.7.0/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0 h1:7gDAcfto/C4Cjtf90SdukQshsxdMxJ/P69QxiF3digI=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.19.0/go.mod h1:/WYikYjhKB7c2j1HmXZhRsAARldRb4M38bLCLOhC3so=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c h1:D8aRO6+mTqHfLsK/BC3j5OAoogv1WLRWzY1AaTo3rBg=
@@ -228,10 +229,10 @@ github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c h1:jXRFpl7+W0YZj/fg
 github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c/go.mod h1:Zkdj9/rW6eyuw0uOeEns6O3pP5G2ak+bI/tgkQ/tEZI=
 github.com/ovirt/go-ovirt-client-log/v3 v3.0.0 h1:uvACVHYhYPMkNJrrgWiABcfELB6qoFfsDDUTbpb4Jv4=
 github.com/ovirt/go-ovirt-client-log/v3 v3.0.0/go.mod h1:chKKxCv4lRjxezrTG+EIhkWXGhDAWByglPVXh/iYdnQ=
-github.com/ovirt/go-ovirt-client/v2 v2.0.0-alpha02 h1:OYa0nbgahE0TfI30FHEa5ZXktP9biyIWoD50Nb60JiQ=
-github.com/ovirt/go-ovirt-client/v2 v2.0.0-alpha02/go.mod h1:Zi2RF2khEr+hcr3fCAf6WL7OEoUwUHeWWiob/WcEaDc=
-github.com/ovirt/terraform-provider-ovirt/v2 v2.1.0 h1:s8iNXVn3q75VeRiK2KzAix4NLNvW13EBlwLngzlzkgw=
-github.com/ovirt/terraform-provider-ovirt/v2 v2.1.0/go.mod h1:lARJqHsH4+Xg10sOZf9eDyCt9VgsJHo4xVWuTHUhhzU=
+github.com/ovirt/go-ovirt-client/v2 v2.0.0-alpha03 h1:a6cZ5CoFuUB+/bwgizPsSSrqevvIvzg/3s+4Ne6EN2I=
+github.com/ovirt/go-ovirt-client/v2 v2.0.0-alpha03/go.mod h1:Zi2RF2khEr+hcr3fCAf6WL7OEoUwUHeWWiob/WcEaDc=
+github.com/ovirt/terraform-provider-ovirt/v2 v2.1.4 h1:oUy4WYle8CpP4ffr5uWdJKp/Ft9iHZNNAvROULxUzE8=
+github.com/ovirt/terraform-provider-ovirt/v2 v2.1.4/go.mod h1:ohSCsq1QekAqU+66kuEtcUYeSwwrwHpPk3szvKJwOXk=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/terraform/providers/ovirt/vendor/github.com/hashicorp/terraform-plugin-log/internal/logging/options.go
+++ b/terraform/providers/ovirt/vendor/github.com/hashicorp/terraform-plugin-log/internal/logging/options.go
@@ -56,9 +56,9 @@ type LoggerOpts struct {
 	//
 	//   OmitLogWithFieldKeys = `['foo', 'baz']`
 	//
-	//   log1 = `{ msg = "...", fields = { 'foo', '...', 'bar', '...' }`   -> omitted
-	//   log2 = `{ msg = "...", fields = { 'bar', '...' }`                 -> printed
-	//   log3 = `{ msg = "...", fields = { 'baz`', '...', 'boo', '...' }`  -> omitted
+	//   log1 = `{ msg = "...", fields = { 'foo': '...', 'bar': '...' }`  -> omitted
+	//   log2 = `{ msg = "...", fields = { 'bar': '...' }`                -> printed
+	//   log3 = `{ msg = "...", fields = { 'baz': '...', 'boo': '...' }`  -> omitted
 	//
 	OmitLogWithFieldKeys []string
 
@@ -95,11 +95,40 @@ type LoggerOpts struct {
 	//
 	//   MaskFieldValuesWithFieldKeys = `['foo', 'baz']`
 	//
-	//   log1 = `{ msg = "...", fields = { 'foo', '***', 'bar', '...' }`   -> masked value
-	//   log2 = `{ msg = "...", fields = { 'bar', '...' }`                 -> as-is value
-	//   log3 = `{ msg = "...", fields = { 'baz`', '***', 'boo', '...' }`  -> masked value
+	//   log1 = `{ msg = "...", fields = { 'foo': '***', 'bar': '...' }`  -> masked value
+	//   log2 = `{ msg = "...", fields = { 'bar': '...' }`                -> as-is value
+	//   log3 = `{ msg = "...", fields = { 'baz': '***', 'boo': '...' }`  -> masked value
 	//
 	MaskFieldValuesWithFieldKeys []string
+
+	// MaskAllFieldValuesRegexes indicates that the logger should replace, within
+	// all the log field values, the portion matching one of the given *regexp.Regexp.
+	//
+	// Note that the replacement will happen, only for field values that are of type string.
+	//
+	// Example:
+	//
+	//   MaskAllFieldValuesRegexes = `[regexp.MustCompile("(foo|bar)")]`
+	//
+	//   log1 = `{ msg = "...", fields = { 'k1': '***', 'k2': '***', 'k3': 'baz' }`  -> masked value
+	//   log2 = `{ msg = "...", fields = { 'k1': 'boo', 'k2': 'far', 'k3': 'baz' }`  -> as-is value
+	//   log2 = `{ msg = "...", fields = { 'k1': '*** *** baz' }`                    -> masked value
+	//
+	MaskAllFieldValuesRegexes []*regexp.Regexp
+
+	// MaskAllFieldValuesStrings indicates that the logger should replace, within
+	// all the log field values, the portion equal to one of the given strings.
+	//
+	// Note that the replacement will happen, only for field values that are of type string.
+	//
+	// Example:
+	//
+	//   MaskAllFieldValuesStrings = `['foo', 'baz']`
+	//
+	//   log1 = `{ msg = "...", fields = { 'k1': '***', 'k2': 'bar', 'k3': '***' }`  -> masked value
+	//   log2 = `{ msg = "...", fields = { 'k1': 'boo', 'k2': 'far', 'k3': '***' }`  -> as-is value
+	//   log2 = `{ msg = "...", fields = { 'k1': '*** bar ***' }`                    -> masked value
+	MaskAllFieldValuesStrings []string
 
 	// MaskMessageRegexes indicates that the logger should replace, within
 	// a log message, the portion matching one of the given *regexp.Regexp.
@@ -115,7 +144,7 @@ type LoggerOpts struct {
 	MaskMessageRegexes []*regexp.Regexp
 
 	// MaskMessageStrings indicates that the logger should replace, within
-	// a log message, the portion matching one of the given strings.
+	// a log message, the portion equal to one of the given strings.
 	//
 	// Example:
 	//
@@ -262,6 +291,22 @@ func WithOmitLogWithMessageStrings(matchingStrings ...string) Option {
 func WithMaskFieldValuesWithFieldKeys(keys ...string) Option {
 	return func(l LoggerOpts) LoggerOpts {
 		l.MaskFieldValuesWithFieldKeys = append(l.MaskFieldValuesWithFieldKeys, keys...)
+		return l
+	}
+}
+
+// WithMaskAllFieldValuesRegexes appends keys to the LoggerOpts.MaskAllFieldValuesRegexes field.
+func WithMaskAllFieldValuesRegexes(expressions ...*regexp.Regexp) Option {
+	return func(l LoggerOpts) LoggerOpts {
+		l.MaskAllFieldValuesRegexes = append(l.MaskAllFieldValuesRegexes, expressions...)
+		return l
+	}
+}
+
+// WithMaskAllFieldValuesStrings appends keys to the LoggerOpts.MaskAllFieldValuesStrings field.
+func WithMaskAllFieldValuesStrings(matchingStrings ...string) Option {
+	return func(l LoggerOpts) LoggerOpts {
+		l.MaskAllFieldValuesStrings = append(l.MaskAllFieldValuesStrings, matchingStrings...)
 		return l
 	}
 }

--- a/terraform/providers/ovirt/vendor/github.com/hashicorp/terraform-plugin-log/tflog/provider.go
+++ b/terraform/providers/ovirt/vendor/github.com/hashicorp/terraform-plugin-log/tflog/provider.go
@@ -146,9 +146,9 @@ func Error(ctx context.Context, msg string, additionalFields ...map[string]inter
 //
 //   configuration = `['foo', 'baz']`
 //
-//   log1 = `{ msg = "...", fields = { 'foo', '...', 'bar', '...' }`   -> omitted
-//   log2 = `{ msg = "...", fields = { 'bar', '...' }`                 -> printed
-//   log3 = `{ msg = "...", fields = { 'baz`', '...', 'boo', '...' }`  -> omitted
+//   log1 = `{ msg = "...", fields = { 'foo': '...', 'bar': '...' }`  -> omitted
+//   log2 = `{ msg = "...", fields = { 'bar': '...' }`                -> printed
+//   log3 = `{ msg = "...", fields = { 'baz': '...', 'boo': '...' }`  -> omitted
 //
 func OmitLogWithFieldKeys(ctx context.Context, keys ...string) context.Context {
 	lOpts := logging.GetProviderRootTFLoggerOpts(ctx)
@@ -214,9 +214,9 @@ func OmitLogWithMessageStrings(ctx context.Context, matchingStrings ...string) c
 //
 //   configuration = `['foo', 'baz']`
 //
-//   log1 = `{ msg = "...", fields = { 'foo', '***', 'bar', '...' }`   -> masked value
-//   log2 = `{ msg = "...", fields = { 'bar', '...' }`                 -> as-is value
-//   log3 = `{ msg = "...", fields = { 'baz`', '***', 'boo', '...' }`  -> masked value
+//   log1 = `{ msg = "...", fields = { 'foo': '***', 'bar': '...' }`  -> masked value
+//   log2 = `{ msg = "...", fields = { 'bar': '...' }`                -> as-is value
+//   log3 = `{ msg = "...", fields = { 'baz': '***', 'boo': '...' }`  -> masked value
 //
 func MaskFieldValuesWithFieldKeys(ctx context.Context, keys ...string) context.Context {
 	lOpts := logging.GetProviderRootTFLoggerOpts(ctx)
@@ -226,9 +226,59 @@ func MaskFieldValuesWithFieldKeys(ctx context.Context, keys ...string) context.C
 	return logging.SetProviderRootTFLoggerOpts(ctx, lOpts)
 }
 
+// MaskAllFieldValuesRegexes returns a new context.Context that has a modified logger
+// that masks (replaces) with asterisks (`***`) all field value substrings,
+// matching one of the given *regexp.Regexp.
+//
+// Note that the replacement will happen, only for field values that are of type string.
+//
+// Each call to this function is additive:
+// the regexp to mask by are added to the existing configuration.
+//
+// Example:
+//
+//   configuration = `[regexp.MustCompile("(foo|bar)")]`
+//
+//   log1 = `{ msg = "...", fields = { 'k1': '***', 'k2': '***', 'k3': 'baz' }`  -> masked value
+//   log2 = `{ msg = "...", fields = { 'k1': 'boo', 'k2': 'far', 'k3': 'baz' }`  -> as-is value
+//   log2 = `{ msg = "...", fields = { 'k1': '*** *** baz' }`                    -> masked value
+//
+func MaskAllFieldValuesRegexes(ctx context.Context, expressions ...*regexp.Regexp) context.Context {
+	lOpts := logging.GetProviderRootTFLoggerOpts(ctx)
+
+	lOpts = logging.WithMaskAllFieldValuesRegexes(expressions...)(lOpts)
+
+	return logging.SetProviderRootTFLoggerOpts(ctx, lOpts)
+}
+
+// MaskAllFieldValuesStrings returns a new context.Context that has a modified logger
+// that masks (replaces) with asterisks (`***`) all field value substrings,
+// equal to one of the given strings.
+//
+// Note that the replacement will happen, only for field values that are of type string.
+//
+// Each call to this function is additive:
+// the regexp to mask by are added to the existing configuration.
+//
+// Example:
+//
+//   configuration = `[regexp.MustCompile("(foo|bar)")]`
+//
+//   log1 = `{ msg = "...", fields = { 'k1': '***', 'k2': '***', 'k3': 'baz' }`  -> masked value
+//   log2 = `{ msg = "...", fields = { 'k1': 'boo', 'k2': 'far', 'k3': 'baz' }`  -> as-is value
+//   log2 = `{ msg = "...", fields = { 'k1': '*** *** baz' }`                    -> masked value
+//
+func MaskAllFieldValuesStrings(ctx context.Context, matchingStrings ...string) context.Context {
+	lOpts := logging.GetProviderRootTFLoggerOpts(ctx)
+
+	lOpts = logging.WithMaskAllFieldValuesStrings(matchingStrings...)(lOpts)
+
+	return logging.SetProviderRootTFLoggerOpts(ctx, lOpts)
+}
+
 // MaskMessageRegexes returns a new context.Context that has a modified logger
-// that masks (replaces) with asterisks (`***`) all message substrings matching one
-// of the given strings.
+// that masks (replaces) with asterisks (`***`) all message substrings,
+// matching one of the given *regexp.Regexp.
 //
 // Each call to this function is additive:
 // the regexp to mask by are added to the existing configuration.
@@ -250,8 +300,8 @@ func MaskMessageRegexes(ctx context.Context, expressions ...*regexp.Regexp) cont
 }
 
 // MaskMessageStrings returns a new context.Context that has a modified logger
-// that masks (replace) with asterisks (`***`) all message substrings equal to one
-// of the given strings.
+// that masks (replace) with asterisks (`***`) all message substrings,
+// equal to one of the given strings.
 //
 // Each call to this function is additive:
 // the string to mask by are added to the existing configuration.
@@ -260,9 +310,9 @@ func MaskMessageRegexes(ctx context.Context, expressions ...*regexp.Regexp) cont
 //
 //   configuration = `['foo', 'bar']`
 //
-//   log1 = `{ msg = "banana apple ***", fields = {...}`     -> masked portion
-//   log2 = `{ msg = "pineapple mango", fields = {...}`      -> as-is
-//   log3 = `{ msg = "pineapple mango ***", fields = {...}`  -> masked portion
+//   log1 = `{ msg = "banana apple ***", fields = { 'k1': 'foo, bar, baz' }`  -> masked portion
+//   log2 = `{ msg = "pineapple mango", fields = {...}`                       -> as-is
+//   log3 = `{ msg = "pineapple mango ***", fields = {...}`                   -> masked portion
 //
 func MaskMessageStrings(ctx context.Context, matchingStrings ...string) context.Context {
 	lOpts := logging.GetProviderRootTFLoggerOpts(ctx)
@@ -270,4 +320,16 @@ func MaskMessageStrings(ctx context.Context, matchingStrings ...string) context.
 	lOpts = logging.WithMaskMessageStrings(matchingStrings...)(lOpts)
 
 	return logging.SetProviderRootTFLoggerOpts(ctx, lOpts)
+}
+
+// MaskLogRegexes is a shortcut to invoke MaskMessageRegexes and MaskAllFieldValuesRegexes using the same input.
+// Refer to those functions for details.
+func MaskLogRegexes(ctx context.Context, expressions ...*regexp.Regexp) context.Context {
+	return MaskMessageRegexes(MaskAllFieldValuesRegexes(ctx, expressions...), expressions...)
+}
+
+// MaskLogStrings is a shortcut to invoke MaskMessageStrings and MaskAllFieldValuesStrings using the same input.
+// Refer to those functions for details.
+func MaskLogStrings(ctx context.Context, matchingStrings ...string) context.Context {
+	return MaskMessageStrings(MaskAllFieldValuesStrings(ctx, matchingStrings...), matchingStrings...)
 }

--- a/terraform/providers/ovirt/vendor/github.com/hashicorp/terraform-plugin-log/tflog/subsystem.go
+++ b/terraform/providers/ovirt/vendor/github.com/hashicorp/terraform-plugin-log/tflog/subsystem.go
@@ -225,9 +225,9 @@ func SubsystemError(ctx context.Context, subsystem, msg string, additionalFields
 //
 //   configuration = `['foo', 'baz']`
 //
-//   log1 = `{ msg = "...", fields = { 'foo', '...', 'bar', '...' }`   -> omitted
-//   log2 = `{ msg = "...", fields = { 'bar', '...' }`                 -> printed
-//   log3 = `{ msg = "...", fields = { 'baz`', '...', 'boo', '...' }`  -> omitted
+//   log1 = `{ msg = "...", fields = { 'foo': '...', 'bar': '...' }`  -> omitted
+//   log2 = `{ msg = "...", fields = { 'bar': '...' }`                -> printed
+//   log3 = `{ msg = "...", fields = { 'baz': '...', 'boo': '...' }`  -> omitted
 //
 func SubsystemOmitLogWithFieldKeys(ctx context.Context, subsystem string, keys ...string) context.Context {
 	lOpts := logging.GetProviderSubsystemTFLoggerOpts(ctx, subsystem)
@@ -293,9 +293,9 @@ func SubsystemOmitLogWithMessageStrings(ctx context.Context, subsystem string, m
 //
 //   configuration = `['foo', 'baz']`
 //
-//   log1 = `{ msg = "...", fields = { 'foo', '***', 'bar', '...' }`   -> masked value
-//   log2 = `{ msg = "...", fields = { 'bar', '...' }`                 -> as-is value
-//   log3 = `{ msg = "...", fields = { 'baz`', '***', 'boo', '...' }`  -> masked value
+//   log1 = `{ msg = "...", fields = { 'foo': '***', 'bar': '...' }`  -> masked value
+//   log2 = `{ msg = "...", fields = { 'bar': '...' }`                -> as-is value
+//   log3 = `{ msg = "...", fields = { 'baz': '***', 'boo': '...' }`  -> masked value
 //
 func SubsystemMaskFieldValuesWithFieldKeys(ctx context.Context, subsystem string, keys ...string) context.Context {
 	lOpts := logging.GetProviderSubsystemTFLoggerOpts(ctx, subsystem)
@@ -305,9 +305,59 @@ func SubsystemMaskFieldValuesWithFieldKeys(ctx context.Context, subsystem string
 	return logging.SetProviderSubsystemTFLoggerOpts(ctx, subsystem, lOpts)
 }
 
+// SubsystemMaskAllFieldValuesRegexes returns a new context.Context that has a modified logger
+// that masks (replaces) with asterisks (`***`) all field value substrings,
+// matching one of the given *regexp.Regexp.
+//
+// Note that the replacement will happen, only for field values that are of type string.
+//
+// Each call to this function is additive:
+// the regexp to mask by are added to the existing configuration.
+//
+// Example:
+//
+//   configuration = `[regexp.MustCompile("(foo|bar)")]`
+//
+//   log1 = `{ msg = "...", fields = { 'k1': '***', 'k2': '***', 'k3': 'baz' }`  -> masked value
+//   log2 = `{ msg = "...", fields = { 'k1': 'boo', 'k2': 'far', 'k3': 'baz' }`  -> as-is value
+//   log2 = `{ msg = "...", fields = { 'k1': '*** *** baz' }`                    -> masked value
+//
+func SubsystemMaskAllFieldValuesRegexes(ctx context.Context, subsystem string, expressions ...*regexp.Regexp) context.Context {
+	lOpts := logging.GetProviderSubsystemTFLoggerOpts(ctx, subsystem)
+
+	lOpts = logging.WithMaskAllFieldValuesRegexes(expressions...)(lOpts)
+
+	return logging.SetProviderSubsystemTFLoggerOpts(ctx, subsystem, lOpts)
+}
+
+// SubsystemMaskAllFieldValuesStrings returns a new context.Context that has a modified logger
+// that masks (replaces) with asterisks (`***`) all field value substrings,
+// equal to one of the given strings.
+//
+// Note that the replacement will happen, only for field values that are of type string.
+//
+// Each call to this function is additive:
+// the regexp to mask by are added to the existing configuration.
+//
+// Example:
+//
+//   configuration = `[regexp.MustCompile("(foo|bar)")]`
+//
+//   log1 = `{ msg = "...", fields = { 'k1': '***', 'k2': '***', 'k3': 'baz' }`  -> masked value
+//   log2 = `{ msg = "...", fields = { 'k1': 'boo', 'k2': 'far', 'k3': 'baz' }`  -> as-is value
+//   log2 = `{ msg = "...", fields = { 'k1': '*** *** baz' }`                    -> masked value
+//
+func SubsystemMaskAllFieldValuesStrings(ctx context.Context, subsystem string, matchingStrings ...string) context.Context {
+	lOpts := logging.GetProviderSubsystemTFLoggerOpts(ctx, subsystem)
+
+	lOpts = logging.WithMaskAllFieldValuesStrings(matchingStrings...)(lOpts)
+
+	return logging.SetProviderSubsystemTFLoggerOpts(ctx, subsystem, lOpts)
+}
+
 // SubsystemMaskMessageRegexes returns a new context.Context that has a modified logger
-// that masks (replaces) with asterisks (`***`) all message substrings matching one
-// of the given strings.
+// that masks (replaces) with asterisks (`***`) all message substrings,
+// matching one of the given *regexp.Regexp.
 //
 // Each call to this function is additive:
 // the regexp to mask by are added to the existing configuration.
@@ -329,8 +379,8 @@ func SubsystemMaskMessageRegexes(ctx context.Context, subsystem string, expressi
 }
 
 // SubsystemMaskMessageStrings returns a new context.Context that has a modified logger
-// that masks (replace) with asterisks (`***`) all message substrings equal to one
-// of the given strings.
+// that masks (replace) with asterisks (`***`) all message substrings,
+// equal to one of the given strings.
 //
 // Each call to this function is additive:
 // the string to mask by are added to the existing configuration.
@@ -339,9 +389,9 @@ func SubsystemMaskMessageRegexes(ctx context.Context, subsystem string, expressi
 //
 //   configuration = `['foo', 'bar']`
 //
-//   log1 = `{ msg = "banana apple ***", fields = {...}`     -> masked portion
-//   log2 = `{ msg = "pineapple mango", fields = {...}`      -> as-is
-//   log3 = `{ msg = "pineapple mango ***", fields = {...}`  -> masked portion
+//   log1 = `{ msg = "banana apple ***", fields = { 'k1': 'foo, bar, baz' }`  -> masked portion
+//   log2 = `{ msg = "pineapple mango", fields = {...}`                       -> as-is
+//   log3 = `{ msg = "pineapple mango ***", fields = {...}`                   -> masked portion
 //
 func SubsystemMaskMessageStrings(ctx context.Context, subsystem string, matchingStrings ...string) context.Context {
 	lOpts := logging.GetProviderSubsystemTFLoggerOpts(ctx, subsystem)
@@ -349,4 +399,16 @@ func SubsystemMaskMessageStrings(ctx context.Context, subsystem string, matching
 	lOpts = logging.WithMaskMessageStrings(matchingStrings...)(lOpts)
 
 	return logging.SetProviderSubsystemTFLoggerOpts(ctx, subsystem, lOpts)
+}
+
+// SubsystemMaskLogRegexes is a shortcut to invoke SubsystemMaskMessageRegexes and SubsystemMaskAllFieldValuesRegexes using the same input.
+// Refer to those functions for details.
+func SubsystemMaskLogRegexes(ctx context.Context, subsystem string, expressions ...*regexp.Regexp) context.Context {
+	return SubsystemMaskMessageRegexes(SubsystemMaskAllFieldValuesRegexes(ctx, subsystem, expressions...), subsystem, expressions...)
+}
+
+// SubsystemMaskLogStrings is a shortcut to invoke SubsystemMaskMessageStrings and SubsystemMaskAllFieldValuesStrings using the same input.
+// Refer to those functions for details.
+func SubsystemMaskLogStrings(ctx context.Context, subsystem string, matchingStrings ...string) context.Context {
+	return SubsystemMaskMessageStrings(SubsystemMaskAllFieldValuesStrings(ctx, subsystem, matchingStrings...), subsystem, matchingStrings...)
 }

--- a/terraform/providers/ovirt/vendor/github.com/hashicorp/terraform-plugin-log/tfsdklog/sdk.go
+++ b/terraform/providers/ovirt/vendor/github.com/hashicorp/terraform-plugin-log/tfsdklog/sdk.go
@@ -229,9 +229,9 @@ func Error(ctx context.Context, msg string, additionalFields ...map[string]inter
 //
 //   configuration = `['foo', 'baz']`
 //
-//   log1 = `{ msg = "...", fields = { 'foo', '...', 'bar', '...' }`   -> omitted
-//   log2 = `{ msg = "...", fields = { 'bar', '...' }`                 -> printed
-//   log3 = `{ msg = "...", fields = { 'baz`', '...', 'boo', '...' }`  -> omitted
+//   log1 = `{ msg = "...", fields = { 'foo': '...', 'bar': '...' }`  -> omitted
+//   log2 = `{ msg = "...", fields = { 'bar': '...' }`                -> printed
+//   log3 = `{ msg = "...", fields = { 'baz': '...', 'boo': '...' }`  -> omitted
 //
 func OmitLogWithFieldKeys(ctx context.Context, keys ...string) context.Context {
 	lOpts := logging.GetSDKRootTFLoggerOpts(ctx)
@@ -297,9 +297,9 @@ func OmitLogWithMessageStrings(ctx context.Context, matchingStrings ...string) c
 //
 //   configuration = `['foo', 'baz']`
 //
-//   log1 = `{ msg = "...", fields = { 'foo', '***', 'bar', '...' }`   -> masked value
-//   log2 = `{ msg = "...", fields = { 'bar', '...' }`                 -> as-is value
-//   log3 = `{ msg = "...", fields = { 'baz`', '***', 'boo', '...' }`  -> masked value
+//   log1 = `{ msg = "...", fields = { 'foo': '***', 'bar': '...' }`  -> masked value
+//   log2 = `{ msg = "...", fields = { 'bar': '...' }`                -> as-is value
+//   log3 = `{ msg = "...", fields = { 'baz': '***', 'boo': '...' }`  -> masked value
 //
 func MaskFieldValuesWithFieldKeys(ctx context.Context, keys ...string) context.Context {
 	lOpts := logging.GetSDKRootTFLoggerOpts(ctx)
@@ -309,9 +309,59 @@ func MaskFieldValuesWithFieldKeys(ctx context.Context, keys ...string) context.C
 	return logging.SetSDKRootTFLoggerOpts(ctx, lOpts)
 }
 
+// MaskAllFieldValuesRegexes returns a new context.Context that has a modified logger
+// that masks (replaces) with asterisks (`***`) all field value substrings,
+// matching one of the given *regexp.Regexp.
+//
+// Note that the replacement will happen, only for field values that are of type string.
+//
+// Each call to this function is additive:
+// the regexp to mask by are added to the existing configuration.
+//
+// Example:
+//
+//   configuration = `[regexp.MustCompile("(foo|bar)")]`
+//
+//   log1 = `{ msg = "...", fields = { 'k1': '***', 'k2': '***', 'k3': 'baz' }`  -> masked value
+//   log2 = `{ msg = "...", fields = { 'k1': 'boo', 'k2': 'far', 'k3': 'baz' }`  -> as-is value
+//   log2 = `{ msg = "...", fields = { 'k1': '*** *** baz' }`                    -> masked value
+//
+func MaskAllFieldValuesRegexes(ctx context.Context, expressions ...*regexp.Regexp) context.Context {
+	lOpts := logging.GetSDKRootTFLoggerOpts(ctx)
+
+	lOpts = logging.WithMaskAllFieldValuesRegexes(expressions...)(lOpts)
+
+	return logging.SetSDKRootTFLoggerOpts(ctx, lOpts)
+}
+
+// MaskAllFieldValuesStrings returns a new context.Context that has a modified logger
+// that masks (replaces) with asterisks (`***`) all field value substrings,
+// equal to one of the given strings.
+//
+// Note that the replacement will happen, only for field values that are of type string.
+//
+// Each call to this function is additive:
+// the regexp to mask by are added to the existing configuration.
+//
+// Example:
+//
+//   configuration = `[regexp.MustCompile("(foo|bar)")]`
+//
+//   log1 = `{ msg = "...", fields = { 'k1': '***', 'k2': '***', 'k3': 'baz' }`  -> masked value
+//   log2 = `{ msg = "...", fields = { 'k1': 'boo', 'k2': 'far', 'k3': 'baz' }`  -> as-is value
+//   log2 = `{ msg = "...", fields = { 'k1': '*** *** baz' }`                    -> masked value
+//
+func MaskAllFieldValuesStrings(ctx context.Context, matchingStrings ...string) context.Context {
+	lOpts := logging.GetSDKRootTFLoggerOpts(ctx)
+
+	lOpts = logging.WithMaskAllFieldValuesStrings(matchingStrings...)(lOpts)
+
+	return logging.SetSDKRootTFLoggerOpts(ctx, lOpts)
+}
+
 // MaskMessageRegexes returns a new context.Context that has a modified logger
-// that masks (replaces) with asterisks (`***`) all message substrings matching one
-// of the given strings.
+// that masks (replaces) with asterisks (`***`) all message substrings,
+// matching one of the given *regexp.Regexp.
 //
 // Each call to this function is additive:
 // the regexp to mask by are added to the existing configuration.
@@ -333,8 +383,8 @@ func MaskMessageRegexes(ctx context.Context, expressions ...*regexp.Regexp) cont
 }
 
 // MaskMessageStrings returns a new context.Context that has a modified logger
-// that masks (replace) with asterisks (`***`) all message substrings equal to one
-// of the given strings.
+// that masks (replace) with asterisks (`***`) all message substrings,
+// equal to one of the given strings.
 //
 // Each call to this function is additive:
 // the string to mask by are added to the existing configuration.
@@ -343,9 +393,9 @@ func MaskMessageRegexes(ctx context.Context, expressions ...*regexp.Regexp) cont
 //
 //   configuration = `['foo', 'bar']`
 //
-//   log1 = `{ msg = "banana apple ***", fields = {...}`     -> masked portion
-//   log2 = `{ msg = "pineapple mango", fields = {...}`      -> as-is
-//   log3 = `{ msg = "pineapple mango ***", fields = {...}`  -> masked portion
+//   log1 = `{ msg = "banana apple ***", fields = { 'k1': 'foo, bar, baz' }`  -> masked portion
+//   log2 = `{ msg = "pineapple mango", fields = {...}`                       -> as-is
+//   log3 = `{ msg = "pineapple mango ***", fields = {...}`                   -> masked portion
 //
 func MaskMessageStrings(ctx context.Context, matchingStrings ...string) context.Context {
 	lOpts := logging.GetSDKRootTFLoggerOpts(ctx)
@@ -353,4 +403,16 @@ func MaskMessageStrings(ctx context.Context, matchingStrings ...string) context.
 	lOpts = logging.WithMaskMessageStrings(matchingStrings...)(lOpts)
 
 	return logging.SetSDKRootTFLoggerOpts(ctx, lOpts)
+}
+
+// MaskLogRegexes is a shortcut to invoke MaskMessageRegexes and MaskAllFieldValuesRegexes using the same input.
+// Refer to those functions for details.
+func MaskLogRegexes(ctx context.Context, expressions ...*regexp.Regexp) context.Context {
+	return MaskMessageRegexes(MaskAllFieldValuesRegexes(ctx, expressions...), expressions...)
+}
+
+// MaskLogStrings is a shortcut to invoke MaskMessageStrings and MaskAllFieldValuesStrings using the same input.
+// Refer to those functions for details.
+func MaskLogStrings(ctx context.Context, matchingStrings ...string) context.Context {
+	return MaskMessageStrings(MaskAllFieldValuesStrings(ctx, matchingStrings...), matchingStrings...)
 }

--- a/terraform/providers/ovirt/vendor/github.com/ovirt/go-ovirt-client/v2/vm.go
+++ b/terraform/providers/ovirt/vendor/github.com/ovirt/go-ovirt-client/v2/vm.go
@@ -2170,9 +2170,11 @@ func vmSerialConsoleConverter(object *ovirtsdk.Vm, v *vm, logger Logger, action 
 }
 
 func vmSoundcardEnabledConverter(object *ovirtsdk.Vm, v *vm) error {
+	// soundcard_enabled is excluded from the response from oVirt engine by default. Therefore, using the default bool value as return value
+	// see: http://ovirt.github.io/ovirt-engine-api-model/master/#services/disk/methods/get/parameters/all_content
 	soundcardEnabled, ok := object.SoundcardEnabled()
 	if !ok {
-		return newFieldNotFound("vm", "soundcard enabled")
+		v.soundcardEnabled = false
 	}
 	v.soundcardEnabled = soundcardEnabled
 	return nil

--- a/terraform/providers/ovirt/vendor/modules.txt
+++ b/terraform/providers/ovirt/vendor/modules.txt
@@ -131,7 +131,7 @@ github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/tfplugin6
 github.com/hashicorp/terraform-plugin-go/tfprotov6/internal/toproto
 github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server
 github.com/hashicorp/terraform-plugin-go/tftypes
-# github.com/hashicorp/terraform-plugin-log v0.6.0
+# github.com/hashicorp/terraform-plugin-log v0.7.0
 ## explicit; go 1.17
 github.com/hashicorp/terraform-plugin-log/internal/fieldutils
 github.com/hashicorp/terraform-plugin-log/internal/hclogutils
@@ -202,10 +202,10 @@ github.com/ovirt/go-ovirt
 # github.com/ovirt/go-ovirt-client-log/v3 v3.0.0
 ## explicit; go 1.16
 github.com/ovirt/go-ovirt-client-log/v3
-# github.com/ovirt/go-ovirt-client/v2 v2.0.0-alpha02
+# github.com/ovirt/go-ovirt-client/v2 v2.0.0-alpha03
 ## explicit; go 1.16
 github.com/ovirt/go-ovirt-client/v2
-# github.com/ovirt/terraform-provider-ovirt/v2 v2.1.0
+# github.com/ovirt/terraform-provider-ovirt/v2 v2.1.4
 ## explicit; go 1.16
 github.com/ovirt/terraform-provider-ovirt/v2
 github.com/ovirt/terraform-provider-ovirt/v2/internal/ovirt


### PR DESCRIPTION
This PR is a continuation of https://github.com/openshift/installer/pull/6148. It updates the `terraform-provider-ovirt` with the necessary fix in `go-ovirt-client` so that a missing soundcard enabled field on the VM struct does not result in an error. 