### PR TITLE
OCPBUGS-1896: Validate Credentials Mode After Install Config step

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -366,15 +366,32 @@ func validateRegion(client API, ic *types.InstallConfig, fieldPath *field.Path) 
 	return nil
 }
 
-// validateCredentialMode checks whether the credential mode is
+// ValidateCredentialMode checks whether the credential mode is
 // compatible with the authentication mode.
-func validateCredentialMode(client API, ic *types.InstallConfig) field.ErrorList {
-	allErrs := field.ErrorList{}
+func ValidateCredentialMode(client API, ic *types.InstallConfig) error {
 	creds := client.GetCredentials()
 
 	if creds.JSON == nil && ic.CredentialsMode != types.ManualCredentialsMode {
 		errMsg := "environmental authentication is only supported with Manual credentials mode"
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("credentialsMode"), errMsg))
+		return field.Forbidden(field.NewPath("credentialsMode"), errMsg)
+	}
+
+	return nil
+}
+
+func validateCredentialMode(client API, ic *types.InstallConfig) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	creds := client.GetCredentials()
+	if creds.JSON == nil {
+		if ic.CredentialsMode == "" {
+			logrus.Warn("Currently using GCP Environmental Authentication. Please set credentialsMode to manual, or provide a service account json file.")
+		} else {
+			if ic.CredentialsMode != "" && ic.CredentialsMode != types.ManualCredentialsMode {
+				errMsg := "environmental authentication is only supported with Manual credentials mode"
+				return append(allErrs, field.Forbidden(field.NewPath("credentialsMode"), errMsg))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/asset/installconfig/platformcredscheck.go
+++ b/pkg/asset/installconfig/platformcredscheck.go
@@ -62,9 +62,14 @@ func (a *PlatformCredsCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 	case gcp.Name:
-		_, err = gcpconfig.GetSession(ctx)
+		client, err := gcpconfig.NewClient(context.TODO())
 		if err != nil {
-			return errors.Wrap(err, "creating GCP session")
+			return err
+		}
+
+		err = gcpconfig.ValidateCredentialMode(client, ic.Config)
+		if err != nil {
+			return errors.Wrap(err, "validating credentials")
 		}
 	case ibmcloud.Name:
 		_, err = ibmcloudconfig.NewClient()


### PR DESCRIPTION
** The install config would fail immediately when the credentials were nil. There was no chance to set the Credentials Mode to Manual. Now the install config can be generated then the user can manually set the credentials mode to manual. ** More tests were generated for this functionality