### PR TITLE
Bug 2098252: bump RHCOS 4.8 bootimage metadata

### DIFF
--- a/data/data/rhcos-amd64.json
+++ b/data/data/rhcos-amd64.json
@@ -1,169 +1,169 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0c879d0aa64259ad0"
+            "hvm": "ami-0359370d57fc93cac"
         },
         "ap-east-1": {
-            "hvm": "ami-0e6a2dea7bfd862a5"
+            "hvm": "ami-0c65cd97d4fbb03a0"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0b9b3588ea302934d"
+            "hvm": "ami-015d3c7e01eb46827"
         },
         "ap-northeast-2": {
-            "hvm": "ami-012b7f860e994e868"
+            "hvm": "ami-0e9cafc0ae9404136"
         },
         "ap-northeast-3": {
-            "hvm": "ami-0e42b5afc5baeea34"
+            "hvm": "ami-0dcd31905f42c296a"
         },
         "ap-south-1": {
-            "hvm": "ami-0cec0dfd6e955718d"
+            "hvm": "ami-08e9be789af110ecd"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0980a2024cd30b5bf"
+            "hvm": "ami-07b4e3fb05ab13111"
         },
         "ap-southeast-2": {
-            "hvm": "ami-032069c0b51483ad1"
+            "hvm": "ami-0513198dc7c3e6796"
         },
         "ap-southeast-3": {
-            "hvm": "ami-0f19ad8d973aea0ec"
+            "hvm": "ami-05cbccdb55066f2d1"
         },
         "ca-central-1": {
-            "hvm": "ami-0f131d428f7d39da7"
+            "hvm": "ami-04a9118f6639f8944"
         },
         "eu-central-1": {
-            "hvm": "ami-089e4575a0dcafb0b"
+            "hvm": "ami-09caf0c25eb83bb58"
         },
         "eu-north-1": {
-            "hvm": "ami-04a0fcdd1fee18228"
+            "hvm": "ami-03d0d41d50363a2af"
         },
         "eu-south-1": {
-            "hvm": "ami-05b65f41216a7da4b"
+            "hvm": "ami-046fa2186c3255cf4"
         },
         "eu-west-1": {
-            "hvm": "ami-0ff5d97cd0b6cd949"
+            "hvm": "ami-0a64742ba31e13ad0"
         },
         "eu-west-2": {
-            "hvm": "ami-06a805d9f546f670a"
+            "hvm": "ami-00153eaf1516e68fc"
         },
         "eu-west-3": {
-            "hvm": "ami-00cca0795cfeead80"
+            "hvm": "ami-087f940ea264a5257"
         },
         "me-south-1": {
-            "hvm": "ami-0e8ba9d5ba5e65106"
+            "hvm": "ami-0745ce6fb6d0b78db"
         },
         "sa-east-1": {
-            "hvm": "ami-041fbbc302a372a36"
+            "hvm": "ami-0a302f5de9ae4b4fd"
         },
         "us-east-1": {
-            "hvm": "ami-0a0091d01a8bd2947"
+            "hvm": "ami-059fea61e7f8e7516"
         },
         "us-east-2": {
-            "hvm": "ami-0147e13e9b1975251"
+            "hvm": "ami-087db69f78b36aada"
         },
         "us-west-1": {
-            "hvm": "ami-05662d869042ffd84"
+            "hvm": "ami-0de9f7cdeb54d2aca"
         },
         "us-west-2": {
-            "hvm": "ami-074ed14912081db41"
+            "hvm": "ami-028e920954a11c96a"
         }
     },
     "azure": {
-        "image": "rhcos-48.84.202206140145-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202206140145-0-azure.x86_64.vhd"
+        "image": "rhcos-48.84.202208021106-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202208021106-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/",
-    "buildid": "48.84.202206140145-0",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/",
+    "buildid": "48.84.202208021106-0",
     "gcp": {
-        "image": "rhcos-48-84-202206140145-0-gcp-x86-64",
+        "image": "rhcos-48-84-202208021106-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202206140145-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202208021106-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.84.202206140145-0-aws.x86_64.vmdk.gz",
-            "sha256": "c43356afc304edc5d2656095b6c4dd3052a35b0fe11adbaa4640b4f56bbc2f4c",
-            "size": 1030828645,
-            "uncompressed-sha256": "5580e5ea6d744e4e535b6416beac2c771a7e668ab86e0fe4b8395cf6eb87a343",
-            "uncompressed-size": 1051906048
+            "path": "rhcos-48.84.202208021106-0-aws.x86_64.vmdk.gz",
+            "sha256": "f44569e416014fe9c4bb186cd759f2dda061e8f3900cfb3afd63e5193bac53e1",
+            "size": 1030696766,
+            "uncompressed-sha256": "4210fdd258ccb96b6c7ea380d281fef7399d7fdffeaf767eb37f8a848e390b45",
+            "uncompressed-size": 1051742208
         },
         "azure": {
-            "path": "rhcos-48.84.202206140145-0-azure.x86_64.vhd.gz",
-            "sha256": "c9e355bb545baf2f34482cfc0a556b90dc89a71cf6058ed1546199fbff8a9c60",
-            "size": 1030940095,
-            "uncompressed-sha256": "333b3560bb635ce5c0f01bfa3784c8cd6ac1fa29ad85c52fbe0a773bf02b28e0",
+            "path": "rhcos-48.84.202208021106-0-azure.x86_64.vhd.gz",
+            "sha256": "4037dcf1ce5970771f4e38bdfdd8288388bac28eaef6ef4727e69823c17f5939",
+            "size": 1030800051,
+            "uncompressed-sha256": "089005e574e3c26b7057482dd0f659ed1c358d6fa33221c898b6c702b532d109",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.84.202206140145-0-gcp.x86_64.tar.gz",
-            "sha256": "7b732b6b3622f5ba00a4b2f3bfd32d6987a814f044daaf3831b0db0b168b81a6",
-            "size": 1016382695
+            "path": "rhcos-48.84.202208021106-0-gcp.x86_64.tar.gz",
+            "sha256": "95df0c7b5dcadf1b728ac2b159df37dd783bde33dbc65f7ee5a0fb2ee4bc4848",
+            "size": 1016284548
         },
         "ibmcloud": {
-            "path": "rhcos-48.84.202206140145-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "5113a7c63abe8a89cbce07d70e93eaeb685df1f4f96b7e467736a824889373d3",
-            "size": 1016732179,
-            "uncompressed-sha256": "87e637ebab6eab1ef9c4ae1d76613b5a0701a31c78793ac325596c77bdbede21",
-            "uncompressed-size": 2534473728
+            "path": "rhcos-48.84.202208021106-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "93d44cd5959cdfe08ece80247bd24aefe723539c9f28ab5af19b2beec0941d94",
+            "size": 1016616403,
+            "uncompressed-sha256": "8df97b6f31dce4d7800c200b76cca5fea228b8aa7327fae66c2eccc6921e86d8",
+            "uncompressed-size": 2534539264
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202206140145-0-live-initramfs.x86_64.img",
-            "sha256": "1641cb2005abf362283ddc328c1ad07c8640900d296e793913b1881faecc8926"
+            "path": "rhcos-48.84.202208021106-0-live-initramfs.x86_64.img",
+            "sha256": "7c599ee03c5b9bbf733d8df6cc5527f98e531f07433c26421c30fade98ff032f"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202206140145-0-live.x86_64.iso",
-            "sha256": "1483da2bb1a64f6f90577036935fd5b47ad6d20758fd241981943c46cf516ff0"
+            "path": "rhcos-48.84.202208021106-0-live.x86_64.iso",
+            "sha256": "b3c66552252f19fa921a8059f1aa882fda6193193617c48bb14f2f353a6be917"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202206140145-0-live-kernel-x86_64",
-            "sha256": "2f73cda50fa9cfcd14b9624cce3fa663c91341a8eafae22bb6bbc6357f83e679"
+            "path": "rhcos-48.84.202208021106-0-live-kernel-x86_64",
+            "sha256": "b00fe158fdce353bf548abf6835c37ee503c187606ede7349e4bc060f2ca69ea"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202206140145-0-live-rootfs.x86_64.img",
-            "sha256": "f0a729b85ace85e158c02a4ea69e53b5663210ffb2cb423f9899239481d9e479"
+            "path": "rhcos-48.84.202208021106-0-live-rootfs.x86_64.img",
+            "sha256": "0e709b2c1a658f0efeafb80b41fac4383dea3ec8818c8dfae915afe1ae2ce0e9"
         },
         "metal": {
-            "path": "rhcos-48.84.202206140145-0-metal.x86_64.raw.gz",
-            "sha256": "c2fb42fe571bc231993889e0790c21b4643d78efaa99eab9035dab506fee2df5",
-            "size": 1018203635,
-            "uncompressed-sha256": "048eef6702941fd566ec67d51426c1fecb469ecdc94d5eae55435593b53f69a6",
-            "uncompressed-size": 3957325824
+            "path": "rhcos-48.84.202208021106-0-metal.x86_64.raw.gz",
+            "sha256": "ebe9ab2df406f8282587aaf42716b371bcaae691a09d7e5d0f0687979bd94f37",
+            "size": 1018342666,
+            "uncompressed-sha256": "63274ae74e8941342488ab8d94ff48d65b3c13c9ee450f866755816ebf850889",
+            "uncompressed-size": 3959422976
         },
         "metal4k": {
-            "path": "rhcos-48.84.202206140145-0-metal4k.x86_64.raw.gz",
-            "sha256": "8fbf4a1b82a763e3dca32de1c5c9a2bd40382d80c576e9eac6a12c03f92c0d41",
-            "size": 1015886091,
-            "uncompressed-sha256": "3842893bf80c00a2f11b6d591284b60b6bf60bead4c3e67fb148d34843d5c9fc",
-            "uncompressed-size": 3957325824
+            "path": "rhcos-48.84.202208021106-0-metal4k.x86_64.raw.gz",
+            "sha256": "be8c9816f16766ba64307baf9b9533b6bb94df9c17a5497985d80ffeff04beb3",
+            "size": 1015775989,
+            "uncompressed-sha256": "53d89eb804d977325bdaad819ef90660639bcd6fe8b43be0ac98aa5aedd4cb4a",
+            "uncompressed-size": 3959422976
         },
         "openstack": {
-            "path": "rhcos-48.84.202206140145-0-openstack.x86_64.qcow2.gz",
-            "sha256": "137c3b236d2bcaa9681c968ad333b112762539c6df196a704f1cd8ba78d49f11",
-            "size": 1016727289,
-            "uncompressed-sha256": "0a147f49f35030fd8153266bb186357043fbc044c77dbaa5b46922984db0d750",
-            "uncompressed-size": 2534473728
+            "path": "rhcos-48.84.202208021106-0-openstack.x86_64.qcow2.gz",
+            "sha256": "6dbad43e2b02c5be49e55ce707a591da882e960d5338d38ee075889415b801c7",
+            "size": 1016616276,
+            "uncompressed-sha256": "7cee7c5eea1d9f500346e561d7a2d17e70b9399a3a710a2612ad450e9896c520",
+            "uncompressed-size": 2534539264
         },
         "ostree": {
-            "path": "rhcos-48.84.202206140145-0-ostree.x86_64.tar",
-            "sha256": "3438b2c53b1078b4e288ad2869fb7ce839f466ae564f0c807ba22ad74d246048",
-            "size": 940503040
+            "path": "rhcos-48.84.202208021106-0-ostree.x86_64.tar",
+            "sha256": "dac901df48a0c9d62cb14474301688df937bd51289cac09c9c455950987b4484",
+            "size": 940564480
         },
         "qemu": {
-            "path": "rhcos-48.84.202206140145-0-qemu.x86_64.qcow2.gz",
-            "sha256": "0120dfdcbfa70eeb804c1cd2368f140c577b12d85391d3553d189fb9b42938a1",
-            "size": 1017896853,
-            "uncompressed-sha256": "158e32571ca4934b05da0fe425eab453e6ceda3245cfc1a6cba45cbb53bf648a",
-            "uncompressed-size": 2571108352
+            "path": "rhcos-48.84.202208021106-0-qemu.x86_64.qcow2.gz",
+            "sha256": "f753b55c1ec9159e92acc891e43bebb6027af6da335776b168025282e4401baa",
+            "size": 1017794262,
+            "uncompressed-sha256": "9c8fe2df4513234901481effa078f566e02ccf456f4640dac7ffdc95315e7b40",
+            "uncompressed-size": 2571173888
         },
         "vmware": {
-            "path": "rhcos-48.84.202206140145-0-vmware.x86_64.ova",
-            "sha256": "7fa00b31d7f28c1318c23fe466a66cced0cbacd32b8833d8af05e874d1195332",
-            "size": 1051914240
+            "path": "rhcos-48.84.202208021106-0-vmware.x86_64.ova",
+            "sha256": "cdeeb17aedeabb244cdfe310289f0b917ae781ba50363303451ffde822bd8375",
+            "size": 1051750400
         }
     },
     "oscontainer": {
-        "digest": "sha256:648258313a495364dcd7663fa36e2d371fe4c78349d14b883fb5f4a301c824a5",
+        "digest": "sha256:276c5255ba29d40590ce7197a0a75741330d937901a30573268f7b7a1b1b0074",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "8fd19b78118cf1ba87bbb38adad80a5f8e74630c969d8c7d908e412ce4fb0e47",
-    "ostree-version": "48.84.202206140145-0"
+    "ostree-commit": "2478234e33a6e6564b39ca4f21cec61398a16a16b31a61b3dbb65de2a0df6ce4",
+    "ostree-version": "48.84.202208021106-0"
 }

