### PR TITLE
Bug 2117439: Azure masters should publish on an internal load balancer

### DIFF
--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -191,7 +191,12 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 
 // ConfigMasters sets the PublicIP flag and assigns a set of load balancers to the given machines
 func ConfigMasters(machines []machineapi.Machine, clusterID string) {
-	//TODO
+	internalLB := fmt.Sprintf("%s-internal", clusterID)
+
+	for _, machine := range machines {
+		providerSpec := machine.Spec.ProviderSpec.Value.Object.(*machineapi.AzureMachineProviderSpec)
+		providerSpec.InternalLoadBalancer = internalLB
+	}
 }
 
 func getNetworkInfo(platform *azure.Platform, clusterID, role string) (string, string, string, error) {


### PR DESCRIPTION
If there's no internal load balancer specified on the Machine provider spec, then, when we replace the Machine, users must manually add the new Machine to the backend pool for the internal load balancer.

This will become more important when users start using controlplanemachinesets to replace machines, but we should make sure users have this data as soon as possible IMO.

I reviewed the terraform for creating the internal load balancer and, as far as I can tell, nothing there was conditional and we should always have an internal load balancer, so I think this is safe to do.