### PR TITLE
OCPBUGS-5960: bump RHCOS 4.12 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.12",
   "metadata": {
-    "last-modified": "2022-12-15T02:09:21Z",
-    "generator": "plume cosa2stream 7db14c5"
+    "last-modified": "2023-02-02T19:16:07Z",
+    "generator": "plume cosa2stream 465b8e2"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-aws.aarch64.vmdk.gz",
-                "sha256": "aa43feb0de2fd804c0569146c15fd7bcd3e26864976408a2839cbcf80fee4191",
-                "uncompressed-sha256": "02d05778e6443b654871fea136acf3426b901167ec012e012b1a5651ec97ed42"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-aws.aarch64.vmdk.gz",
+                "sha256": "11da745e7b96058ec398d5e752af1198b44beab36fe274c6d98fbc8cb0e5d6a1",
+                "uncompressed-sha256": "3874ebac62a2f42cae89817f2e02e3cb80800ec93ade1a26bdcbed1aa56d1d57"
               }
             }
           }
         },
         "azure": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-azure.aarch64.vhd.gz",
-                "sha256": "f89ebe2d2e3a85c7b0e9eebb452005a7113835b564b9b66b0de4510f1931b9bf",
-                "uncompressed-sha256": "aab916dd4a29e0f157ae0634e40874fcd0b16b29bb191804414610d00ce47e34"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-azure.aarch64.vhd.gz",
+                "sha256": "a1f903221952a62b907405d551a4214e6d34f17b20a6346d326028a12b85796a",
+                "uncompressed-sha256": "442883a5e2bec07abd5b8212847b572fec0572b383f253c403ea36ba662bd4da"
               }
             }
           }
         },
         "metal": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-metal4k.aarch64.raw.gz",
-                "sha256": "2c9877c3c017fb1b499135290ecfa69232929e3d35791bbe0c083c328c8fd3d2",
-                "uncompressed-sha256": "df62ad50c7a5d4c053951b8e8a17d953e9884e5360266392a2a47c0d83547df8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-metal4k.aarch64.raw.gz",
+                "sha256": "8585d3695f4ad92b82c1814ca9e69eb6046454e868cc5f318a052055abac8996",
+                "uncompressed-sha256": "719581f857d9cd13d80d16eb78f956cdfd7449c16e59ceea3b4a748e56de3eac"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-live.aarch64.iso",
-                "sha256": "cd7c657fff4c126f4333dd6775ac552020b6f6cb90a7e0302377564363a7f289"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-live.aarch64.iso",
+                "sha256": "3db425052abb432f33f98b0e4e88c390bc8b23dad2831845b0b5ec5be03e4abe"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-live-kernel-aarch64",
-                "sha256": "3fa0578926434b0be2a94e2494711e36ee07044965620e111bc07d3ac583361e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-live-kernel-aarch64",
+                "sha256": "0687b78d6d05e5419189d124e50dbf42b5d5ddb1a70e06b1532f6d09d20077b3"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-live-initramfs.aarch64.img",
-                "sha256": "7abda60cffff4720397aaadc95aaa10adc92f08535a0cf9420eda3dcd5a57257"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-live-initramfs.aarch64.img",
+                "sha256": "2d5b873ad95b5fd2476651d56c8290ba186ebc35793f8ecb9999fa5e88abb113"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-live-rootfs.aarch64.img",
-                "sha256": "549e7a3aaf808581c2bf83b534d41ad0365467fa4da3621e459f4b4ea8395956"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-live-rootfs.aarch64.img",
+                "sha256": "98606b4142fc01be96a23eca7940e3f785c67b7ad43f5e857359a474f077d015"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-metal.aarch64.raw.gz",
-                "sha256": "ef65eb63994e750861733e7bd3199a26404873249cd0668a18ebcd8d4c93487b",
-                "uncompressed-sha256": "ad4ccc3d3342df202658a67dc76b680c322a06b5dc543cc200e73d04b41850a5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-metal.aarch64.raw.gz",
+                "sha256": "6b26513c488c6cc184cc892a99d20ef4c9a20ee76d851914b25420e8d9e55875",
+                "uncompressed-sha256": "7ac6ab2a27a0d1b994380ea8ebad1a42e387b3136a9072fc41dc92ac249904f3"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-openstack.aarch64.qcow2.gz",
-                "sha256": "7415a8ca5b1ec348b19a90a7d9d657a915ada847ab425d01259921cdc458ceb9",
-                "uncompressed-sha256": "9df6534a6b066691c4ef988d8946c846095adc8c75ac217871b6fafacb65deb1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-openstack.aarch64.qcow2.gz",
+                "sha256": "c153837e4ea47e32797ad2973bd4c502b4e5312607f324b959ab04ebb349ec44",
+                "uncompressed-sha256": "192df44a62d9d63ef2244b9a524d8f21911b6c817988abe931d7243d718e04b9"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/aarch64/rhcos-412.86.202212081411-0-qemu.aarch64.qcow2.gz",
-                "sha256": "c27eddaf07d3284cef26f88020a1fa151d8442f4839bb3ef02fad9d2e833c21f",
-                "uncompressed-sha256": "3ca6646558f666892a30408f5c87b923a48e810fc08dc10097788555ad097516"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/aarch64/rhcos-412.86.202301311551-0-qemu.aarch64.qcow2.gz",
+                "sha256": "68821ee1178b84bdcb06b8744eb327a0259a55c7b9d1d9ad58dff9dd48ac7dbd",
+                "uncompressed-sha256": "33925ac380e0b7b74f36737c7d0de4fa3058da719d5fb6a8f442b0d686d9b97b"
               }
             }
           }
