### PR TITLE
OCPBUGS-4997: Set the configured proxy settings for agent installer

### DIFF
--- a/data/data/agent/files/etc/systemd/system.conf.d/10-default-env.conf.template
+++ b/data/data/agent/files/etc/systemd/system.conf.d/10-default-env.conf.template
@@ -1,0 +1,12 @@
+{{if .Proxy -}}
+[Manager]
+{{if .Proxy.HTTPProxy -}}
+DefaultEnvironment=HTTP_PROXY="{{.Proxy.HTTPProxy}}"
+{{end -}}
+{{if .Proxy.HTTPSProxy -}}
+DefaultEnvironment=HTTPS_PROXY="{{.Proxy.HTTPSProxy}}"
+{{end -}}
+{{if .Proxy.NoProxy -}}
+DefaultEnvironment=NO_PROXY="{{.Proxy.NoProxy}}"
+{{end -}}
+{{end -}}

--- a/data/data/agent/systemd/units/agent.service.template
+++ b/data/data/agent/systemd/units/agent.service.template
@@ -3,12 +3,6 @@ Type=simple
 Restart=always
 RestartSec=3
 StartLimitInterval=0
-Environment=HTTP_PROXY=
-Environment=http_proxy=
-Environment=HTTPS_PROXY=
-Environment=https_proxy=
-Environment=NO_PROXY=
-Environment=no_proxy=
 TimeoutStartSec=3000
 ExecStartPre=/usr/local/bin/extract-agent.sh
 ExecStart=/usr/local/bin/start-agent.sh

--- a/pkg/asset/agent/image/ignition.go
+++ b/pkg/asset/agent/image/ignition.go
@@ -64,6 +64,7 @@ type agentTemplateData struct {
 	InfraEnvID                string
 	ClusterName               string
 	OSImage                   *models.OsImage
+	Proxy                     *v1beta1.Proxy
 }
 
 // Name returns the human-friendly name of the asset.
@@ -164,7 +165,8 @@ func (a *Ignition) Generate(dependencies asset.Parents) error {
 		publicContainerRegistries,
 		agentManifests.AgentClusterInstall,
 		infraEnvID,
-		osImage)
+		osImage,
+		infraEnv.Spec.Proxy)
 
 	err = bootstrap.AddStorageFiles(&config, "/", "agent/files", agentTemplateData)
 	if err != nil {
@@ -257,7 +259,8 @@ func getTemplateData(name, pullSecret, nodeZeroIP, releaseImageList, releaseImag
 	releaseImageMirror string, haveMirrorConfig bool, publicContainerRegistries string,
 	agentClusterInstall *hiveext.AgentClusterInstall,
 	infraEnvID string,
-	osImage *models.OsImage) *agentTemplateData {
+	osImage *models.OsImage,
+	proxy *v1beta1.Proxy) *agentTemplateData {
 	serviceBaseURL := url.URL{
 		Scheme: "http",
 		Host:   net.JoinHostPort(nodeZeroIP, "8090"),
@@ -281,6 +284,7 @@ func getTemplateData(name, pullSecret, nodeZeroIP, releaseImageList, releaseImag
 		InfraEnvID:                infraEnvID,
 		ClusterName:               name,
 		OSImage:                   osImage,
+		Proxy:                     proxy,
 	}
 }
 

--- a/pkg/asset/agent/image/ignition_test.go
+++ b/pkg/asset/agent/image/ignition_test.go
@@ -79,9 +79,15 @@ func TestIgnition_getTemplateData(t *testing.T) {
 		URL:              &isoURL,
 		Version:          &ver,
 	}
+
+	proxy := &aiv1beta1.Proxy{
+		HTTPProxy:  "http://1.1.1.1:80",
+		HTTPSProxy: "https://1.1.1.1:443",
+		NoProxy:    "valid-proxy.com,172.30.0.0/16",
+	}
 	clusterName := "test-agent-cluster-install.test"
 
-	templateData := getTemplateData(clusterName, pullSecret, nodeZeroIP, releaseImageList, releaseImage, releaseImageMirror, haveMirrorConfig, publicContainerRegistries, agentClusterInstall, infraEnvID, osImage)
+	templateData := getTemplateData(clusterName, pullSecret, nodeZeroIP, releaseImageList, releaseImage, releaseImageMirror, haveMirrorConfig, publicContainerRegistries, agentClusterInstall, infraEnvID, osImage, proxy)
 	assert.Equal(t, clusterName, templateData.ClusterName)
 	assert.Equal(t, "http", templateData.ServiceProtocol)
 	assert.Equal(t, "http://"+nodeZeroIP+":8090/", templateData.ServiceBaseURL)
@@ -98,6 +104,7 @@ func TestIgnition_getTemplateData(t *testing.T) {
 	assert.Equal(t, publicContainerRegistries, templateData.PublicContainerRegistries)
 	assert.Equal(t, infraEnvID, templateData.InfraEnvID)
 	assert.Equal(t, osImage, templateData.OSImage)
+	assert.Equal(t, proxy, templateData.Proxy)
 }
 
 func TestIgnition_addStaticNetworkConfig(t *testing.T) {


### PR DESCRIPTION
When the registry is only reachable via a proxy, the settings configured in install-config.yaml need to be used for podman. Save the proxy settings in systemd config.