### PR TITLE
OpenStack: Dual stack support with BYON

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3057,6 +3057,49 @@ spec:
                       use for instances in this cluster. Deprecated: use FlavorName
                       in DefaultMachinePlatform to define default flavor.'
                     type: string
+                  controlPlanePort:
+                    description: ControlPlanePort contains details of the network
+                      attached to the control plane port, with the network either
+                      containing one openstack subnet for IPv4 or two openstack subnets
+                      for dualstack clusters. Providing this configuration will prevent
+                      OpenShift from managing or updating this network and its subnets.
+                      The network and its subnets will be used during creation of
+                      all nodes. This is a TechPreview feature and requires setting
+                      featureSet to TechPreviewNoUpgrade.
+                    properties:
+                      fixedIPs:
+                        description: Specify subnets of the network where control
+                          plane port will be discovered.
+                        items:
+                          description: FixedIP identifies a subnet defined by a subnet
+                            filter.
+                          properties:
+                            subnet:
+                              description: SubnetFilter defines a subnet by ID and/or
+                                name.
+                              properties:
+                                id:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                          required:
+                          - subnet
+                          type: object
+                        type: array
+                      network:
+                        description: Network is a query for an openstack network that
+                          the port will be discovered on. This will fail if the query
+                          returns more than one network.
+                        properties:
+                          id:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                    required:
+                    - fixedIPs
+                    type: object
                   defaultMachinePlatform:
                     description: DefaultMachinePlatform is the default configuration
                       used when installing on OpenStack for machine pools which do
@@ -3190,11 +3233,12 @@ spec:
                         type: string
                     type: object
                   machinesSubnet:
-                    description: MachinesSubnet is the UUIDv4 of an openstack subnet.
-                      This subnet will be used by all nodes created by the installer.
-                      By setting this, the installer will no longer create a network
-                      and subnet. The subnet and network specified in MachinesSubnet
-                      will not be deleted or modified by the installer.
+                    description: 'DeprecatedMachinesSubnet is a string of the UUIDv4
+                      of an openstack subnet. This subnet will be used by all nodes
+                      created by the installer. By setting this, the installer will
+                      no longer create a network and subnet. The subnet and network
+                      specified in MachinesSubnet will not be deleted or modified
+                      by the installer. Deprecated: Use ControlPlanePort'
                     type: string
                   octaviaSupport:
                     description: 'OctaviaSupport holds a `0` or `1` value that indicates

--- a/pkg/asset/installconfig/openstack/validation/machinepool.go
+++ b/pkg/asset/installconfig/openstack/validation/machinepool.go
@@ -106,7 +106,7 @@ func validateVolumeTypes(input string, available []string, fldPath *field.Path) 
 func validateUUIDV4s(input []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for idx, uuid := range input {
-		if !validUUIDv4(uuid) {
+		if !ValidUUIDv4(uuid) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Index(idx), uuid, "valid UUID v4 must be specified"))
 		}
 	}
