### PR TITLE
IBMCloud: Add tests for installconfig metadata

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -500,7 +500,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return err
 		}
 		auth := ibmcloudtfvars.Auth{
-			APIKey: client.APIKey,
+			APIKey: client.GetAPIKey(),
 		}
 
 		// Get master and worker machine info

--- a/pkg/asset/installconfig/ibmcloud/metadata.go
+++ b/pkg/asset/installconfig/ibmcloud/metadata.go
@@ -22,7 +22,7 @@ type Metadata struct {
 
 	accountID           string
 	cisInstanceCRN      string
-	client              *Client
+	client              API
 	computeSubnets      map[string]Subnet
 	controlPlaneSubnets map[string]Subnet
 	dnsInstance         *DNSInstance
@@ -89,18 +89,13 @@ func (m *Metadata) CISInstanceCRN(ctx context.Context) (string, error) {
 
 		for _, z := range zones {
 			if z.Name == m.BaseDomain {
-				m.SetCISInstanceCRN(z.InstanceCRN)
+				m.cisInstanceCRN = z.InstanceCRN
 				return m.cisInstanceCRN, nil
 			}
 		}
 		return "", fmt.Errorf("cisInstanceCRN unknown due to DNS zone %q not found", m.BaseDomain)
 	}
 	return m.cisInstanceCRN, nil
-}
-
-// SetCISInstanceCRN sets Cloud Internet Services instance CRN to a string value.
-func (m *Metadata) SetCISInstanceCRN(crn string) {
-	m.cisInstanceCRN = crn
 }
 
 // DNSInstance returns a DNSInstance holding information about the DNS Services instance
@@ -219,7 +214,7 @@ func (m *Metadata) ControlPlaneSubnets(ctx context.Context) (map[string]Subnet, 
 }
 
 // Client returns a client used for making API calls to IBM Cloud services.
