### PR TITLE
OCPBUGS-5663: CVE-2021-4238: goutils: update for randomness fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5 // indirect
 	github.com/IBM/schematics-go-sdk v0.0.2 // indirect
 	github.com/IBM/secrets-manager-go-sdk v0.1.19 // indirect
-	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/Netflix/go-expect v0.0.0-20190729225929-0e00d9168667 // indirect
@@ -407,3 +407,6 @@ replace (
 )
 
 replace github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.2
+
+// https://issues.redhat.com/browse/OCPBUGS-5663
+replace github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
-github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=

--- a/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
+++ b/vendor/github.com/Masterminds/goutils/cryptorandomstringutils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"regexp"
 	"unicode"
 )
 
@@ -99,27 +98,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, CryptoRandom(...)
 */
 func CryptoRandomAlphaNumeric(count int) (string, error) {
-	if count == 0 {
-		return "", nil
-	}
-	RandomString, err := CryptoRandom(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := getCryptoRandomInt(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0' + getCryptoRandomInt(10)) + RandomString[position + 1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return CryptoRandom(count, 0, 0, true, true)
 }
 
 /*
@@ -204,7 +183,7 @@ func CryptoRandom(count int, start int, end int, letters bool, numbers bool, cha
 		if chars == nil {
 			ch = rune(getCryptoRandomInt(gap) + int64(start))
 		} else {
-			ch = chars[getCryptoRandomInt(gap) + int64(start)]
+			ch = chars[getCryptoRandomInt(gap)+int64(start)]
 		}
 
 		if letters && unicode.IsLetter(ch) || numbers && unicode.IsDigit(ch) || !letters && !numbers {

--- a/vendor/github.com/Masterminds/goutils/randomstringutils.go
+++ b/vendor/github.com/Masterminds/goutils/randomstringutils.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"regexp"
 	"time"
 	"unicode"
 )
@@ -75,12 +74,10 @@ func RandomNumeric(count int) (string, error) {
 
 /*
 RandomAlphabetic creates a random string whose length is the number of characters specified.
-Characters will be chosen from the set of alpha-numeric characters as indicated by the arguments.
+Characters will be chosen from the set of alphabetic characters.
 
 Parameters:
 	count - the length of random string to create
-	letters - if true, generated string may include alphabetic characters
-	numbers - if true, generated string may include numeric characters
 
 Returns:
 	string - the random string
@@ -102,24 +99,7 @@ Returns:
 	error - an error stemming from an invalid parameter within underlying function, RandomSeed(...)
 */
 func RandomAlphaNumeric(count int) (string, error) {
-	RandomString, err := Random(count, 0, 0, true, true)
-	if err != nil {
-		return "", fmt.Errorf("Error: %s", err)
-	}
-	match, err := regexp.MatchString("([0-9]+)", RandomString)
-	if err != nil {
-		panic(err)
-	}
-
-	if !match {
-		//Get the position between 0 and the length of the string-1  to insert a random number
-		position := rand.Intn(count)
-		//Insert a random number between [0-9] in the position
-		RandomString = RandomString[:position] + string('0'+rand.Intn(10)) + RandomString[position+1:]
-		return RandomString, err
-	}
-	return RandomString, err
-
+	return Random(count, 0, 0, true, true)
 }
 
 /*

--- a/vendor/github.com/Masterminds/goutils/stringutils.go
+++ b/vendor/github.com/Masterminds/goutils/stringutils.go
@@ -222,3 +222,19 @@ func IndexOf(str string, sub string, start int) int {
 func IsEmpty(str string) bool {
 	return len(str) == 0
 }
+
+// Returns either the passed in string, or if the string is empty, the value of defaultStr.
+func DefaultString(str string, defaultStr string) string {
+	if IsEmpty(str) {
+		return defaultStr
+	}
+	return str
+}
+
+// Returns either the passed in string, or if the string is whitespace, empty (""), the value of defaultStr.
+func DefaultIfBlank(str string, defaultStr string) string {
+	if IsBlank(str) {
+		return defaultStr
+	}
+	return str
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -409,7 +409,7 @@ github.com/IBM/secrets-manager-go-sdk/secretsmanagerv1
 github.com/IBM/vpc-go-sdk/common
 github.com/IBM/vpc-go-sdk/vpcclassicv1
 github.com/IBM/vpc-go-sdk/vpcv1
-# github.com/Masterminds/goutils v1.1.0
+# github.com/Masterminds/goutils v1.1.1 => github.com/Masterminds/goutils v1.1.1
 ## explicit
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver v1.5.0
@@ -3184,3 +3184,4 @@ sigs.k8s.io/yaml
 # google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 # google.golang.org/grpc => google.golang.org/grpc v1.35.0
 # github.com/hashicorp/go-getter => github.com/hashicorp/go-getter v1.6.2
+# github.com/Masterminds/goutils => github.com/Masterminds/goutils v1.1.1


### PR DESCRIPTION
A flaw was found in goutils where randomly generated alphanumeric strings contain significantly less entropy than expected. Both the RandomAlphaNumeric and CryptoRandomAlphaNumeric functions always return strings containing at least one digit from 0 to 9. This issue significantly reduces the amount of entropy generated in short strings by these functions.