### PR TITLE
update RHCOS 4.13 bootimage metadata

### DIFF
--- a/data/data/coreos/rhcos.json
+++ b/data/data/coreos/rhcos.json
@@ -1,95 +1,95 @@
 {
   "stream": "rhcos-4.13",
   "metadata": {
-    "last-modified": "2023-02-15T22:37:28Z",
-    "generator": "plume cosa2stream 3ad4cf5"
+    "last-modified": "2023-03-01T22:32:48Z",
+    "generator": "plume cosa2stream 0.15.0+113-gf35e2c8a7-dirty"
   },
   "architectures": {
     "aarch64": {
       "artifacts": {
         "aws": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-aws.aarch64.vmdk.gz",
-                "sha256": "b557c56f31635b3d521fd8ff197b9fbec3fb82c2d204c1218bdc265881ce70fc",
-                "uncompressed-sha256": "eeac7b88fe8b241d007b91e796f5bbb3761c19f8253b1d87a924c73db236b482"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-aws.aarch64.vmdk.gz",
+                "sha256": "32792d909e7b1a5c1eb5239f0d913c459ca39f1714d73ba504278fe9b4db6698",
+                "uncompressed-sha256": "a671ce479b78670a2554c41c3d476bf4fec90c67dae269d7ab37a42d920e3401"
               }
             }
           }
         },
         "azure": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-azure.aarch64.vhd.gz",
-                "sha256": "11bbe50f659f3606638b0a0bdef4b7010c65b31767fef72976ddd5f1db62c374",
-                "uncompressed-sha256": "d41caffb16817e691ebef30a8244365fe1c98a3eea50e1dbe463cfdc7fe0dbbd"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-azure.aarch64.vhd.gz",
+                "sha256": "0fd001cf07b83c4fbc731cb362de3fdece43ae67d12ce61b631d0c03110550c1",
+                "uncompressed-sha256": "2adc2a9f1bc434fa6f0f8cc4785e08777f70a204ab339dd9d386cfe4f2896c64"
               }
             }
           }
         },
         "metal": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-metal4k.aarch64.raw.gz",
-                "sha256": "9f6e19830d1c419842223b39f41a4360ad353f745fcc4994d343dc6e57c936b8",
-                "uncompressed-sha256": "f79ce6e9e9d5af153d5f248fb82de1792cb5b6649e2f9c293d72e457be3643cf"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-metal4k.aarch64.raw.gz",
+                "sha256": "1d3f957acf56d8d3a3d9b1e4a856aa6561ad1b72a1df8bf40e79e2ba169e6df1",
+                "uncompressed-sha256": "e7c4c486aa7dd3de4a22db11453a250dcce8d3af4628f6da7fcbbb1be40f424e"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-live.aarch64.iso",
-                "sha256": "c6b6ee3824074765b0683b35263d170698dd2353d1296582df8d284700331786"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-live.aarch64.iso",
+                "sha256": "e0250208b9df4b7e1bac5b56d26373443f33aa9d0de885ff9ac186b06464595b"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-live-kernel-aarch64",
-                "sha256": "89bbd45dc9c2fb53bfe30b5b64b6e3dd89c02446fc7f17bf915ae918c9a6ed5e"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-live-kernel-aarch64",
+                "sha256": "04e178f3e1152004f6176e188a9aa48ed5f5ef6beccc1b36c0a9bceb9f2cf1e3"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-live-initramfs.aarch64.img",
-                "sha256": "da310f2d24ec9971702bb20d174297e10dc6eeac9b97b464a9d2072fb03e9366"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-live-initramfs.aarch64.img",
+                "sha256": "8925a3048969fdc1cce57c7fdba4b4f58ff86a940e24effb998e472a29dbd515"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-live-rootfs.aarch64.img",
-                "sha256": "acfde3ca39fe44622eadd929047e939f1592021954149101e0c51e6d3b2882af"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-live-rootfs.aarch64.img",
+                "sha256": "9621519952e7db4bdde7b7b0c79a4807aa9c8ce35d24f7d7501991d50cae3b95"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-metal.aarch64.raw.gz",
-                "sha256": "7395ad6248d42f3ca85c5290eb3356b2071e4e3e4aff61c69afd9faf4998c348",
-                "uncompressed-sha256": "8692d7c57e8d623e5d20232fea514a60dfb79a3f9df0415a86fed143c4ba6b50"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-metal.aarch64.raw.gz",
+                "sha256": "82f05ceb655fb6d406d8d788e09a60dd5d1425ed39b1d57b92590f749bd70573",
+                "uncompressed-sha256": "9c991144667f13f21c5c930399b2a53094a4ecbe6ba27e919e5cfdf8fdf8213f"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-openstack.aarch64.qcow2.gz",
-                "sha256": "582ad4e73cf1f6b4a61c81bd820c270e51d9c533705a27eb84f6ffb6f4122cce",
-                "uncompressed-sha256": "1a54e7e60429d3e96cf709caebc892fd5685adc66ff5fe70d43110a1a6f1ea31"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-openstack.aarch64.qcow2.gz",
+                "sha256": "eb02aea5f55ec906208c22bb61528a0aff83acb0559d56937e1e6fe2d9b90231",
+                "uncompressed-sha256": "8c1c7dba140e512c04244933a31b7f7d2fb7fd6cb48a94109573b983b01cc896"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/aarch64/rhcos-413.86.202302150245-0-qemu.aarch64.qcow2.gz",
-                "sha256": "841fbcf92fcfa2cd75d29bef4c7842a3abc7b941e28edc4674b9016b6f0b2aa6",
-                "uncompressed-sha256": "751b13a0aef916cb8055ed164212a2acc19901012b645cbcbb69401fe918fedc"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/aarch64/rhcos-413.92.202303011445-0-qemu.aarch64.qcow2.gz",
+                "sha256": "e1ed69366d689c7f3fcba8be79cc9963f9707082f1684e4b245e127e21da4b8b",
+                "uncompressed-sha256": "647aaf0db80b206f77d18b2b10fb7ae66ca5685c20f7a2a8f02f4ca06cf5cf4a"
               }
             }
           }
