### PR TITLE
OCPBUGS-2130: import ova resource cluster path fix

### DIFF
--- a/terraform/providers/vsphereprivate/resource_vsphereprivate_import_ova.go
+++ b/terraform/providers/vsphereprivate/resource_vsphereprivate_import_ova.go
@@ -163,8 +163,6 @@ func findImportOvaParams(client *vim25.Client, datacenter, cluster, resourcePool
 	}
 	importOvaParams.Folder = folderObj
 
-	clusterPath := fmt.Sprintf("/%s/host/%s", datacenter, cluster)
-
 	// Find the resource pool object by using its path provided by install-config,
 	// or generated in pkg/asset/machines/vsphere/machines.go
 	resourcePoolObj, err := finder.ResourcePool(ctx, resourcePool)
@@ -173,8 +171,15 @@ func findImportOvaParams(client *vim25.Client, datacenter, cluster, resourcePool
 	}
 	importOvaParams.ResourcePool = resourcePoolObj
 
-	// Find the cluster object by the datacenter and cluster name to
-	// generate the path e.g. /datacenter/host/cluster
+	clusterPathRegexp := regexp.MustCompile("^\\/(.*?)\\/host\\/(.*?)$")
+	clusterPathParts := clusterPathRegexp.FindStringSubmatch(cluster)
+
+	clusterPath := cluster
+	if clusterPathParts == nil {
+		// Find the cluster object by the datacenter and cluster name to
+		// generate the path e.g. /datacenter/host/cluster
+		clusterPath = fmt.Sprintf("/%s/host/%s", datacenter, cluster)
+	}
 	clusterComputeResource, err := finder.ClusterComputeResource(ctx, clusterPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Zonal uses the full absolute path for cluster
in the OVA import. In the existing terraform
the relative path is used.

If `cluster` is a path use that string
otherwise generate it from the datacenter and cluster name (which was the existing method)