### PR TITLE
OCPBUGS-1242: Add PowerVS zone mon01 support

### DIFF
--- a/data/data/powervs/cluster/power_network/pi_network.tf
+++ b/data/data/powervs/cluster/power_network/pi_network.tf
@@ -4,9 +4,10 @@ resource "ibm_pi_dhcp" "dhcp_service" {
 }
 
 resource "ibm_pi_cloud_connection" "cloud_connection" {
-  pi_cloud_instance_id            = var.cloud_instance_id
-  pi_cloud_connection_name        = "cloud-con-${var.cluster_id}"
-  pi_cloud_connection_speed       = 50
-  pi_cloud_connection_vpc_enabled = true
-  pi_cloud_connection_vpc_crns    = [var.vpc_crn]
+  pi_cloud_instance_id               = var.cloud_instance_id
+  pi_cloud_connection_name           = "cloud-con-${var.cluster_id}"
+  pi_cloud_connection_speed          = 50
+  pi_cloud_connection_global_routing = true
+  pi_cloud_connection_vpc_enabled    = true
+  pi_cloud_connection_vpc_crns       = [var.vpc_crn]
 }

--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -48,6 +48,11 @@ var Regions = map[string]Region{
 		VPCRegion:   "au-syd",
 		Zones:       []string{"syd04"},
 	},
+	"mon": {
+		Description: "Montreal, Canada",
+		VPCRegion:   "ca-tor",
+		Zones:       []string{"mon01"},
+	},
 	"sao": {
 		Description: "São Paulo, Brazil",
 		VPCRegion:   "br-sao",


### PR DESCRIPTION
The 4.11 branch of the installer needs to support the zone mon01 in PowerVS for the CI