### PR TITLE
AGENT-348: Warn when information in install-config is ignored

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -288,59 +288,59 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 
 		if vspherePlatform.VCenter != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "VCenter")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.VCenter))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.VCenter))
 		}
 		if vspherePlatform.Username != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "Username")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Username))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Username))
 		}
 		if vspherePlatform.Password != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "Password")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Password))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Password))
 		}
 		if vspherePlatform.Datacenter != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "Datacenter")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Datacenter))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Datacenter))
 		}
 		if vspherePlatform.DefaultDatastore != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "DefaultDatastore")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.DefaultDatastore))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.DefaultDatastore))
 		}
 		if vspherePlatform.Folder != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "Folder")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Folder))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Folder))
 		}
 		if vspherePlatform.Cluster != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "Cluster")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Cluster))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Cluster))
 		}
 		if vspherePlatform.ResourcePool != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "ResourcePool")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.ResourcePool))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.ResourcePool))
 		}
 		if vspherePlatform.ClusterOSImage != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "ClusterOSImage")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.ClusterOSImage))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.ClusterOSImage))
 		}
 		if vspherePlatform.DefaultMachinePlatform != &(vsphere.MachinePool{}) {
 			fieldPath := field.NewPath("Platform", "VSphere", "DefaultMachinePlatform")
-			logrus.Debugf(fmt.Sprintf("%s: %v is ignored", fieldPath, vspherePlatform.DefaultMachinePlatform))
+			logrus.Warnf(fmt.Sprintf("%s: %v is ignored", fieldPath, vspherePlatform.DefaultMachinePlatform))
 		}
 		if vspherePlatform.Network != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "Network")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Network))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.Network))
 		}
 		if vspherePlatform.DiskType != "" {
 			fieldPath := field.NewPath("Platform", "VSphere", "DiskType")
-			logrus.Debugf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.DiskType))
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.DiskType))
 		}
 		if len(vspherePlatform.VCenters) > 1 {
 			fieldPath := field.NewPath("Platform", "VSphere", "VCenters")
-			logrus.Debugf(fmt.Sprintf("%s: %v is ignored", fieldPath, vspherePlatform.VCenters))
+			logrus.Warnf(fmt.Sprintf("%s: %v is ignored", fieldPath, vspherePlatform.VCenters))
 		}
 		if len(vspherePlatform.FailureDomains) > 1 {
 			fieldPath := field.NewPath("Platform", "VSphere", "FailureDomains")
-			logrus.Debugf(fmt.Sprintf("%s: %v is ignored", fieldPath, vspherePlatform.FailureDomains))
+			logrus.Warnf(fmt.Sprintf("%s: %v is ignored", fieldPath, vspherePlatform.FailureDomains))
 		}
 	}
 	// "External" is the default set from generic install config code
@@ -352,12 +352,12 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 		fieldPath := field.NewPath("CredentialsMode")
 		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.CredentialsMode))
 	}
