### PR TITLE
OCPBUGS-4367: Fix missing debug messages when getting baseISO

### DIFF
--- a/pkg/asset/agent/image/baseiso.go
+++ b/pkg/asset/agent/image/baseiso.go
@@ -106,7 +106,6 @@ func (i *BaseIso) Dependencies() []asset.Asset {
 // Generate the baseIso
 func (i *BaseIso) Generate(dependencies asset.Parents) error {
 
-	log := logrus.New()
 	// TODO - if image registry location is defined in InstallConfig,
 	// ic := &agent.OptionalInstallConfig{}
 	// p.Get(ic)
@@ -127,27 +126,27 @@ func (i *BaseIso) Generate(dependencies asset.Parents) error {
 		ocRelease := NewRelease(&executer.CommonExecuter{},
 			Config{MaxTries: OcDefaultTries, RetryDelay: OcDefaultRetryDelay})
 
-		log.Info("Extracting base ISO from release payload")
-		baseIsoFileName, err = ocRelease.GetBaseIso(log, releaseImage, pullSecret, archName, registriesConf.MirrorConfig)
+		logrus.Info("Extracting base ISO from release payload")
+		baseIsoFileName, err = ocRelease.GetBaseIso(releaseImage, pullSecret, archName, registriesConf.MirrorConfig)
 		if err == nil {
-			log.Debugf("Extracted base ISO image %s from release payload", baseIsoFileName)
+			logrus.Debugf("Extracted base ISO image %s from release payload", baseIsoFileName)
 			i.File = &asset.File{Filename: baseIsoFileName}
 			return nil
 		}
 		if !errors.Is(err, &exec.Error{}) { // Already warned about missing oc binary
-			log.Warning("Failed to extract base ISO from release payload - check registry configuration")
+			logrus.Warning("Failed to extract base ISO from release payload - check registry configuration")
 		}
 	}
 
-	log.Info("Downloading base ISO")
+	logrus.Info("Downloading base ISO")
 	isoGetter := newGetIso(GetIsoPluggable)
 	baseIsoFileName, err2 := isoGetter.getter()
 	if err2 == nil {
-		log.Debugf("Using base ISO image %s", baseIsoFileName)
+		logrus.Debugf("Using base ISO image %s", baseIsoFileName)
 		i.File = &asset.File{Filename: baseIsoFileName}
 		return nil
 	}
-	log.Debugf("Failed to download base ISO: %s", err2)
+	logrus.Debugf("Failed to download base ISO: %s", err2)
 
 	return errors.Wrap(err, "failed to get base ISO image")
 }

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -180,7 +180,9 @@ func (n *NMStateConfig) Load(f asset.FileFetcher) (bool, error) {
 		nmStateConfigList = append(nmStateConfigList, &nmStateConfig)
 	}
 
-	staticNetworkConfigGenerator := staticnetworkconfig.New(logrus.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
+	log := logrus.New()
+	log.Level = logrus.WarnLevel
+	staticNetworkConfigGenerator := staticnetworkconfig.New(log.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
 
 	// Validate the network config using nmstatectl
 	if err = staticNetworkConfigGenerator.ValidateStaticConfigParams(context.Background(), staticNetworkConfig); err != nil {
@@ -267,7 +269,9 @@ func GetNodeZeroIP(nmStateConfigs []*aiv1beta1.NMStateConfig) (string, error) {
 // GetNMIgnitionFiles returns the list of NetworkManager configuration files
 func GetNMIgnitionFiles(staticNetworkConfig []*models.HostStaticNetworkConfig) ([]staticnetworkconfig.StaticNetworkConfigData, error) {
 
-	staticNetworkConfigGenerator := staticnetworkconfig.New(logrus.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
+	log := logrus.New()
+	log.Level = logrus.WarnLevel
+	staticNetworkConfigGenerator := staticnetworkconfig.New(log.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
 
 	networkConfigStr, err := staticNetworkConfigGenerator.FormatStaticNetworkConfigForDB(staticNetworkConfig)
 	if err != nil {

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -180,9 +180,10 @@ func (n *NMStateConfig) Load(f asset.FileFetcher) (bool, error) {
 		nmStateConfigList = append(nmStateConfigList, &nmStateConfig)
 	}
 
-	log := logrus.New()
-	log.Level = logrus.WarnLevel
-	staticNetworkConfigGenerator := staticnetworkconfig.New(log.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
+	level := logrus.GetLevel()
+	logrus.SetLevel(logrus.WarnLevel)
+	staticNetworkConfigGenerator := staticnetworkconfig.New(logrus.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
+	defer logrus.SetLevel(level)
 
 	// Validate the network config using nmstatectl
 	if err = staticNetworkConfigGenerator.ValidateStaticConfigParams(context.Background(), staticNetworkConfig); err != nil {
@@ -269,9 +270,10 @@ func GetNodeZeroIP(nmStateConfigs []*aiv1beta1.NMStateConfig) (string, error) {
 // GetNMIgnitionFiles returns the list of NetworkManager configuration files
 func GetNMIgnitionFiles(staticNetworkConfig []*models.HostStaticNetworkConfig) ([]staticnetworkconfig.StaticNetworkConfigData, error) {
 
-	log := logrus.New()
-	log.Level = logrus.WarnLevel
-	staticNetworkConfigGenerator := staticnetworkconfig.New(log.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
+	level := logrus.GetLevel()
+	logrus.SetLevel(logrus.WarnLevel)
+	staticNetworkConfigGenerator := staticnetworkconfig.New(logrus.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
+	defer logrus.SetLevel(level)
 
 	networkConfigStr, err := staticNetworkConfigGenerator.FormatStaticNetworkConfigForDB(staticNetworkConfig)
 	if err != nil {

--- a/pkg/asset/agent/manifests/nmstateconfig.go
+++ b/pkg/asset/agent/manifests/nmstateconfig.go
@@ -180,9 +180,7 @@ func (n *NMStateConfig) Load(f asset.FileFetcher) (bool, error) {
 		nmStateConfigList = append(nmStateConfigList, &nmStateConfig)
 	}
 
-	log := logrus.New()
-	log.Level = logrus.WarnLevel
-	staticNetworkConfigGenerator := staticnetworkconfig.New(log.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
+	staticNetworkConfigGenerator := staticnetworkconfig.New(logrus.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
 
 	// Validate the network config using nmstatectl
 	if err = staticNetworkConfigGenerator.ValidateStaticConfigParams(context.Background(), staticNetworkConfig); err != nil {
@@ -268,8 +266,8 @@ func GetNodeZeroIP(nmStateConfigs []*aiv1beta1.NMStateConfig) (string, error) {
 
 // GetNMIgnitionFiles returns the list of NetworkManager configuration files
 func GetNMIgnitionFiles(staticNetworkConfig []*models.HostStaticNetworkConfig) ([]staticnetworkconfig.StaticNetworkConfigData, error) {
-	log := logrus.New()
-	staticNetworkConfigGenerator := staticnetworkconfig.New(log.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
+
+	staticNetworkConfigGenerator := staticnetworkconfig.New(logrus.WithField("pkg", "manifests"), staticnetworkconfig.Config{MaxConcurrentGenerations: 2})
 
 	networkConfigStr, err := staticNetworkConfigGenerator.FormatStaticNetworkConfigForDB(staticNetworkConfig)
 	if err != nil {


### PR DESCRIPTION
A new logger is currently created for the baseISO and oc commands. Since the default log level is not debug, this results in the messages not being output. It is cleaner to use the global logger which prints the debug log messages by default.

In addition, a log message was added for a failure running the oc command due to the --icspFile option as this indicates that an older oc binary is being used which doesn't support this option.