### PR TITLE
PowerVS: Add capacity checks before installation

### DIFF
--- a/pkg/asset/installconfig/powervs/session.go
+++ b/pkg/asset/installconfig/powervs/session.go
@@ -8,6 +8,7 @@ import (
 	gohttp "net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,11 +21,15 @@ import (
 	bxsession "github.com/IBM-Cloud/bluemix-go/session"
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/form3tech-oss/jwt-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/powervs"
 )
@@ -271,6 +276,155 @@ func (c *BxClient) ValidateCloudConnectionInPowerVSRegion(ctx context.Context, s
 		}
 	}
 	return nil
+}
+
+// GetSystemPools returns the system pools that are in the cloud.
+func (c *BxClient) GetSystemPools(ctx context.Context, serviceInstanceID string) (models.SystemPools, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	systemPoolClient := instance.NewIBMPISystemPoolClient(ctx, c.PISession, serviceInstanceID)
+
+	systemPools, err := systemPoolClient.GetSystemPools()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get system pools")
+	}
+
+	return systemPools, nil
+}
+
+// ValidateCapacityWithPools validates that the VMs created for both the controlPlanes and the
+// computes will fit inside the given systemPools.
+func ValidateCapacityWithPools(controlPlanes []machinev1beta1.Machine, computes []machinev1beta1.MachineSet, systemPools models.SystemPools) error {
+	var (
+		numCompute           int
+		computeSystemType    string
+		computeProcessorType string
+		computeProcessors    float64
+		computeMemoryGiB     int64
+		numWorker            int64
+		workerSystemType     string
+		workerProcessorType  string
+		workerProcessors     float64
+		workerMemoryGiB      int64
+		ok                   bool
+	)
+
+	// Find out the control plane master information
+	numCompute = len(controlPlanes)
+	ctrplConfigs := make([]*machinev1.PowerVSMachineProviderConfig, numCompute)
+	for i, m := range controlPlanes {
+		ctrplConfigs[i], ok = m.Spec.ProviderSpec.Value.Object.(*machinev1.PowerVSMachineProviderConfig)
+		if !ok {
+			return errors.New("m.Spec.ProviderSpec.Value.Object failed")
+		}
+	}
+	computeSystemType = ctrplConfigs[0].SystemType
+	computeProcessorType = string(ctrplConfigs[0].ProcessorType)
+	if ctrplConfigs[0].Processors.Type == intstr.Int {
+		computeProcessors = float64(numCompute) * float64(ctrplConfigs[0].Processors.IntVal)
+	} else {
+		cores, err := strconv.ParseFloat(ctrplConfigs[0].Processors.StrVal, 64)
+		if err != nil {
+			return errors.Wrap(err, "failed to convert compute cores to a float")
+		}
+		computeProcessors = float64(numCompute) * cores
+	}
+	computeMemoryGiB = int64(numCompute) * int64(ctrplConfigs[0].MemoryGiB)
+
+	// Find out the worker information
+	computeReplicas := make([]int64, len(computes))
+	computeConfigs := make([]*machinev1.PowerVSMachineProviderConfig, len(computes))
+	for i, w := range computes {
+		computeReplicas[i] = int64(*w.Spec.Replicas)
+		numWorker = computeReplicas[i]
+		computeConfigs[i], ok = w.Spec.Template.Spec.ProviderSpec.Value.Object.(*machinev1.PowerVSMachineProviderConfig)
+		if !ok {
+			return errors.New("w.Spec.Template.Spec.ProviderSpec.Value.Object")
+		}
+
+		workerSystemType = computeConfigs[i].SystemType
+		workerProcessorType = string(computeConfigs[i].ProcessorType)
+		if computeConfigs[i].Processors.Type == intstr.Int {
+			workerProcessors = float64(computeReplicas[i]) * float64(computeConfigs[0].Processors.IntVal)
+		} else {
+			cores, err := strconv.ParseFloat(computeConfigs[0].Processors.StrVal, 64)
+			if err != nil {
+				return errors.Wrap(err, "failed to convert worker cores to a float")
+			}
+			workerProcessors = float64(computeReplicas[i]) * cores
+		}
+		workerMemoryGiB += numWorker * int64(computeConfigs[i].MemoryGiB)
+	}
+
+	// Helpful debug statement to save typing
+	// fmt.Printf("ValidateCapacityWithPools: compute(%v) = {%v, %v, %v, %v}, worker(%v) = {%v, %v, %v, %v}\n", numCompute, computeSystemType, computeProcessorType, computeProcessors, computeMemoryGiB, numWorker, workerSystemType, workerProcessorType, workerProcessors, workerMemoryGiB)
+
+	switch computeProcessorType {
+	case "Dedicated":
+	case "Shared":
+		// @TODO I would think we should reduce the number of cores by some factor.
+		// However, I cannot currently find documentation which describes what
+		// PowerVS uses internally.
+		computeProcessors = 0
+	default:
+		return errors.Errorf("Unknown compute processor type (%v)", computeProcessorType)
+	}
+
+	switch workerProcessorType {
+	case "Dedicated":
+	case "Shared":
+		// @TODO I would think we should reduce the number of cores by some factor.
+		// However, I cannot currently find documentation which describes what
+		// PowerVS uses internally.
+		workerProcessors = 0
+	default:
+		return errors.Errorf("Unknown worker processor type (%v)", workerProcessorType)
+	}
+
+	for _, systemPool := range systemPools {
+		// Helpful debug statement to save typing
+		// fmt.Printf("ValidateCapacityWithPools: pool %v, cores %v, memory %v\n", systemPool.Type, *systemPool.MaxCoresAvailable.Cores, *systemPool.MaxCoresAvailable.Memory)
+
+		if computeSystemType == systemPool.Type {
+			if computeProcessors > *systemPool.MaxCoresAvailable.Cores {
+				return errors.Errorf("Not enough cores available (%v) for the compute nodes (need %v)", *systemPool.MaxCoresAvailable.Cores, computeProcessors)
+			}
+			*systemPool.MaxCoresAvailable.Cores -= computeProcessors
+
+			if computeMemoryGiB > *systemPool.MaxCoresAvailable.Memory {
+				return errors.Errorf("Not enough memory available (%v) for the compute nodes (need %v)", *systemPool.MaxCoresAvailable.Memory, computeMemoryGiB)
+			}
+			*systemPool.MaxCoresAvailable.Memory -= computeMemoryGiB
+		}
+		if workerSystemType == systemPool.Type {
+			if workerProcessors > *systemPool.MaxCoresAvailable.Cores {
+				return errors.Errorf("Not enough cores available (%v) for the worker nodes (need %v)", *systemPool.MaxCoresAvailable.Cores, workerProcessors)
+			}
+			*systemPool.MaxCoresAvailable.Cores -= workerProcessors
+
+			if workerMemoryGiB > *systemPool.MaxCoresAvailable.Memory {
+				return errors.Errorf("Not enough memory available (%v) for the worker nodes (need %v)", *systemPool.MaxCoresAvailable.Memory, workerMemoryGiB)
+			}
+			*systemPool.MaxCoresAvailable.Memory -= workerMemoryGiB
+		}
+	}
+
+	return nil
+}
+
+// ValidateCapacity validates space for processors and storage in the cloud.
+func (c *BxClient) ValidateCapacity(ctx context.Context, controlPlanes []machinev1beta1.Machine, computes []machinev1beta1.MachineSet, serviceInstanceID string) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	systemPools, err := c.GetSystemPools(ctx, serviceInstanceID)
+	if err != nil {
+		return errors.Wrap(err, "failed to get system pools")
+	}
+
+	// Call another function which we can also test with mock
+	return ValidateCapacityWithPools(controlPlanes, computes, systemPools)
 }
 
 // NewPISession updates pisession details, return error on fail

