### PR TITLE
pkg/asset/releaseimage/pullspec: Include override pullspec in log message

### DIFF
--- a/pkg/asset/releaseimage/pullspec.go
+++ b/pkg/asset/releaseimage/pullspec.go
@@ -27,7 +27,7 @@ func (a *Image) Dependencies() []asset.Asset {
 func (a *Image) Generate(dependencies asset.Parents) error {
 	var pullSpec string
 	if ri, ok := os.LookupEnv("OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE"); ok && ri != "" {
-		logrus.Warn("Found override for release image. Please be warned, this is not advised")
+		logrus.Warnf("Found override for release image (%s). Please be warned, this is not advised", ri)
 		pullSpec = ri
 	} else {
 		var err error


### PR DESCRIPTION
This code-branch should be very rare, probably mostly internal testing.  A chattier line in those situations isn't a big user-experience concern, and including the pullspec makes it easier for folks who are trying to understand internal-test results to figure out which pullspec was being used.

The log line is originally from 456a373aed (#1910), and it was tweaked in cd0b70f992 (#2361), and neither of those make explicit arguments for why they didn't include the pullspec.