### PR TITLE
CORS-2280: IBMCloud: Add TF support for private DNS

### DIFF
--- a/data/data/ibmcloud/bootstrap/main.tf
+++ b/data/data/ibmcloud/bootstrap/main.tf
@@ -67,7 +67,7 @@ resource "ibm_is_security_group" "bootstrap" {
 resource "ibm_is_security_group_rule" "bootstrap_ssh_inbound" {
   group     = ibm_is_security_group.bootstrap.id
   direction = "inbound"
-  remote    = local.public_endpoints ? "0.0.0.0/0" : var.control_plane_security_group_id_list.0.id
+  remote    = local.public_endpoints ? "0.0.0.0/0" : var.control_plane_security_group_id_list[0]
   tcp {
     port_min = 22
     port_max = 22

--- a/data/data/ibmcloud/network/cis/main.tf
+++ b/data/data/ibmcloud/network/cis/main.tf
@@ -3,6 +3,8 @@
 ############################################
 
 data "ibm_cis_domain" "base_domain" {
+  count = var.is_external ? 1 : 0
+
   cis_id = var.cis_id
   domain = var.base_domain
 }
@@ -12,8 +14,10 @@ data "ibm_cis_domain" "base_domain" {
 ############################################
 
 resource "ibm_cis_dns_record" "kubernetes_api" {
+  count = var.is_external ? 1 : 0
+
   cis_id    = var.cis_id
-  domain_id = data.ibm_cis_domain.base_domain.id
+  domain_id = data.ibm_cis_domain.base_domain[0].id
   type      = "CNAME"
   name      = "api.${var.cluster_domain}"
   content   = var.lb_kubernetes_api_public_hostname != "" ? var.lb_kubernetes_api_public_hostname : var.lb_kubernetes_api_private_hostname
@@ -21,8 +25,10 @@ resource "ibm_cis_dns_record" "kubernetes_api" {
 }
 
 resource "ibm_cis_dns_record" "kubernetes_api_internal" {
+  count = var.is_external ? 1 : 0
+
   cis_id    = var.cis_id
-  domain_id = data.ibm_cis_domain.base_domain.id
+  domain_id = data.ibm_cis_domain.base_domain[0].id
   type      = "CNAME"
   name      = "api-int.${var.cluster_domain}"
   content   = var.lb_kubernetes_api_private_hostname

--- a/data/data/ibmcloud/network/dns/common.tf
+++ b/data/data/ibmcloud/network/dns/common.tf
@@ -1,0 +1,13 @@
+locals {
+  dns_zone_id = var.is_external ? "" : data.ibm_dns_zones.zones[0].dns_zones[index(data.ibm_dns_zones.zones[0].dns_zones[*].name, var.base_domain)].zone_id
+}
+
+############################################
+# DNS Zone
+############################################
+
+data "ibm_dns_zones" "zones" {
+  count = var.is_external ? 0 : 1
+
+  instance_id = var.dns_id
+}

--- a/data/data/ibmcloud/network/dns/main.tf
+++ b/data/data/ibmcloud/network/dns/main.tf
@@ -1,0 +1,27 @@
+############################################
+# DNS permitted networks
+############################################
+
+resource "ibm_dns_permitted_network" "vpc" {
+  count = var.is_external ? 0 : 1
+
+  instance_id = var.dns_id
+  zone_id     = local.dns_zone_id
+  vpc_crn     = var.vpc_crn
+  type        = "vpc"
+}
+
+############################################
+# DNS records (CNAME)
+############################################
+
+resource "ibm_dns_resource_record" "kubernetes_api_private" {
+  count = var.is_external ? 0 : 1
+
+  instance_id = var.dns_id
+  zone_id     = local.dns_zone_id
+  type        = "CNAME"
+  name        = "api-int.${var.cluster_domain}"
+  rdata       = var.lb_kubernetes_api_private_hostname
+  ttl         = "60"
+}

--- a/data/data/ibmcloud/network/dns/variables.tf
+++ b/data/data/ibmcloud/network/dns/variables.tf
@@ -1,8 +1,12 @@
 ############################################
-# CIS module variables
+# DNS module variables
 ############################################
 
-variable "cis_id" {
+variable "dns_id" {
+  type = string
+}
+
+variable "vpc_crn" {
   type = string
 }
 
@@ -16,10 +20,6 @@ variable "cluster_domain" {
 
 variable "is_external" {
   type = bool
-}
-
-variable "lb_kubernetes_api_public_hostname" {
-  type = string
 }
 
 variable "lb_kubernetes_api_private_hostname" {

--- a/data/data/ibmcloud/network/main.tf
+++ b/data/data/ibmcloud/network/main.tf
@@ -54,8 +54,26 @@ module "cis" {
   cis_id         = var.ibmcloud_cis_crn
   base_domain    = var.base_domain
   cluster_domain = var.cluster_domain
+  is_external    = local.public_endpoints
 
   lb_kubernetes_api_public_hostname  = module.vpc.lb_kubernetes_api_public_hostname
+  lb_kubernetes_api_private_hostname = module.vpc.lb_kubernetes_api_private_hostname
+}
+
+############################################
+# DNS module
+############################################
+
+module "dns" {
+  source     = "./dns"
+  depends_on = [module.vpc]
+
+  dns_id         = var.ibmcloud_dns_id
+  vpc_crn        = module.vpc.vpc_crn
+  base_domain    = var.base_domain
+  cluster_domain = var.cluster_domain
+  is_external    = local.public_endpoints
+
   lb_kubernetes_api_private_hostname = module.vpc.lb_kubernetes_api_private_hostname
 }
 

--- a/data/data/ibmcloud/network/vpc/common.tf
+++ b/data/data/ibmcloud/network/vpc/common.tf
@@ -2,7 +2,10 @@ locals {
   # Common locals
   prefix    = var.cluster_id
   zones_all = distinct(concat(var.zones_master, var.zones_worker))
-  vpc_id    = var.preexisting_vpc ? data.ibm_is_vpc.vpc[0].id : ibm_is_vpc.vpc[0].id
+
+  # VPC locals
+  vpc_id  = var.preexisting_vpc ? data.ibm_is_vpc.vpc[0].id : ibm_is_vpc.vpc[0].id
+  vpc_crn = var.preexisting_vpc ? data.ibm_is_vpc.vpc[0].crn : ibm_is_vpc.vpc[0].crn
 
   # LB locals
   port_kubernetes_api   = 6443

--- a/data/data/ibmcloud/network/vpc/outputs.tf
+++ b/data/data/ibmcloud/network/vpc/outputs.tf
@@ -59,3 +59,7 @@ output "lb_pool_machine_config_id" {
 output "vpc_id" {
   value = local.vpc_id
 }
+
+output "vpc_crn" {
+  value = local.vpc_crn
+}

--- a/data/data/ibmcloud/variables-ibmcloud.tf
+++ b/data/data/ibmcloud/variables-ibmcloud.tf
@@ -17,6 +17,13 @@ variable "ibmcloud_bootstrap_instance_type" {
 variable "ibmcloud_cis_crn" {
   type        = string
   description = "The CRN of CIS instance to use."
+  default     = ""
+}
+
+variable "ibmcloud_dns_id" {
+  type        = string
+  description = "The ID of DNS Service instance to use."
+  default     = ""
 }
 
 variable "ibmcloud_region" {

--- a/pkg/asset/cluster/ibmcloud/ibmcloud.go
+++ b/pkg/asset/cluster/ibmcloud/ibmcloud.go
@@ -13,6 +13,13 @@ import (
 func Metadata(infraID string, config *types.InstallConfig, meta *icibmcloud.Metadata) *ibmcloud.Metadata {
 	accountID, _ := meta.AccountID(context.TODO())
 	cisCrn, _ := meta.CISInstanceCRN(context.TODO())
+	dnsInstance, _ := meta.DNSInstance(context.TODO())
+
+	var dnsInstanceID string
+	if dnsInstance != nil {
+		dnsInstanceID = dnsInstance.ID
+	}
+
 	subnets := []string{}
 	controlPlaneSubnets, _ := meta.ControlPlaneSubnets(context.TODO())
 	for id := range controlPlaneSubnets {
@@ -30,6 +37,7 @@ func Metadata(infraID string, config *types.InstallConfig, meta *icibmcloud.Meta
 		AccountID:         accountID,
 		BaseDomain:        config.BaseDomain,
 		CISInstanceCRN:    cisCrn,
+		DNSInstanceID:     dnsInstanceID,
 		Region:            config.Platform.IBMCloud.Region,
 		ResourceGroupName: config.Platform.IBMCloud.ClusterResourceGroupName(infraID),
 		Subnets:           subnets,

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -526,16 +526,30 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			}
 		}
 
-		// Get CISInstanceCRN from InstallConfig metadata
-		crn, err := installConfig.IBMCloud.CISInstanceCRN(ctx)
-		if err != nil {
-			return err
+		var cisCRN, dnsID string
+
+		if installConfig.Config.Publish == types.InternalPublishingStrategy {
+			// Get DNSInstanceCRN from InstallConfig metadata
+			dnsInstance, err := installConfig.IBMCloud.DNSInstance(ctx)
+			if err != nil {
+				return err
+			}
+			if dnsInstance != nil {
+				dnsID = dnsInstance.ID
+			}
+		} else {
+			// Get CISInstanceCRN from InstallConfig metadata
+			cisCRN, err = installConfig.IBMCloud.CISInstanceCRN(ctx)
+			if err != nil {
+				return err
+			}
 		}
 
 		data, err = ibmcloudtfvars.TFVars(
 			ibmcloudtfvars.TFVarsSources{
 				Auth:                 auth,
-				CISInstanceCRN:       crn,
+				CISInstanceCRN:       cisCRN,
+				DNSInstanceID:        dnsID,
 				ImageURL:             string(*rhcosImage),
 				MasterConfigs:        masterConfigs,
 				MasterDedicatedHosts: masterDedicatedHosts,

--- a/pkg/tfvars/ibmcloud/ibmcloud.go
+++ b/pkg/tfvars/ibmcloud/ibmcloud.go
@@ -26,6 +26,7 @@ type config struct {
 	Region                  string          `json:"ibmcloud_region,omitempty"`
 	BootstrapInstanceType   string          `json:"ibmcloud_bootstrap_instance_type,omitempty"`
 	CISInstanceCRN          string          `json:"ibmcloud_cis_crn,omitempty"`
+	DNSInstanceID           string          `json:"ibmcloud_dns_id,omitempty"`
 	ExtraTags               []string        `json:"ibmcloud_extra_tags,omitempty"`
 	MasterAvailabilityZones []string        `json:"ibmcloud_master_availability_zones"`
 	WorkerAvailabilityZones []string        `json:"ibmcloud_worker_availability_zones"`
@@ -45,6 +46,7 @@ type config struct {
 type TFVarsSources struct {
 	Auth                 Auth
 	CISInstanceCRN       string
+	DNSInstanceID        string
 	ImageURL             string
 	MasterConfigs        []*ibmcloudprovider.IBMCloudMachineProviderSpec
 	MasterDedicatedHosts []DedicatedHost
@@ -90,6 +92,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Auth:                    sources.Auth,
 		BootstrapInstanceType:   masterConfig.Profile,
 		CISInstanceCRN:          sources.CISInstanceCRN,
+		DNSInstanceID:           sources.DNSInstanceID,
 		ImageFilePath:           cachedImage,
 		MasterAvailabilityZones: masterAvailabilityZones,
 		MasterDedicatedHosts:    sources.MasterDedicatedHosts,

--- a/pkg/types/ibmcloud/metadata.go
+++ b/pkg/types/ibmcloud/metadata.go
@@ -4,7 +4,8 @@ package ibmcloud
 type Metadata struct {
 	AccountID         string   `json:"accountID"`
 	BaseDomain        string   `json:"baseDomain"`
-	CISInstanceCRN    string   `json:"cisInstanceCRN"`
+	CISInstanceCRN    string   `json:"cisInstanceCRN,omitempty"`
+	DNSInstanceID     string   `json:"dnsInstanceID,omitempty"`
 	Region            string   `json:"region,omitempty"`
 	ResourceGroupName string   `json:"resourceGroupName,omitempty"`
 	VPC               string   `json:"vpc,omitempty"`


### PR DESCRIPTION
Add support for creating, configuring, and destroying Terraform
resources for private (Internal) IPI clusters on IBM Cloud, using
DNS Services, rather than CIS (public/External).

Partial: https://issues.redhat.com/browse/CORS-2255