### PR TITLE
[release-4.12] OCPBUGS-7746: Convert platform type for AgentClusterInstall

### DIFF
--- a/pkg/asset/agent/common.go
+++ b/pkg/asset/agent/common.go
@@ -1,18 +1,51 @@
 package agent
 
 import (
+	hiveext "github.com/openshift/assisted-service/api/hiveextension/v1beta1"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/none"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
-// SupportedPlatforms lists the supported platforms for agent installer
-var SupportedPlatforms = []string{baremetal.Name, vsphere.Name, none.Name}
+// SupportedInstallerPlatforms lists the supported platforms for agent installer.
+func SupportedInstallerPlatforms() []string {
+	return []string{baremetal.Name, vsphere.Name, none.Name}
+}
+
+var supportedHivePlatforms = []hiveext.PlatformType{
+	hiveext.BareMetalPlatformType,
+	hiveext.VSpherePlatformType,
+	hiveext.NonePlatformType,
+}
+
+// SupportedHivePlatforms lists the supported platforms for AgentClusterInstall.
+func SupportedHivePlatforms() []string {
+	platforms := []string{}
+	for _, p := range supportedHivePlatforms {
+		platforms = append(platforms, string(p))
+	}
+	return platforms
+}
+
+// HivePlatformType returns the PlatformType for the ZTP Hive API corresponding
+// to the given InstallConfig platform.
+func HivePlatformType(platform types.Platform) hiveext.PlatformType {
+	switch platform.Name() {
+	case baremetal.Name:
+		return hiveext.BareMetalPlatformType
+	case none.Name:
+		return hiveext.NonePlatformType
+	case vsphere.Name:
+		return hiveext.VSpherePlatformType
+	}
+	return ""
+}
 
 // IsSupportedPlatform returns true if provided platform is supported.
-// Otherwise, returns false
-func IsSupportedPlatform(platform string) bool {
-	for _, p := range SupportedPlatforms {
+// Otherwise, returns false.
+func IsSupportedPlatform(platform hiveext.PlatformType) bool {
+	for _, p := range supportedHivePlatforms {
 		if p == platform {
 			return true
 		}

--- a/pkg/asset/agent/installconfig.go
+++ b/pkg/asset/agent/installconfig.go
@@ -82,8 +82,8 @@ func (a *OptionalInstallConfig) validateSupportedPlatforms(installConfig *types.
 
 	fieldPath := field.NewPath("Platform")
 
-	if installConfig.Platform.Name() != "" && !IsSupportedPlatform(installConfig.Platform.Name()) {
-		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.Name(), SupportedPlatforms))
+	if installConfig.Platform.Name() != "" && !IsSupportedPlatform(HivePlatformType(installConfig.Platform)) {
+		allErrs = append(allErrs, field.NotSupported(fieldPath, installConfig.Platform.Name(), SupportedInstallerPlatforms()))
 	}
 	return allErrs
 }

--- a/pkg/asset/agent/manifests/agentclusterinstall.go
+++ b/pkg/asset/agent/manifests/agentclusterinstall.go
@@ -16,7 +16,11 @@ import (
 	"github.com/openshift/installer/pkg/asset/agent"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/defaults"
+	"github.com/openshift/installer/pkg/types/none"
+	"github.com/openshift/installer/pkg/types/vsphere"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -141,7 +145,7 @@ func (a *AgentClusterInstall) Generate(dependencies asset.Parents) error {
 					ControlPlaneAgents: int(*installConfig.Config.ControlPlane.Replicas),
 					WorkerAgents:       numberOfWorkers,
 				},
-				PlatformType: hiveext.PlatformType(installConfig.Config.Platform.Name()),
+				PlatformType: agent.HivePlatformType(installConfig.Config.Platform),
 			},
 		}
 
@@ -237,6 +241,18 @@ func (a *AgentClusterInstall) Load(f asset.FileFetcher) (bool, error) {
 	}
 
 	setNetworkType(agentClusterInstall, &types.InstallConfig{}, "NetworkType is not specified in AgentClusterInstall.")
+
+	// Due to OCPBUGS-7495 we previously required lowercase platform names here,
+	// even though that is incorrect. Rewrite to the correct mixed case names
+	// for backward compatibility.
+	switch string(agentClusterInstall.Spec.PlatformType) {
+	case baremetal.Name:
+		agentClusterInstall.Spec.PlatformType = hiveext.BareMetalPlatformType
+	case none.Name:
+		agentClusterInstall.Spec.PlatformType = hiveext.NonePlatformType
+	case vsphere.Name:
+		agentClusterInstall.Spec.PlatformType = hiveext.VSpherePlatformType
+	}
 
 	a.Config = agentClusterInstall
 
@@ -342,8 +358,8 @@ func (a *AgentClusterInstall) validateSupportedPlatforms() field.ErrorList {
 
 	fieldPath := field.NewPath("spec", "platformType")
 
-	if a.Config.Spec.PlatformType != "" && !agent.IsSupportedPlatform(fmt.Sprintf("%s", a.Config.Spec.PlatformType)) {
-		allErrs = append(allErrs, field.NotSupported(fieldPath, a.Config.Spec.PlatformType, agent.SupportedPlatforms))
+	if a.Config.Spec.PlatformType != "" && !agent.IsSupportedPlatform(a.Config.Spec.PlatformType) {
+		allErrs = append(allErrs, field.NotSupported(fieldPath, a.Config.Spec.PlatformType, agent.SupportedHivePlatforms()))
 	}
 	return allErrs
 }

--- a/pkg/asset/agent/manifests/util_test.go
+++ b/pkg/asset/agent/manifests/util_test.go
@@ -427,7 +427,7 @@ func getGoodACI() *hiveext.AgentClusterInstall {
 			},
 			APIVIP:       "192.168.122.10",
 			IngressVIP:   "192.168.122.11",
-			PlatformType: hiveext.PlatformType(baremetal.Name),
+			PlatformType: hiveext.BareMetalPlatformType,
 		},
 	}
 	return goodACI


### PR DESCRIPTION
The platform types in AgentClusterInstall are in mixed case. Previously we were just casting the lowercase platform name to set the PlatformType field. This resulted in the platform type being silently ignored when creating the Cluster in the assisted API. Clusters were getting the default type for their topology (None for SNO, otherwise BareMetal), but there was no way to set VSphere as the platform.

Backport of #6855 