### PR TITLE
GCP: Add createFirewallRules parameter to installconfig.

### DIFF
--- a/data/data/gcp/bootstrap/main.tf
+++ b/data/data/gcp/bootstrap/main.tf
@@ -50,10 +50,11 @@ resource "google_compute_address" "bootstrap" {
 }
 
 resource "google_compute_firewall" "bootstrap_ingress_ssh" {
-  count       = var.gcp_network_project_id != "" ? 0 : 1
+  count       = var.gcp_create_firewall_rules ? 1 : 0
   name        = "${var.cluster_id}-bootstrap-in-ssh"
   network     = var.network
   description = local.description
+  project     = var.gcp_network_project_id
 
   allow {
     protocol = "tcp"

--- a/data/data/gcp/cluster/main.tf
+++ b/data/data/gcp/cluster/main.tf
@@ -65,6 +65,8 @@ module "network" {
   master_subnet       = var.gcp_control_plane_subnet
   worker_subnet       = var.gcp_compute_subnet
   network_project_id  = var.gcp_network_project_id
+
+  create_firewall_rules = var.gcp_create_firewall_rules
 }
 
 module "dns" {

--- a/data/data/gcp/cluster/network/firewall.tf
+++ b/data/data/gcp/cluster/network/firewall.tf
@@ -1,8 +1,9 @@
 resource "google_compute_firewall" "api" {
-  count       = var.network_project_id != "" ? 0 : 1
+  count       = var.create_firewall_rules ? 1 : 0
   name        = "${var.cluster_id}-api"
   network     = local.cluster_network
   description = local.description
+  project     = var.network_project_id
 
   # API
   allow {
@@ -15,10 +16,11 @@ resource "google_compute_firewall" "api" {
 }
 
 resource "google_compute_firewall" "health_checks" {
-  count       = var.network_project_id != "" ? 0 : 1
+  count       = var.create_firewall_rules ? 1 : 0
   name        = "${var.cluster_id}-health-checks"
   network     = local.cluster_network
   description = local.description
+  project     = var.network_project_id
 
   # API, MCS (http)
   allow {
@@ -31,10 +33,11 @@ resource "google_compute_firewall" "health_checks" {
 }
 
 resource "google_compute_firewall" "etcd" {
-  count       = var.network_project_id != "" ? 0 : 1
+  count       = var.create_firewall_rules ? 1 : 0
   name        = "${var.cluster_id}-etcd"
   network     = local.cluster_network
   description = local.description
+  project     = var.network_project_id
 
   # ETCD
   allow {
@@ -47,10 +50,11 @@ resource "google_compute_firewall" "etcd" {
 }
 
 resource "google_compute_firewall" "control_plane" {
-  count       = var.network_project_id != "" ? 0 : 1
+  count       = var.create_firewall_rules ? 1 : 0
   name        = "${var.cluster_id}-control-plane"
   network     = local.cluster_network
   description = local.description
+  project     = var.network_project_id
 
   # kube manager
   allow {
@@ -78,10 +82,11 @@ resource "google_compute_firewall" "control_plane" {
 }
 
 resource "google_compute_firewall" "internal_network" {
-  count       = var.network_project_id != "" ? 0 : 1
+  count       = var.create_firewall_rules ? 1 : 0
   name        = "${var.cluster_id}-internal-network"
   network     = local.cluster_network
   description = local.description
+  project     = var.network_project_id
 
   # icmp
   allow {
@@ -102,10 +107,11 @@ resource "google_compute_firewall" "internal_network" {
 }
 
 resource "google_compute_firewall" "internal_cluster" {
-  count       = var.network_project_id != "" ? 0 : 1
+  count       = var.create_firewall_rules ? 1 : 0
   name        = "${var.cluster_id}-internal-cluster"
   network     = local.cluster_network
   description = local.description
+  project     = var.network_project_id
 
   # VXLAN and GENEVE
   allow {

--- a/data/data/gcp/cluster/network/variables.tf
+++ b/data/data/gcp/cluster/network/variables.tf
@@ -19,6 +19,11 @@ variable "cluster_network" {
   type = string
 }
 
+variable "create_firewall_rules" {
+  type    = bool
+  default = true
+}
+
 variable "master_subnet" {
   type = string
 }

--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -139,3 +139,8 @@ variable "gcp_control_plane_tags" {
 
 }
 
+variable "gcp_create_firewall_rules" {
+  type = bool
+  default = true
+  description = "Create the cluster's network firewall rules."
+}

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2169,6 +2169,13 @@ spec:
                       control plane will be deployed. The value should be the name
                       of the subnet.
                     type: string
+                  createFirewallRules:
+                    description: CreateFirewallRules specifies if the installer should
+                      create the cluster firewall rules in the gcp cloud network.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
                   defaultMachinePlatform:
                     description: DefaultMachinePlatform is the default configuration
                       used when installing on GCP for machine pools which do not define
@@ -2264,9 +2271,9 @@ spec:
                       should be created rather than provisioning a new one.
                     type: string
                   networkProjectID:
-                    description: NetworkProjectID is currently unsupported. NetworkProjectID
-                      specifies which project the network and subnets exist in when
-                      they are not in the main ProjectID.
+                    description: NetworkProjectID is currently Technology Preview.
+                      NetworkProjectID specifies which project the network and subnets
+                      exist in when they are not in the main ProjectID.
                     type: string
                   projectID:
                     description: ProjectID is the the project that will be used for

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -424,6 +424,11 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 		preexistingnetwork := installConfig.Config.GCP.Network != ""
 
+		createFirewallRules := true
+		if installConfig.Config.GCP.CreateFirewallRules == gcp.CreateFirewallRulesDisabled {
+			createFirewallRules = false
+		}
+
 		archName := coreosarch.RpmArch(string(installConfig.Config.ControlPlane.Architecture))
 		st, err := rhcospkg.FetchCoreOSBuild(ctx)
 		if err != nil {
@@ -447,6 +452,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				Auth:                   auth,
 				MasterConfigs:          masterConfigs,
 				WorkerConfigs:          workerConfigs,
+				CreateFirewallRules:    createFirewallRules,
 				ImageURI:               imageURL,
 				ImageLicenses:          installConfig.Config.GCP.Licenses,
 				InstanceServiceAccount: instanceServiceAccount,

--- a/pkg/tfvars/gcp/gcp.go
+++ b/pkg/tfvars/gcp/gcp.go
@@ -24,6 +24,7 @@ type config struct {
 	Auth                    `json:",inline"`
 	Region                  string   `json:"gcp_region,omitempty"`
 	BootstrapInstanceType   string   `json:"gcp_bootstrap_instance_type,omitempty"`
+	CreateFirewallRules     bool     `json:"gcp_create_firewall_rules"`
 	MasterInstanceType      string   `json:"gcp_master_instance_type,omitempty"`
 	MasterAvailabilityZones []string `json:"gcp_master_availability_zones"`
 	ImageURI                string   `json:"gcp_image_uri,omitempty"`
@@ -46,6 +47,7 @@ type config struct {
 // TFVarsSources contains the parameters to be converted into Terraform variables
 type TFVarsSources struct {
 	Auth                   Auth
+	CreateFirewallRules    bool
 	ImageURI               string
 	ImageLicenses          []string
 	InstanceServiceAccount string
@@ -69,6 +71,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		Auth:                    sources.Auth,
 		Region:                  masterConfig.Region,
 		BootstrapInstanceType:   masterConfig.MachineType,
+		CreateFirewallRules:     sources.CreateFirewallRules,
 		MasterInstanceType:      masterConfig.MachineType,
 		MasterAvailabilityZones: masterAvailabilityZones,
 		VolumeType:              masterConfig.Disks[0].Type,

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -1,5 +1,16 @@
 package gcp
 
+// CreateFirewallRules specifies if the installer should create firewall rules.
+// +kubebuilder:validation:Enum="Enabled";"Disabled"
+type CreateFirewallRules string
+
+const (
+	// CreateFirewallRulesEnabled is Enabled
+	CreateFirewallRulesEnabled CreateFirewallRules = "Enabled"
+	// CreateFirewallRulesDisabled is Disabled
+	CreateFirewallRulesDisabled CreateFirewallRules = "Disabled"
+)
+
 // Platform stores all the global configuration that all machinesets
 // use.
 type Platform struct {
@@ -8,6 +19,11 @@ type Platform struct {
 
 	// Region specifies the GCP region where the cluster will be created.
 	Region string `json:"region"`
+
+	// CreateFirewallRules specifies if the installer should create the
+	// cluster firewall rules in the gcp cloud network.
+	// +optional
+	CreateFirewallRules CreateFirewallRules `json:"createFirewallRules,omitempty"`
 
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on GCP for machine pools which do not define their own
@@ -20,7 +36,7 @@ type Platform struct {
 	// +optional
 	Network string `json:"network,omitempty"`
 
-	// NetworkProjectID is currently unsupported.
+	// NetworkProjectID is currently Technology Preview.
 	// NetworkProjectID specifies which project the network and subnets exist in when
 	// they are not in the main ProjectID.
 	// +optional

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -5,6 +5,7 @@ import (
 
 	"sort"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -92,6 +93,14 @@ func ValidatePlatform(p *gcp.Platform, fldPath *field.Path, ic *types.InstallCon
 			allErrs = append(allErrs, field.Required(fldPath.Child("controlPlaneSubnet"), "must provide a control plane subnet when a network is specified"))
 		}
 	}
+
+	if p.CreateFirewallRules != "" {
+		validCreateFirewallRules := sets.NewString(string(gcp.CreateFirewallRulesEnabled), string(gcp.CreateFirewallRulesDisabled))
+		if !validCreateFirewallRules.Has(string(p.CreateFirewallRules)) {
+			allErrs = append(allErrs, field.NotSupported(fldPath.Child("createFirewallRules"), p.CreateFirewallRules, validCreateFirewallRules.List()))
+		}
+	}
+
 	if (p.ComputeSubnet != "" || p.ControlPlaneSubnet != "") && p.Network == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("network"), "must provide a VPC network when supplying subnets"))
 	}

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -152,6 +152,30 @@ func TestValidatePlatform(t *testing.T) {
 			credentialsMode: types.MintCredentialsMode,
 			valid:           false,
 		},
+		{
+			name: "Valid CreateFirewallRules: Enabled",
+			platform: &gcp.Platform{
+				CreateFirewallRules: "Enabled",
+				Region:              "us-east1",
+			},
+			valid: true,
+		},
+		{
+			name: "Valid CreateFirewallRules: Disabled",
+			platform: &gcp.Platform{
+				CreateFirewallRules: "Disabled",
+				Region:              "us-east1",
+			},
+			valid: true,
+		},
+		{
+			name: "Invalid CreateFirewallRules",
+			platform: &gcp.Platform{
+				CreateFirewallRules: "invalid",
+				Region:              "us-east1",
+			},
+			valid: false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The createFirewallRules parameter in the install config can be used to toggle the creation of the firewall rules. This enables users to provide their own rules in advance of the installer and skip the installer from attempting to create them.

https://issues.redhat.com/browse/CORS-2288