### PR TITLE
agent: Add documentation for patching installer

### DIFF
--- a/docs/dev/agent/OWNERS
+++ b/docs/dev/agent/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file just uses aliases defined in OWNERS_ALIASES.
+
+approvers:
+  - agent-approvers
+reviewers:
+  - agent-reviewers

--- a/docs/dev/agent/building.md
+++ b/docs/dev/agent/building.md
@@ -1,0 +1,34 @@
+# Building the binary for development
+
+Just like in any other development build of the openshift-install, the process starts with running:
+
+    $ ./hack/build.sh
+
+This will result in the binary being written to *bin/openshift-install*
+
+Since the agent based installer has version / release image checks, though, it is important to patch the binary with the release that you intend to use for your development deployments. If you have not built your own release payload, it is usually a good idea to pick the latest nightly. You can check what the latest nightly is by doing:
+
+    $ RELEASE_VERSION=$(curl -s https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.12.0-0.nightly/latest | jq -r '.name')
+    $ RELEASE_IMAGE=$(curl -s https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.12.0-0.nightly/latest | jq -r '.pullSpec')
+
+Once we have these values, we can write them into the binary:
+
+    $ RELEASE_VERSION_LOCATION=$(grep -oba ._RELEASE_VERSION_LOCATION_.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX bin/openshift-install | cut -d':' -f1)
+    $ RELEASE_IMAGE_LOCATION=$(grep -oba ._RELEASE_IMAGE_LOCATION_.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX bin/openshift-install | cut -d':' -f1)
+    $ printf "%s\0" "$RELEASE_VERSION" | dd of="bin/openshift-install" bs=1 seek="$RELEASE_VERSION_LOCATION" conv=notrunc
+    $ printf "%s\0" "$RELEASE_IMAGE" | dd of="bin/openshift-install" bs=1 seek="$RELEASE_IMAGE_LOCATION" conv=notrunc
+
+You can verify you got the right patching by running:
+
+    $ ./bin/openshift-install version
+    ./bin/openshift-install 4.12.0-0.nightly-2022-10-18-192348¹
+    built from commit 6a5cc95fe77676c3d38d6aac5d6668c9f2d65ddb²
+    release image registry.ci.openshift.org/ocp/release:4.12.0-0.nightly-2022-10-18-192348³
+    release architecture amd64
+
+Where
+* <sup>1</sup> Should be the latest nightly version
+* <sup>2</sup> Should be the commit id of the tip of your branch
+* <sup>3</sup> Should be the latest nightly release image
+
+Once all of this is done. You can use the *openshift-install* binary normally.


### PR DESCRIPTION
In the agent workflow, due to the assisted-service version checks, it is necessary to have the installer correctly patched for version and release image. This is a guide on how to do it on a development environment.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>