### PR TITLE
vsphere: prevent duplicate validation check in multi-zone

### DIFF
--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -110,9 +110,10 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 	case vsphere.Name:
-		err = vsconfig.ValidateForProvisioning(ic.Config)
 		if len(ic.Config.VSphere.VCenters) > 0 {
 			err = vsconfig.ValidateMultiZoneForProvisioning(ic.Config)
+		} else {
+			err = vsconfig.ValidateForProvisioning(ic.Config)
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
`ValidateMultiZoneForProvisioning` is calling `ValidateForProvisioning` [here](https://github.com/openshift/installer/blob/2d0389c782601cd76e9b6454aee657c1c274a26b/pkg/asset/installconfig/vsphere/validation.go#L66-L72) already so it can be skipped in `platformprovisioncheck.go`