### PR TITLE
Add bind-utils in upi installer image

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -37,6 +37,7 @@ RUN yum update -y && \
       openssh-clients \
       openssl \
       PyYAML \
+      bind-utils \
       util-linux && \
     yum clean all && \
     rm -rf /var/cache/yum/* && \

--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -33,6 +33,7 @@ RUN yum update -y && \
       python3-pyOpenSSL \
       python2-pyyaml \
       python3-pyyaml \
+      bind-utils \
       util-linux && \
     yum clean all && \
     rm -rf /var/cache/yum/* && \


### PR DESCRIPTION
In latest 4.12 upi-installer image, we found it's missing `dig` command that's required for https://github.com/openshift/release/blob/master/ci-operator/step-registry/azure/provision/bastionhost/azure-provision-bastionhost-commands.sh#L17