### PR TITLE
OCPBUGS-4809: Azure: toggle image in machinesets

### DIFF
--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -120,7 +120,11 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 		imageID := fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s/versions/latest", rg, galleryName, id)
 		image.ResourceID = imageID
 	} else {
-		image.ResourceID = fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/images/%s", rg, clusterID)
+		imageID := fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/images/%s", rg, clusterID)
+		if hyperVGen == "V2" && platform.CloudName != azure.StackCloud {
+			imageID += "-gen2"
+		}
+		image.ResourceID = imageID
 	}
 
 	networkResourceGroup, virtualNetwork, subnet, err := getNetworkInfo(platform, clusterID, role)

--- a/pkg/asset/machines/azure/machinesets.go
+++ b/pkg/asset/machines/azure/machinesets.go
@@ -41,7 +41,8 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 		if int64(idx) < total%numOfAZs {
 			replicas++
 		}
-		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx, capabilities, rhcosVersion)
+		useImageGallery := platform.CloudName != azure.StackCloud
+		provider, err := provider(platform, mpool, osImage, userDataSecret, clusterID, role, &idx, capabilities, useImageGallery)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create provider")
 		}

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -137,7 +137,6 @@ func (m *Master) Dependencies() []asset.Asset {
 		&installconfig.PlatformCredsCheck{},
 		&installconfig.InstallConfig{},
 		new(rhcos.Image),
-		new(rhcos.Release),
 		&machine.Master{},
 	}
 }
@@ -148,9 +147,8 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	clusterID := &installconfig.ClusterID{}
 	installConfig := &installconfig.InstallConfig{}
 	rhcosImage := new(rhcos.Image)
-	rhcosRelease := new(rhcos.Release)
 	mign := &machine.Master{}
-	dependencies.Get(clusterID, installConfig, rhcosImage, rhcosRelease, mign)
+	dependencies.Get(clusterID, installConfig, rhcosImage, mign)
 
 	masterUserDataSecretName := "master-user-data"
 
@@ -369,8 +367,9 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return err
 		}
+		useImageGallery := installConfig.Azure.CloudName != azuretypes.StackCloud
 
-		machines, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, capabilities, rhcosRelease.GetAzureReleaseVersion())
+		machines, err = azure.Machines(clusterID.InfraID, ic, &pool, string(*rhcosImage), "master", masterUserDataSecretName, capabilities, useImageGallery)
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}


### PR DESCRIPTION
Hive vendors the installer and uses the asset package to generate machinesets for scaleup. Because Hive is using the latest code version but installing multiple previous versions, the machinesets--particularly the values--need to be backward compatible.

In this particular case, the installer switched from using Azure managed images to image galleries in 4.12. In 4.12+ Azure machinesets expect an image referencing an image gallery, while prior to this change the machinesets looked for a managed image.

This commit updates the machineset code to allow a toggle which will allow Hive to generate Azure machinesets utilizing managed images, which should be done with 4.11 and earlier clusters.

This change also future proofs the 4.12+ by switching the machinesets to use the latest version, rather than tying them to a particular RHCOS version.