### PR TITLE
OCPBUGS-2911: Use project after creation

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -189,7 +189,7 @@ func validateManagedZones(client API, ic *types.InstallConfig, fieldPath *field.
 
 	if ic.GCP.PrivateDNSZone != nil && ic.GCP.PrivateDNSZone.ID != "" {
 		project := findProject(ic.GCP.PrivateDNSZone, ic.GCP.ProjectID)
-		returnedZone, err := findDNSZone(client, ic.Platform.GCP.PrivateDNSZone, ic.GCP.ProjectID)
+		returnedZone, err := findDNSZone(client, ic.Platform.GCP.PrivateDNSZone, project)
 		if err != nil {
 			switch {
 			case IsNotFound(err):


### PR DESCRIPTION
** Private DNS Zone needs to use project during validation lookup after it is found instead of using the Platform Project ID.