### PR TITLE
Collapse AgentConfig spec and add versioning

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -45,7 +45,7 @@ func (a *AgentConfig) Generate(dependencies asset.Parents) error {
 	// Change this when its interactive survey is implemented.
 	agentConfigTemplate := `#
 # Note: This is a sample AgentConfig file showing
-# which fields are available to aid you in creating your 
+# which fields are available to aid you in creating your
 # own agent-config.yaml file.
 #
 apiVersion: v1
@@ -53,36 +53,35 @@ kind: AgentConfig
 metadata:
   name: example-agent-config
   namespace: cluster0
-spec:
 # All fields are optional
-  rendezvousIP: your-node0-ip
-  hosts:
-  # If a host is listed, then at least one interface
-  # needs to be specified.
-  - hostname: change-to-hostname
-    role: master
-    # For more information about rootDeviceHints:
-    # https://docs.openshift.com/container-platform/4.10/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#root-device-hints_ipi-install-installation-workflow
-    rootDeviceHints:
-	  deviceName: /dev/sda
-	# interfaces are used to identify the host to apply this configuration to
+rendezvousIP: your-node0-ip
+hosts:
+# If a host is listed, then at least one interface
+# needs to be specified.
+- hostname: change-to-hostname
+  role: master
+  # For more information about rootDeviceHints:
+  # https://docs.openshift.com/container-platform/4.10/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#root-device-hints_ipi-install-installation-workflow
+  rootDeviceHints:
+ deviceName: /dev/sda
+ interfaces are used to identify the host to apply this configuration to
+  interfaces:
+    - macAddress: 00:00:00:00:00:00
+      name: host-network-interface-name
+  # networkConfig contains the network configuration for the host in NMState format.
+  # See https://nmstate.io/examples.html for examples.
+  networkConfig:
     interfaces:
-      - macAddress: 00:00:00:00:00:00
-        name: host-network-interface-name
-    # networkConfig contains the network configuration for the host in NMState format.
-    # See https://nmstate.io/examples.html for examples.
-    networkConfig:
-      interfaces:
-        - name: eth0
-          type: ethernet
-          state: up
-          mac-address: 00:00:00:00:00:00
-          ipv4:
-            enabled: true
-            address:
-              - ip: 192.168.122.2
-                prefix-length: 23
-            dhcp: false
+      - name: eth0
+        type: ethernet
+        state: up
+        mac-address: 00:00:00:00:00:00
+        ipv4:
+          enabled: true
+          address:
+            - ip: 192.168.122.2
+              prefix-length: 23
+          dhcp: false
 `
 
 	a.Template = agentConfigTemplate
@@ -165,14 +164,14 @@ func (a *AgentConfig) validateAgent() field.ErrorList {
 func (a *AgentConfig) validateNodesHaveAtLeastOneMacAddressDefined() field.ErrorList {
 	var allErrs field.ErrorList
 
-	if len(a.Config.Spec.Hosts) == 0 {
+	if len(a.Config.Hosts) == 0 {
 		return allErrs
 	}
 
-	rootPath := field.NewPath("Spec", "Hosts")
+	rootPath := field.NewPath("Hosts")
 
-	for i := range a.Config.Spec.Hosts {
-		node := a.Config.Spec.Hosts[i]
+	for i := range a.Config.Hosts {
+		node := a.Config.Hosts[i]
 		interfacePath := rootPath.Index(i).Child("Interfaces")
 		if len(node.Interfaces) == 0 {
 			allErrs = append(allErrs, field.Required(interfacePath, "at least one interface must be defined for each node"))
@@ -190,9 +189,9 @@ func (a *AgentConfig) validateNodesHaveAtLeastOneMacAddressDefined() field.Error
 
 func (a *AgentConfig) validateRootDeviceHints() field.ErrorList {
 	var allErrs field.ErrorList
-	rootPath := field.NewPath("Spec", "Hosts")
+	rootPath := field.NewPath("Hosts")
 
-	for i, host := range a.Config.Spec.Hosts {
+	for i, host := range a.Config.Hosts {
 		hostPath := rootPath.Index(i)
 		if host.RootDeviceHints.WWNWithExtension != "" {
 			allErrs = append(allErrs, field.Forbidden(
@@ -211,9 +210,9 @@ func (a *AgentConfig) validateRootDeviceHints() field.ErrorList {
 
 func (a *AgentConfig) validateRoles() field.ErrorList {
 	var allErrs field.ErrorList
-	rootPath := field.NewPath("Spec", "Hosts")
+	rootPath := field.NewPath("Hosts")
 
-	for i, host := range a.Config.Spec.Hosts {
+	for i, host := range a.Config.Hosts {
 		hostPath := rootPath.Index(i)
 		if len(host.Role) > 0 && host.Role != "master" && host.Role != "worker" {
 			allErrs = append(allErrs, field.Forbidden(
@@ -237,7 +236,7 @@ func (a *AgentConfig) HostConfigFiles() (HostConfigFileMap, error) {
 	}
 
 	files := HostConfigFileMap{}
-	for i, host := range a.Config.Spec.Hosts {
+	for i, host := range a.Config.Hosts {
 		name := fmt.Sprintf("host-%d", i)
 		if host.Hostname != "" {
 			name = host.Hostname

--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/types/agent"
+	"github.com/openshift/installer/pkg/types/agent/conversion"
 )
 
 var (
@@ -48,7 +49,7 @@ func (a *AgentConfig) Generate(dependencies asset.Parents) error {
 # which fields are available to aid you in creating your
 # own agent-config.yaml file.
 #
-apiVersion: v1
+apiVersion: v1alpha1
 kind: AgentConfig
 metadata:
   name: example-agent-config
@@ -125,6 +126,11 @@ func (a *AgentConfig) Load(f asset.FileFetcher) (bool, error) {
 	config := &agent.Config{}
 	if err := yaml.UnmarshalStrict(file.Data, config); err != nil {
 		return false, errors.Wrapf(err, "failed to unmarshal %s", agentConfigFilename)
+	}
+
+	// Upconvert any deprecated fields
+	if err := conversion.ConvertAgentConfig(config); err != nil {
+		return false, err
 	}
 
 	a.File, a.Config = file, config

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -27,7 +27,7 @@ import (
 // 			expectedConfig: &agent.Config{
 // 				TypeMeta: metav1.TypeMeta{
 // 					Kind:       "AgentConfig",
-// 					APIVersion: "v1",
+//					APIVersion: agent.AgentConfigVersion,
 // 				},
 // 				ObjectMeta: metav1.ObjectMeta{
 // 					Name:      "example-agent-config",
@@ -96,6 +96,7 @@ func TestAgentConfig_LoadedFromDisk(t *testing.T) {
 		{
 			name: "valid-config-single-node",
 			data: `
+apiVersion: v1alpha1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -120,6 +121,9 @@ hosts:
       interfaces:`,
 			expectedFound: true,
 			expectedConfig: &agent.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: agent.AgentConfigVersion,
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "agent-config-cluster0",
 				},
@@ -158,6 +162,7 @@ hosts:
 		{
 			name: "valid-config-multiple-nodes",
 			data: `
+apiVersion: v1alpha1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -189,6 +194,9 @@ hosts:
         macAddress: 28:d2:44:d2:b2:1b`,
 			expectedFound: true,
 			expectedConfig: &agent.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: agent.AgentConfigVersion,
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "agent-config-cluster0",
 				},
@@ -255,6 +263,7 @@ hosts:
 		{
 			name: "unknown-field",
 			data: `
+apiVersion: v1alpha1
 metadata:
   name: agent-config-wrong
 wrongField: wrongValue`,
@@ -263,6 +272,7 @@ wrongField: wrongValue`,
 		{
 			name: "interface-missing-mac-address-error",
 			data: `
+apiVersion: v1alpha1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -277,6 +287,7 @@ hosts:
 		{
 			name: "unsupported wwn extension root device hint",
 			data: `
+apiVersion: v1alpha1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -292,6 +303,7 @@ hosts:
 		{
 			name: "unsupported wwn vendor extension root device hint",
 			data: `
+apiVersion: v1alpha1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -307,6 +319,7 @@ hosts:
 		{
 			name: "node-hostname-and-role-are-not-required",
 			data: `
+apiVersion: v1alpha1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -316,6 +329,9 @@ hosts:
         macAddress: 28:d2:44:d2:b2:1a`,
 			expectedFound: true,
 			expectedConfig: &agent.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: agent.AgentConfigVersion,
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "agent-config-cluster0",
 				},
@@ -335,6 +351,7 @@ hosts:
 		{
 			name: "host-roles-have-correct-values",
 			data: `
+apiVersion: v1alpha1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -349,6 +366,9 @@ hosts:
         macAddress: 28:d2:44:d2:b2:1b`,
 			expectedFound: true,
 			expectedConfig: &agent.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: agent.AgentConfigVersion,
+				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "agent-config-cluster0",
 				},
@@ -378,6 +398,7 @@ hosts:
 		{
 			name: "host-roles-have-incorrect-values",
 			data: `
+apiVersion: v1alpha1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -261,11 +261,11 @@ spec:
 		{
 			name: "unknown-field",
 			data: `
-		metadata:
-		  name: agent-config-wrong
-		spec:
-		  wrongField: wrongValue`,
-			expectedError: "failed to unmarshal agent-config.yaml: error converting YAML to JSON: yaml: line 2: found character that cannot start any token",
+metadata:
+  name: agent-config-wrong
+spec:
+  wrongField: wrongValue`,
+			expectedError: "failed to unmarshal agent-config.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"wrongField\"",
 		},
 		{
 			name: "interface-missing-mac-address-error",

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -98,61 +98,58 @@ func TestAgentConfig_LoadedFromDisk(t *testing.T) {
 			data: `
 metadata:
   name: agent-config-cluster0
-spec:
-  rendezvousIP: 192.168.111.80
-  hosts:
-    - hostname: control-0.example.org
-      role: master
-      rootDeviceHints:
-        deviceName: "/dev/sda"
-        hctl: "hctl-value"
-        model: "model-value"
-        vendor: "vendor-value"
-        serialNumber: "serial-number-value"
-        minSizeGigabytes: 20
-        wwn: "wwn-value"
-        rotational: false
-      interfaces:
-        - name: enp2s0
-          macAddress: 98:af:65:a5:8d:01
-        - name: enp3s1
-          macAddress: 28:d2:44:d2:b2:1a
-      networkConfig:
-        interfaces:`,
+rendezvousIP: 192.168.111.80
+hosts:
+  - hostname: control-0.example.org
+    role: master
+    rootDeviceHints:
+      deviceName: "/dev/sda"
+      hctl: "hctl-value"
+      model: "model-value"
+      vendor: "vendor-value"
+      serialNumber: "serial-number-value"
+      minSizeGigabytes: 20
+      wwn: "wwn-value"
+      rotational: false
+    interfaces:
+      - name: enp2s0
+        macAddress: 98:af:65:a5:8d:01
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1a
+    networkConfig:
+      interfaces:`,
 			expectedFound: true,
 			expectedConfig: &agent.Config{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "agent-config-cluster0",
 				},
-				Spec: agent.Spec{
-					RendezvousIP: "192.168.111.80",
-					Hosts: []agent.Host{
-						{
-							Hostname: "control-0.example.org",
-							Role:     "master",
-							RootDeviceHints: baremetal.RootDeviceHints{
-								DeviceName:       "/dev/sda",
-								HCTL:             "hctl-value",
-								Model:            "model-value",
-								Vendor:           "vendor-value",
-								SerialNumber:     "serial-number-value",
-								MinSizeGigabytes: 20,
-								WWN:              "wwn-value",
-								Rotational:       falsePtr,
+				RendezvousIP: "192.168.111.80",
+				Hosts: []agent.Host{
+					{
+						Hostname: "control-0.example.org",
+						Role:     "master",
+						RootDeviceHints: baremetal.RootDeviceHints{
+							DeviceName:       "/dev/sda",
+							HCTL:             "hctl-value",
+							Model:            "model-value",
+							Vendor:           "vendor-value",
+							SerialNumber:     "serial-number-value",
+							MinSizeGigabytes: 20,
+							WWN:              "wwn-value",
+							Rotational:       falsePtr,
+						},
+						Interfaces: []*aiv1beta1.Interface{
+							{
+								Name:       "enp2s0",
+								MacAddress: "98:af:65:a5:8d:01",
 							},
-							Interfaces: []*aiv1beta1.Interface{
-								{
-									Name:       "enp2s0",
-									MacAddress: "98:af:65:a5:8d:01",
-								},
-								{
-									Name:       "enp3s1",
-									MacAddress: "28:d2:44:d2:b2:1a",
-								},
+							{
+								Name:       "enp3s1",
+								MacAddress: "28:d2:44:d2:b2:1a",
 							},
-							NetworkConfig: aiv1beta1.NetConfig{
-								Raw: unmarshalJSON([]byte("interfaces:")),
-							},
+						},
+						NetworkConfig: aiv1beta1.NetConfig{
+							Raw: unmarshalJSON([]byte("interfaces:")),
 						},
 					},
 				},
@@ -163,81 +160,78 @@ spec:
 			data: `
 metadata:
   name: agent-config-cluster0
-spec:
-  rendezvousIP: 192.168.111.80
-  hosts:
-    - hostname: control-0.example.org
-      role: master
-      rootDeviceHints:
-        deviceName: "/dev/sda"
-        hctl: "hctl-value"
-        model: "model-value"
-        vendor: "vendor-value"
-        serialNumber: "serial-number-value"
-        minSizeGigabytes: 20
-        wwn: "wwn-value"
-        rotational: false
+rendezvousIP: 192.168.111.80
+hosts:
+  - hostname: control-0.example.org
+    role: master
+    rootDeviceHints:
+      deviceName: "/dev/sda"
+      hctl: "hctl-value"
+      model: "model-value"
+      vendor: "vendor-value"
+      serialNumber: "serial-number-value"
+      minSizeGigabytes: 20
+      wwn: "wwn-value"
+      rotational: false
+    interfaces:
+      - name: enp2s0
+        macAddress: 98:af:65:a5:8d:01
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1a
+    networkConfig:
       interfaces:
-        - name: enp2s0
-          macAddress: 98:af:65:a5:8d:01
-        - name: enp3s1
-          macAddress: 28:d2:44:d2:b2:1a
-      networkConfig:
-        interfaces:
-    - hostname: control-1.example.org
-      role: master
-      interfaces:
-        - name: enp2s0
-          macAddress: 98:af:65:a5:8d:02
-        - name: enp3s1
-          macAddress: 28:d2:44:d2:b2:1b`,
+  - hostname: control-1.example.org
+    role: master
+    interfaces:
+      - name: enp2s0
+        macAddress: 98:af:65:a5:8d:02
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1b`,
 			expectedFound: true,
 			expectedConfig: &agent.Config{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "agent-config-cluster0",
 				},
-				Spec: agent.Spec{
-					RendezvousIP: "192.168.111.80",
-					Hosts: []agent.Host{
-						{
-							Hostname: "control-0.example.org",
-							Role:     "master",
-							RootDeviceHints: baremetal.RootDeviceHints{
-								DeviceName:       "/dev/sda",
-								HCTL:             "hctl-value",
-								Model:            "model-value",
-								Vendor:           "vendor-value",
-								SerialNumber:     "serial-number-value",
-								MinSizeGigabytes: 20,
-								WWN:              "wwn-value",
-								Rotational:       falsePtr,
+				RendezvousIP: "192.168.111.80",
+				Hosts: []agent.Host{
+					{
+						Hostname: "control-0.example.org",
+						Role:     "master",
+						RootDeviceHints: baremetal.RootDeviceHints{
+							DeviceName:       "/dev/sda",
+							HCTL:             "hctl-value",
+							Model:            "model-value",
+							Vendor:           "vendor-value",
+							SerialNumber:     "serial-number-value",
+							MinSizeGigabytes: 20,
+							WWN:              "wwn-value",
+							Rotational:       falsePtr,
+						},
+						Interfaces: []*aiv1beta1.Interface{
+							{
+								Name:       "enp2s0",
+								MacAddress: "98:af:65:a5:8d:01",
 							},
-							Interfaces: []*aiv1beta1.Interface{
-								{
-									Name:       "enp2s0",
-									MacAddress: "98:af:65:a5:8d:01",
-								},
-								{
-									Name:       "enp3s1",
-									MacAddress: "28:d2:44:d2:b2:1a",
-								},
-							},
-							NetworkConfig: aiv1beta1.NetConfig{
-								Raw: unmarshalJSON([]byte("interfaces:")),
+							{
+								Name:       "enp3s1",
+								MacAddress: "28:d2:44:d2:b2:1a",
 							},
 						},
-						{
-							Hostname: "control-1.example.org",
-							Role:     "master",
-							Interfaces: []*aiv1beta1.Interface{
-								{
-									Name:       "enp2s0",
-									MacAddress: "98:af:65:a5:8d:02",
-								},
-								{
-									Name:       "enp3s1",
-									MacAddress: "28:d2:44:d2:b2:1b",
-								},
+						NetworkConfig: aiv1beta1.NetConfig{
+							Raw: unmarshalJSON([]byte("interfaces:")),
+						},
+					},
+					{
+						Hostname: "control-1.example.org",
+						Role:     "master",
+						Interfaces: []*aiv1beta1.Interface{
+							{
+								Name:       "enp2s0",
+								MacAddress: "98:af:65:a5:8d:02",
+							},
+							{
+								Name:       "enp3s1",
+								MacAddress: "28:d2:44:d2:b2:1b",
 							},
 						},
 					},
@@ -263,8 +257,7 @@ spec:
 			data: `
 metadata:
   name: agent-config-wrong
-spec:
-  wrongField: wrongValue`,
+wrongField: wrongValue`,
 			expectedError: "failed to unmarshal agent-config.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"wrongField\"",
 		},
 		{
@@ -272,73 +265,67 @@ spec:
 			data: `
 metadata:
   name: agent-config-cluster0
-spec:
-  rendezvousIP: 192.168.111.80
-  hosts:
-    - hostname: control-0.example.org
-      interfaces:
-        - name: enp2s0
-        - name: enp3s1
-          macAddress: 28:d2:44:d2:b2:1a`,
-			expectedError: "invalid Agent Config configuration: Spec.Hosts[0].Interfaces[0].macAddress: Required value: each interface must have a MAC address defined",
+rendezvousIP: 192.168.111.80
+hosts:
+  - hostname: control-0.example.org
+    interfaces:
+      - name: enp2s0
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1a`,
+			expectedError: "invalid Agent Config configuration: Hosts[0].Interfaces[0].macAddress: Required value: each interface must have a MAC address defined",
 		},
 		{
 			name: "unsupported wwn extension root device hint",
 			data: `
 metadata:
   name: agent-config-cluster0
-spec:
-  rendezvousIP: 192.168.111.80
-  hosts:
-    - hostname: control-0.example.org
-      interfaces:
-        - name: enp2s0
-          macAddress: 98:af:65:a5:8d:01
-      rootDeviceHints:
-        wwnWithExtension: "wwn-with-extension-value"`,
-			expectedError: "invalid Agent Config configuration: Spec.Hosts[0].RootDeviceHints.WWNWithExtension: Forbidden: WWN extensions are not supported in root device hints",
+rendezvousIP: 192.168.111.80
+hosts:
+  - hostname: control-0.example.org
+    interfaces:
+      - name: enp2s0
+        macAddress: 98:af:65:a5:8d:01
+    rootDeviceHints:
+      wwnWithExtension: "wwn-with-extension-value"`,
+			expectedError: "invalid Agent Config configuration: Hosts[0].RootDeviceHints.WWNWithExtension: Forbidden: WWN extensions are not supported in root device hints",
 		},
 		{
 			name: "unsupported wwn vendor extension root device hint",
 			data: `
 metadata:
   name: agent-config-cluster0
-spec:
-  rendezvousIP: 192.168.111.80
-  hosts:
-    - hostname: control-0.example.org
-      interfaces:
-        - name: enp2s0
-          macAddress: 98:af:65:a5:8d:01
-      rootDeviceHints:
-        wwnVendorExtension: "wwn-with-vendor-extension-value"`,
-			expectedError: "invalid Agent Config configuration: Spec.Hosts[0].RootDeviceHints.WWNVendorExtension: Forbidden: WWN vendor extensions are not supported in root device hints",
+rendezvousIP: 192.168.111.80
+hosts:
+  - hostname: control-0.example.org
+    interfaces:
+      - name: enp2s0
+        macAddress: 98:af:65:a5:8d:01
+    rootDeviceHints:
+      wwnVendorExtension: "wwn-with-vendor-extension-value"`,
+			expectedError: "invalid Agent Config configuration: Hosts[0].RootDeviceHints.WWNVendorExtension: Forbidden: WWN vendor extensions are not supported in root device hints",
 		},
 		{
 			name: "node-hostname-and-role-are-not-required",
 			data: `
 metadata:
   name: agent-config-cluster0
-spec:
-  rendezvousIP: 192.168.111.80
-  hosts:
-    - interfaces:
-        - name: enp3s1
-          macAddress: 28:d2:44:d2:b2:1a`,
+rendezvousIP: 192.168.111.80
+hosts:
+  - interfaces:
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1a`,
 			expectedFound: true,
 			expectedConfig: &agent.Config{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "agent-config-cluster0",
 				},
-				Spec: agent.Spec{
-					RendezvousIP: "192.168.111.80",
-					Hosts: []agent.Host{
-						{
-							Interfaces: []*aiv1beta1.Interface{
-								{
-									Name:       "enp3s1",
-									MacAddress: "28:d2:44:d2:b2:1a",
-								},
+				RendezvousIP: "192.168.111.80",
+				Hosts: []agent.Host{
+					{
+						Interfaces: []*aiv1beta1.Interface{
+							{
+								Name:       "enp3s1",
+								MacAddress: "28:d2:44:d2:b2:1a",
 							},
 						},
 					},
@@ -350,41 +337,38 @@ spec:
 			data: `
 metadata:
   name: agent-config-cluster0
-spec:
-  rendezvousIP: 192.168.111.80
-  hosts:
-    - role: master
-      interfaces:
-        - name: enp3s1
-          macAddress: 28:d2:44:d2:b2:1a
-    - role: worker
-      interfaces:
-        - name: enp3s1
-          macAddress: 28:d2:44:d2:b2:1b`,
+rendezvousIP: 192.168.111.80
+hosts:
+  - role: master
+    interfaces:
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1a
+  - role: worker
+    interfaces:
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1b`,
 			expectedFound: true,
 			expectedConfig: &agent.Config{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "agent-config-cluster0",
 				},
-				Spec: agent.Spec{
-					RendezvousIP: "192.168.111.80",
-					Hosts: []agent.Host{
-						{
-							Role: "master",
-							Interfaces: []*aiv1beta1.Interface{
-								{
-									Name:       "enp3s1",
-									MacAddress: "28:d2:44:d2:b2:1a",
-								},
+				RendezvousIP: "192.168.111.80",
+				Hosts: []agent.Host{
+					{
+						Role: "master",
+						Interfaces: []*aiv1beta1.Interface{
+							{
+								Name:       "enp3s1",
+								MacAddress: "28:d2:44:d2:b2:1a",
 							},
 						},
-						{
-							Role: "worker",
-							Interfaces: []*aiv1beta1.Interface{
-								{
-									Name:       "enp3s1",
-									MacAddress: "28:d2:44:d2:b2:1b",
-								},
+					},
+					{
+						Role: "worker",
+						Interfaces: []*aiv1beta1.Interface{
+							{
+								Name:       "enp3s1",
+								MacAddress: "28:d2:44:d2:b2:1b",
 							},
 						},
 					},
@@ -396,14 +380,13 @@ spec:
 			data: `
 metadata:
   name: agent-config-cluster0
-spec:
-  rendezvousIP: 192.168.111.80
-  hosts:
-    - role: invalid-role
-      interfaces:
-        - name: enp3s1
-          macAddress: 28:d2:44:d2:b2:1a`,
-			expectedError: "invalid Agent Config configuration: Spec.Hosts[0].Host: Forbidden: host role has incorrect value. Role must either be 'master' or 'worker'",
+rendezvousIP: 192.168.111.80
+hosts:
+  - role: invalid-role
+    interfaces:
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1a`,
+			expectedError: "invalid Agent Config configuration: Hosts[0].Host: Forbidden: host role has incorrect value. Role must either be 'master' or 'worker'",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -316,10 +316,10 @@ func addMirrorData(config *igntypes.Config, registriesConfig *mirror.RegistriesC
 func addMacAddressToHostnameMappings(
 	config *igntypes.Config,
 	agentConfigAsset *agentconfig.AgentConfig) {
-	if agentConfigAsset.Config == nil || len(agentConfigAsset.Config.Spec.Hosts) == 0 {
+	if agentConfigAsset.Config == nil || len(agentConfigAsset.Config.Hosts) == 0 {
 		return
 	}
-	for _, host := range agentConfigAsset.Config.Spec.Hosts {
+	for _, host := range agentConfigAsset.Config.Hosts {
 		if host.Hostname != "" {
 			file := ignition.FileFromBytes(filepath.Join(hostnamesPath,
 				strings.ToLower(filepath.Base(host.Interfaces[0].MacAddress))),
@@ -370,15 +370,15 @@ func retrieveRendezvousIP(agentConfig *agent.Config, nmStateConfigs []*v1beta1.N
 	var err error
 	var rendezvousIP string
 
-	if agentConfig != nil && agentConfig.Spec.RendezvousIP != "" {
-		rendezvousIP = agentConfig.Spec.RendezvousIP
+	if agentConfig != nil && agentConfig.RendezvousIP != "" {
+		rendezvousIP = agentConfig.RendezvousIP
 		logrus.Debug("RendezvousIP from the AgentConfig ", rendezvousIP)
 
 	} else if len(nmStateConfigs) > 0 {
 		rendezvousIP, err = manifests.GetNodeZeroIP(nmStateConfigs)
 		logrus.Debug("RendezvousIP from the NMStateConfig ", rendezvousIP)
 	} else {
-		err = errors.New("missing Spec.RendezvousIP in agent-config or atleast one nmstateconfig manifest file")
+		err = errors.New("missing rendezvousIP in agent-config or at least one NMStateConfig manifest")
 	}
 	return rendezvousIP, err
 }

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -161,13 +161,11 @@ func TestRetrieveRendezvousIP(t *testing.T) {
 		{
 			Name: "valid-agent-config-provided-with-RendezvousIP",
 			agentConfig: &agent.Config{
-				Spec: agent.Spec{
-					RendezvousIP: "192.168.122.21",
-					Hosts: []agent.Host{
-						{
-							Hostname: "control-0.example.org",
-							Role:     "master",
-						},
+				RendezvousIP: "192.168.122.21",
+				Hosts: []agent.Host{
+					{
+						Hostname: "control-0.example.org",
+						Role:     "master",
 					},
 				},
 			},
@@ -189,16 +187,14 @@ func TestRetrieveRendezvousIP(t *testing.T) {
 		{
 			Name: "neither-agent-config-was-provided-with-RendezvousIP-nor-nmstateconfig-manifest",
 			agentConfig: &agent.Config{
-				Spec: agent.Spec{
-					Hosts: []agent.Host{
-						{
-							Hostname: "control-0.example.org",
-							Role:     "master",
-						},
+				Hosts: []agent.Host{
+					{
+						Hostname: "control-0.example.org",
+						Role:     "master",
 					},
 				},
 			},
-			expectedError: "missing Spec.RendezvousIP in agent-config or atleast one nmstateconfig manifest file",
+			expectedError: "missing rendezvousIP in agent-config or at least one NMStateConfig manifest",
 		},
 	}
 	for _, tc := range cases {
@@ -225,11 +221,9 @@ func TestAddHostConfig_Roles(t *testing.T) {
 			Name: "one-host-role-defined",
 			agentConfig: &agentconfig.AgentConfig{
 				Config: &agent.Config{
-					Spec: agent.Spec{
-						Hosts: []agent.Host{
-							{
-								Role: "master",
-							},
+					Hosts: []agent.Host{
+						{
+							Role: "master",
 						},
 					},
 				},
@@ -240,23 +234,21 @@ func TestAddHostConfig_Roles(t *testing.T) {
 			Name: "multiple-host-roles-defined",
 			agentConfig: &agentconfig.AgentConfig{
 				Config: &agent.Config{
-					Spec: agent.Spec{
-						Hosts: []agent.Host{
-							{
-								Role: "master",
-							},
-							{
-								Role: "master",
-							},
-							{
-								Role: "master",
-							},
-							{
-								Role: "worker",
-							},
-							{
-								Role: "worker",
-							},
+					Hosts: []agent.Host{
+						{
+							Role: "master",
+						},
+						{
+							Role: "master",
+						},
+						{
+							Role: "master",
+						},
+						{
+							Role: "worker",
+						},
+						{
+							Role: "worker",
 						},
 					},
 				},
@@ -393,9 +385,7 @@ func buildIgnitionAssetDefaultDependencies() []asset.Asset {
 		},
 		&agentconfig.AgentConfig{
 			Config: &agent.Config{
-				Spec: agent.Spec{
-					RendezvousIP: "192.168.111.80",
-				},
+				RendezvousIP: "192.168.111.80",
 			},
 			File: &asset.File{
 				Filename: "/cluster-manifests/agent-config.yaml",

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -75,7 +75,7 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 	var data string
 
 	if agentConfig.Config != nil {
-		for i, host := range agentConfig.Config.Spec.Hosts {
+		for i, host := range agentConfig.Config.Hosts {
 			nmStateConfig := aiv1beta1.NMStateConfig{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "NMStateConfig",

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -85,87 +85,85 @@ func getValidAgentConfig() *agentconfig.AgentConfig {
 				Name:      "ocp-edge-cluster-0",
 				Namespace: "cluster-0",
 			},
-			Spec: agenttypes.Spec{
-				RendezvousIP: "192.168.122.2",
-				Hosts: []agenttypes.Host{
-					{
-						Hostname: "control-0.example.org",
-						Role:     "master",
-						RootDeviceHints: baremetal.RootDeviceHints{
-							DeviceName:         "/dev/sda",
-							HCTL:               "hctl-value",
-							Model:              "model-value",
-							Vendor:             "vendor-value",
-							SerialNumber:       "serial-number-value",
-							MinSizeGigabytes:   20,
-							WWN:                "wwn-value",
-							WWNWithExtension:   "wwn-with-extension-value",
-							WWNVendorExtension: "wwn-vendor-extension-value",
-							Rotational:         new(bool),
+			RendezvousIP: "192.168.122.2",
+			Hosts: []agenttypes.Host{
+				{
+					Hostname: "control-0.example.org",
+					Role:     "master",
+					RootDeviceHints: baremetal.RootDeviceHints{
+						DeviceName:         "/dev/sda",
+						HCTL:               "hctl-value",
+						Model:              "model-value",
+						Vendor:             "vendor-value",
+						SerialNumber:       "serial-number-value",
+						MinSizeGigabytes:   20,
+						WWN:                "wwn-value",
+						WWNWithExtension:   "wwn-with-extension-value",
+						WWNVendorExtension: "wwn-vendor-extension-value",
+						Rotational:         new(bool),
+					},
+					Interfaces: []*v1beta1.Interface{
+						{
+							Name:       "enp2s0",
+							MacAddress: "98:af:65:a5:8d:01",
 						},
-						Interfaces: []*v1beta1.Interface{
-							{
-								Name:       "enp2s0",
-								MacAddress: "98:af:65:a5:8d:01",
-							},
-							{
-								Name:       "enp3s1",
-								MacAddress: "28:d2:44:d2:b2:1a",
-							},
-						},
-						NetworkConfig: v1beta1.NetConfig{
-							Raw: unmarshalJSON([]byte("interfaces:")),
+						{
+							Name:       "enp3s1",
+							MacAddress: "28:d2:44:d2:b2:1a",
 						},
 					},
-					{
-						Hostname: "control-1.example.org",
-						Role:     "master",
-						RootDeviceHints: baremetal.RootDeviceHints{
-							DeviceName:         "/dev/sdb",
-							HCTL:               "hctl-value",
-							Model:              "model-value",
-							Vendor:             "vendor-value",
-							SerialNumber:       "serial-number-value",
-							MinSizeGigabytes:   40,
-							WWN:                "wwn-value",
-							WWNWithExtension:   "wwn-with-extension-value",
-							WWNVendorExtension: "wwn-vendor-extension-value",
-							Rotational:         new(bool),
-						},
-						Interfaces: []*v1beta1.Interface{
-							{
-								Name:       "enp2t0",
-								MacAddress: "98:af:65:a5:8d:02",
-							},
-						},
-						NetworkConfig: v1beta1.NetConfig{
-							Raw: unmarshalJSON([]byte("interfaces:")),
+					NetworkConfig: v1beta1.NetConfig{
+						Raw: unmarshalJSON([]byte("interfaces:")),
+					},
+				},
+				{
+					Hostname: "control-1.example.org",
+					Role:     "master",
+					RootDeviceHints: baremetal.RootDeviceHints{
+						DeviceName:         "/dev/sdb",
+						HCTL:               "hctl-value",
+						Model:              "model-value",
+						Vendor:             "vendor-value",
+						SerialNumber:       "serial-number-value",
+						MinSizeGigabytes:   40,
+						WWN:                "wwn-value",
+						WWNWithExtension:   "wwn-with-extension-value",
+						WWNVendorExtension: "wwn-vendor-extension-value",
+						Rotational:         new(bool),
+					},
+					Interfaces: []*v1beta1.Interface{
+						{
+							Name:       "enp2t0",
+							MacAddress: "98:af:65:a5:8d:02",
 						},
 					},
-					{
-						Hostname: "control-2.example.org",
-						Role:     "master",
-						RootDeviceHints: baremetal.RootDeviceHints{
-							DeviceName:         "/dev/sdc",
-							HCTL:               "hctl-value",
-							Model:              "model-value",
-							Vendor:             "vendor-value",
-							SerialNumber:       "serial-number-value",
-							MinSizeGigabytes:   60,
-							WWN:                "wwn-value",
-							WWNWithExtension:   "wwn-with-extension-value",
-							WWNVendorExtension: "wwn-vendor-extension-value",
-							Rotational:         new(bool),
+					NetworkConfig: v1beta1.NetConfig{
+						Raw: unmarshalJSON([]byte("interfaces:")),
+					},
+				},
+				{
+					Hostname: "control-2.example.org",
+					Role:     "master",
+					RootDeviceHints: baremetal.RootDeviceHints{
+						DeviceName:         "/dev/sdc",
+						HCTL:               "hctl-value",
+						Model:              "model-value",
+						Vendor:             "vendor-value",
+						SerialNumber:       "serial-number-value",
+						MinSizeGigabytes:   60,
+						WWN:                "wwn-value",
+						WWNWithExtension:   "wwn-with-extension-value",
+						WWNVendorExtension: "wwn-vendor-extension-value",
+						Rotational:         new(bool),
+					},
+					Interfaces: []*v1beta1.Interface{
+						{
+							Name:       "enp2u0",
+							MacAddress: "98:af:65:a5:8d:03",
 						},
-						Interfaces: []*v1beta1.Interface{
-							{
-								Name:       "enp2u0",
-								MacAddress: "98:af:65:a5:8d:03",
-							},
-						},
-						NetworkConfig: v1beta1.NetConfig{
-							Raw: unmarshalJSON([]byte("interfaces:")),
-						},
+					},
+					NetworkConfig: v1beta1.NetConfig{
+						Raw: unmarshalJSON([]byte("interfaces:")),
 					},
 				},
 			},

--- a/pkg/types/agent/OWNERS
+++ b/pkg/types/agent/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - agent-approvers
+reviewers:
+  - agent-reviewers

--- a/pkg/types/agent/agent_config_type.go
+++ b/pkg/types/agent/agent_config_type.go
@@ -6,6 +6,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// AgentConfigVersion is the version supported by this package.
+// If you bump this, you must also update the list of convertable values in
+// pkg/types/conversion/agentconfig.go
+const AgentConfigVersion = "v1alpha1"
+
 // Config or aka AgentConfig is the API for specifying additional
 // configuration for the agent-based installer not covered by
 // install-config.

--- a/pkg/types/agent/agent_config_type.go
+++ b/pkg/types/agent/agent_config_type.go
@@ -13,12 +13,6 @@ type Config struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec Spec `json:"spec,omitempty"`
-	// No status
-}
-
-// Spec contains additional configuration for the agent-based installer
-type Spec struct {
 	// ip address of node0
 	RendezvousIP string `json:"rendezvousIP,omitempty"`
 	Hosts        []Host `json:"hosts,omitempty"`

--- a/pkg/types/agent/conversion/agentconfig.go
+++ b/pkg/types/agent/conversion/agentconfig.go
@@ -1,0 +1,28 @@
+package conversion
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types/agent"
+)
+
+// ConvertAgentConfig is modeled after the k8s conversion schemes, which is
+// how deprecated values are upconverted.
+// This updates the APIVersion to reflect the fact that we've internally
+// upconverted.
+func ConvertAgentConfig(config *agent.Config) error {
+	// check that the version is convertible
+	switch config.APIVersion {
+	case agent.AgentConfigVersion:
+		// works
+	case "":
+		return field.Required(field.NewPath("apiVersion"), "no version was provided")
+	default:
+		return field.Invalid(field.NewPath("apiVersion"), config.APIVersion, fmt.Sprintf("cannot upconvert from version %s", config.APIVersion))
+	}
+
+	config.APIVersion = agent.AgentConfigVersion
+	return nil
+}

--- a/pkg/types/agent/conversion/agentconfig_test.go
+++ b/pkg/types/agent/conversion/agentconfig_test.go
@@ -1,0 +1,59 @@
+package conversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/installer/pkg/types/agent"
+)
+
+func TestConvertAgentConfig(t *testing.T) {
+	cases := []struct {
+		name          string
+		config        *agent.Config
+		expected      *agent.Config
+		expectedError string
+	}{
+		{
+			name: "empty",
+			config: &agent.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: agent.AgentConfigVersion,
+				},
+			},
+			expected: &agent.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: agent.AgentConfigVersion,
+				},
+			},
+		},
+		{
+			name:          "no version",
+			config:        &agent.Config{},
+			expectedError: "no version was provided",
+		},
+		{
+			name: "bad version",
+			config: &agent.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1alpha0",
+				},
+			},
+			expectedError: "cannot upconvert from version v1alpha0",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ConvertAgentConfig(tc.config)
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, tc.config, "unexpected install config")
+			} else {
+				assert.Regexp(t, tc.expectedError, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The InstallConfig schema does not have a Spec subresource, so
configuration items are added directly at the top level of the file. It
is desirable that the AgentConfig should behave the same. There is no
Status subresource for an AgentConfig either, and in fact not even any
plans to ever install AgentConfig into clusters as a CRD, so there is no
need for a Spec.

Set the initial version of AgentConfig to v1alpha1, since we are not yet
committing to not changing it. This will now be required.

This is a breaking change that will require users to change their
existing agent-config.yaml files, so better that it happen now.