### PR TITLE
BUG 2110982: GCP skip public loadbalancer ip addresses

### DIFF
--- a/data/data/gcp/cluster/network/firewall.tf
+++ b/data/data/gcp/cluster/network/firewall.tf
@@ -28,8 +28,10 @@ resource "google_compute_firewall" "health_checks" {
     ports    = ["6080", "6443", "22624"]
   }
 
-  source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22"]
-  target_tags   = ["${var.cluster_id}-master"]
+  # Add the public load balancer ips when the cluster is public/external
+  source_ranges = concat(["35.191.0.0/16", "130.211.0.0/22"], var.public_endpoints ? ["209.85.152.0/22", "209.85.204.0/22"] : [])
+
+  target_tags = ["${var.cluster_id}-master"]
 }
 
 resource "google_compute_firewall" "etcd" {


### PR DESCRIPTION
** There is no need to add the public load balancer IP addresses to firewall rules when the cluster is internal. ** The internal load balancer ip addresses will be present for internal and external cluster.

https://issues.redhat.com/browse/OCPBUGSM-47223