### PR TITLE
AGENT-326: Fix releaseImage mirror handling with unit test

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -139,15 +140,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 	registryCABundle := &mirror.CaBundle{}
 	dependencies.Get(registriesConfig, registryCABundle)
 
-	// Get the mirror for release image
-	releaseImageMirror := ""
-	source := strings.Split(agentManifests.ClusterImageSet.Spec.ReleaseImage, ":")
-	for _, config := range registriesConfig.MirrorConfig {
-		if config.Location == source[0] {
-			// include the tag with the build release image
-			releaseImageMirror = fmt.Sprintf("%s:%s", config.Mirror, source[1])
-		}
-	}
+	releaseImageMirror := getMirrorFromRelease(agentManifests.ClusterImageSet.Spec.ReleaseImage, registriesConfig)
 
 	infraEnvID := uuid.New().String()
 	logrus.Debug("Generated random infra-env id ", infraEnvID)
@@ -386,4 +379,23 @@ func RetrieveRendezvousIP(agentConfig *agent.Config, nmStateConfigs []*v1beta1.N
 		err = errors.New("missing rendezvousIP in agent-config or at least one NMStateConfig manifest")
 	}
 	return rendezvousIP, err
+}
+
+func getMirrorFromRelease(releaseImage string, registriesConfig *mirror.RegistriesConf) string {
+
+	releaseImageMirror := ""
+	source := regexp.MustCompile(`^(.+?)(@sha256)?:(.+)`).FindStringSubmatch(releaseImage)
+	for _, config := range registriesConfig.MirrorConfig {
+		if config.Location == source[1] {
+			// include the tag with the build release image
+			if len(source) == 4 {
+				// Has Sha256
+				releaseImageMirror = fmt.Sprintf("%s%s:%s", config.Mirror, source[2], source[3])
+			} else if len(source) == 3 {
+				releaseImageMirror = fmt.Sprintf("%s:%s", config.Mirror, source[2])
+			}
+		}
+	}
+
+	return releaseImageMirror
 }


### PR DESCRIPTION
Based on https://github.com/openshift/installer/pull/6272, this fixes the mirror generation to handle release images that include the sha256 checksum, e.g:
`quay.io/openshift-release-dev/ocp- release@sha256:300bce8246cf880e792e106607925de0a404484637627edf5f517375517d54a4`