### PR TITLE
vsphere: match username field names

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3284,7 +3284,7 @@ spec:
                             the IP address of the vCenter server.
                           maxLength: 255
                           type: string
-                        user:
+                        username:
                           description: Username is the username that will be used
                             to connect to vCenter
                           type: string
@@ -3292,7 +3292,7 @@ spec:
                       - datacenters
                       - password
                       - server
-                      - user
+                      - username
                       type: object
                     maxItems: 1
                     minItems: 1

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -208,7 +208,7 @@ type VCenter struct {
 	Port uint `json:"port,omitempty"`
 	// Username is the username that will be used to connect to vCenter
 	// +kubebuilder:validation:Required
-	Username string `json:"user"`
+	Username string `json:"username"`
 	// Password is the password for the user to use to connect to the vCenter.
 	// +kubebuilder:validation:Required
 	Password string `json:"password"`


### PR DESCRIPTION
This should match the username field used in legacy platform config and match the error message that's printed if the field is missing:

https://github.com/openshift/installer/blob/master/pkg/types/vsphere/validation/platform.go#L132-L134
`platform.vsphere.vcenters.username: Required value: must specify the username`