### PR TITLE
gcp: Add validation for Network Project Data

### DIFF
--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -6,14 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/gcp"
 )
 
 func TestValidatePlatform(t *testing.T) {
 	cases := []struct {
-		name     string
-		platform *gcp.Platform
-		valid    bool
+		name            string
+		platform        *gcp.Platform
+		credentialsMode types.CredentialsMode
+		valid           bool
 	}{
 		{
 			name: "minimal",
@@ -88,10 +90,83 @@ func TestValidatePlatform(t *testing.T) {
 			},
 			valid: true,
 		},
+		{
+			name: "GCP valid network project data",
+			platform: &gcp.Platform{
+				Region:             "us-east1",
+				NetworkProjectID:   "valid-network-project",
+				ProjectID:          "valid-project",
+				Network:            "valid-vpc",
+				ComputeSubnet:      "valid-compute-subnet",
+				ControlPlaneSubnet: "valid-cp-subnet",
+			},
+			credentialsMode: types.PassthroughCredentialsMode,
+			valid:           true,
+		},
+		{
+			name: "GCP invalid network project missing network",
+			platform: &gcp.Platform{
+				Region:             "us-east1",
+				NetworkProjectID:   "valid-network-project",
+				ProjectID:          "valid-project",
+				ComputeSubnet:      "valid-compute-subnet",
+				ControlPlaneSubnet: "valid-cp-subnet",
+			},
+			credentialsMode: types.PassthroughCredentialsMode,
+			valid:           false,
+		},
+		{
+			name: "GCP invalid network project missing compute subnet",
+			platform: &gcp.Platform{
+				Region:             "us-east1",
+				NetworkProjectID:   "valid-network-project",
+				ProjectID:          "valid-project",
+				Network:            "valid-vpc",
+				ControlPlaneSubnet: "valid-cp-subnet",
+			},
+			credentialsMode: types.PassthroughCredentialsMode,
+			valid:           false,
+		},
+		{
+			name: "GCP invalid network project missing control plane subnet",
+			platform: &gcp.Platform{
+				Region:           "us-east1",
+				NetworkProjectID: "valid-network-project",
+				ProjectID:        "valid-project",
+				Network:          "valid-vpc",
+				ComputeSubnet:    "valid-compute-subnet",
+			},
+			credentialsMode: types.PassthroughCredentialsMode,
+			valid:           false,
+		},
+		{
+			name: "GCP invalid network project bad credentials mode",
+			platform: &gcp.Platform{
+				Region:             "us-east1",
+				NetworkProjectID:   "valid-network-project",
+				ProjectID:          "valid-project",
+				Network:            "valid-vpc",
+				ComputeSubnet:      "valid-compute-subnet",
+				ControlPlaneSubnet: "valid-cp-subnet",
+			},
+			credentialsMode: types.MintCredentialsMode,
+			valid:           false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidatePlatform(tc.platform, field.NewPath("test-path")).ToAggregate()
+
+			credentialsMode := tc.credentialsMode
+			if credentialsMode == "" {
+				credentialsMode = types.MintCredentialsMode
+			}
+
+			// the only item currently used is the credentialsMode
+			ic := types.InstallConfig{
+				CredentialsMode: credentialsMode,
+			}
+
+			err := ValidatePlatform(tc.platform, field.NewPath("test-path"), &ic).ToAggregate()
 			if tc.valid {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -489,7 +489,7 @@ func validatePlatform(platform *types.Platform, fldPath *field.Path, network *ty
 		})
 	}
 	if platform.GCP != nil {
-		validate(gcp.Name, platform.GCP, func(f *field.Path) field.ErrorList { return gcpvalidation.ValidatePlatform(platform.GCP, f) })
+		validate(gcp.Name, platform.GCP, func(f *field.Path) field.ErrorList { return gcpvalidation.ValidatePlatform(platform.GCP, f, c) })
 	}
 	if platform.IBMCloud != nil {
 		validate(ibmcloud.Name, platform.IBMCloud, func(f *field.Path) field.ErrorList { return ibmcloudvalidation.ValidatePlatform(platform.IBMCloud, f) })


### PR DESCRIPTION
** Added checks in types to ensure that network, computeSubnet, and controlPlaneSubnet
are set when NetworkProjectID exists.
** Added checks in installconfig to ensure that CredentialsMode is set to either Passthrough or
Manual when NetworkProjectID exists.
    
[CORS-2048](https://issues.redhat.com//browse/CORS-2048)
Requires #6166