### PR TITLE
Bug 2115790: bump RHCOS 4.12 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.11",
   "metadata": {
-    "last-modified": "2022-07-17T01:52:17Z",
-    "generator": "plume cosa2stream 0.14.0+129-g80da54553-dirty"
+    "last-modified": "2022-08-10T14:54:27Z",
+    "generator": "plume cosa2stream 0.13.0+9-ga19a99c94"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "412.86.202207160442-0",
+          "release": "412.86.202208101040-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-aws.aarch64.vmdk.gz",
-                "sha256": "504992b8fefc2d756ffb0efa4c2f2d77ce2981b6eebf0a77099766249cc8d7fa",
-                "uncompressed-sha256": "10b51f7da9673d7aa4ede28cb9b37ab5a144c0ffeb383ec6f1a499fc822f5565"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-aws.aarch64.vmdk.gz",
+                "sha256": "1ee0c83cd97d3c2ebbaebc6e3bb80211da1aaddc81fe03a07ab979e8904970d4",
+                "uncompressed-sha256": "93726dad30ca9839197be0daa12b60f67901d6ed1590a2958d32c3ddaee29624"
               }
             }
           }
         },
         "azure": {
-          "release": "412.86.202207160442-0",
+          "release": "412.86.202208101040-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-azure.aarch64.vhd.gz",
-                "sha256": "9bc00cbda48bdf464bd559f046f497a785d2ff1d0d50df15ac9930e69b5d967e",
-                "uncompressed-sha256": "b741facc26fed2a2e71dcabf46ced199f2e6cd44502f75465d370aeaf1a74f01"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-azure.aarch64.vhd.gz",
+                "sha256": "68cc42523e2dbbf469bfb9b554e9e0ace3352efb42f13cb557fa9d5f516f52ab",
+                "uncompressed-sha256": "832ed0ec85816d83479f1c57c632d3e4d85462543fd20fbe0a9143d869980d30"
               }
             }
           }
         },
         "metal": {
-          "release": "412.86.202207160442-0",
+          "release": "412.86.202208101040-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-metal4k.aarch64.raw.gz",
-                "sha256": "738221ee2e34c004e902ec54a1646b41074f6b02cc7bacfebccf5e935c4c20c4",
-                "uncompressed-sha256": "b5d604e8b6e811c5317a9f60c3eb66ede77fdab4ea1dfab52516c54348cf2fc0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-metal4k.aarch64.raw.gz",
+                "sha256": "7e1b504d3a5700fee90e476ad4503de71735ff786362c4b0bcf2a373d4ce204a",
+                "uncompressed-sha256": "34fd418a99e2daaa3adc76c988bbf24338fb82ee9e5b28b0e577b069a1743fb4"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-live.aarch64.iso",
-                "sha256": "82257aeb0af837e20fa5c125c62e69486cc8947719c412b5fcbdf377eb2aa68c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-live.aarch64.iso",
+                "sha256": "6b9675d4840f970efe1055dd9a4e03fcefeba8a54b08a9952075a41cc30e3260"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-live-kernel-aarch64",
-                "sha256": "eaf770aec132b748c0a5a9e1363949e85f71b796a12bf082a086120c6b1d3a5e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-live-kernel-aarch64",
+                "sha256": "e34756ed1eb76bf23994b5b65e32a57170b3af2cda55c868633a6e5efb3d1b3d"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-live-initramfs.aarch64.img",
-                "sha256": "7d64edc973a43a7df7e415f8fd357b6bacb076c4aea555bcee395fbb335041e9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-live-initramfs.aarch64.img",
+                "sha256": "af8adcf588516ae06d4c4dc462df0260683eac1df3d2f66ad634e541f3f7bf26"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-live-rootfs.aarch64.img",
-                "sha256": "4a62658769c3d6026443469beb1b64c67af1ff6c926064942b275216f8a09229"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-live-rootfs.aarch64.img",
+                "sha256": "9f04a5eac80c63d225c7e0395dcc2d1deb74fa23d8cb3a9e710c9756808bd955"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-metal.aarch64.raw.gz",
-                "sha256": "e06c00602fe4c8f61121f6b83505589a3ca8869af0310e440be8411f46d7424f",
-                "uncompressed-sha256": "062cca494138863f13820cab27919249efa381519aedd57ff1131ac2db1ef303"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-metal.aarch64.raw.gz",
+                "sha256": "3c3a4aa9173390a4492aaf1a095248f249cd2293843032219913bbeeeb1ec934",
+                "uncompressed-sha256": "d0d523336c980e0251986f71bdfb10fe3423659021942e44b8ce61c1ed0a3fd0"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202207160442-0",
+          "release": "412.86.202208101040-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-openstack.aarch64.qcow2.gz",
-                "sha256": "7c03b8662b9ce03343dc16dc3c4d0829d71753bf958e281f9c3e3f98f2dffbdb",
-                "uncompressed-sha256": "262e88bb80aed165317872a691ca77c47ac3ccb5e01e89099b144e460cc1a1e7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-openstack.aarch64.qcow2.gz",
+                "sha256": "413c33096a6226bbe82bef84becbc8088efbe7cfc68b0419879fc857c6c68c4e",
+                "uncompressed-sha256": "894ec8559000972d6d61e516379db3f407f1c8a66a09c92621b877967c23c324"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202207160442-0",
+          "release": "412.86.202208101040-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202207160442-0/aarch64/rhcos-412.86.202207160442-0-qemu.aarch64.qcow2.gz",
-                "sha256": "26cb1bb9263cdcb136dc3a9bbbc7ea1a93121fe6ba4ac9b5a802474c4c8c878f",
-                "uncompressed-sha256": "cee2815ba075fe39f7859044b34e644a0f031f4d49fc3d353c930ac42ea633e0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-aarch64/412.86.202208101040-0/aarch64/rhcos-412.86.202208101040-0-qemu.aarch64.qcow2.gz",
+                "sha256": "7070c53f2da263f935cd4dd51553f065eda282c038125792185d2217bafd600f",
+                "uncompressed-sha256": "13356d15256c5e538cbf8d613a7345d6af495d639f1d77d07bdaa0e455ecbc67"
               }
             }
           }
