### PR TITLE
OCPBUGS-562: bump RHCOS 4.11 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.11",
   "metadata": {
-    "last-modified": "2022-08-15T02:35:13Z",
-    "generator": "plume cosa2stream 1e6eb0f"
+    "last-modified": "2022-10-04T18:22:41Z",
+    "generator": "plume cosa2stream 5cce8c7"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "411.86.202208111758-0",
+          "release": "411.86.202210032347-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-aws.aarch64.vmdk.gz",
-                "sha256": "7897efde6a0ffe1af7fbf5486d3565d88d21eccab507a191c1e7cf56d443c904",
-                "uncompressed-sha256": "95af6738d072870bd693a025070afeac8ecd85084d02dfb373960ef55b528bc5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-aws.aarch64.vmdk.gz",
+                "sha256": "e1b4aa989eef1eaf97a2cef3316bee759a213c8cda0eacd878c34dc6ad3343ed",
+                "uncompressed-sha256": "2f17c67c668a06b2e81dce64a2e35a35bff1cd4131a6e3c73c3a1754d1e0db3f"
               }
             }
           }
         },
         "azure": {
-          "release": "411.86.202208111758-0",
+          "release": "411.86.202210032347-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-azure.aarch64.vhd.gz",
-                "sha256": "88eb5c2eb06a9d663235e037730f0b47030ba70250eed9e07d231bd72ccd4528",
-                "uncompressed-sha256": "54e7486bfa9af8f0ed8ec34f21064f57b410322cc6976e9968d4779c1eeefe68"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-azure.aarch64.vhd.gz",
+                "sha256": "ed0275822e3d8711f023812da896514fb3e55c5220bf23d228a4176f88792c6a",
+                "uncompressed-sha256": "1cca80c7353303f14a67e5349c75dc21dbcd826627803ef183ace0e3d8ddd0f1"
               }
             }
           }
         },
         "metal": {
-          "release": "411.86.202208111758-0",
+          "release": "411.86.202210032347-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-metal4k.aarch64.raw.gz",
-                "sha256": "d9f2ecfb1b0f0ffc129b5851a64f2c2d60e02181269818136800915d697a8b76",
-                "uncompressed-sha256": "0bb60a0e0ac2ad31ef80ff0643c1917b160a85225c2c449e7f7aea8f6558d3c2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-metal4k.aarch64.raw.gz",
+                "sha256": "61948430a822cc8474bb302f43bee59f705e888d44cba4ae1ba3eb2dca886934",
+                "uncompressed-sha256": "ffa7168be5d0740781a58e1d26eb888df40ffce2fd2b71e8c74fe6970240cbcd"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-live.aarch64.iso",
-                "sha256": "efefa30d521193a5a56f4d25a03e0b150891463f3a8ed6693934cadb1dcf2d9c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-live.aarch64.iso",
+                "sha256": "3b2f742b6c0eb4016f5d1875e521eecfe082bae7ea53dcab50bb55993ed23ebc"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-live-kernel-aarch64",
-                "sha256": "e34756ed1eb76bf23994b5b65e32a57170b3af2cda55c868633a6e5efb3d1b3d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-live-kernel-aarch64",
+                "sha256": "4f972794c5c42af2358b0d44bf3744a689b2d4fd90e53355ec15010e4cf8791d"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-live-initramfs.aarch64.img",
-                "sha256": "0e7bade9c1bc4d183138525165a27402a1ef7742d901636e7b246cf836466ce7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-live-initramfs.aarch64.img",
+                "sha256": "3df7732013fc460c7108aec9e79f11742fefd2eec6196000149498a0377d2037"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-live-rootfs.aarch64.img",
-                "sha256": "2c8c5da6bbd6971fc29f35fe56a5508028dc40a8d1f602dff46fe9e7b3b67bb2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-live-rootfs.aarch64.img",
+                "sha256": "289202044391ce32e185b70903528b1656da0c7b77cb850854e63170d8d0607b"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-metal.aarch64.raw.gz",
-                "sha256": "fc0df18c93973ae61542b9b31409b926be6ea48bb5a0202abc64280025849e8a",
-                "uncompressed-sha256": "b7a3f5d3c773a33a08f0985cae7114db42f5062533bf71bbcb8330ae47581ec2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-metal.aarch64.raw.gz",
+                "sha256": "d3906892c13ca720dcb905efa536f004084c08e92131729c5a7355d02c47aaee",
+                "uncompressed-sha256": "644c8a3fe5774516be306ffe92b7785fb1f0253dd18dababa2761f01397114f9"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.86.202208111758-0",
+          "release": "411.86.202210032347-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-openstack.aarch64.qcow2.gz",
-                "sha256": "335d1d633064a3b1dc2013daff40b6080d79a11291b6662185a9384c5503f8d0",
-                "uncompressed-sha256": "1e8f2a758b42b4595759da1e745c352269345b3872c1520f52251774fa2dbb67"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-openstack.aarch64.qcow2.gz",
+                "sha256": "b8dc8b5e6655360ef1980cdfea18dc082ee87c79e495669c414de58bfa3dc9e6",
+                "uncompressed-sha256": "9cff47bd747ae4447c349d0eebfd27f34df114ef6d21b49373d589275802fd55"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.86.202208111758-0",
+          "release": "411.86.202210032347-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202208111758-0/aarch64/rhcos-411.86.202208111758-0-qemu.aarch64.qcow2.gz",
-                "sha256": "0b073da4b494e8485dafc4c08deb7646c944dd47957ce4b38101e2d3ed511528",
-                "uncompressed-sha256": "c63c518d3818d90c1283102ee9c7fd5a612f0b29e1047750dfff826afaf0c209"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-aarch64/411.86.202210032347-0/aarch64/rhcos-411.86.202210032347-0-qemu.aarch64.qcow2.gz",
+                "sha256": "e0e4f5e05a9a04b6de6b412a02268a0071af7ec3cb8f2c4bf5bca4fd34e4de85",
+                "uncompressed-sha256": "88f6619a7f9ac1d8e2179ee7c1ba8e3e0b31183bf2940cfc5e43627c6363c75d"
               }
             }
           }
