### PR TITLE
OCPBUGS-2088: Validate that the rendevousIP is assigned to a master

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -165,6 +165,10 @@ func (a *AgentConfig) validateAgent() field.ErrorList {
 		allErrs = append(allErrs, err...)
 	}
 
+	if err := a.validateRendevousIPNotWorker(a.Config.RendezvousIP, a.Config.Hosts); err != nil {
+		allErrs = append(allErrs, err...)
+	}
+
 	return allErrs
 }
 
@@ -273,6 +277,24 @@ func (a *AgentConfig) validateAdditionalNTPSources(additionalNTPSourcesPath *fie
 			ipErr := validate.IP(source)
 			if ipErr != nil {
 				allErrs = append(allErrs, field.Invalid(additionalNTPSourcesPath.Index(i), source, "NTP source is not a valid domain name nor a valid IP"))
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func (a *AgentConfig) validateRendevousIPNotWorker(rendezvousIP string, hosts []agent.Host) field.ErrorList {
+	var allErrs field.ErrorList
+
+	if rendezvousIP != "" {
+		for i, host := range hosts {
+			hostPath := field.NewPath("Hosts").Index(i)
+			if strings.Contains(string(host.NetworkConfig.Raw), rendezvousIP) && host.Role != "master" {
+				if len(host.Role) > 0 {
+					errMsg := "Host " + host.Hostname + " is not of role 'master' and has the rendevousIP assigned to it. The rendevousIP must be assigned to a host of role 'master'"
+					allErrs = append(allErrs, field.Forbidden(hostPath.Child("Host"), errMsg))
+				}
 			}
 		}
 	}

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -331,6 +331,79 @@ rendezvousIP: 192.168.111.80`,
 			expectedFound: false,
 			expectedError: "invalid Agent Config configuration: AdditionalNTPSources[4]: Invalid value: \"invalid_pool.ntp.org\": NTP source is not a valid domain name nor a valid IP",
 		},
+		{
+			name: "valid-rendezvousIPAssignedToMaster",
+			data: `
+apiVersion: v1alpha1
+metadata:
+  name: agent-config-cluster0
+rendezvousIP: 192.168.111.80
+hosts:
+    - hostname: host0
+      role: master
+      interfaces:
+        - name: eth0
+          macAddress: 00:d4:3f:3b:80:bb
+      networkConfig:
+        interfaces:
+          - name: eth0
+            type: ethernet
+            state: up
+            mac-address: 00:d4:3f:3b:80:bb
+            ipv4:
+              enabled: true
+              address:
+                - ip: 192.168.111.80
+                  prefix-length: 24
+              dhcp: false`,
+			expectedFound: true,
+			expectedConfig: agentConfig().hosts(
+				agentHost().
+					name("host0").
+					role("master").
+					interfaces(iface("eth0", "00:d4:3f:3b:80:bb")).
+					networkConfig(
+						`interfaces:
+                          - name: eth0
+                            type: ethernet
+                            state: up
+                            mac-address: 00:d4:3f:3b:80:bb
+                            ipv4:
+                              enabled: true
+                              address:
+                                - ip: 192.168.111.80
+                                  prefix-length: 24
+                              dhcp: false`),
+			),
+		},
+		{
+			name: "invalid-rendezvousIPAssignedToWorker",
+			data: `
+apiVersion: v1alpha1
+metadata:
+  name: agent-config-cluster0
+rendezvousIP: 192.168.111.80
+hosts:
+    - hostname: host0
+      role: worker
+      interfaces:
+        - name: eth0
+          macAddress: 00:d4:3f:3b:80:bb
+      networkConfig:
+        interfaces:
+          - name: eth0
+            type: ethernet
+            state: up
+            mac-address: 00:d4:3f:3b:80:bb
+            ipv4:
+              enabled: true
+              address:
+                - ip: 192.168.111.80
+                  prefix-length: 24
+              dhcp: false`,
+			expectedFound: false,
+			expectedError: "invalid Agent Config configuration: Hosts[0].Host: Forbidden: Host host0 is not of role 'master' and has the rendevousIP assigned to it. The rendevousIP must be assigned to a host of role 'master'",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Add validation that the rendezvousIP is assigned to a host with role "master".

This hasn't been tested beyond unit tests. Please test and review!