### PR TITLE
AGENT-321: Move validation failures to debug log level

### DIFF
--- a/pkg/agent/validations.go
+++ b/pkg/agent/validations.go
@@ -125,13 +125,13 @@ func checkHostsValidations(cluster *models.Cluster, log *logrus.Logger) bool {
 			return true
 		}
 
-		log.Info("Checking for validation failures ----------------------------------------------")
+		log.Debug("Checking for validation failures ----------------------------------------------")
 		for _, v := range previousValidations {
 			log.WithFields(logrus.Fields{
 				"category": v.category,
 				"label":    v.label,
 				"message":  v.message,
-			}).Error(v.header)
+			}).Debug(v.header)
 		}
 	}
 


### PR DESCRIPTION
Moving these to the debug level because a validation can resolve on its own. Leaving it at the error level confuses the customer, this is more of a debugging feature for the customer.

[AGENT-321](https://issues.redhat.com//browse/AGENT-321)