### PR TITLE
OCPBUGSM-47737: Do not enable pre-network-manager-config.service

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -59,22 +59,6 @@ type agentTemplateData struct {
 	InfraEnvID          string
 }
 
-var (
-	agentEnabledServices = []string{
-		"agent.service",
-		"assisted-service-db.service",
-		"assisted-service-pod.service",
-		"assisted-service.service",
-		"create-cluster-and-infraenv.service",
-		"node-zero.service",
-		"multipathd.service",
-		"pre-network-manager-config.service",
-		"selinux.service",
-		"set-hostname.service",
-		"start-cluster-installation.service",
-	}
-)
-
 // Name returns the human-friendly name of the asset.
 func (a *Ignition) Name() string {
 	return "Agent Installer Ignition"
@@ -196,6 +180,24 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 	err = addStaticNetworkConfig(&config, agentManifests.StaticNetworkConfigs)
 	if err != nil {
 		return err
+	}
+
+	agentEnabledServices := []string{
+		"agent.service",
+		"assisted-service-db.service",
+		"assisted-service-pod.service",
+		"assisted-service.service",
+		"create-cluster-and-infraenv.service",
+		"node-zero.service",
+		"multipathd.service",
+		"selinux.service",
+		"set-hostname.service",
+		"start-cluster-installation.service",
+	}
+
+	// Enable pre-network-manager-config.service only when there are network configs defined
+	if len(agentManifests.StaticNetworkConfigs) != 0 {
+		agentEnabledServices = append(agentEnabledServices, "pre-network-manager-config.service")
 	}
 
 	err = bootstrap.AddSystemdUnits(&config, "agent/systemd/units", agentTemplateData, agentEnabledServices)

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -283,6 +283,11 @@ func TestAddHostConfig_Roles(t *testing.T) {
 }
 
 func TestIgnition_Generate(t *testing.T) {
+	// Generate calls addStaticNetworkConfig which calls nmstatectl
+	_, execErr := exec.LookPath("nmstatectl")
+	if execErr != nil {
+		t.Skip("No nmstatectl binary available")
+	}
 
 	// This patch currently allows testing the Ignition asset using the embedded resources.
 	// TODO: Replace it by mocking the filesystem in bootstrap.AddStorageFiles()

--- a/pkg/asset/agent/manifests/agent.go
+++ b/pkg/asset/agent/manifests/agent.go
@@ -65,7 +65,6 @@ func (m *AgentManifests) Generate(dependencies asset.Parents) error {
 		&ClusterImageSet{},
 	} {
 		dependencies.Get(a)
-		m.FileList = append(m.FileList, a.Files()...)
 
 		switch v := a.(type) {
 		case *AgentPullSecret:
@@ -73,6 +72,11 @@ func (m *AgentManifests) Generate(dependencies asset.Parents) error {
 		case *InfraEnv:
 			m.InfraEnv = v.Config
 		case *NMStateConfig:
+			// continue if there are no configs defined to avoid
+			// writing out a empty nmstateconfig.yaml file
+			if len(v.Config) == 0 {
+				continue
+			}
 			m.StaticNetworkConfigs = append(m.StaticNetworkConfigs, v.StaticNetworkConfig...)
 			m.NMStateConfigs = append(m.NMStateConfigs, v.Config...)
 		case *AgentClusterInstall:
@@ -82,6 +86,8 @@ func (m *AgentManifests) Generate(dependencies asset.Parents) error {
 		case *ClusterImageSet:
 			m.ClusterImageSet = v.Config
 		}
+
+		m.FileList = append(m.FileList, a.Files()...)
 	}
 
 	asset.SortFiles(m.FileList)

--- a/pkg/asset/agent/manifests/nmstateconfig_test.go
+++ b/pkg/asset/agent/manifests/nmstateconfig_test.go
@@ -25,11 +25,11 @@ func TestNMStateConfig_Generate(t *testing.T) {
 		expectedConfig []*aiv1beta1.NMStateConfig
 	}{
 		{
-			name: "valid dhcp agent config no hosts",
+			name: "agent-config does not contain networkConfig",
 			dependencies: []asset.Asset{
 				getValidDHCPAgentConfigNoHosts(),
 			},
-			expectedConfig: []*aiv1beta1.NMStateConfig(nil),
+			expectedConfig: nil,
 		},
 		{
 			name: "valid dhcp agent config with some hosts without networkconfig",


### PR DESCRIPTION
when there are no nmstateconfigs defined.

When DHCP is used, agent-config.yaml may have no networkConfigs defined, and therefore no nmstateconfigs will be generated. When nmstateconfigs are absent, the pre-network-manager-config systemd service should not be enabled.