### PR TITLE
OCPBUGS-1824: enhance agent systemd service dependency

### DIFF
--- a/data/data/agent/systemd/units/create-cluster-and-infraenv.service.template
+++ b/data/data/agent/systemd/units/create-cluster-and-infraenv.service.template
@@ -1,7 +1,6 @@
 [Unit]
 Description=Service that creates initial cluster and infraenv
-Wants=network-online.target
-Requires=assisted-service.service
+Wants=network-online.target assisted-service.service
 PartOf=assisted-service-pod.service
 After=network-online.target assisted-service.service
 ConditionPathExists=/etc/assisted-service/node0


### PR DESCRIPTION
The create-cluster-and-infraenv.service "Requires" assisted-service.service, this will make it be deactived when assisted-service.service fail to start. When assisted-service.service restarts, sinece create-cluster-and-infraenv.service was deactived, it will not restart automatically. Therefore, it is better to use "Wants=", it is a weaker version of Requires, and the dependency failure will not affect the dependent. https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=