### PR TITLE
OCPBUGS-3668: fully qualified username must be provided

### DIFF
--- a/pkg/asset/installconfig/vsphere/permission_test.go
+++ b/pkg/asset/installconfig/vsphere/permission_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/vim25/mo"
 	vim25types "github.com/vmware/govmomi/vim25/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -189,7 +190,13 @@ func TestPermissionValidate(t *testing.T) {
 	invalidDatacenterInstallConfig := validIPIInstallConfig("DC0", "")
 	invalidDatacenterInstallConfig.VSphere.Datacenter = "invalid"
 
-	username := validInstallConfig.VSphere.Username
+	sessionMgr := session.NewManager(client)
+	userSession, err := sessionMgr.UserSession(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	username := userSession.UserName
 
 	validPermissionsAuthManagerClient, err := buildAuthManagerClient(ctx, mockCtrl, finder, username, nil, nil, nil)
 	if err != nil {
@@ -487,7 +494,6 @@ func TestPermissionValidate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			validationCtx := &validationContext{
-				User:        username,
 				AuthManager: test.authManager,
 				Finder:      finder,
 				Client:      client,

--- a/pkg/asset/installconfig/vsphere/validation.go
+++ b/pkg/asset/installconfig/vsphere/validation.go
@@ -19,7 +19,6 @@ import (
 )
 
 type validationContext struct {
-	User        string
 	AuthManager AuthManager
 	Finder      Finder
 	Client      *vim25.Client
@@ -48,7 +47,6 @@ func getVCenterClient(failureDomain vsphere.FailureDomain, ic *types.InstallConf
 			}
 
 			validationCtx := validationContext{
-				User:        vcenter.Username,
 				AuthManager: newAuthManager(vim25Client),
 				Finder:      find.NewFinder(vim25Client),
 				Client:      vim25Client,
@@ -161,7 +159,6 @@ func ValidateForProvisioning(ic *types.InstallConfig) error {
 
 	finder := NewFinder(vim25Client)
 	validationCtx := &validationContext{
-		User:        ic.VSphere.Username,
 		AuthManager: newAuthManager(vim25Client),
 		Finder:      finder,
 		Client:      vim25Client,

--- a/pkg/asset/installconfig/vsphere/validation_test.go
+++ b/pkg/asset/installconfig/vsphere/validation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/session"
 	vim25types "github.com/vmware/govmomi/vim25/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
@@ -231,14 +232,21 @@ func TestValidate(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	validPermissionsAuthManagerClient, err := buildAuthManagerClient(ctx, ctrl, finder, "test_username", nil, nil, nil)
+
+	sessionMgr := session.NewManager(client)
+	userSession, err := sessionMgr.UserSession(ctx)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	username := userSession.UserName
+	validPermissionsAuthManagerClient, err := buildAuthManagerClient(ctx, ctrl, finder, username, nil, nil, nil)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
 	validationCtx := &validationContext{
-		User:        "test_username",
 		AuthManager: validPermissionsAuthManagerClient,
 		Finder:      finder,
 		Client:      client,


### PR DESCRIPTION
The problem:
If a vCenter is configured with a default domain and the domain is not provided to the installer, the vCenter API is unable to validate privileges.

The fix:
Use the UserSession from session manager to determine fully qualified username