### PR TITLE
OCPBUGS-4419: Revert "images: updating images to be consistent with ART"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.12
+  tag: rhel-8-release-golang-1.18-openshift-4.12

--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -3,7 +3,7 @@
 
 ARG libvirt_version="8.0.0"
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 ARG libvirt_version
 ARG TAGS="libvirt baremetal"
 RUN dnf install -y libvirt-devel-$libvirt_version && \

--- a/images/installer-artifacts/Dockerfile.rhel
+++ b/images/installer-artifacts/Dockerfile.rhel
@@ -1,7 +1,7 @@
 # This Dockerfile builds an image containing Mac and Linux/AMD64 versions of
 # the installer layered on top of the cluster-native Linux installer image.
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS macbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS macbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
@@ -13,13 +13,13 @@ WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN GOOS=darwin GOARCH=arm64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS linuxbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS linuxbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .
 RUN GOOS=linux GOARCH=amd64 DEFAULT_ARCH="$(go env GOHOSTARCH)" hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS linuxarmbuilder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS linuxarmbuilder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .

--- a/images/installer/Dockerfile.ci
+++ b/images/installer/Dockerfile.ci
@@ -1,7 +1,7 @@
 # This Dockerfile is used by CI to publish the installer image.
 # It builds an image containing only the openshift-install.
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
 ARG TAGS=""
 WORKDIR /go/src/github.com/openshift/installer
 COPY . .


### PR DESCRIPTION
Image build failurs due to missing dependencies

This reverts commit c1df1ebdafe636520c100f42c5b4fa1bd7002245.