### PR TITLE
OpenStack: Store ignition file in Swift when the upload in Glance fails

### DIFF
--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/asset/cluster"
 	osp "github.com/openshift/installer/pkg/destroy/openstack"
@@ -34,6 +35,11 @@ func Destroy(dir string) (err error) {
 		imageName := metadata.InfraID + "-ignition"
 		if err := osp.DeleteGlanceImage(imageName, metadata.OpenStack.Cloud); err != nil {
 			return errors.Wrapf(err, "Failed to delete glance image %s", imageName)
+		}
+
+		if err := osp.DeleteSwiftContainer(metadata.InfraID, metadata.OpenStack.Cloud); err != nil {
+			// Dose not return for environments without swift storage
+			logrus.Warningf("Failed to delete swift container %s: %v", metadata.InfraID, err)
 		}
 	}
 


### PR DESCRIPTION
Some openstack environments do not allow users to upload or download image data. This is because the cloud providers prevent them from using illegal images on the openstack or getting proprietary images on a local.

This PR is based on the Swift functions removed in PR #2960 and adds the feature to store a ignition file in Swift when an upload in Glance fails, as follows:

   |Glance enable | Swift enable | used storage |
   | -- | -- | --|
   |   v   |   v    | Glance |
   |   v   |        | Glance |
   |       |   v    | Swift   <- this PR |
   |       |        | none |
