### PR TITLE
OCPBUGS-2966: Add GCP CreateFirewallRules to tech preview

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2202,8 +2202,9 @@ spec:
                       of the subnet.
                     type: string
                   createFirewallRules:
-                    description: CreateFirewallRules specifies if the installer should
-                      create the cluster firewall rules in the gcp cloud network.
+                    description: CreateFirewallRules is currently TechPreview. CreateFirewallRules
+                      specifies if the installer should create the cluster firewall
+                      rules in the gcp cloud network.
                     enum:
                     - Enabled
                     - Disabled

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -35,6 +35,7 @@ type Platform struct {
 	// Region specifies the GCP region where the cluster will be created.
 	Region string `json:"region"`
 
+	// CreateFirewallRules is currently TechPreview.
 	// CreateFirewallRules specifies if the installer should create the
 	// cluster firewall rules in the gcp cloud network.
 	// +optional

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -998,8 +998,14 @@ func validateFeatureSet(c *types.InstallConfig) field.ErrorList {
 	if c.FeatureSet != configv1.TechPreviewNoUpgrade {
 		errMsg := "the TechPreviewNoUpgrade feature set must be enabled to use this field"
 
-		if c.GCP != nil && len(c.GCP.NetworkProjectID) > 0 {
-			allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "networkProjectID"), errMsg))
+		if c.GCP != nil {
+			if len(c.GCP.NetworkProjectID) > 0 {
+				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "networkProjectID"), errMsg))
+			}
+
+			if len(c.GCP.CreateFirewallRules) > 0 && c.GCP.CreateFirewallRules != gcp.CreateFirewallRulesEnabled {
+				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "createFirewallRules"), errMsg))
+			}
 		}
 
 		if c.VSphere != nil {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1999,6 +1999,19 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 			expectedError: "platform.vsphere.apiVIPs: Required value: must specify VIP for API, when VIP for ingress is set",
 		},
+		{
+			name: "GCP Create Firewall Rules should return error if used WITHOUT tech preview when not enabled",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{
+					GCP: validGCPPlatform(),
+				}
+				c.GCP.CreateFirewallRules = gcp.CreateFirewallRulesDisabled
+
+				return c
+			}(),
+			expectedError: "platform.gcp.createFirewallRules: Forbidden: the TechPreviewNoUpgrade feature set must be enabled to use this field",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
** Require the Tech preview feature to be set in the install config when the platform.gcp.createFirewallRules is set to any value other than the default ("Enabled").

Linked to #6522 