### PR TITLE
OCPBUGS-6919: vsphere: fix validation of CPUS and CoresPerSocket

### DIFF
--- a/pkg/types/vsphere/validation/machinepool.go
+++ b/pkg/types/vsphere/validation/machinepool.go
@@ -25,20 +25,20 @@ func ValidateMachinePool(platform *vsphere.Platform, machinePool *types.MachineP
 	if vspherePool.MemoryMiB < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("memoryMB"), vspherePool.MemoryMiB, "memory size must be positive"))
 	}
-	if vspherePool.NumCPUs < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("cpus"), vspherePool.NumCPUs, "number of CPUs must be positive"))
+	numCPUs := vspherePool.NumCPUs
+	if numCPUs < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("cpus"), numCPUs, "number of CPUs must be positive"))
 	}
-	if vspherePool.NumCoresPerSocket < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("coresPerSocket"), vspherePool.NumCoresPerSocket, "cores per socket must be positive"))
+	numCoresPerSocket := vspherePool.NumCoresPerSocket
+	if numCoresPerSocket < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("coresPerSocket"), numCoresPerSocket, "cores per socket must be positive"))
 	}
 
 	// Either the number set by the user or a default value
-	numCPUs := vspherePool.NumCPUs
-	if numCPUs == 0 {
+	if numCPUs <= 0 {
 		numCPUs = defaultNumCPUs
 	}
-	numCoresPerSocket := vspherePool.NumCoresPerSocket
-	if numCoresPerSocket == 0 {
+	if numCoresPerSocket <= 0 {
 		numCoresPerSocket = defaultCoresPerSocket
 	}
 

--- a/pkg/types/vsphere/validation/machinepool.go
+++ b/pkg/types/vsphere/validation/machinepool.go
@@ -33,17 +33,12 @@ func ValidateMachinePool(platform *vsphere.Platform, machinePool *types.MachineP
 	}
 
 	// Either the number set by the user or a default value
-	var numCPUs int32
-	if vspherePool.NumCPUs > 0 {
-		numCPUs = vspherePool.NumCPUs
-	} else {
+	numCPUs := vspherePool.NumCPUs
+	if numCPUs == 0 {
 		numCPUs = defaultNumCPUs
 	}
-	// Either the number set by the user or a default value
-	var numCoresPerSocket int32
-	if vspherePool.NumCoresPerSocket > 0 {
-		numCoresPerSocket = vspherePool.NumCoresPerSocket
-	} else {
+	numCoresPerSocket := vspherePool.NumCoresPerSocket
+	if numCoresPerSocket == 0 {
 		numCoresPerSocket = defaultCoresPerSocket
 	}
 

--- a/pkg/types/vsphere/validation/machinepool_test.go
+++ b/pkg/types/vsphere/validation/machinepool_test.go
@@ -84,7 +84,7 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: `^test-path\.coresPerSocket: Invalid value: 8: cores per socket must be less than number of CPUs$`,
+			expectedErrMsg: `^test-path\.coresPerSocket: Invalid value: 8: cores per socket must be less than the number of CPUs \(which is by default \d+\)$`,
 		},
 		{
 			name:     "numCPUs not a multiple of cores per socket",
@@ -97,7 +97,7 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket$`,
+			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket \(which is by default \d+\)$`,
 		},
 		{
 			name:     "numCPUs not a multiple of default cores per socket",
@@ -109,7 +109,7 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket which is by default 4$`,
+			expectedErrMsg: `^test-path.cpus: Invalid value: 7: numCPUs specified should be a multiple of cores per socket \(which is by default \d+\)$`,
 		},
 		{
 			name: "multi-zone invalid zone name",


### PR DESCRIPTION
I think the original intention behind the validation was to check that, in case `CoresPerSocket` was not set by the user, it would be checked against a default value (currently set to 4). However, that's not what is happening in practice, and both the check against the user-inputed value and the default were being performed.

That means that using CPUS=2 and CoresPerSocket=2 as exemplified in the official docs [1] would result in a validation error:
```
failed to create install config: invalid "install-config.yaml" file: controlPlane.platform.vsphere.cpus:
Invalid value: 2: numCPUs specified should be a multiple of cores per socket which is by default 4]
```
even though it's a valid configuration (albeit a pretty tiny compute node).

I'm changing the code a bit to make it more clear what the defaults values are representing and fixing the checks so they are made only once with the correct values for CPUs and CoresPerSocket.

[1] https://docs.openshift.com/container-platform/4.11/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-customizations