### PR TITLE
Revert "baremetal: Extra time for provisioning interface"

### DIFF
--- a/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
+++ b/data/data/bootstrap/baremetal/files/usr/local/bin/startironic.sh.template
@@ -107,14 +107,10 @@ PROVISIONING_IP_OPTIONS="ip=dhcp"
   {{ end }}
 {{ end }}
 
-# Allow some extra time for the provisioning interface to come up
-# https://issues.redhat.com/browse/OCPBUGS-5151
-PROVISIONING_IP_OPTIONS="rd.net.timeout.carrier=30 ${PROVISIONING_IP_OPTIONS}"
-
 
 podman run -d --name coreos-downloader \
      --restart on-failure \
-     --env "IP_OPTIONS=${PROVISIONING_IP_OPTIONS}" \
+     --env IP_OPTIONS=${PROVISIONING_IP_OPTIONS} \
      -v $IRONIC_SHARED_VOLUME:/shared:z \
      ${MACHINE_OS_IMAGES_IMAGE} /bin/copy-metal --all /shared/html/images/
 
@@ -214,7 +210,7 @@ podman run -d --net host --privileged --name ironic \
      --env OS_CONDUCTOR__HEARTBEAT_TIMEOUT=120 \
      --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD} \
      --env INSPECTOR_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env "IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS}" \
+     --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
      --entrypoint /bin/runironic \
      -v $AUTH_DIR:/auth:ro \
      -v $IRONIC_SHARED_VOLUME:/shared:z ${IRONIC_IMAGE}
@@ -224,7 +220,7 @@ podman run -d --net host --privileged --name ironic-inspector \
      --env PROVISIONING_INTERFACE=$PROVISIONING_NIC \
      --env IRONIC_HTPASSWD=${IRONIC_HTPASSWD} \
      --env INSPECTOR_HTPASSWD=${IRONIC_HTPASSWD} \
-     --env "IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS}" \
+     --env IRONIC_KERNEL_PARAMS=${PROVISIONING_IP_OPTIONS} \
      --entrypoint /bin/runironic-inspector \
      -v $AUTH_DIR:/auth:ro \
      -v $IRONIC_SHARED_VOLUME:/shared:z "${IRONIC_IMAGE}"


### PR DESCRIPTION
This reverts commit abf1de99e04eeb756eebaa57d81518e929679338.