### PR TITLE
openstack: Rely on Go's stdlib for errors

### DIFF
--- a/pkg/asset/cluster/openstack/openstack.go
+++ b/pkg/asset/cluster/openstack/openstack.go
@@ -4,10 +4,10 @@ package openstack
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/types"
@@ -28,14 +28,14 @@ func PreTerraform(ctx context.Context, clusterID string, installConfig *installc
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		return errors.Wrapf(err, "unable to determine working directory")
+		return fmt.Errorf("unable to determine working directory: %w", err)
 	}
 
 	cloudsYAML := filepath.Join(cwd, "clouds.yaml")
 	if _, err = os.Stat(cloudsYAML); err == nil {
 		os.Setenv("OS_CLIENT_CONFIG_FILE", cloudsYAML)
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return errors.Wrapf(err, "unable to determine if clouds.yaml exists")
+		return fmt.Errorf("unable to determine if clouds.yaml exists: %w", err)
 	}
 
 	return nil

--- a/pkg/asset/installconfig/openstack/openstack.go
+++ b/pkg/asset/installconfig/openstack/openstack.go
@@ -2,12 +2,12 @@
 package openstack
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
-	"github.com/pkg/errors"
 
 	"github.com/openshift/installer/pkg/types/openstack"
 )
@@ -36,14 +36,14 @@ func Platform() (*openstack.Platform, error) {
 				value := ans.(core.OptionAnswer).Value
 				i := sort.SearchStrings(cloudNames, value)
 				if i == len(cloudNames) || cloudNames[i] != value {
-					return errors.Errorf("invalid cloud name %q, should be one of %+v", value, strings.Join(cloudNames, ", "))
+					return fmt.Errorf("invalid cloud name %q, should be one of %s", value, strings.Join(cloudNames, ", "))
 				}
 				return nil
 			}),
 		},
 	}, &cloud)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed UserInput")
+		return nil, fmt.Errorf("failed UserInput: %w", err)
 	}
 
 	networkNames, err := getExternalNetworkNames(cloud)
@@ -65,7 +65,7 @@ func Platform() (*openstack.Platform, error) {
 				value := ans.(core.OptionAnswer).Value
 				i := sort.SearchStrings(networkNames, value)
 				if i == len(networkNames) || networkNames[i] != value {
-					return errors.Errorf("invalid network name %q, should be one of %+v", value, strings.Join(networkNames, ", "))
+					return fmt.Errorf("invalid network name %q, should be one of %s", value, strings.Join(networkNames, ", "))
 				}
 				return nil
 			}),
@@ -75,7 +75,7 @@ func Platform() (*openstack.Platform, error) {
 		extNet = ""
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "failed UserInput")
+		return nil, fmt.Errorf("failed UserInput: %w", err)
 	}
 
 	var apiFloatingIP string
@@ -95,14 +95,14 @@ func Platform() (*openstack.Platform, error) {
 				},
 				Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
 					if value := ans.(core.OptionAnswer).Value; !floatingIPs.Contains(value) {
-						return errors.Errorf("invalid floating IP %q, should be one of %+v", value, strings.Join(floatingIPs.Names(), ", "))
+						return fmt.Errorf("invalid floating IP %q, should be one of %s", value, strings.Join(floatingIPs.Names(), ", "))
 					}
 					return nil
 				}),
 			},
 		}, &apiFloatingIP)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed UserInput")
+			return nil, fmt.Errorf("failed UserInput: %w", err)
 		}
 	}
 
@@ -123,14 +123,14 @@ func Platform() (*openstack.Platform, error) {
 				value := ans.(core.OptionAnswer).Value
 				i := sort.SearchStrings(flavorNames, value)
 				if i == len(flavorNames) || flavorNames[i] != value {
-					return errors.Errorf("invalid flavor name %q, should be one of %+v", value, strings.Join(flavorNames, ", "))
+					return fmt.Errorf("invalid flavor name %q, should be one of %s", value, strings.Join(flavorNames, ", "))
 				}
 				return nil
 			}),
 		},
 	}, &flavor)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed UserInput")
