### PR TITLE
integration: Don't pass host data in the install-config

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/configurations/compact.txt
+++ b/cmd/openshift-install/testdata/agent/image/configurations/compact.txt
@@ -35,13 +35,6 @@ platform:
         - 192.168.111.5
       ingressVips: 
         - 192.168.111.4
-      hosts:
-          - name: host0
-            bootMACAddress: 00:0e:3b:0d:e8:5a
-          - name: host1
-            bootMACAddress: 00:0e:3b:0d:e8:5b
-          - name: host2
-            bootMACAddress: 00:0e:3b:0d:e8:5c
 sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
 

--- a/cmd/openshift-install/testdata/agent/image/validations/compact_not_enough_hosts.txt
+++ b/cmd/openshift-install/testdata/agent/image/validations/compact_not_enough_hosts.txt
@@ -35,9 +35,6 @@ platform:
         - 192.168.111.5
       ingressVips: 
         - 192.168.111.4
-      hosts:
-          - name: host0
-            bootMACAddress: 00:0e:3b:0d:e8:5a
 sshKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=
 pullSecret: '{"auths": {"quay.io": {"auth": "c3VwZXItc2VjcmV0Cg=="}}}'
 


### PR DESCRIPTION
This data is no longer required since the fix for OCPBUGS-4874, so don't add it to the install-config in the integration tests. This will allow us to pick up any regression.