### PR TITLE
AGENT-264: validate agent-config macs

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -150,81 +150,66 @@ func (a *AgentConfig) finish() error {
 }
 
 func (a *AgentConfig) validateAgent() field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if err := a.validateNodesHaveAtLeastOneMacAddressDefined(); err != nil {
-		allErrs = append(allErrs, err...)
-	}
-
-	if err := a.validateRootDeviceHints(); err != nil {
-		allErrs = append(allErrs, err...)
-	}
-
-	if err := a.validateRoles(); err != nil {
-		allErrs = append(allErrs, err...)
-	}
-
-	return allErrs
-}
-
-func (a *AgentConfig) validateNodesHaveAtLeastOneMacAddressDefined() field.ErrorList {
 	var allErrs field.ErrorList
-
-	if len(a.Config.Hosts) == 0 {
-		return allErrs
-	}
-
-	rootPath := field.NewPath("Hosts")
-
-	for i := range a.Config.Hosts {
-		node := a.Config.Hosts[i]
-		interfacePath := rootPath.Index(i).Child("Interfaces")
-		if len(node.Interfaces) == 0 {
-			allErrs = append(allErrs, field.Required(interfacePath, "at least one interface must be defined for each node"))
-		}
-
-		for j := range node.Interfaces {
-			if node.Interfaces[j].MacAddress == "" {
-				macAddressPath := interfacePath.Index(j).Child("macAddress")
-				allErrs = append(allErrs, field.Required(macAddressPath, "each interface must have a MAC address defined"))
-			}
-		}
-	}
-	return allErrs
-}
-
-func (a *AgentConfig) validateRootDeviceHints() field.ErrorList {
-	var allErrs field.ErrorList
-	rootPath := field.NewPath("Hosts")
 
 	for i, host := range a.Config.Hosts {
-		hostPath := rootPath.Index(i)
-		if host.RootDeviceHints.WWNWithExtension != "" {
-			allErrs = append(allErrs, field.Forbidden(
-				hostPath.Child("RootDeviceHints", "WWNWithExtension"),
-				"WWN extensions are not supported in root device hints"))
+
+		hostPath := field.NewPath("Hosts").Index(i)
+
+		if err := a.validateHostInterfaces(hostPath, host); err != nil {
+			allErrs = append(allErrs, err...)
 		}
-		if host.RootDeviceHints.WWNVendorExtension != "" {
-			allErrs = append(allErrs, field.Forbidden(
-				hostPath.Child("RootDeviceHints", "WWNVendorExtension"),
-				"WWN vendor extensions are not supported in root device hints"))
+
+		if err := a.validateHostRootDeviceHints(hostPath, host); err != nil {
+			allErrs = append(allErrs, err...)
+		}
+
+		if err := a.validateRoles(hostPath, host); err != nil {
+			allErrs = append(allErrs, err...)
 		}
 	}
 
 	return allErrs
 }
 
-func (a *AgentConfig) validateRoles() field.ErrorList {
+func (a *AgentConfig) validateHostInterfaces(hostPath *field.Path, host agent.Host) field.ErrorList {
 	var allErrs field.ErrorList
-	rootPath := field.NewPath("Hosts")
 
-	for i, host := range a.Config.Hosts {
-		hostPath := rootPath.Index(i)
-		if len(host.Role) > 0 && host.Role != "master" && host.Role != "worker" {
-			allErrs = append(allErrs, field.Forbidden(
-				hostPath.Child("Host"),
-				"host role has incorrect value. Role must either be 'master' or 'worker'"))
+	interfacePath := hostPath.Child("Interfaces")
+	if len(host.Interfaces) == 0 {
+		allErrs = append(allErrs, field.Required(interfacePath, "at least one interface must be defined for each node"))
+	}
+
+	for j := range host.Interfaces {
+		if host.Interfaces[j].MacAddress == "" {
+			macAddressPath := interfacePath.Index(j).Child("macAddress")
+			allErrs = append(allErrs, field.Required(macAddressPath, "each interface must have a MAC address defined"))
 		}
+	}
+
+	return allErrs
+}
+
+func (a *AgentConfig) validateHostRootDeviceHints(hostPath *field.Path, host agent.Host) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if host.RootDeviceHints.WWNWithExtension != "" {
+		allErrs = append(allErrs, field.Forbidden(
+			hostPath.Child("RootDeviceHints", "WWNWithExtension"), "WWN extensions are not supported in root device hints"))
+	}
+
+	if host.RootDeviceHints.WWNVendorExtension != "" {
+		allErrs = append(allErrs, field.Forbidden(hostPath.Child("RootDeviceHints", "WWNVendorExtension"), "WWN vendor extensions are not supported in root device hints"))
+	}
+
+	return allErrs
+}
+
+func (a *AgentConfig) validateRoles(hostPath *field.Path, host agent.Host) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if len(host.Role) > 0 && host.Role != "master" && host.Role != "worker" {
+		allErrs = append(allErrs, field.Forbidden(hostPath.Child("Host"), "host role has incorrect value. Role must either be 'master' or 'worker'"))
 	}
 
 	return allErrs

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -1,6 +1,7 @@
 package agentconfig
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -10,88 +11,20 @@ import (
 	"github.com/openshift/installer/pkg/asset/mock"
 	"github.com/openshift/installer/pkg/types/agent"
 	"github.com/openshift/installer/pkg/types/baremetal"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// func TestAgentConfig_Generate(t *testing.T) {
-
-// 	cases := []struct {
-// 		name           string
-// 		expectedError  string
-// 		expectedConfig *agent.Config
-// 	}{
-// 		{
-// 			name: "generate-basic-template",
-// 			expectedConfig: &agent.Config{
-// 				TypeMeta: metav1.TypeMeta{
-// 					Kind:       "AgentConfig",
-//					APIVersion: agent.AgentConfigVersion,
-// 				},
-// 				ObjectMeta: metav1.ObjectMeta{
-// 					Name:      "example-agent-config",
-// 					Namespace: "cluster0",
-// 				},
-// 				Spec: agent.Spec{
-// 					RendezvousIP: "your-node0-ip",
-// 					Hosts: []agent.Host{
-// 						{
-// 							Hostname: "change-to-hostname",
-// 							Role:     "master",
-// 							RootDeviceHints: baremetal.RootDeviceHints{
-// 								DeviceName: "/dev/sda",
-// 							},
-// 							Interfaces: []*aiv1beta1.Interface{
-// 								{
-// 									Name:       "your-network-interface-name",
-// 									MacAddress: "00:00:00:00:00",
-// 								},
-// 							},
-// 						},
-// 					},
-// 				},
-// 			},
-// 		},
-// 	}
-// 	for _, tc := range cases {
-// 		t.Run(tc.name, func(t *testing.T) {
-
-// 			parents := asset.Parents{}
-// 			asset := &AgentConfig{}
-// 			err := asset.Generate(parents)
-
-// 			if tc.expectedError != "" {
-// 				assert.Equal(t, tc.expectedError, err.Error())
-// 			} else {
-// 				assert.NoError(t, err)
-// 				assert.Equal(t, tc.expectedConfig, asset.Config)
-// 				assert.NotEmpty(t, asset.Files())
-
-// 				configFile := asset.Files()[0]
-// 				assert.Equal(t, "agent-config.yaml", configFile.Filename)
-
-// 				var actualConfig agent.Config
-// 				err = yaml.Unmarshal(configFile.Data, &actualConfig)
-// 				assert.NoError(t, err)
-// 				assert.Equal(t, *tc.expectedConfig, actualConfig)
-// 			}
-// 		})
-// 	}
-
-// }
-
 func TestAgentConfig_LoadedFromDisk(t *testing.T) {
-	falseBool := false
-	falsePtr := &falseBool
 
 	cases := []struct {
-		name           string
-		data           string
-		fetchError     error
-		expectedFound  bool
+		name       string
+		data       string
+		fetchError error
+
 		expectedError  string
-		expectedConfig *agent.Config
+		expectedFound  bool
+		expectedConfig *AgentConfigBuilder
 	}{
 		{
 			name: "valid-config-single-node",
@@ -119,45 +52,9 @@ hosts:
         macAddress: 28:d2:44:d2:b2:1a
     networkConfig:
       interfaces:`,
-			expectedFound: true,
-			expectedConfig: &agent.Config{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: agent.AgentConfigVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "agent-config-cluster0",
-				},
-				RendezvousIP: "192.168.111.80",
-				Hosts: []agent.Host{
-					{
-						Hostname: "control-0.example.org",
-						Role:     "master",
-						RootDeviceHints: baremetal.RootDeviceHints{
-							DeviceName:       "/dev/sda",
-							HCTL:             "hctl-value",
-							Model:            "model-value",
-							Vendor:           "vendor-value",
-							SerialNumber:     "serial-number-value",
-							MinSizeGigabytes: 20,
-							WWN:              "wwn-value",
-							Rotational:       falsePtr,
-						},
-						Interfaces: []*aiv1beta1.Interface{
-							{
-								Name:       "enp2s0",
-								MacAddress: "98:af:65:a5:8d:01",
-							},
-							{
-								Name:       "enp3s1",
-								MacAddress: "28:d2:44:d2:b2:1a",
-							},
-						},
-						NetworkConfig: aiv1beta1.NetConfig{
-							Raw: unmarshalJSON([]byte("interfaces:")),
-						},
-					},
-				},
-			},
+
+			expectedFound:  true,
+			expectedConfig: agentConfig().hosts(defaultAgentHost("control-0.example.org")),
 		},
 		{
 			name: "valid-config-multiple-nodes",
@@ -170,14 +67,14 @@ hosts:
   - hostname: control-0.example.org
     role: master
     rootDeviceHints:
-      deviceName: "/dev/sda"
-      hctl: "hctl-value"
-      model: "model-value"
-      vendor: "vendor-value"
-      serialNumber: "serial-number-value"
-      minSizeGigabytes: 20
-      wwn: "wwn-value"
-      rotational: false
+        deviceName: "/dev/sda"
+        hctl: "hctl-value"
+        model: "model-value"
+        vendor: "vendor-value"
+        serialNumber: "serial-number-value"
+        minSizeGigabytes: 20
+        wwn: "wwn-value"
+        rotational: false
     interfaces:
       - name: enp2s0
         macAddress: 98:af:65:a5:8d:01
@@ -192,72 +89,38 @@ hosts:
         macAddress: 98:af:65:a5:8d:02
       - name: enp3s1
         macAddress: 28:d2:44:d2:b2:1b`,
+
 			expectedFound: true,
-			expectedConfig: &agent.Config{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: agent.AgentConfigVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "agent-config-cluster0",
-				},
-				RendezvousIP: "192.168.111.80",
-				Hosts: []agent.Host{
-					{
-						Hostname: "control-0.example.org",
-						Role:     "master",
-						RootDeviceHints: baremetal.RootDeviceHints{
-							DeviceName:       "/dev/sda",
-							HCTL:             "hctl-value",
-							Model:            "model-value",
-							Vendor:           "vendor-value",
-							SerialNumber:     "serial-number-value",
-							MinSizeGigabytes: 20,
-							WWN:              "wwn-value",
-							Rotational:       falsePtr,
-						},
-						Interfaces: []*aiv1beta1.Interface{
-							{
-								Name:       "enp2s0",
-								MacAddress: "98:af:65:a5:8d:01",
-							},
-							{
-								Name:       "enp3s1",
-								MacAddress: "28:d2:44:d2:b2:1a",
-							},
-						},
-						NetworkConfig: aiv1beta1.NetConfig{
-							Raw: unmarshalJSON([]byte("interfaces:")),
-						},
-					},
-					{
-						Hostname: "control-1.example.org",
-						Role:     "master",
-						Interfaces: []*aiv1beta1.Interface{
-							{
-								Name:       "enp2s0",
-								MacAddress: "98:af:65:a5:8d:02",
-							},
-							{
-								Name:       "enp3s1",
-								MacAddress: "28:d2:44:d2:b2:1b",
-							},
-						},
-					},
-				},
-			},
+			expectedConfig: agentConfig().
+				hosts(
+					defaultAgentHost("control-0.example.org"),
+					agentHost().
+						name("control-1.example.org").
+						role("master").
+						interfaces(
+							iface("enp2s0", "98:af:65:a5:8d:02"),
+							iface("enp3s1", "28:d2:44:d2:b2:1b"),
+						),
+				),
 		},
 		{
-			name:          "not-yaml",
-			data:          `This is not a yaml file`,
+			name: "not-yaml",
+			data: `This is not a yaml file`,
+
+			expectedFound: false,
 			expectedError: "failed to unmarshal agent-config.yaml: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type agent.Config",
 		},
 		{
 			name:       "file-not-found",
 			fetchError: &os.PathError{Err: os.ErrNotExist},
+
+			expectedFound: false,
 		},
 		{
-			name:          "error-fetching-file",
-			fetchError:    errors.New("fetch failed"),
+			name:       "error-fetching-file",
+			fetchError: errors.New("fetch failed"),
+
+			expectedFound: false,
 			expectedError: "failed to load agent-config.yaml file: fetch failed",
 		},
 		{
@@ -267,6 +130,8 @@ apiVersion: v1alpha1
 metadata:
   name: agent-config-wrong
 wrongField: wrongValue`,
+
+			expectedFound: false,
 			expectedError: "failed to unmarshal agent-config.yaml: error unmarshaling JSON: while decoding JSON: json: unknown field \"wrongField\"",
 		},
 		{
@@ -282,6 +147,8 @@ hosts:
       - name: enp2s0
       - name: enp3s1
         macAddress: 28:d2:44:d2:b2:1a`,
+
+			expectedFound: false,
 			expectedError: "invalid Agent Config configuration: Hosts[0].Interfaces[0].macAddress: Required value: each interface must have a MAC address defined",
 		},
 		{
@@ -298,6 +165,8 @@ hosts:
         macAddress: 98:af:65:a5:8d:01
     rootDeviceHints:
       wwnWithExtension: "wwn-with-extension-value"`,
+
+			expectedFound: false,
 			expectedError: "invalid Agent Config configuration: Hosts[0].RootDeviceHints.WWNWithExtension: Forbidden: WWN extensions are not supported in root device hints",
 		},
 		{
@@ -314,6 +183,8 @@ hosts:
         macAddress: 98:af:65:a5:8d:01
     rootDeviceHints:
       wwnVendorExtension: "wwn-with-vendor-extension-value"`,
+
+			expectedFound: false,
 			expectedError: "invalid Agent Config configuration: Hosts[0].RootDeviceHints.WWNVendorExtension: Forbidden: WWN vendor extensions are not supported in root device hints",
 		},
 		{
@@ -327,26 +198,12 @@ hosts:
   - interfaces:
       - name: enp3s1
         macAddress: 28:d2:44:d2:b2:1a`,
+
 			expectedFound: true,
-			expectedConfig: &agent.Config{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: agent.AgentConfigVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "agent-config-cluster0",
-				},
-				RendezvousIP: "192.168.111.80",
-				Hosts: []agent.Host{
-					{
-						Interfaces: []*aiv1beta1.Interface{
-							{
-								Name:       "enp3s1",
-								MacAddress: "28:d2:44:d2:b2:1a",
-							},
-						},
-					},
-				},
-			},
+			expectedConfig: agentConfig().hosts(
+				agentHost().interfaces(
+					iface("enp3s1", "28:d2:44:d2:b2:1a"),
+				)),
 		},
 		{
 			name: "host-roles-have-correct-values",
@@ -364,36 +221,12 @@ hosts:
     interfaces:
       - name: enp3s1
         macAddress: 28:d2:44:d2:b2:1b`,
+
 			expectedFound: true,
-			expectedConfig: &agent.Config{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: agent.AgentConfigVersion,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "agent-config-cluster0",
-				},
-				RendezvousIP: "192.168.111.80",
-				Hosts: []agent.Host{
-					{
-						Role: "master",
-						Interfaces: []*aiv1beta1.Interface{
-							{
-								Name:       "enp3s1",
-								MacAddress: "28:d2:44:d2:b2:1a",
-							},
-						},
-					},
-					{
-						Role: "worker",
-						Interfaces: []*aiv1beta1.Interface{
-							{
-								Name:       "enp3s1",
-								MacAddress: "28:d2:44:d2:b2:1b",
-							},
-						},
-					},
-				},
-			},
+			expectedConfig: agentConfig().hosts(
+				agentHost().role("master").interfaces(iface("enp3s1", "28:d2:44:d2:b2:1a")),
+				agentHost().role("worker").interfaces(iface("enp3s1", "28:d2:44:d2:b2:1b")),
+			),
 		},
 		{
 			name: "host-roles-have-incorrect-values",
@@ -407,6 +240,8 @@ hosts:
     interfaces:
       - name: enp3s1
         macAddress: 28:d2:44:d2:b2:1a`,
+
+			expectedFound: false,
 			expectedError: "invalid Agent Config configuration: Hosts[0].Host: Forbidden: host role has incorrect value. Role must either be 'master' or 'worker'",
 		},
 	}
@@ -427,16 +262,138 @@ hosts:
 
 			asset := &AgentConfig{}
 			found, err := asset.Load(fileFetcher)
+			assert.Equal(t, tc.expectedFound, found)
 			if tc.expectedError != "" {
 				assert.Equal(t, tc.expectedError, err.Error())
 			} else {
 				assert.NoError(t, err)
-			}
-			assert.Equal(t, tc.expectedFound, found, "unexpected found value returned from Load")
-			if tc.expectedFound {
-				assert.Equal(t, tc.expectedConfig, asset.Config, "unexpected Config in AgentConfig")
+				if tc.expectedConfig != nil {
+					assert.Equal(t, tc.expectedConfig.build(), asset.Config, "unexpected Config in AgentConfig")
+				}
 			}
 		})
 	}
 
+}
+
+// AgentConfigBuilder it's a builder class to make it easier creating agent.Config instance
+// used in the test cases
+type AgentConfigBuilder struct {
+	agent.Config
+}
+
+func agentConfig() *AgentConfigBuilder {
+	return &AgentConfigBuilder{
+		Config: agent.Config{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "agent-config-cluster0",
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: agent.AgentConfigVersion,
+			},
+			RendezvousIP: "192.168.111.80",
+		},
+	}
+}
+
+func (acb *AgentConfigBuilder) build() *agent.Config {
+	return &acb.Config
+}
+
+func (acb *AgentConfigBuilder) hosts(builders ...*AgentHostBuilder) *AgentConfigBuilder {
+
+	hosts := []agent.Host{}
+	for _, b := range builders {
+		hosts = append(hosts, *b.build())
+	}
+	acb.Config.Hosts = hosts
+
+	return acb
+}
+
+// AgentHostBuilder it's a builder class to make it easier creating agent.Host instances
+// used in the test cases, as part of the agent.Config type
+type AgentHostBuilder struct {
+	agent.Host
+}
+
+func agentHost() *AgentHostBuilder {
+	return &AgentHostBuilder{}
+}
+
+func defaultAgentHost(name string) *AgentHostBuilder {
+	return agentHost().
+		name(name).
+		role("master").
+		interfaces(
+			iface("enp2s0", "98:af:65:a5:8d:01"),
+			iface("enp3s1", "28:d2:44:d2:b2:1a"),
+		).
+		defaultRootDeviceHints().
+		networkConfig("interfaces:")
+}
+
+func (ahb *AgentHostBuilder) build() *agent.Host {
+	return &ahb.Host
+}
+
+func (ahb *AgentHostBuilder) name(name string) *AgentHostBuilder {
+	ahb.Host.Hostname = name
+	return ahb
+}
+
+func (ahb *AgentHostBuilder) role(role string) *AgentHostBuilder {
+	ahb.Host.Role = role
+	return ahb
+}
+
+func (ahb *AgentHostBuilder) interfaces(builders ...*InterfacetBuilder) *AgentHostBuilder {
+	ifaces := []*aiv1beta1.Interface{}
+	for _, b := range builders {
+		ifaces = append(ifaces, b.build())
+	}
+	ahb.Host.Interfaces = ifaces
+	return ahb
+}
+
+func (ahb *AgentHostBuilder) networkConfig(raw string) *AgentHostBuilder {
+	ahb.Host.NetworkConfig = aiv1beta1.NetConfig{
+		Raw: unmarshalJSON([]byte(raw)),
+	}
+	return ahb
+}
+
+// TODO: Create BaremetalRootDeviceHintsBuilder, for the current tests not required
+func (ahb *AgentHostBuilder) defaultRootDeviceHints() *AgentHostBuilder {
+	falseBool := false
+	ahb.Host.RootDeviceHints = baremetal.RootDeviceHints{
+		DeviceName:       "/dev/sda",
+		HCTL:             "hctl-value",
+		Model:            "model-value",
+		Vendor:           "vendor-value",
+		SerialNumber:     "serial-number-value",
+		MinSizeGigabytes: 20,
+		WWN:              "wwn-value",
+		Rotational:       &falseBool,
+	}
+	return ahb
+}
+
+// InterfacetBuilder it's a builder class to make it easier creating aiv1beta1.Interface instances
+// used in the test cases, as part of the agent.Config type
+type InterfacetBuilder struct {
+	aiv1beta1.Interface
+}
+
+func iface(name string, mac string) *InterfacetBuilder {
+	return &InterfacetBuilder{
+		Interface: aiv1beta1.Interface{
+			Name:       name,
+			MacAddress: mac,
+		},
+	}
+}
+
+func (ib *InterfacetBuilder) build() *aiv1beta1.Interface {
+	return &ib.Interface
 }

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -244,6 +244,41 @@ hosts:
 			expectedFound: false,
 			expectedError: "invalid Agent Config configuration: Hosts[0].Host: Forbidden: host role has incorrect value. Role must either be 'master' or 'worker'",
 		},
+		{
+			name: "different-ifaces-same-host-cannot-have-same-mac",
+			data: `
+apiVersion: v1alpha1
+metadata:
+  name: agent-config-cluster0
+rendezvousIP: 192.168.111.80
+hosts:
+  - interfaces:
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1a
+      - name: enp3s2
+        macAddress: 28:d2:44:d2:b2:1a`,
+
+			expectedFound: false,
+			expectedError: "invalid Agent Config configuration: Hosts[0].Interfaces[1].macAddress: Invalid value: \"duplicate MAC address found\": 28:d2:44:d2:b2:1a",
+		},
+		{
+			name: "different-hosts-cannot-have-same-mac",
+			data: `
+apiVersion: v1alpha1
+metadata:
+  name: agent-config-cluster0
+rendezvousIP: 192.168.111.80
+hosts:
+  - interfaces:
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1a
+  - interfaces:
+      - name: enp3s1
+        macAddress: 28:d2:44:d2:b2:1a`,
+
+			expectedFound: false,
+			expectedError: "invalid Agent Config configuration: Hosts[1].Interfaces[0].macAddress: Invalid value: \"duplicate MAC address found\": 28:d2:44:d2:b2:1a",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This patch adds two new validations for the agent-config file to ensure that the configured mac addresses are not duplicated.
Additionaly, tests have been refactored to improve (hopefully) the readability and to make it easier adding new cases.