### PR TITLE
manifests: Pass the NetworkProjectID to manifests

### DIFF
--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -179,7 +179,7 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 		if installConfig.Config.GCP.ComputeSubnet != "" {
 			subnet = installConfig.Config.GCP.ComputeSubnet
 		}
-		gcpConfig, err := gcpmanifests.CloudProviderConfig(clusterID.InfraID, installConfig.Config.GCP.ProjectID, subnet)
+		gcpConfig, err := gcpmanifests.CloudProviderConfig(clusterID.InfraID, installConfig.Config.GCP.ProjectID, subnet, installConfig.Config.GCP.NetworkProjectID)
 		if err != nil {
 			return errors.Wrap(err, "could not create cloud provider config")
 		}

--- a/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -22,10 +22,12 @@ type global struct {
 	ExternalInstanceGroupsPrefix string   `gcfg:"external-instance-groups-prefix"`
 
 	SubnetworkName string `gcfg:"subnetwork-name"`
+
+	NetworkProjectID string `gcfg:"network-project-id"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the GCP platform.
-func CloudProviderConfig(infraID, projectID, subnet string) (string, error) {
+func CloudProviderConfig(infraID, projectID, subnet, networkProjectID string) (string, error) {
 	config := &config{
 		Global: global{
 			ProjectID: projectID,
@@ -41,8 +43,12 @@ func CloudProviderConfig(infraID, projectID, subnet string) (string, error) {
 
 			// Used for internal load balancers
 			SubnetworkName: subnet,
+
+			// Used for shared vpc installations,
+			NetworkProjectID: networkProjectID,
 		},
 	}
+
 	buf := &bytes.Buffer{}
 	template := template.Must(template.New("gce cloudproviderconfig").Parse(configTmpl))
 	if err := template.Execute(buf, config); err != nil {
@@ -61,5 +67,6 @@ node-tags       = {{$tag}}
 node-instance-prefix = {{.Global.NodeInstancePrefix}}
 external-instance-groups-prefix = {{.Global.ExternalInstanceGroupsPrefix}}
 subnetwork-name = {{.Global.SubnetworkName}}
+{{ if ne .Global.NetworkProjectID "" }}network-project-id = {{.Global.NetworkProjectID}}{{end}}
 
 `

--- a/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
+++ b/pkg/asset/manifests/gcp/cloudproviderconfig_test.go
@@ -17,8 +17,27 @@ node-instance-prefix = uid
 external-instance-groups-prefix = uid
 subnetwork-name = uid-worker-subnet
 
+
 `
-	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet")
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "")
+	assert.NoError(t, err, "failed to create cloud provider config")
+	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
+}
+
+func TestCloudProviderConfigWithNPID(t *testing.T) {
+	expectedConfig := `[global]
+project-id      = test-project-id
+regional        = true
+multizone       = true
+node-tags       = uid-master
+node-tags       = uid-worker
+node-instance-prefix = uid
+external-instance-groups-prefix = uid
+subnetwork-name = uid-worker-subnet
+network-project-id = test-network-project-id
+
+`
+	actualConfig, err := CloudProviderConfig("uid", "test-project-id", "uid-worker-subnet", "test-network-project-id")
 	assert.NoError(t, err, "failed to create cloud provider config")
 	assert.Equal(t, expectedConfig, actualConfig, "unexpected cloud provider config")
 }


### PR DESCRIPTION
** Pull the NetworkProjectID out of the installconfig and pass it to the cloud provider manifests
** Added tests for the new manifest information
** Added the network project ID to match that of
https://github.com/openshift/origin/blob/57b52e0a9528027448422d678c4ef682dfc0b885/vendor/k8s.io/legacy-cloud-providers/gce/gce.go#L136

[CORS-2037](https://issues.redhat.com//browse/CORS-2037)