### PR TITLE
Revert "[release-4.11] OCPBUGS-1157: Add depends to enforce order for azure terraform dependencies"

### DIFF
--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -15,8 +15,6 @@ resource "azureprivatedns_zone_virtual_network_link" "network" {
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azureprivatedns_zone.private.name
   virtual_network_id    = var.virtual_network_id
-
-  depends_on = [azurerm_private_dns_zone.private]
 }
 
 resource "azureprivatedns_a_record" "apiint_internal" {


### PR DESCRIPTION
Reverts openshift/installer#6333 which broke Azure installs but those jobs weren't blocking.