### PR TITLE
GCP: Tfvars will determine the user has create firewall permissions

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2201,14 +2201,6 @@ spec:
                       control plane will be deployed. The value should be the name
                       of the subnet.
                     type: string
-                  createFirewallRules:
-                    description: CreateFirewallRules is currently TechPreview. CreateFirewallRules
-                      specifies if the installer should create the cluster firewall
-                      rules in the gcp cloud network.
-                    enum:
-                    - Enabled
-                    - Disabled
-                    type: string
                   defaultMachinePlatform:
                     description: DefaultMachinePlatform is the default configuration
                       used when installing on GCP for machine pools which do not define

--- a/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
+++ b/pkg/asset/installconfig/gcp/mock/gcpclient_generated.go
@@ -12,6 +12,7 @@ import (
 	google "golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
 	dns "google.golang.org/api/dns/v1"
+	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MockAPI is a mock of API interface.
@@ -109,6 +110,21 @@ func (m *MockAPI) GetNetwork(ctx context.Context, network, project string) (*com
 func (mr *MockAPIMockRecorder) GetNetwork(ctx, network, project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetwork", reflect.TypeOf((*MockAPI)(nil).GetNetwork), ctx, network, project)
+}
+
+// GetProjectPermissions mocks base method.
+func (m *MockAPI) GetProjectPermissions(ctx context.Context, project string, permissions []string) (sets.String, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProjectPermissions", ctx, project, permissions)
+	ret0, _ := ret[0].(sets.String)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProjectPermissions indicates an expected call of GetProjectPermissions.
+func (mr *MockAPIMockRecorder) GetProjectPermissions(ctx, project, permissions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectPermissions", reflect.TypeOf((*MockAPI)(nil).GetProjectPermissions), ctx, project, permissions)
 }
 
 // GetProjects mocks base method.
@@ -214,4 +230,19 @@ func (m *MockAPI) GetZones(ctx context.Context, project, filter string) ([]*comp
 func (mr *MockAPIMockRecorder) GetZones(ctx, project, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetZones", reflect.TypeOf((*MockAPI)(nil).GetZones), ctx, project, filter)
+}
+
+// ValidateServiceAccountHasPermissions mocks base method.
+func (m *MockAPI) ValidateServiceAccountHasPermissions(ctx context.Context, project string, permissions []string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateServiceAccountHasPermissions", ctx, project, permissions)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateServiceAccountHasPermissions indicates an expected call of ValidateServiceAccountHasPermissions.
+func (mr *MockAPIMockRecorder) ValidateServiceAccountHasPermissions(ctx, project, permissions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateServiceAccountHasPermissions", reflect.TypeOf((*MockAPI)(nil).ValidateServiceAccountHasPermissions), ctx, project, permissions)
 }

--- a/pkg/asset/installconfig/vsphere/mock/authmanager_generated.go
+++ b/pkg/asset/installconfig/vsphere/mock/authmanager_generated.go
@@ -77,3 +77,41 @@ func (mr *MockAuthManagerMockRecorder) Reference() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reference", reflect.TypeOf((*MockAuthManager)(nil).Reference))
 }
+
+// MockSessionManager is a mock of SessionManager interface.
+type MockSessionManager struct {
+	ctrl     *gomock.Controller
+	recorder *MockSessionManagerMockRecorder
+}
+
+// MockSessionManagerMockRecorder is the mock recorder for MockSessionManager.
+type MockSessionManagerMockRecorder struct {
+	mock *MockSessionManager
+}
+
+// NewMockSessionManager creates a new mock instance.
+func NewMockSessionManager(ctrl *gomock.Controller) *MockSessionManager {
+	mock := &MockSessionManager{ctrl: ctrl}
+	mock.recorder = &MockSessionManagerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSessionManager) EXPECT() *MockSessionManagerMockRecorder {
+	return m.recorder
+}
+
+// UserSession mocks base method.
+func (m *MockSessionManager) UserSession(ctx context.Context) (*types.UserSession, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UserSession", ctx)
+	ret0, _ := ret[0].(*types.UserSession)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UserSession indicates an expected call of UserSession.
+func (mr *MockSessionManagerMockRecorder) UserSession(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserSession", reflect.TypeOf((*MockSessionManager)(nil).UserSession), ctx)
+}

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -1,16 +1,5 @@
 package gcp
 
-// CreateFirewallRules specifies if the installer should create firewall rules.
-// +kubebuilder:validation:Enum="Enabled";"Disabled"
-type CreateFirewallRules string
-
-const (
-	// CreateFirewallRulesEnabled is Enabled
-	CreateFirewallRulesEnabled CreateFirewallRules = "Enabled"
-	// CreateFirewallRulesDisabled is Disabled
-	CreateFirewallRulesDisabled CreateFirewallRules = "Disabled"
-)
-
 // DNSZone stores the information common and required to create DNS zones including
 // the project and id/name of the zone.
 type DNSZone struct {
@@ -34,12 +23,6 @@ type Platform struct {
 
 	// Region specifies the GCP region where the cluster will be created.
 	Region string `json:"region"`
-
-	// CreateFirewallRules is currently TechPreview.
-	// CreateFirewallRules specifies if the installer should create the
-	// cluster firewall rules in the gcp cloud network.
-	// +optional
-	CreateFirewallRules CreateFirewallRules `json:"createFirewallRules,omitempty"`
 
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on GCP for machine pools which do not define their own

--- a/pkg/types/gcp/validation/platform.go
+++ b/pkg/types/gcp/validation/platform.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"sort"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/types"
@@ -91,13 +90,6 @@ func ValidatePlatform(p *gcp.Platform, fldPath *field.Path, ic *types.InstallCon
 		}
 		if p.ControlPlaneSubnet == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("controlPlaneSubnet"), "must provide a control plane subnet when a network is specified"))
-		}
-	}
-
-	if p.CreateFirewallRules != "" {
-		validCreateFirewallRules := sets.NewString(string(gcp.CreateFirewallRulesEnabled), string(gcp.CreateFirewallRulesDisabled))
-		if !validCreateFirewallRules.Has(string(p.CreateFirewallRules)) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("createFirewallRules"), p.CreateFirewallRules, validCreateFirewallRules.List()))
 		}
 	}
 

