### PR TITLE
PowerVS: Defer cancel when calling contextWithTimeout

### DIFF
--- a/pkg/destroy/powervs/cloud-instance.go
+++ b/pkg/destroy/powervs/cloud-instance.go
@@ -19,7 +19,8 @@ const (
 func (o *ClusterUninstaller) listCloudInstances() (cloudResources, error) {
 	o.Logger.Debugf("Listing virtual Cloud service instances")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	options := o.vpcSvc.NewListInstancesOptions()
 
@@ -66,7 +67,8 @@ func (o *ClusterUninstaller) destroyCloudInstance(item cloudResource) error {
 		response              *core.DetailedResponse
 	)
 
-	ctx, _ = o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	getInstanceOptions = o.vpcSvc.NewGetInstanceOptions(item.id)
 
@@ -107,7 +109,8 @@ func (o *ClusterUninstaller) destroyCloudInstances() error {
 
 	items := o.insertPendingItems(cloudInstanceTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/cloud-sshkey.go
+++ b/pkg/destroy/powervs/cloud-sshkey.go
@@ -32,7 +32,8 @@ func (o *ClusterUninstaller) listCloudSSHKeys() (cloudResources, error) {
 		sshKey           vpcv1.Key
 	)
 
-	ctx, _ = o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -122,7 +123,8 @@ func (o *ClusterUninstaller) deleteCloudSSHKey(item cloudResource) error {
 		err              error
 	)
 
-	ctx, _ = o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -167,7 +169,8 @@ func (o *ClusterUninstaller) destroyCloudSSHKeys() error {
 
 	items := o.insertPendingItems(cloudSSHKeyTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/cloudconnection.go
+++ b/pkg/destroy/powervs/cloudconnection.go
@@ -24,7 +24,8 @@ func (o *ClusterUninstaller) listCloudConnections() (cloudResources, error) {
 
 	o.Logger.Debugf("Listing Cloud Connections")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -86,7 +87,8 @@ func (o *ClusterUninstaller) destroyCloudConnections() error {
 
 	items := o.insertPendingItems(jobTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/cloudobjectstorage.go
+++ b/pkg/destroy/powervs/cloudobjectstorage.go
@@ -24,7 +24,8 @@ const cosResourceID = "dff97f5c-bc5e-4455-b470-411c3edbe49c"
 func (o *ClusterUninstaller) listCOSInstances() (cloudResources, error) {
 	o.Logger.Debugf("Listing COS instances")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	options := o.controllerSvc.NewListResourceInstancesOptions()
 	options.SetResourceID(cosResourceID)
@@ -78,7 +79,8 @@ func (o *ClusterUninstaller) findReclaimedCOSInstance(item cloudResource) (*reso
 
 	getReclamationOptions = o.controllerSvc.NewListReclamationsOptions()
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	reclamations, response, err = o.controllerSvc.ListReclamationsWithContext(ctx, getReclamationOptions)
 	if err != nil {
@@ -121,7 +123,8 @@ func (o *ClusterUninstaller) destroyCOSInstance(item cloudResource) error {
 
 	getOptions = o.controllerSvc.NewGetResourceInstanceOptions(item.id)
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	_, response, err = o.controllerSvc.GetResourceInstanceWithContext(ctx, getOptions)
 
@@ -179,7 +182,8 @@ func (o *ClusterUninstaller) destroyCOSInstances() error {
 
 	items := o.insertPendingItems(cosTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/dhcp.go
+++ b/pkg/destroy/powervs/dhcp.go
@@ -107,7 +107,8 @@ func (o *ClusterUninstaller) destroyDHCPNetworks() error {
 
 	items := o.insertPendingItems(dhcpTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/dns-dns.go
+++ b/pkg/destroy/powervs/dns-dns.go
@@ -19,7 +19,8 @@ const (
 func (o *ClusterUninstaller) listDNSRecords() (cloudResources, error) {
 	o.Logger.Debugf("Listing DNS records")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -97,7 +98,8 @@ func (o *ClusterUninstaller) destroyDNSRecord(item cloudResource) error {
 		err      error
 	)
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -152,7 +154,8 @@ func (o *ClusterUninstaller) destroyDNSRecords() error {
 
 	items := o.insertPendingItems(cisDNSRecordTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/dns-resource.go
+++ b/pkg/destroy/powervs/dns-resource.go
@@ -21,7 +21,8 @@ const (
 func (o *ClusterUninstaller) listResourceRecords() (cloudResources, error) {
 	o.Logger.Debugf("Listing DNS resource records")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -68,7 +69,8 @@ func (o *ClusterUninstaller) destroyResourceRecord(item cloudResource) error {
 		err      error
 	)
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -130,7 +132,8 @@ func (o *ClusterUninstaller) destroyResourceRecords() error {
 
 	items := o.insertPendingItems(ibmDNSRecordTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/image.go
+++ b/pkg/destroy/powervs/image.go
@@ -15,7 +15,8 @@ const imageTypeName = "image"
 func (o *ClusterUninstaller) listImages() (cloudResources, error) {
 	o.Logger.Debugf("Listing images")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -59,7 +60,8 @@ func (o *ClusterUninstaller) deleteImage(item cloudResource) error {
 	var img *models.Image
 	var err error
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -109,7 +111,8 @@ func (o *ClusterUninstaller) destroyImages() error {
 		o.Logger.Debugf("destroyImages: firstPassList: %v / %v", item.name, item.id)
 	}
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/job.go
+++ b/pkg/destroy/powervs/job.go
@@ -19,7 +19,8 @@ func (o *ClusterUninstaller) listJobs() (cloudResources, error) {
 
 	o.Logger.Debugf("Listing jobs")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -72,7 +73,8 @@ func (o *ClusterUninstaller) deleteJob(item cloudResource) (DeleteJobResult, err
 	var job *models.Job
 	var err error
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -129,7 +131,8 @@ func (o *ClusterUninstaller) destroyJobs() error {
 
 	items := o.insertPendingItems(jobTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/loadbalancer.go
+++ b/pkg/destroy/powervs/loadbalancer.go
@@ -17,7 +17,8 @@ const loadBalancerTypeName = "load balancer"
 func (o *ClusterUninstaller) listLoadBalancers() (cloudResources, error) {
 	o.Logger.Debugf("Listing load balancers")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -65,7 +66,8 @@ func (o *ClusterUninstaller) deleteLoadBalancer(item cloudResource) error {
 	var response *core.DetailedResponse
 	var err error
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -130,7 +132,8 @@ func (o *ClusterUninstaller) destroyLoadBalancers() error {
 
 	items := o.insertPendingItems(loadBalancerTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/power-instance.go
+++ b/pkg/destroy/powervs/power-instance.go
@@ -88,7 +88,8 @@ func (o *ClusterUninstaller) destroyPowerInstances() error {
 
 	items := o.insertPendingItems(powerInstanceTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/power-sshkey.go
+++ b/pkg/destroy/powervs/power-sshkey.go
@@ -15,7 +15,8 @@ const powerSSHKeyTypeName = "powerSshKey"
 func (o *ClusterUninstaller) listPowerSSHKeys() (cloudResources, error) {
 	o.Logger.Debugf("Listing Power SSHKeys")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -62,7 +63,8 @@ func (o *ClusterUninstaller) listPowerSSHKeys() (cloudResources, error) {
 func (o *ClusterUninstaller) deletePowerSSHKey(item cloudResource) error {
 	var err error
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -103,7 +105,8 @@ func (o *ClusterUninstaller) destroyPowerSSHKeys() error {
 
 	items := o.insertPendingItems(powerSSHKeyTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -240,7 +240,9 @@ func (o *ClusterUninstaller) Run() (*types.ClusterQuota, error) {
 	var ok bool
 	var err error
 
-	ctx, _ = o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
+
 	if ctx == nil {
 		return nil, errors.Wrap(err, "powervs.Run: contextWithTimeout returns nil")
 	}
@@ -369,7 +371,9 @@ func (o *ClusterUninstaller) executeStageFunction(f struct {
 	var ok bool
 	var err error
 
-	ctx, _ = o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
+
 	if ctx == nil {
 		return errors.Wrap(err, "executeStageFunction contextWithTimeout returns nil")
 	}
@@ -520,34 +524,32 @@ func (o *ClusterUninstaller) loadSDKServices() error {
 		return fmt.Errorf("loadSDKServices: loadSDKServices: o.piSession is nil")
 	}
 
-	ctx, _ := o.contextWithTimeout()
-
-	o.instanceClient = instance.NewIBMPIInstanceClient(ctx, o.piSession, o.ServiceGUID)
+	o.instanceClient = instance.NewIBMPIInstanceClient(context.Background(), o.piSession, o.ServiceGUID)
 	if o.instanceClient == nil {
 		return fmt.Errorf("loadSDKServices: loadSDKServices: o.instanceClient is nil")
 	}
 
-	o.imageClient = instance.NewIBMPIImageClient(ctx, o.piSession, o.ServiceGUID)
+	o.imageClient = instance.NewIBMPIImageClient(context.Background(), o.piSession, o.ServiceGUID)
 	if o.imageClient == nil {
 		return fmt.Errorf("loadSDKServices: loadSDKServices: o.imageClient is nil")
 	}
 
-	o.jobClient = instance.NewIBMPIJobClient(ctx, o.piSession, o.ServiceGUID)
+	o.jobClient = instance.NewIBMPIJobClient(context.Background(), o.piSession, o.ServiceGUID)
 	if o.jobClient == nil {
 		return fmt.Errorf("loadSDKServices: loadSDKServices: o.jobClient is nil")
 	}
 
-	o.keyClient = instance.NewIBMPIKeyClient(ctx, o.piSession, o.ServiceGUID)
+	o.keyClient = instance.NewIBMPIKeyClient(context.Background(), o.piSession, o.ServiceGUID)
 	if o.keyClient == nil {
 		return fmt.Errorf("loadSDKServices: loadSDKServices: o.keyClient is nil")
 	}
 
-	o.cloudConnectionClient = instance.NewIBMPICloudConnectionClient(ctx, o.piSession, o.ServiceGUID)
+	o.cloudConnectionClient = instance.NewIBMPICloudConnectionClient(context.Background(), o.piSession, o.ServiceGUID)
 	if o.cloudConnectionClient == nil {
 		return fmt.Errorf("loadSDKServices: loadSDKServices: o.cloudConnectionClient is nil")
 	}
 
-	o.dhcpClient = instance.NewIBMPIDhcpClient(ctx, o.piSession, o.ServiceGUID)
+	o.dhcpClient = instance.NewIBMPIDhcpClient(context.Background(), o.piSession, o.ServiceGUID)
 	if o.dhcpClient == nil {
 		return fmt.Errorf("loadSDKServices: loadSDKServices: o.dhcpClient is nil")
 	}
@@ -625,6 +627,9 @@ func (o *ClusterUninstaller) loadSDKServices() error {
 		if err != nil {
 			return fmt.Errorf("loadSDKServices: loadSDKServices: creating zonesSvc: %v", err)
 		}
+
+		ctx, cancel := o.contextWithTimeout()
+		defer cancel()
 
 		// Get the Zone ID
 		zoneOptions := o.zonesSvc.NewListZonesOptions()

--- a/pkg/destroy/powervs/publicgateway.go
+++ b/pkg/destroy/powervs/publicgateway.go
@@ -19,7 +19,8 @@ const (
 func (o *ClusterUninstaller) listAttachedSubnets(publicGatewayID string) (cloudResources, error) {
 	o.Logger.Debugf("Finding subnets attached to public gateway %s", publicGatewayID)
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	options := o.vpcSvc.NewListSubnetsOptions()
 	resources, _, err := o.vpcSvc.ListSubnetsWithContext(ctx, options)
@@ -59,7 +60,8 @@ func (o *ClusterUninstaller) listPublicGateways() (cloudResources, error) {
 
 	o.Logger.Debugf("Listing publicGateways")
 
-	ctx, _ = o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -143,7 +145,8 @@ func (o *ClusterUninstaller) listPublicGateways() (cloudResources, error) {
 }
 
 func (o *ClusterUninstaller) deletePublicGateway(item cloudResource) error {
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -203,7 +206,8 @@ func (o *ClusterUninstaller) destroyPublicGateways() error {
 
 	items := o.insertPendingItems(publicGatewayTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/securitygroup.go
+++ b/pkg/destroy/powervs/securitygroup.go
@@ -17,7 +17,8 @@ const securityGroupTypeName = "security group"
 func (o *ClusterUninstaller) listSecurityGroups() (cloudResources, error) {
 	o.Logger.Debugf("Listing security groups")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -64,7 +65,8 @@ func (o *ClusterUninstaller) deleteSecurityGroup(item cloudResource) error {
 	var response *core.DetailedResponse
 	var err error
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -114,7 +116,8 @@ func (o *ClusterUninstaller) destroySecurityGroups() error {
 
 	items := o.insertPendingItems(securityGroupTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/subnet.go
+++ b/pkg/destroy/powervs/subnet.go
@@ -17,7 +17,8 @@ const subnetTypeName = "subnet"
 func (o *ClusterUninstaller) listSubnets() (cloudResources, error) {
 	o.Logger.Debugf("Listing Subnets")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -64,7 +65,8 @@ func (o *ClusterUninstaller) deleteSubnet(item cloudResource) error {
 	var response *core.DetailedResponse
 	var err error
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -113,7 +115,8 @@ func (o *ClusterUninstaller) destroySubnets() error {
 
 	items := o.insertPendingItems(subnetTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {

--- a/pkg/destroy/powervs/vpc.go
+++ b/pkg/destroy/powervs/vpc.go
@@ -17,7 +17,8 @@ const vpcTypeName = "vpc"
 func (o *ClusterUninstaller) listVPCs() (cloudResources, error) {
 	o.Logger.Debugf("Listing VPCs")
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -65,7 +66,8 @@ func (o *ClusterUninstaller) deleteVPC(item cloudResource) error {
 	var deleteResponse *core.DetailedResponse
 	var err error
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
@@ -125,7 +127,8 @@ func (o *ClusterUninstaller) destroyVPCs() error {
 
 	items := o.insertPendingItems(vpcTypeName, firstPassList.list())
 
-	ctx, _ := o.contextWithTimeout()
+	ctx, cancel := o.contextWithTimeout()
+	defer cancel()
 
 	for _, item := range items {
 		select {


### PR DESCRIPTION
Every place where this occurs:
        ctx, _ := o.contextWithTimeout()
Change to:
        ctx, cancel := o.contextWithTimeout()
        defer cancel()

NOTE:
For the functions instance.NewIBMPI.*Client(, we now use context.Background() because o.contextWithTimeout() and then cancel() will cause future calls to these functions to error out with "context canceled."