@@ -99,164 +99,164 @@
         "aws": {
           "regions": {
             "ap-east-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-01fc78d8f1de3b321"
+              "release": "412.86.202208101040-0",
+              "image": "ami-064da6b3bc322cd4d"
             },
             "ap-northeast-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-068b6ece9d007d962"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0621ea595a658781d"
             },
             "ap-northeast-2": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-069571d4a0af48e32"
+              "release": "412.86.202208101040-0",
+              "image": "ami-05907a43a21af3055"
             },
             "ap-south-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0bb47e06d5cb73553"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0a58ff7c0f4ae9703"
             },
             "ap-southeast-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0936434cf20500c4f"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0f7f5b2eb4ecc38f2"
             },
             "ap-southeast-2": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0f3473d8d4edc7414"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0ed4e196dd00bc89a"
             },
             "ca-central-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0725162edbfe7d9a5"
+              "release": "412.86.202208101040-0",
+              "image": "ami-02e5e1b6f0890e3aa"
             },
             "eu-central-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0add2891c7356e1f2"
+              "release": "412.86.202208101040-0",
+              "image": "ami-095c81eebb632be80"
             },
             "eu-north-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-012a6e91a6ffb7d6d"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0cb2cb136bd94dc73"
             },
             "eu-south-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0669e33bff8b26bc7"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0c4946556d379fe51"
             },
             "eu-west-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-09ba5e60d1ded4aa8"
+              "release": "412.86.202208101040-0",
+              "image": "ami-08a294a49f92f750c"
             },
             "eu-west-2": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0f4dc5b0e63dfa612"
+              "release": "412.86.202208101040-0",
+              "image": "ami-07295015e9b1deb59"
             },
             "eu-west-3": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0452139490c73b5a2"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0373c1dacbfb03322"
             },
             "me-south-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-082870ad6537d64e7"
+              "release": "412.86.202208101040-0",
+              "image": "ami-095377addd5a6fbd3"
             },
             "sa-east-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0f31e0b14b49826db"
+              "release": "412.86.202208101040-0",
+              "image": "ami-00362c5b6151337d6"
             },
             "us-east-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-066d84c996a02f4f9"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0d2921a5f38445c67"
             },
             "us-east-2": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-02277def1155a7154"
