### PR TITLE
Bug 2072202: Check for reachability of API and API-Int URLs later in bootkube

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template
@@ -360,18 +360,13 @@ then
     record_service_stage_success
 fi
 
-# Check if the API and API_INT Server URLs can be resolved and reached.
+# Check if the API and API_INT Server URLs can be resolved.
 echo "Check if API and API-Int URLs are resolvable during bootstrap"
 API_SERVER_URL="{{.APIServerURL}}"
 API_INT_SERVER_URL="{{.APIIntServerURL}}" 
 
-if [[ ! -z "${API_SERVER_URL}" ]] ; then
-    check_url "API_URL" "${API_SERVER_URL}"
-fi
-
-if [[ ! -z "${API_INT_SERVER_URL}" ]] ; then
-    check_url "API_INT_URL" "${API_INT_SERVER_URL}"
-fi
+resolve_url "API_URL" "${API_SERVER_URL}"
+resolve_url "API_INT_URL" "${API_INT_SERVER_URL}"
 
 if [ ! -f cco-bootstrap.done ]
 then
@@ -480,6 +475,12 @@ else
         record_service_stage_success
     fi
 fi
+
+# Check if the API and API_INT Server URLs can be reached.
+echo "Check if API and API-Int URLs are reachable during bootstrap"
+
+check_url "API_URL" "${API_SERVER_URL}"
+check_url "API_INT_URL" "${API_INT_SERVER_URL}"
 
 # Workaround for https://github.com/opencontainers/runc/pull/1807
 touch /opt/openshift/.bootkube.done

--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-verify-api-server-urls.sh
@@ -6,17 +6,12 @@
 # This functions expects 2 arguments:
 # 1. name of the URL
 # 2. The value of the URL
-function resolve_url() {
+function lookup_url() {
     unset IPS
     unset IP
     IPS=$(dig "${2}" +short)
     if [[ ! -z "${IPS}" ]] ; then
         echo "Successfully resolved ${1} ${2}"
-        # dig returns multiple IPs. Check if the
-        # first IP is reachable.
-        ip_arr=""
-        readarray ip_arr -t <<<"${IPS}"
-        IP="$(echo "${ip_arr[0]}" | tr -d '\n')"
         return 0
     else
         echo "Unable to resolve ${1} ${2}"
@@ -37,6 +32,40 @@ function validate_url() {
     fi
 }
 
+function resolve_url() {
+    if [[ -z "${1}" ]] || [[ -z "${2}" ]]; then
+        echo "Usage: resolve_url <API_URL or API_INT URL> <URL that needs to be verified>"
+        return
+    fi
+
+    local URL_TYPE=${1}
+    local SERVER_URL=${2}
+
+    if [[ ${URL_TYPE} != API_URL ]] && [[ ${URL_TYPE} != API_INT_URL ]]; then
+        echo "Usage: resolve_url <API_URL or API_INT URL> <URL that needs to be verified>"
+        return
+    fi
+
+    echo "Checking if ${SERVER_URL} of type ${URL_TYPE} is resolvable"
+
+    if [[ "${URL_TYPE}" = "API_URL" ]]; then
+        local URL_STAGE_NAME="resolve-api-url"
+    else 
+        local URL_STAGE_NAME="resolve-api-int-url"
+    fi
+
+    echo "Starting stage ${URL_STAGE_NAME}"
+    record_service_stage_start ${URL_STAGE_NAME}
+    if lookup_url "$URL_TYPE" "$SERVER_URL"; then
+        record_service_stage_success
+    else
+        record_service_stage_failure
+        # We do not want to stop bootkube service due to this failure.
+        # So not returning failure at this point.
+        return
+    fi
+}
+
 function check_url() {
     if [[ -z "${1}" ]] || [[ -z "${2}" ]]; then
         echo "Usage: check_url <API_URL or API_INT URL> <URL that needs to be verified>"
@@ -51,7 +80,7 @@ function check_url() {
         return
     fi
 
-    echo "Checking validity of ${SERVER_URL} of type ${URL_TYPE}"
+    echo "Checking if ${SERVER_URL} of type ${URL_TYPE} reachable"
 
     if [[ "${URL_TYPE}" = "API_URL" ]]; then
         local URL_STAGE_NAME="check-api-url"
@@ -59,24 +88,16 @@ function check_url() {
         local URL_STAGE_NAME="check-api-int-url"
     fi
 
-    echo "Starting stage ${URL_STAGE_NAME}"
-    record_service_stage_start ${URL_STAGE_NAME}
-    if resolve_url "$URL_TYPE" "$SERVER_URL"; then
-        record_service_stage_success
-    else
-        record_service_stage_failure
-        # We do not want to stop bootkube service due to this failure.
-        # So not returning failure at this point.
-        return
-    fi
-
-    CURL_URL="https://${IP}:6443/version"
+    CURL_URL="https://${2}:6443/version"
 
     record_service_stage_start ${URL_STAGE_NAME}
     if validate_url "$URL_TYPE" "$CURL_URL"; then
         record_service_stage_success
     else
-        echo "It might be too early for the ${CURL_URL} to be available."
+        echo "Unable to validate. ${CURL_URL} is currently unreachable."
         record_service_stage_failure
+        # We do not want to stop bootkube service due to this failure.
+        # So not returning failure at this point.
+	return
     fi
 }


### PR DESCRIPTION
The check to resolve the API and Internal API server URLs were performed together within the bootkube service right after MCO was started. This resulted in false negatives because the API Server became periodically unavailable during the bootstrap process. 
To make these checks better, this PR splits the check into 2 parts:
1. URLs resolvable - This can be checked early and hence this is the only check that happens before MCO is started.
2. URLs reachable - This check was causing the false -ives and hence has been moved to the end of bootkube service when we expect the API Server to be stable.

This split has resulted in these checks happening in 2 stages "resolve-api(-int)-url" and "check-api(-int)-url" so the success and failure of these stages can be reported individually. Also, although a stage may report failure, they will not cause the bootstrap process to stop. The output from these stages are available in the analyse output to diagnose any issues.