### PR TITLE
CORS-2469: upi: Document removal of CPMS for UPI installation

### DIFF
--- a/docs/user/azure/install_upi.md
+++ b/docs/user/azure/install_upi.md
@@ -84,6 +84,7 @@ We'll be providing those ourselves and don't want to involve the [machine-API op
 ```sh
 rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml
 rm -f openshift/99_openshift-cluster-api_worker-machineset-*.yaml
+rm -f openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml
 ```
 
 ### Make control-plane nodes unschedulable

--- a/docs/user/azure/install_upi_azurestack.md
+++ b/docs/user/azure/install_upi_azurestack.md
@@ -96,6 +96,7 @@ We'll be providing those ourselves and don't want to involve the [machine-API op
 ```sh
 rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml
 rm -f openshift/99_openshift-cluster-api_worker-machineset-*.yaml
+rm -f openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml
 ```
 
 ### Make control-plane nodes unschedulable

--- a/docs/user/gcp/install_upi.md
+++ b/docs/user/gcp/install_upi.md
@@ -90,11 +90,12 @@ INFO Consuming "Install Config" from target directory
 ```
 
 ### Remove control plane machines
-Remove the control plane machines from the manifests.
+Remove the control plane machines and machinesets from the manifests.
 We'll be providing those ourselves and don't want to involve [the machine-API operator][machine-api-operator].
 
 ```sh
 rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml
+rm -f openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml
 ```
 
 ### Remove compute machinesets (optional)


### PR DESCRIPTION
Documenting the extra step of removing the control plane machine set files created for Azure and GCP which need to be removed for UPI installation.