### PR TITLE
OCPBUGS-5184: azure: validate Windows-only VM types

### DIFF
--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -162,9 +162,15 @@ func validateFamily(fieldPath *field.Path, instanceType, family string) field.Er
 		"standardECASv5Family",
 		"standardECADSv5Family",
 	)
+	windowsVMFamilies := sets.NewString(
+		"standardNVSv4Family",
+	)
 	allErrs := field.ErrorList{}
 	if confidentialVMFamilies.Has(family) {
 		errMsg := fmt.Sprintf("%s is not currently supported but will be in a future release", family)
+		allErrs = append(allErrs, field.Invalid(fieldPath, instanceType, errMsg))
+	} else if windowsVMFamilies.Has(family) {
+		errMsg := fmt.Sprintf("%s is currently only supported on Windows", family)
 		allErrs = append(allErrs, field.Invalid(fieldPath, instanceType, errMsg))
 	}
 


### PR DESCRIPTION
From azure doc
https://learn.microsoft.com/en-us/azure/virtual-machines/nvv4-series, looks like the NVv4 series only supports Windows.