@@ -99,204 +99,204 @@
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-05c47148e37f3e4e4"
+              "release": "413.92.202303011445-0",
+              "image": "ami-02d92bb5610758f4b"
             },
             "ap-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-00c959995c94e815a"
+              "release": "413.92.202303011445-0",
+              "image": "ami-07840c280671c9498"
             },
             "ap-northeast-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0094f5c7685201ba1"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0e064aec57712ad49"
             },
             "ap-northeast-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0dce45170b7553059"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0723c8faff00513d8"
             },
             "ap-northeast-3": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0d550e040c9dc0873"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0e937faf7a5cbda24"
             },
             "ap-south-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0641eb79281a21a69"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0fb43efc4f8be4ec1"
             },
             "ap-south-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-09ee467081d7768c7"
+              "release": "413.92.202303011445-0",
+              "image": "ami-00fbeaf27db3ced08"
             },
             "ap-southeast-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0574985f1b431b96e"
+              "release": "413.92.202303011445-0",
+              "image": "ami-03b843e7ffd002e9d"
             },
             "ap-southeast-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-05d370d716a1f874d"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0376b8af3e30d7087"
             },
             "ap-southeast-3": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-020f73dd2489dce43"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0c55c997cad606080"
             },
             "ap-southeast-4": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-04a70532ee93da390"
+              "release": "413.92.202303011445-0",
+              "image": "ami-041d346a47840d6e9"
             },
             "ca-central-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-076e3d73d4dedf4aa"
+              "release": "413.92.202303011445-0",
+              "image": "ami-03e579402db2c3edc"
             },
             "eu-central-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-05e2b51a6dd6a865b"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0d3ef39ffc132a5f3"
             },
             "eu-central-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0aa9d0f6bc21ec79f"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0755d910947f2d638"
             },
             "eu-north-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-07c0a250693c2ceab"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0337c5b62f704b80c"
             },
             "eu-south-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0bae746303252482c"
+              "release": "413.92.202303011445-0",
+              "image": "ami-03658e00711de0ab8"
             },
             "eu-south-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-04999295e95c9cd03"
+              "release": "413.92.202303011445-0",
+              "image": "ami-08d00b80050ff04a2"
             },
             "eu-west-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0e79e10970bae8ff5"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0d3d2e9d07c53a0f6"
             },
             "eu-west-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0e93d5931da3ac038"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0648d89035dabf332"
             },
             "eu-west-3": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0277fa6a937389910"
+              "release": "413.92.202303011445-0",
+              "image": "ami-055beaa1c7d8bd98b"
             },
             "me-central-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-01af55ef27f8b2ef7"
+              "release": "413.92.202303011445-0",
+              "image": "ami-02b2d22a682917cef"
             },
             "me-south-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-077880aae2dd4155d"
+              "release": "413.92.202303011445-0",
+              "image": "ami-00e121a19e7ca28c8"
             },
             "sa-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-06416a032d7c7e748"
+              "release": "413.92.202303011445-0",
+              "image": "ami-08652e0b96fef20c4"
             },
             "us-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0f2341e687f9b007e"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0ce61ccb976233aa7"
             },
             "us-east-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-059f69497e1f69ae5"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0ddec3aee34e1595d"
             },
             "us-gov-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0bba66e1fc9a82cac"
+              "release": "413.92.202303011445-0",
+              "image": "ami-03d55e36c096b843e"
             },
             "us-gov-west-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0ad82ffbf40ca2b57"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0d52ec42c4a10e8fe"
             },
             "us-west-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0c66872e13f49e792"
+              "release": "413.92.202303011445-0",
+              "image": "ami-02685357a6facd8dc"
             },
             "us-west-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-006bb7735fb3f9cd5"
