### PR TITLE
validation: Allow machine-pool validation based on FeatureSet

### DIFF
--- a/pkg/types/openstack/validation/machinepool.go
+++ b/pkg/types/openstack/validation/machinepool.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
@@ -14,7 +15,7 @@ var validServerGroupPolicies = []string{
 }
 
 // ValidateMachinePool validates Control plane and Compute MachinePools
-func ValidateMachinePool(_ *openstack.Platform, machinePool *openstack.MachinePool, _ string, fldPath *field.Path) field.ErrorList {
+func ValidateMachinePool(_ configv1.FeatureSet, machinePool *openstack.MachinePool, _ string, fldPath *field.Path) field.ErrorList {
 	if machinePool == nil {
 		return nil
 	}

--- a/pkg/types/openstack/validation/machinepool_test.go
+++ b/pkg/types/openstack/validation/machinepool_test.go
@@ -6,6 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
 
@@ -69,7 +70,7 @@ func TestValidateMachinePool(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			errs := ValidateMachinePool(nil, tc.machinePool, "", nil)
+			errs := ValidateMachinePool(configv1.Default, tc.machinePool, "", nil)
 			for _, check := range tc.checks {
 				if e := check(errs); e != nil {
 					t.Error(e)

--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -19,7 +19,7 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field
 		}
 	}
 
-	allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, "default", fldPath.Child("defaultMachinePlatform"))...)
+	allErrs = append(allErrs, ValidateMachinePool(c.FeatureSet, p.DefaultMachinePlatform, "default", fldPath.Child("defaultMachinePlatform"))...)
 
 	// Platform fields only allowed in TechPreviewNoUpgrade
 	if c.FeatureSet != configv1.TechPreviewNoUpgrade {

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -433,19 +433,19 @@ func validateControlPlane(featureSet configv1.FeatureSet, platform *types.Platfo
 func validateCompute(featureSet configv1.FeatureSet, platform *types.Platform, control *types.MachinePool, pools []types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	poolNames := map[string]bool{}
-	for i, p := range pools {
+	for i := range pools {
 		poolFldPath := fldPath.Index(i)
-		if p.Name != types.MachinePoolComputeRoleName {
-			allErrs = append(allErrs, field.NotSupported(poolFldPath.Child("name"), p.Name, []string{"worker"}))
+		if pools[i].Name != types.MachinePoolComputeRoleName {
+			allErrs = append(allErrs, field.NotSupported(poolFldPath.Child("name"), pools[i].Name, []string{"worker"}))
 		}
-		if poolNames[p.Name] {
-			allErrs = append(allErrs, field.Duplicate(poolFldPath.Child("name"), p.Name))
+		if poolNames[pools[i].Name] {
+			allErrs = append(allErrs, field.Duplicate(poolFldPath.Child("name"), pools[i].Name))
 		}
-		poolNames[p.Name] = true
-		if control != nil && control.Architecture != p.Architecture {
-			allErrs = append(allErrs, field.Invalid(poolFldPath.Child("architecture"), p.Architecture, "heteregeneous multi-arch is not supported; compute pool architecture must match control plane"))
+		poolNames[pools[i].Name] = true
+		if control != nil && control.Architecture != pools[i].Architecture {
+			allErrs = append(allErrs, field.Invalid(poolFldPath.Child("architecture"), pools[i].Architecture, "heteregeneous multi-arch is not supported; compute pool architecture must match control plane"))
 		}
-		allErrs = append(allErrs, ValidateMachinePool(featureSet, platform, &p, poolFldPath)...)
+		allErrs = append(allErrs, ValidateMachinePool(featureSet, platform, &pools[i], poolFldPath)...)
 	}
 	return allErrs
 }

--- a/pkg/types/validation/machinepools.go
+++ b/pkg/types/validation/machinepools.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	awsvalidation "github.com/openshift/installer/pkg/types/aws/validation"
@@ -59,7 +60,7 @@ var (
 )
 
 // ValidateMachinePool checks that the specified machine pool is valid.
-func ValidateMachinePool(platform *types.Platform, p *types.MachinePool, fldPath *field.Path) field.ErrorList {
+func ValidateMachinePool(featureSet configv1.FeatureSet, platform *types.Platform, p *types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if p.Replicas != nil {
 		if *p.Replicas < 0 {
@@ -77,11 +78,11 @@ func ValidateMachinePool(platform *types.Platform, p *types.MachinePool, fldPath
 	if platform.AWS != nil {
 		allErrs = append(allErrs, awsvalidation.ValidateMachinePoolArchitecture(p, fldPath.Child("architecture"))...)
 	}
-	allErrs = append(allErrs, validateMachinePoolPlatform(platform, &p.Platform, p, fldPath.Child("platform"))...)
+	allErrs = append(allErrs, validateMachinePoolPlatform(featureSet, platform, &p.Platform, p, fldPath.Child("platform"))...)
 	return allErrs
 }
 
-func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolPlatform, pool *types.MachinePool, fldPath *field.Path) field.ErrorList {
+func validateMachinePoolPlatform(featureSet configv1.FeatureSet, platform *types.Platform, p *types.MachinePoolPlatform, pool *types.MachinePool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	platformName := platform.Name()
 	validate := func(n string, value interface{}, validation func(*field.Path) field.ErrorList) {
@@ -130,7 +131,7 @@ func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolP
 	}
 	if p.OpenStack != nil {
 		validate(openstack.Name, p.OpenStack, func(f *field.Path) field.ErrorList {
-			return openstackvalidation.ValidateMachinePool(platform.OpenStack, p.OpenStack, pool.Name, f)
+			return openstackvalidation.ValidateMachinePool(featureSet, p.OpenStack, pool.Name, f)
 		})
 	}
 	return allErrs

--- a/pkg/types/validation/machinepools_test.go
+++ b/pkg/types/validation/machinepools_test.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/pointer"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
@@ -193,7 +194,7 @@ func TestValidateMachinePool(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateMachinePool(tc.platform, tc.pool, field.NewPath("test-path")).ToAggregate()
+			err := ValidateMachinePool(configv1.Default, tc.platform, tc.pool, field.NewPath("test-path")).ToAggregate()
 			if tc.valid {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
After this change, validations of the OpenStack machine-pool will be able to depend on the `installConfig.FeatureSet` value to allow or reject TechPreview-only configurations.