### PR TITLE
AGENT-349: Allow console login to Agent ISO

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -88,6 +88,10 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 	extraManifests := &manifests.ExtraManifests{}
 	dependencies.Get(agentManifests, agentConfigAsset, extraManifests)
 
+	pwd := &password.KubeadminPassword{}
+	dependencies.Get(pwd)
+	pwdHash := string(pwd.PasswordHash)
+
 	infraEnv := agentManifests.InfraEnv
 
 	config := igntypes.Config{
@@ -101,6 +105,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 					SSHAuthorizedKeys: []igntypes.SSHAuthorizedKey{
 						igntypes.SSHAuthorizedKey(infraEnv.Spec.SSHAuthorizedKey),
 					},
+					PasswordHash: &pwdHash,
 				},
 			},
 		},


### PR DESCRIPTION
Allow the 'core' user to log in to the agent ISO via the host console using the kubeadmin password for the cluster.

sshd in CoreOS is configured not to allow password authentication, so this doesn't allow the user to login via ssh without supplying their public key when building the image.

The password hash is not persisted to disk, so this does not allow users to log in to the installed OpenShift node after rebooting.