### PR TITLE
Bug 2115770: Check for RendezvousIP in Agent config if NMStateConfig is not provided

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -124,7 +124,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		return errors.New("at least one NMState configuration must be provided")
 	}
 
-	nodeZeroIP, err := retrieveRendezvousIP(agentConfigAsset.Config, agentManifests.NMStateConfigs)
+	nodeZeroIP, err := RetrieveRendezvousIP(agentConfigAsset.Config, agentManifests.NMStateConfigs)
 	if err != nil {
 		return err
 	}
@@ -370,7 +370,8 @@ func addExtraManifests(config *igntypes.Config, extraManifests *manifests.ExtraM
 	}
 }
 
-func retrieveRendezvousIP(agentConfig *agent.Config, nmStateConfigs []*v1beta1.NMStateConfig) (string, error) {
+// RetrieveRendezvousIP Returns the Rendezvous IP from either AgentConfig or NMStateConfig
+func RetrieveRendezvousIP(agentConfig *agent.Config, nmStateConfigs []*v1beta1.NMStateConfig) (string, error) {
 	var err error
 	var rendezvousIP string
 

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -148,9 +148,9 @@ func TestIgnition_addStaticNetworkConfig(t *testing.T) {
 }
 
 func TestRetrieveRendezvousIP(t *testing.T) {
-	rawConfig := `interfaces: 
-  - ipv4: 
-      address: 
+	rawConfig := `interfaces:
+  - ipv4:
+      address:
         - ip: "192.168.122.21"`
 	cases := []struct {
 		Name                 string
@@ -204,7 +204,7 @@ func TestRetrieveRendezvousIP(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			rendezvousIP, err := retrieveRendezvousIP(tc.agentConfig, tc.nmStateConfigs)
+			rendezvousIP, err := RetrieveRendezvousIP(tc.agentConfig, tc.nmStateConfigs)
 			if tc.expectedError != "" {
 				assert.Regexp(t, tc.expectedError, err.Error())
 			} else {


### PR DESCRIPTION
Digging around I found this function already implemented so I decided to use it.