### PR TITLE
OCPBUGS-2881: Destroy the service and host project dns records

### DIFF
--- a/pkg/destroy/gcp/dns.go
+++ b/pkg/destroy/gcp/dns.go
@@ -11,31 +11,40 @@ import (
 )
 
 type dnsZone struct {
-	name   string
-	domain string
+	name    string
+	domain  string
+	project string
 }
 
 func (o *ClusterUninstaller) listDNSZones() (private *dnsZone, public []dnsZone, err error) {
 	o.Logger.Debugf("Listing DNS Zones")
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.dnsSvc.ManagedZones.List(o.ProjectID).Fields("managedZones(name,dnsName,visibility),nextPageToken")
-	err = req.Pages(ctx, func(response *dns.ManagedZonesListResponse) error {
-		for _, zone := range response.ManagedZones {
-			switch zone.Visibility {
-			case "private":
-				if o.isClusterResource(zone.Name) {
-					o.Logger.Debugf("Found cluster private dns zone: %s\n", zone.Name)
-					private = &dnsZone{name: zone.Name, domain: zone.DnsName}
+
+	projects := []string{o.ProjectID}
+	if o.NetworkProjectID != "" {
+		projects = append(projects, o.NetworkProjectID)
+	}
+
+	for _, project := range projects {
+		req := o.dnsSvc.ManagedZones.List(project).Fields("managedZones(name,dnsName,visibility),nextPageToken")
+		err = req.Pages(ctx, func(response *dns.ManagedZonesListResponse) error {
+			for _, zone := range response.ManagedZones {
+				switch zone.Visibility {
+				case "private":
+					if o.isClusterResource(zone.Name) {
+						o.Logger.Debugf("Found cluster private dns zone: %s\n", zone.Name)
+						private = &dnsZone{name: zone.Name, domain: zone.DnsName, project: project}
+					}
+				default:
+					public = append(public, dnsZone{name: zone.Name, domain: zone.DnsName, project: project})
 				}
-			default:
-				public = append(public, dnsZone{name: zone.Name, domain: zone.DnsName})
 			}
+			return nil
+		})
+		if err != nil {
+			err = errors.Wrapf(err, "failed to fetch dns zones")
 		}
-		return nil
-	})
-	if err != nil {
-		err = errors.Wrapf(err, "failed to fetch dns zones")
 	}
 	return
 }
@@ -52,25 +61,25 @@ func (o *ClusterUninstaller) deleteDNSZone(name string) error {
 	return nil
 }
 
-func (o *ClusterUninstaller) listDNSZoneRecordSets(dnsZoneName string) ([]*dns.ResourceRecordSet, error) {
+func (o *ClusterUninstaller) listDNSZoneRecordSets(zone *dnsZone) ([]*dns.ResourceRecordSet, error) {
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	req := o.dnsSvc.ResourceRecordSets.List(o.ProjectID, dnsZoneName)
+	req := o.dnsSvc.ResourceRecordSets.List(zone.project, zone.name)
 	result := []*dns.ResourceRecordSet{}
 	err := req.Pages(ctx, func(response *dns.ResourceRecordSetsListResponse) error {
 		result = append(result, response.Rrsets...)
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to fetch resource record sets for zone: %s", dnsZoneName)
+		return nil, errors.Wrapf(err, "failed to fetch resource record sets for zone: %s", zone.name)
 	}
 	return result, nil
 }
 
-func (o *ClusterUninstaller) deleteDNSZoneRecordSets(zoneName string, zoneDomain string, recordSets []*dns.ResourceRecordSet) error {
+func (o *ClusterUninstaller) deleteDNSZoneRecordSets(zone *dnsZone, recordSets []*dns.ResourceRecordSet) error {
 	change := &dns.Change{}
 	for _, rr := range recordSets {
-		if (rr.Type == "NS" || rr.Type == "SOA") && strings.TrimRight(rr.Name, ".") == strings.TrimRight(zoneDomain, ".") {
+		if (rr.Type == "NS" || rr.Type == "SOA") && strings.TrimRight(rr.Name, ".") == strings.TrimRight(zone.domain, ".") {
 			continue
 		}
 		change.Deletions = append(change.Deletions, rr)
@@ -80,18 +89,18 @@ func (o *ClusterUninstaller) deleteDNSZoneRecordSets(zoneName string, zoneDomain
 	}
 	ctx, cancel := o.contextWithTimeout()
 	defer cancel()
-	o.Logger.Debugf("Deleting %d recordset(s) in zone %s", len(change.Deletions), zoneName)
-	change, err := o.dnsSvc.Changes.Create(o.ProjectID, zoneName, change).ClientOperationId(o.requestID("recordsets", zoneName)).Context(ctx).Do()
+	o.Logger.Debugf("Deleting %d recordset(s) in zone %s", len(change.Deletions), zone.name)
+	change, err := o.dnsSvc.Changes.Create(zone.project, zone.name, change).ClientOperationId(o.requestID("recordsets", zone.name)).Context(ctx).Do()
 	if err != nil && !isNoOp(err) {
-		o.resetRequestID("recordsets", zoneName)
-		return errors.Wrapf(err, "failed to delete DNS zone %s recordsets", zoneName)
+		o.resetRequestID("recordsets", zone.name)
+		return errors.Wrapf(err, "failed to delete DNS zone %s recordsets", zone.name)
 	}
 	if change != nil && isErrorStatus(int64(change.ServerResponse.HTTPStatusCode)) {
-		o.resetRequestID("recordsets", zoneName)
-		return errors.Errorf("failed to delete DNS zone %s recordsets with code: %d", zoneName, change.ServerResponse.HTTPStatusCode)
+		o.resetRequestID("recordsets", zone.name)
+		return errors.Errorf("failed to delete DNS zone %s recordsets with code: %d", zone.name, change.ServerResponse.HTTPStatusCode)
 	}
-	o.resetRequestID("recordsets", zoneName)
-	o.Logger.Infof("Deleted %d recordset(s) in zone %s", len(change.Deletions), zoneName)
+	o.resetRequestID("recordsets", zone.name)
+	o.Logger.Infof("Deleted %d recordset(s) in zone %s", len(change.Deletions), zone.name)
 	return nil
 }
 
@@ -105,17 +114,19 @@ func possibleZoneParents(dnsDomain string) []string {
 	return result
 }
 
-func getParentDNSZone(dnsDomain string, publicZones []dnsZone, logger logrus.FieldLogger) *dnsZone {
+func getParentDNSZones(dnsDomain string, publicZones []dnsZone, logger logrus.FieldLogger) []*dnsZone {
+	parentZones := []*dnsZone{}
+
 	possibleParents := possibleZoneParents(dnsDomain)
 	for _, parentDomain := range possibleParents {
 		for _, zone := range publicZones {
 			if zone.domain == parentDomain {
 				logger.Debugf("Found parent dns zone: %s", zone.name)
-				return &dnsZone{name: zone.name, domain: parentDomain}
+				parentZones = append(parentZones, &dnsZone{name: zone.name, domain: parentDomain, project: zone.project})
 			}
 		}
 	}
-	return nil
+	return parentZones
 }
 
 // getMatchingRecordSets finds all recordsets in the parent list that match recordsets in the child list
@@ -155,24 +166,26 @@ func (o *ClusterUninstaller) destroyDNS() error {
 		return nil
 	}
 
-	zoneRecordSets, err := o.listDNSZoneRecordSets(privateZone.name)
+	zoneRecordSets, err := o.listDNSZoneRecordSets(privateZone)
 	if err != nil {
 		return err
 	}
 
-	parentZone := getParentDNSZone(privateZone.domain, publicZones, o.Logger)
-	if parentZone != nil {
-		parentRecordSets, err := o.listDNSZoneRecordSets(parentZone.name)
+	parentZones := getParentDNSZones(privateZone.domain, publicZones, o.Logger)
+	for _, parentZone := range parentZones {
+		parentRecordSets, err := o.listDNSZoneRecordSets(parentZone)
 		if err != nil {
 			return err
 		}
 		matchingRecordSets := o.getMatchingRecordSets(parentRecordSets, zoneRecordSets)
-		err = o.deleteDNSZoneRecordSets(parentZone.name, parentZone.domain, matchingRecordSets)
-		if err != nil {
-			return err
+		if len(matchingRecordSets) > 0 {
+			err = o.deleteDNSZoneRecordSets(parentZone, matchingRecordSets)
+			if err != nil {
+				return err
+			}
 		}
 	}
-	err = o.deleteDNSZoneRecordSets(privateZone.name, privateZone.domain, zoneRecordSets)
+	err = o.deleteDNSZoneRecordSets(privateZone, zoneRecordSets)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
** Search the host and service projects for the DNS records that were created during the install (when using the a networkProjectID).