### PR TITLE
OCPBUGS-7261: Update AgentConfig template

### DIFF
--- a/pkg/asset/agent/agentconfig/agent_config.go
+++ b/pkg/asset/agent/agentconfig/agent_config.go
@@ -50,13 +50,16 @@ func (a *AgentConfig) Generate(dependencies asset.Parents) error {
 # which fields are available to aid you in creating your
 # own agent-config.yaml file.
 #
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: example-agent-config
   namespace: cluster0
 # All fields are optional
 rendezvousIP: your-node0-ip
+additionalNTPSources:
+- 0.rhel.pool.ntp.org
+- 1.rhel.pool.ntp.org
 hosts:
 # If a host is listed, then at least one interface
 # needs to be specified.

--- a/pkg/asset/agent/agentconfig/agent_config_test.go
+++ b/pkg/asset/agent/agentconfig/agent_config_test.go
@@ -30,7 +30,7 @@ func TestAgentConfig_LoadedFromDisk(t *testing.T) {
 		{
 			name: "valid-config-single-node",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -60,7 +60,7 @@ hosts:
 		{
 			name: "valid-config-multiple-nodes",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -127,7 +127,7 @@ hosts:
 		{
 			name: "unknown-field",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-wrong
 wrongField: wrongValue`,
@@ -138,7 +138,7 @@ wrongField: wrongValue`,
 		{
 			name: "interface-missing-mac-address-error",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -155,7 +155,7 @@ hosts:
 		{
 			name: "unsupported wwn extension root device hint",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -173,7 +173,7 @@ hosts:
 		{
 			name: "unsupported wwn vendor extension root device hint",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -191,7 +191,7 @@ hosts:
 		{
 			name: "node-hostname-and-role-are-not-required",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -209,7 +209,7 @@ hosts:
 		{
 			name: "host-roles-have-correct-values",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -232,7 +232,7 @@ hosts:
 		{
 			name: "host-roles-have-incorrect-values",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -248,7 +248,7 @@ hosts:
 		{
 			name: "different-ifaces-same-host-cannot-have-same-mac",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -265,7 +265,7 @@ hosts:
 		{
 			name: "different-hosts-cannot-have-same-mac",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -283,7 +283,7 @@ hosts:
 		{
 			name: "invalid-mac",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -298,7 +298,7 @@ hosts:
 		{
 			name: "empty-rendezvousIP",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0`,
 
@@ -308,7 +308,7 @@ metadata:
 		{
 			name: "invalid-rendezvousIP",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: not-a-valid-ip`,
@@ -319,7 +319,7 @@ rendezvousIP: not-a-valid-ip`,
 		{
 			name: "invalid-additionalNTPSourceDomain",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 additionalNTPSources:
@@ -335,7 +335,7 @@ rendezvousIP: 192.168.111.80`,
 		{
 			name: "valid-rendezvousIPAssignedToMaster",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80
@@ -380,7 +380,7 @@ hosts:
 		{
 			name: "invalid-rendezvousIPAssignedToWorker",
 			data: `
-apiVersion: v1alpha1
+apiVersion: v1beta1
 metadata:
   name: agent-config-cluster0
 rendezvousIP: 192.168.111.80


### PR DESCRIPTION
Due to it being a string, it had become out of date in a way that it impacted users. This commit syncs its content back to what is in pkg/types

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>