### PR TITLE
Agent based installer - assert that user provided release image architecture is supported

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -121,7 +121,16 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 	}
 	logrus.Infof("The rendezvous host IP (node0 IP) is %s", nodeZeroIP)
 
-	// TODO: don't hard-code target arch
+	// TODO: don't hard-code target arch, but for now make a best effort to assert that the
+	// user is not trying to install a non-x86_64 cluster.
+	if strings.Contains(agentManifests.ClusterImageSet.Spec.ReleaseImage, "aarch64") {
+		return errors.Errorf("release image pull-spec %q contains aarch64, which is not supported", agentManifests.ClusterImageSet.Spec.ReleaseImage)
+	}
+
+	if strings.Contains(agentManifests.ClusterImageSet.Spec.ReleaseImage, "arm64") {
+		return errors.Errorf("release image pull-spec %q contains arm64, which is not supported", agentManifests.ClusterImageSet.Spec.ReleaseImage)
+	}
+
 	releaseImageList, err := releaseImageList(agentManifests.ClusterImageSet.Spec.ReleaseImage, archName)
 	if err != nil {
 		return err


### PR DESCRIPTION
Right now the agent based installer hardcodes the x86 architecture and
this causes issues much further in the installation process that are
harder to track down.

I've added a couple of assertions to make the issue clearer for the
user.

This is obviously not robust as it's just parsing the pull-spec looking
for mentions of the arm architecture, they should be removed once
the agent based installer adds proper support for other architectures
and does away with hardcoding x86.