### PR TITLE
OCPBUGS-1704: gcp: fail during validation if service usage is not enabled

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -388,11 +388,9 @@ func ValidateEnabledServices(ctx context.Context, client API, project string) er
 		"storage-api.googleapis.com",
 		"storage-component.googleapis.com")
 	projectServices, err := client.GetEnabledServices(ctx, project)
-
 	if err != nil {
 		if IsForbidden(err) {
-			logrus.Warn("Permission denied. Unable to fetch enabled services for project.")
-			return nil
+			return errors.Wrap(err, "unable to fetch enabled services for project. Make sure 'serviceusage.googleapis.com' is enabled")
 		}
 		return err
 	}


### PR DESCRIPTION
We were only printing a warning in case Service Usage was missing and proceeding with the installation. However, that service is required by the CCO and the deployment would end up failing later on.

Instead, let's fail during install-config validation time so users can enabled the service before proceeding.