### PR TITLE
azure: add support for arm64 instances (Dps_v5 instances)

### DIFF
--- a/docs/user/azure/limits.md
+++ b/docs/user/azure/limits.md
@@ -42,7 +42,7 @@ allows for many clusters to be created. The network security groups which exist 
 
 ## Instance Limits
 
-By default, a cluster will create:
+By default, an x86 cluster will create:
 
 * One Standard_D4s_v3 bootstrap machine (removed after install)
 * Three Standard_D8s_v3 master nodes.
@@ -76,6 +76,32 @@ The specs for the VM sizes (Dsv3-series) are as follows:
    * 4 data disks max
 
 More details on VM sizes can be found [here][sizes-general].
+
+By default, an arm64 cluster will create:
+
+* One Standard_D8ps_v5 bootstrap machine (removed after install)
+* Three Standard_D8ps_v5 master nodes.
+* Three Standard_D4ps_v5 worker nodes.
+
+The specs for the VM sizes (Dpsv5-series) are as follows:
+
+* Standard_D8ps_v5
+   * 8 vCPU's, 32GiB ram
+   * IOPs / Throughput (Mbps): (uncached burst) 20000 / 1200
+   * IOPs / Throughput (Mbps): (uncached) 12800 / 290
+   * NICs / Bandwidth (Mbps): 4 / 12500
+   * 16 data disks max
+   * Remote Storage Only
+
+* Standard_D4ps_v5
+   * 4 vCPU's, 16GiB ram
+   * IOPs / Throughput (Mbps): (uncached burst) 20000 / 1200
+   * IOPs / Throughput (Mbps): (uncached) 6400 / 145
+   * NICs / Bandwidth (Mbps): 2 / 12500
+   * 8 data disks max
+   * Remote Storage Only
+
+More details on VM sizes can be found [here][sizes-arm64]. All VMs are Gen2 only.
 
 The default subscription only allows for 20 vCPU's and will need to be [increased](#increasing-limits) to at least 22.
 If you intend to start with a higher number of workers, enable autoscaling and large workloads
@@ -137,3 +163,4 @@ You will then review and submit your request.
 [load-balancing]: https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview
 [service-limits]: https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits
 [sizes-general]: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-general
