### PR TITLE
Enabling VPCZone setting in install-config.yaml for PowerVS

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3089,6 +3089,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  vpcZone:
+                    description: VPCZone specifies the IBM Cloud zone in which to
+                      create VPC resources. Leave unset to allow installer to select
+                      the closest VPC region.
+                    type: string
                   zone:
                     description: Zone specifies the IBM Cloud colo region where the
                       cluster will be created. At this time, only single-zone clusters

--- a/data/data/powervs/cluster/main.tf
+++ b/data/data/powervs/cluster/main.tf
@@ -90,7 +90,7 @@ resource "ibm_pi_image" "boot_image" {
   pi_cloud_instance_id      = var.powervs_cloud_instance_id
   pi_image_bucket_name      = var.powervs_image_bucket_name
   pi_image_bucket_access    = "public"
-  pi_image_bucket_region    = var.powervs_vpc_region
+  pi_image_bucket_region    = var.powervs_cos_region
   pi_image_bucket_file_name = var.powervs_image_bucket_file_name
   pi_image_storage_type     = var.powervs_image_storage_type
 }

--- a/data/data/powervs/variables-powervs.tf
+++ b/data/data/powervs/variables-powervs.tf
@@ -48,6 +48,12 @@ variable "powervs_publish_strategy" {
 ################################################################
 # Configure storage
 ################################################################
+variable "powervs_cos_region" {
+  type        = string
+  description = "The region where your COS instance is located in"
+  default     = "eu-gb"
+}
+
 variable "powervs_cos_instance_location" {
   type        = string
   description = "The location of your COS instance"

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -62,6 +62,7 @@ import (
 	"github.com/openshift/installer/pkg/types/openstack"
 	"github.com/openshift/installer/pkg/types/ovirt"
 	"github.com/openshift/installer/pkg/types/powervs"
+	powervstypes "github.com/openshift/installer/pkg/types/powervs"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
@@ -825,6 +826,14 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1.PowerVSMachineProviderConfig)
 		}
 
+		var vpcRegion string
+		vpcZone := installConfig.Config.PowerVS.VPCZone
+		if vpcZone != "" {
+			vpcRegion, err = powervstypes.VPCRegionForVPCZone(vpcZone)
+		} else if vpcRegion, err = powervstypes.VPCRegionForPowerVSRegion(installConfig.Config.PowerVS.Region); err != nil {
+			return err
+		}
+
 		osImage := strings.SplitN(string(*rhcosImage), "/", 2)
 		data, err = powervstfvars.TFVars(
 			powervstfvars.TFVarsSources{
@@ -837,6 +846,8 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				ImageBucketName:      osImage[0],
 				ImageBucketFileName:  osImage[1],
 				NetworkName:          installConfig.Config.PowerVS.PVSNetworkName,
+				VPCRegion:            vpcRegion,
+				VPCZone:              vpcZone,
 				VPCName:              installConfig.Config.PowerVS.VPCName,
 				VPCSubnetName:        vpcSubnet,
 				VPCPermitted:         vpcPermitted,

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -139,6 +139,13 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 		err = powervsconfig.ValidatePreExistingDNS(client, ic.Config, ic.PowerVS)
+		if err != nil {
+			return err
+		}
+		err = powervsconfig.ValidateCustomVPCSetup(client, ic.Config)
+		if err != nil {
+			return err
+		}
 	case libvirt.Name, none.Name:
 		// no special provisioning requirements to check
 	case nutanix.Name:

--- a/pkg/asset/installconfig/powervs/client.go
+++ b/pkg/asset/installconfig/powervs/client.go
@@ -35,6 +35,7 @@ type API interface {
 	GetAuthenticatorAPIKeyDetails(ctx context.Context) (*iamidentityv1.APIKey, error)
 	GetAPIKey() string
 	SetVPCServiceURLForRegion(ctx context.Context, region string) error
+	GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error)
 }
 
 // Client makes calls to the PowerVS API.
@@ -514,4 +515,25 @@ func (c *Client) GetAuthenticatorAPIKeyDetails(ctx context.Context) (*iamidentit
 // GetAPIKey returns the PowerVS API key
 func (c *Client) GetAPIKey() string {
 	return c.APIKey
+}
+
+// GetVPCs gets all VPCs in a region
+func (c *Client) GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error) {
+	_, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+
+	err := c.SetVPCServiceURLForRegion(ctx, region)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to set vpc api service url")
+	}
+
+	allVPCs := []vpcv1.VPC{}
+	if vpcs, detailedResponse, err := c.vpcAPI.ListVpcs(c.vpcAPI.NewListVpcsOptions()); err != nil {
+		if detailedResponse.GetStatusCode() != http.StatusNotFound {
+			return nil, err
+		}
+	} else if vpcs != nil {
+		allVPCs = append(allVPCs, vpcs.Vpcs...)
+	}
+	return allVPCs, nil
 }

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -172,6 +172,21 @@ func (mr *MockAPIMockRecorder) GetVPCByName(ctx, vpcName interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCByName", reflect.TypeOf((*MockAPI)(nil).GetVPCByName), ctx, vpcName)
 }
 
+// GetVPCs mocks base method.
+func (m *MockAPI) GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPCs", ctx, region)
+	ret0, _ := ret[0].([]vpcv1.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPCs indicates an expected call of GetVPCs.
+func (mr *MockAPIMockRecorder) GetVPCs(ctx, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCs", reflect.TypeOf((*MockAPI)(nil).GetVPCs), ctx, region)
+}
+
 // SetVPCServiceURLForRegion mocks base method.
 func (m *MockAPI) SetVPCServiceURLForRegion(ctx context.Context, region string) error {
 	m.ctrl.T.Helper()

--- a/pkg/asset/installconfig/powervs/validation_test.go
+++ b/pkg/asset/installconfig/powervs/validation_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/golang/mock/gomock"
 	"github.com/openshift/installer/pkg/asset/installconfig/powervs"
 	"github.com/openshift/installer/pkg/asset/installconfig/powervs/mock"
@@ -52,6 +53,60 @@ var (
 	}
 	noDNSRecordsResponse = []powervs.DNSRecordResponse{}
 	invalidArchitecture  = func(ic *types.InstallConfig) { ic.ControlPlane.Architecture = "ppc64" }
+
+	validVPCRegion    = "eu-gb"
+	validRG           = "valid-resource-group"
+	anotherValidRG    = "another-valid-resource-group"
+	validVPCZone      = func(ic *types.InstallConfig) { ic.Platform.PowerVS.VPCZone = "eu-gb-1" }
+	invalidVPCZone    = "bogus-vpc-zone"
+	validVPCID        = "valid-id"
+	anotherValidVPCID = "another-valid-id"
+	validVPC          = "valid-vpc"
+	anotherValidVPC   = "another-valid-vpc"
+	invalidVPC        = "bogus-vpc"
+	validVPCs         = []vpcv1.VPC{
+		{
+			Name: &validVPC,
+			ID:   &validVPCID,
+			ResourceGroup: &vpcv1.ResourceGroupReference{
+				Name: &validRG,
+				ID:   &validRG,
+			},
+		},
+		{
+			Name: &anotherValidVPC,
+			ID:   &anotherValidVPCID,
+			ResourceGroup: &vpcv1.ResourceGroupReference{
+				Name: &anotherValidRG,
+				ID:   &anotherValidRG,
+			},
+		},
+	}
+	validVPCSubnet   = "valid-vpc-subnet"
+	invalidVPCSubnet = "invalid-vpc-subnet"
+	wrongVPCSubnet   = "wrong-vpc-subnet"
+	validSubnet      = &vpcv1.Subnet{
+		Name: &validRG,
+		VPC: &vpcv1.VPCReference{
+			Name: &validVPC,
+			ID:   &validVPCID,
+		},
+		ResourceGroup: &vpcv1.ResourceGroupReference{
+			Name: &validRG,
+			ID:   &validRG,
+		},
+	}
+	wrongSubnet = &vpcv1.Subnet{
+		Name: &validRG,
+		VPC: &vpcv1.VPCReference{
+			Name: &anotherValidVPC,
+			ID:   &anotherValidVPCID,
+		},
+		ResourceGroup: &vpcv1.ResourceGroupReference{
+			Name: &validRG,
+			ID:   &validRG,
+		},
+	}
 )
 
 func validInstallConfig() *types.InstallConfig {
@@ -191,6 +246,183 @@ func TestValidatePreExistingPublicDNS(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			aggregatedErrors := powervs.ValidatePreExistingDNS(powervsClient, validInstallConfig(), metadata)
+			if tc.errorMsg != "" {
+				assert.Regexp(t, tc.errorMsg, aggregatedErrors)
+			} else {
+				assert.NoError(t, aggregatedErrors)
+			}
+		})
+	}
+}
+
+func TestValidateCustomVPCSettings(t *testing.T) {
+	cases := []struct {
+		name     string
+		edits    editFunctions
+		errorMsg string
+	}{
+		{
+			name: "invalid VPC name supplied, without zone",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = invalidVPC
+				},
+			},
+			errorMsg: "VPC.vpcName: Internal error: vpcName",
+		},
+		{
+			name: "valid VPC name supplied, without zone",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = validVPC
+				},
+			},
+			errorMsg: "",
+		},
+		{
+			name: "valid VPC name, but invalid subnet, without zone",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = validVPC
+					ic.Platform.PowerVS.VPCSubnets = []string{invalidVPCSubnet}
+				},
+			},
+			errorMsg: "VPC.vpcSubnets: Internal error",
+		},
+		{
+			name: "valid VPC name, valid subnet, without zone",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = validVPC
+					ic.Platform.PowerVS.VPCSubnets = []string{validVPCSubnet}
+				},
+			},
+			errorMsg: "",
+		},
+		{
+			name: "invalid VPC zone supplied",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCZone = invalidVPCZone
+				},
+			},
+			errorMsg: fmt.Sprintf(`VPC.vpcZone: Invalid value: "null": %s`, invalidVPCZone),
+		},
+		{
+			name: "valid VPC zone supplied",
+			edits: editFunctions{
+				validVPCZone,
+			},
+			errorMsg: "",
+		},
+		{
+			name: "VPC not found for the specified zone",
+			edits: editFunctions{
+				validVPCZone,
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = invalidVPC
+				},
+			},
+			errorMsg: fmt.Sprintf(`VPC.vpcName: Not found: "%s"`, invalidVPC),
+		},
+		{
+			name: "VPC found for the specified zone",
+			edits: editFunctions{
+				validVPCZone,
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = validVPC
+				},
+			},
+			errorMsg: "",
+		},
+		{
+			name: "VPC found, but not subnet, for the specified zone",
+			edits: editFunctions{
+				validVPCZone,
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = validVPC
+					ic.Platform.PowerVS.VPCSubnets = []string{invalidVPCSubnet}
+				},
+			},
+			errorMsg: "VPC.vpcSubnets: Internal error",
+		},
+		{
+			name: "VPC found, subnet found as well, but not attached to the VPC",
+			edits: editFunctions{
+				validVPCZone,
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = validVPC
+					ic.Platform.PowerVS.VPCSubnets = []string{wrongVPCSubnet}
+				},
+			},
+			errorMsg: `VPC.vpcSubnets: Invalid value: "null": not attached to VPC`,
+		},
+		{
+			name: "VPC and subnet both found for the specified zone",
+			edits: editFunctions{
+				validVPCZone,
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = validVPC
+					ic.Platform.PowerVS.VPCSubnets = []string{validVPCSubnet}
+				},
+			},
+			errorMsg: "",
+		},
+	}
+	setMockEnvVars()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	powervsClient := mock.NewMockAPI(mockCtrl)
+
+	// Mocks: invalid VPC name results in error
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(nil, fmt.Errorf("vpcName: not found"))
+
+	// Mocks: valid VPC name only, no issues
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+
+	// Mocks: valid VPC name, invalid VPC subnet
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+	powervsClient.EXPECT().GetSubnetByName(gomock.Any(), invalidVPCSubnet, validVPCRegion).Return(nil, fmt.Errorf(""))
+
+	// Mocks: valid VPC name, valid VPC subnet, all good
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+	powervsClient.EXPECT().GetSubnetByName(gomock.Any(), validVPCSubnet, validVPCRegion).Return(validSubnet, nil)
+
+	// Mocks: invalid Zone name results in error
+	// nothing to mock
+
+	// Mocks: valid Zone name only, no issues
+	// nothing to mock
+
+	// Mocks: valid Zone name, but no matching VPC name
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+
+	// Mocks: valid Zone name, valid VPC found
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+
+	// Mocks: valid Zone, valid VPC, but invalid subnet
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+	powervsClient.EXPECT().GetSubnetByName(gomock.Any(), invalidVPCSubnet, validVPCRegion).Return(nil, fmt.Errorf(""))
+
+	// Mocks: valid Zone, valid VPC, but wrong subnet (present, but not attached)
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+	powervsClient.EXPECT().GetSubnetByName(gomock.Any(), wrongVPCSubnet, validVPCRegion).Return(wrongSubnet, nil)
+
+	// Mocks: valid Zone, valid VPC, valid subnet, all good
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+	powervsClient.EXPECT().GetSubnetByName(gomock.Any(), validVPCSubnet, validVPCRegion).Return(validSubnet, nil)
+
+	// Run tests
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			editedInstallConfig := validInstallConfig()
+			for _, edit := range tc.edits {
+				edit(editedInstallConfig)
+			}
+
+			aggregatedErrors := powervs.ValidateCustomVPCSetup(powervsClient, editedInstallConfig)
 			if tc.errorMsg != "" {
 				assert.Regexp(t, tc.errorMsg, aggregatedErrors)
 			} else {

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -251,7 +251,10 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			return err
 		}
 
