### PR TITLE
download 'aliyun'

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -49,6 +49,11 @@ RUN echo "${YQ_HASH} -" > /tmp/sum.txt && \
   chmod +x /bin/yq-go && \
   rm /tmp/sum.txt
 
+ARG ALIYUN_URI=https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz
+RUN curl -sSL "${ALIYUN_URI}" --output /tmp/aliyun-cli-linux-latest-amd64.tgz && \
+  tar --directory=/bin/ -xvf /tmp/aliyun-cli-linux-latest-amd64.tgz && \
+  rm -f /tmp/aliyun-cli-linux-latest-amd64.tgz
+
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
 RUN python get-pip.py 'pip<21.0'
 RUN python -m pip install pyopenssl

--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -45,6 +45,11 @@ RUN echo "${YQ_HASH} -" > /tmp/sum.txt && \
   chmod +x /bin/yq-go && \
   rm /tmp/sum.txt
 
+ARG ALIYUN_URI=https://aliyuncli.alicdn.com/aliyun-cli-linux-latest-amd64.tgz
+RUN curl -sSL "${ALIYUN_URI}" --output /tmp/aliyun-cli-linux-latest-amd64.tgz && \
+  tar --directory=/bin/ -xvf /tmp/aliyun-cli-linux-latest-amd64.tgz && \
+  rm -f /tmp/aliyun-cli-linux-latest-amd64.tgz
+
 # Not packaged for Python 2, but required by gcloud.  See https://cloud.google.com/sdk/crypto
 RUN pip-2 install pyopenssl
 ENV CLOUDSDK_PYTHON=/usr/bin/python


### PR DESCRIPTION
The alibabacloud client "aliyun" would be used when pre-configuring some resources (e.g. VPC, bastion host, etc.) before launching an OCP cluster with customization.