### PR TITLE
CORS-2405: Create ControlPlaneMachineSet CRDs

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -368,12 +368,14 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 			return err
 		}
 		useImageGallery := installConfig.Azure.CloudName != azuretypes.StackCloud
-
-		machines, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, capabilities, useImageGallery)
+		machines, controlPlaneMachineSet, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, capabilities, useImageGallery)
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
-		azure.ConfigMasters(machines, clusterID.InfraID)
+		err = azure.ConfigMasters(machines, controlPlaneMachineSet, clusterID.InfraID)
+		if err != nil {
+			return err
+		}
 	case baremetaltypes.Name:
 		mpool := defaultBareMetalMachinePoolPlatform()
 		mpool.Set(ic.Platform.BareMetal.DefaultMachinePlatform)


### PR DESCRIPTION
Creating an extra CRD asset for the ControlPlaneMachineSet which is required for the machine api operator for more control over the control-plane nodes that come up on Azure.