-		if vpcRegion, err = powervstypes.VPCRegionForPowerVSRegion(installConfig.Config.PowerVS.Region); err != nil {
+		vpcZone := installConfig.Config.PowerVS.VPCZone
+		if vpcZone != "" {
+			vpcRegion, err = powervstypes.VPCRegionForVPCZone(vpcZone)
+		} else if vpcRegion, err = powervstypes.VPCRegionForPowerVSRegion(installConfig.Config.PowerVS.Region); err != nil {
 			return err
 		}
 

--- a/pkg/types/powervs/platform.go
+++ b/pkg/types/powervs/platform.go
@@ -23,6 +23,12 @@ type Platform struct {
 	// +optional
 	VPCRegion string `json:"vpcRegion,omitempty"`
 
+	// VPCZone specifies the IBM Cloud zone in which to create VPC resources.
+	// Leave unset to allow installer to select the closest VPC region.
+	//
+	// +optional
+	VPCZone string `json:"vpcZone,omitempty"`
+
 	// UserID is the login for the user's IBM Cloud account.
 	UserID string `json:"userID"`
 

--- a/pkg/types/powervs/vpc_regions.go
+++ b/pkg/types/powervs/vpc_regions.go
@@ -1,0 +1,101 @@
+package powervs
+
+import (
+	"fmt"
+)
+
+// Since there is no API to query these, we have to hard-code them here.
+
+// VPCRegion describes zones associated with a region for IBM Cloud VPC.
+type VPCRegion struct {
+	Description string
+	Zones       []string
+}
+
+// VPCRegions holds the region names for IBM Cloud VPC
+var VPCRegions = map[string]VPCRegion{
+	"au-syd": {
+		Description: "Sydney, Australia",
+		Zones: []string{
+			"au-syd-1",
+			"au-syd-2",
+			"au-syd-3",
+		},
+	},
+	"br-sao": {
+		Description: "São Paulo, Brazil",
+		Zones: []string{
+			"br-sao-1",
+			"br-sao-2",
+			"br-sao-3",
+		},
+	},
+	"ca-tor": {
+		Description: "Toronto, Canada",
+		Zones: []string{
+			"ca-tor-1",
+			"ca-tor-2",
+			"ca-tor-3",
+		},
+	},
+	"eu-de": {
+		Description: "Frankfurt, Germany",
+		Zones: []string{
+			"eu-de-1",
+			"eu-de-2",
+			"eu-de-3",
+		},
+	},
+	"eu-gb": {
+		Description: "London, UK.",
+		Zones: []string{
+			"eu-gb-1",
+			"eu-gb-2",
+			"eu-gb-3",
+		},
+	},
+	"jp-osa": {
+		Description: "Osaka, Japan",
+		Zones: []string{
+			"jp-osa-1",
+			"jp-osa-2",
+			"jp-osa-3",
+		},
+	},
+	"jp-tok": {
+		Description: "Tokyo, Japan",
+		Zones: []string{
+			"jp-tok-1",
+			"jp-tok-2",
+			"jp-tok-3",
+		},
+	},
+	"us-east": {
+		Description: "Washington DC, USA",
+		Zones: []string{
+			"us-east-1",
+			"us-east-2",
+			"us-east-3",
+		},
+	},
+	"us-south": {
+		Description: "Dallas, USA",
+		Zones: []string{
+			"us-south-1",
+			"us-south-2",
+			"us-south-3",
+		},
+	},
+}
+
+// VPCRegionForVPCZone returns the VPC region for the specified VPC zone.
+func VPCRegionForVPCZone(vpczone string) (string, error) {
+	for rk := range VPCRegions {
+		for zk := range VPCRegions[rk].Zones {
+			if VPCRegions[rk].Zones[zk] == vpczone {
+				return rk, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("VPC region corresponding to given zone %s not found ", vpczone)
+}


### PR DESCRIPTION
Adding support for `vpcZone` setting in `install-config.yaml` for `create manifests` operation. When specified;
- it'll be validated to be a valid VPC zone in IBM Cloud
- it'll be used to infer `vpcRegion` (in other words, specifying `vpcRegion` in `install-config.yaml` has no effects)
- the inferred region will be used to look up the `vpcName`, if also specified, and would fail if not found in the inferred region
- the inferred region will be used to look up the `vpcSubnets[0]`, if also specified, and would fail if not found in the inferred region
- it will _not_ affect the COS location for the bootstrap ignition file which will still be near the specified PowerVS region

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>