+		return nil, fmt.Errorf("failed UserInput: %w", err)
 	}
 
 	return &openstack.Platform{

--- a/pkg/asset/installconfig/openstack/session.go
+++ b/pkg/asset/installconfig/openstack/session.go
@@ -2,11 +2,11 @@
 package openstack
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/ghodss/yaml"
 	"github.com/gophercloud/utils/openstack/clientconfig"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
@@ -43,7 +43,7 @@ func (opts yamlLoadOpts) LoadCloudsYAML() (map[string]clientconfig.Cloud, error)
 	}
 	err = yaml.Unmarshal(content, &clouds)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal yaml")
+		return nil, fmt.Errorf("failed to unmarshal yaml: %w", err)
 	}
 
 	return clouds.Clouds, nil
@@ -60,7 +60,7 @@ func (opts yamlLoadOpts) LoadSecureCloudsYAML() (map[string]clientconfig.Cloud, 
 	}
 	err = yaml.Unmarshal(content, &clouds)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal yaml")
+		return nil, fmt.Errorf("failed to unmarshal yaml: %w", err)
 	}
 	return clouds.Clouds, err
 }
@@ -76,7 +76,7 @@ func (opts yamlLoadOpts) LoadPublicCloudsYAML() (map[string]clientconfig.Cloud, 
 	}
 	err = yaml.Unmarshal(content, &publicClouds)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal yaml")
+		return nil, fmt.Errorf("failed to unmarshal yaml: %w", err)
 	}
 	return publicClouds.Clouds, err
 }

--- a/pkg/asset/installconfig/openstack/validvaluesfetcher.go
+++ b/pkg/asset/installconfig/openstack/validvaluesfetcher.go
@@ -1,13 +1,14 @@
 package openstack
 
 import (
+	"fmt"
+
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/utils/openstack/clientconfig"
 	networkutils "github.com/gophercloud/utils/openstack/networking/v2/networks"
-	"github.com/pkg/errors"
 
 	openstackdefaults "github.com/openshift/installer/pkg/types/openstack/defaults"
 )
@@ -77,7 +78,7 @@ func getFlavorNames(cloud string) ([]string, error) {
 	}
 
 	if len(allFlavors) == 0 {
-		return nil, errors.New("no OpenStack flavors were found")
+		return nil, fmt.Errorf("no OpenStack flavors were found")
 	}
 
 	flavorNames := make([]string, len(allFlavors))
@@ -148,7 +149,7 @@ func getFloatingIPs(cloud string, floatingNetworkName string) (sortableFloatingI
 	}
 
 	if len(allFloatingIPs) == 0 {
-		return nil, errors.New("there are no unassigned floating IP addresses available")
+		return nil, fmt.Errorf("there are no unassigned floating IP addresses available")
 	}
 
 	return allFloatingIPs, nil

--- a/pkg/destroy/openstack/glance.go
+++ b/pkg/destroy/openstack/glance.go
@@ -1,11 +1,11 @@
 package openstack
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	"github.com/gophercloud/utils/openstack/clientconfig"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -23,7 +23,7 @@ func DeleteGlanceImage(name string, cloud string) error {
 		return deleteGlanceImage(name, cloud)
 	})
 	if err != nil {
-		return errors.Errorf("Unrecoverable error/timed out: %v", err)
+		return fmt.Errorf("unrecoverable error/timed out: %w", err)
 	}
 
 	return nil

