### PR TITLE
AGENT-453: Create interactive console service for agent installer

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
+++ b/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "agent-interactive-console start"
+systemctl status pre-network-manager-config.service
+
+# TODO: Execute tui and remove sleep
+echo "sleeping 60 seconds"
+sleep 60
+
+echo "agent-interactive-console end"

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -2,6 +2,7 @@
 Description=Get interactive user configuration at boot
 After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
 Before=network.target network.service agent.service NetworkManager-wait-online.service
+ConditionPathExists=/usr/local/bin/agent-tui
 
 [Service]
 Type=oneshot

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Get interactive user configuration at boot
+After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
+Before=network.target network.service agent.service NetworkManager-wait-online.service
+
+[Service]
+Type=oneshot
+TTYPath=/dev/tty15
+ExecStartPre=/usr/bin/chvt 15
+ExecStart="/usr/local/bin/agent-interactive-console.sh"
+ExecStartPost=/usr/bin/chvt 1
+TimeoutStartSec=0
+StandardInput=tty
+TTYVHangup=yes
+TTYVTDisallocate=yes
+
+[Install]
+WantedBy=default.target
+RequiredBy=sshd.service systemd-logind.service getty@tty1.service

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -2,7 +2,6 @@
 Description=Get interactive user configuration at boot
 After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
 Before=network.target network.service agent.service NetworkManager-wait-online.service
-ConditionPathExists=/usr/local/bin/agent-tui
 
 [Service]
 Type=oneshot

--- a/data/data/agent/systemd/units/agent-tui.path
+++ b/data/data/agent/systemd/units/agent-tui.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Activate agent-interactive-console.service only when the agent-tui path exists
+
+[Path]
+PathExists=/usr/local/bin/agent-tui
+Unit=agent-interactive-console.service
+
+[Install]
+WantedBy=default.target

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -215,7 +215,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 
 	agentEnabledServices := []string{
 		"agent.service",
-		"agent-interactive-console.service",
+		"agent-tui.path",
 		"assisted-service-db.service",
 		"assisted-service-pod.service",
 		"assisted-service.service",

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -215,6 +215,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 
 	agentEnabledServices := []string{
 		"agent.service",
+		"agent-interactive-console.service",
 		"assisted-service-db.service",
 		"assisted-service-pod.service",
 		"assisted-service.service",

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -389,6 +389,7 @@ metadata:
 				"/root/assisted.te",
 				"/usr/local/bin/common.sh",
 				"/usr/local/bin/agent-gather",
+				"/usr/local/bin/agent-interactive-console.sh",
 				"/usr/local/bin/extract-agent.sh",
 				"/usr/local/bin/get-container-images.sh",
 				"/usr/local/bin/install-status.sh",


### PR DESCRIPTION
Users would like the ability to change their network configuration at the console if network connectivity problems are detected.

To achieve this goal, this patch adds a new service called agent-interactive-console.service to block the login prompt and the agent services that pulls an image from the registry.

The service will execute the agent TUI to allow users to update their network configuration. The TUI will check there is connectivity to the registry and to the rendezvous host. If the connectivity checks pass, the TUI exits, which also lead the interactive console service to exit, and this unblocks the login prompt and agent services waiting for pull from the registry, allowing the agent-based installer to proceed.

The agent TUI will be added in a future patch.

For now, the service executes a script that logs its presence, sleeps for 60 seconds, and exits. This should not block the automated flow.

Most of the service definition was lifted from @celebdor's POC: https://github.com/openshift/installer/pull/6560/

Signed-off-by: Richard Su <rwsu@redhat.com>