### PR TITLE
OCPBUGS-3405: Redact pull secret from agent-gather

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-gather
+++ b/data/data/agent/files/usr/local/bin/agent-gather
@@ -10,6 +10,10 @@ function gather_agent_data() {
 	( >&2 echo -n "Gathering agent installation data" )
 	mkdir -p "${ARTIFACTS_DIR}/etc"
 	cp -a /etc/assisted{,-service} "${ARTIFACTS_DIR}/etc/"
+	# Redact pull secrets
+	for manifest in "${ARTIFACTS_DIR}"/etc/assisted/manifests/*; do
+		sed -i -e '/"auth":/ s/: *"[A-Za-z0-9+/]*=*"/: "<redacted>"/g' "${manifest}"
+	done
 	( >&2 echo -n ".")
 	mkdir "${ARTIFACTS_DIR}/etc/containers"
 	cp -a /etc/containers/registries.conf "${ARTIFACTS_DIR}/etc/containers/"

--- a/data/data/agent/files/usr/local/bin/agent-gather
+++ b/data/data/agent/files/usr/local/bin/agent-gather
@@ -1,8 +1,26 @@
 #!/bin/bash
 
+function redact_pull_secret_sed() {
+	# Produce a sed script to redact any of the pull secrets we know about.
+	# The journal export format is binary, so the redacted output must be
+	# the same length as the input.
+	jq -r '.auths[].auth' </root/.docker/config.json | sed -f <(cat <<EOF
+h
+s/.*/s#\0#/
+x
+s/././g
+s/^.\{10\}/<redacted>/
+s/.*/\0#g/
+x
+G
+s/\n//
+EOF
+)
+}
+
 function gather_journal() {
 	( >&2 echo -n "Gathering node journal" )
-	journalctl -o export > "${ARTIFACTS_DIR}/journal.export"
+	journalctl -o export | sed -f <(redact_pull_secret_sed) >"${ARTIFACTS_DIR}/journal.export"
 	( >&2 echo " Done")
 }
 

--- a/data/data/agent/systemd/units/agent.service.template
+++ b/data/data/agent/systemd/units/agent.service.template
@@ -9,9 +9,6 @@ Environment=HTTPS_PROXY=
 Environment=https_proxy=
 Environment=NO_PROXY=
 Environment=no_proxy=
