### PR TITLE
[CFE-465] Add additionalTrustBundlePolicy field to allow CA bundle propagation

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -25,6 +25,17 @@ spec:
             description: AdditionalTrustBundle is a PEM-encoded X.509 certificate
               bundle that will be added to the nodes' trusted certificate store.
             type: string
+          additionalTrustBundlePolicy:
+            description: 'AdditionalTrustBundlePolicy determines when to add the AdditionalTrustBundle
+              to the nodes'' trusted certificate store. "Proxyonly" is the default.
+              The field can be set to following specified values. "Proxyonly" : adds
+              the AdditionalTrustBundle to nodes when http/https proxy is configured.
+              "Always" : always adds AdditionalTrustBundle.'
+            enum:
+            - ""
+            - Proxyonly
+            - Always
+            type: string
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest

--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -21,6 +21,10 @@ The following `install-config.yaml` properties are available:
     The installer may also support older API versions.
 * `additionalTrustBundle` (optional string): a PEM-encoded X.509 certificate bundle that will be added to the nodes' trusted certificate store.
     This trust bundle may also be used when [a proxy has been configured](#proxy).
+* `additionalTrustBundlePolicy` (optional string): determines when to add the AdditionalTrustBundle to the nodes'' trusted certificate store.
+    "Proxyonly" is the default. The field can be set to following specified values.
+    "Proxyonly" : adds the AdditionalTrustBundle to nodes when http/https proxy is configured.
+    "Always" : always adds AdditionalTrustBundle.
 * `baseDomain` (required string): The base domain to which the cluster should belong.
 * `capabilities` (optional [capabilities](#capabilities)): Capabilities configures the installation of optional core cluster components.
 * `controlPlane` (optional [machine-pool](#machine-pools)): The configuration for the machines that comprise the control plane.

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -151,7 +151,8 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				BaseDomain: "test-domain",
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
 				Networking: &types.Networking{
 					MachineNetwork: []types.MachineNetworkEntry{
 						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},

--- a/pkg/asset/installconfig/installconfig_test.go
+++ b/pkg/asset/installconfig/installconfig_test.go
@@ -47,7 +47,8 @@ func TestInstallConfigGenerate_FillsInDefaults(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-cluster",
 		},
-		BaseDomain: "test-domain",
+		AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+		BaseDomain:                  "test-domain",
 		Networking: &types.Networking{
 			MachineNetwork: []types.MachineNetworkEntry{
 				{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
@@ -113,7 +114,8 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				BaseDomain: "test-domain",
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
 				Networking: &types.Networking{
 					MachineNetwork: []types.MachineNetworkEntry{
 						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
@@ -183,6 +185,7 @@ metadata:
 apiVersion: v1
 metadata:
   name: test-cluster
+additionalTrustBundlePolicy: Proxyonly
 baseDomain: test-domain
 platform:
   aws:
@@ -198,7 +201,8 @@ wrong_key: wrong_value
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				BaseDomain: "test-domain",
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
 				Networking: &types.Networking{
 					MachineNetwork: []types.MachineNetworkEntry{
 						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
@@ -255,7 +259,8 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				BaseDomain: "test-domain",
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
 				Networking: &types.Networking{
 					MachineNetwork: []types.MachineNetworkEntry{
 						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
@@ -314,7 +319,8 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				BaseDomain: "test-domain",
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
 				Networking: &types.Networking{
 					MachineNetwork: []types.MachineNetworkEntry{
 						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
@@ -374,7 +380,8 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				BaseDomain: "test-domain",
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
 				Networking: &types.Networking{
 					MachineNetwork: []types.MachineNetworkEntry{
 						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
@@ -434,7 +441,8 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-cluster",
 				},
-				BaseDomain: "test-domain",
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
 				Networking: &types.Networking{
 					MachineNetwork: []types.MachineNetworkEntry{
 						{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},

--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/alibabacloud"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -68,7 +69,10 @@ func (p *Proxy) Generate(dependencies asset.Parents) error {
 			HTTPSProxy: installConfig.Config.Proxy.HTTPSProxy,
 			NoProxy:    installConfig.Config.Proxy.NoProxy,
 		}
+	}
 
+	if installConfig.Config.AdditionalTrustBundlePolicy == types.PolicyAlways ||
+		installConfig.Config.Proxy != nil {
 		if installConfig.Config.AdditionalTrustBundle != "" {
 			p.Config.Spec.TrustedCA = configv1.ConfigMapNameReference{
 				Name: additionalTrustBundleConfigMapName,

--- a/pkg/explain/printer_test.go
+++ b/pkg/explain/printer_test.go
@@ -22,6 +22,10 @@ func Test_PrintFields(t *testing.T) {
     additionalTrustBundle <string>
       AdditionalTrustBundle is a PEM-encoded X.509 certificate bundle that will be added to the nodes' trusted certificate store.
 
+    additionalTrustBundlePolicy <string>
+      Valid Values: "","Proxyonly","Always"
+      AdditionalTrustBundlePolicy determines when to add the AdditionalTrustBundle to the nodes' trusted certificate store. "Proxyonly" is the default. The field can be set to following specified values. "Proxyonly" : adds the AdditionalTrustBundle to nodes when http/https proxy is configured. "Always" : always adds AdditionalTrustBundle.
+
     apiVersion <string>
       APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
 

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -119,4 +119,7 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		nutanixdefaults.SetPlatformDefaults(c.Platform.Nutanix)
 	}
 
+	if c.AdditionalTrustBundlePolicy == "" {
+		c.AdditionalTrustBundlePolicy = types.PolicyProxyOnly
+	}
 }

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -24,6 +24,7 @@ import (
 
 func defaultInstallConfig() *types.InstallConfig {
 	return &types.InstallConfig{
+		AdditionalTrustBundlePolicy: defaultAdditionalTrustBundlePolicy(),
 		Networking: &types.Networking{
 			MachineNetwork: []types.MachineNetworkEntry{
 				{CIDR: *defaultMachineCIDR},
@@ -83,6 +84,10 @@ func defaultOvirtInstallConfig() *types.InstallConfig {
 		ovirtdefaults.SetComputeDefaults(c.Platform.Ovirt, &c.Compute[i])
 	}
 	return c
+}
+
+func defaultAdditionalTrustBundlePolicy() types.PolicyType {
+	return types.PolicyProxyOnly
 }
 
 func defaultNoneInstallConfig() *types.InstallConfig {

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -70,6 +70,17 @@ const (
 	InternalPublishingStrategy PublishingStrategy = "Internal"
 )
 
+// PolicyType is for usage polices that are applied to additionalTrustBundle.
+// +kubebuilder:validation:Enum="";Proxyonly;Always
+type PolicyType string
+
+const (
+	// PolicyProxyOnly  enables use of AdditionalTrustBundle when http/https proxy is configured.
+	PolicyProxyOnly PolicyType = "Proxyonly"
+	// PolicyAlways ignores all conditions and uses AdditionalTrustBundle.
+	PolicyAlways PolicyType = "Always"
+)
+
 //go:generate go run ../../vendor/sigs.k8s.io/controller-tools/cmd/controller-gen crd:crdVersions=v1 paths=. output:dir=../../data/data/
 
 // InstallConfig is the configuration for an OpenShift install.
@@ -84,6 +95,13 @@ type InstallConfig struct {
 	//
 	// +optional
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
+
+	// AdditionalTrustBundlePolicy determines when to add the AdditionalTrustBundle
+	// to the nodes' trusted certificate store. "Proxyonly" is the default.
+	// The field can be set to following specified values.
+	// "Proxyonly" : adds the AdditionalTrustBundle to nodes when http/https proxy is configured.
+	// "Always" : always adds AdditionalTrustBundle.
+	AdditionalTrustBundlePolicy PolicyType `json:"additionalTrustBundlePolicy,omitempty"`
 
 	// SSHKey is the public Secure Shell (SSH) key to provide access to instances.
 	// +optional

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -81,6 +81,11 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("additionalTrustBundle"), c.AdditionalTrustBundle, err.Error()))
 		}
 	}
+	if c.AdditionalTrustBundlePolicy != "" {
+		if err := validateAdditionalCABundlePolicy(c); err != nil {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("additionalTrustBundlePolicy"), c.AdditionalTrustBundlePolicy, err.Error()))
+		}
+	}
 	nameErr := validate.ClusterName(c.ObjectMeta.Name)
 	if c.Platform.GCP != nil || c.Platform.Azure != nil {
 		nameErr = validate.ClusterName1035(c.ObjectMeta.Name)
@@ -741,6 +746,7 @@ func validateProxy(p *types.Proxy, c *types.InstallConfig, fldPath *field.Path) 
 	if p.HTTPProxy == "" && p.HTTPSProxy == "" {
 		allErrs = append(allErrs, field.Required(fldPath, "must include httpProxy or httpsProxy"))
 	}
+
 	if p.HTTPProxy != "" {
 		allErrs = append(allErrs, validateURI(p.HTTPProxy, fldPath.Child("httpProxy"), []string{"http"})...)
 		if c.Networking != nil {
@@ -960,4 +966,13 @@ func validateCapabilities(c *types.Capabilities, fldPath *field.Path) field.Erro
 		}
 	}
 	return allErrs
+}
+
+func validateAdditionalCABundlePolicy(c *types.InstallConfig) error {
+	switch c.AdditionalTrustBundlePolicy {
+	case types.PolicyProxyOnly, types.PolicyAlways:
+		return nil
+	default:
+		return fmt.Errorf("supported values \"Proxyonly\", \"Always\"")
+	}
 }


### PR DESCRIPTION
 A new field _additionalTrustBundlePolicy_ is added to support transparent proxy scenario. 
_additionalTrustBundlePolicy_ defines conditional policy to add AdditionalTrustBundle to the nodes' trusted certificate store. Following are the valid values :
_default_ : use AdditionalTrustBundle if there is http/https proxy configured
_always_ : ignore all conditions and use AdditionalTrustBundle