### PR TITLE
OCPBUGS-4874: Remove order dependency for agent CLI string

### DIFF
--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -405,7 +405,14 @@ func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field
 		}
 	}
 
-	agentBasedInstallation := len(os.Args) > 1 && os.Args[1] == "agent"
+	agentBasedInstallation := false
+	if len(os.Args) > 1 {
+		for _, arg := range os.Args {
+			if arg == "agent" {
+				agentBasedInstallation = true
+			}
+		}
+	}
 
 	if !agentBasedInstallation && p.Hosts == nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("hosts"), p.Hosts, "bare metal hosts are missing"))


### PR DESCRIPTION
In order to remove the dependency on providing baremetal hosts, the "agent" string is checked in the CLI command. This fixes the requirement that it always be after the "create".

(Note that this solution is an improvement, but not perfect, as it can result in a false positive if "agent" is used elsewhere in the command line. A more complete solution will come in a later release).