### PR TITLE
Bug 2117687: Check for compute.replicas must be 0 for SNO

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -156,7 +156,12 @@ func (a *OptionalInstallConfig) validateSNOConfiguration(installConfig *types.In
 
 	var workers int
 	for _, worker := range installConfig.Compute {
-		workers = workers + int(*worker.Replicas)
+		if worker.Replicas == nil {
+			fieldPath = field.NewPath("Compute", "Replicas")
+			allErrs = append(allErrs, field.Required(fieldPath, "Installing a Single Node Openshift requires explicitly setting Compute.Replicas to 0"))
+		} else {
+			workers = workers + int(*worker.Replicas)
+		}
 	}
 
 	//  platform None always imply SNO cluster
@@ -171,7 +176,7 @@ func (a *OptionalInstallConfig) validateSNOConfiguration(installConfig *types.In
 			allErrs = append(allErrs, field.Required(fieldPath, fmt.Sprintf("ControlPlane.Replicas must be 1 for %s platform. Found %v", none.Name, *installConfig.ControlPlane.Replicas)))
 		} else if len(installConfig.Compute) == 0 {
 			fieldPath = field.NewPath("Compute", "Replicas")
-			allErrs = append(allErrs, field.Required(fieldPath, "Installing a Single Node Openshift requires explicitly setting compute replicas to zero"))
+			allErrs = append(allErrs, field.Required(fieldPath, "Installing a Single Node Openshift requires explicitly setting Compute.Replicas to 0"))
 		}
 
 		if workers != 0 {

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -103,6 +103,32 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			expectedError: "invalid install-config configuration: [ControlPlane.Replicas: Required value: ControlPlane.Replicas must be 1 for none platform. Found 3, Compute.Replicas: Required value: Total number of Compute.Replicas must be 0 for none platform. Found 2]",
 		},
 		{
+			name: "compute.replicas missing for SNO",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  networkType: OVNKubernetes
+compute:
+- architecture: amd64
+  hyperthreading: Enabled
+  name: worker
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 1
+platform:
+  none : {}
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: "invalid install-config configuration: Compute.Replicas: Required value: Installing a Single Node Openshift requires explicitly setting Compute.Replicas to 0",
+		},
+		{
 			name: "no compute.replicas set for SNO",
 			data: `
 apiVersion: v1
@@ -122,7 +148,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: Compute.Replicas: Required value: Installing a Single Node Openshift requires explicitly setting compute replicas to zero",
+			expectedError: "invalid install-config configuration: Compute.Replicas: Required value: Installing a Single Node Openshift requires explicitly setting Compute.Replicas to 0",
 		},
 		{
 			name: "invalid networkType for SNO cluster",


### PR DESCRIPTION
When controlPlane.replicas = 1 and compute.replicas is missing from install-config.yaml, validation warns users that compute.replicas needs to be set to 0 when controlPlane.replicas = 1 for SNO cluster on none platform.

validation error: invalid install-config configuration: Compute.Replicas: Required value: Installing a Single Node Openshift requires explicitly setting compute replicas to zero

https://bugzilla.redhat.com/show_bug.cgi?id=2117687