### PR TITLE
OCPBUGS-1247: Restrict CPMS from being created with single node clusters

### DIFF
--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -4,6 +4,8 @@ package aws
 import (
 	"fmt"
 
+	v1 "github.com/openshift/api/config/v1"
+	machinev1 "github.com/openshift/api/machine/v1"
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -17,9 +19,9 @@ import (
 )
 
 // Machines returns a list of machines for a machinepool.
-func Machines(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, role, userDataSecret string, userTags map[string]string) ([]machineapi.Machine, error) {
+func Machines(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, role, userDataSecret string, userTags map[string]string) ([]machineapi.Machine, *machinev1.ControlPlaneMachineSet, error) {
 	if poolPlatform := pool.Platform.Name(); poolPlatform != aws.Name {
-		return nil, fmt.Errorf("non-AWS machine-pool: %q", poolPlatform)
+		return nil, nil, fmt.Errorf("non-AWS machine-pool: %q", poolPlatform)
 	}
 	mpool := pool.Platform.AWS
 
@@ -28,11 +30,12 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 		total = *pool.Replicas
 	}
 	var machines []machineapi.Machine
+	machineSetProvider := &machineapi.AWSMachineProviderConfig{}
 	for idx := int64(0); idx < total; idx++ {
 		zone := mpool.Zones[int(idx)%len(mpool.Zones)]
 		subnet, ok := subnets[zone]
 		if len(subnets) > 0 && !ok {
-			return nil, errors.Errorf("no subnet for zone %s", zone)
+			return nil, nil, errors.Errorf("no subnet for zone %s", zone)
 		}
 		provider, err := provider(
 			clusterID,
@@ -48,8 +51,9 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 			userTags,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create provider")
+			return nil, nil, errors.Wrap(err, "failed to create provider")
 		}
+		*machineSetProvider = *provider
 		machine := machineapi.Machine{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.openshift.io/v1beta1",
@@ -75,7 +79,77 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 		machines = append(machines, machine)
 	}
 
-	return machines, nil
+	replicas := int32(total)
+	failureDomains := []machinev1.AWSFailureDomain{}
+
+	for _, zone := range mpool.Zones {
+		subnet := subnets[zone]
+		domain := machinev1.AWSFailureDomain{
+			Subnet: &machinev1.AWSResourceReference{},
+			Placement: machinev1.AWSFailureDomainPlacement{
+				AvailabilityZone: zone,
+			},
+		}
+		if subnet == "" {
+			domain.Subnet.Type = machinev1.AWSFiltersReferenceType
+			domain.Subnet.Filters = &[]machinev1.AWSResourceFilter{{
+				Name:   "tag:Name",
+				Values: []string{fmt.Sprintf("%s-private-%s", clusterID, zone)},
+			}}
+		} else {
+			domain.Subnet.Type = machinev1.AWSIDReferenceType
+			domain.Subnet.ID = pointer.StringPtr(subnet)
+		}
+		failureDomains = append(failureDomains, domain)
+	}
+
+	machineSetProvider.Placement.AvailabilityZone = ""
+	machineSetProvider.Subnet = machineapi.AWSResourceReference{}
+	controlPlaneMachineSet := &machinev1.ControlPlaneMachineSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machine.openshift.io/v1",
+			Kind:       "ControlPlaneMachineSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "openshift-machine-api",
+			Name:      "cluster",
+			Labels: map[string]string{
+				"machine.openshift.io/cluster-api-cluster": clusterID,
+			},
+		},
+		Spec: machinev1.ControlPlaneMachineSetSpec{
+			Replicas: &replicas,
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"machine.openshift.io/cluster-api-machine-role": role,
+					"machine.openshift.io/cluster-api-machine-type": role,
+					"machine.openshift.io/cluster-api-cluster":      clusterID,
+				},
+			},
+			Template: machinev1.ControlPlaneMachineSetTemplate{
+				MachineType: machinev1.OpenShiftMachineV1Beta1MachineType,
+				OpenShiftMachineV1Beta1Machine: &machinev1.OpenShiftMachineV1Beta1MachineTemplate{
+					FailureDomains: machinev1.FailureDomains{
+						Platform: v1.AWSPlatformType,
+						AWS:      &failureDomains,
+					},
+					ObjectMeta: machinev1.ControlPlaneMachineSetTemplateObjectMeta{
+						Labels: map[string]string{
+							"machine.openshift.io/cluster-api-cluster":      clusterID,
+							"machine.openshift.io/cluster-api-machine-role": role,
+							"machine.openshift.io/cluster-api-machine-type": role,
+						},
+					},
+					Spec: machineapi.MachineSpec{
+						ProviderSpec: machineapi.ProviderSpec{
+							Value: &runtime.RawExtension{Object: machineSetProvider},
+						},
+					},
+				},
+			},
+		},
+	}
+	return machines, controlPlaneMachineSet, nil
 }
 
 func provider(clusterID string, region string, subnet string, instanceType string, root *aws.EC2RootVolume, imds aws.EC2Metadata, osImage string, zone, role, userDataSecret string, userTags map[string]string) (*machineapi.AWSMachineProviderConfig, error) {
@@ -156,7 +230,7 @@ func tagsFromUserTags(clusterID string, usertags map[string]string) ([]machineap
 }
 
 // ConfigMasters sets the PublicIP flag and assigns a set of load balancers to the given machines
-func ConfigMasters(machines []machineapi.Machine, clusterID string, publish types.PublishingStrategy) {
+func ConfigMasters(machines []machineapi.Machine, controlPlane *machinev1.ControlPlaneMachineSet, clusterID string, publish types.PublishingStrategy) {
 	lbrefs := []machineapi.LoadBalancerReference{{
 		Name: fmt.Sprintf("%s-int", clusterID),
 		Type: machineapi.NetworkLoadBalancerType,
@@ -173,4 +247,7 @@ func ConfigMasters(machines []machineapi.Machine, clusterID string, publish type
 		providerSpec := machine.Spec.ProviderSpec.Value.Object.(*machineapi.AWSMachineProviderConfig)
 		providerSpec.LoadBalancers = lbrefs
 	}
+
+	providerSpec := controlPlane.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value.Object.(*machineapi.AWSMachineProviderConfig)
+	providerSpec.LoadBalancers = lbrefs
 }

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -66,9 +66,10 @@ import (
 
 // Master generates the machines for the `master` machine pool.
 type Master struct {
-	UserDataFile       *asset.File
-	MachineConfigFiles []*asset.File
-	MachineFiles       []*asset.File
+	UserDataFile           *asset.File
+	MachineConfigFiles     []*asset.File
+	MachineFiles           []*asset.File
+	ControlPlaneMachineSet *asset.File
 
 	// SecretFiles is used by the baremetal platform to register the
 	// credential information for communicating with management
@@ -107,6 +108,9 @@ const (
 	// masterUserDataFileName is the filename used for the master
 	// user-data secret.
 	masterUserDataFileName = "99_openshift-cluster-api_master-user-data-secret.yaml"
+
+	// masterUserDataFileName is the filename used for the control plane machine sets.
+	controlPlaneMachineSetFileName = "99_openshift-machine-api_master-control-plane-machine-set.yaml"
 )
 
 var (
@@ -154,6 +158,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	pool := *ic.ControlPlane
 	var err error
 	machines := []machinev1beta1.Machine{}
+	var controlPlaneMachineSet *machinev1.ControlPlaneMachineSet
 	switch ic.Platform.Name() {
 	case alibabacloudtypes.Name:
 		client, err := installConfig.AlibabaCloud.Client()
@@ -242,7 +247,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		}
 
 		pool.Platform.AWS = &mpool
-		machines, err = aws.Machines(
+		machines, controlPlaneMachineSet, err = aws.Machines(
 			clusterID.InfraID,
 			installConfig.Config.Platform.AWS.Region,
 			subnets,
@@ -254,7 +259,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
-		aws.ConfigMasters(machines, clusterID.InfraID, ic.Publish)
+		aws.ConfigMasters(machines, controlPlaneMachineSet, clusterID.InfraID, ic.Publish)
 	case gcptypes.Name:
 		mpool := defaultGCPMachinePoolPlatform()
 		mpool.Set(ic.Platform.GCP.DefaultMachinePlatform)
@@ -503,6 +508,16 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	}
 
 	m.MachineFiles = make([]*asset.File, len(machines))
+	if controlPlaneMachineSet != nil {
+		data, err := yaml.Marshal(controlPlaneMachineSet)
+		if err != nil {
+			return errors.Wrapf(err, "marshal control plane machine set")
+		}
+		m.ControlPlaneMachineSet = &asset.File{
+			Filename: filepath.Join(directory, controlPlaneMachineSetFileName),
+			Data:     data,
+		}
+	}
 	padFormat := fmt.Sprintf("%%0%dd", len(fmt.Sprintf("%d", len(machines))))
 	for i, machine := range machines {
 		data, err := yaml.Marshal(machine)
@@ -535,6 +550,9 @@ func (m *Master) Files() []*asset.File {
 	// reconcile a machine it can pick up the related host.
 	files = append(files, m.HostFiles...)
 	files = append(files, m.MachineFiles...)
+	if m.ControlPlaneMachineSet != nil {
+		files = append(files, m.ControlPlaneMachineSet)
+	}
 	return files
 }
 

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -508,7 +508,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	}
 
 	m.MachineFiles = make([]*asset.File, len(machines))
-	if controlPlaneMachineSet != nil {
+	if controlPlaneMachineSet != nil && *pool.Replicas > 1 {
 		data, err := yaml.Marshal(controlPlaneMachineSet)
 		if err != nil {
 			return errors.Wrapf(err, "marshal control plane machine set")


### PR DESCRIPTION
Single node clusters do not need the CPMS manifests and hence adding
a check to stop the creation of CPMS when the Replicas is set to
anything below 1.

Ideally, the replicas are set to 0 when the installer needs to create
single node clusters.