+              "release": "412.86.202208101040-0",
+              "image": "ami-06f946606049a1b50"
             },
             "us-west-1": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-0e69cdc42d63d27b2"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0d61a860c19f3e6ac"
             },
             "us-west-2": {
-              "release": "412.86.202207160442-0",
-              "image": "ami-02e7f79bf863c81fa"
+              "release": "412.86.202208101040-0",
+              "image": "ami-0385dbe95e301c760"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "412.86.202207160442-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202207160442-0-azure.aarch64.vhd"
+          "release": "412.86.202208101040-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202208101040-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "412.86.202207151711-0",
+          "release": "412.86.202208090152-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-metal4k.ppc64le.raw.gz",
-                "sha256": "359ce1f2e721eaaed3c5ab205c0ca112cc939561d821b49df144083235c444d9",
-                "uncompressed-sha256": "f9330eb545c584a6af9ef6c67c85368fe32fa8643c89ceff6f9f625b7d026e58"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202208090152-0/ppc64le/rhcos-412.86.202208090152-0-metal4k.ppc64le.raw.gz",
+                "sha256": "f45bec7db5d336e6a022a0749f722643b0eb4708a9cf1397e0a5c99eb74db53a",
+                "uncompressed-sha256": "d639068efb3393750f6a918f61dc00564560b30361078573d424650e74679b59"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-live.ppc64le.iso",
-                "sha256": "65ff867f818ae80e3523abae9bb688fea3aaad5f307d516f899c9d2407aefbeb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202208090152-0/ppc64le/rhcos-412.86.202208090152-0-live.ppc64le.iso",
+                "sha256": "2d2f47b42c59a09a0c64deee3eb638468be188f376c6d38f1266bb66cc8e7b48"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-live-kernel-ppc64le",
-                "sha256": "7f3c269bd78edbf69d38a71fccc15235a319904edfe57e702ad63a54142a77d7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202208090152-0/ppc64le/rhcos-412.86.202208090152-0-live-kernel-ppc64le",
+                "sha256": "77d7d3ed90dfb8ae0e6eb9b6b98f0ef30775817ad6bd34d92d4bc3bcae16b5c1"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-live-initramfs.ppc64le.img",
-                "sha256": "6d0b8ddecd327171ac780dc048ce3c19ec5175b297d9e846c646849164c751d0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202208090152-0/ppc64le/rhcos-412.86.202208090152-0-live-initramfs.ppc64le.img",
+                "sha256": "2b01f5c3aa241dcaa7a015a41bedf6401423e255ff7fd33e0ee548fdc5cc2163"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-live-rootfs.ppc64le.img",
-                "sha256": "5d022414dab538fcb024b19b7ff333e8c476e4c6bca2e6197d63546492c9d4ec"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202208090152-0/ppc64le/rhcos-412.86.202208090152-0-live-rootfs.ppc64le.img",
+                "sha256": "a2df57c1351edf91669c07e6a0c368c4debd119bf5970659910565144cb85fd2"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-metal.ppc64le.raw.gz",
-                "sha256": "f7de8ebedb4104c8ebbdab6845d12194354f53c3cdcff5336349440d6977c609",
-                "uncompressed-sha256": "4f7d92fcd32d65d3ad24f311d0bc9eff39068fd80f90c3d54d918d23ea42061e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202208090152-0/ppc64le/rhcos-412.86.202208090152-0-metal.ppc64le.raw.gz",
+                "sha256": "987083d02ef578be51067c1c620a82de83225a007bbf7c1e3e51038e753b1d5c",
+                "uncompressed-sha256": "c9cf7c2360529d79c0a720e7632bca0cbeb4ed9644aadf88da45baf707f55d0d"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202207151711-0",
+          "release": "412.86.202208090152-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "1fb02c8c40772dcc36b1538ede0f653af3817d8a63ee09c928fd3af4441745f4",
-                "uncompressed-sha256": "9dfef585f1b6a319a5c67fc9a90560f88fb9503ce0f28d0f570732ee5c907897"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202208090152-0/ppc64le/rhcos-412.86.202208090152-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "e07b761153af165e41032986da37310062d1b901bb9e74302e083e74db8949a4",
+                "uncompressed-sha256": "8cd042dfd810d20316e81ba01edae9f8364597fa2f8f094d6adede79e8ced427"
               }
             }
           }
         },
         "powervs": {
-          "release": "412.86.202207151711-0",
+          "release": "412.86.202208090152-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-powervs.ppc64le.ova.gz",
-                "sha256": "6c5200febfda986beff2776adb30dbefafb5d60494df3ddf0cdc019655190f10",
-                "uncompressed-sha256": "3a1a5e1414c5202a6cf2fa69860db4bed0e4d30a5d54ec941db0b8755f3246e7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202208090152-0/ppc64le/rhcos-412.86.202208090152-0-powervs.ppc64le.ova.gz",
+                "sha256": "614f5838a9122bfd157081ddaee802d6c9463ad6e93e199d23926c4a6108b8a3",
+                "uncompressed-sha256": "3696788cbb87111084bf87f10c67650e1a854f8996053e4a43e30420cde78e89"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202207151711-0",
+          "release": "412.86.202208090152-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202207151711-0/ppc64le/rhcos-412.86.202207151711-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "cbdde8834a9cca226f620dec889dfadac4e37a403b476a6014a32be770ecc59a",
-                "uncompressed-sha256": "b2901174fd809ca9d8c47f68697d74184520c24bf45d9a32fc7da33b18a1dd65"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-ppc64le/412.86.202208090152-0/ppc64le/rhcos-412.86.202208090152-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "1c3b0bd3ce7745c8b6011dd7e1f795a3347c52a59426e67641c3eec747f0d0d8",
+                "uncompressed-sha256": "3a74f8177619fa2227d9e887b5560317f9769b30fd9dc5464b4ee10422ad90ab"
               }
             }
           }
