### PR TITLE
CORS-2043: GCP: Passsthrough installer service account to Terraform r…

### DIFF
--- a/data/data/gcp/cluster/iam/main.tf
+++ b/data/data/gcp/cluster/iam/main.tf
@@ -3,19 +3,22 @@ locals {
 }
 
 resource "google_service_account" "worker-node-sa" {
+  count        = var.service_account == "" ? 1 : 0
   account_id   = "${var.cluster_id}-w"
   display_name = "${var.cluster_id}-worker-node"
   description  = local.description
 }
 
 resource "google_project_iam_member" "worker-compute-viewer" {
+  count   = var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = "roles/compute.viewer"
-  member  = "serviceAccount:${google_service_account.worker-node-sa.email}"
+  member  = "serviceAccount:${google_service_account.worker-node-sa[0].email}"
 }
 
 resource "google_project_iam_member" "worker-storage-admin" {
+  count   = var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = "roles/storage.admin"
-  member  = "serviceAccount:${google_service_account.worker-node-sa.email}"
+  member  = "serviceAccount:${google_service_account.worker-node-sa[0].email}"
 }

--- a/data/data/gcp/cluster/iam/variables.tf
+++ b/data/data/gcp/cluster/iam/variables.tf
@@ -6,3 +6,8 @@ variable "project_id" {
 variable "cluster_id" {
   type = string
 }
+
+variable "service_account" {
+  type        = string
+  description = "The service account used by the instances."
+}

--- a/data/data/gcp/cluster/main.tf
+++ b/data/data/gcp/cluster/main.tf
@@ -23,17 +23,19 @@ provider "google" {
 module "master" {
   source = "./master"
 
-  image          = local.gcp_image
-  instance_count = var.master_count
-  machine_type   = var.gcp_master_instance_type
-  project_id     = var.gcp_project_id
-  cluster_id     = var.cluster_id
-  ignition       = var.ignition_master
-  subnet         = module.network.master_subnet
-  zones          = distinct(var.gcp_master_availability_zones)
+  image           = local.gcp_image
+  instance_count  = var.master_count
+  machine_type    = var.gcp_master_instance_type
+  project_id      = var.gcp_project_id
+  cluster_id      = var.cluster_id
+  service_account = var.gcp_instance_service_account
+  ignition        = var.ignition_master
+  subnet          = module.network.master_subnet
+  zones           = distinct(var.gcp_master_availability_zones)
 
-  root_volume_size         = var.gcp_master_root_volume_size
-  root_volume_type         = var.gcp_master_root_volume_type
+  root_volume_size = var.gcp_master_root_volume_size
+  root_volume_type = var.gcp_master_root_volume_type
+
   root_volume_kms_key_link = var.gcp_root_volume_kms_key_link
 
   tags   = var.gcp_control_plane_tags
@@ -45,6 +47,8 @@ module "iam" {
 
   project_id = var.gcp_project_id
   cluster_id = var.cluster_id
+
+  service_account = var.gcp_instance_service_account
 }
 
 module "network" {

--- a/data/data/gcp/cluster/master/main.tf
+++ b/data/data/gcp/cluster/master/main.tf
@@ -3,39 +3,45 @@ locals {
 }
 
 resource "google_service_account" "master-node-sa" {
+  count        = var.service_account == "" ? 1 : 0
   account_id   = "${var.cluster_id}-m"
   display_name = "${var.cluster_id}-master-node"
   description  = local.description
 }
 
 resource "google_project_iam_member" "master-compute-admin" {
+  count   = var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = "roles/compute.instanceAdmin"
-  member  = "serviceAccount:${google_service_account.master-node-sa.email}"
+  member  = "serviceAccount:${google_service_account.master-node-sa[0].email}"
 }
 
 resource "google_project_iam_member" "master-network-admin" {
+  count   = var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = "roles/compute.networkAdmin"
-  member  = "serviceAccount:${google_service_account.master-node-sa.email}"
+  member  = "serviceAccount:${google_service_account.master-node-sa[0].email}"
 }
 
 resource "google_project_iam_member" "master-compute-security" {
+  count   = var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = "roles/compute.securityAdmin"
-  member  = "serviceAccount:${google_service_account.master-node-sa.email}"
+  member  = "serviceAccount:${google_service_account.master-node-sa[0].email}"
 }
 
 resource "google_project_iam_member" "master-storage-admin" {
+  count   = var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = "roles/storage.admin"
-  member  = "serviceAccount:${google_service_account.master-node-sa.email}"
+  member  = "serviceAccount:${google_service_account.master-node-sa[0].email}"
 }
 
 resource "google_project_iam_member" "master-service-account-user" {
+  count   = var.service_account == "" ? 1 : 0
   project = var.project_id
   role    = "roles/iam.serviceAccountUser"
-  member  = "serviceAccount:${google_service_account.master-node-sa.email}"
+  member  = "serviceAccount:${google_service_account.master-node-sa[0].email}"
 }
 
 resource "google_compute_instance" "master" {
@@ -71,7 +77,7 @@ resource "google_compute_instance" "master" {
   labels = var.labels
 
   service_account {
-    email  = google_service_account.master-node-sa.email
+    email  = var.service_account != "" ? var.service_account : google_service_account.master-node-sa[0].email
     scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
 

--- a/data/data/gcp/cluster/master/variables.tf
+++ b/data/data/gcp/cluster/master/variables.tf
@@ -34,6 +34,10 @@ variable "machine_type" {
   description = "The machine type for the master instances."
 }
 
+variable "service_account" {
+  type        = string
+  description = "The service account used by the instances."
+}
 variable "subnet" {
   type        = string
   description = "The subnetwork the master instances will be added to."

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -62,6 +62,12 @@ variable "gcp_image" {
   description = "URL to the Image for all nodes."
 }
 
+variable "gcp_instance_service_account" {
+  type = string
+  description = "The service account used by the instances."
+  default = ""
+}
+
 variable "gcp_preexisting_image" {
   type = bool
   default = true

--- a/pkg/asset/machines/gcp/machinesets.go
+++ b/pkg/asset/machines/gcp/machinesets.go
@@ -26,6 +26,8 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 	mpool := pool.Platform.GCP
 	azs := mpool.Zones
 
+	credentialsMode := config.CredentialsMode
+
 	total := int64(0)
 	if pool.Replicas != nil {
 		total = *pool.Replicas
@@ -38,7 +40,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 			replicas++
 		}
 
-		provider, err := provider(clusterID, platform, mpool, osImage, idx, role, userDataSecret)
+		provider, err := provider(clusterID, platform, mpool, osImage, idx, role, userDataSecret, credentialsMode)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -29,6 +29,7 @@ type config struct {
 	ImageURI                string   `json:"gcp_image_uri,omitempty"`
 	Image                   string   `json:"gcp_image,omitempty"`
 	PreexistingImage        bool     `json:"gcp_preexisting_image"`
+	InstanceServiceAccount  string   `json:"gcp_instance_service_account,omitempty"`
 	ImageLicenses           []string `json:"gcp_image_licenses,omitempty"`
 	VolumeType              string   `json:"gcp_master_root_volume_type"`
 	VolumeSize              int64    `json:"gcp_master_root_volume_size"`
@@ -44,14 +45,15 @@ type config struct {
 
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
-	Auth               Auth
-	ImageURI           string
-	ImageLicenses      []string
-	MasterConfigs      []*machineapi.GCPMachineProviderSpec
-	WorkerConfigs      []*machineapi.GCPMachineProviderSpec
-	PublicZoneName     string
-	PublishStrategy    types.PublishingStrategy
-	PreexistingNetwork bool
+	Auth                   Auth
+	ImageURI               string
+	ImageLicenses          []string
+	InstanceServiceAccount string
+	MasterConfigs          []*machineapi.GCPMachineProviderSpec
+	WorkerConfigs          []*machineapi.GCPMachineProviderSpec
+	PublicZoneName         string
+	PublishStrategy        types.PublishingStrategy
+	PreexistingNetwork     bool
 }
 
 // TFVars generates gcp-specific Terraform variables launching the cluster.
@@ -74,6 +76,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ImageURI:                sources.ImageURI,
 		Image:                   masterConfig.Disks[0].Image,
 		ImageLicenses:           sources.ImageLicenses,
+		InstanceServiceAccount:  sources.InstanceServiceAccount,
 		PublicZoneName:          sources.PublicZoneName,
 		PublishStrategy:         string(sources.PublishStrategy),
 		ClusterNetwork:          masterConfig.NetworkInterfaces[0].Network,


### PR DESCRIPTION
…esources

**skip creating service accounts in Terraform when using passthrough credentialsMode for control and compute plane. Instead, pass the installer service account to Terraform to be used as the service account for instances 
** when using passthrough credentialsMode the machinesets email is modified to use the installer service account