### PR TITLE
Revert "AWS: Create ControlPlaneMachineSet CRDs"

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -66,10 +66,9 @@ import (
 
 // Master generates the machines for the `master` machine pool.
 type Master struct {
-	UserDataFile           *asset.File
-	MachineConfigFiles     []*asset.File
-	MachineFiles           []*asset.File
-	ControlPlaneMachineSet *asset.File
+	UserDataFile       *asset.File
+	MachineConfigFiles []*asset.File
+	MachineFiles       []*asset.File
 
 	// SecretFiles is used by the baremetal platform to register the
 	// credential information for communicating with management
@@ -108,9 +107,6 @@ const (
 	// masterUserDataFileName is the filename used for the master
 	// user-data secret.
 	masterUserDataFileName = "99_openshift-cluster-api_master-user-data-secret.yaml"
-
-	// masterUserDataFileName is the filename used for the control plane machine sets.
-	controlPlaneMachineSetFileName = "99_openshift-machine-api_master-control-plane-machine-set.yaml"
 )
 
 var (
@@ -158,7 +154,6 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	pool := *ic.ControlPlane
 	var err error
 	machines := []machinev1beta1.Machine{}
-	var controlPlaneMachineSet *machinev1.ControlPlaneMachineSet
 	switch ic.Platform.Name() {
 	case alibabacloudtypes.Name:
 		client, err := installConfig.AlibabaCloud.Client()
@@ -247,7 +242,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		}
 
 		pool.Platform.AWS = &mpool
-		machines, controlPlaneMachineSet, err = aws.Machines(
+		machines, err = aws.Machines(
 			clusterID.InfraID,
 			installConfig.Config.Platform.AWS.Region,
 			subnets,
@@ -259,7 +254,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
-		aws.ConfigMasters(machines, controlPlaneMachineSet, clusterID.InfraID, ic.Publish)
+		aws.ConfigMasters(machines, clusterID.InfraID, ic.Publish)
 	case gcptypes.Name:
 		mpool := defaultGCPMachinePoolPlatform()
 		mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
@@ -508,16 +503,6 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	}
 
 	m.MachineFiles = make([]*asset.File, len(machines))
-	if controlPlaneMachineSet != nil {
-		data, err := yaml.Marshal(controlPlaneMachineSet)
-		if err != nil {
-			return errors.Wrapf(err, "marshal control plane machine set")
-		}
-		m.ControlPlaneMachineSet = &asset.File{
-			Filename: filepath.Join(directory, controlPlaneMachineSetFileName),
-			Data:     data,
-		}
-	}
 	padFormat := fmt.Sprintf("%%0%dd", len(fmt.Sprintf("%d", len(machines))))
 	for i, machine := range machines {
 		data, err := yaml.Marshal(machine)
@@ -550,9 +535,6 @@ func (m *Master) Files() []*asset.File {
 	// reconcile a machine it can pick up the related host.
 	files = append(files, m.HostFiles...)
 	files = append(files, m.MachineFiles...)
-	if m.ControlPlaneMachineSet != nil {
-		files = append(files, m.ControlPlaneMachineSet)
-	}
 	return files
 }
 


### PR DESCRIPTION
Reverts openshift/installer#6172 ; tracked by OCPBUGS-1056

TRT are reverting this breaking change.  This change has broken single-node openshift.

Errors from single-node:

```
Sep 08 07:39:14 ip-10-0-54-229 bootkube.sh[5263]: "99_openshift-machine-api_master-control-plane-machine-set.yaml": failed to create controlplanemachinesets.v1.machine.openshift.io/cluster -n openshift-machine-api: ControlPlaneMachineSet.machine.openshift.io "cluster" is invalid: spec.replicas: Unsupported value: 1: supported values: "3", "5"
```


To unrevert this revert, revert this PR, and layer an additional separate commit on top that addresses the problem.   Please verify the unrevert works correctly on single-node by  invoking appropriate `/test` commands (such as `/test e2e-aws-single-node`).


CC: @rna-afk, @JoelSpeed 