### PR TITLE
OCPBUGSM-47740: No networkconfig needed with DHCP agent config

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -121,10 +121,6 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		},
 	}
 
-	if len(agentManifests.NMStateConfigs) == 0 {
-		return errors.New("at least one NMState configuration must be provided")
-	}
-
 	nodeZeroIP, err := RetrieveRendezvousIP(agentConfigAsset.Config, agentManifests.NMStateConfigs)
 	if err != nil {
 		return err

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -73,61 +73,72 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 	staticNetworkConfig := []*models.HostStaticNetworkConfig{}
 	nmStateConfigs := []*aiv1beta1.NMStateConfig{}
 	var data string
+	var isNetWorkConfigAvailable bool
 
 	if agentConfig.Config != nil {
-		for i, host := range agentConfig.Config.Hosts {
-			nmStateConfig := aiv1beta1.NMStateConfig{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "NMStateConfig",
-					APIVersion: "agent-install.openshift.io/v1beta1",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf(getNMStateConfigName(agentConfig)+"-%d", i),
-					Namespace: getNMStateConfigNamespace(agentConfig),
-					Labels:    getNMStateConfigLabelsFromAgentConfig(agentConfig),
-				},
-				Spec: aiv1beta1.NMStateConfigSpec{
-					NetConfig: aiv1beta1.NetConfig{
-						Raw: []byte(host.NetworkConfig.Raw),
-					},
-				},
-			}
-			for _, hostInterface := range host.Interfaces {
-				intrfc := aiv1beta1.Interface{
-					Name:       hostInterface.Name,
-					MacAddress: hostInterface.MacAddress,
+		if len(agentConfig.Config.Hosts) > 0 {
+			for i, host := range agentConfig.Config.Hosts {
+				if host.NetworkConfig.Raw != nil {
+					isNetWorkConfigAvailable = true
+
+					nmStateConfig := aiv1beta1.NMStateConfig{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "NMStateConfig",
+							APIVersion: "agent-install.openshift.io/v1beta1",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      fmt.Sprintf(getNMStateConfigName(agentConfig)+"-%d", i),
+							Namespace: getNMStateConfigNamespace(agentConfig),
+							Labels:    getNMStateConfigLabelsFromAgentConfig(agentConfig),
+						},
+						Spec: aiv1beta1.NMStateConfigSpec{
+							NetConfig: aiv1beta1.NetConfig{
+								Raw: []byte(host.NetworkConfig.Raw),
+							},
+						},
+					}
+					for _, hostInterface := range host.Interfaces {
+						intrfc := aiv1beta1.Interface{
+							Name:       hostInterface.Name,
+							MacAddress: hostInterface.MacAddress,
+						}
+						nmStateConfig.Spec.Interfaces = append(nmStateConfig.Spec.Interfaces, &intrfc)
+
+					}
+					nmStateConfigs = append(nmStateConfigs, &nmStateConfig)
+
+					staticNetworkConfig = append(staticNetworkConfig, &models.HostStaticNetworkConfig{
+						MacInterfaceMap: buildMacInterfaceMap(nmStateConfig),
+						NetworkYaml:     string(nmStateConfig.Spec.NetConfig.Raw),
+					})
+
+					// Marshal the nmStateConfig one at a time
+					// and add a yaml seperator with new line
+					// so as not to marshal the nmStateConfigs
+					// as a yaml list in the generated nmstateconfig.yaml
+					nmStateConfigData, err := k8syaml.Marshal(nmStateConfig)
+
+					if err != nil {
+						return errors.Wrap(err, "failed to marshal agent installer NMStateConfig")
+					}
+					data = fmt.Sprint(data, fmt.Sprint(string(nmStateConfigData), "---\n"))
 				}
-				nmStateConfig.Spec.Interfaces = append(nmStateConfig.Spec.Interfaces, &intrfc)
-
 			}
-			nmStateConfigs = append(nmStateConfigs, &nmStateConfig)
 
-			staticNetworkConfig = append(staticNetworkConfig, &models.HostStaticNetworkConfig{
-				MacInterfaceMap: buildMacInterfaceMap(nmStateConfig),
-				NetworkYaml:     string(nmStateConfig.Spec.NetConfig.Raw),
-			})
+			if isNetWorkConfigAvailable {
+				n.Config = nmStateConfigs
+				n.StaticNetworkConfig = staticNetworkConfig
 
-			// Marshal the nmStateConfig one at a time
-			// and add a yaml seperator with new line
-			// so as not to marshal the nmStateConfigs
-			// as a yaml list in the generated nmstateconfig.yaml
-			nmStateConfigData, err := k8syaml.Marshal(nmStateConfig)
-
-			if err != nil {
-				return errors.Wrap(err, "failed to marshal agent installer NMStateConfig")
+				n.File = &asset.File{
+					Filename: nmStateConfigFilename,
+					Data:     []byte(data),
+				}
+				return n.finish()
 			}
-			data = fmt.Sprint(data, fmt.Sprint(string(nmStateConfigData), "---\n"))
-		}
-
-		n.Config = nmStateConfigs
-		n.StaticNetworkConfig = staticNetworkConfig
-
-		n.File = &asset.File{
-			Filename: nmStateConfigFilename,
-			Data:     []byte(data),
+		} else {
+			return nil
 		}
 	}
-
 	return n.finish()
 }
 

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -196,10 +196,6 @@ func (n *NMStateConfig) Load(f asset.FileFetcher) (bool, error) {
 
 func (n *NMStateConfig) finish() error {
 
-	if n.Config == nil {
-		return errors.New("missing configuration or manifest file")
-	}
-
 	if err := n.validateNMStateConfig().ToAggregate(); err != nil {
 		return errors.Wrapf(err, "invalid NMStateConfig configuration")
 	}

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -76,67 +76,66 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 	var isNetWorkConfigAvailable bool
 
 	if agentConfig.Config != nil {
-		if len(agentConfig.Config.Hosts) > 0 {
-			for i, host := range agentConfig.Config.Hosts {
-				if host.NetworkConfig.Raw != nil {
-					isNetWorkConfigAvailable = true
-
-					nmStateConfig := aiv1beta1.NMStateConfig{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "NMStateConfig",
-							APIVersion: "agent-install.openshift.io/v1beta1",
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf(getNMStateConfigName(agentConfig)+"-%d", i),
-							Namespace: getNMStateConfigNamespace(agentConfig),
-							Labels:    getNMStateConfigLabelsFromAgentConfig(agentConfig),
-						},
-						Spec: aiv1beta1.NMStateConfigSpec{
-							NetConfig: aiv1beta1.NetConfig{
-								Raw: []byte(host.NetworkConfig.Raw),
-							},
-						},
-					}
-					for _, hostInterface := range host.Interfaces {
-						intrfc := aiv1beta1.Interface{
-							Name:       hostInterface.Name,
-							MacAddress: hostInterface.MacAddress,
-						}
-						nmStateConfig.Spec.Interfaces = append(nmStateConfig.Spec.Interfaces, &intrfc)
-
-					}
-					nmStateConfigs = append(nmStateConfigs, &nmStateConfig)
-
-					staticNetworkConfig = append(staticNetworkConfig, &models.HostStaticNetworkConfig{
-						MacInterfaceMap: buildMacInterfaceMap(nmStateConfig),
-						NetworkYaml:     string(nmStateConfig.Spec.NetConfig.Raw),
-					})
-
-					// Marshal the nmStateConfig one at a time
-					// and add a yaml seperator with new line
-					// so as not to marshal the nmStateConfigs
-					// as a yaml list in the generated nmstateconfig.yaml
-					nmStateConfigData, err := k8syaml.Marshal(nmStateConfig)
-
-					if err != nil {
-						return errors.Wrap(err, "failed to marshal agent installer NMStateConfig")
-					}
-					data = fmt.Sprint(data, fmt.Sprint(string(nmStateConfigData), "---\n"))
-				}
-			}
-
-			if isNetWorkConfigAvailable {
-				n.Config = nmStateConfigs
-				n.StaticNetworkConfig = staticNetworkConfig
-
-				n.File = &asset.File{
-					Filename: nmStateConfigFilename,
-					Data:     []byte(data),
-				}
-				return n.finish()
-			}
-		} else {
+		if len(agentConfig.Config.Hosts) == 0 {
 			return nil
+		}
+		for i, host := range agentConfig.Config.Hosts {
+			if host.NetworkConfig.Raw != nil {
+				isNetWorkConfigAvailable = true
+
+				nmStateConfig := aiv1beta1.NMStateConfig{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "NMStateConfig",
+						APIVersion: "agent-install.openshift.io/v1beta1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf(getNMStateConfigName(agentConfig)+"-%d", i),
+						Namespace: getNMStateConfigNamespace(agentConfig),
+						Labels:    getNMStateConfigLabelsFromAgentConfig(agentConfig),
+					},
+					Spec: aiv1beta1.NMStateConfigSpec{
+						NetConfig: aiv1beta1.NetConfig{
+							Raw: []byte(host.NetworkConfig.Raw),
+						},
+					},
+				}
+				for _, hostInterface := range host.Interfaces {
+					intrfc := aiv1beta1.Interface{
+						Name:       hostInterface.Name,
+						MacAddress: hostInterface.MacAddress,
+					}
+					nmStateConfig.Spec.Interfaces = append(nmStateConfig.Spec.Interfaces, &intrfc)
+
+				}
+				nmStateConfigs = append(nmStateConfigs, &nmStateConfig)
+
+				staticNetworkConfig = append(staticNetworkConfig, &models.HostStaticNetworkConfig{
+					MacInterfaceMap: buildMacInterfaceMap(nmStateConfig),
+					NetworkYaml:     string(nmStateConfig.Spec.NetConfig.Raw),
+				})
+
+				// Marshal the nmStateConfig one at a time
+				// and add a yaml seperator with new line
+				// so as not to marshal the nmStateConfigs
+				// as a yaml list in the generated nmstateconfig.yaml
+				nmStateConfigData, err := k8syaml.Marshal(nmStateConfig)
+
+				if err != nil {
+					return errors.Wrap(err, "failed to marshal agent installer NMStateConfig")
+				}
+				data = fmt.Sprint(data, fmt.Sprint(string(nmStateConfigData), "---\n"))
+			}
+		}
+
+		if isNetWorkConfigAvailable {
+			n.Config = nmStateConfigs
+			n.StaticNetworkConfig = staticNetworkConfig
+
+			n.File = &asset.File{
+				Filename: nmStateConfigFilename,
+				Data:     []byte(data),
+			}
+			return n.finish()
 		}
 	}
 	return n.finish()

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -73,7 +73,7 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 	staticNetworkConfig := []*models.HostStaticNetworkConfig{}
 	nmStateConfigs := []*aiv1beta1.NMStateConfig{}
 	var data string
-	var isNetWorkConfigAvailable bool
+	var isNetworkConfigAvailable bool
 
 	if agentConfig.Config != nil {
 		if len(agentConfig.Config.Hosts) == 0 {
@@ -81,7 +81,7 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 		}
 		for i, host := range agentConfig.Config.Hosts {
 			if host.NetworkConfig.Raw != nil {
-				isNetWorkConfigAvailable = true
+				isNetworkConfigAvailable = true
 
 				nmStateConfig := aiv1beta1.NMStateConfig{
 					TypeMeta: metav1.TypeMeta{
@@ -127,7 +127,7 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 			}
 		}
 
-		if isNetWorkConfigAvailable {
+		if isNetworkConfigAvailable {
 			n.Config = nmStateConfigs
 			n.StaticNetworkConfig = staticNetworkConfig
 
@@ -135,7 +135,6 @@ func (n *NMStateConfig) Generate(dependencies asset.Parents) error {
 				Filename: nmStateConfigFilename,
 				Data:     []byte(data),
 			}
-			return n.finish()
 		}
 	}
 	return n.finish()

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -241,7 +241,7 @@ func getValidDHCPAgentConfigWithSomeHostsWithoutNetworkConfig() *agentconfig.Age
 					Interfaces: []*v1beta1.Interface{
 						{
 							Name:       "enp2t0",
-							MacAddress: "98:af:65:a5:8d:02",
+							MacAddress: "98:af:65:a5:8d:03",
 						},
 					},
 				},

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -169,6 +169,87 @@ func getValidAgentConfig() *agentconfig.AgentConfig {
 	}
 }
 
+func getValidDHCPAgentConfigNoHosts() *agentconfig.AgentConfig {
+	return &agentconfig.AgentConfig{
+		Config: &agenttypes.Config{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AgentConfig",
+				APIVersion: "v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ocp-edge-cluster-0",
+				Namespace: "cluster-0",
+			},
+			RendezvousIP: "192.168.122.2",
+		},
+	}
+}
+
+func getValidDHCPAgentConfigWithSomeHostsWithoutNetworkConfig() *agentconfig.AgentConfig {
+	return &agentconfig.AgentConfig{
+		Config: &agenttypes.Config{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AgentConfig",
+				APIVersion: "v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ocp-edge-cluster-0",
+				Namespace: "cluster-0",
+			},
+			RendezvousIP: "192.168.122.2",
+			Hosts: []agenttypes.Host{
+				{
+					Hostname: "control-0.example.org",
+					Role:     "master",
+					RootDeviceHints: baremetal.RootDeviceHints{
+						DeviceName:         "/dev/sda",
+						HCTL:               "hctl-value",
+						Model:              "model-value",
+						Vendor:             "vendor-value",
+						SerialNumber:       "serial-number-value",
+						MinSizeGigabytes:   20,
+						WWN:                "wwn-value",
+						WWNWithExtension:   "wwn-with-extension-value",
+						WWNVendorExtension: "wwn-vendor-extension-value",
+						Rotational:         new(bool),
+					},
+					Interfaces: []*v1beta1.Interface{
+						{
+							Name:       "enp2t0",
+							MacAddress: "98:af:65:a5:8d:02",
+						},
+					},
+					NetworkConfig: v1beta1.NetConfig{
+						Raw: unmarshalJSON([]byte("interfaces:")),
+					},
+				},
+				{
+					Hostname: "control-1.example.org",
+					Role:     "master",
+					RootDeviceHints: baremetal.RootDeviceHints{
+						DeviceName:         "/dev/sdb",
+						HCTL:               "hctl-value",
+						Model:              "model-value",
+						Vendor:             "vendor-value",
+						SerialNumber:       "serial-number-value",
+						MinSizeGigabytes:   40,
+						WWN:                "wwn-value",
+						WWNWithExtension:   "wwn-with-extension-value",
+						WWNVendorExtension: "wwn-vendor-extension-value",
+						Rotational:         new(bool),
+					},
+					Interfaces: []*v1beta1.Interface{
+						{
+							Name:       "enp2t0",
+							MacAddress: "98:af:65:a5:8d:02",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func unmarshalJSON(b []byte) []byte {
 	output, _ := yaml.JSONToYAML(b)
 	return output


### PR DESCRIPTION
When creating DHCP only cluster with agent config ( i.e. only RendezvousIP), do not require any networkConfig to be provided.