### PR TITLE
GCP: Remove firewall rules when providing network project id

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -50,6 +50,7 @@ resource "google_compute_address" "bootstrap" {
 }
 
 resource "google_compute_firewall" "bootstrap_ingress_ssh" {
+  count       = var.gcp_network_project_id != "" ? 0 : 1
   name        = "${var.cluster_id}-bootstrap-in-ssh"
   network     = var.network
   description = local.description

--- a/data/data/gcp/cluster/main.tf
+++ b/data/data/gcp/cluster/main.tf
@@ -60,6 +60,7 @@ module "network" {
   cluster_network     = var.gcp_cluster_network
   master_subnet       = var.gcp_control_plane_subnet
   worker_subnet       = var.gcp_compute_subnet
+  network_project_id  = var.gcp_network_project_id
 }
 
 module "dns" {

--- a/data/data/gcp/cluster/network/firewall.tf
+++ b/data/data/gcp/cluster/network/firewall.tf
@@ -1,4 +1,5 @@
 resource "google_compute_firewall" "api" {
+  count       = var.network_project_id != "" ? 0 : 1
   name        = "${var.cluster_id}-api"
   network     = local.cluster_network
   description = local.description
@@ -14,6 +15,7 @@ resource "google_compute_firewall" "api" {
 }
 
 resource "google_compute_firewall" "health_checks" {
+  count       = var.network_project_id != "" ? 0 : 1
   name        = "${var.cluster_id}-health-checks"
   network     = local.cluster_network
   description = local.description
@@ -29,6 +31,7 @@ resource "google_compute_firewall" "health_checks" {
 }
 
 resource "google_compute_firewall" "etcd" {
+  count       = var.network_project_id != "" ? 0 : 1
   name        = "${var.cluster_id}-etcd"
   network     = local.cluster_network
   description = local.description
@@ -44,6 +47,7 @@ resource "google_compute_firewall" "etcd" {
 }
 
 resource "google_compute_firewall" "control_plane" {
+  count       = var.network_project_id != "" ? 0 : 1
   name        = "${var.cluster_id}-control-plane"
   network     = local.cluster_network
   description = local.description
@@ -74,6 +78,7 @@ resource "google_compute_firewall" "control_plane" {
 }
 
 resource "google_compute_firewall" "internal_network" {
+  count       = var.network_project_id != "" ? 0 : 1
   name        = "${var.cluster_id}-internal-network"
   network     = local.cluster_network
   description = local.description
@@ -97,6 +102,7 @@ resource "google_compute_firewall" "internal_network" {
 }
 
 resource "google_compute_firewall" "internal_cluster" {
+  count       = var.network_project_id != "" ? 0 : 1
   name        = "${var.cluster_id}-internal-cluster"
   network     = local.cluster_network
   description = local.description

--- a/data/data/gcp/cluster/network/variables.tf
+++ b/data/data/gcp/cluster/network/variables.tf
@@ -36,3 +36,8 @@ variable "public_endpoints" {
   type        = bool
   description = "If the bootstrap instance should have externally accessible resources."
 }
+
+variable "network_project_id" {
+  type        = string
+  description = "The project that the network and subnets exist in when they are not in the main ProjectID."
+}

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -3,6 +3,12 @@ variable "gcp_project_id" {
   description = "The target GCP project for the cluster."
 }
 
+variable "gcp_network_project_id" {
+  type        = string
+  description = "The project that the network and subnets exist in when they are not in the main ProjectID."
+  default     = null
+}
+
 variable "gcp_service_account" {
   type        = string
   description = "The service account for authenticating with GCP APIs."

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -6,7 +6,7 @@ variable "gcp_project_id" {
 variable "gcp_network_project_id" {
   type        = string
   description = "The project that the network and subnets exist in when they are not in the main ProjectID."
-  default     = null
+  default     = ""
 }
 
 variable "gcp_service_account" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -379,8 +379,9 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return err
 		}
 		auth := gcptfvars.Auth{
-			ProjectID:      installConfig.Config.GCP.ProjectID,
-			ServiceAccount: string(sess.Credentials.JSON),
+			ProjectID:        installConfig.Config.GCP.ProjectID,
+			NetworkProjectID: installConfig.Config.GCP.NetworkProjectID,
+			ServiceAccount:   string(sess.Credentials.JSON),
 		}
 
 		masters, err := mastersAsset.Machines()

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -15,8 +15,9 @@ const (
 
 // Auth is the collection of credentials that will be used by terrform.
 type Auth struct {
-	ProjectID      string `json:"gcp_project_id,omitempty"`
-	ServiceAccount string `json:"gcp_service_account,omitempty"`
+	ProjectID        string `json:"gcp_project_id,omitempty"`
+	NetworkProjectID string `json:"gcp_network_project_id,omitempty"`
+	ServiceAccount   string `json:"gcp_service_account,omitempty"`
 }
 
 type config struct {


### PR DESCRIPTION
** Added the Network Project ID data to gcp terraform vars
** Added checks to GCP terraform to set count to 0 for firewall rules when
the Network Project ID is available.

CORS 2039
Requires #6166