### PR TITLE
OCPBUGS-2144: Azure: Set appropriate architecture for gen v1 image

### DIFF
--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -103,6 +103,7 @@ resource "azurerm_shared_image" "cluster" {
   resource_group_name = data.azurerm_resource_group.main.name
   location            = var.azure_region
   os_type             = "Linux"
+  architecture        = var.azure_vm_architecture
 
   identifier {
     publisher = "RedHat"


### PR DESCRIPTION
Although the gen v1 image will never be used for arm64 VMs (they are all gen2), set the appropriate architecture, so the appropriate architecture image is created.