+              "release": "413.92.202303011445-0",
+              "image": "ami-07873206681cc7145"
             }
           }
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.86.202302150245-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.86.202302150245-0-azure.aarch64.vhd"
+          "release": "413.92.202303011445-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202303011445-0-azure.aarch64.vhd"
         }
       }
     },
     "ppc64le": {
       "artifacts": {
         "metal": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-metal4k.ppc64le.raw.gz",
-                "sha256": "112d6ae1969cff286b120b9b56005a8ffe6e23e380d97ee83eb94da0d6210b0f",
-                "uncompressed-sha256": "a7cf5075d23ff881667a0977c90da7ae8f67fe1333bfbb1df306e6356275d239"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/ppc64le/rhcos-413.92.202303011445-0-metal4k.ppc64le.raw.gz",
+                "sha256": "7dec27ec3206ec24c818dae9761cccd82ebbf305766dbba94102f1c189e97137",
+                "uncompressed-sha256": "96b4aa6c5cd16f5308eb4e0441c2b01484ceefae4682e489a98298e59f3bf9f5"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-live.ppc64le.iso",
-                "sha256": "7d7010f79723ef977e624992d0343a3902ec441bc08e0a4ac9e861be87c2686f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/ppc64le/rhcos-413.92.202303011445-0-live.ppc64le.iso",
+                "sha256": "a5b98b1aa9d0bc8d9e3a37029545bd4367fdd552f5cf7c47354002861b0e698b"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-live-kernel-ppc64le",
-                "sha256": "e77ba60252c58cbed0a22ca4bad51e98abb4d8ab5841539555c24d2299754522"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/ppc64le/rhcos-413.92.202303011445-0-live-kernel-ppc64le",
+                "sha256": "a744e914bdfbbd7bd7155238ef4db148224546938bbb429616237378b8d9571f"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-live-initramfs.ppc64le.img",
-                "sha256": "d208a27f685b0ed675961d7aff0e5f921050c0ffbd24f554c9e127e6ed72d1f1"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/ppc64le/rhcos-413.92.202303011445-0-live-initramfs.ppc64le.img",
+                "sha256": "d263a474395a8229175b88b72bb08addfd34bc9d6af8b03198e3114c2d5f28f0"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-live-rootfs.ppc64le.img",
-                "sha256": "eced843e531009c7419e8153ef980aa6fe8f206bd5e4297c8bd261fa67a9e17c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/ppc64le/rhcos-413.92.202303011445-0-live-rootfs.ppc64le.img",
+                "sha256": "a89b1cbff8c005e838bbbbd8e63b04064b045608ba2ee6fe65b65247afc261f5"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-metal.ppc64le.raw.gz",
-                "sha256": "69593d80075b96d34291ccd37e7a082b0387c6ad0068c9de8477e1b580ac0447",
-                "uncompressed-sha256": "3919773632cd951098924cf9ac70244ba6baa05989bc54451f382001d626dc80"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/ppc64le/rhcos-413.92.202303011445-0-metal.ppc64le.raw.gz",
+                "sha256": "deb5ac9be1dcb4e60c0810172ae310e3dab238a621bfed5aa30d066ca93c82c4",
+                "uncompressed-sha256": "bcd7a089d1482811ad7cd5c8acbcb3563eb1d3b02733c2c29049cf870994eaff"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-openstack.ppc64le.qcow2.gz",
-                "sha256": "7fbf95274610679d30e85e16824af578c1f2c288ff2955ccaeb2d29429c0fc96",
-                "uncompressed-sha256": "c3d5c1c3cf7204c3684925c691de87bc6277f7042c5a2cc455ab39a6d51d8e6f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/ppc64le/rhcos-413.92.202303011445-0-openstack.ppc64le.qcow2.gz",
+                "sha256": "6d960f3879d4e17f9da7a3e845af661c6c4d00c21b6863fdbfd8ea7fa31288aa",
+                "uncompressed-sha256": "1e4a01beceb2c24c0cd6a31a690baee1ba26cc50d2d0de7313f3e6dec320f63e"
               }
             }
           }
         },
         "powervs": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "ova.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-powervs.ppc64le.ova.gz",
-                "sha256": "ad8c79402bd63504712fcfe15aad6f950a741f490341ebad7429247041391471",
-                "uncompressed-sha256": "081796f73eaaa2cd32a163f916fbccc852548fbd64c5c0fee88da890c7e4f9cb"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/ppc64le/rhcos-413.92.202303011445-0-powervs.ppc64le.ova.gz",
+                "sha256": "087c9f934b9b633c9a75f7cd752665985cd39768e59e3724085adb1b073e875b",
+                "uncompressed-sha256": "07350c5a66fc9ac880691c9491563f7f32861885058958c15335ea2c2cb0af4f"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/ppc64le/rhcos-413.86.202302150245-0-qemu.ppc64le.qcow2.gz",
-                "sha256": "303447ae8fcdd363a7b5d2e51d766baf8df9e78ce96523b71d4f1f9d5262203e",
-                "uncompressed-sha256": "efb602e5c1d3e150eece5b23f392f3b4dbf26e3df3a2f6ba4c46f34804d66c0f"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/ppc64le/rhcos-413.92.202303011445-0-qemu.ppc64le.qcow2.gz",
+                "sha256": "68a45eae2f03312eb1e2bde7ea7c9417fdf204b682fb933938accf8907e8ca2d",
+                "uncompressed-sha256": "6285074ace64fd3412a2542431f812aeaed23ca613ce9d7cc139838b175860fb"
               }
             }
           }
@@ -306,58 +306,58 @@
         "powervs": {
           "regions": {
             "au-syd": {
-              "release": "413.86.202302150245-0",
-              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202303011445-0",
+              "object": "rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-au-syd",
-              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz"
             },
             "br-sao": {
-              "release": "413.86.202302150245-0",
-              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202303011445-0",
+              "object": "rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-br-sao",
-              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz"
             },
             "ca-tor": {
-              "release": "413.86.202302150245-0",
-              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202303011445-0",
+              "object": "rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-ca-tor",
-              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz"
             },
             "eu-de": {
-              "release": "413.86.202302150245-0",
-              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202303011445-0",
+              "object": "rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-de",
-              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz"
             },
             "eu-gb": {
-              "release": "413.86.202302150245-0",
-              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202303011445-0",
+              "object": "rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-eu-gb",
-              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz"
             },
             "jp-osa": {
-              "release": "413.86.202302150245-0",
-              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202303011445-0",
+              "object": "rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-osa",
-              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz"
             },
             "jp-tok": {
-              "release": "413.86.202302150245-0",
-              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202303011445-0",
+              "object": "rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-jp-tok",
-              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz"
             },
             "us-east": {
-              "release": "413.86.202302150245-0",
-              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202303011445-0",
+              "object": "rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-east",
-              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz"
             },
             "us-south": {
-              "release": "413.86.202302150245-0",
-              "object": "rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz",
+              "release": "413.92.202303011445-0",
+              "object": "rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz",
               "bucket": "rhcos-powervs-images-us-south",
-              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-86-202302150245-0-ppc64le-powervs.ova.gz"
+              "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-413-92-202303011445-0-ppc64le-powervs.ova.gz"
             }
           }
         }