@@ -99,184 +99,184 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0574bcc5f80b0ad9a"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0bc4958afdd762f70"
             },
             "ap-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0a65e79822ae2d235"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0953b21470750b0c3"
             },
             "ap-northeast-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0f7ef19d48e22353b"
+              "release": "412.86.202301311551-0",
+              "image": "ami-073adb074bbea15c7"
             },
             "ap-northeast-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-051dc6de359975e3c"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0aba5fecd7c6f43ad"
             },
             "ap-northeast-3": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0fd0b4222595650ac"
+              "release": "412.86.202301311551-0",
+              "image": "ami-02607e00e48056d04"
             },
             "ap-south-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-05f9d14fe4a90ed6f"
+              "release": "412.86.202301311551-0",
+              "image": "ami-09a89d0704357dd2f"
             },
             "ap-southeast-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0afdb9133d22fba5f"
+              "release": "412.86.202301311551-0",
+              "image": "ami-03880abf3e298164f"
             },
             "ap-southeast-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0ef979abe82d07d44"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0c30952d150abf53a"
             },
             "ap-southeast-3": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-025f9103ac4310e7f"
+              "release": "412.86.202301311551-0",
+              "image": "ami-057fb3c796e19315e"
             },
             "ca-central-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0588cdf59e5c14847"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0777c8c09d2e49f48"
             },
             "eu-central-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0ef24c0e18f93fa42"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0886025a977036a73"
             },
             "eu-north-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0439e2a3bf315df1a"
+              "release": "412.86.202301311551-0",
+              "image": "ami-095dcd4470ae0c748"
             },
             "eu-south-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0714e7c2e0106cdd3"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0b92e7eb49b30168b"
             },
             "eu-west-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0b960e76764ccd0c3"
+              "release": "412.86.202301311551-0",
+              "image": "ami-071f95269a9c21be6"
             },
             "eu-west-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-02621f50de62b3b89"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0568d53c1ae1b7574"
             },
             "eu-west-3": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0933ce7f5e2bfb50e"
+              "release": "412.86.202301311551-0",
+              "image": "ami-099efa492a5c2c167"
             },
             "me-south-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-074bde61a2ab740ee"
+              "release": "412.86.202301311551-0",
+              "image": "ami-09b163a8ac6075cdb"
             },
             "sa-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-03b4f97cfc8033ae0"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0dd9e073099706f98"
             },
             "us-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-02a574449d4f4d280"
+              "release": "412.86.202301311551-0",
+              "image": "ami-093157675ab1769a7"
             },
             "us-east-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-020e5600ef28c60ae"
+              "release": "412.86.202301311551-0",
+              "image": "ami-06fa3a8e3be9cf7d1"
             },
             "us-gov-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-069f60e1dcf766d24"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0925aa7299355e768"
             },
             "us-gov-west-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0db3cda4dbaccda02"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0358ce8d34602ca57"
             },
             "us-west-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0c90cabeb5dee3178"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0bc2994c6dd9266ec"
             },
             "us-west-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0f96437a23aeae53f"
