### PR TITLE
OCPBUGS-7180: update RHCOS 4.13 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.13",
   "metadata": {
-    "last-modified": "2023-01-31T13:14:55Z",
-    "generator": "plume cosa2stream aeecd6b"
+    "last-modified": "2023-02-15T22:37:28Z",
+    "generator": "plume cosa2stream 3ad4cf5"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-aws.aarch64.vmdk.gz",
-                "sha256": "79acc0463bb472cf226c2178dc948e3e2e0052e1d5c02db749a4a92ea369b0fb",
-                "uncompressed-sha256": "c342673a5a07f0f3235b59c33e3505f4113c901fb6b1d7f34718914ecb5972cc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-aws.aarch64.vmdk.gz",
+                "sha256": "b557c56f31635b3d521fd8ff197b9fbec3fb82c2d204c1218bdc265881ce70fc",
+                "uncompressed-sha256": "eeac7b88fe8b241d007b91e796f5bbb3761c19f8253b1d87a924c73db236b482"
               }
             }
           }
         },
         "azure": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-azure.aarch64.vhd.gz",
-                "sha256": "65a9975cc7487e5399ab86d8420e6c6fb07ad2da7fc94f3ca77170247ddfed2f",
-                "uncompressed-sha256": "783949480da7dd64b18114bca1d7a902f2b1698c6b7dfc919736cee435a88a71"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-azure.aarch64.vhd.gz",
+                "sha256": "11bbe50f659f3606638b0a0bdef4b7010c65b31767fef72976ddd5f1db62c374",
+                "uncompressed-sha256": "d41caffb16817e691ebef30a8244365fe1c98a3eea50e1dbe463cfdc7fe0dbbd"
               }
             }
           }
         },
         "metal": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-metal4k.aarch64.raw.gz",
-                "sha256": "38c8a228d41fc7351e1e8e6c3dd26093939752e57d4d53cdb40eb33480a3bc97",
-                "uncompressed-sha256": "837b56e5af879efd067a46e4f8fc4a4e580dc7c100f570aab37a9051c1abd366"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-metal4k.aarch64.raw.gz",
+                "sha256": "9f6e19830d1c419842223b39f41a4360ad353f745fcc4994d343dc6e57c936b8",
+                "uncompressed-sha256": "f79ce6e9e9d5af153d5f248fb82de1792cb5b6649e2f9c293d72e457be3643cf"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-live.aarch64.iso",
-                "sha256": "d365f15a2c090c7c033846a6f7edaae9ed04d1bb59dc4d1f869a6445cb120312"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-live.aarch64.iso",
+                "sha256": "c6b6ee3824074765b0683b35263d170698dd2353d1296582df8d284700331786"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-live-kernel-aarch64",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-live-kernel-aarch64",
                 "sha256": "89bbd45dc9c2fb53bfe30b5b64b6e3dd89c02446fc7f17bf915ae918c9a6ed5e"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-live-initramfs.aarch64.img",
-                "sha256": "0903aa0516e348dddc83c3c016e03663c1bf347d8298d07c392731ddab50581a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-live-initramfs.aarch64.img",
+                "sha256": "da310f2d24ec9971702bb20d174297e10dc6eeac9b97b464a9d2072fb03e9366"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-live-rootfs.aarch64.img",
-                "sha256": "71050849c03ab26129ed4ba5a7e25c04364701ea2859ef051e96a33bf6bca7ae"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-live-rootfs.aarch64.img",
+                "sha256": "acfde3ca39fe44622eadd929047e939f1592021954149101e0c51e6d3b2882af"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-metal.aarch64.raw.gz",
-                "sha256": "7a46fa1e508e3bd51352120fdc850deb52e7ac3dc2d8ce7909803d4e168a1464",
-                "uncompressed-sha256": "5a4970e242082746fd9631e139e3bcc1a4945e351e50b0c12102c457aa135913"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-metal.aarch64.raw.gz",
+                "sha256": "7395ad6248d42f3ca85c5290eb3356b2071e4e3e4aff61c69afd9faf4998c348",
+                "uncompressed-sha256": "8692d7c57e8d623e5d20232fea514a60dfb79a3f9df0415a86fed143c4ba6b50"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-openstack.aarch64.qcow2.gz",
-                "sha256": "c9a0ece05d6549a804c6a35b31d38c5f12a564c3394b8e15901cec0463129b1a",
-                "uncompressed-sha256": "7650ea6044b42bbe9266bd58960c822caeb85259afe2e3ebe484f29bb319c705"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-openstack.aarch64.qcow2.gz",
+                "sha256": "582ad4e73cf1f6b4a61c81bd820c270e51d9c533705a27eb84f6ffb6f4122cce",
+                "uncompressed-sha256": "1a54e7e60429d3e96cf709caebc892fd5685adc66ff5fe70d43110a1a6f1ea31"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/aarch64/rhcos-413.86.202301302144-0-qemu.aarch64.qcow2.gz",
-                "sha256": "b0f9d68969345d0806276a9cb254330b652e79620319ff2efc64b294348a16e8",
-                "uncompressed-sha256": "cfdf94db925c22207920fd69172af4ab14221c0f65d06f0e899c78d2a21abe6f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-qemu.aarch64.qcow2.gz",
+                "sha256": "841fbcf92fcfa2cd75d29bef4c7842a3abc7b941e28edc4674b9016b6f0b2aa6",
+                "uncompressed-sha256": "751b13a0aef916cb8055ed164212a2acc19901012b645cbcbb69401fe918fedc"
               }
             }
           }
