### PR TITLE
AGENT-364: Validate  network type for SNO clusters

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -156,6 +156,10 @@ func (a *OptionalInstallConfig) validateSNOConfiguration(installConfig *types.In
 
 	//  platform None always imply SNO cluster
 	if installConfig.Platform.Name() == none.Name {
+		if installConfig.Networking.NetworkType != "OVNKubernetes" {
+			fieldPath = field.NewPath("Networking", "NetworkType")
+			allErrs = append(allErrs, field.Invalid(fieldPath, installConfig.Networking.NetworkType, "Only OVNKubernetes network type is allowed for Single Node OpenShift (SNO) cluster"))
+		}
 		if *installConfig.ControlPlane.Replicas != 1 {
 			fieldPath = field.NewPath("ControlPlane", "Replicas")
 			allErrs = append(allErrs, field.Required(fieldPath, fmt.Sprintf("control plane replicas must be 1 for %s platform. Found %v", none.Name, *installConfig.ControlPlane.Replicas)))

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -81,6 +81,8 @@ apiVersion: v1
 metadata:
   name: test-cluster
 baseDomain: test-domain
+networking:
+  networkType: OVNKubernetes
 compute:
   - architecture: amd64
     hyperthreading: Enabled
@@ -107,6 +109,8 @@ apiVersion: v1
 metadata:
   name: test-cluster
 baseDomain: test-domain
+networking:
+  networkType: OVNKubernetes
 controlPlane:
   architecture: amd64
   hyperthreading: Enabled
@@ -121,12 +125,42 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			expectedError: "invalid install-config configuration: Compute.Replicas: Required value: Installing a Single Node Openshift requires explicitly setting compute replicas to zero",
 		},
 		{
+			name: "invalid networkType for SNO cluster",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  networkType: OpenShiftSDN
+compute:
+  - architecture: amd64
+    hyperthreading: Enabled
+    name: worker
+    platform: {}
+    replicas: 0
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 1
+platform:
+  none : {}
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: "invalid install-config configuration: Networking.NetworkType: Invalid value: \"OpenShiftSDN\": Only OVNKubernetes network type is allowed for Single Node OpenShift (SNO) cluster",
+		},
+		{
 			name: "valid configuration for none platform for sno",
 			data: `
 apiVersion: v1
 metadata:
   name: test-cluster
 baseDomain: test-domain
+networking:
+  networkType: OVNKubernetes
 compute:
   - architecture: amd64
     hyperthreading: Enabled


### PR DESCRIPTION
Validate `Networking.NetworkType` is set as `OVNKubernetes` for SNO clusters in install-config.yaml