### PR TITLE
vsphere: error checking while creating vsphere clients

### DIFF
--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -44,6 +44,10 @@ func getVCenterClient(deploymentZone vsphere.DeploymentZone, ic *types.InstallCo
 				vcenter.Username,
 				vcenter.Password)
 
+			if err != nil {
+				return nil, nil, err
+			}
+
 			validationCtx := validationContext{
 				User:        vcenter.Username,
 				AuthManager: newAuthManager(vim25Client),


### PR DESCRIPTION
The following nil pointer was found while installing into a multi-zone vsphere. 

```
sh-4.4$ ./openshift-install-zonal create cluster --dir cluster/
INFO Consuming Install Config from target directory 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1c8 pc=0x2fd69aa]

goroutine 1 [running]:
github.com/vmware/govmomi/object.NewSearchIndex(...)
	/var/home/rbost/go/src/github.com/openshift/installer/vendor/github.com/vmware/govmomi/object/search_index.go:33
github.com/vmware/govmomi/find.NewFinder(0x0, {0x0?, 0x0, 0x1d?})
	/var/home/rbost/go/src/github.com/openshift/installer/vendor/github.com/vmware/govmomi/find/finder.go:51 +0x6a
github.com/openshift/installer/pkg/asset/installconfig/vsphere.getVCenterClient({{0xc000517ab0, 0x9}, {0xc0006425a0, 0x1d}, {0xc000517aa0, 0x9}, {0x0, 0x0}, {{0xc0006386f0, 0x2e}, ...}}, ...)
	/var/home/rbost/go/src/github.com/openshift/installer/pkg/asset/installconfig/vsphere/validation.go:47 +0x1eb
github.com/openshift/installer/pkg/asset/installconfig/vsphere.ValidateMultiZoneForProvisioning(0xc0003e7d40)
	/var/home/rbost/go/src/github.com/openshift/installer/pkg/asset/installconfig/vsphere/validation.go:79 +0x248
github.com/openshift/installer/pkg/asset/installconfig.(*PlatformProvisionCheck).Generate(0xc0000f8000?, 0x5?)
	/var/home/rbost/go/src/github.com/openshift/installer/pkg/asset/installconfig/platformprovisioncheck.go:115 +0x45e
github.com/openshift/installer/pkg/asset/store.(*storeImpl).fetch(0xc0000f2360, {0x19def860, 0x1cfa8690}, {0x47dab14, 0x2})
	/var/home/rbost/go/src/github.com/openshift/installer/pkg/asset/store/store.go:227 +0x5fa
github.com/openshift/installer/pkg/asset/store.(*storeImpl).fetch(0xc0000f2360, {0x19def620, 0x1cf580c0}, {0x0, 0x0})
	/var/home/rbost/go/src/github.com/openshift/installer/pkg/asset/store/store.go:221 +0x74e
github.com/openshift/installer/pkg/asset/store.(*storeImpl).Fetch(0x19dff358?, {0x19def620, 0x1cf580c0}, {0x1cf38360, 0x8, 0x8})
	/var/home/rbost/go/src/github.com/openshift/installer/pkg/asset/store/store.go:77 +0x48
main.runTargetCmd.func1({0x7fff69358b84, 0x8})
	/var/home/rbost/go/src/github.com/openshift/installer/cmd/openshift-install/create.go:251 +0x125
main.runTargetCmd.func2(0x1cf3df40?, {0xc00119afa0?, 0x2?, 0x2?})
	/var/home/rbost/go/src/github.com/openshift/installer/cmd/openshift-install/create.go:280 +0xe7
github.com/spf13/cobra.(*Command).execute(0x1cf3df40, {0xc00119af60, 0x2, 0x2})
	/var/home/rbost/go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:876 +0x67b
github.com/spf13/cobra.(*Command).ExecuteC(0xc00085c000)
	/var/home/rbost/go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:990 +0x3b4
github.com/spf13/cobra.(*Command).Execute(...)
	/var/home/rbost/go/src/github.com/openshift/installer/vendor/github.com/spf13/cobra/command.go:918
main.installerMain()
	/var/home/rbost/go/src/github.com/openshift/installer/cmd/openshift-install/main.go:60 +0x29e
main.main()
	/var/home/rbost/go/src/github.com/openshift/installer/cmd/openshift-install/main.go:38 +0xff
```