+              "release": "412.86.202301311551-0",
+              "image": "ami-030ac7b8db33c6c0d"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "412.86.202212081411-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202212081411-0-azure.aarch64.vhd"
+          "release": "412.86.202301311551-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202301311551-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/ppc64le/rhcos-412.86.202212081411-0-metal4k.ppc64le.raw.gz",
-                "sha256": "fc0d997a7646ecff17655975300d3422f7a5dbacc39e6d1b2aa3a6b16eecf04d",
-                "uncompressed-sha256": "18a5a523522eff7a0605f52fbe6f3b1c8b27158cc7d590c3cd7b58ad7f5dd843"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/ppc64le/rhcos-412.86.202301311551-0-metal4k.ppc64le.raw.gz",
+                "sha256": "ad529de446109060b4d585d2448cc69e7c7ba1e05a20dbc6ddb5fedba71a2748",
+                "uncompressed-sha256": "d8f02d7157238ddf9d2cca75ddadc2a3c29d927eb06d9f38affb07d88c9771a2"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/ppc64le/rhcos-412.86.202212081411-0-live.ppc64le.iso",
-                "sha256": "01fd215f7a043ca536933caabc7598c0441751c69a2e97541e4fc9e57abbf2a5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/ppc64le/rhcos-412.86.202301311551-0-live.ppc64le.iso",
+                "sha256": "64197ebe58a8aa8926269985af3ce9b3b5e3c937fdff76824c5fe3fd2c66bd04"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/ppc64le/rhcos-412.86.202212081411-0-live-kernel-ppc64le",
-                "sha256": "384c2fc885f5c4069675c483b13b94e69075e0ea533d8245687d66f2a498de77"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/ppc64le/rhcos-412.86.202301311551-0-live-kernel-ppc64le",
+                "sha256": "24fcd3bd7cea04c4caf6b3420ae14bbd77f9464b1aa098a55d505426fe705611"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/ppc64le/rhcos-412.86.202212081411-0-live-initramfs.ppc64le.img",
-                "sha256": "a888a495ec27d95c552991fa75ee1a6a2f3db75433cdbd22e46efe4979b529a3"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/ppc64le/rhcos-412.86.202301311551-0-live-initramfs.ppc64le.img",
+                "sha256": "427b9f441684be810bbe1ab77e3c1c9be4b9772f90a26814ef7cc9efa52bcbf1"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/ppc64le/rhcos-412.86.202212081411-0-live-rootfs.ppc64le.img",
-                "sha256": "2db188fdac990d31dcee77b7cfa59a0b777bbe15e92da069e91d519602d06c06"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/ppc64le/rhcos-412.86.202301311551-0-live-rootfs.ppc64le.img",
+                "sha256": "904f9bdc99b37d79f8736fcaff730d25316a64e2652fcb12eaf5702d00f38540"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/ppc64le/rhcos-412.86.202212081411-0-metal.ppc64le.raw.gz",
-                "sha256": "328543f66410bc061607a1113a90b6528ba4d1f627facabbe663ff824fbeae1c",
-                "uncompressed-sha256": "cdc74e6363188c691d8cc29cea4cfdaadc401cf08e7b1f4bca97d2119b1bbb1d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/ppc64le/rhcos-412.86.202301311551-0-metal.ppc64le.raw.gz",
+                "sha256": "ad5c157a30f4b52c70e59a4f00fbd053e18987899cb3f3737ab7b43329e7aa67",
+                "uncompressed-sha256": "b5d348752de5004f67fee37e062b275bfd4a260066548298429f6fbac7895d60"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/ppc64le/rhcos-412.86.202212081411-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "1ec7538f15b8a6d79859a64ed7dfec9d7181983dd60a48248992b51b9d07752f",
-                "uncompressed-sha256": "67e1d7127a29db7b53d2f54b9927c0f4143107e792c19a49d164b487b540575d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/ppc64le/rhcos-412.86.202301311551-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "b0245387ebcec51aecf34ca6116cd49697164c58fa6659c6f9fc737abbdf2ad1",
+                "uncompressed-sha256": "7e4daa08eca7b51de60e2cd4c6c823aec0248c080858849b847c90c58257cab7"
               }
             }
           }
         },
         "powervs": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/ppc64le/rhcos-412.86.202212081411-0-powervs.ppc64le.ova.gz",
-                "sha256": "6d1552f60fffad884698acc89317510bb15d4512e067b67cd33c6e19fc1c2846",
-                "uncompressed-sha256": "06980feedfd39e35dd46e83d17b5d5d569fbc7023f4ca1f58009aa16e29ff696"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/ppc64le/rhcos-412.86.202301311551-0-powervs.ppc64le.ova.gz",
+                "sha256": "89fb72e8e52c15331c8573e56a4889c3a73e5c3d76118d601f3eb2cfbcfb1e97",
+                "uncompressed-sha256": "ad60fc5c0c199f7570449969219fe426ac01bd01db12aa402a826879d57d5483"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/ppc64le/rhcos-412.86.202212081411-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "c5901d8a1e992cbd5a563e98bfb53779690f1b088bb2c505e7c7cdb1e61f5572",
-                "uncompressed-sha256": "e5b15d307dbf35aa6875d70fd0870a586d364e76084530fe0021b03f9a4ed2c5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/ppc64le/rhcos-412.86.202301311551-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "fd3ce4449d9593f0ed5554e661c69d7b13b2c25c4eab75bb5117ee797f4326d6",
+                "uncompressed-sha256": "dc6c54198a4c7ab89c421305c614c0a99f44d1e8468f0cfb1fefa48a98da4005"
               }
             }
           }
@@ -286,58 +286,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "412.86.202212081411-0",
-              "object": "rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202301311551-0",
+              "object": "rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "412.86.202212081411-0",
-              "object": "rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202301311551-0",
+              "object": "rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "412.86.202212081411-0",
-              "object": "rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202301311551-0",
+              "object": "rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "412.86.202212081411-0",
-              "object": "rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202301311551-0",
+              "object": "rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "412.86.202212081411-0",
-              "object": "rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202301311551-0",
+              "object": "rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "412.86.202212081411-0",
-              "object": "rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202301311551-0",
+              "object": "rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "412.86.202212081411-0",
-              "object": "rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202301311551-0",
+              "object": "rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "412.86.202212081411-0",
-              "object": "rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202301311551-0",
+              "object": "rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "412.86.202212081411-0",
-              "object": "rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz",
+              "release": "412.86.202301311551-0",
+              "object": "rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-412-86-202212081411-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-412-86-202301311551-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -346,76 +346,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/s390x/rhcos-412.86.202212081411-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "82747e9e31496666424a209ebcf239fa0424f81306eae13befb44ac42f8c96f0",
-                "uncompressed-sha256": "7896fd642d3be66ae48b79cc821ff74b57d8dd2fe6f68e5b2d1f70980240d965"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "f4ac2ebc0e518040b37943b0d6447242efce8368bf893947ebfeba7481da7ecb",
+                "uncompressed-sha256": "800da56db7a7e05d247bb7dc0e420b88f6720f2cb6521af3218f070462b5b9fd"
               }
             }
           }
         },
         "metal": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/s390x/rhcos-412.86.202212081411-0-metal4k.s390x.raw.gz",