@@ -99,164 +99,164 @@
         "aws": {
           "regions": {
             "ap-east-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0421e79ce996ecbed"
+              "release": "411.86.202210032347-0",
+              "image": "ami-09214d40875a4a0cb"
             },
             "ap-northeast-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-00da9eb59c593fd0d"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0672a3c627f5a1a7e"
             },
             "ap-northeast-2": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0de89adc51cebae39"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0465abf46a9c23389"
             },
             "ap-south-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0a67c169be912a3b3"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0cac4d531cf7bdb5f"
             },
             "ap-southeast-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0be51961b13d8895c"
+              "release": "411.86.202210032347-0",
+              "image": "ami-03b92ea83b7bb5ca8"
             },
             "ap-southeast-2": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-06a5fc7892a28f634"
+              "release": "411.86.202210032347-0",
+              "image": "ami-07ca36e93b26fa47f"
             },
             "ca-central-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0482177f65210956f"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0ba3e170381ff79b8"
             },
             "eu-central-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0c7e3e5f556be57cc"
+              "release": "411.86.202210032347-0",
+              "image": "ami-00a73984f4ba7cd40"
             },
             "eu-north-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0e7ba8da12d0ea287"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0eacc2fbc9c086258"
             },
             "eu-south-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0a73ca1db787214df"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0ce541fb1bc2a972e"
             },
             "eu-west-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-08b9e8f8343d32e91"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0cb168a2942764fc0"
             },
             "eu-west-2": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-08425d80f473d9702"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0c0791e9ccfdf719a"
             },
             "eu-west-3": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-06b6f5dd4b91db197"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0ba09fba9e37e7396"
             },
             "me-south-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0edafae1f3eb823bc"
+              "release": "411.86.202210032347-0",
+              "image": "ami-02866fd5392a05e90"
             },
             "sa-east-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0e60ec9f7484144ff"