--- a/data/data/rhcos-ppc64le.json
+++ b/data/data/rhcos-ppc64le.json
@@ -1,61 +1,61 @@
 {
-    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/",
-    "buildid": "48.84.202206132151-0",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/",
+    "buildid": "48.84.202207281745-0",
     "images": {
         "live-initramfs": {
-            "path": "rhcos-48.84.202206132151-0-live-initramfs.ppc64le.img",
-            "sha256": "8a1d182869d65eeb5e9a9245ebeec6f278c9936bf341ef202278fa9d8eed2039"
+            "path": "rhcos-48.84.202207281745-0-live-initramfs.ppc64le.img",
+            "sha256": "3f86a482fc51fd6d28aff62e3bd777f4af41db89e9f7bf4b555b7167f62e4082"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202206132151-0-live.ppc64le.iso",
-            "sha256": "a1a80feb7ed74179fa5058efc6ddac17ce07630fc1d1903bf6d862dee0c6cb8e"
+            "path": "rhcos-48.84.202207281745-0-live.ppc64le.iso",
+            "sha256": "46219eb854635b1c86a2d5d6a3a8d28e06d31f40da4a9eb5597be8bc5b4649d7"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202206132151-0-live-kernel-ppc64le",
-            "sha256": "44e70f6abe2bf6e828ce8f833323cdf44035de6f9cc041219a2ddc16036fa210"
+            "path": "rhcos-48.84.202207281745-0-live-kernel-ppc64le",
+            "sha256": "e3920af3462b5a626539215a0f0a25954b349afeaece5d186da57c276c64b189"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202206132151-0-live-rootfs.ppc64le.img",
-            "sha256": "209ffd30459bec61c9cea34abf3869845f7c3343bbe40c276af8c044cc339f12"
+            "path": "rhcos-48.84.202207281745-0-live-rootfs.ppc64le.img",
+            "sha256": "3fce5e5bb30e092d7596b2392ea57c4357f2b3d0c538298014208402c328e661"
         },
         "metal": {
-            "path": "rhcos-48.84.202206132151-0-metal.ppc64le.raw.gz",
-            "sha256": "a78c0d8dce939b8bd27020e5950e3e160f255886cbb21a86ae9f3535fac9209c",
-            "size": 984654794,
-            "uncompressed-sha256": "c5ec1cb253791c79b412b1777b4e95e7dae72ebc2338226234d9343211b883cd",
+            "path": "rhcos-48.84.202207281745-0-metal.ppc64le.raw.gz",
+            "sha256": "92b7e42e2b2bc004ab58c1c4043b58674c54d033cba3ae77bbe0537af52b58d7",
+            "size": 984658385,
+            "uncompressed-sha256": "5313aa610639fa2c9c03ea1820e3a72fcc4fbb1b4481e5016b35d4d275c86903",
             "uncompressed-size": 4103077888
         },
         "metal4k": {
-            "path": "rhcos-48.84.202206132151-0-metal4k.ppc64le.raw.gz",
-            "sha256": "9289afcdd91b1209c8c3201727281d2992559bd7f2d3b1177aaef759cddfcf73",
-            "size": 984771184,
-            "uncompressed-sha256": "434a1e6dbdc2ffec338df9328fc16e555c78989b3059ed8068a1a2e2360ff255",
+            "path": "rhcos-48.84.202207281745-0-metal4k.ppc64le.raw.gz",
+            "sha256": "5ef906a64dfcb72093c7a845ec8482dc6f17ed1113e81504cc44ce102b193029",
+            "size": 984959931,
+            "uncompressed-sha256": "14f5ac9ab55c78f80638acfc3a9f5b39f3f20bc9081e1eaf1d86f81efbc6d9e2",
             "uncompressed-size": 4103077888
         },
         "openstack": {
-            "path": "rhcos-48.84.202206132151-0-openstack.ppc64le.qcow2.gz",
-            "sha256": "8f674bef48429a8d8e42ee8ec03dc2ad4137417883388c64f40b1b876bfcbcc7",
-            "size": 982859226,
-            "uncompressed-sha256": "9fdc89ac3bdf7e9539b1bef1e59b5805ea9fd2388c9305678898245bba586a89",
-            "uncompressed-size": 2649292800
+            "path": "rhcos-48.84.202207281745-0-openstack.ppc64le.qcow2.gz",
+            "sha256": "4cbf2dfc1798732efb325f7b12885aa84295d972f5fa4c15b9543cebcf20b7ba",
+            "size": 982833841,
+            "uncompressed-sha256": "5c04e54adbab6624d58711d1acd721263ed3984269eb4472b675b835a4cf0f0e",
+            "uncompressed-size": 2649948160
         },
         "ostree": {
-            "path": "rhcos-48.84.202206132151-0-ostree.ppc64le.tar",
-            "sha256": "f3fc03dabc34a7e5662125c3c89ae169345a5ed77efeed31eaab591257e83cec",
-            "size": 905461760
+            "path": "rhcos-48.84.202207281745-0-ostree.ppc64le.tar",
+            "sha256": "7868ec0e105d1f3a0a067f8bfd5937a87a956aeb329d33fed37bd1f7d5e806b6",
+            "size": 905492480
         },
         "qemu": {
-            "path": "rhcos-48.84.202206132151-0-qemu.ppc64le.qcow2.gz",
-            "sha256": "c262bb5a71b8b53dfeda1e2f0d88c8b6609d9790d486a4c603268f82b61fd323",
-            "size": 983932188,
-            "uncompressed-sha256": "04c54cde0bcdfea17ee74d09e3afdee3bedae29df15d04fd2848ba20b2000dbf",
+            "path": "rhcos-48.84.202207281745-0-qemu.ppc64le.qcow2.gz",
+            "sha256": "d9afb1d8738e924247e3a1ec37ba4580422f57db1b6e4a26ea7c879241311f32",
+            "size": 983958306,
+            "uncompressed-sha256": "9d7f54c44cc7c24f7b92ee34f57263f344a459ae7bd9fc576ed15b46b6668f47",
             "uncompressed-size": 2686976000
         }
     },
     "oscontainer": {
-        "digest": "sha256:57f7af528f3d866924411735c4a64ea7b9b3763f9f1dbd45afeda9df3d020ecc",
+        "digest": "sha256:8bd237e197c3610ef8268ce73e1f96caa96b35c36807658b4de3d9aa67e3a774",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "27ccb7f5641f6f842b82889a268f9101a953d63a91b2b2a361dcabd991cd5880",
-    "ostree-version": "48.84.202206132151-0"
+    "ostree-commit": "dbe5d753ebc442538911209ba13cf23b983b916228b41f8c572f0378de3a3eb1",
+    "ostree-version": "48.84.202207281745-0"
 }

--- a/data/data/rhcos-s390x.json
+++ b/data/data/rhcos-s390x.json
@@ -1,68 +1,68 @@
 {
-    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/",
-    "buildid": "48.84.202206132149-0",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/",
+    "buildid": "48.84.202208020845-0",
     "images": {
         "dasd": {
-            "path": "rhcos-48.84.202206132149-0-dasd.s390x.raw.gz",
-            "sha256": "f4a6017cfb77db9973f8333783b941229a3592f699b8a90f80fb8ce881452e54",
-            "size": 891244845,
-            "uncompressed-sha256": "61ea55957d4a26b4cc61cc6e8d2a6599529f009e6afd061b493a2d5ba089c228",
-            "uncompressed-size": 3688890368
+            "path": "rhcos-48.84.202208020845-0-dasd.s390x.raw.gz",
+            "sha256": "3e6fa4d5282d237f4653bc7c396f820fd96374577fdcc1a27db1c7149ccfea22",
+            "size": 891416907,
+            "uncompressed-sha256": "59bba945f1a53b9676f5f880c08045f738d481c089e8e083a230eedbb8aa2ca6",
+            "uncompressed-size": 3689938944
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202206132149-0-live-initramfs.s390x.img",
-            "sha256": "630ce92d10f4636533cc2340a2e0c72442e0629dd7d097b314661065ba5bd580"
+            "path": "rhcos-48.84.202208020845-0-live-initramfs.s390x.img",
+            "sha256": "f7824203c89a0bc037c79aae7c1226debf573bd711fcf0bbef95cb4d20a6e596"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202206132149-0-live.s390x.iso",
-            "sha256": "4665d304f3757aeef8f15cde37935c1ee1473d384c23101c993d4c72e99adf94"
+            "path": "rhcos-48.84.202208020845-0-live.s390x.iso",
+            "sha256": "f1c6fd13a7fa5050fe5749d1d76392857bfa5b5047bcc3ef4f24ecbccc6fae2d"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202206132149-0-live-kernel-s390x",
-            "sha256": "de91cc8ffbd3b35c1e1f33deed6c8393ffe95b558d60b79bd34792e595397f7c"
+            "path": "rhcos-48.84.202208020845-0-live-kernel-s390x",
+            "sha256": "e00f6d3cd28868587607765edd5c70f493d795e85471a3b780ccf918706f11a2"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202206132149-0-live-rootfs.s390x.img",
-            "sha256": "6d4b51ed83d7273a7110aeccd9f848769912dc9b99b7efe07859027ad9150d84"
+            "path": "rhcos-48.84.202208020845-0-live-rootfs.s390x.img",
+            "sha256": "fa0294b18aac116052f3b2914c399707df806ae32475ce69bfb900bb776b907b"
         },
         "metal": {
-            "path": "rhcos-48.84.202206132149-0-metal.s390x.raw.gz",
-            "sha256": "302d8d724b65a68d642fefb40109e410e635f4cd2414bf7325d4e3810ff9e8c6",
-            "size": 891259390,
-            "uncompressed-sha256": "1dd9ab5dc127f9d0d22565b25b94d0e8603fb642d67f70fa6754d50ef587d6aa",
-            "uncompressed-size": 3688890368
+            "path": "rhcos-48.84.202208020845-0-metal.s390x.raw.gz",
+            "sha256": "4abf65811d834cebdcaaae06d77cfddddb05c0ab11f2cffb3e91d5752bade5b6",
+            "size": 891286685,
+            "uncompressed-sha256": "14c0d97b2ff164044d0ef5047a554c8236eff31cc3aeb83b377193b6f50e3dfb",
+            "uncompressed-size": 3689938944
         },
         "metal4k": {
-            "path": "rhcos-48.84.202206132149-0-metal4k.s390x.raw.gz",
-            "sha256": "6f3306b9b8ebeccdcb2e59d80d21ad20bdfe2d9fc9a338ba2714ed48bde03d66",
-            "size": 891519818,
-            "uncompressed-sha256": "228ba0b9fd1b0625d698d6ad7202ffb760e43b37d824d19a86b7447d3ecd94e6",
-            "uncompressed-size": 3688890368
+            "path": "rhcos-48.84.202208020845-0-metal4k.s390x.raw.gz",
+            "sha256": "2a0f091b59136e1d91214749623b3957147dad2a9c3842ccff91d951a9a7490d",
+            "size": 891433576,
+            "uncompressed-sha256": "ad8b02fe3b63fb14c14e9c04bbb95d73afd09c79ab01de2a960b1c834a7a45cf",
+            "uncompressed-size": 3689938944
         },
         "openstack": {
-            "path": "rhcos-48.84.202206132149-0-openstack.s390x.qcow2.gz",
-            "sha256": "b327ed36c1d42277a0cb1f75da420dcbb5c768aa76ed3df6f488bc08c4879c8d",
-            "size": 889679936,
-            "uncompressed-sha256": "92238a282bb9adeee4600880a2d7388ae46c99551929ce6e7756ece7b7ace5cc",
+            "path": "rhcos-48.84.202208020845-0-openstack.s390x.qcow2.gz",
+            "sha256": "abd0b7d669d24cff88f5bdc621e2b51dd36e337b2f3bd4d4acc3bb080d52b0b9",
+            "size": 889714066,
+            "uncompressed-sha256": "cfaccf0c099908e9ba4812783bc215016cd249c0985b63be9f8829880f8b2311",
             "uncompressed-size": 2303000576
         },
         "ostree": {
-            "path": "rhcos-48.84.202206132149-0-ostree.s390x.tar",
-            "sha256": "f0bf24961d1426a8232ebe5f4f06417a19b89178e9a4fcfb2116efc6323ee66f",
-            "size": 837990400
+            "path": "rhcos-48.84.202208020845-0-ostree.s390x.tar",
+            "sha256": "2df6f0878febf21297166df77c6670771d5498639585c17d1586a5fbc98a2c1b",
+            "size": 838021120
         },
         "qemu": {
-            "path": "rhcos-48.84.202206132149-0-qemu.s390x.qcow2.gz",
-            "sha256": "8c5b9d24682834c285f0c9145cbc5247d39c5455cf163e0a815f6e4c6f1825a9",
-            "size": 890797115,
-            "uncompressed-sha256": "68169b0017a651adff9ba662f2b501dc51681efcde7ac65ca1952fe8ec79b5f1",
-            "uncompressed-size": 2338848768
+            "path": "rhcos-48.84.202208020845-0-qemu.s390x.qcow2.gz",
+            "sha256": "300b4ff10cc0b52a0cea987d6496b3d232f0933635bc13daadcc05c7da94a7b9",
+            "size": 890763533,
+            "uncompressed-sha256": "a17dc9783b29b825c9c7bd0f39ff3cec590591ee4740ac9185cb0ac45437a901",
+            "uncompressed-size": 2338979840
         }
     },
     "oscontainer": {
-        "digest": "sha256:c746b90e659da4b445423d6627a3e1a3a2306f25a45c8b660a7a216f31cc9cbd",
+        "digest": "sha256:e391ffa3d7ff1b98afc92e38eae32130c36f076c1a8c53724ce68d2b41101ca4",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "fc31cb78f858f5e7cdac5dd8693bebd4ef40bce5755a4d6e3405be853772aadd",
-    "ostree-version": "48.84.202206132149-0"
+    "ostree-commit": "63483c1a736e93bc05c43194498383c1ed81dbf7a607b806af85870d5dc87cbe",
+    "ostree-version": "48.84.202208020845-0"
 }

--- a/data/data/rhcos-stream.json
+++ b/data/data/rhcos-stream.json
@@ -1,8 +1,8 @@
 {
   "stream": "rhcos-4.8",
   "metadata": {
-    "last-modified": "2022-06-15T16:36:48Z",
-    "generator": "plume cosa2stream 0.14.0+14-g5f11e7652-dirty"
+    "last-modified": "2022-08-09T10:14:47Z",
+    "generator": "plume cosa2stream 0.13.0+9-ga19a99c94"
   },
   "architectures": {
     "aarch64": {
@@ -153,72 +153,72 @@
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "48.84.202206132151-0",
+          "release": "48.84.202207281745-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-metal4k.ppc64le.raw.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-metal4k.ppc64le.raw.gz.sig",
-                "sha256": "9289afcdd91b1209c8c3201727281d2992559bd7f2d3b1177aaef759cddfcf73",
-                "uncompressed-sha256": "434a1e6dbdc2ffec338df9328fc16e555c78989b3059ed8068a1a2e2360ff255"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-metal4k.ppc64le.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-metal4k.ppc64le.raw.gz.sig",
+                "sha256": "5ef906a64dfcb72093c7a845ec8482dc6f17ed1113e81504cc44ce102b193029",
+                "uncompressed-sha256": "14f5ac9ab55c78f80638acfc3a9f5b39f3f20bc9081e1eaf1d86f81efbc6d9e2"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live.ppc64le.iso",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live.ppc64le.iso.sig",
-                "sha256": "a1a80feb7ed74179fa5058efc6ddac17ce07630fc1d1903bf6d862dee0c6cb8e"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-live.ppc64le.iso",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-live.ppc64le.iso.sig",
+                "sha256": "46219eb854635b1c86a2d5d6a3a8d28e06d31f40da4a9eb5597be8bc5b4649d7"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-kernel-ppc64le",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-kernel-ppc64le.sig",
-                "sha256": "44e70f6abe2bf6e828ce8f833323cdf44035de6f9cc041219a2ddc16036fa210"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-live-kernel-ppc64le",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-live-kernel-ppc64le.sig",
+                "sha256": "e3920af3462b5a626539215a0f0a25954b349afeaece5d186da57c276c64b189"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-initramfs.ppc64le.img",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-initramfs.ppc64le.img.sig",
-                "sha256": "8a1d182869d65eeb5e9a9245ebeec6f278c9936bf341ef202278fa9d8eed2039"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-live-initramfs.ppc64le.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-live-initramfs.ppc64le.img.sig",
+                "sha256": "3f86a482fc51fd6d28aff62e3bd777f4af41db89e9f7bf4b555b7167f62e4082"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-rootfs.ppc64le.img",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-live-rootfs.ppc64le.img.sig",
-                "sha256": "209ffd30459bec61c9cea34abf3869845f7c3343bbe40c276af8c044cc339f12"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-live-rootfs.ppc64le.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-live-rootfs.ppc64le.img.sig",
+                "sha256": "3fce5e5bb30e092d7596b2392ea57c4357f2b3d0c538298014208402c328e661"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-metal.ppc64le.raw.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-metal.ppc64le.raw.gz.sig",
-                "sha256": "a78c0d8dce939b8bd27020e5950e3e160f255886cbb21a86ae9f3535fac9209c",
-                "uncompressed-sha256": "c5ec1cb253791c79b412b1777b4e95e7dae72ebc2338226234d9343211b883cd"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-metal.ppc64le.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-metal.ppc64le.raw.gz.sig",
+                "sha256": "92b7e42e2b2bc004ab58c1c4043b58674c54d033cba3ae77bbe0537af52b58d7",
+                "uncompressed-sha256": "5313aa610639fa2c9c03ea1820e3a72fcc4fbb1b4481e5016b35d4d275c86903"
               }
             }
           }
         },
         "openstack": {
-          "release": "48.84.202206132151-0",
+          "release": "48.84.202207281745-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-openstack.ppc64le.qcow2.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-openstack.ppc64le.qcow2.gz.sig",
-                "sha256": "8f674bef48429a8d8e42ee8ec03dc2ad4137417883388c64f40b1b876bfcbcc7",
-                "uncompressed-sha256": "9fdc89ac3bdf7e9539b1bef1e59b5805ea9fd2388c9305678898245bba586a89"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-openstack.ppc64le.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-openstack.ppc64le.qcow2.gz.sig",
+                "sha256": "4cbf2dfc1798732efb325f7b12885aa84295d972f5fa4c15b9543cebcf20b7ba",
+                "uncompressed-sha256": "5c04e54adbab6624d58711d1acd721263ed3984269eb4472b675b835a4cf0f0e"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202206132151-0",
+          "release": "48.84.202207281745-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-qemu.ppc64le.qcow2.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202206132151-0/ppc64le/rhcos-48.84.202206132151-0-qemu.ppc64le.qcow2.gz.sig",
-                "sha256": "c262bb5a71b8b53dfeda1e2f0d88c8b6609d9790d486a4c603268f82b61fd323",
-                "uncompressed-sha256": "04c54cde0bcdfea17ee74d09e3afdee3bedae29df15d04fd2848ba20b2000dbf"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-qemu.ppc64le.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/rhcos-48.84.202207281745-0-qemu.ppc64le.qcow2.gz.sig",
+                "sha256": "d9afb1d8738e924247e3a1ec37ba4580422f57db1b6e4a26ea7c879241311f32",
+                "uncompressed-sha256": "9d7f54c44cc7c24f7b92ee34f57263f344a459ae7bd9fc576ed15b46b6668f47"
               }
             }
           }
