### PR TITLE
gcp: let load balancer access node proxy healthz on port 10256

### DIFF
--- a/upi/gcp/03_firewall.py
+++ b/upi/gcp/03_firewall.py
@@ -37,6 +37,21 @@ def GenerateConfig(context):
             'targetTags': [context.properties['infra_id'] + '-master']
         }
     }, {
+        'name': context.properties['infra_id'] + '-node-health-checks',
+        'type': 'compute.v1.firewall',
+        'properties': {
+            'network': context.properties['cluster_network'],
+            'allowed': [{
+                'IPProtocol': 'tcp',
+                'ports': ['10256']
+            }],
+            'sourceRanges': ['35.191.0.0/16', '130.211.0.0/22', '209.85.152.0/22', '209.85.204.0/22'],
+            'targetTags': [
+                context.properties['infra_id'] + '-master',
+                context.properties['infra_id'] + '-worker'
+            ]
+        }
+    }, {
         'name': context.properties['infra_id'] + '-etcd',
         'type': 'compute.v1.firewall',
         'properties': {


### PR DESCRIPTION
kube-proxy and ovn-kubernetes serve healthz on node port 10256 to allow the GCE load balancer to check node health for services with "Cluster" traffic-policy. GCE cloud provider

staging/src/k8s.io/legacy-cloud-providers/gce/gce_healthchecks.go:

```
const (
	nodesHealthCheckPath = "/healthz"
	// NOTE: Please keep the following port in sync with ProxyHealthzPort in pkg/cluster/ports/ports.go
	// ports.ProxyHealthzPort was not used here to avoid dependencies to k8s.io/kubernetes in the
	// GCE cloud provider which is required as part of the out-of-tree cloud provider efforts.
	// TODO: use a shared constant once ports in pkg/cluster/ports are in a common external repo.
	lbNodesHealthCheckPort = 10256
)

// GetNodesHealthCheckPort returns the health check port used by the GCE load
// balancers (l4) for performing health checks on nodes.
func GetNodesHealthCheckPort() int32 {
	return lbNodesHealthCheckPort
}
```

And it calls GetNodesHealthCheckPort() in a bunch of places to health-check services:

```
	// Ensure health check exists before creating the backend service. The health check is shared
	// if externalTrafficPolicy=Cluster.
	sharedHealthCheck := !servicehelpers.RequestsOnlyLocalTraffic(svc)
	hcName := makeHealthCheckName(loadBalancerName, clusterID, sharedHealthCheck)
	hcPath, hcPort := GetNodesHealthCheckPath(), GetNodesHealthCheckPort()
	if !sharedHealthCheck {
		// Service requires a special health check, retrieve the OnlyLocal port & path
		hcPath, hcPort = servicehelpers.GetServiceHealthCheckPathPort(svc)
	}
	hc, err := g.ensureInternalHealthCheck(hcName, nm, sharedHealthCheck, hcPath, hcPort)
	if err != nil {
		return nil, err
	}
```

See also https://issues.redhat.com/browse/OCPBUGS-7158