@@ -99,184 +99,204 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-018d0f48bc2f14660"
+              "release": "413.86.202302150245-0",
+              "image": "ami-05c47148e37f3e4e4"
             },
             "ap-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-006978fe64cef3f56"
+              "release": "413.86.202302150245-0",
+              "image": "ami-00c959995c94e815a"
             },
             "ap-northeast-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-05e3527cdffe95b6c"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0094f5c7685201ba1"
             },
             "ap-northeast-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0781bacc0cc1a6057"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0dce45170b7553059"
             },
             "ap-northeast-3": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0cfe81d3ba14a1cd0"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0d550e040c9dc0873"
             },
             "ap-south-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-05f30d0c68b07f560"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0641eb79281a21a69"
+            },
+            "ap-south-2": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-09ee467081d7768c7"
             },
             "ap-southeast-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0069eb692fa4d85e7"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0574985f1b431b96e"
             },
             "ap-southeast-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0e2a3ea15287a588a"
+              "release": "413.86.202302150245-0",
+              "image": "ami-05d370d716a1f874d"
             },
             "ap-southeast-3": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-05bad077049711c33"
+              "release": "413.86.202302150245-0",
+              "image": "ami-020f73dd2489dce43"
+            },
+            "ap-southeast-4": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-04a70532ee93da390"
             },
             "ca-central-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0e8020eac35784696"
+              "release": "413.86.202302150245-0",
+              "image": "ami-076e3d73d4dedf4aa"
             },
             "eu-central-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-022168729b39e68ab"
+              "release": "413.86.202302150245-0",
+              "image": "ami-05e2b51a6dd6a865b"
+            },
+            "eu-central-2": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-0aa9d0f6bc21ec79f"
             },
             "eu-north-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-05b8a42422acb965b"
+              "release": "413.86.202302150245-0",
+              "image": "ami-07c0a250693c2ceab"
             },
             "eu-south-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-01e5ecbd03e0fa1e1"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0bae746303252482c"
+            },
+            "eu-south-2": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-04999295e95c9cd03"
             },
             "eu-west-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-026014f3c75171afd"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0e79e10970bae8ff5"
             },
             "eu-west-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0c43ecf24c06c33dd"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0e93d5931da3ac038"
             },
             "eu-west-3": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0e94f32512136bcba"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0277fa6a937389910"
+            },
+            "me-central-1": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-01af55ef27f8b2ef7"
             },
             "me-south-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-00ec80810db7fcb9e"
+              "release": "413.86.202302150245-0",
+              "image": "ami-077880aae2dd4155d"
             },
             "sa-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0de478e7d94f2b78e"
+              "release": "413.86.202302150245-0",
+              "image": "ami-06416a032d7c7e748"
             },
             "us-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-08a1484d325aaebd3"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0f2341e687f9b007e"
             },
             "us-east-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0e123bb998f2ce1ad"
+              "release": "413.86.202302150245-0",
+              "image": "ami-059f69497e1f69ae5"
             },
             "us-gov-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0e6434211809a2151"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0bba66e1fc9a82cac"
             },
             "us-gov-west-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0b6657cac566c5d9f"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0ad82ffbf40ca2b57"
             },
             "us-west-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-08c7bd9e71541bbeb"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0c66872e13f49e792"
             },
             "us-west-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-038110a3cf276f767"
+              "release": "413.86.202302150245-0",
+              "image": "ami-006bb7735fb3f9cd5"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.86.202301302144-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.86.202301302144-0-azure.aarch64.vhd"
+          "release": "413.86.202302150245-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.86.202302150245-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/ppc64le/rhcos-413.86.202301302144-0-metal4k.ppc64le.raw.gz",
-                "sha256": "95a114bdbdfd9c4fbf9630ba6526f960dc9f1d8ebb7fd697eaaf3e8ced362af8",
-                "uncompressed-sha256": "60d65d1cd6aefc7ec73d754ba5138d0e4efbb065b837fc9373ac0604b9c7b657"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-metal4k.ppc64le.raw.gz",
+                "sha256": "112d6ae1969cff286b120b9b56005a8ffe6e23e380d97ee83eb94da0d6210b0f",
+                "uncompressed-sha256": "a7cf5075d23ff881667a0977c90da7ae8f67fe1333bfbb1df306e6356275d239"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/ppc64le/rhcos-413.86.202301302144-0-live.ppc64le.iso",
-                "sha256": "e1d4cefd63abd85b94dd20f16f637cbbb2d731097d8cd907f5f467fa23dec335"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-live.ppc64le.iso",
+                "sha256": "7d7010f79723ef977e624992d0343a3902ec441bc08e0a4ac9e861be87c2686f"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/ppc64le/rhcos-413.86.202301302144-0-live-kernel-ppc64le",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-live-kernel-ppc64le",
                 "sha256": "e77ba60252c58cbed0a22ca4bad51e98abb4d8ab5841539555c24d2299754522"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/ppc64le/rhcos-413.86.202301302144-0-live-initramfs.ppc64le.img",