-                "sha256": "c85469133f1ce3a1d7065df61e7768b785eae631799485624e68bc61e491f904",
-                "uncompressed-sha256": "a3fff27207384b340717cb31b2e91b61397844beaca5aa9f371d183b5dc94246"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-metal4k.s390x.raw.gz",
+                "sha256": "1edb076db038d345642957412cc27b7d4f53b5d627ed7737f4a7f82069a3a052",
+                "uncompressed-sha256": "0bb1bb220a31e01539221a9a90d89cc3392bf933af21ea2ad3d8242dcb8454f2"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/s390x/rhcos-412.86.202212081411-0-live.s390x.iso",
-                "sha256": "8c7a7cd13faa324a366f18f37b0f250880400d631e4ca78fcb11f47210affe46"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-live.s390x.iso",
+                "sha256": "97dd0d5d3e70fba946a980d209115d2424a3cdaaf0bf3ee15147f255890a8525"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/s390x/rhcos-412.86.202212081411-0-live-kernel-s390x",
-                "sha256": "6e4749152f10939e317e84f0e0197a8d84d165ef87bec7b0accd17dd3b174ca2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-live-kernel-s390x",
+                "sha256": "9a1caf3d00f7a40d2a880f2aadb6eb7cda88b5883fbdaa56d3a782511c491d47"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/s390x/rhcos-412.86.202212081411-0-live-initramfs.s390x.img",
-                "sha256": "d9e21677dbe7fe13f2f743368475431ac6d48c0fcd68487dbb4cd4f6e0e29054"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-live-initramfs.s390x.img",
+                "sha256": "c30bc027ad9707ebf4915218f375af99d1e17fc3482ccab177e79cb2a6ee9b41"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/s390x/rhcos-412.86.202212081411-0-live-rootfs.s390x.img",
-                "sha256": "75ff7ac13d1fb23655e34d8031616481f04351d58a7de7fcbbc67a1ad410f9bd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-live-rootfs.s390x.img",
+                "sha256": "2bb940a877b4f8bb7f6dc24d171e6f82061f597a8e7129ae925099f26fe01281"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/s390x/rhcos-412.86.202212081411-0-metal.s390x.raw.gz",
-                "sha256": "b1a317170807216afee7d3ad4c7964569624dc5d28ffe8370eae90f21ac634cc",
-                "uncompressed-sha256": "bb90b5fdf7d804773fdb85265b19e104ae17fb82b0238d3aca92589f2ce63d0c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-metal.s390x.raw.gz",
+                "sha256": "ad976b60bd9354b44a180bdbe61e31f324f63ac9d27d937f5823af16cc4e0108",
+                "uncompressed-sha256": "5ddc9a02e08aac7a70da1a588ee93b93155188c50f728cd5084ac5f4d59a6143"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/s390x/rhcos-412.86.202212081411-0-openstack.s390x.qcow2.gz",
-                "sha256": "4029dfa4ebfee172c863ec982ef8614b081256418fa9885820364603286d455f",
-                "uncompressed-sha256": "aa52f831774ea0f7614a4167e986bf4d2a16958f2a75a1db67834a21e6574622"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-openstack.s390x.qcow2.gz",
+                "sha256": "cb8aca7ef729960a27f8b067ce6c8d08695fe2879b84b30c544b4107fa6fe494",
+                "uncompressed-sha256": "a762ab507c93355cc383809886b2b294cd46dfb587e1dae3614ec83140b53c29"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/s390x/rhcos-412.86.202212081411-0-qemu.s390x.qcow2.gz",
-                "sha256": "ec09c39364d38a4a638eeafae9bdb5fd44e5f9e5b5056f9aab364374671ab71b",
-                "uncompressed-sha256": "4c76a419599c5c27beb712156df02ed9e5fae68ef280590d86b9424e38c73dfb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-qemu.s390x.qcow2.gz",
+                "sha256": "8af7d33af68c6ea68e215cec4fea288581c81dc89e3c84a3ae84d53604db4afc",
+                "uncompressed-sha256": "d44dc5dd00c422bc5b20b15ba012ab50ac903a82ea63c143a690f5e0384de27c"
+              }
+            }
+          }
+        },
+        "qemu-secex": {
+          "release": "412.86.202301311551-0",
+          "formats": {
+            "qcow2.gz": {
+              "disk": {
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/s390x/rhcos-412.86.202301311551-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "95bd415ea2bc9f35102585189763982522cf444aef60ee2d0595d7b158c81fbc",
+                "uncompressed-sha256": "4d34228d68388cfd75b2b2118eeb75c4c82ff665d729bae29d7f5343b0882cf4"
               }
             }
           }
@@ -426,158 +438,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "6a0cd0ada65fb3477754802f9cc73c8fdda3ad9acbc924ec020fc8d4379bc082",
-                "uncompressed-sha256": "369b4c3d8f0eec85206252ec6466f2dd08410e7943321698b1741cf4f4ad0096"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "2356ca56c25dd86aaf1ea8f503af15d2c0356621552124456887a550fdbd7623",
+                "uncompressed-sha256": "0a0efa1b91a4116681f1beabeacccb03f4b780994b6ba64b68cbe54ec3dc8236"
               }
             }
           }
         },
         "aws": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-aws.x86_64.vmdk.gz",
