### PR TITLE
OCPBUGS-3164: hold bootkube service until bootstrap has pivoted

### DIFF
--- a/data/data/bootstrap/systemd/units/release-image-pivot.service.template
+++ b/data/data/bootstrap/systemd/units/release-image-pivot.service.template
@@ -3,6 +3,7 @@
 Description=Pivot bootstrap to the OpenShift Release Image
 Wants=release-image.service
 After=release-image.service
+Before=bootkube.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This solves a race between release-image-pivot and bootkube on firstboot. While manifests are being generated pivot may reboot a machine, which may cause corrupted manifests. Instead in OKD bootkube should wait for pivot to be completed.

This service doesn't run on OCP and has no effect in OCP installs