@@ -266,58 +266,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "412.86.202207151711-0",
-              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202208090152-0",
+              "object": "rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "412.86.202207151711-0",
-              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202208090152-0",
+              "object": "rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "412.86.202207151711-0",
-              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202208090152-0",
+              "object": "rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "412.86.202207151711-0",
-              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202208090152-0",
+              "object": "rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "412.86.202207151711-0",
-              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202208090152-0",
+              "object": "rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "412.86.202207151711-0",
-              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202208090152-0",
+              "object": "rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "412.86.202207151711-0",
-              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202208090152-0",
+              "object": "rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "412.86.202207151711-0",
-              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202208090152-0",
+              "object": "rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "412.86.202207151711-0",
-              "object": "rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202208090152-0",
+              "object": "rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-412-86-202207151711-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-412-86-202208090152-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -326,64 +326,64 @@
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "412.86.202207142236-0",
+          "release": "412.86.202208090843-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-metal4k.s390x.raw.gz",
-                "sha256": "0f7e51de04c00f8494ea886a4564ee77bab2a9b7067449371a0122070ea4a08f",
-                "uncompressed-sha256": "60e24d250331ec121329533cec8669e4efff9f4d9e8440118e93b5f5ed608766"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202208090843-0/s390x/rhcos-412.86.202208090843-0-metal4k.s390x.raw.gz",
+                "sha256": "f196fde297fb38e1eb3bd553c0d9eabee890b4f788ac8d69c76bd40d7fadee84",
+                "uncompressed-sha256": "4c2d5f75776b5320d693c2553fb6c642dfa2945ec550493fc5c1e12be4ef62eb"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-live.s390x.iso",
-                "sha256": "4641e5fbff87e86b323f5f80be307fc3ecab3a053a34910ce39994198f1242f5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202208090843-0/s390x/rhcos-412.86.202208090843-0-live.s390x.iso",
+                "sha256": "bad49e6d72ffae3a0a981f70fdc33965515ed58579eceee1e62a268febe00b2c"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-live-kernel-s390x",
-                "sha256": "f563e0135192798520a869aac81482d11f17fbb8ca91a9515d3c749a7f5a31f3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202208090843-0/s390x/rhcos-412.86.202208090843-0-live-kernel-s390x",
+                "sha256": "9fcbbbbb2f69b34bd17f3c6d5bad5ee73c583c8b8e9dfb87a6da61b245b8cfb1"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-live-initramfs.s390x.img",
-                "sha256": "9445b763fe55552858c93da71e32efcea053f0603c21e4478e8ac317906b5af9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202208090843-0/s390x/rhcos-412.86.202208090843-0-live-initramfs.s390x.img",
+                "sha256": "0e9ddf64b94ba1fb0ac672640ec276cbadfaf42feaf39bdfe3e43155cab94c1b"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-live-rootfs.s390x.img",
-                "sha256": "69a11e815c4bbc0493d1466ae97ebcf5359cc54bc6b2deacbae57e88fc347deb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202208090843-0/s390x/rhcos-412.86.202208090843-0-live-rootfs.s390x.img",
+                "sha256": "8f969edfde9aa7b4684264604bfd5e35ff250c16d6ec3613332a904b61c94f00"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-metal.s390x.raw.gz",
-                "sha256": "da4178181044451c1a3125801160e58fea69a9f1d0d61486fe88e8bdd2b8619c",
-                "uncompressed-sha256": "0dfe122fc5a11ecb5898c82f313f92b150db3cb16ff49394b0bd406f3202f78f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202208090843-0/s390x/rhcos-412.86.202208090843-0-metal.s390x.raw.gz",
+                "sha256": "861b167cee9eaf5ac5c76bbaaeac32c2474933dc7e9e8794b543febcd75b2ea0",
+                "uncompressed-sha256": "5c048865fbc5e0334616470515f0262b48ad8cf1093da1e1af96508b78d12a8b"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202207142236-0",
+          "release": "412.86.202208090843-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-openstack.s390x.qcow2.gz",
-                "sha256": "a02659cc28aa97615c6d8ae70e6435efe45958a9f0c328f952932309ade1e288",
-                "uncompressed-sha256": "b6931da9d839f172736e362fe2e53009dd194380c4bab620e6e58f612d3e9a7a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202208090843-0/s390x/rhcos-412.86.202208090843-0-openstack.s390x.qcow2.gz",
+                "sha256": "158d58d5133c95dff125ac39f009e17a0aa61972a9e7418a2370c696eb1a45b5",
+                "uncompressed-sha256": "96f91fce27b7cf37bbea7c18138e22610a5f7d63761f11aabe1df4d6dee60e12"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202207142236-0",
+          "release": "412.86.202208090843-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202207142236-0/s390x/rhcos-412.86.202207142236-0-qemu.s390x.qcow2.gz",
-                "sha256": "4b17a4b545d539b40c43cff56a07446973aecd9a686d2acb2f0a6fcc010a7731",
-                "uncompressed-sha256": "8def26944144535fc6aa3bcd800f5c9c31edf2b603749bb68e1251936f748b0d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12-s390x/412.86.202208090843-0/s390x/rhcos-412.86.202208090843-0-qemu.s390x.qcow2.gz",
+                "sha256": "ef9475981aea74f7d5d5a793529d175d91966f58f2fb2df3c146abbfd985d888",
+                "uncompressed-sha256": "61660a9a44a9fd261665e13c1211a6add2abcc606ee0e7de252883aea9c2a974"
               }
             }
           }
