### PR TITLE
Bug 2028474: oVirt: Removed cluster name length limitation

### DIFF
--- a/pkg/asset/installconfig/clustername.go
+++ b/pkg/asset/installconfig/clustername.go
@@ -43,9 +43,8 @@ func (a *clusterName) Generate(parents asset.Parents) error {
 	}
 
 	if platform.Ovirt != nil {
-		// FIX-ME: As soon bz#1915122 get resolved remove the limitation of 14 chars for the clustername
 		validator = survey.ComposeValidators(validator, func(ans interface{}) error {
-			return validate.ClusterNameMaxLength(ans.(string), 14)
+			return validate.ClusterName(ans.(string))
 		})
 	}
 	if platform.VSphere != nil || platform.BareMetal != nil || platform.Nutanix != nil {

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -88,10 +88,6 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 	if c.Platform.GCP != nil || c.Platform.Azure != nil {
 		nameErr = validate.ClusterName1035(c.ObjectMeta.Name)
 	}
-	if c.Platform.Ovirt != nil {
-		// FIX-ME: As soon bz#1915122 get resolved remove the limitation of 14 chars for the clustername
-		nameErr = validate.ClusterNameMaxLength(c.ObjectMeta.Name, 14)
-	}
 	if c.Platform.VSphere != nil || c.Platform.BareMetal != nil || c.Platform.Nutanix != nil {
 		nameErr = validate.OnPremClusterName(c.ObjectMeta.Name)
 	}


### PR DESCRIPTION
This PR fixes [OCPBUGSM-37760](https://issues.redhat.com/browse/OCPBUGSM-37760) (or [BZ 2028474](https://bugzilla.redhat.com/show_bug.cgi?id=2028474)) by removing the checks for the cluster name length on oVirt platform. 