### PR TITLE
Bug/rosa tag count

### DIFF
--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -51,7 +51,7 @@ func validateUserTags(tags map[string]string, propagatingTags bool, fldPath *fie
 	if len(tags) == 0 {
 		return allErrs
 	}
-	if len(tags) > AWS_CUSTOMER_TAG_COUNT {
+	if len(tags) > AWS_CUSTOMER_TAG_LIMIT {
 		allErrs = append(allErrs, field.Invalid(fldPath, len(tags), fmt.Sprintf("number of user tags cannot be more than %d", AWS_CUSTOMER_TAG_LIMIT)))
 	}
 	for key, value := range tags {

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -11,6 +11,9 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 )
 
+// AWS supports <=50 tags on resources, this reserves 10 for Managed OpenShift use
+const AWS_CUSTOMER_TAG_COUNT = 40
+
 // tagRegex is used to check that the keys and values of a tag contain only valid characters.
 var tagRegex = regexp.MustCompile(`^[0-9A-Za-z_.:/=+-@]*$`)
 
@@ -48,8 +51,8 @@ func validateUserTags(tags map[string]string, propagatingTags bool, fldPath *fie
 	if len(tags) == 0 {
 		return allErrs
 	}
-	if len(tags) > 8 {
-		allErrs = append(allErrs, field.Invalid(fldPath, len(tags), "number of user tags cannot be more than 8"))
+	if len(tags) > AWS_CUSTOMER_TAG_COUNT {
+		allErrs = append(allErrs, field.Invalid(fldPath, len(tags), fmt.Sprintf("number of user tags cannot be more than %d", AWS_CUSTOMER_TAG_COUNT)))
 	}
 	for key, value := range tags {
 		if strings.EqualFold(key, "Name") {

--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -12,7 +12,7 @@ import (
 )
 
 // AWS supports <=50 tags on resources, this reserves 10 for Managed OpenShift use
-const AWS_CUSTOMER_TAG_COUNT = 40
+const AWS_CUSTOMER_TAG_LIMIT = 40
 
 // tagRegex is used to check that the keys and values of a tag contain only valid characters.
 var tagRegex = regexp.MustCompile(`^[0-9A-Za-z_.:/=+-@]*$`)
@@ -52,7 +52,7 @@ func validateUserTags(tags map[string]string, propagatingTags bool, fldPath *fie
 		return allErrs
 	}
 	if len(tags) > AWS_CUSTOMER_TAG_COUNT {
-		allErrs = append(allErrs, field.Invalid(fldPath, len(tags), fmt.Sprintf("number of user tags cannot be more than %d", AWS_CUSTOMER_TAG_COUNT)))
+		allErrs = append(allErrs, field.Invalid(fldPath, len(tags), fmt.Sprintf("number of user tags cannot be more than %d", AWS_CUSTOMER_TAG_LIMIT)))
 	}
 	for key, value := range tags {
 		if strings.EqualFold(key, "Name") {


### PR DESCRIPTION
For ROSA|OSD-on-AWS installs the installer limits customer tags to 8. This has two issues:

- It's based on the limit of 10 for *object* tags (buckets are 50) -> https://docs.aws.amazon.com/AmazonS3/latest/userguide/CostAllocTagging.html
- The Managed ROSA or OSD installs actually use 4 of the available tags

ROSA/OSD doesn't tag objects, just the buckets, so the limit of 50 is a more appropriate place to start.

This PR includes simple changes to allow for up to 40 customer-defined tags to be applied.