### PR TITLE
CORS-1558: Add uninstall complete after destroy code

### DIFF
--- a/cmd/openshift-install/destroy.go
+++ b/cmd/openshift-install/destroy.go
@@ -54,6 +54,7 @@ func newDestroyClusterCmd() *cobra.Command {
 			if err != nil {
 				logrus.Fatal(err)
 			}
+			logrus.Infof("Uninstallation complete!")
 		},
 	}
 }


### PR DESCRIPTION
This adds a log line to the end of the destroy code.