### PR TITLE
docs: fix broken link to default kubelet.service taint

### DIFF
--- a/docs/user/customization.md
+++ b/docs/user/customization.md
@@ -377,7 +377,7 @@ For example:
     EOF
     ```
 
-    `machineconfiguration.openshift.io/role: master` label attaches this `MachineConfig` to the [master][master-machine-config-pool] `MachineConfigPool`. The [default][default-kubelet-service] configuration for the `kubelet.service` on libvirt includes the taint.
+    `machineconfiguration.openshift.io/role: master` label attaches this `MachineConfig` to the [master][master-machine-config-pool] `MachineConfigPool`. The default configuration for the `kubelet.service` includes the [taint][default-kubelet-service-taint].
 
 3. Run `cluster` target to create the cluster using the custom manifests.
 
@@ -601,7 +601,7 @@ An example `worker.ign` is shown below. It has been modified to increase the HTT
 ```
 
 [cidr-notation]: https://tools.ietf.org/html/rfc4632#section-3.1
-[default-kubelet-service]: https://github.com/openshift/machine-config-operator/blob/master/templates/master/01-master-kubelet/_base/units/kubelet.yaml
+[default-kubelet-service-taint]: https://github.com/openshift/machine-config-operator/blob/ad4bb0cdd514cf902e04189e0f8e146dde5affb0/templates/master/01-master-kubelet/_base/units/kubelet.service.yaml#L44
 [ignition]: https://coreos.com/ignition/docs/latest/
 [machine-config-operator]: https://github.com/openshift/machine-config-operator#machine-config-operator
 [machine-config-pool]: https://github.com/openshift/machine-config-operator/blob/master/docs/MachineConfigController.md#machinepool


### PR DESCRIPTION
Signed-off-by: Eran Cohen <eranco@redhat.com>