### PR TITLE
OCPBUGS-1349: OpenStack: Lift validation for 14 chars cluster names

### DIFF
--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -3,7 +3,6 @@ package validation
 import (
 	"errors"
 	"net"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -15,8 +14,6 @@ import (
 // ValidatePlatform checks that the specified platform is valid.
 func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field.Path, c *types.InstallConfig) field.ErrorList {
 	var allErrs field.ErrorList
-
-	allErrs = append(allErrs, validateClusterName(c.ObjectMeta.Name)...)
 
 	for _, ip := range p.ExternalDNS {
 		if err := validate.IP(ip); err != nil {
@@ -51,16 +48,4 @@ func validateVIP(vip string, n *types.Networking) error {
 		}
 	}
 	return nil
-}
-
-func validateClusterName(name string) (allErrs field.ErrorList) {
-	if len(name) > 14 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), name, "cluster name is too long, please restrict it to 14 characters"))
-	}
-
-	if strings.Contains(name, ".") {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), name, "cluster name can't contain \".\" character"))
-	}
-
-	return
 }

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -30,27 +30,6 @@ func validNetworking() *types.Networking {
 	}
 }
 
-func TestValidateClusterName(t *testing.T) {
-	testConfig := types.InstallConfig{}
-
-	// valid platform
-	testConfig.ObjectMeta.Name = "test"
-	errs := ValidatePlatform(validPlatform(), validNetworking(), field.NewPath("test-path"), &testConfig)
-	assert.NoError(t, errs.ToAggregate())
-
-	// too long cluster name (more than 14 chars)
-	testConfig.ObjectMeta.Name = "0123456789abcde"
-	errs = ValidatePlatform(validPlatform(), validNetworking(), field.NewPath("test-path"), &testConfig)
-	assert.True(t, len(errs) == 1)
-	assert.Equal(t, "cluster name is too long, please restrict it to 14 characters", errs[0].Detail)
-
-	// . in the name
-	testConfig.ObjectMeta.Name = "test.cluster"
-	errs = ValidatePlatform(validPlatform(), validNetworking(), field.NewPath("test-path"), &testConfig)
-	assert.True(t, len(errs) == 1)
-	assert.Equal(t, "cluster name can't contain \".\" character", errs[0].Detail)
-}
-
 func TestValidatePlatform(t *testing.T) {
 	cases := []struct {
 		name                  string

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -92,7 +92,7 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 		// FIX-ME: As soon bz#1915122 get resolved remove the limitation of 14 chars for the clustername
 		nameErr = validate.ClusterNameMaxLength(c.ObjectMeta.Name, 14)
 	}
-	if c.Platform.VSphere != nil || c.Platform.BareMetal != nil || c.Platform.Nutanix != nil {
+	if c.Platform.VSphere != nil || c.Platform.BareMetal != nil || c.Platform.OpenStack != nil || c.Platform.Nutanix != nil {
 		nameErr = validate.OnPremClusterName(c.ObjectMeta.Name)
 	}
 	if nameErr != nil {


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/installer/pull/6309/.

The validation is no longer necessary now that we stopped using mDNS. Instead, rely on cluster name validation common to all platforms for length check and the on-prem cluster name validation for names containing dots.

This aligns with other on-prem platforms.