### PR TITLE
OWNER_ALIASES: remove Saqib Ali from the coreos approvers and reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -131,7 +131,6 @@ aliases:
     - lucab
     - sohankunkerkar
     - travier
-    - saqibali-2k
     - HuijingHei
     - jmarrero
     - aaradhak
@@ -151,7 +150,6 @@ aliases:
     - lucab
     - sohankunkerkar
     - travier
-    - saqibali-2k
     - HuijingHei
     - jmarrero
     - aaradhak


### PR DESCRIPTION
Signed-off-by: Clement Verna <cverna@tutanota.com>