### PR TITLE
MULTIARCH-3212: Update resource group in PowerVSPlatformStatus

### DIFF
--- a/pkg/asset/manifests/infrastructure.go
+++ b/pkg/asset/manifests/infrastructure.go
@@ -259,6 +259,7 @@ func (i *Infrastructure) Generate(dependencies asset.Parents) error {
 			return errors.New("unknown publishing strategy")
 		}
 		config.Status.PlatformStatus.PowerVS = &configv1.PowerVSPlatformStatus{
+			ResourceGroup:  installConfig.Config.Platform.PowerVS.PowerVSResourceGroup,
 			Region:         installConfig.Config.Platform.PowerVS.Region,
 			Zone:           installConfig.Config.Platform.PowerVS.Zone,
 			CISInstanceCRN: cisInstanceCRN,


### PR DESCRIPTION
Supporting IBM COS as storage for PowerVS platform in image registry operator requires ResourceGroup to be present in PowerVSPlatformStatus.