### PR TITLE
Change PowerVS default machine CIDR

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -1500,7 +1500,7 @@ spec:
                   This field replaces MachineCIDR, and if set MachineCIDR must be
                   empty or match the first entry in the list. Default is 10.0.0.0/16
                   for all platforms other than libvirt and Power VS. For libvirt,
-                  the default is 192.168.126.0/24. For Power VS, the default is 192.168.0.0/16.
+                  the default is 192.168.126.0/24. For Power VS, the default is 192.168.0.0/24.
                 items:
                   description: MachineNetworkEntry is a single IP address block for
                     node IP blocks.

--- a/pkg/asset/installconfig/powervs/validation_test.go
+++ b/pkg/asset/installconfig/powervs/validation_test.go
@@ -22,7 +22,7 @@ type editFunctions []func(ic *types.InstallConfig)
 
 var (
 	validRegion                  = "lon"
-	validCIDR                    = "192.168.0.0/16"
+	validCIDR                    = "192.168.0.0/24"
 	validCISInstanceCRN          = "crn:v1:bluemix:public:internet-svcs:global:a/valid-account-id:valid-instance-id::"
 	validClusterName             = "valid-cluster-name"
 	validDNSZoneID               = "valid-zone-id"

--- a/pkg/types/installconfig.go
+++ b/pkg/types/installconfig.go
@@ -310,7 +310,7 @@ type Networking struct {
 	// be empty or match the first entry in the list.
 	// Default is 10.0.0.0/16 for all platforms other than libvirt and Power VS.
 	// For libvirt, the default is 192.168.126.0/24.
-	// For Power VS, the default is 192.168.0.0/16.
+	// For Power VS, the default is 192.168.0.0/24.
 	//
 	// +optional
 	MachineNetwork []MachineNetworkEntry `json:"machineNetwork,omitempty"`

--- a/pkg/types/powervs/defaults/platform.go
+++ b/pkg/types/powervs/defaults/platform.go
@@ -9,7 +9,7 @@ import (
 var (
 	// DefaultMachineCIDR is the PowerVS default IP address space from
 	// which to assign machine IPs.
-	DefaultMachineCIDR = ipnet.MustParseCIDR("192.168.0.0/16")
+	DefaultMachineCIDR = ipnet.MustParseCIDR("192.168.0.0/24")
 )
 
 // SetPlatformDefaults sets the defaults for the platform.


### PR DESCRIPTION
The default CIDR for PowerVS has always been 192.168.0.0/24. However, this was only recently enforced by PowerVS.