### PR TITLE
OCPBUGS-3304: Always use first matching mirror in assisted-service

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -469,20 +469,18 @@ func RetrieveRendezvousIP(agentConfig *agent.Config, nmStateConfigs []*v1beta1.N
 }
 
 func getMirrorFromRelease(releaseImage string, registriesConfig *mirror.RegistriesConf) string {
-
-	releaseImageMirror := ""
 	source := regexp.MustCompile(`^(.+?)(@sha256)?:(.+)`).FindStringSubmatch(releaseImage)
 	for _, config := range registriesConfig.MirrorConfig {
 		if config.Location == source[1] {
 			// include the tag with the build release image
 			if len(source) == 4 {
 				// Has Sha256
-				releaseImageMirror = fmt.Sprintf("%s%s:%s", config.Mirror, source[2], source[3])
+				return fmt.Sprintf("%s%s:%s", config.Mirror, source[2], source[3])
 			} else if len(source) == 3 {
-				releaseImageMirror = fmt.Sprintf("%s:%s", config.Mirror, source[2])
+				return fmt.Sprintf("%s:%s", config.Mirror, source[2])
 			}
 		}
 	}
 
-	return releaseImageMirror
+	return ""
 }


### PR DESCRIPTION
The ICSP may contain multiple mirrors for the release image. In some cases this may even be necessary: if the environment in which the Agent ISO is generated is disconnected, such that the CoreOS ISO must be extracted from a particular mirror, and the cluster is to be installed in a _different_ disconnected environment with a different mirror, then two mirror options must be specified to allow both the ISO generation and the eventual installation to work.

However, assisted-service accepts only a single mirror in its config. It uses this single mirror to extract the installer binary and get other information, such as the release version. This must be the mirror that is accessible in the cluster environment.

Previously we used the last matching mirror for this. It seems easier to document that it should be the *first* matching mirror.

/cc @bfournie 