### PR TITLE
Allow overriding the default machine CIDR for Nutanix

### DIFF
--- a/pkg/asset/installconfig/nutanix/nutanix.go
+++ b/pkg/asset/installconfig/nutanix/nutanix.go
@@ -15,9 +15,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/defaults"
 	"github.com/openshift/installer/pkg/types/nutanix"
 	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
+	nutanixdefaults "github.com/openshift/installer/pkg/types/nutanix/defaults"
 	"github.com/openshift/installer/pkg/types/validation"
 	"github.com/openshift/installer/pkg/validate"
 )
@@ -269,10 +269,11 @@ func getSubnet(ctx context.Context, client *nutanixclientv3.Client, peUUID strin
 func getVIPs() (string, string, error) {
 	var apiVIP, ingressVIP string
 
+	cidr := nutanixdefaults.GetMachineCIDR()
 	defaultMachineNetwork := &types.Networking{
 		MachineNetwork: []types.MachineNetworkEntry{
 			{
-				CIDR: *defaults.DefaultMachineCIDR,
+				CIDR: *cidr,
 			},
 		},
 	}

--- a/pkg/types/defaults/installconfig.go
+++ b/pkg/types/defaults/installconfig.go
@@ -2,6 +2,7 @@ package defaults
 
 import (
 	operv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	awsdefaults "github.com/openshift/installer/pkg/types/aws/defaults"
@@ -45,6 +46,12 @@ func SetInstallConfigDefaults(c *types.InstallConfig) {
 		if c.Platform.PowerVS != nil {
 			c.Networking.MachineNetwork = []types.MachineNetworkEntry{
 				{CIDR: *powervsdefaults.DefaultMachineCIDR},
+			}
+		}
+		if c.Platform.Nutanix != nil {
+			cidr := nutanixdefaults.GetMachineCIDR()
+			c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+				{CIDR: *cidr},
 			}
 		}
 	}

--- a/pkg/types/nutanix/defaults/platform.go
+++ b/pkg/types/nutanix/defaults/platform.go
@@ -1,8 +1,30 @@
 package defaults
 
 import (
+	"log"
+	"os"
+
+	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types/nutanix"
+)
+
+var (
+	defaultMachineCIDR = ipnet.MustParseCIDR("10.0.0.0/16")
 )
 
 // SetPlatformDefaults sets the defaults for the platform.
 func SetPlatformDefaults(p *nutanix.Platform) {}
+
+func GetMachineCIDR() *ipnet.IPNet {
+	cidrOverride, ok := os.LookupEnv("NUTANIX_MACHINE_CIDR_OVERRIDE")
+	if ok && cidrOverride != "" {
+		log.Println("NUTANIX_MACHINE_CIDR_OVERRIDE is set, using it instead of default machine CIDR", "NUTANIX_MACHINE_CIDR_OVERRIDE", cidrOverride)
+		cidr, err := ipnet.ParseCIDR(cidrOverride)
+		if err != nil {
+			return defaultMachineCIDR
+		}
+		return cidr
+	}
+
+	return defaultMachineCIDR
+}

--- a/pkg/types/nutanix/defaults/platform_test.go
+++ b/pkg/types/nutanix/defaults/platform_test.go
@@ -1,6 +1,7 @@
 package defaults
 
 import (
+	"github.com/openshift/installer/pkg/ipnet"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,4 +33,17 @@ func TestSetPlatformDefaults(t *testing.T) {
 			assert.Equal(t, tc.expected, tc.platform, "unexpected platform")
 		})
 	}
+}
+
+func TestGetMachineCIDRDefault(t *testing.T) {
+	cidr := GetMachineCIDR()
+	assert.Equal(t, *defaultMachineCIDR, *cidr, "unexpected machine CIDR")
+}
+
+func TestGetMachineCIDROverride(t *testing.T) {
+	t.Setenv("NUTANIX_MACHINE_CIDR_OVERRIDE", "10.40.0.0/16")
+	cidr := GetMachineCIDR()
+	assert.NotEqual(t, *defaultMachineCIDR, *cidr, "unexpected machine CIDR")
+	expectedCIDR := ipnet.MustParseCIDR("10.40.0.0/16")
+	assert.Equal(t, *expectedCIDR, *cidr, "unexpected machine CIDR")
 }


### PR DESCRIPTION
This allows for overriding the default machine CIDR for Nutanix using an environment variable.