### PR TITLE
OCPBUGS-7495: Convert platform type for AgentClusterInstall

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -62,7 +62,7 @@ spec:
     networkType: OVNKubernetes
     serviceNetwork:
     - 172.30.0.0/16
-  platformType: none
+  platformType: None
   provisionRequirements:
     controlPlaneAgents: 1
   sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDK6UTEydcEKzuNdPaofn8Z2DwgHqdcionLZBiPf/zIRNco++etLsat7Avv7yt04DINQd5zjxIFgG8jblaUB5E5C9ClUcMwb52GO0ay2Y9v1uBv1a4WhI3peKktAzYNk0EBMQlJtXPjRMrC9ylBPh+DsBHMu+KmDnfk7PIwyN4efC8k5kSRuPWoNdme1rz2+umU8FSmaWTHIajrbspf4GQbsntA5kuKEtDbfoNCU97o2KrRnUbeg3a8hwSjfh3u6MhlnGcg5K2Ij+zivEsWGCLKYUtE1ErqwfIzwWmJ6jnV66XCQGHf4Q1iIxqF7s2a1q24cgG2Z/iDXfqXrCIfy4P7b/Ztak3bdT9jfAdVZtdO5/r7I+O5hYhF86ayFlDWzZWP/ByiSb+q4CQbfVgK3BMmiAv2MqLHdhesmD/SmIcoOWUF6rFmRKZVFFpKpt5ATNTgUJ3JRowoXrrDruVXClUGRiCS6Zabd1rZ3VmTchaPJwtzQMdfIWISXj+Ig+C4UK0=

