### PR TITLE
OCPBUGS-268: vSphere - enable steal time accounting

### DIFF
--- a/data/data/vsphere/master/main.tf
+++ b/data/data/vsphere/master/main.tf
@@ -45,6 +45,7 @@ resource "vsphere_virtual_machine" "vm_master" {
     "guestinfo.ignition.config.data"          = base64encode(var.ignition_master)
     "guestinfo.ignition.config.data.encoding" = "base64"
     "guestinfo.hostname"                      = "${var.cluster_id}-master-${count.index}"
+    "stealclock.enable"                       = "TRUE"
   }
 
   tags = var.tags

--- a/upi/vsphere/vm/main.tf
+++ b/upi/vsphere/vm/main.tf
@@ -32,6 +32,7 @@ resource "vsphere_virtual_machine" "vm" {
     "guestinfo.ignition.config.data"           = base64encode(var.ignition)
     "guestinfo.ignition.config.data.encoding"  = "base64"
     "guestinfo.afterburn.initrd.network-kargs" = "ip=${each.value}::${cidrhost(var.machine_cidr, 1)}:${cidrnetmask(var.machine_cidr)}:${element(split(".", each.key), 0)}:ens192:none:${join(":", var.dns_addresses)}"
+    "stealclock.enable"                        = "TRUE"
   }
 }
 


### PR DESCRIPTION
This PR enables steal time accounting on
control plane virtual machines.

From the linux commit:

Steal time is the amount of CPU time needed by a guest virtual machine
that is not provided by the host. Steal time occurs when the host
allocates this CPU time elsewhere, for example, to another guest.

Steal time can be enabled by adding the VM configuration option
stealclock.enable = "TRUE". It is supported by VMs that run hardware
version 13 or newer.