### PR TITLE
OCPBUGS-1913: Agent Installer: Do not fail on deprecated apiVip and ingressVip values

### DIFF
--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -87,10 +87,10 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "failed to create install config: invalid \"install-config.yaml\" file: [platform.baremetal.apiVIPs: Invalid value: []string{\"DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host\"}: ip <nil> is invalid, platform.baremetal.apiVIPs: Invalid value: \"DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host\": \"DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host\" is not a valid IP, platform.baremetal.apiVIPs: Invalid value: \"DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host\": IP expected to be in one of the machine networks: 192.168.122.0/23]",
+			expectedError: "platform.baremetal.apiVIPs: Invalid value",
 		},
 		{
-			name: "Required values not set and invalid apiVips set for vsphere platform",
+			name: "Required values not set for vsphere platform",
 			data: `
 apiVersion: v1
 metadata:
@@ -103,7 +103,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "failed to create install config: invalid \"install-config.yaml\" file: [platform.vsphere.apiVIPs: Invalid value: \"192.168.122.10\": IP expected to be in one of the machine networks: 10.0.0.0/16, platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set, platform.vsphere.vCenter: Required value: must specify the name of the vCenter, platform.vsphere.username: Required value: must specify the username, platform.vsphere.password: Required value: must specify the password, platform.vsphere.datacenter: Required value: must specify the datacenter, platform.vsphere.defaultDatastore: Required value: must specify the default datastore]",
+			expectedError: "platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set, platform.vsphere.vCenter: Required value: must specify the name of the vCenter, platform.vsphere.username: Required value: must specify the username, platform.vsphere.password: Required value: must specify the password, platform.vsphere.datacenter: Required value: must specify the datacenter, platform.vsphere.defaultDatastore: Required value: must specify the default datastore]",
 		},
 		{
 			name: "invalid configuration for none platform for sno",
@@ -533,7 +533,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			found, err := asset.Load(fileFetcher)
 			assert.Equal(t, tc.expectedFound, found, "unexpected found value returned from Load")
 			if tc.expectedError != "" {
-				assert.Equal(t, tc.expectedError, err.Error())
+				assert.Contains(t, err.Error(), tc.expectedError)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"net"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -12,7 +13,10 @@ import (
 	"github.com/openshift/installer/pkg/asset/mock"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+
+	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/none"
+	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
 func TestInstallConfigLoad(t *testing.T) {
@@ -40,26 +44,53 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			expectedError: `invalid install-config configuration: Platform: Unsupported value: "aws": supported values: "baremetal", "vsphere", "none"`,
 		},
 		{
-			name: "apiVips not set for baremetal platform",
+			name: "apiVips not set for baremetal Compact platform",
 			data: `
 apiVersion: v1
 metadata:
   name: test-cluster
 baseDomain: test-domain
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OpenShiftSDN
+  machineNetwork:
+  - cidr: 192.168.122.0/23
+  serviceNetwork: 
+  - 172.30.0.0/16
+compute:
+  - architecture: amd64
+    hyperthreading: Enabled
+    name: worker
+    platform: {}
+    replicas: 0
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 3
 platform:
   baremetal:
+    externalMACAddress: "52:54:00:f6:b4:02"
+    provisioningMACAddress: "52:54:00:6e:3b:02"
+    ingressVIPs: 
+      - 192.168.122.11
     hosts:
       - name: host1
-        bootMACAddress: 52:54:01:xx:zz:z1
-    ingressVips:
-      - 192.168.122.11
+        bootMACAddress: 52:54:01:aa:aa:a1
+      - name: host2
+        bootMACAddress: 52:54:01:bb:bb:b1
+      - name: host3
+        bootMACAddress: 52:54:01:cc:cc:c1
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: Platform.Baremetal.ApiVips: Required value: apiVips must be set for baremetal platform",
+			expectedError: "failed to create install config: invalid \"install-config.yaml\" file: [platform.baremetal.apiVIPs: Invalid value: []string{\"DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host\"}: ip <nil> is invalid, platform.baremetal.apiVIPs: Invalid value: \"DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host\": \"DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host\" is not a valid IP, platform.baremetal.apiVIPs: Invalid value: \"DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host\": IP expected to be in one of the machine networks: 192.168.122.0/23]",
 		},
 		{
-			name: "ingressVips not set for vsphere platform",
+			name: "Required values not set and invalid apiVips set for vsphere platform",
 			data: `
 apiVersion: v1
 metadata:
@@ -72,7 +103,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: Platform.VSphere.IngressVips: Required value: ingressVips must be set for vsphere platform",
+			expectedError: "failed to create install config: invalid \"install-config.yaml\" file: [platform.vsphere.apiVIPs: Invalid value: \"192.168.122.10\": IP expected to be in one of the machine networks: 10.0.0.0/16, platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set, platform.vsphere.vCenter: Required value: must specify the name of the vCenter, platform.vsphere.username: Required value: must specify the username, platform.vsphere.password: Required value: must specify the password, platform.vsphere.datacenter: Required value: must specify the datacenter, platform.vsphere.defaultDatastore: Required value: must specify the default datastore]",
 		},
 		{
 			name: "invalid configuration for none platform for sno",
@@ -122,7 +153,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: Compute.Replicas: Required value: Installing a Single Node Openshift requires explicitly setting compute replicas to zero",
+			expectedError: "invalid install-config configuration: Compute.Replicas: Required value: Total number of Compute.Replicas must be 0 for none platform. Found 3",
 		},
 		{
 			name: "invalid networkType for SNO cluster",
@@ -244,6 +275,241 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 					},
 				},
 				Platform:   types.Platform{None: &none.Platform{}},
+				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				Publish:    types.ExternalPublishingStrategy,
+			},
+		},
+		{
+			name: "valid configuration for baremetal platform for HA cluster - deprecated fields",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OpenShiftSDN
+  machineNetwork:
+  - cidr: 192.168.122.0/23
+  serviceNetwork: 
+  - 172.30.0.0/16
+compute:
+  - architecture: amd64
+    hyperthreading: Enabled
+    name: worker
+    platform: {}
+    replicas: 2
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 3
+platform:
+  baremetal:
+    externalMACAddress: "52:54:00:f6:b4:02"
+    provisioningMACAddress: "52:54:00:6e:3b:02"
+    apiVIP: 192.168.122.10
+    ingressVIP: 192.168.122.11
+    hosts:
+      - name: host1
+        bootMACAddress: 52:54:01:aa:aa:a1
+      - name: host2
+        bootMACAddress: 52:54:01:bb:bb:b1
+      - name: host3
+        bootMACAddress: 52:54:01:cc:cc:c1
+      - name: host4
+        bootMACAddress: 52:54:01:dd:dd:d1
+      - name: host5
+        bootMACAddress: 52:54:01:ee:ee:e1
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: true,
+			expectedConfig: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
+				Networking: &types.Networking{
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("192.168.122.0/23")},
+					},
+					NetworkType:    "OpenShiftSDN",
+					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
+					ClusterNetwork: []types.ClusterNetworkEntry{
+						{
+							CIDR:       *ipnet.MustParseCIDR("10.128.0.0/14"),
+							HostPrefix: 23,
+						},
+					},
+				},
+				ControlPlane: &types.MachinePool{
+					Name:           "master",
+					Replicas:       pointer.Int64Ptr(3),
+					Hyperthreading: types.HyperthreadingEnabled,
+					Architecture:   types.ArchitectureAMD64,
+				},
+				Compute: []types.MachinePool{
+					{
+						Name:           "worker",
+						Replicas:       pointer.Int64Ptr(2),
+						Hyperthreading: types.HyperthreadingEnabled,
+						Architecture:   types.ArchitectureAMD64,
+					},
+				},
+				Platform: types.Platform{
+					BareMetal: &baremetal.Platform{
+						LibvirtURI:              "qemu:///system",
+						ClusterProvisioningIP:   "172.22.0.3",
+						BootstrapProvisioningIP: "172.22.0.2",
+						ExternalBridge:          "baremetal",
+						ExternalMACAddress:      "52:54:00:f6:b4:02",
+						ProvisioningNetwork:     "Managed",
+						ProvisioningBridge:      "provisioning",
+						ProvisioningMACAddress:  "52:54:00:6e:3b:02",
+						ProvisioningDHCPRange:   "172.22.0.10,172.22.0.254",
+						ProvisioningNetworkCIDR: &ipnet.IPNet{
+							IPNet: net.IPNet{
+								IP:   []byte("\xac\x16\x00\x00"),
+								Mask: []byte("\xff\xff\xff\x00"),
+							},
+						},
+						Hosts: []*baremetal.Host{
+							{
+								Name:            "host1",
+								BootMACAddress:  "52:54:01:aa:aa:a1",
+								BootMode:        "UEFI",
+								HardwareProfile: "default",
+							},
+							{
+								Name:            "host2",
+								BootMACAddress:  "52:54:01:bb:bb:b1",
+								BootMode:        "UEFI",
+								HardwareProfile: "default",
+							},
+							{
+								Name:            "host3",
+								BootMACAddress:  "52:54:01:cc:cc:c1",
+								BootMode:        "UEFI",
+								HardwareProfile: "default",
+							},
+							{
+								Name:            "host4",
+								BootMACAddress:  "52:54:01:dd:dd:d1",
+								BootMode:        "UEFI",
+								HardwareProfile: "default",
+							},
+							{
+								Name:            "host5",
+								BootMACAddress:  "52:54:01:ee:ee:e1",
+								BootMode:        "UEFI",
+								HardwareProfile: "default",
+							}},
+						DeprecatedAPIVIP:     "192.168.122.10",
+						APIVIPs:              []string{"192.168.122.10"},
+						DeprecatedIngressVIP: "192.168.122.11",
+						IngressVIPs:          []string{"192.168.122.11"},
+					},
+				},
+				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
+				Publish:    types.ExternalPublishingStrategy,
+			},
+		},
+		{
+			name: "valid configuration for vsphere platform for compact cluster - deprecated field apiVip",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OpenShiftSDN
+  machineNetwork:
+  - cidr: 192.168.122.0/23
+  serviceNetwork: 
+  - 172.30.0.0/16
+compute:
+  - architecture: amd64
+    hyperthreading: Enabled
+    name: worker
+    platform: {}
+    replicas: 0
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 3
+platform:
+  vsphere :
+    vcenter: 192.168.122.30
+    username: testUsername
+    password: testPassword
+    datacenter: testDataCenter
+    defaultDataStore: testDefaultDataStore
+    apiVIP: 192.168.122.10
+    ingressVIPs: 
+      - 192.168.122.11
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: true,
+			expectedConfig: &types.InstallConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: types.InstallConfigVersion,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				AdditionalTrustBundlePolicy: types.PolicyProxyOnly,
+				BaseDomain:                  "test-domain",
+				Networking: &types.Networking{
+					MachineNetwork: []types.MachineNetworkEntry{
+						{CIDR: *ipnet.MustParseCIDR("192.168.122.0/23")},
+					},
+					NetworkType:    "OpenShiftSDN",
+					ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
+					ClusterNetwork: []types.ClusterNetworkEntry{
+						{
+							CIDR:       *ipnet.MustParseCIDR("10.128.0.0/14"),
+							HostPrefix: 23,
+						},
+					},
+				},
+				ControlPlane: &types.MachinePool{
+					Name:           "master",
+					Replicas:       pointer.Int64Ptr(3),
+					Hyperthreading: types.HyperthreadingEnabled,
+					Architecture:   types.ArchitectureAMD64,
+				},
+				Compute: []types.MachinePool{
+					{
+						Name:           "worker",
+						Replicas:       pointer.Int64Ptr(0),
+						Hyperthreading: types.HyperthreadingEnabled,
+						Architecture:   types.ArchitectureAMD64,
+					},
+				},
+				Platform: types.Platform{
+					VSphere: &vsphere.Platform{
+						VCenter:          "192.168.122.30",
+						Username:         "testUsername",
+						Password:         "testPassword",
+						Datacenter:       "testDataCenter",
+						DefaultDatastore: "testDefaultDataStore",
+						DeprecatedAPIVIP: "192.168.122.10",
+						APIVIPs:          []string{"192.168.122.10"},
+						IngressVIPs:      []string{"192.168.122.11"},
+					},
+				},
 				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,
 				Publish:    types.ExternalPublishingStrategy,
 			},


### PR DESCRIPTION
With this PR we now first validate the install config via the installer's default validations and later do the additional validations for the agent installer.

Signed-off-by: Pawan Pinjarkar <ppinjark@redhat.com>