### PR TITLE
CORS-2503: azure: use marketplace images for all nodes

### DIFF
--- a/data/data/azure/cluster/main.tf
+++ b/data/data/azure/cluster/main.tf
@@ -41,6 +41,12 @@ module "master" {
   ultra_ssd_enabled          = var.azure_control_plane_ultra_ssd_enabled
   vm_networking_type         = var.azure_control_plane_vm_networking_type
   azure_extra_tags           = var.azure_extra_tags
+  use_marketplace_image      = var.azure_use_marketplace_image
+  vm_image_has_plan          = var.azure_marketplace_image_has_plan
+  vm_image_publisher         = var.azure_marketplace_image_publisher
+  vm_image_offer             = var.azure_marketplace_image_offer
+  vm_image_sku               = var.azure_marketplace_image_sku
+  vm_image_version           = var.azure_marketplace_image_version
 
   use_ipv4 = var.use_ipv4
   use_ipv6 = var.use_ipv6

--- a/data/data/azure/cluster/master/master.tf
+++ b/data/data/azure/cluster/master/master.tf
@@ -118,7 +118,29 @@ resource "azurerm_linux_virtual_machine" "master" {
     disk_encryption_set_id = var.disk_encryption_set_id
   }
 
-  source_image_id = var.vm_image
+  # Either source_image_id or source_image_reference must be defined
+  source_image_id = ! var.use_marketplace_image ? var.vm_image : null
+
+  dynamic "source_image_reference" {
+    for_each = var.use_marketplace_image ? [1] : []
+
+    content {
+      publisher = var.vm_image_publisher
+      offer     = var.vm_image_offer
+      sku       = var.vm_image_sku
+      version   = var.vm_image_version
+    }
+  }
+
+  dynamic "plan" {
+    for_each = var.use_marketplace_image && var.vm_image_has_plan ? [1] : []
+
+    content {
+      publisher = var.vm_image_publisher
+      product   = var.vm_image_offer
+      name      = var.vm_image_sku
+    }
+  }
 
   //we don't provide a ssh key, because it is set with ignition.
   //it is required to provide at least 1 auth method to deploy a linux vm

--- a/data/data/azure/cluster/master/variables.tf
+++ b/data/data/azure/cluster/master/variables.tf
@@ -32,6 +32,36 @@ variable "vm_image" {
   description = "The resource id of the vm image used for masters."
 }
 
+variable "use_marketplace_image" {
+  type        = string
+  description = "Whether to use marketplace images"
+}
+
+variable "vm_image_has_plan" {
+  type        = bool
+  description = "Whether the image has a purchase plan or not"
+}
+
+variable "vm_image_publisher" {
+  type        = string
+  description = "Publisher of the marketplace image"
+}
+
+variable "vm_image_offer" {
+  type        = string
+  description = "Offer of the marketplace image"
+}
+
+variable "vm_image_sku" {
+  type        = string
+  description = "SKU of the marketplace image"
+}
+
+variable "vm_image_version" {
+  type        = string
+  description = "Version of the marketplace image"
+}
+
 variable "identity" {
   type        = string
   description = "The user assigned identity id for the vm."

--- a/data/data/azure/variables-azure.tf
+++ b/data/data/azure/variables-azure.tf
@@ -217,3 +217,36 @@ variable "azure_image_release" {
   description = "RHCOS release image version - used when creating the image definition in the gallery"
 }
 
+variable "azure_use_marketplace_image" {
+  type        = bool
+  description = "Whether to use a Marketplace image for all nodes"
+}
+
+variable "azure_marketplace_image_has_plan" {
+  type        = bool
+  description = "Whether the Marketplace image has a purchase plan"
+}
+
+variable "azure_marketplace_image_publisher" {
+  type        = string
+  description = "Publisher of the marketplace image"
+  default     = ""
+}
+
+variable "azure_marketplace_image_offer" {
+  type        = string
+  description = "Offer of the marketplace image"
+  default     = ""
+}
+
+variable "azure_marketplace_image_sku" {
+  type        = string
+  description = "SKU of the marketplace image"
+  default     = ""
+}
+
+variable "azure_marketplace_image_version" {
+  type        = string
+  description = "Version of the marketplace image"
+  default     = ""
+}

--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -293,6 +293,13 @@ spec:
                             offer:
                               description: Offer is the offer of the image.
                               type: string
+                            plan:
+                              description: Plan is the purchase plan of the image.
+                                If omitted, it defaults to "WithPurchasePlan".
+                              enum:
+                              - WithPurchasePlan
+                              - NoPurchasePlan
+                              type: string
                             publisher:
                               description: Publisher is the publisher of the image.
                               type: string
@@ -1057,6 +1064,13 @@ spec:
                         properties:
                           offer:
                             description: Offer is the offer of the image.
+                            type: string
+                          plan:
+                            description: Plan is the purchase plan of the image. If
+                              omitted, it defaults to "WithPurchasePlan".
+                            enum:
+                            - WithPurchasePlan
+                            - NoPurchasePlan
                             type: string
                           publisher:
                             description: Publisher is the publisher of the image.
@@ -2166,6 +2180,13 @@ spec:
                         properties:
                           offer:
                             description: Offer is the offer of the image.
+                            type: string
+                          plan:
+                            description: Plan is the purchase plan of the image. If
+                              omitted, it defaults to "WithPurchasePlan".
+                            enum:
+                            - WithPurchasePlan
+                            - NoPurchasePlan
                             type: string
                           publisher:
                             description: Publisher is the publisher of the image.

--- a/pkg/asset/installconfig/azure/capabilities.go
+++ b/pkg/asset/installconfig/azure/capabilities.go
@@ -19,7 +19,7 @@ func GetHyperVGenerationVersion(capabilities map[string]string, imageHyperVGen s
 	if imageHyperVGen != "" && generations.Has(imageHyperVGen) {
 		return imageHyperVGen, nil
 	} else if generations.Len() > 0 { // otherwise, return the highest version available
-		return generations.List()[generations.Len()-1], nil
+		return sets.List(generations)[generations.Len()-1], nil
 	}
 	if generations.Has("V2") {
 		return "V2", nil
@@ -28,9 +28,9 @@ func GetHyperVGenerationVersion(capabilities map[string]string, imageHyperVGen s
 }
 
 // GetHyperVGenerationVersions returns all the HyperVGeneration versions supported by the instance type according to its capabilities as a string set V = {"V1", "V2", ...}
-func GetHyperVGenerationVersions(capabilities map[string]string) (sets.String, error) {
+func GetHyperVGenerationVersions(capabilities map[string]string) (sets.Set[string], error) {
 	if val, ok := capabilities["HyperVGenerations"]; ok {
-		generations := sets.NewString()
+		generations := sets.New[string]()
 		for _, g := range strings.Split(val, ",") {
 			g = strings.TrimSpace(g)
 			g = strings.ToUpper(g)

--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -643,6 +643,11 @@ func validateMarketplaceImage(client API, installConfig *types.InstallConfig) fi
 			continue
 		}
 
+		// Images with no purchase plan have no terms to be accepted
+		if platform.OSImage.Plan == aztypes.ImageNoPurchasePlan {
+			continue
+		}
+
 		termsAccepted, err := client.AreMarketplaceImageTermsAccepted(context.Background(), platform.OSImage.Publisher, platform.OSImage.Offer, platform.OSImage.SKU)
 		if err == nil {
 			if !termsAccepted {

--- a/pkg/asset/installconfig/azure/validation.go
+++ b/pkg/asset/installconfig/azure/validation.go
@@ -54,7 +54,7 @@ func Validate(client API, ic *types.InstallConfig) error {
 		}
 		allErrs = append(allErrs, validateAzureStackClusterOSImage(StorageEndpointSuffix, ic.Azure.ClusterOSImage, field.NewPath("platform").Child("azure"))...)
 	}
-	allErrs = append(allErrs, validateMarketplaceImage(client, ic)...)
+	allErrs = append(allErrs, validateMarketplaceImages(client, ic)...)
 	return allErrs.ToAggregate()
 }
 
@@ -595,70 +595,93 @@ func validateAzureStackClusterOSImage(StorageEndpointSuffix string, ClusterOSIma
 	return allErrs
 }
 
-func validateMarketplaceImage(client API, installConfig *types.InstallConfig) field.ErrorList {
+func validateMarketplaceImages(client API, installConfig *types.InstallConfig) field.ErrorList {
 	var allErrs field.ErrorList
+
+	region := installConfig.Azure.Region
+	cloudName := installConfig.Azure.CloudName
+
+	var defaultInstanceType string
+	if installConfig.Azure.DefaultMachinePlatform != nil {
+		defaultInstanceType = installConfig.Azure.DefaultMachinePlatform.InstanceType
+	}
+
+	// Validate Compute marketplace images
 	for i, compute := range installConfig.Compute {
 		platform := compute.Platform.Azure
 		if platform == nil {
 			continue
 		}
-		if platform.OSImage.Publisher == "" {
-			continue
-		}
-		osImageFieldPath := field.NewPath("compute").Index(i).Child("platform", "azure", "osImage")
-		vmImage, err := client.GetMarketplaceImage(
-			context.Background(),
-			installConfig.Platform.Azure.Region,
-			platform.OSImage.Publisher,
-			platform.OSImage.Offer,
-			platform.OSImage.SKU,
-			platform.OSImage.Version,
-		)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(osImageFieldPath, platform.OSImage, err.Error()))
-			continue
-		}
+		fldPath := field.NewPath("compute").Index(i)
+
+		// Determine instance type
 		instanceType := platform.InstanceType
-		if instanceType == "" && installConfig.Platform.Azure.DefaultMachinePlatform != nil {
-			instanceType = installConfig.Platform.Azure.DefaultMachinePlatform.InstanceType
+		if instanceType == "" {
+			instanceType = defaultInstanceType
 		}
 		if instanceType == "" {
-			instanceType = defaults.ComputeInstanceType(installConfig.Azure.CloudName, installConfig.Azure.Region, compute.Architecture)
+			instanceType = defaults.ComputeInstanceType(cloudName, region, compute.Architecture)
 		}
-		capabilities, err := client.GetVMCapabilities(context.Background(), instanceType, installConfig.Azure.Region)
+
+		capabilities, err := client.GetVMCapabilities(context.Background(), instanceType, region)
 		if err != nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("compute").Index(i).Child("platform", "azure", "type"), instanceType, err.Error()))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("platform", "azure", "type"), instanceType, err.Error()))
 			continue
 		}
 
 		generations, err := GetHyperVGenerationVersions(capabilities)
 		if err != nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("compute").Index(i).Child("platform", "azure", "type"), instanceType, err.Error()))
-			continue
-		}
-		imageHyperVGen := string(vmImage.HyperVGeneration)
-		if !generations.Has(imageHyperVGen) {
-			errMsg := fmt.Sprintf("instance type %s supports HyperVGenerations %v but the specified image is for HyperVGeneration %s; to correct this issue either specify a compatible instance type or change the HyperVGeneration for the image by using a different SKU", instanceType, generations.UnsortedList(), imageHyperVGen)
-			allErrs = append(allErrs, field.Invalid(osImageFieldPath, platform.OSImage.SKU, errMsg))
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("platform", "azure", "type"), instanceType, err.Error()))
 			continue
 		}
 
