### PR TITLE
UPI image: update gcloud python interpretor

### DIFF
--- a/images/installer/Dockerfile.upi.ci
+++ b/images/installer/Dockerfile.upi.ci
@@ -58,7 +58,7 @@ RUN curl -sSL "${ALIYUN_URI}" --output /tmp/aliyun-cli-linux-latest-amd64.tgz &&
 RUN curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
 RUN python get-pip.py 'pip<21.0'
 RUN python -m pip install pyopenssl
-ENV CLOUDSDK_PYTHON=/usr/bin/python
+ENV CLOUDSDK_PYTHON=/usr/bin/python3
 
 RUN python3 -m pip install yq
 


### PR DESCRIPTION
Point to python3 so we stop getting spammy messages like:

```
WARNING:  Python 2 will soon be deprecated by the Google Cloud SDK and may not function correctly. Please use Python version 3.5 and up.
```

in our CI logs.