### PR TITLE
OCPBUGS-1900: Avoid SNO bootstrap jsonpath error

### DIFF
--- a/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
+++ b/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
@@ -33,7 +33,8 @@ function restart_kubelet {
 
 function approve_csr {
   echo "Approving csrs ..."
-  until [ "$(oc get nodes --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' | grep -c "True")" -eq 1 ];
+  # use [*] and not [0] in the jsonpath because the node resource may not have been created yet
+  until [ "$(oc get nodes --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}' | grep -c "True")" -eq 1 ];
   do
     echo "Approving csrs ..."
     oc get csr -o go-template='{{range .items}}{{if not .status}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}' | xargs --no-run-if-empty oc adm certificate approve &> /dev/null || true


### PR DESCRIPTION
Use `[*]` and not `[0]` in the BIP post-reboot `approve_csr` jsonpath
when counting ready nodes while approving CSRs, because the node
resource may not have been created yet.

This prevents the following harmless error message:
```
Sep 30 09:01:17 test.metalkube.org bootstrap-in-place-post-reboot.sh[2409]: Approving csrs ...
Sep 30 09:01:17 test.metalkube.org bootstrap-in-place-post-reboot.sh[3045]: error: error executing jsonpath "{.items[0].status.conditions[?(@.type==\"Ready\")].status}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
Sep 30 09:01:17 test.metalkube.org bootstrap-in-place-post-reboot.sh[3045]:         template was:
Sep 30 09:01:17 test.metalkube.org bootstrap-in-place-post-reboot.sh[3045]:                 {.items[0].status.conditions[?(@.type=="Ready")].status}
Sep 30 09:01:17 test.metalkube.org bootstrap-in-place-post-reboot.sh[3045]:         object given to jsonpath engine was:
Sep 30 09:01:17 test.metalkube.org bootstrap-in-place-post-reboot.sh[3045]:                 map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":""}}
```