### PR TITLE
Removing jstuever from OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,6 @@ aliases:
     - AnnaZivkovic
     - barbacbd
     - jhixson74
-    - jstuever
     - patrickdillon
     - r4f4
     - rna-afk
@@ -48,13 +47,11 @@ aliases:
     - dav1x
     - jcpowermac
     - patrickdillon
-    - jstuever
     - rvanderp3
   vsphere-reviewers:
     - bostrt
     - jcpowermac
     - patrickdillon
-    - jstuever
   baremetal-approvers:
     - andfasano
     - dtantsur
@@ -71,18 +68,14 @@ aliases:
     - iurygregory
     - sadasu
   aws-approvers:
-    - jstuever
     - mtulio
     - patrickdillon
   aws-reviewers:
-    - jstuever
     - mtulio
     - patrickdillon
   gcp-approvers:
-    - jstuever
     - patrickdillon
   gcp-reviewers:
-    - jstuever
     - patrickdillon
   azure-approvers:
     - jhixson74


### PR DESCRIPTION
Removing jstuever from the OWNERS files so that pull requests continue to get assigned to two active reviewers.