### PR TITLE
linter: enable reporting about exported names lacking comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -128,3 +128,7 @@ linters-settings:
     # It's a comma-separated list of prefixes.
     # Default: ""
     local-prefixes: github.com/openshift
+issues:
+  include:
+  - EXC0012 # EXC0012 revive: issue about not having a comment on exported.
+  - EXC0014 # EXC0014 revive: issue about not having a comment in the right format.

--- a/pkg/asset/agent/common.go
+++ b/pkg/asset/agent/common.go
@@ -28,6 +28,8 @@ func SupportedHivePlatforms() []string {
 	return platforms
 }
 
+// HivePlatformType returns the PlatformType for the ZTP Hive API corresponding
+// to the given InstallConfig platform.
 func HivePlatformType(platform types.Platform) hiveext.PlatformType {
 	switch platform.Name() {
 	case baremetal.Name:

--- a/pkg/asset/agent/image/cpio.go
+++ b/pkg/asset/agent/image/cpio.go
@@ -99,7 +99,7 @@ func (ca *CpioArchive) StoreFile(filename string, dstPath string) error {
 	return nil
 }
 
-// Save the content of the current archive and returns
+// SaveBuffer saves the content of the current archive and returns
 // the buffer content.
 func (ca *CpioArchive) SaveBuffer() ([]byte, error) {
 	err := ca.cpioWriter.Close()

--- a/pkg/asset/manifests/nutanix/cloudproviderconfig.go
+++ b/pkg/asset/manifests/nutanix/cloudproviderconfig.go
@@ -8,7 +8,7 @@ import (
 	nutanixtypes "github.com/openshift/installer/pkg/types/nutanix"
 )
 
-// Config of Nutanix cloud provider
+// CloudConfig is the config of Nutanix cloud provider
 // ref: https://github.com/nutanix-cloud-native/cloud-provider-nutanix/blob/main/pkg/provider/config/config.go
 type CloudConfig struct {
 	PrismCentral         PrismEndpoint     `json:"prismCentral"`
@@ -16,29 +16,36 @@ type CloudConfig struct {
 	EnableCustomLabeling bool              `json:"enableCustomLabeling"`
 }
 
+// TopologyDiscovery of the cloud provider.
 type TopologyDiscovery struct {
 	// Default type will be set to Prism via the newConfig function
 	Type               TopologyDiscoveryType `json:"type"`
 	TopologyCategories *TopologyCategories   `json:"topologyCategories"`
 }
 
+// TopologyDiscoveryType type alias.
 type TopologyDiscoveryType string
 
 const (
-	PrismTopologyDiscoveryType      = TopologyDiscoveryType("Prism")
+	// PrismTopologyDiscoveryType is the DiscoveryType for Prism provider.
+	PrismTopologyDiscoveryType = TopologyDiscoveryType("Prism")
+	// CategoriesTopologyDiscoveryType is the DiscoveryType for Categories provider.
 	CategoriesTopologyDiscoveryType = TopologyDiscoveryType("Categories")
 )
 
+// TopologyInfo contains topology information.
 type TopologyInfo struct {
 	Zone   string `json:"zone"`
 	Region string `json:"region"`
 }
 
+// TopologyCategories contains topology categories.
 type TopologyCategories struct {
 	ZoneCategory   string `json:"zoneCategory"`
 	RegionCategory string `json:"regionCategory"`
 }
 
+// PrismEndpoint contains endpoint details for Prism provider.
 type PrismEndpoint struct {
 	// address is the endpoint address (DNS name or IP address) of the Nutanix Prism Central or Element (cluster)
 	Address string `json:"address"`
@@ -51,10 +58,13 @@ type PrismEndpoint struct {
 	CredentialRef *CredentialReference `json:"credentialRef,omitempty"`
 }
 
+// CredentialKind type alias.
 type CredentialKind string
 
+// SecretKind a credential of type "Secret".
 var SecretKind = CredentialKind("Secret")
 
+// CredentialReference holds details of a credential.
 type CredentialReference struct {
 	// Kind of the Nutanix credential
 	Kind CredentialKind `json:"kind"`

--- a/pkg/destroy/aws/iamhelpers.go
+++ b/pkg/destroy/aws/iamhelpers.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	// ErrCodeAccessDeniedException is the access denied error code returned by IAM.
 	ErrCodeAccessDeniedException = "AccessDeniedException"
 )
 

--- a/pkg/types/vsphere/conversion/installconfig.go
+++ b/pkg/types/vsphere/conversion/installconfig.go
@@ -12,6 +12,7 @@ import (
 
 var localLogger = logrus.New()
 
+// ConvertInstallConfig modifies a given platform spec for the new requirements.
 func ConvertInstallConfig(config *types.InstallConfig) error {
 	platform := config.Platform.VSphere
 

--- a/pkg/validate/method.go
+++ b/pkg/validate/method.go
@@ -2,6 +2,8 @@ package validate
 
 import "os"
 
+// IsAgentBasedInstallation determines whether we are using the 'agent'
+// subcommand to install.
 func IsAgentBasedInstallation() bool {
 	if len(os.Args) > 1 {
 		for _, arg := range os.Args {


### PR DESCRIPTION
This type of reporting is disabled by default in golangci-lint. However, we used to enforce it when using golang/lint and I think it's useful to have.

* Fix some recent cases that were only caught during backport.