### PR TITLE
OCPBUGS-3280: Automatically retry install

### DIFF
--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -58,11 +58,13 @@ if [[ "${APIVIP}" != "" ]]; then
     fi
 fi
 
-while [[ "${cluster_status}" != "ready" ]]
+while [[ "${cluster_status}" != "installed" ]]
 do
+    sleep 5
     cluster_status=$(curl -s -S "${BASE_URL}/clusters" | jq -r .[].status)
     echo "Cluster status: ${cluster_status}" 1>&2
-    sleep 5
+    # Start the cluster install, if it transitions back to Ready due to a failure,
+    # then it will be restarted
     if [[ "${cluster_status}" == "ready" ]]; then
         echo "Starting cluster installation..." 1>&2
         curl -s -S -X POST "${BASE_URL}/clusters/${cluster_id}/actions/install" \

--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -209,8 +209,8 @@ func (czero *Cluster) IsBootstrapComplete() (bool, bool, error) {
 
 		if *clusterMetadata.Status == models.ClusterStatusReady {
 			stuck, err := czero.IsClusterStuckInReady()
-			if stuck {
-				return false, true, err
+			if err != nil {
+				return false, stuck, err
 			}
 		} else {
 			czero.installHistory.NotReadyTime = time.Now()
@@ -315,9 +315,10 @@ func (czero *Cluster) IsInstallComplete() (bool, error) {
 // IsClusterStuckInReady Determine if the cluster has stopped transitioning out of the Ready state
 func (czero *Cluster) IsClusterStuckInReady() (bool, error) {
 
-	// If the status changes back to Ready from Installing it indicates an error
+	// If the status changes back to Ready from Installing it indicates an error. This condition
+	// will be retried
 	if czero.installHistory.RestAPIPreviousClusterStatus == models.ClusterStatusPreparingForInstallation {
-		return true, errors.New("failed to prepare cluster installation")
+		return false, errors.New("failed to prepare cluster installation, retrying")
 	}
 
 	// Check if stuck in Ready state


### PR DESCRIPTION
In https://github.com/openshift/installer/pull/6470 we detected a failure when the cluster state moves back to Ready after an installation has been initiated. This adds an automatic retry when that condition occurs. It will help resolve issues like https://issues.redhat.com/browse/OCPBUGS-3280 and, in general, any problems that cause a cluster prepare failure.