### PR TITLE
WIP: openstack: Delay cluster destroy

### DIFF
--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -88,6 +88,8 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 
 // Run is the entrypoint to start the uninstall process.
 func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
+	time.Sleep(3 * time.Hour)
+
 	opts := openstackdefaults.DefaultClientOpts(o.Cloud)
 
 	// Check that the cloud has the minimum requirements for the destroy


### PR DESCRIPTION
DO NOT MERGE
The goal of this PR is to debug a failing CI job that clusterbot doesn't destroy right away after a failed deployment.