### PR TITLE
Verifying yq is installed properly in libvirt installer containers

### DIFF
--- a/images/libvirt/Dockerfile.ci
+++ b/images/libvirt/Dockerfile.ci
@@ -25,8 +25,13 @@ RUN yum update -y && \
     openssh-clients && \
     yum clean all && rm -rf /var/cache/yum/*
 
-RUN curl -L https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64 -o /usr/bin/yq && \
-    chmod +x /usr/bin/yq
+ARG YQ_URI=https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
+ARG YQ_HASH=e70e482e7ddb9cf83b52f5e83b694a19e3aaf36acf6b82512cbe66e41d569201
+RUN echo "${YQ_HASH} -" > /tmp/sum.txt && \
+  curl -L --fail "${YQ_URI}" | tee /bin/yq | sha256sum -c /tmp/sum.txt >/dev/null && \
+  chmod +x /bin/yq && \
+  rm /tmp/sum.txt
+
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin


### PR DESCRIPTION
Found recent failure in CI with incorrectly downloaded yq 
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-sdn-remote-libvirt-ppc64le/1567624076510367744#1:build-log.txt%3A34-40 

cc @r4f4 