-                "sha256": "59985eb36f43da83147a050259079da79f600a5641c1a5673b7d06439b2971bc",
-                "uncompressed-sha256": "12e46f9dd5ea59d5cb0b8738fa6be84f79ead084c6498c500191e62e131e5474"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-aws.x86_64.vmdk.gz",
+                "sha256": "bd0c4ed751883c4e94221afdc28da2f6b12ac99f5a3f28160022a7026607c0aa",
+                "uncompressed-sha256": "43b6006e0847849de40035cba8a7309cde50e2eb898bb70f3be1d67991505f76"
               }
             }
           }
         },
         "azure": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-azure.x86_64.vhd.gz",
-                "sha256": "b01a98fc356560546e4ae795f55560d07f455d28ffc07ff0dd368c8b0cea1f0c",
-                "uncompressed-sha256": "3e7c06e4810d500c8bd262ee1e4ae7da756382530b7634ed61f1ea596ac3a221"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-azure.x86_64.vhd.gz",
+                "sha256": "ee007060b2bdf642409c642cd5819426a443095fff34c71088b28577ec23c36f",
+                "uncompressed-sha256": "cddfa20eff2db3660fb942bd9afc1df29267b4e440be3149f91d92288164de5d"
               }
             }
           }
         },
         "azurestack": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-azurestack.x86_64.vhd.gz",
-                "sha256": "a804f47df82f3b4965758d212f95f2027df49d507b678daa7aa1db5c556ec316",
-                "uncompressed-sha256": "381bcd28c7e9167ac4e1dafc35e57596b3c62015ab04fa70af37dbca5fc5f479"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-azurestack.x86_64.vhd.gz",
+                "sha256": "fa0f572b59006114cda16c134bf8e45e837f162517f5513fdc0c63551142c7d3",
+                "uncompressed-sha256": "0482322d1f74339e537e263b94f0a4db303680751e773592ef30f1b8de5ef352"
               }
             }
           }
         },
         "gcp": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-gcp.x86_64.tar.gz",
-                "sha256": "54ac00967658147d4979b9cc613b3b7b60d81fdc607f9e0a95fc882541273f43",
-                "uncompressed-sha256": "8f87a3155907440b66f906145b6dc1704f87d5305c072dda741c534dfc8d02d4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-gcp.x86_64.tar.gz",
+                "sha256": "21cd6e2bc26b2e0b6d8cdce38882e18bccc4259327c920d7d4befcc6d5c8b7af",
+                "uncompressed-sha256": "053293c539c91a2c6e29b79e30a0f4330e12516c2fd222cfcecd40a3e6622352"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "c0a6f18d9c93136314cf36c72176b80af215c20e89ce597ce14b4121990ccedd",
-                "uncompressed-sha256": "793296ff4152430e0e54e0f2d922788763162ac9266291ac4842a0e1a9fde7b2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "c1b31e8c1ee9d731358bbcbee144e51a622ecd1fec7c47003092d37fd544cdac",
+                "uncompressed-sha256": "7913036493d7ef249429b04c6d799abb242036aee2bc1706b6404d77d7609be0"
               }
             }
           }
         },
         "metal": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-metal4k.x86_64.raw.gz",