@@ -229,72 +229,72 @@
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "48.84.202206132149-0",
+          "release": "48.84.202208020845-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-metal4k.s390x.raw.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-metal4k.s390x.raw.gz.sig",
-                "sha256": "6f3306b9b8ebeccdcb2e59d80d21ad20bdfe2d9fc9a338ba2714ed48bde03d66",
-                "uncompressed-sha256": "228ba0b9fd1b0625d698d6ad7202ffb760e43b37d824d19a86b7447d3ecd94e6"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-metal4k.s390x.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-metal4k.s390x.raw.gz.sig",
+                "sha256": "2a0f091b59136e1d91214749623b3957147dad2a9c3842ccff91d951a9a7490d",
+                "uncompressed-sha256": "ad8b02fe3b63fb14c14e9c04bbb95d73afd09c79ab01de2a960b1c834a7a45cf"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live.s390x.iso",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live.s390x.iso.sig",
-                "sha256": "4665d304f3757aeef8f15cde37935c1ee1473d384c23101c993d4c72e99adf94"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-live.s390x.iso",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-live.s390x.iso.sig",
+                "sha256": "f1c6fd13a7fa5050fe5749d1d76392857bfa5b5047bcc3ef4f24ecbccc6fae2d"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-kernel-s390x",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-kernel-s390x.sig",
-                "sha256": "de91cc8ffbd3b35c1e1f33deed6c8393ffe95b558d60b79bd34792e595397f7c"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-live-kernel-s390x",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-live-kernel-s390x.sig",
+                "sha256": "e00f6d3cd28868587607765edd5c70f493d795e85471a3b780ccf918706f11a2"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-initramfs.s390x.img",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-initramfs.s390x.img.sig",
-                "sha256": "630ce92d10f4636533cc2340a2e0c72442e0629dd7d097b314661065ba5bd580"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-live-initramfs.s390x.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-live-initramfs.s390x.img.sig",
+                "sha256": "f7824203c89a0bc037c79aae7c1226debf573bd711fcf0bbef95cb4d20a6e596"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-rootfs.s390x.img",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-live-rootfs.s390x.img.sig",
-                "sha256": "6d4b51ed83d7273a7110aeccd9f848769912dc9b99b7efe07859027ad9150d84"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-live-rootfs.s390x.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-live-rootfs.s390x.img.sig",
+                "sha256": "fa0294b18aac116052f3b2914c399707df806ae32475ce69bfb900bb776b907b"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-metal.s390x.raw.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-metal.s390x.raw.gz.sig",
-                "sha256": "302d8d724b65a68d642fefb40109e410e635f4cd2414bf7325d4e3810ff9e8c6",
-                "uncompressed-sha256": "1dd9ab5dc127f9d0d22565b25b94d0e8603fb642d67f70fa6754d50ef587d6aa"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-metal.s390x.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-metal.s390x.raw.gz.sig",
+                "sha256": "4abf65811d834cebdcaaae06d77cfddddb05c0ab11f2cffb3e91d5752bade5b6",
+                "uncompressed-sha256": "14c0d97b2ff164044d0ef5047a554c8236eff31cc3aeb83b377193b6f50e3dfb"
               }
             }
           }
         },
         "openstack": {
-          "release": "48.84.202206132149-0",
+          "release": "48.84.202208020845-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-openstack.s390x.qcow2.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-openstack.s390x.qcow2.gz.sig",
-                "sha256": "b327ed36c1d42277a0cb1f75da420dcbb5c768aa76ed3df6f488bc08c4879c8d",
-                "uncompressed-sha256": "92238a282bb9adeee4600880a2d7388ae46c99551929ce6e7756ece7b7ace5cc"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-openstack.s390x.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-openstack.s390x.qcow2.gz.sig",
+                "sha256": "abd0b7d669d24cff88f5bdc621e2b51dd36e337b2f3bd4d4acc3bb080d52b0b9",
+                "uncompressed-sha256": "cfaccf0c099908e9ba4812783bc215016cd249c0985b63be9f8829880f8b2311"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202206132149-0",
+          "release": "48.84.202208020845-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-qemu.s390x.qcow2.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202206132149-0/s390x/rhcos-48.84.202206132149-0-qemu.s390x.qcow2.gz.sig",
-                "sha256": "8c5b9d24682834c285f0c9145cbc5247d39c5455cf163e0a815f6e4c6f1825a9",
-                "uncompressed-sha256": "68169b0017a651adff9ba662f2b501dc51681efcde7ac65ca1952fe8ec79b5f1"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-qemu.s390x.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/rhcos-48.84.202208020845-0-qemu.s390x.qcow2.gz.sig",
+                "sha256": "300b4ff10cc0b52a0cea987d6496b3d232f0933635bc13daadcc05c7da94a7b9",
+                "uncompressed-sha256": "a17dc9783b29b825c9c7bd0f39ff3cec590591ee4740ac9185cb0ac45437a901"
               }
             }
           }
