### PR TITLE
OCPBUGS-6270: Don't require vSphere details for agent installer

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/vsphere_compact.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/vsphere_compact.txt
@@ -1,0 +1,46 @@
+# Verify a default configuration for the compact topology on vsphere
+
+exec openshift-install agent create image --dir $WORK
+
+stderr 'The rendezvous host IP \(node0 IP\) is 192.168.111.20'
+
+exists $WORK/agent.x86_64.iso
+exists $WORK/auth/kubeconfig
+exists $WORK/auth/kubeadmin-password
+
+-- install-config.yaml --
+apiVersion: v1
+baseDomain: test.metalkube.org
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 0
+metadata:
+  namespace: cluster0
+  name: ostest
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+    vsphere:
+      apiVips:
+        - 192.168.111.5
+      ingressVips:
+        - 192.168.111.4
+sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
+pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
+
+-- agent-config.yaml --
+apiVersion: v1alpha1
+metadata:
+  name: ostest
+  namespace: cluster0
+rendezvousIP: 192.168.111.20

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -348,7 +349,7 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 			fieldPath := field.NewPath("Platform", "VSphere", "ClusterOSImage")
 			logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, vspherePlatform.ClusterOSImage))
 		}
-		if vspherePlatform.DefaultMachinePlatform != &(vsphere.MachinePool{}) {
+		if vspherePlatform.DefaultMachinePlatform != nil && !reflect.DeepEqual(*vspherePlatform.DefaultMachinePlatform, vsphere.MachinePool{}) {
 			fieldPath := field.NewPath("Platform", "VSphere", "DefaultMachinePlatform")
 			logrus.Warnf(fmt.Sprintf("%s: %v is ignored", fieldPath, vspherePlatform.DefaultMachinePlatform))
 		}
@@ -382,8 +383,8 @@ func warnUnusedConfig(installConfig *types.InstallConfig) {
 		fieldPath := field.NewPath("BootstrapInPlace", "InstallationDisk")
 		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.BootstrapInPlace.InstallationDisk))
 	}
-	if installConfig.Capabilities != &(types.Capabilities{}) {
+	if installConfig.Capabilities != nil {
 		fieldPath := field.NewPath("Capabilities")
-		logrus.Warnf(fmt.Sprintf("%s: %s is ignored", fieldPath, installConfig.Capabilities))
+		logrus.Warnf(fmt.Sprintf("%s: %v is ignored", fieldPath, *installConfig.Capabilities))
 	}
 }

--- a/pkg/types/baremetal/validation/platform.go
+++ b/pkg/types/baremetal/validation/platform.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 
@@ -405,14 +404,7 @@ func ValidatePlatform(p *baremetal.Platform, n *types.Networking, fldPath *field
 		}
 	}
 
-	agentBasedInstallation := false
-	if len(os.Args) > 1 {
-		for _, arg := range os.Args {
-			if arg == "agent" {
-				agentBasedInstallation = true
-			}
-		}
-	}
+	agentBasedInstallation := validate.IsAgentBasedInstallation()
 
 	if !agentBasedInstallation && p.Hosts == nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("hosts"), p.Hosts, "bare metal hosts are missing"))

--- a/pkg/types/vsphere/validation/platform.go
+++ b/pkg/types/vsphere/validation/platform.go
@@ -16,20 +16,22 @@ import (
 func ValidatePlatform(p *vsphere.Platform, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(p.VCenter) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("vCenter"), "must specify the name of the vCenter"))
-	}
-	if len(p.Username) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("username"), "must specify the username"))
-	}
-	if len(p.Password) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("password"), "must specify the password"))
-	}
-	if len(p.Datacenter) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("datacenter"), "must specify the datacenter"))
-	}
-	if len(p.DefaultDatastore) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("defaultDatastore"), "must specify the default datastore"))
+	if !validate.IsAgentBasedInstallation() {
+		if len(p.VCenter) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("vCenter"), "must specify the name of the vCenter"))
+		}
+		if len(p.Username) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("username"), "must specify the username"))
+		}
+		if len(p.Password) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("password"), "must specify the password"))
+		}
+		if len(p.Datacenter) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("datacenter"), "must specify the datacenter"))
+		}
+		if len(p.DefaultDatastore) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("defaultDatastore"), "must specify the default datastore"))
+		}
 	}
 
 	if len(p.VCenter) != 0 {

--- a/pkg/validate/method.go
+++ b/pkg/validate/method.go
@@ -1,0 +1,14 @@
+package validate
+
+import "os"
+
+func IsAgentBasedInstallation() bool {
+	if len(os.Args) > 1 {
+		for _, arg := range os.Args {
+			if arg == "agent" {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Copy the same fix as for the baremetal platform (OCPBUGS-3278) to
vSphere to prevent validation of the presence of fields in the
install-config that are, in fact, ignored by the agent installer.