@@ -366,88 +366,88 @@
     "s390x": {
       "artifacts": {
         "ibmcloud": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-ibmcloud.s390x.qcow2.gz",
-                "sha256": "c1d0f67c6422fe36bd93f3b3ff8e168b7fee0eafb243eb6a8ccd7aad88fba484",
-                "uncompressed-sha256": "6cdd11732a43bea39590098059b1df8fef10cfb172a0bade402e9997170af323"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-ibmcloud.s390x.qcow2.gz",
+                "sha256": "c3f1a2d2421ce29c96a7c3e487e7514c876633661f4fd0fd651c4bd6bcf888a0",
+                "uncompressed-sha256": "aae4bbc44c8e03318d695c0624e466728f783cd5952650775659b057a4ece8e1"
               }
             }
           }
         },
         "metal": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-metal4k.s390x.raw.gz",
-                "sha256": "b3f05fffa012de9bc50d5d4fca69c90d1ddf7849d249c13281462f1df0547be5",
-                "uncompressed-sha256": "5266e949fea6c576627142cfbc3b1702bdab70d83c0497011666c0aba439fb32"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-metal4k.s390x.raw.gz",
+                "sha256": "aeb40b5870e51b897d7a4f6339d92ca6510fd753f23d9d8b65bc0e21cdae433f",
+                "uncompressed-sha256": "1fae633aa7f4b3b5fc6d877f1aeb070b23c3de1db3201b4273efebd5afe09f24"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-live.s390x.iso",
-                "sha256": "580d42a3266ef66fd5362a19233518776b1008d89e1e59af187d4c49b957002a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-live.s390x.iso",
+                "sha256": "da1581ea011666de5b24496e22977f4b611058402f13b9d19cea2d4edcfad344"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-live-kernel-s390x",
-                "sha256": "3c2a5d99790ef006e3544d502354ef512c2590267640ba293d9bfb7aa28798a5"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-live-kernel-s390x",
+                "sha256": "431d835959fab014bfba603bdaa832de2223018ffaa2bfb614c7d3a7df526863"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-live-initramfs.s390x.img",
-                "sha256": "508aced4fc57f93ae4774ea32d99a3e3119350c533eb83a8036ef287401527c7"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-live-initramfs.s390x.img",
+                "sha256": "8832b902a48545094e578c55545175860274f770b69fc0798ec98dd16dd9284b"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-live-rootfs.s390x.img",
-                "sha256": "e103798995315a1a953783210c7bcbf1dc74992457cc390be3d5a92efd372d27"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-live-rootfs.s390x.img",
+                "sha256": "fbe967edbbc4f0da9f089b173e1d252696e22b9f300c4bc2cddcbcd403b5d7aa"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-metal.s390x.raw.gz",
-                "sha256": "22ca4d4a6c1e0aa64ed53a62983486a9d8eb32342797e6898a8b3b11c34b4f7b",
-                "uncompressed-sha256": "62c070fcee681ab21dc98211950f11ea7beb98ee5838dac943ad5949a8ae97f9"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-metal.s390x.raw.gz",
+                "sha256": "f779dfdaa8d024c2dd5808c6d44e88d065d2bc89bc586393376e078bcd6ef592",
+                "uncompressed-sha256": "5557ffedaed2cbe410cf67264fc2066aa7855574239bca96c534a5a5a0011dc1"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-openstack.s390x.qcow2.gz",
-                "sha256": "ace77129d918c10ce7cd4d8451611574fd843c4b3922aef3e560ab810706e7a0",
-                "uncompressed-sha256": "f17b29ab38700c947393b73506a82b0935f2573bca280bae091ca4ef059f0546"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-openstack.s390x.qcow2.gz",
+                "sha256": "1cafe93e3d4ae5bd0b32a8f3cd3f9b2a63b73e5b6f8e5ecaf39cd3c73b1c7c5a",
+                "uncompressed-sha256": "856e883df2b8e2e577cffbfbdd0760be3d4145d8008671c8ee8fc5a2c19f7549"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-qemu.s390x.qcow2.gz",
-                "sha256": "ed05ea76c91b300d79cc0fa4c6964e661243e2f44e45b47996b51d801717d7a1",
-                "uncompressed-sha256": "8d43b2db3556ea9513a75f09ec80fdaf82d8119f0a698d09bac1418af66f00e4"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-qemu.s390x.qcow2.gz",
+                "sha256": "23962e6ec0bbbe4071928dbae0c0029f08560f3e86052c1a58b56eaad350bb66",
+                "uncompressed-sha256": "2b567c1134c503bba75dda4cd232da5af81c5d909d14eb727a1e1dfd20681f6b"
               }
             }
           }
         },
         "qemu-secex": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/s390x/rhcos-413.86.202302150245-0-qemu-secex.s390x.qcow2.gz",
-                "sha256": "4d212733a61dda5b0dcbf4923e68bbc744a260565d3bc7e9ef1a9a05508f7069",
-                "uncompressed-sha256": "405d11f63e987992c8d04d7087d88840168dc17380561287b3947469e303837d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/s390x/rhcos-413.92.202303011445-0-qemu-secex.s390x.qcow2.gz",
+                "sha256": "cc4299c0fdbfb001fc1d88b1f2cecb7a50234b3505c13c759353fcd389b62c73",
+                "uncompressed-sha256": "722710da144a5c7f621eaa57143a0d691676577f2b7f22833a9354063332ff4e"
               }
             }
           }
