### PR TITLE
OCPBUGS-7356: data/manifests/bootkube/cvo-overrides: Default to stable-4.13

### DIFF
--- a/data/data/manifests/bootkube/cvo-overrides.yaml.template
+++ b/data/data/manifests/bootkube/cvo-overrides.yaml.template
@@ -11,7 +11,7 @@ spec:
   upstream: https://amd64.origin.releases.ci.openshift.org/graph
   channel: stable-scos-4
 {{- else }}
-  channel: stable-4.12
+  channel: stable-4.13
 {{- end }}
   clusterID: {{.CVOClusterID}}
 {{- if .CVOCapabilities }}


### PR DESCRIPTION
Following up on 4.12's 35023b3804 (#6302), 4.11's f995341c32 (#5621), and similar.