-		// Images with no purchase plan have no terms to be accepted
-		if platform.OSImage.Plan == aztypes.ImageNoPurchasePlan {
-			continue
-		}
-
-		termsAccepted, err := client.AreMarketplaceImageTermsAccepted(context.Background(), platform.OSImage.Publisher, platform.OSImage.Offer, platform.OSImage.SKU)
-		if err == nil {
-			if !termsAccepted {
-				allErrs = append(allErrs, field.Invalid(osImageFieldPath, platform.OSImage, "the license terms for the marketplace image have not been accepted"))
-			}
-		} else {
-			allErrs = append(allErrs, field.Invalid(osImageFieldPath, platform.OSImage,
-				fmt.Sprintf("could not determine if the license terms for the marketplace image have been accepted: %v", err)))
+		imgErr := validateMarketplaceImage(client, region, generations, &platform.OSImage, fldPath)
+		if imgErr != nil {
+			allErrs = append(allErrs, imgErr)
 		}
 	}
+
 	return allErrs
+}
+
+func validateMarketplaceImage(client API, region string, instanceHyperVGenSet sets.Set[string], osImage *aztypes.OSImage, fldPath *field.Path) *field.Error {
+	// Marketplace image not specified
+	if osImage.Publisher == "" {
+		return nil
+	}
+
+	osImageFieldPath := fldPath.Child("platform", "azure", "osImage")
+	vmImage, err := client.GetMarketplaceImage(
+		context.Background(),
+		region,
+		osImage.Publisher,
+		osImage.Offer,
+		osImage.SKU,
+		osImage.Version,
+	)
+	if err != nil {
+		return field.Invalid(osImageFieldPath, osImage, err.Error())
+	}
+	imageHyperVGen := string(vmImage.HyperVGeneration)
+	if !instanceHyperVGenSet.Has(imageHyperVGen) {
+		errMsg := fmt.Sprintf("instance type supports HyperVGenerations %v but the specified image is for HyperVGeneration %s; to correct this issue either specify a compatible instance type or change the HyperVGeneration for the image by using a different SKU", instanceHyperVGenSet.UnsortedList(), imageHyperVGen)
+		return field.Invalid(osImageFieldPath, osImage.SKU, errMsg)
+	}
+
+	// Images with no purchase plan have no terms to be accepted
+	if osImage.Plan == aztypes.ImageNoPurchasePlan {
+		return nil
+	}
+
+	termsAccepted, err := client.AreMarketplaceImageTermsAccepted(context.Background(), osImage.Publisher, osImage.Offer, osImage.SKU)
+	if err != nil {
+		return field.Invalid(osImageFieldPath, osImage, fmt.Sprintf("could not determine if the license terms for the marketplace image have been accepted: %v", err))
+	}
+	if !termsAccepted {
+		return field.Invalid(osImageFieldPath, osImage, "the license terms for the marketplace image have not been accepted")
+	}
+
+	return nil
 }
 
 func validateAzureStackDiskType(_ API, installConfig *types.InstallConfig) field.ErrorList {

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -375,7 +375,7 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 		{
 			name:     "Undefined default instance types",
 			edits:    editFunctions{undefinedDefaultInstanceTypes},
-			errorMsg: `\[controlPlane.platform.azure.type: Invalid value: "Dne_D2_v4": not found in region centralus, compute\[0\].platform.azure.type: Invalid value: "Dne_D2_v4": not found in region centralus\]`,
+			errorMsg: `\[controlPlane.platform.azure.type: Invalid value: "Dne_D2_v4": not found in region centralus, compute\[0\].platform.azure.type: Invalid value: "Dne_D2_v4": not found in region centralus, controlPlane.platform.azure.type: Invalid value: "Dne_D2_v4": unable to determine HyperVGeneration version\]`,
 		},
 		{
 			name:     "Invalid compute instance types",

--- a/pkg/asset/installconfig/azure/validation_test.go
+++ b/pkg/asset/installconfig/azure/validation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/openshift/installer/pkg/asset/installconfig/azure/mock"
@@ -221,8 +222,9 @@ var (
 	validOSImageOffer                = "test-offer"
 	validOSImageSKU                  = "test-sku"
 	validOSImageVersion              = "test-version"
+	noPlanOSImageSKU                 = "no-plan-sku"
 	invalidOSImageSKU                = "bad-sku"
-	erroringOSImageSKU               = "test-sku-gen1"
+	erroringOSImageSKU               = "test-sku-gen2"
 	erroringLicenseTermsOSImageSKU   = "erroring-license-terms"
 	unacceptedLicenseTermsOSImageSKU = "unaccepted-license-terms"
 	validOSImage                     = azure.OSImage{
@@ -420,30 +422,6 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 			edits:    editFunctions{invalidVMNetworkingIstanceTypes, vmNetworkingTypeAcceleratedCompute},
 			errorMsg: `compute\[0\].platform.azure.vmNetworkingType: Invalid value: "Accelerated": vm networking type is not supported for instance type Standard_B4ms`,
 		},
-		{
-			name:  "Valid OS Image",
-			edits: editFunctions{validOSImageCompute},
-		},
-		{
-			name:     "Invalid OS Image",
-			edits:    editFunctions{invalidOSImageCompute},
-			errorMsg: `compute\[0\].platform.azure.osImage: Invalid value: .*: not found`,
-		},
-		{
-			name:     "OS Image causing error determining license terms",
-			edits:    editFunctions{erroringLicenseTermsOSImageCompute},
-			errorMsg: `compute\[0\].platform.azure.osImage: Invalid value: .*: could not determine if the license terms for the marketplace image have been accepted: error`,
-		},
-		{
-			name:     "OS Image with unaccepted license terms",
-			edits:    editFunctions{unacceptedLicenseTermsOSImageCompute},
-			errorMsg: `compute\[0\].platform.azure.osImage: Invalid value: .*: the license terms for the marketplace image have not been accepted`,
-		},
-		{
-			name:     "OS Image with wrong HyperV generation",
-			edits:    editFunctions{erroringGenerationOsImageCompute},
-			errorMsg: `compute\[0\].platform.azure.osImage: Invalid value: .* supports HyperVGenerations \[(V[12])\] but the specified image is for HyperVGeneration [^\\1].*`,
-		},
 	}
 
 	mockCtrl := gomock.NewController(t)
@@ -489,24 +467,6 @@ func TestAzureInstallConfigValidation(t *testing.T) {
 	// Resource SKUs
 	azureClient.EXPECT().GetDiskSkus(gomock.Any(), validResourceSkuRegions).Return(nil, fmt.Errorf("invalid disk type")).AnyTimes()
 	azureClient.EXPECT().GetDiskSkus(gomock.Any(), invalidResourceSkuRegion).Return(nil, fmt.Errorf("invalid region")).AnyTimes()
-
-	// OS Images
-	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, validOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
-	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, validOSImageSKU).Return(true, nil).AnyTimes()
-	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, invalidOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, fmt.Errorf("not found")).AnyTimes()
-	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringLicenseTermsOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
-	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringLicenseTermsOSImageSKU).Return(false, fmt.Errorf("error")).AnyTimes()
-	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
-	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU).Return(false, nil).AnyTimes()
-	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringOSImageSKU, validOSImageVersion).Return(azenc.VirtualMachineImage{
-		VirtualMachineImageProperties: &azenc.VirtualMachineImageProperties{
-			HyperVGeneration: azenc.HyperVGenerationTypesV2,
-		},
-	}, nil).AnyTimes()
-
-	// HyperVGenerations
-	azureClient.EXPECT().GetHyperVGenerationVersion(gomock.Any(), gomock.Any(), gomock.Any(), "V1").Return("", fmt.Errorf("instance type Standard_D8s_v3 supports HyperVGenerations [V2] but the specified image is for HyperVGeneration V1; to correct this issue either specify a compatible instance type or change the HyperVGeneration for the image by using a different SKU")).AnyTimes()
-	azureClient.EXPECT().GetHyperVGenerationVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("V2", nil).AnyTimes()
 
 	azureClient.EXPECT().GetAvailabilityZones(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"1", "2", "3"}, nil).AnyTimes()
 
