### PR TITLE
vSphere: ignore all bootstrap disk changes

### DIFF
--- a/data/data/vsphere/bootstrap/main.tf
+++ b/data/data/vsphere/bootstrap/main.tf
@@ -33,12 +33,12 @@ resource "vsphere_virtual_machine" "vm_bootstrap" {
     eagerly_scrub    = var.scrub_disk
     thin_provisioned = var.thin_disk
   }
+
   lifecycle {
     ignore_changes = [
-      disk[0].eagerly_scrub,
+      disk[0],
     ]
   }
-
 
   clone {
     template_uuid = var.template

--- a/data/data/vspherezoning/bootstrap/main.tf
+++ b/data/data/vspherezoning/bootstrap/main.tf
@@ -37,6 +37,12 @@ resource "vsphere_virtual_machine" "vm_bootstrap" {
     thin_provisioned = var.template[0].disks.0.thin_provisioned
   }
 
+  lifecycle {
+    ignore_changes = [
+      disk[0],
+    ]
+  }
+
   clone {
     template_uuid = var.template[0].uuid
   }


### PR DESCRIPTION
In some vSphere infrastructures the disk type
could change underneath terraform state causing
bootstrap delete to fail.

Ignore all bootstrap disk changes.