### PR TITLE
linter: bump version to sync with CI

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,7 +9,7 @@ run:
   - ^scripts
   - ^terraform
   - ^upi
-  go: '1.18'
+  go: '1.19'
   modules-download-mode: vendor
 output:
   print-linter-name: true

--- a/hack/go-lint.sh
+++ b/hack/go-lint.sh
@@ -5,5 +5,5 @@ podman run --rm \
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/installer:z" \
     --workdir /go/src/github.com/openshift/installer \
-    docker.io/golangci/golangci-lint:v1.46.0 \
+    docker.io/golangci/golangci-lint:v1.48.0 \
     golangci-lint run "${@}"


### PR DESCRIPTION
CI now has golangci-lint 1.48 which supports Golang 1.19. Let's make sure our hack/ tool uses the same version.