### PR TITLE
terraform: add ignition s3 bucket prefix variable

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -45,7 +45,7 @@ data "aws_partition" "current" {}
 data "aws_ebs_default_kms_key" "current" {}
 
 resource "aws_s3_bucket" "ignition" {
-  bucket = var.aws_ignition_bucket
+  bucket = "${var.cluster_id}${var.aws_ignition_bucket}"
 
   tags = merge(
     {
@@ -59,7 +59,7 @@ resource "aws_s3_bucket" "ignition" {
   }
 }
 
-resource "aws_s3_bucket_acl" ignition {
+resource "aws_s3_bucket_acl" "ignition" {
   bucket = aws_s3_bucket.ignition.id
   acl    = "private"
 }
@@ -122,8 +122,8 @@ EOF
 
 resource "aws_iam_role_policy" "bootstrap" {
   count = var.aws_master_iam_role_name == "" ? 1 : 0
-  name = "${var.cluster_id}-bootstrap-policy"
-  role = aws_iam_role.bootstrap[0].id
+  name  = "${var.cluster_id}-bootstrap-policy"
+  role  = aws_iam_role.bootstrap[0].id
 
   policy = <<EOF
 {

--- a/data/data/aws/variables-aws.tf
+++ b/data/data/aws/variables-aws.tf
@@ -25,6 +25,12 @@ variable "aws_bootstrap_instance_type" {
   description = "Instance type for the bootstrap node. Example: `m4.large`."
 }
 
+variable "aws_bootstrap_s3_bucket_prefix" {
+  type        = string
+  default     = ""
+  description = "Prefix value for bootstrap s3 bucket name."
+}
+
 variable "aws_master_instance_type" {
   type        = string
   description = "Instance type for the master node(s). Example: `m4.large`."
@@ -53,12 +59,12 @@ EOF
 }
 
 variable "aws_master_root_volume_type" {
-  type = string
+  type        = string
   description = "The type of volume for the root block device of master nodes."
 }
 
 variable "aws_master_root_volume_size" {
-  type = string
+  type        = string
   description = "The size of the volume in gigabytes for the root block device of master nodes."
 }
 
@@ -157,13 +163,13 @@ EOF
 }
 
 variable "aws_master_iam_role_name" {
-  type = string
+  type        = string
   description = "The name of the IAM role that will be attached to master instances."
-  default = ""
+  default     = ""
 }
 
 variable "aws_worker_iam_role_name" {
-  type = string
+  type        = string
   description = "The name of the IAM role that will be attached to worker instances."
-  default = ""
+  default     = ""
 }

--- a/pkg/tfvars/aws/aws.go
+++ b/pkg/tfvars/aws/aws.go
@@ -19,6 +19,7 @@ type config struct {
 	CustomEndpoints              map[string]string `json:"custom_endpoints,omitempty"`
 	ExtraTags                    map[string]string `json:"aws_extra_tags,omitempty"`
 	BootstrapInstanceType        string            `json:"aws_bootstrap_instance_type,omitempty"`
+	BootstrapS3BucketPrefix      string            `json:"aws_bootstrap_s3_bucket_prefix,omitempty"`
 	MasterInstanceType           string            `json:"aws_master_instance_type,omitempty"`
 	MasterAvailabilityZones      []string          `json:"aws_master_availability_zones"`
 	WorkerAvailabilityZones      []string          `json:"aws_worker_availability_zones"`


### PR DESCRIPTION
This allows the AWS s3 bucket used during installation to have a configurable prefix.