+              "release": "411.86.202210032347-0",
+              "image": "ami-085683f56a1677352"
             },
             "us-east-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-0c56128e9aaca4dc1"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0ad3ffa2e20eaefd3"
             },
             "us-east-2": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-098ce9898b0f583b7"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0491ac2af6cc34571"
             },
             "us-west-1": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-03bd7877df6547501"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0ee6b0d08f0a8c20a"
             },
             "us-west-2": {
-              "release": "411.86.202208111758-0",
-              "image": "ami-00b041d0342a1fc2d"
+              "release": "411.86.202210032347-0",
+              "image": "ami-0de527f104e2b1785"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "411.86.202208111758-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-411.86.202208111758-0-azure.aarch64.vhd"
+          "release": "411.86.202210032347-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-411.86.202210032347-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "411.86.202208112105-0",
+          "release": "411.86.202210032141-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202208112105-0/ppc64le/rhcos-411.86.202208112105-0-metal4k.ppc64le.raw.gz",
-                "sha256": "bb021c058841be7a167e4b820088b21ebb10bdf27ed70761a9b6c4383ace6048",
-                "uncompressed-sha256": "b644c626cd5e81105a466480ffcae0331b41005de4abdf93a3cb9aa01cba00b0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202210032141-0/ppc64le/rhcos-411.86.202210032141-0-metal4k.ppc64le.raw.gz",
+                "sha256": "59cc3f6830e0424c5ea8d1365077dfa3d007a78e326a71d7817dccfd1db29cda",
+                "uncompressed-sha256": "aa42409e89651c32b1ba3acc9aca2cb473dd7c47094895d99f49f3236d1def98"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202208112105-0/ppc64le/rhcos-411.86.202208112105-0-live.ppc64le.iso",
-                "sha256": "586f77d8108a8bed2d2c17cd9aabf458b8ca40afda803a6aead8d8f14583e6d1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202210032141-0/ppc64le/rhcos-411.86.202210032141-0-live.ppc64le.iso",
+                "sha256": "8cc790fcffd89044ddc4b7919c166e487da3e8be94b57431043fad21b912d25d"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202208112105-0/ppc64le/rhcos-411.86.202208112105-0-live-kernel-ppc64le",
-                "sha256": "77d7d3ed90dfb8ae0e6eb9b6b98f0ef30775817ad6bd34d92d4bc3bcae16b5c1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202210032141-0/ppc64le/rhcos-411.86.202210032141-0-live-kernel-ppc64le",
+                "sha256": "ffc7e54200be86d91cd15d78706ec2107c0501cc38ca97c6967fb4d8c7d2080c"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202208112105-0/ppc64le/rhcos-411.86.202208112105-0-live-initramfs.ppc64le.img",
-                "sha256": "8ebb8cba7c2ec4f613bf8ad9508704d0cb8b8e61d9422369243ca12bd03960c3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202210032141-0/ppc64le/rhcos-411.86.202210032141-0-live-initramfs.ppc64le.img",
+                "sha256": "19e9d76bb99acdf6a870607f1a96ad357374d6318d388af20225d300dc812263"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202208112105-0/ppc64le/rhcos-411.86.202208112105-0-live-rootfs.ppc64le.img",
-                "sha256": "6520dbe725f8e6a0179dc0e8125921642df72bd2b79497d1c6e913bff7a67aea"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202210032141-0/ppc64le/rhcos-411.86.202210032141-0-live-rootfs.ppc64le.img",
+                "sha256": "7136a7cb20c0aff3c9a0dcca881613bd8c3e6a2f0acfa5f08e4b6bb738310ed6"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202208112105-0/ppc64le/rhcos-411.86.202208112105-0-metal.ppc64le.raw.gz",
-                "sha256": "7e7ae19ef1d271e0b1621930008d227b6a025d0818c3357f2b044d231fe83b1e",
-                "uncompressed-sha256": "4f3a9eab64cc096372461ff0af056383be3ab5c99c1abb54b8bf8507844e3d5e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202210032141-0/ppc64le/rhcos-411.86.202210032141-0-metal.ppc64le.raw.gz",
+                "sha256": "1fdd4f10c33f57305a3095d0a802b688def1228eec05948613748b6d10cecceb",
+                "uncompressed-sha256": "c0f1dcd17832b9309fe298ca50dce3d4fba0f0a6ae50eee23fbebe4b20439e48"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.86.202208112105-0",
+          "release": "411.86.202210032141-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202208112105-0/ppc64le/rhcos-411.86.202208112105-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "4e4f4568393e74698bd17076135a74b7c43584be6d4153f1b5625ef257627ae0",
-                "uncompressed-sha256": "db4387a927ce0cc7416bad7440f93fdf234ab7ab0a74ceab7a9980d6b0457d6a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202210032141-0/ppc64le/rhcos-411.86.202210032141-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "8d2f998f508c04ac1571770d3beb64bac6c0bdd805d02c4fb296bf295424db68",
+                "uncompressed-sha256": "747de884ff0aac9aa1bf0f992212aed40d75f41da8a0b5e323266780519421c3"
               }
             }
           }
         },
         "powervs": {
-          "release": "411.86.202208112105-0",
+          "release": "411.86.202210032141-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202208112105-0/ppc64le/rhcos-411.86.202208112105-0-powervs.ppc64le.ova.gz",
-                "sha256": "55470d1ce1a01de700f254c792de944a8506ec61628b524ea858f1d0c21f1146",
-                "uncompressed-sha256": "d0e8da7ee96c5b31b627d8d35bf360ecd9e5f73940775f8f69c0564dac09ac44"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202210032141-0/ppc64le/rhcos-411.86.202210032141-0-powervs.ppc64le.ova.gz",
+                "sha256": "e10df0d6fcef6b491da9827abcb8fe4265caacbba84a85e43a7fd40f57508e7c",
+                "uncompressed-sha256": "743d3d8abc410155e09feea2168f130ffd98f6050f5ad95b110f58d751395ae3"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.86.202208112105-0",
+          "release": "411.86.202210032141-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202208112105-0/ppc64le/rhcos-411.86.202208112105-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "dabc60ebbcfaaddb57aac49e8c5c5591f78be0fc983b48aa9bfa5c4b261fa851",
-                "uncompressed-sha256": "9a9c783f35fda8a8703e1f24af89abe83a6d31bc54959c5a9e4ed4fc0f275f7b"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-ppc64le/411.86.202210032141-0/ppc64le/rhcos-411.86.202210032141-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "454dbfcd96c788ddff0365a84cc8d965ca5c055ab423079e16322e6ac475fa44",
+                "uncompressed-sha256": "05b3e6b815f3a68f985628a527d04ca6b13abf8b4930e145623d7e80908d3982"
               }
             }
           }