-func (m *Metadata) Client() (*Client, error) {
+func (m *Metadata) Client() (API, error) {
 	if m.client != nil {
 		return m.client, nil
 	}

--- a/pkg/asset/installconfig/ibmcloud/metadata_test.go
+++ b/pkg/asset/installconfig/ibmcloud/metadata_test.go
@@ -1,0 +1,863 @@
+package ibmcloud
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/installer/pkg/asset/installconfig/ibmcloud/mock"
+	"github.com/openshift/installer/pkg/asset/installconfig/ibmcloud/responses"
+	"github.com/openshift/installer/pkg/types"
+)
+
+type editMetadata []func(m *Metadata)
+
+var (
+	// Shared test values.
+	goodDomain = "domain.good.com"
+	badDomain  = "domain.bad"
+	region     = "us-south"
+
+	// Account ID test values.
+	newAccountID      = "new-account-id"
+	existingAccountID = "existing-account-id"
+
+	// CIS Instance CRN test values.
+	newCISCRN      = "new-cis-crn"
+	existingCISCRN = "existing-cis-crn"
+
+	// DNS Instance test values.
+	newDNSInstanceID       = "new-dns-instance-id"
+	newDNSInstanceCRN      = "new-dns-instance-crn"
+	existingDNSInstanceID  = "existing-dns-instance-id"
+	existingDNSInstanceCRN = "existing-dns-instance-crn"
+	unknownDNSInstanceID   = "unknown-dns-instance-id"
+	unknownDNSInstanceCRN  = "unknown-dns-instance-crn"
+
+	// Newly retrieved Compute Subnets.
+	newComputeSubnet1Name     = "new-compute-subnet-1"
+	newComputeSubnet1ID       = "new-compute-1-id"
+	newComputeSubnet1CIDR     = "new-compute-1-cidr"
+	newComputeSubnet1CRN      = "new-compute-1-crn"
+	newComputeSubnet1VPCName  = "new-compute-1-vpc"
+	newComputeSubnet1ZoneName = "new-compute-1-zone"
+	newComputeSubnet2Name     = "new-compute-subnet-2"
+	newComputeSubnet2ID       = "new-compute-2-id"
+	newComputeSubnet2CIDR     = "new-compute-2-cidr"
+	newComputeSubnet2CRN      = "new-compute-2-crn"
+	newComputeSubnet2VPCName  = "new-compute-2-vpc"
+	newComputeSubnet2ZoneName = "new-compute-2-zone"
+	newComputeSubnets         = map[string]Subnet{
+		newComputeSubnet1ID: {
+			Name: newComputeSubnet1Name,
+			ID:   newComputeSubnet1ID,
+			CIDR: newComputeSubnet1CIDR,
+			CRN:  newComputeSubnet1CRN,
+			VPC:  newComputeSubnet1VPCName,
+			Zone: newComputeSubnet1ZoneName,
+		},
+		newComputeSubnet2ID: {
+			Name: newComputeSubnet2Name,
+			ID:   newComputeSubnet2ID,
+			CIDR: newComputeSubnet2CIDR,
+			CRN:  newComputeSubnet2CRN,
+			VPC:  newComputeSubnet2VPCName,
+			Zone: newComputeSubnet2ZoneName,
+		},
+	}
+
+	// Previously retrieved Compute Subnets.
+	existingComputeSubnets = map[string]Subnet{
+		"existing-compute-1-id": {
+			Name: "existing-compute-subnet-1",
+			ID:   "existing-compute-1-id",
+			CIDR: "existing-compute-1-cidr",
+			CRN:  "existing-compute-1-crn",
+			VPC:  "existing-compute-1-vpc",
+			Zone: "existing-compute-1-zone",
+		},
+		"existing-compute-2-id": {
+			Name: "existing-compute-subnet-2",
+			ID:   "existing-compute-2-id",
+			CIDR: "existing-compute-2-cidr",
+			CRN:  "existing-compute-2-crn",
+			VPC:  "existing-compute-2-vpc",
+			Zone: "existing-compute-2-zone",
+		},
+	}
+
+	// Newly retrieved Control Plane Subnets.
+	newControlPlaneSubnet1Name     = "new-cp-subnet-1"
+	newControlPlaneSubnet1ID       = "new-cp-1-id"
+	newControlPlaneSubnet1CIDR     = "new-cp-1-cidr"
+	newControlPlaneSubnet1CRN      = "new-cp-1-crn"
+	newControlPlaneSubnet1VPCName  = "new-cp-1-vpc"
+	newControlPlaneSubnet1ZoneName = "new-cp-1-zone"
+	newControlPlaneSubnet2Name     = "new-cp-subnet-2"
+	newControlPlaneSubnet2ID       = "new-cp-2-id"
+	newControlPlaneSubnet2CIDR     = "new-cp-2-cidr"
+	newControlPlaneSubnet2CRN      = "new-cp-2-crn"
+	newControlPlaneSubnet2VPCName  = "new-cp-2-vpc"
+	newControlPlaneSubnet2ZoneName = "new-cp-2-zone"
+	newControlPlaneSubnets         = map[string]Subnet{
+		newControlPlaneSubnet1ID: {
+			Name: newControlPlaneSubnet1Name,
+			ID:   newControlPlaneSubnet1ID,
+			CIDR: newControlPlaneSubnet1CIDR,
+			CRN:  newControlPlaneSubnet1CRN,
+			VPC:  newControlPlaneSubnet1VPCName,
+			Zone: newControlPlaneSubnet1ZoneName,
+		},
+		newControlPlaneSubnet2ID: {
+			Name: newControlPlaneSubnet2Name,
+			ID:   newControlPlaneSubnet2ID,
+			CIDR: newControlPlaneSubnet2CIDR,
+			CRN:  newControlPlaneSubnet2CRN,
+			VPC:  newControlPlaneSubnet2VPCName,
+			Zone: newControlPlaneSubnet2ZoneName,
+		},
+	}
+
+	// Previously retrieved Control Plane Subnets.
+	existingControlPlaneSubnets = map[string]Subnet{
+		"existing-cp-1-id": {
+			Name: "existing-cp-subnet-1",
+			ID:   "existing-cp-1-id",
+			CIDR: "existing-cp-1-cidr",
+			CRN:  "existing-cp-1-crn",
+			VPC:  "existing-cp-1-vpc",
+			Zone: "existing-cp-1-zone",
+		},
+		"existing-cp-2-id": {
+			Name: "existing-cp-subnet-2",
+			ID:   "existing-cp-2-id",
+			CIDR: "existing-cp-2-cidr",
+			CRN:  "existing-cp-2-crn",
+			VPC:  "existing-cp-2-vpc",
+			Zone: "existing-cp-2-zone",
+		},
+	}
+
+	// Subnet Names for failure finding subnets.
+	failedGetComputeSubnetName      = "failed-get-compute-subnet"
+	failedGetControlPlaneSubnetName = "failed-get-cp-subnet"
+
+	// Subnet Names and ID's for missing values.
+	noIDComputeSubnetName       = "no-id-compute-subnet"
+	incompleteComputeSubnetName = "incomplete-compute-subnet-name"
+	noCIDRComputeSubnetID       = "no-cidr-compute-subnet-id"
+	noCRNComputeSubnetID        = "no-crn-compute-subnet-id"
+	noNameComputeSubnetID       = "no-name-compute-subnet-id"
+	noVPCComputeSubnetID        = "no-vpc-compute-subnet-id"
+	noZoneComputeSubnetID       = "no-zone-compute-subnet-id"
+
+	// VPCReferences for Client Subnet responses.
+	vpcReferenceComputeSubnet1      = vpcv1.VPCReference{Name: &newComputeSubnet1VPCName}
+	vpcReferenceComputeSubnet2      = vpcv1.VPCReference{Name: &newComputeSubnet2VPCName}
+	vpcReferenceControlPlaneSubnet1 = vpcv1.VPCReference{Name: &newControlPlaneSubnet1VPCName}
+	vpcReferenceControlPlaneSubnet2 = vpcv1.VPCReference{Name: &newControlPlaneSubnet2VPCName}
+
+	// ZoneRefences for Client Subnet responses.
+	zoneReferenceComputeSubnet1      = vpcv1.ZoneReference{Name: &newComputeSubnet1ZoneName}
+	zoneReferenceComputeSubnet2      = vpcv1.ZoneReference{Name: &newComputeSubnet2ZoneName}
+	zoneReferenceControlPlaneSubnet1 = vpcv1.ZoneReference{Name: &newControlPlaneSubnet1ZoneName}
+	zoneReferenceControlPlaneSubnet2 = vpcv1.ZoneReference{Name: &newControlPlaneSubnet2ZoneName}
+)
+
+func baseMetadata() *Metadata {
+	return NewMetadata(goodDomain, region, nil, nil)
+}
+
+func TestAccountID(t *testing.T) {
+	testCases := []struct {
+		name          string
+		edits         editMetadata
+		errorMsg      string
+		expectedValue string
+	}{
+		{
+			name:          "new accountID",
+			expectedValue: newAccountID,
+		},
+		{
+			name: "existing accountID",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.accountID = existingAccountID
+				},
+			},
+			expectedValue: existingAccountID,
+		},
+		{
+			name:     "auth apikey error",
+			errorMsg: "bad api key",
+		},
+	}
+
+	// IBM Cloud Client Mocks.
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	ibmcloudClient := mock.NewMockAPI(mockCtrl)
+
+	// Shared Mocks.
+	ibmcloudClient.EXPECT().SetVPCServiceURLForRegion(gomock.Any(), "us-south").AnyTimes()
+
+	// Mocks: new accountID.
+	ibmcloudClient.EXPECT().GetAuthenticatorAPIKeyDetails(gomock.Any()).Return(&iamidentityv1.APIKey{AccountID: &newAccountID}, nil)
+
+	// Mocks: existing accountID.
+	// N/A.
+
+	// Mocks: auth apikey error.
+	ibmcloudClient.EXPECT().GetAuthenticatorAPIKeyDetails(gomock.Any()).Return(nil, fmt.Errorf("bad api key"))
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			metadata := baseMetadata()
+			metadata.client = ibmcloudClient
+			for _, edit := range tCase.edits {
+				edit(metadata)
+			}
+
+			actualValue, err := metadata.AccountID(context.TODO())
+			if err != nil {
+				assert.Regexp(t, tCase.errorMsg, err)
+			} else {
+				assert.Equal(t, tCase.expectedValue, actualValue)
+			}
+		})
+	}
+}
+
+func TestCISInstanceCRN(t *testing.T) {
+	testCases := []struct {
+		name          string
+		edits         editMetadata
+		errorMsg      string
+		expectedValue string
+	}{
+		{
+			name:          "new cis crn",
+			expectedValue: newCISCRN,
+		},
+		{
+			name: "existing cis crn",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.cisInstanceCRN = existingCISCRN
+				},
+			},
+			expectedValue: existingCISCRN,
+		},
+		{
+			name:     "get dns zone error",
+			errorMsg: "dns zone error",
+		},
+		{
+			name:     "dns zone not found error",
+			errorMsg: fmt.Sprintf("cisInstanceCRN unknown due to DNS zone %q not found", goodDomain),
+		},
+	}
+
+	// IBM Cloud Client Mocks.
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	ibmcloudClient := mock.NewMockAPI(mockCtrl)
+
+	// Shared Mocks.
+	// N/A.
+
+	// Mocks: new cis crn.
+	ibmcloudClient.EXPECT().GetDNSZones(gomock.Any(), types.ExternalPublishingStrategy).Return([]responses.DNSZoneResponse{{Name: goodDomain, InstanceCRN: newCISCRN}}, nil)
+
+	// Mocks: existing cis crn.
+	// N/A.
+
+	// Mocks: get dns zone error.
+	ibmcloudClient.EXPECT().GetDNSZones(gomock.Any(), types.ExternalPublishingStrategy).Return(nil, fmt.Errorf("dns zone error"))
+
+	// Mocks: dns zone not found error.
+	ibmcloudClient.EXPECT().GetDNSZones(gomock.Any(), types.ExternalPublishingStrategy).Return([]responses.DNSZoneResponse{{Name: badDomain}}, nil)
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			metadata := baseMetadata()
+			metadata.client = ibmcloudClient
+			for _, edit := range tCase.edits {
+				edit(metadata)
+			}
+
+			actualValue, err := metadata.CISInstanceCRN(context.TODO())
+			if err != nil {
+				assert.Regexp(t, tCase.errorMsg, err)
+			} else {
+				assert.Equal(t, tCase.expectedValue, actualValue)
+			}
+		})
+	}
+}
+
+func TestSetCISInstanceCRN(t *testing.T) {
+	testCases := []struct {
+		name   string
+		cisCRN string
+	}{
+		{
+			name:   "set cis crn",
+			cisCRN: "cis-instance-crn",
+		},
+	}
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			metadata := baseMetadata()
+
+			metadata.cisInstanceCRN = tCase.cisCRN
+			actualValue, err := metadata.CISInstanceCRN(context.TODO())
+			assert.NoError(t, err)
+			assert.Equal(t, tCase.cisCRN, actualValue)
+		})
+	}
+}
+
+func TestDNSInstance(t *testing.T) {
+	testCases := []struct {
+		name        string
+		edits       editMetadata
+		errorMsg    string
+		expectedID  string
+		expectedCRN string
+	}{
+		{
+			name:        "new dns instance",
+			expectedID:  newDNSInstanceID,
+			expectedCRN: newDNSInstanceCRN,
+		},
+		{
+			name: "existing dns instance",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.dnsInstance = &DNSInstance{
+						ID:  existingDNSInstanceID,
+						CRN: existingDNSInstanceCRN,
+					}
+				},
+			},
+			expectedID:  existingDNSInstanceID,
+			expectedCRN: existingDNSInstanceCRN,
+		},
+		{
+			name:     "get dns zone error",
+			errorMsg: "dns zone error",
+		},
+		{
+			name:     "dns instance unknown id error",
+			errorMsg: fmt.Sprintf("dnsInstance has unknown ID/CRN: %q - %q", "", unknownDNSInstanceCRN),
+		},
+		{
+			name:     "dns instance unknown crn error",
+			errorMsg: fmt.Sprintf("dnsInstance has unknown ID/CRN: %q - %q", unknownDNSInstanceID, ""),
+		},
+		{
+			name:     "dns zone not found error",
+			errorMsg: fmt.Sprintf("dnsInstance unknown due to DNS zone %q not found", goodDomain),
+		},
+	}
+
+	// IBM Cloud Client Mocks.
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	ibmcloudClient := mock.NewMockAPI(mockCtrl)
+
+	// Shared Mocks.
+	// N/A.
+
+	// Mocks: new dns instance.
+	ibmcloudClient.EXPECT().GetDNSZones(gomock.Any(), types.InternalPublishingStrategy).Return([]responses.DNSZoneResponse{{Name: goodDomain, InstanceID: newDNSInstanceID, InstanceCRN: newDNSInstanceCRN}}, nil)
+
+	// Mocks: existing dns instance.
+	// N/A.
+
+	// Mocks: get dns zone error.
+	ibmcloudClient.EXPECT().GetDNSZones(gomock.Any(), types.InternalPublishingStrategy).Return(nil, fmt.Errorf("dns zone error"))
+
+	// Mocks: dns instance unknown id error.
+	ibmcloudClient.EXPECT().GetDNSZones(gomock.Any(), types.InternalPublishingStrategy).Return([]responses.DNSZoneResponse{{Name: goodDomain, InstanceCRN: unknownDNSInstanceCRN}}, nil)
+
+	// Mocks: dns instance unknown crn error.
+	ibmcloudClient.EXPECT().GetDNSZones(gomock.Any(), types.InternalPublishingStrategy).Return([]responses.DNSZoneResponse{{Name: goodDomain, InstanceID: unknownDNSInstanceID}}, nil)
+
+	// Mocks: dns zone not found error.
+	ibmcloudClient.EXPECT().GetDNSZones(gomock.Any(), types.InternalPublishingStrategy).Return([]responses.DNSZoneResponse{{Name: badDomain}}, nil)
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			metadata := baseMetadata()
+			metadata.client = ibmcloudClient
+			for _, edit := range tCase.edits {
+				edit(metadata)
+			}
+
+			actualDNS, err := metadata.DNSInstance(context.TODO())
+			if err != nil {
+				assert.Regexp(t, tCase.errorMsg, err)
+			} else {
+				assert.Equal(t, tCase.expectedID, actualDNS.ID)
+				assert.Equal(t, tCase.expectedCRN, actualDNS.CRN)
+			}
+		})
+	}
+}
+
+func TestSetDNSInstance(t *testing.T) {
+	testCases := []struct {
+		name   string
+		dnsID  string
+		dnsCRN string
+	}{
+		{
+			name:   "set dns id/crn",
+			dnsID:  "dns-instance-id",
+			dnsCRN: "dns-instance-crn",
+		},
+	}
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			metadata := baseMetadata()
+
+			metadata.dnsInstance = &DNSInstance{
+				ID:  tCase.dnsID,
+				CRN: tCase.dnsCRN,
+			}
+			actualDNS, err := metadata.DNSInstance(context.TODO())
+			assert.NoError(t, err)
+			assert.Equal(t, tCase.dnsID, actualDNS.ID)
+			assert.Equal(t, tCase.dnsCRN, actualDNS.CRN)
+		})
+	}
+}
+
+func TestComputeSubnets(t *testing.T) {
+	testCases := []struct {
+		name          string
+		edits         editMetadata
+		errorMsg      string
+		expectedValue map[string]Subnet
+	}{
+		{
+			name:          "no compute subnets",
+			expectedValue: nil,
+		},
+		{
+			name: "new compute subnets",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ComputeSubnetNames = []string{newComputeSubnet1Name, newComputeSubnet2Name}
+				},
+			},
+			expectedValue: newComputeSubnets,
+		},
+		{
+			name: "new single compute subnet",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ComputeSubnetNames = []string{newComputeSubnet2Name}
+				},
+			},
+			expectedValue: map[string]Subnet{
+				newComputeSubnet2ID: newComputeSubnets[newComputeSubnet2ID],
+			},
+		},
+		{
+			name: "existing compute subnets",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.computeSubnets = existingComputeSubnets
+				},
+			},
+			expectedValue: existingComputeSubnets,
+		},
+		{
+			name: "failed getting compute subnet",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ComputeSubnetNames = []string{failedGetComputeSubnetName}
+				},
+			},
+			errorMsg: fmt.Sprintf("getting subnet %s", failedGetComputeSubnetName),
+		},
+		{
+			name: "compute subnet has no id",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ComputeSubnetNames = []string{noIDComputeSubnetName}
+				},
+			},
+			errorMsg: fmt.Sprintf("%s has no ID", noIDComputeSubnetName),
+		},
+		{
+			name: "compute subnet has no CIDR block",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ComputeSubnetNames = []string{incompleteComputeSubnetName}
+				},
+			},
+			errorMsg: fmt.Sprintf("%s has no Ipv4CIDRBlock", noCIDRComputeSubnetID),
+		},
+		{
+			name: "compute subnet has no CRN",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ComputeSubnetNames = []string{incompleteComputeSubnetName}
+				},
+			},
+			errorMsg: fmt.Sprintf("%s has no CRN", noCRNComputeSubnetID),
+		},
+		{
+			name: "compute subnet has no Name",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ComputeSubnetNames = []string{incompleteComputeSubnetName}
+				},
+			},
+			errorMsg: fmt.Sprintf("%s has no Name", noNameComputeSubnetID),
+		},
+		{
+			name: "compute subnet has no VPC",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ComputeSubnetNames = []string{incompleteComputeSubnetName}
+				},
+			},
+			errorMsg: fmt.Sprintf("%s has no VPC", noVPCComputeSubnetID),
+		},
+		{
+			name: "compute subnet has no Zone",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ComputeSubnetNames = []string{incompleteComputeSubnetName}
+				},
+			},
+			errorMsg: fmt.Sprintf("%s has no Zone", noZoneComputeSubnetID),
+		},
+	}
+
+	// IBM Cloud Client Mocks.
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	ibmcloudClient := mock.NewMockAPI(mockCtrl)
+
+	// Shared Mocks.
+	// N/A.
+
+	// Mocks: no compute subnets.
+	// N/A.
+
+	// Mocks: new compute subnets.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), newComputeSubnet1Name, region).Return(
+		&vpcv1.Subnet{
+			Name:          &newComputeSubnet1Name,
+			ID:            &newComputeSubnet1ID,
+			Ipv4CIDRBlock: &newComputeSubnet1CIDR,
+			CRN:           &newComputeSubnet1CRN,
+			VPC:           &vpcReferenceComputeSubnet1,
+			Zone:          &zoneReferenceComputeSubnet1,
+		},
+		nil,
+	)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), newComputeSubnet2Name, region).Return(
+		&vpcv1.Subnet{
+			Name:          &newComputeSubnet2Name,
+			ID:            &newComputeSubnet2ID,
+			Ipv4CIDRBlock: &newComputeSubnet2CIDR,
+			CRN:           &newComputeSubnet2CRN,
+			VPC:           &vpcReferenceComputeSubnet2,
+			Zone:          &zoneReferenceComputeSubnet2,
+		},
+		nil,
+	)
+
+	// Mocks: new single compute subnet.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), newComputeSubnet2Name, region).Return(
+		&vpcv1.Subnet{
+			Name:          &newComputeSubnet2Name,
+			ID:            &newComputeSubnet2ID,
+			Ipv4CIDRBlock: &newComputeSubnet2CIDR,
+			CRN:           &newComputeSubnet2CRN,
+			VPC:           &vpcReferenceComputeSubnet2,
+			Zone:          &zoneReferenceComputeSubnet2,
+		},
+		nil,
+	)
+
+	// Mocks: existing compute subnets.
+	// N/A.
+
+	// Mocks: failed getting compute subnet.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), failedGetComputeSubnetName, region).Return(nil, &VPCResourceNotFoundError{})
+
+	// Mocks: compute subnet has no ID.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), noIDComputeSubnetName, region).Return(
+		&vpcv1.Subnet{
+			Name: &noIDComputeSubnetName,
+			// ID Skipped.
+			Ipv4CIDRBlock: &newComputeSubnet1CIDR,
+			CRN:           &newComputeSubnet1CRN,
+			VPC:           &vpcReferenceComputeSubnet1,
+			Zone:          &zoneReferenceComputeSubnet1,
+		},
+		nil,
+	)
+
+	// Mocks: compute subnet has no CIDR.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), incompleteComputeSubnetName, region).Return(
+		&vpcv1.Subnet{
+			Name: &incompleteComputeSubnetName,
+			ID:   &noCIDRComputeSubnetID,
+			// Ipv4CIDRBlock Skipped.
+			CRN:  &newComputeSubnet1CRN,
+			VPC:  &vpcReferenceComputeSubnet1,
+			Zone: &zoneReferenceComputeSubnet1,
+		},
+		nil,
+	)
+
+	// Mocks: compute subnet has no CRN.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), incompleteComputeSubnetName, region).Return(
+		&vpcv1.Subnet{
+			Name:          &incompleteComputeSubnetName,
+			ID:            &noCRNComputeSubnetID,
+			Ipv4CIDRBlock: &newComputeSubnet1CIDR,
+			// CRN Skipped.
+			VPC:  &vpcReferenceComputeSubnet1,
+			Zone: &zoneReferenceComputeSubnet1,
+		},
+		nil,
+	)
+
+	// Mocks: compute subnet has no Name.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), incompleteComputeSubnetName, region).Return(
+		&vpcv1.Subnet{
+			// Name Skipped.
+			ID:            &noNameComputeSubnetID,
+			Ipv4CIDRBlock: &newComputeSubnet1CIDR,
+			CRN:           &newComputeSubnet1CRN,
+			VPC:           &vpcReferenceComputeSubnet1,
+			Zone:          &zoneReferenceComputeSubnet1,
+		},
+		nil,
+	)
+
+	// Mocks: compute subnet has no VPC.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), incompleteComputeSubnetName, region).Return(
+		&vpcv1.Subnet{
+			Name:          &incompleteComputeSubnetName,
+			ID:            &noVPCComputeSubnetID,
+			Ipv4CIDRBlock: &newComputeSubnet1CIDR,
+			CRN:           &newComputeSubnet1CRN,
+			// VPC Skipped.
+			Zone: &zoneReferenceComputeSubnet1,
+		},
+		nil,
+	)
+
+	// Mocks: compute subnet has no Zone.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), incompleteComputeSubnetName, region).Return(
+		&vpcv1.Subnet{
+			Name:          &incompleteComputeSubnetName,
+			ID:            &noZoneComputeSubnetID,
+			Ipv4CIDRBlock: &newComputeSubnet1CIDR,
+			CRN:           &newComputeSubnet1CRN,
+			VPC:           &vpcReferenceComputeSubnet1,
+			// Zone Skipped.
+		},
+		nil,
+	)
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			metadata := baseMetadata()
+			metadata.client = ibmcloudClient
+
+			for _, edit := range tCase.edits {
+				edit(metadata)
+			}
+
+			actualValue, err := metadata.ComputeSubnets(context.TODO())
+			if err != nil {
+				assert.Regexp(t, tCase.errorMsg, err)
+			} else {
+				assert.Equal(t, tCase.expectedValue, actualValue)
+			}
+		})
+	}
+}
+
+func TestControlPlaneSubnets(t *testing.T) {
+	testCases := []struct {
+		name          string
+		edits         editMetadata
+		errorMsg      string
+		expectedValue map[string]Subnet
+	}{
+		{
+			name:          "no control plane subnets",
+			expectedValue: nil,
+		},
+		{
+			name: "new control plane subnets",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ControlPlaneSubnetNames = []string{newControlPlaneSubnet1Name, newControlPlaneSubnet2Name}
+				},
+			},
+			expectedValue: newControlPlaneSubnets,
+		},
+		{
+			name: "new single control plane subnet",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ControlPlaneSubnetNames = []string{newControlPlaneSubnet2Name}
+				},
+			},
+			expectedValue: map[string]Subnet{
+				newControlPlaneSubnet2ID: newControlPlaneSubnets[newControlPlaneSubnet2ID],
+			},
+		},
+		{
+			name: "existing control plane subnets",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.controlPlaneSubnets = existingControlPlaneSubnets
+				},
+			},
+			expectedValue: existingControlPlaneSubnets,
+		},
+		{
+			name: "failed getting control plane subnet",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.ControlPlaneSubnetNames = []string{failedGetControlPlaneSubnetName}
+				},
+			},
+			errorMsg: fmt.Sprintf("getting subnet %v", failedGetControlPlaneSubnetName),
+		},
+	}
+
+	// IBM Cloud Client Mocks.
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	ibmcloudClient := mock.NewMockAPI(mockCtrl)
+
+	// Shared Mocks.
+	// N/A.
+
+	// Mocks: no control plane subnets.
+	// N/A.
+
+	// Mocks: new control plane subnets.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), newControlPlaneSubnet1Name, region).Return(
+		&vpcv1.Subnet{
+			Name:          &newControlPlaneSubnet1Name,
+			ID:            &newControlPlaneSubnet1ID,
+			Ipv4CIDRBlock: &newControlPlaneSubnet1CIDR,
+			CRN:           &newControlPlaneSubnet1CRN,
+			VPC:           &vpcReferenceControlPlaneSubnet1,
+			Zone:          &zoneReferenceControlPlaneSubnet1,
+		},
+		nil,
+	)
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), newControlPlaneSubnet2Name, region).Return(
+		&vpcv1.Subnet{
+			Name:          &newControlPlaneSubnet2Name,
+			ID:            &newControlPlaneSubnet2ID,
+			Ipv4CIDRBlock: &newControlPlaneSubnet2CIDR,
+			CRN:           &newControlPlaneSubnet2CRN,
+			VPC:           &vpcReferenceControlPlaneSubnet2,
+			Zone:          &zoneReferenceControlPlaneSubnet2,
+		},
+		nil,
+	)
+
+	// Mocks: new single control plane subnet.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), newControlPlaneSubnet2Name, region).Return(
+		&vpcv1.Subnet{
+			Name:          &newControlPlaneSubnet2Name,
+			ID:            &newControlPlaneSubnet2ID,
+			Ipv4CIDRBlock: &newControlPlaneSubnet2CIDR,
+			CRN:           &newControlPlaneSubnet2CRN,
+			VPC:           &vpcReferenceControlPlaneSubnet2,
+			Zone:          &zoneReferenceControlPlaneSubnet2,
+		},
+		nil,
+	)
+
+	// Mocks: existing control plane subnets.
+	// N/A.
+
+	// Mocks: failed getting control plane subnet.
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), failedGetControlPlaneSubnetName, region).Return(nil, &VPCResourceNotFoundError{})
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			metadata := baseMetadata()
+			metadata.client = ibmcloudClient
+
+			for _, edit := range tCase.edits {
+				edit(metadata)
+			}
+
+			actualValue, err := metadata.ControlPlaneSubnets(context.TODO())
+			if err != nil {
+				assert.Regexp(t, tCase.errorMsg, err)
+			} else {
+				assert.Equal(t, tCase.expectedValue, actualValue)
+			}
+		})
+	}
+}
+
+func TestClient(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	ibmcloudClient := mock.NewMockAPI(mockCtrl)
+
+	testCases := []struct {
+		name          string
+		edits         editMetadata
+		errorMsg      string
+		expectedValue API
+	}{
+		{
+			name: "existing client",
+			edits: editMetadata{
+				func(m *Metadata) {
+					m.client = ibmcloudClient
+				},
+			},
+			expectedValue: ibmcloudClient,
+		},
+	}
+
+	// IBM Cloud Client Mocks.
+	// N/A.
+
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			metadata := baseMetadata()
+
+			actualValue, err := metadata.Client()
+			if err != nil {
+				assert.Regexp(t, tCase.errorMsg, err)
+			} else {
+				assert.Equal(t, tCase.expectedValue, actualValue)
+			}
+		})
+	}
+}