-                "sha256": "7faef33e649aca5d429e2bc61f176fb4c36d404ae0617646a75e57c19b84e70f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-live-initramfs.ppc64le.img",
+                "sha256": "d208a27f685b0ed675961d7aff0e5f921050c0ffbd24f554c9e127e6ed72d1f1"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/ppc64le/rhcos-413.86.202301302144-0-live-rootfs.ppc64le.img",
-                "sha256": "36c419ab908d31650d47730b653d26bd72c3babb9fd29cfef547590d378d0357"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-live-rootfs.ppc64le.img",
+                "sha256": "eced843e531009c7419e8153ef980aa6fe8f206bd5e4297c8bd261fa67a9e17c"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/ppc64le/rhcos-413.86.202301302144-0-metal.ppc64le.raw.gz",
-                "sha256": "d4d6e2a34252e4add30af6af3499b0597511df2a8e66470a7aa3ec60feb074fa",
-                "uncompressed-sha256": "689f85f1ab822305ecba100e59a66a9396e905b67c49a4656c6b9c83a1ead76d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-metal.ppc64le.raw.gz",
+                "sha256": "69593d80075b96d34291ccd37e7a082b0387c6ad0068c9de8477e1b580ac0447",
+                "uncompressed-sha256": "3919773632cd951098924cf9ac70244ba6baa05989bc54451f382001d626dc80"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/ppc64le/rhcos-413.86.202301302144-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "c40806486b1b4aeef78177dcd00978bdb1e022c343fbc907b68a0be41c324b99",
-                "uncompressed-sha256": "42cdc2a58b4b334986863955feb03edf355d852de984dae5047f5c28acc79423"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "7fbf95274610679d30e85e16824af578c1f2c288ff2955ccaeb2d29429c0fc96",
+                "uncompressed-sha256": "c3d5c1c3cf7204c3684925c691de87bc6277f7042c5a2cc455ab39a6d51d8e6f"
               }
             }
           }
         },
         "powervs": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/ppc64le/rhcos-413.86.202301302144-0-powervs.ppc64le.ova.gz",
-                "sha256": "b06ea5411cae7222ae25efe983aa894efc98079476874bb1777843dcf85e0086",
-                "uncompressed-sha256": "eacb086749e5c732dc83312f0c5e92a0f81fdcdb92fe6966c22b4deb0aad37d1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-powervs.ppc64le.ova.gz",
+                "sha256": "ad8c79402bd63504712fcfe15aad6f950a741f490341ebad7429247041391471",
+                "uncompressed-sha256": "081796f73eaaa2cd32a163f916fbccc852548fbd64c5c0fee88da890c7e4f9cb"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/ppc64le/rhcos-413.86.202301302144-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "d8ad6dfd58386093a98c99d69e388abd88bd82da510649fb9374a0680e5c31e4",
-                "uncompressed-sha256": "fdfbbf868d99705492953ea26f0968f708f5e4136e37c7c87bd5419cd9a56ad1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "303447ae8fcdd363a7b5d2e51d766baf8df9e78ce96523b71d4f1f9d5262203e",
+                "uncompressed-sha256": "efb602e5c1d3e150eece5b23f392f3b4dbf26e3df3a2f6ba4c46f34804d66c0f"
               }
             }
           }
@@ -286,58 +306,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "413.86.202301302144-0",
-              "object": "rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz",
+              "release": "413.86.202302150245-0",
+              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "413.86.202301302144-0",
-              "object": "rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz",
+              "release": "413.86.202302150245-0",
+              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "413.86.202301302144-0",
-              "object": "rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz",
+              "release": "413.86.202302150245-0",
+              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "413.86.202301302144-0",
-              "object": "rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz",
+              "release": "413.86.202302150245-0",
+              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "413.86.202301302144-0",
-              "object": "rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz",
+              "release": "413.86.202302150245-0",
+              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "413.86.202301302144-0",
-              "object": "rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz",
+              "release": "413.86.202302150245-0",
+              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "413.86.202301302144-0",
-              "object": "rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz",
+              "release": "413.86.202302150245-0",
+              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "413.86.202301302144-0",
-              "object": "rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz",
+              "release": "413.86.202302150245-0",
+              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "413.86.202301302144-0",
-              "object": "rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz",
+              "release": "413.86.202302150245-0",
+              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-86-202301302144-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -346,88 +366,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "71f59a7d67860d9653f62730bdd616a9478ae07355267c82b1417aab4672b562",
-                "uncompressed-sha256": "c40a75b0e54442905367fdb03f53554ec0ca33908477441df7fdadd5605b3928"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "c1d0f67c6422fe36bd93f3b3ff8e168b7fee0eafb243eb6a8ccd7aad88fba484",
+                "uncompressed-sha256": "6cdd11732a43bea39590098059b1df8fef10cfb172a0bade402e9997170af323"
               }
             }
           }
         },
         "metal": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-metal4k.s390x.raw.gz",