-# TODO: If AUTH_TYPE != none, then PULL_SECRET_TOKEN needs to be updated
-# https://github.com/openshift/assisted-service/blob/master/internal/ignition/ignition.go#L1381
-Environment=PULL_SECRET_TOKEN={{.PullSecretToken}}
 TimeoutStartSec=3000
 ExecStartPre=/usr/local/bin/extract-agent.sh
 ExecStart=/usr/local/bin/start-agent.sh

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -47,12 +47,9 @@ type Ignition struct {
 // agentTemplateData is the data used to replace values in agent template
 // files.
 type agentTemplateData struct {
-	ServiceProtocol string
-	ServiceBaseURL  string
-	PullSecret      string
-	// PullSecretToken is token to use for authentication when AUTH_TYPE=rhsso
-	// in assisted-service
-	PullSecretToken           string
+	ServiceProtocol           string
+	ServiceBaseURL            string
+	PullSecret                string
 	NodeZeroIP                string
 	AssistedServiceHost       string
 	APIVIP                    string
@@ -259,7 +256,6 @@ func getTemplateData(pullSecret, nodeZeroIP, releaseImageList, releaseImage,
 		ServiceProtocol:           serviceBaseURL.Scheme,
 		ServiceBaseURL:            serviceBaseURL.String(),
 		PullSecret:                pullSecret,
-		PullSecretToken:           "",
 		NodeZeroIP:                serviceBaseURL.Hostname(),
 		AssistedServiceHost:       serviceBaseURL.Host,
 		APIVIP:                    agentClusterInstall.Spec.APIVIP,

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -84,7 +84,6 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, "http://"+nodeZeroIP+":8090/", templateData.ServiceBaseURL)
 	assert.Equal(t, pullSecret, templateData.PullSecret)
-	assert.Equal(t, "", templateData.PullSecretToken)
 	assert.Equal(t, nodeZeroIP, templateData.NodeZeroIP)
 	assert.Equal(t, nodeZeroIP+":8090", templateData.AssistedServiceHost)
 	assert.Equal(t, agentClusterInstall.Spec.APIVIP, templateData.APIVIP)

--- a/pkg/asset/agent/manifests/agentpullsecret.go
+++ b/pkg/asset/agent/manifests/agentpullsecret.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/agent"
+	"github.com/openshift/installer/pkg/validate"
 	"github.com/pkg/errors"
 )
 
@@ -124,13 +125,17 @@ func (a *AgentPullSecret) finish() error {
 }
 
 func (a *AgentPullSecret) validatePullSecret() field.ErrorList {
-	allErrs := field.ErrorList{}
-
 	if err := a.validateSecretIsNotEmpty(); err != nil {
-		allErrs = append(allErrs, err...)
+		return err
 	}
 
-	return allErrs
+	fieldPath := field.NewPath("StringData")
+	dockerConfig := a.Config.StringData[pullSecretKey]
+	if err := validate.ImagePullSecret(dockerConfig); err != nil {
+		return field.ErrorList{field.Invalid(fieldPath, dockerConfig, err.Error())}
+	}
+
+	return field.ErrorList{}
 }
 
 func (a *AgentPullSecret) validateSecretIsNotEmpty() field.ErrorList {

--- a/pkg/asset/agent/manifests/agentpullsecret.go
+++ b/pkg/asset/agent/manifests/agentpullsecret.go
@@ -15,10 +15,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	agentPullSecretName     = "pull-secret"
-	agentPullSecretFilename = filepath.Join(clusterManifestDir, fmt.Sprintf("%s.yaml", agentPullSecretName))
+const (
+	pullSecretKey       = ".dockerconfigjson"
+	agentPullSecretName = "pull-secret"
 )
+
+var agentPullSecretFilename = filepath.Join(clusterManifestDir, fmt.Sprintf("%s.yaml", agentPullSecretName))
 
 // AgentPullSecret generates the pull-secret file used by the agent installer.
 type AgentPullSecret struct {
@@ -58,7 +60,7 @@ func (a *AgentPullSecret) Generate(dependencies asset.Parents) error {
 				Namespace: getObjectMetaNamespace(installConfig),
 			},
 			StringData: map[string]string{
-				".dockerconfigjson": installConfig.Config.PullSecret,
+				pullSecretKey: installConfig.Config.PullSecret,
 			},
 		}
 		a.Config = secret
@@ -142,7 +144,7 @@ func (a *AgentPullSecret) validateSecretIsNotEmpty() field.ErrorList {
 		return allErrs
 	}
 
-	pullSecret, ok := a.Config.StringData[".dockerconfigjson"]
+	pullSecret, ok := a.Config.StringData[pullSecretKey]
 	if !ok {
 		allErrs = append(allErrs, field.Required(fieldPath, "the pull secret key '.dockerconfigjson' is not defined"))
 		return allErrs

--- a/pkg/asset/agent/manifests/agentpullsecret_test.go
+++ b/pkg/asset/agent/manifests/agentpullsecret_test.go
@@ -146,6 +146,18 @@ stringData:
 			expectedError: "invalid PullSecret configuration: StringData: Required value: the pull secret does not contain any data",
 		},
 		{
+			name: "bad-secret-format",
+			data: `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pull-secret
+  namespace: cluster-0
+stringData:
+  .dockerconfigjson: 'foo'`,
+			expectedError: "invalid PullSecret configuration: StringData: Invalid value: \"foo\": invalid character 'o' in literal false (expecting 'a')",
+		},
+		{
 			name:       "file-not-found",
 			fetchError: &os.PathError{Err: os.ErrNotExist},
 		},

--- a/pkg/asset/agent/manifests/agentpullsecret_test.go
+++ b/pkg/asset/agent/manifests/agentpullsecret_test.go
@@ -45,7 +45,7 @@ func TestAgentPullSecret_Generate(t *testing.T) {
 					Namespace: getObjectMetaNamespace(getValidOptionalInstallConfig()),
 				},
 				StringData: map[string]string{
-					".dockerconfigjson": TestSecret,
+					".dockerconfigjson": testSecret,
 				},
 			},
 		},
@@ -97,7 +97,7 @@ metadata:
   name: pull-secret
   namespace: cluster-0
 stringData:
-  .dockerconfigjson: c3VwZXItc2VjcmV0Cg==`,
+  .dockerconfigjson: '{"auths":{"cloud.test":{"auth":"c3VwZXItc2VjcmV0Cg=="}}}'`,
 			expectedFound: true,
 			expectedConfig: &corev1.Secret{
 				TypeMeta: v1.TypeMeta{
@@ -109,7 +109,7 @@ stringData:
 					Namespace: "cluster-0",
 				},
 				StringData: map[string]string{
-					".dockerconfigjson": "c3VwZXItc2VjcmV0Cg==",
+					".dockerconfigjson": "{\"auths\":{\"cloud.test\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}",
 				},
 			},
 		},

--- a/pkg/asset/agent/manifests/agentpullsecret_test.go
+++ b/pkg/asset/agent/manifests/agentpullsecret_test.go
@@ -45,7 +45,7 @@ func TestAgentPullSecret_Generate(t *testing.T) {
 					Namespace: getObjectMetaNamespace(getValidOptionalInstallConfig()),
 				},
 				StringData: map[string]string{
-					".dockerconfigjson": testSecret,
+					".dockerconfigjson": "{\n  \"auths\": {\n    \"cloud.openshift.com\": {\n      \"auth\": \"b3BlUTA=\",\n      \"email\": \"test@redhat.com\"\n    }\n  }\n}",
 				},
 			},
 		},
