### PR TITLE
WIP: CORS-2291: Log terraform messages to file.

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -184,7 +184,6 @@ func (c *Cluster) applyStage(platform string, stage terraform.Stage, terraformDi
 func (c *Cluster) applyTerraform(tmpDir string, platform string, stage terraform.Stage, terraformDir string, opts ...tfexec.ApplyOption) (*asset.File, error) {
 	timer.StartTimer(stage.Name())
 	defer timer.StopTimer(stage.Name())
-
 	applyErr := terraform.Apply(tmpDir, platform, stage, terraformDir, opts...)
 
 	// Write the state file to the install directory even if the apply failed.
@@ -206,6 +205,7 @@ func (c *Cluster) applyTerraform(tmpDir string, platform string, stage terraform
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get outputs from stage %q", stage.Name())
 	}
+	logrus.StandardLogger().SetOutput(os.Stdout)
 
 	outputsFile := &asset.File{
 		Filename: stage.OutputsFilename(),


### PR DESCRIPTION
Terraform logs are currently being added to the installer logs even if the TF_LOG_PATH variable is set. This causes the logs to become large and unreadable.

Moving the terraform logs to a separate file determined by the TF_LOG_PATH variable.