### PR TITLE
AGENT-365: Set install invoker to "agent-installer"

### DIFF
--- a/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
+++ b/data/data/agent/files/usr/local/share/assisted-service/assisted-service.env.template
@@ -11,6 +11,7 @@ ENABLE_SINGLE_NODE_DNSMASQ=true
 EPHEMERAL_INSTALLER_CLUSTER_TLS_CERTS_OVERRIDE_DIR=/opt/agent/tls
 HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]
 IMAGE_SERVICE_BASE_URL=http://{{.NodeZeroIP}}:8888
+INSTALL_INVOKER=agent-installer
 IPV6_SUPPORT=true
 NTP_DEFAULT_SERVER=
 PUBLIC_CONTAINER_REGISTRIES=quay.io


### PR DESCRIPTION
Ensure that in telemetry data we can distinguish between the ephemeral agent-based installer and the hosted assisted installer.