### PR TITLE
OCPBUGS-302: bootstrap gather: fix panic when platform is "none"

### DIFF
--- a/pkg/terraform/stages/platform/stages.go
+++ b/pkg/terraform/stages/platform/stages.go
@@ -23,6 +23,7 @@ import (
 	gcptypes "github.com/openshift/installer/pkg/types/gcp"
 	ibmcloudtypes "github.com/openshift/installer/pkg/types/ibmcloud"
 	libvirttypes "github.com/openshift/installer/pkg/types/libvirt"
+	nonetypes "github.com/openshift/installer/pkg/types/none"
 	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
 	openstacktypes "github.com/openshift/installer/pkg/types/openstack"
 	ovirttypes "github.com/openshift/installer/pkg/types/ovirt"
@@ -59,6 +60,9 @@ func StagesForPlatform(platform string) []terraform.Stage {
 		return ovirt.PlatformStages
 	case vspheretypes.Name:
 		return vsphere.PlatformStages
+	case nonetypes.Name:
+		// terraform is not used when the platform is "none"
+		return []terraform.Stage{}
 	default:
 		panic(fmt.Sprintf("unsupported platform %q", platform))
 	}


### PR DESCRIPTION
If "none" is specified as platform, we should skip the terraform stages
extraction since terraform is not used in that case. Otherwise we'll get
the following panic:

```
panic: unsupported platform "none"

goroutine 1 [running]:
github.com/openshift/installer/pkg/terraform/stages/platform.StagesForPlatform({0x146f2d0a, 0x1619aa08})
        /go/src/github.com/openshift/installer/pkg/terraform/stages/platform/stages.go:55 +0x2ff
main.runGatherBootstrapCmd({0x14d8e028, 0x1})
        /go/src/github.com/openshift/installer/cmd/openshift-install/gather.go:115 +0x2d6
main.newGatherBootstrapCmd.func1(0xc001364500, {0xc0005a0b40, 0x2, 0x2})
        /go/src/github.com/openshift/installer/cmd/openshift-install/gather.go:65 +0x59
github.com/spf13/cobra.(*Command).execute(0xc001364500, {0xc0005a0b20, 0x2, 0x2})
        /go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:860 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc001334c80)
        /go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        /go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:902
main.installerMain()
        /go/src/github.com/openshift/installer/cmd/openshift-install/main.go:72 +0x29e
main.main()
        /go/src/github.com/openshift/installer/cmd/openshift-install/main.go:50 +0x125
```