+[sizes-arm64]: https://docs.microsoft.com/en-us/azure/virtual-machines/dpsv5-dpdsv5-series

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -38,29 +38,47 @@ var (
 	validResourceSkuRegions        = "southeastasia"
 
 	instanceTypeSku = []*azsku.ResourceSku{
-		{Name: to.StringPtr("Standard_D4s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}}},
-		{Name: to.StringPtr("Standard_A1_v2"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("1")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("2")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("False")}}},
-		{Name: to.StringPtr("Standard_D2_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("2")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("8")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}}},
-		{Name: to.StringPtr("Standard_D4_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}}},
-		{Name: to.StringPtr("Standard_D2s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}}},
-		{Name: to.StringPtr("Standard_D8s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}}},
-		{Name: to.StringPtr("Standard_Dc4_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V2")}}},
+		{Name: to.StringPtr("Standard_D4s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}, {Name: to.StringPtr("CpuArchitectureType"), Value: to.StringPtr("x64")}}},
+		{Name: to.StringPtr("Standard_A1_v2"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("1")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("2")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("False")}, {Name: to.StringPtr("CpuArchitectureType"), Value: to.StringPtr("x64")}}},
+		{Name: to.StringPtr("Standard_D2_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("2")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("8")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}, {Name: to.StringPtr("CpuArchitectureType"), Value: to.StringPtr("x64")}}},
+		{Name: to.StringPtr("Standard_D4_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}, {Name: to.StringPtr("CpuArchitectureType"), Value: to.StringPtr("x64")}}},
+		{Name: to.StringPtr("Standard_D2s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}, {Name: to.StringPtr("CpuArchitectureType"), Value: to.StringPtr("x64")}}},
+		{Name: to.StringPtr("Standard_D8s_v3"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}, {Name: to.StringPtr("CpuArchitectureType"), Value: to.StringPtr("x64")}}},
+		{Name: to.StringPtr("Standard_Dc4_v4"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V2")}, {Name: to.StringPtr("CpuArchitectureType"), Value: to.StringPtr("x64")}}},
+		{Name: to.StringPtr("Standard_D4ps_v5"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("4")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("16")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}, {Name: to.StringPtr("CpuArchitectureType"), Value: to.StringPtr("Arm64")}}},
+		{Name: to.StringPtr("Standard_D8ps_v5"), Capabilities: &[]azsku.ResourceSkuCapabilities{{Name: to.StringPtr("vCPUsAvailable"), Value: to.StringPtr("8")}, {Name: to.StringPtr("MemoryGB"), Value: to.StringPtr("32")}, {Name: to.StringPtr("PremiumIO"), Value: to.StringPtr("True")}, {Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V2")}, {Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")}, {Name: to.StringPtr("CpuArchitectureType"), Value: to.StringPtr("Arm64")}}},
 	}
 	vmCapabilities = map[string]map[string]string{
-		"Standard_D8s_v3": {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True"},
-		"Standard_D4s_v3": {"vCPUsAvailable": "4", "MemoryGB": "32", "PremiumIO": "True", "HyperVGenerations": "V1", "AcceleratedNetworkingEnabled": "True"},
-		"Standard_A1_v2":  {"vCPUsAvailable": "1", "MemoryGB": "2", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "False"},
-		"Standard_D2_v4":  {"vCPUsAvailable": "2", "MemoryGB": "8", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True"},
-		"Standard_D4_v4":  {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "False", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True"},
-		"Standard_D2s_v3": {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True"},
-		"Standard_Dc4_v4": {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V2"},
-		"Standard_B4ms":   {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "False"},
+		"Standard_D8s_v3":  {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "x64"},
+		"Standard_D4s_v3":  {"vCPUsAvailable": "4", "MemoryGB": "32", "PremiumIO": "True", "HyperVGenerations": "V1", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "x64"},
+		"Standard_A1_v2":   {"vCPUsAvailable": "1", "MemoryGB": "2", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "False", "CpuArchitectureType": "x64"},
+		"Standard_D2_v4":   {"vCPUsAvailable": "2", "MemoryGB": "8", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "x64"},
+		"Standard_D4_v4":   {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "False", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "x64"},
+		"Standard_D2s_v3":  {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "x64"},
+		"Standard_Dc4_v4":  {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V2", "CpuArchitectureType": "x64"},
+		"Standard_B4ms":    {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V1,V2", "AcceleratedNetworkingEnabled": "False", "CpuArchitectureType": "x64"},
+		"Standard_D8ps_v5": {"vCPUsAvailable": "8", "MemoryGB": "32", "PremiumIO": "True", "HyperVGenerations": "V2", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "Arm64"},
+		"Standard_D4ps_v5": {"vCPUsAvailable": "4", "MemoryGB": "16", "PremiumIO": "True", "HyperVGenerations": "V2", "AcceleratedNetworkingEnabled": "True", "CpuArchitectureType": "Arm64"},
 	}
 
 	validInstanceTypes = func(ic *types.InstallConfig) {
 		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_D4s_v3"
 		ic.ControlPlane.Platform.Azure.InstanceType = "Standard_D8s_v3"
 		ic.Compute[0].Platform.Azure.InstanceType = "Standard_D4s_v3"
+	}
+
+	validArm64InstanceTypes = func(ic *types.InstallConfig) {
+		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_D4ps_v5"
+		ic.ControlPlane.Architecture = types.ArchitectureARM64
+		ic.ControlPlane.Platform.Azure.InstanceType = "Standard_D8ps_v5"
+		ic.Compute[0].Architecture = types.ArchitectureARM64
+		ic.Compute[0].Platform.Azure.InstanceType = "Standard_D4ps_v5"
+	}
+
+	invalidArchInstanceTypes = func(ic *types.InstallConfig) {
+		ic.Platform.Azure.DefaultMachinePlatform.InstanceType = "Standard_D4ps_v5"
+		ic.ControlPlane.Platform.Azure.InstanceType = "Standard_D8ps_v5"
+		ic.Compute[0].Platform.Azure.InstanceType = "Standard_D4ps_v5"
 	}
 
 	invalidateDefaultInstanceTypes = func(ic *types.InstallConfig) {
@@ -266,11 +284,13 @@ func validInstallConfig() *types.InstallConfig {
 			},
 		},
 		ControlPlane: &types.MachinePool{
+			Architecture: types.ArchitectureAMD64,
 			Platform: types.MachinePoolPlatform{
 				Azure: &azure.MachinePool{},
 			},
 		},
 		Compute: []types.MachinePool{{
+			Architecture: types.ArchitectureAMD64,
 			Platform: types.MachinePoolPlatform{
 				Azure: &azure.MachinePool{},
 			},
@@ -323,6 +343,16 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 			name:     "Valid instance types",
 			edits:    editFunctions{validInstanceTypes},
 			errorMsg: "",
+		},
+		{
+			name:     "Valid Arm64 instance types",
+			edits:    editFunctions{validArm64InstanceTypes},
+			errorMsg: "",
+		},
+		{
+			name:     "Invalid arch instance types",
+			edits:    editFunctions{invalidArchInstanceTypes},
+			errorMsg: `\[controlPlane.platform.azure.type: Invalid value: "Standard_D8ps_v5": instance type architecture 'Arm64' does not match install config architecture amd64, compute\[0\].platform.azure.type: Invalid value: "Standard_D4ps_v5": instance type architecture 'Arm64' does not match install config architecture amd64, platform.azure.defaultMachinePlatform.type: Invalid value: "Standard_D4ps_v5": instance type architecture 'Arm64' does not match install config architecture amd64\]`,
 		},
 		{
 			name:     "Invalid default machine type",

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -332,6 +332,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		mpool.InstanceType = azuredefaults.ControlPlaneInstanceType(
 			installConfig.Config.Platform.Azure.CloudName,
 			installConfig.Config.Platform.Azure.Region,
+			installConfig.Config.ControlPlane.Architecture,
 		)
 		mpool.OSDisk.DiskSizeGB = 1024
 		mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -374,6 +374,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			mpool.InstanceType = azuredefaults.ComputeInstanceType(
 				installConfig.Config.Platform.Azure.CloudName,
 				installConfig.Config.Platform.Azure.Region,
+				pool.Architecture,
 			)
 			mpool.Set(ic.Platform.Azure.DefaultMachinePlatform)
 			mpool.Set(pool.Platform.Azure)

--- a/pkg/types/azure/defaults/machines.go
+++ b/pkg/types/azure/defaults/machines.go
@@ -3,6 +3,7 @@ package defaults
 import (
 	"fmt"
 
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
@@ -11,9 +12,12 @@ import (
 // D8s_v3 gives us 8 CPU's, 32GiB ram and 64GiB of temporary storage
 // This extra bump is done to prevent etcd from overloading
 // DS4_v2 gives us 8 CPUs, 28GiB ram, and 56GiB of temporary storage.
-func ControlPlaneInstanceType(cloud azure.CloudEnvironment, region string) string {
+func ControlPlaneInstanceType(cloud azure.CloudEnvironment, region string, arch types.Architecture) string {
 	instanceClass := getInstanceClass(region)
 	size := "D8s_v3"
+	if arch == types.ArchitectureARM64 {
+		size = "D8ps_v5"
+	}
 	if cloud == azure.StackCloud {
 		size = "DS4_v2"
 	}
@@ -24,9 +28,12 @@ func ControlPlaneInstanceType(cloud azure.CloudEnvironment, region string) strin
 // Minimum requirements are 2 CPU's, 8GiB of ram, and 120GiB storage.
 // D4s v3 gives us 4 CPU's, 16GiB ram and 32GiB of temporary storage
 // DS3_v2 gives us 4 CPUs, 14GiB ram, and 28GiB of temporary storage.
-func ComputeInstanceType(cloud azure.CloudEnvironment, region string) string {
+func ComputeInstanceType(cloud azure.CloudEnvironment, region string, arch types.Architecture) string {
 	instanceClass := getInstanceClass(region)
 	size := "D4s_v3"
+	if arch == types.ArchitectureARM64 {
+		size = "D4ps_v5"
+	}
 	if cloud == azure.StackCloud {
 		size = "DS3_v2"
 	}


### PR DESCRIPTION
As part of the overall effort to add IPI support for Azure on ARM
instances (https://issues.redhat.com/browse/ARMOCP-16), this PR enables
the creation of arm64 machines when the arm64 architecture is specified
in the install config. Also added validation and tests.