@@ -116,7 +116,7 @@ func validateUUIDV4s(input []string, fldPath *field.Path) field.ErrorList {
 
 // validUUIDv4 checks if string is in UUID v4 format
 // For more information: https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_(random)
-func validUUIDv4(s string) bool {
+func ValidUUIDv4(s string) bool {
 	uuid, err := guuid.Parse(s)
 	if err != nil {
 		return false

--- a/pkg/asset/installconfig/openstack/validation/platform.go
+++ b/pkg/asset/installconfig/openstack/validation/platform.go
@@ -2,13 +2,14 @@ package validation
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"net"
 	"net/url"
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilsslice "k8s.io/utils/strings/slices"
 
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/openstack"
@@ -19,8 +20,10 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	var allErrs field.ErrorList
 	fldPath := field.NewPath("platform", "openstack")
 
-	// validate BYO machinesSubnet usage
-	allErrs = append(allErrs, validateMachinesSubnet(p, n, ci, fldPath)...)
+	// validate BYO controlPlanePort usage
+	if p.ControlPlanePort != nil {
+		allErrs = append(allErrs, validateControlPlanePort(p, n, ci, fldPath)...)
+	}
 
 	// validate the externalNetwork
 	allErrs = append(allErrs, validateExternalNetwork(p, ci, fldPath)...)
@@ -37,24 +40,77 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, ci *CloudInfo)
 	return allErrs
 }
 
-// validateMachinesSubnet validates the machines subnet and enforces proper byo subnet usage and returns a list of all validation errors
-func validateMachinesSubnet(p *openstack.Platform, n *types.Networking, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {
-	if p.MachinesSubnet != "" {
-		if len(p.ExternalDNS) > 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("externalDNS"), p.ExternalDNS, "externalDNS is set, externalDNS is not supported when machinesSubnet is set"))
-		}
-		if ci.MachinesSubnet == nil {
-			allErrs = append(allErrs, field.NotFound(fldPath.Child("machinesSubnet"), p.MachinesSubnet))
-		} else if !validUUIDv4(p.MachinesSubnet) {
-			allErrs = append(allErrs, field.InternalError(fldPath.Child("machinesSubnet"), errors.New("invalid subnet ID")))
-		} else {
-			if n.MachineNetwork[0].CIDR.String() != ci.MachinesSubnet.CIDR {
-				allErrs = append(allErrs, field.InternalError(fldPath.Child("machinesSubnet"), fmt.Errorf("the first CIDR in machineNetwork, %s, doesn't match the CIDR of the machineSubnet, %s", n.MachineNetwork[0].CIDR.String(), ci.MachinesSubnet.CIDR)))
+// validateControlPlanePort validates the machines subnets and network, while enforcing proper byo subnets usage and returns a list of all validation errors.
+func validateControlPlanePort(p *openstack.Platform, n *types.Networking, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {
+	networkID := ""
+	hasIPv4Subnet := false
+	hasIPv6Subnet := false
+	if len(p.ExternalDNS) > 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("externalDNS"), p.ExternalDNS, "externalDNS is set, externalDNS is not supported when ControlPlanePort is set"))
+		return allErrs
+	}
+	networkCIDRs := networksCIDRs(n.MachineNetwork)
+	for _, fixedIP := range p.ControlPlanePort.FixedIPs {
+		subnet := getSubnet(ci.ControlPlanePortSubnets, fixedIP.Subnet.ID, fixedIP.Subnet.Name)
+		if subnet == nil {
+			subnetDetail := fixedIP.Subnet.ID
+			if subnetDetail == "" {
+				subnetDetail = fixedIP.Subnet.Name
 			}
+			allErrs = append(allErrs, field.NotFound(fldPath.Child("controlPlanePort").Child("fixedIPs"), subnetDetail))
+		} else {
+			if subnet.IPVersion == 6 {
+				hasIPv6Subnet = true
+			} else {
+				hasIPv4Subnet = true
+			}
+			if !utilsslice.Contains(networkCIDRs, subnet.CIDR) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("controlPlanePort").Child("fixedIPs"), subnet.CIDR, "controlPlanePort CIDR does not match machineNetwork"))
+			}
+			if networkID != "" && networkID != subnet.NetworkID {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("controlPlanePort").Child("fixedIPs"), subnet.NetworkID, "fixedIPs subnets must be on the same Network"))
+			}
+			networkID = subnet.NetworkID
 		}
 	}
-
+	if !hasIPv4Subnet && hasIPv6Subnet {
+		allErrs = append(allErrs, field.InternalError(fldPath.Child("controlPlanePort").Child("fixedIPs"), fmt.Errorf("one IPv4 subnet must be specified")))
+	} else if hasIPv4Subnet && !hasIPv6Subnet && len(p.ControlPlanePort.FixedIPs) == 2 {
+		allErrs = append(allErrs, field.InternalError(fldPath.Child("controlPlanePort").Child("fixedIPs"), fmt.Errorf("multiple IPv4 subnets is not supported")))
+	}
+	controlPlaneNetwork := p.ControlPlanePort.Network
+	if controlPlaneNetwork.ID != "" || controlPlaneNetwork.Name != "" {
+		networkDetail := controlPlaneNetwork.ID
+		if networkDetail == "" {
+			networkDetail = controlPlaneNetwork.Name
+		}
+		// check if the networks does not exist. If it does, verifies if the network contains the subnets
+		if ci.ControlPlanePortNetwork == nil {
+			allErrs = append(allErrs, field.NotFound(fldPath.Child("controlPlanePort").Child("network"), networkDetail))
+		} else if ci.ControlPlanePortNetwork.ID != networkID {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("controlPlanePort").Child("network"), networkDetail, "network must contain subnets"))
+		}
+	}
 	return allErrs
