### PR TITLE
hack: Use golang-1.16 image of origin-release

### DIFF
--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -2,7 +2,8 @@
 # Example:  ./hack/go-lint.sh installer/... pkg/... tests/smoke
 
 if [ "$IS_CONTAINER" != "" ]; then
-  golint -set_exit_status "${@}"
+  go install golang.org/x/lint/golint@latest
+  ${GOPATH}/bin/golint -set_exit_status "${@}"
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -2,8 +2,8 @@
 # Example:  ./hack/go-lint.sh installer/... pkg/... tests/smoke
 
 if [ "$IS_CONTAINER" != "" ]; then
-  go install golang.org/x/lint/golint@latest
-  ${GOPATH}/bin/golint -set_exit_status "${@}"
+  GOFLAGS="" go install golang.org/x/lint/golint@latest
+  "${GOPATH}"/bin/golint -set_exit_status "${@}"
 else
   podman run --rm \
     --env IS_CONTAINER=TRUE \


### PR DESCRIPTION
go-lint.sh outputs the following errors:
```
$ hack/go-lint.sh $(go list -f '{{ .ImportPath }}' ./...)
./hack/go-lint.sh: 5: golint: not found
```

AFAIK, golint does not exist in docker.io/golang-1.15 or later. So, the script uses the image of origin-release before commit 2c09bc5.