### PR TITLE
OCPBUGS-2895: Azure: Fix DiskEncryptionSet regex validation

### DIFF
--- a/pkg/types/azure/validation/disk.go
+++ b/pkg/types/azure/validation/disk.go
@@ -10,16 +10,16 @@ import (
 
 var (
 	// RxDiskEncryptionSetID is a regular expression that validates a disk encryption set ID.
-	RxDiskEncryptionSetID = regexp.MustCompile(`(?i)^/subscriptions/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/resourceGroups/([-a-z0-9_().]{0,89}[-a-z0-9_()])/providers/Microsoft\.Compute/diskEncryptionSets/([-a-z0-9_]{1,80})$`)
+	RxDiskEncryptionSetID = regexp.MustCompile(`(?i)^/subscriptions/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/resourceGroups/([-a-zA-Z0-9_().]{0,89}[-a-zA-Z0-9_()])/providers/Microsoft\.Compute/diskEncryptionSets/([-a-zA-Z0-9_]{1,80})$`)
 
 	// RxSubscriptionID is a regular expression that validates a subscription ID.
-	RxSubscriptionID = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	RxSubscriptionID = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 	// RxResourceGroup is a regular expression that validates a resource group.
-	RxResourceGroup = regexp.MustCompile(`^[-a-z0-9_().]{0,89}[-a-z0-9_()]$`)
+	RxResourceGroup = regexp.MustCompile(`^[-a-zA-Z0-9_().]{0,89}[-a-zA-Z0-9_()]$`)
 
 	// RxDiskEncryptionSetName is a regular expression that validates a disk encryption set name
-	RxDiskEncryptionSetName = regexp.MustCompile(`^[-a-z0-9_]{1,80}$`)
+	RxDiskEncryptionSetName = regexp.MustCompile(`^[-a-zA-Z0-9_]{1,80}$`)
 )
 
 // ValidateDiskEncryption checks that the specified disk encryption configuration is valid.

--- a/pkg/types/azure/validation/disk_test.go
+++ b/pkg/types/azure/validation/disk_test.go
@@ -10,11 +10,9 @@ import (
 )
 
 var (
-	subscriptionID        = "08675309-1111-2222-3333-303606808909"
-	resourceGroup         = "test-resource-group"
-	diskEncryptionSetName = "test-encryption-set"
-	diskEncryptionSetID   = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/diskEncryptionSets/%s",
-		subscriptionID, resourceGroup, diskEncryptionSetName)
+	subscriptionID        = "aF675309-bE11-cD22-aF33-bE3606808909"
+	resourceGroup         = "Test-res.o(ur)Ce_gRoup"
+	diskEncryptionSetName = "teSt-encrypTion_Set"
 )
 
 func validDiskEncryptionMachinePool() *azure.MachinePool {
@@ -47,7 +45,7 @@ func TestValidateDiskEncryption(t *testing.T) {
 			name:      "invalid disk encryption set (platform is stack cloud)",
 			pool:      validDiskEncryptionMachinePool(),
 			cloudName: azure.StackCloud,
-			expected:  fmt.Sprintf(`diskEncryptionSet.diskEncryptionSet: Invalid value: azure.DiskEncryptionSet{SubscriptionID:"%s", ResourceGroup:"%s", Name:"%s"}: disk encryption sets are not supported on this platform`, subscriptionID, resourceGroup, diskEncryptionSetName),
+			expected:  fmt.Sprintf(`diskEncryptionSet.diskEncryptionSet: Invalid value: azure.DiskEncryptionSet{SubscriptionID:"%s", ResourceGroup:".+", Name:"%s"}: disk encryption sets are not supported on this platform`, subscriptionID, diskEncryptionSetName),
 		},
 		{
 			name: "invalid disk encryption set (invalid subscription ID)",


### PR DESCRIPTION
Current validation excludes upper-case letters. I expanded the test suite to cover some of the ugliest (legitimate) names possible.