### PR TITLE
AGENT-505: Embed agent files in initrd

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
+++ b/cmd/openshift-install/testdata/agent/image/assets/default_assets.txt
@@ -5,7 +5,6 @@ exec openshift-install agent create image --dir $WORK
 exists $WORK/agent.x86_64.iso
 
 ignitionImgContains agent.x86_64.iso config.ign
-ignitionImgContains agent.x86_64.iso agent
 
 -- install-config.yaml --
 apiVersion: v1


### PR DESCRIPTION
This patch is a follow up of #6786, and it introduces a new approach for embedding files which is compatible also with the PXE booting.

The required files are added in a compressed cpio archive, which is appended to the `initrd.img` extracted from the base coreos ISO during the execution of the `agent create image` command. The newly added agent archive contains also a dracut hook script to copy the files before switching root.