-                "sha256": "992e94945ebad63d617155eb5040ec53433703728ecb4c11ba19ddb1353c683b",
-                "uncompressed-sha256": "c846394a4b004ced7ec72b7094db861e53639ecdd7418c065acd75bd4f7d0060"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-metal4k.s390x.raw.gz",
+                "sha256": "b3f05fffa012de9bc50d5d4fca69c90d1ddf7849d249c13281462f1df0547be5",
+                "uncompressed-sha256": "5266e949fea6c576627142cfbc3b1702bdab70d83c0497011666c0aba439fb32"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-live.s390x.iso",
-                "sha256": "caf8a1e8a96e0619ff3be511275d6a800dec631fb3a61ad332fa8b566cc7e011"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-live.s390x.iso",
+                "sha256": "580d42a3266ef66fd5362a19233518776b1008d89e1e59af187d4c49b957002a"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-live-kernel-s390x",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-live-kernel-s390x",
                 "sha256": "3c2a5d99790ef006e3544d502354ef512c2590267640ba293d9bfb7aa28798a5"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-live-initramfs.s390x.img",
-                "sha256": "ab85a0949c95ec22450810fe0758291ba83649c82b59513ea7bed41acc7f166f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-live-initramfs.s390x.img",
+                "sha256": "508aced4fc57f93ae4774ea32d99a3e3119350c533eb83a8036ef287401527c7"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-live-rootfs.s390x.img",
-                "sha256": "42ae299f10a61b412692711b408ba963a1bfae3b0467821f9a751a73c68e0f3f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-live-rootfs.s390x.img",
+                "sha256": "e103798995315a1a953783210c7bcbf1dc74992457cc390be3d5a92efd372d27"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-metal.s390x.raw.gz",
-                "sha256": "47b825fbfbb0bc9eb79c148069f5669a974fae757a458b275fd06ee0b164d11c",
-                "uncompressed-sha256": "2db6f2f7e832398515c9a7e4da0d79848254d789a7d36e1c597ef786eb4ad05a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-metal.s390x.raw.gz",
+                "sha256": "22ca4d4a6c1e0aa64ed53a62983486a9d8eb32342797e6898a8b3b11c34b4f7b",
+                "uncompressed-sha256": "62c070fcee681ab21dc98211950f11ea7beb98ee5838dac943ad5949a8ae97f9"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-openstack.s390x.qcow2.gz",
-                "sha256": "c3eed2ea7dc883d6fee3cd86a8afa08bf93b728e4dfaba0bbb9a8640b6c2a2cb",
-                "uncompressed-sha256": "8a0bae3cb9dca39e7b13f3e205f2bcd79d71a0dc51846379e7d47839911d5ac4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-openstack.s390x.qcow2.gz",
+                "sha256": "ace77129d918c10ce7cd4d8451611574fd843c4b3922aef3e560ab810706e7a0",
+                "uncompressed-sha256": "f17b29ab38700c947393b73506a82b0935f2573bca280bae091ca4ef059f0546"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-qemu.s390x.qcow2.gz",
-                "sha256": "9aed7377732180a018121fb4373c4da6cabd7fbcb9e30f1a968d0032d2698179",
-                "uncompressed-sha256": "5372f1dfd3608a834154354d4d69009a0dd22795c85238f607c6879558141422"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-qemu.s390x.qcow2.gz",
+                "sha256": "ed05ea76c91b300d79cc0fa4c6964e661243e2f44e45b47996b51d801717d7a1",
+                "uncompressed-sha256": "8d43b2db3556ea9513a75f09ec80fdaf82d8119f0a698d09bac1418af66f00e4"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/s390x/rhcos-413.86.202301302144-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "d61e99a5267c70611498075525b1bbbc45df3d35396d52659e3d413def6691d1",
-                "uncompressed-sha256": "576ff8ed51ac22dccd0be02748a9f6760a77cbe313e40a61b382bb1c91f806b8"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "4d212733a61dda5b0dcbf4923e68bbc744a260565d3bc7e9ef1a9a05508f7069",
+                "uncompressed-sha256": "405d11f63e987992c8d04d7087d88840168dc17380561287b3947469e303837d"
               }
             }
           }
@@ -438,158 +458,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "dafe897074823001558b35c69c232e21fe156996a2f40990750fb6c2b4f8630d",
-                "uncompressed-sha256": "605af1d2b50ea032c4b8af2b9a9a20bd58240f19db19f0b42d3647ee99a96d96"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "0db3501511dc9c20077be657e43494962b7cac048379fe748757d4fae87982d5",
+                "uncompressed-sha256": "07adaf7ddc6a6ffb840b97344e35165817c2b9ce3154fe653165d37236206245"
               }
             }
           }
         },
         "aws": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-aws.x86_64.vmdk.gz",
