### PR TITLE
AGENT-319: Set agent-config version to v1beta1

### DIFF
--- a/pkg/types/agent/agent_config_type.go
+++ b/pkg/types/agent/agent_config_type.go
@@ -9,7 +9,7 @@ import (
 // AgentConfigVersion is the version supported by this package.
 // If you bump this, you must also update the list of convertable values in
 // pkg/types/conversion/agentconfig.go
-const AgentConfigVersion = "v1alpha1"
+const AgentConfigVersion = "v1beta1"
 
 // Config or aka AgentConfig is the API for specifying additional
 // configuration for the agent-based installer not covered by

--- a/pkg/types/agent/conversion/agentconfig.go
+++ b/pkg/types/agent/conversion/agentconfig.go
@@ -15,7 +15,7 @@ import (
 func ConvertAgentConfig(config *agent.Config) error {
 	// check that the version is convertible
 	switch config.APIVersion {
-	case agent.AgentConfigVersion:
+	case agent.AgentConfigVersion, "v1alpha1":
 		// works
 	case "":
 		return field.Required(field.NewPath("apiVersion"), "no version was provided")

--- a/pkg/types/agent/conversion/agentconfig_test.go
+++ b/pkg/types/agent/conversion/agentconfig_test.go
@@ -30,6 +30,19 @@ func TestConvertAgentConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "v1alpha1",
+			config: &agent.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1alpha1",
+				},
+			},
+			expected: &agent.Config{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: agent.AgentConfigVersion,
+				},
+			},
+		},
+		{
 			name:          "no version",
 			config:        &agent.Config{},
 			expectedError: "no version was provided",


### PR DESCRIPTION
We expect to add more fields to the agent-config file in the future (thus it is not time for v1 yet), but it will now appear in the 4.12 release and thus must be kept stable. Change the version to v1beta1.

Existing configs with version v1alpha1 will continue to work.