### PR TITLE
HIVE-2090: Add clusterID to the end of the resource pool for vsphere

### DIFF
--- a/pkg/asset/machines/vsphere/machines.go
+++ b/pkg/asset/machines/vsphere/machines.go
@@ -103,11 +103,11 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 func provider(clusterID string, platform *vsphere.Platform, mpool *vsphere.MachinePool, osImage string, userDataSecret string) (*machineapi.VSphereMachineProviderSpec, error) {
 	folder := fmt.Sprintf("/%s/vm/%s", platform.Datacenter, clusterID)
 
-	resourcePool := fmt.Sprintf("/%s/host/%s/Resources", platform.Datacenter, platform.Cluster)
+	resourcePool := fmt.Sprintf("/%s/host/%s/Resources/%s", platform.Datacenter, platform.Cluster, clusterID)
 	resourcePoolPrefix := "^\\/(.*?)\\/host\\/(.*?)"
 	hasFullPath, _ := regexp.MatchString(resourcePoolPrefix, platform.Cluster)
 	if hasFullPath {
-		resourcePool = fmt.Sprintf("%s/Resources", platform.Cluster)
+		resourcePool = fmt.Sprintf("%s/Resources/%s", platform.Cluster, clusterID)
 	}
 
 	if platform.Folder != "" {

--- a/pkg/asset/machines/vsphere/machines_test.go
+++ b/pkg/asset/machines/vsphere/machines_test.go
@@ -254,7 +254,7 @@ func TestConfigMasters(t *testing.T) {
 					Datacenter:   "datacenter",
 					Folder:       "/datacenter/vm/test",
 					Datastore:    "datastore",
-					ResourcePool: "/datacenter/host//Resources",
+					ResourcePool: "/datacenter/host//Resources/test",
 				},
 			},
 		},
@@ -328,7 +328,7 @@ func TestConfigMasters(t *testing.T) {
 					Datacenter:   "dc1",
 					Folder:       "/dc1/vm/folder1",
 					Datastore:    "datastore1",
-					ResourcePool: "/dc1/host/c1/Resources",
+					ResourcePool: "/dc1/host/c1/Resources/test",
 				},
 				{
 					Server:       "your.vcenter.example.com",

--- a/pkg/asset/machines/vsphere/machinesets_test.go
+++ b/pkg/asset/machines/vsphere/machinesets_test.go
@@ -148,7 +148,7 @@ func TestConfigMachinesets(t *testing.T) {
 					Datacenter:   "datacenter",
 					Folder:       "/datacenter/vm/test",
 					Datastore:    "datastore",
-					ResourcePool: "/datacenter/host//Resources",
+					ResourcePool: "/datacenter/host//Resources/test",
 				},
 			},
 		},
@@ -250,7 +250,7 @@ func TestConfigMachinesets(t *testing.T) {
 					Datacenter:   "dc1",
 					Folder:       "/dc1/vm/folder1",
 					Datastore:    "datastore1",
-					ResourcePool: "/dc1/host/c1/Resources",
+					ResourcePool: "/dc1/host/c1/Resources/test",
 				},
 				{
 					Server:       "your.vcenter.example.com",


### PR DESCRIPTION
Similar to the folder parameter, if a full resource pool path is not provided, it should be constructed with the clusterID as the last part of the path.

xref: [HIVE-2090](https://issues.redhat.com//browse/HIVE-2090)