### PR TITLE
OCPBUGS-5665: CVE-2021-4238: goutils: update for randomness fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,3 +216,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220315160706-3147a52
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -115,7 +115,7 @@ github.com/IBM/vpc-go-sdk v0.20.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvs
 github.com/InVisionApp/go-health v2.1.0+incompatible/go.mod h1:/+Gv1o8JUsrjC6pi6MN6/CgKJo4OqZ6x77XAnImrzhg=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.20.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=

--- a/terraform/providers/aws/go.mod
+++ b/terraform/providers/aws/go.mod
@@ -85,3 +85,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/aws/go.sum
+++ b/terraform/providers/aws/go.sum
@@ -34,7 +34,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/terraform/providers/aws/vendor/modules.txt
+++ b/terraform/providers/aws/vendor/modules.txt
@@ -948,3 +948,4 @@ google.golang.org/protobuf/types/known/timestamppb
 gopkg.in/yaml.v2
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/azureprivatedns/go.mod
+++ b/terraform/providers/azureprivatedns/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
@@ -109,3 +109,6 @@ require (
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2064702
 replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/azureprivatedns/go.sum
+++ b/terraform/providers/azureprivatedns/go.sum
@@ -77,8 +77,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/terraform/providers/azureprivatedns/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
+++ b/terraform/providers/azureprivatedns/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"regexp"
 	"unicode"
 )
 