--- a/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
+++ b/pkg/asset/installconfig/ibmcloud/mock/ibmcloudclient_generated.go
@@ -14,7 +14,7 @@ import (
 	resourcemanagerv2 "github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 	vpcv1 "github.com/IBM/vpc-go-sdk/vpcv1"
 	gomock "github.com/golang/mock/gomock"
-	ibmcloud "github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
+	responses "github.com/openshift/installer/pkg/asset/installconfig/ibmcloud/responses"
 	types "github.com/openshift/installer/pkg/types"
 )
 
@@ -39,6 +39,20 @@ func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
+}
+
+// GetAPIKey mocks base method.
+func (m *MockAPI) GetAPIKey() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAPIKey")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetAPIKey indicates an expected call of GetAPIKey.
+func (mr *MockAPIMockRecorder) GetAPIKey() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIKey", reflect.TypeOf((*MockAPI)(nil).GetAPIKey))
 }
 
 // GetAuthenticatorAPIKeyDetails mocks base method.
@@ -132,10 +146,10 @@ func (mr *MockAPIMockRecorder) GetDNSZoneIDByName(ctx, name, publish interface{}
 }
 
 // GetDNSZones mocks base method.
-func (m *MockAPI) GetDNSZones(ctx context.Context, publish types.PublishingStrategy) ([]ibmcloud.DNSZoneResponse, error) {
+func (m *MockAPI) GetDNSZones(ctx context.Context, publish types.PublishingStrategy) ([]responses.DNSZoneResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDNSZones", ctx, publish)
-	ret0, _ := ret[0].([]ibmcloud.DNSZoneResponse)
+	ret0, _ := ret[0].([]responses.DNSZoneResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -177,10 +191,10 @@ func (mr *MockAPIMockRecorder) GetDedicatedHostProfiles(ctx, region interface{})
 }
 
 // GetEncryptionKey mocks base method.
-func (m *MockAPI) GetEncryptionKey(ctx context.Context, keyCRN string) (*ibmcloud.EncryptionKeyResponse, error) {
+func (m *MockAPI) GetEncryptionKey(ctx context.Context, keyCRN string) (*responses.EncryptionKeyResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEncryptionKey", ctx, keyCRN)
-	ret0, _ := ret[0].(*ibmcloud.EncryptionKeyResponse)
+	ret0, _ := ret[0].(*responses.EncryptionKeyResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/asset/installconfig/ibmcloud/responses/responses.go
+++ b/pkg/asset/installconfig/ibmcloud/responses/responses.go
@@ -1,0 +1,28 @@
+package responses
+
+// DNSZoneResponse represents a DNS zone response.
+type DNSZoneResponse struct {
+	// Name is the domain name of the zone.
+	Name string
+
+	// ID is the zone's ID.
+	ID string
+
+	// InstanceID is the IBM Cloud Resource ID for the service instance where
+	// the DNS zone is managed.
+	InstanceID string
+
+	// InstanceCRN is the IBM Cloud Resource CRN for the service instance where
+	// the DNS zone is managed.
+	InstanceCRN string
+
+	// InstanceName is the display name of the service instance where the DNS zone
+	// is managed.
+	InstanceName string
+
+	// ResourceGroupID is the resource group ID of the service instance.
+	ResourceGroupID string
+}
+
+// EncryptionKeyResponse represents an encryption key response.
+type EncryptionKeyResponse struct{}

--- a/pkg/asset/installconfig/ibmcloud/subnet.go
+++ b/pkg/asset/installconfig/ibmcloud/subnet.go
@@ -16,7 +16,7 @@ type Subnet struct {
 	Zone string
 }
 
-func getSubnets(ctx context.Context, client *Client, region string, subnetNames []string) (map[string]Subnet, error) {
+func getSubnets(ctx context.Context, client API, region string, subnetNames []string) (map[string]Subnet, error) {
 	subnets := map[string]Subnet{}
 
 	for _, name := range subnetNames {

--- a/pkg/asset/installconfig/ibmcloud/validation_test.go
+++ b/pkg/asset/installconfig/ibmcloud/validation_test.go
@@ -1,4 +1,4 @@
-package ibmcloud_test
+package ibmcloud
 
 import (
 	"errors"
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openshift/installer/pkg/asset/installconfig/ibmcloud"
 	"github.com/openshift/installer/pkg/asset/installconfig/ibmcloud/mock"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
@@ -642,7 +641,7 @@ func TestValidate(t *testing.T) {
 	// Mocks: control plane subnet not found
 	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
 	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
-	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "missing-cp-subnet", validRegion).Return(nil, &ibmcloud.VPCResourceNotFoundError{})
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "missing-cp-subnet", validRegion).Return(nil, &VPCResourceNotFoundError{})
 
 	// Mocks: control plane subnet IBM error
 	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
@@ -701,7 +700,7 @@ func TestValidate(t *testing.T) {
 	// Mocks: compute subnet not found
 	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
 	ibmcloudClient.EXPECT().GetVPCs(gomock.Any(), validRegion).Return(validVPCs, nil)
-	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "missing-compute-subnet", validRegion).Return(nil, &ibmcloud.VPCResourceNotFoundError{})
+	ibmcloudClient.EXPECT().GetSubnetByName(gomock.Any(), "missing-compute-subnet", validRegion).Return(nil, &VPCResourceNotFoundError{})
 
 	// Mocks: compute subnet IBM error
 	ibmcloudClient.EXPECT().GetResourceGroups(gomock.Any()).Return(validResourceGroups, nil)
@@ -781,7 +780,7 @@ func TestValidate(t *testing.T) {
 				edit(editedInstallConfig)
 			}
 
-			aggregatedErrors := ibmcloud.Validate(ibmcloudClient, editedInstallConfig)
+			aggregatedErrors := Validate(ibmcloudClient, editedInstallConfig)
 			if tc.errorMsg != "" {
 				assert.Regexp(t, tc.errorMsg, aggregatedErrors)
 			} else {
@@ -832,8 +831,8 @@ func TestValidatePreExistingPublicDNS(t *testing.T) {
 
 	dnsRecordName := fmt.Sprintf("api.%s.%s", validClusterName, validBaseDomain)
 
-	metadata := ibmcloud.NewMetadata(validBaseDomain, "us-south", nil, nil)
-	metadata.SetCISInstanceCRN(validCISInstanceCRN)
+	metadata := NewMetadata(validBaseDomain, "us-south", nil, nil)
+	metadata.cisInstanceCRN = validCISInstanceCRN
 
 	// Mocks: no pre-existing External DNS records
 	ibmcloudClient.EXPECT().GetDNSZoneIDByName(gomock.Any(), validBaseDomain, types.ExternalPublishingStrategy).Return(validDNSZoneID, nil)
@@ -856,7 +855,7 @@ func TestValidatePreExistingPublicDNS(t *testing.T) {
 			if tc.internal {
 				validInstallConfig.Publish = types.InternalPublishingStrategy
 			}
-			aggregatedErrors := ibmcloud.ValidatePreExistingPublicDNS(ibmcloudClient, validInstallConfig, metadata)
+			aggregatedErrors := ValidatePreExistingPublicDNS(ibmcloudClient, validInstallConfig, metadata)
 			if tc.errorMsg != "" {
 				assert.Regexp(t, tc.errorMsg, aggregatedErrors)
 			} else {

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -143,7 +143,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		}
 		cloudCreds = cloudCredsSecretData{
 			IBMCloud: &IBMCloudCredsSecretData{
-				Base64encodeAPIKey: base64.StdEncoding.EncodeToString([]byte(client.APIKey)),
+				Base64encodeAPIKey: base64.StdEncoding.EncodeToString([]byte(client.GetAPIKey())),
 			},
 		}
 	case openstacktypes.Name:


### PR DESCRIPTION
Add tests to improve coverage of the IBM Cloud installconfig metadata package. This includes removing public access for metadata values (used for test purposes), refactoring test package, and moving response structs to unique package to prevent cyclic dependencies.