### PR TITLE
AGENT-502: Enable agent tui

### DIFF
--- a/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
+++ b/cmd/openshift-install/testdata/agent/image/manifests/default_manifests.txt
@@ -100,7 +100,7 @@ metadata:
   name: openshift-was not built correctly
   namespace: cluster0
 spec:
-  releaseImage: registry.ci.openshift.org/origin/release:4.12
+  releaseImage: registry.ci.openshift.org/origin/release:4.13
 status: {}
 -- expected/infraenv.yaml --
 metadata:

--- a/data/data/agent/files/etc/assisted/agent-installer.env.template
+++ b/data/data/agent/files/etc/assisted/agent-installer.env.template
@@ -8,5 +8,6 @@
 # ASSISTED_SERVICE_HOST must be updated.
 #   
 NODE_ZERO_IP={{.NodeZeroIP}}
+LD_LIBRARY_PATH=/usr/local/bin/
 RELEASE_IMAGE={{.ReleaseImage}}
 AGENT_TUI_LOG_PATH=/var/log/agent/agent-tui.log

--- a/data/data/agent/systemd/units/agent-interactive-console.service
+++ b/data/data/agent/systemd/units/agent-interactive-console.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Get interactive user configuration at boot
 After=network-pre.target NetworkManager.service pre-network-manager-config.service selinux.service
-Before=network.target network.service agent.service NetworkManager-wait-online.service
+Before=network.target network.service agent.service node-zero.service NetworkManager-wait-online.service
 
 [Service]
 Type=oneshot

--- a/data/data/agent/systemd/units/set-hostname.service
+++ b/data/data/agent/systemd/units/set-hostname.service
@@ -2,7 +2,7 @@
 Description=Agent-based installer hostname update service
 Wants=network-online.target
 After=local-fs.target
-Before=node-zero.service
+Before=agent-interactive-console.service
 
 [Service]
 ExecStart=/usr/local/bin/set-hostname.sh

--- a/pkg/asset/releaseimage/default.go
+++ b/pkg/asset/releaseimage/default.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// defaultReleaseImageOriginal is the value served when defaultReleaseImagePadded is unmodified.
-	defaultReleaseImageOriginal = "registry.ci.openshift.org/origin/release:4.12"
+	defaultReleaseImageOriginal = "registry.ci.openshift.org/origin/release:4.13"
 	// defaultReleaseImagePadded may be replaced in the binary with a pull spec that overrides defaultReleaseImage as
 	// a null-terminated string within the allowed character length. This allows a distributor to override the payload
 	// location without having to rebuild the source.


### PR DESCRIPTION
This patch finalizes the integration of the agent-tui binary within the agent ISO

This patch also bumps up the default release image to `registry.ci.openshift.org/origin/release:4.13`, as it's required by the integration tests (as pointed out by @zane in the comment, there's also a ticket for it https://issues.redhat.com/browse/CORS-2235)