### PR TITLE
OCPBUGS-1737: OpenStack: Lift validation for 14 chars cluster names

### DIFF
--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -54,10 +54,6 @@ func validateVIP(vip string, n *types.Networking) error {
 }
 
 func validateClusterName(name string) (allErrs field.ErrorList) {
-	if len(name) > 14 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), name, "cluster name is too long, please restrict it to 14 characters"))
-	}
-
 	if strings.Contains(name, ".") {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), name, "cluster name can't contain \".\" character"))
 	}

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -38,12 +38,6 @@ func TestValidateClusterName(t *testing.T) {
 	errs := ValidatePlatform(validPlatform(), validNetworking(), field.NewPath("test-path"), &testConfig)
 	assert.NoError(t, errs.ToAggregate())
 
-	// too long cluster name (more than 14 chars)
-	testConfig.ObjectMeta.Name = "0123456789abcde"
-	errs = ValidatePlatform(validPlatform(), validNetworking(), field.NewPath("test-path"), &testConfig)
-	assert.True(t, len(errs) == 1)
-	assert.Equal(t, "cluster name is too long, please restrict it to 14 characters", errs[0].Detail)
-
 	// . in the name
 	testConfig.ObjectMeta.Name = "test.cluster"
 	errs = ValidatePlatform(validPlatform(), validNetworking(), field.NewPath("test-path"), &testConfig)


### PR DESCRIPTION
The validation is no longer necessary now that we stopped using mDNS.

This aligns with other on-prem platforms.

Manual cherry-pick of https://github.com/openshift/installer/pull/6355/.