### PR TITLE
OCPBUGS-3524: data: azurerm: restore RHCOS SA access configuration

### DIFF
--- a/data/data/azure/vnet/main.tf
+++ b/data/data/azure/vnet/main.tf
@@ -43,12 +43,13 @@ data "azurerm_resource_group" "network" {
 }
 
 resource "azurerm_storage_account" "cluster" {
-  name                     = "cluster${var.random_storage_account_suffix}"
-  resource_group_name      = data.azurerm_resource_group.main.name
-  location                 = var.azure_region
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  min_tls_version          = contains(local.environments_with_min_tls_version, var.azure_environment) ? "TLS1_2" : null
+  name                            = "cluster${var.random_storage_account_suffix}"
+  resource_group_name             = data.azurerm_resource_group.main.name
+  location                        = var.azure_region
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  min_tls_version                 = contains(local.environments_with_min_tls_version, var.azure_environment) ? "TLS1_2" : null
+  allow_nested_items_to_be_public = false
 }
 
 resource "azurerm_user_assigned_identity" "main" {


### PR DESCRIPTION
In the transition from v2 to v3 of the azurerm terraform provider, not only was an option renamed from `allow_blob_public_access` to `allow_nested_items_to_be_public` but its default value was also changed from `false` to `true` [1].

So to restore the previous access setting for the RHCOS Storage Account, we need to explicitly set the new option to `false`.

Thanks Jinyun Ma for pointing this out.

[1] https://github.com/hashicorp/terraform-provider-azurerm/blob/main/CHANGELOG.md#300-march-24-2022