### PR TITLE
OCPBUGS-2338: Don't use error messages as default values

### DIFF
--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -87,7 +87,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "platform.baremetal.apiVIPs: Invalid value",
+			expectedError: "failed to create install config: invalid \"install-config.yaml\" file: [platform.baremetal.apiVIPs: Required value: must specify at least one VIP for the API, platform.baremetal.apiVIPs: Required value: must specify VIP for API, when VIP for ingress is set]",
 		},
 		{
 			name: "Required values not set for vsphere platform",
@@ -103,7 +103,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set, platform.vsphere.vCenter: Required value: must specify the name of the vCenter, platform.vsphere.username: Required value: must specify the username, platform.vsphere.password: Required value: must specify the password, platform.vsphere.datacenter: Required value: must specify the datacenter, platform.vsphere.defaultDatastore: Required value: must specify the default datastore]",
+			expectedError: "failed to create install config: invalid \"install-config.yaml\" file: [platform.vsphere.apiVIPs: Invalid value: \"192.168.122.10\": IP expected to be in one of the machine networks: 10.0.0.0/16, platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set, platform.vsphere.vCenter: Required value: must specify the name of the vCenter, platform.vsphere.username: Required value: must specify the username, platform.vsphere.password: Required value: must specify the password, platform.vsphere.datacenter: Required value: must specify the datacenter, platform.vsphere.defaultDatastore: Required value: must specify the default datastore]",
 		},
 		{
 			name: "invalid configuration for none platform for sno",
@@ -533,7 +533,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			found, err := asset.Load(fileFetcher)
 			assert.Equal(t, tc.expectedFound, found, "unexpected found value returned from Load")
 			if tc.expectedError != "" {
-				assert.Contains(t, err.Error(), tc.expectedError)
+				assert.Equal(t, tc.expectedError, err.Error())
 			} else {
 				assert.NoError(t, err)
 			}

--- a/pkg/types/baremetal/defaults/platform.go
+++ b/pkg/types/baremetal/defaults/platform.go
@@ -32,12 +32,10 @@ var lookupHost = func(host string) (addrs []string, err error) {
 }
 
 // GenerateMAC a randomized MAC address with the libvirt prefix
-func GenerateMAC() (string, error) {
+func GenerateMAC() string {
 	buf := make([]byte, 3)
 	rand.Seed(time.Now().UnixNano())
-	if _, err := rand.Read(buf); err != nil {
-		return "", err
-	}
+	rand.Read(buf)
 
 	// set local bit and unicast
 	buf[0] = (buf[0] | 2) & 0xfe
@@ -47,7 +45,7 @@ func GenerateMAC() (string, error) {
 		buf[0] = 0xee
 	}
 
-	return fmt.Sprintf("52:54:00:%02x:%02x:%02x", buf[0], buf[1], buf[2]), nil
+	return fmt.Sprintf("52:54:00:%02x:%02x:%02x", buf[0], buf[1], buf[2])
 }
 
 // SetPlatformDefaults sets the defaults for the platform.
@@ -57,20 +55,10 @@ func SetPlatformDefaults(p *baremetal.Platform, c *types.InstallConfig) {
 	}
 
 	if p.ExternalMACAddress == "" {
-		mac, err := GenerateMAC()
-		if err != nil {
-			p.ExternalMACAddress = fmt.Sprintf("Failed to Generate an External MAC: %s", err.Error())
-		} else {
-			p.ExternalMACAddress = mac
-		}
+		p.ExternalMACAddress = GenerateMAC()
 	}
 	if p.ProvisioningMACAddress == "" {
-		mac, err := GenerateMAC()
-		if err != nil {
-			p.ProvisioningMACAddress = fmt.Sprintf("Failed to Generate an Provisioning MAC: %s", err.Error())
-		} else {
-			p.ProvisioningMACAddress = mac
-		}
+		p.ProvisioningMACAddress = GenerateMAC()
 	}
 
 	if p.ProvisioningNetwork == "" {

--- a/pkg/types/baremetal/defaults/platform.go
+++ b/pkg/types/baremetal/defaults/platform.go
@@ -125,22 +125,14 @@ func SetPlatformDefaults(p *baremetal.Platform, c *types.InstallConfig) {
 
 	if len(p.APIVIPs) == 0 && p.DeprecatedAPIVIP == "" {
 		// This name should resolve to exactly one address
-		vip, err := lookupHost("api." + c.ClusterDomain())
-		if err != nil {
-			// This will fail validation and abort the install
-			p.APIVIPs = []string{fmt.Sprintf("DNS lookup failure: %s", err.Error())}
-		} else {
+		if vip, err := lookupHost("api." + c.ClusterDomain()); err == nil {
 			p.APIVIPs = []string{vip[0]}
 		}
 	}
 
 	if len(p.IngressVIPs) == 0 && p.DeprecatedIngressVIP == "" {
 		// This name should resolve to exactly one address
-		vip, err := lookupHost("test.apps." + c.ClusterDomain())
-		if err != nil {
-			// This will fail validation and abort the install
-			p.IngressVIPs = []string{fmt.Sprintf("DNS lookup failure: %s", err.Error())}
-		} else {
+		if vip, err := lookupHost("test.apps." + c.ClusterDomain()); err == nil {
 			p.IngressVIPs = []string{vip[0]}
 		}
 	}


### PR DESCRIPTION
If we fail to look up the API VIP in DNS, there is nowhere to return the
error. Previously we were setting the error message as
the default value, which resulted in a pretty horrible-looking error:

[platform.baremetal.apiVIPs: Invalid value: []string{"DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host"}: ip <nil> is invalid, platform.baremetal.apiVIPs: Invalid value: "DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host": "DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host" is not a valid IP, platform.baremetal.apiVIPs: Invalid value: "DNS lookup failure: lookup api.test-cluster.test-domain on 10.0.80.11:53: no such host": IP expected to be in one of the machine networks: 192.168.122.0/23]

This is confusing to the user, because they did not in fact provide an
invalid value. It was made particularly egregious by the change from a
single VIP to a list, which means we see the golang []string{} in the
value output.

If we can't automagically detect the correct default, just leave the
field blank and let the error be reported as a missing value.