### PR TITLE
CORS-2280: IBMCloud: Add DNS Record for internal public traffic

### DIFF
--- a/data/data/ibmcloud/network/dns/main.tf
+++ b/data/data/ibmcloud/network/dns/main.tf
@@ -16,6 +16,17 @@ resource "ibm_dns_permitted_network" "vpc" {
 # DNS records (CNAME)
 ############################################
 
+resource "ibm_dns_resource_record" "kubernetes_api_internal_public" {
+  count = var.is_external ? 0 : 1
+
+  instance_id = var.dns_id
+  zone_id     = local.dns_zone_id
+  type        = "CNAME"
+  name        = "api.${var.cluster_domain}"
+  rdata       = var.lb_kubernetes_api_private_hostname
+  ttl         = "60"
+}
+
 resource "ibm_dns_resource_record" "kubernetes_api_private" {
   count = var.is_external ? 0 : 1
 


### PR DESCRIPTION
Add a DNS Services DNS Record for Private clusters to allow traffic to the public server URL to be directed to the private LB.