### PR TITLE
OCPBUGS-2290: Power VS Check for existing DNS permitted network and public gateway

### DIFF
--- a/data/data/powervs/cluster/dns/dns.tf
+++ b/data/data/powervs/cluster/dns/dns.tf
@@ -38,7 +38,7 @@ data "ibm_dns_zones" "dns_zones" {
 }
 
 resource "ibm_dns_permitted_network" "permit_vpc_network_for_dns" {
-  count       = var.publish_strategy == "Internal" ? 1 : 0
+  count       = var.publish_strategy == "Internal" && ! var.vpc_permitted ? 1 : 0
   instance_id = var.service_id
   zone_id     = local.dns_zone.zone_id
   vpc_crn     = var.vpc_crn

--- a/data/data/powervs/cluster/dns/templates/cloud-init.yaml.tpl
+++ b/data/data/powervs/cluster/dns/templates/cloud-init.yaml.tpl
@@ -30,6 +30,10 @@ runcmd:
   - systemctl enable named.service
   - systemctl start named.service
 %{ if is_proxy ~}
+  - echo 'acl ibm_endpoints dstdomain .cloud.ibm.com' > /tmp/squid.conf
+  - echo 'http_access deny !ibm_endpoints' >> /tmp/squid.conf
+  - cat /etc/squid/squid.conf >> /tmp/squid.conf
+  - mv -f /tmp/squid.conf /etc/squid/squid.conf
   - service httpd start
   - service squid start
 %{ endif ~}

--- a/data/data/powervs/cluster/dns/variables.tf
+++ b/data/data/powervs/cluster/dns/variables.tf
@@ -53,6 +53,11 @@ variable "vpc_zone" {
   description = "The IBM Cloud zone in which the VPC is created."
 }
 
+variable "vpc_permitted" {
+  type        = bool
+  description = "Specifies whether an existing VPC is already a Permitted Network for DNS Instance, for Private clusters."
+}
+
 variable "dns_vm_image_name" {
   type        = string
   description = "The image name for the DNS VM."

--- a/data/data/powervs/cluster/main.tf
+++ b/data/data/powervs/cluster/main.tf
@@ -18,12 +18,15 @@ module "vpc" {
   }
   source = "./vpc"
 
-  cluster_id      = var.cluster_id
-  resource_group  = var.powervs_resource_group
-  vpc_zone        = var.powervs_vpc_zone
-  vpc_subnet_name = var.powervs_vpc_subnet_name
-  vpc_name        = var.powervs_vpc_name
-  wait_for_vpc    = var.powervs_wait_for_vpc
+  cluster_id           = var.cluster_id
+  publish_strategy     = var.powervs_publish_strategy
+  resource_group       = var.powervs_resource_group
+  vpc_zone             = var.powervs_vpc_zone
+  vpc_subnet_name      = var.powervs_vpc_subnet_name
+  vpc_name             = var.powervs_vpc_name
+  vpc_gateway_name     = var.powervs_vpc_gateway_name
+  vpc_gateway_attached = var.powervs_vpc_gateway_attached
+  wait_for_vpc         = var.powervs_wait_for_vpc
 }
 
 module "pi_network" {
@@ -40,6 +43,7 @@ module "pi_network" {
   cloud_conn_name   = var.powervs_ccon_name
   vpc_crn           = module.vpc.vpc_crn
   dns_server        = module.dns.dns_server
+  enable_snat       = var.powervs_enable_snat
 }
 
 resource "ibm_pi_key" "cluster_key" {
@@ -132,6 +136,7 @@ module "dns" {
   vpc_subnet_id              = module.vpc.vpc_subnet_id
   vpc_zone                   = module.vpc.vpc_zone
   vpc_region                 = var.powervs_vpc_region
+  vpc_permitted              = var.powervs_vpc_permitted
   ssh_key                    = var.powervs_ssh_key
   publish_strategy           = var.powervs_publish_strategy
   enable_snat                = var.powervs_enable_snat

--- a/data/data/powervs/cluster/vpc/variables.tf
+++ b/data/data/powervs/cluster/vpc/variables.tf
@@ -3,6 +3,11 @@ variable "cluster_id" {
   description = "The ID created by the installer to uniquely identify the created cluster."
 }
 
+variable "publish_strategy" {
+  type        = string
+  description = "Publishing strategy used by cluster. Internal or External"
+}
+
 variable "resource_group" {
   type        = string
   description = "The name of the Power VS resource group to which the user belongs."
@@ -30,3 +35,14 @@ variable "vpc_name" {
   default     = ""
 }
 
+variable "vpc_gateway_name" {
+  type        = string
+  description = "Name of the pre-existing VPC gateway."
+  default     = ""
+}
+
+variable "vpc_gateway_attached" {
+  type        = bool
+  description = "Boolean indicating if the pre-existing VPC gateway already attached."
+  default     = false
+}

--- a/data/data/powervs/variables-powervs.tf
+++ b/data/data/powervs/variables-powervs.tf
@@ -87,6 +87,24 @@ variable "powervs_vpc_name" {
   default     = ""
 }
 
+variable "powervs_vpc_permitted" {
+  type        = bool
+  description = "Specifies whether an existing VPC is already a Permitted Network for DNS Instance, for Private clusters."
+  default     = false
+}
+
+variable "powervs_vpc_gateway_attached" {
+  type        = bool
+  description = "Specifies whether an existing gateway is already attached to an existing VPC."
+  default     = false
+}
+
+variable "powervs_vpc_gateway_name" {
+  type        = string
+  description = "The name of a pre-created VPC gateway. Must be in $powervs_vpc_region"
+  default     = ""
+}
+
 variable "powervs_vpc_subnet_name" {
   type        = string
   description = "The name of a pre-created IBM Cloud Subnet. Must be in $powervs_vpc_region"

--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -3,11 +3,13 @@ package powervs
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/IBM-Cloud/bluemix-go/crn"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/networking-go-sdk/dnsrecordsv1"
+	"github.com/IBM/networking-go-sdk/dnssvcsv1"
 	"github.com/IBM/networking-go-sdk/dnszonesv1"
 	"github.com/IBM/networking-go-sdk/resourcerecordsv1"
 	"github.com/IBM/networking-go-sdk/zonesv1"
@@ -26,16 +28,22 @@ type API interface {
 	GetDNSRecordsByName(ctx context.Context, crnstr string, zoneID string, recordName string, publish types.PublishingStrategy) ([]DNSRecordResponse, error)
 	GetDNSZoneIDByName(ctx context.Context, name string, publish types.PublishingStrategy) (string, error)
 	GetDNSZones(ctx context.Context, publish types.PublishingStrategy) ([]DNSZoneResponse, error)
+	GetDNSInstancePermittedNetworks(ctx context.Context, dnsID string, dnsZone string) ([]string, error)
+	GetVPCByName(ctx context.Context, vpcName string) (*vpcv1.VPC, error)
+	GetPublicGatewayByVPC(ctx context.Context, vpcName string) (*vpcv1.PublicGateway, error)
+	GetSubnetByName(ctx context.Context, subnetName string, region string) (*vpcv1.Subnet, error)
 	GetAuthenticatorAPIKeyDetails(ctx context.Context) (*iamidentityv1.APIKey, error)
 	GetAPIKey() string
+	SetVPCServiceURLForRegion(ctx context.Context, region string) error
 }
 
 // Client makes calls to the PowerVS API.
 type Client struct {
-	APIKey        string
-	managementAPI *resourcemanagerv2.ResourceManagerV2
-	controllerAPI *resourcecontrollerv2.ResourceControllerV2
-	vpcAPI        *vpcv1.VpcV1
+	APIKey         string
+	managementAPI  *resourcemanagerv2.ResourceManagerV2
+	controllerAPI  *resourcecontrollerv2.ResourceControllerV2
+	vpcAPI         *vpcv1.VpcV1
+	dnsServicesAPI *dnssvcsv1.DnsSvcsV1
 }
 
 // cisServiceID is the Cloud Internet Services' catalog service ID.
@@ -93,6 +101,7 @@ func (c *Client) loadSDKServices() error {
 		c.loadResourceManagementAPI,
 		c.loadResourceControllerAPI,
 		c.loadVPCV1API,
+		c.loadDNSServicesAPI,
 	}
 
 	// Call all the load functions.
@@ -287,6 +296,120 @@ func (c *Client) GetDNSZones(ctx context.Context, publish types.PublishingStrate
 	return allZones, nil
 }
 
+// GetDNSInstancePermittedNetworks gets the permitted VPC networks for a DNS Services instance
+func (c *Client) GetDNSInstancePermittedNetworks(ctx context.Context, dnsID string, dnsZone string) ([]string, error) {
+	_, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	listPermittedNetworksOptions := c.dnsServicesAPI.NewListPermittedNetworksOptions(dnsID, dnsZone)
+	permittedNetworks, _, err := c.dnsServicesAPI.ListPermittedNetworksWithContext(ctx, listPermittedNetworksOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	networks := []string{}
+	for _, network := range permittedNetworks.PermittedNetworks {
+		networks = append(networks, *network.PermittedNetwork.VpcCrn)
+	}
+	return networks, nil
+}
+
+// GetVPCByName gets a VPC by its name.
+func (c *Client) GetVPCByName(ctx context.Context, vpcName string) (*vpcv1.VPC, error) {
+	_, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	listRegionsOptions := c.vpcAPI.NewListRegionsOptions()
+	listRegionsResponse, _, err := c.vpcAPI.ListRegionsWithContext(ctx, listRegionsOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list vpc regions")
+	}
+
+	for _, region := range listRegionsResponse.Regions {
+		err := c.vpcAPI.SetServiceURL(fmt.Sprintf("%s/v1", *region.Endpoint))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to set vpc api service url")
+		}
+
+		vpcs, detailedResponse, err := c.vpcAPI.ListVpcsWithContext(ctx, c.vpcAPI.NewListVpcsOptions())
+		if err != nil {
+			if detailedResponse.GetStatusCode() != http.StatusNotFound {
+				return nil, err
+			}
+		} else {
+			for _, vpc := range vpcs.Vpcs {
+				if *vpc.Name == vpcName {
+					return &vpc, nil
+				}
+			}
+		}
+	}
+
+	return nil, errors.New("failed to find VPC")
+}
+
+// GetPublicGatewayByVPC gets all PublicGateways in a region
+func (c *Client) GetPublicGatewayByVPC(ctx context.Context, vpcName string) (*vpcv1.PublicGateway, error) {
+	_, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	vpc, err := c.GetVPCByName(ctx, vpcName)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get VPC")
+	}
+
+	vpcCRN, err := crn.Parse(*vpc.CRN)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse VPC CRN")
+	}
+
+	err = c.SetVPCServiceURLForRegion(ctx, vpcCRN.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	listPublicGatewaysOptions := c.vpcAPI.NewListPublicGatewaysOptions()
+	publicGatewayCollection, detailedResponse, err := c.vpcAPI.ListPublicGatewaysWithContext(ctx, listPublicGatewaysOptions)
+	if err != nil {
+		return nil, err
+	} else if detailedResponse.GetStatusCode() == http.StatusNotFound {
+		return nil, errors.New("failed to find publicGateways")
+	}
+	for _, gw := range publicGatewayCollection.PublicGateways {
+		if *vpc.ID == *gw.VPC.ID {
+			return &gw, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// GetSubnetByName gets a VPC Subnet by its name and region.
+func (c *Client) GetSubnetByName(ctx context.Context, subnetName string, region string) (*vpcv1.Subnet, error) {
+	_, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	err := c.SetVPCServiceURLForRegion(ctx, region)
+	if err != nil {
+		return nil, err
+	}
+
+	listSubnetsOptions := c.vpcAPI.NewListSubnetsOptions()
+	subnetCollection, detailedResponse, err := c.vpcAPI.ListSubnetsWithContext(ctx, listSubnetsOptions)
+	if err != nil {
+		return nil, err
+	} else if detailedResponse.GetStatusCode() == http.StatusNotFound {
+		return nil, errors.New("failed to find VPC Subnet")
+	}
+	for _, subnet := range subnetCollection.Subnets {
+		if subnetName == *subnet.Name {
+			return &subnet, nil
+		}
+	}
+
+	return nil, errors.New("failed to find VPC Subnet")
+}
+
 func (c *Client) loadResourceManagementAPI() error {
 	authenticator := &core.IamAuthenticator{
 		ApiKey: c.APIKey,
@@ -328,6 +451,34 @@ func (c *Client) loadVPCV1API() error {
 		return err
 	}
 	c.vpcAPI = vpcService
+	return nil
+}
+
+func (c *Client) loadDNSServicesAPI() error {
+	authenticator := &core.IamAuthenticator{
+		ApiKey: c.APIKey,
+	}
+	dnsService, err := dnssvcsv1.NewDnsSvcsV1(&dnssvcsv1.DnsSvcsV1Options{
+		Authenticator: authenticator,
+	})
+	if err != nil {
+		return err
+	}
+	c.dnsServicesAPI = dnsService
+	return nil
+}
+
+// SetVPCServiceURLForRegion will set the VPC Service URL to a specific IBM Cloud Region, in order to access Region scoped resources
+func (c *Client) SetVPCServiceURLForRegion(ctx context.Context, region string) error {
+	regionOptions := c.vpcAPI.NewGetRegionOptions(region)
+	vpcRegion, _, err := c.vpcAPI.GetRegionWithContext(ctx, regionOptions)
+	if err != nil {
+		return err
+	}
+	err = c.vpcAPI.SetServiceURL(fmt.Sprintf("%s/v1", *vpcRegion.Endpoint))
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	iamidentityv1 "github.com/IBM/platform-services-go-sdk/iamidentityv1"
+	vpcv1 "github.com/IBM/vpc-go-sdk/vpcv1"
 	gomock "github.com/golang/mock/gomock"
 	powervs "github.com/openshift/installer/pkg/asset/installconfig/powervs"
 	types "github.com/openshift/installer/pkg/types"
@@ -66,6 +67,21 @@ func (mr *MockAPIMockRecorder) GetAuthenticatorAPIKeyDetails(ctx interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthenticatorAPIKeyDetails", reflect.TypeOf((*MockAPI)(nil).GetAuthenticatorAPIKeyDetails), ctx)
 }
 
+// GetDNSInstancePermittedNetworks mocks base method.
+func (m *MockAPI) GetDNSInstancePermittedNetworks(ctx context.Context, dnsID, dnsZone string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDNSInstancePermittedNetworks", ctx, dnsID, dnsZone)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDNSInstancePermittedNetworks indicates an expected call of GetDNSInstancePermittedNetworks.
+func (mr *MockAPIMockRecorder) GetDNSInstancePermittedNetworks(ctx, dnsID, dnsZone interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSInstancePermittedNetworks", reflect.TypeOf((*MockAPI)(nil).GetDNSInstancePermittedNetworks), ctx, dnsID, dnsZone)
+}
+
 // GetDNSRecordsByName mocks base method.
 func (m *MockAPI) GetDNSRecordsByName(ctx context.Context, crnstr, zoneID, recordName string, publish types.PublishingStrategy) ([]powervs.DNSRecordResponse, error) {
 	m.ctrl.T.Helper()
@@ -109,4 +125,63 @@ func (m *MockAPI) GetDNSZones(ctx context.Context, publish types.PublishingStrat
 func (mr *MockAPIMockRecorder) GetDNSZones(ctx, publish interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDNSZones", reflect.TypeOf((*MockAPI)(nil).GetDNSZones), ctx, publish)
+}
+
+// GetPublicGatewayByVPC mocks base method.
+func (m *MockAPI) GetPublicGatewayByVPC(ctx context.Context, vpcName string) (*vpcv1.PublicGateway, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPublicGatewayByVPC", ctx, vpcName)
+	ret0, _ := ret[0].(*vpcv1.PublicGateway)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPublicGatewayByVPC indicates an expected call of GetPublicGatewayByVPC.
+func (mr *MockAPIMockRecorder) GetPublicGatewayByVPC(ctx, vpcName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPublicGatewayByVPC", reflect.TypeOf((*MockAPI)(nil).GetPublicGatewayByVPC), ctx, vpcName)
+}
+
+// GetSubnetByName mocks base method.
+func (m *MockAPI) GetSubnetByName(ctx context.Context, subnetName, region string) (*vpcv1.Subnet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubnetByName", ctx, subnetName, region)
+	ret0, _ := ret[0].(*vpcv1.Subnet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubnetByName indicates an expected call of GetSubnetByName.
+func (mr *MockAPIMockRecorder) GetSubnetByName(ctx, subnetName, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnetByName", reflect.TypeOf((*MockAPI)(nil).GetSubnetByName), ctx, subnetName, region)
+}
+
+// GetVPCByName mocks base method.
+func (m *MockAPI) GetVPCByName(ctx context.Context, vpcName string) (*vpcv1.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPCByName", ctx, vpcName)
+	ret0, _ := ret[0].(*vpcv1.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPCByName indicates an expected call of GetVPCByName.
+func (mr *MockAPIMockRecorder) GetVPCByName(ctx, vpcName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCByName", reflect.TypeOf((*MockAPI)(nil).GetVPCByName), ctx, vpcName)
+}
+
+// SetVPCServiceURLForRegion mocks base method.
+func (m *MockAPI) SetVPCServiceURLForRegion(ctx context.Context, region string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetVPCServiceURLForRegion", ctx, region)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetVPCServiceURLForRegion indicates an expected call of SetVPCServiceURLForRegion.
+func (mr *MockAPIMockRecorder) SetVPCServiceURLForRegion(ctx, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVPCServiceURLForRegion", reflect.TypeOf((*MockAPI)(nil).SetVPCServiceURLForRegion), ctx, region)
 }

--- a/pkg/asset/installconfig/powervs/session.go
+++ b/pkg/asset/installconfig/powervs/session.go
@@ -35,7 +35,7 @@ var (
 	defaultAuthFilePath               = filepath.Join(os.Getenv("HOME"), ".powervs", "config.json")
 )
 
-//BxClient is struct which provides bluemix session details
+// BxClient is struct which provides bluemix session details
 type BxClient struct {
 	*bxsession.Session
 	APIKey       string
@@ -44,7 +44,7 @@ type BxClient struct {
 	AccountAPIV2 accountv2.Accounts
 }
 
-//User is struct with user details
+// User is struct with user details
 type User struct {
 	ID      string
 	Email   string
@@ -100,7 +100,7 @@ func fetchUserDetails(sess *bxsession.Session) (*User, error) {
 	return &user, nil
 }
 
-//NewBxClient func returns bluemix client
+// NewBxClient func returns bluemix client
 func NewBxClient() (*BxClient, error) {
 	c := &BxClient{}
 
@@ -162,7 +162,7 @@ func NewBxClient() (*BxClient, error) {
 	return c, nil
 }
 
-//GetAccountType func return the type of account TRAIL/PAID
+// GetAccountType func return the type of account TRAIL/PAID
 func (c *BxClient) GetAccountType() (string, error) {
 	myAccount, err := c.AccountAPIV2.Get((*c.User).Account)
 	if err != nil {
@@ -172,7 +172,7 @@ func (c *BxClient) GetAccountType() (string, error) {
 	return myAccount.Type, nil
 }
 
-//ValidateAccountPermissions Checks permission for provisioning Power VS resources
+// ValidateAccountPermissions Checks permission for provisioning Power VS resources
 func (c *BxClient) ValidateAccountPermissions() error {
 	accType, err := c.GetAccountType()
 	if err != nil {
@@ -184,7 +184,7 @@ func (c *BxClient) ValidateAccountPermissions() error {
 	return nil
 }
 
-//ValidateDhcpService checks for existing Dhcp service for the provided PowerVS cloud instance
+// ValidateDhcpService checks for existing Dhcp service for the provided PowerVS cloud instance
 func (c *BxClient) ValidateDhcpService(ctx context.Context, svcInsID string) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
@@ -202,7 +202,7 @@ func (c *BxClient) ValidateDhcpService(ctx context.Context, svcInsID string) err
 	return nil
 }
 
-//ValidateCloudConnectionInPowerVSRegion counts cloud connection in PowerVS Region
+// ValidateCloudConnectionInPowerVSRegion counts cloud connection in PowerVS Region
 func (c *BxClient) ValidateCloudConnectionInPowerVSRegion(ctx context.Context, svcInsID string) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()

--- a/pkg/tfvars/powervs/powervs.go
+++ b/pkg/tfvars/powervs/powervs.go
@@ -30,6 +30,9 @@ type config struct {
 	NetworkName          string `json:"powervs_network_name"`
 	VPCName              string `json:"powervs_vpc_name"`
 	VPCSubnetName        string `json:"powervs_vpc_subnet_name"`
+	VPCPermitted         bool   `json:"powervs_vpc_permitted"`
+	VPCGatewayName       string `json:"powervs_vpc_gateway_name"`
+	VPCGatewayAttached   bool   `json:"powervs_vpc_gateway_attached"`
 	CloudConnectionName  string `json:"powervs_ccon_name"`
 	BootstrapMemory      int32  `json:"powervs_bootstrap_memory"`
 	BootstrapProcessors  string `json:"powervs_bootstrap_processors"`
@@ -57,6 +60,9 @@ type TFVarsSources struct {
 	DNSInstanceCRN       string
 	VPCName              string
 	VPCSubnetName        string
+	VPCPermitted         bool
+	VPCGatewayName       string
+	VPCGatewayAttached   bool
 	PublishStrategy      types.PublishingStrategy
 	EnableSNAT           bool
 }
@@ -110,6 +116,9 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		ImageBucketFileName:  sources.ImageBucketFileName,
 		VPCName:              sources.VPCName,
 		VPCSubnetName:        sources.VPCSubnetName,
+		VPCPermitted:         sources.VPCPermitted,
+		VPCGatewayName:       sources.VPCGatewayName,
+		VPCGatewayAttached:   sources.VPCGatewayAttached,
 		CloudConnectionName:  sources.CloudConnectionName,
 		BootstrapMemory:      masterConfig.MemoryGiB,
 		BootstrapProcessors:  processor,


### PR DESCRIPTION
In the private and disconnected scenarios, if you deploy with either an existing public gateway or the VPC already in the permitted networks of the DNS service, terraform will fail. This PR adds logic to create these resources only when needed. Much of the client code is lifted from IBM Cloud's client.go and adapted to work with our minor differences.