### PR TITLE
AGENT-299: Set mode 0644 on containers.conf

### DIFF
--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -350,7 +350,7 @@ func AddStorageFiles(config *igntypes.Config, base string, uri string, templateD
 	appendToFile := false
 	if parentDir == "bin" || parentDir == "dispatcher.d" {
 		mode = 0555
-	} else if filename == "motd" {
+	} else if filename == "motd" || filename == "containers.conf" {
 		mode = 0644
 		appendToFile = true
 	} else {


### PR DESCRIPTION
If the file /etc/containers/containers.conf is not world-readable,
starting the podman API service fails. If nothing else, this leaves a
lot of misleading junk in the journal logs.

In practice, only the agent installation method is populating this file,
but in principle this is the right mode wherever it is used. We are
creating the file to work around a podman configuration bug, so it is
entirely possible that other installation methods will also use it in
the future. Therefore the fix is in the bootstrap ignition population
method.