### PR TITLE
OCPBUGS-3542: Add bootstrapExternalStaticDNS

### DIFF
--- a/data/data/bootstrap/baremetal/files/etc/NetworkManager/system-connections/nmconnection.template
+++ b/data/data/bootstrap/baremetal/files/etc/NetworkManager/system-connections/nmconnection.template
@@ -11,5 +11,5 @@ mac-address={{.PlatformData.BareMetal.ExternalMACAddress}}
 method=manual
 addresses={{.PlatformData.BareMetal.ExternalStaticIP}}/{{.PlatformData.BareMetal.ExternalSubnetCIDR}}
 gateway={{.PlatformData.BareMetal.ExternalStaticGateway}}
-dns={{.PlatformData.BareMetal.ExternalStaticGateway}}
+dns={{.PlatformData.BareMetal.ExternalStaticDNS}}
 {{end}}

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2528,6 +2528,12 @@ spec:
                     maxItems: 2
                     type: array
                     uniqueItems: true
+                  bootstrapExternalStaticDNS:
+                    description: BootstrapExternalStaticDNS is the static network
+                      DNS of the bootstrap node. This can be useful in environments
+                      without a DHCP server.
+                    format: ip
+                    type: string
                   bootstrapExternalStaticGateway:
                     description: BootstrapExternalStaticGateway is the static network
                       gateway of the bootstrap node. This can be useful in environments

--- a/pkg/asset/ignition/bootstrap/baremetal/template.go
+++ b/pkg/asset/ignition/bootstrap/baremetal/template.go
@@ -65,6 +65,9 @@ type TemplateData struct {
 	// ExternalStaticIP is the static gateway of the bootstrap node
 	ExternalStaticGateway string
 
+	// ExternalStaticDNS is the static DNS of the bootstrap node
+	ExternalStaticDNS string
+
 	ExternalSubnetCIDR int
 
 	ExternalMACAddress string
@@ -80,6 +83,7 @@ func GetTemplateData(config *baremetal.Platform, networks []types.MachineNetwork
 	templateData.ProvisioningNetwork = string(config.ProvisioningNetwork)
 	templateData.ExternalStaticIP = config.BootstrapExternalStaticIP
 	templateData.ExternalStaticGateway = config.BootstrapExternalStaticGateway
+	templateData.ExternalStaticDNS = config.BootstrapExternalStaticDNS
 	templateData.ExternalMACAddress = config.ExternalMACAddress
 
 	if len(config.APIVIPs) > 0 {

--- a/pkg/asset/installconfig/baremetal/validation.go
+++ b/pkg/asset/installconfig/baremetal/validation.go
@@ -29,8 +29,24 @@ func ValidateStaticBootstrapNetworking(ic *types.InstallConfig) error {
 		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "You must specify a value for BootstrapExternalStaticGateway when BootstrapExternalStaticIP is set.").Error())
 	}
 
+	if ic.Platform.BareMetal.BootstrapExternalStaticIP != "" && ic.Platform.BareMetal.BootstrapExternalStaticDNS == "" {
+		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "You must specify a value for BootstrapExternalStaticDNS when BootstrapExternalStaticIP is set.").Error())
+	}
+
 	if ic.Platform.BareMetal.BootstrapExternalStaticGateway != "" && ic.Platform.BareMetal.BootstrapExternalStaticIP == "" {
 		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "You must specify a value for BootstrapExternalStaticIP when BootstrapExternalStaticGateway is set.").Error())
+	}
+
+	if ic.Platform.BareMetal.BootstrapExternalStaticGateway != "" && ic.Platform.BareMetal.BootstrapExternalStaticDNS == "" {
+		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "You must specify a value for BootstrapExternalStaticDNS when BootstrapExternalStaticGateway is set.").Error())
+	}
+
+	if ic.Platform.BareMetal.BootstrapExternalStaticDNS != "" && ic.Platform.BareMetal.BootstrapExternalStaticIP == "" {
+		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "You must specify a value for BootstrapExternalStaticIP when BootstrapExternalStaticDNS is set.").Error())
+	}
+
+	if ic.Platform.BareMetal.BootstrapExternalStaticDNS != "" && ic.Platform.BareMetal.BootstrapExternalStaticGateway == "" {
+		return errors.New(field.Required(field.NewPath("platform", "baremetal"), "You must specify a value for BootstrapExternalStaticGateway when BootstrapExternalStaticDNS is set.").Error())
 	}
 
 	return nil

--- a/pkg/types/baremetal/platform.go
+++ b/pkg/types/baremetal/platform.go
@@ -232,4 +232,10 @@ type Platform struct {
 	// LoadBalancer is available in TechPreview.
 	// +optional
 	LoadBalancer *configv1.BareMetalPlatformLoadBalancer `json:"loadBalancer,omitempty"`
+
+	// BootstrapExternalStaticDNS is the static network DNS of the bootstrap node.
+	// This can be useful in environments without a DHCP server.
+	// +kubebuilder:validation:Format=ip
+	// +optional
+	BootstrapExternalStaticDNS string `json:"bootstrapExternalStaticDNS,omitempty"`
 }


### PR DESCRIPTION
Add `bootstrapExternalStaticDNS` option in `install-config.yaml` file to avoid using `bootstrapExternalStaticGateway` as DNS in the bootstrap node.

https://github.com/openshift/installer/blob/0f99618f1c2b45f07d394a5f3e9ddf6a6436bc2e/data/data/bootstrap/baremetal/files/etc/NetworkManager/system-connections/nmconnection.template#L14