### PR TITLE
PowerVS: Remove region requirement

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3092,7 +3092,6 @@ spec:
                     type: string
                 required:
                 - powervsResourceGroup
-                - region
                 - serviceInstanceID
                 - userID
                 - zone

--- a/pkg/asset/installconfig/powervs/session.go
+++ b/pkg/asset/installconfig/powervs/session.go
@@ -257,7 +257,6 @@ func (c *BxClient) NewPISession() error {
 	options := &ibmpisession.IBMPIOptions{
 		Authenticator: authenticator,
 		UserAccount:   c.User.Account,
-		Region:        pisv.Region,
 		Zone:          pisv.Zone,
 		Debug:         false,
 	}

--- a/pkg/destroy/powervs/powervs.go
+++ b/pkg/destroy/powervs/powervs.go
@@ -494,11 +494,6 @@ func (o *ClusterUninstaller) loadSDKServices() error {
 		return fmt.Errorf("loadSDKServices: resourceClientV2.GetInstance: %v", err)
 	}
 
-	region, err := GetRegion(serviceInstance.RegionID)
-	if err != nil {
-		return fmt.Errorf("loadSDKServices: GetRegion: %v", err)
-	}
-
 	var authenticator core.Authenticator = &core.IamAuthenticator{
 		ApiKey: o.APIKey,
 	}
@@ -511,7 +506,6 @@ func (o *ClusterUninstaller) loadSDKServices() error {
 	var options *ibmpisession.IBMPIOptions = &ibmpisession.IBMPIOptions{
 		Authenticator: authenticator,
 		Debug:         false,
-		Region:        region,
 		UserAccount:   user.Account,
 		Zone:          serviceInstance.RegionID,
 	}

--- a/pkg/types/powervs/platform.go
+++ b/pkg/types/powervs/platform.go
@@ -11,7 +11,7 @@ type Platform struct {
 	PowerVSResourceGroup string `json:"powervsResourceGroup"`
 
 	// Region specifies the IBM Cloud colo region where the cluster will be created.
-	Region string `json:"region"`
+	Region string `json:"region,omitempty"`
 
 	// Zone specifies the IBM Cloud colo region where the cluster will be created.
 	// At this time, only single-zone clusters are supported.

--- a/pkg/types/powervs/powervs_regions.go
+++ b/pkg/types/powervs/powervs_regions.go
@@ -109,3 +109,38 @@ func ValidateVPCRegion(region string) bool {
 	}
 	return found
 }
+
+// ValidateZone validates that the given zone is known/tested.
+func ValidateZone(zone string) bool {
+	for r := range Regions {
+		for z := range Regions[r].Zones {
+			if zone == Regions[r].Zones[z] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ZoneNames returns the list of zone names.
+func ZoneNames() []string {
+	zones := []string{}
+	for r := range Regions {
+		for z := range Regions[r].Zones {
+			zones = append(zones, Regions[r].Zones[z])
+		}
+	}
+	return zones
+}
+
+// RegionFromZone returns the region name for a given zone name.
+func RegionFromZone(zone string) string {
+	for r := range Regions {
+		for z := range Regions[r].Zones {
+			if zone == Regions[r].Zones[z] {
+				return r
+			}
+		}
+	}
+	return ""
+}

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -96,7 +96,7 @@ func validIBMCloudPlatform() *ibmcloud.Platform {
 
 func validPowerVSPlatform() *powervs.Platform {
 	return &powervs.Platform{
-		Region: "dal",
+		Zone: "dal12",
 	}
 }
 
@@ -1049,7 +1049,7 @@ func TestValidateInstallConfig(t *testing.T) {
 				}
 				return c
 			}(),
-			expectedError: `^\Qplatform.powervs.region: Required value: region must be specified\E$`,
+			expectedError: `^\Qplatform.powervs.zone: Required value: zone must be specified\E$`,
 		},
 		{
 			name: "valid azurestack platform",


### PR DESCRIPTION
For the power-go-client, Region (and the endpoint name) is now derived from the Zone. Also, the install-config.yaml should handle not specifying the region.

https://issues.redhat.com/browse/MULTIARCH-2418WIP