### PR TITLE
OCPBUGS-1627: [vsphere-zones] Fix user folders

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3215,8 +3215,8 @@ spec:
                               minLength: 1
                               type: string
                             folder:
-                              description: folder is the name or inventory path of
-                                the folder in which the virtual machine is created/located.
+                              description: folder is the inventory path of the folder
+                                in which the virtual machine is created/located.
                               maxLength: 2048
                               minLength: 1
                               type: string

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3219,6 +3219,7 @@ spec:
                                 in which the virtual machine is created/located.
                               maxLength: 2048
                               minLength: 1
+                              pattern: ^/.*?/vm/.*?
                               type: string
                             networks:
                               description: networks is the list of networks within
@@ -3256,6 +3257,7 @@ spec:
                     description: Folder is the absolute path of the folder that will
                       be used and/or created for virtual machines. The absolute path
                       is of the form /<datacenter>/vm/<folder>/<subfolder>.
+                    pattern: ^/.*?/vm/.*?
                     type: string
                   ingressVIP:
                     description: 'DeprecatedIngressVIP is the virtual IP address for

--- a/data/data/vspherezoning/bootstrap/main.tf
+++ b/data/data/vspherezoning/bootstrap/main.tf
@@ -18,7 +18,7 @@ resource "vsphere_virtual_machine" "vm_bootstrap" {
   num_cores_per_socket        = var.vsphere_control_planes[0].numCoresPerSocket
   memory                      = var.vsphere_control_planes[0].memoryMiB
   guest_id                    = var.template[0].guest_id
-  folder                      = var.vsphere_control_planes[0].workspace.folder
+  folder                      = trimprefix(var.vsphere_control_planes[0].workspace.folder, "/${var.vsphere_control_planes[0].workspace.datacenter}/vm")
   enable_disk_uuid            = "true"
   annotation                  = local.description
   wait_for_guest_net_timeout  = "0"

--- a/data/data/vspherezoning/master/main.tf
+++ b/data/data/vspherezoning/master/main.tf
@@ -36,7 +36,7 @@ resource "vsphere_virtual_machine" "vm_master" {
   num_cpus             = var.vsphere_control_planes[count.index].numCPUs
   num_cores_per_socket = var.vsphere_control_planes[count.index].numCoresPerSocket
   memory               = var.vsphere_control_planes[count.index].memoryMiB
-  folder               = var.vsphere_control_planes[count.index].workspace.folder
+  folder               = trimprefix(var.vsphere_control_planes[count.index].workspace.folder, "/${var.vsphere_control_planes[count.index].workspace.datacenter}/vm")
 
   guest_id = local.template_map[var.vsphere_control_planes[count.index].template].guest_id
 

--- a/pkg/tfvars/vsphere/vsphere.go
+++ b/pkg/tfvars/vsphere/vsphere.go
@@ -3,7 +3,6 @@ package vsphere
 import (
 	"encoding/json"
 	"fmt"
-
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/tfvars/internal/cache"
@@ -76,7 +75,14 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 	// The vSphere provider needs the relativepath of the folder,
 	// so get the relPath from the absolute path. Absolute path is always of the form
 	// /<datacenter>/vm/<folder_path> so we can split on "vm/".
-	folderRelPath := strings.SplitAfterN(controlPlaneConfig.Workspace.Folder, "vm/", 2)[1]
+
+	folderPathList := strings.SplitAfterN(controlPlaneConfig.Workspace.Folder, "vm/", 2)
+
+	// This should never happen
+	if len(folderPathList) <= 1 {
+		return nil, errors.Errorf("control plane folder is not defined as a path %s", controlPlaneConfig.Workspace.Folder)
+	}
+	folderRelPath := folderPathList[1]
 
 	vcenterZones := convertVCentersToMap(sources.InstallConfig.Config.VSphere.VCenters)
 	datacentersFolders := createDatacenterFolderMap(sources.InfraID, sources.InstallConfig.Config.VSphere.FailureDomains)
@@ -117,6 +123,7 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 // The datacenter could be reused but a folder could be
 // unique - the key then becomes a string that contains
 // both the datacenter name and the folder to be created.
+
 func createDatacenterFolderMap(infraID string, failureDomains []vtypes.FailureDomain) map[string]*folder {
 	folders := make(map[string]*folder)
 
@@ -130,10 +137,9 @@ func createDatacenterFolderMap(infraID string, failureDomains []vtypes.FailureDo
 		if tempFolder.Name == "" {
 			tempFolder.Name = infraID
 			failureDomains[i].Topology.Folder = infraID
+			key := fmt.Sprintf("%s-%s", tempFolder.Datacenter, tempFolder.Name)
+			folders[key] = tempFolder
 		}
-
-		key := fmt.Sprintf("%s-%s", tempFolder.Datacenter, tempFolder.Name)
-		folders[key] = tempFolder
 	}
 	return folders
 }

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -163,7 +163,7 @@ type Topology struct {
 	// +kubebuilder:validation:Pattern=`^/.*?/host/.*?/Resources.*`
 	// +optional
 	ResourcePool string `json:"resourcePool,omitempty"`
-	// folder is the name or inventory path of the folder in which the
+	// folder is the inventory path of the folder in which the
 	// virtual machine is created/located.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=2048

--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -35,6 +35,8 @@ type Platform struct {
 	DefaultDatastore string `json:"defaultDatastore"`
 	// Folder is the absolute path of the folder that will be used and/or created for
 	// virtual machines. The absolute path is of the form /<datacenter>/vm/<folder>/<subfolder>.
+	// +kubebuilder:validation:Pattern=`^/.*?/vm/.*?`
+	// +optional
 	Folder string `json:"folder,omitempty"`
 	// Cluster is the name of the cluster virtual machines will be cloned into.
 	Cluster string `json:"cluster,omitempty"`
@@ -167,6 +169,7 @@ type Topology struct {
 	// virtual machine is created/located.
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=2048
+	// +kubebuilder:validation:Pattern=`^/.*?/vm/.*?`
 	// +optional
 	Folder string `json:"folder,omitempty"`
 }

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -89,13 +89,39 @@ func validateMultiZone(p *vsphere.Platform, fldPath *field.Path) field.ErrorList
 				p.FailureDomains[idx].Topology.ResourcePool = p.ResourcePool
 			}
 			if len(failureDomain.Topology.Networks) == 0 && len(p.Network) > 0 {
-				p.FailureDomains[idx].Topology.Networks = []string{p.Network}
+				if len(failureDomain.Topology.Networks) == 0 {
+					p.FailureDomains[idx].Topology.Networks = []string{p.Network}
+				}
 			}
 			if len(failureDomain.Topology.Datastore) == 0 {
 				p.FailureDomains[idx].Topology.Datastore = p.DefaultDatastore
 			}
+
+			if len(failureDomain.Topology.ResourcePool) == 0 {
+				// If the legacy resourcePool is not defined we can't use it for FailureDomain
+				if len(p.ResourcePool) != 0 {
+					if strings.Contains(p.ResourcePool, p.FailureDomains[idx].Topology.Datacenter) {
+						// Only use the legacy resourcePool platform spec parameter if the datacenter exists in the path.
+						if strings.Contains(p.ResourcePool, p.FailureDomains[idx].Topology.ComputeCluster) {
+							p.FailureDomains[idx].Topology.ResourcePool = p.ResourcePool
+						} else {
+							allErrs = append(allErrs, field.Invalid(fldPath.Child("resourcePool"), p.ResourcePool, fmt.Sprintf("resource pool must be in compute cluster %s; please define it in a topology", p.FailureDomains[idx].Topology.ComputeCluster)))
+						}
+					} else {
+						allErrs = append(allErrs, field.Invalid(fldPath.Child("resourcePool"), p.ResourcePool, fmt.Sprintf("resource pool must be in datacenter %s; please define it in a topology", p.FailureDomains[idx].Topology.Datacenter)))
+					}
+				}
+			}
 			if len(failureDomain.Topology.Folder) == 0 {
-				p.FailureDomains[idx].Topology.Folder = p.Folder
+				// If the legacy folder is not defined we can't use it for FailureDomain
+				if len(p.Folder) != 0 {
+					// Only use the legacy folder platform spec parameter if the datacenter exists in the path.
+					if strings.Contains(p.Folder, p.FailureDomains[idx].Topology.Datacenter) {
+						p.FailureDomains[idx].Topology.Folder = p.Folder
+					} else {
+						allErrs = append(allErrs, field.Invalid(fldPath.Child("folder"), p.Folder, fmt.Sprintf("folder must be in datacenter %s; please define it in a topology", p.FailureDomains[idx].Topology.Datacenter)))
+					}
+				}
 			}
 		}
 	}
@@ -182,6 +208,18 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path) field.Erro
 
 		if len(failureDomain.Topology.Networks) == 0 {
 			allErrs = append(allErrs, field.Required(topologyFld.Child("networks"), "must specify a network"))
+		}
+		// Folder in failuredomain is optional
+		if len(failureDomain.Topology.Folder) != 0 {
+			folderPathRegexp := regexp.MustCompile("^\\/(.*?)\\/vm\\/(.*?)$")
+			folderPathParts := folderPathRegexp.FindStringSubmatch(failureDomain.Topology.Folder)
+			if len(folderPathParts) < 3 {
+				return append(allErrs, field.Invalid(topologyFld.Child("folder"), failureDomain.Topology.Folder, "full path of folder must be provided in format /<datacenter>/vm/<folder>"))
+			}
+
+			if !strings.Contains(failureDomain.Topology.Folder, failureDomain.Topology.Datacenter) {
+				return append(allErrs, field.Invalid(topologyFld.Child("folder"), failureDomain.Topology.Folder, "the folder defined does not exist in the correct datacenter"))
+			}
 		}
 
 		if len(failureDomain.Topology.ComputeCluster) == 0 {

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -55,7 +55,7 @@ func validMultiVCenterPlatform() *vsphere.Platform {
 					Datastore:      "test-datastore",
 					Networks:       []string{"test-portgroup"},
 					ResourcePool:   "test-resourcepool",
-					Folder:         "test-folder",
+					Folder:         "/test-datacenter/vm/test-folder",
 				},
 			},
 			{
@@ -69,7 +69,7 @@ func validMultiVCenterPlatform() *vsphere.Platform {
 					Datastore:      "test-datastore",
 					Networks:       []string{"test-portgroup"},
 					ResourcePool:   "test-resourcepool",
-					Folder:         "test-folder",
+					Folder:         "/test-datacenter/vm/test-folder",
 				},
 			},
 		},

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -164,6 +164,15 @@ func TestValidatePlatform(t *testing.T) {
 			expectedError: `^test-path\.defaultDatastore: Required value: must specify the default datastore$`,
 		},
 		{
+			name: "Invalid folder path",
+			platform: func() *vsphere.Platform {
+				p := validPlatform()
+				p.Folder = "test-folder"
+				return p
+			}(),
+			expectedError: `^test-path\.folder: Invalid value: "test-folder": folder must be absolute path: expected prefix /test-datacenter/vm/`,
+		},
+		{
 			name: "Capital letters in vCenter",
 			platform: func() *vsphere.Platform {
 				p := validPlatform()


### PR DESCRIPTION
- Adds length check for folderPath split
- Only create a folder when folder name is empty
- Add additional validation for resource pools and folders
- In the vsphereprivate terraform provider support
the ability to use folders as full paths
- In terraform trimprefix of the folder path based on
`/<datacenter>/vm`