### PR TITLE
RFE-2782: Create edge compute pool to support AWS Local Zones

### DIFF
--- a/docs/user/aws/install_existing_vpc_local-zones.md
+++ b/docs/user/aws/install_existing_vpc_local-zones.md
@@ -1,0 +1,489 @@
+# Cluster Installation in existing VPC with Local Zones subnet
+
+The steps below describe how to install a cluster in existing VPC with AWS Local Zones subnets using Edge Machine Pool, introduced in 4.12.
+
+The Edge Machine Pool was created to create a pool of workers running in the AWS Local Zones locations. This pool differs from the default compute pool on these items - Edge workers was not designed to run regular cluster workloads:
+- The resources in AWS Local Zones are more expensive than the normal availability zones
+- The latency between the application and end-users is lower in Local Zones and may vary for each location. So it will impact if some workloads like routers are mixed in the normal availability zones due to the unbalanced latency
+- Network Load Balancers do not support subnets in the Local Zones
+- The total time to connect to the applications running in Local Zones from the end-users close to the metropolitan region running the workload, is almost 10x faster than the parent region.
+
+Table of Contents:
+
+- [Prerequisites](#prerequisites)
+    - [Additional IAM permissions](#prerequisites-iam)
+- [Create the Network stack](#create-network)
+    - [Create the VPC](#create-network-vpc)
+    - [Create the Local Zone subnet](#create-network-subnet)
+        - [Opt-in zone group](#create-network-subnet-optin)
+        - [Creating the Subnet using AWS CloudFormation](#create-network-subnet-cfn)
+- [Install](#install-cluster)
+    - [Create the install-config.yaml](#create-config)
+    - [Setting up the Edge Machine Pool](#create-config-edge-pool")
+        - [Example edge pool created without customization](#create-config-edge-pool)
+        - [Example edge pool with custom Instance type](#reate-config-edge-pool-example-ec2)
+        - [Example edge pool with custom EBS type](#create-config-edge-pool-example-ebs)
+    - [Create the cluster](#create-cluster-run)
+- [Uninstall](#uninstall)
+    - [Destroy the cluster](#uninstall-destroy-cluster)
+    - [Destroy the Local Zone subnet](#uninstall-destroy-subnet)
+    - [Destroy the VPC](#uninstall-destroy-vpc)
+- [Use Cases](#use-cases)
+    - [Example of a sample application deployment](#uc-deployment)
+    - [User-workload ingress traffic](#uc-exposing-ingress)
+___
+
+To install a cluster in an existing VPC with Local Zone subnets, you should provision the network resources and then add the subnet IDs to the `install-config.yaml`.
+
+## Prerequisites <a name="prerequisites"></a>
+
+- [AWS Command Line Interface](aws-cli)
+- [openshift-install >= 4.12](openshift-install)
+- environment variables exported:
+
+```bash
+export CLUSTER_NAME="ipi-localzones"
+
+# AWS Region and extra Local Zone group Information
+export AWS_REGION="us-west-2"
+export ZONE_GROUP_NAME="us-west-2-lax-1"
+export ZONE_NAME="us-west-2-lax-1a"
+
+# VPC Information
+export VPC_CIDR="10.0.0.0/16"
+export VPC_SUBNETS_BITS="10"
+export VPC_SUBNETS_COUNT="3"
+
+# Local Zone Subnet information
+export SUBNET_CIDR="10.0.192.0/22"
+export SUBNET_NAME="${CLUSTER_NAME}-public-usw2-lax-1a"
+```
+
+### Additional IAM permissions
+
+The AWS Local Zone deployment described in this document, requires the additional permission for the user creating the cluster to modify the Local Zone group: `ec2:ModifyAvailabilityZoneGroup`
+
+Example of the permissive IAM Policy that can be attached to the User or Role:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Stmt1677614927608",
+      "Action": [
+        "ec2:ModifyAvailabilityZoneGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## Create the Network Stack <a name="create-network"></a>
+
+### Create the VPC <a name="create-network-vpc"></a>
+
+The steps to install a cluster in an existing VPC are [detailed in the official documentation](aws-install-vpc). You can alternatively use [the CloudFormation templates to create the Network resources](aws-install-cloudformation), which will be used in this document.
+
+- Create the Stack
+
+```bash
+INSTALLER_URL="https://raw.githubusercontent.com/openshift/installer/master"
+TPL_URL="${INSTALLER_URL}/upi/aws/cloudformation/01_vpc.yaml"
+
+aws cloudformation create-stack \
+    --region ${AWS_REGION} \
+    --stack-name ${CLUSTER_NAME}-vpc \
+    --template-body ${TPL_URL} \
+    --parameters \
+        ParameterKey=VpcCidr,ParameterValue=${VPC_CIDR} \
+        ParameterKey=SubnetBits,ParameterValue=${VPC_SUBNETS_BITS} \
+        ParameterKey=AvailabilityZoneCount,ParameterValue=${VPC_SUBNETS_COUNT}
+```
+
+- Wait for the stack to be created: `StackStatus=CREATE_COMPLETE`
+
+```bash
+aws cloudformation wait stack-create-complete \
+    --region ${AWS_REGION} \
+    --stack-name ${CLUSTER_NAME}-vpc 
+```
+
+- Export the VPC ID:
+
+```bash
+export VPC_ID=$(aws cloudformation describe-stacks \
+  --region us-west-2 \
+  --stack-name ${CLUSTER_NAME}-vpc \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="VpcId").OutputValue' )
+```
+
+- Extract the subnets IDs to the environment variable list `SUBNETS`:
+
+```bash
+mapfile -t SUBNETS < <(aws cloudformation describe-stacks \
+  --region us-west-2 \
+  --stack-name ${CLUSTER_NAME}-vpc \
+  | jq -r '.Stacks[0].Outputs[0].OutputValue' | tr ',' '\n')
+mapfile -t -O "${#SUBNETS[@]}" SUBNETS < <(aws cloudformation describe-stacks \
+  --region us-west-2 \
+  --stack-name ${CLUSTER_NAME}-vpc  \
+  | jq -r '.Stacks[0].Outputs[1].OutputValue' | tr ',' '\n')
+```
+
+- Export the Public Route Table ID:
+
+```bash
+export PUBLIC_RTB_ID=$(aws cloudformation describe-stacks \
+  --region us-west-2 \
+  --stack-name ${CLUSTER_NAME}-vpc \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="PublicRouteTableId").OutputValue' )
+```
+
+- Make sure all variables have been correctly set:
+
+```bash
+echo "SUBNETS=${SUBNETS[*]}
+VPC_ID=${VPC_ID}
+PUBLIC_RTB_ID=${PUBLIC_RTB_ID}"
+```
+
+### Create the Local Zone subnet <a name="create-network-subnet"></a>
+
+The following actions are required to create subnets in Local Zones:
+- choose the zone group to be enabled
+- opt-in the zone group
+
+#### Opt-in Zone groups <a name="create-network-subnet-optin"></a>
+
+Opt-in the zone group:
+
+```bash
+aws ec2 modify-availability-zone-group \
+    --region ${AWS_REGION} \
+    --group-name ${ZONE_GROUP_NAME} \
+    --opt-in-status opted-in
+```
+
+#### Creating the Subnet using AWS CloudFormation <a name="create-network-subnet-cfn"></a>
+
+- Create the Stack for Local Zone subnet `us-west-2-lax-1a`
+
+```bash
+INSTALLER_URL="https://raw.githubusercontent.com/openshift/installer/master"
+TPL_URL="${INSTALLER_URL}/upi/aws/cloudformation/01.99_net_local-zone.yaml"
+
+aws cloudformation create-stack \
+    --region ${AWS_REGION} \
+    --stack-name ${SUBNET_NAME} \
+    --template-body ${TPL_URL} \
+    --parameters \
+        ParameterKey=VpcId,ParameterValue=${VPC_ID} \
+        ParameterKey=ZoneName,ParameterValue=${ZONE_NAME} \
+        ParameterKey=SubnetName,ParameterValue=${SUBNET_NAME} \
+        ParameterKey=PublicSubnetCidr,ParameterValue=${SUBNET_CIDR} \
+        ParameterKey=PublicRouteTableId,ParameterValue=${PUBLIC_RTB_ID}
+```
+
+- Wait for the stack to be created `StackStatus=CREATE_COMPLETE`
+
+```bash
+aws cloudformation wait stack-create-complete \
+  --region ${AWS_REGION} \
+  --stack-name ${SUBNET_NAME}
+```
+
+- Export the Local Zone subnet ID
+
+```bash
+export SUBNET_ID=$(aws cloudformation describe-stacks \
+  --region ${AWS_REGION} \
+  --stack-name ${SUBNET_NAME} \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="PublicSubnetIds").OutputValue' )
+
+# Append the Local Zone Subnet ID to the Subnet List
+SUBNETS+=(${SUBNET_ID})
+```
+
+- Check the total of subnets. If you choose 3 AZs to be created on the VPC stack, you should have 7 subnets on this list:
+
+```bash
+$ echo ${#SUBNETS[*]}
+7
+```
+
+## Install the cluster <a name="install-cluster"></a>
+
+To install the cluster in existing VPC with subnets in Local Zones, you should:
+- generate the `install-config.yaml`, or provide yours
+- add the subnet IDs by setting the option `platform.aws.subnets`
+- (optional) customize the `edge` compute pool
+
+### Create the install-config.yaml <a name="create-config"></a>
+
+Create the `install-config.yaml` providing the subnet IDs recently created:
+
+- create the `install-config`
+
+```bash
+$ ./openshift-install create install-config --dir ${CLUSTER_NAME}
+? SSH Public Key /home/user/.ssh/id_rsa.pub
+? Platform aws
+? Region us-west-2
+? Base Domain devcluster.openshift.com
+? Cluster Name ipi-localzone
+? Pull Secret [? for help] **
+INFO Install-Config created in: ipi-localzone     
+```
+
+- Append the subnets to the `platform.aws.subnets`:
+
+```bash
+$ echo "    subnets:"; for SB in ${SUBNETS[*]}; do echo "    - $SB"; done
+    subnets:
+    - subnet-0fc845d8e30fdb431
+    - subnet-0a2675b7cbac2e537
+    - subnet-01c0ac400e1920b47
+    - subnet-0fee60966b7a93da6
+    - subnet-002b48c0a91c8c641
+    - subnet-093f00deb44ce81f4
+    - subnet-0f85ae65796e8d107
+```
+
+### Setting up the Edge Machine Pool <a name="create-config-edge-pool"></a>
+
+Version 4.12 or later introduces a new compute pool named `edge` designed for
+the remote zones. The `edge` compute pool configuration is common between
+AWS Local Zone locations, but due to the limitation of resources (Instance Types
+and Sizes) of the Local Zone, the default instance type created may vary
+from the traditional worker pool.
+
+The default EBS for Local Zone locations is `gp2`, different than the default worker pool.
+
+The preferred list of instance types follows the same order of worker pools, depending
+on the availability of the location, one of those instances will be chosen*:
+> Note: This list can be updated over the time
+- `m6i.xlarge`
+- `m5.xlarge`
+- `c5d.2xlarge`
+
+The `edge` compute pool will also create new labels to help developers to
+deploy their applications onto those locations. The new labels introduced are:
+    - `node-role.kubernetes.io/edge=''`
+    - `zone_type=local-zone`
+    - `zone_group=<Local Zone Group>`
+
+Finally, the Machine Sets created by the `edge` compute pool have `NoSchedule` taint to avoid the
+regular workloads spread out on those machines, and only user workloads will be allowed to run
+when the tolerations are defined on the pod spec (you can see the example in the following sections).
+
+By default, the `edge` compute pool will be created only when AWS Local Zone subnet IDs are added
+to the list of `platform.aws.subnets`.
+
+See below some examples of `install-config.yaml` with `edge` compute pool.
+
+#### Example edge pool created without customization <a name="create-config-edge-pool-example-def"></a>
+
+```yaml
+apiVersion: v1
+baseDomain: devcluster.openshift.com
+metadata:
+  name: ipi-localzone
+platform:
+  aws:
+    region: us-west-2
+    subnets:
+    - subnet-0fc845d8e30fdb431
+    - subnet-0a2675b7cbac2e537
+    - subnet-01c0ac400e1920b47
+    - subnet-0fee60966b7a93da6
+    - subnet-002b48c0a91c8c641
+    - subnet-093f00deb44ce81f4
+    - subnet-0f85ae65796e8d107
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+#### Example edge pool with custom Instance type <a name="create-config-edge-pool-example-ec2"></a>
+
+The Instance Type may differ between locations. You should check the AWS Documentation to check availability in the Local Zone that the cluster will run.
+
+`install-config.yaml` example customizing the Instance Type for the Edge Machine Pool:
+
+```yaml
+apiVersion: v1
+baseDomain: devcluster.openshift.com
+metadata:
+  name: ipi-localzone
+compute:
+- name: edge
+  platform:
+    aws:
+      type: m5.4xlarge
+platform:
+  aws:
+    region: us-west-2
+    subnets:
+    - subnet-0fc845d8e30fdb431
+    - subnet-0a2675b7cbac2e537
+    - subnet-01c0ac400e1920b47
+    - subnet-0fee60966b7a93da6
+    - subnet-002b48c0a91c8c641
+    - subnet-093f00deb44ce81f4
+    - subnet-0f85ae65796e8d107
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+#### Example edge pool with custom EBS type <a name="create-config-edge-pool-example-ebs"></a>
+
+The EBS Type may differ between locations. You should check the AWS Documentation to check availability in the Local Zone that the cluster will run.
+
+`install-config.yaml` example customizing the EBS Type for the Edge Machine Pool:
+
+```yaml
+apiVersion: v1
+baseDomain: devcluster.openshift.com
+metadata:
+  name: ipi-localzone
+compute:
+- name: edge
+  platform:
+    aws:
+      rootVolume:
+        type: gp3
+        size: 120
+platform:
+  aws:
+    region: us-west-2
+    subnets:
+    - subnet-0fc845d8e30fdb431
+    - subnet-0a2675b7cbac2e537
+    - subnet-01c0ac400e1920b47
+    - subnet-0fee60966b7a93da6
+    - subnet-002b48c0a91c8c641
+    - subnet-093f00deb44ce81f4
+    - subnet-0f85ae65796e8d107
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+```
+
+### Create the cluster <a name="create-cluster-run"></a>
+
+```bash
+./openshift-install create cluster --dir ${CLUSTER_NAME}
+```
+
+### Uninstall the cluster <a name="uninstall"></a>
+
+#### Destroy the cluster <a name="uninstall-destroy-cluster"></a>
+
+```bash
+./openshift-install destroy cluster --dir ${CLUSTER_NAME}
+```
+
+#### Destroy the Local Zone subnets <a name="uninstall-destroy-subnet"></a>
+
+```bash
+aws cloudformation delete-stack \
+    --region ${AWS_REGION} \
+    --stack-name ${SUBNET_NAME}
+```
+
+#### Destroy the VPC <a name="uninstall-destroy-vpc"></a>
+
+```bash
+aws cloudformation delete-stack \
+    --region ${AWS_REGION} \
+    --stack-name ${CLUSTER_NAME}-vpc
+```
+
+## Use Cases <a name="use-cases"></a>
+
+### Example of a sample application deployment <a name="uc-deployment"></a>
+
+The example below creates one sample application on the node running in the Local zone, setting the tolerations needed to pin the pod on the correct node:
+
+```bash
+cat << EOF | oc create -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-zone-demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-zone-demo-app-nyc-1
+  namespace: local-zone-demo
+spec:
+  selector:
+    matchLabels:
+      app: local-zone-demo-app-nyc-1
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: local-zone-demo-app-nyc-1
+        machine.openshift.io/zone-group: ${ZONE_GROUP_NAME}
+    spec:
+      nodeSelector:
+        machine.openshift.io/zone-group: ${ZONE_GROUP_NAME}
+      tolerations:
+      - key: "node-role.kubernetes.io/edge"
+        operator: "Equal"
+        value: ""
+        effect: "NoSchedule"
+      containers:
+        - image: openshift/origin-node
+          command:
+           - "/bin/socat"
+          args:
+            - TCP4-LISTEN:8080,reuseaddr,fork
+            - EXEC:'/bin/bash -c \"printf \\\"HTTP/1.0 200 OK\r\n\r\n\\\"; sed -e \\\"/^\r/q\\\"\"'
+          imagePullPolicy: Always
+          name: echoserver
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service 
+metadata:
+  name:  local-zone-demo-app-nyc-1 
+  namespace: local-zone-demo
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: local-zone-demo-app-nyc-1
+EOF
+```
+
+### User-workload ingress traffic <a name="uc-exposing-ingress"></a>
+
+To expose the applications to the internet on AWS Local Zones, application developers
+must expose the applications using an external Load Balancer, for example, AWS Application Load Balancers (ALB). The
+[ALB Operator](https://docs.openshift.com/container-platform/4.11/networking/aws_load_balancer_operator/install-aws-load-balancer-operator.html) is available through OLM on 4.11+.
+
+To explore the best of deploying applications on the AWS Local Zone locations, at least one new
+ALB `Ingress` must be provisioned by location to expose the services deployed on the
+zones.
+
+If the cluster-admin decides to share the ALB `Ingress` subnets between different locations,
+it will impact drastically the latency for the end-users when the traffic is routed to
+backends (compute nodes) placed in different zones that the traffic entered by the Ingress/Load Balancer.
+
+The ALB deployment is not covered by this documentation.
+
+
+[openshift-install]: https://docs.openshift.com/container-platform/4.11/installing/index.html
+[aws-cli]: https://aws.amazon.com/cli/
+[aws-install-vpc]: https://docs.openshift.com/container-platform/4.11/installing/installing_aws/installing-aws-vpc.html
+[aws-install-cloudformation]: https://docs.openshift.com/container-platform/4.11/installing/installing_aws/installing-aws-user-infra.html
+[aws-local-zones]: https://aws.amazon.com/about-aws/global-infrastructure/localzones
+[aws-local-zones-features]: https://aws.amazon.com/about-aws/global-infrastructure/localzones/features

--- a/pkg/asset/machines/aws/machines.go
+++ b/pkg/asset/machines/aws/machines.go
@@ -18,6 +18,21 @@ import (
 	"github.com/openshift/installer/pkg/types/aws"
 )
 
+type machineProviderInput struct {
+	clusterID      string
+	region         string
+	subnet         string
+	instanceType   string
+	osImage        string
+	zone           string
+	role           string
+	userDataSecret string
+	root           *aws.EC2RootVolume
+	imds           aws.EC2Metadata
+	userTags       map[string]string
+	publicSubnet   bool
+}
+
 // Machines returns a list of machines for a machinepool.
 func Machines(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, role, userDataSecret string, userTags map[string]string) ([]machineapi.Machine, *machinev1.ControlPlaneMachineSet, error) {
 	if poolPlatform := pool.Platform.Name(); poolPlatform != aws.Name {
@@ -37,19 +52,20 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 		if len(subnets) > 0 && !ok {
 			return nil, nil, errors.Errorf("no subnet for zone %s", zone)
 		}
-		provider, err := provider(
-			clusterID,
-			region,
-			subnet,
-			mpool.InstanceType,
-			&mpool.EC2RootVolume,
-			mpool.EC2Metadata,
-			mpool.AMIID,
-			zone,
-			role,
-			userDataSecret,
-			userTags,
-		)
+		provider, err := provider(&machineProviderInput{
+			clusterID:      clusterID,
+			region:         region,
+			subnet:         subnet,
+			instanceType:   mpool.InstanceType,
+			osImage:        mpool.AMIID,
+			zone:           zone,
+			role:           role,
+			userDataSecret: userDataSecret,
+			root:           &mpool.EC2RootVolume,
+			imds:           mpool.EC2Metadata,
+			userTags:       userTags,
+			publicSubnet:   false,
+		})
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "failed to create provider")
 		}
@@ -98,7 +114,7 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 			}}
 		} else {
 			domain.Subnet.Type = machinev1.AWSIDReferenceType
-			domain.Subnet.ID = pointer.StringPtr(subnet)
+			domain.Subnet.ID = pointer.String(subnet)
 		}
 		failureDomains = append(failureDomains, domain)
 	}
@@ -153,8 +169,8 @@ func Machines(clusterID string, region string, subnets map[string]string, pool *
 	return machines, controlPlaneMachineSet, nil
 }
 
-func provider(clusterID string, region string, subnet string, instanceType string, root *aws.EC2RootVolume, imds aws.EC2Metadata, osImage string, zone, role, userDataSecret string, userTags map[string]string) (*machineapi.AWSMachineProviderConfig, error) {
-	tags, err := tagsFromUserTags(clusterID, userTags)
+func provider(in *machineProviderInput) (*machineapi.AWSMachineProviderConfig, error) {
+	tags, err := tagsFromUserTags(in.clusterID, in.userTags)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create machineapi.TagSpecifications from UserTags")
 	}
@@ -163,51 +179,59 @@ func provider(clusterID string, region string, subnet string, instanceType strin
 			APIVersion: "machine.openshift.io/v1beta1",
 			Kind:       "AWSMachineProviderConfig",
 		},
-		InstanceType: instanceType,
+		InstanceType: in.instanceType,
 		BlockDevices: []machineapi.BlockDeviceMappingSpec{
 			{
 				EBS: &machineapi.EBSBlockDeviceSpec{
-					VolumeType: pointer.StringPtr(root.Type),
-					VolumeSize: pointer.Int64Ptr(int64(root.Size)),
-					Iops:       pointer.Int64Ptr(int64(root.IOPS)),
-					Encrypted:  pointer.BoolPtr(true),
-					KMSKey:     machineapi.AWSResourceReference{ARN: pointer.StringPtr(root.KMSKeyARN)},
+					VolumeType: pointer.String(in.root.Type),
+					VolumeSize: pointer.Int64(int64(in.root.Size)),
+					Iops:       pointer.Int64(int64(in.root.IOPS)),
+					Encrypted:  pointer.Bool(true),
+					KMSKey:     machineapi.AWSResourceReference{ARN: pointer.String(in.root.KMSKeyARN)},
 				},
 			},
 		},
-		Tags:               tags,
-		IAMInstanceProfile: &machineapi.AWSResourceReference{ID: pointer.StringPtr(fmt.Sprintf("%s-%s-profile", clusterID, role))},
-		UserDataSecret:     &corev1.LocalObjectReference{Name: userDataSecret},
-		CredentialsSecret:  &corev1.LocalObjectReference{Name: "aws-cloud-credentials"},
-		Placement:          machineapi.Placement{Region: region, AvailabilityZone: zone},
+		Tags: tags,
+		IAMInstanceProfile: &machineapi.AWSResourceReference{
+			ID: pointer.String(fmt.Sprintf("%s-%s-profile", in.clusterID, in.role)),
+		},
+		UserDataSecret:    &corev1.LocalObjectReference{Name: in.userDataSecret},
+		CredentialsSecret: &corev1.LocalObjectReference{Name: "aws-cloud-credentials"},
+		Placement:         machineapi.Placement{Region: in.region, AvailabilityZone: in.zone},
 		SecurityGroups: []machineapi.AWSResourceReference{{
 			Filters: []machineapi.Filter{{
 				Name:   "tag:Name",
-				Values: []string{fmt.Sprintf("%s-%s-sg", clusterID, role)},
+				Values: []string{fmt.Sprintf("%s-%s-sg", in.clusterID, in.role)},
 			}},
 		}},
 	}
 
-	if subnet == "" {
+	subnetName := fmt.Sprintf("%s-private-%s", in.clusterID, in.zone)
+	if in.publicSubnet {
+		config.PublicIP = pointer.Bool(in.publicSubnet)
+		subnetName = fmt.Sprintf("%s-public-%s", in.clusterID, in.zone)
+	}
+
+	if in.subnet == "" {
 		config.Subnet.Filters = []machineapi.Filter{{
 			Name:   "tag:Name",
-			Values: []string{fmt.Sprintf("%s-private-%s", clusterID, zone)},
+			Values: []string{subnetName},
 		}}
 	} else {
-		config.Subnet.ID = pointer.StringPtr(subnet)
+		config.Subnet.ID = pointer.String(in.subnet)
 	}
 
-	if osImage == "" {
+	if in.osImage == "" {
 		config.AMI.Filters = []machineapi.Filter{{
 			Name:   "tag:Name",
-			Values: []string{fmt.Sprintf("%s-ami-%s", clusterID, region)},
+			Values: []string{fmt.Sprintf("%s-ami-%s", in.clusterID, in.region)},
 		}}
 	} else {
-		config.AMI.ID = pointer.StringPtr(osImage)
+		config.AMI.ID = pointer.String(in.osImage)
 	}
 
-	if imds.Authentication != "" {
-		config.MetadataServiceOptions.Authentication = machineapi.MetadataServiceAuthentication(imds.Authentication)
+	if in.imds.Authentication != "" {
+		config.MetadataServiceOptions.Authentication = machineapi.MetadataServiceAuthentication(in.imds.Authentication)
 	}
 
 	return config, nil

--- a/pkg/asset/machines/aws/machinesets.go
+++ b/pkg/asset/machines/aws/machinesets.go
@@ -5,16 +5,18 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
+	icaws "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 )
 
 // MachineSets returns a list of machinesets for a machinepool.
-func MachineSets(clusterID string, region string, subnets map[string]string, pool *types.MachinePool, role, userDataSecret string, userTags map[string]string) ([]*machineapi.MachineSet, error) {
+func MachineSets(clusterID string, region string, subnets icaws.Subnets, pool *types.MachinePool, role, userDataSecret string, userTags map[string]string) ([]*machineapi.MachineSet, error) {
 	if poolPlatform := pool.Platform.Name(); poolPlatform != aws.Name {
 		return nil, fmt.Errorf("non-AWS machine-pool: %q", poolPlatform)
 	}
@@ -32,28 +34,62 @@ func MachineSets(clusterID string, region string, subnets map[string]string, poo
 		if int64(idx) < total%numOfAZs {
 			replicas++
 		}
-
 		subnet, ok := subnets[az]
 		if len(subnets) > 0 && !ok {
 			return nil, errors.Errorf("no subnet for zone %s", az)
 		}
-		provider, err := provider(
-			clusterID,
-			region,
-			subnet,
-			mpool.InstanceType,
-			&mpool.EC2RootVolume,
-			mpool.EC2Metadata,
-			mpool.AMIID,
-			az,
-			role,
-			userDataSecret,
-			userTags,
-		)
+
+		publicSubnet := subnet.Public
+		instanceType := mpool.InstanceType
+		nodeLabels := make(map[string]string, 3)
+		nodeTaints := []corev1.Taint{}
+
+		if pool.Name == types.MachinePoolEdgeRoleName {
+			// edge pools typically do not receive the same workloads between
+			// different zoneGroups, thus the installer will discover preferred
+			// instance based on the installer's preferred instance lookup.
+			if subnet.PreferredEdgeInstanceType != "" {
+				instanceType = subnet.PreferredEdgeInstanceType
+			}
+			nodeLabels = map[string]string{
+				"node-role.kubernetes.io/edge":    "",
+				"machine.openshift.io/zone-type":  subnet.ZoneType,
+				"machine.openshift.io/zone-group": subnet.ZoneGroupName,
+			}
+			nodeTaints = append(nodeTaints, corev1.Taint{
+				Key:    "node-role.kubernetes.io/edge",
+				Effect: "NoSchedule",
+			})
+		}
+
+		provider, err := provider(&machineProviderInput{
+			clusterID:      clusterID,
+			region:         region,
+			subnet:         subnet.ID,
+			instanceType:   instanceType,
+			osImage:        mpool.AMIID,
+			zone:           az,
+			role:           "worker",
+			userDataSecret: userDataSecret,
+			root:           &mpool.EC2RootVolume,
+			imds:           mpool.EC2Metadata,
+			userTags:       userTags,
+			publicSubnet:   publicSubnet,
+		})
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}
 		name := fmt.Sprintf("%s-%s-%s", clusterID, pool.Name, az)
+		spec := machineapi.MachineSpec{
+			ProviderSpec: machineapi.ProviderSpec{
+				Value: &runtime.RawExtension{Object: provider},
+			},
+			ObjectMeta: machineapi.ObjectMeta{
+				Labels: nodeLabels,
+			},
+			Taints: nodeTaints,
+		}
+
 		mset := &machineapi.MachineSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.openshift.io/v1beta1",
@@ -83,12 +119,8 @@ func MachineSets(clusterID string, region string, subnets map[string]string, poo
 							"machine.openshift.io/cluster-api-machine-type": role,
 						},
 					},
-					Spec: machineapi.MachineSpec{
-						ProviderSpec: machineapi.ProviderSpec{
-							Value: &runtime.RawExtension{Object: provider},
-						},
-						// we don't need to set Versions, because we control those via cluster operators.
-					},
+					Spec: spec,
+					// we don't need to set Versions, because we control those via cluster operators.
 				},
 			},
 		}

--- a/pkg/asset/machines/worker_test.go
+++ b/pkg/asset/machines/worker_test.go
@@ -233,3 +233,52 @@ func TestComputeIsNotModified(t *testing.T) {
 		t.Fatalf("compute in the install config has been modified")
 	}
 }
+
+func TestDefaultAWSMachinePoolPlatform(t *testing.T) {
+	type testCase struct {
+		name                string
+		poolName            string
+		expectedMachinePool awstypes.MachinePool
+		assert              func(tc *testCase)
+	}
+	cases := []testCase{
+		{
+			name:     "default EBS type for compute pool",
+			poolName: types.MachinePoolComputeRoleName,
+			expectedMachinePool: awstypes.MachinePool{
+				EC2RootVolume: awstypes.EC2RootVolume{
+					Type: awstypes.VolumeTypeGp3,
+					Size: decimalRootVolumeSize,
+				},
+			},
+			assert: func(tc *testCase) {
+				mp := defaultAWSMachinePoolPlatform(tc.poolName)
+				want := tc.expectedMachinePool.EC2RootVolume.Type
+				got := mp.EC2RootVolume.Type
+				assert.Equal(t, want, got, "unexepcted EBS type")
+			},
+		},
+		{
+			name:     "default EBS type for edge pool",
+			poolName: types.MachinePoolEdgeRoleName,
+			expectedMachinePool: awstypes.MachinePool{
+				EC2RootVolume: awstypes.EC2RootVolume{
+					Type: awstypes.VolumeTypeGp2,
+					Size: decimalRootVolumeSize,
+				},
+			},
+			assert: func(tc *testCase) {
+				mp := defaultAWSMachinePoolPlatform(tc.poolName)
+				want := tc.expectedMachinePool.EC2RootVolume.Type
+				got := mp.EC2RootVolume.Type
+				assert.Equal(t, want, got, "unexepcted EBS type")
+			},
+		},
+	}
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			tc.assert(&tc)
+		})
+	}
+}

--- a/pkg/types/aws/availabilityzones.go
+++ b/pkg/types/aws/availabilityzones.go
@@ -1,0 +1,8 @@
+package aws
+
+const (
+	// AvailabilityZoneType is the type of regular zone placed on the region.
+	AvailabilityZoneType = "availability-zone"
+	// LocalZoneType is the type of Local zone placed on the metropolitan areas.
+	LocalZoneType = "local-zone"
+)

--- a/pkg/types/aws/defaults/platform.go
+++ b/pkg/types/aws/defaults/platform.go
@@ -1,19 +1,27 @@
 package defaults
 
 import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 )
 
+const (
+	defaultInstanceSizeHighAvailabilityTopology = "xlarge"
+	defaultInstanceSizeSingleReplicaTopology    = "2xlarge"
+)
+
 var (
-	defaultMachineClass = map[types.Architecture]map[string][]string{
+	defaultMachineTypes = map[types.Architecture]map[string][]string{
 		types.ArchitectureAMD64: {
 			// Example region default machine class override for AMD64:
-			// "ap-east-1":      {"m5", "m4"},
+			// "ap-east-1":      {"m6i.xlarge", "m5.xlarge"},
 		},
 		types.ArchitectureARM64: {
 			// Example region default machine class override for ARM64:
-			// "us-east-1":      {"m6g", "m6gd"},
+			// "us-east-1":      {"m6g.xlarge", "m6gd.xlarge"},
 		},
 	}
 )
@@ -22,19 +30,44 @@ var (
 func SetPlatformDefaults(p *aws.Platform) {
 }
 
-// InstanceClasses returns a list of instance "class", in decreasing priority order, which we should use for a given
-// region. Default is m6i then m5 unless a region override is defined in defaultMachineClass.
-func InstanceClasses(region string, arch types.Architecture) []string {
-	if classesForArch, ok := defaultMachineClass[arch]; ok {
+// InstanceTypes returns a list of instance types, in decreasing priority order, which we should use for a given
+// region. Default is m6i.xlarge, m5.xlarge, lastly c5d.2xlarge unless a region override
+// is defined in defaultMachineTypes.
+// c5d.2xlarge is in the most locations of availability for Local Zone offerings.
+// https://aws.amazon.com/about-aws/global-infrastructure/localzones/features
+// https://aws.amazon.com/ec2/pricing/on-demand/
+func InstanceTypes(region string, arch types.Architecture, topology configv1.TopologyMode) []string {
+	if classesForArch, ok := defaultMachineTypes[arch]; ok {
 		if classes, ok := classesForArch[region]; ok {
 			return classes
 		}
 	}
 
+	instanceSize := defaultInstanceSizeHighAvailabilityTopology
+	// If the control plane is single node, we need to use a larger
+	// instance type for that node, as the minimum requirement for
+	// single-node control-plane nodes is 8 cores, and xlarge only has
+	// 4. Unfortunately 2xlarge has twice as much RAM as we need, but
+	// we default to it because AWS doesn't offer an 8-core 16GiB
+	// instance type
+	if topology == configv1.SingleReplicaTopologyMode {
+		instanceSize = defaultInstanceSizeSingleReplicaTopology
+	}
+
 	switch arch {
 	case types.ArchitectureARM64:
-		return []string{"m6g"}
+		return []string{
+			fmt.Sprintf("m6g.%s", instanceSize),
+		}
 	default:
-		return []string{"m6i", "m5"}
+		return []string{
+			fmt.Sprintf("m6i.%s", instanceSize),
+			fmt.Sprintf("m5.%s", instanceSize),
+			// For Local Zone compatibility
+			fmt.Sprintf("r5.%s", instanceSize),
+			"c5.2xlarge",
+			"m5.2xlarge",
+			"c5d.2xlarge",
+		}
 	}
 }

--- a/pkg/types/aws/defaults/platform_test.go
+++ b/pkg/types/aws/defaults/platform_test.go
@@ -1,0 +1,67 @@
+package defaults
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/installer/pkg/types"
+)
+
+func TestInstanceTypes(t *testing.T) {
+	type testCase struct {
+		name         string
+		region       string
+		architecture types.Architecture
+		topology     configv1.TopologyMode
+		expected     []string
+		assert       func(*testCase)
+	}
+	cases := []testCase{
+		{
+			name:     "default instance types for AMD64",
+			topology: configv1.HighlyAvailableTopologyMode,
+			expected: []string{"m6i.xlarge", "m5.xlarge", "r5.xlarge", "c5.2xlarge", "m5.2xlarge", "c5d.2xlarge"},
+			assert: func(tc *testCase) {
+				instances := InstanceTypes(tc.region, tc.architecture, tc.topology)
+				assert.Equal(t, tc.expected, instances, "unexepcted instance type for AMD64")
+			},
+		},
+		{
+			name:     "default instance types for AMD64",
+			topology: configv1.SingleReplicaTopologyMode,
+			expected: []string{"m6i.2xlarge", "m5.2xlarge", "r5.2xlarge", "c5.2xlarge", "m5.2xlarge", "c5d.2xlarge"},
+			assert: func(tc *testCase) {
+				instances := InstanceTypes(tc.region, tc.architecture, tc.topology)
+				assert.Equal(t, tc.expected, instances, "unexepcted instance type for AMD64")
+			},
+		},
+		{
+			name:         "default instance types for ARM64",
+			architecture: types.ArchitectureARM64,
+			topology:     configv1.HighlyAvailableTopologyMode,
+			expected:     []string{"m6g.xlarge"},
+			assert: func(tc *testCase) {
+				instances := InstanceTypes(tc.region, tc.architecture, tc.topology)
+				assert.Equal(t, tc.expected, instances, "unexepcted instance type for ARM64")
+			},
+		},
+		{
+			name:         "default instance types for ARM64",
+			architecture: types.ArchitectureARM64,
+			topology:     configv1.SingleReplicaTopologyMode,
+			expected:     []string{"m6g.2xlarge"},
+			assert: func(tc *testCase) {
+				instances := InstanceTypes(tc.region, tc.architecture, tc.topology)
+				assert.Equal(t, tc.expected, instances, "unexepcted instance type for ARM64")
+			},
+		},
+	}
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			tc.assert(&tc)
+		})
+	}
+}

--- a/pkg/types/aws/platform.go
+++ b/pkg/types/aws/platform.go
@@ -6,6 +6,13 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 )
 
+const (
+	// VolumeTypeGp2 is the type of EBS volume for General Purpose SSD gp2.
+	VolumeTypeGp2 = "gp2"
+	// VolumeTypeGp3 is the type of EBS volume for General Purpose SSD gp3.
+	VolumeTypeGp3 = "gp3"
+)
+
 // Platform stores all the global configuration that all machinesets
 // use.
 type Platform struct {

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -72,8 +72,16 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 	}
 	c.ControlPlane.Name = "master"
 	SetMachinePoolDefaults(c.ControlPlane, c.Platform.Name())
-	if len(c.Compute) == 0 {
-		c.Compute = []types.MachinePool{{Name: "worker"}}
+
+	defaultComputePoolUndefined := true
+	for _, compute := range c.Compute {
+		if compute.Name == types.MachinePoolComputeRoleName {
+			defaultComputePoolUndefined = false
+			break
+		}
+	}
+	if defaultComputePoolUndefined {
+		c.Compute = append(c.Compute, types.MachinePool{Name: types.MachinePoolComputeRoleName})
 	}
 	for i := range c.Compute {
 		SetMachinePoolDefaults(&c.Compute[i], c.Platform.Name())

--- a/pkg/types/defaults/installconfig_test.go
+++ b/pkg/types/defaults/installconfig_test.go
@@ -44,6 +44,12 @@ func defaultInstallConfig() *types.InstallConfig {
 	}
 }
 
+func defaultInstallConfigWithEdge() *types.InstallConfig {
+	c := defaultInstallConfig()
+	c.Compute = append(c.Compute, *defaultMachinePool("edge"))
+	return c
+}
+
 func defaultAWSInstallConfig() *types.InstallConfig {
 	c := defaultInstallConfig()
 	c.Platform.AWS = &aws.Platform{}
@@ -219,11 +225,25 @@ func TestSetInstallConfigDefaults(t *testing.T) {
 		{
 			name: "Compute present",
 			config: &types.InstallConfig{
-				Compute: []types.MachinePool{{Name: "test-compute"}},
+				Compute: []types.MachinePool{{Name: "worker"}},
 			},
 			expected: func() *types.InstallConfig {
 				c := defaultInstallConfig()
-				c.Compute = []types.MachinePool{*defaultMachinePool("test-compute")}
+				c.Compute = []types.MachinePool{*defaultMachinePool("worker")}
+				return c
+			}(),
+		},
+		{
+			name: "Edge Compute present",
+			config: &types.InstallConfig{
+				Compute: []types.MachinePool{{Name: "worker"}, {Name: "edge"}},
+			},
+			expected: func() *types.InstallConfig {
+				c := defaultInstallConfigWithEdge()
+				c.Compute = []types.MachinePool{
+					*defaultMachinePool("worker"),
+					*defaultEdgeMachinePool("edge"),
+				}
 				return c
 			}(),
 		},

--- a/pkg/types/defaults/machinepools.go
+++ b/pkg/types/defaults/machinepools.go
@@ -12,6 +12,9 @@ func SetMachinePoolDefaults(p *types.MachinePool, platform string) {
 	if platform == libvirt.Name {
 		defaultReplicaCount = 1
 	}
+	if p.Name == types.MachinePoolEdgeRoleName {
+		defaultReplicaCount = 0
+	}
 	if p.Replicas == nil {
 		p.Replicas = &defaultReplicaCount
 	}
@@ -21,4 +24,23 @@ func SetMachinePoolDefaults(p *types.MachinePool, platform string) {
 	if p.Architecture == "" {
 		p.Architecture = version.DefaultArch()
 	}
+}
+
+// CreateEdgeMachinePoolDefaults create the edge compute pool when it is not already defined.
+func CreateEdgeMachinePoolDefaults(pools []types.MachinePool, platform string, replicas int64) *types.MachinePool {
+	edgePoolDefined := false
+	for _, compute := range pools {
+		if compute.Name == types.MachinePoolEdgeRoleName {
+			edgePoolDefined = true
+		}
+	}
+	if edgePoolDefined {
+		return nil
+	}
+	pool := &types.MachinePool{
+		Name:     types.MachinePoolEdgeRoleName,
+		Replicas: &replicas,
+	}
+	SetMachinePoolDefaults(pool, platform)
+	return pool
 }

--- a/pkg/types/defaults/machinepools_test.go
+++ b/pkg/types/defaults/machinepools_test.go
@@ -4,21 +4,29 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/utils/pointer"
 
 	"github.com/openshift/installer/pkg/types"
 )
 
 func defaultMachinePool(name string) *types.MachinePool {
+	repCount := int64(3)
 	return &types.MachinePool{
 		Name:           name,
-		Replicas:       pointer.Int64Ptr(3),
+		Replicas:       &repCount,
 		Hyperthreading: types.HyperthreadingEnabled,
 		Architecture:   types.ArchitectureAMD64,
 	}
 }
 
+func defaultEdgeMachinePool(name string) *types.MachinePool {
+	pool := defaultMachinePool(name)
+	defaultEdgeReplicaCount := int64(0)
+	pool.Replicas = &defaultEdgeReplicaCount
+	return pool
+}
+
 func TestSetMahcinePoolDefaults(t *testing.T) {
+	defaultEdgeReplicaCount := int64(0)
 	cases := []struct {
 		name     string
 		pool     *types.MachinePool
@@ -31,20 +39,47 @@ func TestSetMahcinePoolDefaults(t *testing.T) {
 			expected: defaultMachinePool(""),
 		},
 		{
+			name:     "empty",
+			pool:     &types.MachinePool{Replicas: &defaultEdgeReplicaCount},
+			expected: defaultEdgeMachinePool(""),
+		},
+		{
 			name:     "default",
 			pool:     defaultMachinePool("test-name"),
 			expected: defaultMachinePool("test-name"),
 		},
 		{
+			name:     "default",
+			pool:     defaultEdgeMachinePool("test-name"),
+			expected: defaultEdgeMachinePool("test-name"),
+		},
+		{
 			name: "non-default replicas",
 			pool: func() *types.MachinePool {
 				p := defaultMachinePool("test-name")
-				p.Replicas = pointer.Int64Ptr(5)
+				repCount := int64(5)
+				p.Replicas = &repCount
 				return p
 			}(),
 			expected: func() *types.MachinePool {
 				p := defaultMachinePool("test-name")
-				p.Replicas = pointer.Int64Ptr(5)
+				repCount := int64(5)
+				p.Replicas = &repCount
+				return p
+			}(),
+		},
+		{
+			name: "non-default replicas",
+			pool: func() *types.MachinePool {
+				p := defaultEdgeMachinePool("test-name")
+				repCount := int64(5)
+				p.Replicas = &repCount
+				return p
+			}(),
+			expected: func() *types.MachinePool {
+				p := defaultEdgeMachinePool("test-name")
+				repCount := int64(5)
+				p.Replicas = &repCount
 				return p
 			}(),
 		},
@@ -54,7 +89,8 @@ func TestSetMahcinePoolDefaults(t *testing.T) {
 			platform: "libvirt",
 			expected: func() *types.MachinePool {
 				p := defaultMachinePool("")
-				p.Replicas = pointer.Int64Ptr(1)
+				repCount := int64(1)
+				p.Replicas = &repCount
 				return p
 			}(),
 		},
@@ -67,6 +103,19 @@ func TestSetMahcinePoolDefaults(t *testing.T) {
 			}(),
 			expected: func() *types.MachinePool {
 				p := defaultMachinePool("test-name")
+				p.Hyperthreading = types.HyperthreadingMode("test-hyperthreading")
+				return p
+			}(),
+		},
+		{
+			name: "non-default hyperthreading",
+			pool: func() *types.MachinePool {
+				p := defaultEdgeMachinePool("test-name")
+				p.Hyperthreading = types.HyperthreadingMode("test-hyperthreading")
+				return p
+			}(),
+			expected: func() *types.MachinePool {
+				p := defaultEdgeMachinePool("test-name")
 				p.Hyperthreading = types.HyperthreadingMode("test-hyperthreading")
 				return p
 			}(),

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -27,8 +27,7 @@ const (
 	// InstallConfigVersion is the version supported by this package.
 	// If you bump this, you must also update the list of convertable values in
 	// pkg/types/conversion/installconfig.go
-	InstallConfigVersion  = "v1"
-	workerMachinePoolName = "worker"
+	InstallConfigVersion = "v1"
 )
 
 var (
@@ -478,7 +477,8 @@ type Capabilities struct {
 // WorkerMachinePool retrieves the worker MachinePool from InstallConfig.Compute
 func (c *InstallConfig) WorkerMachinePool() *MachinePool {
 	for _, machinePool := range c.Compute {
-		if machinePool.Name == workerMachinePoolName {
+		switch machinePool.Name {
+		case MachinePoolComputeRoleName, MachinePoolEdgeRoleName:
 			return &machinePool
 		}
 	}

--- a/pkg/types/machinepools.go
+++ b/pkg/types/machinepools.go
@@ -16,9 +16,11 @@ import (
 )
 
 const (
-	// MachinePoolComputeRoleName name associated with the compute machinepool
+	// MachinePoolComputeRoleName name associated with the compute machinepool.
 	MachinePoolComputeRoleName = "worker"
-	// MachinePoolControlPlaneRoleName name associated with the control plane machinepool
+	// MachinePoolEdgeRoleName name associated with the compute edge machinepool.
+	MachinePoolEdgeRoleName = "edge"
+	// MachinePoolControlPlaneRoleName name associated with the control plane machinepool.
 	MachinePoolControlPlaneRoleName = "master"
 )
 

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -430,14 +430,28 @@ func validateControlPlane(platform *types.Platform, pool *types.MachinePool, fld
 	return allErrs
 }
 
+func validateComputeEdge(platform *types.Platform, pName string, fldPath *field.Path, pfld *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if platform.Name() != aws.Name {
+		allErrs = append(allErrs, field.NotSupported(pfld.Child("name"), pName, []string{types.MachinePoolComputeRoleName}))
+	}
+
+	return allErrs
+}
+
 func validateCompute(platform *types.Platform, control *types.MachinePool, pools []types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	poolNames := map[string]bool{}
 	for i, p := range pools {
 		poolFldPath := fldPath.Index(i)
-		if p.Name != types.MachinePoolComputeRoleName {
-			allErrs = append(allErrs, field.NotSupported(poolFldPath.Child("name"), p.Name, []string{"worker"}))
+		switch p.Name {
+		case types.MachinePoolComputeRoleName:
+		case types.MachinePoolEdgeRoleName:
+			allErrs = append(allErrs, validateComputeEdge(platform, p.Name, poolFldPath, poolFldPath)...)
+		default:
+			allErrs = append(allErrs, field.NotSupported(poolFldPath.Child("name"), p.Name, []string{types.MachinePoolComputeRoleName, types.MachinePoolEdgeRoleName}))
 		}
+
 		if poolNames[p.Name] {
 			allErrs = append(allErrs, field.Duplicate(poolFldPath.Child("name"), p.Name))
 		}

--- a/upi/aws/cloudformation/01.99_net_local-zone.yaml
+++ b/upi/aws/cloudformation/01.99_net_local-zone.yaml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for create Public Local Zone subnets
+
+Parameters:
+  VpcId:
+    Description: VPC Id
+    Type: String
+  ZoneName:
+    Description: Local Zone Name (Example us-west-2-lax-1a)
+    Type: String
+  SubnetName:
+    Description: Local Zone Name (Example cluster-usw2-lax-1a)
+    Type: String
+  PublicRouteTableId:
+    Description: Public Route Table ID to associate the Local Zone subnet
+    Type: String
+  PublicSubnetCidr:
+    # yamllint disable-line rule:line-length
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
+    Default: 10.0.128.0/20
+    Description: CIDR block for Public Subnet
+    Type: String
+
+Resources:
+  PublicSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VpcId
+      CidrBlock: !Ref PublicSubnetCidr
+      AvailabilityZone: !Ref ZoneName
+      Tags:
+      - Key: Name
+        Value: !Ref SubnetName
+      - Key: kubernetes.io/cluster/unmanaged
+        Value: "true"
+
+  PublicSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTableId
+
+Outputs:
+  PublicSubnetIds:
+    Description: Subnet IDs of the public subnets.
+    Value:
+      !Join ["", [!Ref PublicSubnet]]

--- a/upi/aws/cloudformation/01_vpc.yaml
+++ b/upi/aws/cloudformation/01_vpc.yaml
@@ -286,3 +286,6 @@ Outputs:
         ",",
         [!Ref PrivateSubnet, !If [DoAz2, !Ref PrivateSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PrivateSubnet3, !Ref "AWS::NoValue"]]
       ]
+  PublicRouteTableId:
+    Description: Public Route table ID
+    Value: !Ref PublicRouteTable


### PR DESCRIPTION
The goal of this PR is to add support to [AWS Local Zones](https://aws.amazon.com/about-aws/global-infrastructure/localzones/) when installing a cluster in an existing VPC. It allows the creation of a compute pool named `edge`, alongside the `worker`, on `install-config.yaml`. The installer will generate MachineSet manifests with `NoSchedule` taint to deploy the instance on edge locations.

This implementation is Phase 1 of the [Enhancement Proposal #1232](https://github.com/openshift/enhancements/pull/1232), which describes in detail the change request.

Nodes are considered `edge` when the availability zone  [`zoneType`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AvailabilityZone.html) is `local-zone`. The `edge` compute pool is valid only for the AWS Platform.

It is not the goal of this PR to create the Subnets on Local Zones locations. This is part of Phase 2.

Note: This PR will change the MTU of ClusterNetwork when edge pool for AWS is defined. FYI https://github.com/openshift/openshift-docs/pull/55327

Refereces:
- https://issues.redhat.com/browse/RFE-2782
- https://issues.redhat.com/browse/SPLAT-636
- https://github.com/openshift/enhancements/pull/1232


List of teams that would be interested in reviewing this PR:

- [x] SPLAT (@rvanderp3 )
- [x] Installer (@patrickdillon  @sadasu )
- [ ] Network Team: Cluster network MTU Changes (@abhat @jcaamano @trozet )
- [ ] Cloud: MachineSet changes (@JoelSpeed @elmiko )