### PR TITLE
SPLAT-901: set default for variables that are deprecated by failure_domains

### DIFF
--- a/upi/vsphere/variables.tf
+++ b/upi/vsphere/variables.tf
@@ -33,16 +33,19 @@ variable "vsphere_password" {
 
 variable "vsphere_cluster" {
   type        = string
+  default     = ""
   description = "This is the name of the vSphere cluster."
 }
 
 variable "vsphere_datacenter" {
   type        = string
+  default     = ""
   description = "This is the name of the vSphere data center."
 }
 
 variable "vsphere_datastore" {
   type        = string
+  default     = ""
   description = "This is the name of the vSphere data store."
 }
 variable "vm_network" {


### PR DESCRIPTION
With the addition of failure_domains, some variables are deprecated and still may be used.  Since these variables may validly be left empty when failure_domains is used, defaults are now being provided for those variables.

cc: @jcpowermac 