+}
+
+func networksCIDRs(machineNetwork []types.MachineNetworkEntry) []string {
+	networks := make([]string, 0, len(machineNetwork))
+	for _, network := range machineNetwork {
+		networks = append(networks, network.CIDR.String())
+	}
+	return networks
+}
+
+func getSubnet(controlPlaneSubnets []*subnets.Subnet, subnetID, subnetName string) *subnets.Subnet {
+	for _, subnet := range controlPlaneSubnets {
+		if subnet.ID == subnetID {
+			return subnet
+		} else if subnet.Name != "" && subnet.Name == subnetName {
+			return subnet
+		}
+	}
+	return nil
 }
 
 // validateExternalNetwork validates the user's input for the externalNetwork and returns a list of all validation errors
@@ -96,9 +152,10 @@ func validateFloatingIPs(p *openstack.Platform, ci *CloudInfo, fldPath *field.Pa
 // platform VIP validation is done in pkg/types/validation/installconfig.go,
 // validateAPIAndIngressVIPs().
 func validateVIPs(p *openstack.Platform, ci *CloudInfo, fldPath *field.Path) (allErrs field.ErrorList) {
-	// If the subnet is not found in the CloudInfo object, abandon validation
-	if ci.MachinesSubnet != nil {
-		for _, allocationPool := range ci.MachinesSubnet.AllocationPools {
+	// If the subnet is not found in the CloudInfo object, abandon validation.
+	// For dual-stack the user needs to pre-create the Port for API and Ingress, so no need for validation.
+	if len(ci.ControlPlanePortSubnets) == 1 {
+		for _, allocationPool := range ci.ControlPlanePortSubnets[0].AllocationPools {
 			start := net.ParseIP(allocationPool.Start)
 			end := net.ParseIP(allocationPool.End)
 

--- a/pkg/asset/quota/openstack/openstack.go
+++ b/pkg/asset/quota/openstack/openstack.go
@@ -56,7 +56,7 @@ func Constraints(ci *validation.CloudInfo, controlPlanes []machineapi.Machine, c
 
 	// If the cluster is using pre-provisioned networks, then the quota constraints should be
 	// null because the installer doesn't need to create any resources.
-	if ci.MachinesSubnet == nil {
+	if len(ci.ControlPlanePortSubnets) == 0 {
 		constraints = append(constraints, networkConstraint(1), routerConstraint(1), subnetConstraint(1))
 	}
 

--- a/pkg/tfvars/openstack/ports.go
+++ b/pkg/tfvars/openstack/ports.go
@@ -1,5 +1,17 @@
 package openstack
 
+import (
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+	"github.com/gophercloud/gophercloud/pagination"
+	network_utils "github.com/gophercloud/utils/openstack/networking/v2/networks"
+
+	machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
+	types_openstack "github.com/openshift/installer/pkg/types/openstack"
+)
+
 type terraformFixedIP struct {
 	SubnetID  string `json:"subnet_id"`
 	IPAddress string `json:"ip_address"`
@@ -8,4 +20,77 @@ type terraformFixedIP struct {
 type terraformPort struct {
 	NetworkID string             `json:"network_id"`
 	FixedIP   []terraformFixedIP `json:"fixed_ips"`
+}
+
+func portTargetToTerraformPort(networkClient *gophercloud.ServiceClient, portTarget types_openstack.PortTarget) (terraformPort, error) {
+	networkID := portTarget.Network.ID
+	if networkID == "" && portTarget.Network.Name != "" {
+		var err error
+		networkID, err = network_utils.IDFromName(networkClient, portTarget.Network.Name)
+		if err != nil {
+			return terraformPort{}, fmt.Errorf("failed to resolve network ID for network name %q: %w", portTarget.Network.Name, err)
+		}
+	}
+
+	terraformFixedIPs := make([]terraformFixedIP, 0, len(portTarget.FixedIPs))
+	for _, fixedIP := range portTarget.FixedIPs {
+		subnetFilter := machinev1alpha1.SubnetFilter{
+			ID:   fixedIP.Subnet.ID,
+			Name: fixedIP.Subnet.Name,
+		}
+		resolvedSubnetID, resolvedNetworkID, err := resolveSubnetFilter(networkClient, networkID, subnetFilter)
+		if err != nil {
+			return terraformPort{}, fmt.Errorf("failed to resolve the subnet filter: %w", err)
+		}
+
+		if networkID == "" {
+			networkID = resolvedNetworkID
+		}
+
+		if networkID != resolvedNetworkID {
+			return terraformPort{}, fmt.Errorf("control plane port has ports on multiple networks")
+		}
+
+		terraformFixedIPs = append(terraformFixedIPs, terraformFixedIP{
+			SubnetID: resolvedSubnetID,
+		})
+	}
+
+	return terraformPort{
+		NetworkID: networkID,
+		FixedIP:   terraformFixedIPs,
+	}, nil
+}
+
+func resolveSubnetFilter(networkClient *gophercloud.ServiceClient, networkID string, subnetFilter machinev1alpha1.SubnetFilter) (resolvedSubnetID, resolvedNetworkID string, err error) {
+	if subnetFilter.ProjectID != "" {
+		subnetFilter.TenantID = ""
+	}
+	if err = subnets.List(networkClient, subnets.ListOpts{
+		NetworkID: networkID,
+		Name:      subnetFilter.Name,
+		ID:        subnetFilter.ID,
+	}).EachPage(func(page pagination.Page) (bool, error) {
+		returnedSubnets, err := subnets.ExtractSubnets(page)
+		if err != nil {
+			return false, err
+		}
+		for _, subnet := range returnedSubnets {
+			if resolvedSubnetID == "" {
+				resolvedSubnetID = subnet.ID
+				resolvedNetworkID = subnet.NetworkID
+			} else {
+				return false, fmt.Errorf("more than one subnet found")
+			}
+		}
+		return true, nil
+	}); err != nil {
+		return "", "", fmt.Errorf("failed to list subnets: %w", err)
+	}
+
+	if resolvedSubnetID == "" {
+		return "", "", fmt.Errorf("no subnet found")
+	}
+
+	return resolvedSubnetID, resolvedNetworkID, err
 }

--- a/pkg/types/openstack/machinepool.go
+++ b/pkg/types/openstack/machinepool.go
@@ -1,7 +1,5 @@
 package openstack
 
-import machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
-
 // MachinePool stores the configuration for a machine pool installed
 // on OpenStack.
 type MachinePool struct {
@@ -90,21 +88,26 @@ type RootVolume struct {
 
 // PortTarget defines, directly or indirectly, one or more subnets where to attach a port.
 type PortTarget struct {
-	// Network is a query for an openstack network that the port will be created or discovered on.
+	// Network is a query for an openstack network that the port will be discovered on.
 	// This will fail if the query returns more than one network.
 	Network NetworkFilter `json:"network,omitempty"`
-	// Specify pairs of subnet and/or IP address. These should be subnets of the network with the given NetworkID.
-	FixedIPs []FixedIP `json:"fixedIPs,omitempty"`
+	// Specify subnets of the network where control plane port will be discovered.
+	FixedIPs []FixedIP `json:"fixedIPs"`
 }
 
-// NetworkFilter defines a network either by name or by ID.
+// NetworkFilter defines a network by name and/or ID.
 type NetworkFilter struct {
 	Name string `json:"name,omitempty"`
 	ID   string `json:"id,omitempty"`
 }
 
-// FixedIP defines a subnet.
+// FixedIP identifies a subnet defined by a subnet filter.
 type FixedIP struct {
-	// subnetID specifies the ID of the subnet where the fixed IP will be allocated.
-	Subnet machinev1alpha1.SubnetFilter `json:"subnet"`
+	Subnet SubnetFilter `json:"subnet"`
+}
+
+// SubnetFilter defines a subnet by ID and/or name.
+type SubnetFilter struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }

--- a/pkg/types/openstack/platform.go
+++ b/pkg/types/openstack/platform.go
@@ -113,11 +113,19 @@ type Platform struct {
 	// +optional
 	IngressVIPs []string `json:"ingressVIPs,omitempty"`
 
-	// MachinesSubnet is the UUIDv4 of an openstack subnet. This subnet will be used by all nodes created by the installer.
+	// DeprecatedMachinesSubnet is a string of the UUIDv4 of an openstack subnet. This subnet will be used by all nodes created by the installer.
 	// By setting this, the installer will no longer create a network and subnet.
 	// The subnet and network specified in MachinesSubnet will not be deleted or modified by the installer.
+	// Deprecated: Use ControlPlanePort
 	// +optional
-	MachinesSubnet string `json:"machinesSubnet,omitempty"`
+	DeprecatedMachinesSubnet string `json:"machinesSubnet,omitempty"`
+
+	// ControlPlanePort contains details of the network attached to the control plane port, with the network either containing one openstack
+	// subnet for IPv4 or two openstack subnets for dualstack clusters. Providing this configuration will prevent OpenShift from managing
+	// or updating this network and its subnets. The network and its subnets will be used during creation of all nodes.
+	// This is a TechPreview feature and requires setting featureSet to TechPreviewNoUpgrade.
+	// +optional
+	ControlPlanePort *PortTarget `json:"controlPlanePort,omitempty"`
 
 	// LoadBalancer defines how the load balancer used by the cluster is configured.
 	// +optional

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -128,6 +128,21 @@ func TestValidatePlatform(t *testing.T) {
 			networking: validNetworking(),
 			valid:      true,
 		},
+		{
+			name: "invalid subnet ID",
+			platform: func() *openstack.Platform {
+				p := validPlatform()
+				fixedIP := openstack.FixedIP{
+					Subnet: openstack.SubnetFilter{ID: "fake"},
+				}
+				p.ControlPlanePort = &openstack.PortTarget{
+					FixedIPs: []openstack.FixedIP{fixedIP},
+				}
+				return p
+			}(),
+			networking:    validNetworking(),
+			expectedError: `^test-path\.controlPlanePort.fixedIPs: Invalid value: "fake": invalid subnet ID`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/types/openstack/validation/techpreview.go
+++ b/pkg/types/openstack/validation/techpreview.go
@@ -14,5 +14,9 @@ func FilledInTechPreviewFields(installConfig *types.InstallConfig) (fields []*fi
 		return nil
 	}
 
+	if installConfig.OpenStack.ControlPlanePort != nil && installConfig.OpenStack.DeprecatedMachinesSubnet == "" {
+		fields = append(fields, field.NewPath("platform", "openstack", "controlPlanePort"))
+	}
+
 	return fields
 }

--- a/pkg/types/openstack/validation/techpreview_test.go
+++ b/pkg/types/openstack/validation/techpreview_test.go
@@ -1,0 +1,41 @@
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/openstack"
+)
+
+func TestFilledInControlPlanePortField(t *testing.T) {
+	t.Run("control_plane_port_field", func(t *testing.T) {
+		fixedIP := openstack.FixedIP{
+			Subnet: openstack.SubnetFilter{ID: "031a5b9d-5a89-4465-8d54-3517ec2bad48"},
+		}
+		installConfig := types.InstallConfig{
+			Platform: types.Platform{
+				OpenStack: &openstack.Platform{
+					ControlPlanePort: &openstack.PortTarget{
+						FixedIPs: []openstack.FixedIP{fixedIP},
+					},
+				},
+			},
+		}
+
+		expectedField := field.NewPath("platform", "openstack", "controlPlanePort")
+
+		var found bool
+
+		for _, f := range FilledInTechPreviewFields(&installConfig) {
+			if f.String() == expectedField.String() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected field %q to be detected", expectedField)
+		}
+	})
+}


### PR DESCRIPTION
This commit adds dual stack support with bring your own network
for OpenStack platform. The new `ControlPlanePort` field accepts IPv4/IPv6
subnets and the network in the install config, while the `machinesSubnet`
that only supports IPv4 Subnets is deprecated.

Partially implements: https://github.com/openshift/enhancements/pull/1365