--- a/pkg/types/gcp/validation/platform_test.go
+++ b/pkg/types/gcp/validation/platform_test.go
@@ -153,30 +153,6 @@ func TestValidatePlatform(t *testing.T) {
 			valid:           false,
 		},
 		{
-			name: "Valid CreateFirewallRules: Enabled",
-			platform: &gcp.Platform{
-				CreateFirewallRules: "Enabled",
-				Region:              "us-east1",
-			},
-			valid: true,
-		},
-		{
-			name: "Valid CreateFirewallRules: Disabled",
-			platform: &gcp.Platform{
-				CreateFirewallRules: "Disabled",
-				Region:              "us-east1",
-			},
-			valid: true,
-		},
-		{
-			name: "Invalid CreateFirewallRules",
-			platform: &gcp.Platform{
-				CreateFirewallRules: "invalid",
-				Region:              "us-east1",
-			},
-			valid: false,
-		},
-		{
 			name: "GCP invalid private dns zone",
 			platform: &gcp.Platform{
 				Region:             "us-east1",

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1003,10 +1003,6 @@ func validateFeatureSet(c *types.InstallConfig) field.ErrorList {
 				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "networkProjectID"), errMsg))
 			}
 
-			if len(c.GCP.CreateFirewallRules) > 0 && c.GCP.CreateFirewallRules != gcp.CreateFirewallRulesEnabled {
-				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "createFirewallRules"), errMsg))
-			}
-
 			if c.GCP.PrivateDNSZone != nil && len(c.GCP.PrivateDNSZone.ProjectID) > 0 {
 				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "privateDNSZone", "projectID"), errMsg))
 			}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2003,19 +2003,6 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: "platform.vsphere.apiVIPs: Required value: must specify VIP for API, when VIP for ingress is set",
 		},
 		{
-			name: "GCP Create Firewall Rules should return error if used WITHOUT tech preview when not enabled",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Platform = types.Platform{
-					GCP: validGCPPlatform(),
-				}
-				c.GCP.CreateFirewallRules = gcp.CreateFirewallRulesDisabled
-
-				return c
-			}(),
-			expectedError: "platform.gcp.createFirewallRules: Forbidden: the TechPreviewNoUpgrade feature set must be enabled to use this field",
-		},
-		{
 			name: "GCP BYO PUBLIC DNS SHOULD return error if used WITHOUT tech preview",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
** Create Firewall permissions option is removed from the install config. The terraform vars checks the user permissions in the project to determine if the user can create firewall rules. If the user does not have permissions to create firewall rules then the firewall rules are skipped.