@@ -305,135 +305,135 @@
     "x86_64": {
       "artifacts": {
         "aws": {
-          "release": "48.84.202206140145-0",
+          "release": "48.84.202208021106-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-aws.x86_64.vmdk.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-aws.x86_64.vmdk.gz.sig",
-                "sha256": "c43356afc304edc5d2656095b6c4dd3052a35b0fe11adbaa4640b4f56bbc2f4c",
-                "uncompressed-sha256": "5580e5ea6d744e4e535b6416beac2c771a7e668ab86e0fe4b8395cf6eb87a343"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-aws.x86_64.vmdk.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-aws.x86_64.vmdk.gz.sig",
+                "sha256": "f44569e416014fe9c4bb186cd759f2dda061e8f3900cfb3afd63e5193bac53e1",
+                "uncompressed-sha256": "4210fdd258ccb96b6c7ea380d281fef7399d7fdffeaf767eb37f8a848e390b45"
               }
             }
           }
         },
         "azure": {
-          "release": "48.84.202206140145-0",
+          "release": "48.84.202208021106-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-azure.x86_64.vhd.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-azure.x86_64.vhd.gz.sig",
-                "sha256": "c9e355bb545baf2f34482cfc0a556b90dc89a71cf6058ed1546199fbff8a9c60",
-                "uncompressed-sha256": "333b3560bb635ce5c0f01bfa3784c8cd6ac1fa29ad85c52fbe0a773bf02b28e0"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-azure.x86_64.vhd.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-azure.x86_64.vhd.gz.sig",
+                "sha256": "4037dcf1ce5970771f4e38bdfdd8288388bac28eaef6ef4727e69823c17f5939",
+                "uncompressed-sha256": "089005e574e3c26b7057482dd0f659ed1c358d6fa33221c898b6c702b532d109"
               }
             }
           }
         },
         "gcp": {
-          "release": "48.84.202206140145-0",
+          "release": "48.84.202208021106-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-gcp.x86_64.tar.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-gcp.x86_64.tar.gz.sig",
-                "sha256": "7b732b6b3622f5ba00a4b2f3bfd32d6987a814f044daaf3831b0db0b168b81a6"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-gcp.x86_64.tar.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-gcp.x86_64.tar.gz.sig",
+                "sha256": "95df0c7b5dcadf1b728ac2b159df37dd783bde33dbc65f7ee5a0fb2ee4bc4848"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "48.84.202206140145-0",
+          "release": "48.84.202208021106-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-ibmcloud.x86_64.qcow2.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-ibmcloud.x86_64.qcow2.gz.sig",
-                "sha256": "5113a7c63abe8a89cbce07d70e93eaeb685df1f4f96b7e467736a824889373d3",
-                "uncompressed-sha256": "87e637ebab6eab1ef9c4ae1d76613b5a0701a31c78793ac325596c77bdbede21"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-ibmcloud.x86_64.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-ibmcloud.x86_64.qcow2.gz.sig",
+                "sha256": "93d44cd5959cdfe08ece80247bd24aefe723539c9f28ab5af19b2beec0941d94",
+                "uncompressed-sha256": "8df97b6f31dce4d7800c200b76cca5fea228b8aa7327fae66c2eccc6921e86d8"
               }
             }
           }
         },
         "metal": {
-          "release": "48.84.202206140145-0",
+          "release": "48.84.202208021106-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-metal4k.x86_64.raw.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-metal4k.x86_64.raw.gz.sig",
-                "sha256": "8fbf4a1b82a763e3dca32de1c5c9a2bd40382d80c576e9eac6a12c03f92c0d41",
-                "uncompressed-sha256": "3842893bf80c00a2f11b6d591284b60b6bf60bead4c3e67fb148d34843d5c9fc"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-metal4k.x86_64.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-metal4k.x86_64.raw.gz.sig",
+                "sha256": "be8c9816f16766ba64307baf9b9533b6bb94df9c17a5497985d80ffeff04beb3",
+                "uncompressed-sha256": "53d89eb804d977325bdaad819ef90660639bcd6fe8b43be0ac98aa5aedd4cb4a"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live.x86_64.iso",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live.x86_64.iso.sig",
-                "sha256": "1483da2bb1a64f6f90577036935fd5b47ad6d20758fd241981943c46cf516ff0"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-live.x86_64.iso",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-live.x86_64.iso.sig",
+                "sha256": "b3c66552252f19fa921a8059f1aa882fda6193193617c48bb14f2f353a6be917"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-kernel-x86_64",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-kernel-x86_64.sig",
-                "sha256": "2f73cda50fa9cfcd14b9624cce3fa663c91341a8eafae22bb6bbc6357f83e679"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-live-kernel-x86_64",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-live-kernel-x86_64.sig",
+                "sha256": "b00fe158fdce353bf548abf6835c37ee503c187606ede7349e4bc060f2ca69ea"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-initramfs.x86_64.img",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-initramfs.x86_64.img.sig",
-                "sha256": "1641cb2005abf362283ddc328c1ad07c8640900d296e793913b1881faecc8926"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-live-initramfs.x86_64.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-live-initramfs.x86_64.img.sig",
+                "sha256": "7c599ee03c5b9bbf733d8df6cc5527f98e531f07433c26421c30fade98ff032f"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-rootfs.x86_64.img",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-live-rootfs.x86_64.img.sig",
-                "sha256": "f0a729b85ace85e158c02a4ea69e53b5663210ffb2cb423f9899239481d9e479"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-live-rootfs.x86_64.img",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-live-rootfs.x86_64.img.sig",
+                "sha256": "0e709b2c1a658f0efeafb80b41fac4383dea3ec8818c8dfae915afe1ae2ce0e9"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-metal.x86_64.raw.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-metal.x86_64.raw.gz.sig",
-                "sha256": "c2fb42fe571bc231993889e0790c21b4643d78efaa99eab9035dab506fee2df5",
-                "uncompressed-sha256": "048eef6702941fd566ec67d51426c1fecb469ecdc94d5eae55435593b53f69a6"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-metal.x86_64.raw.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-metal.x86_64.raw.gz.sig",
+                "sha256": "ebe9ab2df406f8282587aaf42716b371bcaae691a09d7e5d0f0687979bd94f37",
+                "uncompressed-sha256": "63274ae74e8941342488ab8d94ff48d65b3c13c9ee450f866755816ebf850889"
               }
             }
           }
         },
         "openstack": {
-          "release": "48.84.202206140145-0",
+          "release": "48.84.202208021106-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-openstack.x86_64.qcow2.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-openstack.x86_64.qcow2.gz.sig",
-                "sha256": "137c3b236d2bcaa9681c968ad333b112762539c6df196a704f1cd8ba78d49f11",
-                "uncompressed-sha256": "0a147f49f35030fd8153266bb186357043fbc044c77dbaa5b46922984db0d750"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-openstack.x86_64.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-openstack.x86_64.qcow2.gz.sig",
+                "sha256": "6dbad43e2b02c5be49e55ce707a591da882e960d5338d38ee075889415b801c7",
+                "uncompressed-sha256": "7cee7c5eea1d9f500346e561d7a2d17e70b9399a3a710a2612ad450e9896c520"
               }
             }
           }
         },
         "qemu": {
-          "release": "48.84.202206140145-0",
+          "release": "48.84.202208021106-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-qemu.x86_64.qcow2.gz",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-qemu.x86_64.qcow2.gz.sig",
-                "sha256": "0120dfdcbfa70eeb804c1cd2368f140c577b12d85391d3553d189fb9b42938a1",
-                "uncompressed-sha256": "158e32571ca4934b05da0fe425eab453e6ceda3245cfc1a6cba45cbb53bf648a"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-qemu.x86_64.qcow2.gz",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-qemu.x86_64.qcow2.gz.sig",
+                "sha256": "f753b55c1ec9159e92acc891e43bebb6027af6da335776b168025282e4401baa",
+                "uncompressed-sha256": "9c8fe2df4513234901481effa078f566e02ccf456f4640dac7ffdc95315e7b40"
               }
             }
           }
         },
         "vmware": {
-          "release": "48.84.202206140145-0",
+          "release": "48.84.202208021106-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-vmware.x86_64.ova",
-                "signature": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/rhcos-48.84.202206140145-0-vmware.x86_64.ova.sig",
-                "sha256": "7fa00b31d7f28c1318c23fe466a66cced0cbacd32b8833d8af05e874d1195332"
+                "location": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-vmware.x86_64.ova",
+                "signature": "https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/rhcos-48.84.202208021106-0-vmware.x86_64.ova.sig",
+                "sha256": "cdeeb17aedeabb244cdfe310289f0b917ae781ba50363303451ffde822bd8375"
               }
             }
           }
