### PR TITLE
OCPBUGS-1376: aws: remove deprecated s3_bucket field

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -34,7 +34,6 @@ data "aws_ebs_default_kms_key" "current" {}
 
 resource "aws_s3_bucket" "ignition" {
   bucket = var.aws_ignition_bucket
-  acl    = "private"
 
   tags = merge(
     {
@@ -46,6 +45,11 @@ resource "aws_s3_bucket" "ignition" {
   lifecycle {
     ignore_changes = all
   }
+}
+
+resource "aws_s3_bucket_acl" ignition {
+  bucket = aws_s3_bucket.ignition.id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_object" "ignition" {


### PR DESCRIPTION
With v4 of the aws terraform provider, the aws_s3_bucket
resource type no longer has an "acl" field. Instead, the
acl for the s3 bucket is set via an aws_s3_bucket_acl
resource.