@@ -458,158 +458,158 @@
     "x86_64": {
       "artifacts": {
         "aliyun": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-aliyun.x86_64.qcow2.gz",
-                "sha256": "0db3501511dc9c20077be657e43494962b7cac048379fe748757d4fae87982d5",
-                "uncompressed-sha256": "07adaf7ddc6a6ffb840b97344e35165817c2b9ce3154fe653165d37236206245"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-aliyun.x86_64.qcow2.gz",
+                "sha256": "e52c37b78d585305264c62eefd9fefa60a754e3bd2243a71e9df5e465bb39732",
+                "uncompressed-sha256": "3b4764ed8368ceac13b60b0de2f9aedf48907c5608ae11b3b67c168b5176f546"
               }
             }
           }
         },
         "aws": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "vmdk.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-aws.x86_64.vmdk.gz",
-                "sha256": "829f39a06692eae97c3718a336688682bb0fd6336b5a1567dd86481b9fd90263",
-                "uncompressed-sha256": "f2f8142c5945839cd7f057684f2bcaef23ebab51eed87e5df6c0e4b2b1df827d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-aws.x86_64.vmdk.gz",
+                "sha256": "a84940acbbc3b542a35b4b60316d950777993e9bf0c7bfd6e85a23e4f15e74d7",
+                "uncompressed-sha256": "1fd04358d7428112c11b3ab359a8348ea7cd8790c6467597d10f479f17cd9618"
               }
             }
           }
         },
         "azure": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-azure.x86_64.vhd.gz",
-                "sha256": "1013736d31dadb900700a0592525b38cde0b60637f0110b5a82873599bf670e8",
-                "uncompressed-sha256": "d56892f76b241d22ddaad0c281b744f131b2c1fb6b959c8330010049da8c081c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-azure.x86_64.vhd.gz",
+                "sha256": "2efe82bfb291bf83eb006cc468c753447d569c8b9344f4851538e6bd1c2f9cfb",
+                "uncompressed-sha256": "306898dc2b8768e5a5d7a751f0ba30221dffa81c131527cef3551da925c2ebe7"
               }
             }
           }
         },
         "azurestack": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "vhd.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-azurestack.x86_64.vhd.gz",
-                "sha256": "5667f5574659b2c7485c6912265e1ea4e4f05790bb3cd2718e9c75827169a90e",
-                "uncompressed-sha256": "486e3b3a2b45b8b607f28a16f81547094f1b7c15daa183b30937228bf1764d6a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-azurestack.x86_64.vhd.gz",
+                "sha256": "532e092d5465cb3a024e533b5cedd5fb0869bd54f0b2cf4f7d83ec2c3f5d25d7",
+                "uncompressed-sha256": "119556e2547176e8a9959af5eacf4668e888a62fea180cadfcc3c32806bb9d0c"
               }
             }
           }
         },
         "gcp": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "tar.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-gcp.x86_64.tar.gz",
-                "sha256": "2cd5d3480b506407dc78ca972a715c79cf9f756549e60da69c0ef38da81e7eae",
-                "uncompressed-sha256": "223e5e8fbeb5bd3cbe1311ddcd280f834cec85e4e82282fbe7eb6811e4d70c78"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-gcp.x86_64.tar.gz",
+                "sha256": "d47ef908d99aa8de1c41265a4d430c4152df89acf76d933d286cd7b036d56331",
+                "uncompressed-sha256": "e0d6d525d7eddfaadec393e092d80f224103db76e1fbc816785cf3b8c422769c"
               }
             }
           }
         },
         "ibmcloud": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-ibmcloud.x86_64.qcow2.gz",
-                "sha256": "815e72d9d705eccc06964b604e2f72082afd524a75b3abea60aeb506fe7829d7",
-                "uncompressed-sha256": "62da41af2a0859a9244c1ee4056d92c5528cb46badaf97443d1da1763ac63447"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-ibmcloud.x86_64.qcow2.gz",
+                "sha256": "05a9ca29056e7bfff46fffb25f95f627bf0c6b1c7c599bea44e4f4b4f83fe4d5",
+                "uncompressed-sha256": "212d3bf50d0fe1d0da464052b6de6563ce2887bc09957d648692913e1bb4e583"
               }
             }
           }
         },
         "metal": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "4k.raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-metal4k.x86_64.raw.gz",
-                "sha256": "a069f4be89ed991e0d81534fa045c98cfde6de0bfc5e79b3bb2df084be5aa837",
-                "uncompressed-sha256": "cc3f7a4f4da900db4329abbfbf00e66c54939b6f85aa68d6822d6c50bec991ae"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-metal4k.x86_64.raw.gz",
+                "sha256": "515ff937233663fb0438b361d3c8ab8f78cad17b007e1537ebf28cd56a206269",
+                "uncompressed-sha256": "c1483f5d30785e359f34e26ea10e1ef739e0920125e61e6c31afe37f17ab7c99"
               }
             },
             "iso": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-live.x86_64.iso",
