### PR TITLE
OCPBUGS-7993: hack/build-coreos-manifest: support OKD

### DIFF
--- a/hack/build-coreos-manifest.go
+++ b/hack/build-coreos-manifest.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
@@ -17,12 +18,17 @@ import (
 )
 
 const (
-	// FIXME - Add an OKD conditional here
-	streamJSON = "data/data/coreos/rhcos.json"
-	dest       = "bin/manifests/coreos-bootimages.yaml"
+	streamRHCOSJSON = "data/data/coreos/rhcos.json"
+	streamFCOSJSON  = "data/data/coreos/fcos.json"
+	fcosTAG         = "okd"
+	dest            = "bin/manifests/coreos-bootimages.yaml"
 )
 
 func run() error {
+	streamJSON := streamRHCOSJSON
+	if tags, _ := os.LookupEnv("TAGS"); strings.Contains(tags, fcosTAG) {
+		streamJSON = streamFCOSJSON
+	}
 	bootimages, err := os.ReadFile(streamJSON)
 	if err != nil {
 		return err


### PR DESCRIPTION
If TAGS env var contains "fcos" (its an alias to OKD) CoreOS manifest script should use
FCOS json. This is necessary for OKD clusters to be installable via
Hypershift