### PR TITLE
OCPBUGS-7579: azure: fix certificate-based auth with passpharse

### DIFF
--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -290,7 +290,7 @@ func newTokenCredentialFromCertificates(credentials *Credentials, cloudConfig cl
 	// certificate data in PEM or PKCS12 format. It handles common scenarios
 	// but has limitations, for example it doesn't load PEM encrypted private
 	// keys.
-	certs, key, err := azidentity.ParseCertificates(data, nil)
+	certs, key, err := azidentity.ParseCertificates(data, []byte(credentials.ClientCertificatePassword))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse client certificate")
 	}


### PR DESCRIPTION
Fallout from https://github.com/openshift/installer/pull/6003

If we pass `nil` to `azidentity.ParseCertificates`, it assumes the private key isn't encrypted. Let's pipe the password through instead.