@@ -394,158 +394,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "9be779ec3d96c65a8b6cf477219b6fc781da8f315060192051a1b7480c7e32a9",
-                "uncompressed-sha256": "109f8c2817d3f98e5514ce2730509654adfbdb8c554e16056116fbb1f209631b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "3f9d5032440d80628632f69dbd60d5a12bf0a81ed17f99c4c7b0c69f1856b4d8",
+                "uncompressed-sha256": "15736a8ada79a2207766c4c8e3cd5e06cf819805d0144b34ca0742d343fc3fee"
               }
             }
           }
         },
         "aws": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-aws.x86_64.vmdk.gz",
-                "sha256": "6bfbdd7f3a4a53fcc4d567f372fc06d416bc7428244deb8409237dad1a99199e",
-                "uncompressed-sha256": "dda2165dc6ef8cc31112b37e57d9f9b6b82a9c539f642a25972496ccca7bffe2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-aws.x86_64.vmdk.gz",
+                "sha256": "d1532359e5fc6ddb8b57b0351c6a6c5ab0b6270c49b967e27f4845bbef3259a9",
+                "uncompressed-sha256": "1136275253fe1897961001fbd0f1a093b3a2c24bf674a1b994f3cfada15d1528"
               }
             }
           }
         },
         "azure": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-azure.x86_64.vhd.gz",
-                "sha256": "4dd848b6d5d4c1199c3405fa5706f6773ff1503557b8caab70f2a74aed9d4d49",
-                "uncompressed-sha256": "31405e604dc24689c802e1910bef1380cb02e8ae0ff7d78b735c5d528f6da207"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-azure.x86_64.vhd.gz",
+                "sha256": "3016130ef7b43b36c6471f98d9c9ffdaa881325b7f51ca42b97c58cdc6d1ca9c",
+                "uncompressed-sha256": "6f8b66ec26f311afbbfc0fa1d2593dd369720e77c8892882b1a4ac7764055ec9"
               }
             }
           }
         },
         "azurestack": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-azurestack.x86_64.vhd.gz",
-                "sha256": "1514e29bbc4695ed52af04fe7e21231d2c93e5c0d812bd5decadd01f30a32a4c",
-                "uncompressed-sha256": "a831d88b5e64eef701e8ff460dc5ae2b87dbcf05301203e0b01bb77d2c29715b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-azurestack.x86_64.vhd.gz",
+                "sha256": "8fa327e080a7804f945b07f717d79f02fdf204067bfddf42c1d7064c3b3667a0",
+                "uncompressed-sha256": "8239146360fdccfe5b57680eb270d3ba5794a2fc7ca6f235a342c7d17730f7c2"
               }
             }
           }
         },
         "gcp": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-gcp.x86_64.tar.gz",
-                "sha256": "e8bd88269c98b7929d42adf7f44a284a0cb043288fd8ac938d4002016c1a87f2",
-                "uncompressed-sha256": "ad323860ddfc2edbe232723b89398e6eca35eb3a78507f174526c63fae8deb08"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-gcp.x86_64.tar.gz",
+                "sha256": "676df66c410427ab505f1237beed08834e49cb83ce81f330ba848e5da4cd8815",
+                "uncompressed-sha256": "a811357f94834e1f43f13f189223d30b3f03f28b52e60ca7ec7e399328294768"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "b64d7fe413c22c99d4733cba8190cb30bcd318bf4f5728e27be9ac3cfcfd2fba",
-                "uncompressed-sha256": "f78414f3d898deb94b3e198102db29880d32ad436592985bfcf72f9b48ff977f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "d46e776b101793ad5ba3b040f47d77ba4a793feae0daf06cffa054ca174c0956",
+                "uncompressed-sha256": "09b599849b945bdd405b18765225160f50e07ca205fe9787f70f188c8a96f293"
               }
             }
           }
         },
         "metal": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-metal4k.x86_64.raw.gz",
