### PR TITLE
Power VS: use the new name field for the dhcp nw

### DIFF
--- a/data/data/powervs/cluster/power_network/pi_network.tf
+++ b/data/data/powervs/cluster/power_network/pi_network.tf
@@ -14,6 +14,8 @@ resource "ibm_pi_dhcp" "new_dhcp_service" {
   pi_cloud_connection_id = data.ibm_pi_cloud_connection.cloud_connection.id
   pi_dns_server          = "1.1.1.1"
   pi_cidr                = var.machine_cidr
+  # the pi_dhcp_name param will be prefixed by the DHCP ID when created, so keep it short here:
+  pi_dhcp_name = var.cluster_id
 }
 
 resource "ibm_pi_cloud_connection" "new_cloud_connection" {


### PR DESCRIPTION
this will make the destroy logic more robust, as currently we have no way of knowing which networks belonged to which clusters when destroy errors occurred. the current logic is to look at the nw attached to a cluster vm and delete it, but if the cluster vms had been destroyed already, there would be an unused nw left behind.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>