### PR TITLE
mv ibmcloud to /bin folder

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -55,14 +55,6 @@ RUN curl -sSL "${ALIYUN_URI}" --output /tmp/aliyun-cli-linux-latest-amd64.tgz &&
   tar --directory=/bin/ -xvf /tmp/aliyun-cli-linux-latest-amd64.tgz && \
   rm -f /tmp/aliyun-cli-linux-latest-amd64.tgz
 
-# Download the latest IBM Cloud release binary
-ARG IBMCLI_URI=https://clis.cloud.ibm.com/install/linux
-RUN curl -fsSL ${IBMCLI_URI} | sh && \
-    ibmcloud plugin install vpc-infrastructure -f && \
-    ibmcloud plugin install cloud-dns-services -f && \
-    ibmcloud plugin install cloud-internet-services -f && \
-    chmod -R g=u "$HOME/.bluemix/"
-
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
 RUN python get-pip.py 'pip<21.0'
 RUN python -m pip install pyopenssl
@@ -86,7 +78,20 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install -b /bin && \
     rm -rf ./aws awscliv2.zip
 
-RUN mkdir /output && chown 1000:1000 /output
+# Download the latest IBM Cloud release binary
+ARG IBMCLI_URI=https://clis.cloud.ibm.com/install/linux
+RUN mkdir /output && HOME=/output && \ 
+    echo "-4" > $HOME/.curlrc && \
+    curl -fsSL ${IBMCLI_URI} | sh && \    
+    ibmcloud plugin install vpc-infrastructure -f && \
+    ibmcloud plugin install cloud-dns-services -f && \
+    ibmcloud plugin install cloud-internet-services -f && \
+    cp /usr/local/bin/ibmcloud /bin/ibmcloud && \
+    rm -f $HOME/.curlrc && \
+    ibmcloud version && \
+    ibmcloud plugin list
+
+RUN chown -R 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output

--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -51,14 +51,6 @@ RUN curl -sSL "${ALIYUN_URI}" --output /tmp/aliyun-cli-linux-latest-amd64.tgz &&
   tar --directory=/bin/ -xvf /tmp/aliyun-cli-linux-latest-amd64.tgz && \
   rm -f /tmp/aliyun-cli-linux-latest-amd64.tgz
 
-# Download the latest IBM Cloud release binary
-ARG IBMCLI_URI=https://clis.cloud.ibm.com/install/linux
-RUN curl -fsSL ${IBMCLI_URI} | sh && \
-    ibmcloud plugin install vpc-infrastructure -f && \
-    ibmcloud plugin install cloud-dns-services -f && \
-    ibmcloud plugin install cloud-internet-services -f && \
-    chmod -R g=u "$HOME/.bluemix/"
-
 # Not packaged, but required by gcloud. See https://cloud.google.com/sdk/crypto
 RUN pip-3 install cryptography
 
@@ -82,7 +74,20 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install -b /bin && \
     rm -rf ./aws awscliv2.zip
 
-RUN mkdir /output && chown 1000:1000 /output
+# Download the latest IBM Cloud release binary
+ARG IBMCLI_URI=https://clis.cloud.ibm.com/install/linux
+RUN mkdir /output && HOME=/output && \ 
+    echo "-4" > $HOME/.curlrc && \
+    curl -fsSL ${IBMCLI_URI} | sh && \    
+    ibmcloud plugin install vpc-infrastructure -f && \
+    ibmcloud plugin install cloud-dns-services -f && \
+    ibmcloud plugin install cloud-internet-services -f && \
+    cp /usr/local/bin/ibmcloud /bin/ibmcloud && \
+    rm -f $HOME/.curlrc && \
+    ibmcloud version && \
+    ibmcloud plugin list
+
+RUN chown -R 1000:1000 /output
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output


### PR DESCRIPTION
1. ibmcloud installed in /usr/local/bin, the env PATH just has /bin, need mv it. 
2. echo "-4" > ./.curlrc help resolving the download ibmcloud cli error
> Error: Get "https://download.clis.cloud.ibm.com/ibm-cloud-cli-plugin/cloud-internet-services/1.14.9/cloud-internet-services-linux-amd64-1.14.9": dial tcp [2600:1408:c400:21::17d4:fb48]:443: connect: network is unreachable

3.HOME=/output before ibmcloud download to resolve the issue of  no  ibmcloud plugin in release test. 