@@ -266,58 +266,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "411.86.202208112105-0",
-              "object": "rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz",
+              "release": "411.86.202210032141-0",
+              "object": "rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "411.86.202208112105-0",
-              "object": "rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz",
+              "release": "411.86.202210032141-0",
+              "object": "rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "411.86.202208112105-0",
-              "object": "rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz",
+              "release": "411.86.202210032141-0",
+              "object": "rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "411.86.202208112105-0",
-              "object": "rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz",
+              "release": "411.86.202210032141-0",
+              "object": "rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "411.86.202208112105-0",
-              "object": "rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz",
+              "release": "411.86.202210032141-0",
+              "object": "rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "411.86.202208112105-0",
-              "object": "rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz",
+              "release": "411.86.202210032141-0",
+              "object": "rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "411.86.202208112105-0",
-              "object": "rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz",
+              "release": "411.86.202210032141-0",
+              "object": "rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "411.86.202208112105-0",
-              "object": "rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz",
+              "release": "411.86.202210032141-0",
+              "object": "rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "411.86.202208112105-0",
-              "object": "rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz",
+              "release": "411.86.202210032141-0",
+              "object": "rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-411-86-202208112105-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-411-86-202210032141-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -326,64 +326,64 @@
     "s390x": {
       "artifacts": {
         "metal": {
-          "release": "411.86.202208111740-0",
+          "release": "411.86.202210032129-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202208111740-0/s390x/rhcos-411.86.202208111740-0-metal4k.s390x.raw.gz",
-                "sha256": "9e5a00ba2c8a81e438e303b70332691b87dd2d53ebffcfeabedc73541f334e91",
-                "uncompressed-sha256": "8e489977429c817e7ad3444a652e0327e1977c2e210128d79f0b832bbfc5037d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202210032129-0/s390x/rhcos-411.86.202210032129-0-metal4k.s390x.raw.gz",
+                "sha256": "5f49ecd014eaec91453393032e4cc5de7468dfea28b325cc60b87b0c4962e01d",
+                "uncompressed-sha256": "aee027e414a43fe462d8a141ff8f589bb9fa294e0e36c0b4fdbdeb5856c04406"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202208111740-0/s390x/rhcos-411.86.202208111740-0-live.s390x.iso",
-                "sha256": "3c42f75d6f3f1de2656e8da1c90353a914d714a66f844c4ca4d5a70f3bfac357"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202210032129-0/s390x/rhcos-411.86.202210032129-0-live.s390x.iso",
+                "sha256": "1ffbe74a9dfedf9d2e84f595f43590cf3e76b60ee97e27b8dd2bbefff71d7190"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202208111740-0/s390x/rhcos-411.86.202208111740-0-live-kernel-s390x",
-                "sha256": "9fcbbbbb2f69b34bd17f3c6d5bad5ee73c583c8b8e9dfb87a6da61b245b8cfb1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202210032129-0/s390x/rhcos-411.86.202210032129-0-live-kernel-s390x",
+                "sha256": "a579a1b89226d58a7b565f668cb7eb88a5d2df5cfffac0b9341a2a520eb5a1a4"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202208111740-0/s390x/rhcos-411.86.202208111740-0-live-initramfs.s390x.img",
-                "sha256": "8e888b11c7e4a00ace2450c4d1791d706964df8594d00522fceb9e47da88f8ea"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202210032129-0/s390x/rhcos-411.86.202210032129-0-live-initramfs.s390x.img",
+                "sha256": "5b96c1bf9bfbecf028c5833911478c067113be056008d371cc3a9d845d5d4c69"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202208111740-0/s390x/rhcos-411.86.202208111740-0-live-rootfs.s390x.img",
-                "sha256": "ff0d7cf8ea145115944ce8f1578a870575af3a4dd2e4bd62cf2a7192d0fb42f9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202210032129-0/s390x/rhcos-411.86.202210032129-0-live-rootfs.s390x.img",
+                "sha256": "7b59283275785e66ce17bc6bb111857bf048762dfe312172912d8ec87df32666"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202208111740-0/s390x/rhcos-411.86.202208111740-0-metal.s390x.raw.gz",
-                "sha256": "0aea2b78b6665a39b4ed52895f91afa070ef67ac37df753265cfb46e0cb6582d",
-                "uncompressed-sha256": "2aca813adec89111261a47718cdcadc6bf1e5b0cb97584e27216e880746f4db9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202210032129-0/s390x/rhcos-411.86.202210032129-0-metal.s390x.raw.gz",
+                "sha256": "3c4cc16f26b61af64e1941dd0988155ab4c3b874dccd0f71fe7aee39c5faf745",
+                "uncompressed-sha256": "8f9d9d33e77e4428fececc664d5a002abb7f6bbb3cfe6dac8ec7d49d7fa85220"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.86.202208111740-0",
+          "release": "411.86.202210032129-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202208111740-0/s390x/rhcos-411.86.202208111740-0-openstack.s390x.qcow2.gz",
-                "sha256": "d035d549206f7758ef5bd6805754f9120fab91fad9f2b4ef65a01528006ca578",
-                "uncompressed-sha256": "afd2479e8a43427939467fc7887075da6f67184677fcfd37ede1e16ecd0ab84f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202210032129-0/s390x/rhcos-411.86.202210032129-0-openstack.s390x.qcow2.gz",
+                "sha256": "28c3f5064047405d7c779da6c38fe9948fe48ef545e0ae7ca951de22659f6a17",
+                "uncompressed-sha256": "1c569ecda9b7bafabf26c08d6b51ea3f630dca550e1710ca4ea70e488a2c5718"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.86.202208111740-0",
+          "release": "411.86.202210032129-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202208111740-0/s390x/rhcos-411.86.202208111740-0-qemu.s390x.qcow2.gz",
-                "sha256": "61e9f8530b6351a24949133ed009338c6e223a154060fa59eff7df9d61061c3a",
-                "uncompressed-sha256": "16edbc51ee8e7c9dfc9cd5483261022285397f12a1907b477efbccd99b88821d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11-s390x/411.86.202210032129-0/s390x/rhcos-411.86.202210032129-0-qemu.s390x.qcow2.gz",
+                "sha256": "a83a614177bdf9b24b3efc745469b39a211ea1a09c041a40b652be88c2e20216",
+                "uncompressed-sha256": "855f4f6a6876220abcb6a960427731c7a4425e73840662ec47090ecb27e6cc1e"
               }
             }
           }
