### PR TITLE
OCPBUGS-4654: azure: upi: use Image Gallery in ARM templates

### DIFF
--- a/upi/azure/02_storage.json
+++ b/upi/azure/02_storage.json
@@ -1,41 +1,153 @@
 {
-  "$schema" : "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  "contentVersion" : "1.0.0.0",
-  "parameters" : {
-    "baseName" : {
-      "type" : "string",
-      "minLength" : 1,
-      "metadata" : {
-        "description" : "Base name to be used in resource names (usually the cluster's Infra ID)"
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "architecture": {
+      "type": "string",
+      "metadata": {
+        "description": "The architecture of the Virtual Machines"
+      },
+      "defaultValue": "x64",
+      "allowedValues": [
+        "Arm64",
+        "x64"
+      ]
+    },
+    "baseName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Base name to be used in resource names (usually the cluster's Infra ID)"
       }
     },
-    "vhdBlobURL" : {
-      "type" : "string",
-      "metadata" : {
-        "description" : "URL pointing to the blob where the VHD to be used to create master and worker machines is located"
+    "storageAccount": {
+      "type": "string",
+      "metadata": {
+        "description": "The Storage Account name"
+      }
+    },
+    "vhdBlobURL": {
+      "type": "string",
+      "metadata": {
+        "description": "URL pointing to the blob where the VHD to be used to create master and worker machines is located"
       }
     }
   },
-  "variables" : {
-    "location" : "[resourceGroup().location]",
-    "imageName" : "[concat(parameters('baseName'), '-image')]"
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
+    "imageName": "[parameters('baseName')]",
+    "imageNameGen2": "[concat(parameters('baseName'), '-gen2')]",
+    "imageRelease": "1.0.0"
   },
-  "resources" : [
+  "resources": [
     {
-      "apiVersion" : "2018-06-01",
-      "type": "Microsoft.Compute/images",
-      "name": "[variables('imageName')]",
-      "location" : "[variables('location')]",
-      "properties": {
-        "storageProfile": {
-          "osDisk": {
-            "osType": "Linux",
+      "apiVersion": "2021-10-01",
+      "type": "Microsoft.Compute/galleries",
+      "name": "[variables('galleryName')]",
+      "location": "[variables('location')]",
+      "resources": [
+        {
+          "apiVersion": "2021-10-01",
+          "type": "images",
+          "name": "[variables('imageName')]",
+          "location": "[variables('location')]",
+          "dependsOn": [
+            "[variables('galleryName')]"
+          ],
+          "properties": {
+            "architecture": "[parameters('architecture')]",
+            "hyperVGeneration": "V1",
+            "identifier": {
+              "offer": "rhcos",
+              "publisher": "RedHat",
+              "sku": "basic"
+            },
             "osState": "Generalized",
-            "blobUri": "[parameters('vhdBlobURL')]",
-            "storageAccountType": "Standard_LRS"
-          }
+            "osType": "Linux"
+          },
+          "resources": [
+            {
+              "apiVersion": "2021-10-01",
+              "type": "versions",
+              "name": "[variables('imageRelease')]",
+              "location": "[variables('location')]",
+              "dependsOn": [
+                "[variables('imageName')]"
+              ],
+              "properties": {
+                "publishingProfile": {
+                  "storageAccountType": "Standard_LRS",
+                  "targetRegions": [
+                    {
+                      "name": "[variables('location')]",
+                      "regionalReplicaCount": "1"
+                    }
+                  ]
+                },
+                "storageProfile": {
+                  "osDiskImage": {
+                    "source": {
+                      "id": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
+                      "uri": "[parameters('vhdBlobURL')]"
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "apiVersion": "2021-10-01",
+          "type": "images",
+          "name": "[variables('imageNameGen2')]",
+          "location": "[variables('location')]",
+          "dependsOn": [
+            "[variables('galleryName')]"
+          ],
+          "properties": {
+            "architecture": "[parameters('architecture')]",
+            "hyperVGeneration": "V2",
+            "identifier": {
+              "offer": "rhcos-gen2",
+              "publisher": "RedHat-gen2",
+              "sku": "gen2"
+            },
+            "osState": "Generalized",
+            "osType": "Linux"
+          },
+          "resources": [
+            {
+              "apiVersion": "2021-10-01",
+              "type": "versions",
+              "name": "[variables('imageRelease')]",
+              "location": "[variables('location')]",
+              "dependsOn": [
+                "[variables('imageNameGen2')]"
+              ],
+              "properties": {
+                "publishingProfile": {
+                  "storageAccountType": "Standard_LRS",
+                  "targetRegions": [
+                    {
+                      "name": "[variables('location')]",
+                      "regionalReplicaCount": "1"
+                    }
+                  ]
+                },
+                "storageProfile": {
+                  "osDiskImage": {
+                    "source": {
+                      "id": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccount'))]",
+                      "uri": "[parameters('vhdBlobURL')]"
+                    }
+                  }
+                }
+              }
+            }
+          ]
         }
-      }
+      ]
     }
   ]
 }

--- a/upi/azure/04_bootstrap.json
+++ b/upi/azure/04_bootstrap.json
@@ -36,6 +36,17 @@
       "metadata" : {
         "description" : "The size of the Bootstrap Virtual Machine"
       }
+    },
+    "hyperVGen": {
+      "type": "string",
+      "metadata": {
+        "description": "VM generation image to use"
+      },
+      "defaultValue": "V2",
+      "allowedValues": [
+        "V1",
+        "V2"
+      ]
     }
   },
   "variables" : {
@@ -51,7 +62,7 @@
     "vmName" : "[concat(parameters('baseName'), '-bootstrap')]",
     "nicName" : "[concat(variables('vmName'), '-nic')]",
     "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
-    "imageName" : "[parameters('baseName')]",
+    "imageName" : "[concat(parameters('baseName'), if(equals(parameters('hyperVGen'), 'V2'), '-gen2', ''))]",
     "clusterNsgName" : "[concat(if(not(empty(parameters('vnetBaseName'))), parameters('vnetBaseName'), parameters('baseName')), '-nsg')]",
     "sshPublicIpAddressName" : "[concat(variables('vmName'), '-ssh-pip')]"
   },

--- a/upi/azure/04_bootstrap.json
+++ b/upi/azure/04_bootstrap.json
@@ -50,7 +50,8 @@
     "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "vmName" : "[concat(parameters('baseName'), '-bootstrap')]",
     "nicName" : "[concat(variables('vmName'), '-nic')]",
-    "imageName" : "[concat(parameters('baseName'), '-image')]",
+    "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
+    "imageName" : "[parameters('baseName')]",
     "clusterNsgName" : "[concat(if(not(empty(parameters('vnetBaseName'))), parameters('vnetBaseName'), parameters('baseName')), '-nsg')]",
     "sshPublicIpAddressName" : "[concat(variables('vmName'), '-ssh-pip')]"
   },
@@ -132,7 +133,7 @@
         },
         "storageProfile" : {
           "imageReference": {
-            "id": "[resourceId('Microsoft.Compute/images', variables('imageName'))]"
+            "id": "[resourceId('Microsoft.Compute/galleries/images', variables('galleryName'), variables('imageName'))]"
           },
           "osDisk" : {
             "name": "[concat(variables('vmName'),'_OSDisk')]",

--- a/upi/azure/05_masters.json
+++ b/upi/azure/05_masters.json
@@ -58,6 +58,17 @@
       "metadata" : {
         "description" : "Size of the Master VM OS disk, in GB"
       }
+    },
+    "hyperVGen": {
+      "type": "string",
+      "metadata": {
+        "description": "VM generation image to use"
+      },
+      "defaultValue": "V2",
+      "allowedValues": [
+        "V1",
+        "V2"
+      ]
     }
   },
   "variables" : {
@@ -71,7 +82,7 @@
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
     "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
-    "imageName" : "[parameters('baseName')]",
+    "imageName" : "[concat(parameters('baseName'), if(equals(parameters('hyperVGen'), 'V2'), '-gen2', ''))]",
     "copy" : [
       {
         "name" : "vmNames",

--- a/upi/azure/05_masters.json
+++ b/upi/azure/05_masters.json
@@ -70,7 +70,8 @@
     "internalLoadBalancerName" : "[concat(parameters('baseName'), '-internal-lb')]",
     "sshKeyPath" : "/home/core/.ssh/authorized_keys",
     "identityName" : "[concat(parameters('baseName'), '-identity')]",
-    "imageName" : "[concat(parameters('baseName'), '-image')]",
+    "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
+    "imageName" : "[parameters('baseName')]",
     "copy" : [
       {
         "name" : "vmNames",
@@ -144,7 +145,7 @@
         },
         "storageProfile" : {
           "imageReference": {
-            "id": "[resourceId('Microsoft.Compute/images', variables('imageName'))]"
+            "id": "[resourceId('Microsoft.Compute/galleries/images', variables('galleryName'), variables('imageName'))]"
           },
           "osDisk" : {
             "name": "[concat(variables('vmNames')[copyIndex()], '_OSDisk')]",

--- a/upi/azure/06_workers.json
+++ b/upi/azure/06_workers.json
@@ -55,7 +55,8 @@
     "infraLoadBalancerName" : "[parameters('baseName')]",
     "sshKeyPath" : "/home/capi/.ssh/authorized_keys",
     "identityName" : "[concat(parameters('baseName'), '-identity')]",
-    "imageName" : "[concat(parameters('baseName'), '-image')]",
+    "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
+    "imageName" : "[parameters('baseName')]",
     "copy" : [
       {
         "name" : "vmNames",
@@ -130,7 +131,7 @@
                 },
                 "storageProfile" : {
                   "imageReference": {
-                    "id": "[resourceId('Microsoft.Compute/images', variables('imageName'))]"
+                    "id": "[resourceId('Microsoft.Compute/galleries/images', variables('galleryName'), variables('imageName'))]"
                   },
                   "osDisk" : {
                     "name": "[concat(variables('vmNames')[copyIndex()],'_OSDisk')]",

--- a/upi/azure/06_workers.json
+++ b/upi/azure/06_workers.json
@@ -44,6 +44,17 @@
       "metadata" : {
         "description" : "The size of the each Node Virtual Machine"
       }
+    },
+    "hyperVGen": {
+      "type": "string",
+      "metadata": {
+        "description": "VM generation image to use"
+      },
+      "defaultValue": "V2",
+      "allowedValues": [
+        "V1",
+        "V2"
+      ]
     }
   },
   "variables" : {
@@ -56,7 +67,7 @@
     "sshKeyPath" : "/home/capi/.ssh/authorized_keys",
     "identityName" : "[concat(parameters('baseName'), '-identity')]",
     "galleryName": "[concat('gallery_', replace(parameters('baseName'), '-', '_'))]",
-    "imageName" : "[parameters('baseName')]",
+    "imageName" : "[concat(parameters('baseName'), if(equals(parameters('hyperVGen'), 'V2'), '-gen2', ''))]",
     "copy" : [
       {
         "name" : "vmNames",


### PR DESCRIPTION
When we moved to using Image Galleries in Azure/IPI, we also changed the
location that MAO uses for the rhcos bootimages. These changes update
our ARM templates so that the bootimages are picked from the right
location. It fixes the following error when scaling compute nodes:

```
Error Message: failed to reconcile machine "maxu-upi2-gc7n8-worker-eastus3-68gdx": failed to create vm maxu-upi2-gc7n8-worker-eastus3-68gdx: failure sending request for machine maxu-upi2-gc7n8-worker-eastus3-68gdx: cannot create vm: compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=404 -- Original Error: Code="GalleryImageNotFound" Message=""The gallery image /subscriptions/$sub_id/resourceGroups/$resource_group/providers/Microsoft.Compute/galleries/$gallery_name/images/maxu-upi2-gc7n8-gen2/versions/412.86.20220930 is not available in eastus region. Please contact image owner to replicate to this region, or change your requested region."" Target="imageReference"
```

It is also one step closer to getting Azure UPI for aarch64.