### PR TITLE
OCPBUGS-11721:  Enable cluster destroy in AWS us-iso and us-isob regions

### DIFF
--- a/pkg/destroy/aws/aws.go
+++ b/pkg/destroy/aws/aws.go
@@ -28,7 +28,6 @@ import (
 	awssession "github.com/openshift/installer/pkg/asset/installconfig/aws"
 	"github.com/openshift/installer/pkg/destroy/providers"
 	"github.com/openshift/installer/pkg/types"
-	awstypes "github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/version"
 )
 
@@ -96,9 +95,6 @@ func New(logger logrus.FieldLogger, metadata *types.ClusterMetadata) (providers.
 func (o *ClusterUninstaller) validate() error {
 	if len(o.Filters) == 0 {
 		return errors.Errorf("you must specify at least one tag filter")
-	}
-	if r := o.Region; awstypes.IsSecretRegion(r) {
-		return errors.Errorf("cannot destroy cluster in region %q", r)
 	}
 	return nil
 }


### PR DESCRIPTION
Remove the block on cluster destroy in the us-iso and us-isob regions now that the AWS tagging API has been GA'd by AWS for these regions. I have built the openshift-installer code base with these changes and tested them in both the us-iso and us-isob regions. With these changes, cluster destroy works in these regions as expected of any other AWS region.