### PR TITLE
OCPBUGS-927: Move DNS Zone Link out of Module

### DIFF
--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -10,19 +10,13 @@ resource "azurerm_private_dns_zone" "private" {
   depends_on = [azurerm_dns_cname_record.api_external_v4, azurerm_dns_cname_record.api_external_v6]
 }
 
-# Sleep injected due to https://github.com/hashicorp/terraform-provider-azurerm/issues/18350
-resource "time_sleep" "wait_30_seconds" {
-  depends_on      = [azurerm_private_dns_zone.private]
-  create_duration = "30s"
-}
-
 resource "azurerm_private_dns_zone_virtual_network_link" "network" {
   name                  = "${var.cluster_id}-network-link"
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.private.name
   virtual_network_id    = var.virtual_network_id
 
-  depends_on = [time_sleep.wait_30_seconds]
+  depends_on = [azurerm_private_dns_zone.private]
 }
 
 resource "azurerm_private_dns_a_record" "apiint_internal" {

--- a/data/data/azure/cluster/dns/dns.tf
+++ b/data/data/azure/cluster/dns/dns.tf
@@ -10,15 +10,6 @@ resource "azurerm_private_dns_zone" "private" {
   depends_on = [azurerm_dns_cname_record.api_external_v4, azurerm_dns_cname_record.api_external_v6]
 }
 
-resource "azurerm_private_dns_zone_virtual_network_link" "network" {
-  name                  = "${var.cluster_id}-network-link"
-  resource_group_name   = var.resource_group_name
-  private_dns_zone_name = azurerm_private_dns_zone.private.name
-  virtual_network_id    = var.virtual_network_id
-
-  depends_on = [azurerm_private_dns_zone.private]
-}
-
 resource "azurerm_private_dns_a_record" "apiint_internal" {
   count = var.use_ipv4 ? 1 : 0
 

--- a/data/data/azure/cluster/dns/outputs.tf
+++ b/data/data/azure/cluster/dns/outputs.tf
@@ -1,0 +1,3 @@
+output "private_dns_zone_name" {
+  value = azurerm_private_dns_zone.private.name
+}

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -69,3 +69,16 @@ module "dns" {
   use_ipv4 = var.use_ipv4
   use_ipv6 = var.use_ipv6
 }
+
+# This resource has been moved from the dns module due to:
+# https://github.com/hashicorp/terraform-provider-azurerm/issues/18350
+# Having a dependency on the DNS module ensures all dns entries are created
+# in the private zone before the link is created.
+resource "azurerm_private_dns_zone_virtual_network_link" "network" {
+  name                  = "${var.cluster_id}-network-link"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = module.dns.private_dns_zone_name
+  virtual_network_id    = var.virtual_network_id
+
+  depends_on = [module.dns]
+}

--- a/pkg/terraform/stages/azure/stages.go
+++ b/pkg/terraform/stages/azure/stages.go
@@ -23,7 +23,7 @@ var PlatformStages = []terraform.Stage{
 	stages.NewStage(
 		typesazure.Name,
 		"cluster",
-		[]providers.Provider{providers.AzureRM, providers.Time},
+		[]providers.Provider{providers.AzureRM},
 	),
 }
 


### PR DESCRIPTION
This reverts #6349, although I am open to keeping it. It just seemed easier to remove it.

Not sure if this will work, but I analyzed several success and failure cases related to [OCPBUGS-927](https://issues.redhat.com/browse/OCPBUGS-927). There was a correlation between successful creation of the link resource when A records were created in advance of the link resource, and failures when we started trying to create the link resource at the same time as when records were still being created in the zone.

Let's test this out and see if we get any luck.