### PR TITLE
OCPBUGS-2436: Fix ingress config with empty lbType on AWS

### DIFF
--- a/pkg/asset/manifests/ingress.go
+++ b/pkg/asset/manifests/ingress.go
@@ -119,13 +119,15 @@ func (ing *Ingress) generateClusterConfig(config *types.InstallConfig) ([]byte, 
 
 	switch config.Platform.Name() {
 	case aws.Name:
-		obj.Spec.LoadBalancer = configv1.LoadBalancer{
-			Platform: configv1.IngressPlatformSpec{
-				AWS: &configv1.AWSIngressSpec{
-					Type: config.AWS.LBType,
+		if len(config.AWS.LBType) > 0 {
+			obj.Spec.LoadBalancer = configv1.LoadBalancer{
+				Platform: configv1.IngressPlatformSpec{
+					AWS: &configv1.AWSIngressSpec{
+						Type: config.AWS.LBType,
+					},
+					Type: configv1.AWSPlatformType,
 				},
-				Type: configv1.AWSPlatformType,
-			},
+			}
 		}
 	}
 	return yaml.Marshal(obj)


### PR DESCRIPTION
When generating the `ingresses.config.openshift.io/cluster` manifest on AWS, don't set `spec.loadBalancer` unless the install-config `lbType` is nonempty.

Before this PR, if `lbType` was empty, the installer generated a manifest
with the following:

``` yaml
  loadBalancer:
    platform:
      aws: {}
      type: AWS
```


Whereas `loadBalancer`, `platform`, and `aws` are optional fields, the `type` subfield of the `aws` field is required.  As a consequence, the cluster bootstrap would fail with the following error:

```
    "cluster-ingress-02-config.yml": failed to create ingresses.v1.config.openshift.io/cluster -n : Ingress.config.openshift.io "cluster" is invalid: spec.loadBalancer.platform.aws.type: Required value
```


This PR ensures that the installer doesn't generate an invalid ingress manifest when `lbType` is empty.

Follow-up to #6478.

* `pkg/asset/manifests/ingress.go` (`generateClusterConfig`): Don't set `spec.loadBalancer` unless we have a nonempty `lbType` value to put in `spec.loadBalancer.platform.aws.type`.