### PR TITLE
azure: create bootimages using image gallery

### DIFF
--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -194,3 +194,8 @@ variable "random_storage_account_suffix" {
   type        = string
   description = "A random string generated to add a suffix to the storage account and blob"
 }
+
+variable "azure_vm_architecture" {
+  type        = string
+  description = "Architecture of the VMs - used when creating images in the image gallery"
+}

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -199,3 +199,9 @@ variable "azure_vm_architecture" {
   type        = string
   description = "Architecture of the VMs - used when creating images in the image gallery"
 }
+
+variable "azure_image_release" {
+  type        = string
+  description = "RHCOS release image version - used when creating the image definition in the gallery"
+}
+

--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -128,7 +128,7 @@ resource "azurerm_shared_image" "clustergen2" {
 }
 
 resource "azurerm_shared_image_version" "cluster_image_version" {
-  name                = "0.0.1"
+  name                = var.azure_image_release
   gallery_name        = azurerm_shared_image.cluster.gallery_name
   image_name          = azurerm_shared_image.cluster.name
   resource_group_name = azurerm_shared_image.cluster.resource_group_name
@@ -144,7 +144,7 @@ resource "azurerm_shared_image_version" "cluster_image_version" {
 }
 
 resource "azurerm_shared_image_version" "clustergen2_image_version" {
-  name                = "0.0.1"
+  name                = var.azure_image_release
   gallery_name        = azurerm_shared_image.clustergen2.gallery_name
   image_name          = azurerm_shared_image.clustergen2.name
   resource_group_name = azurerm_shared_image.clustergen2.resource_group_name

--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -87,27 +87,75 @@ resource "azurerm_storage_blob" "rhcos_image" {
   metadata               = tomap({ source_uri = var.azure_image_url })
 }
 
-resource "azurerm_image" "cluster" {
+# Creates Shared Image Gallery
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/shared_image_gallery
+resource "azurerm_shared_image_gallery" "sig" {
+  name                = "gallery_${replace(var.cluster_id, "-", "_")}"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.azure_region
+}
+
+# Creates image definition
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/shared_image
+resource "azurerm_shared_image" "cluster" {
   name                = var.cluster_id
+  gallery_name        = azurerm_shared_image_gallery.sig.name
   resource_group_name = data.azurerm_resource_group.main.name
   location            = var.azure_region
+  os_type             = "Linux"
 
-  os_disk {
-    os_type  = "Linux"
-    os_state = "Generalized"
-    blob_uri = azurerm_storage_blob.rhcos_image.url
+  identifier {
+    publisher = "RedHat"
+    offer     = "rhcos"
+    sku       = "basic"
   }
 }
 
-resource "azurerm_image" "clustergen2" {
+resource "azurerm_shared_image" "clustergen2" {
   name                = "${var.cluster_id}-gen2"
+  gallery_name        = azurerm_shared_image_gallery.sig.name
   resource_group_name = data.azurerm_resource_group.main.name
   location            = var.azure_region
+  os_type             = "Linux"
   hyper_v_generation  = "V2"
+  architecture        = var.azure_vm_architecture
 
-  os_disk {
-    os_type  = "Linux"
-    os_state = "Generalized"
-    blob_uri = azurerm_storage_blob.rhcos_image.url
+  identifier {
+    publisher = "RedHat-gen2"
+    offer     = "rhcos-gen2"
+    sku       = "gen2"
   }
 }
+
+resource "azurerm_shared_image_version" "cluster_image_version" {
+  name                = "0.0.1"
+  gallery_name        = azurerm_shared_image.cluster.gallery_name
+  image_name          = azurerm_shared_image.cluster.name
+  resource_group_name = azurerm_shared_image.cluster.resource_group_name
+  location            = azurerm_shared_image.cluster.location
+
+  blob_uri           = azurerm_storage_blob.rhcos_image.url
+  storage_account_id = azurerm_storage_account.cluster.id
+
+  target_region {
+    name                   = azurerm_shared_image.cluster.location
+    regional_replica_count = 1
+  }
+}
+
+resource "azurerm_shared_image_version" "clustergen2_image_version" {
+  name                = "0.0.1"
+  gallery_name        = azurerm_shared_image.clustergen2.gallery_name
+  image_name          = azurerm_shared_image.clustergen2.name
+  resource_group_name = azurerm_shared_image.clustergen2.resource_group_name
+  location            = azurerm_shared_image.clustergen2.location
+
+  blob_uri           = azurerm_storage_blob.rhcos_image.url
+  storage_account_id = azurerm_storage_account.cluster.id
+
+  target_region {
+    name                   = azurerm_shared_image.clustergen2.location
+    regional_replica_count = 1
+  }
+}
+

--- a/data/data/azure/vnet/outputs.tf
+++ b/data/data/azure/vnet/outputs.tf
@@ -51,7 +51,7 @@ output "resource_group_name" {
 }
 
 output "vm_image" {
-  value = var.azure_hypervgeneration_version == "V2" ? azurerm_image.clustergen2.id : azurerm_image.cluster.id
+  value = var.azure_hypervgeneration_version == "V2" ? azurerm_shared_image_version.clustergen2_image_version.id : azurerm_shared_image_version.cluster_image_version.id
 }
 
 output "identity" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -365,6 +365,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				BootstrapIgnStub:                bootstrapIgnStub,
 				BootstrapIgnitionURLPlaceholder: bootstrapIgnURLPlaceholder,
 				HyperVGeneration:                hyperVGeneration,
+				VMArchitecture:                  installConfig.Config.ControlPlane.Architecture,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -97,6 +97,7 @@ func (t *TerraformVariables) Dependencies() []asset.Asset {
 		&installconfig.ClusterID{},
 		&installconfig.InstallConfig{},
 		new(rhcos.Image),
+		new(rhcos.Release),
 		new(rhcos.BootstrapImage),
 		&bootstrap.Bootstrap{},
 		&machine.Master{},
@@ -119,9 +120,10 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 	workersAsset := &machines.Worker{}
 	manifestsAsset := &manifests.Manifests{}
 	rhcosImage := new(rhcos.Image)
+	rhcosRelease := new(rhcos.Release)
 	rhcosBootstrapImage := new(rhcos.BootstrapImage)
 	ironicCreds := &baremetalbootstrap.IronicCreds{}
-	parents.Get(clusterID, installConfig, bootstrapIgnAsset, masterIgnAsset, mastersAsset, workersAsset, manifestsAsset, rhcosImage, rhcosBootstrapImage, ironicCreds)
+	parents.Get(clusterID, installConfig, bootstrapIgnAsset, masterIgnAsset, mastersAsset, workersAsset, manifestsAsset, rhcosImage, rhcosRelease, rhcosBootstrapImage, ironicCreds)
 
 	platform := installConfig.Config.Platform.Name()
 	switch platform {
@@ -359,6 +361,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				MasterConfigs:                   masterConfigs,
 				WorkerConfigs:                   workerConfigs,
 				ImageURL:                        string(*rhcosImage),
+				ImageRelease:                    rhcosRelease.GetAzureReleaseVersion(),
 				PreexistingNetwork:              preexistingnetwork,
 				Publish:                         installConfig.Config.Publish,
 				OutboundType:                    installConfig.Config.Azure.OutboundType,

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"strings"
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
@@ -110,10 +111,13 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		image.SKU = mpool.OSImage.SKU
 		image.Version = mpool.OSImage.Version
 	} else {
-		imageID := fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/images/%s", rg, clusterID)
+		// image gallery names cannot have dashes
+		galleryName := strings.Replace(clusterID, "-", "_", -1)
+		id := clusterID
 		if hyperVGen == "V2" {
-			imageID += "-gen2"
+			id += "-gen2"
 		}
+		imageID := fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s/versions/0.0.1", rg, galleryName, id)
 		image.ResourceID = imageID
 	}
 

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -23,7 +23,7 @@ const (
 )
 
 // Machines returns a list of machines for a machinepool.
-func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string) ([]machineapi.Machine, error) {
+func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string, rhcosVersion string) ([]machineapi.Machine, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != azure.Name {
 		return nil, fmt.Errorf("non-Azure configuration: %q", configPlatform)
 	}
@@ -50,7 +50,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		if len(azs) > 0 {
 			azIndex = int(idx) % len(azs)
 		}
-		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &azIndex, capabilities)
+		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &azIndex, capabilities, rhcosVersion)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
@@ -82,7 +82,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	return machines, nil
 }
 
-func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string, userDataSecret string, clusterID string, role string, azIdx *int, capabilities map[string]string) (*machineapi.AzureMachineProviderSpec, error) {
+func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string, userDataSecret string, clusterID string, role string, azIdx *int, capabilities map[string]string, rhcosVersion string) (*machineapi.AzureMachineProviderSpec, error) {
 	var az *string
 	if len(mpool.Zones) > 0 && azIdx != nil {
 		az = &mpool.Zones[*azIdx]
@@ -117,7 +117,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		if hyperVGen == "V2" {
 			id += "-gen2"
 		}
-		imageID := fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s/versions/0.0.1", rg, galleryName, id)
+		imageID := fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s/versions/%s", rg, galleryName, id, rhcosVersion)
 		image.ResourceID = imageID
 	}
 

--- a/pkg/asset/machines/azure/machinesets.go
+++ b/pkg/asset/machines/azure/machinesets.go
@@ -13,7 +13,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string) ([]*clusterapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string, rhcosVersion string) ([]*clusterapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != azure.Name {
 		return nil, fmt.Errorf("non-azure configuration: %q", configPlatform)
 	}
@@ -41,7 +41,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		if int64(idx) < total%numOfAZs {
 			replicas++
 		}
-		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx, capabilities)
+		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx, capabilities, rhcosVersion)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -138,6 +138,7 @@ func (m *Master) Dependencies() []asset.Asset {
 		&installconfig.PlatformCredsCheck{},
 		&installconfig.InstallConfig{},
 		new(rhcos.Image),
+		new(rhcos.Release),
 		&machine.Master{},
 	}
 }
@@ -148,8 +149,9 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
 	rhcosImage := new(rhcos.Image)
+	rhcosRelease := new(rhcos.Release)
 	mign := &machine.Master{}
-	dependencies.Get(clusterID, installConfig, rhcosImage, mign)
+	dependencies.Get(clusterID, installConfig, rhcosImage, rhcosRelease, mign)
 
 	masterUserDataSecretName := "master-user-data"
 
@@ -369,7 +371,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			return err
 		}
 
