### PR TITLE
OCPBUGS-816: Check that cached base ISP matches hash in release payload

### DIFF
--- a/pkg/asset/agent/image/baseiso.go
+++ b/pkg/asset/agent/image/baseiso.go
@@ -128,7 +128,7 @@ func (i *BaseIso) Generate(dependencies asset.Parents) error {
 			Config{MaxTries: OcDefaultTries, RetryDelay: OcDefaultRetryDelay})
 
 		log.Info("Extracting base ISO from release payload")
-		baseIsoFileName, err = ocRelease.GetBaseIso(log, releaseImage, pullSecret, registriesConf.MirrorConfig, archName)
+		baseIsoFileName, err = ocRelease.GetBaseIso(log, releaseImage, pullSecret, archName, registriesConf.MirrorConfig)
 		if err == nil {
 			log.Debugf("Extracted base ISO image %s from release payload", baseIsoFileName)
 			i.File = &asset.File{Filename: baseIsoFileName}

--- a/pkg/asset/agent/image/cache.go
+++ b/pkg/asset/agent/image/cache.go
@@ -37,7 +37,7 @@ func GetFileFromCache(fileName string, cacheDir string) (string, error) {
 	// If the file has already been cached, return its path
 	_, err := os.Stat(filePath)
 	if err == nil {
-		logrus.Debugf("The file was found in cache: %v. Reusing...", filePath)
+		logrus.Debugf("The file was found in cache: %v", filePath)
 		return filePath, nil
 	}
 	if !os.IsNotExist(err) {


### PR DESCRIPTION
For the base ISO that is cached, it needs to be verified that it matches the one in the release payload. This change first checks the sha256 hash in the rhcos.json file embedded in the installer. If that doesn't match the cached file it extracts the coreos-x86-64.iso.sha256 file from the release payload and compares that.  If neither match then a new iso will be retrieved from the release payload or downloaded.