-                "sha256": "dc870a39ca20632c69d1e58610d0e916a188e249811b2258f2dc772be0aa7a16",
-                "uncompressed-sha256": "61e4f1bb7b7db3e2eb6363250a4684b9f9b641092963efe4447a91905962ab24"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-metal4k.x86_64.raw.gz",
+                "sha256": "a93af26e097d230a0ecb803b9a8af0e3e3295a111e6a35d948c50f797abb68cb",
+                "uncompressed-sha256": "ba44bac151dce4227e38adb95becd0cc99ea34ea2046b700d97003f4f0314ea4"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-live.x86_64.iso",
-                "sha256": "6913df929d4ce48c84341c18052283ce1112f82630c5635a62b0aeaffa8b08df"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-live.x86_64.iso",
+                "sha256": "d5a6f0c90f8a8559401f3f7a6dd5fb722fa198eea69d2530eb27f9e1fe0c1a42"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-live-kernel-x86_64",
-                "sha256": "11820659d669feb51e8b1f77543e1de4186445d99c255242b7c3a5eb9ce87296"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-live-kernel-x86_64",
+                "sha256": "a38f24e8ed9bf9b26906c970c01afbf31c86ba0aa9ad552e3bccc22607340597"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-live-initramfs.x86_64.img",
-                "sha256": "85bf60073cf837cc750aad0547bb4fdbb53856165a0821b85f8a0b801b8cc031"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-live-initramfs.x86_64.img",
+                "sha256": "fd3db18277c91da48af74f94ba42227cb2b0a7ebb59f95667fd0da6c2e8b8505"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-live-rootfs.x86_64.img",
-                "sha256": "c86d5af7cfe60361e2c0b81c8a12fe702c698b85d588040a22570b346cf9bb11"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-live-rootfs.x86_64.img",
+                "sha256": "a53678d21301464f6002041e27fc98148940910d3d4798b7a604e55a6cad11e6"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-metal.x86_64.raw.gz",
-                "sha256": "875892255d580bd6ab46d90fe4320e89e57f3556450d925fc9bc44fe5430c8c8",
-                "uncompressed-sha256": "557bf536edb5eac8e26a370f01072a7c5658bc0a3a39128092a3a3ef475728c8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-metal.x86_64.raw.gz",
+                "sha256": "986439bad987cfe337321b87ee9e2d15539ebea020c5d592974e5b1ea63c0992",
+                "uncompressed-sha256": "c78d460235bb1c81fcfc9311c73e1cc3ddbb44a32c96cd677712013b760b7d14"
               }
             }
           }
         },
         "nutanix": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-nutanix.x86_64.qcow2",
-                "sha256": "0d98ec249b5594de3f5e5adcb1f871bd44eedcae5a23be9bcbb564be6144d6d4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-nutanix.x86_64.qcow2",
+                "sha256": "d91d4620e95250297d18058a1147288cadfbe6ec792229a8fe90b0a370c86968"
               }
             }
           }
         },
         "openstack": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-openstack.x86_64.qcow2.gz",
-                "sha256": "6d9b9c5abe73593c49dadb9c8c7cd2ff907a228ae75f2e4d4194085d4a3e1fd2",
-                "uncompressed-sha256": "4304c8f0f7429cfdb534c28aec7ca72e360e608a5df4ddf50f9b4816ff499277"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-openstack.x86_64.qcow2.gz",
+                "sha256": "a2e134ac635a9454ed40b6e35dc06631b90cab34b9b4a450374432198c1676f5",
+                "uncompressed-sha256": "b3847ff491e51b87691b8be9afd0fb973b46ccbb61715a226537a7374c3b97b7"
               }
             }
           }
         },
         "qemu": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-qemu.x86_64.qcow2.gz",
-                "sha256": "4046273351b478958e64f522731aad8b7e842315ab4524e7df34a2fb54779de8",
-                "uncompressed-sha256": "72443715e6781c1dbd940d64c86ddf88e4ac2a45f774628af8230f5051fbee9e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-qemu.x86_64.qcow2.gz",
+                "sha256": "817807ab6c660288018263f0b0d720ecfc8ad9a3600aa22470ee4715b832a08a",
+                "uncompressed-sha256": "6268691ec4861d30275e9baf7ab423ad562e6a78c85cad16dfd46dde0ef65cb6"
               }
             }
           }
         },
         "vmware": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202212081411-0/x86_64/rhcos-412.86.202212081411-0-vmware.x86_64.ova",
-                "sha256": "4630ef6960567a477234a8f10c89eb1aa17066c250141abbd0c6c8311170bd85"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.12/builds/412.86.202301311551-0/x86_64/rhcos-412.86.202301311551-0-vmware.x86_64.ova",
+                "sha256": "ef27b9bc923fe9a9c7b72f1f8071e69e092e15c9edceef05dcdba50a6a4cafda"
               }
             }
           }
