### PR TITLE
azure: Add error message when authorizer fails.

### DIFF
--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -89,7 +89,8 @@ func credentialsFromFileOrUser(cloudEnv *azureenv.Environment) (*Credentials, er
 	os.Setenv(azureAuthEnv, authFilePath)
 	_, err := auth.NewAuthorizerFromFileWithResource(cloudEnv.ResourceManagerEndpoint)
 	if err != nil {
-		logrus.Debug("Could not get an azure authorizer from file. Asking user to provide authentication info")
+		logrus.Infof("Could not get an azure authorizer from file: %s", err.Error())
+		logrus.Infof("Asking user to provide authentication info")
 		credentials, err := askForCredentials()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to retrieve credentials from user")


### PR DESCRIPTION
When the authorizer fails, the installer prints a generic message and continues with the collection of the service principal info. A clear error message as to why the authorizer fails would be helpful.