### PR TITLE
OCPBUGS-1769: Check for AWS STS installation before trying to get all IAM Roles

### DIFF
--- a/pkg/destroy/aws/iamhelpers.go
+++ b/pkg/destroy/aws/iamhelpers.go
@@ -13,6 +13,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+const (
+	ErrCodeAccessDeniedException = "AccessDeniedException"
+)
+
 type iamRoleSearch struct {
 	client    *iam.IAM
 	filters   []Filter
@@ -39,13 +43,21 @@ func (search *iamRoleSearch) find(ctx context.Context) (arns []string, names []s
 				// Unfortunately role.Tags is empty from ListRoles, so we need to query each one
 				response, err := search.client.GetRoleWithContext(ctx, &iam.GetRoleInput{RoleName: role.RoleName})
 				if err != nil {
-					if err.(awserr.Error).Code() == iam.ErrCodeNoSuchEntityException {
-						search.unmatched[*role.Arn] = exists
-					} else {
-						if lastError != nil {
-							search.logger.Debug(lastError)
+					var awsErr awserr.Error
+					if errors.As(err, &awsErr) {
+						switch awsErr.Code() {
+						case ErrCodeAccessDeniedException, iam.ErrCodeNoSuchEntityException:
+							// Installer does not have access to this IAM role or the
+							// the role does not exist.
+							// Ignore this IAM Role and donot report this error via
+							// lastError
+							search.unmatched[*role.Arn] = exists
+						default:
+							if lastError != nil {
+								search.logger.Debug(lastError)
+							}
+							lastError = errors.Wrapf(err, "get tags for %s", *role.Arn)
 						}
-						lastError = errors.Wrapf(err, "get tags for %s", *role.Arn)
 					}
 				} else {
 					role = response.Role


### PR DESCRIPTION
In the AWS cluster destroy/uninstall path, the Installer tries to find all the IAM Roles in the cluster and then attempts to delete the resources with the tag `kubernetes.io/cluster/<cluster-name>`. In the case of STS clusters, all IAM Roles are cleared outside the cluster (not by the Installer) and even trying to find them in the cluster results in errors because the Installer does not have the privileges to do that, let alone deleting them.

The goal of the fix is not attempt to delete these IAM Roles that Installer does not have access to. 
