### PR TITLE
[release-4.11] OCPBUGS-1157: azure: add sleep between zone and link creation

### DIFF
--- a/pkg/terraform/stages/azure/stages.go
+++ b/pkg/terraform/stages/azure/stages.go
@@ -23,7 +23,7 @@ var PlatformStages = []terraform.Stage{
 	stages.NewStage(
 		typesazure.Name,
 		"cluster",
-		[]providers.Provider{providers.AzureRM, providers.AzurePrivateDNS},
+		[]providers.Provider{providers.AzureRM, providers.AzurePrivateDNS, providers.Time},
 	),
 }
 


### PR DESCRIPTION
We started seeing errors from Azure about network links not being able to find a previously created private zone.  The order in terraform seems to be correct:

```
time="2022-09-14T16:33:55Z" level=debug msg="module.dns.azurerm_private_dns_zone.private: Creating..."
time="2022-09-14T16:34:27Z" level=debug msg="module.dns.azurerm_private_dns_zone.private: Creation complete after 33s [id=/subscriptions/d38f1e38-4bed-438e-b227-833f997adf6a/resourceGroups/ci-op-r0j51ij5-0e6bb-22jzf-rg/providers/Microsoft.Network/privateDnsZones/ci-op-r0j51ij5-0e6bb.ci.azure.devcluster.openshift.com]"
time="2022-09-14T16:34:27Z" level=debug msg="module.dns.azurerm_private_dns_zone_virtual_network_link.network: Creating..."
time="2022-09-14T16:54:51Z" level=error msg="Error: creating/updating Virtual Network Link (Subscription: \"d38f1e38-4bed-438e-b227-833f997adf6a\""
time="2022-09-14T16:54:51Z" level=error msg="Resource Group Name: \"ci-op-r0j51ij5-0e6bb-22jzf-rg\""
time="2022-09-14T16:54:51Z" level=error msg="Private Zone Name: \"ci-op-r0j51ij5-0e6bb.ci.azure.devcluster.openshift.com\""
time="2022-09-14T16:54:51Z" level=error msg="Virtual Network Link Name: \"ci-op-r0j51ij5-0e6bb-22jzf-network-link\"): performing CreateOrUpdate: virtualnetworklinks.VirtualNetworkLinksClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code=\"ParentResourceNotFound\" Message=\"Can not perform requested operation on nested resource. Parent resource 'ci-op-r0j51ij5-0e6bb.ci.azure.devcluster.openshift.com' not found.\""
```

Because we immediately go from creating the zone to creating the link, we may not be giving enough time for Azure to settle -- it may be reporting the zone was created, but the response may be inaccurate.

Attempting to workaround this by adding a short sleep between the two resources.