### PR TITLE
Switch back to gp2 ebs volume type for bootstrap instance

### DIFF
--- a/data/data/aws/bootstrap/main.tf
+++ b/data/data/aws/bootstrap/main.tf
@@ -8,7 +8,7 @@ locals {
   description = "Created By OpenShift Installer"
 
   public_endpoints = var.aws_publish_strategy == "External" ? true : false
-  volume_type      = "gp3"
+  volume_type      = "gp2"
   volume_size      = 30
   volume_iops      = local.volume_type == "io1" ? 100 : 0
 
@@ -240,4 +240,3 @@ resource "aws_security_group_rule" "bootstrap_journald_gateway" {
   from_port   = 19531
   to_port     = 19531
 }
-


### PR DESCRIPTION
PR #5239 switched the default EBS volume type from gp2 to gp3. But in doing so, this breaks support for AWS regions which do not have gp3 (e.g. us-iso-east-1, us-isob-east-1). While it's possible to set the EBS volume type in the install-config for control plane and compute nodes, the bootstrap instance is hardcoded in the terraform.

Since the bootstrap instance is a short lived instance, doesn't require large amounts of iops, and will be destroyed after cluster bootstrapping, switch it back to gp2.