### PR TITLE
CORS-2479: bootstrap: set 0644 mode for registries.conf

### DIFF
--- a/data/data/bootstrap/files/usr/local/bin/bootstrap-pivot.sh.template
+++ b/data/data/bootstrap/files/usr/local/bin/bootstrap-pivot.sh.template
@@ -37,6 +37,7 @@ if [ ! -f /opt/openshift/.pivot-done ]; then
     . ./pre-pivot.sh
   popd
 {{else if .IsSCOS -}}
+  chmod 0644 /etc/containers/registries.conf
   rpm-ostree rebase --experimental "ostree-unverified-registry:${MACHINE_OS_IMAGE}"
   touch /opt/openshift/.pivot-done
   record_service_stage_success


### PR DESCRIPTION
This should fix OKD SCOS, which pivots the bootstrap node and requires the file to be world-readable so that rpm-ostree could read it and fetch machine-os-content image