### PR TITLE
Bug 2104997: Add additional fields to proxy manifest

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -158,6 +158,11 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 
 	// TODO: IBM[#95]: proxy
 
+	if platform == azure.Name && installConfig.Azure.CloudName == azure.StackCloud {
+		set.Insert("168.63.129.16")
+		set.Insert(installConfig.Config.Azure.ARMEndpoint)
+	}
+
 	// From https://cloud.google.com/vpc/docs/special-configurations add GCP metadata.
 	// "metadata.google.internal." added due to https://bugzilla.redhat.com/show_bug.cgi?id=1754049
 	if platform == gcp.Name {


### PR DESCRIPTION
** Add 168.63.129.16 IP to noProxy in Azure Stack Hub 
** Add ArmEndpoint (from install config) when performing azure installation

https://issues.redhat.com/browse/OCPBUGSM-46450