-                "sha256": "9dcea5933d813111e696f2dd88efbbefc552c060cd862c96186a83af307b282b",
-                "uncompressed-sha256": "0257f69ba8e0e8080a4abb6d8254b1fa4367a23ae7a072916b08a169fe7715ff"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-metal4k.x86_64.raw.gz",
+                "sha256": "63f702fe73d7338698e1a1b9110fd77973a426afd16eb5b3217cc13c95991dea",
+                "uncompressed-sha256": "dc2e03da4a6b3297eab027693aa43d642661c23e4fc3632ae4eab02e017eaca9"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-live.x86_64.iso",
-                "sha256": "151b1aeb322d02c1ca60026244895ff45128d70f6d3e05934d55e4b8d98407fb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-live.x86_64.iso",
+                "sha256": "10cc521fe287319c9600f5b31eb9b0cafa7086f7e88f2bea0ddec1331d98ab8e"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-live-kernel-x86_64",
-                "sha256": "90bf526e7e31f42ae5b5804a2b47479f5512b6dc2d33cf7c1d5cc6b6eebb34d3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-live-kernel-x86_64",
+                "sha256": "d469c82375a7358371490514c9946e9f214e14a3df95cba42156dba765c5abde"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-live-initramfs.x86_64.img",
-                "sha256": "e82fcdb46860a51757de26b521aada0e5e851904034e02c276ef22a1fad982ab"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-live-initramfs.x86_64.img",
+                "sha256": "49a46017c218d89e4ffaa3f38b1c15cf54f2f2689cdbe0fc145a014c84a373e6"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-live-rootfs.x86_64.img",
-                "sha256": "e493380e2b17d25f4b722d4adae3e31a6fa27f4e125e9a664ddba19cc649c3e4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-live-rootfs.x86_64.img",
+                "sha256": "3adc01d5aea56195f016a582a9f7ddde78e207dbd94189f04b6c35aaff93b3a8"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-metal.x86_64.raw.gz",
-                "sha256": "a5738ab1573dda2732dbb7d52b3706d30e985367681d23a9160901b020090dc1",
-                "uncompressed-sha256": "641292012941c180fc02a0a3d8da66030106bc58daa6a222c2a8c2c542b1b7f7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-metal.x86_64.raw.gz",
+                "sha256": "4fb2591ab1b3daaac113cd2a1652bd2c8d28d9edde1f1d0b471f24a276dcbcd0",
+                "uncompressed-sha256": "95c35e99b0eed723918631c41871732747b4c51e838bc690ea2ed43b72f02841"
               }
             }
           }
         },
         "nutanix": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-nutanix.x86_64.qcow2",
-                "sha256": "0c32012d340993bbb3b4e6d604882dfd68bbf038ae0e1181e4e32b1be6c8dcf8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-nutanix.x86_64.qcow2",
+                "sha256": "a55c92a480453edc0aa3a4167438cc46887054ecc8e170803bbd0b26e1d12b73"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-openstack.x86_64.qcow2.gz",
-                "sha256": "81731680ae10e189da57e64103bdfacd5df1a6d876c23f15fbaf3de049dabc14",
-                "uncompressed-sha256": "5af1125de5dc3884bb570c69a54b6bbe8599cab5c5e704c73b22d29b4e0d8516"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-openstack.x86_64.qcow2.gz",
+                "sha256": "9004b7b3511c11565ac9c60ebb3327ade5c610fa6c6acd5c8ca7287f4132f8ec",
+                "uncompressed-sha256": "81c31cb0214d7bd9bab8300b36334eb8796642e817e48606ccef677afc509726"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-qemu.x86_64.qcow2.gz",
-                "sha256": "51b4423d9d195b30b416adfec47b446e8b650363cba99bd8c9b0b34be747a47d",
-                "uncompressed-sha256": "e6e78eb6b7358d1bbf7374512216a6b28523256a61bc9891aeb897883499ef04"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-qemu.x86_64.qcow2.gz",
+                "sha256": "cc6a55dfc16c384c23063bede5c2a6c235a576c1a5515a042382a7e37f858d28",
+                "uncompressed-sha256": "0083c5fe1048d8fa01df7b534a5e2bb8cd4e9ba6c864bf06da6a489e608b398c"
               }
             }
           }
         },
         "vmware": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202207142104-0/x86_64/rhcos-412.86.202207142104-0-vmware.x86_64.ova",
-                "sha256": "8bb22350cf61ac431120f99c58e175132c12d9fc7696ffbc567f87bdb963c0a5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.12/412.86.202208101039-0/x86_64/rhcos-412.86.202208101039-0-vmware.x86_64.ova",
+                "sha256": "5c659e4ce73291843332f04cab7b2ec96437fdff4aad707b941d904bb5b3f737"
               }
             }
           }
