### PR TITLE
CFE-586 : Apply user defined tags on created azure resources

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -2,12 +2,6 @@ locals {
   bootstrap_nic_ip_v4_configuration_name = "bootstrap-nic-ip-v4"
   bootstrap_nic_ip_v6_configuration_name = "bootstrap-nic-ip-v6"
   description                            = "Created By OpenShift Installer"
-  tags = merge(
-    {
-      "kubernetes.io_cluster.${var.cluster_id}" = "owned"
-    },
-    var.azure_extra_tags,
-  )
 }
 
 provider "azurerm" {
@@ -88,6 +82,7 @@ resource "azurerm_public_ip" "bootstrap_public_ip_v4" {
   name                = "${var.cluster_id}-bootstrap-pip-v4"
   resource_group_name = var.resource_group_name
   allocation_method   = "Static"
+  tags                = var.azure_extra_tags
 }
 
 data "azurerm_public_ip" "bootstrap_public_ip_v4" {
@@ -106,6 +101,7 @@ resource "azurerm_public_ip" "bootstrap_public_ip_v6" {
   resource_group_name = var.resource_group_name
   allocation_method   = "Static"
   ip_version          = "IPv6"
+  tags                = var.azure_extra_tags
 }
 
 data "azurerm_public_ip" "bootstrap_public_ip_v6" {
@@ -154,6 +150,8 @@ resource "azurerm_network_interface" "bootstrap" {
       public_ip_address_id          = ip_configuration.value.public_ip_id
     }
   }
+
+  tags = var.azure_extra_tags
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "public_lb_bootstrap_v4" {
@@ -234,6 +232,8 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
     azurerm_network_interface_backend_address_pool_association.internal_lb_bootstrap_v4,
     azurerm_network_interface_backend_address_pool_association.internal_lb_bootstrap_v6
   ]
+
+  tags = var.azure_extra_tags
 }
 
 resource "azurerm_network_security_rule" "bootstrap_ssh_in" {

--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -6,8 +6,8 @@ locals {
 resource "azurerm_private_dns_zone" "private" {
   name                = var.cluster_domain
   resource_group_name = var.resource_group_name
-
-  depends_on = [azurerm_dns_cname_record.api_external_v4, azurerm_dns_cname_record.api_external_v6]
+  depends_on          = [azurerm_dns_cname_record.api_external_v4, azurerm_dns_cname_record.api_external_v6]
+  tags                = var.azure_extra_tags
 }
 
 # Sleep injected due to https://github.com/hashicorp/terraform-provider-azurerm/issues/18350
@@ -21,8 +21,8 @@ resource "azurerm_private_dns_zone_virtual_network_link" "network" {
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.private.name
   virtual_network_id    = var.virtual_network_id
-
-  depends_on = [time_sleep.wait_30_seconds]
+  depends_on            = [time_sleep.wait_30_seconds]
+  tags                  = var.azure_extra_tags
 }
 
 resource "azurerm_private_dns_a_record" "apiint_internal" {
@@ -33,6 +33,7 @@ resource "azurerm_private_dns_a_record" "apiint_internal" {
   resource_group_name = var.resource_group_name
   ttl                 = 300
   records             = [var.internal_lb_ipaddress_v4]
+  tags                = var.azure_extra_tags
 }
 
 resource "azurerm_private_dns_aaaa_record" "apiint_internal_v6" {
@@ -43,6 +44,7 @@ resource "azurerm_private_dns_aaaa_record" "apiint_internal_v6" {
   resource_group_name = var.resource_group_name
   ttl                 = 300
   records             = [var.internal_lb_ipaddress_v6]
+  tags                = var.azure_extra_tags
 }
 
 resource "azurerm_private_dns_a_record" "api_internal" {
@@ -53,6 +55,7 @@ resource "azurerm_private_dns_a_record" "api_internal" {
   resource_group_name = var.resource_group_name
   ttl                 = 300
   records             = [var.internal_lb_ipaddress_v4]
+  tags                = var.azure_extra_tags
 }
 
 resource "azurerm_private_dns_aaaa_record" "api_internal_v6" {
@@ -63,6 +66,7 @@ resource "azurerm_private_dns_aaaa_record" "api_internal_v6" {
   resource_group_name = var.resource_group_name
   ttl                 = 300
   records             = [var.internal_lb_ipaddress_v6]
+  tags                = var.azure_extra_tags
 }
 
 resource "azurerm_dns_cname_record" "api_external_v4" {
@@ -73,6 +77,7 @@ resource "azurerm_dns_cname_record" "api_external_v4" {
   resource_group_name = var.base_domain_resource_group_name
   ttl                 = 300
   record              = var.external_lb_fqdn_v4
+  tags                = var.azure_extra_tags
 }
 
 resource "azurerm_dns_cname_record" "api_external_v6" {
@@ -83,6 +88,7 @@ resource "azurerm_dns_cname_record" "api_external_v6" {
   resource_group_name = var.base_domain_resource_group_name
   ttl                 = 300
   record              = var.external_lb_fqdn_v6
+  tags                = var.azure_extra_tags
 }
 
 

--- a/data/data/azure/cluster/dns/variables.tf
+++ b/data/data/azure/cluster/dns/variables.tf
@@ -1,70 +1,77 @@
-variable "tags" {
-  type        = map(string)
-  default     = {}
-  description = "tags to be applied to created resources."
+variable "azure_extra_tags" {
+  type = map(string)
+
+  description = <<EOF
+(optional) Extra Azure tags to be applied to created resources.
+
+Example: `{ "key" = "value", "foo" = "bar" }`
+EOF
+
+
+  default = {}
 }
 
 variable "cluster_id" {
   description = "The identifier for the cluster."
-  type        = string
+  type = string
 }
 
 variable "cluster_domain" {
   description = "The domain for the cluster that all DNS records must belong"
-  type        = string
+  type = string
 }
 
 variable "base_domain" {
   description = "The base domain used for public records"
-  type        = string
+  type = string
 }
 
 variable "base_domain_resource_group_name" {
   description = "The resource group where the base domain is"
-  type        = string
+  type = string
 }
 
 variable "external_lb_fqdn_v4" {
   description = "External API's LB fqdn for IPv4"
-  type        = string
+  type = string
 }
 
 variable "external_lb_fqdn_v6" {
   description = "External API's LB fqdn for IPv6"
-  type        = string
+  type = string
 }
 
 variable "internal_lb_ipaddress_v4" {
   description = "External API's LB IP v4 address"
-  type        = string
+  type = string
 }
 
 variable "internal_lb_ipaddress_v6" {
   description = "External API's LB IP v6 address"
-  type        = string
+  type = string
 }
 
 variable "virtual_network_id" {
   description = "The ID for Virtual Network that will be linked to the Private DNS zone."
-  type        = string
+  type = string
 }
 
 variable "resource_group_name" {
-  type        = string
+  type = string
   description = "Resource group for the deployment"
 }
 
 variable "private" {
-  type        = bool
+  type = bool
   description = "This value determines if this is a private cluster or not."
 }
 
 variable "use_ipv4" {
-  type        = bool
+  type = bool
   description = "This value determines if this is cluster should use IPv4 networking."
 }
 
 variable "use_ipv6" {
-  type        = bool
+  type = bool
   description = "This value determines if this is cluster should use IPv6 networking."
 }

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -1,14 +1,7 @@
 locals {
-  tags = merge(
-    {
-      "kubernetes.io_cluster.${var.cluster_id}" = "owned"
-    },
-    var.azure_extra_tags,
-  )
   description = "Created By OpenShift Installer"
   # At this time min_tls_version is only supported in the Public Cloud and US Government Cloud.
   environments_with_min_tls_version = ["public", "usgovernment"]
-
 }
 
 provider "azurerm" {
@@ -47,6 +40,7 @@ module "master" {
   outbound_udr               = var.azure_outbound_user_defined_routing
   ultra_ssd_enabled          = var.azure_control_plane_ultra_ssd_enabled
   vm_networking_type         = var.azure_control_plane_vm_networking_type
+  azure_extra_tags           = var.azure_extra_tags
 
   use_ipv4 = var.use_ipv4
   use_ipv6 = var.use_ipv6
@@ -65,6 +59,7 @@ module "dns" {
   resource_group_name             = var.resource_group_name
   base_domain_resource_group_name = var.azure_base_domain_resource_group_name
   private                         = var.azure_private
+  azure_extra_tags                = var.azure_extra_tags
 
   use_ipv4 = var.use_ipv4
   use_ipv6 = var.use_ipv6

--- a/data/data/azure/cluster/master/master.tf
+++ b/data/data/azure/cluster/master/master.tf
@@ -49,6 +49,8 @@ resource "azurerm_network_interface" "master" {
       private_ip_address_allocation = "Dynamic"
     }
   }
+
+  tags = var.azure_extra_tags
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "master_v4" {
@@ -131,4 +133,6 @@ resource "azurerm_linux_virtual_machine" "master" {
   boot_diagnostics {
     storage_account_uri = data.azurerm_storage_account.storage_account.primary_blob_endpoint
   }
+
+  tags = var.azure_extra_tags
 }

--- a/data/data/azure/cluster/master/variables.tf
+++ b/data/data/azure/cluster/master/variables.tf
@@ -82,14 +82,21 @@ variable "os_volume_size" {
   description = "The size of the volume in gigabytes for the root block device."
 }
 
-variable "tags" {
-  type        = map(string)
-  default     = {}
-  description = "tags to be applied to created resources."
+variable "azure_extra_tags" {
+  type = map(string)
+
+  description = <<EOF
+(optional) Extra Azure tags to be applied to created resources.
+
+Example: `{ "key" = "value", "foo" = "bar" }`
+EOF
+
+
+  default = {}
 }
 
 variable "storage_account_name" {
-  type        = any
+  type = any
   description = "the name of the storage account for the cluster. It can be used for boot diagnostics."
 }
 
@@ -98,27 +105,27 @@ variable "ignition" {
 }
 
 variable "availability_zones" {
-  type        = list(string)
+  type = list(string)
   description = "List of the availability zones in which to create the masters. The length of this list must match instance_count."
 }
 
 variable "private" {
-  type        = bool
+  type = bool
   description = "This value determines if this is a private cluster or not."
 }
 
 variable "use_ipv4" {
-  type        = bool
+  type = bool
   description = "This value determines if this is cluster should use IPv4 networking."
 }
 
 variable "use_ipv6" {
-  type        = bool
+  type = bool
   description = "This value determines if this is cluster should use IPv6 networking."
 }
 
 variable "outbound_udr" {
-  type    = bool
+  type = bool
   default = false
 
   description = <<EOF
@@ -131,12 +138,12 @@ EOF
 }
 
 variable "ultra_ssd_enabled" {
-  type = bool
+  type        = bool
   description = "Determines if the control plane should have UltraSSD Enabled."
 }
 
 variable "vm_networking_type" {
-  type = bool
+  type        = bool
   description = <<EOF
 networking_type specifies whether to enable accelerated networking. Accelerated networking
 enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its networking performance.

--- a/data/data/azure/vnet/internal-lb.tf
+++ b/data/data/azure/vnet/internal-lb.tf
@@ -30,6 +30,8 @@ resource "azurerm_lb" "internal" {
       private_ip_address            = frontend_ip_configuration.value.ipv6 ? cidrhost(local.master_subnet_cidr_v6, -2) : null
     }
   }
+
+  tags = var.azure_extra_tags
 }
 
 resource "azurerm_lb_backend_address_pool" "internal_lb_controlplane_pool_v4" {

--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -27,7 +27,7 @@ resource "azurerm_resource_group" "main" {
 
   name     = "${var.cluster_id}-rg"
   location = var.azure_region
-  tags     = local.tags
+  tags     = var.azure_extra_tags
 }
 
 data "azurerm_resource_group" "main" {
@@ -50,13 +50,14 @@ resource "azurerm_storage_account" "cluster" {
   account_replication_type        = "LRS"
   min_tls_version                 = contains(local.environments_with_min_tls_version, var.azure_environment) ? "TLS1_2" : null
   allow_nested_items_to_be_public = false
+  tags                            = var.azure_extra_tags
 }
 
 resource "azurerm_user_assigned_identity" "main" {
   resource_group_name = data.azurerm_resource_group.main.name
   location            = data.azurerm_resource_group.main.location
-
-  name = "${var.cluster_id}-identity"
+  name                = "${var.cluster_id}-identity"
+  tags                = var.azure_extra_tags
 }
 
 resource "azurerm_role_assignment" "main" {
@@ -94,6 +95,7 @@ resource "azurerm_shared_image_gallery" "sig" {
   name                = "gallery_${replace(var.cluster_id, "-", "_")}"
   resource_group_name = data.azurerm_resource_group.main.name
   location            = var.azure_region
+  tags                = var.azure_extra_tags
 }
 
 # Creates image definition
@@ -111,6 +113,8 @@ resource "azurerm_shared_image" "cluster" {
     offer     = "rhcos"
     sku       = "basic"
   }
+
+  tags = var.azure_extra_tags
 }
 
 resource "azurerm_shared_image" "clustergen2" {
@@ -127,6 +131,8 @@ resource "azurerm_shared_image" "clustergen2" {
     offer     = "rhcos-gen2"
     sku       = "gen2"
   }
+
+  tags = var.azure_extra_tags
 }
 
 resource "azurerm_shared_image_version" "cluster_image_version" {
@@ -143,6 +149,8 @@ resource "azurerm_shared_image_version" "cluster_image_version" {
     name                   = azurerm_shared_image.cluster.location
     regional_replica_count = 1
   }
+
+  tags = var.azure_extra_tags
 }
 
 resource "azurerm_shared_image_version" "clustergen2_image_version" {
@@ -159,5 +167,7 @@ resource "azurerm_shared_image_version" "clustergen2_image_version" {
     name                   = azurerm_shared_image.clustergen2.location
     regional_replica_count = 1
   }
+
+  tags = var.azure_extra_tags
 }
 

--- a/data/data/azure/vnet/nsg.tf
+++ b/data/data/azure/vnet/nsg.tf
@@ -2,6 +2,7 @@ resource "azurerm_network_security_group" "cluster" {
   name                = "${var.cluster_id}-nsg"
   location            = var.azure_region
   resource_group_name = data.azurerm_resource_group.main.name
+  tags                = var.azure_extra_tags
 }
 
 resource "azurerm_subnet_network_security_group_association" "master" {

--- a/data/data/azure/vnet/public-lb.tf
+++ b/data/data/azure/vnet/public-lb.tf
@@ -20,6 +20,7 @@ resource "azurerm_public_ip" "cluster_public_ip_v4" {
   resource_group_name = data.azurerm_resource_group.main.name
   allocation_method   = "Static"
   domain_name_label   = var.cluster_id
+  tags                = var.azure_extra_tags
 }
 
 data "azurerm_public_ip" "cluster_public_ip_v4" {
@@ -41,6 +42,7 @@ resource "azurerm_public_ip" "cluster_public_ip_v6" {
   resource_group_name = data.azurerm_resource_group.main.name
   allocation_method   = "Static"
   domain_name_label   = var.cluster_id
+  tags                = var.azure_extra_tags
 }
 
 data "azurerm_public_ip" "cluster_public_ip_v6" {
@@ -86,6 +88,8 @@ resource "azurerm_lb" "public" {
       private_ip_address_allocation = "Dynamic"
     }
   }
+
+  tags = var.azure_extra_tags
 }
 
 // The backends are only created when frontend configuration exists, because of the following error from Azure API;

--- a/data/data/azure/vnet/vnet.tf
+++ b/data/data/azure/vnet/vnet.tf
@@ -5,6 +5,7 @@ resource "azurerm_virtual_network" "cluster_vnet" {
   resource_group_name = data.azurerm_resource_group.main.name
   location            = var.azure_region
   address_space       = concat(var.machine_v4_cidrs, var.machine_v6_cidrs)
+  tags                = var.azure_extra_tags
 }
 
 resource "azurerm_subnet" "master_subnet" {

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -377,6 +377,7 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				BootstrapIgnitionURLPlaceholder: bootstrapIgnURLPlaceholder,
 				HyperVGeneration:                hyperVGeneration,
 				VMArchitecture:                  installConfig.Config.ControlPlane.Architecture,
+				InfrastructureName:              clusterID.InfraID,
 			},
 		)
 		if err != nil {

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -26,7 +26,7 @@ const (
 )
 
 // Machines returns a list of machines for a machinepool.
-func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string, useImageGallery bool) ([]machineapi.Machine, *machinev1.ControlPlaneMachineSet, error) {
+func Machines(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string, useImageGallery bool, userTags map[string]string) ([]machineapi.Machine, *machinev1.ControlPlaneMachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != azure.Name {
 		return nil, nil, fmt.Errorf("non-Azure configuration: %q", configPlatform)
 	}
@@ -54,7 +54,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		if len(azs) > 0 {
 			azIndex = int(idx) % len(azs)
 		}
-		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &azIndex, capabilities, useImageGallery)
+		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &azIndex, capabilities, useImageGallery, userTags)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "failed to create provider")
 		}
@@ -141,7 +141,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	return machines, controlPlaneMachineSet, nil
 }
 
-func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string, userDataSecret string, clusterID string, role string, azIdx *int, capabilities map[string]string, useImageGallery bool) (*machineapi.AzureMachineProviderSpec, error) {
+func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string, userDataSecret string, clusterID string, role string, azIdx *int, capabilities map[string]string, useImageGallery bool, userTags map[string]string) (*machineapi.AzureMachineProviderSpec, error) {
 	var az *string
 	if len(mpool.Zones) > 0 && azIdx != nil {
 		az = &mpool.Zones[*azIdx]
@@ -249,6 +249,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		NetworkResourceGroup:  networkResourceGroup,
 		PublicLoadBalancer:    publicLB,
 		AcceleratedNetworking: getVMNetworkingType(mpool.VMNetworkingType),
+		Tags:                  userTags,
 	}
 
 	if platform.CloudName == azure.StackCloud {

--- a/pkg/asset/machines/azure/machinesets.go
+++ b/pkg/asset/machines/azure/machinesets.go
@@ -13,7 +13,7 @@ import (
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string, useImageGallery bool) ([]*clusterapi.MachineSet, error) {
+func MachineSets(clusterID string, config *types.InstallConfig, pool *types.MachinePool, osImage, role, userDataSecret string, capabilities map[string]string, useImageGallery bool, userTags map[string]string) ([]*clusterapi.MachineSet, error) {
 	if configPlatform := config.Platform.Name(); configPlatform != azure.Name {
 		return nil, fmt.Errorf("non-azure configuration: %q", configPlatform)
 	}
@@ -41,7 +41,7 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		if int64(idx) < total%numOfAZs {
 			replicas++
 		}
-		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx, capabilities, useImageGallery)
+		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx, capabilities, useImageGallery, userTags)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -371,7 +371,7 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			return err
 		}
 		useImageGallery := installConfig.Azure.CloudName != azuretypes.StackCloud
-		machines, controlPlaneMachineSet, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, capabilities, useImageGallery)
+		machines, controlPlaneMachineSet, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, capabilities, useImageGallery, installConfig.Config.Platform.Azure.UserTags)
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -413,7 +413,7 @@ func (w *Worker) Generate(dependencies asset.Parents) error {
 			}
 
 			useImageGallery := ic.Platform.Azure.CloudName != azuretypes.StackCloud
-			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", workerUserDataSecretName, capabilities, useImageGallery)
+			sets, err := azure.MachineSets(clusterID.InfraID, ic, &pool, string(*rhcosImage), "worker", workerUserDataSecretName, capabilities, useImageGallery, installConfig.Config.Platform.Azure.UserTags)
 			if err != nil {
 				return errors.Wrap(err, "failed to create worker machine objects")
 			}


### PR DESCRIPTION
PR is for applying OCP default tag (`"kubernetes.io_cluster.{cluster_id}" = "owned"`) and user defined tags to all azure resources created.