### PR TITLE
OCPBUGS-2627: agent-config: Generate missing AdditionalNTPSources in InfraEnv

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -315,6 +315,22 @@ rendezvousIP: not-a-valid-ip`,
 			expectedFound: false,
 			expectedError: "invalid Agent Config configuration: rendezvousIP: Invalid value: \"not-a-valid-ip\": \"not-a-valid-ip\" is not a valid IP",
 		},
+		{
+			name: "invalid-additionalNTPSourceDomain",
+			data: `
+apiVersion: v1alpha1
+metadata:
+  name: agent-config-cluster0
+additionalNTPSources:
+  - 0.fedora.pool.ntp.org
+  - 1.fedora.pool.ntp.org
+  - 192.168.111.14
+  - fd10:39:192:1::1337
+  - invalid_pool.ntp.org
+rendezvousIP: 192.168.111.80`,
+			expectedFound: false,
+			expectedError: "invalid Agent Config configuration: AdditionalNTPSources[4]: Invalid value: \"invalid_pool.ntp.org\": NTP source is not a valid domain name nor a valid IP",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/asset/agent/manifests/infraenv.go
+++ b/pkg/asset/agent/manifests/infraenv.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent"
+	"github.com/openshift/installer/pkg/asset/agent/agentconfig"
 )
 
 var (
@@ -38,6 +39,7 @@ func (*InfraEnv) Name() string {
 func (*InfraEnv) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&agent.OptionalInstallConfig{},
+		&agentconfig.AgentConfig{},
 	}
 }
 
@@ -45,7 +47,8 @@ func (*InfraEnv) Dependencies() []asset.Asset {
 func (i *InfraEnv) Generate(dependencies asset.Parents) error {
 
 	installConfig := &agent.OptionalInstallConfig{}
-	dependencies.Get(installConfig)
+	agentConfig := &agentconfig.AgentConfig{}
+	dependencies.Get(installConfig, agentConfig)
 
 	if installConfig.Config != nil {
 		infraEnv := &aiv1beta1.InfraEnv{
@@ -69,6 +72,10 @@ func (i *InfraEnv) Generate(dependencies asset.Parents) error {
 		}
 		if installConfig.Config.Proxy != nil {
 			infraEnv.Spec.Proxy = getProxy(installConfig)
+		}
+
+		if agentConfig.Config != nil {
+			infraEnv.Spec.AdditionalNTPSources = agentConfig.Config.AdditionalNTPSources
 		}
 		i.Config = infraEnv
 

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -258,6 +258,15 @@ func getValidAgentConfig() *agentconfig.AgentConfig {
 	}
 }
 
+func getValidAgentConfigWithAdditionalNTPSources() *agentconfig.AgentConfig {
+	validAC := getValidAgentConfig()
+	validAC.Config.AdditionalNTPSources = []string{
+		"0.fedora.pool.ntp.org",
+		"1.fedora.pool.ntp.org",
+	}
+	return validAC
+}
+
 func getValidDHCPAgentConfigNoHosts() *agentconfig.AgentConfig {
 	return &agentconfig.AgentConfig{
 		Config: &agenttypes.Config{

--- a/pkg/types/agent/agent_config_type.go
+++ b/pkg/types/agent/agent_config_type.go
@@ -18,6 +18,10 @@ type Config struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// AdditionalNTPSources is a list of NTP sources (hostname or IP) to be added to all cluster
+	// hosts. They are added to any NTP sources that were configured through other means.
+	// +optional
+	AdditionalNTPSources []string `json:"additionalNTPSources,omitempty"`
 	// ip address of node0
 	RendezvousIP string `json:"rendezvousIP,omitempty"`
 	Hosts        []Host `json:"hosts,omitempty"`


### PR DESCRIPTION
In Agent based installation ZTP input, one can provide AdditionalNTPSources in InfraEnv. The sources configured there are merged by assisted-service with those that are provided by DHCP option 42 (According to RFC 2132) and provided to the openshift-install that assisted-service runs as MachineConfigs for the different roles defined for the cluster nodes.

This commit closes the gap we had when installing from install-config + agent-config.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>