-                "sha256": "cb93b14b4904ee9e1c0fafea2e1e7355c255166c2354f5501661da6863a0065d",
-                "uncompressed-sha256": "b5fdb82be39b3d181516de6b8ab8029d059e88dd4af03d640469096d22a8d683"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-aws.x86_64.vmdk.gz",
+                "sha256": "829f39a06692eae97c3718a336688682bb0fd6336b5a1567dd86481b9fd90263",
+                "uncompressed-sha256": "f2f8142c5945839cd7f057684f2bcaef23ebab51eed87e5df6c0e4b2b1df827d"
               }
             }
           }
         },
         "azure": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-azure.x86_64.vhd.gz",
-                "sha256": "59486501cc0d6af7eac18732a8656757424e91932b7189baa14865fc3ea4f3ea",
-                "uncompressed-sha256": "d0c23d12493d7afff461d9049cb9b247e8a4c527c1bd55484995bb5896b29a29"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-azure.x86_64.vhd.gz",
+                "sha256": "1013736d31dadb900700a0592525b38cde0b60637f0110b5a82873599bf670e8",
+                "uncompressed-sha256": "d56892f76b241d22ddaad0c281b744f131b2c1fb6b959c8330010049da8c081c"
               }
             }
           }
         },
         "azurestack": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-azurestack.x86_64.vhd.gz",
-                "sha256": "138b5891025ae22d475b3b8f0c2ef05226e87b33c94242bf172fbd4591d8110a",
-                "uncompressed-sha256": "5124f0ae5b009c7da328bd0ddf3ac4836224ba367be82315d8b77268f3faa30e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-azurestack.x86_64.vhd.gz",
+                "sha256": "5667f5574659b2c7485c6912265e1ea4e4f05790bb3cd2718e9c75827169a90e",
+                "uncompressed-sha256": "486e3b3a2b45b8b607f28a16f81547094f1b7c15daa183b30937228bf1764d6a"
               }
             }
           }
         },
         "gcp": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-gcp.x86_64.tar.gz",
-                "sha256": "ec2b9ab8928ca94c09014dcd5df4f7e37cdcca08f0b24591821305973a643540",
-                "uncompressed-sha256": "ac262e52a2f85a674c53f46333f03f3ea84db62cc8bcd8c4d4e9efef84fa4f00"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-gcp.x86_64.tar.gz",
+                "sha256": "2cd5d3480b506407dc78ca972a715c79cf9f756549e60da69c0ef38da81e7eae",
+                "uncompressed-sha256": "223e5e8fbeb5bd3cbe1311ddcd280f834cec85e4e82282fbe7eb6811e4d70c78"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "1405fe35ebb3107e4e97d3aa059b4ac65096b66de25cf9bdec30071682440ab4",
-                "uncompressed-sha256": "a8b3afb1fccbf3ff42c20781d67d63cc35b3072d72eea6004bb704d8bb7b33c1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "815e72d9d705eccc06964b604e2f72082afd524a75b3abea60aeb506fe7829d7",
+                "uncompressed-sha256": "62da41af2a0859a9244c1ee4056d92c5528cb46badaf97443d1da1763ac63447"
               }
             }
           }
         },
         "metal": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-metal4k.x86_64.raw.gz",
-                "sha256": "fed1d5a5ce2aa96ab6e0fd39c10f53e557d9c3d87cea2e641b3ef0a72de392a7",
-                "uncompressed-sha256": "30d1cfc3b88b746f00a87e31502d3342621041424e4cec926b0aece85104fd17"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-metal4k.x86_64.raw.gz",
+                "sha256": "a069f4be89ed991e0d81534fa045c98cfde6de0bfc5e79b3bb2df084be5aa837",
+                "uncompressed-sha256": "cc3f7a4f4da900db4329abbfbf00e66c54939b6f85aa68d6822d6c50bec991ae"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-live.x86_64.iso",
-                "sha256": "3b3024c5a8a6d0ed222a33a3876c07e70891cfc5cc19e1a9947b9b8b891c376a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-live.x86_64.iso",
+                "sha256": "cfb8d20860dde087c15cd562b9cb4c0a11620703dd36fbdb62e9d8fd5a76a9af"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-live-kernel-x86_64",
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-live-kernel-x86_64",
                 "sha256": "4a081639a748f63f97c308f2a37b440e76d3e1da2b14997315306d519b01d24c"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-live-initramfs.x86_64.img",
