### PR TITLE
Set ip=dhcp,dhcp6 for master nodes on dualstack

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -88,7 +88,9 @@ IPTABLES=ip6tables
 IPTABLES=iptables
 {{ end }}
 
-{{ if .UseIPv6ForNodeIP }}
+{{ if .UseDualForNodeIP }}
+EXTERNAL_IP_OPTIONS="ip=dhcp,dhcp6"
+{{ else if .UseIPv6ForNodeIP }}
 EXTERNAL_IP_OPTIONS="ip=dhcp6"
 {{ else }}
 EXTERNAL_IP_OPTIONS="ip=dhcp"

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -78,6 +78,7 @@ type bootstrapTemplateData struct {
 	PlatformData          platformTemplateData
 	BootstrapInPlace      *types.BootstrapInPlace
 	UseIPv6ForNodeIP      bool
+	UseDualForNodeIP      bool
 	IsFCOS                bool
 	IsSCOS                bool
 	IsOKD                 bool
@@ -279,6 +280,15 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 	platformFirstAPIVIP := firstAPIVIP(&installConfig.Config.Platform)
 	APIIntVIPonIPv6 := utilsnet.IsIPv6String(platformFirstAPIVIP)
 
+	networkStack := 0
+	for _, snet := range installConfig.Config.ServiceNetwork {
+		if snet.IP.To4() != nil {
+			networkStack |= 1
+		} else {
+			networkStack |= 2
+		}
+	}
+
 	// Set cluster profile
 	clusterProfile := ""
 	if cp := os.Getenv("OPENSHIFT_INSTALL_EXPERIMENTAL_CLUSTER_PROFILE"); cp != "" {
@@ -306,6 +316,7 @@ func (a *Common) getTemplateData(dependencies asset.Parents, bootstrapInPlace bo
 		ClusterProfile:        clusterProfile,
 		BootstrapInPlace:      bootstrapInPlaceConfig,
 		UseIPv6ForNodeIP:      APIIntVIPonIPv6,
+		UseDualForNodeIP:      networkStack == 3,
 		IsFCOS:                installConfig.Config.IsFCOS(),
 		IsSCOS:                installConfig.Config.IsSCOS(),
 		IsOKD:                 installConfig.Config.IsOKD(),


### PR DESCRIPTION
We were previously only seting this for workers but its also needed on the master nodes to ensure both networks are ready before ovnkube-node starts.