### PR TITLE
Agent-321: Cluster and Host validations rework

### DIFF
--- a/pkg/agent/kube.go
+++ b/pkg/agent/kube.go
@@ -52,7 +52,7 @@ func (kube *ClusterKubeAPIClient) IsKubeAPILive() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	logrus.Debugf("cluster API is up and running %s", version)
+	logrus.Tracef("cluster API is up and running %s", version)
 	return true, nil
 }
 
@@ -73,7 +73,8 @@ func (kube *ClusterKubeAPIClient) IsBootstrapConfigMapComplete() (bool, error) {
 	bootstrap, err := kube.Client.CoreV1().ConfigMaps("kube-system").Get(kube.ctx, "bootstrap", v1.GetOptions{})
 
 	if err != nil {
-		return false, errors.Wrap(err, "bootstrap configmap not found")
+		logrus.Trace(errors.Wrap(err, "bootstrap configmap not found"))
+		return false, nil
 	}
 	// Found a bootstrap configmap need to check its status
 	if bootstrap != nil {

--- a/pkg/agent/waitfor.go
+++ b/pkg/agent/waitfor.go
@@ -35,7 +35,7 @@ func WaitForBootstrapComplete(assetDir string) (*Cluster, error) {
 		}
 
 		if err != nil {
-			if exitOnErr == true {
+			if exitOnErr {
 				lastErr = err
 				cancel()
 			} else {


### PR DESCRIPTION
This rework is to change the output for the cluster and host validations.

After querying the API, for each validation ID check the message against the most recent message received for that ID:

- If the message is unchanged, do nothing
- If the new message is a failure, log it at warning level
- If the new message is a success but there has previously been a failure, log it at info level
- If the new message is a success and this is the first report for that validation, log it at debug level

We won't log anything at error level because no validation in assisted prior to the install starting is ever final. The only error comes when we hit our timeout. 

To help with review [the struct coming from the Assisted API](https://github.com/openshift/assisted-service/blob/master/api/common/common_types.go#L5-L10) is the following:
```
type ValidationResult struct {
	ID      string `json:"id"`
	Status  string `json:"status"`
	Message string `json:"message"`
}
```
An example of this looks like:
```
{
    "id": "pull-secret-set",
    "status": "success",
    "message": "The pull secret is set."
}
```
[AGENT-321](https://issues.redhat.com//browse/AGENT-321)