### PR TITLE
OpenStack: Fix distribution of zones on 32-bit systems

### DIFF
--- a/pkg/asset/machines/openstack/machines.go
+++ b/pkg/asset/machines/openstack/machines.go
@@ -58,7 +58,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 	machines := make([]machineapi.Machine, 0, total)
 	providerConfigs := map[string]*machinev1alpha1.OpenstackProviderSpec{}
 	for idx := int64(0); idx < total; idx++ {
-		zone := mpool.Zones[int(idx)%len(mpool.Zones)]
+		zone := mpool.Zones[uint(idx)%uint(len(mpool.Zones))]
 		var provider *machinev1alpha1.OpenstackProviderSpec
 
 		if _, ok := providerConfigs[zone]; !ok {
@@ -71,7 +71,7 @@ func Machines(clusterID string, config *types.InstallConfig, pool *types.Machine
 				role,
 				userDataSecret,
 				trunkSupport,
-				volumeAZs[int(idx)%len(volumeAZs)],
+				volumeAZs[uint(idx)%uint(len(volumeAZs))],
 			)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
On 32-bit systems, Go `int` values are 32-bit integers. Given that we accept an explicit int64 number of replicas in the machine-pool, the index we use to distribute zones could end up negative when casting to int on 32-bit systems.

As a consequence, using availability zones when the replica number is greater than 2^31-1 on 32-bit systems makes the Installer panic.

With this change, we coerce the wrapping to be positive by casting to an unsigned integer. The automatic casting to int only happens after a modulo operation that is guaranteed to result in a number within int range.

While this fix may look risible, hitting this bug is just marginally less likely than encountering clusters of two billion workers, occurrence that the existing code goes out of its way to cover.