### PR TITLE
OCPBUGS-5734: make VIP 168.63.129.16 noProxy in all clouds except Public

### DIFF
--- a/pkg/asset/manifests/proxy.go
+++ b/pkg/asset/manifests/proxy.go
@@ -158,9 +158,12 @@ func createNoProxy(installConfig *installconfig.InstallConfig, network *Networki
 
 	// TODO: IBM[#95]: proxy
 
-	if platform == azure.Name && installConfig.Azure.CloudName == azure.StackCloud {
+	if platform == azure.Name && installConfig.Azure.CloudName != azure.PublicCloud {
+		// https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
 		set.Insert("168.63.129.16")
-		set.Insert(installConfig.Config.Azure.ARMEndpoint)
+		if installConfig.Azure.CloudName == azure.StackCloud {
+			set.Insert(installConfig.Config.Azure.ARMEndpoint)
+		}
 	}
 
 	// From https://cloud.google.com/vpc/docs/special-configurations add GCP metadata.


### PR DESCRIPTION
It was previously only added for StackCloud but it's also needed for all national clouds.