### PR TITLE
platformprovisioncheck: fix shadowing of `err` variable

### DIFF
--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -49,7 +49,6 @@ func (a *PlatformProvisionCheck) Dependencies() []asset.Asset {
 func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 	ic := &InstallConfig{}
 	dependencies.Get(ic)
-	var err error
 	platform := ic.Config.Platform.Name()
 	switch platform {
 	case aws.Name:
@@ -74,7 +73,7 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		}
 		return azconfig.ValidateForProvisioning(client, ic.Config)
 	case baremetal.Name:
-		err = bmconfig.ValidateBaremetalPlatformSet(ic.Config)
+		err := bmconfig.ValidateBaremetalPlatformSet(ic.Config)
 		if err != nil {
 			return err
 		}
@@ -109,11 +108,12 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 	case openstack.Name:
-		err = osconfig.ValidateForProvisioning(ic.Config)
+		err := osconfig.ValidateForProvisioning(ic.Config)
 		if err != nil {
 			return err
 		}
 	case vsphere.Name:
+		var err error
 		if len(ic.Config.VSphere.VCenters) > 0 {
 			err = vsconfig.ValidateMultiZoneForProvisioning(ic.Config)
 		} else {
@@ -123,7 +123,7 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 	case ovirt.Name:
-		err = ovirtconfig.ValidateForProvisioning(ic.Config)
+		err := ovirtconfig.ValidateForProvisioning(ic.Config)
 		if err != nil {
 			return err
 		}
@@ -133,23 +133,29 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 			return err
 		}
 		err = alibabacloudconfig.ValidateForProvisioning(client, ic.Config, ic.AlibabaCloud)
+		if err != nil {
+			return err
+		}
 	case powervs.Name:
 		client, err := powervsconfig.NewClient()
 		if err != nil {
 			return err
 		}
 		err = powervsconfig.ValidatePreExistingDNS(client, ic.Config, ic.PowerVS)
+		if err != nil {
+			return err
+		}
 	case libvirt.Name, none.Name:
 		// no special provisioning requirements to check
 	case nutanix.Name:
-		err = nutanixconfig.ValidateForProvisioning(ic.Config)
+		err := nutanixconfig.ValidateForProvisioning(ic.Config)
 		if err != nil {
 			return err
 		}
 	default:
-		err = fmt.Errorf("unknown platform type %q", platform)
+		return fmt.Errorf("unknown platform type %q", platform)
 	}
-	return err
+	return nil
 }
 
 // Name returns the human-friendly name of the asset.


### PR DESCRIPTION
Some switch branches were relying on the outer error variable but shadowing it with a local one whereas other branches were just returning right away in case of errors. Let's make them all consistent by returning the error and using `nil` explicitly at the end of the function to make it clear all validations passed at that point.