### PR TITLE
Wait longer for VM to obtain IP from DHCP in PowerVS

### DIFF
--- a/data/data/powervs/bootstrap/vm/main.tf
+++ b/data/data/powervs/bootstrap/vm/main.tf
@@ -61,7 +61,7 @@ resource "ibm_pi_instance" "bootstrap" {
 }
 
 resource "time_sleep" "wait_for_bootstrap_macs" {
-  create_duration = "45s"
+  create_duration = "3m"
 
   depends_on = [ibm_pi_instance.bootstrap]
 }

--- a/data/data/powervs/cluster/master/vm/main.tf
+++ b/data/data/powervs/cluster/master/vm/main.tf
@@ -17,7 +17,7 @@ resource "ibm_pi_instance" "master" {
 }
 
 resource "time_sleep" "wait_for_master_macs" {
-  create_duration = "45s"
+  create_duration = "3m"
 
   depends_on = [ibm_pi_instance.master]
 }


### PR DESCRIPTION
At the moment, it is not possible to verify the target VM has fully booted up in the current setup. Therefore, we just need to find the optimal wait time before assuming it's up and proceeding further in the install automation.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>