### PR TITLE
OCPBUGS-1704: Service Usage API is required, not optional

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -380,13 +380,13 @@ func ValidateEnabledServices(ctx context.Context, client API, project string) er
 		"cloudresourcemanager.googleapis.com",
 		"dns.googleapis.com",
 		"iam.googleapis.com",
-		"iamcredentials.googleapis.com")
+		"iamcredentials.googleapis.com",
+		"serviceusage.googleapis.com")
 	optionalServices := sets.NewString("cloudapis.googleapis.com",
 		"servicemanagement.googleapis.com",
 		"deploymentmanager.googleapis.com",
 		"storage-api.googleapis.com",
-		"storage-component.googleapis.com",
-		"serviceusage.googleapis.com")
+		"storage-component.googleapis.com")
 	projectServices, err := client.GetEnabledServices(ctx, project)
 
 	if err != nil {


### PR DESCRIPTION
Without this, the installation wil lfail without any worker machines launched.