### PR TITLE
CORS-2479: agent: Ensure registries.conf is world readable

### DIFF
--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -371,7 +371,7 @@ func addMirrorData(config *igntypes.Config, registriesConfig *mirror.RegistriesC
 	// This is required for assisted-service to build the ICSP for openshift-install
 	if registriesConfig.File != nil {
 		registriesFile := ignition.FileFromBytes(registriesConfPath,
-			"root", 0600, registriesConfig.File.Data)
+			"root", 0644, registriesConfig.File.Data)
 		config.Storage.Files = append(config.Storage.Files, registriesFile)
 	}
 

--- a/pkg/asset/ignition/bootstrap/common.go
+++ b/pkg/asset/ignition/bootstrap/common.go
@@ -387,6 +387,10 @@ func AddStorageFiles(config *igntypes.Config, base string, uri string, templateD
 	} else if filename == "motd" || filename == "containers.conf" {
 		mode = 0644
 		appendToFile = true
+	} else if filename == "registries.conf" {
+		// Having the mode be private breaks rpm-ostree, xref
+		// https://github.com/openshift/installer/pull/6789
+		mode = 0644
 	} else {
 		mode = 0600
 	}


### PR DESCRIPTION
We should not restrict the mode of this file beyond its defaults. It doesn't contain secret data (and anyways, user workloads are isolated form the host).

But specifically doing this breaks bootc/rpm-ostree's default privilege dropping when fetching container images.