### PR TITLE
Bug 2098072: vsphere: fix default disk type when not speficied

### DIFF
--- a/terraform/providers/vsphereprivate/resource_vsphereprivate_import_ova.go
+++ b/terraform/providers/vsphereprivate/resource_vsphereprivate_import_ova.go
@@ -102,8 +102,8 @@ func resourceVSpherePrivateImportOva() *schema.Resource {
 			},
 			"disk_type": {
 				Type:        schema.TypeString,
-				Description: "The name of the disk provisioning, for e.g eagerZeroedThick or thin, by default it will be thick.",
-				Required:    true,
+				Description: "The name of the disk provisioning type, valid values are thin, thick and eagerZeroedThick.",
+				Optional:    true,
 				ForceNew:    true,
 			},
 		},
@@ -361,21 +361,23 @@ func resourceVSpherePrivateImportOvaCreate(d *schema.ResourceData, meta interfac
 		Network: importOvaParams.Network.Reference(),
 	}}
 
-	var diskType types.OvfCreateImportSpecParamsDiskProvisioningType
-
-	if d.Get("disk_type") == "thin" {
-		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThin
-	} else if d.Get("disk_type") == "eagerZeroedThick" {
-		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeEagerZeroedThick
-	} else {
-		diskType = types.OvfCreateImportSpecParamsDiskProvisioningTypeThick
-	}
-	// This is a very minimal spec for importing
-	// an OVF.
+	// This is a very minimal spec for importing an OVF.
 	cisp := types.OvfCreateImportSpecParams{
-		DiskProvisioning: string(diskType),
-		EntityName:       d.Get("name").(string),
-		NetworkMapping:   networkMappings,
+		EntityName:     d.Get("name").(string),
+		NetworkMapping: networkMappings,
+	}
+
+	switch diskType := d.Get("disk_type"); diskType {
+	case "":
+		// Disk provisioning type will be set according to the default storage policy of vsphere.
+	case "thin":
+		cisp.DiskProvisioning = string(types.OvfCreateImportSpecParamsDiskProvisioningTypeThin)
+	case "thick":
+		cisp.DiskProvisioning = string(types.OvfCreateImportSpecParamsDiskProvisioningTypeThick)
+	case "eagerZeroedThick":
+		cisp.DiskProvisioning = string(types.OvfCreateImportSpecParamsDiskProvisioningTypeEagerZeroedThick)
+	default:
+		return errors.Errorf("Disk provisioning type %q is not supported.", diskType)
 	}
 
 	m := ovf.NewManager(client)


### PR DESCRIPTION
During the terraform decoupling work [1], a fix for the default value
for the disk provisioning type [2] ended up being lost.

This commit bring those changes back, fixing a regression where the
default disk type would be set to "thick" instead of the default storage
policy of vsphere.

[1] https://github.com/openshift/installer/commit/9c77d6a437bcbf7289dc5affb8809bf3d17e018d
[2] https://github.com/openshift/installer/commit/f3c9bfade850662ab74ae4cc62a226d75da43819