### PR TITLE
Replace deprecated io/ioutil package

### DIFF
--- a/cmd/openshift-install/create.go
+++ b/cmd/openshift-install/create.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -603,7 +602,7 @@ func logComplete(directory, consoleURL string) error {
 	}
 	kubeconfig := filepath.Join(absDir, "auth", "kubeconfig")
 	pwFile := filepath.Join(absDir, "auth", "kubeadmin-password")
-	pw, err := ioutil.ReadFile(pwFile)
+	pw, err := os.ReadFile(pwFile)
 	if err != nil {
 		return err
 	}

--- a/cmd/openshift-install/gather.go
+++ b/cmd/openshift-install/gather.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -95,7 +94,7 @@ func runGatherBootstrapCmd(directory string) (string, error) {
 	if err := assetStore.Fetch(bootstrapSSHKeyPair); err != nil {
 		return "", errors.Wrapf(err, "failed to fetch %s", bootstrapSSHKeyPair.Name())
 	}
-	tmpfile, err := ioutil.TempFile("", "bootstrap-ssh")
+	tmpfile, err := os.CreateTemp("", "bootstrap-ssh")
 	if err != nil {
 		return "", err
 	}

--- a/cmd/openshift-install/main.go
+++ b/cmd/openshift-install/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -28,12 +28,12 @@ func main() {
 	var fs flag.FlagSet
 	klog.InitFlags(&fs)
 	fs.Set("stderrthreshold", "4")
-	klog.SetOutput(ioutil.Discard)
+	klog.SetOutput(io.Discard)
 	// Handle k8s.io/klog/v2
 	var fsv2 flag.FlagSet
 	klogv2.InitFlags(&fsv2)
 	fsv2.Set("stderrthreshold", "4")
-	klogv2.SetOutput(ioutil.Discard)
+	klogv2.SetOutput(io.Discard)
 
 	installerMain()
 }
@@ -78,7 +78,7 @@ func newRootCmd() *cobra.Command {
 }
 
 func runRootCmd(cmd *cobra.Command, args []string) {
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 	logrus.SetLevel(logrus.TraceLevel)
 
 	level, err := logrus.ParseLevel(rootOpts.logLevel)
@@ -89,7 +89,7 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 	logrus.AddHook(newFileHookWithNewlineTruncate(os.Stderr, level, &logrus.TextFormatter{
 		// Setting ForceColors is necessary because logrus.TextFormatter determines
 		// whether or not to enable colors by looking at the output of the logger.
-		// In this case, the output is ioutil.Discard, which is not a terminal.
+		// In this case, the output is io.Discard, which is not a terminal.
 		// Overriding it here allows the same check to be done, but against the
 		// hook's output instead of the logger's output.
 		ForceColors:            terminal.IsTerminal(int(os.Stderr.Fd())),

--- a/data/unpack_test.go
+++ b/data/unpack_test.go
@@ -2,7 +2,7 @@ package data
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -16,7 +16,7 @@ func TestUnpack(t *testing.T) {
 	}
 
 	expected := "# Bootstrap Module"
-	content, err := ioutil.ReadFile(filepath.Join(path, "baremetal", "bootstrap", "README.md"))
+	content, err := os.ReadFile(filepath.Join(path, "baremetal", "bootstrap", "README.md"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/hack/build-coreos-manifest.go
+++ b/hack/build-coreos-manifest.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -24,7 +23,7 @@ const (
 )
 
 func run() error {
-	bootimages, err := ioutil.ReadFile(streamJSON)
+	bootimages, err := os.ReadFile(streamJSON)
 	if err != nil {
 		return err
 	}
@@ -58,7 +57,7 @@ func run() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(dest, b, 0644)
+	err = os.WriteFile(dest, b, 0o644)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/cluster.go
+++ b/pkg/agent/cluster.go
@@ -2,7 +2,7 @@ package agent
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -400,7 +400,7 @@ func (czero *Cluster) PrintInstallationComplete() error {
 	}
 	kubeconfig := filepath.Join(absDir, "auth", "kubeconfig")
 	pwFile := filepath.Join(absDir, "auth", "kubeadmin-password")
-	pw, err := ioutil.ReadFile(pwFile)
+	pw, err := os.ReadFile(pwFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/validations_test.go
+++ b/pkg/agent/validations_test.go
@@ -1,7 +1,7 @@
 package agent
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -173,8 +173,8 @@ func TestUpdateValidationHistory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test logger
-			var logger = &logrus.Logger{
-				Out:       ioutil.Discard,
+			logger := &logrus.Logger{
+				Out:       io.Discard,
 				Formatter: new(logrus.TextFormatter),
 				Hooks:     make(logrus.LevelHooks),
 				Level:     logrus.DebugLevel,
@@ -291,8 +291,8 @@ func TestLogValidationHistory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test logger
-			var logger = &logrus.Logger{
-				Out:       ioutil.Discard,
+			logger := &logrus.Logger{
+				Out:       io.Discard,
 				Formatter: new(logrus.TextFormatter),
 				Hooks:     make(logrus.LevelHooks),
 				Level:     logrus.TraceLevel,

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -2,7 +2,6 @@ package asset
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -59,7 +58,7 @@ func PersistToFile(asset WritableAsset, directory string) error {
 		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 			return errors.Wrap(err, "failed to create dir")
 		}
-		if err := ioutil.WriteFile(path, f.Data, 0640); err != nil {
+		if err := os.WriteFile(path, f.Data, 0o640); err != nil {
 			return errors.Wrap(err, "failed to write file")
 		}
 	}

--- a/pkg/asset/asset_test.go
+++ b/pkg/asset/asset_test.go
@@ -2,7 +2,7 @@ package asset
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -82,7 +82,7 @@ func TestPersistToFile(t *testing.T) {
 }
 
 func verifyFilesCreated(t *testing.T, dir string, expectedFiles map[string][]byte) {
-	dirContents, err := ioutil.ReadDir(dir)
+	dirContents, err := os.ReadDir(dir)
 	assert.NoError(t, err, "could not read contents of directory %q", dir)
 	for _, fileinfo := range dirContents {
 		fullPath := filepath.Join(dir, fileinfo.Name())
@@ -94,7 +94,7 @@ func verifyFilesCreated(t *testing.T, dir string, expectedFiles map[string][]byt
 				t.Errorf("Unexpected file created: %v", fullPath)
 				continue
 			}
-			actualData, err := ioutil.ReadFile(fullPath)
+			actualData, err := os.ReadFile(fullPath)
 			assert.NoError(t, err, "unexpected error reading created file %q", fullPath)
 			assert.Equal(t, expectedData, actualData, "unexpected data in created file %q", fullPath)
 			delete(expectedFiles, fullPath)

--- a/pkg/asset/cluster/metadata.go
+++ b/pkg/asset/cluster/metadata.go
@@ -2,7 +2,7 @@ package cluster
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -136,7 +136,7 @@ func (m *Metadata) Load(f asset.FileFetcher) (found bool, err error) {
 // LoadMetadata loads the cluster metadata from an asset directory.
 func LoadMetadata(dir string) (*types.ClusterMetadata, error) {
 	path := filepath.Join(dir, metadataFileName)
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -7,7 +7,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -486,7 +485,7 @@ func AddSystemdUnits(config *igntypes.Config, uri string, templateData interface
 // '.template', strip that extension from the name and render the
 // template.
 func readFile(name string, reader io.Reader, templateData interface{}) (finalName string, data []byte, err error) {
-	data, err = ioutil.ReadAll(reader)
+	data, err = io.ReadAll(reader)
 	if err != nil {
 		return name, []byte{}, err
 	}

--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -2,7 +2,6 @@ package azure
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -224,7 +223,7 @@ func saveCredentials(credentials Credentials, filePath string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(filePath, jsonCreds, 0600)
+	return os.WriteFile(filePath, jsonCreds, 0o600)
 }
 
 func newSessionFromCredentials(cloudEnv azureenv.Environment, credentials *Credentials) (*Session, error) {

--- a/pkg/asset/installconfig/gcp/session.go
+++ b/pkg/asset/installconfig/gcp/session.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,7 +82,7 @@ func getCredentials(ctx context.Context) (*googleoauth.Credentials, error) {
 	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(filePath, creds.JSON, 0600); err != nil {
+	if err := os.WriteFile(filePath, creds.JSON, 0o600); err != nil {
 		return nil, err
 	}
 	return creds, nil
@@ -144,7 +143,7 @@ type fileLoader struct {
 }
 
 func (f *fileLoader) Load(ctx context.Context) (*googleoauth.Credentials, error) {
-	content, err := ioutil.ReadFile(f.path)
+	content, err := os.ReadFile(f.path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/asset/installconfig/ovirt/config.go
+++ b/pkg/asset/installconfig/ovirt/config.go
@@ -2,7 +2,6 @@ package ovirt
 
 import (
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -39,7 +38,7 @@ type clientHTTP struct {
 // 2  $defaultOvirtConfigPath
 // See #@Config for the expected format
 func LoadOvirtConfig() ([]byte, error) {
-	data, err := ioutil.ReadFile(discoverPath())
+	data, err := os.ReadFile(discoverPath())
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +84,7 @@ func (c *Config) Save() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, out, 0600)
+	return os.WriteFile(path, out, 0o600)
 }
 
 // getValidatedConnection will create a connection and validate it before returning.

--- a/pkg/asset/installconfig/ovirt/credentials.go
+++ b/pkg/asset/installconfig/ovirt/credentials.go
@@ -6,7 +6,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -22,7 +21,7 @@ var errHTTPNotFound = errors.New("http response 404")
 // readFile reads a file provided in the args and return
 // the content or in case of failure return an error
 func readFile(pathFile string) ([]byte, error) {
-	content, err := ioutil.ReadFile(pathFile)
+	content, err := os.ReadFile(pathFile)
 	if err != nil {
 		return content, errors.Wrapf(err, "failed to read file: %s", pathFile)
 	}
@@ -195,7 +194,7 @@ func askCredentials(c Config) (Config, error) {
 // showPEM will print information about PEM file provided in param or error
 // if a failure happens
 func showPEM(pemFilePath string) error {
-	certpem, err := ioutil.ReadFile(pemFilePath)
+	certpem, err := os.ReadFile(pemFilePath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read the cert: %s", pemFilePath)
 	}
@@ -291,7 +290,7 @@ func engineSetup() (Config, error) {
 	logrus.Debug("PEM URL: ", engineConfig.PemURL)
 
 	// Create tmpFile to store the Engine PEM file
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "engine-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "engine-")
 	if err != nil {
 		return engineConfig, err
 	}

--- a/pkg/asset/installconfig/powervs/session.go
+++ b/pkg/asset/installconfig/powervs/session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	gohttp "net/http"
 	"os"
 	"path/filepath"
@@ -291,7 +290,7 @@ func getPISessionVarsFromAuthFile(pisv *PISessionVars) error {
 		return nil
 	}
 
-	content, err := ioutil.ReadFile(authFilePath)
+	content, err := os.ReadFile(authFilePath)
 	if err != nil {
 		return err
 	}
@@ -404,7 +403,7 @@ func savePISessionVars(pisv *PISessionVars) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(authFilePath, jsonVars, 0600)
+	return os.WriteFile(authFilePath, jsonVars, 0o600)
 }
 
 func getEnv(envs []string) string {

--- a/pkg/asset/installconfig/ssh.go
+++ b/pkg/asset/installconfig/ssh.go
@@ -2,7 +2,6 @@ package installconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -31,7 +30,7 @@ func (a *sshPublicKey) Dependencies() []asset.Asset {
 }
 
 func readSSHKey(path string) (string, error) {
-	keyAsBytes, err := ioutil.ReadFile(path)
+	keyAsBytes, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/asset/installconfig/vsphere/mock/vsphere_sim.go
+++ b/pkg/asset/installconfig/vsphere/mock/vsphere_sim.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/pem"
 	"errors"
-	"io/ioutil"
 	"os"
 
 	"github.com/vmware/govmomi/find"
@@ -39,7 +38,7 @@ func GetClient(server *simulator.Server) (*vim25.Client, *session.Manager, error
 		Headers: nil,
 		Bytes:   server.TLS.Certificates[0].Certificate[0],
 	}
-	tempFile, err := ioutil.TempFile(tmpCAdir, "*.pem")
+	tempFile, err := os.CreateTemp(tmpCAdir, "*.pem")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/asset/manifests/openshift.go
+++ b/pkg/asset/manifests/openshift.go
@@ -3,7 +3,7 @@ package manifests
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -212,7 +212,7 @@ func (o *Openshift) Generate(dependencies asset.Parents) error {
 		}
 
 		if len(conf.CABundle) == 0 && len(conf.CAFile) > 0 {
-			content, err := ioutil.ReadFile(conf.CAFile)
+			content, err := os.ReadFile(conf.CAFile)
 			if err != nil {
 				return errors.Wrapf(err, "failed to read the cert file: %s", conf.CAFile)
 			}

--- a/pkg/asset/manifests/openstack/cloudproviderconfig.go
+++ b/pkg/asset/manifests/openstack/cloudproviderconfig.go
@@ -1,7 +1,7 @@
 package openstack
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -83,7 +83,7 @@ secret-namespace = kube-system
 
 	if caCertFile := cloudConfig.CACertFile; caCertFile != "" {
 		cloudProviderConfigData += "ca-file = /etc/kubernetes/static-pod-resources/configmaps/cloud-config/ca-bundle.pem\n"
-		caFile, err := ioutil.ReadFile(caCertFile)
+		caFile, err := os.ReadFile(caCertFile)
 		if err != nil {
 			return "", "", Error{err, "failed to read clouds.yaml ca-cert from disk"}
 		}

--- a/pkg/asset/state.go
+++ b/pkg/asset/state.go
@@ -1,7 +1,6 @@
 package asset
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -34,7 +33,7 @@ func (s *State) PersistToFile(directory string) error {
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 			return errors.Wrap(err, "failed to create dir")
 		}
-		if err := ioutil.WriteFile(path, c.Data, 0644); err != nil {
+		if err := os.WriteFile(path, c.Data, 0o644); err != nil {
 			return errors.Wrap(err, "failed to write file")
 		}
 	}

--- a/pkg/asset/store/assetcreate_test.go
+++ b/pkg/asset/store/assetcreate_test.go
@@ -1,7 +1,7 @@
 package store
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -89,7 +89,7 @@ func TestCreatedAssetsAreNotDirty(t *testing.T) {
 			tempDir := t.TempDir()
 
 			for name, contents := range tc.files {
-				if err := ioutil.WriteFile(filepath.Join(tempDir, name), []byte(contents), 0666); err != nil {
+				if err := os.WriteFile(filepath.Join(tempDir, name), []byte(contents), 0666); err != nil {
 					t.Fatalf("could not write the %s file: %v", name, err)
 				}
 			}

--- a/pkg/asset/store/filefetcher.go
+++ b/pkg/asset/store/filefetcher.go
@@ -1,7 +1,7 @@
 package store
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/openshift/installer/pkg/asset"
@@ -13,7 +13,7 @@ type fileFetcher struct {
 
 // FetchByName returns the file with the given name.
 func (f *fileFetcher) FetchByName(name string) (*asset.File, error) {
-	data, err := ioutil.ReadFile(filepath.Join(f.directory, name))
+	data, err := os.ReadFile(filepath.Join(f.directory, name))
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +29,7 @@ func (f *fileFetcher) FetchByPattern(pattern string) (files []*asset.File, err e
 
 	files = make([]*asset.File, 0, len(matches))
 	for _, path := range matches {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/asset/store/filefetcher_test.go
+++ b/pkg/asset/store/filefetcher_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,7 +48,7 @@ func TestFetchByName(t *testing.T) {
 			tempDir := t.TempDir()
 
 			for filename, data := range tt.files {
-				err := ioutil.WriteFile(filepath.Join(tempDir, filename), data, 0666)
+				err := os.WriteFile(filepath.Join(tempDir, filename), data, 0666)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -97,7 +96,7 @@ func TestFetchByPattern(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		err := ioutil.WriteFile(filepath.Join(tempDir, path), data, 0666)
+		err := os.WriteFile(filepath.Join(tempDir, path), data, 0666)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/asset/store/store.go
+++ b/pkg/asset/store/store.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -130,7 +129,7 @@ func (s *storeImpl) DestroyState() error {
 func (s *storeImpl) loadStateFile() error {
 	path := filepath.Join(s.directory, stateFileName)
 	assets := map[string]json.RawMessage{}
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -184,7 +183,7 @@ func (s *storeImpl) saveStateFile() error {
 	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(path, data, 0640); err != nil {
+	if err := os.WriteFile(path, data, 0o640); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/asset/templates/content/helper.go
+++ b/pkg/asset/templates/content/helper.go
@@ -1,7 +1,7 @@
 package content
 
 import (
-	"io/ioutil"
+	"io"
 	"path"
 
 	"github.com/openshift/installer/data"
@@ -32,5 +32,5 @@ func getFileContents(uri string) ([]byte, error) {
 	}
 	defer file.Close()
 
-	return ioutil.ReadAll(file)
+	return io.ReadAll(file)
 }

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -3,7 +3,6 @@ package bootstrap
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -74,7 +73,7 @@ func Destroy(dir string) (err error) {
 			continue
 		}
 
-		tempDir, err := ioutil.TempDir("", fmt.Sprintf("openshift-install-%s-", stage.Name()))
+		tempDir, err := os.MkdirTemp("", fmt.Sprintf("openshift-install-%s-", stage.Name()))
 		if err != nil {
 			return errors.Wrap(err, "failed to create temporary directory for Terraform execution")
 		}
@@ -115,10 +114,10 @@ func Destroy(dir string) (err error) {
 }
 
 func copy(from string, to string) error {
-	data, err := ioutil.ReadFile(from)
+	data, err := os.ReadFile(from)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(to, data, 0666)
+	return os.WriteFile(to, data, 0666)
 }

--- a/pkg/destroy/quota/quota.go
+++ b/pkg/destroy/quota/quota.go
@@ -2,7 +2,7 @@ package quota
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/openshift/installer/pkg/types"
@@ -23,7 +23,7 @@ func WriteQuota(dir string, quota *types.ClusterQuota) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal quota")
 	}
-	if err := ioutil.WriteFile(path, raw, 0777); err != nil {
+	if err := os.WriteFile(path, raw, 0o777); err != nil {
 		return errors.Wrap(err, "failed to write quota")
 	}
 	return nil

--- a/pkg/explain/cmd.go
+++ b/pkg/explain/cmd.go
@@ -1,7 +1,7 @@
 package explain
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -46,7 +46,7 @@ func runCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer file.Close()
 
-	raw, err := ioutil.ReadAll(file)
+	raw, err := io.ReadAll(file)
 	if err != nil {
 		return errors.Wrap(err, "failed to read InstallConfig CRD")
 	}

--- a/pkg/explain/data_test.go
+++ b/pkg/explain/data_test.go
@@ -1,12 +1,12 @@
 package explain
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
 func loadCRD(t *testing.T) []byte {
-	crd, err := ioutil.ReadFile("../../data/data/install.openshift.io_installconfigs.yaml")
+	crd, err := os.ReadFile("../../data/data/install.openshift.io_installconfigs.yaml")
 	if err != nil {
 		t.Fatalf("failed to load CRD: %v", err)
 	}

--- a/pkg/gather/ssh/ssh.go
+++ b/pkg/gather/ssh/ssh.go
@@ -2,7 +2,6 @@
 package ssh
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,7 +99,7 @@ func PullFileTo(client *ssh.Client, remotePath, localPath string) error {
 // It does not return any intermediate errors if at least one private key was loaded.
 func defaultPrivateSSHKeys() (map[string]interface{}, error) {
 	d := filepath.Join(os.Getenv("HOME"), ".ssh")
-	paths, err := ioutil.ReadDir(d)
+	paths, err := os.ReadDir(d)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read directory %q", d)
 	}
@@ -124,7 +123,7 @@ func LoadPrivateSSHKeys(paths []string) (map[string]interface{}, error) {
 	var errs []error
 	keys := make(map[string]interface{})
 	for _, path := range paths {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			errs = append(errs, errors.Wrapf(err, "failed to read %q", path))
 			continue

--- a/pkg/rhcos/builds.go
+++ b/pkg/rhcos/builds.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 
 	"github.com/coreos/stream-metadata-go/stream"
@@ -25,7 +25,7 @@ func FetchRawCoreOSStream(ctx context.Context) ([]byte, error) {
 	}
 	defer file.Close()
 
-	body, err := ioutil.ReadAll(file)
+	body, err := io.ReadAll(file)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read CoreOS stream metadata")
 	}

--- a/pkg/terraform/stages/baremetal/stages.go
+++ b/pkg/terraform/stages/baremetal/stages.go
@@ -2,7 +2,6 @@ package baremetal
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -41,7 +40,7 @@ func extractOutputHostAddresses(s stages.SplitStage, directory string, config *t
 		return "", 0, nil, errors.Wrapf(err, "could not find outputs file %q", outputsFilePath)
 	}
 
-	outputsFile, err := ioutil.ReadFile(outputsFilePath)
+	outputsFile, err := os.ReadFile(outputsFilePath)
 	if err != nil {
 		return "", 0, nil, errors.Wrapf(err, "failed to read outputs file %q", outputsFilePath)
 	}

--- a/pkg/terraform/stages/split.go
+++ b/pkg/terraform/stages/split.go
@@ -3,7 +3,6 @@ package stages
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -119,7 +118,7 @@ func GetTerraformOutputs(s SplitStage, directory string) (map[string]interface{}
 		return nil, errors.Wrapf(err, "could not find outputs file %q", outputsFilePath)
 	}
 
-	outputsFile, err := ioutil.ReadFile(outputsFilePath)
+	outputsFile, err := os.ReadFile(outputsFilePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read outputs file %q", outputsFilePath)
 	}

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -4,8 +4,8 @@ package openstack
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 
 	"github.com/gophercloud/gophercloud"
@@ -70,7 +70,7 @@ func TFVars(
 	var caCert string
 	// Get the ca-cert-bundle key if there is a value for cacert in clouds.yaml
 	if caPath := cloud.CloudConfig.CACertFile; caPath != "" {
-		caFile, err := ioutil.ReadFile(caPath)
+		caFile, err := os.ReadFile(caPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read clouds.yaml ca-cert from disk: %w", err)
 		}

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -3,7 +3,7 @@ package tfvars
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,7 +28,7 @@ type config struct {
 
 // TFVars generates terraform.tfvar JSON for launching the cluster.
 func TFVars(clusterID string, clusterDomain string, baseDomain string, machineV4CIDRs []string, machineV6CIDRs []string, useIPv4, useIPv6 bool, bootstrapIgn string, masterIgn string, masterCount int, mastersSchedulable bool) ([]byte, error) {
-	f, err := ioutil.TempFile("", "openshift-install-bootstrap-*.ign")
+	f, err := os.CreateTemp("", "openshift-install-bootstrap-*.ign")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create tmp file for bootstrap ignition")
 	}


### PR DESCRIPTION
`io/ioutil` has been deprecated since go-1.16 [1]. We should use `io` and `os` instead.

[1] https://github.com/golang/go/issues/42026