@@ -99,27 +98,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, CryptoRandom(...)
 */
 func CryptoRandomAlphaNumeric(count int) (string, error) {
-	if count == 0 {
-		return "", nil
-	}
-	RandomString, err := CryptoRandom(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := getCryptoRandomInt(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0' + getCryptoRandomInt(10)) + RandomString[position + 1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return CryptoRandom(count, 0, 0, true, true)
 }
 
 /*
@@ -204,7 +183,7 @@ func CryptoRandom(count int, start int, end int, letters bool, numbers bool, cha
 		if chars == nil {
 			ch = rune(getCryptoRandomInt(gap) + int64(start))
 		} else {
-			ch = chars[getCryptoRandomInt(gap) + int64(start)]
+			ch = chars[getCryptoRandomInt(gap)+int64(start)]
 		}
 
 		if letters && unicode.IsLetter(ch) || numbers && unicode.IsDigit(ch) || !letters && !numbers {

--- a/terraform/providers/azureprivatedns/vendor/github.com/Masterminds/goutils/randomstringutils.go
+++ b/terraform/providers/azureprivatedns/vendor/github.com/Masterminds/goutils/randomstringutils.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"regexp"
 	"time"
 	"unicode"
 )
@@ -75,12 +74,10 @@ func RandomNumeric(count int) (string, error) {
 
 /*
 RandomAlphabetic creates a random string whose length is the number of characters specified.
-Characters will be chosen from the set of alpha-numeric characters as indicated by the arguments.
+Characters will be chosen from the set of alphabetic characters.
 
 Parameters:
 	count - the length of random string to create
-	letters - if true, generated string may include alphabetic characters
-	numbers - if true, generated string may include numeric characters
 
 Returns:
 	string - the random string
@@ -102,24 +99,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
 */
 func RandomAlphaNumeric(count int) (string, error) {
-	RandomString, err := Random(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := rand.Intn(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0'+rand.Intn(10)) + RandomString[position+1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return Random(count, 0, 0, true, true)
 }
 
 /*

--- a/terraform/providers/azureprivatedns/vendor/github.com/Masterminds/goutils/stringutils.go
+++ b/terraform/providers/azureprivatedns/vendor/github.com/Masterminds/goutils/stringutils.go
@@ -222,3 +222,19 @@ func IndexOf(str string, sub string, start int) int {
 func IsEmpty(str string) bool {
 	return len(str) == 0
 }
+
+// Returns either the passed in string, or if the string is empty, the value of defaultStr.
+func DefaultString(str string, defaultStr string) string {
+	if IsEmpty(str) {
+		return defaultStr
+	}
+	return str
+}
+
+// Returns either the passed in string, or if the string is whitespace, empty (""), the value of defaultStr.
+func DefaultIfBlank(str string, defaultStr string) string {
+	if IsBlank(str) {
+		return defaultStr
+	}
+	return str
+}

--- a/terraform/providers/azureprivatedns/vendor/modules.txt
+++ b/terraform/providers/azureprivatedns/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 ## explicit; go 1.12
 github.com/Azure/go-autorest/tracing
-# github.com/Masterminds/goutils v1.1.0
+# github.com/Masterminds/goutils v1.1.1 => github.com/Masterminds/goutils v1.1.1
 ## explicit
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver v1.5.0
@@ -621,3 +621,4 @@ google.golang.org/protobuf/types/pluginpb
 # github.com/Azure/azure-sdk-for-go => github.com/Azure/azure-sdk-for-go v38.1.0+incompatible
 # github.com/hashicorp/go-azure-helpers => github.com/hashicorp/go-azure-helpers v0.16.5
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/azurerm/go.mod
+++ b/terraform/providers/azurerm/go.mod
@@ -82,3 +82,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/azurerm/go.sum
+++ b/terraform/providers/azurerm/go.sum
@@ -81,7 +81,7 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/terraform/providers/azurerm/vendor/modules.txt
+++ b/terraform/providers/azurerm/vendor/modules.txt
@@ -1054,3 +1054,4 @@ google.golang.org/protobuf/types/known/timestamppb
 gopkg.in/yaml.v2
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/ibm/go.mod
+++ b/terraform/providers/ibm/go.mod
@@ -143,3 +143,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/ibm/go.sum
+++ b/terraform/providers/ibm/go.sum
@@ -103,7 +103,7 @@ github.com/IBM/vpc-go-sdk v0.17.0 h1:H9qsEx1UJoAR79s1R7n3bGPdOPW6+wLNEUyCjnesaxs
 github.com/IBM/vpc-go-sdk v0.17.0/go.mod h1:+fTuJIR/SWXru/B5XEANwV4GCLV5fRppFEzlYGwGm7k=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 h1:vuquMR410psHNax14XKNWa0Ae/kYgWJcXi0IFuX60N0=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56/go.mod h1:Zb3OT4l0mf7P/GOs2w2Ilj5sdm5Whoq3pa24dAEBHFc=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/terraform/providers/ibm/vendor/modules.txt
+++ b/terraform/providers/ibm/vendor/modules.txt
@@ -862,3 +862,4 @@ gopkg.in/go-playground/validator.v9
 gopkg.in/yaml.v2
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/ironic/go.mod
+++ b/terraform/providers/ironic/go.mod
@@ -7,7 +7,7 @@ require github.com/openshift-metal3/terraform-provider-ironic v0.2.8
 require (
 	cloud.google.com/go v0.65.0 // indirect
 	cloud.google.com/go/storage v1.10.0 // indirect
-	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
@@ -127,6 +127,8 @@ require (
 )
 
 replace (
+	// https://issues.redhat.com/browse/OCPBUGS-5665
+	github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1
 	github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.2
 	github.com/metal3-io/baremetal-operator/apis => github.com/metal3-io/baremetal-operator/apis v0.0.0-20220310151803-2b47127ed7ae
 	github.com/metal3-io/baremetal-operator/pkg/hardwareutils => github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.0.0-20220310151803-2b47127ed7ae

--- a/terraform/providers/ironic/go.sum
+++ b/terraform/providers/ironic/go.sum
@@ -44,8 +44,8 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=

--- a/terraform/providers/ironic/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
+++ b/terraform/providers/ironic/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"regexp"
 	"unicode"
 )
 
@@ -99,27 +98,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, CryptoRandom(...)
 */
 func CryptoRandomAlphaNumeric(count int) (string, error) {
-	if count == 0 {
-		return "", nil
-	}
-	RandomString, err := CryptoRandom(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := getCryptoRandomInt(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0' + getCryptoRandomInt(10)) + RandomString[position + 1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return CryptoRandom(count, 0, 0, true, true)
 }
 
 /*
@@ -204,7 +183,7 @@ func CryptoRandom(count int, start int, end int, letters bool, numbers bool, cha
 		if chars == nil {
 			ch = rune(getCryptoRandomInt(gap) + int64(start))
 		} else {
-			ch = chars[getCryptoRandomInt(gap) + int64(start)]
+			ch = chars[getCryptoRandomInt(gap)+int64(start)]
 		}
 
 		if letters && unicode.IsLetter(ch) || numbers && unicode.IsDigit(ch) || !letters && !numbers {

--- a/terraform/providers/ironic/vendor/github.com/Masterminds/goutils/randomstringutils.go
+++ b/terraform/providers/ironic/vendor/github.com/Masterminds/goutils/randomstringutils.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"regexp"
 	"time"
 	"unicode"
 )
@@ -75,12 +74,10 @@ func RandomNumeric(count int) (string, error) {
 
 /*
 RandomAlphabetic creates a random string whose length is the number of characters specified.
-Characters will be chosen from the set of alpha-numeric characters as indicated by the arguments.
+Characters will be chosen from the set of alphabetic characters.
 
 Parameters:
 	count - the length of random string to create
-	letters - if true, generated string may include alphabetic characters
-	numbers - if true, generated string may include numeric characters
 
 Returns:
 	string - the random string
@@ -102,24 +99,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
 */
 func RandomAlphaNumeric(count int) (string, error) {
-	RandomString, err := Random(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := rand.Intn(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0'+rand.Intn(10)) + RandomString[position+1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return Random(count, 0, 0, true, true)
 }
 
 /*

--- a/terraform/providers/ironic/vendor/github.com/Masterminds/goutils/stringutils.go
+++ b/terraform/providers/ironic/vendor/github.com/Masterminds/goutils/stringutils.go
@@ -222,3 +222,19 @@ func IndexOf(str string, sub string, start int) int {
 func IsEmpty(str string) bool {
 	return len(str) == 0
 }
+
+// Returns either the passed in string, or if the string is empty, the value of defaultStr.
+func DefaultString(str string, defaultStr string) string {
+	if IsEmpty(str) {
+		return defaultStr
+	}
+	return str
+}
+
+// Returns either the passed in string, or if the string is whitespace, empty (""), the value of defaultStr.
+func DefaultIfBlank(str string, defaultStr string) string {
+	if IsBlank(str) {
+		return defaultStr
+	}
+	return str
+}

--- a/terraform/providers/ironic/vendor/modules.txt
+++ b/terraform/providers/ironic/vendor/modules.txt
@@ -10,7 +10,7 @@ cloud.google.com/go/internal/version
 # cloud.google.com/go/storage v1.10.0
 ## explicit; go 1.11
 cloud.google.com/go/storage
-# github.com/Masterminds/goutils v1.1.0
+# github.com/Masterminds/goutils v1.1.1 => github.com/Masterminds/goutils v1.1.1
 ## explicit
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver v1.5.0
@@ -942,6 +942,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1
 # github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.2
 # github.com/metal3-io/baremetal-operator/apis => github.com/metal3-io/baremetal-operator/apis v0.0.0-20220310151803-2b47127ed7ae
 # github.com/metal3-io/baremetal-operator/pkg/hardwareutils => github.com/metal3-io/baremetal-operator/pkg/hardwareutils v0.0.0-20220310151803-2b47127ed7ae

--- a/terraform/providers/nutanix/go.mod
+++ b/terraform/providers/nutanix/go.mod
@@ -141,3 +141,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/nutanix/go.sum
+++ b/terraform/providers/nutanix/go.sum
@@ -35,7 +35,7 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/terraform/providers/nutanix/vendor/modules.txt
+++ b/terraform/providers/nutanix/vendor/modules.txt
@@ -715,3 +715,4 @@ sourcegraph.com/sqs/pbtypes
 # github.com/terraform-providers/terraform-provider-nutanix => github.com/nutanix/terraform-provider-nutanix v1.5.0
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/openstack/go.mod
+++ b/terraform/providers/openstack/go.mod
@@ -61,3 +61,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/openstack/go.sum
+++ b/terraform/providers/openstack/go.sum
@@ -34,7 +34,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/terraform/providers/openstack/vendor/modules.txt
+++ b/terraform/providers/openstack/vendor/modules.txt
@@ -460,3 +460,4 @@ google.golang.org/protobuf/types/known/timestamppb
 gopkg.in/yaml.v2
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/ovirt/go.mod
+++ b/terraform/providers/ovirt/go.mod
@@ -74,3 +74,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/ovirt/go.sum
+++ b/terraform/providers/ovirt/go.sum
@@ -1,7 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=

--- a/terraform/providers/ovirt/vendor/modules.txt
+++ b/terraform/providers/ovirt/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Masterminds/goutils v1.1.1
+# github.com/Masterminds/goutils v1.1.1 => github.com/Masterminds/goutils v1.1.1
 ## explicit
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver/v3 v3.1.1
@@ -379,3 +379,4 @@ google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/time/go.mod
+++ b/terraform/providers/time/go.mod
@@ -45,3 +45,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/time/go.sum
+++ b/terraform/providers/time/go.sum
@@ -34,7 +34,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/terraform/providers/time/vendor/modules.txt
+++ b/terraform/providers/time/vendor/modules.txt
@@ -241,3 +241,4 @@ google.golang.org/protobuf/types/known/emptypb
 google.golang.org/protobuf/types/known/timestamppb
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/vsphere/go.mod
+++ b/terraform/providers/vsphere/go.mod
@@ -75,3 +75,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/vsphere/go.sum
+++ b/terraform/providers/vsphere/go.sum
@@ -36,7 +36,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/terraform/providers/vsphere/vendor/modules.txt
+++ b/terraform/providers/vsphere/vendor/modules.txt
@@ -516,3 +516,4 @@ google.golang.org/protobuf/types/pluginpb
 # github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.2
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/vsphereprivate/go.mod
+++ b/terraform/providers/vsphereprivate/go.mod
@@ -80,3 +80,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/providers/vsphereprivate/go.sum
+++ b/terraform/providers/vsphereprivate/go.sum
@@ -36,7 +36,7 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/terraform/providers/vsphereprivate/vendor/modules.txt
+++ b/terraform/providers/vsphereprivate/vendor/modules.txt
@@ -534,3 +534,4 @@ google.golang.org/protobuf/types/pluginpb
 # github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.2
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20221010152910-d6f0a8c073c2
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/terraform/go.mod
+++ b/terraform/terraform/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c // indirect
 	github.com/ChrisTrenkamp/goxpath v0.0.0-20190607011252-c5096ec8773d // indirect
-	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
@@ -173,3 +173,6 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220315160706-3147a52
 
 // https://bugzilla.redhat.com/show_bug.cgi?id=2100495
 replace golang.org/x/text => golang.org/x/text v0.3.7
+
+// https://issues.redhat.com/browse/OCPBUGS-5665
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/terraform/terraform/go.sum
+++ b/terraform/terraform/go.sum
@@ -79,8 +79,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20190607011252-c5096ec8773d h1:W1diKnDQkXxNDhghdBSbQ4LI/E1aJNTwpqPp3KtlB8w=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20190607011252-c5096ec8773d/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
-github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=

--- a/terraform/terraform/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
+++ b/terraform/terraform/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"regexp"
 	"unicode"
 )
 
@@ -99,27 +98,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, CryptoRandom(...)
 */
 func CryptoRandomAlphaNumeric(count int) (string, error) {
-	if count == 0 {
-		return "", nil
-	}
-	RandomString, err := CryptoRandom(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := getCryptoRandomInt(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0' + getCryptoRandomInt(10)) + RandomString[position + 1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return CryptoRandom(count, 0, 0, true, true)
 }
 
 /*
@@ -204,7 +183,7 @@ func CryptoRandom(count int, start int, end int, letters bool, numbers bool, cha
 		if chars == nil {
 			ch = rune(getCryptoRandomInt(gap) + int64(start))
 		} else {
-			ch = chars[getCryptoRandomInt(gap) + int64(start)]
+			ch = chars[getCryptoRandomInt(gap)+int64(start)]
 		}
 
 		if letters && unicode.IsLetter(ch) || numbers && unicode.IsDigit(ch) || !letters && !numbers {

--- a/terraform/terraform/vendor/github.com/Masterminds/goutils/randomstringutils.go
+++ b/terraform/terraform/vendor/github.com/Masterminds/goutils/randomstringutils.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"regexp"
 	"time"
 	"unicode"
 )
@@ -75,12 +74,10 @@ func RandomNumeric(count int) (string, error) {
 
 /*
 RandomAlphabetic creates a random string whose length is the number of characters specified.
-Characters will be chosen from the set of alpha-numeric characters as indicated by the arguments.
+Characters will be chosen from the set of alphabetic characters.
 
 Parameters:
 	count - the length of random string to create
-	letters - if true, generated string may include alphabetic characters
-	numbers - if true, generated string may include numeric characters
 
 Returns:
 	string - the random string
@@ -102,24 +99,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
 */
 func RandomAlphaNumeric(count int) (string, error) {
-	RandomString, err := Random(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := rand.Intn(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0'+rand.Intn(10)) + RandomString[position+1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return Random(count, 0, 0, true, true)
 }
 
 /*

--- a/terraform/terraform/vendor/github.com/Masterminds/goutils/stringutils.go
+++ b/terraform/terraform/vendor/github.com/Masterminds/goutils/stringutils.go
@@ -222,3 +222,19 @@ func IndexOf(str string, sub string, start int) int {
 func IsEmpty(str string) bool {
 	return len(str) == 0
 }
+
+// Returns either the passed in string, or if the string is empty, the value of defaultStr.
+func DefaultString(str string, defaultStr string) string {
+	if IsEmpty(str) {
+		return defaultStr
+	}
+	return str
+}
+
+// Returns either the passed in string, or if the string is whitespace, empty (""), the value of defaultStr.
+func DefaultIfBlank(str string, defaultStr string) string {
+	if IsBlank(str) {
+		return defaultStr
+	}
+	return str
+}

--- a/terraform/terraform/vendor/modules.txt
+++ b/terraform/terraform/vendor/modules.txt
@@ -64,7 +64,7 @@ github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlbuilder
 github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlele
 github.com/ChrisTrenkamp/goxpath/tree/xmltree/xmlnode
 github.com/ChrisTrenkamp/goxpath/xconst
-# github.com/Masterminds/goutils v1.1.0
+# github.com/Masterminds/goutils v1.1.1 => github.com/Masterminds/goutils v1.1.1
 ## explicit
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver v1.5.0
@@ -1110,3 +1110,4 @@ sigs.k8s.io/yaml
 # github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.2
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1375,3 +1375,4 @@ sigs.k8s.io/yaml
 # sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.3.1-0.20200617211605-651903477185
 # golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd
 # golang.org/x/text => golang.org/x/text v0.3.7
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1


### PR DESCRIPTION
A flaw was found in goutils where randomly generated alphanumeric
strings contain significantly less entropy than expected. Both the
RandomAlphaNumeric and CryptoRandomAlphaNumeric functions always
return strings containing at least one digit from 0 to 9. This issue
significantly reduces the amount of entropy generated in short strings
by these functions.