### PR TITLE
AGENT-455: Check registry and rendezvous host access at startup

### DIFF
--- a/data/data/agent/files/etc/assisted/agent-installer.env.template
+++ b/data/data/agent/files/etc/assisted/agent-installer.env.template
@@ -8,3 +8,4 @@
 # ASSISTED_SERVICE_HOST must be updated.
 #   
 NODE_ZERO_IP={{.NodeZeroIP}}
+RELEASE_IMAGE={{.ReleaseImage}}

--- a/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
+++ b/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
@@ -1,86 +1,91 @@
 #!/bin/bash
 
 # shellcheck disable=SC1091
-source /etc/assisted/agent-installer.env
+source common.sh
 
 function has_registry_connectivity() {
-    (>&2 echo "INFO: Checking OpenShift release image at $RELEASE_IMAGE is pullable.")
+    (>&2 echo "INFO: Checking that OpenShift release image at $RELEASE_IMAGE is pullable.")
     (>&2 podman pull "$RELEASE_IMAGE")
     registry_check_status_code=$?
     if [[ "$registry_check_status_code" -ne 0 ]]; then
-      (>&2 echo "WARNING: Unable to pull release image.")
-      echo 0
+        (>&2 echo "WARNING: Unable to pull release image.")
+        echo 0
     else
-      (>&2 echo "INFO: Release image is pullable.")
-      echo 1
+        (>&2 echo "INFO: Release image is pullable.")
+        echo 1
     fi
 }
 
 function has_rendezvous_host_connectivity() {
-    if (>&2 ping -c 4 "$NODE_ZERO_IP"); then
-	  (>&2 echo "INFO: Successfully pinged rendezvous host at ${NODE_ZERO_IP}.")
-	  echo 1
-	else
-	  (>&2 echo "WARNING: Failed to ping rendezvous host at ${NODE_ZERO_IP}.")
-	  echo 0
-	fi
+    if [[ $(is_node_zero) -eq 1 ]]; then
+        (>&2 echo "INFO: Current host is the rendezvous host.")
+        echo 1
+    else
+        if (>&2 ping -c 4 "$NODE_ZERO_IP"); then
+	        (>&2 echo "INFO: Successfully pinged rendezvous host at ${NODE_ZERO_IP}.")
+	        echo 1
+	    else
+            (>&2 echo "WARNING: Failed to ping rendezvous host at ${NODE_ZERO_IP}.")
+            echo 0
+        fi
+    fi
 }
 
 function has_connectivity() {
     (>&2 echo "INFO: Checking connectivity.")
     problem_found=0
     if [[ $(has_registry_connectivity) -eq 0 ]]; then
-      problem_found=1
+        problem_found=1
     fi
     if [[ $(has_rendezvous_host_connectivity) -eq 0 ]]; then
-      problem_found=1
+        problem_found=1
     fi
 
     if [[ $problem_found -eq 1 ]]; then
-      (>&2 echo "WARNING: Connectivity problem found.")
-      echo 0
+        (>&2 echo "WARNING: Connectivity problem found.")
+        echo 0
     else
-      (>&2 echo "INFO: Host has connectivity to release image and rendezvous host.")
-      echo 1
+        (>&2 echo "INFO: Host has connectivity to release image and rendezvous host.")
+        echo 1
     fi
 }
 
 should_configure=1
 while [ $should_configure -eq 1 ]; do
