### PR TITLE
OCPBUGS-5182: validate additional confidential VM types

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -161,6 +161,8 @@ func validateFamily(fieldPath *field.Path, instanceType, family string) field.Er
 		"standardDCADSv5Family",
 		"standardECASv5Family",
 		"standardECADSv5Family",
+		"standardECIADSv5Family",
+		"standardECIASv5Family",
 	)
 	allErrs := field.ErrorList{}
 	if confidentialVMFamilies.Has(family) {


### PR DESCRIPTION
Deploying IPI cluster on azure cloud in the 'westeurope' region with VM size as EC96iads_v5 or EC96ias_v5, installation fails with below error:

12-15 11:47:03.429  level=error msg=Error: creating Linux Virtual Machine: (Name "$infraID-bootstrap" / Resource Group "$infraID-rg"): compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="BadRequest" Message="The VM size 'Standard_EC96iads_v5' is not supported for creation of VMs and Virtual Machine Scale Set with '<NULL>' security type."

From azure portal, we can see that the type of both VM sizes EC96iads_v5 and EC96ias_v5 is confidential compute.