### PR TITLE
OCPBUGS-4125: Enable CVO unmanage overrides in bootstrap-in-place installations

### DIFF
--- a/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
+++ b/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
@@ -63,6 +63,18 @@ function wait_for_cvo {
   done
 }
 
+function restore_cvo_overrides {
+    echo "Restoring CVO overrides"
+    until \
+        oc patch clusterversion.config.openshift.io version \
+            --type=merge \
+            --patch-file=/opt/openshift/original_cvo_overrides.patch
+    do
+        echo "Trying again to restore CVO overrides ..."
+        sleep 10
+    done
+}
+
 function clean {
   if [ -d "/etc/kubernetes/bootstrap-secrets" ]; then
      rm -rf /etc/kubernetes/bootstrap-*
@@ -77,6 +89,7 @@ function clean {
 
 wait_for_api
 signal_bootstrap_complete
+restore_cvo_overrides
 approve_csr
 restart_kubelet
 wait_for_cvo

--- a/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/master-update.fcc
+++ b/data/data/bootstrap/bootstrap-in-place/files/opt/openshift/bootstrap-in-place/master-update.fcc
@@ -45,6 +45,9 @@ storage:
       contents:
         local: bin/installer-gather.sh
       mode: 0555
+    - path: /opt/openshift/original_cvo_overrides.patch
+      contents:
+        local: original_cvo_overrides.patch
 systemd:
   units:
     - name: bootkube.service

--- a/pkg/asset/ignition/bootstrap/bootstrap.go
+++ b/pkg/asset/ignition/bootstrap/bootstrap.go
@@ -2,7 +2,6 @@ package bootstrap
 
 import (
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/asset/ignition"
 )
 
 const (
@@ -16,27 +15,11 @@ type Bootstrap struct {
 
 var _ asset.WritableAsset = (*Bootstrap)(nil)
 
-// Dependencies returns the assets on which the Bootstrap asset depends.
-func (a *Bootstrap) Dependencies() []asset.Asset {
-	return append(
-		a.Common.Dependencies(),
-		&CVOIgnore{},
-	)
-}
-
 // Generate generates the ignition config for the Bootstrap asset.
 func (a *Bootstrap) Generate(dependencies asset.Parents) error {
 	templateData := a.getTemplateData(dependencies, false)
 	if err := a.generateConfig(dependencies, templateData); err != nil {
 		return err
-	}
-
-	// replace cvo-overrides.yaml so that CVO does not try to create resources for the manifests that the installer
-	// is supplying to cluster-bootstrap
-	cvoIgnore := &CVOIgnore{}
-	dependencies.Get(cvoIgnore)
-	for _, file := range ignition.FilesFromAsset(rootDir, "root", 0644, cvoIgnore) {
-		a.Config.Storage.Files = replaceOrAppend(a.Config.Storage.Files, file)
 	}
 
 	if err := a.generateFile(bootstrapIgnFilename); err != nil {

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -103,6 +103,7 @@ type Common struct {
 func (a *Common) Dependencies() []asset.Asset {
 	return []asset.Asset{
 		&baremetal.IronicCreds{},
+		&CVOIgnore{},
 		&installconfig.InstallConfig{},
 		&kubeconfig.AdminInternalClient{},
 		&kubeconfig.Kubelet{},
@@ -514,6 +515,7 @@ func (a *Common) addParentFiles(dependencies asset.Parents) {
 		&machines.Worker{},
 		&mcign.MasterIgnitionCustomizations{},
 		&mcign.WorkerIgnitionCustomizations{},
+		&CVOIgnore{}, // this must come after manifests.Manifests so that it replaces cvo-overrides.yaml
 	} {
 		dependencies.Get(asset)
 


### PR DESCRIPTION
# Background

#5258 introduced a mechanism to tell CVO to not manage some cluster resources,
as that management was creating races between bootkube and CVO.

In #5271, this mechanism was removed from bootstrap-in-place
installations.

The reason for the removal was because attempting to apply
`original_cvo_overrides.patch` after the cluster-bootstrap podman
container was done wasn't working, as in BIP by the time that that
container is down, there's no longer a running kube-apiserver apply the
patch on (unlike regular installations with a bootstrap node where the
API server keeps running on the actual nodes). The justification for
simply disabling the mechanism instead of finding a solution was based
on an incorrect assumption that "CVO doesn't even run in BIP pre-pivot
so there's no need to perform overrides anyway as there's no CVO to race
with".

# Issue

Naturally, since CVO *is* actually running in the pre-pivot phase of
bootstrap-in-place, not applying CVO overrides to disable the CVO
management of bootkube-created resources led to the same races #5258 was
aiming to solve in bootstrap-in-place installations.

One manifestation of that is OCPBUGS-4125.

# Solution

This commit re-introduces the mechanism that was originally introduced in #5258
(and removed in #5271).

To solve the issue that motivated #5271, this commit doesn't attempt to
apply the `original_cvo_overrides.patch` in bootstrap-in-place
pre-reboot, and instead will transfer `original_cvo_overrides.patch` through
`master-update.fcc` to the post-pivot phase and the bootstrap-in-place
post-reboot script will make sure to apply the patch after the API
server is running again.