@@ -394,158 +394,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "f048c3f80a1d50b36bb867057e7fa37e0a3e3dc5a23de8d92b6eef207a85aedd",
-                "uncompressed-sha256": "4d3c8ca4d0a6f0eb94b487cf8ef37135cc7749aa5c84f982dc4dfd852042d924"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "5468b416b35da3041e5bb9a4474ff257cce659e14b71a5de51cb146dd58920a8",
+                "uncompressed-sha256": "04ca5117f9e3dad96e7646009bbd25ee93909ea4311d1e9e193c2234f330ebe4"
               }
             }
           }
         },
         "aws": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-aws.x86_64.vmdk.gz",
-                "sha256": "64085279a84bde28b86d6dcc366c0f4d3e91cb31791687df25112247b69cf948",
-                "uncompressed-sha256": "13e1f3c60ecc23d09842ec449370286834609de19449508bde570ad5222e54fa"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-aws.x86_64.vmdk.gz",
+                "sha256": "d392551cdaa0928903e44dcf0eb31b195c2cf45c5350ddf084fa97f044287c4e",
+                "uncompressed-sha256": "7e86ed1a0a8d67dbe6156050f5e30870b44082d4832de7fdb3ce724500a2ea01"
               }
             }
           }
         },
         "azure": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-azure.x86_64.vhd.gz",
-                "sha256": "a762a7f1f00bba72ac9a74276deb35f716d01a139b8536a14978e1ce8d4c3250",
-                "uncompressed-sha256": "065c95262080a4dd4b6f5738aa4a16a0aad4ca7aa5e48d4ee468f722020e9cdc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-azure.x86_64.vhd.gz",
+                "sha256": "40cf3a7feef443dbfecf92e1735e5aba69c602e3a001c816be56e88877c12a6b",
+                "uncompressed-sha256": "0ade7901e89cb5b783cda72fcf9072f56105206c2c742c34686e40c513370525"
               }
             }
           }
         },
         "azurestack": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-azurestack.x86_64.vhd.gz",
-                "sha256": "e2062b33aef6a7d3cb1e0db0e765a2a8d3fdc838ebdadd81ced5fd48a5423061",
-                "uncompressed-sha256": "8d063215aa345c7514b91d5cb04647962e608f0e5aec980c1d518b9547455be1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-azurestack.x86_64.vhd.gz",
+                "sha256": "5742ae2c3e8d8812c98f95728a54d4bfed4eeaf32ce9f191e42dadf6521a0f0a",
+                "uncompressed-sha256": "3adc33073a81523dd1462e158dfb3a5af2418559ee880f623a4f7f3e944a56c4"
               }
             }
           }
         },
         "gcp": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-gcp.x86_64.tar.gz",
-                "sha256": "0f2f6674276110174d815b4ac559a67851a946ccbf77d1114fca8edf2107e0e6",
-                "uncompressed-sha256": "1bba03f922df0b7bca7a8ab625b122ec44cf4373063b11f62d41c385e9e1a696"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-gcp.x86_64.tar.gz",
+                "sha256": "c5be4eccb70d0e8aa9d4f63fc7080f3ddfc5c9742d61e78c71e708ad9290f042",
+                "uncompressed-sha256": "e4a844eaef4f98a1a5774f4766da8a19329e23436e81264a2f4c67fde8c47279"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "a679e696cb7da2ee554140cc3b7f5ee2c457000eb00371515179caf6d8185ad8",
-                "uncompressed-sha256": "548e93baf98f1c451ed946b4716972b5b4041f0c07e49799a61f3c588f86b108"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "66238a0e5e0509ce0f270f9b022f4f4c200968bad4e67a139dc87feb1d7ec347",
+                "uncompressed-sha256": "b19154982075620f596c149895901403e4f28b85432fa5d12d67b361821261b4"
               }
             }
           }
         },
         "metal": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-metal4k.x86_64.raw.gz",
