### PR TITLE
OCPBUGS-3032: Report status on the console immediately

### DIFF
--- a/data/data/agent/files/usr/local/bin/install-status.sh
+++ b/data/data/agent/files/usr/local/bin/install-status.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
+source "issue_status.sh"
+
 inactive_services() {
     local services="assisted-service.service create-cluster-and-infraenv.service apply-host-config.service start-cluster-installation.service"
     for s in ${services}; do
@@ -10,25 +13,32 @@ inactive_services() {
 }
 
 check_services() {
-    local services_issue="/etc/issue.d/70_agent-services.issue"
+    local services_issue="70_agent-services"
+    local not_started
     not_started="$(inactive_services)"
     if [ -z "${not_started}" ]; then
-        rm -f "${services_issue}"
+        if [ -f "${services_issue}" ]; then
+            rm "${services_issue}"
+            agetty --reload
+        fi
     else
         read -ra show_services <<<"${not_started}"
         {
-            printf '\\e{cyan}Waiting for services:\\e{reset}\n'
-            systemctl --no-legend list-units --all "${show_services[@]}" | awk '{printf("[\\e{cyan}%s\\e{reset}]", $4); for (i=5; i<=NF; i++) {if (i>5 || $i != "start") printf(" %s", $i)}; print ""}'
-        } >"${services_issue}"
+            printf '\\e{cyan}Waiting for services:\\e{reset}'
+            systemctl --no-legend list-units --all "${show_services[@]}" | awk '{printf("\n[\\e{cyan}%s\\e{reset}]", $4); for (i=5; i<=NF; i++) {if (i>5 || $i != "start") printf(" %s", $i)}}'
+        } | set_issue "${services_issue}"
     fi
 }
 
 check_host_config() {
-    local host_config_issue="/etc/issue.d/80_host-config.issue"
+    local host_config_issue="80_host-config"
     if [ -f /var/run/agent-installer/host-config-failures ]; then
-        printf '\n\\e{lightred}Installation cannot proceed:\\e{reset}\n%s\n' "$(cat /var/run/agent-installer/host-config-failures)" >"${host_config_issue}"
+        {
+            printf '\\e{lightred}Installation cannot proceed:\\e{reset}\n'
+            cat /var/run/agent-installer/host-config-failures
+        } | set_issue "${host_config_issue}"
     else
-        rm -f "${host_config_issue}"
+        clear_issue "${host_config_issue}"
     fi
 }
 

--- a/data/data/agent/files/usr/local/bin/install-status.sh
+++ b/data/data/agent/files/usr/local/bin/install-status.sh
@@ -25,7 +25,7 @@ check_services() {
         read -ra show_services <<<"${not_started}"
         {
             printf '\\e{cyan}Waiting for services:\\e{reset}'
-            systemctl --no-legend list-units --all "${show_services[@]}" | awk '{printf("\n[\\e{cyan}%s\\e{reset}]", $4); for (i=5; i<=NF; i++) {if (i>5 || $i != "start") printf(" %s", $i)}}'
+            systemctl --no-legend list-units --all "${show_services[@]}" | awk '{sub("dead", "not started", $4); printf("\n[\\e{cyan}%s\\e{reset}]", $4); for (i=5; i<=NF; i++) {if (i>5 || $i != "start") printf(" %s", $i)}}'
         } | set_issue "${services_issue}"
     fi
 }

--- a/data/data/agent/files/usr/local/bin/issue_status.sh
+++ b/data/data/agent/files/usr/local/bin/issue_status.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+issue_file() {
+    printf "/etc/issue.d/%s.issue" "$1"
+}
+
+set_issue() {
+    local outfile
+    outfile="$(issue_file "$1")"
+    local tmp
+    tmp="$(mktemp)"
+    {
+        printf '\n'
+        cat -
+        printf '\n'
+    } >"${tmp}"
+    if ! diff "${tmp}" "${outfile}" >/dev/null 2>&1; then
+        mv "${tmp}" "${outfile}"
+        agetty --reload
+    else
+        rm "${tmp}"
+    fi
+}
+
+clear_issue() {
+    local outfile
+    outfile="$(issue_file "$1")"
+    if [ -f "${outfile}" ]; then
+        rm "${outfile}"
+        agetty --reload
+    fi
+}

--- a/data/data/agent/files/usr/local/bin/set-node-zero.sh.template
+++ b/data/data/agent/files/usr/local/bin/set-node-zero.sh.template
@@ -42,3 +42,4 @@ fi
 mkdir -p /etc/motd.d/
 echo $rendezvousHostMessage > /etc/motd.d/60-rendezvous-host
 echo $rendezvousHostMessage > /etc/issue.d/60-rendezvous-host.issue
+agetty --reload

--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -82,9 +82,9 @@ do
                 -H 'accept: application/json' \
                 -d ''
             echo "Cluster installation started" 1>&2
-            printf '\\e{lightgreen}Cluster installation started\\e{reset}' | set_issue "${status_issue}"
-            ;;
+            ;&
         "installed" | "preparing-for-installation" | "installing")
