### PR TITLE
OCPBUGS-1698: multi-zone network slice validation

### DIFF
--- a/pkg/types/vsphere/platform.go
+++ b/pkg/types/vsphere/platform.go
@@ -168,7 +168,6 @@ type Topology struct {
 	// +kubebuilder:validation:MaxLength=2048
 	ComputeCluster string `json:"computeCluster"`
 	// networks is the list of networks within this failure domain
-	// +kubebuilder:validation:Optional
 	Networks []string `json:"networks,omitempty"`
 	// datastore is the name or inventory path of the datastore in which the
 	// virtual machine is created/located.

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -88,7 +88,7 @@ func validateMultiZone(p *vsphere.Platform, fldPath *field.Path) field.ErrorList
 			if len(failureDomain.Topology.ResourcePool) == 0 {
 				p.FailureDomains[idx].Topology.ResourcePool = p.ResourcePool
 			}
-			if len(failureDomain.Topology.Networks) == 0 {
+			if len(failureDomain.Topology.Networks) == 0 && len(p.Network) > 0 {
 				p.FailureDomains[idx].Topology.Networks = []string{p.Network}
 			}
 			if len(failureDomain.Topology.Datastore) == 0 {
@@ -178,6 +178,10 @@ func validateFailureDomains(p *vsphere.Platform, fldPath *field.Path) field.Erro
 
 		if len(failureDomain.Topology.Datastore) == 0 {
 			allErrs = append(allErrs, field.Required(topologyFld.Child("datastore"), "must specify a datastore"))
+		}
+
+		if len(failureDomain.Topology.Networks) == 0 {
+			allErrs = append(allErrs, field.Required(topologyFld.Child("networks"), "must specify a network"))
 		}
 
 		if len(failureDomain.Topology.ComputeCluster) == 0 {

--- a/pkg/types/vsphere/validation/platform_test.go
+++ b/pkg/types/vsphere/validation/platform_test.go
@@ -360,6 +360,15 @@ func TestValidatePlatform(t *testing.T) {
 			expectedError: `^test-path\.failureDomains\.topology\.datacenter: Required value: must specify a datacenter`,
 		},
 		{
+			name: "Multi-zone platform failureDomain topology empty networks",
+			platform: func() *vsphere.Platform {
+				p := validMultiVCenterPlatform()
+				p.FailureDomains[0].Topology.Networks = []string{}
+				return p
+			}(),
+			expectedError: `^test-path\.failureDomains\.topology\.networks: Required value: must specify a network`,
+		},
+		{
 			name: "Multi-zone platform failureDomain defaults applied",
 			platform: func() *vsphere.Platform {
 				p := validMultiVCenterPlatform()


### PR DESCRIPTION
add validation to require 'networks' be populated for multi-zone installs