### PR TITLE
gcp: machines to use networkProjectID when defined

### DIFF
--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -107,6 +107,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 		}},
 		NetworkInterfaces: []*machineapi.GCPNetworkInterface{{
 			Network:    network,
+			ProjectID:  platform.NetworkProjectID,
 			Subnetwork: subnetwork,
 		}},
 		ServiceAccounts: []machineapi.GCPServiceAccount{{


### PR DESCRIPTION
This change adds the networkProjectID to the network configuration for
the compute and control plane machine manifests. It will be skipped
(omitempty) when the parameter is not specified in the install config.

https://issues.redhat.com/browse/CORS-2069