### PR TITLE
AGENT-494: Use 0600 for perms of created files

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -97,7 +97,7 @@ func (a *AgentConfig) PersistToFile(directory string) error {
 	templatePath := filepath.Join(directory, agentConfigFilename)
 	templateByte := []byte(a.Template)
 
-	err := os.WriteFile(templatePath, templateByte, 0644)
+	err := os.WriteFile(templatePath, templateByte, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/asset/agent/image/agentimage.go
+++ b/pkg/asset/agent/image/agentimage.go
@@ -84,7 +84,7 @@ func (a *AgentImage) PersistToFile(directory string) error {
 		return err
 	}
 
-	err = os.WriteFile(filepath.Join(directory, "rendezvousIP"), []byte(a.rendezvousIP), 0644)
+	err = os.WriteFile(filepath.Join(directory, "rendezvousIP"), []byte(a.rendezvousIP), 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Gosec requires permissions of 0600 or more restrictive.