### PR TITLE
GCP: Add me-west1 region

### DIFF
--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -40,6 +40,7 @@ var (
 		"europe-west8":            "Milan, Italy",
 		"europe-west9":            "Paris, France",
 		"europe-southwest1":       "Madrid, Spain",
+		"me-west1":                "Tel Aviv, Israel",
 		"northamerica-northeast1": "Montréal, Québec, Canada",
 		"northamerica-northeast2": "Toronto, Ontario, Canada",
 		"southamerica-east1":      "São Paulo, Brazil",


### PR DESCRIPTION
Add me-west1 GCP region that was not previously listed as base regions for the installer to use.

The installer was able to create the cluster and tear it down when this region was selected and QE did the validation for the region

[https://issues.redhat.com/browse/CORS-2294](https://issues.redhat.com/browse/CORS-2294)