### PR TITLE
OCPBUGS-6777: Fix file check for loading openshift manifests

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -621,6 +621,15 @@ func (m *Master) Load(f asset.FileFetcher) (found bool, err error) {
 	}
 	m.MachineFiles = fileList
 
+	file, err = f.FetchByName(filepath.Join(directory, controlPlaneMachineSetFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	m.ControlPlaneMachineSet = file
+
 	return true, nil
 }
 
@@ -644,6 +653,7 @@ func (m *Master) Machines() ([]machinev1beta1.Machine, error) {
 		&machinev1.AlibabaCloudMachineProviderConfig{},
 		&machinev1.NutanixMachineProviderConfig{},
 		&machinev1.PowerVSMachineProviderConfig{},
+		&machinev1.ControlPlaneMachineSet{},
 	)
 
 	machinev1beta1.AddToScheme(scheme)

--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -685,7 +685,7 @@ func IsMachineManifest(file *asset.File) bool {
 		return false
 	}
 	filename := filepath.Base(file.Filename)
-	if filename == masterUserDataFileName || filename == workerUserDataFileName {
+	if filename == masterUserDataFileName || filename == workerUserDataFileName || filename == controlPlaneMachineSetFileName {
 		return true
 	}
 	if matched, err := machineconfig.IsManifest(filename); err != nil {


### PR DESCRIPTION
When generating the openshift manifests, it tries to load the dependency control plane asset that creates files in the openshift directory. It then checks to see if the openshift manifest is actually already generated before this by checking the openshift directory for files that are not generated by the machine asset.

The newly created CPMS file was missing from the check, hence the asset loader always thought the asset was generated since there are files that exist other than the machine files and exits but it actually had to be newly generated with 4 files that were crucial to installation.

Adding the CPMS files to the list of machine asset files.