### PR TITLE
OCPBUGS-3706: Improve error reporting from agent wait-for install-complete

### DIFF
--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -94,6 +94,7 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 			}
 
 			if err = agentpkg.WaitForInstallComplete(cluster); err != nil {
+				logrus.Error(err)
 				err2 := cluster.API.OpenShift.LogClusterOperatorConditions()
 				if err2 != nil {
 					logrus.Error("Attempted to gather ClusterOperator status after wait failure: ", err2)

--- a/cmd/openshift-install/agent/waitfor.go
+++ b/cmd/openshift-install/agent/waitfor.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -42,8 +44,14 @@ func newWaitForBootstrapCompleteCmd() *cobra.Command {
 			if len(assetDir) == 0 {
 				logrus.Fatal("No cluster installation directory found")
 			}
-			cluster, err := agentpkg.WaitForBootstrapComplete(assetDir)
+
+			ctx := context.Background()
+			cluster, err := agentpkg.NewCluster(ctx, assetDir)
 			if err != nil {
+				logrus.Exit(exitCodeBootstrapFailed)
+			}
+
+			if err := agentpkg.WaitForBootstrapComplete(cluster); err != nil {
 				logrus.Debug("Printing the event list gathered from the Agent Rest API")
 				cluster.PrintInfraEnvRestAPIEventList()
 				err2 := cluster.API.OpenShift.LogClusterOperatorConditions()
@@ -70,8 +78,14 @@ func newWaitForInstallCompleteCmd() *cobra.Command {
 			if len(assetDir) == 0 {
 				logrus.Fatal("No cluster installation directory found")
 			}
-			cluster, err := agentpkg.WaitForInstallComplete(assetDir)
+
+			ctx := context.Background()
+			cluster, err := agentpkg.NewCluster(ctx, assetDir)
 			if err != nil {
+				logrus.Exit(exitCodeBootstrapFailed)
+			}
+
+			if err = agentpkg.WaitForInstallComplete(cluster); err != nil {
 				logrus.Debug("Printing the event list gathered from the Agent Rest API")
 				cluster.PrintInfraEnvRestAPIEventList()
 				err2 := cluster.API.OpenShift.LogClusterOperatorConditions()

--- a/pkg/agent/waitfor.go
+++ b/pkg/agent/waitfor.go
@@ -11,14 +11,7 @@ import (
 
 // WaitForBootstrapComplete Wait for the bootstrap process to complete on
 // cluster installations triggered by the agent installer.
-func WaitForBootstrapComplete(assetDir string) (*Cluster, error) {
-
-	ctx := context.Background()
-	cluster, err := NewCluster(ctx, assetDir)
-	if err != nil {
-		return nil, err
-	}
-
+func WaitForBootstrapComplete(cluster *Cluster) error {
 	start := time.Now()
 	previous := time.Now()
 	timeout := 60 * time.Minute
@@ -55,22 +48,21 @@ func WaitForBootstrapComplete(assetDir string) (*Cluster, error) {
 	waitErr := waitContext.Err()
 	if waitErr != nil {
 		if waitErr == context.Canceled && lastErr != nil {
-			return cluster, errors.Wrap(lastErr, "bootstrap process returned error")
+			return errors.Wrap(lastErr, "bootstrap process returned error")
 		}
 		if waitErr == context.DeadlineExceeded {
-			return cluster, errors.Wrap(waitErr, "bootstrap process timed out")
+			return errors.Wrap(waitErr, "bootstrap process timed out")
 		}
 	}
 
-	return cluster, nil
+	return nil
 }
 
 // WaitForInstallComplete Waits for the cluster installation triggered by the
 // agent installer to be complete.
-func WaitForInstallComplete(assetDir string) (*Cluster, error) {
+func WaitForInstallComplete(cluster *Cluster) error {
 
-	cluster, err := WaitForBootstrapComplete(assetDir)
-
+	err := WaitForBootstrapComplete(cluster)
 	if err != nil {
 		return cluster, errors.Wrap(err, "error occured during bootstrap process")
 	}
@@ -90,7 +82,7 @@ func WaitForInstallComplete(assetDir string) (*Cluster, error) {
 
 	waitErr := waitContext.Err()
 	if waitErr != nil && waitErr != context.Canceled {
-		return cluster, errors.Wrap(waitErr, "Cluster installation timed out")
+		return errors.Wrap(waitErr, "Cluster installation timed out")
 	}
-	return cluster, nil
+	return nil
 }

--- a/pkg/agent/waitfor.go
+++ b/pkg/agent/waitfor.go
@@ -90,9 +90,6 @@ func WaitForInstallComplete(assetDir string) (*Cluster, error) {
 
 	waitErr := waitContext.Err()
 	if waitErr != nil && waitErr != context.Canceled {
-		if err != nil {
-			return cluster, errors.Wrap(err, "Error occurred during installation")
-		}
 		return cluster, errors.Wrap(waitErr, "Cluster installation timed out")
 	}
 	return cluster, nil

--- a/pkg/agent/waitfor.go
+++ b/pkg/agent/waitfor.go
@@ -61,12 +61,6 @@ func WaitForBootstrapComplete(cluster *Cluster) error {
 // WaitForInstallComplete Waits for the cluster installation triggered by the
 // agent installer to be complete.
 func WaitForInstallComplete(cluster *Cluster) error {
-
-	err := WaitForBootstrapComplete(cluster)
-	if err != nil {
-		return cluster, errors.Wrap(err, "error occured during bootstrap process")
-	}
-
 	timeout := 90 * time.Minute
 	waitContext, cancel := context.WithTimeout(cluster.Ctx, timeout)
 	defer cancel()

--- a/pkg/agent/waitfor.go
+++ b/pkg/agent/waitfor.go
@@ -16,7 +16,6 @@ func WaitForBootstrapComplete(assetDir string) (*Cluster, error) {
 	ctx := context.Background()
 	cluster, err := NewCluster(ctx, assetDir)
 	if err != nil {
-		logrus.Warn("unable to make cluster object to track installation")
 		return nil, err
 	}
 


### PR DESCRIPTION
When running the `agent wait-for install-complete` command, we first check that bootstrapping is complete (by running the equivalent of `agent wait-for bootstrap-complete`. However, if this failed because the bootstrapping timed out, we would report it as an install failure along with the corresponding debug messages (stating that the problem is with the cluster operators, and inevitably failing to fetch data about which).

If the failure occurs during bootstrapping, report it as a bootstrap error the same as you would get from `agent wait-for bootstrap-complete`. If the failure occurs later, don't print the assisted-installer event list. If the command failed because of a timeout, log that.