### PR TITLE
Power VS: Add Montreal as a supported region

### DIFF
--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -38,6 +38,11 @@ var Regions = map[string]Region{
 			"lon06",
 		},
 	},
+	"mon": {
+		Description: "Montreal, Canada",
+		VPCRegion:   "ca-tor",
+		Zones:       []string{"mon01"},
+	},
 	"osa": {
 		Description: "Osaka, Japan",
 		VPCRegion:   "jp-osa",


### PR DESCRIPTION
Montreal was excluded initilally because it lacked an associated IBM Cloud region. We can instead map it to Toronto.