### PR TITLE
ARMOCP-417: enable arm64 for agent installer

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -111,6 +111,7 @@ spec:
   clusterRef:
     name: ostest
     namespace: cluster0
+  cpuArchitecture: x86_64
   ipxeScriptType: ""
   nmStateConfigLabelSelector:
     matchLabels:

--- a/pkg/asset/agent/image/baseiso_test.go
+++ b/pkg/asset/agent/image/baseiso_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestInfraBaseIso_Generate(t *testing.T) {
 
-	GetIsoPluggable = func() (string, error) {
+	GetIsoPluggable = func(archName string) (string, error) {
 		return "some-openshift-release.iso", nil
 	}
 

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/coreos/ignition/v2/config/util"
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/coreos/stream-metadata-go/arch"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -29,6 +30,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/rhcos"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/agent"
 	"github.com/openshift/installer/pkg/version"
 )
@@ -126,8 +128,12 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 	logrus.Infof("The rendezvous host IP (node0 IP) is %s", nodeZeroIP)
 
 	a.RendezvousIP = nodeZeroIP
+	// Default to x86_64
+	archName := arch.RpmArch(types.ArchitectureAMD64)
+	if infraEnv.Spec.CpuArchitecture != "" {
+		archName = infraEnv.Spec.CpuArchitecture
+	}
 
-	// TODO: don't hard-code target arch
 	releaseImageList, err := releaseImageList(agentManifests.ClusterImageSet.Spec.ReleaseImage, archName)
 	if err != nil {
 		return err

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -96,8 +96,9 @@ func (a *OptionalInstallConfig) validateSupportedArchs(installConfig *types.Inst
 
 	switch string(installConfig.ControlPlane.Architecture) {
 	case types.ArchitectureAMD64:
+	case types.ArchitectureARM64:
 	default:
-		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.ControlPlane.Architecture, []string{types.ArchitectureAMD64}))
+		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.ControlPlane.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64}))
 	}
 
 	for i, compute := range installConfig.Compute {
@@ -105,8 +106,9 @@ func (a *OptionalInstallConfig) validateSupportedArchs(installConfig *types.Inst
 
 		switch string(compute.Architecture) {
 		case types.ArchitectureAMD64:
+		case types.ArchitectureARM64:
 		default:
-			allErrs = append(allErrs, field.NotSupported(fieldPath, compute.Architecture, []string{types.ArchitectureAMD64}))
+			allErrs = append(allErrs, field.NotSupported(fieldPath, compute.Architecture, []string{types.ArchitectureAMD64, types.ArchitectureARM64}))
 		}
 	}
 

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -221,13 +221,13 @@ baseDomain: test-domain
 networking:
   networkType: OVNKubernetes
 compute:
-  - architecture: arm64
+  - architecture: s390x
     hyperthreading: Enabled
     name: worker
     platform: {}
     replicas: 0
 controlPlane:
-  architecture: arm64
+  architecture: s390x
   hyperthreading: Enabled
   name: master
   platform: {}
@@ -237,7 +237,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: Unsupported value: \"arm64\": supported values: \"amd64\", Compute[0].Architecture: Unsupported value: \"arm64\": supported values: \"amd64\"]",
+			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\", Compute[0].Architecture: Unsupported value: \"s390x\": supported values: \"amd64\", \"arm64\"]",
 		},
 		{
 			name: "valid configuration for none platform for sno",


### PR DESCRIPTION
Enable arm64 iso builds for agent installer based on the control plane architecture set in install-config.yaml.