### PR TITLE
OCPBUGS-963: OpenStack: Lift validation for 14 chars cluster names

### DIFF
--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -1,8 +1,6 @@
 package validation
 
 import (
-	"strings"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -14,8 +12,6 @@ import (
 func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field.Path, c *types.InstallConfig) field.ErrorList {
 	var allErrs field.ErrorList
 
-	allErrs = append(allErrs, validateClusterName(c.ObjectMeta.Name)...)
-
 	for _, ip := range p.ExternalDNS {
 		if err := validate.IP(ip); err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("externalDNS"), p.ExternalDNS, err.Error()))
@@ -25,16 +21,4 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field
 	allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, "default", fldPath.Child("defaultMachinePlatform"))...)
 
 	return allErrs
-}
-
-func validateClusterName(name string) (allErrs field.ErrorList) {
-	if len(name) > 14 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), name, "cluster name is too long, please restrict it to 14 characters"))
-	}
-
-	if strings.Contains(name, ".") {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), name, "cluster name can't contain \".\" character"))
-	}
-
-	return
 }

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -30,27 +30,6 @@ func validNetworking() *types.Networking {
 	}
 }
 
-func TestValidateClusterName(t *testing.T) {
-	testConfig := types.InstallConfig{}
-
-	// valid platform
-	testConfig.ObjectMeta.Name = "test"
-	errs := ValidatePlatform(validPlatform(), validNetworking(), field.NewPath("test-path"), &testConfig)
-	assert.NoError(t, errs.ToAggregate())
-
-	// too long cluster name (more than 14 chars)
-	testConfig.ObjectMeta.Name = "0123456789abcde"
-	errs = ValidatePlatform(validPlatform(), validNetworking(), field.NewPath("test-path"), &testConfig)
-	assert.True(t, len(errs) == 1)
-	assert.Equal(t, "cluster name is too long, please restrict it to 14 characters", errs[0].Detail)
-
-	// . in the name
-	testConfig.ObjectMeta.Name = "test.cluster"
-	errs = ValidatePlatform(validPlatform(), validNetworking(), field.NewPath("test-path"), &testConfig)
-	assert.True(t, len(errs) == 1)
-	assert.Equal(t, "cluster name can't contain \".\" character", errs[0].Detail)
-}
-
 func TestValidatePlatform(t *testing.T) {
 	cases := []struct {
 		name                  string

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -85,7 +85,7 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 	if c.Platform.GCP != nil || c.Platform.Azure != nil {
 		nameErr = validate.ClusterName1035(c.ObjectMeta.Name)
 	}
-	if c.Platform.VSphere != nil || c.Platform.BareMetal != nil || c.Platform.Nutanix != nil {
+	if c.Platform.VSphere != nil || c.Platform.BareMetal != nil || c.Platform.OpenStack != nil || c.Platform.Nutanix != nil {
 		nameErr = validate.OnPremClusterName(c.ObjectMeta.Name)
 	}
 	if nameErr != nil {


### PR DESCRIPTION
The validation is no longer necessary now that we stopped using mDNS. Instead, rely on cluster name validation common to all platforms for length check and the on-prem cluster name validation for names containing dots.

This aligns with other on-prem platforms.