### PR TITLE
Azure: use managed storage account for boot logs

### DIFF
--- a/data/data/azure/bootstrap/main.tf
+++ b/data/data/azure/bootstrap/main.tf
@@ -223,7 +223,7 @@ resource "azurerm_linux_virtual_machine" "bootstrap" {
   custom_data   = base64encode(data.ignition_config.redirect.rendered)
 
   boot_diagnostics {
-    storage_account_uri = data.azurerm_storage_account.storage_account.primary_blob_endpoint
+    storage_account_uri = null # null enables managed storage account for boot diagnostics
   }
 
   depends_on = [

--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -33,7 +33,6 @@ module "master" {
   ilb_backend_pool_v6_id     = var.ilb_backend_pool_v6_id
   subnet_id                  = var.master_subnet_id
   instance_count             = var.master_count
-  storage_account_name       = var.storage_account_name
   os_volume_type             = var.azure_master_root_volume_type
   os_volume_size             = var.azure_master_root_volume_size
   private                    = var.azure_private

--- a/data/data/azure/cluster/master/master.tf
+++ b/data/data/azure/cluster/master/master.tf
@@ -6,11 +6,6 @@ locals {
   ip_v6_configuration_name = "pipConfig-v6"
 }
 
-data "azurerm_storage_account" "storage_account" {
-  name                = var.storage_account_name
-  resource_group_name = var.resource_group_name
-}
-
 resource "azurerm_network_interface" "master" {
   count = var.instance_count
 
@@ -131,7 +126,7 @@ resource "azurerm_linux_virtual_machine" "master" {
   custom_data   = base64encode(var.ignition)
 
   boot_diagnostics {
-    storage_account_uri = data.azurerm_storage_account.storage_account.primary_blob_endpoint
+    storage_account_uri = null # null enables managed storage account for boot diagnostics
   }
 
   tags = var.azure_extra_tags

--- a/data/data/azure/cluster/master/variables.tf
+++ b/data/data/azure/cluster/master/variables.tf
@@ -95,11 +95,6 @@ EOF
   default = {}
 }
 
-variable "storage_account_name" {
-  type = any
-  description = "the name of the storage account for the cluster. It can be used for boot diagnostics."
-}
-
 variable "ignition" {
   type = string
 }

--- a/data/data/azure/cluster/variables.tf
+++ b/data/data/azure/cluster/variables.tf
@@ -62,11 +62,6 @@ variable "resource_group_name" {
   description = "The resource group name for the deployment."
 }
 
-variable "storage_account_name" {
-  type        = string
-  description = "the name of the storage account for the cluster. It can be used for boot diagnostics."
-}
-
 variable "vm_image" {
   type        = string
   description = "The resource id of the vm image used for bootstrap."


### PR DESCRIPTION
Update installer-created VMs to use managed-storage accounts rather than custom storage accounts, created by the installer. We're doing this in order to have consistency with the control-plane machinesets and to decrease our dependence on the installer-created storage account, which we would like to remove at bootstrap destroy.