### PR TITLE
OCPBUGS-527: Improve error message in case of failure during the agent image generation

### DIFF
--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -57,8 +57,10 @@ func (a *AgentImage) Generate(dependencies asset.Parents) error {
 
 // PersistToFile writes the iso image in the assets folder
 func (a *AgentImage) PersistToFile(directory string) error {
+	// If the imageReader is not set then it means that either one of the AgentImage
+	// dependencies or the asset itself failed for some reason
 	if a.imageReader == nil {
-		return errors.New("image reader not available")
+		return errors.New("cannot generate ISO image due to configuration errors")
 	}
 
 	defer a.imageReader.Close()


### PR DESCRIPTION
Currently whenever the `agent create image` command fails for any reason (usually a configuration error), a pretty technical and not very user-friendly message is reported.

This patch aims to provide a better message for the end user. The output will look like the following:
```
...
ERROR failed to write asset (Agent Installer ISO) to disk: cannot generate ISO image due some configuration errors 
...