@@ -555,217 +555,217 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "412.86.202207142104-0",
-              "image": "m-6we3we0zoee5j00njbz4"
+              "release": "412.86.202208101039-0",
+              "image": "m-6we0b0m14fgbe6kikanc"
             },
             "ap-south-1": {
-              "release": "412.86.202207142104-0",
-              "image": "m-a2dgqagdl04zn11rjmcw"
+              "release": "412.86.202208101039-0",
+              "image": "m-a2d46i60on8y7ndyqfry"
             },
             "ap-southeast-1": {
-              "release": "412.86.202207142104-0",
-              "image": "m-t4n8gw2lpq6ugxpedu5w"
+              "release": "412.86.202208101039-0",
+              "image": "m-t4nde08s8edlu5r1csd8"
             },
             "ap-southeast-2": {
-              "release": "412.86.202207142104-0",
-              "image": "m-p0w3rjvg02wfcgrdbpqq"
+              "release": "412.86.202208101039-0",
+              "image": "m-p0wha5mjsuqy7uz29dol"
             },
             "ap-southeast-3": {
-              "release": "412.86.202207142104-0",
-              "image": "m-8psgsol78o77epx2ouke"
+              "release": "412.86.202208101039-0",
+              "image": "m-8psbzcy32cgmwyvw7ugs"
             },
             "ap-southeast-5": {
-              "release": "412.86.202207142104-0",
-              "image": "m-k1a5npc1v5o0bynti0k0"
+              "release": "412.86.202208101039-0",
+              "image": "m-k1aehq5v64biof2k9pnq"
             },
             "ap-southeast-6": {
-              "release": "412.86.202207142104-0",
-              "image": "m-5tsajwqroggp4se0dpaj"
+              "release": "412.86.202208101039-0",
+              "image": "m-5tsgc9jgygwi0lrld7dj"
             },
             "cn-beijing": {
-              "release": "412.86.202207142104-0",
-              "image": "m-2zegyq7fyg7esu4w7nl2"
+              "release": "412.86.202208101039-0",
+              "image": "m-2ze8lc6yfke51u17uv7l"
             },
             "cn-chengdu": {
-              "release": "412.86.202207142104-0",
-              "image": "m-2vcf8h4lifonvg6jftlf"
+              "release": "412.86.202208101039-0",
+              "image": "m-2vcf0sae8v6l5ufx7hnf"
             },
             "cn-guangzhou": {
-              "release": "412.86.202207142104-0",
-              "image": "m-7xv08waf9xnx23pypefx"
+              "release": "412.86.202208101039-0",
+              "image": "m-7xv6dn3s9e6v9kt8rkqb"
             },
             "cn-hangzhou": {
-              "release": "412.86.202207142104-0",
-              "image": "m-bp13xtmzxoxl25nqz82j"
+              "release": "412.86.202208101039-0",
+              "image": "m-bp1ez0hvdy5xzisp3h7z"
             },
             "cn-heyuan": {
-              "release": "412.86.202207142104-0",
-              "image": "m-f8zdr8s6479v9795c58f"
+              "release": "412.86.202208101039-0",
+              "image": "m-f8zf1q4bpufro5tjvmtw"
             },
             "cn-hongkong": {
-              "release": "412.86.202207142104-0",
-              "image": "m-j6c4ghaaduaqfukgaa7i"
+              "release": "412.86.202208101039-0",
+              "image": "m-j6c3kvxvzyn7folesu4e"
             },
             "cn-huhehaote": {
-              "release": "412.86.202207142104-0",
-              "image": "m-hp34f9gdp01biolfqf77"
+              "release": "412.86.202208101039-0",
+              "image": "m-hp3ai4lyj0f4msvejotf"
             },
             "cn-nanjing": {
-              "release": "412.86.202207142104-0",
-              "image": "m-gc7bsz0jw5dj6n758n5b"
+              "release": "412.86.202208101039-0",
+              "image": "m-gc7hwm17niesg9vo62n9"
             },
             "cn-qingdao": {
-              "release": "412.86.202207142104-0",
-              "image": "m-m5e2kjvlpikupe11bign"
+              "release": "412.86.202208101039-0",
+              "image": "m-m5easan45sgpowlvv71k"
             },
             "cn-shanghai": {
-              "release": "412.86.202207142104-0",
-              "image": "m-uf60wv2b5wyem2yw7d36"
+              "release": "412.86.202208101039-0",
+              "image": "m-uf6ifww3araoo72abkuq"
             },
             "cn-shenzhen": {
-              "release": "412.86.202207142104-0",
-              "image": "m-wz987iwe7gk68m1p22z6"
+              "release": "412.86.202208101039-0",
+              "image": "m-wz94eyp2zte7x7x6kc39"
             },
             "cn-wulanchabu": {
-              "release": "412.86.202207142104-0",
-              "image": "m-0jlfthtkdgs3rvfpzc9p"
+              "release": "412.86.202208101039-0",
+              "image": "m-0jl30lxv9yoa6lz93ffv"
             },
             "cn-zhangjiakou": {
-              "release": "412.86.202207142104-0",
-              "image": "m-8vbhr4kqgojn7ych6k0a"
+              "release": "412.86.202208101039-0",
+              "image": "m-8vbbkx2u0apf2zx8557g"
             },
             "eu-central-1": {
-              "release": "412.86.202207142104-0",
-              "image": "m-gw89dpnontdxhanoy470"
+              "release": "412.86.202208101039-0",
+              "image": "m-gw8a7hmv2nrm0sdlwsdd"
             },
             "eu-west-1": {
-              "release": "412.86.202207142104-0",
-              "image": "m-d7o1ypzayae9e9mr9s5s"
+              "release": "412.86.202208101039-0",
+              "image": "m-d7o4k740vnaljurn5na0"
             },
             "me-east-1": {
-              "release": "412.86.202207142104-0",
-              "image": "m-eb3a7w8v6gd5x6lw9p2m"
+              "release": "412.86.202208101039-0",
+              "image": "m-eb31dohwa01h79ajaq9m"
             },
             "us-east-1": {
-              "release": "412.86.202207142104-0",
-              "image": "m-0xi1fbppyleyceav7iw4"
+              "release": "412.86.202208101039-0",
+              "image": "m-0xi33q8nxhzjw1s5wzu7"
             },
             "us-west-1": {
-              "release": "412.86.202207142104-0",
-              "image": "m-rj90mi51f4vounwklo4r"
+              "release": "412.86.202208101039-0",
+              "image": "m-rj9350dp53d8qitgnu9i"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-09f93f58d5ee0a7fd"
+              "release": "412.86.202208101039-0",
+              "image": "ami-06a2e3b9eb7032868"
             },
             "ap-east-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0935ab0e3708612a2"