--- a/pkg/asset/installconfig/powervs/validation_test.go
+++ b/pkg/asset/installconfig/powervs/validation_test.go
@@ -5,11 +5,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
+	machinev1 "github.com/openshift/api/machine/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/installer/pkg/asset/installconfig/powervs"
 	"github.com/openshift/installer/pkg/asset/installconfig/powervs/mock"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -411,6 +416,207 @@ func TestValidateCustomVPCSettings(t *testing.T) {
 			}
 		})
 	}
+}
+
+func createControlPlanes(numControlPlanes int, controlPlane *machinev1.PowerVSMachineProviderConfig) []machinev1beta1.Machine {
+	controlPlanes := make([]machinev1beta1.Machine, numControlPlanes)
+
+	for i := range controlPlanes {
+		masterName := fmt.Sprintf("rdr-hamzy-test3-syd04-zwmgs-master-%d", i)
+		controlPlanes[i].TypeMeta = metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: "machine.openshift.io/v1beta1",
+		}
+		controlPlanes[i].ObjectMeta = metav1.ObjectMeta{
+			Name:      masterName,
+			Namespace: "openshift-machine-api",
+			Labels:    make(map[string]string),
+		}
+		controlPlanes[i].Labels["machine.openshift.io/cluster-api-cluster"] = "rdr-hamzy-test3-syd04-zwmgs"
+		controlPlanes[i].Labels["machine.openshift.io/cluster-api-machine-role"] = "master"
+		controlPlanes[i].Labels["machine.openshift.io/cluster-api-machine-type"] = "master"
+
+		controlPlanes[i].Spec.ProviderSpec = machinev1beta1.ProviderSpec{
+			Value: &runtime.RawExtension{
+				Raw:    nil,
+				Object: controlPlane,
+			},
+		}
+	}
+
+	return controlPlanes
+}
+
+func createComputes(numComputes int32, compute *machinev1.PowerVSMachineProviderConfig) []machinev1beta1.MachineSet {
+	computes := make([]machinev1beta1.MachineSet, 1)
+
+	computes[0].Spec.Replicas = &numComputes
+
+	computes[0].Spec.Template.Spec.ProviderSpec = machinev1beta1.ProviderSpec{
+		Value: &runtime.RawExtension{
+			Raw:    nil,
+			Object: compute,
+		},
+	}
+
+	return computes
+}
+
+func TestSystemPool(t *testing.T) {
+	setMockEnvVars()
+
+	dedicatedControlPlane := machinev1.PowerVSMachineProviderConfig{
+		TypeMeta:      metav1.TypeMeta{Kind: "PowerVSMachineProviderConfig", APIVersion: "machine.openshift.io/v1"},
+		KeyPairName:   "rdr-hamzy-test3-syd04-vcwtz-key",
+		SystemType:    "e980",
+		ProcessorType: "Dedicated",
+		Processors:    intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+		MemoryGiB:     32,
+	}
+
+	dedicatedControlPlanes := createControlPlanes(5, &dedicatedControlPlane)
+
+	dedicatedCompute := machinev1.PowerVSMachineProviderConfig{
+		TypeMeta:      metav1.TypeMeta{Kind: "PowerVSMachineProviderConfig", APIVersion: "machine.openshift.io/v1"},
+		KeyPairName:   "rdr-hamzy-test3-syd04-vcwtz-key",
+		SystemType:    "e980",
+		ProcessorType: "Dedicated",
+		Processors:    intstr.IntOrString{Type: intstr.Int, IntVal: 1},
+		MemoryGiB:     32,
+	}
+
+	dedicatedComputes := createComputes(3, &dedicatedCompute)
+
+	systemPoolNEComputeCores := &models.System{
+		Cores:  func(f float64) *float64 { return &f }(2),
+		ID:     1,
+		Memory: func(i int64) *int64 { return &i }(256),
+	}
+	systemPoolsNEComputeCores := models.SystemPools{
+		"NotEnoughComputeCores": models.SystemPool{
+			Capacity:           systemPoolNEComputeCores,
+			CoreMemoryRatio:    float64(1.0),
+			MaxAvailable:       systemPoolNEComputeCores,
+			MaxCoresAvailable:  systemPoolNEComputeCores,
+			MaxMemoryAvailable: systemPoolNEComputeCores,
+			SharedCoreRatio: &models.MinMaxDefault{
+				Default: func(f float64) *float64 { return &f }(4),
+				Max:     func(f float64) *float64 { return &f }(4),
+				Min:     func(f float64) *float64 { return &f }(1),
+			},
+			Systems: []*models.System{
+				systemPoolNEComputeCores,
+			},
+			Type: "e980",
+		},
+	}
+	systemPoolNEWorkerCores := &models.System{
+		Cores:  func(f float64) *float64 { return &f }(6),
+		ID:     1,
+		Memory: func(i int64) *int64 { return &i }(256),
+	}
+	systemPoolsNEWorkerCores := models.SystemPools{
+		"NotEnoughWorkerCores": models.SystemPool{
+			Capacity:           systemPoolNEWorkerCores,
+			CoreMemoryRatio:    float64(1.0),
+			MaxAvailable:       systemPoolNEWorkerCores,
+			MaxCoresAvailable:  systemPoolNEWorkerCores,
+			MaxMemoryAvailable: systemPoolNEWorkerCores,
+			SharedCoreRatio: &models.MinMaxDefault{
+				Default: func(f float64) *float64 { return &f }(4),
+				Max:     func(f float64) *float64 { return &f }(4),
+				Min:     func(f float64) *float64 { return &f }(1),
+			},
+			Systems: []*models.System{
+				systemPoolNEWorkerCores,
+			},
+			Type: "e980",
+		},
+	}
+	systemPoolNEComputeMemory := &models.System{
+		Cores:  func(f float64) *float64 { return &f }(8),
+		ID:     1,
+		Memory: func(i int64) *int64 { return &i }(32),
+	}
+	systemPoolsNEComputeMemory := models.SystemPools{
+		"NotEnoughComputeMemory": models.SystemPool{
+			Capacity:           systemPoolNEComputeMemory,
+			CoreMemoryRatio:    float64(1.0),
+			MaxAvailable:       systemPoolNEComputeMemory,
+			MaxCoresAvailable:  systemPoolNEComputeMemory,
+			MaxMemoryAvailable: systemPoolNEComputeMemory,
+			SharedCoreRatio: &models.MinMaxDefault{
+				Default: func(f float64) *float64 { return &f }(4),
+				Max:     func(f float64) *float64 { return &f }(4),
+				Min:     func(f float64) *float64 { return &f }(1),
+			},
+			Systems: []*models.System{
+				systemPoolNEComputeMemory,
+			},
+			Type: "e980",
+		},
+	}
+	systemPoolNEWorkerMemory := &models.System{
+		Cores:  func(f float64) *float64 { return &f }(8),
+		ID:     1,
+		Memory: func(i int64) *int64 { return &i }(192),
+	}
+	systemPoolsNEWorkerMemory := models.SystemPools{
+		"NotEnoughWorkerMemory": models.SystemPool{
+			Capacity:           systemPoolNEWorkerMemory,
+			CoreMemoryRatio:    float64(1.0),
+			MaxAvailable:       systemPoolNEWorkerMemory,
+			MaxCoresAvailable:  systemPoolNEWorkerMemory,
+			MaxMemoryAvailable: systemPoolNEWorkerMemory,
+			SharedCoreRatio: &models.MinMaxDefault{
+				Default: func(f float64) *float64 { return &f }(4),
+				Max:     func(f float64) *float64 { return &f }(4),
+				Min:     func(f float64) *float64 { return &f }(1),
+			},
+			Systems: []*models.System{
+				systemPoolNEWorkerMemory,
+			},
+			Type: "e980",
+		},
+	}
+	systemPoolGood := &models.System{
+		Cores:  func(f float64) *float64 { return &f }(8),
+		ID:     1,
+		Memory: func(i int64) *int64 { return &i }(256),
+	}
+	systemPoolsGood := models.SystemPools{
+		"Enough": models.SystemPool{
+			Capacity:           systemPoolGood,
+			CoreMemoryRatio:    float64(1.0),
+			MaxAvailable:       systemPoolGood,
+			MaxCoresAvailable:  systemPoolGood,
+			MaxMemoryAvailable: systemPoolGood,
+			SharedCoreRatio: &models.MinMaxDefault{
+				Default: func(f float64) *float64 { return &f }(4),
+				Max:     func(f float64) *float64 { return &f }(4),
+				Min:     func(f float64) *float64 { return &f }(1),
+			},
+			Systems: []*models.System{
+				systemPoolGood,
+			},
+			Type: "e980",
+		},
+	}
+
+	err := powervs.ValidateCapacityWithPools(dedicatedControlPlanes, dedicatedComputes, systemPoolsNEComputeCores)
+	assert.EqualError(t, err, "Not enough cores available (2) for the compute nodes (need 5)")
+
+	err = powervs.ValidateCapacityWithPools(dedicatedControlPlanes, dedicatedComputes, systemPoolsNEWorkerCores)
+	assert.EqualError(t, err, "Not enough cores available (1) for the worker nodes (need 3)")
+
+	err = powervs.ValidateCapacityWithPools(dedicatedControlPlanes, dedicatedComputes, systemPoolsNEComputeMemory)
+	assert.EqualError(t, err, "Not enough memory available (32) for the compute nodes (need 160)")
+
+	err = powervs.ValidateCapacityWithPools(dedicatedControlPlanes, dedicatedComputes, systemPoolsNEWorkerMemory)
+	assert.EqualError(t, err, "Not enough memory available (32) for the worker nodes (need 96)")
+
+	err = powervs.ValidateCapacityWithPools(dedicatedControlPlanes, dedicatedComputes, systemPoolsGood)
+	assert.Empty(t, err)
 }
 
 func setMockEnvVars() {

--- a/pkg/asset/quota/quota.go
+++ b/pkg/asset/quota/quota.go
@@ -163,6 +163,10 @@ func (a *PlatformQuotaCheck) Generate(dependencies asset.Parents) error {
 				return errors.Wrap(err, "failed to meet the prerequisite for Cloud Connections")
 			}
 		}
+		err = bxCli.ValidateCapacity(context.TODO(), masters, workers, ic.Config.Platform.PowerVS.ServiceInstanceID)
+		if err != nil {
+			return err
+		}
 		if ic.Config.Platform.PowerVS.PVSNetworkName == "" {
 			err = bxCli.ValidateDhcpService(context.TODO(), ic.Config.Platform.PowerVS.ServiceInstanceID, ic.Config.MachineNetwork)
 			if err != nil {


### PR DESCRIPTION
Make sure before creating a cluster that we have enough capacity in the system pool.

@TODO I cannot currently find documentation which describes what
PowerVS uses internally for the "Shared" option.  Therefore, we
do not check for capacity if masters or workers use it.

https://issues.redhat.com/browse/MULTIARCH-2115