### PR TITLE
OCPBUGS-4355: Fix return value from execute()

### DIFF
--- a/pkg/asset/agent/image/oc.go
+++ b/pkg/asset/agent/image/oc.go
@@ -272,7 +272,7 @@ func execute(log logrus.FieldLogger, executer executer.Executer, pullSecret, com
 		return strings.TrimSpace(stdout), nil
 	}
 
-	log.Debugf("command '%s' exited with non-zero exit code %d: %s\n%s", executeCommand, exitCode, stdout, stderr)
+	err = fmt.Errorf("command '%s' exited with non-zero exit code %d: %s\n%s", executeCommand, exitCode, stdout, stderr)
 	return "", err
 }
 


### PR DESCRIPTION
The execute() function was not returning an error properly, which allowed failures of the 'oc' command, such was when using an older version of 'oc' that did not support the --icsp-file param.