### PR TITLE
Bug OCPBUGS-3921: OpenStack: fix bootstrap destroy cmd

### DIFF
--- a/pkg/asset/cluster/cluster.go
+++ b/pkg/asset/cluster/cluster.go
@@ -125,7 +125,7 @@ func (c *Cluster) Generate(parents asset.Parents) (err error) {
 			return err
 		}
 	case typesopenstack.Name:
-		if err := openstack.PreTerraform(context.TODO(), clusterID.InfraID, installConfig); err != nil {
+		if err := openstack.PreTerraform(); err != nil {
 			return err
 		}
 	}

--- a/pkg/asset/cluster/openstack/openstack.go
+++ b/pkg/asset/cluster/openstack/openstack.go
@@ -3,20 +3,18 @@
 package openstack
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
 // PreTerraform performs any infrastructure initialization which must
 // happen before Terraform creates the remaining infrastructure.
-func PreTerraform(ctx context.Context, clusterID string, installConfig *installconfig.InstallConfig) error {
+func PreTerraform() error {
 	// Terraform runs in a different directory but we want to allow people to
 	// use clouds.yaml files in their local directory. Emulate this by setting
 	// the necessary environment variable to point to this file if (a) the user

--- a/pkg/destroy/bootstrap/bootstrap.go
+++ b/pkg/destroy/bootstrap/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/asset/cluster"
+	openstackasset "github.com/openshift/installer/pkg/asset/cluster/openstack"
 	osp "github.com/openshift/installer/pkg/destroy/openstack"
 	"github.com/openshift/installer/pkg/terraform"
 	platformstages "github.com/openshift/installer/pkg/terraform/stages/platform"
@@ -30,6 +31,10 @@ func Destroy(dir string) (err error) {
 	}
 
 	if platform == openstack.Name {
+		if err := openstackasset.PreTerraform(); err != nil {
+			return errors.Wrapf(err, "Failed to  initialize infrastructure")
+		}
+
 		imageName := metadata.InfraID + "-ignition"
 		if err := osp.DeleteGlanceImage(imageName, metadata.OpenStack.Cloud); err != nil {
 			return errors.Wrapf(err, "Failed to delete glance image %s", imageName)


### PR DESCRIPTION
The installer bootstrap destroy command does not locate the clouds.yaml file containing the credentials when it's present in the current directory. This commit fixes the issue by ensuring that prior to destroying the resources, the installer attempts to look for the OS_CLIENT_CONFIG_FILE env var and if unset looks for any clouds.yaml file in the current directory.