### PR TITLE
OCPBUGS-2743: skip sts credentials check in terraform

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -16,7 +16,8 @@ locals {
 provider "aws" {
   region = var.aws_region
 
-  skip_region_validation = true
+  skip_region_validation      = true
+  skip_credentials_validation = true
 
   endpoints {
     ec2     = lookup(var.custom_endpoints, "ec2", null)

--- a/data/data/aws/cluster/main.tf
+++ b/data/data/aws/cluster/main.tf
@@ -11,8 +11,8 @@ locals {
 provider "aws" {
   region = var.aws_region
 
-  skip_region_validation = true
-
+  skip_region_validation      = true
+  skip_credentials_validation = true
   endpoints {
     ec2     = lookup(var.custom_endpoints, "ec2", null)
     elb     = lookup(var.custom_endpoints, "elasticloadbalancing", null)


### PR DESCRIPTION
This is a potential fix for OCPBUGS-2743. I'm not 100% certain this is what we want to do, but I think it is good to put it up for discussion. 

When specifying an STS endpoint in the install config, the terraform provider assumes we are also using sts credentials, and the check fails validation:

level=error msg=Error: error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: SignatureDoesNotMatch: Credential should be scoped to a valid region.

This skips the validation check, to allow us to use non-STS credentials.

The only downside I can see for this is if this would make failures for invalid STS creds less user-friendly. Considering that we don't document how to use STS creds for the installer, this seems like a small issue. Nevertheless, it would be good to test this with both valid and invalid STS credentials.

Also, I'm not completely up-to-date on the state of custom endpoints, but my understanding is that we may not even need to include custom endpoints, at least for STS any more.