@@ -443,105 +443,105 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0c879d0aa64259ad0"
+              "release": "48.84.202208021106-0",
+              "image": "ami-0359370d57fc93cac"
             },
             "ap-east-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0e6a2dea7bfd862a5"
+              "release": "48.84.202208021106-0",
+              "image": "ami-0c65cd97d4fbb03a0"
             },
             "ap-northeast-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0b9b3588ea302934d"
+              "release": "48.84.202208021106-0",
+              "image": "ami-015d3c7e01eb46827"
             },
             "ap-northeast-2": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-012b7f860e994e868"
+              "release": "48.84.202208021106-0",
+              "image": "ami-0e9cafc0ae9404136"
             },
             "ap-northeast-3": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0e42b5afc5baeea34"
+              "release": "48.84.202208021106-0",
+              "image": "ami-0dcd31905f42c296a"
             },
             "ap-south-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0cec0dfd6e955718d"
+              "release": "48.84.202208021106-0",
+              "image": "ami-08e9be789af110ecd"
             },
             "ap-southeast-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0980a2024cd30b5bf"
+              "release": "48.84.202208021106-0",
+              "image": "ami-07b4e3fb05ab13111"
             },
             "ap-southeast-2": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-032069c0b51483ad1"
+              "release": "48.84.202208021106-0",
+              "image": "ami-0513198dc7c3e6796"
             },
             "ap-southeast-3": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0f19ad8d973aea0ec"