-                "sha256": "f981a79968141024821eecc9b27d966270dbaa8512d17b4e89619618aa105903",
-                "uncompressed-sha256": "892bce13177d59d6e0f36487e3baf6ef736bff37ab7a494cf43a710f1f39bfa6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-metal4k.x86_64.raw.gz",
+                "sha256": "47743e1eac14aed3485214f5b3650af45848fc7f80fed1cff42dd07ce82b14ea",
+                "uncompressed-sha256": "dfd4e30ceb79292fa52bf24506827a2b8a846f3a624a0a5adba30caca08b62d9"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-live.x86_64.iso",
-                "sha256": "8dc02ab43716d03af56cd5bf45a3182e9b144eab0acbea5504462fddfd3505ee"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-live.x86_64.iso",
+                "sha256": "cb400ed3db47ab73af7493503867e18328a577b7ec68d1d29ca598bd0a7a9b81"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-live-kernel-x86_64",
-                "sha256": "d469c82375a7358371490514c9946e9f214e14a3df95cba42156dba765c5abde"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-live-kernel-x86_64",
+                "sha256": "852c711ab9e9dcc9d021a2917c084ae77075edccec8484d8ef50658889f944ae"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-live-initramfs.x86_64.img",
-                "sha256": "16b39d4ea59d81c36557441389ce165587cbc2d60253eee54c24aa12907fc80d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-live-initramfs.x86_64.img",
+                "sha256": "9ad421838df69eee69d631db4e875094c040c5401fb77a2bbdf974b111d2cda4"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-live-rootfs.x86_64.img",
-                "sha256": "9678ca619a099001a27f8d3d0a472cfdc3706258224e7153105c3a79282caee6"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-live-rootfs.x86_64.img",
+                "sha256": "df8c0b074d88ec59e2db730884306787132dd86811028617bae47b64db09dbe5"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-metal.x86_64.raw.gz",
-                "sha256": "15d2f98d8bb5c3304e98e35aef111a9d46a520960513e962e1c215b1b19d35e5",
-                "uncompressed-sha256": "419e161fb3b5924f003a7a2d59ec57f39dc11de7919668dce0d9370902cf276d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-metal.x86_64.raw.gz",
+                "sha256": "c2ef5ca1dbde51af68e679d9b1f7d124f8f7d445720bce56a1938df59ce85424",
+                "uncompressed-sha256": "bad055078a7a459307774f625a179ca4d65c0effc1853b399c04f97c14b42cef"
               }
             }
           }
         },
         "nutanix": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-nutanix.x86_64.qcow2",
-                "sha256": "1f50f66b565fbc8b2770a642b58260d6abc627f4fdaf59d361e4b55d33c3c9c1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-nutanix.x86_64.qcow2",
+                "sha256": "42e227cac6f11ac37ee8a2f9528bb3665146566890577fd55f9b950949e5a54b"
               }
             }
           }
         },
         "openstack": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-openstack.x86_64.qcow2.gz",
-                "sha256": "1e4dd1992301a9191b59652b4807db284d6e500bd14fa75fcbc95438c6d9d496",
-                "uncompressed-sha256": "beeb04adbac382be269df2bf649047e12e38fc6353525310bb42f738bed11dbb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-openstack.x86_64.qcow2.gz",
+                "sha256": "506bb66f8cb407c74061a8201f13e7b1edd44000d944be85eb7a4df7058dcb79",
+                "uncompressed-sha256": "b00c23ccfbff9491bb95a74449af6d6a367727b142bb9447157dd03c895a0e9f"
               }
             }
           }
         },
         "qemu": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-qemu.x86_64.qcow2.gz",
-                "sha256": "6dd4a2be358ac3791693033c3d8ea0922d51b0831121d3fd69ade9eb66fb8d2e",
-                "uncompressed-sha256": "fc24ad2060fc2ac0e15ce44b69436925aaecca4f4de2249524089d6823d9d17e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-qemu.x86_64.qcow2.gz",
+                "sha256": "3966186deb9fcd93badc469708565779e1fab2cc46e17dc6254ccf27abe86d56",
+                "uncompressed-sha256": "5dbc9dc6bb358a335ce353dd0c0f84bf3960ba855bc501d40edd3d44c26e19a1"
               }
             }
           }
         },
         "vmware": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202208112011-0/x86_64/rhcos-411.86.202208112011-0-vmware.x86_64.ova",
-                "sha256": "f18c625d5698f057ed2c0554f990b5676748c64f24761e2860a71831b6268a3a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/releases/rhcos-4.11/411.86.202210041459-0/x86_64/rhcos-411.86.202210041459-0-vmware.x86_64.ova",
+                "sha256": "9702ea035eafd0731d1238c09961dd5f2408058ed6e5979db969edf86a333ad5"
               }
             }
           }
