### PR TITLE
[release-4.11] OCPBUGS-4405: UPI: Azure: create HyperV2 rhcos image

### DIFF
--- a/upi/azure/02_storage.json
+++ b/upi/azure/02_storage.json
@@ -18,7 +18,8 @@
   },
   "variables" : {
     "location" : "[resourceGroup().location]",
-    "imageName" : "[concat(parameters('baseName'), '-image')]"
+    "imageName" : "[concat(parameters('baseName'), '-image')]",
+    "imageNameGen2" : "[concat(parameters('baseName'), '-gen2')]"
   },
   "resources" : [
     {
@@ -27,6 +28,23 @@
       "name": "[variables('imageName')]",
       "location" : "[variables('location')]",
       "properties": {
+        "storageProfile": {
+          "osDisk": {
+            "osType": "Linux",
+            "osState": "Generalized",
+            "blobUri": "[parameters('vhdBlobURL')]",
+            "storageAccountType": "Standard_LRS"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2020-12-01",
+      "type": "Microsoft.Compute/images",
+      "name": "[variables('imageNameGen2')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "hyperVGeneration": "V2",
         "storageProfile": {
           "osDisk": {
             "osType": "Linux",


### PR DESCRIPTION
Since HyperV support has been added to the installer, it now prefers the HyperV gen2 whenever the VM type selected supports it. This means that we need to upload both gen1 and gen2 RHCOS images to the storage account when doing UPI with MAO to avoid errors like:

```
5h2m Warning FailedCreate machine/$cluster_id-worker-northeurope1-f6kc4 InvalidConfiguration: failed to reconcile machine "$cluster_id-worker-northeurope1-f6kc4": failed to create vm $cluster_id-worker-northeurope1-f6kc4: failure sending request for machine $cluster_id-worker-northeurope1-f6kc4: cannot create vm: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=404 - Original Error: Code="NotFound" Message="The Image '/subscriptions/$sub_id/resourceGroups/$rgroup-rg/providers/Microsoft.Compute/images/$cluster_id-gen2' cannot be found in 'northeurope' region."
```