### PR TITLE
Disabled packet loss check

### DIFF
--- a/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
+++ b/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
@@ -19,3 +19,4 @@ OPENSHIFT_INSTALL_RELEASE_IMAGE_MIRROR={{.ReleaseImageMirror}}
 SERVICE_BASE_URL={{.ServiceBaseURL}}
 STORAGE=filesystem
 INFRA_ENV_ID={{.InfraEnvID}}
+DISABLED_HOST_VALIDATIONS=sufficient-packet-loss-requirement-for-role


### PR DESCRIPTION
    Due to the current behavior of using bond link interfaces for
    connectivity checks, the arp tables get screwed up for the bonds where
    the link interfaces are teamed up. The fix for that is comming on
    OCP 4.12 version of assisted installation. In the meantime, we'll
    disable the connectivity check so bonds continue working.