### PR TITLE
aws user tags: set limit == openshift/api

### DIFF
--- a/pkg/types/aws/validation/platform_test.go
+++ b/pkg/types/aws/validation/platform_test.go
@@ -1,6 +1,8 @@
 package validation
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -165,6 +167,14 @@ func TestValidatePlatform(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "too many userTags",
+			platform: &aws.Platform{
+				Region:   "us-east-1",
+				UserTags: generateTooManyUserTags(),
+			},
+			expected: fmt.Sprintf(`^\Qtest-path.userTags: Too many: %d: must have at most %d items`, userTagLimit+1, userTagLimit),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -252,4 +262,12 @@ func TestValidateTag(t *testing.T) {
 			}
 		})
 	}
+}
+
+func generateTooManyUserTags() map[string]string {
+	tags := map[string]string{}
+	for i := 0; i <= userTagLimit; i++ {
+		tags[strconv.Itoa(i)] = strconv.Itoa(i)
+	}
+	return tags
 }


### PR DESCRIPTION
openshift/api defines a limit for user tags, and this sets our validation to be equal to that. It would be nice if we could vendor the limit, but the limit is set within kubebuilder markers, which are not easily digestable in the installer. Therefore, let's just set a constant value with a reference.

Also cleans up the validation code and adds a test.

/cc @rna-afk @TrilokGeer 