### PR TITLE
[ibmcloud] ibmcloud plugin "permission denied"

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -91,7 +91,7 @@ RUN mkdir /output && HOME=/output && \
     ibmcloud version && \
     ibmcloud plugin list
 
-RUN chown -R 1000:1000 /output
+RUN chown 1000:1000 /output && chmod -R g=u "/output/.bluemix/"
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output

--- a/images/installer/Dockerfile.upi.ci.rhel8
+++ b/images/installer/Dockerfile.upi.ci.rhel8
@@ -87,7 +87,7 @@ RUN mkdir /output && HOME=/output && \
     ibmcloud version && \
     ibmcloud plugin list
 
-RUN chown -R 1000:1000 /output
+RUN chown 1000:1000 /output && chmod -R g=u "$HOME/.bluemix/"
 USER 1000:1000
 ENV PATH /bin
 ENV HOME /output


### PR DESCRIPTION
in release test ibmcloud fail to use. 
$ibmcloud
FAILED
Configuration error: mkdir /output/.bluemix/plugins: permission denied