### PR TITLE
AGENT-246: Temporarily require at least one NMStateConfig to be specified

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -120,6 +120,10 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		},
 	}
 
+	if len(agentManifests.NMStateConfigs) == 0 {
+		return errors.New("at least one NMState configuration must be provided")
+	}
+
 	nodeZeroIP, err := retrieveRendezvousIP(agentConfigAsset.Config, agentManifests.NMStateConfigs)
 	if err != nil {
 		return err

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -12,6 +12,7 @@ import (
 
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/api/v1beta1"
+	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 	"github.com/openshift/assisted-service/models"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/installer/pkg/asset"
@@ -387,6 +388,18 @@ func buildIgnitionAssetDefaultDependencies() []asset.Asset {
 					ProvisionRequirements: hiveext.ProvisionRequirements{
 						ControlPlaneAgents: 3,
 						WorkerAgents:       5,
+					},
+				},
+			},
+			NMStateConfigs: []*aiv1beta1.NMStateConfig{
+				{
+					Spec: aiv1beta1.NMStateConfigSpec{
+						Interfaces: []*aiv1beta1.Interface{
+							{
+								Name:       "eth0",
+								MacAddress: "00:01:02:03:04:05",
+							},
+						},
 					},
 				},
 			},

--- a/pkg/asset/agent/manifests/nmstateconfig_test.go
+++ b/pkg/asset/agent/manifests/nmstateconfig_test.go
@@ -287,7 +287,7 @@ spec:
     - name: "eth0"
       macAddress: "52:54:01:bb:bb:b1"`,
 			requiresNmstatectl: true,
-			expectedError:      "staticNetwork configuration is not valid.*",
+			expectedError:      "staticNetwork configuration is not valid",
 		},
 
 		{
@@ -314,7 +314,7 @@ spec:
     - name: "eth0"
       macAddress: "52:54:01:aa:aa:a1"`,
 			requiresNmstatectl: true,
-			expectedError:      "staticNetwork configuration is not valid.*",
+			expectedError:      "staticNetwork configuration is not valid",
 		},
 
 		{
@@ -383,7 +383,7 @@ spec:
 			found, err := asset.Load(fileFetcher)
 			assert.Equal(t, tc.expectedFound, found, "unexpected found value returned from Load")
 			if tc.expectedError != "" {
-				assert.Regexp(t, tc.expectedError, err.Error())
+				assert.ErrorContains(t, err, tc.expectedError)
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
Numerous places assume that there will be at least one NMStateConfig:

* https://bugzilla.redhat.com/show_bug.cgi?id=2116489
* https://bugzilla.redhat.com/show_bug.cgi?id=2115770
* https://bugzilla.redhat.com/show_bug.cgi?id=2115798
* https://bugzilla.redhat.com/show_bug.cgi?id=2115803
* https://bugzilla.redhat.com/show_bug.cgi?id=2117302

Since these are not easily discoverable by users, temporarily reinstate
the requirement that at least one NMState configuration be provided
(even if the RendezvousIP is specified). This will provide users with an
upfront error rather than a difficult-to-debug mystery.