### PR TITLE
Agent: Don't pass AdminKubeConfigClientCertKey

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -89,7 +89,6 @@ func (a *Ignition) Dependencies() []asset.Asset {
 		&tls.KubeAPIServerLocalhostSignerCertKey{},
 		&tls.KubeAPIServerServiceNetworkSignerCertKey{},
 		&tls.AdminKubeConfigSignerCertKey{},
-		&tls.AdminKubeConfigClientCertKey{},
 		&agentconfig.AgentConfig{},
 		&mirror.RegistriesConf{},
 		&mirror.CaBundle{},
@@ -274,7 +273,6 @@ func addTLSData(config *igntypes.Config, dependencies asset.Parents) {
 		&tls.KubeAPIServerLocalhostSignerCertKey{},
 		&tls.KubeAPIServerServiceNetworkSignerCertKey{},
 		&tls.AdminKubeConfigSignerCertKey{},
-		&tls.AdminKubeConfigClientCertKey{},
 	}
 	dependencies.Get(certKeys...)
 


### PR DESCRIPTION
This depends on the AdminKubeConfigSignerCertKey, which we also pass, with the result that AdminKubeConfigClientCertKey always gets regenerated by the installer when assisted-service runs it. Since this has no effect other than generating a spurious warning, just stop passing it.