### PR TITLE
powervs-delete-named-dhcp

### DIFF
--- a/pkg/destroy/powervs/dhcp.go
+++ b/pkg/destroy/powervs/dhcp.go
@@ -3,6 +3,7 @@ package powervs
 import (
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/pkg/errors"
+	"strings"
 )
 
 const (
@@ -28,10 +29,6 @@ func (o *ClusterUninstaller) listDHCPNetworks() (cloudResources, error) {
 
 	result := []cloudResource{}
 	for _, dhcpServer = range dhcpServers {
-		// Not helpful yet
-		// 2022/03/24 15:30:51 Found: DHCPServer: 40687c22-782a-475c-af46-be765aecdf4a
-		// 2022/03/24 15:30:54 Network.Name: DHCPSERVER2dc32880758344f08c8ff6933e87d27a_Private
-
 		if dhcpServer.Network == nil {
 			o.Logger.Debugf("listDHCPNetworks: DHCP has empty Network: %s\n", *dhcpServer.ID)
 			continue
@@ -41,7 +38,7 @@ func (o *ClusterUninstaller) listDHCPNetworks() (cloudResources, error) {
 			continue
 		}
 
-		if _, ok := o.DHCPNetworks[*dhcpServer.Network.Name]; ok {
+		if strings.Contains(*dhcpServer.Network.Name, o.InfraID) {
 			o.Logger.Debugf("listDHCPNetworks: FOUND: %s (%s)\n", *dhcpServer.Network.Name, *dhcpServer.ID)
 			foundOne = true
 			result = append(result, cloudResource{
@@ -117,7 +114,7 @@ func (o *ClusterUninstaller) destroyDHCPNetworks() error {
 			if _, ok := found[item.key]; !ok {
 				// This item has finished deletion.
 				o.deletePendingItems(item.typeName, []cloudResource{item})
-				o.Logger.Infof("Deleted DHCPNetworks %q", item.name)
+				o.Logger.Infof("Deleted DHCP network %q", item.name)
 				continue
 			}
 			err := o.destroyDHCPNetwork(item)

--- a/pkg/destroy/powervs/power-instance.go
+++ b/pkg/destroy/powervs/power-instance.go
@@ -1,7 +1,6 @@
 package powervs
 
 import (
-	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/pkg/errors"
 	"strings"
 )
@@ -12,9 +11,6 @@ const (
 
 // listPowerInstances lists instances in the Power server.
 func (o *ClusterUninstaller) listPowerInstances() (cloudResources, error) {
-	// https://github.com/IBM-Cloud/power-go-client/blob/v1.0.88/power/models/p_vm_instance_network.go#L16-L44
-	var network *models.PVMInstanceNetwork
-
 	o.Logger.Debugf("Listing virtual Power service instances")
 
 	instances, err := o.instanceClient.GetAll()
@@ -38,12 +34,6 @@ func (o *ClusterUninstaller) listPowerInstances() (cloudResources, error) {
 				typeName: powerInstanceTypeName,
 				id:       *instance.PvmInstanceID,
 			})
-
-			for _, network = range instance.Networks {
-				if strings.HasPrefix(network.NetworkName, "DHCPSERVER") {
-					o.DHCPNetworks[network.NetworkName] = struct{}{}
-				}
-			}
 		}
 	}
 	if !foundOne {

--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -153,8 +153,6 @@ type ClusterUninstaller struct {
 
 	errorTracker
 	pendingItemTracker
-
-	DHCPNetworks map[string]struct{}
 }
 
 // New returns an IBMCloud destroyer from ClusterMetadata.
@@ -207,7 +205,6 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 		Zone:               metadata.ClusterPlatformMetadata.PowerVS.Zone,
 		pendingItemTracker: newPendingItemTracker(),
 		resourceGroupID:    metadata.ClusterPlatformMetadata.PowerVS.PowerVSResourceGroup,
-		DHCPNetworks:       make(map[string]struct{}),
 	}, nil
 }
 


### PR DESCRIPTION
Delete named DHCP service for PowerVS

The DHCP service went from:
DHCPSERVER2dc32880758344f08c8ff6933e87d27a_Private to:
DHCPSERVERrdr-maocp-lon06-hszgr_Private
in order to support multiple clusters in a zone.  Therefore, we need to delete only a specific DHCP service.