### PR TITLE
OCPBUGS-1234 : [CFE-580] Extend user tags limit to 40 based on AWS limits

### DIFF
--- a/pkg/types/aws/validation/platform.go
+++ b/pkg/types/aws/validation/platform.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/aws"
@@ -50,6 +51,11 @@ func validateUserTags(tags map[string]string, propagatingTags bool, fldPath *fie
 	}
 	if len(tags) > 8 {
 		allErrs = append(allErrs, field.Invalid(fldPath, len(tags), "number of user tags cannot be more than 8"))
+		logrus.Warnf("Due to a limit of 10 tags on S3 Bucket Objects, only the first eight lexicographically sorted tags will be applied to the bootstrap ignition object, which is a temporary resource only used during installation")
+	}
+
+	if len(tags) > 40 {
+		allErrs = append(allErrs, field.Invalid(fldPath, len(tags), "number of user tags cannot be more than 40"))
 	}
 	for key, value := range tags {
 		if strings.EqualFold(key, "Name") {


### PR DESCRIPTION
Extend user tag limit to 40 based on AWS limits. 10 tags are reserved for OpenShift use. Previously, there has been a confusion on the tag limit for S3 bucket vs S3 bucket object tag limit. S3 bucket object tag limit is 10 while the requirement is for S3 bucket which has limit of 50 tags.
Reference : https://docs.aws.amazon.com/AmazonS3/latest/userguide/CostAllocTagging.html