-  while true; do
-    if [[ $(has_connectivity) -eq 1 ]]; then
-	    should_configure=0
-    fi
-    if [ $should_configure -eq 1 ]; then
-      # Case 1: Connectivity checks failed, run the tui to allow user to update
-      # network configuration.
-      #
-      # TODO: execute tui and remove sleep. If the tui does connectivity checks,
-      # perhaps we can exit from the loop upon the tui exiting. For now, we always
-      # exit to allow the automated flow to continue to preserve the current
-      # behavior.
-      #/usr/local/bin/agent-tui
-      echo "TODO: execute agent-tui and remove 60s sleep"
-      sleep 60
-      # break here does not work, need exit
-      exit 0
-    else
-      # Case 2: Connectivity checks passed. Give users 60s to use the tui
-      # if they would like to make a change. After 60s, the prompt disappears
-      # and automated flow will start.
-      echo "INFO: Boot will continue in 60s if the next prompt goes unanswered."
-      read -t 60 -e -r -p "Do you wish to enter NetworkManager terminal user interface to change the network configuration? (Y)es/(N)o: " ANSWER
-      if [[ "$ANSWER" =~ ^[Yy](es)?$ ]]; then
-	      # TODO: execute tui
-        #/usr/local/bin/agent-tui
-        # TODO: If the tui does connectivity checks, then we may not need to force
-        # this script to do its own connectivty checks again. The next line may be
-        # removed and can break from the loop.
-        should_configure=1
-      else
-        # The prompt timed out. Proceed with automated flow.
-        break
-      fi
-    fi
-  done
+    while true; do
+        if [[ $(has_connectivity) -eq 1 ]]; then
+	        should_configure=0
+        fi
+        if [ $should_configure -eq 1 ]; then
+            # Case 1: Connectivity checks failed, run the tui to allow user to update
+            # network configuration.
+            #
+            # TODO: execute tui and remove sleep. If the tui does connectivity checks,
+            # perhaps we can exit from the loop upon the tui exiting. For now, we always
+            # exit to allow the automated flow to continue to preserve the current
+            # behavior.
+            #/usr/local/bin/agent-tui
+            echo "TODO: execute agent-tui and remove 60s sleep"
+            sleep 60
+            # break here does not work, need exit
+            exit 0
+        else
+            # Case 2: Connectivity checks passed. Give users 60s to use the tui
+            # if they would like to make a change. After 60s, the prompt disappears
+            # and automated flow will start.
+            echo "INFO: Boot will continue in 60s if the next prompt goes unanswered."
+            read -t 60 -e -r -p "Do you wish to enter NetworkManager terminal user interface to change the network configuration? (Y)es/(N)o: " ANSWER
+            if [[ "$ANSWER" =~ ^[Yy](es)?$ ]]; then
+	              # TODO: execute tui
+                #/usr/local/bin/agent-tui
+                # TODO: If the tui does connectivity checks, then we may not need to force
+                # this script to do its own connectivty checks again. The next line may be
+                # removed and can break from the loop.
+                should_configure=1
+            else
+                # The prompt timed out. Proceed with automated flow.
+                break
+            fi
+        fi
+    done
 done

--- a/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
+++ b/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "agent-interactive-console start"
+systemctl status pre-network-manager-config.service
+
+# TODO: Execute tui and remove sleep
+echo "sleeping 60 seconds"
+sleep 60
+
+echo "agent-interactive-console end"

--- a/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
+++ b/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
@@ -69,7 +69,7 @@ while [ $should_configure -eq 1 ]; do
       # if they would like to make a change. After 60s, the prompt disappears
       # and automated flow will start.
       echo "INFO: Boot will continue in 60s if the next prompt goes unanswered."
-      read -t 60 -e -p "Do you wish to enter NetworkManager terminal user interface to change the network configuration? (Y)es/(N)o: " ANSWER
+      read -t 60 -e -r -p "Do you wish to enter NetworkManager terminal user interface to change the network configuration? (Y)es/(N)o: " ANSWER
       if [[ "$ANSWER" =~ ^[Yy](es)?$ ]]; then
 	      # TODO: execute tui
         #/usr/local/bin/agent-tui

--- a/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
+++ b/data/data/agent/files/usr/local/bin/agent-interactive-console.sh
@@ -1,10 +1,86 @@
 #!/bin/bash
 
-echo "agent-interactive-console start"
-systemctl status pre-network-manager-config.service
+# shellcheck disable=SC1091
+source /etc/assisted/agent-installer.env
 
-# TODO: Execute tui and remove sleep
-echo "sleeping 60 seconds"
-sleep 60
+function has_registry_connectivity() {
+    (>&2 echo "INFO: Checking OpenShift release image at $RELEASE_IMAGE is pullable.")
+    (>&2 podman pull "$RELEASE_IMAGE")
+    registry_check_status_code=$?
+    if [[ "$registry_check_status_code" -ne 0 ]]; then
+      (>&2 echo "WARNING: Unable to pull release image.")
+      echo 0
+    else
+      (>&2 echo "INFO: Release image is pullable.")
+      echo 1
+    fi
+}
 