+              "release": "48.84.202208021106-0",
+              "image": "ami-05cbccdb55066f2d1"
             },
             "ca-central-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0f131d428f7d39da7"
+              "release": "48.84.202208021106-0",
+              "image": "ami-04a9118f6639f8944"
             },
             "eu-central-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-089e4575a0dcafb0b"
+              "release": "48.84.202208021106-0",
+              "image": "ami-09caf0c25eb83bb58"
             },
             "eu-north-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-04a0fcdd1fee18228"
+              "release": "48.84.202208021106-0",
+              "image": "ami-03d0d41d50363a2af"
             },
             "eu-south-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-05b65f41216a7da4b"
+              "release": "48.84.202208021106-0",
+              "image": "ami-046fa2186c3255cf4"
             },
             "eu-west-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0ff5d97cd0b6cd949"
+              "release": "48.84.202208021106-0",
+              "image": "ami-0a64742ba31e13ad0"
             },
             "eu-west-2": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-06a805d9f546f670a"
+              "release": "48.84.202208021106-0",
+              "image": "ami-00153eaf1516e68fc"
             },
             "eu-west-3": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-00cca0795cfeead80"
+              "release": "48.84.202208021106-0",
+              "image": "ami-087f940ea264a5257"
             },
             "me-south-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0e8ba9d5ba5e65106"
+              "release": "48.84.202208021106-0",
+              "image": "ami-0745ce6fb6d0b78db"
             },
             "sa-east-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-041fbbc302a372a36"
+              "release": "48.84.202208021106-0",
+              "image": "ami-0a302f5de9ae4b4fd"
             },
             "us-east-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0a0091d01a8bd2947"
+              "release": "48.84.202208021106-0",
+              "image": "ami-059fea61e7f8e7516"
             },
             "us-east-2": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-0147e13e9b1975251"
