### PR TITLE
AWS UPI docs: remove control plane machineset

### DIFF
--- a/docs/user/aws/install_upi.md
+++ b/docs/user/aws/install_upi.md
@@ -57,7 +57,7 @@ INFO Consuming "Install Config" from target directory
 Remove the control-plane Machines and compute MachineSets, because we'll be providing those ourselves and don't want to involve [the machine-API operator][machine-api-operator]:
 
 ```console
-$ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml
+$ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml 99_openshift-machine-api_master-control-plane-machine-set.yaml
 ```
 
 You are free to leave the compute MachineSets in if you want to create compute machines via the machine API, but if you do you may need to update the various references (`subnet`, etc.) to match your environment.


### PR DESCRIPTION
64665ebccf2ec699ce034ff2f2b996b245a77579 added a control plane machineset manifest. This updates corresponding UPI docs to remove this manifest when the cluster is runnning without MAO.

/cc @JoelSpeed 
/cc @rna-afk 