### PR TITLE
CORS-2449: gcp: Set pre-created CPMS to Active state

### DIFF
--- a/pkg/asset/machines/gcp/machines.go
+++ b/pkg/asset/machines/gcp/machines.go
@@ -95,6 +95,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 		},
 		Spec: machinev1.ControlPlaneMachineSetSpec{
 			Replicas: &replicas,
+			State:    machinev1.ControlPlaneMachineSetStateActive,
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"machine.openshift.io/cluster-api-machine-role": role,
@@ -206,7 +207,7 @@ func provider(clusterID string, platform *gcp.Platform, mpool *gcp.MachinePool, 
 }
 
 // ConfigMasters assigns a set of load balancers to the given machines
-func ConfigMasters(machines []machineapi.Machine, clusterID string, publish types.PublishingStrategy) {
+func ConfigMasters(machines []machineapi.Machine, controlPlane *machinev1.ControlPlaneMachineSet, clusterID string, publish types.PublishingStrategy) error {
 	var targetPools []string
 	if publish == types.ExternalPublishingStrategy {
 		targetPools = append(targetPools, fmt.Sprintf("%s-api", clusterID))
@@ -216,6 +217,13 @@ func ConfigMasters(machines []machineapi.Machine, clusterID string, publish type
 		providerSpec := machine.Spec.ProviderSpec.Value.Object.(*machineapi.GCPMachineProviderSpec)
 		providerSpec.TargetPools = targetPools
 	}
+
+	providerSpec, ok := controlPlane.Spec.Template.OpenShiftMachineV1Beta1Machine.Spec.ProviderSpec.Value.Object.(*machineapi.GCPMachineProviderSpec)
+	if !ok {
+		return errors.New("Unable to set target pools to control plane machine set")
+	}
+	providerSpec.TargetPools = targetPools
+	return nil
 }
 func getNetworks(platform *gcp.Platform, clusterID, role string) (string, string, error) {
 	if platform.Network == "" {

--- a/pkg/asset/machines/gcp/machines_test.go
+++ b/pkg/asset/machines/gcp/machines_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	machinev1 "github.com/openshift/api/machine/v1"
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/installer/pkg/types"
 )
@@ -50,8 +51,24 @@ func TestConfigMasters(t *testing.T) {
 				},
 			},
 		}
+		controlPlaneMachineSet := &machinev1.ControlPlaneMachineSet{
+			Spec: machinev1.ControlPlaneMachineSetSpec{
+				Template: machinev1.ControlPlaneMachineSetTemplate{
+					OpenShiftMachineV1Beta1Machine: &machinev1.OpenShiftMachineV1Beta1MachineTemplate{
+						Spec: machineapi.MachineSpec{
+							ProviderSpec: machineapi.ProviderSpec{
+								Value: &runtime.RawExtension{
+									Object: &machineapi.GCPMachineProviderSpec{},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
 		t.Run(tc.testCase, func(t *testing.T) {
-			ConfigMasters(machines, clusterID, tc.publishingStrategy)
+			err := ConfigMasters(machines, controlPlaneMachineSet, clusterID, tc.publishingStrategy)
+			assert.NoError(t, err)
 			for _, machine := range machines {
 				providerSpec := machine.Spec.ProviderSpec.Value.Object.(*machineapi.GCPMachineProviderSpec)
 				assert.Equal(t, providerSpec.TargetPools, tc.expectedTargetPools)

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -275,7 +275,10 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create master machine objects")
 		}
-		gcp.ConfigMasters(machines, clusterID.InfraID, ic.Publish)
+		err := gcp.ConfigMasters(machines, controlPlaneMachineSet, clusterID.InfraID, ic.Publish)
+		if err != nil {
+			return err
+		}
 	case ibmcloudtypes.Name:
 		subnets := map[string]string{}
 		if len(ic.Platform.IBMCloud.ControlPlaneSubnets) > 0 {


### PR DESCRIPTION
Setting the pre-created state to active in the CPMS manifest.