-                "sha256": "cfb8d20860dde087c15cd562b9cb4c0a11620703dd36fbdb62e9d8fd5a76a9af"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-live.x86_64.iso",
+                "sha256": "9b21a9d7dad612ceb98e4c9671374e55c7e9ba2842627572381eac927acb2b76"
               }
             },
             "pxe": {
               "kernel": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-live-kernel-x86_64",
-                "sha256": "4a081639a748f63f97c308f2a37b440e76d3e1da2b14997315306d519b01d24c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-live-kernel-x86_64",
+                "sha256": "2a05517ca71a67b0833ba0b7f2ef769bf0e040750efcd55ef2a0ab2fe347ae7c"
               },
               "initramfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-live-initramfs.x86_64.img",
-                "sha256": "9297fca4ec75ca6c5d434d254f8e8737ac7c1e1f341f2d2a33822c976ab0b58d"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-live-initramfs.x86_64.img",
+                "sha256": "5bfbe01d2467eb948c2246fa750a44019678f0693cbe176a9dba703fadfbd20d"
               },
               "rootfs": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-live-rootfs.x86_64.img",
-                "sha256": "3ee511d6d1fced79eede61a5bacbb9344fd505e21aa11d508c8746f79fc83903"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-live-rootfs.x86_64.img",
+                "sha256": "3a1476d5901a22b607cb997f553d104d9db77ec74640ebd20282c9ee7ec3b320"
               }
             },
             "raw.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-metal.x86_64.raw.gz",
-                "sha256": "4ee280101bd957359a508b13a393c1899ea78f8e01feba8761a69fd1f10eec06",
-                "uncompressed-sha256": "c0e8b21f8e738687f272d1abe5e23518e6020bf09e3914b14c474eb8a5c7bb46"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-metal.x86_64.raw.gz",
+                "sha256": "ed0fb73cc87b0da41f6bfe3dd604119fd7f8efe017969dc14060c261933c30b2",
+                "uncompressed-sha256": "027fb143cd3e499086d68fbcd5681b79df86d540f5f79b049b9c112dbf319d4c"
               }
             }
           }
         },
         "nutanix": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-nutanix.x86_64.qcow2",
-                "sha256": "c28b4ba7a99f945ee5711ba1acf7ff9f29c502f6ab0096ec7334d1d96249ca1a"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-nutanix.x86_64.qcow2",
+                "sha256": "51316ed542139663a2ba2566c26f64b6da74500d6a82a061c01649750bf0d6f5"
               }
             }
           }
         },
         "openstack": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-openstack.x86_64.qcow2.gz",
-                "sha256": "fbef46936da1f8c3723c1d9e7a8be5e412bcc543c7ec57f63c7b80d5693b9716",
-                "uncompressed-sha256": "544105620117f6e4fbffc3ade2e34ff968da3dc2bd23ebbbbe0f83e07377785c"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-openstack.x86_64.qcow2.gz",
+                "sha256": "a860cf1638f58c4586b1798bd8686772ab5c22b7d03cd820d565dd94d2f7f071",
+                "uncompressed-sha256": "6534cf2afa964016d21035b33146bca832ab83d950c9e7bdc5a33311691b08ce"
               }
             }
           }
         },
         "qemu": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "qcow2.gz": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-qemu.x86_64.qcow2.gz",
-                "sha256": "d3b2cdcd9fced23609dc5235b1254414a29745810e673919259d85ced1f9a117",
-                "uncompressed-sha256": "6999223cc3b32274f86df16d48e663ba2ec7552ed73df2b8deeaf8784554c378"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-qemu.x86_64.qcow2.gz",
+                "sha256": "95f99792fe0b64303d3a7cba48c3ec459aaed5d9acd999897cec98d1c02264af",
+                "uncompressed-sha256": "1b6ecf1b0fda0659c03dd1d6c215ffe42cb1955ccab8f85e2bccb2e0ef5532e0"
               }
             }
           }
         },
         "vmware": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "formats": {
             "ova": {
               "disk": {
-                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13/builds/413.86.202302150245-0/x86_64/rhcos-413.86.202302150245-0-vmware.x86_64.ova",
-                "sha256": "365cb490a33908c65a109b2912b1e1012dbbc31adc79dcbfc67e8940078a3be0"
+                "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.13-9.2/builds/413.92.202303011445-0/x86_64/rhcos-413.92.202303011445-0-vmware.x86_64.ova",
+                "sha256": "a2c6d7fb2352801d3e399807801be170a11b39361c1d96d77ef07acaeed8056e"
               }
             }
           }
