### PR TITLE
tls: only report error if one happened

### DIFF
--- a/pkg/asset/tls/utils.go
+++ b/pkg/asset/tls/utils.go
@@ -46,8 +46,8 @@ func CSRToPem(cert *x509.CertificateRequest) []byte {
 // PublicKeyToPem converts an rsa.PublicKey object to pem string
 func PublicKeyToPem(key *rsa.PublicKey) ([]byte, error) {
 	keyInBytes, err := x509.MarshalPKIXPublicKey(key)
-	logrus.Debugf("Failed to marshal PKIX public key: %s", err)
 	if err != nil {
+		logrus.Debugf("Failed to marshal PKIX public key: %s", err)
 		return nil, errors.Wrap(err, "failed to MarshalPKIXPublicKey")
 	}
 	keyinPem := pem.EncodeToMemory(


### PR DESCRIPTION
Otherwise we'll see the red herring message

time="2022-08-02T14:15:46-04:00" level=debug msg="Failed to marshal PKIX public key: %!s(<nil>)"