### PR TITLE
Remove assisted-ui service from list of agentEnabledServices

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -63,7 +63,6 @@ var (
 		"agent.service",
 		"assisted-service-db.service",
 		"assisted-service-pod.service",
-		"assisted-service-ui.service",
 		"assisted-service.service",
 		"create-cluster-and-infraenv.service",
 		"node-zero.service",


### PR DESCRIPTION
Although this service is no longer started or a dependency it should be removed from this list.