@@ -109,7 +109,7 @@ stringData:
 					Namespace: "cluster-0",
 				},
 				StringData: map[string]string{
-					".dockerconfigjson": "{\"auths\":{\"cloud.test\":{\"auth\":\"c3VwZXItc2VjcmV0Cg==\"}}}",
+					".dockerconfigjson": "{\n  \"auths\": {\n    \"cloud.test\": {\n      \"auth\": \"c3VwZXItc2VjcmV0Cg==\"\n    }\n  }\n}",
 				},
 			},
 		},

--- a/pkg/asset/agent/manifests/infraenv_test.go
+++ b/pkg/asset/agent/manifests/infraenv_test.go
@@ -51,7 +51,7 @@ func TestInfraEnv_Generate(t *testing.T) {
 						Name:      getClusterDeploymentName(getValidOptionalInstallConfig()),
 						Namespace: getObjectMetaNamespace(getValidOptionalInstallConfig()),
 					},
-					SSHAuthorizedKey: strings.Trim(TestSSHKey, "|\n\t"),
+					SSHAuthorizedKey: strings.Trim(testSSHKey, "|\n\t"),
 					PullSecretRef: &corev1.LocalObjectReference{
 						Name: getPullSecretName(getValidOptionalInstallConfig()),
 					},
@@ -74,7 +74,7 @@ func TestInfraEnv_Generate(t *testing.T) {
 				},
 				Spec: aiv1beta1.InfraEnvSpec{
 					Proxy:            getProxy(getProxyValidOptionalInstallConfig()),
-					SSHAuthorizedKey: strings.Trim(TestSSHKey, "|\n\t"),
+					SSHAuthorizedKey: strings.Trim(testSSHKey, "|\n\t"),
 					PullSecretRef: &corev1.LocalObjectReference{
 						Name: getPullSecretName(getProxyValidOptionalInstallConfig()),
 					},
@@ -101,7 +101,7 @@ func TestInfraEnv_Generate(t *testing.T) {
 				},
 				Spec: aiv1beta1.InfraEnvSpec{
 					Proxy:            getProxy(getProxyValidOptionalInstallConfig()),
-					SSHAuthorizedKey: strings.Trim(TestSSHKey, "|\n\t"),
+					SSHAuthorizedKey: strings.Trim(testSSHKey, "|\n\t"),
 					PullSecretRef: &corev1.LocalObjectReference{
 						Name: getPullSecretName(getProxyValidOptionalInstallConfig()),
 					},

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -21,11 +21,9 @@ import (
 )
 
 var (
-	// TestSSHKey provides a ssh key for unit tests
-	TestSSHKey = `|
+	testSSHKey = `|
 	ssh-rsa AAAAB3NzaC1y1LJe3zew1ghc= root@localhost.localdomain`
-	// TestSecret provides a ssh key for unit tests
-	TestSecret = `'{"auths":{"cloud.openshift.com":{"auth":"b3BlUTA=","email":"test@redhat.com"}}}`
+	testSecret = `{"auths":{"cloud.openshift.com":{"auth":"b3BlUTA=","email":"test@redhat.com"}}}`
 )
 
 // GetValidOptionalInstallConfig returns a valid optional install config
@@ -41,8 +39,8 @@ func getValidOptionalInstallConfig() *agent.OptionalInstallConfig {
 					Namespace: "cluster-0",
 				},
 				BaseDomain: "testing.com",
-				PullSecret: TestSecret,
-				SSHKey:     TestSSHKey,
+				PullSecret: testSecret,
+				SSHKey:     testSSHKey,
 				ControlPlane: &types.MachinePool{
 					Name:     "master",
 					Replicas: pointer.Int64Ptr(3),
@@ -102,8 +100,8 @@ func getValidOptionalInstallConfigDualStack() *agent.OptionalInstallConfig {
 					Namespace: "cluster-0",
 				},
 				BaseDomain: "testing.com",
-				PullSecret: TestSecret,
-				SSHKey:     TestSSHKey,
+				PullSecret: testSecret,
+				SSHKey:     testSSHKey,
 				ControlPlane: &types.MachinePool{
 					Name:     "master",
 					Replicas: pointer.Int64Ptr(3),
@@ -383,7 +381,7 @@ func getGoodACI() *hiveext.AgentClusterInstall {
 				ServiceNetwork: []string{"172.30.0.0/16"},
 				NetworkType:    "OVNKubernetes",
 			},
-			SSHPublicKey: strings.Trim(TestSSHKey, "|\n\t"),
+			SSHPublicKey: strings.Trim(testSSHKey, "|\n\t"),
 			ProvisionRequirements: hiveext.ProvisionRequirements{
 				ControlPlaneAgents: 3,
 				WorkerAgents:       5,


### PR DESCRIPTION
The agent-gather output should not contain the user's pull secret. Redact it from `/etc/assisted/manifests/pull-secret.yaml`.