### PR TITLE
data/data/azure/cluster/dns: set explicit dependency on virtual_network_id

### DIFF
--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -22,7 +22,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "network" {
   private_dns_zone_name = azurerm_private_dns_zone.private.name
   virtual_network_id    = var.virtual_network_id
 
-  depends_on = [time_sleep.wait_30_seconds]
+  depends_on = [time_sleep.wait_30_seconds, var.virtual_network_id]
 }
 
 resource "azurerm_private_dns_a_record" "apiint_internal" {


### PR DESCRIPTION
Force dependcy on virtual_network_id. In theory this should add virtual_network_id into the dependency graph so that private dns link does not get created until the virtual network id is created.

https://issues.redhat.com/browse/OCPBUGS-927