### PR TITLE
OCPBUGS-3278: (Agent) Do not require host data in platform baremetal section in installconfig

### DIFF
--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -243,6 +243,10 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 		}
 
 		for i, host := range baremetal.Hosts {
+			if host.Name != "" {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "Name")
+				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.Name))
+			}
 			if host.BMC.Username != "" {
 				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BMC", "Username")
 				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.BMC.Username))
@@ -262,6 +266,10 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 			if host.Role != "" {
 				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "Role")
 				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.Role))
+			}
+			if host.BootMACAddress != "" {
+				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "BootMACAddress")
+				logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, host.BootMACAddress))
 			}
 			if host.HardwareProfile != "" {
 				fieldPath := field.NewPath("Platform", "Baremetal", fmt.Sprintf("Hosts[%d]", i), "HardwareProfile")

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -405,18 +405,17 @@ func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field
 		}
 	}
 
-	pathName, _ := os.Executable()
-	if !strings.Contains(pathName, "agent") {
-		if p.Hosts == nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("hosts"), p.Hosts, "bare metal hosts are missing"))
-		}
+	agentBasedInstallation := len(os.Args) > 1 && os.Args[1] == "agent"
+
+	if !agentBasedInstallation && p.Hosts == nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("hosts"), p.Hosts, "bare metal hosts are missing"))
 	}
 
 	if p.DefaultMachinePlatform != nil {
 		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
 	}
 
-	if !strings.Contains(pathName, "agent") {
+	if !agentBasedInstallation {
 		if err := validateHostsCount(p.Hosts, c); err != nil {
 			allErrs = append(allErrs, field.Required(fldPath.Child("Hosts"), err.Error()))
 		}


### PR DESCRIPTION
For the agent-based installer, do not require the host data in the platform bare metal section in installconfig as it is unused by the agent installer. If still provided, a warning is issued to the user that the data is ignored.


Signed-off-by: Pawan Pinjarkar <ppinjark@redhat.com>