### PR TITLE
AGENT-325 Set NetworkType in AgentClusterInstall

### DIFF
--- a/docs/user/agent/network-type-cni-plugin-selection.md
+++ b/docs/user/agent/network-type-cni-plugin-selection.md
@@ -1,0 +1,13 @@
+# Network Type / Container Network Interface (CNI) plugin selection
+
+### Post OpenShift 4.12 releases 
+
+The default network type (CNI plugin) is OVNKubernetes for OpenShift v4.12. Prior to OpenShift v4.12, the default network type was OpenShiftSDN. OpenShiftSDN supports IPv4 only. For IPv6 or dual stack, a compatible NetworkType like OVNKubernetes must be used.
+
+If you are using the install-config and agent-config yamls to generate the ZTP manifests that feeds into the agent ISO, the Network Type is set in install-config.yaml under Networking.NetworkType [https://docs.openshift.com/container-platform/4.11/installing/installing_bare_metal/installing-bare-metal-network-customizations.html]
+
+If you are using ZTP manifests directly, the NetworkType is specified in the AgentClusterInstall under Spec.Networking.NetworkType.
+
+### Pre Openshift 4.12 releases
+
+The NetworkType always defaulted to OpenShiftSDN because the NetworkType specified either in the AgentClusterInstall or the InstallConfig wasn't being set in the cluster parameters being created. This meant that IPv6 did not work with the agent-installer prior to 4.12. This issue has been fixed in 4.12. 

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -284,6 +284,7 @@ spec:
       hostPrefix: 23
     serviceNetwork:
     - fd02::/112
+    - 172.30.0.0/16
     networkType: "OpenShiftSDN"
   provisionRequirements:
     controlPlaneAgents: 3

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -21,6 +21,9 @@ import (
 
 func TestAgentClusterInstall_Generate(t *testing.T) {
 
+	installConfigWithBadNetworkType := getValidOptionalInstallConfig()
+	installConfigWithBadNetworkType.Config.NetworkType = "bad-network-type-value"
+
 	cases := []struct {
 		name           string
 		dependencies   []asset.Asset
@@ -33,6 +36,13 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				&agent.OptionalInstallConfig{},
 			},
 			expectedError: "missing configuration or manifest file",
+		},
+		{
+			name: "install config has bad network type value",
+			dependencies: []asset.Asset{
+				installConfigWithBadNetworkType,
+			},
+			expectedError: "networkType has incorrect value. Expect value to be either 'OpenShiftSDN' or 'OVNKubernetes'",
 		},
 		{
 			name: "valid configuration",
@@ -59,6 +69,7 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 							},
 						},
 						ServiceNetwork: []string{"172.30.0.0/16"},
+						NetworkType:    "OVNKubernetes",
 					},
 					SSHPublicKey: strings.Trim(TestSSHKey, "|\n\t"),
 					ProvisionRequirements: hiveext.ProvisionRequirements{
@@ -152,6 +163,9 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 
 func TestAgentClusterInstall_LoadedFromDisk(t *testing.T) {
 
+	emptyACI := &hiveext.AgentClusterInstall{}
+	emptyACI.Spec.Networking.NetworkType = "OpenShiftSDN"
+
 	cases := []struct {
 		name           string
 		data           string
@@ -209,6 +223,7 @@ spec:
 						ServiceNetwork: []string{
 							"172.30.0.0/16",
 						},
+						NetworkType: "OpenShiftSDN",
 					},
 					ProvisionRequirements: hiveext.ProvisionRequirements{
 						ControlPlaneAgents: 3,
@@ -227,7 +242,7 @@ spec:
 			name:           "empty",
 			data:           "",
 			expectedFound:  true,
-			expectedConfig: &hiveext.AgentClusterInstall{},
+			expectedConfig: emptyACI,
 			expectedError:  false,
 		},
 		{

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -63,6 +63,7 @@ func getValidOptionalInstallConfig() *agent.OptionalInstallConfig {
 					ServiceNetwork: []ipnet.IPNet{
 						*ipnet.MustParseCIDR("172.30.0.0/16"),
 					},
+					NetworkType: "OVNKubernetes",
 				},
 				Platform: types.Platform{
 					BareMetal: &baremetal.Platform{


### PR DESCRIPTION
The IgnitionConfig NetworkType value should be transferred to
the AgentClusterInstall. This will allow the installed cluster
to have the correct network type installed. Currently, the
installed cluster defaults to OpenShiftSDN even if the
NetworkType is set to OVNKubernetes.

If the NetworkType is unspecified, the value is defaulted to
the IgnitionConfig's default value: OpenShiftSDN. A message
is logged to the console indicating that the value was unspecified
and defaulted to OpenShiftSDN.