### PR TITLE
Updating the releases app endpoint for update bootimage script

### DIFF
--- a/hack/update-rhcos-bootimage.py
+++ b/hack/update-rhcos-bootimage.py
@@ -7,7 +7,7 @@ import urllib.request
 
 # An app running in the CI cluster exposes this public endpoint about ART RHCOS
 # builds.  Do not try to e.g. point to RHT-internal endpoints.
-RHCOS_RELEASES_APP = 'https://rhcos.mirror.openshift.com'
+RHCOS_RELEASES_APP = 'https://rhcos.mirror.openshift.com/art/storage/releases/'
 
 parser = argparse.ArgumentParser()
 parser.add_argument("meta", action='store')


### PR DESCRIPTION
Updated the update-rhcos-bootimage.py file to use the most up to date redirector