-                "sha256": "c4f56e2b8292358bbfbe07f9ef3a9c2b0cbd1595bc6731b2d79a354cfb905dd2"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-live-initramfs.x86_64.img",
+                "sha256": "9297fca4ec75ca6c5d434d254f8e8737ac7c1e1f341f2d2a33822c976ab0b58d"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-live-rootfs.x86_64.img",
-                "sha256": "ef4eb69875f4502187ba31a80df33991ee713bfa004e1d58915c75f0ec1f41b0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-live-rootfs.x86_64.img",
+                "sha256": "3ee511d6d1fced79eede61a5bacbb9344fd505e21aa11d508c8746f79fc83903"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-metal.x86_64.raw.gz",
-                "sha256": "8b3a3daef69869f9bf083aca3e2a2455878b2de4bb3116c33958e9f1a9fc63fd",
-                "uncompressed-sha256": "97ac0237200d926c20250e602cfb5c4708bda981d9aa4203f81cdce4d434f48e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-metal.x86_64.raw.gz",
+                "sha256": "4ee280101bd957359a508b13a393c1899ea78f8e01feba8761a69fd1f10eec06",
+                "uncompressed-sha256": "c0e8b21f8e738687f272d1abe5e23518e6020bf09e3914b14c474eb8a5c7bb46"
               }
             }
           }
         },
         "nutanix": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-nutanix.x86_64.qcow2",
-                "sha256": "1edd18867ff900ac38870005737016978166e3111c714323d2883c124bd67bf7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-nutanix.x86_64.qcow2",
+                "sha256": "c28b4ba7a99f945ee5711ba1acf7ff9f29c502f6ab0096ec7334d1d96249ca1a"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-openstack.x86_64.qcow2.gz",
-                "sha256": "501bfdaef3d3e564e4fa904728deeb3404f9060e2d07d6dca79034f40d03c565",
-                "uncompressed-sha256": "3af4f1cfde749f23d36e1a60be6805ccb2a6c2075f255add8cec127b1aebe2eb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-openstack.x86_64.qcow2.gz",
+                "sha256": "fbef46936da1f8c3723c1d9e7a8be5e412bcc543c7ec57f63c7b80d5693b9716",
+                "uncompressed-sha256": "544105620117f6e4fbffc3ade2e34ff968da3dc2bd23ebbbbe0f83e07377785c"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-qemu.x86_64.qcow2.gz",
-                "sha256": "a802d9d83de0d58cf91c7e2defa4bce90374ce63ad953d5c2a81a3c65e9a7308",
-                "uncompressed-sha256": "84923c47589ea93b15eeee03bd512b5fe45e7da04f2eae61cb64c7d75e50acff"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-qemu.x86_64.qcow2.gz",
+                "sha256": "d3b2cdcd9fced23609dc5235b1254414a29745810e673919259d85ced1f9a117",
+                "uncompressed-sha256": "6999223cc3b32274f86df16d48e663ba2ec7552ed73df2b8deeaf8784554c378"
               }
             }
           }
         },
         "vmware": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202301302144-0/x86_64/rhcos-413.86.202301302144-0-vmware.x86_64.ova",
-                "sha256": "e68916c09462bc4832e2329d7c9cea5ccce20e6d999fe0f1cba04cdb4493c442"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-vmware.x86_64.ova",
+                "sha256": "365cb490a33908c65a109b2912b1e1012dbbc31adc79dcbfc67e8940078a3be0"
               }
             }
           }