-echo "agent-interactive-console end"
+function has_rendezvous_host_connectivity() {
+    if (>&2 ping -c 4 "$NODE_ZERO_IP"); then
+	  (>&2 echo "INFO: Successfully pinged rendezvous host at ${NODE_ZERO_IP}.")
+	  echo 1
+	else
+	  (>&2 echo "WARNING: Failed to ping rendezvous host at ${NODE_ZERO_IP}.")
+	  echo 0
+	fi
+}
+
+function has_connectivity() {
+    (>&2 echo "INFO: Checking connectivity.")
+    problem_found=0
+    if [[ $(has_registry_connectivity) -eq 0 ]]; then
+      problem_found=1
+    fi
+    if [[ $(has_rendezvous_host_connectivity) -eq 0 ]]; then
+      problem_found=1
+    fi
+
+    if [[ $problem_found -eq 1 ]]; then
+      (>&2 echo "WARNING: Connectivity problem found.")
+      echo 0
+    else
+      (>&2 echo "INFO: Host has connectivity to release image and rendezvous host.")
+      echo 1
+    fi
+}
+
+should_configure=1
+while [ $should_configure -eq 1 ]; do
+  while true; do
+    if [[ $(has_connectivity) -eq 1 ]]; then
+	    should_configure=0
+    fi
+    if [ $should_configure -eq 1 ]; then
+      # Case 1: Connectivity checks failed, run the tui to allow user to update
+      # network configuration.
+      #
+      # TODO: execute tui and remove sleep. If the tui does connectivity checks,
+      # perhaps we can exit from the loop upon the tui exiting. For now, we always
+      # exit to allow the automated flow to continue to preserve the current
+      # behavior.
+      #/usr/local/bin/agent-tui
+      echo "TODO: execute agent-tui and remove 60s sleep"
+      sleep 60
+      # break here does not work, need exit
+      exit 0
+    else
+      # Case 2: Connectivity checks passed. Give users 60s to use the tui
+      # if they would like to make a change. After 60s, the prompt disappears
+      # and automated flow will start.
+      echo "INFO: Boot will continue in 60s if the next prompt goes unanswered."
+      read -t 60 -e -p "Do you wish to enter NetworkManager terminal user interface to change the network configuration? (Y)es/(N)o: " ANSWER
+      if [[ "$ANSWER" =~ ^[Yy](es)?$ ]]; then
+	      # TODO: execute tui
+        #/usr/local/bin/agent-tui
+        # TODO: If the tui does connectivity checks, then we may not need to force
+        # this script to do its own connectivty checks again. The next line may be
+        # removed and can break from the loop.
+        should_configure=1
+      else
+        # The prompt timed out. Proceed with automated flow.
+        break
+      fi
+    fi
+  done
+done

