### PR TITLE
Bug 2116904: Base generated NMStateConfig on InstallConfig name

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -184,3 +184,12 @@ func (a *OptionalInstallConfig) contains(platform string, supportedPlatforms []s
 	}
 	return false
 }
+
+// ClusterName returns the name of the cluster, or a default name if no
+// InstallConfig is supplied.
+func (a *OptionalInstallConfig) ClusterName() string {
+	if a.Config != nil && a.Config.ObjectMeta.Name != "" {
+		return a.Config.ObjectMeta.Name
+	}
+	return "agent-cluster"
+}

--- a/pkg/asset/agent/manifests/common.go
+++ b/pkg/asset/agent/manifests/common.go
@@ -8,23 +8,26 @@ import (
 )
 
 func getAgentClusterInstallName(ic *agent.OptionalInstallConfig) string {
-	return ic.Config.ObjectMeta.Name
+	return ic.ClusterName()
 }
 
 func getClusterDeploymentName(ic *agent.OptionalInstallConfig) string {
-	return ic.Config.ObjectMeta.Name
+	return ic.ClusterName()
 }
 
 func getInfraEnvName(ic *agent.OptionalInstallConfig) string {
-	return ic.Config.ObjectMeta.Name
+	return ic.ClusterName()
 }
 
 func getPullSecretName(ic *agent.OptionalInstallConfig) string {
-	return ic.Config.ObjectMeta.Name + "-pull-secret"
+	return ic.ClusterName() + "-pull-secret"
 }
 
 func getObjectMetaNamespace(ic *agent.OptionalInstallConfig) string {
-	return ic.Config.Namespace
+	if ic.Config != nil {
+		return ic.Config.Namespace
+	}
+	return ""
 }
 
 func getNMStateConfigName(a *agentconfig.AgentConfig) string {

--- a/pkg/asset/agent/manifests/common.go
+++ b/pkg/asset/agent/manifests/common.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"github.com/openshift/installer/pkg/asset/agent"
-	"github.com/openshift/installer/pkg/asset/agent/agentconfig"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/version"
 )
@@ -30,23 +29,13 @@ func getObjectMetaNamespace(ic *agent.OptionalInstallConfig) string {
 	return ""
 }
 
-func getNMStateConfigName(a *agentconfig.AgentConfig) string {
-	return a.Config.ObjectMeta.Name
+func getNMStateConfigName(ic *agent.OptionalInstallConfig) string {
+	return ic.ClusterName()
 }
 
-func getNMStateConfigNamespace(a *agentconfig.AgentConfig) string {
-	return a.Config.Namespace
-}
-
-func getNMStateConfigLabelsFromOptionalInstallConfig(ic *agent.OptionalInstallConfig) map[string]string {
+func getNMStateConfigLabels(ic *agent.OptionalInstallConfig) map[string]string {
 	return map[string]string{
 		"infraenvs.agent-install.openshift.io": getInfraEnvName(ic),
-	}
-}
-
-func getNMStateConfigLabelsFromAgentConfig(a *agentconfig.AgentConfig) map[string]string {
-	return map[string]string{
-		"infraenvs.agent-install.openshift.io": getNMStateConfigName(a),
 	}
 }
 

--- a/pkg/asset/agent/manifests/infraenv.go
+++ b/pkg/asset/agent/manifests/infraenv.go
@@ -63,7 +63,7 @@ func (i *InfraEnv) Generate(dependencies asset.Parents) error {
 					Name: getPullSecretName(installConfig),
 				},
 				NMStateConfigLabelSelector: metav1.LabelSelector{
-					MatchLabels: getNMStateConfigLabelsFromOptionalInstallConfig(installConfig),
+					MatchLabels: getNMStateConfigLabels(installConfig),
 				},
 			},
 		}

--- a/pkg/asset/agent/manifests/infraenv_test.go
+++ b/pkg/asset/agent/manifests/infraenv_test.go
@@ -53,7 +53,7 @@ func TestInfraEnv_Generate(t *testing.T) {
 						Name: getPullSecretName(getValidOptionalInstallConfig()),
 					},
 					NMStateConfigLabelSelector: metav1.LabelSelector{
-						MatchLabels: getNMStateConfigLabelsFromOptionalInstallConfig(getValidOptionalInstallConfig()),
+						MatchLabels: getNMStateConfigLabels(getValidOptionalInstallConfig()),
 					},
 				},
 			},

--- a/pkg/asset/agent/manifests/nmstateconfig_test.go
+++ b/pkg/asset/agent/manifests/nmstateconfig_test.go
@@ -28,6 +28,7 @@ func TestNMStateConfig_Generate(t *testing.T) {
 			name: "valid dhcp agent config no hosts",
 			dependencies: []asset.Asset{
 				getValidDHCPAgentConfigNoHosts(),
+				getValidOptionalInstallConfig(),
 			},
 			expectedConfig: []*aiv1beta1.NMStateConfig(nil),
 		},