@@ -599,229 +619,249 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "413.86.202301302144-0",
-              "image": "m-6we3ca1y7md2yk6z2sx9"
+              "release": "413.86.202302150245-0",
+              "image": "m-6weejojhj37ktk2xx5k9"
             },
             "ap-northeast-2": {
-              "release": "413.86.202301302144-0",
-              "image": "m-mj729fmpobhsbqe27cum"
+              "release": "413.86.202302150245-0",
+              "image": "m-mj7bhroqi5x0u6wum061"
             },
             "ap-south-1": {
-              "release": "413.86.202301302144-0",
-              "image": "m-a2dh21eionjdm5v72ree"
+              "release": "413.86.202302150245-0",
+              "image": "m-a2dh9fua2i7qqusjfi6g"
             },
             "ap-southeast-1": {
-              "release": "413.86.202301302144-0",
-              "image": "m-t4n4uq383fxh3rqtzbut"
+              "release": "413.86.202302150245-0",
+              "image": "m-t4ndinvewtjusphuk70d"
             },
             "ap-southeast-2": {
-              "release": "413.86.202301302144-0",
-              "image": "m-p0w6tk7hy9c4a79byb8u"
+              "release": "413.86.202302150245-0",
+              "image": "m-p0wdee2txo076u9sxxfo"
             },
             "ap-southeast-3": {
-              "release": "413.86.202301302144-0",
-              "image": "m-8psijecurflj2h4nj2dz"
+              "release": "413.86.202302150245-0",
+              "image": "m-8ps1ua0nht115pjcjb4u"
             },
             "ap-southeast-5": {
-              "release": "413.86.202301302144-0",
-              "image": "m-k1aiy9y0h4b97165p68k"
+              "release": "413.86.202302150245-0",
+              "image": "m-k1adlllaeuxc5lkvs446"
             },
             "ap-southeast-6": {
-              "release": "413.86.202301302144-0",
-              "image": "m-5tsfanc4t9gpsqhv2ydy"
+              "release": "413.86.202302150245-0",
+              "image": "m-5tshi6b9qwml66kmutma"
             },
             "ap-southeast-7": {
-              "release": "413.86.202301302144-0",
-              "image": "m-0joeqer7hzwmfb4b9b98"
+              "release": "413.86.202302150245-0",
+              "image": "m-0jofjl7eo71cg6cfwze9"
             },
             "cn-beijing": {
-              "release": "413.86.202301302144-0",
-              "image": "m-2ze70kyumts1nzm5iqb8"
+              "release": "413.86.202302150245-0",
+              "image": "m-2zede1088jjn43zxknob"
             },
             "cn-chengdu": {
-              "release": "413.86.202301302144-0",
-              "image": "m-2vchjjzfsc0c0hs3570y"
+              "release": "413.86.202302150245-0",
+              "image": "m-2vc7hnmwmgl0hg2kyo2g"
             },
             "cn-fuzhou": {
-              "release": "413.86.202301302144-0",
-              "image": "m-gw0hrj0g1ruz60wccy76"
+              "release": "413.86.202302150245-0",
+              "image": "m-gw0ecbzoggx0bs2hu3ky"
             },
             "cn-guangzhou": {
-              "release": "413.86.202301302144-0",
-              "image": "m-7xv1gdytyyvezbe36cr0"
+              "release": "413.86.202302150245-0",
+              "image": "m-7xv12plj3ea44qq7wdsa"
             },
             "cn-hangzhou": {
-              "release": "413.86.202301302144-0",
-              "image": "m-bp15nw3ihiukwy55bc2z"
+              "release": "413.86.202302150245-0",
+              "image": "m-bp11fdg3ufj53zbtq3cf"
             },
             "cn-heyuan": {
-              "release": "413.86.202301302144-0",
-              "image": "m-f8z80m9v0n9cuvribzj9"
+              "release": "413.86.202302150245-0",
+              "image": "m-f8z72khqhzpj30nfpk78"
             },
             "cn-hongkong": {
-              "release": "413.86.202301302144-0",
-              "image": "m-j6cil8o7zfxpxbtf69t4"
+              "release": "413.86.202302150245-0",
+              "image": "m-j6c5tve2x4jyem5ulnvx"
             },
             "cn-huhehaote": {
-              "release": "413.86.202301302144-0",
-              "image": "m-hp3feaj16s66r677jsgj"
+              "release": "413.86.202302150245-0",
+              "image": "m-hp33272h4q2mwhuxoy12"
             },
             "cn-nanjing": {
-              "release": "413.86.202301302144-0",
-              "image": "m-gc70twm735f8onyp7j16"
+              "release": "413.86.202302150245-0",
+              "image": "m-gc7c9559cwxqeuyam473"
             },
             "cn-qingdao": {
-              "release": "413.86.202301302144-0",
-              "image": "m-m5e786yswy8azv05wa4q"
+              "release": "413.86.202302150245-0",
+              "image": "m-m5eako3yq9w2xi09s1jm"
             },
             "cn-shanghai": {
-              "release": "413.86.202301302144-0",
-              "image": "m-uf6ciorgma4yw8l1dpwu"
+              "release": "413.86.202302150245-0",
+              "image": "m-uf62383nkx4q965hzq1j"
             },
             "cn-shenzhen": {
-              "release": "413.86.202301302144-0",
-              "image": "m-wz92viou9emrehooxmfl"
+              "release": "413.86.202302150245-0",
+              "image": "m-wz97wkpiyeql5230aqq4"
             },
             "cn-wulanchabu": {
-              "release": "413.86.202301302144-0",
-              "image": "m-0jlf5pxdyac8uq3rxy7d"
+              "release": "413.86.202302150245-0",
+              "image": "m-0jl1kyi7iiuy2wo63rt1"
             },
             "cn-zhangjiakou": {
-              "release": "413.86.202301302144-0",
-              "image": "m-8vbau9rdb0osaollvf1a"
+              "release": "413.86.202302150245-0",
+              "image": "m-8vbgw05auetitxo8fdak"
             },
             "eu-central-1": {
-              "release": "413.86.202301302144-0",
-              "image": "m-gw8fvj2pzd5qq1wegx74"
+              "release": "413.86.202302150245-0",
+              "image": "m-gw89y0ywbh0mo38x5nak"
             },
             "eu-west-1": {
-              "release": "413.86.202301302144-0",
-              "image": "m-d7ogua9w7pn6xyanoymi"
+              "release": "413.86.202302150245-0",
+              "image": "m-d7ohtanqn0zmd7kbs5xq"
             },
             "me-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "m-eb3ifj5yijqmbmur61l6"
+              "release": "413.86.202302150245-0",
+              "image": "m-eb3hpwdabkbj9j8ppr2r"
             },
             "us-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "m-0xi3k9fzy927trzh8vpq"