--- a/pkg/destroy/openstack/openstack.go
+++ b/pkg/destroy/openstack/openstack.go
@@ -1,6 +1,7 @@
 package openstack
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -28,7 +29,6 @@ import (
 	sharesnapshots "github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots"
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/utils/openstack/clientconfig"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -750,12 +750,12 @@ func removeRouterInterfaces(client *gophercloud.ServiceClient, filter Filter, ro
 	allPagesPort, err := ports.List(client, portListOpts).AllPages()
 	if err != nil {
 		logger.Error(err)
-		return false, errors.Wrap(err, "failed to get ports list")
+		return false, fmt.Errorf("failed to get ports list: %w", err)
 	}
 	allPorts, err := ports.ExtractPorts(allPagesPort)
 	if err != nil {
 		logger.Error(err)
-		return false, errors.Wrap(err, "failed to extract ports list")
+		return false, fmt.Errorf("failed to extract ports list: %w", err)
 	}
 	tags := filterTags(filter)
 	SubnetlistOpts := subnets.ListOpts{
@@ -765,13 +765,13 @@ func removeRouterInterfaces(client *gophercloud.ServiceClient, filter Filter, ro
 	allSubnetsPage, err := subnets.List(client, SubnetlistOpts).AllPages()
 	if err != nil {
 		logger.Debug(err)
-		return false, errors.Wrap(err, "failed to list subnets list")
+		return false, fmt.Errorf("failed to list subnets list: %w", err)
 	}
 
 	allSubnets, err := subnets.ExtractSubnets(allSubnetsPage)
 	if err != nil {
 		logger.Debug(err)
-		return false, errors.Wrap(err, "failed to extract subnets list")
+		return false, fmt.Errorf("failed to extract subnets list: %w", err)
 	}
 
 	clusterTag := "openshiftClusterID=" + filter["openshiftClusterID"]
@@ -830,12 +830,12 @@ func getRouterByPort(client *gophercloud.ServiceClient, allPorts []ports.Port) (
 		if port.DeviceID != "" {
 			page, err := routers.List(client, routers.ListOpts{ID: port.DeviceID}).AllPages()
 			if err != nil {
-				return empty, errors.Wrap(err, "failed to get router list")
+				return empty, fmt.Errorf("failed to get router list: %w", err)
 			}
 
 			routerList, err := routers.ExtractRouters(page)
 			if err != nil {
-				return empty, errors.Wrap(err, "failed to extract routers list")
+				return empty, fmt.Errorf("failed to extract routers list: %w", err)
 			}
 
 			if len(routerList) == 1 {
@@ -907,7 +907,7 @@ func deleteLeftoverLoadBalancers(opts *clientconfig.ClientOpts, logger logrus.Fi
 	}
 
 	if deleted != len(allLoadBalancers) {
-		return errors.Errorf("Only deleted %d of %d load balancers", deleted, len(allLoadBalancers))
+		return fmt.Errorf("only deleted %d of %d load balancers", deleted, len(allLoadBalancers))
 	}
 	return nil
 }
@@ -1123,10 +1123,10 @@ func deleteContainers(opts *clientconfig.ClientOpts, filter Filter, logger logru
 						// is the object name, and the second one contains an error message.
 						errs := make([]error, len(resp.Errors))
 						for i, objectError := range resp.Errors {
-							errs[i] = errors.Errorf("cannot delete object %v: %v", objectError[0], objectError[1])
+							errs[i] = fmt.Errorf("cannot delete object %s: %s", objectError[0], objectError[1])
 						}
 
-						return false, errors.Errorf("errors occured during bulk deleting of container %v objects: %v", container, k8serrors.NewAggregate(errs))
+						return false, fmt.Errorf("errors occurred during bulk deleting of container %s objects: %w", container, k8serrors.NewAggregate(errs))
 					}
 
 					return true, nil
@@ -1729,7 +1729,7 @@ func untagRunner(opts *clientconfig.ClientOpts, infraID string, logger logrus.Fi
 		if err == wait.ErrWaitTimeout {
 			return err
 		}
-		return errors.Errorf("Unrecoverable error: %v", err)
+		return fmt.Errorf("unrecoverable error: %w", err)
 	}
 
 	return nil
@@ -1749,7 +1749,7 @@ func deleteRouterRunner(opts *clientconfig.ClientOpts, filter Filter, logger log
 		if err == wait.ErrWaitTimeout {
 			return err
 		}
-		return errors.Errorf("Unrecoverable error: %v", err)
+		return fmt.Errorf("unrecoverable error: %w", err)
 	}
 
 	return nil
@@ -1785,7 +1785,7 @@ func untagPrimaryNetwork(opts *clientconfig.ClientOpts, infraID string, logger l
 	}
 
 	if len(allNetworks) > 1 {
-		return false, errors.Errorf("More than one network with tag %v", networkTag)
+		return false, fmt.Errorf("more than one network with tag %s", networkTag)
 	}
 
 	if len(allNetworks) == 0 {


### PR DESCRIPTION
The package github.com/pkg/errors has been archived and its functionality integrated in Go's standard library.