--- a/data/data/agent/files/usr/local/bin/common.sh
+++ b/data/data/agent/files/usr/local/bin/common.sh
@@ -13,7 +13,8 @@ wait_for_assisted_service() {
 }
 
 is_node_zero() {
-    local is_rendezvous_host=$(ip -j address | jq "[.[].addr_info] | flatten | map(.local==\"$NODE_ZERO_IP\") | any")
+    local is_rendezvous_host
+    is_rendezvous_host=$(ip -j address | jq "[.[].addr_info] | flatten | map(.local==\"$NODE_ZERO_IP\") | any")
     if [[ "${is_rendezvous_host}" == "true" ]]; then
         echo 1
     else

--- a/data/data/agent/files/usr/local/bin/common.sh
+++ b/data/data/agent/files/usr/local/bin/common.sh
@@ -2,6 +2,7 @@
 
 # shellcheck disable=SC1091
 source /usr/local/share/assisted-service/assisted-service.env 
+source /etc/assisted/agent-installer.env
 
 wait_for_assisted_service() {
     echo "Waiting for assisted-service to be ready"
@@ -9,4 +10,13 @@ wait_for_assisted_service() {
         printf '.'
         sleep 5
     done
+}
+
+is_node_zero() {
+    local is_rendezvous_host=$(ip -j address | jq "[.[].addr_info] | flatten | map(.local==\"$NODE_ZERO_IP\") | any")
+    if [[ "${is_rendezvous_host}" == "true" ]]; then
+        echo 1
+    else
+        echo 0
+    fi
 }

--- a/data/data/agent/files/usr/local/bin/set-node-zero.sh
+++ b/data/data/agent/files/usr/local/bin/set-node-zero.sh
@@ -3,18 +3,18 @@
 set -e
 
 # shellcheck disable=SC1091
-source /etc/assisted/agent-installer.env
+source common.sh
 echo "NODE_ZERO_IP: $NODE_ZERO_IP"
 
 timeout=$((SECONDS + 30))
 
 while [[ $SECONDS -lt $timeout ]]
 do
-     IS_NODE_ZERO=$(ip -j address | jq "[.[].addr_info] | flatten | map(.local==\"$NODE_ZERO_IP\") | any")
-     if [ "${IS_NODE_ZERO}" = "true" ]; then
-          break
-     fi
-     sleep 5
+    if [[ $(is_node_zero) -eq 1 ]]; then
+        IS_NODE_ZERO="true"
+        break
+    fi
+    sleep 5
 done
 
 if [ "${IS_NODE_ZERO}" = "true" ]; then

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -2,6 +2,7 @@
 Description=Get interactive user configuration at boot
 After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
 Before=network.target network.service agent.service NetworkManager-wait-online.service
+ConditionPathExists=/usr/local/bin/agent-tui
 
 [Service]
 Type=oneshot

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Get interactive user configuration at boot
+After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
+Before=network.target network.service agent.service NetworkManager-wait-online.service
+
+[Service]
+Type=oneshot
+TTYPath=/dev/tty15
+ExecStartPre=/usr/bin/chvt 15
+ExecStart="/usr/local/bin/agent-interactive-console.sh"
+ExecStartPost=/usr/bin/chvt 1
+TimeoutStartSec=0
+StandardInput=tty
+TTYVHangup=yes
+TTYVTDisallocate=yes
+
+[Install]
+WantedBy=default.target
+RequiredBy=sshd.service systemd-logind.service getty@tty1.service

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -2,7 +2,6 @@
 Description=Get interactive user configuration at boot
 After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
 Before=network.target network.service agent.service NetworkManager-wait-online.service
-ConditionPathExists=/usr/local/bin/agent-tui
 
 [Service]
 Type=oneshot

--- a/data/data/agent/systemd/units/agent-tui.path
+++ b/data/data/agent/systemd/units/agent-tui.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Activate agent-interactive-console.service only when the agent-tui path exists
+
+[Path]
+PathExists=/usr/local/bin/agent-tui
+Unit=agent-interactive-console.service
+
+[Install]
+WantedBy=default.target

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -215,7 +215,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 
 	agentEnabledServices := []string{
 		"agent.service",
-		"agent-interactive-console.service",
+		"agent-tui.path",
 		"assisted-service-db.service",
 		"assisted-service-pod.service",
 		"assisted-service.service",

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -215,6 +215,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 
 	agentEnabledServices := []string{
 		"agent.service",
+		"agent-interactive-console.service",
 		"assisted-service-db.service",
 		"assisted-service-pod.service",
 		"assisted-service.service",

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -389,6 +389,7 @@ metadata:
 				"/root/assisted.te",
 				"/usr/local/bin/common.sh",
 				"/usr/local/bin/agent-gather",
+				"/usr/local/bin/agent-interactive-console.sh",
 				"/usr/local/bin/extract-agent.sh",
 				"/usr/local/bin/get-container-images.sh",
 				"/usr/local/bin/install-status.sh",


### PR DESCRIPTION
Update the interactive console service to have it check the current
host can access the release image and rendezvous host. Display
this connectivity information to the user before prompting to run
the network configuration tui.

If there is connectivity, then the prompt times out after 60s and
the automation flow is allowed to continue.

If there is a connectivity issue, then the network configuration
tui will be executed to allow users to update. The tui, however,
has not been  integrated with the interactive console service, so
in the meantime, there is a 60s sleep in place of executing the tui.
This will be changed in a future patch.

Depends on: https://github.com/openshift/installer/pull/6756