### PR TITLE
OCPBUGS-1033: support multiple documents in the same extra manifest file

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -14,6 +14,7 @@ import (
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 
 	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
 	"github.com/openshift/assisted-service/api/v1beta1"
@@ -228,7 +229,10 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 
 	addHostConfig(&config, agentConfigAsset)
 
-	addExtraManifests(&config, extraManifests)
+	err = addExtraManifests(&config, extraManifests)
+	if err != nil {
+		return err
+	}
 
 	a.Config = &config
 	return nil
@@ -361,7 +365,7 @@ func addHostConfig(config *igntypes.Config, agentConfig *agentconfig.AgentConfig
 	return nil
 }
 
-func addExtraManifests(config *igntypes.Config, extraManifests *manifests.ExtraManifests) {
+func addExtraManifests(config *igntypes.Config, extraManifests *manifests.ExtraManifests) error {
 
 	user := "root"
 	mode := 0644
@@ -380,9 +384,32 @@ func addExtraManifests(config *igntypes.Config, extraManifests *manifests.ExtraM
 	})
 
 	for _, file := range extraManifests.FileList {
-		extraFile := ignition.FileFromBytes(filepath.Join(extraManifestPath, filepath.Base(file.Filename)), user, mode, file.Data)
-		config.Storage.Files = append(config.Storage.Files, extraFile)
+
+		type unstructured map[string]interface{}
+
+		yamlList, err := manifests.GetMultipleYamls[unstructured](file.Data)
+		if err != nil {
+			return errors.Wrapf(err, "could not decode YAML for %s", file.Filename)
+		}
+
+		for n, manifest := range yamlList {
+			m, err := yaml.Marshal(manifest)
+			if err != nil {
+				return err
+			}
+
+			base := filepath.Base(file.Filename)
+			ext := filepath.Ext(file.Filename)
+			baseWithoutExt := strings.TrimSuffix(base, ext)
+			baseFileName := filepath.Join(extraManifestPath, baseWithoutExt)
+			fileName := fmt.Sprintf("%s-%d%s", baseFileName, n, ext)
+
+			extraFile := ignition.FileFromBytes(fileName, user, mode, m)
+			config.Storage.Files = append(config.Storage.Files, extraFile)
+		}
 	}
+
+	return nil
 }
 
 func getOSImagesInfo(cpuArch string) (*models.OsImage, error) {

--- a/pkg/asset/agent/manifests/nmstateconfig_test.go
+++ b/pkg/asset/agent/manifests/nmstateconfig_test.go
@@ -165,14 +165,13 @@ func TestNMStateConfig_Generate(t *testing.T) {
 				assert.Equal(t, "cluster-manifests/nmstateconfig.yaml", configFile.Filename)
 
 				// Split up the file into multiple YAMLs if it contains NMStateConfig for more than one node
-				var decoder nmStateConfigYamlDecoder
-				yamlList, err := getMultipleYamls(configFile.Data, &decoder)
+				yamlList, err := GetMultipleYamls[aiv1beta1.NMStateConfig](configFile.Data)
 
 				assert.NoError(t, err)
 				assert.Equal(t, len(tc.expectedConfig), len(yamlList))
 
 				for i := range tc.expectedConfig {
-					assert.Equal(t, tc.expectedConfig[i], yamlList[i])
+					assert.Equal(t, *tc.expectedConfig[i], yamlList[i])
 
 				}
 				assert.Equal(t, len(tc.expectedConfig), len(asset.StaticNetworkConfig))


### PR DESCRIPTION
This patch allows to specify multiple documents in the same yaml file when when used as an extra manifest for the agent installer.

