### PR TITLE
Better logic to derive vpcRegion/Zone from vpcName/Subnets

### DIFF
--- a/data/data/powervs/cluster/main.tf
+++ b/data/data/powervs/cluster/main.tf
@@ -90,7 +90,7 @@ resource "ibm_pi_image" "boot_image" {
   pi_cloud_instance_id      = var.powervs_cloud_instance_id
   pi_image_bucket_name      = var.powervs_image_bucket_name
   pi_image_bucket_access    = "public"
-  pi_image_bucket_region    = var.powervs_vpc_region
+  pi_image_bucket_region    = var.powervs_cos_region
   pi_image_bucket_file_name = var.powervs_image_bucket_file_name
   pi_image_storage_type     = var.powervs_image_storage_type
 }

--- a/data/data/powervs/variables-powervs.tf
+++ b/data/data/powervs/variables-powervs.tf
@@ -48,6 +48,12 @@ variable "powervs_publish_strategy" {
 ################################################################
 # Configure storage
 ################################################################
+variable "powervs_cos_region" {
+  type        = string
+  description = "The region where your COS instance is located in"
+  default     = "eu-gb"
+}
+
 variable "powervs_cos_instance_location" {
   type        = string
   description = "The location of your COS instance"

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/IBM/vpc-go-sdk/vpcv1"
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	coreosarch "github.com/coreos/stream-metadata-go/arch"
 	"github.com/ghodss/yaml"
@@ -30,6 +33,7 @@ import (
 	aztypes "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	gcpconfig "github.com/openshift/installer/pkg/asset/installconfig/gcp"
 	ovirtconfig "github.com/openshift/installer/pkg/asset/installconfig/ovirt"
+	powervsconfig "github.com/openshift/installer/pkg/asset/installconfig/powervs"
 	vsphereconfig "github.com/openshift/installer/pkg/asset/installconfig/vsphere"
 	"github.com/openshift/installer/pkg/asset/machines"
 	"github.com/openshift/installer/pkg/asset/manifests"
@@ -819,6 +823,46 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			masterConfigs[i] = m.Spec.ProviderSpec.Value.Object.(*machinev1.PowerVSMachineProviderConfig)
 		}
 
+		client, err := powervsconfig.NewClient()
+		if err != nil {
+			return err
+		}
+		var (
+			vpcRegion, vpcZone string
+		)
+		vpcName := installConfig.Config.PowerVS.VPCName
+		if vpcName != "" {
+			var vpc *vpcv1.VPC
+			vpc, err = client.GetVPCByName(ctx, vpcName)
+			if err != nil {
+				return err
+			}
+			var crnElems = strings.SplitN(*vpc.CRN, ":", 8)
+			vpcRegion = crnElems[5]
+		} else {
+			specified := installConfig.Config.PowerVS.VPCRegion
+			if specified != "" {
+				if powervs.ValidateVPCRegion(specified) {
+					vpcRegion = specified
+				} else {
+					return errors.New("unknown VPC region")
+				}
+			} else if vpcRegion, err = powervs.VPCRegionForPowerVSRegion(installConfig.Config.PowerVS.Region); err != nil {
+				return err
+			}
+		}
+		if vpcSubnet != "" {
+			var sn *vpcv1.Subnet
+			sn, err = client.GetSubnetByName(ctx, vpcSubnet, vpcRegion)
+			if err != nil {
+				return err
+			}
+			vpcZone = *sn.Zone.Name
+		} else {
+			rand.Seed(time.Now().UnixNano())
+			vpcZone = fmt.Sprintf("%s-%d", vpcRegion, rand.Intn(2)+1) //nolint:gosec // we don't need a crypto secure number
+		}
+
 		osImage := strings.SplitN(string(*rhcosImage), "/", 2)
 		data, err = powervstfvars.TFVars(
 			powervstfvars.TFVarsSources{
@@ -831,7 +875,9 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 				ImageBucketName:      osImage[0],
 				ImageBucketFileName:  osImage[1],
 				NetworkName:          installConfig.Config.PowerVS.PVSNetworkName,
-				VPCName:              installConfig.Config.PowerVS.VPCName,
+				VPCRegion:            vpcRegion,
+				VPCZone:              vpcZone,
+				VPCName:              vpcName,
 				VPCSubnetName:        vpcSubnet,
 				VPCPermitted:         vpcPermitted,
 				VPCGatewayName:       vpcGatewayName,

--- a/pkg/asset/installconfig/platformprovisioncheck.go
+++ b/pkg/asset/installconfig/platformprovisioncheck.go
@@ -141,6 +141,10 @@ func (a *PlatformProvisionCheck) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+		err = powervsconfig.ValidateCustomVPCSetup(client, ic.Config)
+		if err != nil {
+			return err
+		}
 	case libvirt.Name, none.Name:
 		// no special provisioning requirements to check
 	case nutanix.Name:

--- a/pkg/asset/installconfig/powervs/metadata.go
+++ b/pkg/asset/installconfig/powervs/metadata.go
@@ -152,7 +152,7 @@ func (m *Metadata) SetDNSInstanceCRN(crn string) {
 
 // GetExistingVPCGateway checks if the VPC is a Permitted Network for the DNS Zone
 func (m *Metadata) GetExistingVPCGateway(ctx context.Context, vpcName string, vpcSubnet string) (string, bool, error) {
-	if vpcName == "" {
+	if vpcName == "" || vpcSubnet == "" {
 		return "", false, nil
 	}
 

--- a/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
+++ b/pkg/asset/installconfig/powervs/mock/powervsclient_generated.go
@@ -172,6 +172,21 @@ func (mr *MockAPIMockRecorder) GetVPCByName(ctx, vpcName interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCByName", reflect.TypeOf((*MockAPI)(nil).GetVPCByName), ctx, vpcName)
 }
 
+// GetVPCs mocks base method.
+func (m *MockAPI) GetVPCs(ctx context.Context, region string) ([]vpcv1.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPCs", ctx, region)
+	ret0, _ := ret[0].([]vpcv1.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPCs indicates an expected call of GetVPCs.
+func (mr *MockAPIMockRecorder) GetVPCs(ctx, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCs", reflect.TypeOf((*MockAPI)(nil).GetVPCs), ctx, region)
+}
+
 // SetVPCServiceURLForRegion mocks base method.
 func (m *MockAPI) SetVPCServiceURLForRegion(ctx context.Context, region string) error {
 	m.ctrl.T.Helper()

--- a/pkg/asset/installconfig/powervs/validation.go
+++ b/pkg/asset/installconfig/powervs/validation.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
+	powervstypes "github.com/openshift/installer/pkg/types/powervs"
 )
 
 // Validate executes platform specific validation/
@@ -108,5 +109,77 @@ func validatePreExistingPrivateDNS(fldPath *field.Path, client API, ic *types.In
 			allErrs = append(allErrs, field.Duplicate(fldPath, fmt.Sprintf("record %s already exists in DNS zone (%s) and might be in use by another cluster, please remove it to continue", recordName, zoneID)))
 		}
 	}
+	return allErrs
+}
+
+// ValidateCustomVPCSetup ensures optional VPC settings, if specified, are all legit.
+func ValidateCustomVPCSetup(client API, ic *types.InstallConfig) error {
+	allErrs := field.ErrorList{}
+	var vpcRegion = ic.PowerVS.VPCRegion
+	var vpcName = ic.PowerVS.VPCName
+	var err error
+	fldPath := field.NewPath("VPC")
+
+	if vpcRegion != "" {
+		if !powervstypes.ValidateVPCRegion(vpcRegion) {
+			allErrs = append(allErrs, field.NotFound(fldPath.Child("vpcRegion"), vpcRegion))
+		}
+	} else {
+		vpcRegion, err = powervstypes.VPCRegionForPowerVSRegion(ic.PowerVS.Region)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("region"), nil, ic.PowerVS.Region))
+		}
+	}
+
+	if vpcName != "" {
+		allErrs = append(allErrs, findVPCInRegion(client, vpcName, vpcRegion, fldPath)...)
+		allErrs = append(allErrs, findSubnetInVPC(client, ic.PowerVS.VPCSubnets, vpcRegion, vpcName, fldPath)...)
+	} else if len(ic.PowerVS.VPCSubnets) != 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("vpcSubnets"), nil, "invalid without vpcName"))
+	}
+
+	return allErrs.ToAggregate()
+}
+
+func findVPCInRegion(client API, name string, region string, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if name == "" {
+		return allErrs
+	}
+
+	vpcs, err := client.GetVPCs(context.TODO(), region)
+	if err != nil {
+		return append(allErrs, field.InternalError(path.Child("vpcRegion"), err))
+	}
+
+	found := false
+	for _, vpc := range vpcs {
+		if *vpc.Name == name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		allErrs = append(allErrs, field.NotFound(path.Child("vpcName"), name))
+	}
+
+	return allErrs
+}
+
+func findSubnetInVPC(client API, subnets []string, region string, name string, path *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(subnets) == 0 {
+		return allErrs
+	}
+
+	subnet, err := client.GetSubnetByName(context.TODO(), subnets[0], region)
+	if err != nil {
+		allErrs = append(allErrs, field.InternalError(path.Child("vpcSubnets"), err))
+	} else if *subnet.VPC.Name != name {
+		allErrs = append(allErrs, field.Invalid(path.Child("vpcSubnets"), nil, "not attached to VPC"))
+	}
+
 	return allErrs
 }

--- a/pkg/asset/installconfig/powervs/validation_test.go
+++ b/pkg/asset/installconfig/powervs/validation_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,6 +53,61 @@ var (
 	}
 	noDNSRecordsResponse = []powervs.DNSRecordResponse{}
 	invalidArchitecture  = func(ic *types.InstallConfig) { ic.ControlPlane.Architecture = "ppc64" }
+
+	validVPCRegion    = "eu-gb"
+	invalidVPCRegion  = "foo-bah"
+	setValidVPCRegion = func(ic *types.InstallConfig) { ic.Platform.PowerVS.VPCRegion = validVPCRegion }
+	validRG           = "valid-resource-group"
+	anotherValidRG    = "another-valid-resource-group"
+	validVPCID        = "valid-id"
+	anotherValidVPCID = "another-valid-id"
+	validVPC          = "valid-vpc"
+	setValidVPCName   = func(ic *types.InstallConfig) { ic.Platform.PowerVS.VPCName = validVPC }
+	anotherValidVPC   = "another-valid-vpc"
+	invalidVPC        = "bogus-vpc"
+	validVPCs         = []vpcv1.VPC{
+		{
+			Name: &validVPC,
+			ID:   &validVPCID,
+			ResourceGroup: &vpcv1.ResourceGroupReference{
+				Name: &validRG,
+				ID:   &validRG,
+			},
+		},
+		{
+			Name: &anotherValidVPC,
+			ID:   &anotherValidVPCID,
+			ResourceGroup: &vpcv1.ResourceGroupReference{
+				Name: &anotherValidRG,
+				ID:   &anotherValidRG,
+			},
+		},
+	}
+	validVPCSubnet   = "valid-vpc-subnet"
+	invalidVPCSubnet = "invalid-vpc-subnet"
+	wrongVPCSubnet   = "wrong-vpc-subnet"
+	validSubnet      = &vpcv1.Subnet{
+		Name: &validRG,
+		VPC: &vpcv1.VPCReference{
+			Name: &validVPC,
+			ID:   &validVPCID,
+		},
+		ResourceGroup: &vpcv1.ResourceGroupReference{
+			Name: &validRG,
+			ID:   &validRG,
+		},
+	}
+	wrongSubnet = &vpcv1.Subnet{
+		Name: &validRG,
+		VPC: &vpcv1.VPCReference{
+			Name: &anotherValidVPC,
+			ID:   &anotherValidVPCID,
+		},
+		ResourceGroup: &vpcv1.ResourceGroupReference{
+			Name: &validRG,
+			ID:   &validRG,
+		},
+	}
 )
 
 func validInstallConfig() *types.InstallConfig {
@@ -191,6 +247,163 @@ func TestValidatePreExistingPublicDNS(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			aggregatedErrors := powervs.ValidatePreExistingDNS(powervsClient, validInstallConfig(), metadata)
+			if tc.errorMsg != "" {
+				assert.Regexp(t, tc.errorMsg, aggregatedErrors)
+			} else {
+				assert.NoError(t, aggregatedErrors)
+			}
+		})
+	}
+}
+
+func TestValidateCustomVPCSettings(t *testing.T) {
+	cases := []struct {
+		name     string
+		edits    editFunctions
+		errorMsg string
+	}{
+		{
+			name: "invalid VPC region supplied alone",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCRegion = invalidVPCRegion
+				},
+			},
+			errorMsg: fmt.Sprintf(`VPC.vpcRegion: Not found: "%s"`, invalidVPCRegion),
+		},
+		{
+			name: "valid VPC region supplied alone",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCRegion = validVPCRegion
+				},
+			},
+			errorMsg: "",
+		},
+		{
+			name: "invalid VPC name supplied, without VPC region, not found near PowerVS region",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCName = invalidVPC
+				},
+			},
+			errorMsg: fmt.Sprintf(`VPC.vpcName: Not found: "%s"`, invalidVPC),
+		},
+		{
+			name: "valid VPC name supplied, without VPC region, but found close to PowerVS region",
+			edits: editFunctions{
+				setValidVPCName,
+			},
+			errorMsg: "",
+		},
+		{
+			name: "valid VPC name, with invalid VPC region",
+			edits: editFunctions{
+				setValidVPCName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCRegion = invalidVPCRegion
+				},
+			},
+			errorMsg: "VPC.vpcRegion: Internal error: unknown region",
+		},
+		{
+			name: "valid VPC name, valid VPC region",
+			edits: editFunctions{
+				setValidVPCName,
+				setValidVPCRegion,
+			},
+			errorMsg: "",
+		},
+		{
+			name: "VPC subnet supplied, without vpcName",
+			edits: editFunctions{
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCSubnets = []string{validVPCSubnet}
+				},
+			},
+			errorMsg: `VPC.vpcSubnets: Invalid value: "null": invalid without vpcName`,
+		},
+		{
+			name: "VPC found, but not subnet",
+			edits: editFunctions{
+				setValidVPCName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCSubnets = []string{invalidVPCSubnet}
+				},
+			},
+			errorMsg: "VPC.vpcSubnets: Internal error",
+		},
+		{
+			name: "VPC found, subnet found as well, but not attached to the VPC",
+			edits: editFunctions{
+				setValidVPCName,
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCSubnets = []string{wrongVPCSubnet}
+				},
+			},
+			errorMsg: `VPC.vpcSubnets: Invalid value: "null": not attached to VPC`,
+		},
+		{
+			name: "region specified, VPC found, subnet found, and properly attached",
+			edits: editFunctions{
+				setValidVPCName,
+				setValidVPCRegion,
+				func(ic *types.InstallConfig) {
+					ic.Platform.PowerVS.VPCSubnets = []string{validVPCSubnet}
+				},
+			},
+			errorMsg: "",
+		},
+	}
+	setMockEnvVars()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	powervsClient := mock.NewMockAPI(mockCtrl)
+
+	// Mocks: invalid VPC region only
+	// nothing to mock
+
+	// Mocks: valid VPC region only
+	// nothing to mock
+
+	// Mocks: invalid VPC name results in error
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+
+	// Mocks: valid VPC name only, no issues
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+
+	// Mocks: valid VPC name, invalid VPC region
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), invalidVPCRegion).Return(nil, fmt.Errorf("unknown region"))
+
+	// Mocks: valid VPC name, valid VPC region, all good
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+
+	// Mocks: subnet specified, without vpcName, invalid
+	// nothing to mock
+
+	// Mocks: valid VPC name, but Subnet not found
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+	powervsClient.EXPECT().GetSubnetByName(gomock.Any(), invalidVPCSubnet, validVPCRegion).Return(nil, fmt.Errorf(""))
+
+	// Mocks: valid VPC name, but wrong Subnet (present, but not attached)
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+	powervsClient.EXPECT().GetSubnetByName(gomock.Any(), wrongVPCSubnet, validVPCRegion).Return(wrongSubnet, nil)
+
+	// Mocks: region specified, valid VPC, valid region, valid Subnet, all good
+	powervsClient.EXPECT().GetVPCs(gomock.Any(), validVPCRegion).Return(validVPCs, nil)
+	powervsClient.EXPECT().GetSubnetByName(gomock.Any(), validVPCSubnet, validVPCRegion).Return(validSubnet, nil)
+
+	// Run tests
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			editedInstallConfig := validInstallConfig()
+			for _, edit := range tc.edits {
+				edit(editedInstallConfig)
+			}
+
+			aggregatedErrors := powervs.ValidateCustomVPCSetup(powervsClient, editedInstallConfig)
 			if tc.errorMsg != "" {
 				assert.Regexp(t, tc.errorMsg, aggregatedErrors)
 			} else {

--- a/pkg/asset/manifests/cloudproviderconfig.go
+++ b/pkg/asset/manifests/cloudproviderconfig.go
@@ -250,7 +250,11 @@ func (cpc *CloudProviderConfig) Generate(dependencies asset.Parents) error {
 			return err
 		}
 
-		if vpcRegion, err = powervstypes.VPCRegionForPowerVSRegion(installConfig.Config.PowerVS.Region); err != nil {
+		vpcRegion = installConfig.Config.PowerVS.VPCRegion
+		if vpcRegion == "" {
+			vpcRegion, err = powervstypes.VPCRegionForPowerVSRegion(installConfig.Config.PowerVS.Region)
+		}
+		if err != nil {
 			return err
 		}
 

--- a/pkg/tfvars/powervs/powervs.go
+++ b/pkg/tfvars/powervs/powervs.go
@@ -4,15 +4,13 @@ package powervs
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strings"
-	"time"
 
 	"github.com/IBM-Cloud/bluemix-go/crn"
 
 	machinev1 "github.com/openshift/api/machine/v1"
 	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/powervs"
+	powervstypes "github.com/openshift/installer/pkg/types/powervs"
 )
 
 type config struct {
@@ -23,6 +21,7 @@ type config struct {
 	PowerVSZone          string `json:"powervs_zone"`
 	VPCRegion            string `json:"powervs_vpc_region"`
 	VPCZone              string `json:"powervs_vpc_zone"`
+	COSRegion            string `json:"powervs_cos_region"`
 	PowerVSResourceGroup string `json:"powervs_resource_group"`
 	CISInstanceCRN       string `json:"powervs_cis_crn"`
 	DNSInstanceGUID      string `json:"powervs_dns_guid"`
@@ -59,6 +58,8 @@ type TFVarsSources struct {
 	CloudConnectionName  string
 	CISInstanceCRN       string
 	DNSInstanceCRN       string
+	VPCRegion            string
+	VPCZone              string
 	VPCName              string
 	VPCSubnetName        string
 	VPCPermitted         bool
@@ -71,14 +72,11 @@ type TFVarsSources struct {
 // TFVars generates Power VS-specific Terraform variables launching the cluster.
 func TFVars(sources TFVarsSources) ([]byte, error) {
 	masterConfig := sources.MasterConfigs[0]
-	// TODO(mjturek): Allow user to specify vpcRegion in install config like we're doing for vpcZone
-	vpcRegion := powervs.Regions[sources.Region].VPCRegion
 
-	// Randomly select a zone in the VPC region.
-	// @TODO: Align this with a region later.
-	rand.Seed(time.Now().UnixNano())
-	// All supported Regions are MZRs and have Zones named "region-[1-3]"
-	vpcZone := fmt.Sprintf("%s-%d", vpcRegion, rand.Intn(2)+1)
+	cosRegion, err := powervstypes.VPCRegionForPowerVSRegion(sources.Region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find COS region for PowerVS region")
+	}
 
 	var serviceInstanceID, processor, dnsGUID string
 	if masterConfig.ServiceInstance.ID != nil {
@@ -108,8 +106,9 @@ func TFVars(sources TFVarsSources) ([]byte, error) {
 		SSHKey:               sources.SSHKey,
 		PowerVSRegion:        sources.Region,
 		PowerVSZone:          sources.Zone,
-		VPCRegion:            vpcRegion,
-		VPCZone:              vpcZone,
+		VPCRegion:            sources.VPCRegion,
+		VPCZone:              sources.VPCZone,
+		COSRegion:            cosRegion,
 		PowerVSResourceGroup: sources.PowerVSResourceGroup,
 		CISInstanceCRN:       sources.CISInstanceCRN,
 		DNSInstanceGUID:      dnsGUID,

--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -97,3 +97,15 @@ func RegionShortNames() []string {
 	}
 	return keys
 }
+
+// ValidateVPCRegion validates that given VPC region is known/tested.
+func ValidateVPCRegion(region string) bool {
+	found := false
+	for r := range Regions {
+		if region == Regions[r].VPCRegion {
+			found = true
+			break
+		}
+	}
+	return found
+}


### PR DESCRIPTION
This change would allow users to specify which region to create a new or locate an existing VPC instance and its subnet. With this, users would no longer be tied to the installer-picked region for VPC resources that is hardcoded to be close to the PowerVS region, essentially allowing reuse of an existing VPC infrastructure the user always has, regardless of where the PowerVS instance is located.

The relevant params for VPC resources in question are; 1) `vpcRegion`, 2) `vpcName`, and 3) `vpcSubnets`.

Whether `publish: External` (default) or `publish: Internal`, when `vpcRegion` is specified, the VPC instance the installer works with will be in that region. If `vpcName` is specified additionally, a VPC instance with that name has to be found in that region. If not, one will be created in that region. 

If `vpcSubnets` is specified additionally, the subnet must be found in and attached to the VPC specified by `vpcName`. Custom `vpcSubnets` without `vpcName` will not be supported and thus error outcl. 

If `vpcName` is provided without `vpcRegion`, the VPC by the name will be searched in the nearby region of the PowerVS region, and would be accepted/reused if found, error out otherwise.

The `validation[_test].go` changes would validate all these combos of `vpc*` params.

Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>