### PR TITLE
OCPBUGS-927: azure: add sleep between zone and link creation

### DIFF
--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -12,7 +12,7 @@ resource "azurerm_private_dns_zone" "private" {
 
 # Sleep injected due to https://github.com/hashicorp/terraform-provider-azurerm/issues/18350
 resource "time_sleep" "wait_30_seconds" {
-  depends_on = [azurerm_private_dns_zone.private]
+  depends_on      = [azurerm_private_dns_zone.private]
   create_duration = "30s"
 }
 

--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -10,13 +10,19 @@ resource "azurerm_private_dns_zone" "private" {
   depends_on = [azurerm_dns_cname_record.api_external_v4, azurerm_dns_cname_record.api_external_v6]
 }
 
+# Sleep injected due to https://github.com/hashicorp/terraform-provider-azurerm/issues/18350
+resource "time_sleep" "wait_30_seconds" {
+  depends_on = [azurerm_private_dns_zone.private]
+  create_duration = "30s"
+}
+
 resource "azurerm_private_dns_zone_virtual_network_link" "network" {
   name                  = "${var.cluster_id}-network-link"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.private.name
   virtual_network_id    = var.virtual_network_id
 
-  depends_on = [azurerm_private_dns_zone.private]
+  depends_on = [time_sleep.wait_30_seconds]
 }
 
 resource "azurerm_private_dns_a_record" "apiint_internal" {

--- a/data/data/azure/cluster/dns/versions.tf
+++ b/data/data/azure/cluster/dns/versions.tf
@@ -1,8 +1,0 @@
-terraform {
-  required_providers {
-    time = {
-      source  = "hashicorp/time"
-      version = "0.7.2"
-    }
-  }
-}

--- a/data/data/azure/cluster/dns/versions.tf
+++ b/data/data/azure/cluster/dns/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    time = {
+      source  = "hashicorp/time"
+      version = "0.7.2"
+    }
+  }
+}

--- a/pkg/terraform/stages/azure/stages.go
+++ b/pkg/terraform/stages/azure/stages.go
@@ -23,7 +23,7 @@ var PlatformStages = []terraform.Stage{
 	stages.NewStage(
 		typesazure.Name,
 		"cluster",
-		[]providers.Provider{providers.AzureRM},
+		[]providers.Provider{providers.AzureRM, providers.Time},
 	),
 }
 


### PR DESCRIPTION
We started seeing errors from Azure about network links not being able to find a previously created private zone.  The order in terraform seems to be correct[1]:

```
time="2022-09-14T16:33:55Z" level=debug msg="module.dns.azurerm_private_dns_zone.private: Creating..."
time="2022-09-14T16:34:27Z" level=debug msg="module.dns.azurerm_private_dns_zone.private: Creation complete after 33s [id=/subscriptions/d38f1e38-4bed-438e-b227-833f997adf6a/resourceGroups/ci-op-r0j51ij5-0e6bb-22jzf-rg/providers/Microsoft.Network/privateDnsZones/ci-op-r0j51ij5-0e6bb.ci.azure.devcluster.openshift.com]"
time="2022-09-14T16:34:27Z" level=debug msg="module.dns.azurerm_private_dns_zone_virtual_network_link.network: Creating..."
time="2022-09-14T16:54:51Z" level=error msg="Error: creating/updating Virtual Network Link (Subscription: \"d38f1e38-4bed-438e-b227-833f997adf6a\""
time="2022-09-14T16:54:51Z" level=error msg="Resource Group Name: \"ci-op-r0j51ij5-0e6bb-22jzf-rg\""
time="2022-09-14T16:54:51Z" level=error msg="Private Zone Name: \"ci-op-r0j51ij5-0e6bb.ci.azure.devcluster.openshift.com\""
time="2022-09-14T16:54:51Z" level=error msg="Virtual Network Link Name: \"ci-op-r0j51ij5-0e6bb-22jzf-network-link\"): performing CreateOrUpdate: virtualnetworklinks.VirtualNetworkLinksClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code=\"ParentResourceNotFound\" Message=\"Can not perform requested operation on nested resource. Parent resource 'ci-op-r0j51ij5-0e6bb.ci.azure.devcluster.openshift.com' not found.\""
```

Because we immediately go from creating the zone to creating the link, we may not be giving enough time for Azure to settle -- it may be reporting the zone was created, but the response may be inaccurate.

Attempting to workaround this by adding a short sleep between the two resources.