### PR TITLE
OCPBUGS-927: Add depends to enforce order for azure terraform dependencies

### DIFF
--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -15,6 +15,8 @@ resource "azurerm_private_dns_zone_virtual_network_link" "network" {
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.private.name
   virtual_network_id    = var.virtual_network_id
+
+  depends_on = [azurerm_private_dns_zone.private]
 }
 
 resource "azurerm_private_dns_a_record" "apiint_internal" {


### PR DESCRIPTION
** Added depends for the azurerm_private_dns_zone_virtual_network_link.network to depend on "".private. This should enforce the dependencies.