### PR TITLE
OCPBUGS-2029: Fix agent installation InstallConfig proxy processing

### DIFF
--- a/pkg/asset/agent/manifests/common.go
+++ b/pkg/asset/agent/manifests/common.go
@@ -4,6 +4,8 @@ import (
 	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/version"
+
+	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
 )
 
 func getAgentClusterInstallName(ic *agent.OptionalInstallConfig) string {
@@ -20,6 +22,14 @@ func getInfraEnvName(ic *agent.OptionalInstallConfig) string {
 
 func getPullSecretName(ic *agent.OptionalInstallConfig) string {
 	return ic.ClusterName() + "-pull-secret"
+}
+
+func getProxy(ic *agent.OptionalInstallConfig) *aiv1beta1.Proxy {
+	return &aiv1beta1.Proxy{
+		HTTPProxy:  ic.Config.Proxy.HTTPProxy,
+		HTTPSProxy: ic.Config.Proxy.HTTPSProxy,
+		NoProxy:    ic.Config.Proxy.NoProxy,
+	}
 }
 
 func getObjectMetaNamespace(ic *agent.OptionalInstallConfig) string {

--- a/pkg/asset/agent/manifests/infraenv.go
+++ b/pkg/asset/agent/manifests/infraenv.go
@@ -67,6 +67,9 @@ func (i *InfraEnv) Generate(dependencies asset.Parents) error {
 				},
 			},
 		}
+		if installConfig.Config.Proxy != nil {
+			infraEnv.Spec.Proxy = getProxy(installConfig)
+		}
 		i.Config = infraEnv
 
 		infraEnvData, err := yaml.Marshal(infraEnv)

--- a/pkg/asset/agent/manifests/infraenv_test.go
+++ b/pkg/asset/agent/manifests/infraenv_test.go
@@ -58,6 +58,32 @@ func TestInfraEnv_Generate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "proxy valid configuration",
+			dependencies: []asset.Asset{
+				getProxyValidOptionalInstallConfig(),
+			},
+			expectedConfig: &aiv1beta1.InfraEnv{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      getClusterDeploymentName(getProxyValidOptionalInstallConfig()),
+					Namespace: getObjectMetaNamespace(getProxyValidOptionalInstallConfig()),
+				},
+				Spec: aiv1beta1.InfraEnvSpec{
+					Proxy:            getProxy(getProxyValidOptionalInstallConfig()),
+					SSHAuthorizedKey: strings.Trim(TestSSHKey, "|\n\t"),
+					PullSecretRef: &corev1.LocalObjectReference{
+						Name: getPullSecretName(getProxyValidOptionalInstallConfig()),
+					},
+					NMStateConfigLabelSelector: metav1.LabelSelector{
+						MatchLabels: getNMStateConfigLabels(getProxyValidOptionalInstallConfig()),
+					},
+					ClusterRef: &aiv1beta1.ClusterReference{
+						Name:      getClusterDeploymentName(getProxyValidOptionalInstallConfig()),
+						Namespace: getObjectMetaNamespace(getProxyValidOptionalInstallConfig()),
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -150,6 +150,17 @@ func getValidOptionalInstallConfigDualStack() *agent.OptionalInstallConfig {
 	}
 }
 
+// getProxyValidOptionalInstallConfig returns a valid optional install config for proxied installation
+func getProxyValidOptionalInstallConfig() *agent.OptionalInstallConfig {
+	validIC := getValidOptionalInstallConfig()
+	validIC.InstallConfig.Config.Proxy = &types.Proxy{
+		HTTPProxy:  "http://10.10.10.11:80",
+		HTTPSProxy: "http://my-lab-proxy.org:443",
+		NoProxy:    "internal.com",
+	}
+	return validIC
+}
+
 func getValidAgentConfig() *agentconfig.AgentConfig {
 	return &agentconfig.AgentConfig{
 		Config: &agenttypes.Config{


### PR DESCRIPTION
In order for the proxy config to make it to the installed cluster, it must make it into the infraenv that we then register in the assisted service API. This commit sees to it that if installConfig has the proxy section provided, it makes into the infraenv.