-	if installConfig.BootstrapInPlace.InstallationDisk != "" {
+	if installConfig.BootstrapInPlace != nil && installConfig.BootstrapInPlace.InstallationDisk != "" {
 		fieldPath := field.NewPath("BootstrapInPlace", "InstallationDisk")
 		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.BootstrapInPlace.InstallationDisk))
 	}
 	if installConfig.Capabilities != &(types.Capabilities{}) {
-		fieldPath := field.NewPath("Publish")
-		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.Publish))
+		fieldPath := field.NewPath("Capabilities")
+		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.Capabilities))
 	}
 }

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -6,8 +6,10 @@ import (
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/none"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -58,6 +60,8 @@ func (a *OptionalInstallConfig) validateInstallConfig(installConfig *types.Insta
 	if err := a.validateSupportedPlatforms(installConfig); err != nil {
 		allErrs = append(allErrs, err...)
 	}
+
+	warnUnusedConfig(installConfig)
 
 	if err := a.validateSNOConfiguration(installConfig); err != nil {
 		allErrs = append(allErrs, err...)
@@ -119,4 +123,173 @@ func (a *OptionalInstallConfig) ClusterName() string {
 		return a.Config.ObjectMeta.Name
 	}
 	return "agent-cluster"
+}
+
+func warnUnusedConfig(installConfig *types.InstallConfig) {
+	// "Proxyonly" is the default set from generic install config code
+	if installConfig.AdditionalTrustBundlePolicy != "Proxyonly" {
+		fieldPath := field.NewPath("AdditionalTrustBundlePolicy")
+		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.AdditionalTrustBundlePolicy))
+	}
+
+	for i, compute := range installConfig.Compute {
+		if compute.Hyperthreading != "Enabled" {
+			fieldPath := field.NewPath(fmt.Sprintf("Compute[%d]", i), "Hyperthreading")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, compute.Hyperthreading))
+		}
+		// kubebuilder:default=amd64. Set from generic install config code
+		if compute.Architecture != types.ArchitectureAMD64 && compute.Architecture != "x86_64" {
+			fieldPath := field.NewPath(fmt.Sprintf("Compute[%d]", i), "Architecture")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, compute.Architecture))
+		}
+
+		if compute.Platform.AWS != nil || compute.Platform.AlibabaCloud != nil || compute.Platform.Azure != nil ||
+			compute.Platform.BareMetal != nil || compute.Platform.GCP != nil || compute.Platform.IBMCloud != nil ||
+			compute.Platform.Libvirt != nil || compute.Platform.Nutanix != nil || compute.Platform.OpenStack != nil ||
+			compute.Platform.Ovirt != nil || compute.Platform.PowerVS != nil || compute.Platform.VSphere != nil {
+			fieldPath := field.NewPath(fmt.Sprintf("Compute[%d]", i), "Platform")
+			logrus.Warnf(fmt.Sprintf("%s is ignored", fieldPath))
+		}
+	}
+
+	if installConfig.ControlPlane.Hyperthreading != "Enabled" {
+		fieldPath := field.NewPath("ControlPlane", "Hyperthreading")
+		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.ControlPlane.Hyperthreading))
+	}
+
+	// kubebuilder:default=amd64. Set from generic install config code
+	if installConfig.ControlPlane.Architecture != types.ArchitectureAMD64 && installConfig.ControlPlane.Architecture != "x86_64" {
+		fieldPath := field.NewPath("ControlPlane", "Architecture")
+		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.ControlPlane.Architecture))
+	}
+
+	if installConfig.ControlPlane.Platform.AWS != nil || installConfig.ControlPlane.Platform.AlibabaCloud != nil ||
+		installConfig.ControlPlane.Platform.Azure != nil || installConfig.ControlPlane.Platform.BareMetal != nil ||
+		installConfig.ControlPlane.Platform.GCP != nil || installConfig.ControlPlane.Platform.IBMCloud != nil ||
+		installConfig.ControlPlane.Platform.Libvirt != nil || installConfig.ControlPlane.Platform.Nutanix != nil ||
+		installConfig.ControlPlane.Platform.OpenStack != nil || installConfig.ControlPlane.Platform.Ovirt != nil ||
+		installConfig.ControlPlane.Platform.PowerVS != nil || installConfig.ControlPlane.Platform.VSphere != nil {
+		fieldPath := field.NewPath("ControlPlane", "Platform")
+		logrus.Warnf(fmt.Sprintf("%s is ignored", fieldPath))
+	}
+
+	switch installConfig.Platform.Name() {
+	case baremetal.Name:
+		baremetal := installConfig.Platform.BareMetal
+		// +kubebuilder:default="qemu:///system". Set from generic install config code
+		if baremetal.LibvirtURI != "qemu:///system" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "LibvirtURI")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.LibvirtURI))
+		}
+		if baremetal.ClusterProvisioningIP != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ClusterProvisioningIP")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ClusterProvisioningIP))
+		}
+		if baremetal.DeprecatedProvisioningHostIP != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningHostIP")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.DeprecatedProvisioningHostIP))
+		}
+		if baremetal.BootstrapProvisioningIP != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "BootstrapProvisioningIP")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.BootstrapProvisioningIP))
+		}
+		if baremetal.ExternalBridge != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ExternalBridge")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ExternalBridge))
+		}
+		if baremetal.ExternalMACAddress != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ExternalMACAddress")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ExternalMACAddress))
+		}
+		// +kubebuilder:default=Managed
+		if baremetal.ProvisioningNetwork != "Managed" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningNetwork")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningNetwork))
+		}
+		if baremetal.ProvisioningBridge != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningBridge")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningBridge))
+		}
+		if baremetal.ProvisioningMACAddress != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningMACAddress")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningMACAddress))
+		}
+		if baremetal.ProvisioningNetworkInterface != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningNetworkInterface")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningNetworkInterface))
+		}
+		if baremetal.ProvisioningNetworkCIDR.String() != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningNetworkCIDR")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningNetworkCIDR))
+		}
+		if baremetal.DeprecatedProvisioningDHCPExternal {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningDHCPExternal")
+			logrus.Warnf(fmt.Sprintf("%s: true is ignored", fieldPath))
+		}
+		if baremetal.ProvisioningDHCPRange != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ProvisioningDHCPRange")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ProvisioningDHCPRange))
+		}
+
+		for i, host := range baremetal.Hosts {
+			if host.BMC.Username != "" {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BMC", "Username")
+				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.BMC.Username))
+			}
+			if host.BMC.Password != "" {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BMC", "Password")
+				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.BMC.Password))
+			}
+			if host.BMC.Address != "" {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BMC", "Address")
+				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.BMC.Address))
+			}
+			if host.BMC.DisableCertificateVerification {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BMC", "DisableCertificateVerification")
+				logrus.Warnf(fmt.Sprintf("%s: true is ignored", fieldPath))
+			}
+			if host.Role != "" {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "Role")
+				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.Role))
+			}
+			if host.HardwareProfile != "" {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "HardwareProfile")
+				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.HardwareProfile))
+			}
+			if host.RootDeviceHints != nil {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "RootDeviceHints")
+				logrus.Warnf(fmt.Sprintf("%s is ignored", fieldPath))
+			}
+			// The default is UEFI. +kubebuilder:validation:Enum="";UEFI;UEFISecureBoot;legacy. Set from generic install config code
+			if host.BootMode != "UEFI" {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BootMode")
+				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.BootMode))
+			}
+			if host.NetworkConfig != nil {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "NetworkConfig")
+				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.NetworkConfig))
+			}
+		}
+
+		if baremetal.DefaultMachinePlatform != nil {
+			fieldPath := field.NewPath("Platform", "Baremetal", "DefaultMachinePlatform")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.DefaultMachinePlatform))
+		}
+		if baremetal.BootstrapOSImage != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "BootstrapOSImage")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.BootstrapOSImage))
+		}
+		if baremetal.ClusterOSImage != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "ClusterOSImage")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.ClusterOSImage))
+		}
+		if baremetal.BootstrapExternalStaticIP != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "BootstrapExternalStaticIP")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.BootstrapExternalStaticIP))
+		}
+		if baremetal.BootstrapExternalStaticGateway != "" {
+			fieldPath := field.NewPath("Platform", "Baremetal", "BootstrapExternalStaticGateway")
+			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, baremetal.BootstrapExternalStaticGateway))
+		}
+	}
 }

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -280,7 +280,7 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			},
 		},
 		{
-			name: "valid configuration for baremetal platform for HA cluster - deprecated fields",
+			name: "valid configuration for baremetal platform for HA cluster - deprecated and unused fields",
 			data: `
 apiVersion: v1
 metadata:
@@ -296,26 +296,41 @@ networking:
   serviceNetwork: 
   - 172.30.0.0/16
 compute:
-  - architecture: amd64
-    hyperthreading: Enabled
+  - architecture: arm64
+    hyperthreading: Disabled
     name: worker
     platform: {}
     replicas: 2
 controlPlane:
-  architecture: amd64
-  hyperthreading: Enabled
+  architecture: arm64
+  hyperthreading: Disabled
   name: master
   platform: {}
   replicas: 3
 platform:
   baremetal:
+    libvirtURI: qemu+ssh://root@52.116.73.24/system
+    clusterProvisioningIP: "192.168.122.90"
+    bootstrapProvisioningIP: "192.168.122.91"
+    externalBridge: "somevalue"
     externalMACAddress: "52:54:00:f6:b4:02"
+    provisioningNetwork: "Disabled"
+    provisioningBridge: br0
     provisioningMACAddress: "52:54:00:6e:3b:02"
+    provisioningNetworkInterface: "eth11"
+    provisioningDHCPExternal: true
+    provisioningDHCPRange: 172.22.0.10,172.22.0.254
     apiVIP: 192.168.122.10
     ingressVIP: 192.168.122.11
+    bootstrapOSImage: https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd
+    clusterOSImage: https://mirror.example.com/images/metal.qcow2.gz?sha256=3b5a8
+    bootstrapExternalStaticIP: 192.1168.122.50
+    bootstrapExternalStaticGateway: gateway
     hosts:
       - name: host1
         bootMACAddress: 52:54:01:aa:aa:a1
+        bmc:
+          address: addr
       - name: host2
         bootMACAddress: 52:54:01:bb:bb:b1
       - name: host3
@@ -352,40 +367,43 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 				ControlPlane: &types.MachinePool{
 					Name:           "master",
 					Replicas:       pointer.Int64Ptr(3),
-					Hyperthreading: types.HyperthreadingEnabled,
-					Architecture:   types.ArchitectureAMD64,
+					Hyperthreading: types.HyperthreadingDisabled,
+					Architecture:   types.ArchitectureARM64,
 				},
 				Compute: []types.MachinePool{
 					{
 						Name:           "worker",
 						Replicas:       pointer.Int64Ptr(2),
-						Hyperthreading: types.HyperthreadingEnabled,
-						Architecture:   types.ArchitectureAMD64,
+						Hyperthreading: types.HyperthreadingDisabled,
+						Architecture:   types.ArchitectureARM64,
 					},
 				},
 				Platform: types.Platform{
 					BareMetal: &baremetal.Platform{
-						LibvirtURI:              "qemu:///system",
-						ClusterProvisioningIP:   "172.22.0.3",
-						BootstrapProvisioningIP: "172.22.0.2",
-						ExternalBridge:          "baremetal",
-						ExternalMACAddress:      "52:54:00:f6:b4:02",
-						ProvisioningNetwork:     "Managed",
-						ProvisioningBridge:      "provisioning",
-						ProvisioningMACAddress:  "52:54:00:6e:3b:02",
-						ProvisioningDHCPRange:   "172.22.0.10,172.22.0.254",
+						LibvirtURI:                         "qemu+ssh://root@52.116.73.24/system",
+						ClusterProvisioningIP:              "192.168.122.90",
+						BootstrapProvisioningIP:            "192.168.122.91",
+						ExternalBridge:                     "somevalue",
+						ExternalMACAddress:                 "52:54:00:f6:b4:02",
+						ProvisioningNetwork:                "Disabled",
+						ProvisioningBridge:                 "br0",
+						ProvisioningMACAddress:             "52:54:00:6e:3b:02",
+						ProvisioningDHCPRange:              "172.22.0.10,172.22.0.254",
+						DeprecatedProvisioningDHCPExternal: true,
 						ProvisioningNetworkCIDR: &ipnet.IPNet{
 							IPNet: net.IPNet{
-								IP:   []byte("\xac\x16\x00\x00"),
-								Mask: []byte("\xff\xff\xff\x00"),
+								IP:   []byte("\xc0\xa8\x7a\x00"),
+								Mask: []byte("\xff\xff\xfe\x00"),
 							},
 						},
+						ProvisioningNetworkInterface: "eth11",
 						Hosts: []*baremetal.Host{
 							{
 								Name:            "host1",
 								BootMACAddress:  "52:54:01:aa:aa:a1",
 								BootMode:        "UEFI",
 								HardwareProfile: "default",
+								BMC:             baremetal.BMC{Address: "addr"},
 							},
 							{
 								Name:            "host2",
@@ -411,10 +429,14 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 								BootMode:        "UEFI",
 								HardwareProfile: "default",
 							}},
-						DeprecatedAPIVIP:     "192.168.122.10",
-						APIVIPs:              []string{"192.168.122.10"},
-						DeprecatedIngressVIP: "192.168.122.11",
-						IngressVIPs:          []string{"192.168.122.11"},
+						DeprecatedAPIVIP:               "192.168.122.10",
+						APIVIPs:                        []string{"192.168.122.10"},
+						DeprecatedIngressVIP:           "192.168.122.11",
+						IngressVIPs:                    []string{"192.168.122.11"},
+						BootstrapOSImage:               "https://mirror.example.com/images/qemu.qcow2.gz?sha256=a07bd",
+						ClusterOSImage:                 "https://mirror.example.com/images/metal.qcow2.gz?sha256=3b5a8",
+						BootstrapExternalStaticIP:      "192.1168.122.50",
+						BootstrapExternalStaticGateway: "gateway",
 					},
 				},
 				PullSecret: `{"auths":{"example.com":{"auth":"authorization value"}}}`,


### PR DESCRIPTION
Log warnings for the irrelevant config data provided in install-config.yaml for the agent-based installer.

To Test, run 
`/usr/local/go/bin/go test -timeout 30s -run ^TestInstallConfigLoad/valid_configuration_for_baremetal_platform_for_HA_cluster_-_deprecated_and_unused_fields$ github.com/openshift/installer/pkg/asset/agent -v`

The test will print the warnings and the config data ignored.

Signed-off-by: Pawan Pinjarkar <ppinjark@redhat.com>