### PR TITLE
openstack: consistent TechPreview-only feature validation

### DIFF
--- a/pkg/types/openstack/validation/platform.go
+++ b/pkg/types/openstack/validation/platform.go
@@ -21,13 +21,6 @@ func ValidatePlatform(p *openstack.Platform, n *types.Networking, fldPath *field
 
 	allErrs = append(allErrs, ValidateMachinePool(p, p.DefaultMachinePlatform, "default", fldPath.Child("defaultMachinePlatform"))...)
 
-	// Platform fields only allowed in TechPreviewNoUpgrade
-	if c.FeatureSet != configv1.TechPreviewNoUpgrade {
-		if c.OpenStack.LoadBalancer != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("loadBalancer"), "load balancer is not supported in this feature set"))
-		}
-	}
-
 	if c.OpenStack.LoadBalancer != nil {
 		if !validateLoadBalancer(c.OpenStack.LoadBalancer.Type) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("loadBalancer", "type"), c.OpenStack.LoadBalancer.Type, "invalid load balancer type"))

--- a/pkg/types/openstack/validation/platform_test.go
+++ b/pkg/types/openstack/validation/platform_test.go
@@ -52,23 +52,6 @@ func TestValidatePlatform(t *testing.T) {
 			valid:      true,
 		},
 		{
-			name:     "forbidden load balancer field",
-			platform: validPlatform(),
-			config: &types.InstallConfig{
-				Platform: types.Platform{
-					OpenStack: func() *openstack.Platform {
-						p := validPlatform()
-						p.LoadBalancer = &configv1.OpenStackPlatformLoadBalancer{
-							Type: configv1.LoadBalancerTypeOpenShiftManagedDefault,
-						}
-						return p
-					}(),
-				},
-			},
-			valid:         false,
-			expectedError: `^test-path\.loadBalancer: Forbidden: load balancer is not supported in this feature set`,
-		},
-		{
 			name:     "allowed load balancer field with OpenShift managed default",
 			platform: validPlatform(),
 			config: &types.InstallConfig{

--- a/pkg/types/openstack/validation/techpreview.go
+++ b/pkg/types/openstack/validation/techpreview.go
@@ -1,0 +1,20 @@
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types"
+)
+
+// FilledInTechPreviewFields returns a slice of field paths that were set in
+// install-config, and that are only accepted in the context of a
+// TechPreviewNoUpgrade feature set.
+func FilledInTechPreviewFields(installConfig *types.InstallConfig) []*field.Path {
+	var fields []*field.Path
+
+	if installConfig.OpenStack.LoadBalancer != nil {
+		fields = append(fields, field.NewPath("platform", "openstack", "loadBalancer"))
+	}
+
+	return fields
+}

--- a/pkg/types/openstack/validation/techpreview_test.go
+++ b/pkg/types/openstack/validation/techpreview_test.go
@@ -1,0 +1,39 @@
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/types/openstack"
+)
+
+func TestFilledInTechPreviewFields(t *testing.T) {
+	t.Run("load_balancer", func(t *testing.T) {
+		installConfig := types.InstallConfig{
+			Platform: types.Platform{
+				OpenStack: &openstack.Platform{
+					LoadBalancer: &v1.OpenStackPlatformLoadBalancer{
+						Type: v1.LoadBalancerTypeUserManaged,
+					},
+				},
+			},
+		}
+
+		expectedField := field.NewPath("platform", "openstack", "loadBalancer")
+
+		var found bool
+
+		for _, f := range FilledInTechPreviewFields(&installConfig) {
+			if f.String() == expectedField.String() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected field %q to be detected", expectedField)
+		}
+	})
+}

--- a/pkg/types/validation/installconfig.go
+++ b/pkg/types/validation/installconfig.go
@@ -1003,6 +1003,12 @@ func validateFeatureSet(c *types.InstallConfig) field.ErrorList {
 		if c.Azure != nil && len(c.Azure.UserTags) > 0 {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("platform", "azure", "userTags"), errMsg))
 		}
+
+		if c.OpenStack != nil {
+			for _, f := range openstackvalidation.FilledInTechPreviewFields(c) {
+				allErrs = append(allErrs, field.Forbidden(f, errMsg))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1931,6 +1931,20 @@ func TestValidateInstallConfig(t *testing.T) {
 			expectedError: "platform.openstack.apiVIPs: Invalid value: \"foobar\": \"foobar\" is not a valid IP",
 		},
 		{
+			name: "should reject load balancer on OpenStack if not TechPreviewNoUpgrade",
+			installConfig: func() *types.InstallConfig {
+				c := validInstallConfig()
+				c.Platform = types.Platform{
+					OpenStack: validOpenStackPlatform(),
+				}
+				c.Platform.OpenStack.LoadBalancer = &configv1.OpenStackPlatformLoadBalancer{
+					Type: configv1.LoadBalancerTypeOpenShiftManagedDefault,
+				}
+				return c
+			}(),
+			expectedError: `platform.openstack.loadBalancer: Forbidden: the TechPreviewNoUpgrade feature set must be enabled to use this field`,
+		},
+		{
 			name: "should not validate vips on VSphere if not set (vips are not required on VSphere)",
 			installConfig: func() *types.InstallConfig {
 				c := validInstallConfig()


### PR DESCRIPTION
With this change, filling in TechPreview-only configuration flags in OpenStack throws similar errors as to what happens on other platforms.

Supersedes #6913

/cc mandre patrickdillon 