### PR TITLE
OCPBUGS-7015: Relax MachineCIDR check for vSphere, Nutanix

### DIFF
--- a/pkg/asset/agent/installconfig_test.go
+++ b/pkg/asset/agent/installconfig_test.go
@@ -102,7 +102,7 @@ platform:
 pullSecret: "{\"auths\":{\"example.com\":{\"auth\":\"authorization value\"}}}"
 `,
 			expectedFound: false,
-			expectedError: `invalid install-config configuration: [platform.vsphere.apiVIPs: Invalid value: "192.168.122.10": IP expected to be in one of the machine networks: 10.0.0.0/16, platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set]`,
+			expectedError: `invalid install-config configuration: platform.vsphere.ingressVIPs: Required value: must specify VIP for ingress, when VIP for API is set`,
 		},
 		{
 			name: "invalid configuration for none platform for sno",

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1703,6 +1703,23 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: "platform.baremetal.ingressVIPs: Invalid value: \"2001::1\": IP expected to be in one of the machine networks: 10.0.0.0/16,fe80::/10",
 		},
 		{
+			name: "vsphere_ingressvip_v4_not_in_machinenetwork_cidr",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Networking.MachineNetwork = []types.MachineNetworkEntry{
+					{CIDR: *ipnet.MustParseCIDR("10.0.0.0/16")},
+					{CIDR: *ipnet.MustParseCIDR("fe80::/10")},
+				}
+				c.Platform = types.Platform{
+					VSphere: validVSpherePlatform(),
+				}
+				c.Platform.VSphere.IngressVIPs = []string{"192.168.222.4"}
+				c.Platform.VSphere.APIVIPs = []string{"192.168.1.0"}
+
+				return c
+			}(),
+		},
+		{
 			name: "too_many_ingressvips",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
a58ac55e8a07e442c73747ffcbdbbc3f584b276d introduced many network validations for on-prem platforms. We want to relax one of those, the check that Ingress & API VIPs are in the machinenetwork because the check prevents using the TUI survey to generate the install config and this (mismatched) configuration has been allowed in all of OpenShift 4 without issue.

Fixes OCPBUGS-7015

/cc creydr jcpowermac sadasu cybertron rvanderp3