+              "release": "413.86.202302150245-0",
+              "image": "m-0xi3rohf2hevpgh8ks9d"
             },
             "us-west-1": {
-              "release": "413.86.202301302144-0",
-              "image": "m-rj91cbaaijkduu2yef0t"
+              "release": "413.86.202302150245-0",
+              "image": "m-rj91z29n0eszqytj7kyo"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-026afae06baf6aefa"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0ee7dbd43fa7ad8f5"
             },
             "ap-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-07faa62f35f02cb85"
+              "release": "413.86.202302150245-0",
+              "image": "ami-03618a400960f8c68"
             },
             "ap-northeast-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0777162fff80aa6c6"
+              "release": "413.86.202302150245-0",
+              "image": "ami-00a4b30f42a8870f8"
             },
             "ap-northeast-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0858fdc461800cd43"
+              "release": "413.86.202302150245-0",
+              "image": "ami-05541b783cd430ae8"
             },
             "ap-northeast-3": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-021510369af4f99b1"
+              "release": "413.86.202302150245-0",
+              "image": "ami-08f1d2c144428b458"
             },
             "ap-south-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-004ef4131a11fbe57"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0c939023cd17fead4"
+            },
+            "ap-south-2": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-0f7ee6995f6e3ca68"
             },
             "ap-southeast-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-03e66d23306a2f0b7"
+              "release": "413.86.202302150245-0",
+              "image": "ami-06518bbb76c1545aa"
             },
             "ap-southeast-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0f00e48510dbfc3c2"
+              "release": "413.86.202302150245-0",
+              "image": "ami-091a9990f016eff02"
             },
             "ap-southeast-3": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-095a0fc0b4e3277e8"
+              "release": "413.86.202302150245-0",
+              "image": "ami-04f7a616b22339b49"
+            },
+            "ap-southeast-4": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-02eec652f67fba40d"
             },
             "ca-central-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0ede6fc5d083aa597"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0dfe3fd3d005225dd"
             },
             "eu-central-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-032221e3896914d83"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0f9c9989c9b09461a"
+            },
+            "eu-central-2": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-0e01bb003610c51df"
             },
             "eu-north-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-07c6f07b00464f494"
+              "release": "413.86.202302150245-0",
+              "image": "ami-05d75e527cf1bdebe"
             },
             "eu-south-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0caadb7e90007cb9e"
+              "release": "413.86.202302150245-0",
+              "image": "ami-042340d9d46235830"
+            },
+            "eu-south-2": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-01bb2eb403ae3ebc0"
             },
             "eu-west-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0e6d9fa27f2f5f1e9"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0f3b1ac57cae83cf2"
             },
             "eu-west-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-04b3f73b1dd3ad103"
+              "release": "413.86.202302150245-0",
+              "image": "ami-09c55d890a73548fd"
             },
             "eu-west-3": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0ba7d7a758340053d"
+              "release": "413.86.202302150245-0",
+              "image": "ami-01eac4ba8a459a29d"
+            },
+            "me-central-1": {
+              "release": "413.86.202302150245-0",
+              "image": "ami-0f66fca5ad0eb9fcb"
             },
             "me-south-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0638027d7dc3ba6a5"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0b3c8ebfdfeddfe33"
             },
             "sa-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-032e10d68c16b9620"
+              "release": "413.86.202302150245-0",
+              "image": "ami-090da632dda42973e"
             },
             "us-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0012ff5a459d30e1d"
+              "release": "413.86.202302150245-0",
+              "image": "ami-06e267b8c26b558f6"
             },
             "us-east-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-03992b6847a8e902c"
+              "release": "413.86.202302150245-0",
+              "image": "ami-024e0823a0de2f4f6"
             },
             "us-gov-east-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0572c46ee1693793f"
+              "release": "413.86.202302150245-0",
+              "image": "ami-0deef4891a51e1db8"
             },
             "us-gov-west-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-0a6c3b3929ae3d037"
+              "release": "413.86.202302150245-0",
+              "image": "ami-00d7d8d7b178e6542"
             },
             "us-west-1": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-06658dde28659477a"
+              "release": "413.86.202302150245-0",
+              "image": "ami-087b3a90abc3cd37f"
             },
             "us-west-2": {
-              "release": "413.86.202301302144-0",
-              "image": "ami-08745953b49975e93"
+              "release": "413.86.202302150245-0",
+              "image": "ami-043a19ba4fc7c5820"
             }
           }
         },
         "gcp": {
-          "release": "413.86.202301302144-0",
+          "release": "413.86.202302150245-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-413-86-202301302144-0-gcp-x86-64"
+          "name": "rhcos-413-86-202302150245-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.86.202301302144-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.86.202301302144-0-azure.x86_64.vhd"
+          "release": "413.86.202302150245-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.86.202302150245-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.13 boot image metadata in the installer which includes the fixes for the following:

OCPBUGS-7523 - Add new AWS regions for ROSA

This change was generated using:
```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --no-signatures --url https://rhcos.mirror.openshift.com/art/storage/prod/streams x86_64=413.86.202302150245-0 aarch64=413.86.202302150245-0 s390x=413.86.202302150245-0 ppc64le=413.86.202302150245-0
```