### PR TITLE
OCPBUGS-2262: Update gcp explain for DNS zones

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2296,16 +2296,16 @@ spec:
                   privateDNSZone:
                     description: PrivateDNSZone Technology Preview. PrivateDNSZone
                       contains the zone ID and project where the Private DNS zone
-                      will be created.
+                      records will be created.
                     properties:
                       id:
                         description: ID Technology Preview. ID or name of the zone.
                         type: string
                       project:
-                        description: ProjectID Technology Preview When the ProjectID
-                          is provided, the zone will be created in this project. When
-                          the ProjectID is empty, the DNS zone with this ID will be
-                          created and managed in the Service Project (GCP.ProjectID).
+                        description: ProjectID Technology Preview. When the ProjectID
+                          is provided, the zone will exist in this project. When the
+                          ProjectID is empty, the ProjectID defaults to the Service
+                          Project (GCP.ProjectID).
                         type: string
                     type: object
                   projectID:
@@ -2314,16 +2314,17 @@ spec:
                     type: string
                   publicDNSZone:
                     description: PublicDNSZone Technology Preview. PublicDNSZone contains
-                      the zone ID and project where the Public DNS zone will be created.
+                      the zone ID and project where the Public DNS zone records will
+                      be created.
                     properties:
                       id:
                         description: ID Technology Preview. ID or name of the zone.
                         type: string
                       project:
-                        description: ProjectID Technology Preview When the ProjectID
-                          is provided, the zone will be created in this project. When
-                          the ProjectID is empty, the DNS zone with this ID will be
-                          created and managed in the Service Project (GCP.ProjectID).
+                        description: ProjectID Technology Preview. When the ProjectID
+                          is provided, the zone will exist in this project. When the
+                          ProjectID is empty, the ProjectID defaults to the Service
+                          Project (GCP.ProjectID).
                         type: string
                     type: object
                   region:

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -19,9 +19,9 @@ type DNSZone struct {
 	// +optional
 	ID string `json:"id,omitempty"`
 
-	// ProjectID Technology Preview
-	// When the ProjectID is provided, the zone will be created in this project. When the ProjectID is
-	// empty, the DNS zone with this ID will be created and managed in the Service Project (GCP.ProjectID).
+	// ProjectID Technology Preview.
+	// When the ProjectID is provided, the zone will exist in this project. When the ProjectID is
+	// empty, the ProjectID defaults to the Service Project (GCP.ProjectID).
 	// +optional
 	ProjectID string `json:"project,omitempty"`
 }
@@ -76,12 +76,12 @@ type Platform struct {
 	Licenses []string `json:"licenses,omitempty"`
 
 	// PrivateDNSZone Technology Preview.
-	// PrivateDNSZone contains the zone ID and project where the Private DNS zone will be created.
+	// PrivateDNSZone contains the zone ID and project where the Private DNS zone records will be created.
 	// +optional
 	PrivateDNSZone *DNSZone `json:"privateDNSZone,omitempty"`
 
 	// PublicDNSZone Technology Preview.
-	// PublicDNSZone contains the zone ID and project where the Public DNS zone will be created.
+	// PublicDNSZone contains the zone ID and project where the Public DNS zone records will be created.
 	// +optional
 	PublicDNSZone *DNSZone `json:"publicDNSZone,omitempty"`
 }


### PR DESCRIPTION
** Update the comments/explain docs for the public and private DNS zone in the install config.