### PR TITLE
Switch delete ordering of CloudConnect and VPCs

### DIFF
--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -286,11 +286,11 @@ func (o *ClusterUninstaller) destroyCluster() error {
 	}, {
 		{name: "DHCPs", execute: o.destroyDHCPNetworks},
 	}, {
+		{name: "Cloud Connections", execute: o.destroyCloudConnections},
+	}, {
 		{name: "Images", execute: o.destroyImages},
 		{name: "VPCs", execute: o.destroyVPCs},
 		{name: "Security Groups", execute: o.destroySecurityGroups},
-	}, {
-		{name: "Cloud Connections", execute: o.destroyCloudConnections},
 	}, {
 		{name: "Cloud Object Storage Instances", execute: o.destroyCOSInstances},
 		{name: "DNS Records", execute: o.destroyDNSRecords},


### PR DESCRIPTION
We were asked to delete the existing Cloud Connection before
deleting the VPC.