### PR TITLE
OCPBUGS-3743: build: change ppc64le linking mode

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -44,5 +44,12 @@ then
 	export CGO_ENABLED=1
 fi
 
+case $(go env GOARCH) in
+ppc64le)
+	LDFLAGS="${LDFLAGS} -linkmode=external"
+	export CGO_ENABLED=1
+	;;
+esac
+
 # shellcheck disable=SC2086
 go build ${GOFLAGS} -ldflags "${LDFLAGS}" -tags "${TAGS}" -o "${OUTPUT}" ./cmd/openshift-install


### PR DESCRIPTION
Debugging the following error on ppc64le: 
```
+ go build -mod=vendor -ldflags ' -X github.com/openshift/installer/pkg/version.Raw=v4.10.0 -X github.com/openshift/installer/pkg/version.Commit=f3c53b382264bdebfc31235adcfbfa1718f4a305 -X github.com/openshift/installer/pkg/version.defaultArch=ppc64le -s -w' -tags ' release' -o bin/openshift-install ./cmd/openshift-install
# github.com/openshift/installer/cmd/openshift-install
github.com/aliyun/alibaba-cloud-sdk-go/services/cms.(*Client).DescribeMonitoringAgentHostsWithChan.func1: direct call too far: runtime.duffzero+1f0-tramp0 -2000068
Error: error building at STEP "RUN DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh": error while running runtime: exit status 2
```