### PR TITLE
Bug 1904573: baremetal container modify /etc/passwd group writable

### DIFF
--- a/images/baremetal/Dockerfile.ci
+++ b/images/baremetal/Dockerfile.ci
@@ -20,8 +20,7 @@ COPY --from=builder /go/src/github.com/openshift/installer/bin/openshift-install
 RUN dnf upgrade -y && \
     dnf install --setopt=tsflags=nodocs -y \
     libvirt-libs-$libvirt_version openssl unzip jq openssh-clients && \
-    dnf clean all && rm -rf /var/cache/yum/* && \
-    chmod g+w /etc/passwd
+    dnf clean all && rm -rf /var/cache/yum/*
 
 RUN mkdir /output && chown 1000:1000 /output
 USER 1000:1000


### PR DESCRIPTION
This workaround was introduced because it broke Metal IPI CI. However, the Metal team is now using `nss_wrapper`, so it should not be needed anymore.