### PR TITLE
OpenStack: Add dual-stack support with stateful IPv6

### DIFF
--- a/data/data/bootstrap/openstack/files/etc/NetworkManager/system-connections/nmconnection.template
+++ b/data/data/bootstrap/openstack/files/etc/NetworkManager/system-connections/nmconnection.template
@@ -1,0 +1,4 @@
+[connection]
+type=ethernet
+[ipv6]
+method=auto

--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -48,8 +48,11 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
     value = var.cluster_domain
   }
 
-  fixed_ip {
-    subnet_id = var.nodes_subnet_id
+  dynamic "fixed_ip" {
+    for_each = var.nodes_subnet_ids
+    content {
+      subnet_id = fixed_ip.value
+    }
   }
 
   dynamic "allowed_address_pairs" {

--- a/data/data/openstack/bootstrap/main.tf
+++ b/data/data/openstack/bootstrap/main.tf
@@ -52,8 +52,11 @@ resource "openstack_networking_port_v2" "bootstrap_port" {
     subnet_id = var.nodes_subnet_id
   }
 
-  allowed_address_pairs {
-    ip_address = var.openstack_api_int_ip
+  dynamic "allowed_address_pairs" {
+    for_each = var.openstack_api_int_ips
+    content {
+      ip_address = allowed_address_pairs.value
+    }
   }
 
   depends_on = [var.master_port_ids]

--- a/data/data/openstack/bootstrap/variables.tf
+++ b/data/data/openstack/bootstrap/variables.tf
@@ -7,8 +7,8 @@ variable "private_network_id" {
   type = string
 }
 
-variable "nodes_subnet_id" {
-  type = string
+variable "nodes_subnet_ids" {
+  type = list(string)
 }
 
 variable "master_port_ids" {

--- a/data/data/openstack/masters/outputs.tf
+++ b/data/data/openstack/masters/outputs.tf
@@ -21,6 +21,6 @@ output "private_network_id" {
   value = local.nodes_network_id
 }
 
-output "nodes_subnet_id" {
-  value = local.nodes_subnet_id
+output "nodes_subnet_ids" {
+  value = local.nodes_subnet_ids
 }

--- a/data/data/openstack/masters/private-network.tf
+++ b/data/data/openstack/masters/private-network.tf
@@ -62,12 +62,18 @@ resource "openstack_networking_port_v2" "masters" {
     subnet_id = local.nodes_subnet_id
   }
 
-  allowed_address_pairs {
-    ip_address = var.openstack_api_int_ip
+  dynamic "allowed_address_pairs" {
+    for_each = var.openstack_api_int_ips
+    content {
+      ip_address = allowed_address_pairs.value
+    }
   }
 
-  allowed_address_pairs {
-    ip_address = var.openstack_ingress_ip
+  dynamic "allowed_address_pairs" {
+    for_each = var.openstack_ingress_ips
+    content {
+      ip_address = allowed_address_pairs.value
+    }
   }
 
   depends_on = [openstack_networking_port_v2.api_port, openstack_networking_port_v2.ingress_port]
@@ -84,7 +90,7 @@ resource "openstack_networking_port_v2" "api_port" {
 
   fixed_ip {
     subnet_id  = local.nodes_subnet_id
-    ip_address = var.openstack_api_int_ip
+    ip_address = var.openstack_api_int_ips[0]
   }
 }
 
@@ -99,7 +105,7 @@ resource "openstack_networking_port_v2" "ingress_port" {
 
   fixed_ip {
     subnet_id  = local.nodes_subnet_id
-    ip_address = var.openstack_ingress_ip
+    ip_address = var.openstack_ingress_ips[0]
   }
 }
 

--- a/data/data/openstack/variables-openstack.tf
+++ b/data/data/openstack/variables-openstack.tf
@@ -284,14 +284,14 @@ EOF
 
 }
 
-variable "openstack_api_int_ip" {
-  type        = string
-  description = "IP on the node subnet reserved for api-int VIP."
+variable "openstack_api_int_ips" {
+  type        = list(string)
+  description = "IPs on the node subnets reserved for api-int VIP."
 }
 
-variable "openstack_ingress_ip" {
-  type        = string
-  description = "IP on the nodes subnet reserved for the ingress VIP."
+variable "openstack_ingress_ips" {
+  type        = list(string)
+  description = "IPs on the nodes subnets reserved for the ingress VIP."
 }
 
 variable "openstack_external_dns" {

--- a/pkg/tfvars/openstack/openstack.go
+++ b/pkg/tfvars/openstack/openstack.go
@@ -193,8 +193,8 @@ func TFVars(
 		FlavorName                        string                            `json:"openstack_master_flavor_name,omitempty"`
 		APIFloatingIP                     string                            `json:"openstack_api_floating_ip,omitempty"`
 		IngressFloatingIP                 string                            `json:"openstack_ingress_floating_ip,omitempty"`
-		APIVIP                            string                            `json:"openstack_api_int_ip,omitempty"`
-		IngressVIP                        string                            `json:"openstack_ingress_ip,omitempty"`
+		APIVIPs                           []string                          `json:"openstack_api_int_ips,omitempty"`
+		IngressVIPs                       []string                          `json:"openstack_ingress_ips,omitempty"`
 		TrunkSupport                      bool                              `json:"openstack_trunk_support,omitempty"`
 		OctaviaSupport                    bool                              `json:"openstack_octavia_support,omitempty"`
 		RootVolumeSize                    int                               `json:"openstack_master_root_volume_size,omitempty"`
@@ -218,8 +218,8 @@ func TFVars(
 		FlavorName:                        masterSpecs[0].Flavor,
 		APIFloatingIP:                     installConfig.Config.Platform.OpenStack.APIFloatingIP,
 		IngressFloatingIP:                 installConfig.Config.Platform.OpenStack.IngressFloatingIP,
-		APIVIP:                            installConfig.Config.Platform.OpenStack.APIVIPs[0],
-		IngressVIP:                        installConfig.Config.Platform.OpenStack.IngressVIPs[0],
+		APIVIPs:                           installConfig.Config.Platform.OpenStack.APIVIPs,
+		IngressVIPs:                       installConfig.Config.Platform.OpenStack.IngressVIPs,
 		TrunkSupport:                      masterSpecs[0].Trunk,
 		OctaviaSupport:                    octaviaSupport,
 		RootVolumeSize:                    rootVolumeSize,


### PR DESCRIPTION
This PR enables Dual-Stack support for OpenStack cluster using Stateful IPv6 Subnets.

- [ ] Add required IPv6 security groups rules