### PR TITLE
GCP XPN: remove tech preview feature gate

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -2296,9 +2296,8 @@ spec:
                       should be created rather than provisioning a new one.
                     type: string
                   networkProjectID:
-                    description: NetworkProjectID is currently TechPreview. NetworkProjectID
-                      specifies which project the network and subnets exist in when
-                      they are not in the main ProjectID.
+                    description: NetworkProjectID specifies which project the network
+                      and subnets exist in when they are not in the main ProjectID.
                     type: string
                   privateDNSZone:
                     description: PrivateDNSZone Technology Preview. PrivateDNSZone

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -35,7 +35,6 @@ type Platform struct {
 	// +optional
 	Network string `json:"network,omitempty"`
 
-	// NetworkProjectID is currently TechPreview.
 	// NetworkProjectID specifies which project the network and subnets exist in when
 	// they are not in the main ProjectID.
 	// +optional

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -999,10 +999,6 @@ func validateFeatureSet(c *types.InstallConfig) field.ErrorList {
 		errMsg := "the TechPreviewNoUpgrade feature set must be enabled to use this field"
 
 		if c.GCP != nil {
-			if len(c.GCP.NetworkProjectID) > 0 {
-				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "networkProjectID"), errMsg))
-			}
-
 			if c.GCP.PrivateDNSZone != nil && len(c.GCP.PrivateDNSZone.ProjectID) > 0 {
 				allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "gcp", "privateDNSZone", "projectID"), errMsg))
 			}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -2073,40 +2073,6 @@ func TestValidateInstallConfig(t *testing.T) {
 			}(),
 			expectedError: "platform.gcp.privateDNSZone.id: Forbidden: do not provide an ID for the private DNS zone.",
 		},
-		{
-			name: "GCP XPN SHOULD return an error if used WITHOUT tech preview",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Platform = types.Platform{
-					GCP: validGCPPlatform(),
-				}
-				c.Platform.GCP.NetworkProjectID = "myNetworkProject"
-				c.Platform.GCP.ControlPlaneSubnet = "controlPlaneSubnet"
-				c.Platform.GCP.ComputeSubnet = "computeSubnet"
-				c.Platform.GCP.Network = "vpc"
-				c.CredentialsMode = "Passthrough"
-
-				return c
-			}(),
-			expectedError: "platform.gcp.networkProjectID: Forbidden: the TechPreviewNoUpgrade feature set must be enabled to use this field",
-		},
-		{
-			name: "GCP XPN SHOULD NOT return an error if used WITH tech preview",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.Platform = types.Platform{
-					GCP: validGCPPlatform(),
-				}
-				c.Platform.GCP.NetworkProjectID = "myNetworkProject"
-				c.Platform.GCP.ControlPlaneSubnet = "controlPlaneSubnet"
-				c.Platform.GCP.ComputeSubnet = "computeSubnet"
-				c.Platform.GCP.Network = "vpc"
-				c.CredentialsMode = "Passthrough"
-				c.FeatureSet = TechPreviewNoUpgrade
-
-				return c
-			}(),
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
GCP XPN, with DNS zones in the service projects, is intended to GA in the next release. Let's remove the feature gate requirement, especially because enabling the feature gate enables the CCM; so cluster behavior is different than what we would be seeing in actual deployments.