+            printf '\\e{lightgreen}Cluster installation in progress\\e{reset}' | set_issue "${status_issue}"
             ;;
         *)
             printf '\\e{lightred}Installation cannot proceed:\\e{reset} Cluster status: %s' "${cluster_status}" | set_issue "${status_issue}"

--- a/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
+++ b/data/data/agent/files/usr/local/bin/start-cluster-installation.sh.template
@@ -2,6 +2,7 @@
 set -e
 
 source common.sh
+source issue_status.sh
 
 wait_for_assisted_service
 
@@ -27,7 +28,7 @@ echo "Number of required master nodes: ${required_master_nodes}" 1>&2
 echo "Number of required worker nodes: ${required_worker_nodes}" 1>&2
 echo "Total number of required nodes: ${total_required_nodes}" 1>&2
 
-status_issue="/etc/issue.d/90_start-install.issue"
+status_issue="90_start-install"
 
 num_known_hosts() {
     local known_hosts=0
@@ -45,7 +46,7 @@ num_known_hosts() {
         echo "Hosts known and ready for cluster installation (${known_hosts}/${total_required_nodes})" 1>&2
     fi
     if (( known_hosts != total_required_nodes )); then
-        printf '\n\\e{yellow}Waiting for all hosts to be ready:\\e{reset}\n%d hosts expected\n%d hosts ready, %d hosts not validated\n' "${total_required_nodes}" "${known_hosts}" "${insufficient_hosts}" >"${status_issue}"
+        printf '\\e{yellow}Waiting for all hosts to be ready:\\e{reset}\n%d hosts expected\n%d hosts ready, %d hosts not validated' "${total_required_nodes}" "${known_hosts}" "${insufficient_hosts}" | set_issue "${status_issue}"
     fi
     echo "${known_hosts}"
 }
@@ -57,7 +58,7 @@ do
 done
 
 echo "All ${total_required_nodes} hosts are ready." 1>&2
-rm -f "${status_issue}"
+clear_issue "${status_issue}"
 
 if [[ "${APIVIP}" != "" ]]; then
     api_vip=$(curl -s -S "${BASE_URL}/clusters" | jq -r .[].api_vip)
@@ -81,12 +82,12 @@ do
                 -H 'accept: application/json' \
                 -d ''
             echo "Cluster installation started" 1>&2
-            printf '\n\\e{lightgreen}Cluster installation started\\e{reset}\n' >"${status_issue}"
+            printf '\\e{lightgreen}Cluster installation started\\e{reset}' | set_issue "${status_issue}"
             ;;
         "installed" | "preparing-for-installation" | "installing")
             ;;
         *)
-            printf '\n\\e{lightred}Installation cannot proceed:\\e{reset} Cluster status: %s\n' "${cluster_status}" >"${status_issue}"
+            printf '\\e{lightred}Installation cannot proceed:\\e{reset} Cluster status: %s' "${cluster_status}" | set_issue "${status_issue}"
             ;;
     esac
 done

--- a/data/data/agent/systemd/units/install-status.service
+++ b/data/data/agent/systemd/units/install-status.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Service that monitors host-specific configuration status
-Wants=network-online.target apply-host-config.service
-After=network-online.target apply-host-config.service
+Wants=network-online.target create-cluster-and-infraenv.service
+After=network-online.target create-cluster-and-infraenv.service
 ConditionPathExists=/etc/assisted-service/node0
 
 [Service]

--- a/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/release-image-download.sh.template
@@ -21,10 +21,12 @@ do
     if podman pull --quiet "$RELEASE_IMAGE"
     then
         rm -f "${release_image_issue}"
+        agetty --reload
         record_service_stage_success
         break
     else
         printf '\n\\e{lightred}Unable to pull OpenShift release image\\e{reset}\n' >"${release_image_issue}"
+        agetty --reload
         record_service_stage_failure
         echo "Pull failed. Retrying $RELEASE_IMAGE..."
     fi
@@ -41,6 +43,7 @@ esac
 
 if [[ "$image_arch" != "$host_arch" ]]; then
     printf '\n\\e{lightred}Release image arch %s does not match host arch %s\\e{reset}\n' "${image_arch}" "${host_arch}" >"${release_image_issue}"
+    agetty --reload
     record_service_stage_failure
     echo "ERROR: release image arch $image_arch does not match host arch $host_arch"
     exit 1

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -392,6 +392,7 @@ metadata:
 				"/usr/local/bin/extract-agent.sh",
 				"/usr/local/bin/get-container-images.sh",
 				"/usr/local/bin/install-status.sh",
+				"/usr/local/bin/issue_status.sh",
 				"/usr/local/bin/set-hostname.sh",
 				"/usr/local/bin/start-agent.sh",
 				"/usr/local/bin/start-cluster-installation.sh",


### PR DESCRIPTION
When updating the console debug messages, don't wait for the next refresh. Issue a reload, which will cause the console to be redisplayed unless the user has already started logging in.

Improve reporting of status so that the user can see what is happening when there are host-specific configurations that cannot be applied, and so that an installation that needs user intervention will report when it has recovered.