### PR TITLE
GCP: Added user specified tags on control plane instances

### DIFF
--- a/data/data/gcp/cluster/main.tf
+++ b/data/data/gcp/cluster/main.tf
@@ -36,6 +36,7 @@ module "master" {
   root_volume_type         = var.gcp_master_root_volume_type
   root_volume_kms_key_link = var.gcp_root_volume_kms_key_link
 
+  tags   = var.gcp_control_plane_tags
   labels = local.labels
 }
 

--- a/data/data/gcp/cluster/master/main.tf
+++ b/data/data/gcp/cluster/master/main.tf
@@ -63,7 +63,10 @@ resource "google_compute_instance" "master" {
     user-data = var.ignition
   }
 
-  tags = ["${var.cluster_id}-master"]
+  tags = concat(
+    ["${var.cluster_id}-master"],
+    var.tags,
+  )
 
   labels = var.labels
 

--- a/data/data/gcp/cluster/master/variables.tf
+++ b/data/data/gcp/cluster/master/variables.tf
@@ -39,6 +39,11 @@ variable "subnet" {
   description = "The subnetwork the master instances will be added to."
 }
 
+variable "tags" {
+  type        = list(string)
+  description = "The list of network tags which will be added to the control plane instances."
+}
+
 variable "root_volume_size" {
   type        = string
   description = "The size of the volume in gigabytes for the root block device."

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -120,3 +120,10 @@ variable "gcp_root_volume_kms_key_link" {
   description = "The GCP self link of KMS key to encrypt the volume."
   default = null
 }
+
+variable "gcp_control_plane_tags" {
+  type = list(string)
+  description = "The list of network tags which will be added to the control plane instances."
+
+}
+

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -38,6 +38,7 @@ type config struct {
 	ClusterNetwork          string   `json:"gcp_cluster_network,omitempty"`
 	ControlPlaneSubnet      string   `json:"gcp_control_plane_subnet,omitempty"`
 	ComputeSubnet           string   `json:"gcp_compute_subnet,omitempty"`
+	ControlPlaneTags        []string `json:"gcp_control_plane_tags,omitempty"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -78,6 +79,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ControlPlaneSubnet:      masterConfig.NetworkInterfaces[0].Subnetwork,
 		ComputeSubnet:           workerConfig.NetworkInterfaces[0].Subnetwork,
 		PreexistingNetwork:      sources.PreexistingNetwork,
+		ControlPlaneTags:        masterConfig.Tags,
 	}
 	cfg.PreexistingImage = true
 	if len(sources.ImageLicenses) > 0 {


### PR DESCRIPTION
This is the second step to enabling an IPI cluster using Shared VPC where the service account does not have sufficient permissions to create firewall rules in the Host Project while maintaining cluster-specific firewall rules.