### PR TITLE
GCP: conditionally create bootstrap service account

### DIFF
--- a/data/data/gcp/variables-gcp.tf
+++ b/data/data/gcp/variables-gcp.tf
@@ -163,3 +163,9 @@ variable "gcp_master_on_host_maintenance" {
   description = "The behavior when a maintenance event occurs."
   default = ""
 }
+
+variable "gcp_create_bootstrap_sa" {
+  type = bool
+  default = false
+  description = "Whether a service account should be created to sign the ignition URL."
+}

--- a/pkg/asset/cluster/tfvars.go
+++ b/pkg/asset/cluster/tfvars.go
@@ -392,23 +392,6 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 			return err
 		}
 
-		instanceServiceAccount := ""
-
-		// Passthrough service accounts are only needed for GCP XPN.
-		ic := installConfig.Config
-		if len(ic.GCP.NetworkProjectID) > 0 && ic.CredentialsMode == types.PassthroughCredentialsMode {
-			var found bool
-			serviceAccount := make(map[string]interface{})
-			err := json.Unmarshal([]byte(sess.Credentials.JSON), &serviceAccount)
-			if err != nil {
-				return err
-			}
-			instanceServiceAccount, found = serviceAccount["client_email"].(string)
-			if !found {
-				return errors.New("could not find google service account")
-			}
-		}
-
 		auth := gcptfvars.Auth{
 			ProjectID:        installConfig.Config.GCP.ProjectID,
 			NetworkProjectID: installConfig.Config.GCP.NetworkProjectID,
@@ -475,16 +458,15 @@ func (t *TerraformVariables) Generate(parents asset.Parents) error {
 		imageURL := fmt.Sprintf("https://storage.googleapis.com/rhcos/rhcos/%s.tar.gz", img.Name)
 		data, err := gcptfvars.TFVars(
 			gcptfvars.TFVarsSources{
-				Auth:                   auth,
-				MasterConfigs:          masterConfigs,
-				WorkerConfigs:          workerConfigs,
-				CreateFirewallRules:    createFirewallRules,
-				ImageURI:               imageURL,
-				ImageLicenses:          installConfig.Config.GCP.Licenses,
-				InstanceServiceAccount: instanceServiceAccount,
-				PreexistingNetwork:     preexistingnetwork,
-				PublicZoneName:         publicZone.Name,
-				PublishStrategy:        installConfig.Config.Publish,
+				Auth:                auth,
+				MasterConfigs:       masterConfigs,
+				WorkerConfigs:       workerConfigs,
+				CreateFirewallRules: createFirewallRules,
+				ImageURI:            imageURL,
+				ImageLicenses:       installConfig.Config.GCP.Licenses,
+				PreexistingNetwork:  preexistingnetwork,
+				PublicZoneName:      publicZone.Name,
+				PublishStrategy:     installConfig.Config.Publish,
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
#6330, which introduced environmental auth, changed the default behavior of all installs to create a new service account for signing the ignition URL. Instead, we should only create that service account when using environmental auth (or for some other reason don't have a service account with a key). 