--- a/pkg/asset/agent/common.go
+++ b/pkg/asset/agent/common.go
@@ -1,18 +1,49 @@
 package agent
 
 import (
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/none"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
-// SupportedPlatforms lists the supported platforms for agent installer
-var SupportedPlatforms = []string{baremetal.Name, vsphere.Name, none.Name}
+// SupportedInstallerPlatforms lists the supported platforms for agent installer.
+func SupportedInstallerPlatforms() []string {
+	return []string{baremetal.Name, vsphere.Name, none.Name}
+}
+
+var supportedHivePlatforms = []hiveext.PlatformType{
+	hiveext.BareMetalPlatformType,
+	hiveext.VSpherePlatformType,
+	hiveext.NonePlatformType,
+}
+
+// SupportedHivePlatforms lists the supported platforms for AgentClusterInstall.
+func SupportedHivePlatforms() []string {
+	platforms := []string{}
+	for _, p := range supportedHivePlatforms {
+		platforms = append(platforms, string(p))
+	}
+	return platforms
+}
+
+func HivePlatformType(platform types.Platform) hiveext.PlatformType {
+	switch platform.Name() {
+	case baremetal.Name:
+		return hiveext.BareMetalPlatformType
+	case none.Name:
+		return hiveext.NonePlatformType
+	case vsphere.Name:
+		return hiveext.VSpherePlatformType
+	}
+	return ""
+}
 
 // IsSupportedPlatform returns true if provided platform is supported.
-// Otherwise, returns false
-func IsSupportedPlatform(platform string) bool {
-	for _, p := range SupportedPlatforms {
+// Otherwise, returns false.
+func IsSupportedPlatform(platform hiveext.PlatformType) bool {
+	for _, p := range supportedHivePlatforms {
 		if p == platform {
 			return true
 		}

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -83,8 +83,8 @@ func (a *OptionalInstallConfig) validateSupportedPlatforms(installConfig *types.
 
 	fieldPath := field.NewPath("Platform")
 
-	if installConfig.Platform.Name() != "" && !IsSupportedPlatform(installConfig.Platform.Name()) {
-		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.Name(), SupportedPlatforms))
+	if installConfig.Platform.Name() != "" && !IsSupportedPlatform(HivePlatformType(installConfig.Platform)) {
+		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.Name(), SupportedInstallerPlatforms()))
 	}
 	return allErrs
 }

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -23,7 +23,10 @@ import (
 	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/defaults"
+	"github.com/openshift/installer/pkg/types/none"
+	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
 const (
@@ -142,7 +145,7 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 					ControlPlaneAgents: int(*installConfig.Config.ControlPlane.Replicas),
 					WorkerAgents:       numberOfWorkers,
 				},
-				PlatformType: hiveext.PlatformType(installConfig.Config.Platform.Name()),
+				PlatformType: agent.HivePlatformType(installConfig.Config.Platform),
 			},
 		}
 
@@ -238,6 +241,18 @@ func (a *AgentClusterInstall) Load(f asset.FileFetcher) (bool, error) {
 	}
 
 	setNetworkType(agentClusterInstall, &types.InstallConfig{}, "NetworkType is not specified in AgentClusterInstall.")
+
+	// Due to OCPBUGS-7495 we previously required lowercase platform names here,
+	// even though that is incorrect. Rewrite to the correct mixed case names
+	// for backward compatibility.
+	switch string(agentClusterInstall.Spec.PlatformType) {
+	case baremetal.Name:
+		agentClusterInstall.Spec.PlatformType = hiveext.BareMetalPlatformType
+	case none.Name:
+		agentClusterInstall.Spec.PlatformType = hiveext.NonePlatformType
+	case vsphere.Name:
+		agentClusterInstall.Spec.PlatformType = hiveext.VSpherePlatformType
+	}
 
 	a.Config = agentClusterInstall
 
@@ -343,8 +358,8 @@ func (a *AgentClusterInstall) validateSupportedPlatforms() field.ErrorList {
 
 	fieldPath := field.NewPath("spec", "platformType")
 
-	if a.Config.Spec.PlatformType != "" && !agent.IsSupportedPlatform(fmt.Sprintf("%s", a.Config.Spec.PlatformType)) {
-		allErrs = append(allErrs, field.NotSupported(fieldPath, a.Config.Spec.PlatformType, agent.SupportedPlatforms))
+	if a.Config.Spec.PlatformType != "" && !agent.IsSupportedPlatform(a.Config.Spec.PlatformType) {
+		allErrs = append(allErrs, field.NotSupported(fieldPath, a.Config.Spec.PlatformType, agent.SupportedHivePlatforms()))
 	}
 	return allErrs
 }

--- a/pkg/asset/agent/manifests/agentclusterinstall_test.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/asset/mock"
 	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/baremetal"
 )
 
 func TestAgentClusterInstall_Generate(t *testing.T) {
@@ -151,6 +150,76 @@ metadata:
 spec:
   apiVIP: 192.168.111.5
   ingressVIP: 192.168.111.4
+  platformType: BareMetal
+  clusterDeploymentRef:
+    name: ostest
+  imageSetRef:
+    name: openshift-v4.10.0
+  networking:
+    machineNetwork:
+    - cidr: 10.10.11.0/24
+    clusterNetwork:
+    - cidr: 10.128.0.0/14
+      hostPrefix: 23
+    serviceNetwork:
+    - 172.30.0.0/16
+    networkType: OVNKubernetes
+  provisionRequirements:
+    controlPlaneAgents: 3
+    workerAgents: 2
+  sshPublicKey: |
+    ssh-rsa AAAAmyKey`,
+			expectedFound: true,
+			expectedConfig: &hiveext.AgentClusterInstall{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-agent-cluster-install",
+					Namespace: "cluster0",
+				},
+				Spec: hiveext.AgentClusterInstallSpec{
+					APIVIP:       "192.168.111.5",
+					IngressVIP:   "192.168.111.4",
+					PlatformType: hiveext.BareMetalPlatformType,
+					ClusterDeploymentRef: corev1.LocalObjectReference{
+						Name: "ostest",
+					},
+					ImageSetRef: &hivev1.ClusterImageSetReference{
+						Name: "openshift-v4.10.0",
+					},
+					Networking: hiveext.Networking{
+						MachineNetwork: []hiveext.MachineNetworkEntry{
+							{
+								CIDR: "10.10.11.0/24",
+							},
+						},
+						ClusterNetwork: []hiveext.ClusterNetworkEntry{
+							{
+								CIDR:       "10.128.0.0/14",
+								HostPrefix: 23,
+							},
+						},
+						ServiceNetwork: []string{
+							"172.30.0.0/16",
+						},
+						NetworkType: "OVNKubernetes",
+					},
+					ProvisionRequirements: hiveext.ProvisionRequirements{
+						ControlPlaneAgents: 3,
+						WorkerAgents:       2,
+					},
+					SSHPublicKey: "ssh-rsa AAAAmyKey",
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "lowercase-platform-type-backwards-compat",
+			data: `
+metadata:
+  name: test-agent-cluster-install
+  namespace: cluster0
+spec:
+  apiVIP: 192.168.111.5
+  ingressVIP: 192.168.111.4
   platformType: baremetal
   clusterDeploymentRef:
     name: ostest
@@ -179,7 +248,7 @@ spec:
 				Spec: hiveext.AgentClusterInstallSpec{
 					APIVIP:       "192.168.111.5",
 					IngressVIP:   "192.168.111.4",
-					PlatformType: hiveext.PlatformType(baremetal.Name),
+					PlatformType: hiveext.BareMetalPlatformType,
 					ClusterDeploymentRef: corev1.LocalObjectReference{
 						Name: "ostest",
 					},
@@ -505,7 +574,7 @@ spec:
   sshPublicKey: |
     ssh-rsa AAAAmyKey`,
 			expectedFound: false,
-			expectedError: "invalid PlatformType configured: spec.platformType: Unsupported value: \"aws\": supported values: \"baremetal\", \"vsphere\", \"none\"",
+			expectedError: "invalid PlatformType configured: spec.platformType: Unsupported value: \"aws\": supported values: \"BareMetal\", \"VSphere\", \"None\"",
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -428,7 +428,7 @@ func getGoodACI() *hiveext.AgentClusterInstall {
 			},
 			APIVIP:       "192.168.122.10",
 			IngressVIP:   "192.168.122.11",
-			PlatformType: hiveext.PlatformType(baremetal.Name),
+			PlatformType: hiveext.BareMetalPlatformType,
 		},
 	}
 	return goodACI


### PR DESCRIPTION
The platform types in AgentClusterInstall are in mixed case. Previously we were just casting the lowercase platform name to set the PlatformType field. This resulted in the platform type being silently ignored when creating the Cluster in the assisted API. Clusters were getting the default type for their topology (None for SNO, otherwise BareMetal), but there was no way to set VSphere as the platform.