@@ -619,249 +619,249 @@
         "aliyun": {
           "regions": {
             "ap-northeast-1": {
-              "release": "413.86.202302150245-0",
-              "image": "m-6weejojhj37ktk2xx5k9"
+              "release": "413.92.202303011445-0",
+              "image": "m-6we8kxu3oh0m10x0xsfe"
             },
             "ap-northeast-2": {
-              "release": "413.86.202302150245-0",
-              "image": "m-mj7bhroqi5x0u6wum061"
+              "release": "413.92.202303011445-0",
+              "image": "m-mj7hckx33p5urkynqbuc"
             },
             "ap-south-1": {
-              "release": "413.86.202302150245-0",
-              "image": "m-a2dh9fua2i7qqusjfi6g"
+              "release": "413.92.202303011445-0",
+              "image": "m-a2d8qpg41i3p44l3ayl0"
             },
             "ap-southeast-1": {
-              "release": "413.86.202302150245-0",
-              "image": "m-t4ndinvewtjusphuk70d"
+              "release": "413.92.202303011445-0",
+              "image": "m-t4nf39oxdqt1vrg8j6xt"
             },
             "ap-southeast-2": {
-              "release": "413.86.202302150245-0",
-              "image": "m-p0wdee2txo076u9sxxfo"
+              "release": "413.92.202303011445-0",
+              "image": "m-p0w4av1ond1hhjzko8kd"
             },
             "ap-southeast-3": {
-              "release": "413.86.202302150245-0",
-              "image": "m-8ps1ua0nht115pjcjb4u"
+              "release": "413.92.202303011445-0",
+              "image": "m-8ps0pbud9egubfgcvqiy"
             },
             "ap-southeast-5": {
-              "release": "413.86.202302150245-0",
-              "image": "m-k1adlllaeuxc5lkvs446"
+              "release": "413.92.202303011445-0",
+              "image": "m-k1ad26kmny5xkx7eh0j4"
             },
             "ap-southeast-6": {
-              "release": "413.86.202302150245-0",
-              "image": "m-5tshi6b9qwml66kmutma"
+              "release": "413.92.202303011445-0",
+              "image": "m-5ts0y155nkge7dttb5hs"
             },
             "ap-southeast-7": {
-              "release": "413.86.202302150245-0",
-              "image": "m-0jofjl7eo71cg6cfwze9"
+              "release": "413.92.202303011445-0",
+              "image": "m-0jo7i8ddnmb997ynm3cl"
             },
             "cn-beijing": {
-              "release": "413.86.202302150245-0",
-              "image": "m-2zede1088jjn43zxknob"
+              "release": "413.92.202303011445-0",
+              "image": "m-2zehcc2bwliwbpe5edum"
             },
             "cn-chengdu": {
-              "release": "413.86.202302150245-0",
-              "image": "m-2vc7hnmwmgl0hg2kyo2g"
+              "release": "413.92.202303011445-0",
+              "image": "m-2vcg1pccavtnf8rre0i7"
             },
             "cn-fuzhou": {
-              "release": "413.86.202302150245-0",
-              "image": "m-gw0ecbzoggx0bs2hu3ky"
+              "release": "413.92.202303011445-0",
+              "image": "m-gw0hc54aj0416at4pjb6"
             },
             "cn-guangzhou": {
-              "release": "413.86.202302150245-0",
-              "image": "m-7xv12plj3ea44qq7wdsa"
+              "release": "413.92.202303011445-0",
+              "image": "m-7xvfbug15urcxxg9lz2e"
             },
             "cn-hangzhou": {
-              "release": "413.86.202302150245-0",
-              "image": "m-bp11fdg3ufj53zbtq3cf"
+              "release": "413.92.202303011445-0",
+              "image": "m-bp1eonxfrp8nq3785wq6"
             },
             "cn-heyuan": {
-              "release": "413.86.202302150245-0",
-              "image": "m-f8z72khqhzpj30nfpk78"
+              "release": "413.92.202303011445-0",
+              "image": "m-f8zh5eocw8bp5m1j92jr"
             },
             "cn-hongkong": {
-              "release": "413.86.202302150245-0",
-              "image": "m-j6c5tve2x4jyem5ulnvx"
+              "release": "413.92.202303011445-0",
+              "image": "m-j6c9kctbsrsj7wn9bhxb"
             },
             "cn-huhehaote": {
-              "release": "413.86.202302150245-0",
-              "image": "m-hp33272h4q2mwhuxoy12"
+              "release": "413.92.202303011445-0",
+              "image": "m-hp32aolmc0gfeqqbc3f5"
             },
             "cn-nanjing": {
-              "release": "413.86.202302150245-0",
-              "image": "m-gc7c9559cwxqeuyam473"
+              "release": "413.92.202303011445-0",
+              "image": "m-gc7eayssq9qambk2mzbm"
             },
             "cn-qingdao": {
-              "release": "413.86.202302150245-0",
-              "image": "m-m5eako3yq9w2xi09s1jm"
+              "release": "413.92.202303011445-0",
+              "image": "m-m5e7e9d11prrmea6hqiu"
             },
             "cn-shanghai": {
-              "release": "413.86.202302150245-0",
-              "image": "m-uf62383nkx4q965hzq1j"
+              "release": "413.92.202303011445-0",
+              "image": "m-uf6j3ys5kh5dxj04f8z2"
             },
             "cn-shenzhen": {
-              "release": "413.86.202302150245-0",
-              "image": "m-wz97wkpiyeql5230aqq4"
+              "release": "413.92.202303011445-0",
+              "image": "m-wz9hf3krll57cb52ivbl"
             },
             "cn-wulanchabu": {
-              "release": "413.86.202302150245-0",
-              "image": "m-0jl1kyi7iiuy2wo63rt1"
+              "release": "413.92.202303011445-0",
+              "image": "m-0jldcl970d7zwzwcq4qg"
             },
             "cn-zhangjiakou": {
-              "release": "413.86.202302150245-0",
-              "image": "m-8vbgw05auetitxo8fdak"
+              "release": "413.92.202303011445-0",
+              "image": "m-8vbj5uxzeg6s01s1abpp"
             },
             "eu-central-1": {
-              "release": "413.86.202302150245-0",
-              "image": "m-gw89y0ywbh0mo38x5nak"
+              "release": "413.92.202303011445-0",
+              "image": "m-gw80dk4f8mkb5r6mf2e8"
             },
             "eu-west-1": {
-              "release": "413.86.202302150245-0",
-              "image": "m-d7ohtanqn0zmd7kbs5xq"
+              "release": "413.92.202303011445-0",
+              "image": "m-d7o3g1e8vj4oupan21aq"
             },
             "me-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "m-eb3hpwdabkbj9j8ppr2r"
+              "release": "413.92.202303011445-0",
+              "image": "m-eb3fr0u4it0spkkti2w0"
             },
             "us-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "m-0xi3rohf2hevpgh8ks9d"
+              "release": "413.92.202303011445-0",
+              "image": "m-0xi7fwkq0d42fz09yvqp"
             },
             "us-west-1": {
-              "release": "413.86.202302150245-0",
-              "image": "m-rj91z29n0eszqytj7kyo"
+              "release": "413.92.202303011445-0",
+              "image": "m-rj98hx6y0qsqt37abr8a"
             }
           }
         },
         "aws": {
           "regions": {
             "af-south-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0ee7dbd43fa7ad8f5"
+              "release": "413.92.202303011445-0",
+              "image": "ami-07f9a8270c4e0bdc9"
             },
             "ap-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-03618a400960f8c68"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0d2f865f2ba122135"
             },
             "ap-northeast-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-00a4b30f42a8870f8"
