### PR TITLE
OCPBUGS-3287: agent ased installation fix for dual stack vips

### DIFF
--- a/pkg/asset/agent/manifests/common.go
+++ b/pkg/asset/agent/manifests/common.go
@@ -2,7 +2,6 @@ package manifests
 
 import (
 	"github.com/openshift/installer/pkg/asset/agent"
-	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/version"
 
 	aiv1beta1 "github.com/openshift/assisted-service/api/v1beta1"
@@ -52,19 +51,4 @@ func getNMStateConfigLabels(ic *agent.OptionalInstallConfig) map[string]string {
 func getClusterImageSetReferenceName() string {
 	versionString, _ := version.Version()
 	return "openshift-" + versionString
-}
-
-// getVIPs returns a string representation of the platform's API VIP and Ingress VIP.
-// It returns an empty string if the platform does not configure a VIP
-func getVIPs(p *types.Platform) (string, string) {
-	switch {
-	case p == nil:
-		return "", ""
-	case p.BareMetal != nil:
-		return p.BareMetal.APIVIPs[0], p.BareMetal.IngressVIPs[0]
-	case p.VSphere != nil:
-		return p.VSphere.APIVIPs[0], p.VSphere.IngressVIPs[0]
-	default:
-		return "", ""
-	}
 }

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -154,6 +154,13 @@ func getValidOptionalInstallConfigDualStack() *agent.OptionalInstallConfig {
 	}
 }
 
+func getValidOptionalInstallConfigDualStackDualVIPs() *agent.OptionalInstallConfig {
+	installConfig := getValidOptionalInstallConfigDualStack()
+	installConfig.Config.Platform.BareMetal.APIVIPs = append(installConfig.Config.Platform.BareMetal.APIVIPs, "2001:db8:1111:2222:ffff:ffff:ffff:cafe")
+	installConfig.Config.Platform.BareMetal.IngressVIPs = append(installConfig.Config.Platform.BareMetal.IngressVIPs, "2001:db8:1111:2222:ffff:ffff:ffff:dead")
+	return installConfig
+}
+
 // getProxyValidOptionalInstallConfig returns a valid optional install config for proxied installation
 func getProxyValidOptionalInstallConfig() *agent.OptionalInstallConfig {
 	validIC := getValidOptionalInstallConfig()
@@ -386,6 +393,20 @@ func getGoodACI() *hiveext.AgentClusterInstall {
 			PlatformType: hiveext.PlatformType(baremetal.Name),
 		},
 	}
+	return goodACI
+}
+
+func getGoodACIDualStack() *hiveext.AgentClusterInstall {
+	goodACI := getGoodACI()
+	goodACI.Spec.Networking.MachineNetwork = append(goodACI.Spec.Networking.MachineNetwork, hiveext.MachineNetworkEntry{
+		CIDR: "2001:db8:5dd8:c956::/64",
+	})
+	goodACI.Spec.Networking.ClusterNetwork = append(goodACI.Spec.Networking.ClusterNetwork, hiveext.ClusterNetworkEntry{
+		CIDR:       "2001:db8:1111:2222::/64",
+		HostPrefix: 64,
+	})
+	goodACI.Spec.Networking.ServiceNetwork = append(goodACI.Spec.Networking.ServiceNetwork, "fd02::/112")
+
 	return goodACI
 }
 


### PR DESCRIPTION
Dual stack VIPs were ignored, taking only the first in the list whichever address family the second addresses were. This PR makes the 4.12 dual stack VIPs functionality work with agent based installer by
  leveraging the installconfig overrides escape hatch.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>