### PR TITLE
AGENT-288 Log rendezvous host IP when creating agent ISO

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -125,6 +125,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 	if err != nil {
 		return err
 	}
+	logrus.Infof("The rendezvous host IP (node0 IP) is %s", nodeZeroIP)
 
 	// TODO: don't hard-code target arch
 	releaseImageList, err := releaseImageList(agentManifests.ClusterImageSet.Spec.ReleaseImage, "x86_64")


### PR DESCRIPTION
The rendezvous host IP (node0 IP) can be specified in the agent-config.yaml or automatically chosen from the NMStateConfigs.

The IP address is logged at INFO level to help users know which host has been chosen as the rendezvous host.

Signed-off-by: Richard Su <rwsu@redhat.com>