### PR TITLE
OCPBUGS-3382: Fix cluster wide proxy

### DIFF
--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -152,6 +152,10 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 			icOverrides.FIPS = installConfig.Config.FIPS
 		}
 
+		if installConfig.Config.Proxy != nil {
+			agentClusterInstall.Spec.Proxy = (*hiveext.Proxy)(getProxy(installConfig))
+		}
+
 		if installConfig.Config.Platform.BareMetal != nil {
 			if len(installConfig.Config.Platform.BareMetal.APIVIPs) > 1 {
 				icOverridden = true

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -1,6 +1,7 @@
 package manifests
 
 import (
+	"github.com/openshift/installer/pkg/types"
 	"os"
 	"testing"
 
@@ -32,6 +33,12 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 	goodFIPSACI.SetAnnotations(map[string]string{
 		installConfigOverrides: `{"fips":true}`,
 	})
+
+	installConfigWithProxy := getValidOptionalInstallConfig()
+	installConfigWithProxy.Config.Proxy = (*types.Proxy)(getProxy(getProxyValidOptionalInstallConfig()))
+
+	goodProxyACI := getGoodACI()
+	goodProxyACI.Spec.Proxy = (*hiveext.Proxy)(getProxy(getProxyValidOptionalInstallConfig()))
 
 	goodACIDualStackVIPs := getGoodACIDualStack()
 	goodACIDualStackVIPs.SetAnnotations(map[string]string{
@@ -71,6 +78,13 @@ func TestAgentClusterInstall_Generate(t *testing.T) {
 				installConfigWithFIPS,
 			},
 			expectedConfig: goodFIPSACI,
+		},
+		{
+			name: "valid configuration with proxy",
+			dependencies: []asset.Asset{
+				installConfigWithProxy,
+			},
+			expectedConfig: goodProxyACI,
 		},
 		{
 			name: "valid configuration dual stack",


### PR DESCRIPTION
To create cluster wide proxy, proxy entries must be made in the agent-cluster-install.yaml. This commit will ensure that if the installConfig has the proxy section provided, it must be present into the agent-cluster-install.yaml.