### PR TITLE
AWS: Add wildcard apps domain DNS records for AWS

### DIFF
--- a/data/data/aws/cluster/route53/base.tf
+++ b/data/data/aws/cluster/route53/base.tf
@@ -67,7 +67,7 @@ resource "aws_route53_record" "api_internal_alias" {
   }
 }
 
-resource "aws_route53_record" "api_internal_alias" {
+resource "aws_route53_record" "apps_internal_alias" {
   count = local.use_alias ? 1 : 0
 
   zone_id = data.aws_route53_zone.int.zone_id
@@ -117,7 +117,7 @@ resource "aws_route53_record" "api_internal_cname" {
   records = [var.api_internal_lb_dns_name]
 }
 
-resource "aws_route53_record" "api_internal_cname" {
+resource "aws_route53_record" "apps_internal_cname" {
   count = local.use_cname ? 1 : 0
 
   zone_id = data.aws_route53_zone.int.zone_id

--- a/data/data/aws/cluster/route53/base.tf
+++ b/data/data/aws/cluster/route53/base.tf
@@ -67,6 +67,20 @@ resource "aws_route53_record" "api_internal_alias" {
   }
 }
 
+resource "aws_route53_record" "api_internal_alias" {
+  count = local.use_alias ? 1 : 0
+
+  zone_id = data.aws_route53_zone.int.zone_id
+  name    = "*.apps.${var.cluster_domain}"
+  type    = "A"
+
+  alias {
+    name                   = var.api_internal_lb_dns_name
+    zone_id                = var.api_internal_lb_zone_id
+    evaluate_target_health = false
+  }
+}
+
 resource "aws_route53_record" "api_external_internal_zone_alias" {
   count = local.use_alias ? 1 : 0
 
@@ -97,6 +111,17 @@ resource "aws_route53_record" "api_internal_cname" {
 
   zone_id = data.aws_route53_zone.int.zone_id
   name    = "api-int.${var.cluster_domain}"
+  type    = "CNAME"
+  ttl     = 10
+
+  records = [var.api_internal_lb_dns_name]
+}
+
+resource "aws_route53_record" "api_internal_cname" {
+  count = local.use_cname ? 1 : 0
+
+  zone_id = data.aws_route53_zone.int.zone_id
+  name    = "*.apps.${var.cluster_domain}"
   type    = "CNAME"
   ttl     = 10
 


### PR DESCRIPTION
AWS: Add wildcard apps domain DNS records for AWS

In the User-Provisioned Install there are instructions to create a wildcard apps (*.apps.<cluster_domain>). However, in the Infrastructure-Provisioned code there was no wildcard records being created. This caused errors in the authentication and console ClusterOperators getting deployed.

To be more clear this is the link [AWS UPI Create Ingress Endpoints](https://docs.openshift.com/container-platform/4.8/installing/installing_aws/installing-restricted-networks-aws.html#installation-create-ingress-dns-records_installing-restricted-networks-aws). In retrospect, if this is merged the section linked of the documentation could actually be removed since like the records for `api` and `api-int` this would be made by in Terraform in both instances I believe. 