@@ -555,217 +555,217 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "411.86.202208112011-0",
-              "image": "m-6we2wsvmg6gbaeeooyt8"
+              "release": "411.86.202210041459-0",
+              "image": "m-6weg3zzj2ko94mi0h0z2"
             },
             "ap-south-1": {
-              "release": "411.86.202208112011-0",
-              "image": "m-a2d41zwptq73su6nj88v"
+              "release": "411.86.202210041459-0",
+              "image": "m-a2d8u8byde9h1sxg75nr"
             },
             "ap-southeast-1": {
-              "release": "411.86.202208112011-0",
-              "image": "m-t4n8rcvpls2bd1ue5no9"
+              "release": "411.86.202210041459-0",
+              "image": "m-t4n1te2s7h8gf6de3ib4"
             },
             "ap-southeast-2": {
-              "release": "411.86.202208112011-0",
-              "image": "m-p0w3hzlex6dmbhnt2dh2"
+              "release": "411.86.202210041459-0",
+              "image": "m-p0wfkj2ikiby5kkhy8wj"
             },
             "ap-southeast-3": {
-              "release": "411.86.202208112011-0",
-              "image": "m-8psh8ieysphd09d9kkla"
+              "release": "411.86.202210041459-0",
+              "image": "m-8pseerokuxx48fuokr3t"
             },
             "ap-southeast-5": {
-              "release": "411.86.202208112011-0",
-              "image": "m-k1a4asbxn5sci6t3ft6m"
+              "release": "411.86.202210041459-0",
+              "image": "m-k1aba4cmqd2ppwjq63r5"
             },
             "ap-southeast-6": {
-              "release": "411.86.202208112011-0",
-              "image": "m-5ts67vzlupfslz9y69kb"
+              "release": "411.86.202210041459-0",
+              "image": "m-5tsgzhfv3irydi3v1sdr"
             },
             "cn-beijing": {
-              "release": "411.86.202208112011-0",
-              "image": "m-2ze0s7nnjewqyzv45i7b"
+              "release": "411.86.202210041459-0",
+              "image": "m-2ze672ze642x32mze159"
             },
             "cn-chengdu": {
-              "release": "411.86.202208112011-0",
-              "image": "m-2vc5v1iau68ab6yla9bg"
+              "release": "411.86.202210041459-0",
+              "image": "m-2vc6m0r24pqwqrjxqxpl"
             },
             "cn-guangzhou": {
-              "release": "411.86.202208112011-0",
-              "image": "m-7xvbgihlnq64f8w0d4ya"
+              "release": "411.86.202210041459-0",
+              "image": "m-7xvh61s12m7opgoz624w"
             },
             "cn-hangzhou": {
-              "release": "411.86.202208112011-0",
-              "image": "m-bp14pfy9u07fd1d92d1r"
+              "release": "411.86.202210041459-0",
+              "image": "m-bp17hzdhc305p0yozigh"
             },
             "cn-heyuan": {
-              "release": "411.86.202208112011-0",
-              "image": "m-f8zfmicr2s2oj8g2is6r"
+              "release": "411.86.202210041459-0",
+              "image": "m-f8z3d3srj5t4xcuvq8m8"
             },
             "cn-hongkong": {
-              "release": "411.86.202208112011-0",
-              "image": "m-j6c3p7aglcx7dl1mp4bd"
+              "release": "411.86.202210041459-0",
+              "image": "m-j6c98h92z5jvlb1aumtk"
             },
             "cn-huhehaote": {
-              "release": "411.86.202208112011-0",
-              "image": "m-hp38u619o594uc9ayb9t"
+              "release": "411.86.202210041459-0",
+              "image": "m-hp36dbrjwdkz8hy14owp"
             },
             "cn-nanjing": {
-              "release": "411.86.202208112011-0",
-              "image": "m-gc751f421znb2o3qure6"
+              "release": "411.86.202210041459-0",
+              "image": "m-gc7h5gg4dgw6jr4m8slz"
             },
             "cn-qingdao": {
-              "release": "411.86.202208112011-0",
-              "image": "m-m5e8v3uzcwnkpyibvw9n"
+              "release": "411.86.202210041459-0",
+              "image": "m-m5efl64vb97y25khqgbj"
             },
             "cn-shanghai": {
-              "release": "411.86.202208112011-0",
-              "image": "m-uf6986915mjmp89inamb"
+              "release": "411.86.202210041459-0",
+              "image": "m-uf6bie8iv8yisbqgoyo5"
             },
             "cn-shenzhen": {
-              "release": "411.86.202208112011-0",
-              "image": "m-wz960e2jbse95237kmr4"
+              "release": "411.86.202210041459-0",
+              "image": "m-wz97vry93t71bqfyfvm2"
             },
             "cn-wulanchabu": {
-              "release": "411.86.202208112011-0",
-              "image": "m-0jlftcfs16k15hnwa9rk"
+              "release": "411.86.202210041459-0",
+              "image": "m-0jlaqsl7s3tcdty4cub8"
             },
             "cn-zhangjiakou": {
-              "release": "411.86.202208112011-0",
-              "image": "m-8vbj8756bnmlqu08gjmz"
+              "release": "411.86.202210041459-0",
+              "image": "m-8vbdkczt6xdis5k49dcb"
             },
             "eu-central-1": {
-              "release": "411.86.202208112011-0",
-              "image": "m-gw874hxipy1lf69p9hcl"
+              "release": "411.86.202210041459-0",
+              "image": "m-gw82aj70q0a07p7fi5aj"
             },
             "eu-west-1": {
-              "release": "411.86.202208112011-0",
-              "image": "m-d7o22aeiiu2f4x76zslq"
+              "release": "411.86.202210041459-0",
+              "image": "m-d7o7assvnehthn5p4mw7"
             },
             "me-east-1": {
-              "release": "411.86.202208112011-0",
-              "image": "m-eb33awteb6l835ohpv31"
+              "release": "411.86.202210041459-0",
+              "image": "m-eb32zz38sddeh71rc740"
             },
             "us-east-1": {
-              "release": "411.86.202208112011-0",
-              "image": "m-0xics1i8nmogziigntdk"
+              "release": "411.86.202210041459-0",
+              "image": "m-0xi60yimvc2fx8j2bhkk"
             },
             "us-west-1": {
-              "release": "411.86.202208112011-0",
-              "image": "m-rj91zcu3s5i6sqrl5nvp"
+              "release": "411.86.202210041459-0",
+              "image": "m-rj9hgwmj4hubhag80cfh"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-08729eb76c80fe8d3"
+              "release": "411.86.202210041459-0",
+              "image": "ami-03573439b40a2ca3d"
             },
             "ap-east-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-02d794351349e9ed6"
