### PR TITLE
update to release.openshift.io/feature-set to match OCP 4.12

### DIFF
--- a/docs/user/azure/install_upi_azurestack.md
+++ b/docs/user/azure/install_upi_azurestack.md
@@ -234,8 +234,8 @@ installation to fail. As of 4.10, there is one credential request, for the `capi
 tech preview. Any credential requests from a feature gate can simply be removed before you create the credentials:
 
 ```shell
-$ grep "release.openshift.io/feature-gate" *
-0000_30_capi-operator_00_credentials-request.yaml:    release.openshift.io/feature-gate: TechPreviewNoUpgrade
+$ grep "release.openshift.io/feature-set" *
+0000_30_capi-operator_00_credentials-request.yaml:    release.openshift.io/feature-set: TechPreviewNoUpgrade
 $ rm 0000_30_capi-operator_00_credentials-request.yaml
 ```
 


### PR DESCRIPTION
This was added in https://github.com/openshift/cluster-version-operator/pull/821 to allow more featuresets and allow for a future migration to include actual gates. Because usage of this manifest would prevent upgrades, there are not upgrade concerns for this change.