### PR TITLE
OCPBUGS-2301: Search Network Project For resources

### DIFF
--- a/pkg/asset/cluster/gcp/gcp.go
+++ b/pkg/asset/cluster/gcp/gcp.go
@@ -9,7 +9,8 @@ import (
 // Metadata converts an install configuration to GCP metadata.
 func Metadata(config *types.InstallConfig) *gcp.Metadata {
 	return &gcp.Metadata{
-		Region:    config.Platform.GCP.Region,
-		ProjectID: config.Platform.GCP.ProjectID,
+		Region:           config.Platform.GCP.Region,
+		ProjectID:        config.Platform.GCP.ProjectID,
+		NetworkProjectID: config.Platform.GCP.NetworkProjectID,
 	}
 }

--- a/pkg/destroy/gcp/cloudresource.go
+++ b/pkg/destroy/gcp/cloudresource.go
@@ -6,6 +6,7 @@ import "github.com/openshift/installer/pkg/types/gcp"
 type cloudResource struct {
 	key      string
 	name     string
+	project  string
 	status   string
 	typeName string
 	url      string

--- a/pkg/destroy/gcp/firewall.go
+++ b/pkg/destroy/gcp/firewall.go
@@ -18,44 +18,67 @@ func (o *ClusterUninstaller) listFirewalls() ([]cloudResource, error) {
 // that determines whether a particular result should be returned or not.
 func (o *ClusterUninstaller) listFirewallsWithFilter(fields string, filter string, filterFunc func(*compute.Firewall) bool) ([]cloudResource, error) {
 	o.Logger.Debugf("Listing firewall rules")
-	ctx, cancel := o.contextWithTimeout()
-	defer cancel()
-	result := []cloudResource{}
-	req := o.computeSvc.Firewalls.List(o.ProjectID).Fields(googleapi.Field(fields))
-	if len(filter) > 0 {
-		req = req.Filter(filter)
-	}
-	err := req.Pages(ctx, func(list *compute.FirewallList) error {
-		for _, item := range list.Items {
-			if filterFunc == nil || filterFunc != nil && filterFunc(item) {
-				o.Logger.Debugf("Found firewall rule: %s", item.Name)
-				result = append(result, cloudResource{
-					key:      item.Name,
-					name:     item.Name,
-					typeName: "firewall",
-					quota: []gcp.QuotaUsage{{
-						Metric: &gcp.Metric{
-							Service: gcp.ServiceComputeEngineAPI,
-							Limit:   "firewalls",
-						},
-						Amount: 1,
-					}},
-				})
-			}
+	results := []cloudResource{}
+
+	findFirewallRules := func(projectID string) ([]cloudResource, error) {
+		ctx, cancel := o.contextWithTimeout()
+		defer cancel()
+		result := []cloudResource{}
+		req := o.computeSvc.Firewalls.List(projectID).Fields(googleapi.Field(fields))
+		if len(filter) > 0 {
+			req = req.Filter(filter)
 		}
-		return nil
-	})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list firewall rules")
+		err := req.Pages(ctx, func(list *compute.FirewallList) error {
+			for _, item := range list.Items {
+				if filterFunc == nil || filterFunc != nil && filterFunc(item) {
+					o.Logger.Debugf("Found firewall rule: %s", item.Name)
+					result = append(result, cloudResource{
+						key:      item.Name,
+						name:     item.Name,
+						project:  projectID,
+						typeName: "firewall",
+						quota: []gcp.QuotaUsage{{
+							Metric: &gcp.Metric{
+								Service: gcp.ServiceComputeEngineAPI,
+								Limit:   "firewalls",
+							},
+							Amount: 1,
+						}},
+					})
+				}
+			}
+			return nil
+		})
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list firewall rules for project %s", projectID)
+		}
+		return result, nil
 	}
-	return result, nil
+
+	findResults, err := findFirewallRules(o.ProjectID)
+	if err != nil {
+		return results, err
+	}
+	results = append(results, findResults...)
+
+	if o.NetworkProjectID != "" {
+		o.Logger.Debugf("Listing firewall rules for network project %s", o.NetworkProjectID)
+		findResults, err := findFirewallRules(o.NetworkProjectID)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, findResults...)
+	}
+
+	return results, nil
 }
 
 func (o *ClusterUninstaller) deleteFirewall(item cloudResource) error {
 	o.Logger.Debugf("Deleting firewall rule %s", item.name)
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	op, err := o.computeSvc.Firewalls.Delete(o.ProjectID, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
+	op, err := o.computeSvc.Firewalls.Delete(item.project, item.name).RequestId(o.requestID(item.typeName, item.name)).Context(ctx).Do()
 	if err != nil && !isNoOp(err) {
 		o.resetRequestID(item.typeName, item.name)
 		return errors.Wrapf(err, "failed to delete firewall %s", item.name)

--- a/pkg/destroy/gcp/gcp.go
+++ b/pkg/destroy/gcp/gcp.go
@@ -34,11 +34,12 @@ var (
 
 // ClusterUninstaller holds the various options for the cluster we want to delete
 type ClusterUninstaller struct {
-	Logger    logrus.FieldLogger
-	Region    string
-	ProjectID string
-	ClusterID string
-	Context   context.Context
+	Logger           logrus.FieldLogger
+	Region           string
+	ProjectID        string
+	NetworkProjectID string
+	ClusterID        string
+	Context          context.Context
 
 	computeSvc *compute.Service
 	iamSvc     *iam.Service
@@ -66,6 +67,7 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 		Logger:             logger,
 		Region:             metadata.ClusterPlatformMetadata.GCP.Region,
 		ProjectID:          metadata.ClusterPlatformMetadata.GCP.ProjectID,
+		NetworkProjectID:   metadata.ClusterPlatformMetadata.GCP.NetworkProjectID,
 		ClusterID:          metadata.InfraID,
 		Context:            context.Background(),
 		cloudControllerUID: gcptypes.CloudControllerUID(metadata.InfraID),

--- a/pkg/types/gcp/metadata.go
+++ b/pkg/types/gcp/metadata.go
@@ -2,6 +2,7 @@ package gcp
 
 // Metadata contains GCP metadata (e.g. for uninstalling the cluster).
 type Metadata struct {
-	Region    string `json:"region"`
-	ProjectID string `json:"projectID"`
+	Region           string `json:"region"`
+	ProjectID        string `json:"projectID"`
+	NetworkProjectID string `json:"networkProjectID,omitempty"`
 }


### PR DESCRIPTION
** Adding NetworkProjectID to the Metadata so that it can be used to find resources on destroy. ** Added project name to the cloud resources so that the project where the resource was discovered is tracked ** Use the cloud resource project field to find all firewall rules when a network project ID was specified.