### PR TITLE
AGENT-506: Copy additional files on startup

### DIFF
--- a/data/data/agent/files/usr/local/bin/agent-copy-iso-files.sh
+++ b/data/data/agent/files/usr/local/bin/agent-copy-iso-files.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# ignition.img is a compressed cpio archive usually containing just the
+# config.ign file. In case of agent-based installation, it could be 
+# enriched with additional files
+
+AGENT_FILES_TEMP="$(mktemp -d)"
+
+cd "${AGENT_FILES_TEMP}" || { echo "Temp folder creation failed"; exit 1; }
+zcat /run/media/iso/images/ignition.img | cpio -idmv
+
+# agent-tui is required by the agent-interactive-console.service
+cp agent-tui /usr/local/bin/
+
+rm -rf "${AGENT_FILES_TEMP}"

--- a/data/data/agent/systemd/units/agent-copy-iso-files.service
+++ b/data/data/agent/systemd/units/agent-copy-iso-files.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Copy the additional files stored in the agent ISO during the boot
+After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
+Before=network.target network.service agent.service NetworkManager-wait-online.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/local/bin/agent-copy-iso-files.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -214,6 +214,7 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 	}
 
 	agentEnabledServices := []string{
+		"agent-copy-iso-files.service",
 		"agent.service",
 		"agent-tui.path",
 		"assisted-service-db.service",

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -390,6 +390,7 @@ metadata:
 				"/usr/local/bin/common.sh",
 				"/usr/local/bin/agent-gather",
 				"/usr/local/bin/agent-interactive-console.sh",
+				"/usr/local/bin/agent-copy-iso-files.sh",
 				"/usr/local/bin/extract-agent.sh",
 				"/usr/local/bin/get-container-images.sh",
 				"/usr/local/bin/install-status.sh",


### PR DESCRIPTION
This patch adds a new agent service responsible to extract and copy the required additional files from the agent ISO.

Requires #6786 