### PR TITLE
OCPBUGS-4549: azure: fix MS Graph calls on Gov cloud

### DIFF
--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -95,10 +95,16 @@ func GetSessionWithCredentials(cloudName azure.CloudEnvironment, armEndpoint str
 			return nil, err
 		}
 	}
+	var cred azcore.TokenCredential
 	if credentials.ClientCertificatePath != "" {
-		return newSessionFromCertificates(cloudEnv, credentials, cloudConfig)
+		cred, err = newTokenCredentialFromCertificates(credentials, cloudConfig)
+	} else {
+		cred, err = newTokenCredentialFromCredentials(credentials, cloudConfig)
 	}
-	return newSessionFromCredentials(cloudEnv, credentials, cloudConfig)
+	if err != nil {
+		return nil, err
+	}
+	return newSessionFromCredentials(cloudEnv, credentials, cred)
 }
 
 // credentialsFromFileOrUser returns credentials found
@@ -253,7 +259,7 @@ func saveCredentials(credentials Credentials, filePath string) error {
 	return os.WriteFile(filePath, jsonCreds, 0o600)
 }
 
-func newSessionFromCredentials(cloudEnv azureenv.Environment, credentials *Credentials, cloudConfig cloud.Configuration) (*Session, error) {
+func newTokenCredentialFromCredentials(credentials *Credentials, cloudConfig cloud.Configuration) (azcore.TokenCredential, error) {
 	options := azidentity.ClientSecretCredentialOptions{
 		ClientOptions: azcore.ClientOptions{
 			Cloud: cloudConfig,
@@ -264,29 +270,10 @@ func newSessionFromCredentials(cloudEnv azureenv.Environment, credentials *Crede
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get client credentials from secret")
 	}
-
-	authProvider, err := azurekiota.NewAzureIdentityAuthenticationProvider(cred)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get Azidentity authentication provider")
-	}
-
-	// Use an adapter so azidentity in the Azure SDK can be used as
-	// Authorizer when calling the Azure Management Packages, which we
-	// currently use. Once the Azure SDK clients (found in /sdk) move to
-	// stable, we can update our clients and they will be able to use the
-	// creds directly without the authorizer. The schedule is here:
-	// https://azure.github.io/azure-sdk/releases/latest/index.html#go
-	authorizer := azidext.NewTokenCredentialAdapter(cred, []string{endpointToScope(cloudEnv.TokenAudience)})
-
-	return &Session{
-		Authorizer:   authorizer,
-		Credentials:  *credentials,
-		Environment:  cloudEnv,
-		AuthProvider: authProvider,
-	}, nil
+	return cred, nil
 }
 
-func newSessionFromCertificates(cloudEnv azureenv.Environment, credentials *Credentials, cloudConfig cloud.Configuration) (*Session, error) {
+func newTokenCredentialFromCertificates(credentials *Credentials, cloudConfig cloud.Configuration) (azcore.TokenCredential, error) {
 	options := azidentity.ClientCertificateCredentialOptions{
 		ClientOptions: azcore.ClientOptions{
 			Cloud: cloudConfig,
@@ -312,7 +299,10 @@ func newSessionFromCertificates(cloudEnv azureenv.Environment, credentials *Cred
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get client credentials from certificate")
 	}
+	return cred, nil
+}
 
+func newSessionFromCredentials(cloudEnv azureenv.Environment, credentials *Credentials, cred azcore.TokenCredential) (*Session, error) {
 	authProvider, err := azurekiota.NewAzureIdentityAuthenticationProvider(cred)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get Azidentity authentication provider")

--- a/pkg/destroy/azure/azure.go
+++ b/pkg/destroy/azure/azure.go
@@ -77,6 +77,16 @@ func (o *ClusterUninstaller) configureClients() error {
 	if err != nil {
 		return err
 	}
+	// This can be empty for StackCloud
+	if o.Environment.MicrosoftGraphEndpoint != "" {
+		// Set the service root to the Microsoft Graph for the appropriate
+		// cloud endpoint (e.g, GovCloud). Failing to do so results in an
+		// unhelpful `context deadline exceeded` error.
+		// NOTE: The API version must be included in the URL
+		// See https://issues.redhat.com/browse/OCPBUGS-4549
+		// See https://learn.microsoft.com/en-us/graph/sdks/national-clouds?tabs=go
+		adapter.SetBaseUrl(fmt.Sprintf("%s/v1.0", o.Environment.MicrosoftGraphEndpoint))
+	}
 	o.msgraphClient = msgraphsdk.NewGraphServiceClient(adapter)
 
 	return nil


### PR DESCRIPTION
    When doing API calls to the new MSGraph API, we need to override the URL used to connect to Microsoft Graph national cloud deployments.
    
    This fixes the following error when trying to destroy a Gov cloud cluster:
    ```
    02-07 14:39:50.162  level=debug msg=deleting application registrations
    02-07 14:40:36.775  level=debug msg=failed to gather list of Service Principals by tag: Get "https://graph.microsoft.com/v1.0/servicePrincipals?$filter=startswith%28displayName%2C%20%27$INFRA_ID%27%29%20and%20tags%2Fany%28s%3As%20eq%20%27kubernetes.io_cluster.$INFRA_ID%3Downed%27%29": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
    ```
    
    Notice the usage of `https://graph.microsoft.com/` (global service) instead of `https://graph.microsoft.us/` (US Gov cloud).
    
    https://learn.microsoft.com/en-us/graph/sdks/national-clouds?tabs=go
