### PR TITLE
OCPBUGS-2259: Fix soft-anti-affinity known issue

### DIFF
--- a/docs/user/openstack/known-issues.md
+++ b/docs/user/openstack/known-issues.md
@@ -14,6 +14,19 @@ In order to validate your OpenStack infrastructure prior to installation or upgr
 
 Since the installer requires the *Name* of your external network and Red Hat Core OS image, if you have other networks or images with the same name, it will choose one randomly from the set. This is not a reliable way to run the installer. We highly recommend that you resolve this with your cluster administrator by creating unique names for your resources in openstack.
 
+## Soft-anti-affinity
+
+A long-standing OpenStack Compute issue prevents the soft anti-affinity
+policy to correctly apply when instances are created in parallel. To maximize
+the chances that the default soft-anti-affinity setting applies, the Installer
+generates the Control plane instances sequentially. However, there is no
+guarantee that other machines, and in particular Compute nodes, are created
+sequentially. This applies both to install-time machine building, and day 2
+operations (e.g. MachineSet scale-out).
+
+**When it is a requirement that machines land on distinct Compute hosts,
+explicitly set `serverGroupPolicy` to `anti-affinity`.**
+
 ## Extended installation times
 
 Depending on the infrastructure performance, the installation may take longer than what the global installer timeout expects. In those cases, the installer will fail, but the cluster might still converge to a working state. In case of timeout, if such a case is suspected, it is advised to check the cluster health manually after some time:
@@ -132,22 +145,6 @@ The teardown playbooks provided for UPI installation will not delete:
  - Swift container for image registry (bootstrap container is correctly deleted)
 
 These objects have to be manually removed after running the teardown playbooks.
-
-## Control plane scale out anti-affinity
-
-A long-standing OpenStack Compute issue prevents the "soft"-anti-affinity
-policy to be correctly applied when instances are created in parallel. The
-Installer places the initial control plane nodes in a Server group with
-"soft-anti-affinity" policy and creates the first three sequentially to work
-around the problem. Additional control plane nodes beyond the first three are
-created, according to the "replicas" property, in a later phase. These nodes
-are not guaranteed to be created sequentially.
-
-When anti-affinity is a requirement, it is advised to rely on the more stable
-"anti-affinity" for any node beyond the third. To do so, install with three
-control plane replicas only. Add more nodes as a day-2 operation by assigning
-them a new Server group with "anti-affinity" policy. Use the `ServerGroupID`
-property of the Machine ProviderSpec.
 
 ## Requirement to create Control Plane Machines manifests (Kuryr SDN)
 


### PR DESCRIPTION
Before this documentation patch, the known issue about soft-anti-affinity had several issues:
* it was in the UPI section, when it is not a UPI-specific issue
* it mentioned Control plane scale-out, when OCP only supports exactly 3 masters
* it is now possible to set strict anti-affinity from the install-config.yaml, and that should be the recommended solution when VM distribution across hosts is required.