### PR TITLE
OCPBUGS-2841: (AGENT) only support amd64 archs

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -91,15 +91,19 @@ func (a *OptionalInstallConfig) validateSupportedArchs(installConfig *types.Inst
 
 	fieldPath := field.NewPath("ControlPlane", "Architecture")
 
-	if string(installConfig.ControlPlane.Architecture) != types.ArchitectureAMD64 {
-		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.ControlPlane.Architecture, []string{"x86-64", "x86_64", types.ArchitectureAMD64}))
+	switch string(installConfig.ControlPlane.Architecture) {
+	case types.ArchitectureAMD64:
+	default:
+		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.ControlPlane.Architecture, []string{types.ArchitectureAMD64}))
 	}
 
 	for i, compute := range installConfig.Compute {
 		fieldPath := field.NewPath(fmt.Sprintf("Compute[%d]", i), "Architecture")
 
-		if string(compute.Architecture) != types.ArchitectureAMD64 {
-			allErrs = append(allErrs, field.NotSupported(fieldPath, compute.Architecture, []string{"x86-64", "x86_64", types.ArchitectureAMD64}))
+		switch string(compute.Architecture) {
+		case types.ArchitectureAMD64:
+		default:
+			allErrs = append(allErrs, field.NotSupported(fieldPath, compute.Architecture, []string{types.ArchitectureAMD64}))
 		}
 	}
 

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -213,6 +213,34 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 			expectedError: "invalid install-config configuration: [Platform: Unsupported value: \"aws\": supported values: \"baremetal\", \"vsphere\", \"none\", Platform: Invalid value: \"aws\": Platform should be set to none if the ControlPlane.Replicas is 1 and total number of Compute.Replicas is 0]",
 		},
 		{
+			name: "invalid architecture for SNO cluster",
+			data: `
+apiVersion: v1
+metadata:
+  name: test-cluster
+baseDomain: test-domain
+networking:
+  networkType: OVNKubernetes
+compute:
+  - architecture: arm64
+    hyperthreading: Enabled
+    name: worker
+    platform: {}
+    replicas: 0
+controlPlane:
+  architecture: arm64
+  hyperthreading: Enabled
+  name: master
+  platform: {}
+  replicas: 1
+platform:
+  none : {}
+pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
+`,
+			expectedFound: false,
+			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: Unsupported value: \"arm64\": supported values: \"x86-64\", \"x86_64\", \"amd64\", Compute[0].Architecture: Unsupported value: \"arm64\": supported values: \"x86-64\", \"x86_64\", \"amd64\"]",
+		},
+		{
 			name: "valid configuration for none platform for sno",
 			data: `
 apiVersion: v1
@@ -296,13 +324,13 @@ networking:
   serviceNetwork: 
   - 172.30.0.0/16
 compute:
-  - architecture: arm64
+  - architecture: x86_64
     hyperthreading: Disabled
     name: worker
     platform: {}
     replicas: 2
 controlPlane:
-  architecture: arm64
+  architecture: x86_64
   hyperthreading: Disabled
   name: master
   platform: {}
@@ -368,14 +396,14 @@ pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 					Name:           "master",
 					Replicas:       pointer.Int64Ptr(3),
 					Hyperthreading: types.HyperthreadingDisabled,
-					Architecture:   types.ArchitectureARM64,
+					Architecture:   types.ArchitectureAMD64,
 				},
 				Compute: []types.MachinePool{
 					{
 						Name:           "worker",
 						Replicas:       pointer.Int64Ptr(2),
 						Hyperthreading: types.HyperthreadingDisabled,
-						Architecture:   types.ArchitectureARM64,
+						Architecture:   types.ArchitectureAMD64,
 					},
 				},
 				Platform: types.Platform{

--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -238,7 +238,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: Unsupported value: \"arm64\": supported values: \"x86-64\", \"x86_64\", \"amd64\", Compute[0].Architecture: Unsupported value: \"arm64\": supported values: \"x86-64\", \"x86_64\", \"amd64\"]",
+			expectedError: "invalid install-config configuration: [ControlPlane.Architecture: Unsupported value: \"arm64\": supported values: \"amd64\", Compute[0].Architecture: Unsupported value: \"arm64\": supported values: \"amd64\"]",
 		},
 		{
 			name: "valid configuration for none platform for sno",
@@ -324,13 +324,13 @@ networking:
   serviceNetwork: 
   - 172.30.0.0/16
 compute:
-  - architecture: x86_64
+  - architecture: amd64
     hyperthreading: Disabled
     name: worker
     platform: {}
     replicas: 2
 controlPlane:
-  architecture: x86_64
+  architecture: amd64
   hyperthreading: Disabled
   name: master
   platform: {}

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -115,7 +115,6 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 		allErrs = append(allErrs, field.Required(field.NewPath("networking"), "networking is required"))
 	}
 	allErrs = append(allErrs, validatePlatform(&c.Platform, field.NewPath("platform"), c.Networking, c)...)
-	fixAMD64ArchSupport(c.ControlPlane, c.Compute)
 	if c.ControlPlane != nil {
 		allErrs = append(allErrs, validateControlPlane(&c.Platform, c.ControlPlane, field.NewPath("controlPlane"))...)
 	} else {
@@ -148,19 +147,6 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 	allErrs = append(allErrs, validateFeatureSet(c)...)
 
 	return allErrs
-}
-
-func fixAMD64ArchSupport(controlPlane *types.MachinePool, compute []types.MachinePool) {
-	// "AMD64" is the name chosen by AMD for their 64-bit extension to the Intel x86 instruction set.
-	//  Before release, it was called "x86-64" or "x86_64", and some distributions still use these names
-	if controlPlane != nil && (controlPlane.Architecture == "x86-64" || controlPlane.Architecture == "x86_64") {
-		controlPlane.Architecture = types.ArchitectureAMD64
-	}
-	for i, c := range compute {
-		if c.Architecture == "x86-64" || c.Architecture == "x86_64" {
-			compute[i].Architecture = types.ArchitectureAMD64
-		}
-	}
 }
 
 // ipAddressType indicates the address types provided for a given field

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -115,6 +115,7 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 		allErrs = append(allErrs, field.Required(field.NewPath("networking"), "networking is required"))
 	}
 	allErrs = append(allErrs, validatePlatform(&c.Platform, field.NewPath("platform"), c.Networking, c)...)
+	fixAMD64ArchSupport(c.ControlPlane, c.Compute)
 	if c.ControlPlane != nil {
 		allErrs = append(allErrs, validateControlPlane(&c.Platform, c.ControlPlane, field.NewPath("controlPlane"))...)
 	} else {
@@ -147,6 +148,19 @@ func ValidateInstallConfig(c *types.InstallConfig) field.ErrorList {
 	allErrs = append(allErrs, validateFeatureSet(c)...)
 
 	return allErrs
+}
+
+func fixAMD64ArchSupport(controlPlane *types.MachinePool, compute []types.MachinePool) {
+	// "AMD64" is the name chosen by AMD for their 64-bit extension to the Intel x86 instruction set.
+	//  Before release, it was called "x86-64" or "x86_64", and some distributions still use these names
+	if controlPlane != nil && (controlPlane.Architecture == "x86-64" || controlPlane.Architecture == "x86_64") {
+		controlPlane.Architecture = types.ArchitectureAMD64
+	}
+	for i, c := range compute {
+		if c.Architecture == "x86-64" || c.Architecture == "x86_64" {
+			compute[i].Architecture = types.ArchitectureAMD64
+		}
+	}
 }
 
 // ipAddressType indicates the address types provided for a given field


### PR DESCRIPTION
With this fix, the agent installer's image creation command will fail if some other arch except amd64 is configured.

For example, when control plane and compute architecture in `install-config.yaml`
 is set to `arm64`, the command `openshift-install agent create image` will fail with
```
FATAL failed to fetch Agent Installer ISO: failed to load asset "Install Config":
invalid install-config configuration: 
[ControlPlane.Architecture: 
Unsupported value: "arm64": 
supported values: "amd64", 
Compute[0].Architecture: 
Unsupported value: "arm64": 
supported values: "amd64"]
```



Signed-off-by: Pawan Pinjarkar <ppinjark@redhat.com>