### PR TITLE
OCPBUGS-17866: check GOOGLE_APPLICATION_CREDENTIALS env var

### DIFF
--- a/pkg/asset/installconfig/gcp/session.go
+++ b/pkg/asset/installconfig/gcp/session.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	authEnvs            = []string{"GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"}
+	authEnvs            = []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CREDENTIALS", "GOOGLE_CLOUD_KEYFILE_JSON", "GCLOUD_KEYFILE_JSON"}
 	defaultAuthFilePath = filepath.Join(os.Getenv("HOME"), ".gcp", "osServiceAccount.json")
 	credLoaders         = []credLoader{}
 	onceLoggers         = map[credLoader]*sync.Once{}


### PR DESCRIPTION
according to
https://cloud.google.com/docs/authentication/provide-credentials-adc#local-key the default for application credentials is to set
GOOGLE_APPLICATION_CREDENTIALS. currently this var is missing from the list of environment variables checked.

this should fix issue #6862