### PR TITLE
OCPBUGS-1856: IBMCloud: Allow traffic to kube-api-lb

### DIFF
--- a/data/data/ibmcloud/network/vpc/security-groups.tf
+++ b/data/data/ibmcloud/network/vpc/security-groups.tf
@@ -178,7 +178,7 @@ resource "ibm_is_security_group" "kubernetes_api_lb" {
 resource "ibm_is_security_group_rule" "kubernetes_api_lb_inbound" {
   group     = ibm_is_security_group.kubernetes_api_lb.id
   direction = "inbound"
-  remote    = var.public_endpoints ? "0.0.0.0/0" : ibm_is_security_group.cluster_wide.id
+  remote    = "0.0.0.0/0"
   tcp {
     port_min = 6443
     port_max = 6443


### PR DESCRIPTION
Allow traffic from any source to the kube-api-lb apiserver for IBM Cloud. Private cluster traffic should already be restricted to be from within the VPC, via DNS Services, so removing the restriction it must also be from within the cluster's network as well.

Related: https://issues.redhat.com/browse/OCPBUGS-1856