@@ -35,6 +36,7 @@ func TestNMStateConfig_Generate(t *testing.T) {
 			name: "valid dhcp agent config with some hosts without networkconfig",
 			dependencies: []asset.Asset{
 				getValidDHCPAgentConfigWithSomeHostsWithoutNetworkConfig(),
+				getValidOptionalInstallConfig(),
 			},
 			expectedConfig: []*aiv1beta1.NMStateConfig{
 				{
@@ -43,9 +45,9 @@ func TestNMStateConfig_Generate(t *testing.T) {
 						APIVersion: "agent-install.openshift.io/v1beta1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprint(getNMStateConfigName(getValidDHCPAgentConfigWithSomeHostsWithoutNetworkConfig()), "-0"),
-						Namespace: getNMStateConfigNamespace(getValidDHCPAgentConfigWithSomeHostsWithoutNetworkConfig()),
-						Labels:    getNMStateConfigLabelsFromAgentConfig(getValidDHCPAgentConfigWithSomeHostsWithoutNetworkConfig()),
+						Name:      fmt.Sprint(getNMStateConfigName(getValidOptionalInstallConfig()), "-0"),
+						Namespace: getObjectMetaNamespace(getValidOptionalInstallConfig()),
+						Labels:    getNMStateConfigLabels(getValidOptionalInstallConfig()),
 					},
 					Spec: aiv1beta1.NMStateConfigSpec{
 						Interfaces: []*aiv1beta1.Interface{
@@ -64,7 +66,9 @@ func TestNMStateConfig_Generate(t *testing.T) {
 		{
 			name: "valid config",
 			dependencies: []asset.Asset{
+
 				getValidAgentConfig(),
+				getValidOptionalInstallConfig(),
 			},
 			expectedConfig: []*aiv1beta1.NMStateConfig{
 				{
@@ -73,9 +77,9 @@ func TestNMStateConfig_Generate(t *testing.T) {
 						APIVersion: "agent-install.openshift.io/v1beta1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprint(getNMStateConfigName(getValidAgentConfig()), "-0"),
-						Namespace: getNMStateConfigNamespace(getValidAgentConfig()),
-						Labels:    getNMStateConfigLabelsFromAgentConfig(getValidAgentConfig()),
+						Name:      fmt.Sprint(getNMStateConfigName(getValidOptionalInstallConfig()), "-0"),
+						Namespace: getObjectMetaNamespace(getValidOptionalInstallConfig()),
+						Labels:    getNMStateConfigLabels(getValidOptionalInstallConfig()),
 					},
 					Spec: aiv1beta1.NMStateConfigSpec{
 						Interfaces: []*aiv1beta1.Interface{
@@ -99,9 +103,9 @@ func TestNMStateConfig_Generate(t *testing.T) {
 						APIVersion: "agent-install.openshift.io/v1beta1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprint(getNMStateConfigName(getValidAgentConfig()), "-1"),
-						Namespace: getNMStateConfigNamespace(getValidAgentConfig()),
-						Labels:    getNMStateConfigLabelsFromAgentConfig(getValidAgentConfig()),
+						Name:      fmt.Sprint(getNMStateConfigName(getValidOptionalInstallConfig()), "-1"),
+						Namespace: getObjectMetaNamespace(getValidOptionalInstallConfig()),
+						Labels:    getNMStateConfigLabels(getValidOptionalInstallConfig()),
 					},
 					Spec: aiv1beta1.NMStateConfigSpec{
 						Interfaces: []*aiv1beta1.Interface{
@@ -121,9 +125,9 @@ func TestNMStateConfig_Generate(t *testing.T) {
 						APIVersion: "agent-install.openshift.io/v1beta1",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprint(getNMStateConfigName(getValidAgentConfig()), "-2"),
-						Namespace: getNMStateConfigNamespace(getValidAgentConfig()),
-						Labels:    getNMStateConfigLabelsFromAgentConfig(getValidAgentConfig()),
+						Name:      fmt.Sprint(getNMStateConfigName(getValidOptionalInstallConfig()), "-2"),
+						Namespace: getObjectMetaNamespace(getValidOptionalInstallConfig()),
+						Labels:    getNMStateConfigLabels(getValidOptionalInstallConfig()),
 					},
 					Spec: aiv1beta1.NMStateConfigSpec{
 						Interfaces: []*aiv1beta1.Interface{


### PR DESCRIPTION
We don't want to require that the user provided the same (or, indeed,
any) name for the AgentConfig as for InstallConfig. So if NMStateConfig
is generated from the AgentConfig, use the cluster name from the
InstallConfig to do it.

Ideally if the user provided ZTP manifests *and* an AgentConfig, we
could generate just the NMStateConfig asset from the AgentConfig and
have the name match the one that appears in the InfraEnv. However, that
is not possible because it would entail a dependency between two
resources (NMStateConfig and InfraEnv) generated by the same command
(agent create cluster-manifests).

If no InstallConfig is provided, we will fall back to the default
cluster name "agent-cluster".