### PR TITLE
Extract the image-references file from the release, pass it to `machine-config-operator`

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -293,6 +293,9 @@ then
 		ADDITIONAL_FLAGS="${ADDITIONAL_FLAGS} --cloud-config-file=/assets/config-bootstrap/cloud-provider-config-generated.yaml"
 	fi
 
+	# Dump out image reference file so MCO can consume multiple/additional image references
+	podman run --quiet --rm --net=none --entrypoint="cat" "${RELEASE_IMAGE_DIGEST}" "/release-manifests/image-references" > image-references
+
 	bootkube_podman_run \
 		--name mco-render \
 		--user 0 \
@@ -312,6 +315,7 @@ then
 			--haproxy-image="${HAPROXY_IMAGE}" \
 			--baremetal-runtimecfg-image="${BAREMETAL_RUNTIMECFG_IMAGE}" \
 			--release-image="${RELEASE_IMAGE_DIGEST}" \
+			--image-references=assets/image-references \
 			${ADDITIONAL_FLAGS}
 
 	# Bootstrap MachineConfigController uses /etc/mcc/bootstrap/manifests/ dir to


### PR DESCRIPTION
The MCO needs access to `image-references` during bootstrap so it can reference additional images. 

I'm open to more elegant ways to do this if you have concerns.  
  


As for why...
- As part of [OCP CoreOS Laysering](https://github.com/openshift/enhancements/pull/1150), there are "new format" images that are actually bootable container images rather than just "wrappers" around an ostree commit
- We have built and added these as new ART images `rhel-coreos-8` and `rhel-coreos-8-extensions`. ( https://issues.redhat.com/browse/ART-3883, https://github.com/openshift/release/pull/31118) 
- The MCO eventually wants to use them in lieu of `machine-os-content`
- There will be more images for additional CoreOS versions (e.g. `rhel-coreos-9`, `rhel-coreos-9-extensions`) and potentially other things, so we'd rather have a general case solution rather than add just one more argument (like `--release-image-rhel-coreos-8`) 
- We added a flag to the `machine-config-operator` to accept the `image-references` file in https://github.com/openshift/machine-config-operator/pull/3286 (Specifically: https://github.com/openshift/machine-config-operator/pull/3286/commits/76c17f8ac946025be8236ddb4fafb0e348d2e217) 
- Now we'd like to have `bootkube.sh` feed `image-references` to us so we can use it during bootstrap 
- We will come back for `machine-os-content` later

In service to: https://issues.redhat.com/browse/MCO-291