@@ -587,229 +599,229 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "412.86.202212081411-0",
-              "image": "m-6we92hy9gyvrdwktiiaz"
+              "release": "412.86.202301311551-0",
+              "image": "m-6we06g2h8ze7y1ie1usg"
             },
             "ap-northeast-2": {
-              "release": "412.86.202212081411-0",
-              "image": "m-mj7djef4a1g5vi1m66ry"
+              "release": "412.86.202301311551-0",
+              "image": "m-mj7eudg02coo2updkm79"
             },
             "ap-south-1": {
-              "release": "412.86.202212081411-0",
-              "image": "m-a2d7hgpmhomvvlqdwf2u"
+              "release": "412.86.202301311551-0",
+              "image": "m-a2d4o9kgux22rc30ww0o"
             },
             "ap-southeast-1": {
-              "release": "412.86.202212081411-0",
-              "image": "m-t4n99kheklsvyuw79bcl"
+              "release": "412.86.202301311551-0",
+              "image": "m-t4ngzvm46224ip8dgd14"
             },
             "ap-southeast-2": {
-              "release": "412.86.202212081411-0",
-              "image": "m-p0wiz3t1y6eo4qmliiqe"
+              "release": "412.86.202301311551-0",
+              "image": "m-p0weku2q8p91c1026n93"
             },
             "ap-southeast-3": {
-              "release": "412.86.202212081411-0",
-              "image": "m-8psbyqmzqmloqi8q4mgx"
+              "release": "412.86.202301311551-0",
+              "image": "m-8ps240oiar5shhpo74l7"
             },
             "ap-southeast-5": {
-              "release": "412.86.202212081411-0",
-              "image": "m-k1aecz2x6o6ht7w0bqdf"
+              "release": "412.86.202301311551-0",
+              "image": "m-k1a4mtoj4g8r6mx1dwni"
             },
             "ap-southeast-6": {
-              "release": "412.86.202212081411-0",
-              "image": "m-5tsj1yxloi3prfq3jern"
+              "release": "412.86.202301311551-0",
+              "image": "m-5ts6f6zhyf1x3067ghae"
             },
             "ap-southeast-7": {
-              "release": "412.86.202212081411-0",
-              "image": "m-0jod1und9ze66rf2f5yi"
+              "release": "412.86.202301311551-0",
+              "image": "m-0joh1xj8f580hzuqier7"
             },
             "cn-beijing": {
-              "release": "412.86.202212081411-0",
-              "image": "m-2zedxhk98442fgn5hg7o"
+              "release": "412.86.202301311551-0",
+              "image": "m-2zebygemvlg6ewgszfwv"
             },
             "cn-chengdu": {
-              "release": "412.86.202212081411-0",
-              "image": "m-2vc3k0f06j9j3y9o4ft8"
+              "release": "412.86.202301311551-0",
+              "image": "m-2vcbzlei8or5j4tilxvm"
             },
             "cn-fuzhou": {
-              "release": "412.86.202212081411-0",
-              "image": "m-gw0edjtnt2ztra5v4mfg"
+              "release": "412.86.202301311551-0",
+              "image": "m-gw0g6w6oy9i49t6ssny8"
             },
             "cn-guangzhou": {
-              "release": "412.86.202212081411-0",
-              "image": "m-7xvg5o6cwctseoufn7o1"
+              "release": "412.86.202301311551-0",
+              "image": "m-7xvbf7kvtsy2c1yolsm4"
             },
             "cn-hangzhou": {
-              "release": "412.86.202212081411-0",
-              "image": "m-bp10iiqoivwiqky0fw9m"
+              "release": "412.86.202301311551-0",
+              "image": "m-bp1j8bz13hcy1gx8wmbi"
             },
             "cn-heyuan": {
-              "release": "412.86.202212081411-0",
-              "image": "m-f8zbicl9f82nnn3uf0lu"
+              "release": "412.86.202301311551-0",
+              "image": "m-f8z970qe30x03exh0ecd"
             },
             "cn-hongkong": {
-              "release": "412.86.202212081411-0",
-              "image": "m-j6cj81shutf7xs9ci8j0"
+              "release": "412.86.202301311551-0",
+              "image": "m-j6cebmmsfqobl850ixg0"
             },
             "cn-huhehaote": {
-              "release": "412.86.202212081411-0",
-              "image": "m-hp3g86cstpjtz8r6pzks"
+              "release": "412.86.202301311551-0",
+              "image": "m-hp34go7imk7dd89m6ilm"
             },
             "cn-nanjing": {
-              "release": "412.86.202212081411-0",
-              "image": "m-gc75rbpctjy2ona8tt1b"
+              "release": "412.86.202301311551-0",
+              "image": "m-gc77zq6n8t1ir4onym4h"
             },
             "cn-qingdao": {
-              "release": "412.86.202212081411-0",
-              "image": "m-m5e9felqzdvggvp5016o"
+              "release": "412.86.202301311551-0",
+              "image": "m-m5ecavmj5lpuhmbvndup"
             },
             "cn-shanghai": {
-              "release": "412.86.202212081411-0",
-              "image": "m-uf6c04i5ofxt1rc7qzdl"
+              "release": "412.86.202301311551-0",
+              "image": "m-uf6i6oonbkucq26ruo4h"
             },
             "cn-shenzhen": {
-              "release": "412.86.202212081411-0",
-              "image": "m-wz97mva2hlrd8b31o3lc"
+              "release": "412.86.202301311551-0",
+              "image": "m-wz96k65tm94t2rhzu305"
             },
             "cn-wulanchabu": {
-              "release": "412.86.202212081411-0",
-              "image": "m-0jle2acx8y8rgutbk923"
+              "release": "412.86.202301311551-0",
+              "image": "m-0jl7nhcg5naxudkawh5m"
             },
             "cn-zhangjiakou": {
-              "release": "412.86.202212081411-0",
-              "image": "m-8vbcskxc4svqp6m32she"
+              "release": "412.86.202301311551-0",
+              "image": "m-8vbd0u4qcdphtfhywfcg"
             },
             "eu-central-1": {
-              "release": "412.86.202212081411-0",
-              "image": "m-gw86sffy6f512xceq0sn"
+              "release": "412.86.202301311551-0",
+              "image": "m-gw83lkiyd9icwepgqvpx"
             },
             "eu-west-1": {
-              "release": "412.86.202212081411-0",
-              "image": "m-d7oe2alj2ootweztynbl"
+              "release": "412.86.202301311551-0",
+              "image": "m-d7obevhkplonp0oc30j7"
             },
             "me-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "m-eb32k3q3yp9vnql6vx8h"