@@ -1003,6 +963,207 @@ func TestAzureUltraSSDCapability(t *testing.T) {
 				assert.Regexp(t, tc.errorMsg, aggregatedErrors)
 			} else {
 				assert.NoError(t, aggregatedErrors)
+			}
+		})
+	}
+}
+
+func TestAzureMarketplaceImage(t *testing.T) {
+	validOSImageNoPlan := azure.OSImage{
+		Plan:      azure.ImageNoPurchasePlan,
+		Publisher: validOSImagePublisher,
+		SKU:       noPlanOSImageSKU,
+		Version:   validOSImageVersion,
+		Offer:     validOSImageOffer,
+	}
+
+	invalidOSImage := azure.OSImage{
+		Publisher: validOSImagePublisher,
+		SKU:       invalidOSImageSKU,
+		Version:   validOSImageVersion,
+		Offer:     validOSImageOffer,
+	}
+
+	allHyperVGens := sets.New("V1", "V2")
+
+	cases := []struct {
+		name       string
+		osImage    *azure.OSImage
+		hyperVGens sets.Set[string]
+		errorMsg   string
+	}{
+		{
+			name:       "Valid OS Image",
+			osImage:    &validOSImage,
+			hyperVGens: allHyperVGens,
+			errorMsg:   "",
+		},
+		{
+			name:       "Valid OS Image no purchase plan",
+			osImage:    &validOSImageNoPlan,
+			hyperVGens: allHyperVGens,
+			errorMsg:   "",
+		},
+		{
+			name:       "Invalid OS Image",
+			osImage:    &invalidOSImage,
+			hyperVGens: allHyperVGens,
+			errorMsg:   `compute\[0\].platform.azure.osImage: Invalid value: .*: not found`,
+		},
+		{
+			name: "OS Image causing error determining license terms",
+			osImage: &azure.OSImage{
+				Publisher: validOSImagePublisher,
+				SKU:       erroringLicenseTermsOSImageSKU,
+				Offer:     validOSImageOffer,
+				Version:   validOSImageVersion,
+			},
+			hyperVGens: allHyperVGens,
+			errorMsg:   `compute\[0\].platform.azure.osImage: Invalid value: .*: could not determine if the license terms for the marketplace image have been accepted: error`,
+		},
+		{
+			name: "OS Image with unaccepted license terms",
+			osImage: &azure.OSImage{
+				Publisher: validOSImagePublisher,
+				SKU:       unacceptedLicenseTermsOSImageSKU,
+				Offer:     validOSImageOffer,
+				Version:   validOSImageVersion,
+			},
+			hyperVGens: allHyperVGens,
+			errorMsg:   `compute\[0\].platform.azure.osImage: Invalid value: .*: the license terms for the marketplace image have not been accepted`,
+		},
+		{
+			name: "OS Image with wrong HyperV generation",
+			osImage: &azure.OSImage{
+				Publisher: validOSImagePublisher,
+				SKU:       erroringOSImageSKU,
+				Offer:     validOSImageOffer,
+				Version:   validOSImageVersion,
+			},
+			hyperVGens: sets.New("V1"),
+			errorMsg:   `compute\[0\].platform.azure.osImage: Invalid value: .*: instance type supports HyperVGenerations \[(V[12])\] but the specified image is for HyperVGeneration [^\\1].*$`,
+		},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	azureClient := mock.NewMockAPI(mockCtrl)
+
+	// OS Images
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, validOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, validOSImageSKU).Return(true, nil).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, invalidOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, fmt.Errorf("not found")).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringLicenseTermsOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringLicenseTermsOSImageSKU).Return(false, fmt.Errorf("error")).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU).Return(false, nil).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringOSImageSKU, validOSImageVersion).Return(azenc.VirtualMachineImage{
+		VirtualMachineImageProperties: &azenc.VirtualMachineImageProperties{
+			HyperVGeneration: azenc.HyperVGenerationTypesV2,
+		},
+	}, nil).AnyTimes()
+	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringOSImageSKU).Return(true, nil).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, noPlanOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
+	// Should not check terms of images with no purchase plan
+	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, noPlanOSImageSKU).MaxTimes(0)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMarketplaceImage(azureClient, validRegion, tc.hyperVGens, tc.osImage, field.NewPath("compute").Index(0))
+			if tc.errorMsg != "" {
+				assert.Regexp(t, tc.errorMsg, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestAzureMarketplaceImages(t *testing.T) {
+	defaultMachineInstanceTypeHyperVGen1 := func(ic *types.InstallConfig) {
+		ic.Azure.DefaultMachinePlatform.InstanceType = "Standard_D4s_v3"
+	}
+
+	cases := []struct {
+		name     string
+		edits    editFunctions
+		errorMsg string
+	}{
+		{
+			name:  "Valid OS Image compute",
+			edits: editFunctions{validOSImageCompute, validInstanceTypes},
+		},
+		{
+			name:     "Invalid OS Image compute",
+			edits:    editFunctions{invalidOSImageCompute, validInstanceTypes},
+			errorMsg: `compute\[0\].platform.azure.osImage: Invalid value: .*: not found`,
+		},
+		{
+			name:     "OS Image causing error determining license terms for compute",
+			edits:    editFunctions{erroringLicenseTermsOSImageCompute, validInstanceTypes},
+			errorMsg: `compute\[0\].platform.azure.osImage: Invalid value: .*: could not determine if the license terms for the marketplace image have been accepted: error`,
+		},
+		{
+			name:     "OS Image with unaccepted license terms for compute",
+			edits:    editFunctions{unacceptedLicenseTermsOSImageCompute, validInstanceTypes},
+			errorMsg: `compute\[0\].platform.azure.osImage: Invalid value: .*: the license terms for the marketplace image have not been accepted`,
+		},
+		{
+			name:     "OS Image with wrong HyperV generation for compute",
+			edits:    editFunctions{erroringGenerationOsImageCompute, validInstanceTypes},
+			errorMsg: `compute\[0\].platform.azure.osImage: Invalid value: .*: instance type supports HyperVGenerations \[(V[12])\] but the specified image is for HyperVGeneration [^\\1].*`,
+		},
+		{
+			name:     "OS Image with wrong HyperV generation for inherited instance type for compute",
+			edits:    editFunctions{erroringGenerationOsImageCompute, defaultMachineInstanceTypeHyperVGen1},
+			errorMsg: `compute\[0\].platform.azure.osImage: Invalid value: .*: instance type supports HyperVGenerations \[(V[12])\] but the specified image is for HyperVGeneration [^\\1].*`,
+		},
+	}
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	azureClient := mock.NewMockAPI(mockCtrl)
+
+	// Marketplace images
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, validOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, validOSImageSKU).Return(true, nil).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, invalidOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, fmt.Errorf("not found")).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringLicenseTermsOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringLicenseTermsOSImageSKU).Return(false, fmt.Errorf("error")).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU, validOSImageVersion).Return(marketplaceImageAPIResult, nil).AnyTimes()
+	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, unacceptedLicenseTermsOSImageSKU).Return(false, nil).AnyTimes()
+	azureClient.EXPECT().GetMarketplaceImage(gomock.Any(), validRegion, validOSImagePublisher, validOSImageOffer, erroringOSImageSKU, validOSImageVersion).Return(azenc.VirtualMachineImage{
+		VirtualMachineImageProperties: &azenc.VirtualMachineImageProperties{
+			HyperVGeneration: azenc.HyperVGenerationTypesV2,
+		},
+	}, nil).AnyTimes()
+	azureClient.EXPECT().AreMarketplaceImageTermsAccepted(gomock.Any(), validOSImagePublisher, validOSImageOffer, erroringOSImageSKU).Return(true, nil).AnyTimes()
+
+	// VM Capabilities
+	for key, value := range vmCapabilities {
+		azureClient.EXPECT().GetVMCapabilities(gomock.Any(), key, validRegion).Return(value, nil).AnyTimes()
+	}
+	azureClient.EXPECT().GetVMCapabilities(gomock.Any(), "Dne_D2_v4", validRegion).Return(nil, fmt.Errorf("not found in region centralus")).AnyTimes()
+	azureClient.EXPECT().GetVMCapabilities(gomock.Any(), gomock.Any(), gomock.Any()).Return(vmCapabilities["Standard_D8s_v3"], nil).AnyTimes()
+
+	// HyperVGenerations
+	azureClient.EXPECT().GetHyperVGenerationVersion(gomock.Any(), gomock.Any(), gomock.Any(), "V1").Return("", fmt.Errorf("instance type Standard_D8s_v3 supports HyperVGenerations [V2] but the specified image is for HyperVGeneration V1; to correct this issue either specify a compatible instance type or change the HyperVGeneration for the image by using a different SKU")).AnyTimes()
+	azureClient.EXPECT().GetHyperVGenerationVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("V2", nil).AnyTimes()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			editedInstallConfig := validInstallConfig()
+			for _, edit := range tc.edits {
+				edit(editedInstallConfig)
+			}
+			aggregatedErrors := validateMarketplaceImages(azureClient, editedInstallConfig)
+			err := aggregatedErrors.ToAggregate()
+			if tc.errorMsg != "" {
+				assert.Regexp(t, tc.errorMsg, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/asset/machines/azure/machines.go
+++ b/pkg/asset/machines/azure/machines.go
@@ -165,6 +165,9 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 	var image machineapi.Image
 	if mpool.OSImage.Publisher != "" {
 		image.Type = machineapi.AzureImageTypeMarketplaceWithPlan
+		if mpool.OSImage.Plan == azure.ImageNoPurchasePlan {
+			image.Type = machineapi.AzureImageTypeMarketplaceNoPlan
+		}
 		image.Publisher = mpool.OSImage.Publisher
 		image.Offer = mpool.OSImage.Offer
 		image.SKU = mpool.OSImage.SKU

--- a/pkg/types/azure/machinepool.go
+++ b/pkg/types/azure/machinepool.go
@@ -104,8 +104,23 @@ func (a *MachinePool) Set(required *MachinePool) {
 	}
 }
 
+// ImagePurchasePlan defines the purchase plan of a Marketplace image.
+// +kubebuilder:validation:Enum=WithPurchasePlan;NoPurchasePlan
+type ImagePurchasePlan string
+
+const (
+	// ImageWithPurchasePlan enum attribute which is the default setting.
+	ImageWithPurchasePlan ImagePurchasePlan = "WithPurchasePlan"
+	// ImageNoPurchasePlan  enum attribute which speficies the image does not need a purchase plan.
+	ImageNoPurchasePlan ImagePurchasePlan = "NoPurchasePlan"
+)
+
 // OSImage is the image to use for the OS of a machine.
 type OSImage struct {
+	// Plan is the purchase plan of the image.
+	// If omitted, it defaults to "WithPurchasePlan".
+	// +optional
+	Plan ImagePurchasePlan `json:"plan"`
 	// Publisher is the publisher of the image.
 	Publisher string `json:"publisher"`
 	// Offer is the offer of the image.

--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -53,25 +53,18 @@ func ValidateMachinePool(p *azure.MachinePool, poolName string, platform *azure.
 		}
 	}
 
-	allErrs = append(allErrs, validateOSImage(p, poolName, fldPath)...)
+	allErrs = append(allErrs, validateOSImage(p, fldPath)...)
 
 	return allErrs
 }
 
-func validateOSImage(p *azure.MachinePool, poolName string, fldPath *field.Path) field.ErrorList {
+func validateOSImage(p *azure.MachinePool, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	osImageFldPath := fldPath.Child("osImage")
 
 	emptyOSImage := azure.OSImage{}
 	if p.OSImage != emptyOSImage {
-		// The control plane cannot use the marketplace image. Don't let the default machine pool specify the
-		// marketplace image either.
-		if poolName == "" || poolName == "master" {
-			allErrs = append(allErrs, field.Invalid(osImageFldPath, p.OSImage, "cannot specify the OS image for the master machines"))
-			return allErrs
-		}
-
 		if p.OSImage.Plan != "" {
 			planOptions := sets.NewString(
 				string(azure.ImageNoPurchasePlan),

--- a/pkg/types/azure/validation/machinepool.go
+++ b/pkg/types/azure/validation/machinepool.go
@@ -72,6 +72,15 @@ func validateOSImage(p *azure.MachinePool, poolName string, fldPath *field.Path)
 			return allErrs
 		}
 
+		if p.OSImage.Plan != "" {
+			planOptions := sets.NewString(
+				string(azure.ImageNoPurchasePlan),
+				string(azure.ImageWithPurchasePlan),
+			)
+			if !planOptions.Has(string(p.OSImage.Plan)) {
+				allErrs = append(allErrs, field.NotSupported(osImageFldPath.Child("plan"), p.OSImage.Plan, planOptions.List()))
+			}
+		}
 		if p.OSImage.Publisher == "" {
 			allErrs = append(allErrs, field.Required(osImageFldPath.Child("publisher"), "must specify publisher for the OS image"))
 		}

--- a/pkg/types/azure/validation/machinepool_test.go
+++ b/pkg/types/azure/validation/machinepool_test.go
@@ -131,6 +131,23 @@ func TestValidateMachinePool(t *testing.T) {
 							Offer:     "test-offer",
 							SKU:       "test-sku",
 							Version:   "test-version",
+							Plan:      "NoPurchasePlan",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid OS image with purchase plan omitted",
+			pool: &types.MachinePool{
+				Name: "worker",
+				Platform: types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{
+						OSImage: azure.OSImage{
+							Publisher: "test-publisher",
+							Offer:     "test-offer",
+							SKU:       "test-sku",
+							Version:   "test-version",
 						},
 					},
 				},
@@ -199,6 +216,24 @@ func TestValidateMachinePool(t *testing.T) {
 				},
 			},
 			expected: `^test-path\.osImage.version: Required value: must specify version for the OS image$`,
+		},
+		{
+			name: "OS image with invalid plan",
+			pool: &types.MachinePool{
+				Name: "worker",
+				Platform: types.MachinePoolPlatform{
+					Azure: &azure.MachinePool{
+						OSImage: azure.OSImage{
+							Publisher: "test-publisher",
+							Offer:     "test-offer",
+							SKU:       "test-sku",
+							Version:   "test-version",
+							Plan:      "test-plan",
+						},
+					},
+				},
+			},
+			expected: `^test-path\.osImage.plan: Unsupported value: ".*": supported values: "NoPurchasePlan", "WithPurchasePlan"$`,
 		},
 		{
 			name: "OS image for master",

--- a/pkg/types/azure/validation/machinepool_test.go
+++ b/pkg/types/azure/validation/machinepool_test.go
@@ -250,7 +250,6 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expected: `^test-path\.osImage: Invalid value: .* cannot specify the OS image for the master machines$`,
 		},
 		{
 			name: "OS image for default pool",
@@ -267,7 +266,6 @@ func TestValidateMachinePool(t *testing.T) {
 					},
 				},
 			},
-			expected: `^test-path\.osImage: Invalid value: .* cannot specify the OS image for the master machines$`,
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
This PR adds a new field `Plan` to the install-config, so the Installer can also use Marketplace images with no purchase plan. It was hard-coded to assume all images needed a purchase plan (therefore requiring its terms to be accepted).
It then extends the usage of Azure Marketplace images to nodes other than compute.
Some changes were made to the validation unit tests so the Marketplace image functionality can be tested independently from the more encompassing install-config validation test.

**Note**
I had to also fix a deprecated warning about `sets.String` usage so the linter would be happy

**Limitations**
To simplify things, the RHCOS image is still created and uploaded to the user's storage account. That way it can still be used for future scaleups. The Marketplace image, however, is not uploaded to the user's account.

**Local testing scenarios**

1. Marketplace image with no purchase plan defined in the default MachinePlatform
```bash
$: az vm list --resource-group "rdossant-02211659-pkztx-rg" | jq '.[] | .name, .storageProfile.imageReference'
"rdossant-02211659-pkztx-master-0"
{
  "communityGalleryImageId": null,
  "exactVersion": "411.86.20220811",
  "id": null,
  "offer": "<redacted>",
  "publisher": "<redacted>",
  "sharedGalleryImageId": null,
  "sku": "<redacted>",
  "version": "411.86.20220811"
}
"rdossant-02211659-pkztx-master-1"
{
  "communityGalleryImageId": null,
  "exactVersion": "411.86.20220811",
  "id": null,
  "offer": "<redacted>",
  "publisher": "<redacted>",
  "sharedGalleryImageId": null,
  "sku": "<redacted>",
  "version": "411.86.20220811"
}
"rdossant-02211659-pkztx-master-2"
{
  "communityGalleryImageId": null,
  "exactVersion": "411.86.20220811",
  "id": null,
  "offer": "<redacted>",
  "publisher": "<redacted>",
  "sharedGalleryImageId": null,
  "sku": "<redacted>",
  "version": "411.86.20220811"
}
"rdossant-02211659-pkztx-worker-centralus1-bcrrj"
{
  "communityGalleryImageId": null,
  "exactVersion": "411.86.20220811",
  "id": null,
  "offer": "<redacted>",
  "publisher": "<redacted>",
  "sharedGalleryImageId": null,
  "sku": "<redacted>",
  "version": "411.86.20220811"
}
"rdossant-02211659-pkztx-worker-centralus2-tfsfd"
{
  "communityGalleryImageId": null,
  "exactVersion": "411.86.20220811",
  "id": null,
  "offer": "<redacted>",
  "publisher": "<redacted>",
  "sharedGalleryImageId": null,
  "sku": "<redacted>",
  "version": "411.86.20220811"
}
"rdossant-02211659-pkztx-worker-centralus3-pcvjf"
{
  "communityGalleryImageId": null,
  "exactVersion": "411.86.20220811",
  "id": null,
  "offer": "<redacted>",
  "publisher": "<redacted>",
  "sharedGalleryImageId": null,
  "sku": "<redacted>",
  "version": "411.86.20220811"
}
```
2. Marketplace images with no purchase plan defined for the ControlPlane machines:
```bash
$: az vm list --resource-group "rdossant-02211805-rpg55-rg" | jq '.[] | .name, .storageProfile.imageReference'
"rdossant-02211805-rpg55-master-0"
{
  "communityGalleryImageId": null,
  "exactVersion": "411.86.20220811",
  "id": null,
  "offer": "<redacted>",
  "publisher": "<redacted>",
  "sharedGalleryImageId": null,
  "sku": "<redacted>",
  "version": "411.86.20220811"
}
"rdossant-02211805-rpg55-master-1"
{
  "communityGalleryImageId": null,
  "exactVersion": "411.86.20220811",
  "id": null,
  "offer": "<redacted>",
  "publisher": "<redacted>",
  "sharedGalleryImageId": null,
  "sku": "<redacted>",
  "version": "411.86.20220811"
}
"rdossant-02211805-rpg55-master-2"
{
  "communityGalleryImageId": null,
  "exactVersion": "411.86.20220811",
  "id": null,
  "offer": "<redacted>",
  "publisher": "<redacted>",
  "sharedGalleryImageId": null,
  "sku": "<redacted>",
  "version": "411.86.20220811"
}
"rdossant-02211805-rpg55-worker-centralus1-tws7g"
{
  "communityGalleryImageId": null,
  "exactVersion": "413.86.20230130",
  "id": "/subscriptions/<redacted>/resourceGroups/rdossant-02211805-rpg55-rg/providers/Microsoft.Compute/galleries/gallery_rdossant_02211805_rpg55/images/rdossant-02211805-rpg55-gen2/versions/latest",
  "offer": null,
  "publisher": null,
  "resourceGroup": "rdossant-02211805-rpg55-rg",
  "sharedGalleryImageId": null,
  "sku": null,
  "version": null
}
"rdossant-02211805-rpg55-worker-centralus2-q2chn"
{
  "communityGalleryImageId": null,
  "exactVersion": "413.86.20230130",
  "id": "/subscriptions/<redacted>/resourceGroups/rdossant-02211805-rpg55-rg/providers/Microsoft.Compute/galleries/gallery_rdossant_02211805_rpg55/images/rdossant-02211805-rpg55-gen2/versions/latest",
  "offer": null,
  "publisher": null,
  "resourceGroup": "rdossant-02211805-rpg55-rg",
  "sharedGalleryImageId": null,
  "sku": null,
  "version": null
}
"rdossant-02211805-rpg55-worker-centralus3-knm9q"
{
  "communityGalleryImageId": null,
  "exactVersion": "413.86.20230130",
  "id": "/subscriptions/<redacted>/resourceGroups/rdossant-02211805-rpg55-rg/providers/Microsoft.Compute/galleries/gallery_rdossant_02211805_rpg55/images/rdossant-02211805-rpg55-gen2/versions/latest",
  "offer": null,
  "publisher": null,
  "resourceGroup": "rdossant-02211805-rpg55-rg",
  "sharedGalleryImageId": null,
  "sku": null,
  "version": null
}
```
3. Marketplace image with purchase plan in ControlPlane:
```bash
ERROR Error: creating Linux Virtual Machine: (Name "rdossant-02221252-rb8p2-bootstrap" / Resource Group "rdossant-02221252-rb8p2-rg"): compute.VirtualMachinesClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="ResourcePurchaseValidationFailed" Message="User failed validation to purchase resources. Error message: 'Offer with PublisherId: 'redhat', OfferId: 'rh-ocp-worker' cannot be purchased due to validation errors. For more information see details. Correlation Id: '6c3b219b-d0e0-fedb-395a-fb40c4e7df51' Cannot complete purchase as your enrollment for this subscription doesn't allow purchase of marketplace products. Your Azure enrollment administrator can enable purchase of paid marketplace products. for details, see https://go.microsoft.com/fwlink/?linkid=2110642. Correlation Id: '6c3b219b-d0e0-fedb-395a-fb40c4e7df51'.'" 
ERROR                                              
ERROR   with azurerm_linux_virtual_machine.bootstrap, 
ERROR   on main.tf line 193, in resource "azurerm_linux_virtual_machine" "bootstrap": 
ERROR  193: resource "azurerm_linux_virtual_machine" "bootstrap" { 
ERROR                                              
ERROR                                              
```
So it tries to use the Marketplace image but my subscription is not allowed to use images with purchase plan