### PR TITLE
[release-4.11] OCPBUGS-1157: Use azureprivatedns not azurerm_private_dns

### DIFF
--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -15,6 +15,8 @@ resource "azureprivatedns_zone_virtual_network_link" "network" {
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azureprivatedns_zone.private.name
   virtual_network_id    = var.virtual_network_id
+
+  depends_on = [azureprivatedns_zone.private]
 }
 
 resource "azureprivatedns_a_record" "apiint_internal" {


### PR DESCRIPTION
This commit changed from azureprivatedns to azurerm in 4.12:
  https://github.com/openshift/installer/commit/d9b073429b2ea639bf075777f727dcd51b1fcf98

For 4.11 and earlier, the fix we backported in
https://github.com/openshift/installer/pull/6333 was incorrect. This changes it to depend on the older resource type, and we can backport this PR to older releases.