### PR TITLE
Remove Azure disk encryption validation

### DIFF
--- a/pkg/types/azure/validation/disk.go
+++ b/pkg/types/azure/validation/disk.go
@@ -1,44 +1,31 @@
 package validation
 
 import (
-	"regexp"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
-var (
-	// RxDiskEncryptionSetID is a regular expression that validates a disk encryption set ID.
-	RxDiskEncryptionSetID = regexp.MustCompile(`(?i)^/subscriptions/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/resourceGroups/([-a-z0-9_().]{0,89}[-a-z0-9_()])/providers/Microsoft\.Compute/diskEncryptionSets/([-a-z0-9_]{1,80})$`)
-
-	// RxSubscriptionID is a regular expression that validates a subscription ID.
-	RxSubscriptionID = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
-
-	// RxResourceGroup is a regular expression that validates a resource group.
-	RxResourceGroup = regexp.MustCompile(`^[-a-z0-9_().]{0,89}[-a-z0-9_()]$`)
-
-	// RxDiskEncryptionSetName is a regular expression that validates a disk encryption set name
-	RxDiskEncryptionSetName = regexp.MustCompile(`^[-a-z0-9_]{1,80}$`)
-)
-
 // ValidateDiskEncryption checks that the specified disk encryption configuration is valid.
 func ValidateDiskEncryption(p *azure.MachinePool, cloudName azure.CloudEnvironment, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	childFldPath := fldPath.Child("osDisk", "diskEncryptionSet")
-
 	diskEncryptionSet := p.OSDisk.DiskEncryptionSet
-	if diskEncryptionSet != nil && cloudName == azure.StackCloud {
-		return append(allErrs, field.Invalid(childFldPath.Child("diskEncryptionSet"), diskEncryptionSet, "disk encryption sets are not supported on this platform"))
+
+	// diskEncryptionSet is optional, so it's valid if it's nil
+	if diskEncryptionSet == nil {
+		return allErrs
 	}
-	if diskEncryptionSet.SubscriptionID != "" && !RxSubscriptionID.MatchString(diskEncryptionSet.SubscriptionID) {
-		return append(allErrs, field.Invalid(childFldPath.Child("subscriptionID"), diskEncryptionSet.SubscriptionID, "invalid subscription ID format"))
+
+	if cloudName == azure.StackCloud {
+		return append(allErrs, field.Invalid(fldPath, diskEncryptionSet, "disk encryption sets are not supported on this platform"))
 	}
-	if !RxResourceGroup.MatchString(diskEncryptionSet.ResourceGroup) {
-		return append(allErrs, field.Invalid(childFldPath.Child("resourceGroup"), diskEncryptionSet.ResourceGroup, "invalid resource group format"))
+
+	if len(diskEncryptionSet.Name) <= 0 {
+		return append(allErrs, field.Required(fldPath.Child("name"), "name is required when specifying a diskEncryptionSet"))
 	}
-	if !RxDiskEncryptionSetName.MatchString(diskEncryptionSet.Name) {
-		return append(allErrs, field.Invalid(childFldPath.Child("diskEncryptionSetName"), diskEncryptionSet.Name, "invalid name format"))
+
+	if len(diskEncryptionSet.ResourceGroup) <= 0 {
+		return append(allErrs, field.Required(fldPath.Child("resourceGroup"), "resourceGroup is required when specifying a diskEncryptionSet"))
 	}
 
 	return allErrs
@@ -49,8 +36,8 @@ func ValidateEncryptionAtHost(p *azure.MachinePool, cloudName azure.CloudEnviron
 	allErrs := field.ErrorList{}
 
 	encryptionAtHost := p.EncryptionAtHost
-	if encryptionAtHost == true && cloudName == azure.StackCloud {
-		return append(allErrs, field.Invalid(fldPath.Child("encryptionAtHost"), encryptionAtHost, "encryption at host is not supported on this platform"))
+	if encryptionAtHost && cloudName == azure.StackCloud {
+		return append(allErrs, field.Invalid(fldPath, encryptionAtHost, "encryption at host is not supported on this platform"))
 	}
 
 	return allErrs

--- a/pkg/types/azure/validation/disk.go
+++ b/pkg/types/azure/validation/disk.go
@@ -10,16 +10,16 @@ import (
 
 var (
 	// RxDiskEncryptionSetID is a regular expression that validates a disk encryption set ID.
-	RxDiskEncryptionSetID = regexp.MustCompile(`(?i)^/subscriptions/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/resourceGroups/([-a-zA-Z0-9_().]{0,89}[-a-zA-Z0-9_()])/providers/Microsoft\.Compute/diskEncryptionSets/([-a-zA-Z0-9_]{1,80})$`)
+	RxDiskEncryptionSetID = regexp.MustCompile(`(?i)^/subscriptions/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/resourceGroups/([-a-z0-9_().]{0,89}[-a-z0-9_()])/providers/Microsoft\.Compute/diskEncryptionSets/([-a-z0-9_]{1,80})$`)
 
 	// RxSubscriptionID is a regular expression that validates a subscription ID.
-	RxSubscriptionID = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	RxSubscriptionID = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 	// RxResourceGroup is a regular expression that validates a resource group.
-	RxResourceGroup = regexp.MustCompile(`^[-a-zA-Z0-9_().]{0,89}[-a-zA-Z0-9_()]$`)
+	RxResourceGroup = regexp.MustCompile(`^[-a-z0-9_().]{0,89}[-a-z0-9_()]$`)
 
 	// RxDiskEncryptionSetName is a regular expression that validates a disk encryption set name
-	RxDiskEncryptionSetName = regexp.MustCompile(`^[-a-zA-Z0-9_]{1,80}$`)
+	RxDiskEncryptionSetName = regexp.MustCompile(`^[-a-z0-9_]{1,80}$`)
 )
 
 // ValidateDiskEncryption checks that the specified disk encryption configuration is valid.

--- a/pkg/types/azure/validation/disk_test.go
+++ b/pkg/types/azure/validation/disk_test.go
@@ -47,43 +47,33 @@ func TestValidateDiskEncryption(t *testing.T) {
 			name:      "invalid disk encryption set (platform is stack cloud)",
 			pool:      validDiskEncryptionMachinePool(),
 			cloudName: azure.StackCloud,
-			expected:  fmt.Sprintf(`diskEncryptionSet.diskEncryptionSet: Invalid value: azure.DiskEncryptionSet{SubscriptionID:"%s", ResourceGroup:"%s", Name:"%s"}: disk encryption sets are not supported on this platform`, subscriptionID, resourceGroup, diskEncryptionSetName),
+			expected:  fmt.Sprintf(`azure.osDisk.diskEncryptionSet: Invalid value: azure.DiskEncryptionSet{SubscriptionID:"%s", ResourceGroup:"%s", Name:"%s"}: disk encryption sets are not supported on this platform`, subscriptionID, resourceGroup, diskEncryptionSetName),
 		},
 		{
-			name: "invalid disk encryption set (invalid subscription ID)",
-			pool: func() *azure.MachinePool {
-				p := validDiskEncryptionMachinePool()
-				p.OSDisk.DiskEncryptionSet.SubscriptionID = "invalid"
-				return p
-			}(),
-			cloudName: azure.PublicCloud,
-			expected:  `subscriptionID: Invalid value: "invalid": invalid subscription ID format`,
-		},
-		{
-			name: "invalid disk encryption set (invalid resource group)",
-			pool: func() *azure.MachinePool {
-				p := validDiskEncryptionMachinePool()
-				p.OSDisk.DiskEncryptionSet.ResourceGroup = ""
-				return p
-			}(),
-			cloudName: azure.PublicCloud,
-			expected:  `resourceGroup: Invalid value: "": invalid resource group format`,
-		},
-		{
-			name: "invalid disk encryption set (invalid name)",
+			name: "invalid disk encryption set (missing name)",
 			pool: func() *azure.MachinePool {
 				p := validDiskEncryptionMachinePool()
 				p.OSDisk.DiskEncryptionSet.Name = ""
 				return p
 			}(),
 			cloudName: azure.PublicCloud,
-			expected:  `diskEncryptionSetName: Invalid value: "": invalid name format`,
+			expected:  `azure.osDisk.diskEncryptionSet.name: Required value: name is required when specifying a diskEncryptionSet`,
+		},
+		{
+			name: "invalid disk encryption set (missing resource group)",
+			pool: func() *azure.MachinePool {
+				p := validDiskEncryptionMachinePool()
+				p.OSDisk.DiskEncryptionSet.ResourceGroup = ""
+				return p
+			}(),
+			cloudName: azure.PublicCloud,
+			expected:  `azure.osDisk.diskEncryptionSet.resourceGroup: Required value: resourceGroup is required when specifying a diskEncryptionSet`,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateDiskEncryption(tc.pool, tc.cloudName, field.NewPath("test-path")).ToAggregate()
+			err := ValidateDiskEncryption(tc.pool, tc.cloudName, field.NewPath("azure").Child("osDisk", "diskEncryptionSet")).ToAggregate()
 			if tc.expected == "" {
 				assert.NoError(t, err)
 			} else {
@@ -118,13 +108,13 @@ func TestValidateEncryptionAtHost(t *testing.T) {
 				return p
 			}(),
 			cloudName: azure.StackCloud,
-			expected:  `encryptionAtHost: Invalid value: true: encryption at host is not supported on this platform`,
+			expected:  `azure.osDisk.encryptionAtHost: Invalid value: true: encryption at host is not supported on this platform`,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateEncryptionAtHost(tc.pool, tc.cloudName, field.NewPath("test-path")).ToAggregate()
+			err := ValidateEncryptionAtHost(tc.pool, tc.cloudName, field.NewPath("azure").Child("osDisk", "encryptionAtHost")).ToAggregate()
 			if tc.expected == "" {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/types/azure/validation/disk_test.go
+++ b/pkg/types/azure/validation/disk_test.go
@@ -10,9 +10,11 @@ import (
 )
 
 var (
-	subscriptionID        = "aF675309-bE11-cD22-aF33-bE3606808909"
-	resourceGroup         = "Test-res.o(ur)Ce_gRoup"
-	diskEncryptionSetName = "teSt-encrypTion_Set"
+	subscriptionID        = "08675309-1111-2222-3333-303606808909"
+	resourceGroup         = "test-resource-group"
+	diskEncryptionSetName = "test-encryption-set"
+	diskEncryptionSetID   = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/diskEncryptionSets/%s",
+		subscriptionID, resourceGroup, diskEncryptionSetName)
 )
 
 func validDiskEncryptionMachinePool() *azure.MachinePool {
@@ -45,7 +47,7 @@ func TestValidateDiskEncryption(t *testing.T) {
 			name:      "invalid disk encryption set (platform is stack cloud)",
 			pool:      validDiskEncryptionMachinePool(),
 			cloudName: azure.StackCloud,
-			expected:  fmt.Sprintf(`diskEncryptionSet.diskEncryptionSet: Invalid value: azure.DiskEncryptionSet{SubscriptionID:"%s", ResourceGroup:".+", Name:"%s"}: disk encryption sets are not supported on this platform`, subscriptionID, diskEncryptionSetName),
+			expected:  fmt.Sprintf(`diskEncryptionSet.diskEncryptionSet: Invalid value: azure.DiskEncryptionSet{SubscriptionID:"%s", ResourceGroup:"%s", Name:"%s"}: disk encryption sets are not supported on this platform`, subscriptionID, resourceGroup, diskEncryptionSetName),
 		},
 		{
 			name: "invalid disk encryption set (invalid subscription ID)",

--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -38,10 +38,8 @@ func ValidateMachinePool(p *azure.MachinePool, poolName string, platform *azure.
 		}
 	}
 
-	allErrs = append(allErrs, ValidateEncryptionAtHost(p, platform.CloudName, fldPath.Child("defaultMachinePlatform"))...)
-	if p.OSDisk.DiskEncryptionSet != nil {
-		allErrs = append(allErrs, ValidateDiskEncryption(p, platform.CloudName, fldPath.Child("defaultMachinePlatform"))...)
-	}
+	allErrs = append(allErrs, ValidateEncryptionAtHost(p, platform.CloudName, fldPath.Child("osDisk"))...)
+	allErrs = append(allErrs, ValidateDiskEncryption(p, platform.CloudName, fldPath.Child("osDisk", "encryptionAtHost"))...)
 
 	if p.VMNetworkingType != "" {
 		acceleratedNetworkingOptions := sets.NewString(string(azure.VMnetworkingTypeAccelerated), string(azure.VMNetworkingTypeBasic))


### PR DESCRIPTION
#6513 fixed the validation for Azure disk encryption sets, but that validation is unnecessary:  The installer is not creating any resources here, we're only using these values to retrieve existing sets. The dynamic validation of retrieving the sets should cover these use cases (if the name is invalid, the set won't be found).

It seems like it would be more robust to just remove that validation. So this PR reverts #6513 (to make it easier to backport) and fixes the validation.