### PR TITLE
Agent: Increase bootstrap-complete timeout

### DIFF
--- a/pkg/agent/waitfor.go
+++ b/pkg/agent/waitfor.go
@@ -22,7 +22,7 @@ func WaitForBootstrapComplete(assetDir string) (*Cluster, error) {
 
 	start := time.Now()
 	previous := time.Now()
-	timeout := 30 * time.Minute
+	timeout := 45 * time.Minute
 	waitContext, cancel := context.WithTimeout(cluster.Ctx, timeout)
 	defer cancel()
 


### PR DESCRIPTION
It appears that installs of 4.12 are taking consistently longer to bootstrap than for 4.11 - a local test run recorded 28 minutes, vs. 17-20 minutes in previous 4.11 testing. In CI testing, we are exceeding the 30 minute timeout.

Until such time as we are able to determine and address the reason for the slower bootstrapping, increase the timeout.