### PR TITLE
OCPBUGS-2847: GCP XPN Featuregates

### DIFF
--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -385,7 +385,10 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		}
 
 		instanceServiceAccount := ""
-		if installConfig.Config.CredentialsMode == types.PassthroughCredentialsMode {
+
+		// Passthrough service accounts are only needed for GCP XPN.
+		ic := installConfig.Config
+		if len(ic.GCP.NetworkProjectID) > 0 && ic.CredentialsMode == types.PassthroughCredentialsMode {
 			var found bool
 			serviceAccount := make(map[string]interface{})
 			err := json.Unmarshal([]byte(sess.Credentials.JSON), &serviceAccount)

--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 
@@ -96,7 +97,8 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 	}
 
 	instanceServiceAccount := fmt.Sprintf("%s-%s@%s.iam.gserviceaccount.com", clusterID, role[0:1], platform.ProjectID)
-	if credentialsMode == types.PassthroughCredentialsMode {
+	// Passthrough service accounts are only needed for GCP XPN.
+	if len(platform.NetworkProjectID) > 0 && credentialsMode == types.PassthroughCredentialsMode {
 		sess, err := gcpconfig.GetSession(context.TODO())
 		if err != nil {
 			return nil, err

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1006,6 +1006,14 @@ func validateFeatureSet(c *types.InstallConfig) field.ErrorList {
 			if len(c.GCP.CreateFirewallRules) > 0 && c.GCP.CreateFirewallRules != gcp.CreateFirewallRulesEnabled {
 				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "createFirewallRules"), errMsg))
 			}
+
+			if c.GCP.PrivateDNSZone != nil && len(c.GCP.PrivateDNSZone.ProjectID) > 0 {
+				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "privateDNSZone", "projectID"), errMsg))
+			}
+
+			if c.GCP.PublicDNSZone != nil && len(c.GCP.PublicDNSZone.ProjectID) > 0 {
+				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "publicDNSZone", "projectID"), errMsg))
+			}
 		}
 
 		if c.VSphere != nil {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2012,6 +2012,58 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 			expectedError: "platform.gcp.createFirewallRules: Forbidden: the TechPreviewNoUpgrade feature set must be enabled to use this field",
 		},
+		{
+			name: "GCP BYO PUBLIC DNS SHOULD return error if used WITHOUT tech preview",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{
+					GCP: validGCPPlatform(),
+				}
+				c.Platform.GCP.PublicDNSZone = &gcp.DNSZone{
+					ID:        "myZone",
+					ProjectID: "myProject",
+				}
+
+				return c
+			}(),
+			expectedError: "platform.gcp.publicDNSZone.projectID: Forbidden: the TechPreviewNoUpgrade feature set must be enabled to use this field",
+		},
+		{
+			name: "GCP BYO PRIVATE DNS SHOULD return error if used WITHOUT tech preview",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{
+					GCP: validGCPPlatform(),
+				}
+				c.Platform.GCP.PrivateDNSZone = &gcp.DNSZone{
+					ID:        "myZone",
+					ProjectID: "myProject",
+				}
+
+				return c
+			}(),
+			expectedError: "platform.gcp.privateDNSZone.projectID: Forbidden: the TechPreviewNoUpgrade feature set must be enabled to use this field",
+		},
+		{
+			name: "GCP BYO DNS should NOT return error if used WITH tech preview",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{
+					GCP: validGCPPlatform(),
+				}
+				c.Platform.GCP.PublicDNSZone = &gcp.DNSZone{
+					ID:        "myZone",
+					ProjectID: "myProject",
+				}
+				c.Platform.GCP.PrivateDNSZone = &gcp.DNSZone{
+					ID:        "myZone",
+					ProjectID: "myProject",
+				}
+				c.FeatureSet = "TechPreviewNoUpgrade"
+
+				return c
+			}(),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2064,6 +2064,40 @@ func TestValidateInstallConfig(t *testing.T) {
 				return c
 			}(),
 		},
+		{
+			name: "GCP XPN SHOULD return an error if used WITHOUT tech preview",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{
+					GCP: validGCPPlatform(),
+				}
+				c.Platform.GCP.NetworkProjectID = "myNetworkProject"
+				c.Platform.GCP.ControlPlaneSubnet = "controlPlaneSubnet"
+				c.Platform.GCP.ComputeSubnet = "computeSubnet"
+				c.Platform.GCP.Network = "vpc"
+				c.CredentialsMode = "Passthrough"
+
+				return c
+			}(),
+			expectedError: "platform.gcp.networkProjectID: Forbidden: the TechPreviewNoUpgrade feature set must be enabled to use this field",
+		},
+		{
+			name: "GCP XPN SHOULD NOT return an error if used WITH tech preview",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{
+					GCP: validGCPPlatform(),
+				}
+				c.Platform.GCP.NetworkProjectID = "myNetworkProject"
+				c.Platform.GCP.ControlPlaneSubnet = "controlPlaneSubnet"
+				c.Platform.GCP.ComputeSubnet = "computeSubnet"
+				c.Platform.GCP.Network = "vpc"
+				c.CredentialsMode = "Passthrough"
+				c.FeatureSet = "TechPreviewNoUpgrade"
+
+				return c
+			}(),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
3bac80b688cfc9cca4f10cca612235cc5bbe24d9: adds feature gate protection to install config fields for projects for DNS zones

39c8e9f6a4498cb5070ceec82e4ebdfdb6a62f77: we should only passthrough service accounts when doing an XPN install