### PR TITLE
bug 2055247: pkg/asset/installconfig/azure: standardDDv5Family is not currently supported

### DIFF
--- a/pkg/asset/installconfig/azure/client.go
+++ b/pkg/asset/installconfig/azure/client.go
@@ -26,6 +26,7 @@ type API interface {
 	ListLocations(ctx context.Context) (*[]azsubs.Location, error)
 	GetResourcesProvider(ctx context.Context, resourceProviderNamespace string) (*azres.Provider, error)
 	GetVirtualMachineSku(ctx context.Context, name, region string) (*azsku.ResourceSku, error)
+	GetVirtualMachineFamily(ctx context.Context, name, region string) (string, error)
 	GetDiskSkus(ctx context.Context, region string) ([]azsku.ResourceSku, error)
 	GetGroup(ctx context.Context, groupName string) (*azres.Group, error)
 	ListResourceIDsByGroup(ctx context.Context, groupName string) ([]string, error)
@@ -276,6 +277,22 @@ func (c *Client) GetDiskEncryptionSet(ctx context.Context, subscriptionID, group
 	return &diskEncryptionSet, nil
 }
 
+// GetVirtualMachineFamily retrieves the VM family of an instance type.
+func (c *Client) GetVirtualMachineFamily(ctx context.Context, name, region string) (string, error) {
+	typeMeta, err := c.GetVirtualMachineSku(ctx, name, region)
+	if err != nil {
+		return "", fmt.Errorf("error connecting to Azure client: %v", err)
+	}
+	if typeMeta == nil {
+		return "", fmt.Errorf("not found in region %s", region)
+	}
+	if typeMeta.Family == nil {
+		return "", fmt.Errorf("error getting resource family")
+	}
+
+	return to.String(typeMeta.Family), nil
+}
+
 // GetVMCapabilities retrieves the capabilities of an instant type in a specific region. Returns these values
 // in a map with the capability name as the key and the corresponding value.
 func (c *Client) GetVMCapabilities(ctx context.Context, instanceType, region string) (map[string]string, error) {
@@ -286,11 +303,11 @@ func (c *Client) GetVMCapabilities(ctx context.Context, instanceType, region str
 	if typeMeta == nil {
 		return nil, fmt.Errorf("not found in region %s", region)
 	}
-
 	capabilities := make(map[string]string)
 	for _, capability := range *typeMeta.Capabilities {
 		capabilities[to.String(capability.Name)] = to.String(capability.Value)
 	}
+
 	return capabilities, nil
 }
 

--- a/pkg/asset/installconfig/azure/mock/azureclient_generated.go
+++ b/pkg/asset/installconfig/azure/mock/azureclient_generated.go
@@ -234,6 +234,21 @@ func (mr *MockAPIMockRecorder) GetVMCapabilities(ctx, instanceType, region inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMCapabilities", reflect.TypeOf((*MockAPI)(nil).GetVMCapabilities), ctx, instanceType, region)
 }
 
+// GetVirtualMachineFamily mocks base method.
+func (m *MockAPI) GetVirtualMachineFamily(ctx context.Context, name, region string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVirtualMachineFamily", ctx, name, region)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVirtualMachineFamily indicates an expected call of GetVirtualMachineFamily.
+func (mr *MockAPIMockRecorder) GetVirtualMachineFamily(ctx, name, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualMachineFamily", reflect.TypeOf((*MockAPI)(nil).GetVirtualMachineFamily), ctx, name, region)
+}
+
 // GetVirtualMachineSku mocks base method.
 func (m *MockAPI) GetVirtualMachineSku(ctx context.Context, name, region string) (*compute.ResourceSku, error) {
 	m.ctrl.T.Helper()

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -504,6 +504,8 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 
 	azureClient.EXPECT().GetAvailabilityZones(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"1", "2", "3"}, nil).AnyTimes()
 
+	azureClient.EXPECT().GetVirtualMachineFamily(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			editedInstallConfig := validInstallConfig()
@@ -980,6 +982,8 @@ func TestAzureUltraSSDCapability(t *testing.T) {
 	}
 	// ResourceProvider
 	azureClient.EXPECT().GetResourcesProvider(gomock.Any(), validResourceGroupNamespace).Return(resourcesProviderAPIResult, nil).AnyTimes()
+
+	azureClient.EXPECT().GetVirtualMachineFamily(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION

Validate that the the VM family is not standardDDv5Family. This family of
confidential machines will be supported in a future release.

https://bugzilla.redhat.com/show_bug.cgi?id=2055247