### PR TITLE
Bug 2117687: compute.replicas must be 0 for SNO

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -159,6 +159,9 @@ func (a *OptionalInstallConfig) validateSNOConfiguration(installConfig *types.In
 		if *installConfig.ControlPlane.Replicas != 1 {
 			fieldPath = field.NewPath("ControlPlane", "Replicas")
 			allErrs = append(allErrs, field.Required(fieldPath, fmt.Sprintf("control plane replicas must be 1 for %s platform. Found %v", none.Name, *installConfig.ControlPlane.Replicas)))
+		} else if len(installConfig.Compute) == 0 {
+			fieldPath = field.NewPath("Compute", "Replicas")
+			allErrs = append(allErrs, field.Required(fieldPath, "Installing a Single Node Openshift requires explicitly setting compute replicas to zero"))
 		}
 
 		var workers int

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -99,6 +99,26 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			expectedError: "invalid install-config configuration: [ControlPlane.Replicas: Required value: control plane replicas must be 1 for none platform. Found 3, Compute.Replicas: Required value: total number of worker replicas must be 0 for none platform. Found 2]",
 		},
 		{
+			name: "no compute.replicas set for SNO",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 1
+platform:
+  none : {}
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: "invalid install-config configuration: Compute.Replicas: Required value: Installing a Single Node Openshift requires explicitly setting compute replicas to zero",
+		},
+		{
 			name: "valid configuration for none platform for sno",
 			data: `
 apiVersion: v1


### PR DESCRIPTION
When controlPlane.replicas = 1 and compute.replicas is missing from install-config.yaml,  validation warns users that compute.replicas needs to be set to 0 when controlPlane.replicas = 1 for SNO cluster on none platform.

validation error: `invalid install-config configuration: Compute.Replicas: Required value: Installing a Single Node Openshift requires explicitly setting compute replicas to zero`

https://bugzilla.redhat.com/show_bug.cgi?id=2117687
