### PR TITLE
AGENT-505: Embed agent-tui binary in the agent ISO

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
+++ b/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
@@ -1,0 +1,41 @@
+# Verify that the most relevant assets are properly generated in the ISO
+
+exec openshift-install agent create image --dir $WORK
+
+exists $WORK/agent.x86_64.iso
+
+ignitionImgContains agent.x86_64.iso config.ign
+ignitionImgContains agent.x86_64.iso agent
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane: 
+  name: master
+  replicas: 1
+compute: 
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 
+    hostPrefix: 23 
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: 
+  - 172.30.0.0/16
+platform:
+  none: {}
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20

--- a/pkg/asset/agent/image/cpio.go
+++ b/pkg/asset/agent/image/cpio.go
@@ -75,7 +75,6 @@ func (ca *CpioArchive) StoreFile(filename string) error {
 	_, err = io.Copy(ca.cpioWriter, f)
 	if err != nil {
 		return err
-
 	}
 
 	return nil

--- a/pkg/asset/agent/image/cpio.go
+++ b/pkg/asset/agent/image/cpio.go
@@ -1,0 +1,109 @@
+package image
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+
+	"github.com/cavaliercoder/go-cpio"
+)
+
+// CpioArchive simplifies the creation of a compressed cpio archive.
+type CpioArchive struct {
+	buffer     *bytes.Buffer
+	gzipWriter *gzip.Writer
+	cpioWriter *cpio.Writer
+}
+
+// NewCpioArchive creates a new CpioArchive instance.
+func NewCpioArchive() *CpioArchive {
+	buf := new(bytes.Buffer)
+	gw := gzip.NewWriter(buf)
+	cw := cpio.NewWriter(gw)
+
+	return &CpioArchive{
+		buffer:     buf,
+		gzipWriter: gw,
+		cpioWriter: cw,
+	}
+}
+
+// StoreBytes appends to the current archive the given content using
+// the specified filename.
+func (ca *CpioArchive) StoreBytes(filename string, content []byte) error {
+	header := cpio.Header{
+		Name: filename,
+		Mode: 0o100_644,
+		Size: int64(len(content)),
+	}
+
+	err := ca.cpioWriter.WriteHeader(&header)
+	if err != nil {
+		return err
+	}
+
+	_, err = ca.cpioWriter.Write(content)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// StoreFile appends to the current archive the specified file.
+func (ca *CpioArchive) StoreFile(filename string) error {
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	fileInfo, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := cpio.FileInfoHeader(fileInfo, "")
+	if err != nil {
+		return err
+	}
+	if err := ca.cpioWriter.WriteHeader(header); err != nil {
+		return err
+	}
+
+	_, err = io.Copy(ca.cpioWriter, f)
+	if err != nil {
+		return err
+
+	}
+
+	return nil
+}
+
+// Save appends persists the archive on the disk.
+func (ca *CpioArchive) Save(archivePath string) error {
+	err := ca.cpioWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	err = ca.gzipWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.Create(archivePath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	bs := ca.buffer.Bytes()
+	_, err = out.Write(bs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This patches modifies the current ISO generation to insert also the agent-tui binary.

How it works:
* The rhcos base ISO is unpacked in a temp folder
* A new compressed cpio archive `ignition.img` is created, containing:
  * The `config.ign` file generated by the agent installer
  * The `agent-tui` binary
 * The new `ignition.img` is saved in the temp folder, overwriting the older one
 * A new ISO is created with the content of the temp folder

For manual testing: 
```
$ iso-read --image agent.x86_64.iso --extract /images/ignition.img --output-file ignition.img
$ zcat ignition.img | cpio -idmv
```