+              "release": "48.84.202208021106-0",
+              "image": "ami-087db69f78b36aada"
             },
             "us-west-1": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-05662d869042ffd84"
+              "release": "48.84.202208021106-0",
+              "image": "ami-0de9f7cdeb54d2aca"
             },
             "us-west-2": {
-              "release": "48.84.202206140145-0",
-              "image": "ami-074ed14912081db41"
+              "release": "48.84.202208021106-0",
+              "image": "ami-028e920954a11c96a"
             }
           }
         },
         "gcp": {
-          "release": "48.84.202206140145-0",
+          "release": "48.84.202208021106-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-48-84-202206140145-0-gcp-x86-64"
+          "name": "rhcos-48-84-202208021106-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "48.84.202206140145-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202206140145-0-azure.x86_64.vhd"
+          "release": "48.84.202208021106-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202208021106-0-azure.x86_64.vhd"
         }
       }
     }

--- a/data/data/rhcos.json
+++ b/data/data/rhcos.json
@@ -1,169 +1,169 @@
 {
     "amis": {
         "af-south-1": {
-            "hvm": "ami-0c879d0aa64259ad0"
+            "hvm": "ami-0359370d57fc93cac"
         },
         "ap-east-1": {
-            "hvm": "ami-0e6a2dea7bfd862a5"
+            "hvm": "ami-0c65cd97d4fbb03a0"
         },
         "ap-northeast-1": {
-            "hvm": "ami-0b9b3588ea302934d"
+            "hvm": "ami-015d3c7e01eb46827"
         },
         "ap-northeast-2": {
-            "hvm": "ami-012b7f860e994e868"
+            "hvm": "ami-0e9cafc0ae9404136"
         },
         "ap-northeast-3": {
-            "hvm": "ami-0e42b5afc5baeea34"
+            "hvm": "ami-0dcd31905f42c296a"
         },
         "ap-south-1": {
-            "hvm": "ami-0cec0dfd6e955718d"
+            "hvm": "ami-08e9be789af110ecd"
         },
         "ap-southeast-1": {
-            "hvm": "ami-0980a2024cd30b5bf"
+            "hvm": "ami-07b4e3fb05ab13111"
         },
         "ap-southeast-2": {
-            "hvm": "ami-032069c0b51483ad1"
+            "hvm": "ami-0513198dc7c3e6796"
         },
         "ap-southeast-3": {
-            "hvm": "ami-0f19ad8d973aea0ec"
+            "hvm": "ami-05cbccdb55066f2d1"
         },
         "ca-central-1": {
-            "hvm": "ami-0f131d428f7d39da7"
+            "hvm": "ami-04a9118f6639f8944"
         },
         "eu-central-1": {
-            "hvm": "ami-089e4575a0dcafb0b"
+            "hvm": "ami-09caf0c25eb83bb58"
         },
         "eu-north-1": {
-            "hvm": "ami-04a0fcdd1fee18228"
+            "hvm": "ami-03d0d41d50363a2af"
         },
         "eu-south-1": {
-            "hvm": "ami-05b65f41216a7da4b"
+            "hvm": "ami-046fa2186c3255cf4"
         },
         "eu-west-1": {
-            "hvm": "ami-0ff5d97cd0b6cd949"
+            "hvm": "ami-0a64742ba31e13ad0"
         },
         "eu-west-2": {
-            "hvm": "ami-06a805d9f546f670a"
+            "hvm": "ami-00153eaf1516e68fc"
         },
         "eu-west-3": {
-            "hvm": "ami-00cca0795cfeead80"
+            "hvm": "ami-087f940ea264a5257"
         },
         "me-south-1": {
-            "hvm": "ami-0e8ba9d5ba5e65106"
+            "hvm": "ami-0745ce6fb6d0b78db"
         },
         "sa-east-1": {
-            "hvm": "ami-041fbbc302a372a36"
+            "hvm": "ami-0a302f5de9ae4b4fd"
         },
         "us-east-1": {
-            "hvm": "ami-0a0091d01a8bd2947"
+            "hvm": "ami-059fea61e7f8e7516"
         },
         "us-east-2": {
-            "hvm": "ami-0147e13e9b1975251"
+            "hvm": "ami-087db69f78b36aada"
         },
         "us-west-1": {
-            "hvm": "ami-05662d869042ffd84"
+            "hvm": "ami-0de9f7cdeb54d2aca"
         },
         "us-west-2": {
-            "hvm": "ami-074ed14912081db41"
+            "hvm": "ami-028e920954a11c96a"
         }
     },
     "azure": {
-        "image": "rhcos-48.84.202206140145-0-azure.x86_64.vhd",
-        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202206140145-0-azure.x86_64.vhd"
+        "image": "rhcos-48.84.202208021106-0-azure.x86_64.vhd",
+        "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-48.84.202208021106-0-azure.x86_64.vhd"
     },
-    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202206140145-0/x86_64/",
-    "buildid": "48.84.202206140145-0",
+    "baseURI": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/",
+    "buildid": "48.84.202208021106-0",
     "gcp": {
-        "image": "rhcos-48-84-202206140145-0-gcp-x86-64",
+        "image": "rhcos-48-84-202208021106-0-gcp-x86-64",
         "project": "rhcos-cloud",
-        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202206140145-0-gcp-x86-64.tar.gz"
+        "url": "https://storage.googleapis.com/rhcos/rhcos/rhcos-48-84-202208021106-0-gcp-x86-64.tar.gz"
     },
     "images": {
         "aws": {
-            "path": "rhcos-48.84.202206140145-0-aws.x86_64.vmdk.gz",
-            "sha256": "c43356afc304edc5d2656095b6c4dd3052a35b0fe11adbaa4640b4f56bbc2f4c",
-            "size": 1030828645,
-            "uncompressed-sha256": "5580e5ea6d744e4e535b6416beac2c771a7e668ab86e0fe4b8395cf6eb87a343",
-            "uncompressed-size": 1051906048
+            "path": "rhcos-48.84.202208021106-0-aws.x86_64.vmdk.gz",
+            "sha256": "f44569e416014fe9c4bb186cd759f2dda061e8f3900cfb3afd63e5193bac53e1",
+            "size": 1030696766,
+            "uncompressed-sha256": "4210fdd258ccb96b6c7ea380d281fef7399d7fdffeaf767eb37f8a848e390b45",
+            "uncompressed-size": 1051742208
         },
         "azure": {
-            "path": "rhcos-48.84.202206140145-0-azure.x86_64.vhd.gz",
-            "sha256": "c9e355bb545baf2f34482cfc0a556b90dc89a71cf6058ed1546199fbff8a9c60",
-            "size": 1030940095,
-            "uncompressed-sha256": "333b3560bb635ce5c0f01bfa3784c8cd6ac1fa29ad85c52fbe0a773bf02b28e0",
+            "path": "rhcos-48.84.202208021106-0-azure.x86_64.vhd.gz",
+            "sha256": "4037dcf1ce5970771f4e38bdfdd8288388bac28eaef6ef4727e69823c17f5939",
+            "size": 1030800051,
+            "uncompressed-sha256": "089005e574e3c26b7057482dd0f659ed1c358d6fa33221c898b6c702b532d109",
             "uncompressed-size": 17179869696
         },
         "gcp": {
-            "path": "rhcos-48.84.202206140145-0-gcp.x86_64.tar.gz",
-            "sha256": "7b732b6b3622f5ba00a4b2f3bfd32d6987a814f044daaf3831b0db0b168b81a6",
-            "size": 1016382695
+            "path": "rhcos-48.84.202208021106-0-gcp.x86_64.tar.gz",
+            "sha256": "95df0c7b5dcadf1b728ac2b159df37dd783bde33dbc65f7ee5a0fb2ee4bc4848",
+            "size": 1016284548
         },
         "ibmcloud": {
-            "path": "rhcos-48.84.202206140145-0-ibmcloud.x86_64.qcow2.gz",
-            "sha256": "5113a7c63abe8a89cbce07d70e93eaeb685df1f4f96b7e467736a824889373d3",
-            "size": 1016732179,
-            "uncompressed-sha256": "87e637ebab6eab1ef9c4ae1d76613b5a0701a31c78793ac325596c77bdbede21",
-            "uncompressed-size": 2534473728
+            "path": "rhcos-48.84.202208021106-0-ibmcloud.x86_64.qcow2.gz",
+            "sha256": "93d44cd5959cdfe08ece80247bd24aefe723539c9f28ab5af19b2beec0941d94",
+            "size": 1016616403,
+            "uncompressed-sha256": "8df97b6f31dce4d7800c200b76cca5fea228b8aa7327fae66c2eccc6921e86d8",
+            "uncompressed-size": 2534539264
         },
         "live-initramfs": {
-            "path": "rhcos-48.84.202206140145-0-live-initramfs.x86_64.img",
-            "sha256": "1641cb2005abf362283ddc328c1ad07c8640900d296e793913b1881faecc8926"
+            "path": "rhcos-48.84.202208021106-0-live-initramfs.x86_64.img",
+            "sha256": "7c599ee03c5b9bbf733d8df6cc5527f98e531f07433c26421c30fade98ff032f"
         },
         "live-iso": {
-            "path": "rhcos-48.84.202206140145-0-live.x86_64.iso",
-            "sha256": "1483da2bb1a64f6f90577036935fd5b47ad6d20758fd241981943c46cf516ff0"
+            "path": "rhcos-48.84.202208021106-0-live.x86_64.iso",
+            "sha256": "b3c66552252f19fa921a8059f1aa882fda6193193617c48bb14f2f353a6be917"
         },
         "live-kernel": {
-            "path": "rhcos-48.84.202206140145-0-live-kernel-x86_64",
-            "sha256": "2f73cda50fa9cfcd14b9624cce3fa663c91341a8eafae22bb6bbc6357f83e679"
+            "path": "rhcos-48.84.202208021106-0-live-kernel-x86_64",
+            "sha256": "b00fe158fdce353bf548abf6835c37ee503c187606ede7349e4bc060f2ca69ea"
         },
         "live-rootfs": {
-            "path": "rhcos-48.84.202206140145-0-live-rootfs.x86_64.img",
-            "sha256": "f0a729b85ace85e158c02a4ea69e53b5663210ffb2cb423f9899239481d9e479"
+            "path": "rhcos-48.84.202208021106-0-live-rootfs.x86_64.img",
+            "sha256": "0e709b2c1a658f0efeafb80b41fac4383dea3ec8818c8dfae915afe1ae2ce0e9"
         },
         "metal": {
-            "path": "rhcos-48.84.202206140145-0-metal.x86_64.raw.gz",
-            "sha256": "c2fb42fe571bc231993889e0790c21b4643d78efaa99eab9035dab506fee2df5",
-            "size": 1018203635,
-            "uncompressed-sha256": "048eef6702941fd566ec67d51426c1fecb469ecdc94d5eae55435593b53f69a6",
-            "uncompressed-size": 3957325824
+            "path": "rhcos-48.84.202208021106-0-metal.x86_64.raw.gz",
+            "sha256": "ebe9ab2df406f8282587aaf42716b371bcaae691a09d7e5d0f0687979bd94f37",
+            "size": 1018342666,
+            "uncompressed-sha256": "63274ae74e8941342488ab8d94ff48d65b3c13c9ee450f866755816ebf850889",
+            "uncompressed-size": 3959422976
         },
         "metal4k": {
-            "path": "rhcos-48.84.202206140145-0-metal4k.x86_64.raw.gz",
-            "sha256": "8fbf4a1b82a763e3dca32de1c5c9a2bd40382d80c576e9eac6a12c03f92c0d41",
-            "size": 1015886091,
-            "uncompressed-sha256": "3842893bf80c00a2f11b6d591284b60b6bf60bead4c3e67fb148d34843d5c9fc",
-            "uncompressed-size": 3957325824
+            "path": "rhcos-48.84.202208021106-0-metal4k.x86_64.raw.gz",
+            "sha256": "be8c9816f16766ba64307baf9b9533b6bb94df9c17a5497985d80ffeff04beb3",
+            "size": 1015775989,
+            "uncompressed-sha256": "53d89eb804d977325bdaad819ef90660639bcd6fe8b43be0ac98aa5aedd4cb4a",
+            "uncompressed-size": 3959422976
         },
         "openstack": {
-            "path": "rhcos-48.84.202206140145-0-openstack.x86_64.qcow2.gz",
-            "sha256": "137c3b236d2bcaa9681c968ad333b112762539c6df196a704f1cd8ba78d49f11",
-            "size": 1016727289,
-            "uncompressed-sha256": "0a147f49f35030fd8153266bb186357043fbc044c77dbaa5b46922984db0d750",
-            "uncompressed-size": 2534473728
+            "path": "rhcos-48.84.202208021106-0-openstack.x86_64.qcow2.gz",
+            "sha256": "6dbad43e2b02c5be49e55ce707a591da882e960d5338d38ee075889415b801c7",
+            "size": 1016616276,
+            "uncompressed-sha256": "7cee7c5eea1d9f500346e561d7a2d17e70b9399a3a710a2612ad450e9896c520",
+            "uncompressed-size": 2534539264
         },
         "ostree": {
-            "path": "rhcos-48.84.202206140145-0-ostree.x86_64.tar",
-            "sha256": "3438b2c53b1078b4e288ad2869fb7ce839f466ae564f0c807ba22ad74d246048",
-            "size": 940503040
+            "path": "rhcos-48.84.202208021106-0-ostree.x86_64.tar",
+            "sha256": "dac901df48a0c9d62cb14474301688df937bd51289cac09c9c455950987b4484",
+            "size": 940564480
         },
         "qemu": {
-            "path": "rhcos-48.84.202206140145-0-qemu.x86_64.qcow2.gz",
-            "sha256": "0120dfdcbfa70eeb804c1cd2368f140c577b12d85391d3553d189fb9b42938a1",
-            "size": 1017896853,
-            "uncompressed-sha256": "158e32571ca4934b05da0fe425eab453e6ceda3245cfc1a6cba45cbb53bf648a",
-            "uncompressed-size": 2571108352
+            "path": "rhcos-48.84.202208021106-0-qemu.x86_64.qcow2.gz",
+            "sha256": "f753b55c1ec9159e92acc891e43bebb6027af6da335776b168025282e4401baa",
+            "size": 1017794262,
+            "uncompressed-sha256": "9c8fe2df4513234901481effa078f566e02ccf456f4640dac7ffdc95315e7b40",
+            "uncompressed-size": 2571173888
         },
         "vmware": {
-            "path": "rhcos-48.84.202206140145-0-vmware.x86_64.ova",
-            "sha256": "7fa00b31d7f28c1318c23fe466a66cced0cbacd32b8833d8af05e874d1195332",
-            "size": 1051914240
+            "path": "rhcos-48.84.202208021106-0-vmware.x86_64.ova",
+            "sha256": "cdeeb17aedeabb244cdfe310289f0b917ae781ba50363303451ffde822bd8375",
+            "size": 1051750400
         }
     },
     "oscontainer": {
-        "digest": "sha256:648258313a495364dcd7663fa36e2d371fe4c78349d14b883fb5f4a301c824a5",
+        "digest": "sha256:276c5255ba29d40590ce7197a0a75741330d937901a30573268f7b7a1b1b0074",
         "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
     },
-    "ostree-commit": "8fd19b78118cf1ba87bbb38adad80a5f8e74630c969d8c7d908e412ce4fb0e47",
-    "ostree-version": "48.84.202206140145-0"
+    "ostree-commit": "2478234e33a6e6564b39ca4f21cec61398a16a16b31a61b3dbb65de2a0df6ce4",
+    "ostree-version": "48.84.202208021106-0"
 }


### PR DESCRIPTION
These changes will update the RHCOS 4.8 boot image metadata in the installer which includes fixing the following BZ:

BZ 2059307 [tracker] HPE Synergy 480 Gen10 Plus servers fail to boot control plane nodes with kernel panic

Changes generated with:
```
$ plume cosa2stream --target=data/data/rhcos-stream.json --distro=rhcos x86_64=48.84.202208021106-0 s390x=48.84.202208020845-0 ppc64le=48.84.202207281745-0

$ hack/update-rhcos-bootimage.py https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8/48.84.202208021106-0/x86_64/meta.json amd64

$ hack/update-rhcos-bootimage.py https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-ppc64le/48.84.202207281745-0/ppc64le/meta.json ppc64le

$ hack/update-rhcos-bootimage.py https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.8-s390x/48.84.202208020845-0/s390x/meta.json s390x
```