+              "release": "413.92.202303011445-0",
+              "image": "ami-05703499c78648613"
             },
             "ap-northeast-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-05541b783cd430ae8"
+              "release": "413.92.202303011445-0",
+              "image": "ami-01b485d997dc4205c"
             },
             "ap-northeast-3": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-08f1d2c144428b458"
+              "release": "413.92.202303011445-0",
+              "image": "ami-05caa594b0d750259"
             },
             "ap-south-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0c939023cd17fead4"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0b2819d44e412579e"
             },
             "ap-south-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0f7ee6995f6e3ca68"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0604d2b40d8e04f2c"
             },
             "ap-southeast-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-06518bbb76c1545aa"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0657711982bc9c6da"
             },
             "ap-southeast-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-091a9990f016eff02"
+              "release": "413.92.202303011445-0",
+              "image": "ami-067cc18e980490ca2"
             },
             "ap-southeast-3": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-04f7a616b22339b49"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0558baa04806ae92b"
             },
             "ap-southeast-4": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-02eec652f67fba40d"
+              "release": "413.92.202303011445-0",
+              "image": "ami-00e66fa999059c252"
             },
             "ca-central-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0dfe3fd3d005225dd"
+              "release": "413.92.202303011445-0",
+              "image": "ami-034fadf03b498a890"
             },
             "eu-central-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0f9c9989c9b09461a"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0d1fcbb28707c30ee"
             },
             "eu-central-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0e01bb003610c51df"
+              "release": "413.92.202303011445-0",
+              "image": "ami-098589124d9ede31f"
             },
             "eu-north-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-05d75e527cf1bdebe"
+              "release": "413.92.202303011445-0",
+              "image": "ami-03302d76045f3a773"
             },
             "eu-south-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-042340d9d46235830"
+              "release": "413.92.202303011445-0",
+              "image": "ami-03a49fd961aa43b9a"
             },
             "eu-south-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-01bb2eb403ae3ebc0"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0afa8b4d70d2c3a5a"
             },
             "eu-west-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0f3b1ac57cae83cf2"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0731e54b768db5d88"
             },
             "eu-west-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-09c55d890a73548fd"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0b012566c46aa678b"
             },
             "eu-west-3": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-01eac4ba8a459a29d"
+              "release": "413.92.202303011445-0",
+              "image": "ami-09cdec4a38b3baab6"
             },
             "me-central-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0f66fca5ad0eb9fcb"
+              "release": "413.92.202303011445-0",
+              "image": "ami-083482c49a4512bb4"
             },
             "me-south-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0b3c8ebfdfeddfe33"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0b2d56141c9422f3d"
             },
             "sa-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-090da632dda42973e"
+              "release": "413.92.202303011445-0",
+              "image": "ami-02fbb5c129651c25c"
             },
             "us-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-06e267b8c26b558f6"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0ade97ab9e67ef465"
             },
             "us-east-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-024e0823a0de2f4f6"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0f7bb50ca50227505"
             },
             "us-gov-east-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-0deef4891a51e1db8"
+              "release": "413.92.202303011445-0",
+              "image": "ami-02d24a928d40779a4"
             },
             "us-gov-west-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-00d7d8d7b178e6542"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0420855dac61e8546"
             },
             "us-west-1": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-087b3a90abc3cd37f"
+              "release": "413.92.202303011445-0",
+              "image": "ami-0b8de45a1ddbc86bd"
             },
             "us-west-2": {
-              "release": "413.86.202302150245-0",
-              "image": "ami-043a19ba4fc7c5820"
+              "release": "413.92.202303011445-0",
+              "image": "ami-090bc6e4345db156d"
             }
           }
         },
         "gcp": {
-          "release": "413.86.202302150245-0",
+          "release": "413.92.202303011445-0",
           "project": "rhcos-cloud",
-          "name": "rhcos-413-86-202302150245-0-gcp-x86-64"
+          "name": "rhcos-413-92-202303011445-0-gcp-x86-64"
         }
       },
       "rhel-coreos-extensions": {
         "azure-disk": {
-          "release": "413.86.202302150245-0",
-          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.86.202302150245-0-azure.x86_64.vhd"
+          "release": "413.92.202303011445-0",
+          "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-413.92.202303011445-0-azure.x86_64.vhd"
         }
       }
     }


### PR DESCRIPTION
These changes will update the RHCOS 4.13 boot image metadata in the installer.

This change was generated using:
```
plume cosa2stream --target data/data/coreos/rhcos.json --distro rhcos --no-signatures --url https://rhcos.mirror.openshift.com/art/storage/prod/streams x86_64=413.92.202302171914-0 aarch64=413.92.202302171914-0 s390x=413.92.202302171914-0 ppc64le=413.92.202302171914-0
```