### PR TITLE
OCPBUGS-2795: Bump gophercloud

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -359,7 +359,7 @@ replace (
 	cloud.google.com/go => cloud.google.com/go v0.57.0
 	github.com/IBM-Cloud/terraform-provider-ibm => github.com/openshift/terraform-provider-ibm v1.26.2-openshift-2
 	github.com/go-log/log => github.com/go-log/log v0.1.1-0.20181211034820-a514cf01a3eb // Pinned by MCO
-	github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.17.0
+	github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.18.0
 	github.com/hashicorp/terraform => github.com/openshift/hashicorp-terraform v0.14.6-openshift-1 // Pin to fork with deduplicated rpc types v0.14.6-openshift-1
 	github.com/hashicorp/terraform-plugin-sdk => github.com/openshift/hashicorp-terraform-plugin-sdk v1.16.0-openshift // Pin to fork with public rpc types
 	github.com/hashicorp/terraform-provider-vsphere => github.com/openshift/terraform-provider-vsphere v1.24.3-openshift
@@ -369,6 +369,7 @@ replace (
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 // Pin client-go
 	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20201009041932-4fe8559913b8 // Pin MCO so it doesn't get downgraded
 	github.com/spf13/afero => github.com/spf13/afero v1.2.2
+	github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible => github.com/tencentcloud/tencentcloud-sdk-go v1.0.191 // https://github.com/hashicorp/terraform/issues/29021
 	github.com/terraform-providers/terraform-provider-aws => github.com/openshift/terraform-provider-aws v1.60.1-0.20211215220004-24df6d73af46 // Pin to openshift fork with tag v3.1.0-openshift-2
 	github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.44.1-0.20210224232508-7509319df0f4 // Pin to 2.48.0-openshift
 	github.com/terraform-providers/terraform-provider-azurestack => github.com/openshift/terraform-provider-azurestack v0.10.0-openshift // Use OpenShift fork

--- a/go.sum
+++ b/go.sum
@@ -913,8 +913,8 @@ github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gookit/color v1.1.7/go.mod h1:R3ogXq2B9rTbXoSHJ1HyUVAZ3poOJHpd9nQmyGZsfvQ=
 github.com/gookit/color v1.2.4/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
-github.com/gophercloud/gophercloud v0.17.0 h1:BgVw0saxyeHWH5us/SQe1ltp0GRnytjmOLXDA8pO77E=
-github.com/gophercloud/gophercloud v0.17.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
+github.com/gophercloud/gophercloud v0.18.0 h1:V6hcuMPmjXg+js9flU8T3RIHDCjV7F5CG5GD0MRhP/w=
+github.com/gophercloud/gophercloud v0.18.0/go.mod h1:wRtmUelyIIv3CSSDI47aUwbs075O6i+LY+pXsKCBsb4=
 github.com/gophercloud/utils v0.0.0-20200423144003-7c72efc7435d/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gophercloud/utils v0.0.0-20210202040619-eca783186fc4/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
 github.com/gophercloud/utils v0.0.0-20210530213738-7c693d7efe47/go.mod h1:wx8HMD8oQD0Ryhz6+6ykq75PJ79iPyEqYHfwZ4l7OsA=
@@ -1850,7 +1850,7 @@ github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BST
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
-github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
+github.com/tencentcloud/tencentcloud-sdk-go v1.0.191/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
 github.com/tencentyun/cos-go-sdk-v5 v0.0.0-20190808065407-f07404cefc8c/go.mod h1:wk2XFUg6egk4tSDNZtXeKfe2G6690UVyt163PuUxBZk=
 github.com/terraform-provider-openstack/terraform-provider-openstack v1.37.0 h1:g7mB+EJWenwFZ2ieTnhstOj3XTNuCwpl+in8vC1HGPc=
 github.com/terraform-provider-openstack/terraform-provider-openstack v1.37.0/go.mod h1:tPCEc/DdR9fVX9rmcJiqa85oTG7BUb5Xc0bSY/aOTf8=

--- a/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
+++ b/vendor/github.com/gophercloud/gophercloud/.zuul.yaml
@@ -13,7 +13,7 @@
       Run gophercloud acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test/run.yaml
     timeout: 18000 # 5 hours
-    nodeset: ubuntu-bionic
+    nodeset: ubuntu-focal
 
 - job:
     name: gophercloud-acceptance-test-ironic
@@ -21,7 +21,7 @@
     description: |
       Run gophercloud ironic acceptance test on master branch
     run: .zuul/playbooks/gophercloud-acceptance-test-ironic/run.yaml
-    nodeset: ubuntu-bionic
+    nodeset: ubuntu-focal
 
 - job:
     name: gophercloud-acceptance-test-ussuri

--- a/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
+++ b/vendor/github.com/gophercloud/gophercloud/CHANGELOG.md
@@ -1,4 +1,44 @@
-## 0.18.0 (Unreleased)
+## 0.19.0 (Unreleased)
+
+## 0.18.0 (June 11, 2021)
+
+NOTES / BREAKING CHANGES
+
+* As of [GH-2160](https://github.com/gophercloud/gophercloud/pull/2160), Gophercloud no longer URL encodes Object Storage containers and object names. You can still encode them yourself before passing the names to the Object Storage functions.
+
+* `baremetal/v1/nodes.ListBIOSSettings` now takes three parameters. The third, new, parameter is `ListBIOSSettingsOptsBuilder` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+
+BUG FIXES
+
+* Fixed expected OK codes to use default codes [GH-2173](https://github.com/gophercloud/gophercloud/pull/2173)
+* Fixed inablity to create sub-containers (objects with `/` in their name) [GH-2160](https://github.com/gophercloud/gophercloud/pull/2160)
+
+IMPROVEMENTS
+
+* Added `orchestration/v1/stacks.ListOpts.ShowHidden` [GH-2104](https://github.com/gophercloud/gophercloud/pull/2104)
+* Added `loadbalancer/v2/listeners.ProtocolSCTP` [GH-2149](https://github.com/gophercloud/gophercloud/pull/2149)
+* Added `loadbalancer/v2/listeners.CreateOpts.TLSVersions` [GH-2150](https://github.com/gophercloud/gophercloud/pull/2150)
+* Added `loadbalancer/v2/listeners.UpdateOpts.TLSVersions` [GH-2150](https://github.com/gophercloud/gophercloud/pull/2150)
+* Added `baremetal/v1/nodes.CreateOpts.NetworkData` [GH-2154](https://github.com/gophercloud/gophercloud/pull/2154)
+* Added `baremetal/v1/nodes.Node.NetworkData` [GH-2154](https://github.com/gophercloud/gophercloud/pull/2154)
+* Added `loadbalancer/v2/pools.ProtocolPROXYV2` [GH-2158](https://github.com/gophercloud/gophercloud/pull/2158)
+* Added `loadbalancer/v2/pools.ProtocolSCTP` [GH-2158](https://github.com/gophercloud/gophercloud/pull/2158)
+* Added `placement/v1/resourceproviders.GetAllocations` [GH-2162](https://github.com/gophercloud/gophercloud/pull/2162)
+* Added `baremetal/v1/nodes.CreateOpts.BIOSInterface` [GH-2164](https://github.com/gophercloud/gophercloud/pull/2164)
+* Added `baremetal/v1/nodes.Node.BIOSInterface` [GH-2164](https://github.com/gophercloud/gophercloud/pull/2164)
+* Added `baremetal/v1/nodes.NodeValidation.BIOS` [GH-2164](https://github.com/gophercloud/gophercloud/pull/2164)
+* Added `baremetal/v1/nodes.ListBIOSSettings` [GH-2171](https://github.com/gophercloud/gophercloud/pull/2171)
+* Added `baremetal/v1/nodes.GetBIOSSetting` [GH-2171](https://github.com/gophercloud/gophercloud/pull/2171)
+* Added `baremetal/v1/nodes.ListBIOSSettingsOpts` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.AttributeType` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.AllowableValues` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.LowerBound` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.UpperBound` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.MinLength` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.MaxLength` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.ReadOnly` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.ResetRequired` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
+* Added `baremetal/v1/nodes.BIOSSetting.Unique` [GH-2174](https://github.com/gophercloud/gophercloud/pull/2174)
 
 ## 0.17.0 (April 9, 2021)
 

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/requests.go
@@ -185,6 +185,9 @@ type CreateOpts struct {
 	// Requires microversion 1.47 or later.
 	AutomatedClean *bool `json:"automated_clean,omitempty"`
 
+	// The BIOS interface for a Node, e.g. “redfish”.
+	BIOSInterface string `json:"bios_interface,omitempty"`
+
 	// The boot interface for a Node, e.g. “pxe”.
 	BootInterface string `json:"boot_interface,omitempty"`
 
@@ -247,6 +250,9 @@ type CreateOpts struct {
 
 	// A string or UUID of the tenant who owns the baremetal node.
 	Owner string `json:"owner,omitempty"`
+
+	// Static network configuration to use during deployment and cleaning.
+	NetworkData map[string]interface{} `json:"network_data,omitempty"`
 }
 
 // ToNodeCreateMap assembles a request body based on the contents of a CreateOpts.
@@ -629,6 +635,61 @@ func SetRAIDConfig(client *gophercloud.ServiceClient, id string, raidConfigOptsB
 
 	resp, err := client.Put(raidConfigURL(client, id), reqBody, nil, &gophercloud.RequestOpts{
 		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListBIOSSettingsOptsBuilder allows extensions to add additional parameters to the
+// ListBIOSSettings request.
+type ListBIOSSettingsOptsBuilder interface {
+	ToListBIOSSettingsOptsQuery() (string, error)
+}
+
+// ListBIOSSettingsOpts defines query options that can be passed to ListBIOSettings
+type ListBIOSSettingsOpts struct {
+	// Provide additional information for the BIOS Settings
+	Detail bool `q:"detail"`
+
+	// One or more fields to be returned in the response.
+	Fields []string `q:"fields"`
+}
+
+// ToListBIOSSettingsOptsQuery formats a ListBIOSSettingsOpts into a query string
+func (opts ListBIOSSettingsOpts) ToListBIOSSettingsOptsQuery() (string, error) {
+	if opts.Detail == true && len(opts.Fields) > 0 {
+		return "", fmt.Errorf("cannot have both fields and detail options for BIOS settings")
+	}
+
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Get the current BIOS Settings for the given Node.
+// To use the opts requires microversion 1.74.
+func ListBIOSSettings(client *gophercloud.ServiceClient, id string, opts ListBIOSSettingsOptsBuilder) (r ListBIOSSettingsResult) {
+	url := biosListSettingsURL(client, id)
+	if opts != nil {
+
+		query, err := opts.ToListBIOSSettingsOptsQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+
+	resp, err := client.Get(url, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get one BIOS Setting for the given Node.
+func GetBIOSSetting(client *gophercloud.ServiceClient, id string, setting string) (r GetBIOSSettingResult) {
+	resp, err := client.Get(biosGetSettingURL(client, id, setting), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
 	})
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return

--- a/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes/urls.go
@@ -57,3 +57,11 @@ func provisionStateURL(client *gophercloud.ServiceClient, id string) string {
 func raidConfigURL(client *gophercloud.ServiceClient, id string) string {
 	return statesResourceURL(client, id, "raid")
 }
+
+func biosListSettingsURL(client *gophercloud.ServiceClient, id string) string {
+	return client.ServiceURL("nodes", id, "bios")
+}
+
+func biosGetSettingURL(client *gophercloud.ServiceClient, id string, setting string) string {
+	return client.ServiceURL("nodes", id, "bios", setting)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/requests.go
@@ -12,12 +12,25 @@ type Protocol string
 
 // Supported attributes for create/update operations.
 const (
-	ProtocolTCP             Protocol = "TCP"
-	ProtocolUDP             Protocol = "UDP"
-	ProtocolPROXY           Protocol = "PROXY"
-	ProtocolHTTP            Protocol = "HTTP"
-	ProtocolHTTPS           Protocol = "HTTPS"
+	ProtocolTCP   Protocol = "TCP"
+	ProtocolUDP   Protocol = "UDP"
+	ProtocolPROXY Protocol = "PROXY"
+	ProtocolHTTP  Protocol = "HTTP"
+	ProtocolHTTPS Protocol = "HTTPS"
+	// Protocol SCTP requires octavia microversion 2.23
+	ProtocolSCTP            Protocol = "SCTP"
 	ProtocolTerminatedHTTPS Protocol = "TERMINATED_HTTPS"
+)
+
+// Type TLSVersion represents a tls version
+type TLSVersion string
+
+const (
+	TLSVersionSSLv3   TLSVersion = "SSLv3"
+	TLSVersionTLSv1   TLSVersion = "TLSv1"
+	TLSVersionTLSv1_1 TLSVersion = "TLSv1.1"
+	TLSVersionTLSv1_2 TLSVersion = "TLSv1.2"
+	TLSVersionTLSv1_3 TLSVersion = "TLSv1.3"
 )
 
 // ListOptsBuilder allows extensions to add additional parameters to the
@@ -88,7 +101,7 @@ type CreateOpts struct {
 	// The load balancer on which to provision this listener.
 	LoadbalancerID string `json:"loadbalancer_id,omitempty"`
 
-	// The protocol - can either be TCP, HTTP, HTTPS or TERMINATED_HTTPS.
+	// The protocol - can either be TCP, SCTP, HTTP, HTTPS or TERMINATED_HTTPS.
 	Protocol Protocol `json:"protocol" required:"true"`
 
 	// The port on which to listen for client traffic.
@@ -151,6 +164,9 @@ type CreateOpts struct {
 
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs []string `json:"allowed_cidrs,omitempty"`
+
+	// A list of TLS protocol versions. Available from microversion 2.17
+	TLSVersions []TLSVersion `json:"tls_versions,omitempty"`
 }
 
 // ToListenerCreateMap builds a request body from CreateOpts.
@@ -230,6 +246,9 @@ type UpdateOpts struct {
 
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs *[]string `json:"allowed_cidrs,omitempty"`
+
+	// A list of TLS protocol versions. Available from microversion 2.17
+	TLSVersions *[]TLSVersion `json:"tls_versions,omitempty"`
 }
 
 // ToListenerUpdateMap builds a request body from UpdateOpts.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/listeners/results.go
@@ -27,7 +27,7 @@ type Listener struct {
 	// Human-readable description for the Listener.
 	Description string `json:"description"`
 
-	// The protocol to loadbalance. A valid value is TCP, HTTP, or HTTPS.
+	// The protocol to loadbalance. A valid value is TCP, SCTP, HTTP, HTTPS or TERMINATED_HTTPS.
 	Protocol string `json:"protocol"`
 
 	// The port on which to listen to client traffic that is associated with the
@@ -83,6 +83,9 @@ type Listener struct {
 
 	// A list of IPv4, IPv6 or mix of both CIDRs
 	AllowedCIDRs []string `json:"allowed_cidrs"`
+
+	// A list of TLS protocol versions. Available from microversion 2.17
+	TLSVersions []string `json:"tls_versions"`
 }
 
 type Stats struct {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/loadbalancer/v2/pools/requests.go
@@ -71,6 +71,10 @@ const (
 	ProtocolPROXY Protocol = "PROXY"
 	ProtocolHTTP  Protocol = "HTTP"
 	ProtocolHTTPS Protocol = "HTTPS"
+	// Protocol PROXYV2 requires octavia microversion 2.22
+	ProtocolPROXYV2 Protocol = "PROXYV2"
+	// Protocol SCTP requires octavia microversion 2.23
+	ProtocolSCTP Protocol = "SCTP"
 )
 
 // CreateOptsBuilder allows extensions to add additional parameters to the
@@ -88,7 +92,8 @@ type CreateOpts struct {
 	LBMethod LBMethod `json:"lb_algorithm" required:"true"`
 
 	// The protocol used by the pool members, you can use either
-	// ProtocolTCP, ProtocolUDP, ProtocolPROXY, ProtocolHTTP, or ProtocolHTTPS.
+	// ProtocolTCP, ProtocolUDP, ProtocolPROXY, ProtocolHTTP, ProtocolHTTPS,
+	// ProtocolSCTP or ProtocolPROXYV2.
 	Protocol Protocol `json:"protocol" required:"true"`
 
 	// The Loadbalancer on which the members of the pool will be associated with.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
@@ -17,7 +17,7 @@ type SecGroupRule struct {
 	// instance. An egress rule is applied to traffic leaving the instance.
 	Direction string
 
-	// Descripton of the rule
+	// Description of the rule
 	Description string `json:"description"`
 
 	// Must be IPv4 or IPv6, and addresses represented in CIDR must match the

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/requests.go
@@ -1,7 +1,6 @@
 package containers
 
 import (
-	"net/url"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
@@ -108,7 +107,7 @@ func Create(c *gophercloud.ServiceClient, containerName string, opts CreateOptsB
 			h[k] = v
 		}
 	}
-	resp, err := c.Request("PUT", createURL(c, url.QueryEscape(containerName)), &gophercloud.RequestOpts{
+	resp, err := c.Request("PUT", createURL(c, containerName), &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
@@ -123,7 +122,7 @@ func BulkDelete(c *gophercloud.ServiceClient, containers []string) (r BulkDelete
 	// https://github.com/openstack/swift/blob/stable/train/swift/common/swob.py#L302
 	encodedContainers := make([]string, len(containers))
 	for i, v := range containers {
-		encodedContainers[i] = url.QueryEscape(v)
+		encodedContainers[i] = v
 	}
 	b := strings.NewReader(strings.Join(encodedContainers, "\n") + "\n")
 	resp, err := c.Post(bulkDeleteURL(c), b, &r.Body, &gophercloud.RequestOpts{
@@ -139,7 +138,7 @@ func BulkDelete(c *gophercloud.ServiceClient, containers []string) (r BulkDelete
 
 // Delete is a function that deletes a container.
 func Delete(c *gophercloud.ServiceClient, containerName string) (r DeleteResult) {
-	resp, err := c.Delete(deleteURL(c, url.QueryEscape(containerName)), nil)
+	resp, err := c.Delete(deleteURL(c, containerName), nil)
 	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
 	return
 }
@@ -202,7 +201,7 @@ func Update(c *gophercloud.ServiceClient, containerName string, opts UpdateOptsB
 			h[k] = v
 		}
 	}
-	resp, err := c.Request("POST", updateURL(c, url.QueryEscape(containerName)), &gophercloud.RequestOpts{
+	resp, err := c.Request("POST", updateURL(c, containerName), &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201, 202, 204},
 	})
@@ -242,7 +241,7 @@ func Get(c *gophercloud.ServiceClient, containerName string, opts GetOptsBuilder
 			h[k] = v
 		}
 	}
-	resp, err := c.Head(getURL(c, url.QueryEscape(containerName)), &gophercloud.RequestOpts{
+	resp, err := c.Head(getURL(c, containerName), &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{200, 204},
 	})

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers/results.go
@@ -72,7 +72,7 @@ func ExtractNames(page pagination.Page) ([]string, error) {
 			names = append(names, container.Name)
 		}
 		return names, nil
-	case strings.HasPrefix(ct, "text/plain"):
+	case strings.HasPrefix(ct, "text/plain") || ct == "":
 		names := make([]string, 0, 50)
 
 		body := string(page.(ContainerPage).Body.([]uint8))

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/url"
 	"strings"
 	"time"
 
@@ -54,7 +53,7 @@ func (opts ListOpts) ToObjectListParams() (bool, string, error) {
 func List(c *gophercloud.ServiceClient, containerName string, opts ListOptsBuilder) pagination.Pager {
 	headers := map[string]string{"Accept": "text/plain", "Content-Type": "text/plain"}
 
-	url := listURL(c, url.QueryEscape(containerName))
+	url := listURL(c, containerName)
 	if opts != nil {
 		full, query, err := opts.ToObjectListParams()
 		if err != nil {
@@ -119,7 +118,7 @@ func (opts DownloadOpts) ToObjectDownloadParams() (map[string]string, string, er
 // To extract just the content, pass the DownloadResult response to the
 // ExtractContent function.
 func Download(c *gophercloud.ServiceClient, containerName, objectName string, opts DownloadOptsBuilder) (r DownloadResult) {
-	url := downloadURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := downloadURL(c, containerName, objectName)
 	h := make(map[string]string)
 	if opts != nil {
 		headers, query, err := opts.ToObjectDownloadParams()
@@ -225,7 +224,7 @@ func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, str
 // checksum, the failed request will automatically be retried up to a maximum
 // of 3 times.
 func Create(c *gophercloud.ServiceClient, containerName, objectName string, opts CreateOptsBuilder) (r CreateResult) {
-	url := createURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := createURL(c, containerName, objectName)
 	h := make(map[string]string)
 	var b io.Reader
 	if opts != nil {
@@ -289,7 +288,7 @@ func Copy(c *gophercloud.ServiceClient, containerName, objectName string, opts C
 		h[k] = v
 	}
 
-	url := copyURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := copyURL(c, containerName, objectName)
 	resp, err := c.Request("COPY", url, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 		OkCodes:     []int{201},
@@ -317,7 +316,7 @@ func (opts DeleteOpts) ToObjectDeleteQuery() (string, error) {
 
 // Delete is a function that deletes an object.
 func Delete(c *gophercloud.ServiceClient, containerName, objectName string, opts DeleteOptsBuilder) (r DeleteResult) {
-	url := deleteURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := deleteURL(c, containerName, objectName)
 	if opts != nil {
 		query, err := opts.ToObjectDeleteQuery()
 		if err != nil {
@@ -362,7 +361,7 @@ func (opts GetOpts) ToObjectGetParams() (map[string]string, string, error) {
 // the custom metadata, pass the GetResult response to the ExtractMetadata
 // function.
 func Get(c *gophercloud.ServiceClient, containerName, objectName string, opts GetOptsBuilder) (r GetResult) {
-	url := getURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := getURL(c, containerName, objectName)
 	h := make(map[string]string)
 	if opts != nil {
 		headers, query, err := opts.ToObjectGetParams()
@@ -434,7 +433,7 @@ func Update(c *gophercloud.ServiceClient, containerName, objectName string, opts
 			h[k] = v
 		}
 	}
-	url := updateURL(c, url.QueryEscape(containerName), url.QueryEscape(objectName))
+	url := updateURL(c, containerName, objectName)
 	resp, err := c.Post(url, nil, nil, &gophercloud.RequestOpts{
 		MoreHeaders: h,
 	})
@@ -489,7 +488,7 @@ func CreateTempURL(c *gophercloud.ServiceClient, containerName, objectName strin
 
 	duration := time.Duration(opts.TTL) * time.Second
 	expiry := date.Add(duration).Unix()
-	getHeader, err := containers.Get(c, url.QueryEscape(containerName), nil).Extract()
+	getHeader, err := containers.Get(c, containerName, nil).Extract()
 	if err != nil {
 		return "", err
 	}
@@ -521,10 +520,7 @@ func BulkDelete(c *gophercloud.ServiceClient, container string, objects []string
 	// https://github.com/openstack/swift/blob/stable/train/swift/common/swob.py#L302
 	encodedObjects := make([]string, len(objects))
 	for i, v := range objects {
-		encodedObjects[i] = strings.Join([]string{
-			url.QueryEscape(container),
-			url.QueryEscape(v)},
-			"/")
+		encodedObjects[i] = strings.Join([]string{container, v}, "/")
 	}
 	b := strings.NewReader(strings.Join(encodedObjects, "\n") + "\n")
 	resp, err := c.Post(bulkDeleteURL(c), b, &r.Body, &gophercloud.RequestOpts{

--- a/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks/requests.go
@@ -253,6 +253,9 @@ type ListOpts struct {
 	// ShowNested set to `true` to include nested stacks in the list.
 	ShowNested bool `q:"show_nested"`
 
+	// ShowHidden set to `true` to include hiddened stacks in the list.
+	ShowHidden bool `q:"show_hidden"`
+
 	// Tags lists stacks that contain one or more simple string tags.
 	Tags string `q:"tags"`
 

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -440,7 +440,7 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 		respErr := ErrUnexpectedResponseCode{
 			URL:            url,
 			Method:         method,
-			Expected:       options.OkCodes,
+			Expected:       okc,
 			Actual:         resp.StatusCode,
 			Body:           body,
 			ResponseHeader: resp.Header,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1060,7 +1060,7 @@ github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/jsonschema
 github.com/googleapis/gnostic/openapiv2
-# github.com/gophercloud/gophercloud v0.22.0 => github.com/gophercloud/gophercloud v0.17.0
+# github.com/gophercloud/gophercloud v0.22.0 => github.com/gophercloud/gophercloud v0.18.0
 ## explicit; go 1.13
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
@@ -3145,7 +3145,7 @@ sigs.k8s.io/yaml
 # cloud.google.com/go => cloud.google.com/go v0.57.0
 # github.com/IBM-Cloud/terraform-provider-ibm => github.com/openshift/terraform-provider-ibm v1.26.2-openshift-2
 # github.com/go-log/log => github.com/go-log/log v0.1.1-0.20181211034820-a514cf01a3eb
-# github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.17.0
+# github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.18.0
 # github.com/hashicorp/terraform => github.com/openshift/hashicorp-terraform v0.14.6-openshift-1
 # github.com/hashicorp/terraform-plugin-sdk => github.com/openshift/hashicorp-terraform-plugin-sdk v1.16.0-openshift
 # github.com/hashicorp/terraform-provider-vsphere => github.com/openshift/terraform-provider-vsphere v1.24.3-openshift
@@ -3155,6 +3155,7 @@ sigs.k8s.io/yaml
 # github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
 # github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20201009041932-4fe8559913b8
 # github.com/spf13/afero => github.com/spf13/afero v1.2.2
+# github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible => github.com/tencentcloud/tencentcloud-sdk-go v1.0.191
 # github.com/terraform-providers/terraform-provider-aws => github.com/openshift/terraform-provider-aws v1.60.1-0.20211215220004-24df6d73af46
 # github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.44.1-0.20210224232508-7509319df0f4
 # github.com/terraform-providers/terraform-provider-azurestack => github.com/openshift/terraform-provider-azurestack v0.10.0-openshift


### PR DESCRIPTION
Update the pin to gophercloud v0.18.0 so that we get a fix that came
with https://github.com/gophercloud/gophercloud/pull/2160.

Also use a replacement for tencentcloud-sdk-go as they removed their
tags and broke all downstream projects in the process
(https://github.com/hashicorp/terraform#29021). This is needed in
order to run `go mod vendor`.