### PR TITLE
OCPBUGS-891: aws: add explicit EIP dependency for nat gw

### DIFF
--- a/data/data/aws/cluster/vpc/vpc-public.tf
+++ b/data/data/aws/cluster/vpc/vpc-public.tf
@@ -96,5 +96,5 @@ resource "aws_nat_gateway" "nat_gw" {
   )
 
   # https://issues.redhat.com/browse/OCPBUGS-891
-  depends_on = [aws_eip.nat_eip]
+  depends_on = [aws_eip.nat_eip, aws_subnet.public_subnet]
 }

--- a/data/data/aws/cluster/vpc/vpc-public.tf
+++ b/data/data/aws/cluster/vpc/vpc-public.tf
@@ -94,4 +94,7 @@ resource "aws_nat_gateway" "nat_gw" {
     },
     var.tags,
   )
+
+  # https://issues.redhat.com/browse/OCPBUGS-891
+  depends_on = [aws_eip.nat_eip]
 }


### PR DESCRIPTION
Hopefully by making the dependency between them explicit, we might alleviate the following error in CI

Error: error creating EC2 NAT Gateway: InvalidElasticIpID.NotFound: The elasticIp ID 'eipalloc-094ec9d0482d5b9f2' does not exist