+              "release": "412.86.202301311551-0",
+              "image": "m-eb30jhwjygs1zgyijlv1"
             },
             "us-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "m-0xi67ek28y49owje0n45"
+              "release": "412.86.202301311551-0",
+              "image": "m-0xiero5g1o1tbr54vwi3"
             },
             "us-west-1": {
-              "release": "412.86.202212081411-0",
-              "image": "m-rj9cuag5oy9pvbugddm7"
+              "release": "412.86.202301311551-0",
+              "image": "m-rj9gd0wp8opitn4tvc1y"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-073850a7021953a5c"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0767633d1ff39ca51"
             },
             "ap-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0f8800a05c09be42d"
+              "release": "412.86.202301311551-0",
+              "image": "ami-068525d48b135dc06"
             },
             "ap-northeast-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0a226dbcc9a561c40"
+              "release": "412.86.202301311551-0",
+              "image": "ami-08ad6151dfa98f983"
             },
             "ap-northeast-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-041ae0537e2eddec1"
+              "release": "412.86.202301311551-0",
+              "image": "ami-00f5a114d722f7a5d"
             },
             "ap-northeast-3": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0bb8d9b69dc5b7670"
+              "release": "412.86.202301311551-0",
+              "image": "ami-077f2bc1d03f6a9dd"
             },
             "ap-south-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0e9c18058fc5f94fd"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0bf5c58172634850c"
             },
             "ap-southeast-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-03022d358ba2168be"
+              "release": "412.86.202301311551-0",
+              "image": "ami-07e5ffd1ff9375b4d"
             },
             "ap-southeast-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-09ffdc5be9b973be0"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0146d3d003f4a37af"
             },
             "ap-southeast-3": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0facf1a0edeb20314"
+              "release": "412.86.202301311551-0",
+              "image": "ami-06fce55f2fb95c621"
             },
             "ca-central-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-028cea206c2d03317"
+              "release": "412.86.202301311551-0",
+              "image": "ami-089ee8a0df876273f"
             },
             "eu-central-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-002eb441f329ccb0f"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0699ed38c7b4cb4bb"
             },
             "eu-north-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0b1a1fb68b3b9fee7"
+              "release": "412.86.202301311551-0",
+              "image": "ami-09a57bc99cbd11623"
             },
             "eu-south-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0bd0fd41a1d3f799a"
+              "release": "412.86.202301311551-0",
+              "image": "ami-00a8b2640f0dc2130"
             },
             "eu-west-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-04504e8799057980c"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0e3df83cd6630da18"
             },
             "eu-west-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0cc9297ddb3bce971"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0d50f7c421a2e18e6"
             },
             "eu-west-3": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-06f98f607a50937c6"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0076f3576ea2bc58e"
             },
             "me-south-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0fe39da7871a5b2a5"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0d1ce0917721345fd"
             },
             "sa-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-08265cc3226697767"
+              "release": "412.86.202301311551-0",
+              "image": "ami-03e97b79111092c1f"
             },
             "us-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0fe05b1aa8dacfa90"
+              "release": "412.86.202301311551-0",
+              "image": "ami-017fe5c9fac0d4064"
             },
             "us-east-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0ff64f495c7e977cf"
+              "release": "412.86.202301311551-0",
+              "image": "ami-057fe628c533932e2"
             },
             "us-gov-east-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0c99658076c41872a"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0fcbd1917317e73bf"
             },
             "us-gov-west-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0ca4acd5b8ba1cb1d"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0a72176702967ea63"
             },
             "us-west-1": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-01dc5d8e6bb6f23f4"
+              "release": "412.86.202301311551-0",
+              "image": "ami-0253c26ddd5a4703c"
             },
             "us-west-2": {
-              "release": "412.86.202212081411-0",
-              "image": "ami-0404a109adfd00019"
+              "release": "412.86.202301311551-0",
+              "image": "ami-013994154dfc6ed4a"
             }
           }
         },
         "gcp": {
-          "release": "412.86.202212081411-0",
+          "release": "412.86.202301311551-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-412-86-202212081411-0-gcp-x86-64"
+          "name": "rhcos-412-86-202301311551-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "412.86.202212081411-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202212081411-0-azure.x86_64.vhd"
+          "release": "412.86.202301311551-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-412.86.202301311551-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.12 boot image metadata in the
installer which includes the fixes for the following:

OCPBUGS-5958 - Update bootimage with new ignition build (to support FIPS mode in s390x)
OCPBUGS-6722 - bootimage: move secure execution artifact to separate
OCPBUGS-6509 - Agent service fails to start since cannot pull assisted-installer-agent image

Changes generated with:
```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --no-signatures --url https://rhcos.mirror.openshift.com/art/storage/prod/streams x86_64=412.86.202301272018-0 aarch64=412.86.202301272018-0 s390x=412.86.202301272018-0 ppc64le=412.86.202301272018-0