### PR TITLE
OCPBUGS-717: Upgrade python3.7 to 3.8 for AWS UPI

### DIFF
--- a/upi/aws/cloudformation/02_cluster_infra.yaml
+++ b/upi/aws/cloudformation/02_cluster_infra.yaml
@@ -294,7 +294,7 @@ Resources:
               elb.register_targets(TargetGroupArn=event['ResourceProperties']['TargetArn'],Targets=[{'Id': event['ResourceProperties']['TargetIp']}])
             responseData = {}
             cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['TargetArn']+event['ResourceProperties']['TargetIp'])
-      Runtime: "python3.7"
+      Runtime: "python3.8"
       Timeout: 120
 
   RegisterSubnetTagsLambdaIamRole:
@@ -354,7 +354,7 @@ Resources:
                 ec2_client.create_tags(Resources=[subnet_id], Tags=[{'Key': 'kubernetes.io/cluster/' + event['ResourceProperties']['InfrastructureName'], 'Value': 'shared'}]);
             responseData = {}
             cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, event['ResourceProperties']['InfrastructureName']+event['ResourceProperties']['Subnets'][0])
-      Runtime: "python3.7"
+      Runtime: "python3.8"
       Timeout: 120
 
   RegisterPublicSubnetTags:


### PR DESCRIPTION
** Upgrade Python3.7 to 3.8 for AWS UPI jobs. Currently the dependent packages
do not support 3.8+.