### PR TITLE
WIP AGENT-62: Add the ability to view and download logs from Agent API

### DIFF
--- a/cmd/openshift-install/agent.go
+++ b/cmd/openshift-install/agent.go
@@ -24,6 +24,7 @@ func newAgentCmd() *cobra.Command {
 
 	agentCmd.AddCommand(newAgentCreateCmd())
 	agentCmd.AddCommand(agent.NewWaitForCmd())
+	agentCmd.AddCommand(agent.NewLogsCmd())
 	return agentCmd
 }
 

--- a/cmd/openshift-install/agent/logs.go
+++ b/cmd/openshift-install/agent/logs.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	agentpkg "github.com/openshift/installer/pkg/agent"
+)
+
+// NewLogsCmd Add commands to gather logs in agent based installations
+func NewLogsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Retrieve installation logs",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newLogsEventsCmd())
+	cmd.AddCommand(newLogsClusterCmd())
+	return cmd
+}
+
+func newLogsEventsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "event",
+		Short: "Print the installation events log",
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			assetDir := cmd.Flags().Lookup("dir").Value.String()
+			logrus.Debugf("asset directory: %s", assetDir)
+			if len(assetDir) == 0 {
+				logrus.Fatal("No cluster installation directory found")
+			}
+			agentpkg.RetrieveEventsLog(assetDir)
+		},
+	}
+}
+
+func newLogsClusterCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "cluster",
+		Short: "Download the cluster installation logs to a file",
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			assetDir := cmd.Flags().Lookup("dir").Value.String()
+			logrus.Debugf("asset directory: %s", assetDir)
+			if len(assetDir) == 0 {
+				logrus.Fatal("No cluster installation directory found")
+			}
+			agentpkg.DownloadClusterLogs(assetDir)
+		},
+	}
+}

--- a/pkg/agent/logs.go
+++ b/pkg/agent/logs.go
@@ -1,0 +1,87 @@
+package agent
+
+import (
+	"context"
+	"os"
+
+	"github.com/openshift/assisted-service/client/installer"
+	"github.com/openshift/assisted-service/models"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// PrintMostRecentEvent Print most recent event associated with the clusterInfraEnvID
+func PrintMostRecentEvent(cluster *Cluster) {
+	eventList, err := cluster.API.Rest.GetInfraEnvEvents(cluster.clusterInfraEnvID)
+	if err != nil {
+		errors.Wrap(err, "Unable to retrieve events about the cluster from the Agent Rest API")
+	}
+	if len(eventList) == 0 {
+		logrus.Trace("No cluster installation events detected from the Agent Rest API.")
+	} else {
+		mostRecentEvent := eventList[len(eventList)-1]
+		// Don't print the same status message back to back
+		if *mostRecentEvent.Message != cluster.installHistory.RestAPIPreviousEventMessage {
+			if *mostRecentEvent.Severity == models.EventSeverityInfo {
+				logrus.Info(*mostRecentEvent.Message)
+			} else {
+				logrus.Warn(*mostRecentEvent.Message)
+			}
+		}
+		cluster.installHistory.RestAPIPreviousEventMessage = *mostRecentEvent.Message
+		cluster.installHistory.RestAPIInfraEnvEventList = eventList
+	}
+}
+
+// RetrieveEventsLog Retrieve the event log from the Agent API
+func RetrieveEventsLog(assetDir string) {
+	ctx := context.Background()
+	cluster, err := NewCluster(ctx, assetDir)
+	if err != nil {
+		logrus.Warn("unable to make cluster object to track installation")
+	}
+	eventList, err := cluster.API.Rest.GetInfraEnvEvents(cluster.clusterInfraEnvID)
+	if err != nil {
+		errors.Wrap(err, "Agent Rest API is not available. Unable to retrieve installation events.")
+	}
+	PrintFullEventsLog(eventList)
+}
+
+// PrintFullEventsLog Print the entire event log from the Agent API
+func PrintFullEventsLog(eventList models.EventList) {
+	if len(eventList) == 0 {
+		logrus.Trace("No cluster installation events detected from the Agent Rest API.")
+	} else {
+		for _, event := range eventList {
+			logrus.Info(event.Message)
+		}
+	}
+}
+
+// DownloadClusterLogs Download the cluster logs from the Agent API
+func DownloadClusterLogs(assetDir string) error {
+	ctx := context.Background()
+	cluster, err := NewCluster(ctx, assetDir)
+	if err != nil {
+		logrus.Warn("unable to make cluster object to track installation")
+	}
+
+	filename := "logs-" + string(*cluster.clusterID)
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		file.Close()
+	}()
+
+	logrus.Infof("Downloading cluster logs to %s", filename)
+	_, err = cluster.API.Rest.Client.Installer.V2DownloadClusterLogs(
+		ctx, &installer.V2DownloadClusterLogsParams{ClusterID: *cluster.clusterID}, file)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
When the Agent API is available:
- Print out the event log to the screen
- Download the cluster logs to a file