### PR TITLE
AWS: Provide a name for security groups

### DIFF
--- a/data/data/aws/cluster/vpc/sg-master.tf
+++ b/data/data/aws/cluster/vpc/sg-master.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "master" {
+  name        = "${var.cluster_id}-master-sg"
   vpc_id      = data.aws_vpc.cluster_vpc.id
   description = local.description
 

--- a/data/data/aws/cluster/vpc/sg-worker.tf
+++ b/data/data/aws/cluster/vpc/sg-worker.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "worker" {
+  name        = "${var.cluster_id}-worker-sg"
   vpc_id      = data.aws_vpc.cluster_vpc.id
   description = local.description
 


### PR DESCRIPTION
Prior to this change, security groups are getting a name generated by terraform (something like 'terraform-xxx'), see:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#name

This change uses the infrastructure id to create a name. This change is primarily aesthetic and for improved UX when browsing installer-created resources.