### PR TITLE
gcp: specify network_project_id for network and subnets

### DIFF
--- a/data/data/gcp/cluster/network/common.tf
+++ b/data/data/gcp/cluster/network/common.tf
@@ -4,19 +4,22 @@
 data "google_compute_network" "preexisting_cluster_network" {
   count = var.preexisting_network ? 1 : 0
 
-  name = var.cluster_network
+  name    = var.cluster_network
+  project = var.network_project_id
 }
 
 data "google_compute_subnetwork" "preexisting_master_subnet" {
   count = var.preexisting_network ? 1 : 0
 
-  name = var.master_subnet
+  name    = var.master_subnet
+  project = var.network_project_id
 }
 
 data "google_compute_subnetwork" "preexisting_worker_subnet" {
   count = var.preexisting_network ? 1 : 0
 
-  name = var.worker_subnet
+  name    = var.worker_subnet
+  project = var.network_project_id
 }
 
 locals {


### PR DESCRIPTION
This change modifies the GCP Terraform data resources for the
pre-existing networks and subnets to specify the project as defined
in the network_project_id variable. This variable is derived from the
install config networkProjectID parameter. When defined, this causes
Terraform to look in the specified project for these resources. When
undefined, the default, this variable will be an empty string at which
point Terraform will look in the default project.

https://issues.redhat.com/browse/CORS-2038