### PR TITLE
Bug 2114977: Populate staticNetworkConfig in NMStateConfig.Generate

### DIFF
--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -70,6 +70,7 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 	agentConfig := &agentconfig.AgentConfig{}
 	dependencies.Get(agentConfig)
 
+	staticNetworkConfig := []*models.HostStaticNetworkConfig{}
 	nmStateConfigs := []*aiv1beta1.NMStateConfig{}
 	var data string
 
@@ -101,6 +102,11 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 			}
 			nmStateConfigs = append(nmStateConfigs, &nmStateConfig)
 
+			staticNetworkConfig = append(staticNetworkConfig, &models.HostStaticNetworkConfig{
+				MacInterfaceMap: buildMacInterfaceMap(nmStateConfig),
+				NetworkYaml:     string(nmStateConfig.Spec.NetConfig.Raw),
+			})
+
 			// Marshal the nmStateConfig one at a time
 			// and add a yaml seperator with new line
 			// so as not to marshal the nmStateConfigs
@@ -114,6 +120,7 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 		}
 
 		n.Config = nmStateConfigs
+		n.StaticNetworkConfig = staticNetworkConfig
 
 		n.File = &asset.File{
 			Filename: nmStateConfigFilename,

--- a/pkg/asset/agent/manifests/nmstateconfig_test.go
+++ b/pkg/asset/agent/manifests/nmstateconfig_test.go
@@ -142,6 +142,8 @@ func TestNMStateConfig_Generate(t *testing.T) {
 					assert.Equal(t, tc.expectedConfig[i], yamlList[i])
 
 				}
+
+				assert.Equal(t, len(tc.expectedConfig), len(asset.StaticNetworkConfig))
 			}
 		})
 	}


### PR DESCRIPTION
The NMStateConfig.Generate was not populating the staticNetworkConfig
when the asset was being generated from the AgentConfig.

Because the staticNetworkConfig is missing, the Ignition asset does
does not add the /usr/local/bin/pre-network-manager-config.sh script
to the ignition config.

This causes the pre-network-manager-config.service to fail on
node0.