-		machines, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, capabilities)
+		machines, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, capabilities, rhcosRelease.GetAzureReleaseVersion())
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}

--- a/pkg/asset/machines/master_test.go
+++ b/pkg/asset/machines/master_test.go
@@ -159,6 +159,7 @@ spec:
 					},
 				},
 				(*rhcos.Image)(pointer.StringPtr("test-image")),
+				(*rhcos.Release)(pointer.StringPtr("412.86.202208101040-0")),
 				&machine.Master{
 					File: &asset.File{
 						Filename: "master-ignition",
@@ -218,6 +219,7 @@ func TestControlPlaneIsNotModified(t *testing.T) {
 		},
 		&installConfig,
 		(*rhcos.Image)(pointer.StringPtr("test-image")),
+		(*rhcos.Release)(pointer.StringPtr("412.86.202208101040-0")),
 		&machine.Master{
 			File: &asset.File{
 				Filename: "master-ignition",
@@ -287,6 +289,7 @@ func TestBaremetalGeneratedAssetFiles(t *testing.T) {
 		},
 		&installConfig,
 		(*rhcos.Image)(pointer.StringPtr("test-image")),
+		(*rhcos.Release)(pointer.StringPtr("412.86.202208101040-0")),
 		&machine.Master{
 			File: &asset.File{
 				Filename: "master-ignition",

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -215,6 +215,7 @@ func (w *Worker) Dependencies() []asset.Asset {
 		&installconfig.PlatformCredsCheck{},
 		&installconfig.InstallConfig{},
 		new(rhcos.Image),
+		new(rhcos.Release),
 		&machine.Worker{},
 	}
 }
@@ -225,8 +226,9 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
 	rhcosImage := new(rhcos.Image)
+	rhcosRelease := new(rhcos.Release)
 	wign := &machine.Worker{}
-	dependencies.Get(clusterID, installConfig, rhcosImage, wign)
+	dependencies.Get(clusterID, installConfig, rhcosImage, rhcosRelease, wign)
 
 	workerUserDataSecretName := "worker-user-data"
 
@@ -410,7 +412,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 				return err
 			}
 
-			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", workerUserDataSecretName, capabilities)
+			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", workerUserDataSecretName, capabilities, rhcosRelease.GetAzureReleaseVersion())
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -155,6 +155,7 @@ spec:
 					},
 				},
 				(*rhcos.Image)(pointer.StringPtr("test-image")),
+				(*rhcos.Release)(pointer.StringPtr("412.86.202208101040-0")),
 				&machine.Worker{
 					File: &asset.File{
 						Filename: "worker-ignition",
@@ -217,6 +218,7 @@ func TestComputeIsNotModified(t *testing.T) {
 		},
 		&installConfig,
 		(*rhcos.Image)(pointer.StringPtr("test-image")),
+		(*rhcos.Release)(pointer.StringPtr("412.86.202208101040-0")),
 		&machine.Worker{
 			File: &asset.File{
 				Filename: "worker-ignition",

--- a/pkg/asset/rhcos/release.go
+++ b/pkg/asset/rhcos/release.go
@@ -1,0 +1,88 @@
+// Package rhcos contains assets for RHCOS.
+package rhcos
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/coreos/stream-metadata-go/arch"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/rhcos"
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/azure"
+)
+
+// Release is a string which denotes the rhcos release, eg: 412.86.202208101040-0.
+// Currently we need this only for Azure to set the image version in the gallery.
+// In the future we could extend to other platforms as necessary.
+type Release string
+
+var _ asset.Asset = (*Release)(nil)
+
+// Name returns the human-friendly name of the asset.
+func (r *Release) Name() string {
+	return "Release"
+}
+
+// Dependencies returns dependencies used by the RHCOS asset.
+func (r *Release) Dependencies() []asset.Asset {
+	return []asset.Asset{
+		&installconfig.InstallConfig{},
+	}
+}
+
+// Generate the Release string.
+func (r *Release) Generate(p asset.Parents) error {
+	ic := &installconfig.InstallConfig{}
+	p.Get(ic)
+	config := ic.Config
+	release, err := release(config)
+	if err != nil {
+		return err
+	}
+	*r = Release(release)
+	return nil
+}
+
+func release(config *types.InstallConfig) (string, error) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	defer cancel()
+
+	archName := arch.RpmArch(string(config.ControlPlane.Architecture))
+
+	st, err := rhcos.FetchCoreOSBuild(ctx)
+	if err != nil {
+		return "", err
+	}
+	streamArch, err := st.GetArchitecture(archName)
+	if err != nil {
+		return "", err
+	}
+	switch config.Platform.Name() {
+	case azure.Name:
+		ext := streamArch.RHELCoreOSExtensions
+		if ext == nil {
+			return "", fmt.Errorf("%s: No azure build found", st.FormatPrefix(archName))
+		}
+		azd := ext.AzureDisk
+		if azd == nil {
+			return "", fmt.Errorf("%s: No azure build found", st.FormatPrefix(archName))
+		}
+		return azd.Release, nil
+	default:
+		return "", nil
+	}
+}
+
+// GetAzureReleaseVersion - generates a modified string for Azure image gallery images. Image gallery image versions cannot have
+// a "-" in the name and must be between 0-2147483647, so we have to truncate the hour and minutes of the date.
+func (r *Release) GetAzureReleaseVersion() string {
+	imageVersion := string(*r)
+	if imageVersion != "" {
+		imageVersion = imageVersion[:len(imageVersion)-6]
+	}
+	return imageVersion
+}

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -36,6 +36,7 @@ type config struct {
 	VolumeType                      string            `json:"azure_master_root_volume_type"`
 	VolumeSize                      int32             `json:"azure_master_root_volume_size"`
 	ImageURL                        string            `json:"azure_image_url,omitempty"`
+	ImageRelease                    string            `json:"azure_image_release,omitempty"`
 	Region                          string            `json:"azure_region,omitempty"`
 	BaseDomainResourceGroupName     string            `json:"azure_base_domain_resource_group_name,omitempty"`
 	ResourceGroupName               string            `json:"azure_resource_group_name"`
@@ -64,6 +65,7 @@ type TFVarsSources struct {
 	MasterConfigs                   []*machineapi.AzureMachineProviderSpec
 	WorkerConfigs                   []*machineapi.AzureMachineProviderSpec
 	ImageURL                        string
+	ImageRelease                    string
 	PreexistingNetwork              bool
 	Publish                         types.PublishingStrategy
 	OutboundType                    azure.OutboundType
@@ -117,6 +119,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		VolumeType:                      masterConfig.OSDisk.ManagedDisk.StorageAccountType,
 		VolumeSize:                      masterConfig.OSDisk.DiskSizeGB,
 		ImageURL:                        sources.ImageURL,
+		ImageRelease:                    sources.ImageRelease,
 		Private:                         sources.Publish == types.InternalPublishingStrategy,
 		OutboundUDR:                     sources.OutboundType == azure.UserDefinedRoutingOutboundType,
 		ResourceGroupName:               sources.ResourceGroupName,

--- a/pkg/tfvars/azure/azure.go
+++ b/pkg/tfvars/azure/azure.go
@@ -51,6 +51,7 @@ type config struct {
 	HyperVGeneration                string            `json:"azure_hypervgeneration_version"`
 	VMNetworkingType                bool              `json:"azure_control_plane_vm_networking_type"`
 	RandomStringPrefix              string            `json:"random_storage_account_suffix"`
+	VMArchitecture                  string            `json:"azure_vm_architecture"`
 }
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
@@ -69,6 +70,7 @@ type TFVarsSources struct {
 	BootstrapIgnStub                string
 	BootstrapIgnitionURLPlaceholder string
 	HyperVGeneration                string
+	VMArchitecture                  types.Architecture
 }
 
 // TFVars generates Azure-specific Terraform variables launching the cluster.
@@ -95,6 +97,11 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	var masterDiskEncryptionSetID string
 	if masterConfig.OSDisk.ManagedDisk.DiskEncryptionSet != nil {
 		masterDiskEncryptionSetID = masterConfig.OSDisk.ManagedDisk.DiskEncryptionSet.ID
+	}
+
+	vmarch := "x64"
+	if sources.VMArchitecture == types.ArchitectureARM64 {
+		vmarch = "Arm64"
 	}
 
 	cfg := &config{
@@ -124,6 +131,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		HyperVGeneration:                sources.HyperVGeneration,
 		VMNetworkingType:                masterConfig.AcceleratedNetworking,
 		RandomStringPrefix:              randomStringPrefixFunction(),
+		VMArchitecture:                  vmarch,
 	}
 
 	return json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
In order to support provisioning of arm64 bootimages, these need to be
created using the image gallery resource as they are not supported
through managed images. For this purpose, it would be good to unify the
implementation of x86 and arm64 to use image galleries as Microsoft have
said that it will be the supported way of creating bootimages going forward
for new instance types of new architectures.

This implementation would create one image gallery with two images: a
gen1 and a gen2 image which we would then pick appropriately based on
the VM generation.

xref: https://issues.redhat.com/browse/ARMOCP-16