### PR TITLE
OCPBUGS-1612: vsphere: set default resource pool when missing failure domain topology

### DIFF
--- a/pkg/types/vsphere/defaults/platform.go
+++ b/pkg/types/vsphere/defaults/platform.go
@@ -1,24 +1,11 @@
 package defaults
 
 import (
-	"fmt"
-
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
 // SetPlatformDefaults sets the defaults for the platform.
 func SetPlatformDefaults(p *vsphere.Platform, installConfig *types.InstallConfig) {
-
-	// We need to deploy templates (OVA) via DeploymentZones
-	// since we could have compute (workers) in those zones
-	// but _not_ control plane nodes. If the placementConstraints
-	// are not defined we must use the default for the datacenter
-	// and cluster.
-	for i := range p.FailureDomains {
-		if p.FailureDomains[i].Topology.ResourcePool == "" {
-			p.FailureDomains[i].Topology.ResourcePool = fmt.Sprintf("%s/%s", p.FailureDomains[i].Topology.ComputeCluster, "/Resources")
-		}
-	}
 
 }

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -72,55 +72,55 @@ func validateMultiZone(p *vsphere.Platform, fldPath *field.Path) field.ErrorList
 			Password:    p.Password,
 			Datacenters: []string{p.Datacenter},
 		})
+	}
 