+              "release": "412.86.202208101039-0",
+              "image": "ami-00f83912d1116d5d8"
             },
             "ap-northeast-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-07ef07362b6646d19"
+              "release": "412.86.202208101039-0",
+              "image": "ami-05056b9e232dc9efb"
             },
             "ap-northeast-2": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-08371ad2cebc2d147"
+              "release": "412.86.202208101039-0",
+              "image": "ami-0c2f79dcd0eef818d"
             },
             "ap-northeast-3": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-042af50035f4fd0fd"
+              "release": "412.86.202208101039-0",
+              "image": "ami-03e0b1aba82853a39"
             },
             "ap-south-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-07daddde37f6a56b3"
+              "release": "412.86.202208101039-0",
+              "image": "ami-0eb6f822f2d92eded"
             },
             "ap-southeast-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0cdbb41c078813e35"
+              "release": "412.86.202208101039-0",
+              "image": "ami-0bf2d5b860256297c"
             },
             "ap-southeast-2": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0bc6d84fc93ef2e3d"
+              "release": "412.86.202208101039-0",
+              "image": "ami-00914d7b9eae2dce3"
             },
             "ap-southeast-3": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-07a9a840aeb577409"
+              "release": "412.86.202208101039-0",
+              "image": "ami-064f36b1d024eeb66"
             },
             "ca-central-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-04746acad988da069"
+              "release": "412.86.202208101039-0",
+              "image": "ami-0765941cc7cf00a91"
             },
             "eu-central-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-067e348b7982bfab1"
+              "release": "412.86.202208101039-0",
+              "image": "ami-0121f3a22383aac72"
             },
             "eu-north-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0e835b635925bdffc"
+              "release": "412.86.202208101039-0",
+              "image": "ami-035781c6ee9025a75"
             },
             "eu-south-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0aea999da238a1a4b"
+              "release": "412.86.202208101039-0",
+              "image": "ami-082151f2d18576f21"
             },
             "eu-west-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-045368cb4885eec18"
+              "release": "412.86.202208101039-0",
+              "image": "ami-029b29d2c4c0b0872"
             },
             "eu-west-2": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0532324310ab6d3ab"
+              "release": "412.86.202208101039-0",
+              "image": "ami-09a74929c311b8518"
             },
             "eu-west-3": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-08a5176fb110a4ab8"
+              "release": "412.86.202208101039-0",
+              "image": "ami-035bbcaa8d09fb5a7"
             },
             "me-south-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0deeb2d32037d6e12"
+              "release": "412.86.202208101039-0",
+              "image": "ami-0a99354fdd4b3bb26"
             },
             "sa-east-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-06ffafd7376921e5b"
+              "release": "412.86.202208101039-0",
+              "image": "ami-026612603ba93702f"
             },
             "us-east-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0b9c602d07818c309"
+              "release": "412.86.202208101039-0",
+              "image": "ami-02adc9be71e65dd76"
             },
             "us-east-2": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-03c8407be1de91c11"
+              "release": "412.86.202208101039-0",
+              "image": "ami-0a814b3bdf7f2a432"
             },
             "us-gov-east-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-08e70a8a41769bfc4"
+              "release": "412.86.202208101039-0",
+              "image": "ami-02826f9bc54682bcd"
             },
             "us-gov-west-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0cc998428b51e5686"
+              "release": "412.86.202208101039-0",
+              "image": "ami-09636306c7ffc37ef"
             },
             "us-west-1": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-0fbf66888a591222d"
+              "release": "412.86.202208101039-0",
+              "image": "ami-02d555adca2b312d1"
             },
             "us-west-2": {
-              "release": "412.86.202207142104-0",
-              "image": "ami-025a4755a86cf05a3"
+              "release": "412.86.202208101039-0",
+              "image": "ami-0ab16b88bf13c27ab"
             }
           }
         },
         "gcp": {
-          "release": "412.86.202207142104-0",
+          "release": "412.86.202208101039-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-412-86-202207142104-0-gcp-x86-64"
+          "name": "rhcos-412-86-202208101039-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "412.86.202207142104-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202207142104-0-azure.x86_64.vhd"
+          "release": "412.86.202208101039-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202208101039-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.12 boot image metadata in the
installer which includes the fixes for the following BZs:

BZ 2115528 This will bump bootimage to include latest rpm-ostree

Changes generated with:

```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --url https://rhcos.mirror.openshift.com/art/storage/releases --no-signatures x86_64=412.86.202208101039-0 aarch64=412.86.202208101040-0 s390x=412.86.202208090843-0 ppc64le=412.86.202208090152-0
```