### PR TITLE
[release-4.11] OCPBUGS-4325: gcp: fail during validation if service usage is not enabled

### DIFF
--- a/pkg/asset/installconfig/gcp/validation.go
+++ b/pkg/asset/installconfig/gcp/validation.go
@@ -2,12 +2,12 @@ package gcp
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -235,13 +235,11 @@ func ValidateEnabledServices(ctx context.Context, client API, project string) er
 		"storage-api.googleapis.com",
 		"storage-component.googleapis.com")
 	projectServices, err := client.GetEnabledServices(ctx, project)
-
 	if err != nil {
 		var gErr *googleapi.Error
 		if errors.As(err, &gErr) {
 			if gErr.Code == http.StatusForbidden {
-				logrus.Warn("Permission denied. Unable to fetch enabled services for project.")
-				return nil
+				return errors.Wrap(err, "unable to fetch enabled services for project. Make sure 'serviceusage.googleapis.com' is enabled")
 			}
 		}
 		return err

--- a/pkg/asset/installconfig/gcp/validation_test.go
+++ b/pkg/asset/installconfig/gcp/validation_test.go
@@ -1,15 +1,19 @@
 package gcp
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	compute "google.golang.org/api/compute/v1"
 	dns "google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/installer/pkg/asset/installconfig/gcp/mock"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -354,21 +358,27 @@ func TestGCPEnabledServicesList(t *testing.T) {
 	}{{
 		name:     "No services present",
 		services: nil,
-		err: "following required services are not enabled in this project storage-component.googleapis.com," +
-			" servicemanagement.googleapis.com, storage-api.googleapis.com, compute.googleapis.com," +
-			" cloudapis.googleapis.com, dns.googleapis.com, iam.googleapis.com, iamcredentials.googleapis.com," +
-			" serviceusage.googleapis.com, cloudresourcemanager.googleapis.com",
+		err:      "unable to fetch enabled services for project. Make sure 'serviceusage.googleapis.com' is enabled",
+	}, {
+		name:     "Service Usage missing",
+		services: []string{"compute.googleapis.com"},
+		err:      "unable to fetch enabled services for project. Make sure 'serviceusage.googleapis.com' is enabled",
 	}, {
 		name: "All pre-existing",
-		services: []string{"compute.googleapis.com",
+		services: []string{
+			"compute.googleapis.com",
 			"cloudresourcemanager.googleapis.com", "dns.googleapis.com",
 			"iam.googleapis.com", "iamcredentials.googleapis.com", "serviceusage.googleapis.com",
-			"deploymentmanager.googleapis.com"},
+			"deploymentmanager.googleapis.com",
+		},
 	}, {
 		name:     "Some services present",
-		services: []string{"compute.googleapis.com"},
-		err:      "enable all services before creating the cluster",
+		services: []string{"compute.googleapis.com", "serviceusage.googleapis.com"},
+		err: "the following required services are not enabled in this project: " +
+			"cloudresourcemanager.googleapis.com,dns.googleapis.com,iam.googleapis.com,iamcredentials.googleapis.com",
 	}}
+
+	errForbidden := &googleapi.Error{Code: http.StatusForbidden}
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
@@ -376,12 +386,16 @@ func TestGCPEnabledServicesList(t *testing.T) {
 			defer mockCtrl.Finish()
 			gcpClient := mock.NewMockAPI(mockCtrl)
 
-			gcpClient.EXPECT().GetEnabledServices(gomock.Any(), gomock.Any()).Return(test.services, nil).AnyTimes()
-			err := ValidateEnabledServices(nil, gcpClient, "")
+			if !sets.NewString(test.services...).Has("serviceusage.googleapis.com") {
+				gcpClient.EXPECT().GetEnabledServices(gomock.Any(), gomock.Any()).Return(nil, errForbidden).AnyTimes()
+			} else {
+				gcpClient.EXPECT().GetEnabledServices(gomock.Any(), gomock.Any()).Return(test.services, nil).AnyTimes()
+			}
+			err := ValidateEnabledServices(context.TODO(), gcpClient, "")
 			if test.err == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				assert.Regexp(t, test.err, err)
 			}
 		})
 	}


### PR DESCRIPTION
We were only printing a warning in case Service Usage was missing and proceeding with the installation. However, that service is required by the CCO and the deployment would end up failing later on.

Instead, let's fail during install-config validation time so users can enable the service before proceeding.