-		// populate failure domains that dont explicitly define a server
-		for idx, failureDomain := range p.FailureDomains {
-			if len(failureDomain.Server) == 0 {
-				p.FailureDomains[idx].Server = p.VCenter
+	// populate failure domains that dont explicitly define a server
+	for idx, failureDomain := range p.FailureDomains {
+		if len(failureDomain.Server) == 0 {
+			p.FailureDomains[idx].Server = p.VCenter
+		}
+		if len(failureDomain.Topology.Datacenter) == 0 {
+			p.FailureDomains[idx].Topology.Datacenter = p.Datacenter
+		}
+		if len(failureDomain.Topology.ComputeCluster) == 0 {
+			p.FailureDomains[idx].Topology.ComputeCluster = fmt.Sprintf("/%s/host/%s", p.Datacenter, p.Cluster)
+		}
+		if len(failureDomain.Topology.Networks) == 0 && len(p.Network) > 0 {
+			if len(failureDomain.Topology.Networks) == 0 {
+				p.FailureDomains[idx].Topology.Networks = []string{p.Network}
 			}
-			if len(failureDomain.Topology.Datacenter) == 0 {
-				p.FailureDomains[idx].Topology.Datacenter = p.Datacenter
-			}
-			if len(failureDomain.Topology.ComputeCluster) == 0 {
-				p.FailureDomains[idx].Topology.ComputeCluster = fmt.Sprintf("/%s/host/%s", p.Datacenter, p.Cluster)
-			}
-			if len(failureDomain.Topology.ResourcePool) == 0 {
-				p.FailureDomains[idx].Topology.ResourcePool = p.ResourcePool
-			}
-			if len(failureDomain.Topology.Networks) == 0 && len(p.Network) > 0 {
-				if len(failureDomain.Topology.Networks) == 0 {
-					p.FailureDomains[idx].Topology.Networks = []string{p.Network}
+		}
+		if len(failureDomain.Topology.Datastore) == 0 {
+			p.FailureDomains[idx].Topology.Datastore = p.DefaultDatastore
+		}
+		if len(failureDomain.Topology.Folder) == 0 {
+			// If the legacy folder is not defined we can't use it for FailureDomain
+			if len(p.Folder) != 0 {
+				// Only use the legacy folder platform spec parameter if the datacenter exists in the path.
+				if strings.Contains(p.Folder, p.FailureDomains[idx].Topology.Datacenter) {
+					p.FailureDomains[idx].Topology.Folder = p.Folder
+				} else {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("folder"), p.Folder, fmt.Sprintf("folder must be in datacenter %s; please define it in a topology", p.FailureDomains[idx].Topology.Datacenter)))
 				}
 			}
-			if len(failureDomain.Topology.Datastore) == 0 {
-				p.FailureDomains[idx].Topology.Datastore = p.DefaultDatastore
-			}
+		}
 
-			if len(failureDomain.Topology.ResourcePool) == 0 {
-				// If the legacy resourcePool is not defined we can't use it for FailureDomain
-				if len(p.ResourcePool) != 0 {
-					if strings.Contains(p.ResourcePool, p.FailureDomains[idx].Topology.Datacenter) {
-						// Only use the legacy resourcePool platform spec parameter if the datacenter exists in the path.
-						if strings.Contains(p.ResourcePool, p.FailureDomains[idx].Topology.ComputeCluster) {
-							p.FailureDomains[idx].Topology.ResourcePool = p.ResourcePool
-						} else {
-							allErrs = append(allErrs, field.Invalid(fldPath.Child("resourcePool"), p.ResourcePool, fmt.Sprintf("resource pool must be in compute cluster %s; please define it in a topology", p.FailureDomains[idx].Topology.ComputeCluster)))
-						}
+		// Always try to set the default resourcePool
+		if len(failureDomain.Topology.ResourcePool) == 0 {
+			if len(p.ResourcePool) != 0 {
+				if strings.Contains(p.ResourcePool, p.FailureDomains[idx].Topology.Datacenter) {
+					// Only use the legacy resourcePool platform spec parameter if the datacenter exists in the path.
+					if strings.Contains(p.ResourcePool, p.FailureDomains[idx].Topology.ComputeCluster) {
+						p.FailureDomains[idx].Topology.ResourcePool = p.ResourcePool
 					} else {
-						allErrs = append(allErrs, field.Invalid(fldPath.Child("resourcePool"), p.ResourcePool, fmt.Sprintf("resource pool must be in datacenter %s; please define it in a topology", p.FailureDomains[idx].Topology.Datacenter)))
+						allErrs = append(allErrs, field.Invalid(fldPath.Child("resourcePool"), p.ResourcePool, fmt.Sprintf("resource pool must be in compute cluster %s; please define it in a topology", p.FailureDomains[idx].Topology.ComputeCluster)))
 					}
+				} else {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("resourcePool"), p.ResourcePool, fmt.Sprintf("resource pool must be in datacenter %s; please define it in a topology", p.FailureDomains[idx].Topology.Datacenter)))
 				}
-			}
-			if len(failureDomain.Topology.Folder) == 0 {
-				// If the legacy folder is not defined we can't use it for FailureDomain
-				if len(p.Folder) != 0 {
-					// Only use the legacy folder platform spec parameter if the datacenter exists in the path.
-					if strings.Contains(p.Folder, p.FailureDomains[idx].Topology.Datacenter) {
-						p.FailureDomains[idx].Topology.Folder = p.Folder
-					} else {
-						allErrs = append(allErrs, field.Invalid(fldPath.Child("folder"), p.Folder, fmt.Sprintf("folder must be in datacenter %s; please define it in a topology", p.FailureDomains[idx].Topology.Datacenter)))
-					}
-				}
+			} else {
+				// Default to the resourcePool inside compute cluster since there is no legacy resourcePool
+				p.FailureDomains[idx].Topology.ResourcePool = fmt.Sprintf("%s/%s", p.FailureDomains[idx].Topology.ComputeCluster, "Resources")
 			}
 		}
 	}
@@ -234,6 +234,23 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path) field.Erro
 
 			if len(failureDomain.Topology.Datacenter) != 0 && datacenterName != failureDomain.Topology.Datacenter {
 				return append(allErrs, field.Invalid(topologyFld.Child("computeCluster"), computeCluster, fmt.Sprintf("compute cluster must be in datacenter %s", failureDomain.Topology.Datacenter)))
+			}
+		}
+
+		if len(failureDomain.Topology.ResourcePool) != 0 {
+			resourcePool := failureDomain.Topology.ResourcePool
+			resourcePoolRegexp := regexp.MustCompile("^\\/(.*?)\\/host\\/(.*?)\\/(.*?)$")
+			resourcePoolPathParts := resourcePoolRegexp.FindStringSubmatch(resourcePool)
+			if len(resourcePoolPathParts) < 4 {
+				return append(allErrs, field.Invalid(topologyFld.Child("resourcePool"), resourcePool, "full path of resource pool must be provided in format /<datacenter>/host/<cluster>/..."))
+			}
+			datacenterName := resourcePoolPathParts[1]
+			clusterName := resourcePoolPathParts[2]
+			if len(failureDomain.Topology.Datacenter) != 0 && datacenterName != failureDomain.Topology.Datacenter {
+				return append(allErrs, field.Invalid(topologyFld.Child("resourcePool"), resourcePool, fmt.Sprintf("resource pool must be in datacenter %s", failureDomain.Topology.Datacenter)))
+			}
+			if len(failureDomain.Topology.ComputeCluster) != 0 && !strings.Contains(failureDomain.Topology.ComputeCluster, clusterName) {
+				return append(allErrs, field.Invalid(topologyFld.Child("resourcePool"), resourcePool, fmt.Sprintf("resource pool must be in compute cluster %s", failureDomain.Topology.ComputeCluster)))
 			}
 		}
 	}

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -210,7 +210,7 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path) field.Erro
 		}
 		// Folder in failuredomain is optional
 		if len(failureDomain.Topology.Folder) != 0 {
-			folderPathRegexp := regexp.MustCompile("^\\/(.*?)\\/vm\\/(.*?)$")
+			folderPathRegexp := regexp.MustCompile(`^\/(.*?)\/vm\/(.*?)$`)
 			folderPathParts := folderPathRegexp.FindStringSubmatch(failureDomain.Topology.Folder)
 			if len(folderPathParts) < 3 {
 				return append(allErrs, field.Invalid(topologyFld.Child("folder"), failureDomain.Topology.Folder, "full path of folder must be provided in format /<datacenter>/vm/<folder>"))
@@ -225,7 +225,7 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path) field.Erro
 			allErrs = append(allErrs, field.Required(topologyFld.Child("computeCluster"), "must specify a computeCluster"))
 		} else {
 			computeCluster := failureDomain.Topology.ComputeCluster
-			clusterPathRegexp := regexp.MustCompile("^\\/(.*?)\\/host\\/(.*?)$")
+			clusterPathRegexp := regexp.MustCompile(`^\/(.*?)\/host\/(.*?)$`)
 			clusterPathParts := clusterPathRegexp.FindStringSubmatch(computeCluster)
 			if len(clusterPathParts) < 3 {
 				return append(allErrs, field.Invalid(topologyFld.Child("computeCluster"), computeCluster, "full path of compute cluster must be provided in format /<datacenter>/host/<cluster>"))
@@ -239,7 +239,7 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path) field.Erro
 
 		if len(failureDomain.Topology.ResourcePool) != 0 {
 			resourcePool := failureDomain.Topology.ResourcePool
-			resourcePoolRegexp := regexp.MustCompile("^\\/(.*?)\\/host\\/(.*?)\\/(.*?)$")
+			resourcePoolRegexp := regexp.MustCompile(`^\/(.*?)\/host\/(.*?)\/(.*?)$`)
 			resourcePoolPathParts := resourcePoolRegexp.FindStringSubmatch(resourcePool)
 			if len(resourcePoolPathParts) < 4 {
 				return append(allErrs, field.Invalid(topologyFld.Child("resourcePool"), resourcePool, "full path of resource pool must be provided in format /<datacenter>/host/<cluster>/..."))


### PR DESCRIPTION
Moved code for setting default values and adjusted how `resourcePool` is defaulted in the event there's no `resourcePool` defined in higher level vsphere platform config. 