### PR TITLE
OCPBUGS-889: bump default channel to stable-4.12

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -8,7 +8,7 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-4
 {{- else }}
-  channel: stable-4.11
+  channel: stable-4.12
 {{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}


### PR DESCRIPTION
```
╰─ oc get clusterversion
NAME      VERSION                              AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.12.0-0.nightly-2022-09-02-154321   True        False         84m     Cluster version is 4.12.0-0.nightly-2022-09-02-154321

╰─ oc get clusterversion/version -ojson | jq .spec
{
  "channel": "stable-4.11",
  "clusterID": "f96fff8e-4905-4f9a-92e0-96a659fe8cc6"
}
```