+              "release": "411.86.202210041459-0",
+              "image": "ami-06856c01bdb7eb7a3"
             },
             "ap-northeast-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-07edffa13a06dfbe8"
+              "release": "411.86.202210041459-0",
+              "image": "ami-026bd591b27e41aa2"
             },
             "ap-northeast-2": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-07baa02d734fd1a6f"
+              "release": "411.86.202210041459-0",
+              "image": "ami-09cf7ea75cda2c20e"
             },
             "ap-northeast-3": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-0d08c09f943e940ca"
+              "release": "411.86.202210041459-0",
+              "image": "ami-03cd2e6353f08c86e"
             },
             "ap-south-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-063ff36cf45f4d9ee"
+              "release": "411.86.202210041459-0",
+              "image": "ami-060180cf2266feb98"
             },
             "ap-southeast-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-03c587264791fe80b"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0623803cd22fee48e"
             },
             "ap-southeast-2": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-0f84683fe331cdb04"
+              "release": "411.86.202210041459-0",
+              "image": "ami-092c6329c23a2aab9"
             },
             "ap-southeast-3": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-00a3dcdd19b6377c5"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0aba0e2f5e0653162"
             },
             "ca-central-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-00961724dd21cc19c"
+              "release": "411.86.202210041459-0",
+              "image": "ami-04785ba9d5a38d4ad"
             },
             "eu-central-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-0471e6514b3dd711e"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0f2fb62b5e1da79bd"
             },
             "eu-north-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-0b5c0d649629f5df1"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0d1daa40efb851353"
             },
             "eu-south-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-069ec2a719a2f0241"
+              "release": "411.86.202210041459-0",
+              "image": "ami-003be3441d33d8487"
             },
             "eu-west-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-04369719e5146a30c"
+              "release": "411.86.202210041459-0",
+              "image": "ami-04e716ae12150f4a6"
             },
             "eu-west-2": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-0993bc7222e12bd80"
+              "release": "411.86.202210041459-0",
+              "image": "ami-02254298b653aa6b0"
             },
             "eu-west-3": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-07e37de7d9e861df5"
+              "release": "411.86.202210041459-0",
+              "image": "ami-078710d123349216b"
             },
             "me-south-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-0ca5e7ed686ebc3f4"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0bca3874eb407a3dd"
             },
             "sa-east-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-04947810ecaef3bb9"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0c5b12a6ddd5aa4df"
             },
             "us-east-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-0dda0c86141adbb55"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0e835bf425b1a9136"
             },
             "us-east-2": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-0fce3b366eca6ca2b"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0abf0ec5cdd856934"
             },
             "us-gov-east-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-0a55c43ba5264d29e"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0cfa371b0879cc215"
             },
             "us-gov-west-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-01ad5e162030b3b29"
+              "release": "411.86.202210041459-0",
+              "image": "ami-08fa72d2b4c5c93c9"
             },
             "us-west-1": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-046a57db4377eae2c"
+              "release": "411.86.202210041459-0",
+              "image": "ami-0b981ee576eef2a27"
             },
             "us-west-2": {
-              "release": "411.86.202208112011-0",
-              "image": "ami-09ab4dddae91099e9"
+              "release": "411.86.202210041459-0",
+              "image": "ami-04e1ca274c50f2acb"
             }
           }
         },
         "gcp": {
-          "release": "411.86.202208112011-0",
+          "release": "411.86.202210041459-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-411-86-202208112011-0-gcp-x86-64"
+          "name": "rhcos-411-86-202210041459-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "411.86.202208112011-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-411.86.202208112011-0-azure.x86_64.vhd"
+          "release": "411.86.202210041459-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-411.86.202210041459-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.11 boot image metadata in the installer which includes the fixes for the following:

OCPBUGS-1937 Booting live ISO: /dev/sr0 already mounted or mount point busy
OCPBUGS-565 Unable to install RHCOS 4.11.0-rc2-ppc64le on Bare-metal Power system

```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --no-signatures --url https://rhcos.mirror.openshift.com/art/storage/releases x86_64=411.86.202210041459-0 aarch64=411.86.202210032347-0 s390x=411.86.202210032129-0 ppc64le=411.86.202210032141-0
```