### PR TITLE
Require the user to specify the `none` platform when performing bootstrap-in-place

### DIFF
--- a/pkg/asset/ignition/bootstrap/bootstrap_in_place.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap_in_place.go
@@ -61,6 +61,10 @@ func (a *SingleNodeBootstrapInPlace) Load(f asset.FileFetcher) (found bool, err 
 // verifyBootstrapInPlace validate the number of control plane replica is one and that installation disk is set
 func verifyBootstrapInPlace(installConfig *types.InstallConfig) error {
 	errorList := field.ErrorList{}
+	if installConfig.Platform.None == nil {
+		errorList = append(errorList, field.Required(field.NewPath("platform", "none"),
+			"must use none platform for single node bootstrap in place installation, other platforms are not supported"))
+	}
 	if installConfig.ControlPlane.Replicas == nil {
 		errorList = append(errorList, field.Invalid(field.NewPath("controlPlane", "replicas"), installConfig.ControlPlane.Replicas,
 			"bootstrap in place requires ControlPlane.Replicas configuration"))


### PR DESCRIPTION
Currently the installer allows users to do bootstrap in place
(`./openshift-install create single-node-ignition-config`) even when
they're using platforms other than `none`.

This is unsupported and will probably not work, yet the manifests get
generated without any explicit error about it.

To prevent users from doing this, the installer will now give an error
when the user runs `single-node-ignition-config` with a platform that is
not the none-platform.

(The installer already correctly gives an error when the user doesn't
set any platform or when the user sets more than one platform, so it's
sufficient to just additionaly check that the none platform is set)